### PR TITLE
Rollout collection with cached rows

### DIFF
--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -164,6 +164,7 @@ class RolloutCollectionHelper(BaseModel):  # pragma: no cover
                 else:
                     await raise_for_status(response)
                 result = await response.json()
+                result = row | result
                 if config.enable_cache:
                     assert "_rollout_cache_key" not in result
                     result["_rollout_cache_key"] = {


### PR DESCRIPTION
This allows for easily restarting a rollout collection session without having to re-collect rollouts for already cached rows in the jsonl output file.