### PR TITLE
fix: allow nested responses create params overrides

### DIFF
--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -161,12 +161,8 @@ class RolloutCollectionHelper(BaseModel):
                 row_idxs_missing_agent_ref.append(row_idx)
 
             # Responses create params
-            overrides = OmegaConf.to_container(
-                OmegaConf.create(config.responses_create_params), resolve=True
-            )
-            row[RESPONSES_CREATE_PARAMS_KEY_NAME] = (
-                row[RESPONSES_CREATE_PARAMS_KEY_NAME] | overrides
-            )
+            overrides = OmegaConf.to_container(OmegaConf.create(config.responses_create_params), resolve=True)
+            row[RESPONSES_CREATE_PARAMS_KEY_NAME] = row[RESPONSES_CREATE_PARAMS_KEY_NAME] | overrides
 
             # Resolve task index
             row[TASK_INDEX_KEY_NAME] = row_to_task_idx.setdefault(row_str, len(row_to_task_idx))


### PR DESCRIPTION
when I use:
+responses_create_params.reasoning.effort=high

I get
```
  File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/sanyamk/code/sanyamk/bixbench/Gym/nemo_gym/rollout_collection.py", line 245, in run_from_config
    f.write(orjson.dumps(row) + b"\n")
```

this resolves it: 
```
(Gym-35) cmunley@yoda:~/Gym-35$ ng_collect_rollouts   +agent_name=reasoning_gym_simple_agent   +input_jsonl_fpath=resources_servers/reasoning_gym/data/example.jsonl   +output_jsonl_fpath=results/reasoning_gym_rollouts.jsonl   +limit=1   +responses_create_params.reasoning.effort=low
Limiting the number of rows to 1
Using `reasoning_gym_simple_agent` for rows that do not already have an agent ref
Overriding responses_create_params fields with {'reasoning': {'effort': 'low'}}
Repeating rows 1 times (in a pattern of abc to aabbcc)!
Reading rows: 0it [00:00, ?it/s]
Clearing output fpath since `resume_from_cache=False`!
INFO:     127.0.0.1:50420 - "GET /global_config_dict_yaml HTTP/1.1" 200 OK
Collecting rollouts: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:04<00:00,  4.05s/it]
Agent level metrics (mean only):
[
    {
        "agent_ref": {
            "name": "reasoning_gym_simple_agent"
        },
        "mean/reward": 0.0,
        "mean/score": 0.0,
        "mean/input_tokens": 208.0,
        "mean/output_tokens": 312.0,
        "mean/total_tokens": 520.0
    }
]
Finished rollout collection! View results at:
Fully materialized inputs: results/reasoning_gym_rollouts_materialized_inputs.jsonl
Rollouts: results/reasoning_gym_rollouts.jsonl
Reward profiling outputs: results/reasoning_gym_rollouts_reward_profiling.jsonl
Agent-level metrics: results/reasoning_gym_rollouts_agent_metrics.json
```