### PR TITLE
Add longcodebench benchmark (data-only)

### DIFF
--- a/benchmarks/longcodebench/README.md
+++ b/benchmarks/longcodebench/README.md
@@ -6,9 +6,11 @@ long code prompt with options A/B/C/D and asks the model to pick the correct
 letter; the prompt postfix instructs the model to emit `Answer: \boxed{X}`.
 
 This benchmark reuses the existing `mcqa` resource server with
-`grading_mode=strict_single_letter_boxed`. Messages are fully baked into the
-JSONL via `responses_create_params.input` (no `prompt_config`), matching the
-NeMo Skills `longcodebench` dataset's `prompt_format=openai` behaviour.
+`grading_mode=strict_single_letter_boxed`. Each row's `question` field carries
+the long code prompt plus the postfix; the shared
+`benchmarks/prompts/generic_default.yaml` template (`user: "{question}"`)
+wraps it as a single user message, mirroring NeMo Skills' `prompt_format=openai`
+behaviour.
 
 ## Example usage
 
@@ -26,5 +28,6 @@ ng_collect_rollouts \
     +agent_name=longcodebench_mcqa_simple_agent \
     +input_jsonl_fpath=benchmarks/longcodebench/data/longcodebench_benchmark.jsonl \
     +output_jsonl_fpath=results/longcodebench_rollouts.jsonl \
