### PR TITLE
docs: Fix broken README links and clean up unsloth docs

### DIFF
--- a/docs/get-started/first-training-run.md
+++ b/docs/get-started/first-training-run.md
@@ -153,9 +153,9 @@ Multi-node GRPO training with NeMo RL for production workloads.
 :::
 
 :::{grid-item-card} {octicon}`package;1.5em;sd-mr-1` Try Different Environments
-:link: https://github.com/NVIDIA-NeMo/Gym#-available-resource-servers
+:link: https://github.com/NVIDIA-NeMo/Gym#-available-environments
 
-Browse available resource servers for math, code, tool-use, and more.
+Browse available environments for math, code, tool-use, and more.
 +++
 {bdg-secondary}`environments`
 :::

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -117,11 +117,11 @@ Now that you can generate rollouts, choose your path:
 :gutter: 3
 
 :::{grid-item-card} {octicon}`package;1.5em;sd-mr-1` Use an Existing Training Environment
-:link: https://github.com/NVIDIA-NeMo/Gym#-available-resource-servers
+:link: https://github.com/NVIDIA-NeMo/Gym#-available-environments
 
 Browse the available resource servers on GitHub to find a training-ready environment that matches your goals.
 +++
-{bdg-secondary}`github` {bdg-secondary}`resource-servers`
+{bdg-secondary}`github` {bdg-secondary}`environments`
 :::
 
 :::{grid-item-card} {octicon}`tools;1.5em;sd-mr-1` Build a Custom Training Environment

--- a/docs/get-started/rollout-collection.md
+++ b/docs/get-started/rollout-collection.md
@@ -198,11 +198,11 @@ Congratulations! You now have a working NeMo Gym installation and understand how
 :gutter: 3
 
 :::{grid-item-card} {octicon}`package;1.5em;sd-mr-1` Use an Existing Training Environment
-:link: https://github.com/NVIDIA-NeMo/Gym#-available-resource-servers
+:link: https://github.com/NVIDIA-NeMo/Gym#-available-environments
 
 Browse the available resource servers on GitHub to find a training-ready environment that matches your goals.
 +++
-{bdg-secondary}`github` {bdg-secondary}`resource-servers`
+{bdg-secondary}`github` {bdg-secondary}`environments`
 :::
 
 :::{grid-item-card} {octicon}`tools;1.5em;sd-mr-1` Build a Custom Training Environment

--- a/docs/training-tutorials/nemo-rl-grpo/index.md
+++ b/docs/training-tutorials/nemo-rl-grpo/index.md
@@ -125,9 +125,9 @@ After completing this tutorial, explore these options:
 :gutter: 3
 
 :::{grid-item-card} {octicon}`package;1.5em;sd-mr-1` Use Other Training Environments
-:link: https://github.com/NVIDIA-NeMo/Gym#-available-resource-servers
+:link: https://github.com/NVIDIA-NeMo/Gym#-available-environments
 
-Browse available resource servers on GitHub to find other training environments.
+Explore other environments available for training and evaluation.
 +++
 {bdg-secondary}`github` {bdg-secondary}`resource-servers`
 :::

--- a/docs/training-tutorials/nemo-rl-grpo/multi-node-training.md
+++ b/docs/training-tutorials/nemo-rl-grpo/multi-node-training.md
@@ -131,9 +131,9 @@ Congratulations! You've trained Nemotron Nano 9B v2 for multi-step tool calling 
 :gutter: 3
 
 :::{grid-item-card} {octicon}`package;1.5em;sd-mr-1` Use Other Training Environments
-:link: https://github.com/NVIDIA-NeMo/Gym#-available-resource-servers
+:link: https://github.com/NVIDIA-NeMo/Gym#-available-environments
 
-Browse available resource servers on GitHub to find other training environments.
+Explore other environments available for training and evaluation.
 :::
 
 :::{grid-item-card} {octicon}`tools;1.5em;sd-mr-1` Build a Custom Training Environment

--- a/docs/training-tutorials/unsloth.md
+++ b/docs/training-tutorials/unsloth.md
@@ -2,11 +2,9 @@
 
 # RL Training with Unsloth
 
-This tutorial demonstrates how to use [Unsloth](https://github.com/unslothai/unsloth) to fine-tune models for single-step tasks with NeMo Gym verifiers and datasets.
+This tutorial demonstrates how to use [Unsloth](https://github.com/unslothai/unsloth) to fine-tune models with NeMo Gym environments.
 
 **Unsloth** is a fast, memory-efficient library for fine-tuning large language models. It provides optimized implementations that significantly reduce memory usage and training time, making it possible to fine-tune larger models on consumer hardware.
-
-Unsloth can be used with NeMo Gym single-step verifiers including math tasks, structured outputs, instruction following, reasoning gym, and more.
 
 ## Prerequisites
 
@@ -35,33 +33,3 @@ Multi-Environment Training
 
 Check out [Unsloth's documentation](https://docs.unsloth.ai/models/nemotron-3#reinforcement-learning--nemo-gym) for more details.
 
-> **Note:** These notebooks support **single-step tasks** including math, structured outputs, instruction following, reasoning gym, and more. For multi-step tool calling scenarios, see the {doc}`GRPO with NeMo RL <nemo-rl-grpo/index>` tutorial.
-
----
-
-
-## Next Steps
-
-After completing this tutorial, explore these options:
-
-::::{grid} 1 1 2 2
-:gutter: 3
-
-:::{grid-item-card} {octicon}`package;1.5em;sd-mr-1` Use Other Training Environments
-:link: https://github.com/NVIDIA-NeMo/Gym#-available-resource-servers
-
-Browse available resource servers on GitHub to find other training environments.
-+++
-{bdg-secondary}`github` {bdg-secondary}`resource-servers`
-:::
-
-:::{grid-item-card} {octicon}`workflow;1.5em;sd-mr-1` Multi-Step Tool Calling
-:link: nemo-rl-grpo/index
-:link-type: doc
-
-Scale to multi-step scenarios with GRPO and NeMo RL.
-+++
-{bdg-secondary}`rl` {bdg-secondary}`grpo` {bdg-secondary}`multi-step`
-:::
-
-::::


### PR DESCRIPTION
Fixes #670 
- Fix #-available-resource-servers anchor to #-available-environments across 5 files
- Remove Next Steps section from unsloth tutorial
- Improve environment card descriptions