### PR TITLE
Add tutorial links on docs home

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,9 +37,17 @@ Quickstart
 ```{button-ref} environment-tutorials/index
 :ref-type: doc
 :color: secondary
+:class: sd-rounded-pill sd-mr-3
+
+Environment Tutorials
+```
+
+```{button-ref} training-tutorials/index
+:ref-type: doc
+:color: secondary
 :class: sd-rounded-pill
 
-Explore Tutorials
+Training Tutorials
 ```
 ````
 


### PR DESCRIPTION
Add back the third button for Training Tutorials and rename "Explore Tutorials" to "Environment Tutorials" for clarity.