### PR TITLE
fix: serialize concurrent venv setup with flock to avoid uv seed-package race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.venv.lock
 env/
 venv/
 ENV/

--- a/nemo_gym/cli_setup_command.py
+++ b/nemo_gym/cli_setup_command.py
@@ -177,12 +177,17 @@ def setup_env_command(dir_path: Path, global_config_dict: DictConfig, prefix: st
         #     .venv/lib/python3.12/site-packages/pip-26.0.1.dist-info/RECORD
         # Serialize venv setup with `flock` keyed on a lockfile next to the venv;
         # re-source the activate script after the lock so the python entrypoint
-        # downstream still inherits the venv in the parent shell.
+        # downstream still inherits the venv in the parent shell. The `-w` timeout
+        # is well above any plausible cold-start install (heavy deps like vllm can
+        # take ~10 min and queued waiters mostly hit a warm cache afterwards) but
+        # bounded so a stuck lock holder fails loudly rather than hangs forever.
         lock_path = f"{venv_path}.lock"
+        lock_timeout_seconds = 1800
         inner_setup = f"{uv_venv_cmd}{prefix_cmd} && source {venv_activate_fpath} && {install_cmd}{prefix_cmd}"
         env_setup_cmd = (
             f"mkdir -p {shlex.quote(str(venv_path.parent))}"
-            f" && flock -x {shlex.quote(lock_path)} bash -c {shlex.quote(inner_setup)}"
+            f" && flock -w {lock_timeout_seconds} -x {shlex.quote(lock_path)}"
+            f" bash -c {shlex.quote(inner_setup)}"
             f" && source {venv_activate_fpath}"
         )
 

--- a/nemo_gym/cli_setup_command.py
+++ b/nemo_gym/cli_setup_command.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import importlib.metadata
 import os
+import shlex
 from os import environ
 from pathlib import Path
 from subprocess import Popen
@@ -167,7 +168,23 @@ def setup_env_command(dir_path: Path, global_config_dict: DictConfig, prefix: st
             )
 
         prefix_cmd = f" > >(sed 's/^/({prefix}) /') 2> >(sed 's/^/({prefix}) /' >&2)"
-        env_setup_cmd = f"{uv_venv_cmd}{prefix_cmd} && source {venv_activate_fpath} && {install_cmd}{prefix_cmd}"
+        # Multiple server instances can share a server-type directory (e.g., several
+        # `vllm_model` servers) and therefore the same target `.venv`. Concurrent
+        # `uv venv --seed --allow-existing` invocations on the same target dir race
+        # during pip-seed install/uninstall and crash with
+        #   Failed to uninstall build dependencies
+        #   Cannot uninstall package; `RECORD` file not found at:
+        #     .venv/lib/python3.12/site-packages/pip-26.0.1.dist-info/RECORD
+        # Serialize venv setup with `flock` keyed on a lockfile next to the venv;
+        # re-source the activate script after the lock so the python entrypoint
+        # downstream still inherits the venv in the parent shell.
+        lock_path = f"{venv_path}.lock"
+        inner_setup = f"{uv_venv_cmd}{prefix_cmd} && source {venv_activate_fpath} && {install_cmd}{prefix_cmd}"
+        env_setup_cmd = (
+            f"mkdir -p {shlex.quote(str(venv_path.parent))}"
+            f" && flock -x {shlex.quote(lock_path)} bash -c {shlex.quote(inner_setup)}"
+            f" && source {venv_activate_fpath}"
+        )
 
     return f"cd {dir_path} && {env_setup_cmd}"
 

--- a/tests/unit_tests/test_cli_setup_command.py
+++ b/tests/unit_tests/test_cli_setup_command.py
@@ -47,10 +47,12 @@ class TestCLISetupCommandSetupEnvCommand:
     def _wrap_setup(server_dir: Path, venv_path: Path, inner_setup: str) -> str:
         """Mirror the production wrapping: serialize venv setup with flock keyed on a per-venv lockfile."""
         lock_path = f"{venv_path}.lock"
+        lock_timeout_seconds = 1800
         return (
             f"cd {server_dir} && "
             f"mkdir -p {shlex.quote(str(venv_path.parent))}"
-            f" && flock -x {shlex.quote(lock_path)} bash -c {shlex.quote(inner_setup)}"
+            f" && flock -w {lock_timeout_seconds} -x {shlex.quote(lock_path)}"
+            f" bash -c {shlex.quote(inner_setup)}"
             f" && source {venv_path}/bin/activate"
         )
 
@@ -316,7 +318,8 @@ class TestCLISetupCommandSetupEnvCommand:
         # Lockfile sits next to the target venv so the per-venv-path serialization is unambiguous.
         venv_path = server_dir / ".venv"
         expected_lock = f"{venv_path}.lock"
-        assert f"flock -x {shlex.quote(expected_lock)} bash -c " in actual_command, actual_command
+        # `-w 1800` bounds the wait so a stuck lock holder fails loudly instead of hanging forever.
+        assert f"flock -w 1800 -x {shlex.quote(expected_lock)} bash -c " in actual_command, actual_command
         # Activate is re-sourced after the locked subshell so the python entrypoint downstream
         # inherits the venv in the parent shell.
         assert actual_command.endswith(f" && source {venv_path}/bin/activate")

--- a/tests/unit_tests/test_cli_setup_command.py
+++ b/tests/unit_tests/test_cli_setup_command.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib.metadata
+import shlex
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -42,6 +43,17 @@ class TestCLISetupCommandSetupEnvCommand:
     def _debug_global_config_dict(self, tmp_path: Path) -> dict:
         return _TestGlobalConfig._default_global_config_dict_values.fget(None) | {UV_VENV_DIR_KEY_NAME: str(tmp_path)}
 
+    @staticmethod
+    def _wrap_setup(server_dir: Path, venv_path: Path, inner_setup: str) -> str:
+        """Mirror the production wrapping: serialize venv setup with flock keyed on a per-venv lockfile."""
+        lock_path = f"{venv_path}.lock"
+        return (
+            f"cd {server_dir} && "
+            f"mkdir -p {shlex.quote(str(venv_path.parent))}"
+            f" && flock -x {shlex.quote(lock_path)} bash -c {shlex.quote(inner_setup)}"
+            f" && source {venv_path}/bin/activate"
+        )
+
     def test_sanity(self, tmp_path: Path) -> None:
         server_dir = self._setup_server_dir(tmp_path)
 
@@ -50,7 +62,14 @@ class TestCLISetupCommandSetupEnvCommand:
             global_config_dict=self._debug_global_config_dict(tmp_path),
             prefix="my server name",
         )
