### PR TITLE
Add copy-pr-bot

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,3 @@
+enabled: true
+auto_sync_draft: false
+auto_sync_ready: true


### PR DESCRIPTION
Add copy-pr-bot

They will just need cpu runners apparently.  So should hopefully be able to just use the cpu machines from NV GH Runners for now.