### PR TITLE
Workaround for uv pip install vllm on cpu targets

### DIFF
--- a/nemo_gym/cli.py
+++ b/nemo_gym/cli.py
@@ -84,7 +84,7 @@ def _setup_env_command(dir_path: Path, global_config_dict: DictConfig) -> str:  
         if dir_path.name == "vllm_model":
             # NB: --no-deps is a workaround for installing vllm (current version: 0.11.2) on a cpu target,
             # b/c `uv pip install` resolves dependencies differently vs `pip install`.
-            install_cmd = f"""uv pip install {uv_pip_python_flag} --no-deps '-e .' 'vllm==0.11.2' && {install_cmd}"""
+            install_cmd = f"""uv pip install {uv_pip_python_flag} --no-deps 'vllm==0.11.2' && {install_cmd}"""
     elif has_requirements_txt:
         install_cmd = f"""uv pip install {uv_pip_python_flag} -r requirements.txt {" ".join(head_server_deps)}"""
     else:


### PR DESCRIPTION
Another possible fix for https://github.com/NVIDIA-NeMo/Gym/issues/549