### PR TITLE
fix: Revert package info version to 0.3.0.rc0

### DIFF
--- a/nemo_gym/package_info.py
+++ b/nemo_gym/package_info.py
@@ -15,9 +15,9 @@
 
 
 MAJOR = 0
-MINOR = 2
-PATCH = 1
-PRE_RELEASE = ""
+MINOR = 3
+PATCH = 0
+PRE_RELEASE = "rc0"
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)


### PR DESCRIPTION
fix: Revert package info version to 0.3.0.rc0

On main branch, we set package version to 0.2.1 inadvertently. It didn't cause any problems initially. But it caused the wheel install test to fail after 0.2.1 was actually released. This is because the gym environments would refer to the actual published nemo gym 0.2.1 instead of the local one being tested.