### PR TITLE
docs: pin working unsloth version

### DIFF
--- a/docs/training-tutorials/unsloth.md
+++ b/docs/training-tutorials/unsloth.md
@@ -11,6 +11,8 @@ This tutorial demonstrates how to use [Unsloth](https://github.com/unslothai/uns
 - A Google account (for Colab) or a local GPU with 16GB+ VRAM
 - Familiarity with NeMo Gym concepts ({doc}`/get-started/index`)
 
+The NeMo Gym integration with Unsloth is tested on `unsloth==2026.1.4` and `unsloth_zoo==2026.1.4`. Other versions are not guaranteed to work.
+
 ---
 
 ## Getting Started


### PR DESCRIPTION
pin working unsloth version in docs 

resolves https://github.com/NVIDIA-NeMo/Gym/issues/830


Note that really the unsloth version does not matter too much, but there is a bug in the latest version causing our example to fail (unrelated to nemo gym compat) 