### PR TITLE
Add Nemotron 3 Nano 30B multi-node training tutorial

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -313,6 +313,15 @@ Offline Training (SFT/DPO) <training-tutorials/offline-training-w-rollouts>
 ```
 
 ```{toctree}
+:caption: Model Recipes
+:hidden:
+:maxdepth: 1
+
+Overview <model-recipes/index>
+Nemotron 3 Nano <model-recipes/nemotron-3-nano>
+```
+
+```{toctree}
 :caption: Infrastructure
 :hidden:
 :maxdepth: 1

--- a/docs/model-recipes/index.md
+++ b/docs/model-recipes/index.md
@@ -1,0 +1,21 @@
+(model-recipes-index)=
+
+# Model Recipes
+
+Model recipes are tutorials to run Gym with various data recipes that were used to train models.
+
+
+## Backend Guides
+
+::::{grid} 1 2 2 2
+:gutter: 1 1 1 2
+
+:::{grid-item-card} {octicon}`server;1.5em;sd-mr-1` Nemotron 3 Nano
+:link: model-recipes-nemotron-3-nano
+:link-type: ref
+Distributed training of Nemotron 3 Nano 30B across multiple nodes using Slurm and Ray.
++++
+{bdg-secondary}`model recipe` {bdg-secondary}`nemotron`
+:::
+
+::::

--- a/docs/model-recipes/nemotron-3-nano.md
+++ b/docs/model-recipes/nemotron-3-nano.md
@@ -1,3 +1,5 @@
+(model-recipes-nemotron-3-nano)=
+
 # Nemotron 3 Nano 30B
 
 This tutorial walks through the complete setup for distributed training of Nemotron 3 Nano 30B across multiple nodes using Slurm and Ray.
@@ -62,10 +64,6 @@ cd RL-nano-v3
 ```
 
 **✅ Success Check**: Repository cloned with nano-v3 branch checked out.
-
----
-
----
 
 ---
 


### PR DESCRIPTION
## Summary                                                                                                                                     
Adds a new tutorial for training Nemotron 3 Nano 30B on 32 nodes with GRPO, building on the existing multi-node training guide. 

## Changes
**New tutorial**: `nemotron-3-nano-30b-multi-node.md` for 32-node (256 GPU) training
**Updated**: `multi-node-training.md` to link to the new advanced tutorial

## Testing
Tested with:
- 2-node jobs (16 GPUs)
- 32-node jobs (256 GPUs)
- Both completed successfully with proper Ray cluster formation

## Documentation Flow
Single Node Training -> Multi-Node Training -> **Nemotron 3 Nano 30B** (new) -> Custom Environment

 Closes #389