### PR TITLE
docs: move FAQ

### DIFF
--- a/docs/how-to-faq.md
+++ b/docs/how-to-faq.md
@@ -1,4 +1,4 @@
-# How-Tos and FAQs
+# FAQ
 
 :::{warning}
 This document is a collection of How-Tos and FAQs that have not made their way into an official tutorial yet. The following guides are **experimental** and may contain bugs. Proceed with caution.

--- a/docs/index.md
+++ b/docs/index.md
@@ -177,7 +177,6 @@ tutorials/index.md
 tutorials/creating-resource-server
 tutorials/offline-training-w-rollouts
 tutorials/rl-training-with-nemo-rl
-how-to-faq.md
 ```
 
 ```{toctree}
@@ -195,6 +194,7 @@ training/rl-framework-integration/index.md
 :hidden:
 :maxdepth: 1
 
+FAQ <how-to-faq.md>
 Configuration <reference/configuration>
 reference/cli-commands.md
 apidocs/index.rst


### PR DESCRIPTION
moves how-to-faq to render under "references" and display as FAQ. no material changes to the content.