### PR TITLE
Update math_with_judge artifact paths

### DIFF
--- a/resources_servers/math_with_judge/configs/math_with_judge.yaml
+++ b/resources_servers/math_with_judge/configs/math_with_judge.yaml
@@ -29,14 +29,14 @@ math_with_judge_simple_agent:
         jsonl_fpath: resources_servers/math_with_judge/data/train.jsonl
         huggingface_identifier:
           repo_id: nvidia/Nemotron-RL-math-OpenMathReasoning
-          artifact_fpath: open_math_reasoning_problems.jsonl
+          artifact_fpath: train.jsonl
         license: Creative Commons Attribution 4.0 International
       - name: validation
         type: validation
         jsonl_fpath: resources_servers/math_with_judge/data/aime24_validation.jsonl
         huggingface_identifier:
           repo_id: nvidia/Nemotron-RL-math-OpenMathReasoning
-          artifact_fpath: aime24_validation.jsonl
+          artifact_fpath: validation.jsonl
         license: Apache 2.0
       - name: example
         type: example


### PR DESCRIPTION
The default artifact paths for the math_with_judge resource server doesn't match the filenames for the provided dataset (nvidia/Nemotron-RL-math-OpenMathReasoning) [as saved on Hugging Face](https://huggingface.co/datasets/nvidia/Nemotron-RL-math-OpenMathReasoning/tree/main). This results in an error when attempting to download the files automatically from Hugging Face. The artifact paths for both training and validation need to be updated with the names as shown on Hugging Face for proper downloading.