### PR TITLE
docs: Fix product naming and broken link in infrastructure docs

### DIFF
--- a/docs/contribute/environments/index.md
+++ b/docs/contribute/environments/index.md
@@ -2,7 +2,7 @@
 
 # Contribute Environments
 
-Help advance RL training for the community by contributing new environments. There are two main ways to get involved:
+Help advance RL training for the community by contributing new environments. There are several ways to get involved:
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -204,7 +204,7 @@ View all training tutorials →
 
 ## Infrastructure
 
-Deploy and scale NeMo Gym for production workloads.
+Deploy NeMo Gym and plan cluster resources for training.
 
 ::::{grid} 1 2 2 2
 :gutter: 1 1 1 2

--- a/docs/infrastructure/deployment-topology.md
+++ b/docs/infrastructure/deployment-topology.md
@@ -49,8 +49,8 @@ flowchart LR
 
 **How it works:**
 1. The training framework initializes the Ray cluster and creates vLLM workers with HTTP servers
-2. The training framework creates a NemoGym Ray actor within the same cluster
-3. The NemoGym actor spawns Gym servers (Head, Agent, Model, Resources) as subprocesses
+2. The training framework creates a NeMo Gym Ray actor within the same cluster
+3. The NeMo Gym actor spawns NeMo Gym servers (Head, Agent, Model, Resources) as subprocesses
 4. NeMo Gym's Model Server proxies inference requests to the training framework's vLLM HTTP endpoints
 5. Results flow back through the actor to the training loop
 
@@ -62,7 +62,7 @@ When NeMo Gym connects to an existing Ray cluster, the same Ray and Python versi
 
 ---
 
-#### Gym's Own Ray Cluster
+#### NeMo Gym's Own Ray Cluster
 
 When the training framework **does not use Ray**, NeMo Gym spins up its own independent Ray cluster for coordination.
 
@@ -105,7 +105,7 @@ flowchart LR
         vLLM["vLLM + HTTP"]
         Workers["Policy Workers"]
     end
-    subgraph B["Gym Cluster · CPU"]
+    subgraph B["NeMo Gym Cluster · CPU"]
         Agent["Agent Server"]
         Model["Model Server (proxy)"]
         Resources["Resources Server"]
@@ -118,18 +118,18 @@ flowchart LR
 ```
 
 **When to use:**
-- Training framework and Gym are deployed independently by different teams
-- Clusters have different lifecycle requirements (e.g., Gym always on, training runs are transient)
+- Training framework and NeMo Gym are deployed independently by different teams
+- Clusters have different lifecycle requirements (e.g., NeMo Gym always on, training runs are transient)
 - Network security policies require isolation between training and environment infrastructure
 - Hybrid cloud setups where training runs on GPU cloud and environments run on CPU cloud
 
 **Requirements:**
-- The training cluster must expose its generation backend (e.g., vLLM) as HTTP endpoints reachable from the Gym cluster
+- The training cluster must expose its generation backend (e.g., vLLM) as HTTP endpoints reachable from the NeMo Gym cluster
 - Network connectivity and firewall rules between clusters must allow HTTP traffic on the configured ports
 
 ### Choosing a Deployment Strategy
 
-| Factor | Single Ray Cluster | Gym's Own Ray Cluster | Separate Clusters |
+| Factor | Single Ray Cluster | NeMo Gym's Own Ray Cluster | Separate Clusters |
 |--------|-------------------|----------------------|-------------------|
 | **Training framework** | Ray-based | Non-Ray | Any |
 | **Startup** | Co-launched | Independent | Independent |

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -1,7 +1,7 @@
 (infrastructure-index)=
 # Infrastructure
 
-Learn how NeMo Gym is deployed and scaled for production workloads.
+Learn how to deploy NeMo Gym and plan cluster resources for training.
 
 ::::{grid} 1 2 2 2
 :gutter: 1 1 1 2
@@ -15,7 +15,7 @@ Server deployment patterns and training framework integration.
 :::
 
 :::{grid-item-card} {octicon}`server;1.5em;sd-mr-1` SWE RL Infrastructure Case Study
-:link: deployment-topology
+:link: swe-rl-case-study
 :link-type: doc
 Infrastructure challenges regarding SoftWare Engineering (SWE) task RL as a case study.
 +++


### PR DESCRIPTION
- Replace NemoGym and Gym with NeMo Gym throughout infrastructure docs
- Fix SWE RL case study card linking to wrong page
- Update infrastructure section descriptions