### PR TITLE
Add task-info logging to nemo_gym/rollout_collection.py through optional logging flag. + Add codex debugging skill

### DIFF
--- a/.codex/skills/nemo-gym-debugging/SKILL.md
+++ b/.codex/skills/nemo-gym-debugging/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: nemo-gym-debugging
+description: >-
+  Use when debugging a Nemo Gym run or reward profiling job. Covers rollout collection failures,
+  empty or partial JSONL outputs, stale materialized inputs, verifier/schema errors, Ray or Slurm
+  issues, vLLM readiness, judge failures, tool/sandbox failures, cache problems, and throughput
+  bottlenecks.
+---
+
+# Nemo Gym Debugging
+
+## Invocation Check
+
+Use this skill when something failed or looks suspicious in a Nemo Gym run. If the task is adding a new env, use `$nemo-gym-env-integration`; if it is changing profiling behavior, use `$nemo-gym-reward-profiling`.
+
+Debug by classification, not by guessing. The first goal is to decide whether the issue is:
+
+- infra: Slurm, Ray, container, filesystem, network, ports
+- model serving: vLLM startup/readiness/throughput
+- config: wrong config bundle, missing agent, wrong extra args
+- data/schema: JSONL fields do not match verifier/resource server expectations
+- verifier/runtime: resource server exception or malformed verify response
+- cache/resume: stale materialized inputs or partial rollout output
+- throughput/resources: concurrency too high, judge bottleneck, tool/sandbox latency
+
+## Debug Order
+
+1. Check Slurm/Ray job state and logs.
+2. Check vLLM readiness and `/models` availability.
+3. Check Gym server readiness: all expected servers started.
+4. Check tool routing if the env uses tools; check sandbox readiness only if a sandbox is configured.
+5. Check materialized inputs and source data timestamps.
+6. Check rollout output and profiling/metrics output counts.
+7. Inspect the first real verifier exception, not shutdown noise.
+8. Compare failing row schema against the resource server request model.
+
+## High-Value Suspects
+
+- If data changed and `resume_from_cache` was enabled, stale materialized inputs are a first-class suspect.
+- If rollout output has a few rows and profiling is empty, inspect verifier errors and partial-output cache.
+- If all servers are ready but verifier returns 422/500, inspect request body schema before debugging infra.
+- If tool envs hang or partially work, check tool ownership/loading before changing model settings; check sandbox readiness only when a sandbox is actually part of the env.
+- If tool-call rows fail before generation with vLLM grammar/schema errors, read `references/vllm-tool-call-schema-checks.md` and run a static tool-schema check before changing Gym wrappers.
+- If logs only show nested "inner server" 500s without the real provider/verifier body, first enable existing request-boundary visibility with `++global_aiohttp_client_request_debug=True`. Read `references/request-boundary-visibility.md` before changing code.
+
+## Reference Loading
+
+- Read `references/error-profiles.md` to classify the failing layer before changing code or data.
+- Read `references/diagnostic-snippets.md` when you need copy-paste commands to inspect logs, output counts, materialized inputs, rollout JSONL shape, server readiness, or reward summaries without mutating run state.
+- Read `references/vllm-tool-call-schema-checks.md` when a tool-call dataset may be rejected by vLLM/Outlines grammar compilation before any meaningful generation happens.
+- Read `references/request-boundary-visibility.md` when `/run` 500s hide row identity or nested Gym 500s hide the inner model/verifier/provider error. It covers the existing Gym debug flag, shipped request-boundary markers, empty provider bodies, and vLLM provider-side escalation.
+
+## Communication Pattern
+
+When reporting back, state:
+
+- observed symptom
+- failing layer
+- evidence from logs/files
+- likely cause
+- next concrete action

--- a/.codex/skills/nemo-gym-debugging/agents/openai.yaml
+++ b/.codex/skills/nemo-gym-debugging/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Nemo Gym Debugging"
+  short_description: "Triage Nemo Gym rollout and profiling failures"
+  default_prompt: "Use $nemo-gym-debugging to debug a Nemo Gym rollout, profiling, Ray, vLLM, sandbox, or verifier failure."

