### PR TITLE
fix: remove stale Sphinx references and fix broken redirect in Fern docs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -94,7 +94,7 @@ redirects:
   - source: "nemo/gym/training/rl-framework-integration/openai-compatible-http-server-on-policy-correction.html"
     destination: "/contribute/rl-framework-integration/openai-compatible-http-server-on-policy-correction"
   - source: "nemo/gym/tutorials/creating-resource-server.html"
-    destination: "/environment-tutorials/creating-training-environment"
+    destination: "/environment-tutorials/single-step-environment"
   - source: "nemo/gym/tutorials/index.html"
     destination: "/training-tutorials"
   - source: "nemo/gym/tutorials/nemo-rl-grpo/about-workplace-assistant.html"
@@ -119,6 +119,6 @@ redirects:
     destination: "/nemo/gym/v0.2/:path*"
   - source: "nemo/gym/:path*/index.html"
     destination: "/nemo/gym/:path*"
-  # Sphinx page URLs (foo.html); must follow all :path*/index.html rules above
+  # Legacy page URLs (foo.html); must follow all :path*/index.html rules above
   - source: "nemo/gym/:path*.html"
     destination: "/nemo/gym/:path*"

--- a/fern/versions/_nav_order.yml
+++ b/fern/versions/_nav_order.yml
@@ -1,7 +1,6 @@
-# Page ordering derived from toctree (use with add_frontmatter.py --nav-order)
+# Page ordering (use with add_frontmatter.py --nav-order)
 "./versions/latest/pages/about/index.mdx": 1
 "./versions/latest/pages/agent-server/index.mdx": 1
-"./versions/latest/pages/benchmarks/index.mdx": 1
 "./versions/latest/pages/contribute/index.mdx": 1
 "./versions/latest/pages/data/index.mdx": 1
 "./versions/latest/pages/environment-tutorials/index.mdx": 1
@@ -15,7 +14,6 @@
 "./versions/latest/pages/training-tutorials/index.mdx": 1
 "./versions/latest/pages/troubleshooting/configuration.mdx": 1
 "./versions/latest/pages/about/concepts/index.mdx": 2
-"./versions/latest/pages/benchmarks/run-benchmark-suite.mdx": 2
 "./versions/latest/pages/contribute/development-setup.mdx": 2
 "./versions/latest/pages/data/prepare-validate.mdx": 2
 "./versions/latest/pages/environment-tutorials/single-step-environment.mdx": 2
@@ -26,7 +24,6 @@
 "./versions/latest/pages/reference/rl-framework-compatibility.mdx": 2
 "./versions/latest/pages/training-tutorials/nemo-rl-grpo/index.mdx": 2
 "./versions/latest/pages/about/ecosystem.mdx": 3
-"./versions/latest/pages/benchmarks/adding-a-benchmark.mdx": 3
 "./versions/latest/pages/contribute/environments/index.mdx": 3
 "./versions/latest/pages/data/download-huggingface.mdx": 3
 "./versions/latest/pages/environment-tutorials/multi-step-environment.mdx": 3
@@ -35,13 +32,12 @@
 "./versions/latest/pages/model-recipes/nemotron-3-super.mdx": 3
 "./versions/latest/pages/reference/cli-commands.mdx": 3
 "./versions/latest/pages/training-tutorials/unsloth.mdx": 3
-"./versions/latest/pages/benchmarks/designing-customer-evaluation.mdx": 4
 "./versions/latest/pages/contribute/rl-framework-integration/index.mdx": 4
 "./versions/latest/pages/data/prompt-config.mdx": 4
 "./versions/latest/pages/environment-tutorials/stateful-environment.mdx": 4
 "./versions/latest/pages/reference/faq.mdx": 4
 "./versions/latest/pages/training-tutorials/multi-environment-training.mdx": 4
-"./versions/latest/pages/environment-tutorials/real-world-environment.mdx": 5
+"./versions/latest/pages/environment-tutorials/real-world-environment/index.mdx": 5
 "./versions/latest/pages/training-tutorials/offline-training-w-rollouts.mdx": 5
 "./versions/latest/pages/environment-tutorials/integrate-external-environments.mdx": 6
 "./versions/latest/pages/environment-tutorials/aggregate-metrics.mdx": 7

--- a/fern/versions/latest/pages/contribute/development-setup.mdx
+++ b/fern/versions/latest/pages/contribute/development-setup.mdx
@@ -62,16 +62,12 @@ All contributions must pass these automated checks:
 
 If the build-docs check fails:
 
