### PR TITLE
fix(ruler): factor RULER's thread-unsafe nltk init into its own module

### DIFF
--- a/benchmarks/ruler/ruler_prepare_script.py
+++ b/benchmarks/ruler/ruler_prepare_script.py
@@ -19,10 +19,13 @@
 
 import argparse
 import concurrent.futures
+import fcntl
 import json
 import subprocess
 import tempfile
 from pathlib import Path
+
+from ruler_thread_unsafe import ensure_thread_unsafe_resources
 
 
 DEFAULT_SETTINGS = """
@@ -135,6 +138,32 @@ def get_ruler_data(
             )
 
         max_seq_length -= template_tokens  # Adjusting for template tokens
+
+        # Run upstream RULER's thread-unsafe lazy-init once, under a
+        # process-wide flock, BEFORE fanning out the parallel
+        # `python prepare.py` subprocesses below.
+        #
+        # See `ruler_thread_unsafe.py` for the why; in short, RULER's
+        # `prepare.py` does `nltk.download(...)` at module load, NLTK's
+        # downloader is not multi-process-safe, and 13 concurrent
+        # subprocesses crash on the race. By pre-populating /root/nltk_data
+        # under the lock, the parallel `nltk.data.find(...)` calls inside
+        # those subprocesses hit the warmed cache and skip the racy
+        # `nltk.download(...)` branch entirely.
+        #
+        # The lock also coordinates across multiple `get_ruler_data`
+        # callers (e.g. `ng_prepare_benchmark` pool workers) on the same
+        # host — `tempfile.gettempdir()` is `/tmp`, host-shared, and
+        # `flock(2)` is a kernel-level lock, so it serializes correctly
+        # across processes regardless of which Python venv they run in.
+        nltk_init_lock_path = Path(tempfile.gettempdir()) / "gym_ruler_nltk_init.lock"
+        nltk_init_lock_path.touch(exist_ok=True)
+        with open(nltk_init_lock_path, "r") as _lock:
+            fcntl.flock(_lock.fileno(), fcntl.LOCK_EX)
+            try:
+                ensure_thread_unsafe_resources()
+            finally:
+                fcntl.flock(_lock.fileno(), fcntl.LOCK_UN)
 
         # preparing the datasets based on user options, in parallel
         def prepare_task(task):

--- a/benchmarks/ruler/ruler_thread_unsafe.py
+++ b/benchmarks/ruler/ruler_thread_unsafe.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Thread-unsafe init mirrored from upstream RULER's `prepare.py`.
+
+Why this module exists
+----------------------
+The Gym wrapper (`ruler_prepare_script.py`) fans out ~13 `python prepare.py`
+subprocesses through `concurrent.futures.ThreadPoolExecutor` to generate
+RULER's per-task data. Each subprocess imports upstream RULER's
+`scripts/data/prepare.py`, which performs *process-shared, thread-unsafe*
+lazy initialization at module load:
+
+    # NVIDIA/RULER scripts/data/prepare.py L41-L47
+    import nltk
+    try:
+        nltk.data.find('tokenizers/punkt')
+    except LookupError:
+        nltk.download('punkt')
+        nltk.download('punkt_tab')
+
+NLTK's downloader is not multi-process-safe (urlretrieve + zipfile.extractall
+on the same target dir, no internal locking). When N of those subprocesses
+race on `nltk.download(...)`, they corrupt /root/nltk_data and crash with
+`LookupError: Resource 'punkt' not found.` or `FileNotFoundError:
+…punkt_tab.zip`.
+
+Architectural rather than pointwise fix
+---------------------------------------
+Rather than serialize the whole subprocess fan-out (loses parallelism) or
+guess "tasks[0] warms enough" (couples our correctness to upstream RULER's
+internal lazy-init choices), we factor the thread-unsafe surface area into
+this module — a single, named, separately-callable function. The wrapper
+then takes a process-wide flock around exactly this call, populates the
+cache, and lets the parallel fan-out proceed race-free (every parallel
+`nltk.data.find(...)` hits the warmed cache and skips the racy
+`nltk.download(...)` branch entirely).
+
+Maintenance contract
+--------------------
+This module's contents *must mirror* the racy module-level operations in
+`NVIDIA/RULER/scripts/data/prepare.py`. If upstream RULER changes which
+corpora it lazily fetches at module load, update `_NLTK_CORPORA` below.
+The list is cross-referenced against the upstream URL pinned by Gym's
+`benchmarks/ruler/ruler_prepare_script.py`.
+
+Adding a new entry: add the corpus name to `_NLTK_CORPORA`. Removing one
+RULER no longer fetches: remove from the list (overshooting is harmless,
+just wastes a few hundred KB of /root/nltk_data).
+"""
+
+import nltk
+
+
+# Mirror of `nltk.download(...)` calls in upstream RULER `prepare.py`.
+# Source-of-truth: https://github.com/NVIDIA/RULER/blob/main/scripts/data/prepare.py
+# (lines 46-47 at time of writing).
+_NLTK_CORPORA = ("punkt", "punkt_tab")
+
+
+def ensure_thread_unsafe_resources() -> None:
+    """Idempotently populate /root/nltk_data with the corpora upstream RULER
+    `prepare.py` lazy-loads at module import.
+
+    Caller is responsible for serializing this across processes (see
+    `ruler_prepare_script.py` for the flock pattern). `nltk.download(...)`
+    is a no-op when the corpus is already cached on disk.
+    """
+    for pkg in _NLTK_CORPORA:
+        nltk.download(pkg, quiet=True)


### PR DESCRIPTION
## Summary

Adds `benchmarks/ruler/ruler_thread_unsafe.py` — a dedicated module that mirrors the racy module-level `nltk.download(...)` calls in upstream RULER's `prepare.py`. The Gym wrapper now takes a process-wide `fcntl.flock(2)` around exactly that module's `ensure_thread_unsafe_resources()` call to pre-populate `/root/nltk_data` once, then fans out the per-task `prepare.py` subprocesses via `ThreadPoolExecutor` as before. Every parallel `nltk.data.find(...)` inside those subprocesses now hits the warmed cache and skips the racy `nltk.download(...)` branch entirely.

## Problem

RULER's per-task `prepare.py` (third-party) does this at module load:

```python
import nltk
try:
    nltk.data.find('tokenizers/punkt')
except LookupError:
    nltk.download('punkt')
    nltk.download('punkt_tab')
```

NLTK's downloader is not multi-process-safe (`urlretrieve` + `zipfile.extractall`, no internal locking). When ~13 of those subprocesses fan out concurrently from the Gym wrapper, they race on `/root/nltk_data` and crash with either `LookupError: Resource 'punkt' not found.` or `FileNotFoundError: …punkt_tab.zip`. Reproducible deterministically on `nvidia-core-evals` CI's nemo-gym arm64 build.

## Why a dedicated module rather than inline init

Names the unsafe surface area, documents the upstream-source contract, and makes the maintenance story explicit. If upstream RULER changes which corpora it lazy-loads, you update one named list in `ruler_thread_unsafe.py` instead of chasing inline magic. The wrapper's locking pattern is independent of which corpora are inside.

`fcntl.flock(2)` on a host-shared `/tmp/...lock` serializes correctly across processes/threads/venvs on the same host — covers concurrent `get_ruler_data` callers (e.g. `ng_prepare_benchmark` pool workers).

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] AST parse OK
- [ ] arm64 nvidia-core-evals CI build (the deterministic reproducer) passes after this commit is pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)