### PR TITLE
feat: add aime26 benchmark (symbolic-only, MathArena source)

### DIFF
--- a/benchmarks/aime26/README.md
+++ b/benchmarks/aime26/README.md
@@ -1,0 +1,26 @@
+# AIME 2026
+
+AIME 2026 (American Invitational Mathematics Examination) — 30 competition math problems requiring integer answers in [0, 999]. Verification uses symbolic math equivalence (`math_verify`) with an LLM judge fallback.
+
+## Prepare data
+
+```bash
+ng_prepare_benchmark "+config_paths=[benchmarks/aime26/config.yaml]"
+```
+
+## Run servers
+
+```bash
+config_paths="responses_api_models/vllm_model/configs/vllm_model.yaml,benchmarks/aime26/config.yaml"
+ng_run "+config_paths=[$config_paths]"
+```
+
+## Collect rollouts
+
+```bash
+ng_collect_rollouts \
+    +agent_name=aime26_math_with_judge_simple_agent \
+    +input_jsonl_fpath=benchmarks/aime26/data/aime26_benchmark.jsonl \
+    +output_jsonl_fpath=results/aime26_rollouts.jsonl \
+    +num_repeats=4
+```

--- a/benchmarks/aime26/config.yaml
+++ b/benchmarks/aime26/config.yaml
@@ -1,0 +1,20 @@
+# Chain to existing resource server + agent config
+config_paths:
+  - resources_servers/math_with_judge/configs/math_with_judge.yaml
+
+# We use `_inherit_from` directives to inherit from and not use the generic config above to ensure this benchmark config is isolated.
+aime26_math_with_judge_resources_server:
+  _inherit_from: math_with_judge
+
+aime26_math_with_judge_simple_agent:
+  _inherit_from: math_with_judge_simple_agent
+  responses_api_agents:
+    simple_agent:
+      resources_server:
+        name: aime26_math_with_judge_resources_server
+      datasets:
+      - name: aime26
+        type: benchmark
+        jsonl_fpath: benchmarks/aime26/data/aime26_benchmark.jsonl
+        prompt_config: benchmarks/aime26/prompts/default.yaml
+        prepare_script: benchmarks/aime26/prepare.py

--- a/benchmarks/aime26/data/.gitignore
+++ b/benchmarks/aime26/data/.gitignore
@@ -1,0 +1,1 @@
+*benchmark.jsonl

--- a/benchmarks/aime26/prepare.py
+++ b/benchmarks/aime26/prepare.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Prepare AIME 2026 benchmark data.
+
+Downloads AIME 2026 problems from HuggingFace and converts them to the
+Gym benchmark JSONL format with `question` and `expected_answer` fields.
+"""
+
+import json
+from pathlib import Path
+
+from datasets import load_dataset
+
+
+BENCHMARK_DIR = Path(__file__).parent
+DATA_DIR = BENCHMARK_DIR / "data"
+OUTPUT_FPATH = DATA_DIR / "aime26_benchmark.jsonl"
+
+# HuggingFace dataset for AIME 2026
+HF_REPO_ID = "MathArena/aime_2026"
+
+
+def prepare() -> Path:
+    """Download and prepare AIME 2026 data. Returns the output file path."""
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading AIME 2026 data from {HF_REPO_ID}...")
+    ds = load_dataset(HF_REPO_ID, split="train")
+
+    count = 0
+    with open(OUTPUT_FPATH, "w") as f:
+        for row in ds:
+            out = {
+                "question": row["problem"],
+                "expected_answer": str(row["answer"]),
+            }
+            f.write(json.dumps(out) + "\n")
+            count += 1
+
+    print(f"Wrote {count} problems to {OUTPUT_FPATH}")
+    return OUTPUT_FPATH
+
+
+if __name__ == "__main__":
+    prepare()

--- a/benchmarks/aime26/prompts/default.yaml
+++ b/benchmarks/aime26/prompts/default.yaml
@@ -1,0 +1,2 @@
+system: "Your task is to solve a math problem.  Make sure to put the answer (and only the answer) inside \\boxed{{}}."
+user: "{question}"


### PR DESCRIPTION
Migrates aime26 from NeMo Skills (`nemo_skills/dataset/aime26/`) into Gym.