### PR TITLE
fix: Update incorrect path in docs: library_judge_math -> math_with_j…

### DIFF
--- a/docs/how-to-faq.md
+++ b/docs/how-to-faq.md
@@ -204,7 +204,7 @@ Naming convention for Huggingface datasets is as follows.
 
 E.g.:
 
-`Nvidia/Nemo-Gym-Math-library_judge_math-dapo17k`
+`Nvidia/Nemo-Gym-Math-math_with_judge-dapo17k`
 
 
 You will only need to manually input the `{your dataset name}` portion of the above when inputting the `dataset_name` flag in the upload command (see below). Everything preceding it will be automatically populated using your config prior to upload.

--- a/docs/tutorials/rl-training-with-nemo-rl.md
+++ b/docs/tutorials/rl-training-with-nemo-rl.md
@@ -69,7 +69,7 @@ uv sync --active --extra dev
 
 # Prepare data
 config_paths="responses_api_models/openai_model/configs/openai_model.yaml,\
-resources_servers/library_judge_math/configs/bytedtsinghua_dapo17k.yaml"
+resources_servers/math_with_judge/configs/bytedtsinghua_dapo17k.yaml"
 ng_prepare_data "+config_paths=[${config_paths}]" \
     +output_dirpath=data/bytedtsinghua_dapo17k \
     +mode=train_preparation +should_download=true


### PR DESCRIPTION
- Updated config path in rl-training-with-nemo-rl.md tutorial
- Updated HuggingFace dataset naming example in how-to-faq.md
- Corrects path from resources_servers/library_judge_math to resources_servers/math_with_judge