-        expected_command = f"cd {server_dir} && uv venv --seed --allow-existing --python test python version {server_dir}/.venv > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2) && source {server_dir}/.venv/bin/activate && uv pip install -r requirements.txt ray[default]==test ray version openai==test openai version > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        inner_setup = (
+            f"uv venv --seed --allow-existing --python test python version {server_dir}/.venv"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+            f" && source {server_dir}/.venv/bin/activate"
+            f" && uv pip install -r requirements.txt ray[default]==test ray version openai==test openai version"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        )
+        expected_command = self._wrap_setup(server_dir, server_dir / ".venv", inner_setup)
         assert expected_command == actual_command
 
     def test_skips_install_when_venv_present(self, tmp_path: Path) -> None:
@@ -83,7 +102,14 @@ class TestCLISetupCommandSetupEnvCommand:
             prefix="my server name",
         )
 
-        expected_command = f"cd {server_dir} && uv venv --seed --allow-existing --python test python version {server_dir}/.venv > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2) && source {server_dir}/.venv/bin/activate && uv pip install -r requirements.txt ray[default]==test ray version openai==test openai version > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        inner_setup = (
+            f"uv venv --seed --allow-existing --python test python version {server_dir}/.venv"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+            f" && source {server_dir}/.venv/bin/activate"
+            f" && uv pip install -r requirements.txt ray[default]==test ray version openai==test openai version"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        )
+        expected_command = self._wrap_setup(server_dir, server_dir / ".venv", inner_setup)
         assert expected_command == actual_command
 
     def test_head_server_deps(self, tmp_path: Path) -> None:
@@ -94,7 +120,14 @@ class TestCLISetupCommandSetupEnvCommand:
             global_config_dict=self._debug_global_config_dict(tmp_path) | {"head_server_deps": ["dep 1", "dep 2"]},
             prefix="my server name",
         )
