### PR TITLE
docs: add aiohttp-over-httpx guidance and multi-turn agent patterns

### DIFF
--- a/.claude/skills/add-benchmark/SKILL.md
+++ b/.claude/skills/add-benchmark/SKILL.md
@@ -240,6 +240,7 @@ git checkout -- resources_servers/other_server/
 ## Constraints
 
 - Use NeMo Gym's OpenAI client (`nemo_gym/openai_utils.py`), not LiteLLM/Anthropic/other
+- **Use aiohttp, not httpx, for async HTTP.** All async HTTP calls must go through `nemo_gym.server_utils.request()` (aiohttp). httpx has O(n^2) connection pooling that hangs at high concurrency. When wrapping external libraries that use httpx internally, replace their HTTP transport with an aiohttp adapter — see `resources_servers/tavily_search/app.py` (`TavilySearchAIOHTTPClient`) for the pattern and `docs/infrastructure/engineering-notes/aiohttp-vs-httpx.md` for the rationale.
 - Pass configuration through Gym config (YAML), not environment variables
 - Code must run on Linux
 - `/run` endpoint must be async

--- a/.claude/skills/add-benchmark/references/patterns.md
+++ b/.claude/skills/add-benchmark/references/patterns.md
@@ -373,10 +373,14 @@ class MyAgent(SimpleResponsesAPIAgent):
 
 ### Key rules
 
-- Propagate cookies through every server call: `cookies=request.cookies`, then update with `response.cookies`
+- Propagate cookies through every server call: `cookies=request.cookies`, then update with `response.cookies`. This is critical for stateful environments that track per-task sessions.
 - Call `raise_for_status()` after every inter-server call
 - The agent calls itself (`self.config.name`) for `/v1/responses` to keep middleware chain intact
 - Use `ConfigDict(extra="allow")` on request/response models for flexible field forwarding
+- **Token ID propagation**: model responses include `prompt_token_ids`, `generation_token_ids`, and `generation_log_probs`. Propagate these from each model response into the next turn's input — required for RL training. See `swe_agents/app.py` for the implementation pattern.
+- **Monotonic trajectories**: NeMo RL requires the token sequence across multi-turn rollouts to only grow. Never summarize, truncate, or modify prior turns between steps.
+- **Thinking model compatibility**: thinking models emit `<think>`/`<thinking>` blocks. Strip these before parsing tool calls from model output, or parsing will break. See `harbor_agent` for the handling pattern.
+- **Concurrency control for external services**: if the agent calls external services (Docker containers, APIs), use `asyncio.Semaphore` to throttle concurrent calls — external services may not handle thousands of simultaneous requests.
 
 ---
 
@@ -632,6 +636,42 @@ class ExternalBenchmarkAgent(SimpleResponsesAPIAgent):
 Add the dependency in `requirements.txt`. If needs are more complex than pip packages, use `setup.py` or `pyproject.toml`.
 
 Reproduction requirement: run the original repo first, reproduce published numbers, then integrate into Gym and reproduce again. This decouples Gym integration bugs from benchmark bugs.
+
+### Replacing httpx with aiohttp in external libraries
+
+Many external libraries use `httpx.AsyncClient` internally. NeMo Gym requires all async HTTP to go through its global aiohttp client (`nemo_gym.server_utils.request()`) because httpx/httpcore has O(n^2) connection pooling that causes hangs at high concurrency. See `docs/infrastructure/engineering-notes/aiohttp-vs-httpx.md`.
+
+When wrapping such a library, create an adapter class that mimics the library's expected HTTP interface but routes calls through aiohttp. The `tavily_search` resources server demonstrates this pattern:
+
+```python
+from nemo_gym.server_utils import request
+
+class AIOHTTPAdapter(BaseModel):
+    headers: Dict[str, str]
+    base_url: str
+
+    async def post(self, endpoint: str, content: str, **kwargs) -> AdapterResponse:
+        response = await request(
+            method="POST",
+            url=f"{self.base_url}{endpoint}",
+            headers=self.headers,
+            data=content,
+        )
+        return AdapterResponse(status_code=response.status, data=await response.json())
+
+    @classmethod
+    def from_httpx_client(cls, client: AsyncClient) -> "AIOHTTPAdapter":
+        return cls(headers=dict(client.headers), base_url=str(client.base_url))
+```
+
+Then in `model_post_init()`, replace the library's internal client:
+```python
+def model_post_init(self, context):
+    self._external_client = ExternalLibraryClient(api_key=key)
+    self._external_client._http_client = AIOHTTPAdapter.from_httpx_client(
+        self._external_client._http_client
+    )
+```
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,6 +355,7 @@ When a benchmark requires an external tool (compiler, runtime, etc.), auto-insta
 
 ## Async Patterns
 
+- **Use aiohttp, not httpx, for async HTTP.** All async HTTP calls must go through NeMo Gym's global aiohttp client (`nemo_gym.server_utils.request()`). Do not use `httpx.AsyncClient` — httpx/httpcore has O(n^2) connection pooling that causes hangs at high concurrency (16k+ requests). When wrapping external libraries that use httpx internally, replace their HTTP transport with an aiohttp adapter. See `docs/infrastructure/engineering-notes/aiohttp-vs-httpx.md` for the full writeup and `resources_servers/tavily_search/app.py` (`TavilySearchAIOHTTPClient`) for the adapter pattern.
 - Use `asyncio.Semaphore` to bound concurrent subprocess/external calls
 - For Ray remote tasks in async code: `result = await future` (Ray futures are directly awaitable). Never call `ray.get()` directly in async context.
 - Decode all subprocess output with `errors="replace"` to handle non-UTF8


### PR DESCRIPTION
Surface the aiohttp requirement in CLAUDE.md and the add-benchmark skill so contributors wrapping external libraries know to replace httpx with an aiohttp adapter. Also document token ID propagation, monotonic trajectories, thinking model handling, and external service concurrency control.