### PR TITLE
chore: bump `_code_freeze` workflow to `v0.86.0`

### DIFF
--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -35,7 +35,7 @@ on:
         default: true
 jobs:
   code-freeze:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_code_freeze.yml@v0.55.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_code_freeze.yml@v0.86.0
     with:
       library-name: NeMo-Gym
       python-package: nemo_gym


### PR DESCRIPTION
## Summary
- Bumps `_code_freeze` workflow reference to `v0.86.0`
- `v0.86.0` adds automatic creation of the cherry-pick label (e.g. \`r0.2.5\`) on the target repo right after the release branch is pushed, so no manual label setup is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)