### PR TITLE
feat: Fix vLLM placement group conflicts in Ray clusters and add local mode…

### DIFF
--- a/responses_api_models/local_vllm_model/app.py
+++ b/responses_api_models/local_vllm_model/app.py
@@ -159,13 +159,21 @@ class LocalVLLMModelActor:
         vLLM actors or other Ray actors use placement groups, additional node resource keys
         are created (e.g., 'node:IP_group_N_hash'). This patch filters out placement group
         keys to only use the base node IP key.
+
+        Based on vLLM v0.11.2's CoreEngineActorManager.create_dp_placement_groups:
+        https://github.com/vllm-project/vllm/blob/v0.11.2/vllm/v1/engine/utils.py#L329-L528
         """
         try:
             from vllm.v1.engine import utils as vllm_utils
 
             @staticmethod
             def patched_create_dp_placement_groups(vllm_config):
-                """Patched version that filters out placement group node keys."""
+                """
+                Create placement groups for data parallel.
+
+                This is a patched version of vLLM's create_dp_placement_groups that handles
+                multiple node resource keys from existing placement groups.
+                """
                 import ray
                 from ray._private.state import available_resources_per_node
                 from vllm import envs
@@ -174,38 +182,117 @@ class LocalVLLMModelActor:
 
                 logger = init_logger(__name__)
 
-                # Extract configuration - matching the original function's structure
+                ########################################
+                # START Patch: Enhanced logging for debugging
+                ########################################
+                # Original code:
+                # logger.info("Creating placement groups for data parallel")
+
+                # Modified code:
                 logger.info("=== PATCHED create_dp_placement_groups called ===")
                 logger.info("Creating placement groups for data parallel")
+                ########################################
+                # END Patch: Enhanced logging for debugging
+                ########################################
 
-                # Generate unique suffix to avoid name conflicts with existing placement groups
+                ########################################
+                # START Patch: Unique placement group names
+                ########################################
+                # Original code:
+                # (no unique suffix generation)
+
+                # Modified code:
                 import time
 
                 unique_suffix = int(time.time() * 1000) % 1000000  # Use timestamp for uniqueness
+                ########################################
+                # END Patch: Unique placement group names
+                ########################################
 
                 dp_master_ip = vllm_config.parallel_config.data_parallel_master_ip
                 dp_size = vllm_config.parallel_config.data_parallel_size
                 dp_size_local = vllm_config.parallel_config.data_parallel_size_local
-                world_size = vllm_config.parallel_config.world_size
-                device_str = current_platform.ray_device_key
-                pack_strategy = envs.VLLM_RAY_DP_PACK_STRATEGY
 
                 available_resources = available_resources_per_node()
+                world_size = vllm_config.parallel_config.world_size
                 placement_groups = []
                 local_dp_ranks = []
 
                 dp_master_ip_key = f"node:{dp_master_ip}"
                 nodes = sorted(available_resources.values(), key=lambda x: dp_master_ip_key not in x)
+                assert len(nodes) > 0, "No nodes with resources found in Ray cluster."
+                assert dp_master_ip_key in nodes[0], (
+                    "The DP master node (ip: %s) is missing or dead",
+                    dp_master_ip,
+                )
+                device_str = current_platform.ray_device_key
+                n_node_devices = [
+                    int(node_resources[device_str]) for node_resources in nodes if device_str in node_resources
+                ]
+                assert n_node_devices, f"No {device_str} found in Ray cluster."
+                max_device_per_node = max(n_node_devices)
 
-                # Determine placement strategy
-                placement_strategy = "STRICT_PACK" if pack_strategy in ("strict", "fill") else "PACK"
+                pack_strategy = envs.VLLM_RAY_DP_PACK_STRATEGY
+                _supported_pack_strategies = ("strict", "fill", "span")
+                if pack_strategy not in _supported_pack_strategies:
+                    raise ValueError(
+                        f"{envs.VLLM_RAY_DP_PACK_STRATEGY} is not supported. "
+                        "Make sure to set `VLLM_RAY_DP_PACK_STRATEGY` "
+                        f"to one of {_supported_pack_strategies}"
+                    )
 
-                # Patched collection logic
+                all2all_backend = vllm_config.parallel_config.all2all_backend
+                if pack_strategy == "fill" and (
+                    all2all_backend == "deepep_high_throughput" or all2all_backend == "deepep_low_latency"
+                ):
+                    raise ValueError(
+                        "DeepEP kernels require EP ranks [0,7] (same for [8,15], ...) "
+                        "to be on the same node, but VLLM_RAY_DP_PACK_STRATEGY=fill "
+                        "does not guarantee that. "
+                        "Please use VLLM_RAY_DP_PACK_STRATEGY=strict instead."
+                    )
+
+                if pack_strategy in ("strict", "fill"):
+                    placement_strategy = "STRICT_PACK"
+                else:
+                    placement_strategy = "PACK"
+                    assert world_size > max_device_per_node, (
+                        f"World size {world_size} is smaller than the "
+                        "maximum number of devices per node "
+                        f"{max_device_per_node}. Make sure to set "
+                        "`VLLM_RAY_DP_PACK_STRATEGY` to `strict` or `fill`"
+                    )
+
+                    assert set(n_node_devices) == {max_device_per_node}, f"Nodes are not homogenous, {nodes}"
+                    assert world_size % max_device_per_node == 0, (
+                        f"For multi-node data parallel groups, world_size ({world_size}) must "
+                        f"be a multiple of number of devices per node ({max_device_per_node})."
+                    )
+                    assert len(n_node_devices) * max_device_per_node >= world_size * dp_size, (
+                        f"Not enough total available nodes ({len(n_node_devices)}) "
+                        f"and devices per node ({max_device_per_node}) "
+                        f"to satisfy required world size {world_size} and data parallel size "
+                        f"{dp_size}"
+                    )
+                    assert dp_size_local == 1, (
+                        f"data-parallel-size-local {dp_size_local} should be set as the "
+                        "default (1) for VLLM_RAY_DP_PACK_STRATEGY=span. "
+                        "The actual data-parallel-size-local will be auto determined."
+                    )
+
+                collected_bundles = []
                 for node_resources in nodes:
-                    if len(placement_groups) == dp_size:
-                        break
+                    ########################################
+                    # START Patch: Filter placement group node keys
+                    ########################################
+                    # Original code:
+                    # node_ip_keys = [
+                    #     key
+                    #     for key in node_resources
+                    #     if key != "node:__internal_head__" and key.startswith("node:")
+                    # ]
 
-                    # PATCHED: Filter out placement group keys
+                    # Modified code:
                     node_ip_keys = [
                         key
                         for key in node_resources
@@ -213,10 +300,12 @@ class LocalVLLMModelActor:
                         and key.startswith("node:")
                         and "_group_" not in key  # Filter out placement group keys
                     ]
+                    ########################################
+                    # END Patch: Filter placement group node keys
+                    ########################################
 
-                    # Original assertion should now pass
                     assert len(node_ip_keys) == 1, (
-                        "Zero or multiple node IP keys found in node resources after filtering: %s",
+                        "Zero or multiple node IP keys found in node resources: %s",
                         node_ip_keys,
                     )
                     node_ip_key = node_ip_keys[0]
@@ -232,8 +321,10 @@ class LocalVLLMModelActor:
                         if dp_size_available < dp_size_local:
                             raise ValueError(
                                 "Not enough resources to allocate %s DP ranks "
-                                "on DP master node %s, possible to fit %s DP ranks"
-                                % (dp_size_local, node_ip, dp_size_available)
+                                "on DP master node %s, possible to fit %s DP ranks",
+                                dp_size_local,
+                                dp_master_ip,
+                                dp_size_available,
                             )
                         dp_size_to_allocate = dp_size_local
                     elif pack_strategy == "strict":
@@ -251,10 +342,32 @@ class LocalVLLMModelActor:
 
                     for i in range(dp_size_to_allocate):
                         device_bundle = [{device_str: 1.0, "node:" + node_ip: 0.001}]
-                        # Create placement group for each DP rank
-                        # Add an extra CPU bundle for the engine manager
-                        bundles = device_bundle * world_size + [{"CPU": 1.0}]
+                        if pack_strategy == "span":
+                            collected_bundles += device_bundle * n_device_on_node
+                            assert len(collected_bundles) <= world_size, (
+                                "collected_bundles should be <= world_size, "
+                                f"but got {len(collected_bundles)=} and {world_size=}"
+                            )
 
+                            if len(collected_bundles) < world_size:
+                                continue
+
+                            bundles = collected_bundles + [{"CPU": 1.0}]
+                            collected_bundles = []
+                        else:
+                            bundles = device_bundle * world_size + [{"CPU": 1.0}]
+
+                        ########################################
+                        # START Patch: Unique placement group names and enhanced logging
+                        ########################################
+                        # Original code:
+                        # pg = ray.util.placement_group(
+                        #     name=f"dp_rank_{len(placement_groups)}",
+                        #     strategy=placement_strategy,
+                        #     bundles=bundles,
+                        # )
+
+                        # Modified code:
                         pg_name = f"dp_rank_{len(placement_groups)}_{unique_suffix}"
                         logger.info(
                             f"Creating placement group {pg_name} with {len(bundles)} bundles (world_size={world_size})"
@@ -273,21 +386,29 @@ class LocalVLLMModelActor:
                         logger.info(
                             f"Placement group {pg_name} created successfully with {actual_bundle_count} bundles"
                         )
+                        ########################################
+                        # END Patch: Unique placement group names and enhanced logging
+                        ########################################
 
                         placement_groups.append(pg)
                         local_dp_ranks.append(i)
                         if len(placement_groups) == dp_size:
                             break
 
-                # Validate we created the right number of placement groups
                 if len(placement_groups) < dp_size:
                     raise ValueError(
                         f"Not enough resources to allocate {dp_size} "
                         "placement groups, only created "
                         f"{len(placement_groups)} placement groups. "
-                        f"Available resources: {available_resources}"
+                        "Available resources: "
+                        f"{available_resources}"
                     )
-
+                assert len(placement_groups) == dp_size, (
+                    f"Created {len(placement_groups)} DP placement groups, expected {dp_size}"
+                )
+                assert len(local_dp_ranks) == dp_size, (
+                    f"local_dp_ranks length {len(local_dp_ranks)} does not match expected {dp_size}"
+                )
                 return placement_groups, local_dp_ranks
 
             # Apply the patch


### PR DESCRIPTION
# What does this PR do?

**Fixes vLLM placement group conflicts in Ray clusters and adds support for local model paths.**

This PR patches vLLM's v1 engine to handle multiple Ray placement groups, preventing crashes when running multiple vLLM instances in the same cluster. It also adds support for using locally stored models instead of always downloading from HuggingFace.

# Issues

List issues that this PR closes ([syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)):

- Fixes [#148](https://github.com/NVIDIA-NeMo/Internal-Planning/issues/148) 

# Changes in this PR

- **vLLM Placement Group Patch**: `_patch_vllm_placement_group_filter()`
  - Filters out placement group node resource keys (e.g., `node:IP_group_N_hash`)
  - Allows multiple vLLM instances to coexist in the same Ray cluster
  - Adds unique timestamp-based suffixes to avoid placement group name conflicts
  - Includes comprehensive logging for debugging placement group creation

- **Local Model Support**: Modified `download_model()`
  - Checks if model path exists locally before attempting HuggingFace download
  - Skips download step for local models, improving startup time

- **Debugging Infrastructure**: `_cleanup_stale_placement_groups()`
  - Logs existing placement groups when `debug=True`
  - Helps diagnose placement group conflicts and resource allocation issues

- **Import Updates**
  - Added `list_placement_groups` from `ray.util.state` for placement group inspection
  
  