--- a/.codex/skills/nemo-gym-debugging/references/diagnostic-snippets.md
+++ b/.codex/skills/nemo-gym-debugging/references/diagnostic-snippets.md
@@ -1,0 +1,148 @@
+# Diagnostic Snippets
+
+Scope: packageable Nemo Gym debugging commands. Substitute paths before running.
+
+Prefer commands that read logs and JSONL files without mutating state. Do not remove caches or outputs until the stale-cache hypothesis is supported and the user agrees.
+
+## Find the First Useful Error
+
+```bash
+rg -n -C 4 "Traceback|Exception|ERROR|ValueError|KeyError|TypeError|Validation|Pydantic|Unprocessable|Verifier|verify|sandbox|Ray|vLLM|ready|died|timeout" PATH_TO_LOG | head -240
+```
+
+Shutdown `CancelledError` stacks are often secondary. Prefer the first verifier/resource-server exception before shutdown.
+
+## Boundary Diagnostic Logs
+
+Use this when request-boundary debug is enabled or when a log may contain Gym boundary markers.
+
+```bash
+rg -n -C 3 "\\[rollout_collection\\] /run failed|Request info:|Response content:|Request kwargs:|Hit an exception in|/run failed|/v1/responses failed" PATH_TO_LOG | head -240
+```
+
+If the useful inner body is still absent, read `request-boundary-visibility.md`.
+
+## Output Shape
+
+```bash
+wc -l PATH_TO_OUTPUT.jsonl PATH_TO_MATERIALIZED_INPUTS.jsonl PATH_TO_REWARD_PROFILE.jsonl 2>/dev/null
+stat -c '%y %s %n' PATH_TO_SOURCE.jsonl PATH_TO_MATERIALIZED_INPUTS.jsonl PATH_TO_OUTPUT.jsonl 2>/dev/null
+```
+
+Interpretation:
+
+- materialized inputs exist, rollout output missing: collection may not have started or output path changed
+- rollout output has very few rows: early verifier/runtime failure or cancellation
+- materialized inputs older than source data: suspect stale cache
+- profiling/metrics missing while rollouts exist: profiling step or reward profile command failed
+
+## JSONL Shape Summary
+
+```bash
+python - <<'PY'
+import json
+from collections import Counter
+p = "PATH_TO_JSONL"
+key_counts = Counter()
+type_counts = Counter()
+examples = {}
+with open(p) as f:
+    for i, line in enumerate(f, 1):
+        obj = json.loads(line)
+        key_counts.update(obj.keys())
+        for k, v in obj.items():
+            type_counts[(k, type(v).__name__)] += 1
+            examples.setdefault((k, type(v).__name__), (i, repr(v)[:300]))
+        if i >= 1000:
+            break
+print("keys", key_counts.most_common(40))
+print("types", type_counts.most_common(60))
+for (k, typ), (line, ex) in list(examples.items())[:20]:
+    print(k, typ, "line", line, ex)
+PY
+```
+
+## Compare Source and Materialized Rows
+
+```bash
+python - <<'PY'
+import json
+for p in ["PATH_TO_SOURCE.jsonl", "PATH_TO_MATERIALIZED_INPUTS.jsonl", "PATH_TO_OUTPUT.jsonl"]:
+    print("\\n", p)
+    try:
+        with open(p) as f:
+            for i, line in zip(range(2), f):
+                obj = json.loads(line)
+                print("row", i, sorted(obj.keys()))
+                for k in ["agent_ref", "responses_create_params", "verifier_type", "_ng_task_index", "_ng_rollout_index", "response", "reward"]:
+                    if k in obj:
+                        print(k, type(obj[k]).__name__, repr(obj[k])[:500])
+    except FileNotFoundError:
+        print("missing")
+PY
+```
+
+## Server Readiness Search
+
+```bash
+rg -n "All .* servers ready|Uvicorn running|/models|Started Ray cluster|Connected to Ray|Loaded .* tools|Sandbox ready|readiness timeout|connection_error|not ready" PATH_TO_LOG
+```
+
+If readiness succeeds and verifier schema errors follow, stop debugging Ray/vLLM and inspect data/config.
+
+## Per-File Log Overview
+
+```bash
+find PATH_TO_LOG_DIR -maxdepth 2 -type f | sort | sed -n '1,200p'
+wc -l PATH_TO_LOG_DIR/* 2>/dev/null | sort -n | tail -40
+```
+
+Use this to find the log that actually contains the first failure. Driver logs often show summaries; worker/resource logs often show the root exception.
+
+## Rollout Reward and Usage Probe
+
+```bash
+python - <<'PY'
+import json
+from collections import Counter
+p = "PATH_TO_ROLLOUTS.jsonl"
+rewards = Counter()
+usage_keys = Counter()
+missing_usage = 0
+with open(p) as f:
+    for i, line in enumerate(f, 1):
+        row = json.loads(line)
+        rewards[repr(row.get("reward"))] += 1
+        usage = (row.get("response") or {}).get("usage")
+        if not usage:
+            missing_usage += 1
+        else:
+            usage_keys.update(usage.keys())
+print("reward values", rewards.most_common(20))
+print("usage keys", usage_keys.most_common(20))
+print("missing usage", missing_usage)
+PY
+```
+
+## Materialized Identity Probe
+
+```bash
+python - <<'PY'
+import json
+from collections import Counter
+p = "PATH_TO_MATERIALIZED_INPUTS.jsonl"
+tasks = Counter()
+rollouts = Counter()
+with open(p) as f:
+    for line in f:
+        row = json.loads(line)
+        key = (row.get("_ng_task_index"), row.get("_ng_rollout_index"))
+        tasks[row.get("_ng_task_index")] += 1
+        rollouts[key] += 1
+print("num tasks", len(tasks))
+print("repeat count histogram", Counter(tasks.values()).most_common())
+print("duplicate task/rollout keys", [k for k, c in rollouts.items() if c > 1][:20])
+PY
+```
+
+If the target repo uses different global key names, inspect `nemo_gym/global_config.py` and substitute them.