-        expected_command = f"cd {server_dir} && uv venv --seed --allow-existing --python test python version {server_dir}/.venv > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2) && source {server_dir}/.venv/bin/activate && uv pip install -r requirements.txt dep 1 dep 2 > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        inner_setup = (
+            f"uv venv --seed --allow-existing --python test python version {server_dir}/.venv"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+            f" && source {server_dir}/.venv/bin/activate"
+            f" && uv pip install -r requirements.txt dep 1 dep 2"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        )
+        expected_command = self._wrap_setup(server_dir, server_dir / ".venv", inner_setup)
         assert expected_command == actual_command
 
     def test_python_version(self, tmp_path: Path) -> None:
@@ -105,7 +138,14 @@ class TestCLISetupCommandSetupEnvCommand:
             global_config_dict=self._debug_global_config_dict(tmp_path) | {"python_version": "my python version"},
             prefix="my server name",
         )
-        expected_command = f"cd {server_dir} && uv venv --seed --allow-existing --python my python version {server_dir}/.venv > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2) && source {server_dir}/.venv/bin/activate && uv pip install -r requirements.txt ray[default]==test ray version openai==test openai version > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        inner_setup = (
+            f"uv venv --seed --allow-existing --python my python version {server_dir}/.venv"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+            f" && source {server_dir}/.venv/bin/activate"
+            f" && uv pip install -r requirements.txt ray[default]==test ray version openai==test openai version"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        )
+        expected_command = self._wrap_setup(server_dir, server_dir / ".venv", inner_setup)
         assert expected_command == actual_command
 
     def test_uv_pip_set_python(self, tmp_path: Path) -> None:
@@ -116,7 +156,14 @@ class TestCLISetupCommandSetupEnvCommand:
             global_config_dict=self._debug_global_config_dict(tmp_path) | {"uv_pip_set_python": True},
             prefix="my server name",
         )
-        expected_command = f"cd {server_dir} && uv venv --seed --allow-existing --python test python version {server_dir}/.venv > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2) && source {server_dir}/.venv/bin/activate && uv pip install --python {server_dir}/.venv/bin/python -r requirements.txt ray[default]==test ray version openai==test openai version > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        inner_setup = (
+            f"uv venv --seed --allow-existing --python test python version {server_dir}/.venv"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+            f" && source {server_dir}/.venv/bin/activate"
+            f" && uv pip install --python {server_dir}/.venv/bin/python -r requirements.txt ray[default]==test ray version openai==test openai version"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        )
+        expected_command = self._wrap_setup(server_dir, server_dir / ".venv", inner_setup)
         assert expected_command == actual_command
 
     def test_pip_install_verbose(self, tmp_path: Path) -> None:
@@ -127,7 +174,14 @@ class TestCLISetupCommandSetupEnvCommand:
             global_config_dict=self._debug_global_config_dict(tmp_path) | {"pip_install_verbose": True},
             prefix="my server name",
         )
-        expected_command = f"cd {server_dir} && uv venv --seed --allow-existing --python test python version {server_dir}/.venv > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2) && source {server_dir}/.venv/bin/activate && uv pip install -v -r requirements.txt ray[default]==test ray version openai==test openai version > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        inner_setup = (
+            f"uv venv --seed --allow-existing --python test python version {server_dir}/.venv"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+            f" && source {server_dir}/.venv/bin/activate"
+            f" && uv pip install -v -r requirements.txt ray[default]==test ray version openai==test openai version"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        )
+        expected_command = self._wrap_setup(server_dir, server_dir / ".venv", inner_setup)
         assert expected_command == actual_command
 
     def test_pyproject_requirements_raises_error(self, tmp_path: Path) -> None:
@@ -162,7 +216,14 @@ class TestCLISetupCommandSetupEnvCommand:
             global_config_dict=self._debug_global_config_dict(tmp_path),
             prefix="my server name",
         )
-        expected_command = f"cd {server_dir} && uv venv --seed --allow-existing --python test python version {server_dir}/.venv > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2) && source {server_dir}/.venv/bin/activate && uv pip install '-e .' ray[default]==test ray version openai==test openai version > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        inner_setup = (
+            f"uv venv --seed --allow-existing --python test python version {server_dir}/.venv"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+            f" && source {server_dir}/.venv/bin/activate"
+            f" && uv pip install '-e .' ray[default]==test ray version openai==test openai version"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        )
+        expected_command = self._wrap_setup(server_dir, server_dir / ".venv", inner_setup)
         assert expected_command == actual_command
 
     def test_uv_venv_dir_with_install(self, tmp_path: Path) -> None:
