### PR TITLE
Add Hugging Face identifier for coding resource

### DIFF
--- a/resources_servers/code_gen/configs/code_gen.yaml
+++ b/resources_servers/code_gen/configs/code_gen.yaml
@@ -30,6 +30,9 @@ code_gen_simple_agent:
       - name: livecodebench_v5_validation
         type: validation
         jsonl_fpath: resources_servers/code_gen/data/livecodebench_v5_2024-07-01_2025-02-01_validation.jsonl
+        huggingface_identifier:
+          repo_id: nvidia/nemotron-RL-coding-competitive_coding
+          artifact_fpath: validation.jsonl
         gitlab_identifier:
           dataset_name: livecodebench
           version: 0.0.1


### PR DESCRIPTION
The competitive coding resource config is missing a Hugging Face identifier which prevents it from being downloaded via Hugging Face using the data preparation tools.

Without the HF identifier run the following:

```
config_paths="responses_api_models/vllm_model/configs/vllm_model_for_training.yaml,resources_servers/math_with_judge/configs/math_with_judge.yaml,resources_servers/code_gen/configs/code_gen.yaml,resources_servers/workplace_assistant/configs/workplace_assistant.yaml,resources_servers/mcqa/configs/mcqa.yaml,resources_servers/instruction_following/configs/instruction_following.yaml,resources_servers/structured_outputs/configs/structured_outputs_json.yaml"
ng_prepare_data "+config_paths=[${config_paths}]" +output_dirpath=data/ +mode=train_preparation +should_download=true +data_source=huggingface
```

This will throw a warning:

```
Dataset `livecodebench_v5_validation` missing huggingface_identifier for HuggingFace backend
```

And eventually this error:

```
Traceback (most recent call last):
  File "/opt/nemo_rl_venv/bin/ng_prepare_data", line 10, in <module>
    sys.exit(prepare_data())
             ^^^^^^^^^^^^^^
  File "/opt/nemo-rl/3rdparty/Gym-workspace/Gym/nemo_gym/train_data_utils.py", line 819, in prepare_data
    data_processor.run(global_config_dict)
  File "/opt/nemo-rl/3rdparty/Gym-workspace/Gym/nemo_gym/train_data_utils.py", line 350, in run
    dataset_type_to_aggregate_metrics = self.validate_samples_and_aggregate_metrics(server_instance_configs)
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/nemo-rl/3rdparty/Gym-workspace/Gym/nemo_gym/train_data_utils.py", line 657, in validate_samples_and_aggregate_metrics
    state = self._validate_samples_and_aggregate_metrics_single_dataset(d)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/nemo-rl/3rdparty/Gym-workspace/Gym/nemo_gym/train_data_utils.py", line 553, in _validate_samples_and_aggregate_metrics_single_dataset
    for sample_idx, sample_dict_str in enumerate(self._iter_dataset_lines(dataset_config)):
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/nemo-rl/3rdparty/Gym-workspace/Gym/nemo_gym/train_data_utils.py", line 542, in _iter_dataset_lines
    with open(dataset_config.jsonl_fpath) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'resources_servers/code_gen/data/livecodebench_v5_2024-07-01_2025-02-01_validation.jsonl'
```

This fix will download the validation file as intended and resolve the errors.