--- a/.codex/skills/nemo-gym-debugging/references/error-profiles.md
+++ b/.codex/skills/nemo-gym-debugging/references/error-profiles.md
@@ -1,0 +1,319 @@
+# Error Profiles
+
+Scope: detailed Nemo Gym failure classification. Use this file after a run fails or behaves suspiciously.
+
+## Read Order
+
+Start with the first fatal error in time order, not the loudest shutdown stack. Then classify the layer:
+
+- Slurm/container/filesystem
+- Ray process layout
+- model serving/vLLM
+- Gym config/Hydra
+- resource server/verifier
+- data/schema/materialized cache
+- judge model
+- tool/sandbox
+- throughput/backpressure
+- profiling/postprocess
+
+If every visible error is a nested "Hit an exception in ... calling an inner server" 500 and the inner model/verifier/provider body is missing, use `request-boundary-visibility.md`. Start with existing request debug before adding temporary boundary logs.
+
+## Slurm, Container, Filesystem
+
+Symptoms:
+
+- job exits before Ray or Gym logs appear
+- `srun` reports container/image/mount errors
+- logs are missing, empty, or written in an unexpected directory
+- permissions or path-not-found errors appear before Python startup
+
+Likely causes:
+
+- wrong container image path
+- missing mount for data, cache, output, or sandbox temp directory
+- log directory not created before job start
+- submit environment did not export expected variables
+- base path differs between submit host and container
+
+Evidence to collect:
+
+- Slurm stdout/stderr
+- first 100 lines of driver/head/worker logs
+- resolved command and environment exports, if logged
+- `stat`/`ls` on data, output, and log dirs
+
+Next actions:
+
+- fix image/mount/log/export before touching Gym code
+- make log paths explicit and env-controlled in launchers
+- avoid CPU-only submit paths when the run requires model GPUs
+
+## Ray Layout
+
+Symptoms:
+
+- head starts but workers never join
+- worker logs show connection refused to Ray head
+- resources are fewer than expected
+- driver waits indefinitely for placement/resources
+
+Likely causes:
+
+- wrong head node address
+- worker `srun` excluded or included wrong nodes
+- container networking mismatch
+- GPUs not visible inside worker containers
+- single-node vs multi-node logic mismatch
+
+Evidence to collect:
+
+- head log readiness line
+- worker logs around Ray start
+- resource summary from the driver, if available
+- Slurm node allocation
+
+Next actions:
+
+- verify head and worker launch commands separately
+- distinguish "no worker needed" single-node behavior from failed multi-node registration
+- do not debug env data until Ray resources are sane
+
+## vLLM or Policy Model Serving
+
+Symptoms:
+
+- `/models` never becomes available
+- rollout requests fail with connection errors
+- model logs show OOM, tokenizer load failure, unsupported dtype, or port conflict
+- very low throughput with no verifier errors
+
+Likely causes:
+
+- model path or served model name mismatch
+- insufficient GPU memory or wrong tensor/pipeline parallel settings
+- port already in use
+- policy base URL points to the wrong port/node
+- `num_samples_in_parallel` too high for available serving capacity
+
+Evidence to collect:
+
+- vLLM startup logs
+- model readiness probes
+- policy base URL/model name in Gym config
+- first failed OpenAI-compatible request error
+
+Next actions:
+
+- confirm `/v1/models` before running large collection
+- tune concurrency only after readiness is stable
+- separate serving bottlenecks from verifier/judge/tool bottlenecks
+
+## Hydra or Config Composition
+
+Symptoms:
+
+- `ng_run` or `ng_collect_rollouts` fails before launching servers
+- errors mention missing config keys, unknown overrides, or interpolation failures
+- wrong agent/resource server starts despite expected data
+
+Likely causes:
+
+- config path typo
+- composition order override collision
+- branch uses different config schema than the script assumes
+- launcher passes stale extra args
+- explicit `agent_name` conflicts with row-level routing expectations
+
+Evidence to collect:
+
+- full command line
+- composed config if the repo can print it
+- target YAML files and extra overrides
+- CLI help for the target checkout
+
+Next actions:
+
+- reduce to a minimal `ng_run "+config_paths=[...]"` command
+- add overrides back one at a time
+- trust target checkout code over copied command templates
+
+## Data Schema or Materialized Cache
+
+Symptoms:
+
+- verifier errors mention missing fields, wrong types, invalid enum values, or parser failures
+- source data was fixed but failures still mention old bad values
+- materialized inputs contain different data than source JSONL
+- output row count resumes from an older partial run
+
+Likely causes:
+
+- JSONL does not match verifier request model
+- row-level `responses_create_params` has wrong shape
+- row-level `agent_ref` missing or wrong
+- stale `*_materialized_inputs.jsonl`
+- `resume_from_cache=True` reused partial output after schema/config changes
+
+Evidence to collect:
+
+- first failing row, redacted if needed
+- first few source/materialized/output rows
+- modification times of source, materialized, and output files
+- Pydantic validation error, if available
+
+Next actions:
+
+- validate rows against the request model
+- rerun on a clean output path after schema/config changes
+- if data owner must fix it, send the log, schema error, and a minimal row sample
+
+## Resource Server or Verifier Runtime
+
+Symptoms:
+
+- Gym servers are ready, model requests complete, but verification returns 500/422
+- traceback is inside a resource server or verifier
+- rollouts are written until a specific row triggers failure
+
+Likely causes:
+
+- verifier assumes a field absent from data
+- verifier cannot parse model output
+- external dependency missing in container
+- env-specific scoring code bug
+- stale cache sends old schema to new verifier
+
+Evidence to collect:
+
+- first verifier traceback
+- request body shape, if logged
+- sample source/materialized row for the failing task
+- verifier request/response models
+
+Next actions:
+
+- decide whether it is data, verifier code, or container dependency
+- do not change model serving unless model calls are failing before verification
+
+## Judge Model
+
+Symptoms:
+
+- policy rollouts complete but verifier waits or fails during judge calls
+- errors mention judge base URL, judge server name, parse errors from judge output, or judge timeout
+- throughput is much lower than direct-verifier envs
+
+Likely causes:
+
+- judge server not started or not registered
+- judge base URL/server name mismatch
+- judge prompt expects fields missing from data
+- judge output parser too strict
+- judge model capacity lower than policy rollout concurrency
+
+Evidence to collect:
+
+- judge server logs and readiness
+- resource server config for judge client
+- first judge request/response error
+- data fields consumed by judge prompt
+
+Next actions:
+
+- verify judge readiness independently
+- tune concurrency against judge throughput
+- classify parser failures separately from infra failures
+
+## Tool or Sandbox
+
+Symptoms:
+
+- tool env starts but first tool call fails
+- sandbox logs missing or never show readiness, when a sandbox is expected
+- errors mention unknown tool, tool timeout, code execution failure, missing package, or session restore
+- only tool-integrated envs fail while direct envs work
+
+Likely causes:
+
+- tool execution ownership is unclear: agent, resource server, or sandbox
+- sandbox image does not contain expected runtime, when a sandbox is expected
+- sandbox command was not launched on the nodes that need it, when a sandbox is expected
+- tool spec omitted or mismatched with agent
+- per-node ports/mounts not exported
+- concurrency overwhelms sandbox
+- stale materialized inputs preserve old tool specs
+
+Evidence to collect:
+
+- sandbox startup logs
+- tool loading logs
+- first tool call request/error
+- data row `responses_create_params.tools`
+- relevant agent/resource config
+
+Next actions:
+
+- check whether the env actually needs a sandbox
+- check tool names and ownership before changing model settings
+- check sandbox readiness before data/schema work only when a sandbox is configured
+- reduce concurrency to separate correctness from saturation
+
+## Throughput and Saturation
+
+Symptoms:
+
+- no correctness errors, but jobs run slowly
+- vLLM logs show sustained high request concurrency
+- GPU utilization high but output advances steadily
+- resource server or judge logs show queues/timeouts under load
+
+Likely causes:
+
+- expected saturation from high `num_samples_in_parallel`
+- verifier/judge/tool bottleneck
+- policy model context length or generation length dominates latency
+- filesystem logging overhead
+
+Evidence to collect:
+
+- rollout completion rate
+- model server throughput logs
+- verifier/judge/tool latency or timeout lines
+- output JSONL growth over time
+
+Next actions:
+
+- if output is steady and errors absent, do not "fix" saturation
+- tune concurrency per env; GPU count alone is not the concurrency setting
+- reduce concurrency for debugging, increase only after correctness is established
+
+## Profiling or Postprocess
+
+Symptoms:
+
+- rollout JSONL exists but profiling output is missing or empty
+- profile command fails on missing task/rollout keys
+- token usage metrics are missing or all null
+- materialized or rollout counts do not match expected repeats
+
+Likely causes:
+
+- profiling command used wrong input paths
+- rollouts were collected without repeated samples
+- materialized inputs and rollouts are from different runs
+- results are out of order and code assumes zip alignment without sorting/joining
+- responses do not include `usage`
+
+Evidence to collect:
+
+- line counts for source, materialized, rollout, and profiling files
+- sample rows showing task/rollout keys
+- reward and usage field summary
+- target `nemo_gym/reward_profile.py`
+
+Next actions:
+
+- join by `(task index, rollout index)`
+- keep missing usage explicit
+- profile from clean materialized/output pairs

