### PR TITLE
Update ns_tools to use NeMo Skills nemo-skills-tools subpackage

### DIFF
--- a/resources_servers/ns_tools/README.md
+++ b/resources_servers/ns_tools/README.md
@@ -88,5 +88,5 @@ Code: Apache 2.0
 
 Dependencies
 - nemo_gym: Apache 2.0
-- nemo_skills-core: Apache 2.0
+- nemo-skills-tools: Apache 2.0
 - math-verify: [Apache 2.0](https://github.com/huggingface/Math-Verify/blob/5d148cfaaf99214c2e4ffb4bc497ab042c592a7a/LICENCE)

--- a/resources_servers/ns_tools/README.md
+++ b/resources_servers/ns_tools/README.md
@@ -70,7 +70,7 @@ python prepare_dataset.py \
     --input /path/to/nemo_skills/dataset/comp-math-24-25/test.txt \
     --output data/compmath_prepared.jsonl \
     --prompt_config generic/math \
-    --tools nemo_skills.mcp.servers.python_tool.PythonTool \
+    --tools nemo_skills.mcp.servers.python_tool::DirectPythonTool \
     --verifier_type math_with_judge
 ```
 
@@ -88,5 +88,5 @@ Code: Apache 2.0
 
 Dependencies
 - nemo_gym: Apache 2.0
-- nemo_skills: Apache 2.0
+- nemo_skills-core: Apache 2.0
 - math-verify: [Apache 2.0](https://github.com/huggingface/Math-Verify/blob/5d148cfaaf99214c2e4ffb4bc497ab042c592a7a/LICENCE)

--- a/resources_servers/ns_tools/app.py
+++ b/resources_servers/ns_tools/app.py
@@ -17,11 +17,12 @@
 NeMo Skills Tools Resources Server.
 
 This resources server provides:
-- Integration with nemo_skills ToolManager for tool execution (e.g., PythonTool)
+- Integration with nemo_skills ToolManager for tool execution (e.g., DirectPythonTool)
 - Verification delegation to math_with_judge
 """
 
 import asyncio
+import inspect
 import json
 import logging
 import subprocess
@@ -34,6 +35,7 @@ import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import PlainTextResponse
 from nemo_skills.mcp.tool_manager import ToolManager
+from nemo_skills.mcp.utils import locate
 from pydantic import ConfigDict, Field
 
 from nemo_gym.base_resources_server import (
@@ -65,7 +67,7 @@ class NSToolsConfig(BaseResourcesServerConfig):
     # At minimum, should include math_with_judge
     verifiers: Dict[str, ResourcesServerRef] = Field(default_factory=dict)
 
-    # NeMo Skills tool modules to load (e.g., "nemo_skills.mcp.servers.python_tool.PythonTool")
+    # NeMo Skills tool modules to load (e.g., "nemo_skills.mcp.servers.python_tool::DirectPythonTool")
     nemo_skills_tools: List[str] = Field(default_factory=list)
 
     # Per-tool overrides for nemo_skills tools
@@ -75,7 +77,7 @@ class NSToolsConfig(BaseResourcesServerConfig):
     sandbox_host: str = "127.0.0.1"
     sandbox_port: str = "6000"
 
-    # python_tool HTTP server port (spawned automatically)
+    # Legacy python_tool HTTP server port (only used for pre-main HTTP PythonTool variants)
     python_tool_port: int = 8765
 
     # Verbose logging for tool execution timing (disabled by default)
@@ -132,14 +134,19 @@ class NSToolsResourcesServer(SimpleResourcesServer):
     _tool_name_map: Dict[str, str] = {}  # Maps tool names to qualified names
     _python_tool_process: Optional[subprocess.Popen] = None
     _timing_by_session: Dict[str, list] = {}  # session_id -> list of timing records
+    _uses_python_tool_sidecar: bool = False
 
     def setup_webserver(self) -> FastAPI:
         app = super().setup_webserver()
 
         # Initialize nemo_skills ToolManager if tools are configured
         if self.config.nemo_skills_tools:
-            # Start the python_tool HTTP server first
-            self._start_python_tool_server()
+            self._uses_python_tool_sidecar = any(
+                self._tool_uses_python_tool_sidecar(tool_spec) for tool_spec in self.config.nemo_skills_tools
+            )
+            if self._uses_python_tool_sidecar:
+                # Legacy HTTP PythonTool variants require a local sidecar process.
+                self._start_python_tool_server()
             self._initialize_nemo_skills_tools()
 
             # Register a catch-all endpoint for tool execution
@@ -148,9 +155,20 @@ class NSToolsResourcesServer(SimpleResourcesServer):
 
         return app
 
+    def _tool_uses_python_tool_sidecar(self, tool_spec: str) -> bool:
+        """Detect whether a tool spec refers to the legacy HTTP-backed PythonTool."""
+        tool_cls_or_obj = locate(tool_spec)
+        tool = tool_cls_or_obj() if inspect.isclass(tool_cls_or_obj) else tool_cls_or_obj
+        if tool.__class__.__name__ != "PythonTool":
+            return False
+
+        default_config = tool.default_config()
+        client_params = default_config.get("client_params", {})
+        return "base_url" in client_params
+
     def _start_python_tool_server(self):
-        """Spawn python_tool HTTP server as a subprocess."""
-        logger.info(f"Starting python_tool HTTP server on port {self.config.python_tool_port}")
+        """Spawn the legacy python_tool HTTP sidecar as a subprocess."""
+        logger.info("Starting legacy python_tool HTTP server on port %s", self.config.python_tool_port)
 
         # Build command with sandbox config
         cmd = [
@@ -178,7 +196,7 @@ class NSToolsResourcesServer(SimpleResourcesServer):
         logger.info(f"python_tool HTTP server started (PID: {self._python_tool_process.pid})")
 
     def _wait_for_server_ready(self, timeout: float = 30.0, poll_interval: float = 0.5):
-        """Wait for the python_tool HTTP server to be ready."""
+        """Wait for the legacy python_tool HTTP sidecar to be ready."""
         url = f"http://127.0.0.1:{self.config.python_tool_port}/mcp"
         start_time = time.time()
 
@@ -234,14 +252,20 @@ class NSToolsResourcesServer(SimpleResourcesServer):
                 "sandbox_type": "local",
                 "host": self.config.sandbox_host,
                 "port": self.config.sandbox_port,
+                "disable_session_restore": self.config.disable_session_restore,
             }
         }
 
-        # Merge in PythonTool URL override to point to our spawned HTTP server
-        overrides = dict(self.config.nemo_skills_tool_overrides)
-        python_tool_url = f"http://127.0.0.1:{self.config.python_tool_port}/mcp"
-        overrides.setdefault("PythonTool", {})
-        overrides["PythonTool"]["client_params"] = {"base_url": python_tool_url}
+        overrides = {
+            tool_name: dict(tool_config) for tool_name, tool_config in self.config.nemo_skills_tool_overrides.items()
+        }
+        if self._uses_python_tool_sidecar:
+            # Legacy HTTP PythonTool expects an explicit sidecar URL.
+            python_tool_url = f"http://127.0.0.1:{self.config.python_tool_port}/mcp"
+            overrides.setdefault("PythonTool", {})
+            client_params = dict(overrides["PythonTool"].get("client_params", {}))
+            client_params["base_url"] = python_tool_url
+            overrides["PythonTool"]["client_params"] = client_params
 
         self.tool_manager = ToolManager(
             module_specs=self.config.nemo_skills_tools,
@@ -424,7 +448,7 @@ class NSToolsResourcesServer(SimpleResourcesServer):
         if self.tool_manager:
             await self.tool_manager.shutdown()
 
-        # Terminate the python_tool subprocess
+        # Terminate the legacy python_tool subprocess if one was started.
         if self._python_tool_process:
             logger.info(f"Terminating python_tool server (PID: {self._python_tool_process.pid})")
             self._python_tool_process.terminate()

--- a/resources_servers/ns_tools/app.py
+++ b/resources_servers/ns_tools/app.py
@@ -156,7 +156,7 @@ class NSToolsResourcesServer(SimpleResourcesServer):
         return app
 
     def _tool_uses_python_tool_sidecar(self, tool_spec: str) -> bool:
-        """Detect whether a tool spec refers to the legacy HTTP-backed PythonTool."""
+        """Detect whether a tool spec refers to the HTTP-backed PythonTool."""
         tool_cls_or_obj = locate(tool_spec)
         tool = tool_cls_or_obj() if inspect.isclass(tool_cls_or_obj) else tool_cls_or_obj
         if tool.__class__.__name__ != "PythonTool":
@@ -167,8 +167,8 @@ class NSToolsResourcesServer(SimpleResourcesServer):
         return "base_url" in client_params
 
     def _start_python_tool_server(self):
-        """Spawn the legacy python_tool HTTP sidecar as a subprocess."""
-        logger.info("Starting legacy python_tool HTTP server on port %s", self.config.python_tool_port)
+        """Spawn the python_tool HTTP sidecar as a subprocess."""
+        logger.info("Starting python_tool HTTP server on port %s", self.config.python_tool_port)
 
         # Build command with sandbox config
         cmd = [
@@ -196,7 +196,7 @@ class NSToolsResourcesServer(SimpleResourcesServer):
         logger.info(f"python_tool HTTP server started (PID: {self._python_tool_process.pid})")
 
     def _wait_for_server_ready(self, timeout: float = 30.0, poll_interval: float = 0.5):
-        """Wait for the legacy python_tool HTTP sidecar to be ready."""
+        """Wait for the python_tool HTTP sidecar to be ready."""
         url = f"http://127.0.0.1:{self.config.python_tool_port}/mcp"
         start_time = time.time()
 
@@ -448,7 +448,7 @@ class NSToolsResourcesServer(SimpleResourcesServer):
         if self.tool_manager:
             await self.tool_manager.shutdown()
 
-        # Terminate the legacy python_tool subprocess if one was started.
+        # Terminate the python_tool subprocess if one was started.
         if self._python_tool_process:
             logger.info(f"Terminating python_tool server (PID: {self._python_tool_process.pid})")
             self._python_tool_process.terminate()

--- a/resources_servers/ns_tools/configs/ns_tools.yaml
+++ b/resources_servers/ns_tools/configs/ns_tools.yaml
@@ -24,12 +24,14 @@ ns_tools:
           name: math_with_judge
       
       # NeMo Skills tools to load
+      # DirectPythonTool is the main-compatible path: it calls the sandbox directly
+      # and avoids the legacy branch-only python_tool HTTP sidecar.
       nemo_skills_tools:
-        - nemo_skills.mcp.servers.python_tool.PythonTool
+        - nemo_skills.mcp.servers.python_tool::DirectPythonTool
       
       # Per-tool configuration overrides
       nemo_skills_tool_overrides:
-        PythonTool:
+        DirectPythonTool:
           exec_timeout_s: 10
 
       # Sandbox configuration

--- a/resources_servers/ns_tools/configs/ns_tools.yaml
+++ b/resources_servers/ns_tools/configs/ns_tools.yaml
@@ -24,8 +24,7 @@ ns_tools:
           name: math_with_judge
       
       # NeMo Skills tools to load
-      # DirectPythonTool is the main-compatible path: it calls the sandbox directly
-      # and avoids the legacy branch-only python_tool HTTP sidecar.
+      # DirectPythonTool is the preferred python tool path: it calls the sandbox directly
       nemo_skills_tools:
         - nemo_skills.mcp.servers.python_tool::DirectPythonTool
       

--- a/resources_servers/ns_tools/prepare_dataset.py
+++ b/resources_servers/ns_tools/prepare_dataset.py
@@ -24,7 +24,7 @@ Usage:
         --input /path/to/source.jsonl \
         --output /path/to/output.jsonl \
         --prompt_config generic/math \
-        --tools nemo_skills.mcp.servers.python_tool.PythonTool \
+        --tools nemo_skills.mcp.servers.python_tool::DirectPythonTool \
         --verifier_type math_with_judge
 
 Example:
@@ -32,7 +32,7 @@ Example:
         --input ~/nemo_skills/dataset/comp-math-24-25/test.txt \
         --output data/compmath_prepared.jsonl \
         --prompt_config generic/math \
-        --tools nemo_skills.mcp.servers.python_tool.PythonTool
+        --tools nemo_skills.mcp.servers.python_tool::DirectPythonTool
 """
 
 import argparse
@@ -77,8 +77,8 @@ def parse_args():
     parser.add_argument(
         "--tools",
         nargs="+",
-        default=["nemo_skills.mcp.servers.python_tool.PythonTool"],
-        help="List of tool module specs to include (e.g., nemo_skills.mcp.servers.python_tool.PythonTool)",
+        default=["nemo_skills.mcp.servers.python_tool::DirectPythonTool"],
+        help="List of tool module specs to include (e.g., nemo_skills.mcp.servers.python_tool::DirectPythonTool)",
     )
     parser.add_argument(
         "--verifier_type",

--- a/resources_servers/ns_tools/requirements.txt
+++ b/resources_servers/ns_tools/requirements.txt
@@ -1,2 +1,3 @@
 -e nemo-gym[dev] @ ../../
-nemo-skills-tools @ git+https://github.com/NVIDIA-NeMo/Skills.git@01f4c48c8afb0acff85c3a22a7e1a88ede163868#subdirectory=tools
+## NeMo-Skills tools subpackage as of April 8, 2026
+nemo-skills-tools @ git+https://github.com/NVIDIA-NeMo/Skills.git@0596dd20cf9ce338a9a4f1e0010fd67ceb1bb4e6#subdirectory=tools

--- a/resources_servers/ns_tools/requirements.txt
+++ b/resources_servers/ns_tools/requirements.txt
@@ -1,2 +1,2 @@
 -e nemo-gym[dev] @ ../../
-nemo-skills-tools @ git+https://github.com/NVIDIA-NeMo/Skills.git@de07233e49bddcb2404558f1db307f00e610346f#subdirectory=tools
+nemo-skills-tools @ git+https://github.com/NVIDIA-NeMo/Skills.git@01f4c48c8afb0acff85c3a22a7e1a88ede163868#subdirectory=tools

--- a/resources_servers/ns_tools/requirements.txt
+++ b/resources_servers/ns_tools/requirements.txt
@@ -1,2 +1,2 @@
 -e nemo-gym[dev] @ ../../
-nemo-skills @ git+https://github.com/NVIDIA-NeMo/Skills.git@georgea/super-rl-02062026
+nemo-skills-tools @ git+https://github.com/NVIDIA-NeMo/Skills.git@de07233e49bddcb2404558f1db307f00e610346f#subdirectory=tools

--- a/resources_servers/ns_tools/tests/test_app.py
+++ b/resources_servers/ns_tools/tests/test_app.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from app import (
     NSToolsConfig,
@@ -54,6 +54,30 @@ class TestApp:
         assert len(server.config.verifiers) == 1
         assert "math_with_judge" in server.config.verifiers
         assert server.config.default_verifier == "math_with_judge"
+
+    def test_tool_sidecar_detection(self) -> None:
+        """Legacy HTTP PythonTool variants require a sidecar; direct tools do not."""
+
+        class PythonTool:
+            def default_config(self):
+                return {"client_params": {"base_url": "http://127.0.0.1:8765/mcp"}}
+
+        class DirectPythonTool:
+            def default_config(self):
+                return {"sandbox": {}}
+
+        server = NSToolsResourcesServer(
+            config=NSToolsConfig(host="0.0.0.0", port=8080, entrypoint="", name="ns_tools"),
+            server_client=MagicMock(spec=ServerClient),
+        )
+
+        with patch("app.locate", return_value=PythonTool):
+            assert server._tool_uses_python_tool_sidecar("legacy.python_tool.PythonTool") is True
+
+        with patch("app.locate", return_value=DirectPythonTool):
+            assert (
+                server._tool_uses_python_tool_sidecar("nemo_skills.mcp.servers.python_tool::DirectPythonTool") is False
+            )
 
     async def test_verify_delegates_to_math_with_judge(self) -> None:
         """Test that verification is delegated to math_with_judge verifier."""


### PR DESCRIPTION
Rebase Gym onto recent NeMo Skills main to pick up the nemo-skills-tools subpackage (DirectPythonTool, HTTP transport for python_tool), and pin the ns_tools requirements.txt to a compatible Skills commit.  This enables ns_tools to use DirectPythonTool directly instead of the MCP stdio transport path.