### PR TITLE
feat: responses-native api 

### DIFF
--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -67,7 +67,7 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
     uses_reasoning_parser: bool
     replace_developer_role_with_system: bool = False
 
-    use_native_responses_api: bool = False
+    use_responses_endpoint: bool = False
 
     chat_template_kwargs: Optional[Dict[str, Any]] = None
 
@@ -110,12 +110,12 @@ class VLLMModel(SimpleResponsesAPIModel):
             self._session_id_to_client[session_id] = client
         client = self._session_id_to_client[session_id]
 
-        if self.config.use_native_responses_api:
-            return await self._handle_native_responses_api(client, body)
+        if self.config.use_responses_endpoint:
+            return await self._call_responses(client, body)
 
-        return await self._handle_chat_completions_responses(request, body)
+        return await self._call_chat_completions(request, body)
 
-    async def _handle_native_responses_api(
+    async def _call_responses(
         self, client: NeMoGymAsyncOpenAI, body: NeMoGymResponseCreateParamsNonStreaming
     ) -> NeMoGymResponse:
         body_dict = body.model_dump(exclude_unset=True)
@@ -200,7 +200,7 @@ class VLLMModel(SimpleResponsesAPIModel):
 
         return NeMoGymResponse.model_validate(vllm_response_dict)
 
-    async def _handle_chat_completions_responses(
+    async def _call_chat_completions(
         self, request: Request, body: NeMoGymResponseCreateParamsNonStreaming
     ) -> NeMoGymResponse:
         chat_completion_create_params = self._converter.responses_to_chat_completion_create_params(body)

--- a/responses_api_models/vllm_model/configs/vllm_model.yaml
+++ b/responses_api_models/vllm_model/configs/vllm_model.yaml
@@ -7,4 +7,4 @@ policy_model:
       model: ${policy_model_name}
       return_token_id_information: false
       uses_reasoning_parser: true
-      use_native_responses_api: false
+      use_responses_endpoint: false

--- a/responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
+++ b/responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
@@ -7,4 +7,4 @@ policy_model:
       model: ${policy_model_name}
       return_token_id_information: true
       uses_reasoning_parser: true
-      use_native_responses_api: false
+      use_responses_endpoint: false

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -666,7 +666,7 @@ class TestApp:
         monkeypatch: MonkeyPatch,
         return_token_id_information: bool = False,
         uses_reasoning_parser: bool = False,
-        use_native_responses_api: bool = False,
+        use_responses_endpoint: bool = False,
     ):
         config = VLLMModelConfig(
             host="0.0.0.0",
@@ -678,7 +678,7 @@ class TestApp:
             name="",
             return_token_id_information=return_token_id_information,
             uses_reasoning_parser=uses_reasoning_parser,
-            use_native_responses_api=use_native_responses_api,
+            use_responses_endpoint=use_responses_endpoint,
         )
 
         get_global_config_dict_mock = MagicMock()
@@ -2047,7 +2047,7 @@ class TestApp:
         assert expected_messages == actual_messages
 
     def test_native_responses_api_basic(self, monkeypatch: MonkeyPatch):
-        server = self._setup_server(monkeypatch, use_native_responses_api=True)
+        server = self._setup_server(monkeypatch, use_responses_endpoint=True)
         app = server.setup_webserver()
         client = TestClient(app)
 
@@ -2093,7 +2093,7 @@ class TestApp:
         assert mock_create_response.call_args.kwargs["model"] == "dummy_model"
 
     def test_native_responses_api_with_reasoning(self, monkeypatch: MonkeyPatch):
-        server = self._setup_server(monkeypatch, use_native_responses_api=True)
+        server = self._setup_server(monkeypatch, use_responses_endpoint=True)
         app = server.setup_webserver()
         client = TestClient(app)
 
@@ -2147,7 +2147,7 @@ class TestApp:
         assert data["output"][1]["content"][0]["text"] == "Let me help you with that!"
 
     def test_native_responses_api_with_token_ids(self, monkeypatch: MonkeyPatch):
-        server = self._setup_server(monkeypatch, return_token_id_information=True, use_native_responses_api=True)
+        server = self._setup_server(monkeypatch, return_token_id_information=True, use_responses_endpoint=True)
         app = server.setup_webserver()
         client = TestClient(app)
 
@@ -2209,7 +2209,7 @@ class TestApp:
         assert mock_create_response.called
 
     def test_native_responses_api_tool_calls(self, monkeypatch: MonkeyPatch):
-        server = self._setup_server(monkeypatch, use_native_responses_api=True)
+        server = self._setup_server(monkeypatch, use_responses_endpoint=True)
         app = server.setup_webserver()
         client = TestClient(app)
 
@@ -2251,7 +2251,7 @@ class TestApp:
         assert mock_create_response.called
 
     def test_native_responses_api_multiturn(self, monkeypatch: MonkeyPatch):
-        server = self._setup_server(monkeypatch, use_native_responses_api=True)
+        server = self._setup_server(monkeypatch, use_responses_endpoint=True)
         app = server.setup_webserver()
         client = TestClient(app)
 
@@ -2308,7 +2308,7 @@ class TestApp:
         ]
 
     def test_native_responses_api_string_input(self, monkeypatch: MonkeyPatch):
-        server = self._setup_server(monkeypatch, use_native_responses_api=True)
+        server = self._setup_server(monkeypatch, use_responses_endpoint=True)
         app = server.setup_webserver()
         client = TestClient(app)
 
@@ -2354,7 +2354,7 @@ class TestApp:
         assert mock_create_response.call_args.kwargs["input"] == "Hello"
 
     def test_native_responses_api_with_instructions(self, monkeypatch: MonkeyPatch):
-        server = self._setup_server(monkeypatch, use_native_responses_api=True)
+        server = self._setup_server(monkeypatch, use_responses_endpoint=True)
         app = server.setup_webserver()
         client = TestClient(app)
 


### PR DESCRIPTION
support responses native models. currently we convert responses to chat completions requests. this enables using responses endpoint directly. 

basic tests working, needs further testing

https://github.com/NVIDIA-NeMo/Gym/issues/521