### PR TITLE
Feature/nvidia if bench validators integrations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
     - id: end-of-file-fixer
       # only include python files
@@ -25,7 +25,7 @@ repos:
       files: \.py$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.9.9" # Use the appropriate version
+    rev: "v0.15.4" # Use the appropriate version
     hooks:
     - id: ruff
       args: ["--fix"]

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -125,8 +125,8 @@ class TestGlobalConfig:
 
         # Override OmegaConf.load to avoid file reads.
         omegaconf_load_mock = MagicMock()
-        omegaconf_load_mock.side_effect = (
-            lambda path: DictConfig({}) if "env" not in str(path) else DictConfig({"extra_dot_env_key": 2})
+        omegaconf_load_mock.side_effect = lambda path: (
+            DictConfig({}) if "env" not in str(path) else DictConfig({"extra_dot_env_key": 2})
         )
         monkeypatch.setattr(nemo_gym.server_utils.OmegaConf, "load", omegaconf_load_mock)
 


### PR DESCRIPTION
## Turing VIF
A validation service in the NeMo Gym pipeline that answers: Did the model’s reply follow all the instructions? It does not generate text; it only grades one reply against a list of instructions and returns pass/fail and a reward (0 or 1) for training.

## Two Kinds of Validators
- **Fast (rule-based):** Counts and patterns (word count, start/end phrase, keywords, forbidden words, lists, tables, case, punctuation, etc.). Runs on the server; no external API.
- **Judge (LLM-based):** Meaning and style (tone, formality, politeness, role, audience, custom yes/no questions). The server calls a separate “judge” LLM; those calls run in parallel.

## Multi-language support
Turing VIF supports multiple languages (e.g. en, es, fre, de, it, pt-BR, ja, zh, ko, hi, ar). Language is set per request.
- Fast validators use language-specific rules (word boundaries, sentence splitting, vowels, case).
- Case-related instructions are disabled where they don’t apply (e.g. “all caps” for Chinese/Japanese).
- If any instruction is not supported for the requested language, the request fails early and the reply is not validated.

## What Happens When It Runs
1. Request arrives with the model reply, list of instructions, optional custom judge questions, and language.
2. **Basic checks:** Request format and language support. If invalid or unsupported language/instruction, return failure and do not validate.
3. Instructions are split into **fast** vs **judge**.
4. Fast validators run sequentially; each returns **Pass/Fail + short message**.
5. Judge validators (and custom questions) run in parallel; judge returns **YES/NO → Pass/Fail**.
6. **Misalignment:** For instructions marked “misalignment,” if the model *did* follow them, the result is flipped to **Fail** (we want the model *not* to follow those).
7. **Result:** One reward (**1.0** if all passed, **0.0** otherwise), a per-instruction pass/fail list, and validation messages. Training uses this reward and list.

## Results, errors, and skipping rollouts
- **Results:** Each verify response includes:
  - `reward` (1.0 or 0.0)
  - `follow_all_instructions`
  - `follow_instruction_list` (one boolean per instruction)
  - `validation_results` (per instruction: ID, status Passed/Failed/Skipped, message)
  Training uses `reward` and the list; `validation_results` are for debugging and evals.
- **Errors:** Schema validation or language compatibility (unsupported instruction for that language) → reward 0, `validation_results` with status Failed → rollout **skipped** (not used for training, recorded e.g. in `errors.json`).
  Per-instruction failures (valid request, some instructions fail) → reward 0, `validation_results` Passed/Failed per instruction → rollout **not skipped** (still used for training with reward 0).
- **Skipping:** Rollouts are skipped only on schema or language-compatibility failure. When validators run and some instructions fail, the rollout is not skipped; it’s processed with reward 0.