### PR TITLE
Increase test_train_data_utils coverage

### DIFF
--- a/tests/unit_tests/test_train_data_utils.py
+++ b/tests/unit_tests/test_train_data_utils.py
@@ -30,6 +30,7 @@ from nemo_gym.train_data_utils import (
     StringMetrics,
     TrainDataProcessor,
     TrainDataProcessorConfig,
+    validate_backend_credentials,
 )
 
 
@@ -258,11 +259,6 @@ class TestLoadDatasets:
             )
 
     def test_load_datasets_missing_credentials(self, monkeypatch: MonkeyPatch) -> None:
-        exit_called = []
-
-        def mock_exit(code):
-            exit_called.append(code)
-
         monkeypatch.setattr(nemo_gym.train_data_utils, "get_global_config_dict", lambda: DictConfig({}))
 
         config = TrainDataProcessorConfig(
@@ -304,18 +300,52 @@ class TestLoadDatasets:
             }
         }
 
-        processor.load_datasets(
-            config=config,
-            server_instance_configs=[
-                ResponsesAPIAgentServerInstanceConfig(
-                    name="example_multi_step_simple_agent",
-                    server_type_config_dict=DictConfig(server_type_config_dict),
-                    responses_api_agents=server_type_config_dict["responses_api_agents"],
-                ),
-            ],
+        with raises(SystemExit) as exc_info:
+            processor.load_datasets(
+                config=config,
+                server_instance_configs=[
+                    ResponsesAPIAgentServerInstanceConfig(
+                        name="example_multi_step_simple_agent",
+                        server_type_config_dict=DictConfig(server_type_config_dict),
+                        responses_api_agents=server_type_config_dict["responses_api_agents"],
+                    ),
+                ],
+            )
+        assert exc_info.value.code == 1
+
+    def test_validate_backend_credentials_missing(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            nemo_gym.train_data_utils,
+            "get_global_config_dict",
+            lambda: DictConfig({}),
         )
 
-        assert exit_called == [1]
+        is_valid, error_msg = validate_backend_credentials("gitlab")
+        assert not is_valid
+        assert "GitLab backend selected but missing credentials" in error_msg
+        assert "mlflow_tracking_uri" in error_msg
+        assert "mlflow_tracking_token" in error_msg
+
+        is_valid, error_msg = validate_backend_credentials("huggingface")
+        assert not is_valid
+        assert "HuggingFace backend selected but missing credentials" in error_msg
+        assert "hf_token" in error_msg
+
+    def test_validate_backend_credentials_valid(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            nemo_gym.train_data_utils,
+            "get_global_config_dict",
+            lambda: DictConfig(
+                {
+                    "mlflow_tracking_uri": "https://example.com",
+                    "mlflow_tracking_token": "token123",
+                }
+            ),
+        )
+
+        is_valid, error_msg = validate_backend_credentials("gitlab")
+        assert is_valid is True
+        assert error_msg == ""
 
 
 class TestValidateSamplesAndAggregateMetrics:
@@ -716,6 +746,11 @@ class TestValidateSamplesAndAggregateMetrics:
                 {"items": [1, 1, 2]},
                 {"items": [1, 2, 2]},  # different duplicates
                 False,
+            ),
+            (
+                {"items": [{"a": 1}, {"b": 2}]},
+                {"items": [{"b": 2}, {"a": 1}]},  # lists containing dicts
+                True,
             ),
         ]
 


### PR DESCRIPTION
Overall coverage failure threhsold is 95%, and test coverage is too low for train_data_utils which brings down overall coverage of the ng_dev_test suite. This covers some of those lingering test cases to bring it from 89% to 97%.