### PR TITLE
Compatibility with inference other than vllm < 0.10.2

### DIFF
--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -377,50 +377,45 @@ class VLLMModel(SimpleResponsesAPIModel):
             )
 
         if self.config.return_token_id_information:
-            log_probs = choice_dict["logprobs"]["content"]
-            generation_log_probs = [log_prob["logprob"] for log_prob in log_probs]
-
-            """
-            START TODO remove this when NeMo RL upgrades to vLLM 0.10.2 support for prompt token ids
-            """
-            # Looks like `"token_id:151667"`
-            generation_token_ids = [log_prob["token"].removeprefix("token_id:") for log_prob in log_probs]
-
-            # The tokenize endpoint doesn't accept any sampling parameters
-            # The only relevant params are model, messages, and tools.
-            #
-            # IMPORTANT: pass through chat-template knobs (e.g. enable_thinking)
-            # when tokenizing, otherwise `prompt_token_ids` (and therefore logged
-            # `prompt_str`) can be built with different chat template settings than
-            # the actual generation request.
-            tokenize_body_dict = dict()
-            for key in ("model", "messages", "tools", "chat_template_kwargs"):
-                if key in body_dict:
-                    tokenize_body_dict[key] = body_dict[key]
-
-            # The base url has /v1 at the end but vLLM's tokenize endpoint does not have v1, hence the ..
-            tokenize_response = await client.create_tokenize(**tokenize_body_dict)
-            """
-            END
-            """
-
             message_dict = choice_dict["message"]
-            message_dict.update(
-                dict(
-                    # TODO add this when NeMo RL upgrades to vLLM 0.10.2 support for prompt token ids
-                    # prompt_token_ids=chat_completion_dict["prompt_token_ids"],
-                    prompt_token_ids=tokenize_response["tokens"],
-                    # generation_token_ids=choice_dict["token_ids"],
-                    generation_token_ids=generation_token_ids,
-                    generation_log_probs=generation_log_probs,
-                )
-            )
 
-            # Clean the duplicated information
-            choice_dict.pop("logprobs")
-            # TODO add this when NeMo RL upgrades to vLLM 0.10.2 support for prompt token ids
-            # chat_completion_dict.pop("prompt_token_ids")
-            # choice_dict.pop("token_ids")
+            # Extract generation_log_probs from logprobs if not already provided by the backend
+            if "generation_log_probs" not in message_dict:
+                log_probs = choice_dict["logprobs"]["content"]
+                message_dict["generation_log_probs"] = [log_prob["logprob"] for log_prob in log_probs]
+
+            # Get prompt_token_ids and generation_token_ids if not already provided
+            if "prompt_token_ids" not in message_dict:
+                if "prompt_token_ids" in chat_completion_dict:
+                    # Token IDs available at the top level of the response
+                    message_dict["prompt_token_ids"] = chat_completion_dict.pop("prompt_token_ids")
+                    message_dict["generation_token_ids"] = choice_dict.pop("token_ids")
+                else:
+                    # If not available, fetch prompt token IDs via tokenize endpoint
+                    log_probs = choice_dict["logprobs"]["content"]
+                    # Looks like `"token_id:151667"`
+                    message_dict["generation_token_ids"] = [
+                        log_prob["token"].removeprefix("token_id:") for log_prob in log_probs
+                    ]
+
+                    # The tokenize endpoint doesn't accept any sampling parameters
+                    # The only relevant params are model, messages, and tools.
+                    #
+                    # IMPORTANT: pass through chat-template knobs (e.g. enable_thinking)
+                    # when tokenizing, otherwise `prompt_token_ids` (and therefore logged
+                    # `prompt_str`) can be built with different chat template settings than
+                    # the actual generation request.
+                    tokenize_body_dict = dict()
+                    for key in ("model", "messages", "tools", "chat_template_kwargs"):
+                        if key in body_dict:
+                            tokenize_body_dict[key] = body_dict[key]
+
+                    # The base url has /v1 at the end but vLLM's tokenize endpoint does not have v1, hence the ..
+                    tokenize_response = await client.create_tokenize(**tokenize_body_dict)
+                    message_dict["prompt_token_ids"] = tokenize_response["tokens"]
+
+            # Clean up duplicated information
+            choice_dict.pop("logprobs", None)
 
         return NeMoGymChatCompletion.model_validate(chat_completion_dict)
 


### PR DESCRIPTION
Inside `vllm_model/app.py`, there is a comment bloc that says:

>            """
>            START TODO remove this when NeMo RL upgrades to vLLM 0.10.2 support for prompt token ids
>            """

The associated code always assumes that the user is using vLLM < 0.10.2. This removes that assumption, allowing NeMo Gym to work easily with vLLM >= 0.10.2 or any other inference framework.