--- a/.codex/skills/nemo-gym-debugging/references/request-boundary-visibility.md
+++ b/.codex/skills/nemo-gym-debugging/references/request-boundary-visibility.md
@@ -29,8 +29,14 @@ When internal HTTP calls use `nemo_gym.server_utils.request()` and `raise_for_st
 - `Request info`: URL, method, and request headers for non-OK responses
 - `Response content`: raw response body from the inner server
 - `Request kwargs`: OpenAI/vLLM adapter request shape for failed provider calls
-- `[rollout_collection] /run failed`: compact task, rollout, agent, and source row identity for failed `/run` requests
+- `[rollout_collection] /run failed`: compact Gym task index, rollout index, and agent identity for failed `/run` requests
 - nested `Hit an exception in ... calling an inner server` messages from Gym middleware
+
+Example rollout marker:
+
+```text
+[rollout_collection] /run failed status=500 row={"_ng_rollout_index": 0, "_ng_task_index": 48, "agent_name": "my_agent"}
+```
 
 This is usually enough to classify:
 
@@ -39,7 +45,7 @@ This is usually enough to classify:
 - whether the inner server returned a useful error body
 - whether the failure should be investigated in Gym logs or provider logs
 
-If the innermost provider response is empty, for example `Response content: b''`, Gym cannot recover the missing provider-side details. Inspect the model server logs next.
+If the innermost provider call is visible but the provider response is empty, for example `Response content: b''` from a `/v1/chat/completions` request, Gym has exposed the request boundary but cannot recover the missing provider-side details. Inspect the model server logs next.
 
 ## vLLM Provider-Side Logging
 

--- a/.codex/skills/nemo-gym-debugging/references/request-boundary-visibility.md
+++ b/.codex/skills/nemo-gym-debugging/references/request-boundary-visibility.md
@@ -1,0 +1,92 @@
+# Request Boundary Visibility
+
+Use this when a Nemo Gym run fails with nested 500s such as "Hit an exception in ... calling an inner server" and the failing layer is unclear.
+
+This is an escalation ladder. Do not patch agents, resource servers, model adapters, or rollout collection until the existing request-debug path is insufficient.
+
+## Order
+
+1. Enable Gym's existing request debug flag:
+
+   ```bash
+   ng_run '+config_paths=[...]' ++global_aiohttp_client_request_debug=True
+   ```
+
+2. Re-run the smallest failing case and capture stdout/stderr.
+
+3. Search the log for the request-boundary markers:
+
+   ```bash
+   rg "\\[rollout_collection\\] /run failed|Request info:|Response content:|Request kwargs:|Hit an exception in" <log>
+   ```
+
+4. Interpret the result before editing code.
+
+## What The Existing Flag Covers
+
+When internal HTTP calls use `nemo_gym.server_utils.request()` and `raise_for_status()`, the flag prints:
+
+- `Request info`: URL, method, and request headers for non-OK responses
+- `Response content`: raw response body from the inner server
+- `Request kwargs`: OpenAI/vLLM adapter request shape for failed provider calls
+- `[rollout_collection] /run failed`: compact task, rollout, agent, and source row identity for failed `/run` requests
+- nested `Hit an exception in ... calling an inner server` messages from Gym middleware
+
+This is usually enough to classify:
+
+- rollout caller vs agent vs resource server vs model adapter
+- provider endpoint URL and status
+- whether the inner server returned a useful error body
+- whether the failure should be investigated in Gym logs or provider logs
+
+If the innermost provider response is empty, for example `Response content: b''`, Gym cannot recover the missing provider-side details. Inspect the model server logs next.
+
+## vLLM Provider-Side Logging
+
+If Gym request-boundary logs identify the provider call but the provider body is empty or generic, the remaining root issue may be on the inference server side. For vLLM-backed endpoints, re-run the smallest failing repro with vLLM-side logging enabled.
+
+Start with request logging:
+
+```bash
+export VLLM_LOGGING_LEVEL=INFO
+vllm serve ... --enable-log-requests
+```
+
+For a tiny repro where prompts and outputs are safe to log, increase detail:
+
+```bash
+export VLLM_LOGGING_LEVEL=DEBUG
+vllm serve ... --enable-log-requests --enable-log-outputs
+```
+
+Caveats:
+
+- This is vLLM-specific provider-side debugging, not a Gym code change.
+- Use it on the smallest repro, not broad rollout collection.
+- `--enable-log-requests` can expose request parameters; at `DEBUG`, it can expose prompt inputs.
+- `--enable-log-outputs` can expose generated text or tool-call strings and requires `--enable-log-requests`.
+- Turn the extra logging off after classifying the inference-side error.
+
+## When More Logging Is Still Needed
+
+Consider more logging only when the shipped request-boundary markers do not expose the missing evidence:
+
+- stage identity is missing, such as conversion vs provider call vs postprocess vs verifier call
+- the failure happens after HTTP 200 during local parsing, validation, or postprocess
+- the code path bypasses Nemo Gym's `raise_for_status()`
+- retrying agents hide which attempt produced the terminal error
+
+Extra logs should answer one narrow question, avoid full prompts/documents/schemas unless explicitly needed, and stay gated or temporary.
+
+## Do Not Mix Logging With Fixes
+
+Do not change behavior while adding visibility. In particular, do not combine logging with:
+
+- schema relaxation or sanitization
+- recoverable HTTP status codes
+- smaller or larger `max_output_tokens`
+- `tool_choice`, tool schema, or prompt changes
+- retry policy changes
+- verifier strictness changes
+
+Those may be valid later, but decide them only after the failing layer is classified.

--- a/.codex/skills/nemo-gym-debugging/references/vllm-tool-call-schema-checks.md
+++ b/.codex/skills/nemo-gym-debugging/references/vllm-tool-call-schema-checks.md
@@ -1,0 +1,82 @@
+# vLLM Tool-Call Schema Checks
+
+Use this when a Nemo Gym dataset sends `responses_create_params.tools` to a
+vLLM/OpenAI-compatible endpoint and failures happen before meaningful model
+generation.
+
+## Failure Profile
+
+Symptoms:
+
+- Gym reports nested 500s from agent/model servers.
+- vLLM returns 400s mentioning grammar, guided decoding, Outlines, JSON Schema,
+  `Unknown format`, or `Unsupported JSON Schema`.
+- Direct endpoint probes fail before the model returns a tool call.
+- The verifier is never reached, or the rollout dies at the policy model call.
+
+Common causes:
+
+- tool schemas contain JSON Schema constructs that are valid in general but not
+  supported by the vLLM/Outlines tool grammar path
+- boolean schema nodes in model-facing tool parameters, especially object
+  closure like `additionalProperties: false`
+- `format` annotations such as `uri`
+- invalid entries inside `properties` maps
+- stale materialized inputs preserve an older bad tool schema after regenerating
+  source data
+
+The key distinction: this is a model-serving schema compatibility issue, not a
+tool execution issue. Do not debug sandbox/tool execution if the request fails
+while compiling the tool grammar.
+
+## Static Check
+
+If the repo has a local checker for its own row contract, prefer that. If it
+does not, use the portable script bundled with this skill:
+
+```bash
+python scripts/check_tool_call_jsonl.py \
+    -i PATH_TO_TOOL_CALL_DATA.jsonl
+```
+
+Expected output:
+
+```text
+Errors: 0
+```
+
+These checks are offline and do not prove the endpoint can compile every
+schema, but they catch the high-value failures before running expensive
+rollouts.
+
+Optional row summaries can help compare a failing subset with the full data:
+
+```bash
+python scripts/check_tool_call_jsonl.py \
+    -i PATH_TO_TOOL_CALL_DATA.jsonl \
+    --summary-key tool_schema_mode \
+    --summary-key num_tools
+```
+
+## Endpoint Preflight
+
+When static checks pass but vLLM may still reject the grammar, run a direct
+endpoint preflight from the active repo. The useful pattern is: preserve
+`tools`, preserve the same Responses-to-Chat conversion path used by the model
+wrapper, replace the expensive document with a tiny prompt, and send a tiny
+`max_tokens` request.
+
+Treat incomplete generation parse errors after grammar compilation separately
+from schema/compiler errors. A short `max_tokens=1` request can produce
+incomplete tool-call JSON while still proving the schema compiled.
+
+## How To Classify Results
+
+- Static checker fails: fix data generation or the model-facing tool schema.
+- Static checker passes, endpoint preflight fails with grammar/schema error:
+  inspect the exact provider error and add a targeted compatibility transform
+  in data generation.
+- Endpoint preflight passes, Gym rollout fails before verifier: inspect
+  Responses-to-Chat conversion and model wrapper logs.
+- Gym reaches verifier and then fails reward: debug verifier/data semantics,
+  not vLLM schema compilation.

--- a/.codex/skills/nemo-gym-debugging/scripts/check_tool_call_jsonl.py
+++ b/.codex/skills/nemo-gym-debugging/scripts/check_tool_call_jsonl.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Static sanity checks for Nemo Gym tool-call JSONL data."""
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VALUE_EXEMPT_KEYS = {"enum", "const", "default", "examples"}
+
+
+def iter_jsonl(path: Path):
+    with path.open(encoding="utf-8") as f:
+        for row_idx, line in enumerate(f):
+            if not line.strip():
+                continue
+            try:
+                yield row_idx, json.loads(line)
+            except json.JSONDecodeError as exc:
+                yield row_idx, {"__json_error__": f"{type(exc).__name__}: {exc}"}
+
+
+def value_key(value: Any) -> str:
+    if value is None:
+        return "None"
+    return str(value)
+
+
+def add_issue(
+    issues: list[dict[str, Any]],
+    *,
+    row_idx: int,
+    severity: str,
+    code: str,
+    message: str,
+    source_record_id: Any = None,
+) -> None:
+    issues.append(
+        {
+            "row_idx": row_idx,
+            "source_record_id": source_record_id,
+            "severity": severity,
+            "code": code,
+            "message": message,
+        }
+    )
+
+
+def walk_tool_schema(
+    value: Any,
+    *,
+    path: str = "$",
+    key: str | None = None,
+    in_properties_map: bool = False,
+    check_vllm_compat: bool = True,
+):
+    if key in SCHEMA_VALUE_EXEMPT_KEYS:
+        return
+
+    if isinstance(value, bool):
+        if check_vllm_compat:
+            yield "boolean_schema_node", path, value
+        return
+
+    if isinstance(value, list):
+        for i, item in enumerate(value):
+            yield from walk_tool_schema(
+                item,
+                path=f"{path}/{i}",
+                key=key,
+                check_vllm_compat=check_vllm_compat,
+            )
+        return
+
+    if not isinstance(value, dict):
+        return
+
+    if in_properties_map:
+        for prop_name, prop_schema in value.items():
+            prop_path = f"{path}/{prop_name}"
+            if not isinstance(prop_schema, (dict, bool)):
+                yield "invalid_property_schema", prop_path, prop_schema
+                continue
+            yield from walk_tool_schema(
+                prop_schema,
+                path=prop_path,
+                key=prop_name,
+                check_vllm_compat=check_vllm_compat,
+            )
+        return
+
+    if check_vllm_compat and isinstance(value.get("format"), str):
+        yield "format_annotation", f"{path}/format", value["format"]
+
+    for child_key, child_value in value.items():
+        yield from walk_tool_schema(
+            child_value,
+            path=f"{path}/{child_key}",
+            key=child_key,
+            in_properties_map=child_key == "properties" and isinstance(child_value, dict),
+            check_vllm_compat=check_vllm_compat,
+        )
+
+
+def schema_contains_property_key(value: Any, property_key: str) -> bool:
+    if isinstance(value, dict):
+        properties = value.get("properties")
+        if isinstance(properties, dict) and property_key in properties:
+            return True
+        return any(schema_contains_property_key(child, property_key) for child in value.values())
+    if isinstance(value, list):
+        return any(schema_contains_property_key(child, property_key) for child in value)
+    return False
+
+
+def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool, check_vllm_compat: bool):
+    issues: list[dict[str, Any]] = []
+    source_record_id = row.get("source_record_id")
+
+    if "__json_error__" in row:
+        add_issue(
+            issues,
+            row_idx=row_idx,
+            severity="error",
+            code="json_parse_error",
+            message=row["__json_error__"],
+            source_record_id=source_record_id,
+        )
+        return issues
+
+    if require_response_mode and row.get("response_mode") != "tool_call":
+        add_issue(
+            issues,
+            row_idx=row_idx,
+            severity="error",
+            code="bad_response_mode",
+            message=f"Expected response_mode='tool_call', got {row.get('response_mode')!r}",
+            source_record_id=source_record_id,
+        )
+
+    responses_create_params = row.get("responses_create_params")
+    if not isinstance(responses_create_params, dict):
+        add_issue(
+            issues,
+            row_idx=row_idx,
+            severity="error",
+            code="missing_responses_create_params",
+            message="responses_create_params must be an object",
+            source_record_id=source_record_id,
+        )
+        return issues
+
+    tools = responses_create_params.get("tools")
+    if not isinstance(tools, list) or not tools:
+        add_issue(
+            issues,
+            row_idx=row_idx,
+            severity="error",
+            code="missing_tools",
+            message="responses_create_params.tools must be a non-empty list",
+            source_record_id=source_record_id,
+        )
+        return issues
+
+    tool_by_name: dict[str, dict[str, Any]] = {}
+    tool_names = []
+    for tool_idx, tool in enumerate(tools):
+        if not isinstance(tool, dict):
+            add_issue(
+                issues,
+                row_idx=row_idx,
+                severity="error",
+                code="bad_tool",
+                message=f"tools[{tool_idx}] must be an object",
+                source_record_id=source_record_id,
+            )
+            continue
+
+        name = tool.get("name")
+        if not isinstance(name, str) or not name:
+            add_issue(
+                issues,
+                row_idx=row_idx,
+                severity="error",
+                code="bad_tool_name",
+                message=f"tools[{tool_idx}].name must be a non-empty string",
+                source_record_id=source_record_id,
+            )
+            continue
+        tool_names.append(name)
+        if name in tool_by_name:
+            add_issue(
+                issues,
+                row_idx=row_idx,
+                severity="error",
+                code="duplicate_tool_name",
+                message=f"Duplicate tool name {name!r}",
+                source_record_id=source_record_id,
+            )
+        tool_by_name[name] = tool
+
+        if tool.get("type") != "function":
+            add_issue(
+                issues,
+                row_idx=row_idx,
+                severity="error",
+                code="bad_tool_type",
+                message=f"tools[{tool_idx}].type must be 'function', got {tool.get('type')!r}",
+                source_record_id=source_record_id,
+            )
+
+        parameters = tool.get("parameters")
+        if not isinstance(parameters, dict):
+            add_issue(
+                issues,
+                row_idx=row_idx,
+                severity="error",
+                code="bad_tool_parameters",
+                message=f"tools[{tool_idx}].parameters must be an object",
+                source_record_id=source_record_id,
+            )
+            continue
+        for code, path, value in walk_tool_schema(parameters, check_vllm_compat=check_vllm_compat):
+            add_issue(
+                issues,
+                row_idx=row_idx,
+                severity="error",
+                code=code,
+                message=f"tools[{tool_idx}].parameters{path[1:]} = {value!r}",
+                source_record_id=source_record_id,
+            )
+
+    expected_tool_name = row.get("tool_name")
+    target_tool = tool_by_name.get(expected_tool_name) if expected_tool_name else None
+    if expected_tool_name and target_tool is None:
+        add_issue(
+            issues,
+            row_idx=row_idx,
+            severity="error",
+            code="target_tool_missing",
+            message=f"tool_name {expected_tool_name!r} not found in tools {tool_names}",
+            source_record_id=source_record_id,
+        )
+
+    tool_payload_key = row.get("tool_payload_key")
+    if tool_payload_key and target_tool is not None:
+        parameters = target_tool.get("parameters")
+        if isinstance(parameters, dict) and not schema_contains_property_key(parameters, str(tool_payload_key)):
+            add_issue(
+                issues,
+                row_idx=row_idx,
+                severity="error",
+                code="payload_key_not_in_target_tool_schema",
+                message=f"tool_payload_key {tool_payload_key!r} not found in target tool parameters",
+                source_record_id=source_record_id,
+            )
+
+    schema_str = row.get("schema_str")
+    if schema_str is not None:
+        try:
+            json.loads(schema_str)
+        except json.JSONDecodeError as exc:
+            add_issue(
+                issues,
+                row_idx=row_idx,
+                severity="error",
+                code="schema_str_parse_error",
+                message=f"{type(exc).__name__}: {exc}",
+                source_record_id=source_record_id,
+            )
+
+    num_tools = row.get("num_tools")
+    if num_tools is not None and num_tools != len(tools):
+        add_issue(
+            issues,
+            row_idx=row_idx,
+            severity="error",
+            code="num_tools_mismatch",
+            message=f"num_tools={num_tools!r}, actual tools={len(tools)}",
+            source_record_id=source_record_id,
+        )
+
+    return issues
+
+
+def print_distribution(rows: list[dict[str, Any]], keys: list[str]) -> None:
+    if not keys:
+        return
+
+    print("\nDistributions:")
+    for key in keys:
+        counter = Counter(value_key(row.get(key)) for row in rows if key in row)
+        if not counter:
+            print(f"  {key}: <absent>")
+            continue
+        print(f"  {key}:")
+        for value, count in sorted(counter.items(), key=lambda item: (-item[1], item[0])):
+            print(f"    {value}: {count}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-i", "--input", required=True)
+    parser.add_argument("--max-errors", type=int, default=30)
+    parser.add_argument("--require-response-mode", action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument("--check-vllm-compat", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument(
+        "--summary-key",
+        action="append",
+        default=[],
+        help="Print a distribution for this row-level key. Repeat to inspect multiple keys.",
+    )
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    rows: list[dict[str, Any]] = []
+    issues: list[dict[str, Any]] = []
+    for row_idx, row in iter_jsonl(input_path):
+        rows.append(row)
+        issues.extend(
+            check_row(
+                row_idx,
+                row,
+                require_response_mode=args.require_response_mode,
+                check_vllm_compat=args.check_vllm_compat,
+            )
+        )
+
+    error_counts = Counter(issue["code"] for issue in issues if issue["severity"] == "error")
+    print(f"Checked {len(rows)} rows from {input_path}")
+    if error_counts:
+        print("\nErrors:")
+        for code, count in sorted(error_counts.items(), key=lambda item: (-item[1], item[0])):
+            print(f"  {code}: {count}")
+    else:
+        print("\nErrors: 0")
+
+    print_distribution(rows, args.summary_key)
+
+    if issues:
+        print(f"\nFirst {min(args.max_errors, len(issues))} issues:")
+        for issue in issues[: args.max_errors]:
+            print(
+                f"  row={issue['row_idx']} source_record_id={issue.get('source_record_id')} "
+                f"{issue['severity']} {issue['code']}: {issue['message']}"
+            )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.codex/skills/nemo-gym-debugging/scripts/check_tool_call_jsonl.py
+++ b/.codex/skills/nemo-gym-debugging/scripts/check_tool_call_jsonl.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Static sanity checks for Nemo Gym tool-call JSONL data."""
 
 import argparse

--- a/.codex/skills/nemo-gym-debugging/scripts/check_tool_call_jsonl.py
+++ b/.codex/skills/nemo-gym-debugging/scripts/check_tool_call_jsonl.py
@@ -50,12 +50,10 @@ def add_issue(
     severity: str,
     code: str,
     message: str,
-    source_record_id: Any = None,
 ) -> None:
     issues.append(
         {
             "row_idx": row_idx,
-            "source_record_id": source_record_id,
             "severity": severity,
             "code": code,
             "message": message,
@@ -130,9 +128,14 @@ def schema_contains_property_key(value: Any, property_key: str) -> bool:
     return False
 
 
-def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool, check_vllm_compat: bool):
+def check_row(
+    row_idx: int,
+    row: dict[str, Any],
+    *,
+    require_response_mode: bool,
+    check_vllm_compat: bool,
+):
     issues: list[dict[str, Any]] = []
-    source_record_id = row.get("source_record_id")
 
     if "__json_error__" in row:
         add_issue(
@@ -141,7 +144,6 @@ def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool,
             severity="error",
             code="json_parse_error",
             message=row["__json_error__"],
-            source_record_id=source_record_id,
         )
         return issues
 
@@ -152,7 +154,6 @@ def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool,
             severity="error",
             code="bad_response_mode",
             message=f"Expected response_mode='tool_call', got {row.get('response_mode')!r}",
-            source_record_id=source_record_id,
         )
 
     responses_create_params = row.get("responses_create_params")
@@ -163,7 +164,6 @@ def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool,
             severity="error",
             code="missing_responses_create_params",
             message="responses_create_params must be an object",
-            source_record_id=source_record_id,
         )
         return issues
 
@@ -175,7 +175,6 @@ def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool,
             severity="error",
             code="missing_tools",
             message="responses_create_params.tools must be a non-empty list",
-            source_record_id=source_record_id,
         )
         return issues
 
@@ -189,7 +188,6 @@ def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool,
                 severity="error",
                 code="bad_tool",
                 message=f"tools[{tool_idx}] must be an object",
-                source_record_id=source_record_id,
             )
             continue
 
@@ -201,7 +199,6 @@ def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool,
                 severity="error",
                 code="bad_tool_name",
                 message=f"tools[{tool_idx}].name must be a non-empty string",
-                source_record_id=source_record_id,
             )
             continue
         tool_names.append(name)
@@ -212,7 +209,6 @@ def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool,
                 severity="error",
                 code="duplicate_tool_name",
                 message=f"Duplicate tool name {name!r}",
-                source_record_id=source_record_id,
             )
         tool_by_name[name] = tool
 
@@ -223,7 +219,6 @@ def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool,
                 severity="error",
                 code="bad_tool_type",
                 message=f"tools[{tool_idx}].type must be 'function', got {tool.get('type')!r}",
-                source_record_id=source_record_id,
             )
 
         parameters = tool.get("parameters")
@@ -234,7 +229,6 @@ def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool,
                 severity="error",
                 code="bad_tool_parameters",
                 message=f"tools[{tool_idx}].parameters must be an object",
-                source_record_id=source_record_id,
             )
             continue
         for code, path, value in walk_tool_schema(parameters, check_vllm_compat=check_vllm_compat):
@@ -244,7 +238,6 @@ def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool,
                 severity="error",
                 code=code,
                 message=f"tools[{tool_idx}].parameters{path[1:]} = {value!r}",
-                source_record_id=source_record_id,
             )
 
     expected_tool_name = row.get("tool_name")
@@ -256,7 +249,6 @@ def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool,
             severity="error",
             code="target_tool_missing",
             message=f"tool_name {expected_tool_name!r} not found in tools {tool_names}",
-            source_record_id=source_record_id,
         )
 
     tool_payload_key = row.get("tool_payload_key")
@@ -269,7 +261,6 @@ def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool,
                 severity="error",
                 code="payload_key_not_in_target_tool_schema",
                 message=f"tool_payload_key {tool_payload_key!r} not found in target tool parameters",
-                source_record_id=source_record_id,
             )
 
     schema_str = row.get("schema_str")
@@ -283,7 +274,6 @@ def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool,
                 severity="error",
                 code="schema_str_parse_error",
                 message=f"{type(exc).__name__}: {exc}",
-                source_record_id=source_record_id,
             )
 
     num_tools = row.get("num_tools")
@@ -294,7 +284,6 @@ def check_row(row_idx: int, row: dict[str, Any], *, require_response_mode: bool,
             severity="error",
             code="num_tools_mismatch",
             message=f"num_tools={num_tools!r}, actual tools={len(tools)}",
-            source_record_id=source_record_id,
         )
 
     return issues
@@ -357,10 +346,7 @@ def main() -> None:
     if issues:
         print(f"\nFirst {min(args.max_errors, len(issues))} issues:")
         for issue in issues[: args.max_errors]:
-            print(
-                f"  row={issue['row_idx']} source_record_id={issue.get('source_record_id')} "
-                f"{issue['severity']} {issue['code']}: {issue['message']}"
-            )
+            print(f"  row={issue['row_idx']} {issue['severity']} {issue['code']}: {issue['message']}")
         sys.exit(1)
 
 

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -44,6 +44,7 @@ from nemo_gym.server_utils import (
     ServerClient,
     get_global_config_dict,
     get_response_json,
+    is_global_aiohttp_client_request_debug_enabled,
     is_global_aiohttp_client_setup,
     raise_for_status,
     set_global_aiohttp_client,
@@ -130,6 +131,19 @@ class RolloutCollectionConfig(SharedRolloutCollectionConfig):
     def materialized_jsonl_fpath(self) -> Path:
         output_fpath = Path(self.output_jsonl_fpath)
         return output_fpath.with_stem(output_fpath.stem + "_materialized_inputs").with_suffix(".jsonl")
+
+
+def _rollout_request_debug_summary(row: Dict[str, Any]) -> Dict[str, Any]:
+    agent_ref = row.get(AGENT_REF_KEY_NAME) or {}
+    summary = {
+        TASK_INDEX_KEY_NAME: row.get(TASK_INDEX_KEY_NAME),
+        ROLLOUT_INDEX_KEY_NAME: row.get(ROLLOUT_INDEX_KEY_NAME),
+        "agent_name": agent_ref.get("name") if isinstance(agent_ref, dict) else None,
+        "source_record_id": row.get("source_record_id"),
+        "task_id": row.get("task_id"),
+        "problem_type": row.get("problem_type"),
+    }
+    return {k: v for k, v in summary.items() if v is not None}
 
 
 class RolloutCollectionHelper(BaseModel):
@@ -445,7 +459,17 @@ Aggregate metrics: {aggregate_metrics_fpath}""")
         async def _post_subroutine(row: Dict) -> Tuple[Dict, Dict]:
             async with semaphore:
                 res = await server_client.post(server_name=row["agent_ref"]["name"], url_path="/run", json=row)
-                await raise_for_status(res)
+                try:
+                    await raise_for_status(res)
+                except Exception:
+                    if is_global_aiohttp_client_request_debug_enabled():
+                        print(
+                            "[rollout_collection] /run failed "
+                            f"status={getattr(res, 'status', None)} "
+                            f"row={json.dumps(_rollout_request_debug_summary(row), sort_keys=True)}",
+                            flush=True,
+                        )
+                    raise
                 return row, await get_response_json(res)
 
         return tqdm.as_completed(

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -139,9 +139,6 @@ def _rollout_request_debug_summary(row: Dict[str, Any]) -> Dict[str, Any]:
         TASK_INDEX_KEY_NAME: row.get(TASK_INDEX_KEY_NAME),
         ROLLOUT_INDEX_KEY_NAME: row.get(ROLLOUT_INDEX_KEY_NAME),
         "agent_name": agent_ref.get("name") if isinstance(agent_ref, dict) else None,
-        "source_record_id": row.get("source_record_id"),
-        "task_id": row.get("task_id"),
-        "problem_type": row.get("problem_type"),
     }
     return {k: v for k, v in summary.items() if v is not None}
 

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -127,6 +127,10 @@ def is_global_aiohttp_client_setup() -> bool:  # pragma: no cover
     return _GLOBAL_AIOHTTP_CLIENT is not None
 
 
+def is_global_aiohttp_client_request_debug_enabled() -> bool:
+    return _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG
+
+
 def global_aiohttp_client_exit():  # pragma: no cover
     if not is_global_aiohttp_client_setup():
         return

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -21,14 +21,88 @@ import orjson
 import pytest
 import yaml
 
+import nemo_gym.rollout_collection
 from nemo_gym.base_resources_server import AggregateMetrics, AggregateMetricsRequest
 from nemo_gym.global_config import AGENT_REF_KEY_NAME, ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
 from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
 from nemo_gym.reward_profile import compute_aggregate_metrics
-from nemo_gym.rollout_collection import RolloutCollectionConfig, RolloutCollectionHelper
+from nemo_gym.rollout_collection import (
+    RolloutCollectionConfig,
+    RolloutCollectionHelper,
+    _rollout_request_debug_summary,
+)
 
 
 class TestRolloutCollection:
+    def test_rollout_request_debug_summary_compact(self) -> None:
+        row = {
+            AGENT_REF_KEY_NAME: {"name": "my_agent"},
+            TASK_INDEX_KEY_NAME: 12,
+            ROLLOUT_INDEX_KEY_NAME: 3,
+            "source_record_id": "DS1-ABC",
+            "task_id": "task-123",
+            "problem_type": "tool_call",
+            "responses_create_params": {"input": "large prompt", "tools": ["large schema"]},
+        }
+
+        assert _rollout_request_debug_summary(row) == {
+            "agent_name": "my_agent",
+            TASK_INDEX_KEY_NAME: 12,
+            ROLLOUT_INDEX_KEY_NAME: 3,
+            "source_record_id": "DS1-ABC",
+            "task_id": "task-123",
+            "problem_type": "tool_call",
+        }
+
+    @pytest.mark.parametrize("request_debug_enabled", [True, False])
+    async def test_run_examples_logs_failed_run_when_request_debug_enabled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        request_debug_enabled: bool,
+    ) -> None:
+        row = {
+            AGENT_REF_KEY_NAME: {"name": "my_agent"},
+            TASK_INDEX_KEY_NAME: 7,
+            ROLLOUT_INDEX_KEY_NAME: 0,
+            "source_record_id": "DS1-FAIL",
+            "responses_create_params": {"input": "do not log this"},
+        }
+        response = MagicMock()
+        response.status = 500
+
+        mock_server_client = MagicMock()
+        mock_server_client.post = AsyncMock(return_value=response)
+
+        class MockHelper(RolloutCollectionHelper):
+            def setup_server_client(self, *args, **kwargs):
+                return mock_server_client
+
+        async def fail_raise_for_status(_response):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(nemo_gym.rollout_collection, "raise_for_status", fail_raise_for_status)
+        monkeypatch.setattr(
+            nemo_gym.rollout_collection,
+            "is_global_aiohttp_client_request_debug_enabled",
+            lambda: request_debug_enabled,
+        )
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await next(MockHelper().run_examples([row]))
+
+        captured = capsys.readouterr()
+        if request_debug_enabled:
+            assert "[rollout_collection] /run failed status=500" in captured.out
+            assert '"_ng_task_index": 7' in captured.out
+            assert '"_ng_rollout_index": 0' in captured.out
+            assert '"agent_name": "my_agent"' in captured.out
+            assert '"source_record_id": "DS1-FAIL"' in captured.out
+            assert "responses_create_params" not in captured.out
+            assert "do not log this" not in captured.out
+        else:
+            assert "[rollout_collection] /run failed" not in captured.out
+
     def test_preprocess_rows_with_prompt_config(self, tmp_path: Path) -> None:
         """prompt_config builds responses_create_params.input from template."""
         prompt_path = tmp_path / "prompt.yaml"

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -39,9 +39,7 @@ class TestRolloutCollection:
             AGENT_REF_KEY_NAME: {"name": "my_agent"},
             TASK_INDEX_KEY_NAME: 12,
             ROLLOUT_INDEX_KEY_NAME: 3,
-            "source_record_id": "DS1-ABC",
-            "task_id": "task-123",
-            "problem_type": "tool_call",
+            "env_specific_metadata": "do not include",
             "responses_create_params": {"input": "large prompt", "tools": ["large schema"]},
         }
 
@@ -49,9 +47,6 @@ class TestRolloutCollection:
             "agent_name": "my_agent",
             TASK_INDEX_KEY_NAME: 12,
             ROLLOUT_INDEX_KEY_NAME: 3,
-            "source_record_id": "DS1-ABC",
-            "task_id": "task-123",
-            "problem_type": "tool_call",
         }
 
     @pytest.mark.parametrize("request_debug_enabled", [True, False])
@@ -65,7 +60,7 @@ class TestRolloutCollection:
             AGENT_REF_KEY_NAME: {"name": "my_agent"},
             TASK_INDEX_KEY_NAME: 7,
             ROLLOUT_INDEX_KEY_NAME: 0,
-            "source_record_id": "DS1-FAIL",
+            "env_specific_metadata": "do not log this either",
             "responses_create_params": {"input": "do not log this"},
         }
         response = MagicMock()
@@ -97,7 +92,8 @@ class TestRolloutCollection:
             assert '"_ng_task_index": 7' in captured.out
             assert '"_ng_rollout_index": 0' in captured.out
             assert '"agent_name": "my_agent"' in captured.out
-            assert '"source_record_id": "DS1-FAIL"' in captured.out
+            assert "env_specific_metadata" not in captured.out
+            assert "do not log this either" not in captured.out
             assert "responses_create_params" not in captured.out
             assert "do not log this" not in captured.out
         else:

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -34,6 +34,13 @@ from nemo_gym.server_utils import (
 
 
 class TestServerUtils:
+    def test_global_aiohttp_client_request_debug_enabled(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG", False)
+        assert not nemo_gym.server_utils.is_global_aiohttp_client_request_debug_enabled()
+
+        monkeypatch.setattr(nemo_gym.server_utils, "_GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG", True)
+        assert nemo_gym.server_utils.is_global_aiohttp_client_request_debug_enabled()
+
     def test_ServerClient_load_head_server_config(self, monkeypatch: MonkeyPatch) -> None:
         global_config_dict = DictConfig(
             {


### PR DESCRIPTION
# Add task-info logging to nemo_gym/rollout_collection.py through optional logging flag.

## Summary

This PR adds optional rollout task-info logging behind the existing `global_aiohttp_client_request_debug` flag.

When a rollout `/run` request fails, `ng_collect_rollouts` now prints a compact row summary with Gym task index, rollout index, and agent name before re-raising the original error. This makes nested Gym 500s easier to debug without printing full prompts, schemas, documents, tools, cookies, request bodies, or env-specific metadata.

## Usage

Enable the existing request debug flag when starting Gym:

```bash
ng_run "+config_paths=[responses_api_models/vllm_model/configs/vllm_model.yaml,resources_servers/my_env/configs/my_env.yaml]" \
    ++global_aiohttp_client_request_debug=True
```

Then run collection as usual. If an agent `/run` call fails, rollout collection now emits a compact row marker like:

```text
[rollout_collection] /run failed status=500 row={"_ng_rollout_index": 0, "_ng_task_index": 48, "agent_name": "my_agent"}
```

The existing request-debug logs still show the HTTP request boundary and response body. The new line adds the missing row identity.

# Add Codex Debugging Skill

## Summary

This PR also adds a repo-local Codex skill at `.codex/skills/nemo-gym-debugging`.

The skill captures the reusable debugging workflow for Nemo Gym rollout and reward-profiling failures:

- classify failures by layer before changing code
- inspect stale cache/materialized-input issues
- use the shipped request-boundary debug flag for nested 500s
- interpret empty provider bodies and escalate to model-server logs
- use vLLM-side logging only when Gym cannot expose the inference-side root cause
- run static checks for tool-call JSONL/schema issues

This is intended to make future debugging sessions less dependent on ad hoc memory of commands and log markers.