@@ -175,7 +236,15 @@ class TestCLISetupCommandSetupEnvCommand:
             global_config_dict=self._debug_global_config_dict(tmp_path) | {"uv_venv_dir": str(uv_venv_dir)},
             prefix="my server name",
         )
-        expected_command = f"cd {server_dir} && uv venv --seed --allow-existing --python test python version {uv_venv_dir}/first_level/second_level/.venv > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2) && source {uv_venv_dir}/first_level/second_level/.venv/bin/activate && uv pip install -r requirements.txt ray[default]==test ray version openai==test openai version > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        venv_path = uv_venv_dir / "first_level/second_level/.venv"
+        inner_setup = (
+            f"uv venv --seed --allow-existing --python test python version {venv_path}"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+            f" && source {venv_path}/bin/activate"
+            f" && uv pip install -r requirements.txt ray[default]==test ray version openai==test openai version"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        )
+        expected_command = self._wrap_setup(server_dir, venv_path, inner_setup)
         assert expected_command == actual_command
 
     @pytest.mark.parametrize("version", ["0.3.0", "0.3.0rc0", "1.0.0", "2.1.3rc1"])
@@ -196,7 +265,14 @@ class TestCLISetupCommandSetupEnvCommand:
                 global_config_dict=self._debug_global_config_dict(tmp_path),
                 prefix="my server name",
             )
-        expected_command = f"cd {server_dir} && uv venv --seed --allow-existing --python test python version {server_dir}/.venv > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2) && source {server_dir}/.venv/bin/activate && (echo 'nemo-gym=={version}' && grep -v -F '../..' requirements.txt) | uv pip install -r /dev/stdin ray[default]==test ray version openai==test openai version > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        inner_setup = (
+            f"uv venv --seed --allow-existing --python test python version {server_dir}/.venv"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+            f" && source {server_dir}/.venv/bin/activate"
+            f" && (echo 'nemo-gym=={version}' && grep -v -F '../..' requirements.txt) | uv pip install -r /dev/stdin ray[default]==test ray version openai==test openai version"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        )
+        expected_command = self._wrap_setup(server_dir, server_dir / ".venv", inner_setup)
         assert expected_command == actual_command
 
     @pytest.mark.parametrize("version", ["0.3.0", "0.3.0rc0", "1.0.0", "2.1.3rc1"])
@@ -217,8 +293,33 @@ class TestCLISetupCommandSetupEnvCommand:
                 global_config_dict=self._debug_global_config_dict(tmp_path),
                 prefix="my server name",
             )
-        expected_command = f"cd {server_dir} && uv venv --seed --allow-existing --python test python version {server_dir}/.venv > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2) && source {server_dir}/.venv/bin/activate && uv pip install nemo-gym=={version} && uv pip install --no-sources '-e .' ray[default]==test ray version openai==test openai version > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        inner_setup = (
+            f"uv venv --seed --allow-existing --python test python version {server_dir}/.venv"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+            f" && source {server_dir}/.venv/bin/activate"
+            f" && uv pip install nemo-gym=={version} && uv pip install --no-sources '-e .' ray[default]==test ray version openai==test openai version"
+            f" > >(sed 's/^/(my server name) /') 2> >(sed 's/^/(my server name) /' >&2)"
+        )
+        expected_command = self._wrap_setup(server_dir, server_dir / ".venv", inner_setup)
         assert expected_command == actual_command
