### PR TITLE
Aviary rollouts can be configured to return transitions or not

### DIFF
--- a/resources_servers/aviary/schemas.py
+++ b/resources_servers/aviary/schemas.py
@@ -70,8 +70,8 @@ class AviaryStepResponse(BaseModel):
 class AviaryNeMoGymResponse(NeMoGymResponse):
     env_id: str
     group_id: str
-    contains_transitions: Literal[True] = True
-    output: list[list[NeMoGymResponseOutputItem]]
+    contains_transitions: bool
+    output: list[NeMoGymResponseOutputItem] | list[list[NeMoGymResponseOutputItem]]
 
 
 class AviaryAgentVerifyRequest(BaseVerifyRequest):


### PR DESCRIPTION
Per title. This PR retains the current default of returning transitions, but it is reasonable to change that default to match the other Gym agents. 