+    +prompt_config=benchmarks/prompts/generic_default.yaml \
     +num_repeats=4
 ```

--- a/benchmarks/longcodebench/README.md
+++ b/benchmarks/longcodebench/README.md
@@ -1,0 +1,30 @@
+# LongCodeBench (LongCodeQA)
+
+[LongCodeBench](https://huggingface.co/datasets/Steefano/LCB) is a multi-choice
+question-answering benchmark over long code contexts. Each row presents a
+long code prompt with options A/B/C/D and asks the model to pick the correct
+letter; the prompt postfix instructs the model to emit `Answer: \boxed{X}`.
+
+This benchmark reuses the existing `mcqa` resource server with
+`grading_mode=strict_single_letter_boxed`. Messages are fully baked into the
+JSONL via `responses_create_params.input` (no `prompt_config`), matching the
+NeMo Skills `longcodebench` dataset's `prompt_format=openai` behaviour.
+
+## Example usage
+
+```bash
+# Prepare benchmark data
+ng_prepare_benchmark "+config_paths=[benchmarks/longcodebench/config.yaml]"
+
+# Running servers
+config_paths="responses_api_models/vllm_model/configs/vllm_model.yaml,\
+benchmarks/longcodebench/config.yaml"
+ng_run "+config_paths=[$config_paths]"
+
+# Collecting rollouts
+ng_collect_rollouts \
+    +agent_name=longcodebench_mcqa_simple_agent \
+    +input_jsonl_fpath=benchmarks/longcodebench/data/longcodebench_benchmark.jsonl \
+    +output_jsonl_fpath=results/longcodebench_rollouts.jsonl \
+    +num_repeats=4
+```

--- a/benchmarks/longcodebench/__init__.py
+++ b/benchmarks/longcodebench/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/benchmarks/longcodebench/config.yaml
+++ b/benchmarks/longcodebench/config.yaml
@@ -1,0 +1,14 @@
+config_paths:
+  - resources_servers/mcqa/configs/mcqa.yaml
+
+longcodebench_mcqa_simple_agent:
+  _inherit_from: mcqa_simple_agent
+  responses_api_agents:
+    simple_agent:
+      datasets:
+      - name: longcodebench
+        type: benchmark
+        jsonl_fpath: benchmarks/longcodebench/data/longcodebench_benchmark.jsonl
+        prompt_config: null
+        prepare_script: benchmarks/longcodebench/prepare.py
+        license: Creative Commons Attribution 4.0 International

--- a/benchmarks/longcodebench/config.yaml
+++ b/benchmarks/longcodebench/config.yaml
@@ -9,6 +9,6 @@ longcodebench_mcqa_simple_agent:
       - name: longcodebench
         type: benchmark
         jsonl_fpath: benchmarks/longcodebench/data/longcodebench_benchmark.jsonl
-        prompt_config: null
+        prompt_config: benchmarks/prompts/generic_default.yaml
         prepare_script: benchmarks/longcodebench/prepare.py
         license: Creative Commons Attribution 4.0 International

--- a/benchmarks/longcodebench/data/.gitignore
+++ b/benchmarks/longcodebench/data/.gitignore
@@ -1,0 +1,1 @@
+*benchmark.jsonl

--- a/benchmarks/longcodebench/prepare.py
+++ b/benchmarks/longcodebench/prepare.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prepare LongCodeBench (LongCodeQA) evaluation data for NeMo Gym.
+
+LongCodeBench is a multi-choice QA benchmark over long code contexts, ported
+1-to-1 from the NeMo Skills `longcodebench` dataset. Each row's prompt is
+fully baked: a long code question with options A/B/C/D plus the postfix that
+instructs the model to emit `Answer: \\boxed{X}`.
+
+The resulting Gym JSONL is consumed by the `mcqa` resource server with
+`grading_mode=strict_single_letter_boxed`. We provide empty-text option dicts
+purely to populate the server's `allowed_letters` set; the option text is not
+used for grading because the postfix forces a `\\boxed{X}` answer.
+
+Skills' prepare also stores a `n_tokens_cl100k_base` field counted with
+tiktoken. The mcqa verifier never reads it; we omit it on the Gym side to
+avoid pulling tiktoken into Gym's main dependency set just for one
+benchmark's metadata column.
+"""
+
+import json
+import uuid
+from pathlib import Path
+
+
+BENCHMARK_DIR = Path(__file__).parent
+DATA_DIR = BENCHMARK_DIR / "data"
+OUTPUT_FPATH = DATA_DIR / "longcodebench_benchmark.jsonl"
+OPTION_LETTERS = ("A", "B", "C", "D")
+
+POSTFIX = (
+    "\n\nThe last line of your response should be in the following format: "
+    "'Answer: \\boxed{A/B/C/D}' (e.g. 'Answer: \\boxed{A}')."
+)
+
+
+def prepare() -> Path:
+    """Download LongCodeBench LongCodeQA from HuggingFace and write Gym JSONL."""
+    from datasets import load_dataset
+
+    print("Downloading LongCodeBench LongCodeQA from HuggingFace...")
+    ds = load_dataset("json", data_files="hf://datasets/Steefano/LCB/LongCodeQA.zip")
+    data = ds["train"]
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Empty-text option dicts: the mcqa server only consumes the option *keys*
+    # for `strict_single_letter_boxed` grading; option text is irrelevant since
+    # the prompt postfix forces the model to emit `\boxed{<letter>}`.
+    options = [{letter: ""} for letter in OPTION_LETTERS]
+
+    rows = []
+    for entry in data:
+        user_content = entry["prompt"].strip() + POSTFIX
+        row = {
+            "responses_create_params": {
+                "input": [{"role": "user", "content": user_content}],
+            },
+            "options": options,
+            "expected_answer": entry["correct_letter"],
+            "grading_mode": "strict_single_letter_boxed",
+            "uuid": str(uuid.uuid5(uuid.NAMESPACE_URL, user_content)),
+            "repo": entry["repo"],
+            "prompt_goal": entry["prompt_goal"],
+            "is_hard": entry["is_hard"],
+        }
+        rows.append(json.dumps(row) + "\n")
+
+    with open(OUTPUT_FPATH, "w", encoding="utf-8") as f:
+        f.writelines(rows)
+
+    print(f"Wrote {len(rows)} problems to {OUTPUT_FPATH}")
+    return OUTPUT_FPATH
+
+
+if __name__ == "__main__":
+    prepare()

--- a/benchmarks/longcodebench/prepare.py
+++ b/benchmarks/longcodebench/prepare.py
@@ -16,9 +16,11 @@
 """Prepare LongCodeBench (LongCodeQA) evaluation data for NeMo Gym.
 
 LongCodeBench is a multi-choice QA benchmark over long code contexts, ported
-1-to-1 from the NeMo Skills `longcodebench` dataset. Each row's prompt is
-fully baked: a long code question with options A/B/C/D plus the postfix that
-instructs the model to emit `Answer: \\boxed{X}`.
+1-to-1 from the NeMo Skills `longcodebench` dataset. Each row's `question`
+field is the long code prompt plus the postfix that instructs the model to
+emit `Answer: \\boxed{X}`. The shared `benchmarks/prompts/generic_default.yaml`
+template (`user: "{question}"`) wraps it as a single user message, mirroring
+Skills' `prompt_format=openai` behaviour.
 
 The resulting Gym JSONL is consumed by the `mcqa` resource server with
 `grading_mode=strict_single_letter_boxed`. We provide empty-text option dicts
@@ -64,15 +66,13 @@ def prepare() -> Path:
 
     rows = []
     for entry in data:
-        user_content = entry["prompt"].strip() + POSTFIX
+        question = entry["prompt"].strip() + POSTFIX
         row = {
-            "responses_create_params": {
-                "input": [{"role": "user", "content": user_content}],
-            },
+            "question": question,
             "options": options,
             "expected_answer": entry["correct_letter"],
             "grading_mode": "strict_single_letter_boxed",
-            "uuid": str(uuid.uuid5(uuid.NAMESPACE_URL, user_content)),
+            "uuid": str(uuid.uuid5(uuid.NAMESPACE_URL, question)),
             "repo": entry["repo"],
             "prompt_goal": entry["prompt_goal"],
             "is_hard": entry["is_hard"],


### PR DESCRIPTION
## Summary

Adds the **LongCodeBench (LongCodeQA)** benchmark as a **data-only** migration from NeMo Skills. LongCodeBench is a multi-choice QA benchmark over long code contexts: each row presents a long code prompt with options A/B/C/D and asks the model to pick the correct letter; the prompt postfix instructs the model to emit `Answer: \boxed{X}`.

This PR adds **only** `benchmarks/longcodebench/` and **does not** modify any resources server. Verification is delegated to the existing `mcqa` resources server with `grading_mode=strict_single_letter_boxed` — the same configuration that grades `gpqa`, `mmlu_pro`, etc.

- Data source: [Steefano/LCB · LongCodeQA.zip](https://huggingface.co/datasets/Steefano/LCB)
- 443 rows, multi-choice (A/B/C/D), single-letter expected answer
- Skills source: [`nemo_skills/dataset/longcodebench/`](https://github.com/NVIDIA-NeMo/Skills/tree/main/nemo_skills/dataset/longcodebench)

## Includes

- `benchmarks/longcodebench/` — benchmark config, prepare.py, README
  - Data source: HuggingFace `Steefano/LCB/LongCodeQA.zip` (443 rows)
  - Prompt strategy: messages fully baked into JSONL via `responses_create_params.input` (`prompt_config: null`), mirroring Skills' `prompt_format=openai`
  - Bound to the existing `mcqa` resource server via `_inherit_from: mcqa_simple_agent`
  - `grading_mode=strict_single_letter_boxed` to match Skills' `Answer: \boxed{X}` postfix; metrics inherited from `mcqa`

## Implementation notes

- **Messages are baked into the JSONL.** Skills uses `prompt_format=openai`, sending the full `prompt + postfix` as a user message with no prompt template. We mirror this on the Gym side via `responses_create_params.input` per row, with `prompt_config: null` in the dataset entry — same shape used by the `aalcr` benchmark.
- **`options` are empty-text dicts keyed `A`/`B`/`C`/`D`.** The mcqa server's `strict_single_letter_boxed` grading mode only consumes the option *keys* (to populate `allowed_letters`); option text is irrelevant since the prompt postfix forces the model to emit `\boxed{<letter>}`. The four-letter option set matches Skills' implicit allowed-letter set for `eval_type=multichoice`.

## Data-parity validation

Both prepare scripts download the same source (`Steefano/LCB/LongCodeQA.zip` on HuggingFace) and emit one JSONL row per upstream record. Skills writes the prompt+postfix into `messages`; Gym writes the same prompt+postfix into `responses_create_params.input` (mcqa server's expected shape).

| Check | Result |
|-------|--------|
| Row count | 443 / 443 (MATCH) |
| Common questions (normalized user-message text) | 443 / 443 |
| `expected_answer` agreement | 100% |
| `repo` agreement | 100% |
| `prompt_goal` agreement | 100% |
| `is_hard` agreement | 100% |

Intentional schema deltas:
- Skills-only: `messages` (replaced by `responses_create_params.input` on Gym), `n_tokens_cl100k_base` (omitted, see above).
- Gym-only: `responses_create_params`, `options`, `grading_mode`, `uuid` — mcqa server contract fields.

## Test plan
- [x] `prepare.py` runs and writes 443-row JSONL
- [x] Skills-vs-Gym data-parity comparison reports row-count MATCH and 100% required-field agreement on `repo` / `prompt_goal` / `is_hard` / `expected_answer`
- [x] mcqa server contract: `grading_mode=strict_single_letter_boxed`, `options` keys A/B/C/D populated
