### PR TITLE
docs: remove server components summary from homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,8 +23,6 @@ content_type: index
 
 [NeMo Gym](https://github.com/NVIDIA-NeMo/Gym) is a library for building reinforcement learning (RL) training environments for large language models (LLMs). NeMo Gym provides infrastructure to develop environments, scale rollout collection, and integrate seamlessly with your preferred training framework.
 
-A training environment consists of three server components: **Agents** orchestrate the rollout lifecycle—calling models, executing tool calls through resources, and coordinating verification. **Models** provide stateless text generation using LLM inference endpoints. **Resources** define tasks, tool implementations, and verification logic.
-
 ````{div} sd-d-flex-row
 ```{button-ref} gs-quickstart
 :ref-type: ref


### PR DESCRIPTION
The three-server architecture is now covered in detail on the Environment Components and dedicated server pages.