### PR TITLE
docs: Add Tutorial proposal for RLHF using genrm_compare resources server.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,6 +139,7 @@ redirects = {
     "tutorials/nemo-rl-grpo/setup.html": "../../training-tutorials/nemo-rl-grpo/setup.html",
     "tutorials/nemo-rl-grpo/single-node-training.html": "../../training-tutorials/nemo-rl-grpo/single-node-training.html",
     "tutorials/nemo-rl-grpo/multi-node-training.html": "../../training-tutorials/nemo-rl-grpo/multi-node-training.html",
+    "tutorials/nemo-rl-grpo/rlhf-genrm-helpsteer3.html": "../../training-tutorials/nemo-rl-grpo/rlhf-genrm-helpsteer3.html",
     # Get Started section renames (same directory)
     "get-started/setup-installation.html": "detailed-setup.html",
     # RL Framework Integration moved from training/ to contribute/

--- a/docs/model-recipes/index.md
+++ b/docs/model-recipes/index.md
@@ -27,3 +27,7 @@ Distributed training of Nemotron 3 Super 120B across multiple nodes using Slurm 
 :::
 
 ::::
+
+## See also
+
+- {ref}`RLHF-style GRPO with GenRM and HelpSteer3 <training-nemo-rl-grpo-rlhf-genrm-helpsteer3>` — Gym JSONL from HelpSteer3, GenRM compare wiring, and Arena-Hard v2 evaluation (pairs with the Nemotron launch recipes above).

--- a/docs/training-tutorials/index.md
+++ b/docs/training-tutorials/index.md
@@ -20,6 +20,14 @@ Tutorial-series: GRPO training to improve multi-step tool calling on the Workpla
 {bdg-secondary}`nemo rl` {bdg-secondary}`grpo` {bdg-secondary}`3-5 hours`
 :::
 
+:::{grid-item-card} {octicon}`law;1.5em;sd-mr-1` RLHF (GenRM + HelpSteer3)
+:link: training-nemo-rl-grpo-rlhf-genrm-helpsteer3
+:link-type: ref
+Recipe: GRPO with GenRM pairwise rewards, HelpSteer3 → Gym JSONL, and Arena-Hard v2 evaluation.
++++
+{bdg-secondary}`genrm` {bdg-secondary}`nemotron`
+:::
+
 :::{grid-item-card} {octicon}`link-external;1.5em;sd-mr-1` OpenRLHF
 :link: https://github.com/OpenRLHF/OpenRLHF/blob/main/examples/python/agent_func_nemogym_executor.py
 :link-type: url

--- a/docs/training-tutorials/nemo-rl-grpo/index.md
+++ b/docs/training-tutorials/nemo-rl-grpo/index.md
@@ -113,6 +113,15 @@ Scale to multi-node GRPO training for production.
 {bdg-primary}`training`
 :::
 
+:::{grid-item-card} RLHF with GenRM + HelpSteer3
+:link: training-nemo-rl-grpo-rlhf-genrm-helpsteer3
+:link-type: ref
+
+Prepare HelpSteer3 as Gym JSONL, wire `genrm_compare`, and evaluate on Arena-Hard v2.
++++
+{bdg-secondary}`rlhf` {bdg-secondary}`genrm`
+:::
+
 ::::
 
 ---
@@ -154,4 +163,5 @@ nemo-rl-configuration.md
 setup.md
 single-node-training.md
 multi-node-training.md
+rlhf-genrm-helpsteer3.md
 ```

--- a/docs/training-tutorials/nemo-rl-grpo/rlhf-genrm-helpsteer3.md
+++ b/docs/training-tutorials/nemo-rl-grpo/rlhf-genrm-helpsteer3.md
@@ -1,0 +1,192 @@
+(training-nemo-rl-grpo-rlhf-genrm-helpsteer3)=
+
+# RLHF-style GRPO with GenRM Compare and HelpSteer3
+
+This recipe connects **NeMo RL** (GRPO), **NeMo Gym**, and the GenRM compare resources server ({doc}`/resources-server/index`) so you can improve a chat policy using a **generative reward model** instead of hand-written verifiers. Prompts come from the public [**HelpSteer3**](https://huggingface.co/datasets/nvidia/HelpSteer3) preference subset; the policy you tune can be [**Nemotron 3 Super**](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16) or [**Nemotron 3 Nano**](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16) on Hugging Face.
+
+:::{card}
+
+**Goal**: Prepare HelpSteer3 as NeMo Gym JSONL, wire `genrm_compare.yaml` into a GRPO training config, and evaluate on **Arena-Hard v2**–style benchmarks.
+
+**Time**: ~1–2 hours to read and prepare data; training time depends on your cluster (large MoE runs match your existing NeMo RL recipes).
+
+^^^
+
+**In this guide, you will**:
+
+1. Convert HelpSteer3 **preference** conversations into NeMo Gym JSONL (same shape as `resources_servers/genrm_compare/data/example.jsonl`).
+2. Point NeMo RL’s data paths at those files and load `resources_servers/genrm_compare/configs/genrm_compare.yaml` in `env.nemo_gym.config_paths`.
+3. Align `num_rollouts_per_prompt` / `num_generations_per_prompt` with GRPO cohort sizes.
+4. Run **Arena-Hard-Auto** to compare base vs post-training checkpoints.
+
+:::
+
+> **Scope:** NeMo RL launch commands and full cluster YAMLs live in the [NeMo RL](https://github.com/NVIDIA-NeMo/RL) repository and your job scripts. This page documents the **NeMo Gym** side (data + environment wiring) and how it fits GRPO RLHF workflows.
+
+---
+
+## Prerequisites
+
+- Completed or skimmed the {ref}`NeMo RL GRPO tutorial <training-nemo-rl-grpo-index>` so you know how `data` and `env.nemo_gym` work in your training YAML.
+- **NeMo Gym** installed ({doc}`/get-started/detailed-setup`) with Hugging Face dependencies (`datasets` is included in the Gym dev install).
+- **Hardware**: Same class of cluster you would use for Nemotron-3 GRPO (policy + vLLM + GenRM judge). Large models require multi-GPU / multi-node settings from your NeMo RL recipe.
+- Optional: read {doc}`/data/index` for the JSONL schema and {doc}`/data/prepare-validate` for `ng_prepare_data`.
+
+---
+
+## 1. How the pieces fit together
+
+| Component | Role |
+|-----------|------|
+| **Policy model** | Nemotron 3 Super or Nano (HF checkpoint path in NeMo RL `policy.model_name` or your launcher’s equivalent). |
+| **Training prompts** | Rows from HelpSteer3 **preference**: multi-turn `context` becomes `responses_create_params.input`. |
+| **Reward** | GenRM compares **multiple rollouts per prompt** (GRPO group) via `genrm_compare` → pairwise JSON scores → aggregated rewards. |
+| **Human preference columns** | `response1` / `response2` / `overall_preference` are **not** used during GRPO; the environment generates new answers and judges them with GenRM. |
+
+NeMo RL’s dataloader reads **static JSONL** for `NemoGymDataset`. There is no built-in “stream HelpSteer3 inside the trainer” hook in NeMo Gym today, so conversion is done **once** (or in CI) with the script below—not inside the training loop.
+
+---
+
+## 2. Convert HelpSteer3 to NeMo Gym JSONL
+
+Use the converter maintained next to the GenRM compare server:
+
+```bash
+cd /path/to/nemo-gym   # repository root
+
+uv run python resources_servers/genrm_compare/scripts/helpsteer3_to_nemo_gym_jsonl.py \
+  --output-dir data/helpsteer3_gym
+```
+
+This writes `train.jsonl` and `validation.jsonl`. Each line looks like the shipped example (OpenAI-style `input`, empty `tools`, `agent_ref` → `genrm_simple_agent`):
+
+```json
+{
+  "responses_create_params": {
+    "input": [{"role": "user", "content": "..."}],
+    "tools": [],
+    "parallel_tool_calls": false
+  },
+  "agent_ref": {"type": "responses_api_agents", "name": "genrm_simple_agent"},
+  "dataset": "helpsteer3_preference"
+}
+```
+
+**Details the script applies:**
+
+- **Subset**: `config_name=preference` (multi-turn chat before the pairwise human labels).
+- **GenRM requirement**: The compare server expects the conversation history to end with a **user** turn. The script **truncates** after the last user message.
+- **HTML entities** in text (e.g. `&lt;`) are unescaped to literal `<` for cleaner prompts.
+
+**Options:**
+
+| Flag | Purpose |
+|------|---------|
+| `--max-samples N` | Write at most `N` rows **per split** (debug). |
+| `--hf-token` | Token if access is restricted. |
+| `--agent-ref-name` | Must match the `responses_api_agents` block name merged from `genrm_compare.yaml` (default `genrm_simple_agent`). |
+
+Validate with {doc}`/data/prepare-validate` once your NeMo Gym `env.yaml` points at a policy server.
+
+---
+
+## 3. Wire `genrm_compare.yaml` in NeMo RL
+
+Load the GenRM stack by appending these paths to `env.nemo_gym.config_paths` (order can matter for overrides; follow your NeMo RL template):
+
+```yaml
+env:
+  should_use_nemo_gym: true
+  nemo_gym:
+    config_paths:
+      - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
+      - resources_servers/genrm_compare/configs/genrm_compare.yaml
+      - responses_api_models/genrm_model/configs/genrm_model.yaml
+```
+
+From `genrm_compare.yaml`, the important blocks are:
+
+- **`genrm_compare_resources_server`** → `/compare` pairwise judging.
+- **`genrm_model`** → vLLM (or compatible) server for the GenRM; set `genrm_model_name` in the environment to a checkpoint whose template supports `response_1` / `response_2` (and optionally `principle` if you enable `use_principle`). See `resources_servers/genrm_compare/README.md` for compatible models.
+- **`genrm_simple_agent`** → agent that uses the policy for rollouts and GenRM for rewards.
+
+Override resource server settings to match GRPO **group size**, e.g.:
+
+```yaml
+nemo_gym:
+  genrm_compare_resources_server:
+    resources_servers:
+      genrm_compare:
+        num_rollouts_per_prompt: ${grpo.num_generations_per_prompt}
+```
+
+Keep **`num_rollouts_per_prompt`** and **`grpo.num_generations_per_prompt`** equal so cohorts flush correctly (see `resources_servers/genrm_compare/README.md`).
+
+### Example NeMo RL config (Nemotron 3 Super + GenRM + HelpSteer3)
+
+A **pipeclean-scale** NeMo RL YAML that matches the layout of large-cluster GRPO runs (async GRPO, Megatron MoE policy, non-colocated vLLM rollouts, separate GenRM judge with `tensor_parallel_size: 4`) lives in the Gym repo:
+
+`examples/nemo_rl/grpo_nemotron3_super_genrm_helpsteer3_pipeclean.yaml`
+
+It sets **`policy.model_name`** to the Hugging Face checkpoint [`nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16`](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16). Copy or compose-config it from your NeMo RL job (paths are relative to the Gym tree bundled with your run).
+
+**You still must set at launch** (or override in Hydra):
+
+| Item | Notes |
+|------|--------|
+| **`data.train.data_path` / `data.validation.data_path`** | Paths to JSONL from the HelpSteer3 conversion step (e.g. `data/helpsteer3_gym/train.jsonl`). |
+| **`env.nemo_gym.genrm_model.responses_api_models.genrm_model.model`** | GenRM checkpoint (HF id or local path); `null` in the example. |
+| **`genrm_model_name`** | If your launcher uses this env var instead of inline YAML, keep it consistent with the GenRM `model` field. |
+| **`cluster` / GPU counts** | The example keeps a 64-node × 4 GPU skeleton; your submit script should override to match allocation. |
+| **`NRL_MAX_STEPS`** | Optional; shortens the default `grpo.max_num_steps: 10` for smoke tests. |
+
+**Batch consistency:** `policy.train_global_batch_size` should match `grpo.num_prompts_per_step × grpo.num_generations_per_prompt` (here `16 × 4 = 64`), same as in the reference pipeclean recipe.
+
+**Principle-guided judging:** The example has `use_principle: true` and a long `default_principle`. Use this only if your GenRM supports the `principle` role; otherwise set `use_principle: false` (see the compatibility table in `resources_servers/genrm_compare/README.md`).
+
+**Nemotron 3 Nano:** Swap in [`nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16`](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16) for `policy.model_name` and **resize** Megatron/vLLM parallel sizes to your Nano recipe—do not reuse the Super MoE EP/TP numbers without checking the NeMo RL Nano launch config.
+
+---
+
+## 4. Evaluation: Arena-Hard v2
+
+To show improvement after GRPO, run an **open-ended** benchmark correlated with Chatbot Arena:
+
+- **Tooling**: [lmarena/arena-hard-auto](https://github.com/lmarena/arena-hard-auto) (Arena-Hard-Auto).
+- **Data**: [lmarena-ai/arena-hard-auto](https://huggingface.co/datasets/lmarena-ai/arena-hard-auto) on Hugging Face (includes Arena-Hard v2 prompts).
+
+**Suggested workflow:**
+
+1. Export **baseline** and **GRPO** checkpoints behind the same inference stack (vLLM or your production server) with identical decoding settings.
+2. Run Arena-Hard-Auto twice, only swapping the model endpoint or checkpoint path.
+3. Compare aggregate win rates / judged scores the pipeline prints (and publish alongside training logs).
+
+This is the same class of evaluation HelpSteer3’s authors report for instruction-following quality (see the [HelpSteer3 dataset card](https://huggingface.co/datasets/nvidia/HelpSteer3)); your GRPO + GenRM run targets **policy improvement** rather than training a standalone reward model.
+
+---
+
+## 5. Troubleshooting
+
+| Symptom | Check |
+|---------|--------|
+| No reward variance | GenRM JSON parse failures → see `default_score` / logs in `genrm_compare`; confirm `genrm_model_name` loads and outputs `score_1`, `score_2`, `ranking`. |
+| Hangs or partial cohorts | `num_rollouts_per_prompt` ≠ `num_generations_per_prompt`. |
+| Invalid template errors | Policy or GenRM chat template mismatch; Nemotron-3 models need their matching tokenizer / template flags in NeMo RL. |
+| Empty JSONL after conversion | Rows whose `context` does not contain a **user** turn after trimming are skipped; try another subset or inspect raw rows. |
+
+---
+
+## See also
+
+- `examples/nemo_rl/grpo_nemotron3_super_genrm_helpsteer3_pipeclean.yaml` — NeMo RL example recipe (Nemotron 3 Super + GenRM + HelpSteer3).
+- `resources_servers/genrm_compare/README.md` — GenRM compare API and configuration.
+- {doc}`Gym configuration <gym-configuration>` — `env.nemo_gym` structure in NeMo RL.
+- {doc}`/model-recipes/nemotron-3-nano` and {doc}`/model-recipes/nemotron-3-super` — cluster launch patterns for Nemotron-3.
+
+```{button-ref} training-nemo-rl-grpo-index
+:color: secondary
+:outline:
+:ref-type: ref
+
+← Back to NeMo RL GRPO overview
+```

--- a/docs/training-tutorials/nemo-rl-grpo/rlhf-genrm-helpsteer3.md
+++ b/docs/training-tutorials/nemo-rl-grpo/rlhf-genrm-helpsteer3.md
@@ -173,16 +173,28 @@ surfaced the gotchas below — fold these into your config/launcher:
   `genrm_model` block; also loading `genrm_model.yaml` produces an inconsistently merged block
   (`data_parallel_size_local` from one file, `data_parallel_size` from the other). If you load both
   (as this recipe does), fully specify the merged `vllm_serve_kwargs`.
+- **Put the GenRM server venv on shared storage for multi-node.** NeMo Gym builds each model-server
+  venv under a node-local dir by default, so the GenRM venv is missing on the worker node and its
+  Ray actor fails (`.../genrm_model/.venv/bin/python: No such file` → `ActorUnschedulable`). Set
+  `NEMO_GYM_VENV_DIR` to a path on shared storage (e.g. lustre) so every node sees the same venv.
+- **Offload the Megatron optimizer to CPU if the policy OOMs.** On 8×80 GB the policy memory is
+  dominated by optimizer states (the distributed optimizer can't shard at DP=1), so trimming
+  sequence length / batch barely helps — set `policy.megatron_cfg.optimizer.optimizer_cpu_offload:
+  true` (with `optimizer_offload_fraction: 1.0`).
+- **Use a fresh `checkpointing.checkpoint_dir` when you change batch/step config.** NeMo RL
+  auto-resumes from an existing checkpoint and aborts on a scheduler mismatch
+  (`OptimizerParamScheduler ... warmup iterations do not match`).
 
-:::{warning}
-**Known blocker — GenRM returns HTTP 500, rewards collapse to `default_score`.** On some container
-vLLM builds the GenRM model server raises on **every** `/v1/chat/completions`:
-`AttributeError: '_IncludedRouter' object has no attribute 'path'` inside
-`prometheus_fastapi_instrumentator`. `genrm_compare` retries, then falls back to `default_score`,
-so training "runs" but `reward_mean` is **constant** (no learning signal). Fix by pinning a newer
-`prometheus-fastapi-instrumentator` (or disabling metrics instrumentation) in the GenRM model
-server's environment and rebuilding the container. Always confirm `reward_mean` varies before
-trusting a run.
+:::{note}
+**GenRM HTTP 500 → flat reward (fixed in this PR).** vLLM's in-process OpenAI API server is
+instrumented with `prometheus-fastapi-instrumentator`, whose `get_route_name()` does `route.path`
+and raises `AttributeError` on routes that lack it (e.g. vLLM's `_IncludedRouter`) — turning every
+GenRM `/v1/chat/completions` into an HTTP 500, so `genrm_compare` falls back to `default_score` and
+`reward_mean` stays constant. `responses_api_models/local_vllm_model/` now wraps
+`routing.get_route_name` defensively (the middleware already falls back to `request.url.path`), so
+the GenRM serves normally. Still sanity-check that `reward_mean` varies before trusting a run —
+validated end-to-end on 2×8×H100 (Nano-30B policy + 235B GenRM): 0 server 500s, reward varied
+across steps.
 :::
 
 ---

--- a/docs/training-tutorials/nemo-rl-grpo/rlhf-genrm-helpsteer3.md
+++ b/docs/training-tutorials/nemo-rl-grpo/rlhf-genrm-helpsteer3.md
@@ -146,6 +146,45 @@ It sets **`policy.model_name`** to the Hugging Face checkpoint [`nvidia/NVIDIA-N
 
 **Nemotron 3 Nano:** Swap in [`nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16`](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16) for `policy.model_name` and **resize** Megatron/vLLM parallel sizes to your Nano recipe—do not reuse the Super MoE EP/TP numbers without checking the NeMo RL Nano launch config.
 
+### Validated 2-node H100 smoke setup (Nano-30B policy + 235B GenRM)
+
+The pipeclean recipe targets a large B200 cluster. The following **2× 8×H100** layout was run
+end-to-end (5/5 NeMo Gym servers up → rollouts → GenRM pairwise judging → GRPO steps) and
+surfaced the gotchas below — fold these into your config/launcher:
+
+- **The NeMo RL container must include the `nemo_gym` extra.** The stock container does not ship
+  it; build it in (`uv sync --extra nemo_gym`) so the `NemoGym` Ray actor can `import nemo_gym`
+  on every node — otherwise spin-up fails with `ModuleNotFoundError: nemo_gym`.
+- **`data.use_multiple_dataloader: false`** is required by current NeMo RL (see fix above).
+- **`reasoning_parser_plugin` must be an absolute path.** vLLM resolves it against the Ray
+  generation worker's CWD, not the repo root, so a relative path fails at `load_model()` with
+  `reasoning_parser_name='nano_v3' has not been registered`. Override at launch with
+  `++policy.generation.vllm_cfg.reasoning_parser_plugin=$(find "$PWD" -name nano_v3_reasoning_parser.py | head -1)`.
+- **Repoint `genrm_simple_agent_reasoning_off` → `policy_model`** (see fix above), or NeMo Gym
+  config validation aborts on the undefined `policy_model_reasoning_off`.
+- **Cap the GenRM `vllm_serve_kwargs.max_model_len`** (e.g. `40960`). At `tensor_parallel_size: 4`
+  on 80 GB GPUs the model default (`262144`) needs more KV cache than is free after weights and the
+  server won't start (`ValueError: ... KV cache ... larger than available`).
+- **GPU layout / node count.** Policy ran on node 1 (Megatron `TP4/EP8/PP1/CP2` + colocated vLLM,
+  `cluster.num_nodes: 1`); the GenRM model server needs its **own** GPUs, so allocate **one extra
+  Slurm node beyond `cluster.num_nodes`** (`NUM_SLURM_NODES > NUM_ACTOR_NODES` in
+  `launch_nemo_gym_multinode_training.sh`) — the GenRM vLLM lands on the spare node.
+- **Prefer loading only `genrm_compare.yaml` + setting `genrm_model_name`.** It already contains a
+  `genrm_model` block; also loading `genrm_model.yaml` produces an inconsistently merged block
+  (`data_parallel_size_local` from one file, `data_parallel_size` from the other). If you load both
+  (as this recipe does), fully specify the merged `vllm_serve_kwargs`.
+
+:::{warning}
+**Known blocker — GenRM returns HTTP 500, rewards collapse to `default_score`.** On some container
+vLLM builds the GenRM model server raises on **every** `/v1/chat/completions`:
+`AttributeError: '_IncludedRouter' object has no attribute 'path'` inside
+`prometheus_fastapi_instrumentator`. `genrm_compare` retries, then falls back to `default_score`,
+so training "runs" but `reward_mean` is **constant** (no learning signal). Fix by pinning a newer
+`prometheus-fastapi-instrumentator` (or disabling metrics instrumentation) in the GenRM model
+server's environment and rebuilding the container. Always confirm `reward_mean` varies before
+trusting a run.
+:::
+
 ---
 
 ## 4. Evaluation: Arena-Hard v2
@@ -173,6 +212,11 @@ This is the same class of evaluation HelpSteer3’s authors report for instructi
 | Hangs or partial cohorts | `num_rollouts_per_prompt` ≠ `num_generations_per_prompt`. |
 | Invalid template errors | Policy or GenRM chat template mismatch; Nemotron-3 models need their matching tokenizer / template flags in NeMo RL. |
 | Empty JSONL after conversion | Rows whose `context` does not contain a **user** turn after trimming are skipped; try another subset or inspect raw rows. |
+| `KeyError: 'use_multiple_dataloader'` at startup | Add `data.use_multiple_dataloader: false` (required by current NeMo RL). |
+| `reasoning_parser_name='nano_v3' has not been registered` | `reasoning_parser_plugin` is relative; pass an **absolute** path (vLLM resolves it against the worker CWD). |
+| `Could not find ... name='policy_model_reasoning_off'` | Repoint `genrm_simple_agent_reasoning_off.model_server.name` to `policy_model`. |
+| GenRM model server won't start (KV-cache `ValueError`) | Set the GenRM `vllm_serve_kwargs.max_model_len` (model default 262144 may exceed free KV at TP4 on 80 GB GPUs). |
+| Constant `reward_mean` ≈ `default_score` despite "training" | GenRM `/v1/chat/completions` returning HTTP 500 (e.g. `prometheus_fastapi_instrumentator` `_IncludedRouter` crash) → all comparisons default. Inspect the `genrm_model` server log for tracebacks. |
 
 ---
 

--- a/examples/nemo_rl/grpo_nemotron3_super_genrm_helpsteer3_pipeclean.yaml
+++ b/examples/nemo_rl/grpo_nemotron3_super_genrm_helpsteer3_pipeclean.yaml
@@ -1,0 +1,454 @@
+# =============================================================================
+# GRPO + NeMo Gym (GenRM compare) — Nemotron 3 Super + HelpSteer3 (pipeclean)
+# =============================================================================
+# Example NeMo RL recipe: async GRPO on a large MoE policy with non-colocated
+# vLLM rollouts and a separate GenRM judge (pairwise comparisons via
+# resources_servers/genrm_compare).
+#
+# Intended for short validation runs (default max_num_steps: 10). Override at
+# launch with NRL_MAX_STEPS for CI-style smoke tests.
+#
+# Before training:
+#   1. Build JSONL: resources_servers/genrm_compare/scripts/helpsteer3_to_nemo_gym_jsonl.py
+#   2. Set policy.model_name (below) or override via your launcher to a local
+#      Megatron/HF path for Nemotron 3 Super.
+#   3. Set env.nemo_gym.genrm_model / genrm_model_name to a GenRM checkpoint
+#      that supports response_1 / response_2 (and principle if use_principle).
+#   4. Set data.train.data_path / data.validation.data_path to your JSONL files.
+#
+# Layout reference (tune for your cluster; launch scripts often override):
+#   - gpus_per_node: 4
+#   - Policy Megatron TP: 8, CP: 8, EP: 32
+#   - Policy vLLM TP: 8
+#   - GenRM judge vLLM TP: 4
+# =============================================================================
+
+# =============================================================================
+# Cluster — overridden by launch script
+# =============================================================================
+cluster:
+  gpus_per_node: 4
+  num_nodes: 64
+  segment_size: 16
+
+# =============================================================================
+# Checkpointing
+# =============================================================================
+checkpointing:
+  enabled: true
+  checkpoint_dir: "results/grpo_nemotron3_super_genrm_hs3_pipeclean"
+  metric_name: "val:total_reward/mean"
+  higher_is_better: true
+  keep_top_k: 1000000
+  save_period: 4
+  checkpoint_must_save_by: "00:03:30:00"
+  model_save_format: "safetensors"
+  save_consolidated: false
+
+# =============================================================================
+# GRPO Algorithm
+# =============================================================================
+grpo:
+  num_prompts_per_step: 16
+  num_generations_per_prompt: 4
+  num_val_generations_per_prompt: 2
+  max_rollout_turns: 1
+  max_num_epochs: 1
+  max_num_steps: 10
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  advantage_clip_low: -50
+  advantage_clip_high: 50
+  val_period: -1
+  val_at_start: false
+  val_at_end: false
+  overlong_filtering: false
+  max_val_samples: null
+  val_batch_size: 256
+  seed: 42
+
+  use_dynamic_sampling: false
+  dynamic_sampling_max_gen_batches: 10
+  batch_multiplier: 1
+
+  penalize_invalid_tool_call: true
+  invalid_tool_call_advantage: -5.0
+  penalize_malformed_thinking: true
+  malformed_thinking_advantage: -5.0
+
+  reward_shaping:
+    enabled: false
+    overlong_buffer_length: 128
+    overlong_buffer_penalty: 1
+    max_response_length: ${policy.max_total_sequence_length}
+    stop_properly_penalty_coef: null
+  reward_scaling:
+    enabled: false
+    source_min: 0.0
+    source_max: 1.0
+    target_min: 0.0
+    target_max: 1.0
+
+  async_grpo:
+    enabled: true
+    max_trajectory_age_steps: 1
+    in_flight_weight_updates: true
+    recompute_kv_cache_after_weight_updates: false
+
+  use_best_at_k: false
+  best_at_k_k: 8
+  best_at_k_m: 1000
+
+  use_combined_training: false
+  combined_training_weight_mode: "auto"
+  combined_training_best_at_k_weight: 0.2
+  combined_training_pass_at_1_weight: 1.0
+
+  dynamic_sampling_oversample_ratio: 1.0
+  seq_logprob_error_threshold: 2
+
+# =============================================================================
+# Loss Function
+# =============================================================================
+loss_fn:
+  reference_policy_kl_penalty: 0.0
+  reference_policy_kl_type: "k3"
+  kl_input_clamp_value: null
+  kl_output_clamp_value: null
+
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.28
+  ratio_clip_c: null
+  use_on_policy_kl_approximation: true
+  use_importance_sampling_correction: true
+  truncated_importance_sampling_ratio: 5
+  truncated_importance_sampling_ratio_min: null
+  truncated_importance_sampling_type: tis
+  sequence_level_importance_ratios: false
+  token_level_loss: true
+  force_on_policy_ratio: true
+  use_kl_in_reward: false
+
+# =============================================================================
+# Policy — Nemotron 3 Super (HF id or converted checkpoint path)
+# =============================================================================
+policy:
+  model_name: "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"
+  tokenizer:
+    name: ${policy.model_name}
+    chat_template_kwargs: null
+  hf_config_overrides: {}
+
+  train_global_batch_size: 64
+  train_micro_batch_size: 1
+  generation_batch_size: 64
+  logprob_batch_size: 1
+  max_total_sequence_length: 32768
+  precision: "bfloat16"
+  logprob_chunk_size: 2048
+  offload_optimizer_for_logprob: false
+
+  dtensor_cfg:
+    _v2: true
+    enabled: false
+    cpu_offload: false
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    custom_parallel_plan: null
+
+  megatron_cfg:
+    enabled: true
+    empty_unused_memory_level: 1
+    activation_checkpointing: true
+
+    tensor_model_parallel_size: 8
+    expert_tensor_parallel_size: 1
+    expert_model_parallel_size: 32
+    pipeline_model_parallel_size: 1
+    num_layers_in_first_pipeline_stage: null
+    num_layers_in_last_pipeline_stage: null
+    context_parallel_size: 8
+    pipeline_dtype: ${policy.precision}
+    sequence_parallel: true
+
+    freeze_moe_router: true
+    moe_router_dtype: "fp32"
+    moe_router_load_balancing_type: "none"
+    moe_router_bias_update_rate: 1.0e-3
+    moe_router_enable_expert_bias: true
+    moe_permute_fusion: true
+    moe_enable_deepep: false
+    moe_token_dispatcher_type: "alltoall"
+    moe_aux_loss_coeff: 0.0
+    moe_shared_expert_overlap: false
+    use_gloo_process_groups: false
+
+    apply_rope_fusion: true
+    bias_activation_fusion: false
+    defer_fp32_logits: true
+
+    track_moe_metrics: true
+    moe_per_layer_logging: true
+    do_not_average_loss: true
+    cp_normalize: true
+    calculate_per_token_loss: true
+    scale_loss_by_dp_cp_size: false
+
+    mtp_loss_scaling_factor: 0.3
+    mtp_use_repeated_layer: true
+    mtp_num_layers: 5
+    mtp_detach_heads: true
+
+    optimizer:
+      optimizer: "adam"
+      lr: 3.0e-6
+      min_lr: 3.0e-6
+      weight_decay: 0.0
+      bf16: true
+      fp16: false
+      params_dtype: "float32"
+
+      adam_beta1: 0.9
+      adam_beta2: 0.999
+      adam_eps: 1e-8
+
+      sgd_momentum: 0.9
+
+      use_distributed_optimizer: true
+      use_precision_aware_optimizer: true
+
+      clip_grad: ${policy.max_grad_norm}
+
+      optimizer_cpu_offload: false
+      optimizer_offload_fraction: 0.0
+
+    scheduler:
+      start_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      end_weight_decay: ${policy.megatron_cfg.optimizer.weight_decay}
+      weight_decay_incr_style: "constant"
+      lr_decay_style: "constant"
+      lr_decay_iters: null
+      lr_warmup_iters: 0
+      lr_warmup_init: 3e-7
+
+    distributed_data_parallel_config:
+      grad_reduce_in_fp32: false
+      overlap_grad_reduce: false
+      overlap_param_gather: true
+      average_in_collective: false
+      use_custom_fsdp: false
+      data_parallel_sharding_strategy: "optim_grads_params"
+
+    fp8_cfg:
+      enabled: false
+      fp8: "e4m3"
+      fp8_recipe: "mxfp8"
+      fp8_param: false
+
+    first_last_layers_bf16: true
+    num_layers_at_start_in_bf16: 1
+    num_layers_at_end_in_bf16: 1
+
+    checkpoint:
+      async_save: true
+      ckpt_assume_constant_structure: true
+      fully_parallel_save_process_group: "ep_dp"
+      fully_parallel_load_process_group: "ep_dp"
+      fully_parallel_load_exchange_algo: "broadcast"
+
+    env_vars: null
+
+  dynamic_batching:
+    enabled: false
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    sequence_length_round: 64
+
+  sequence_packing:
+    enabled: true
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    algorithm: "modified_first_fit_decreasing"
+    sequence_length_round: 64
+
+  make_sequence_length_divisible_by: ${policy.megatron_cfg.tensor_model_parallel_size}
+  max_grad_norm: 1.0
+  optimizer: null
+  scheduler: null
+
+  generation:
+    port_range_low: 3000
+    port_range_high: 4999
+    backend: "vllm"
+    max_new_tokens: 32768
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_token_ids: null
+    stop_strings: null
+    vllm_cfg:
+      async_engine: true
+      precision: ${policy.precision}
+      kv_cache_dtype: "auto"
+      tensor_parallel_size: 8
+      pipeline_parallel_size: 1
+      expert_parallel_size: 1
+      gpu_memory_utilization: 0.85
+      max_model_len: 32768
+      enforce_eager: false
+      use_deep_gemm: false
+      num_last_layers_in_bf16: 0
+      num_first_layers_in_bf16: 0
+      enable_vllm_metrics_logger: true
+      vllm_metrics_logger_interval: 0.5
+      expose_http_server: true
+      skip_tokenizer_init: false
+      http_server_serving_chat_kwargs:
+        enable_auto_tools: true
+        tool_parser: qwen3_coder
+        reasoning_parser: nano_v3
+        reasoning_parser_plugin: nemo_rl/utils/nano_v3_reasoning_parser.py
+
+    vllm_kwargs:
+      attention_backend: FLASH_ATTN
+      max_num_seqs: 256
+      mamba_ssm_cache_dtype: "float32"
+      compilation_config:
+        cudagraph_capture_sizes: [1, 2, 4, 8, 16, 32, 64]
+        pass_config:
+          fuse_allreduce_rms: false
+
+    colocated:
+      enabled: false
+      resources:
+        gpus_per_node: 4
+        num_nodes: 26
+
+# =============================================================================
+# Data — NemoGymDataset + HelpSteer3 JSONL (see conversion script)
+# =============================================================================
+data:
+  max_input_seq_length: 16384
+  shuffle: false
+  num_workers: 1
+  train:
+    data_path: null
+  validation:
+    data_path: null
+  default:
+    dataset_name: NemoGymDataset
+    env_name: "nemo_gym"
+    prompt_file: null
+    system_prompt_file: null
+    processor: "nemo_gym_data_processor"
+
+# =============================================================================
+# Environment — NeMo Gym + GenRM compare + GenRM model server
+# =============================================================================
+env:
+  should_use_nemo_gym: true
+  nemo_gym:
+    nemo_gym_log_dir: "logs/nemo_gym"
+    skip_venv_if_present: false
+    port_range_low: 5000
+    port_range_high: 5999
+    invalid_tool_call_patterns:
+      - "<tool_call>"
+      - "</tool_call>"
+      - "<function_call>"
+      - "</function_call>"
+    thinking_tags:
+      - "<redacted_thinking>"
+      - "</redacted_thinking>"
+    config_paths:
+      - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
+      - resources_servers/genrm_compare/configs/genrm_compare.yaml
+      - responses_api_models/genrm_model/configs/genrm_model.yaml
+
+    genrm_compare_resources_server:
+      resources_servers:
+        genrm_compare:
+          num_rollouts_per_prompt: ${grpo.num_generations_per_prompt}
+          genrm_model_server:
+            type: responses_api_models
+            name: genrm_model
+          genrm_responses_create_params:
+            max_output_tokens: 16384
+            temperature: 0.6
+            top_p: 0.95
+          comparison_strategy: "circular"
+          num_judges_per_comparison: 1
+          use_principle: true
+          default_principle: "Please act as an impartial judge and evaluate the quality of the responses provided by two AI assistants to the user prompt. Begin your evaluation by generating your own answer to the prompt. You must provide your answer before judging any answers. When evaluating the assistants' answers, compare both assistants' answers with your answer. You must identify and correct any mistakes or inaccurate information. Then consider if the assistant's answers are helpful, relevant, and concise. Helpful means the answer correctly responds to the prompt or follows the instructions. Note when user prompt has any ambiguity or more than one interpretation, it is more helpful and appropriate to ask for clarifications or more information from the user than providing an answer based on assumptions. Relevant means all parts of the response closely connect or are appropriate to what is being asked. Concise means the response is clear and not verbose or excessive. Then consider the creativity and novelty of the assistant's answers when needed. Finally, identify any missing important information in the assistants' answers that would be beneficial to include when responding to the user prompt."
+          aggregator_method: "simple_tiebreaker"
+          reasoning_bonus: 0.5
+          answer_bonus: 0.5
+          top_percentile: 0.2
+          group_reasoning_length_penalty_coeff: 0.1
+          group_answer_length_penalty_coeff: 0.1
+          group_style_penalty_coeff: 0.0
+          default_score: 3.0
+          default_ranking: 3.5
+
+    genrm_model:
+      responses_api_models:
+        genrm_model:
+          entrypoint: app.py
+          model: null
+          uses_reasoning_parser: true
+          supports_principle_role: true
+          return_token_id_information: false
+          debug: true
+          vllm_serve_env_vars:
+            VLLM_RAY_DP_PACK_STRATEGY: strict
+          server_env:
+            NCCL_MNNVL_ENABLE: "0"
+          vllm_serve_kwargs:
+            attention_backend: FLASH_ATTN
+            trust_remote_code: true
+            tensor_parallel_size: 4
+            data_parallel_size: 6
+            data_parallel_size_local: 1
+            pipeline_parallel_size: 1
+            reasoning_parser: deepseek_r1
+            gpu_memory_utilization: 0.85
+            max_model_len: 60000
+            max_num_seqs: 256
+            model_loader_extra_config:
+              enable_multithread_load: true
+              num_threads: 112
+            compilation_config:
+              cudagraph_capture_sizes: [1, 2, 4, 8, 16, 32]
+
+# =============================================================================
+# Logger
+# =============================================================================
+logger:
+  log_dir: "logs"
+  num_val_samples_to_print: 0
+  wandb_enabled: false
+  tensorboard_enabled: false
+  mlflow_enabled: false
+  monitor_gpus: true
+  swanlab_enabled: false
+  wandb:
+    project: "grpo-nemotron3-super-genrm-hs3-pipeclean"
+    name: "grpo-nemotron3-super-genrm-hs3-pipeclean"
+  tensorboard: {}
+  mlflow:
+    experiment_name: "grpo-nemotron3-super-genrm-hs3-pipeclean"
+    run_name: "grpo-nemotron3-super-genrm-hs3-pipeclean"
+  gpu_monitoring:
+    collection_interval: 10
+    flush_interval: 10
+
+# =============================================================================
+# Effort Levels
+# =============================================================================
+effort_levels:
+  low_string: "{reasoning effort: low}"
+  low_weight: 0.2
+  low_penalty: 1
+  low_ub: 3000

--- a/examples/nemo_rl/grpo_nemotron3_super_genrm_helpsteer3_pipeclean.yaml
+++ b/examples/nemo_rl/grpo_nemotron3_super_genrm_helpsteer3_pipeclean.yaml
@@ -309,7 +309,13 @@ policy:
         enable_auto_tools: true
         tool_parser: qwen3_coder
         reasoning_parser: nano_v3
-        reasoning_parser_plugin: nemo_rl/utils/nano_v3_reasoning_parser.py
+        # vLLM resolves this plugin path against the generation worker's CWD (the Ray
+        # workdir), NOT the repo root, so a bare relative path fails at load_model() with
+        # "reasoning_parser_name='nano_v3' has not been registered". Pass an ABSOLUTE path
+        # at launch, e.g.:
+        #   ++policy.generation.vllm_cfg.reasoning_parser_plugin=$(find "$PWD" -name nano_v3_reasoning_parser.py | head -1)
+        # (current nemo_rl ships it under nemo_rl/models/generation/vllm/reasoning_parsers/)
+        reasoning_parser_plugin: nemo_rl/models/generation/vllm/reasoning_parsers/nano_v3_reasoning_parser.py
 
     vllm_kwargs:
       attention_backend: FLASH_ATTN
@@ -333,6 +339,9 @@ data:
   max_input_seq_length: 16384
   shuffle: false
   num_workers: 1
+  # Required by current NeMo RL: grpo.py `setup()` reads data["use_multiple_dataloader"];
+  # omitting it raises `KeyError: 'use_multiple_dataloader'` before training starts.
+  use_multiple_dataloader: false
   train:
     data_path: null
   validation:
@@ -366,6 +375,16 @@ env:
       - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
       - resources_servers/genrm_compare/configs/genrm_compare.yaml
       - responses_api_models/genrm_model/configs/genrm_model.yaml
+
+    # genrm_compare.yaml ships a `genrm_simple_agent_reasoning_off` agent that references an
+    # undefined `policy_model_reasoning_off` model server. Without this repoint, NeMo Gym
+    # config validation aborts with "Could not find ... name='policy_model_reasoning_off'".
+    # This agent is unused for GRPO (the dataset rows use genrm_simple_agent → policy_model).
+    genrm_simple_agent_reasoning_off:
+      responses_api_agents:
+        simple_agent:
+          model_server:
+            name: policy_model
 
     genrm_compare_resources_server:
       resources_servers:

--- a/resources_servers/genrm_compare/README.md
+++ b/resources_servers/genrm_compare/README.md
@@ -55,6 +55,17 @@ The GenRM model should output JSON in the following format:
 
 > **Note**: The GenRM model must have a chat template that supports the special roles `response_1` and `response_2`. The conversation history should use standard `user` and `assistant` roles, with the last turn being a user turn.
 
+## HelpSteer3 → NeMo Gym JSONL
+
+To train with GRPO on prompts from [nvidia/HelpSteer3](https://huggingface.co/datasets/nvidia/HelpSteer3) (preference subset), convert rows to Gym JSONL with:
+
+```bash
+uv run python resources_servers/genrm_compare/scripts/helpsteer3_to_nemo_gym_jsonl.py \
+  --output-dir data/helpsteer3_gym
+```
+
+See the docs recipe `docs/training-tutorials/nemo-rl-grpo/rlhf-genrm-helpsteer3.md` (RLHF-style GRPO with GenRM compare and HelpSteer3) for NeMo RL wiring, GenRM alignment, and Arena-Hard v2 evaluation. A concrete NeMo RL YAML example is `examples/nemo_rl/grpo_nemotron3_super_genrm_helpsteer3_pipeclean.yaml`.
+
 ## Quick Start
 
 ### 1. Configuration

--- a/resources_servers/genrm_compare/scripts/helpsteer3_to_nemo_gym_jsonl.py
+++ b/resources_servers/genrm_compare/scripts/helpsteer3_to_nemo_gym_jsonl.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Convert Hugging Face `nvidia/HelpSteer3` (preference subset) to NeMo Gym JSONL.
+
+Each output row matches the format expected by the GenRM compare agent
+(`resources_servers/genrm_compare/data/example.jsonl`): OpenAI-style messages in
+`responses_create_params.input`, optional empty `tools`, and `agent_ref` pointing
+at `genrm_simple_agent`.
+
+Human preference columns (`response1`, `response2`, `overall_preference`, etc.)
+are not copied: GRPO generates fresh completions and the GenRM assigns rewards.
+
+Usage::
+
+    python resources_servers/genrm_compare/scripts/helpsteer3_to_nemo_gym_jsonl.py \\
+        --output-dir data/helpsteer3_gym
+
+    # Smoke test without writing full splits
+    python resources_servers/genrm_compare/scripts/helpsteer3_to_nemo_gym_jsonl.py \\
+        --output-dir /tmp/hs3 --max-samples 100
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+
+def _content_to_str(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                t = block.get("type")
+                if t in ("text", "output_text") and "text" in block:
+                    parts.append(str(block["text"]))
+                elif "content" in block:
+                    parts.append(_content_to_str(block["content"]))
+            elif isinstance(block, str):
+                parts.append(block)
+        return "\n".join(p for p in parts if p)
+    return str(content)
+
+
+def _normalize_message(msg: Any) -> dict[str, str] | None:
+    if not isinstance(msg, dict):
+        return None
+    role = msg.get("role")
+    if role not in ("user", "assistant", "system"):
+        return None
+    text = html.unescape(_content_to_str(msg.get("content")))
+    return {"role": role, "content": text}
+
+
+def parse_context(context: Any) -> list[dict[str, str]]:
+    if context is None:
+        return []
+    if isinstance(context, str):
+        try:
+            context = json.loads(context)
+        except json.JSONDecodeError:
+            return []
+    if not isinstance(context, list):
+        return []
+    out: list[dict[str, str]] = []
+    for item in context:
+        m = _normalize_message(item)
+        if m and m["content"].strip():
+            out.append(m)
+    return out
+
+
+def trim_to_last_user(messages: list[dict[str, str]]) -> list[dict[str, str]]:
+    """GenRM compare expects history whose last turn is from the user."""
+    last_user = -1
+    for i, m in enumerate(messages):
+        if m["role"] == "user":
+            last_user = i
+    if last_user < 0:
+        return []
+    return messages[: last_user + 1]
+
+
+def row_to_gym_record(
+    row: dict[str, Any],
+    idx: int,
+    *,
+    agent_ref_name: str,
+    dataset_tag: str,
+) -> dict[str, Any] | None:
+    messages = trim_to_last_user(parse_context(row.get("context")))
+    if not messages:
+        logger.debug("skip idx=%s: empty or invalid context after trim", idx)
+        return None
+    return {
+        "id": row.get("id", idx),
+        "responses_create_params": {
+            "input": messages,
+            "tools": [],
+            "parallel_tool_calls": False,
+        },
+        "agent_ref": {"type": "responses_api_agents", "name": agent_ref_name},
+        "dataset": dataset_tag,
+    }
+
+
+def convert_split(
+    split_name: str,
+    output_path: Path,
+    *,
+    repo_id: str,
+    config_name: str,
+    agent_ref_name: str,
+    dataset_tag: str,
+    max_samples: int | None,
+    hf_token: str | None,
+) -> tuple[int, int]:
+    from datasets import load_dataset
+
+    ds = load_dataset(repo_id, name=config_name, split=split_name, token=hf_token)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    written = 0
+    skipped = 0
+    with output_path.open("w", encoding="utf-8") as f:
+        for i, row in enumerate(ds):
+            if max_samples is not None and written >= max_samples:
+                break
+            rec = row_to_gym_record(
+                dict(row),
+                i,
+                agent_ref_name=agent_ref_name,
+                dataset_tag=dataset_tag,
+            )
+            if rec is None:
+                skipped += 1
+                continue
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            written += 1
+    return written, skipped
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory for train.jsonl and validation.jsonl",
+    )
+    p.add_argument("--repo-id", default="nvidia/HelpSteer3", help="Hugging Face dataset id")
+    p.add_argument(
+        "--config-name",
+        default="preference",
+        help="HelpSteer3 subset (use `preference` for pairwise-prompt conversations)",
+    )
+    p.add_argument(
+        "--agent-ref-name",
+        default="genrm_simple_agent",
+        help="Must match responses_api_agents block loaded in NeMo Gym config",
+    )
+    p.add_argument(
+        "--dataset-tag",
+        default="helpsteer3_preference",
+        help="Optional tag stored on each JSONL row under `dataset`",
+    )
+    p.add_argument(
+        "--max-samples",
+        type=int,
+        default=None,
+        help="Cap rows per split (for debugging)",
+    )
+    p.add_argument("--hf-token", default=None, help="Hugging Face token if the dataset is gated")
+    args = p.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    total_w = total_s = 0
+    for split in ("train", "validation"):
+        out = args.output_dir / f"{split}.jsonl"
+        try:
+            w, s = convert_split(
+                split,
+                out,
+                repo_id=args.repo_id,
+                config_name=args.config_name,
+                agent_ref_name=args.agent_ref_name,
+                dataset_tag=args.dataset_tag,
+                max_samples=args.max_samples,
+                hf_token=args.hf_token,
+            )
+        except ValueError as e:
+            # Older `datasets` versions may not support missing splits the same way
+            logger.warning("split %s: %s — skipping", split, e)
+            continue
+        logger.info("wrote %s rows to %s (skipped %s)", w, out, s)
+        total_w += w
+        total_s += s
+    if total_w == 0:
+        raise SystemExit(
+            "No rows written. Check repo_id/config_name, network access, and that "
+            "`context` fields parse to messages ending with a user turn."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/responses_api_models/local_vllm_model/app.py
+++ b/responses_api_models/local_vllm_model/app.py
@@ -70,6 +70,35 @@ class LocalVLLMModelConfig(VLLMModelConfig):
 def _vllm_asyncio_task(server_args: Namespace):
     from vllm.entrypoints.openai.api_server import run_server
 
+    # vLLM instruments its in-process OpenAI API server with
+    # prometheus-fastapi-instrumentator, whose get_route_name() does `route.path` and
+    # raises AttributeError on routes that lack it (e.g. vLLM's `_IncludedRouter`),
+    # which turns EVERY request (incl. GenRM /v1/chat/completions) into an HTTP 500.
+    # The middleware already falls back to request.url.path when route-name resolution
+    # returns None, so make it defensive. Patch here (in the server thread, right before
+    # run_server) so it is active when vLLM instruments the app. No-op if the lib is absent.
+    try:
+        from prometheus_fastapi_instrumentator import routing as _pfi_routing
+
+        _pfi_orig_get_route_name = _pfi_routing.get_route_name
+
+        def _pfi_safe_get_route_name(request):  # type: ignore[no-untyped-def]
+            try:
+                return _pfi_orig_get_route_name(request)
+            except AttributeError:
+                return None
+
+        _pfi_routing.get_route_name = _pfi_safe_get_route_name
+        try:
+            from prometheus_fastapi_instrumentator import middleware as _pfi_mw
+
+            if hasattr(_pfi_mw, "get_route_name"):
+                _pfi_mw.get_route_name = _pfi_safe_get_route_name
+        except Exception:
+            pass
+    except Exception:
+        pass
+
     asyncio.run(run_server(server_args))
 
 

--- a/tests/test_helpsteer3_to_nemo_gym_jsonl.py
+++ b/tests/test_helpsteer3_to_nemo_gym_jsonl.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for HelpSteer3 → NeMo Gym JSONL conversion helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_SCRIPT = (
+    Path(__file__).resolve().parent.parent / "resources_servers/genrm_compare/scripts/helpsteer3_to_nemo_gym_jsonl.py"
+)
+
+
+@pytest.fixture(scope="module")
+def hs3():
+    spec = importlib.util.spec_from_file_location("helpsteer3_to_nemo_gym_jsonl", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.unit
+def test_trim_to_last_user(hs3):
+    msgs = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+    ]
+    assert hs3.trim_to_last_user(msgs) == msgs
+
+
+@pytest.mark.unit
+def test_trim_drops_trailing_assistant(hs3):
+    msgs = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+    ]
+    assert hs3.trim_to_last_user(msgs) == [{"role": "user", "content": "a"}]
+
+
+@pytest.mark.unit
+def test_trim_no_user_returns_empty(hs3):
+    assert hs3.trim_to_last_user([{"role": "assistant", "content": "x"}]) == []
+
+
+@pytest.mark.unit
+def test_html_unescape_in_normalize(hs3):
+    ctx = [{"role": "user", "content": "use &lt; here"}]
+    out = hs3.parse_context(ctx)
+    assert out[0]["content"] == "use < here"
+
+
+@pytest.mark.unit
+def test_row_to_gym_record(hs3):
+    row = {
+        "id": 42,
+        "context": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "next"},
+        ],
+    }
+    rec = hs3.row_to_gym_record(row, 0, agent_ref_name="genrm_simple_agent", dataset_tag="helpsteer3_preference")
+    assert rec is not None
+    assert rec["id"] == 42
+    assert rec["dataset"] == "helpsteer3_preference"
+    assert rec["agent_ref"]["name"] == "genrm_simple_agent"
+    inp = rec["responses_create_params"]["input"]
+    assert inp[-1] == {"role": "user", "content": "next"}
+    assert rec["responses_create_params"]["tools"] == []
+    assert rec["responses_create_params"]["parallel_tool_calls"] is False
+
+
+@pytest.mark.unit
+def test_context_as_json_string(hs3):
+    row = {"context": '[{"role": "user", "content": "from json"}]'}
+    rec = hs3.row_to_gym_record(row, 0, agent_ref_name="genrm_simple_agent", dataset_tag="t")
+    assert rec["responses_create_params"]["input"] == [{"role": "user", "content": "from json"}]


