### PR TITLE
[Fix] use venv Python for swerl_gen Ray workers instead of hardcoded PYTHONPATH

### DIFF
--- a/resources_servers/swerl_gen/eval/singularity_utils.py
+++ b/resources_servers/swerl_gen/eval/singularity_utils.py
@@ -200,10 +200,7 @@ def _run_instance(
 
 
 # Using SPREAD scheduling so that Ray assigns tasks to as many distinct nodes as possible.
-@ray.remote(
-    scheduling_strategy="SPREAD",
-    runtime_env={"env_vars": {"PYTHONPATH": "/opt/nemo-rl/3rdparty/Gym-workspace/Gym"}},
-)
+@ray.remote(scheduling_strategy="SPREAD", runtime_env={"py_executable": sys.executable})
 def compute_score(
     extra_info_base64: str,
     patch_str: str,


### PR DESCRIPTION
## Fix: use venv Python for swerl_gen Ray workers

Replace the hardcoded `PYTHONPATH="/opt/nemo-rl/3rdparty/Gym-workspace/Gym"` in `singularity_utils.py` with `py_executable: sys.executable`.

### Problem

The `compute_score` Ray remote task hardcodes an internal deployment path in its `runtime_env`. This breaks any setup where Gym is installed at a different location.

### Fix

Set `py_executable: sys.executable` so Ray workers use the same venv Python as the server process. Since `nemo_gym` is installed as an editable package and `resources_servers` is included in `pyproject.toml`'s package list, all imports resolve correctly from the venv — no `PYTHONPATH` override needed.

This is the same pattern applied to `compute_code_generation_metrics.py` in #908.