+
+    def test_serializes_concurrent_venv_setup_with_flock(self, tmp_path: Path) -> None:
+        """Multiple servers can target the same .venv; flock must serialize the racy seed-package phase."""
+        server_dir = self._setup_server_dir(tmp_path)
+
+        actual_command = setup_env_command(
+            dir_path=server_dir,
+            global_config_dict=self._debug_global_config_dict(tmp_path),
+            prefix="my server name",
+        )
+
+        # Lockfile sits next to the target venv so the per-venv-path serialization is unambiguous.
+        venv_path = server_dir / ".venv"
+        expected_lock = f"{venv_path}.lock"
+        assert f"flock -x {shlex.quote(expected_lock)} bash -c " in actual_command, actual_command
+        # Activate is re-sourced after the locked subshell so the python entrypoint downstream
+        # inherits the venv in the parent shell.
+        assert actual_command.endswith(f" && source {venv_path}/bin/activate")
 
     def test_uv_venv_dir_and_skip_install_when_venv_present(self, tmp_path: Path) -> None:
         server_dir = self._setup_server_dir(tmp_path)


### PR DESCRIPTION
## Problem

Multiple server instances can share a server-type directory (e.g. several `vllm_model`-based servers — `policy_model`, `policy_model_reasoning_off`, and a Qwen3-style reference judge) and therefore the same target `.venv`. The Gym head spawns those server processes concurrently. On a **cold uv cache** they all enter `setup_env_command` at the same time, each running

```
uv venv --seed --allow-existing --python <ver> <same_path>/.venv
```

against the **same target directory**. uv's seed-install phase installs `pip 26.0.1` then upgrades to `pip 26.1` and uninstalls `26.0.1`'s metadata — and that uninstall is not safe under multiple concurrent writers on the same path. All but one process crashes:

```
error: Failed to install seed packages into virtual environment
  Caused by: Failed to uninstall build dependencies
  Caused by: Cannot uninstall package; `RECORD` file not found at:
             .venv/lib/python3.12/site-packages/pip-26.0.1.dist-info/RECORD
```

The Gym head then declares the dependent server "finished unexpectedly" and tears down the whole rollout collection. Cache-warming doesn't help because the race is on the venv target dir, not the cache. The existing `skip_venv_if_present` knob only helps after the **first** successful run — chicken/egg on the cold-start path.

Real-world repro on HSG (Nemotron Ultra V3 / GDPVal Stirrup pipeline, 2026-04-27):

```
(Qwen3-235B-A22B-Instruct-2507-FP8)   Caused by: Cannot uninstall package; `RECORD` file not found …
(policy_model_reasoning_off)          Caused by: Cannot uninstall package; `RECORD` file not found …
(policy_model)                        Caused by: Cannot uninstall package; `RECORD` file not found …
…
RuntimeError: Process \`policy_model\` finished unexpectedly!
```

(Other concurrent servers using *different* server-type directories — `gdpval_judge_model`, `gdpval_stirrup_agent`, `gdpval_resources_server`, `allenai_wildguard_model_server` — succeeded in the same run, confirming the race is per-target-dir, not per-process.)

## Fix

Wrap the `uv venv` + `source` + `uv pip install` chain inside `flock -x <venv>.lock bash -c '…'` so the racy seed-install phase serializes per target venv path. After the locked subshell exits, re-`source` the activate script in the parent shell so the python entrypoint downstream still inherits the venv.

Touched: `nemo_gym/cli_setup_command.py:setup_env_command`. Lockfile lives next to the venv (e.g., `responses_api_models/vllm_model/.venv.lock`); a `mkdir -p` precedes flock so the lock file's parent dir always exists (handles the `uv_venv_dir` non-default case).

## Tests

- All 9 existing `setup_env_command` string-equality tests updated via a small `_wrap_setup` helper that mirrors the production wrapping (so adding more flags later doesn't drift).
- New `test_serializes_concurrent_venv_setup_with_flock` documents the intent: lockfile path is `<venv>.lock`, command contains the `flock -x <lockfile> bash -c` prefix, command ends with the re-`source` of activate.
- `pytest tests/unit_tests/` → 203 passed.
- `ruff check` / `ruff format --check` clean.

## Notes for reviewers

- This is the cold-cache complement to `skip_venv_if_present`. Once a venv is fully created, subsequent process startups still pass through the lock but the inner `uv venv --allow-existing` is a no-op and the `uv pip install` is a fast cache-hit — so the steady-state cost is small.
- `flock` is util-linux; assumed available everywhere Gym runs (sandbox container, slurm nodes, dev VMs). If anyone runs on a stripped image without it we should hear early.
- Not enabled behind a flag because the current behaviour is unsafe; staying default-on. Happy to gate behind a config knob if reviewers want a fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)