### PR TITLE
fix: ng prepare data metrics conflict

### DIFF
--- a/nemo_gym/train_data_utils.py
+++ b/nemo_gym/train_data_utils.py
@@ -720,6 +720,12 @@ This could be due to a change in how metrics are calculated, leading to outdated
             aggregate_metrics = aggregate_metrics.aggregate()
 
             aggregate_metrics_dict = aggregate_metrics.model_dump(mode="json", by_alias=True)
+            d = next(
+                (dataset for c in server_instance_configs for dataset in c.datasets if dataset.type == type),
+                None,
+            )
+            if d is not None:
+                aggregate_metrics_dict = d.model_dump() | aggregate_metrics_dict
 
             parent = Path(config.output_dirpath)
             parent.mkdir(exist_ok=True, parents=True)


### PR DESCRIPTION
issue described in https://github.com/NVIDIA-NeMo/Gym/issues/736

collate_samples writes metrics without the dataset config  metadata eg name type jsonl_fpath while validate_samples_and_aggregate_emtrics wrote those with metadata , causing a conflict. this mirrors what the validate step does to merge the metadata before the conflict check