### PR TITLE
Reorganize to allow for custom mixins

### DIFF
--- a/nemo_gym/base_resources_server.py
+++ b/nemo_gym/base_resources_server.py
@@ -12,12 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import importlib
 from abc import abstractmethod
 
-from fastapi import FastAPI
+from fastapi import Body, FastAPI
 from pydantic import BaseModel
 
 from nemo_gym.config_types import AggregateMetrics, AggregateMetricsRequest
+from nemo_gym.global_config import NEMO_GYM_RESERVED_TOP_LEVEL_KEYS, get_first_server_config_dict
 from nemo_gym.openai_utils import (
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
@@ -63,7 +65,31 @@ class SimpleResourcesServer(BaseResourcesServer, AggregateMetricsMixin, SimpleSe
         self.setup_session_middleware(app)
 
         app.post("/seed_session")(self.seed_session)
-        app.post("/verify")(self.verify)
+
+        # Auto-discover verify_request_cls from model server in the global config.
+        verify_request_cls = None
+        for key in self.server_client.global_config_dict:
+            if key in NEMO_GYM_RESERVED_TOP_LEVEL_KEYS:
+                continue
+            try:
+                server_config = get_first_server_config_dict(self.server_client.global_config_dict, key)
+                dotted_path = server_config.get("verify_request_cls")
+                if dotted_path:
+                    mod, cls_name = dotted_path.rsplit(".", 1)
+                    verify_request_cls = getattr(importlib.import_module(mod), cls_name)
+                    break
+            except (KeyError, TypeError, AttributeError):
+                continue
+
+        if verify_request_cls:
+
+            async def verify_with_custom_cls(body: verify_request_cls = Body()) -> BaseVerifyResponse:
+                return await self.verify(body)
+
+            app.post("/verify")(verify_with_custom_cls)
+        else:
+            app.post("/verify")(self.verify)
+
         app.post("/aggregate_metrics")(self.aggregate_metrics)
 
         return app

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -225,18 +225,19 @@ RESPONSES_TO_TRAIN = {
 
 
 NeMoGymResponseInputItem = Union[
+    # Training types first so Pydantic prefers them when training fields are present,
+    # rather than matching a base type and silently dropping the extra fields.
+    NeMoGymEasyInputMessageForTraining,
+    NeMoGymMessageForTraining,
+    NeMoGymResponseOutputMessageForTraining,
+    NeMoGymResponseFunctionToolCallForTraining,
+    NeMoGymResponseReasoningItemForTraining,
     NeMoGymEasyInputMessage,
     NeMoGymMessage,
     NeMoGymResponseOutputMessage,
     NeMoGymResponseFunctionToolCall,
     NeMoGymFunctionCallOutput,
     NeMoGymResponseReasoningItem,
-    # For training:
-    NeMoGymEasyInputMessageForTraining,
-    NeMoGymMessageForTraining,
-    NeMoGymResponseOutputMessageForTraining,
-    NeMoGymResponseFunctionToolCallForTraining,
-    NeMoGymResponseReasoningItemForTraining,
 ]
 NeMoGymResponseInput: TypeAlias = List[NeMoGymResponseInputItem]
 

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -12,8 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import importlib
 import json
-from typing import List
+from typing import ClassVar, List
 
 from fastapi import Request, Response
 from pydantic import ConfigDict, ValidationError
@@ -31,6 +32,7 @@ from nemo_gym.base_responses_api_agent import (
     SimpleResponsesAPIAgent,
 )
 from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
+from nemo_gym.global_config import get_first_server_config_dict
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymFunctionCallOutput,
@@ -62,6 +64,22 @@ class SimpleAgentVerifyResponse(BaseVerifyResponse):
 
 class SimpleAgent(SimpleResponsesAPIAgent):
     config: SimpleAgentConfig
+
+    _response_cls: ClassVar[type] = NeMoGymResponse
+    _verify_request_cls: ClassVar[type] = SimpleAgentVerifyRequest
+    _verify_response_cls: ClassVar[type] = SimpleAgentVerifyResponse
+
+    def model_post_init(self, context):
+        # Auto-discover custom response/verify types from the model server's config.
+        model_config = get_first_server_config_dict(
+            self.server_client.global_config_dict, self.config.model_server.name
+        )
+        for attr in ("response_cls", "verify_request_cls", "verify_response_cls"):
+            dotted_path = model_config.get(attr)
+            if dotted_path:
+                mod, cls = dotted_path.rsplit(".", 1)
+                object.__setattr__(self, f"_{attr}", getattr(importlib.import_module(mod), cls))
+        return super().model_post_init(context)
 
     async def responses(
         self,
@@ -95,7 +113,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
             model_response_json = await get_response_json(model_response)
             model_server_cookies = model_response.cookies
             try:
-                model_response = NeMoGymResponse.model_validate(model_response_json)
+                model_response = self._response_cls.model_validate(model_response_json)
             except ValidationError as e:
                 raise RuntimeError(
                     f"Received an invalid response from model server: {json.dumps(model_response_json)}"
@@ -177,7 +195,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         await raise_for_status(response)
         cookies = response.cookies
 
-        verify_request = SimpleAgentVerifyRequest.model_validate(
+        verify_request = self._verify_request_cls.model_validate(
             body.model_dump() | {"response": await get_response_json(response)}
         )
 
@@ -188,7 +206,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
             cookies=cookies,
         )
         await raise_for_status(verify_response)
-        return SimpleAgentVerifyResponse.model_validate(await get_response_json(verify_response))
+        return self._verify_response_cls.model_validate(await get_response_json(verify_response))
 
     async def aggregate_metrics(self, body: AggregateMetricsRequest = Body()) -> AggregateMetrics:
         """Proxy aggregate_metrics to the resources server."""

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -93,6 +93,9 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
 class VLLMModel(SimpleResponsesAPIModel):
     config: VLLMModelConfig
 
+    _chat_completion_cls: ClassVar[type] = NeMoGymChatCompletion
+    _response_cls: ClassVar[type] = NeMoGymResponse
+
     def get_converter(self) -> "VLLMConverter":
         """Return the converter used for Responses API <-> Chat Completions mapping.
 
@@ -149,7 +152,7 @@ class VLLMModel(SimpleResponsesAPIModel):
             )
 
         # Chat Completion -> Response
-        return NeMoGymResponse(
+        return self._response_cls(
             id=f"resp_{uuid4().hex}",
             created_at=int(time()),
             model=body.model,
@@ -335,7 +338,7 @@ class VLLMModel(SimpleResponsesAPIModel):
                 "context length" in result_content_str or "max_tokens" in result_content_str
             )
             if is_out_of_context_length:
-                return NeMoGymChatCompletion(
+                return self._chat_completion_cls(
                     id="chtcmpl-123",
                     object="chat.completion",
                     created=int(time()),
@@ -422,7 +425,7 @@ class VLLMModel(SimpleResponsesAPIModel):
             # chat_completion_dict.pop("prompt_token_ids")
             # choice_dict.pop("token_ids")
 
-        return NeMoGymChatCompletion.model_validate(chat_completion_dict)
+        return self._chat_completion_cls.model_validate(chat_completion_dict)
 
     def _resolve_client(self, request: Request) -> NeMoGymAsyncOpenAI:
         session_id = request.session[SESSION_ID_KEY]
@@ -702,6 +705,12 @@ class VLLMConverter(BaseModel):
     # Chat Completion to Response
     # =======================================================
 
+    def get_train_response_output_item_cls(self, response_output_item_cls: type[BaseModel]) -> type[BaseModel]:
+        return RESPONSES_TO_TRAIN[response_output_item_cls]
+
+    def get_extra_training_fields(self, message_dict: Dict[str, Any]) -> Dict[str, Any]:
+        return {}
+
     def postprocess_chat_response(self, choice: NeMoGymChoice) -> List[NeMoGymResponseOutputItem]:
         return self.postprocess_assistant_message_dict(choice.message.model_dump())
 
@@ -760,12 +769,13 @@ class VLLMConverter(BaseModel):
         # In these cases, there are no token id information provided.
         if self.return_token_id_information and "prompt_token_ids" in message_dict:
             last_response_output_item = response_output[-1]
-            train_cls = RESPONSES_TO_TRAIN[last_response_output_item.__class__]
+            train_cls = self.get_train_response_output_item_cls(last_response_output_item.__class__)
             response_output[-1] = train_cls(
                 **last_response_output_item.model_dump(),
                 prompt_token_ids=message_dict["prompt_token_ids"],
                 generation_token_ids=message_dict["generation_token_ids"],
                 generation_log_probs=message_dict["generation_log_probs"],
+                **self.get_extra_training_fields(message_dict),
             )
 
         return response_output


### PR DESCRIPTION
This factors `NeMoGymChatCompletion` / `NeMoGymResponse` out of the deep methods of `VLLMModel` into class variables, allowing for custom mix-ins to be provided.