### PR TITLE
add unsloth and trl to docs 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -137,7 +137,15 @@ Transform rollouts into training data for {term}`supervised fine-tuning (SFT) <S
 :link-type: ref
 Learn how to set up NeMo Gym and NeMo RL training environments, run tests, prepare data, and launch single-node and multi-node training runs.
 +++
-{bdg-primary}`training` {bdg-secondary}`rl` {bdg-secondary}`grpo`
+{bdg-primary}`training` {bdg-secondary}`rl` {bdg-secondary}`grpo` {bdg-secondary}`multi-step`
+:::
+
+:::{grid-item-card} {octicon}`zap;1.5em;sd-mr-1` Unsloth and TRL
+:link: training-unsloth-trl
+:link-type: ref
+Fast, memory-efficient fine-tuning for single-step tasks: math, structured outputs, instruction following, reasoning gym and more.
++++
+{bdg-primary}`training` {bdg-secondary}`unsloth` {bdg-secondary}`trl` {bdg-secondary}`single-step`
 :::
 
 ::::
@@ -201,8 +209,9 @@ Rollout Collection <get-started/rollout-collection.md>
 
 tutorials/index.md
 tutorials/creating-resource-server
-tutorials/nemo-rl-grpo/index.md
 tutorials/offline-training-w-rollouts
+tutorials/nemo-rl-grpo/index.md
+tutorials/unsloth-trl-training
 ```
 
 ```{toctree}

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -49,7 +49,7 @@ Transform rollouts into training data for {term}`supervised fine-tuning (SFT) <S
 
 ## RL Training
 
-::::{grid} 1 1 1 1
+::::{grid} 1 1 2 2
 :gutter: 1 1 1 2
 
 :::{grid-item-card} {octicon}`workflow;1.5em;sd-mr-1` GRPO with NeMo RL
@@ -57,7 +57,15 @@ Transform rollouts into training data for {term}`supervised fine-tuning (SFT) <S
 :link-type: ref
 Learn how to set up NeMo Gym and NeMo RL training environments, run tests, prepare data, and launch single-node and multi-node training runs.
 +++
-{bdg-primary}`training` {bdg-secondary}`rl` {bdg-secondary}`grpo`
+{bdg-primary}`training` {bdg-secondary}`rl` {bdg-secondary}`grpo` {bdg-secondary}`multi-step`
+:::
+
+:::{grid-item-card} {octicon}`zap;1.5em;sd-mr-1` Unsloth and TRL
+:link: training-unsloth-trl
+:link-type: ref
+Fast, memory-efficient fine-tuning for single-step tasks: math, structured outputs, instruction following, reasoning gym and more.
++++
+{bdg-primary}`training` {bdg-secondary}`unsloth` {bdg-secondary}`trl` {bdg-secondary}`single-step`
 :::
 
 ::::

--- a/docs/tutorials/unsloth-trl-training.md
+++ b/docs/tutorials/unsloth-trl-training.md
@@ -1,0 +1,69 @@
+(training-unsloth-trl)=
+
+# RL Training with Unsloth and TRL
+
+This tutorial demonstrates how to use [Unsloth](https://github.com/unslothai/unsloth) and [TRL (Transformer Reinforcement Learning)](https://github.com/huggingface/trl) to fine-tune models for single-step tasks with NeMo Gym verifiers and datasets.
+
+**Unsloth** is a fast, memory-efficient library for fine-tuning large language models. It provides optimized implementations that significantly reduce memory usage and training time, making it possible to fine-tune larger models on consumer hardware.
+
+**TRL** is a library from HuggingFace for post-training models using techniques like SFT, GRPO, and DPO. It is built on top of [Transformers](https://github.com/huggingface/transformers) and supports a variety of model architectures and modalities. 
+
+
+Both Unsloth and TRL can be used with NeMo Gym single-step verifiers including math tasks, structured outputs, instruction following, reasoning gym, and more. 
+
+:::{card}
+
+**Goal**: Fine-tune a model for single-step tasks using Unsloth and TRL with NeMo Gym verifiers.
+
+^^^
+
+**In this tutorial, you will**:
+
+1. Set up Unsloth for efficient fine-tuning
+2. Use NeMo Gym for tasks and verification
+3. Train a model using GRPO on a single gpu 
+4. Evaluate trained model performance 
+
+:::
+
+## Getting Started
+
+Follow this interactive notebook to train your first model with Unsloth or TRL and NeMo Gym:
+
+:::{button-link} https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/nemo_gym_sudoku.ipynb
+:color: primary
+:class: sd-rounded-pill
+
+Unsloth GRPO notebook
+:::
+
+> **Note:** This notebook supports **single-step tasks** including math, structured outputs, instruction following, reasoning gym, and more. For multi-step tool calling scenarios, see the {doc}`GRPO with NeMo RL <nemo-rl-grpo/index>` tutorial. A complete multi-step and multi-turn integration with Unsloth and TRL is under construction! 
+
+---
+
+
+## What's Next?
+
+After completing this tutorial, explore these options:
+
+::::{grid} 1 1 2 2
+:gutter: 3
+
+:::{grid-item-card} {octicon}`package;1.5em;sd-mr-1` Use Other Training Environments
+:link: https://github.com/NVIDIA-NeMo/Gym#-available-resource-servers
+
+Browse available resource servers on GitHub to find other training environments.
++++
+{bdg-secondary}`github` {bdg-secondary}`resource-servers`
+:::
+
+:::{grid-item-card} {octicon}`workflow;1.5em;sd-mr-1` Multi-Step Tool Calling
+:link: nemo-rl-grpo/index
+:link-type: doc
+
+Scale to multi-step scenarios with GRPO and NeMo RL.
++++
+{bdg-secondary}`rl` {bdg-secondary}`grpo` {bdg-secondary}`multi-step`
+:::
+
+::::


### PR DESCRIPTION
adds a section for single-step training with unsloth and trl 

not sure if these should be broken into separate sections. Left as one since the same notebook works for both, but could be confusing. 

not sure if we should also add more info about multi-step (hopefully) coming soon. 