### PR TITLE
[Fix] guard nltk download with local find() to avoid unnecessary remote fetch

### DIFF
--- a/resources_servers/instruction_following/app.py
+++ b/resources_servers/instruction_following/app.py
@@ -65,11 +65,19 @@ class InstructionFollowingResourcesServer(SimpleResourcesServer):
         self._ensure_nltk_data()
 
     def _ensure_nltk_data(self):
-        """Download required NLTK data at startup."""
+        """Ensure required NLTK data is available at startup.
+
+        nltk.download() always fetches the remote package index even when the
+        data is already present. Guard with a local find() first to skip the
+        download when the data already exists.
+        """
         try:
             import nltk
 
-            nltk.download("punkt_tab", quiet=True)
+            try:
+                nltk.data.find("tokenizers/punkt_tab")
+            except LookupError:
+                nltk.download("punkt_tab", quiet=True)
         except ImportError:
             # ifbench not available, skip
             pass


### PR DESCRIPTION
`nltk.download()` always fetches the remote package index even when the
data is already present. Guard with a local `find()` first to skip the
download when the data already exists.