-1. **Test documentation locally**:
-   ```bash
-   cd docs
-   uv run --frozen --only-group docs sphinx-build --fail-on-warning --builder html . _build/html
-   ```
+1. **Test documentation locally**: Preview the Fern docs by running `fern docs dev` from the repository root.
 
 2. **Common issues**:
    - Missing docstrings in public functions
    - Broken markdown links in README or tutorials
-   - Invalid rst/sphinx syntax
+   - Invalid MDX syntax
 
 ### Copyright Header Errors
 

--- a/fern/versions/latest/pages/reference/faq.mdx
+++ b/fern/versions/latest/pages/reference/faq.mdx
@@ -439,18 +439,7 @@ This is a fundamental incompatibility between:
 There's no practical workaround that NeMo Gym can implement - the solution is to run with appropriate permissions for your environment.
 
 # FAQ: build-docs / Build docs CI failures
-If you see some docs building related errors that are kind of cryptic regarding .rst files like the following
-```
-updating environment: [config changed ('toc_object_entries_show_parents')] 16 added, 0 changed, 0 removed
-reading sources... [100%] index
-/Users/bxyu/Documents/nemo-gym/nemo_gym/server_utils.py.rst:3: WARNING: Document headings start at H2, not H1 [myst.header]
-/Users/bxyu/Documents/nemo-gym/nemo_gym/server_utils.py.rst:3: WARNING: Document headings start at H2, not H1 [myst.header]
-/Users/bxyu/Documents/nemo-gym/README.md:: WARNING: image file not readable: resources/rl_verifiers_system_design.png [image.not_readable]
-looking for now-outdated files... none found
-pickling environment... done
-checking consistency... done
-```
-You may need to reformat some of your docstrings to Napoleon format docstrings https://sphinxcontrib-napoleon.readthedocs.io/en/latest/
+If the build-docs CI check fails, preview the Fern docs locally by running `fern docs dev` from the repository root. Common causes include broken markdown links, invalid MDX syntax, or missing frontmatter in new pages.
 
 # FAQ: Monotonic (Strictly-Increasing) Trajectories
 

--- a/fern/versions/v0.2/pages/contribute/development-setup.mdx
+++ b/fern/versions/v0.2/pages/contribute/development-setup.mdx
@@ -62,16 +62,12 @@ All contributions must pass these automated checks:
 
 If the build-docs check fails:
 
-1. **Test documentation locally**:
-   ```bash
-   cd docs
-   uv run --frozen --only-group docs sphinx-build --fail-on-warning --builder html . _build/html
-   ```
+1. **Test documentation locally**: Preview the Fern docs by running `fern docs dev` from the repository root.
 
 2. **Common issues**:
    - Missing docstrings in public functions
    - Broken markdown links in README or tutorials
-   - Invalid rst/sphinx syntax
+   - Invalid MDX syntax
 
 ### Copyright Header Errors
 

--- a/fern/versions/v0.2/pages/reference/faq.mdx
+++ b/fern/versions/v0.2/pages/reference/faq.mdx
@@ -439,18 +439,7 @@ This is a fundamental incompatibility between:
 There's no practical workaround that NeMo Gym can implement - the solution is to run with appropriate permissions for your environment.
 
 # FAQ: build-docs / Build docs CI failures
-If you see some docs building related errors that are kind of cryptic regarding .rst files like the following
-```
-updating environment: [config changed ('toc_object_entries_show_parents')] 16 added, 0 changed, 0 removed
-reading sources... [100%] index
-/Users/bxyu/Documents/nemo-gym/nemo_gym/server_utils.py.rst:3: WARNING: Document headings start at H2, not H1 [myst.header]
-/Users/bxyu/Documents/nemo-gym/nemo_gym/server_utils.py.rst:3: WARNING: Document headings start at H2, not H1 [myst.header]
-/Users/bxyu/Documents/nemo-gym/README.md:: WARNING: image file not readable: resources/rl_verifiers_system_design.png [image.not_readable]
-looking for now-outdated files... none found
-pickling environment... done
-checking consistency... done
-```
-You may need to reformat some of your docstrings to Napoleon format docstrings https://sphinxcontrib-napoleon.readthedocs.io/en/v0.2/
+If the build-docs CI check fails, preview the Fern docs locally by running `fern docs dev` from the repository root. Common causes include broken markdown links, invalid MDX syntax, or missing frontmatter in new pages.
 
 # FAQ: Monotonic (Strictly-Increasing) Trajectories
 


### PR DESCRIPTION
Replace sphinx-build instructions with Fern workflow, update broken redirect destination, clean up stale _nav_order.yml entries, and remove obsolete Sphinx FAQ section from both doc versions.