### PR TITLE
fix: replace 9 bare excepts with except Exception across 6 files

### DIFF
--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -442,7 +442,7 @@ Formatted exception: {format_exc()}
 repr(e): {repr(e)}"""
                 )
                 return JSONResponse(content=repr(e), status_code=500)
-            except:
+            except Exception:
                 print_exc()
                 print(
                     f"""🚨 Caught an unknown exception printed above in {self.config.name} ({self.__class__.__name__}). If you expect this to be fed back into this model, nothing meaningful is returned to the model. Please make sure this exception is caught in your server and returned to the model as appropriate. See https://fastapi.tiangolo.com/tutorial/handling-errors/#use-httpexception"""

--- a/resources_servers/calendar/utils.py
+++ b/resources_servers/calendar/utils.py
@@ -188,7 +188,7 @@ def grade_assistant_response(assistant_response, exp_cal_state, allow_no_json_li
             for event_id in exp_cal_state.keys():
                 if not is_constraint_satisfied(events_dict[event_id], exp_cal_state[event_id]):
                     return 0, "constraint_violated"
-        except:
+        except Exception:
             return 0, "error_in_grading"
 
     return 1, "pass"

--- a/resources_servers/code_gen/lcb_integration/testing_util.py
+++ b/resources_servers/code_gen/lcb_integration/testing_util.py
@@ -129,7 +129,7 @@ def clean_if_name(code: str) -> str:
                 code = (
                     ast.unparse(astree.body[:-1]) + "\n" + ast.unparse(last_block.body)  # type: ignore
                 )
-    except:
+    except Exception:
         pass
 
     return code
@@ -227,7 +227,7 @@ def compile_code(code: str, timeout: int):
 def convert_line_to_decimals(line: str) -> tuple[bool, list[Decimal]]:
     try:
         decimal_line = [Decimal(elem) for elem in line.split()]
-    except:
+    except Exception:
         return False, []
     return True, decimal_line
 

--- a/resources_servers/code_gen/scripts/preprocess_train_dataset.py
+++ b/resources_servers/code_gen/scripts/preprocess_train_dataset.py
@@ -74,7 +74,7 @@ with open("resources_servers/code_gen/data/opencodereasoning_filtered_25k_train.
     for d in ds:
         try:
             UnitTests.model_validate_json(d["unit_tests"])
-        except:
+        except Exception:
             from collections import Counter
 
             unit_tests = json.loads(d["unit_tests"])

--- a/resources_servers/swerl_gen/utils.py
+++ b/resources_servers/swerl_gen/utils.py
@@ -72,7 +72,7 @@ def checkout_commit(repo_name, repo_playground, commit_id, reset=False):
         subprocess.run(["git", "-C", repo_path, "checkout", commit_id], check=True)
         print("Commit checked out successfully.")
         return True
-    except:
+    except Exception:
         print("An error occurred while checking out the commit")
         return False
 
@@ -325,7 +325,7 @@ def create_structure(directory_path):
                 try:
                     with open(os.path.join(root, file_name), "r") as f:
                         content = f.read().splitlines()
-                except:
+                except Exception:
                     content = "[BINARY FILE]"
                 curr_struct[file_name] = {
                     "text": content,

--- a/resources_servers/swerl_llm_judge/utils.py
+++ b/resources_servers/swerl_llm_judge/utils.py
@@ -71,7 +71,7 @@ def checkout_commit(repo_name, repo_playground, commit_id, reset=False):
         subprocess.run(["git", "-C", repo_path, "checkout", commit_id], check=True)
         print("Commit checked out successfully.")
         return True
-    except:
+    except Exception:
         print("An error occurred while checking out the commit")
         return False
 
@@ -327,7 +327,7 @@ def create_structure(directory_path):
                 try:
                     with open(os.path.join(root, file_name), "r") as f:
                         content = f.read().splitlines()
-                except:
+                except Exception:
                     content = "[BINARY FILE]"
                 curr_struct[file_name] = {
                     "text": content,


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` across 6 files (9 sites).

**Why:** Bare `except:` catches `BaseException` including `KeyboardInterrupt` and `SystemExit`. `except Exception:` preserves all fallback behavior while allowing system exceptions to propagate.

**Files:** `server_utils.py`, `calendar/utils.py`, `testing_util.py` (2), `preprocess_train_dataset.py`, `swerl_gen/utils.py` (2), `swerl_llm_judge/utils.py` (2)