### PR DESCRIPTION
# What does this PR do?

**Adds documentation and tooling for GRPO / RLHF-style training with NeMo Gym’s GenRM compare server, HelpSteer3 → JSONL conversion, a Nemotron 3 Super NeMo RL example recipe, tests, and doc/navigation updates.**

To build the docs and visualize locally please do:

```
cd docs
make docs-live
```

# Issues

Closes #354

# Usage

**Convert HelpSteer3 (preference subset) to NeMo Gym JSONL** (from repo root, with Gym dev env / `uv`):

```bash
uv run python resources_servers/genrm_compare/scripts/helpsteer3_to_nemo_gym_jsonl.py \
  --output-dir data/helpsteer3_gym
```

**Run unit tests** for the conversion helpers:

```bash
uv run pytest tests/test_helpsteer3_to_nemo_gym_jsonl.py -q
```

**NeMo RL:** Use or compose from the example recipe (paths relative to the bundled Gym tree):

- `examples/nemo_rl/grpo_nemotron3_super_genrm_helpsteer3_pipeclean.yaml`

Set `data.train.data_path` / `data.validation.data_path` to the converted JSONL files and configure the GenRM checkpoint in `env.nemo_gym.genrm_model` (or your launcher’s `genrm_model_name`).

**Docs:** Build or read the tutorial:

