### PR TITLE
docs: environment components and integrate existing agents

### DIFF
--- a/docs/agent-server/index.md
+++ b/docs/agent-server/index.md
@@ -47,7 +47,11 @@ class Agent:
 
 You can use an existing agent in NeMo Gym, integrate an external one, or build your own from scratch.
 
-[`SimpleAgent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/simple_agent) is a native NeMo Gym agent that handles general-purpose multi-step tool calling with configurable max steps, and works with any Resources server out of the box. NeMo Gym also includes agents that integrate external tools: for example, [`MiniSWEAgent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/mini_swe_agent) wraps an external coding harness running in Docker containers and converts its output back into the NeMo Gym format.
+[`SimpleAgent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/simple_agent) is a native NeMo Gym agent that handles general-purpose multi-step tool calling with configurable max steps, and works with any Resources server out of the box. NeMo Gym also includes agents that integrate external tools and frameworks:
+
+- [`MiniSWEAgent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/mini_swe_agent) wraps an external coding harness running in Docker containers and converts its output back into the NeMo Gym format.
+- [`LangGraphAgent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/langgraph_agent) adapter lets you run LangGraph graphs as NeMo Gym agent servers, with built-in support for multi-turn patterns like reflection. See the {doc}`LangGraph agent tutorial </environment-tutorials/langgraph-agent>` for details.
+- [`VerifiersAgent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/verifiers_agent) integrates the [verifiers](https://github.com/PrimeIntellect-ai/verifiers) library, which provides environment implementations that bundle multi-turn orchestration, state logic, tools, and verification together, similar to how NeMo Gym environments work. Because verifiers handles the full environment internally, no separate Resources server is needed.
 
 ### Tools in Agent vs. Resources Server
 

--- a/docs/environment-tutorials/langgraph-agent.md
+++ b/docs/environment-tutorials/langgraph-agent.md
@@ -1,0 +1,122 @@
+(langgraph-agent)=
+
+# LangGraph Agent
+
+The LangGraph agent adapter lets you run [LangGraph](https://github.com/langchain-ai/langgraph) agents as NeMo Gym agent servers. It enables bringing existing LangGraph agents into NeMo Gym, for use with resources servers to construct new environments and train agents on diverse tasks. 
+
+`reflection_agent` is used as an example here. Additional example implementations (`orchestrator_agent`, `rewoo_agent`, `parallel_thinking_agent`) are included in the source, but may not produce monotonic trajectories, and therefore will not work with NeMo RL by default. They work for evaluations, serve as examples, and can sometimes be adapted for training depending on the RL framework and use case.
+
+---
+
+## Base Adapter
+
+`LangGraphAgentAdapter` (`app.py`) is an abstract base class. Subclass it and implement three methods:
+
+```python
+class LangGraphAgentAdapter(SimpleResponsesAPIAgent):
+
+    @abstractmethod
+    def build_graph(self) -> Any:
+        # Return a compiled LangGraph graph
+        ...
+
+    @abstractmethod
+    async def get_initial_state(
+        self, body: NeMoGymResponseCreateParamsNonStreaming, cookies: dict
+    ) -> dict:
+        # Build the initial graph state from the incoming request
+        ...
+
+    @abstractmethod
+    def extract_outputs(self, final_state: dict) -> list:
+        # Extract the output messages from the final graph state
+        ...
+```
+
+The adapter's `responses()` method invokes the graph (`graph.ainvoke`), propagates session cookies, and returns a `NeMoGymResponse`. The `run()` method handles the full rollout: `seed_session`, `responses`, `verify`.
+
+State must include `last_policy_response` (a `NeMoGymResponse`) or you must override `extract_model_response()`.
+
+---
+
+## Reflection Agent
+
+**File:** `reflection_agent.py`
+**Config:** `configs/reflection_agent.yaml`
+
+After each generation step, the agent checks for an `<answer>` tag or whether `max_reflections` has been reached. If so it stops, otherwise it critiques the answer and generates again. With `max_reflections=2` you get at most 3 generate calls and 2 critique calls.
+
+When using the agent with a resources server, the convention is to put the config in the resources server's `configs/` folder. Recall that an environment is composed of agent + resources server + datasets together. For agent-only environments with no resources server, the config lives in the agent's `configs/` folder.
+
+**Example config:**
+
+```yaml
+reflection_agent:
+  responses_api_agents:
+    reflection_agent:
+      entrypoint: reflection_agent.py
+      resources_server:
+        type: resources_servers
+        name: ???          # set to your resources server name
+      model_server:
+        type: responses_api_models
+        name: policy_model
+      max_reflections: 2
+```
+
+---
+
+## Quick Start
+
+Start the servers. This example uses the `reasoning_gym` resources server:
+
+```bash
+ng_run "+config_paths=[resources_servers/reasoning_gym/configs/reflection_agent.yaml,responses_api_models/vllm_model/configs/vllm_model.yaml]"
+```
+
+Collect rollouts:
+
+```bash
+ng_collect_rollouts \
+    +agent_name=reasoning_gym_reflection_agent \
+    +input_jsonl_fpath=resources_servers/reasoning_gym/data/example.jsonl \
+    +output_jsonl_fpath=example_rollouts.jsonl \
+    +limit=1
+```
+
+---
+
+## Implementing a Custom LangGraph Agent
+
+1. Subclass `LangGraphAgentAdapter` from `app.py`.
+2. Implement `build_graph()`: return a compiled `StateGraph`.
+3. Implement `get_initial_state()`: convert the input data `NeMoGymResponseCreateParamsNonStreaming` body into the graph's initial state dict.
+4. Implement `extract_outputs()`: return `final_state["policy_outputs"]`, the list of all model outputs.
+5. Store the most recent model call response as `last_policy_response` in state. The adapter replaces the `.output` field with the full `policy_outputs` trajectory before returning, the same pattern as `simple_agent`. The full trajectory across all turns is what is returned for training and verification.
+6. Propagate `cookies` through all `server_client.post()` calls and carry `resp.cookies` forward in state.
+7. Create a YAML config in `configs/` pointing to your entrypoint file.
+
+```python
+from app import LangGraphAgentAdapter, LangGraphAgentConfig
+from langgraph.graph import END, StateGraph
+
+class MyAgentConfig(LangGraphAgentConfig):
+    my_param: int = 3
+
+class MyAgent(LangGraphAgentAdapter):
+    config: MyAgentConfig
+
+    def build_graph(self):
+        graph = StateGraph(...)
+        # add nodes, edges
+        return graph.compile()
+
+    async def get_initial_state(self, body, cookies):
+        return {"messages": [...], "policy_outputs": [], "cookies": cookies, ...}
+
+    def extract_outputs(self, final_state):
+        return final_state["policy_outputs"]
+
+if __name__ == "__main__":
+    MyAgent.run_webserver()
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,9 +117,9 @@ Generate batches of scored interactions and view them with the rollout viewer.
 
 ::::
 
-## Environment Configuration
+## Environment Components
 
-Configure and customize environment components and prepare datasets.
+An environment can be constructed from solely an agent, but is typically composed of two components: Agent server, and one or more Resources servers, plus the datsets that provide environment or task instances. Additionaly, the Model server configures LLM inference backends including vLLM and OpenAI.
 
 ::::{grid} 1 2 2 2
 :gutter: 1 1 1 2
@@ -294,28 +294,14 @@ Rollout Collection <get-started/rollout-collection.md>
 ```
 
 ```{toctree}
-:caption: Agent Server
+:caption: Environment Components
 :hidden:
 :maxdepth: 1
 
-Overview <agent-server/index>
-```
-
-```{toctree}
-:caption: Model Server
-:hidden:
-:maxdepth: 1
-
-Overview <model-server/index>
+Agent Server <agent-server/index>
+Model Server <model-server/index>
 vLLM <model-server/vllm>
-```
-
-```{toctree}
-:caption: Resources Server
-:hidden:
-:maxdepth: 1
-
-Overview <resources-server/index>
+Resources Server <resources-server/index>
 ```
 
 ```{toctree}
@@ -340,6 +326,7 @@ Multi-Step Environment <environment-tutorials/multi-step-environment>
 Stateful Environment <environment-tutorials/stateful-environment>
 Real-World Environment <environment-tutorials/real-world-environment>
 Integrate external libraries <environment-tutorials/integrate-external-environments>
+LangGraph Agent <environment-tutorials/langgraph-agent>
 Aggregate Metrics <environment-tutorials/aggregate-metrics>
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -296,12 +296,11 @@ Rollout Collection <get-started/rollout-collection.md>
 ```{toctree}
 :caption: Environment Components
 :hidden:
-:maxdepth: 1
+:maxdepth: 2
 
 Agent Server <agent-server/index>
-Model Server <model-server/index>
-vLLM <model-server/vllm>
 Resources Server <resources-server/index>
+Model Server <model-server/index>
 ```
 
 ```{toctree}
@@ -326,7 +325,7 @@ Multi-Step Environment <environment-tutorials/multi-step-environment>
 Stateful Environment <environment-tutorials/stateful-environment>
 Real-World Environment <environment-tutorials/real-world-environment>
 Integrate external libraries <environment-tutorials/integrate-external-environments>
-LangGraph Agent <environment-tutorials/langgraph-agent>
+LangGraph Integration <environment-tutorials/langgraph-agent>
 Aggregate Metrics <environment-tutorials/aggregate-metrics>
 ```
 

--- a/docs/model-server/index.md
+++ b/docs/model-server/index.md
@@ -33,3 +33,10 @@ Self-hosted inference with vLLM for maximum control.
 :::{seealso}
 [Model Server Fields](../reference/configuration.md#model-server-fields) for server configuration syntax and fields.
 :::
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+vLLM <vllm>
+```

--- a/responses_api_agents/langgraph_agent/README.md
+++ b/responses_api_agents/langgraph_agent/README.md
@@ -1,10 +1,12 @@
 # LangGraph Agent
 
-LangGraph agent adapter. 
+LangGraph agent adapter.
 
-Examples here include a iterative reflection agent, subagent orchestrator agent, parallel thinking agent, and rewoo agent. Most of these are based on langgraph examples: https://github.com/langchain-ai/langgraph/tree/main/examples
+Examples here include an iterative reflection agent, subagent orchestrator agent, parallel thinking agent, and rewoo agent. Most of these are based on langgraph examples: https://github.com/langchain-ai/langgraph/tree/main/examples
 
-Please note that agents such as parallel thinking which produce non-monotonically increasing trajectories will not work with NeMo RL training by default, as NeMo RL expects monotonically increasing trajecories. These can be used for rollouts or evaluations, or used in research experiments in developing approaches to train on non-monotonic agent trajectories.
+Please note that agents such as parallel thinking which produce non-monotonically increasing trajectories will not work with NeMo RL training by default, as NeMo RL expects monotonically increasing trajectories. These can be used for rollouts or evaluations, or used in research experiments in developing approaches to train on non-monotonic agent trajectories.
+
+**[Full documentation](../../docs/environment-tutorials/langgraph-agent.md)**
 
 ## Quick Start
 


### PR DESCRIPTION
creates a sidebar section: environment components with the 3 main server types under it
adds langgraph integration documentation page, and mentions prime intellect verifiers in integrate existing. These things can be broken up if needed..