### PR TITLE
update server logging format to be more consistent

### DIFF
--- a/nemo_gym/train_data_utils.py
+++ b/nemo_gym/train_data_utils.py
@@ -260,7 +260,7 @@ class TrainDataProcessor(BaseModel):
 
         server_names_list_str = "\n- ".join([""] + [f"{c.name} ({c.SERVER_TYPE})" for c in agent_configs_without_data])
         print(
-            f"Found {len(agent_configs_without_data)} agent server instance configs withOUT datasets:{server_names_list_str}\n\n"
+            f"Found {len(agent_configs_without_data)} agent server instance configs WITHOUT datasets:{server_names_list_str}\n\n"
         )
 
         server_names_list_str = ""


### PR DESCRIPTION
updated the following logging print when running ng_prepare_data from, for example: 

"Found 0 agent server instance configs withOUT datasets:"

to 

"Found 0 agent server instance configs WITHOUT datasets:" 

to match the format of the subsequent logs, for example: 
"Found 1 agent server instance configs WITH datasets:"