### PR TITLE
fix(stirrup_agent): pin Ray worker venv via runtime_env (fixes GDPVal reward=0)

### DIFF
--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import shutil
+import sys
 import tempfile
 import time
 from asyncio import Semaphore
@@ -114,7 +115,17 @@ def _build_gdpval_user_prompt(task_prompt: str, input_files_dir: Optional[str] =
     return _GDPVAL_PROMPT_TEMPLATE.format(task=task_prompt, reference_files=files_section)
 
 
-@ray.remote(scheduling_strategy="SPREAD")
+# Pin the Ray worker to this server's venv (same pattern as
+# swe_agents / harbor_agent / mini_swe_agent / code_gen / spider2_lite).
+# Without this, workers fall back to the cluster's default Python, which
+# does not have the per-server `stirrup` extra installed, and every
+# rollout dies with `ModuleNotFoundError: No module named 'stirrup'` at
+# the `from stirrup.tools import DEFAULT_TOOLS` import inside
+# `_run_stirrup_agent` below.
+@ray.remote(
+    scheduling_strategy="SPREAD",
+    runtime_env={"py_executable": sys.executable},
+)
 def run_stirrup_agent_remote(params: dict[str, Any]) -> Any:
     return asyncio.run(_run_stirrup_agent(**params))
 


### PR DESCRIPTION
## Problem

`responses_api_agents/stirrup_agent/app.py:117` decorates the Ray remote function with bare `@ray.remote(scheduling_strategy=\"SPREAD\")`, so Ray dispatches the task to workers using the cluster's default Python rather than the stirrup_agent server's `.venv`. The `stirrup>=0.1.7` extra is declared as an *extra of the stirrup_agent server*, not of core (intentionally, per PR #1090), so it's only present in `responses_api_agents/stirrup_agent/.venv` — not on Ray workers.

Every rollout therefore hits, at `_run_stirrup_agent` line 150:

```
from stirrup.tools import DEFAULT_TOOLS
```

with `ModuleNotFoundError: No module named 'stirrup'`. The agent catches the exception per-rollout, sets `reward=0.0`, and proceeds. The resources server then short-circuits without calling the judge.

## Fix

Add `runtime_env={\"py_executable\": sys.executable}` to the decorator, matching the well-established pattern in the rest of the codebase



## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] AST parse OK
- [ ] End-to-end re-run on the failing 220-task GDPVal config from the EFB side; will pin `install_on_the_fly.commit` to this branch's HEAD and post results in the linked GDPVal thread
- [ ] (Author of #1090 to confirm) — no other places where the bare `@ray.remote` pattern was intentional for stirrup specifically
