### PR TITLE
Add longbench-v2 benchmark (data-only)

### DIFF
--- a/benchmarks/longbench_v2/README.md
+++ b/benchmarks/longbench_v2/README.md
@@ -33,5 +33,6 @@ ng_collect_rollouts \
     +agent_name=longbench_v2_mcqa_simple_agent \
     +input_jsonl_fpath=benchmarks/longbench_v2/data/longbench_v2_benchmark.jsonl \
     +output_jsonl_fpath=results/longbench_v2_rollouts.jsonl \
+    +prompt_config=benchmarks/longbench_v2/prompts/default.yaml \
     +num_repeats=4
 ```

--- a/benchmarks/longbench_v2/README.md
+++ b/benchmarks/longbench_v2/README.md
@@ -1,0 +1,37 @@
+# LongBench-v2
+
+[LongBench v2](https://arxiv.org/abs/2412.15204) is a multiple-choice
+long-context benchmark (4 choices: A/B/C/D, 503 questions) covering 6
+domains over 8k-2M-word contexts: single-doc QA, multi-doc QA, long
+in-context learning, long-dialogue history, code-repo understanding,
+and long structured data.
+
+Mirrors nemo-skills' `nemo_skills/dataset/longbench-v2`. Reuses the
+existing [`mcqa`](../../resources_servers/mcqa) resource server for
+grading; this directory adds only the dataset and prompt.
+
+Data source: HuggingFace `THUDM/LongBench-v2` (single "train" split,
+which is the full eval set). `prepare.py` preserves every Skills
+field (`index`, `context`, `question`, `choice_A..D`, `expected_answer`,
+`domain`, `sub_domain`, `difficulty`, `length`, `context_tokens` via
+tiktoken `cl100k_base`) and additionally emits `options` and
+`grading_mode` for the mcqa server.
+
+## Example usage
+
+```bash
+# Prepare benchmark data
+ng_prepare_benchmark "+config_paths=[benchmarks/longbench_v2/config.yaml]"
+
+# Running servers
+config_paths="responses_api_models/vllm_model/configs/vllm_model.yaml,\
+benchmarks/longbench_v2/config.yaml"
+ng_run "+config_paths=[$config_paths]"
+
+# Collecting rollouts
+ng_collect_rollouts \
+    +agent_name=longbench_v2_mcqa_simple_agent \
+    +input_jsonl_fpath=benchmarks/longbench_v2/data/longbench_v2_benchmark.jsonl \
+    +output_jsonl_fpath=results/longbench_v2_rollouts.jsonl \
+    +num_repeats=4
+```

--- a/benchmarks/longbench_v2/config.yaml
+++ b/benchmarks/longbench_v2/config.yaml
@@ -1,0 +1,14 @@
+config_paths:
+  - resources_servers/mcqa/configs/mcqa.yaml
+
+longbench_v2_mcqa_simple_agent:
+  _inherit_from: mcqa_simple_agent
+  responses_api_agents:
+    simple_agent:
+      datasets:
+      - name: longbench_v2
+        type: benchmark
+        jsonl_fpath: benchmarks/longbench_v2/data/longbench_v2_benchmark.jsonl
+        prompt_config: benchmarks/longbench_v2/prompts/default.yaml
+        prepare_script: benchmarks/longbench_v2/prepare.py
+        license: Apache 2.0

--- a/benchmarks/longbench_v2/data/.gitignore
+++ b/benchmarks/longbench_v2/data/.gitignore
@@ -1,0 +1,1 @@
+*benchmark.jsonl

--- a/benchmarks/longbench_v2/prepare.py
+++ b/benchmarks/longbench_v2/prepare.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Prepare LongBench-v2 data for NeMo Gym.
+
+Mirrors `nemo_skills/dataset/longbench-v2/prepare.py`: loads the same
+HuggingFace dataset (`THUDM/LongBench-v2`, single "train" split that
+holds all 503 evaluation questions), preserves every Skills field
+(`index`, `context`, `question`, `choice_A..D`, `expected_answer`,
+`domain`, `sub_domain`, `difficulty`, `length`, `context_tokens`),
+and additionally emits the `options` list and `grading_mode` that the
+existing `mcqa` resource server consumes for grading.
+
+LongBench v2 covers 6 long-context domains (8k-2M words):
+single-doc QA, multi-doc QA, long in-context learning, long-dialogue
+history, code-repo understanding, long structured data.
+
+Dataset: https://huggingface.co/datasets/THUDM/LongBench-v2
+Paper:   https://arxiv.org/abs/2412.15204
+"""
+
+import json
+from pathlib import Path
+
+import tiktoken
+from datasets import load_dataset
+from tqdm import tqdm
+
+
+BENCHMARK_DIR = Path(__file__).parent
+DATA_DIR = BENCHMARK_DIR / "data"
+OUTPUT_FPATH = DATA_DIR / "longbench_v2_benchmark.jsonl"
+
+# tiktoken encoding name used by Skills' prepare.py for `context_tokens`.
+TOKENIZER_NAME = "cl100k_base"
+
+
+def prepare() -> Path:
+    """Download LongBench-v2, convert to Gym JSONL, return the output file path."""
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading THUDM/LongBench-v2 (split='train', {TOKENIZER_NAME} for context tokens) ...")
+    dataset = load_dataset("THUDM/LongBench-v2", split="train")
+    encoder = tiktoken.get_encoding(TOKENIZER_NAME)
+
+    count = 0
+    with open(OUTPUT_FPATH, "w", encoding="utf-8") as out:
+        for entry in tqdm(dataset, desc="Writing longbench_v2_benchmark.jsonl"):
+            record = {
+                # Fields preserved verbatim from Skills' prepare.py
+                "index": entry["_id"],
+                "context": entry["context"],
+                "question": entry["question"],
+                "choice_A": entry["choice_A"],
+                "choice_B": entry["choice_B"],
+                "choice_C": entry["choice_C"],
+                "choice_D": entry["choice_D"],
+                "expected_answer": entry["answer"],
+                "domain": entry["domain"],
+                "sub_domain": entry["sub_domain"],
+                "difficulty": entry["difficulty"],
+                "length": entry["length"],
+                "context_tokens": len(encoder.encode(entry["context"])),
+                # Gym-side additions consumed by the `mcqa` resource server.
+                # mcqa's verify() reads `options`, `expected_answer`, `grading_mode`.
+                "options": [
+                    {"A": entry["choice_A"]},
+                    {"B": entry["choice_B"]},
+                    {"C": entry["choice_C"]},
+                    {"D": entry["choice_D"]},
+                ],
+                "grading_mode": "strict_single_letter_boxed",
+            }
+            out.write(json.dumps(record, ensure_ascii=False) + "\n")
+            count += 1
+
+    print(f"Wrote {count} problems to {OUTPUT_FPATH}")
+    return OUTPUT_FPATH
+
+
+if __name__ == "__main__":
+    prepare()

--- a/benchmarks/longbench_v2/prepare.py
+++ b/benchmarks/longbench_v2/prepare.py
@@ -71,7 +71,11 @@ def prepare() -> Path:
                 "sub_domain": entry["sub_domain"],
                 "difficulty": entry["difficulty"],
                 "length": entry["length"],
-                "context_tokens": len(encoder.encode(entry["context"])),
+                # disallowed_special=() — some LongBench-v2 contexts contain
+                # raw `<|endoftext|>` strings that tiktoken would otherwise
+                # refuse to encode. We only need the count, so encode them
+                # as plain text.
+                "context_tokens": len(encoder.encode(entry["context"], disallowed_special=())),
                 # Gym-side additions consumed by the `mcqa` resource server.
                 # mcqa's verify() reads `options`, `expected_answer`, `grading_mode`.
                 "options": [

--- a/benchmarks/longbench_v2/prompts/default.yaml
+++ b/benchmarks/longbench_v2/prompts/default.yaml
@@ -1,0 +1,17 @@
+user: |-
+  Please read the following text and answer the questions below.
+
+  <text>
+  {context}
+  </text>
+
+  What is the correct answer to this question: {question}
+  Choices:
+  (A) {choice_A}
+  (B) {choice_B}
+  (C) {choice_C}
+  (D) {choice_D}
+
+  Let's think step by step.
+
+  Based on your thoughts, what is the single, most likely answer choice? The last line of your response should be in the following format: 'Answer: \boxed{{A/B/C/D}}' (e.g. 'Answer: \boxed{{A}}').

--- a/resources_servers/mcqa/requirements.txt
+++ b/resources_servers/mcqa/requirements.txt
@@ -1,3 +1,2 @@
 -e nemo-gym[dev] @ ../../
-
-
+tiktoken


### PR DESCRIPTION
<!--
Opened via: gh pr create --repo NVIDIA-NeMo/Gym --base main \
            --head georgea/migrate-gym-data-only-longbench-v2 \
            --title "Add longbench-v2 benchmark (data-only)" \
            -F PR_DESCRIPTION.md
-->

## One-sentence summary

Migrates the `longbench-v2` benchmark (THUDM/LongBench-v2, 503
long-context MCQ questions) from NeMo Skills into Gym on top of the
existing `mcqa` resource server. No new servers or agents, no
metric-infra changes. Scope is deliberately data-prep-only: the new
`prepare.py` mirrors the Skills prepare method and the final file is
validated against Skills' output for every row.

## Includes

- `benchmarks/longbench_v2/` — full LongBench-v2 test split
  - Data source: `THUDM/LongBench-v2` (HuggingFace, single `train` split
    holding all 503 evaluation questions) — identical upstream dataset
    to Skills' `nemo_skills/dataset/longbench-v2/prepare.py`
  - LongBench-v2 covers 6 long-context domains (8k-2M words):
    single-doc QA, multi-doc QA, long in-context learning, long-dialogue
    history, code-repo understanding, long structured data
  - Reuses the existing `mcqa` resource server (no server changes);
    `prepare.py` emits the standard mcqa `options` list and
    `grading_mode: strict_single_letter_boxed`
- `benchmarks/longbench_v2/prompts/default.yaml` — character-for-character
  port of `nemo_skills/prompt/config/eval/longbench/default.yaml`
  (single user message, CoT-style, ends with `Answer: \boxed{A/B/C/D}`)

## Tiktoken `<|endoftext|>` handling

LongBench-v2 contexts contain raw `<|endoftext|>` strings as plain text
inside long-document corpora. tiktoken refuses to encode them by
default. Both Skills' upstream `prepare.py` (when run unpatched) and an
earlier draft of this Gym `prepare.py` aborted on these rows. The fix
(commit `a4bd3e8e` on this branch) passes `disallowed_special=()` so
the count is computed treating the literals as ordinary text — we only
need a length, not a faithful token-id sequence. The same patch is
applied on the Skills side in the parity-check recipe so both sides
are exercised symmetrically.

## Validated against NeMo Skills

Scope is data-prep parity only. This PR does not include rollout or
metrics-parity numbers (no model runs were made). The new
`prepare()` output is compared row-by-row against Skills' `prepare.py`
output. Every Skills field is identical on every row:

```
==================================================================
Data-prep parity · Skills prepare.py vs Gym prepare()
==================================================================
Benchmark           Skills rows    Gym rows    Identical
------------------------------------------------------------------
longbench_v2             503            503    503 / 503
```

Per-field equality on the 13 Skills fields (`index`, `context`,
`question`, `choice_A..D`, `expected_answer`, `domain`, `sub_domain`,
`difficulty`, `length`, `context_tokens`): `value_diff=0` on all 503
rows. Expected-answer agreement: 503 / 503. Normalized-question overlap:
100 % (15 questions repeat verbatim across different long contexts in
the upstream dataset, hence 488 unique normalized questions for 503
rows). Gym's `options` list matches `choice_A..D` on all 503 rows.

## Grader-mode note

Skills' `eval_mcq` runs two extraction passes: try `\boxed{}` first,
fall back to `(?i)Answer\s*:\s*([A-Z])`. The mcqa resource server
exposes either pass independently (`strict_single_letter_boxed` or
`lenient_answer_colon`) but not the combined fallback. Since the
prompt explicitly instructs the model to emit `Answer: \boxed{X}`, the
boxed pass catches the dominant case and `strict_single_letter_boxed`
(the mcqa default and the convention used by every other mcqa-backed
Gym benchmark) is used here. This is a property of the existing mcqa
server and is out of scope for this data-only PR — if a future Skills-vs-Gym
end-to-end check shows a `no_answer` gap larger than ~2 pp, it would
be addressed inside `mcqa` (e.g. by adding a
`lenient_boxed_then_answer_colon` mode), not by re-doing this data port.