- Source: `docs/training-tutorials/nemo-rl-grpo/rlhf-genrm-helpsteer3.md`
- After `make docs-html` under `docs/`: `training-tutorials/nemo-rl-grpo/rlhf-genrm-helpsteer3.html`

# Additional Information

- **Tutorial** (`rlhf-genrm-helpsteer3.md`): HelpSteer3 formatting, wiring `resources_servers/genrm_compare/configs/genrm_compare.yaml` + `genrm_model`, batch / `num_rollouts_per_prompt` alignment, Arena-Hard v2 evaluation pointers, Nemotron 3 Nano vs Super note.
- **Example config** (`examples/nemo_rl/grpo_nemotron3_super_genrm_helpsteer3_pipeclean.yaml`): Pipeclean-scale NeMo RL YAML aligned with large-cluster GRPO + GenRM judge layout; policy default HF id `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16`.
- **Script** (`resources_servers/genrm_compare/scripts/helpsteer3_to_nemo_gym_jsonl.py`): Truncates context to the last user turn (GenRM requirement), HTML-unescapes content, optional `--max-samples` for smoke tests.
- **Tests** (`tests/test_helpsteer3_to_nemo_gym_jsonl.py`): Covers trim, unescape, JSON-string `context`, and full row shape.
- **Navigation**: Training tutorial index + NeMo RL GRPO toctree card; `docs/conf.py` redirect `tutorials/nemo-rl-grpo/rlhf-genrm-helpsteer3.html`; model recipes “See also”; `resources_servers/genrm_compare/README.md` links to the tutorial and example YAML.
