### PR TITLE
[fix] (code_gen): use runtime_env py_executable for Ray workers

### DIFF
--- a/resources_servers/code_gen/lcb_integration/compute_code_generation_metrics.py
+++ b/resources_servers/code_gen/lcb_integration/compute_code_generation_metrics.py
@@ -49,6 +49,8 @@ def _temp_run(in_outs, generation, debug, result, metadata_list, timeout):
 #      lcb_integration has no pyproject.toml so can't be pip-installed; it must be on sys.path.
 #      Pattern from swerl_gen/eval/singularity_utils.py.
 _CODE_GEN_DIR = str(Path(__file__).parent.parent)
+
+
 @ray.remote(
     scheduling_strategy="SPREAD",
     runtime_env={


### PR DESCRIPTION
  `check_correctness_remote` was decorated with `@ray.remote` without
  `runtime_env`, so Ray workers spawned on system Python could not import
  `lcb_integration`. The workaround was a symlink from the server's venv
  into `/usr/local/lib/python3.12/dist-packages/`.

  Fix: add `runtime_env={"py_executable": sys.executable}` to the
  decorator, consistent with the pattern already used in `swe_agents`,
  `mini_swe_agent`, and `harbor_agent`.

  This ensures Ray workers inherit the code_gen server's venv and can
  import `lcb_integration` directly, with no system path side effects.
