### PR TITLE
Use python env for precommit hook; alter files trigger

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,15 +50,8 @@ repos:
         exclude: '^\.github/'
         types: [file]
       - id: update-readme-table
-        name: "Update resource server list in README"
-        entry: |
-          bash -c '
-            if git diff --cached --name-only --diff-filter=ACMR | grep -q "^resources_servers/.*/configs/.*\.yaml$"; then
-              echo "[pre-commit] Saw staged config changes; updating resource servers in README." >&2
-              python scripts/update_resource_servers.py
-            else
-              echo [pre-commit] "No staged config changes; skipping README update." >&2
-            fi
-          '
-        language: system
-        files: ^README\.md$
+        name: Update resource server list in README
+        language: python
+        entry: python scripts/update_resource_servers.py
+        additional_dependencies: [pyyaml]
+        files: ^README\.md$|^resources_servers/.*/configs/.*\.yaml$


### PR DESCRIPTION
This change uses python instead of bash system language to get around the `python: command not found` error when using vs code source control gui.