### PR TITLE
fix(stirrup_agent): accept local paths in reference_file_urls

### DIFF
--- a/responses_api_agents/stirrup_agent/tasks/gdpval.py
+++ b/responses_api_agents/stirrup_agent/tasks/gdpval.py
@@ -56,13 +56,19 @@ def _download_reference_files(
     reference_file_urls: list[str],
     dest_dir: Path,
 ) -> list[str]:
-    """Download reference files with HF auth + retry-on-429/5xx.
+    """Materialize reference files into ``dest_dir``.
 
-    Anonymous HuggingFace downloads hit an aggressive rate limit when the
-    agent runs tasks concurrently; the previous urlretrieve-based version
-    silently dropped files, leaving subsequent judging/scoring without
-    the reference context.  We now pass the ``HF_TOKEN`` env var as a
-    bearer token and retry with exponential backoff on HTTP 429 / 5xx.
+    Each entry in ``reference_file_urls`` is one of:
+    - an HTTP(S) URL — downloaded with HF auth + retry-on-429/5xx (anonymous
+      HuggingFace downloads hit an aggressive rate limit when the agent runs
+      tasks concurrently; the previous urlretrieve-based version silently
+      dropped files, leaving subsequent judging/scoring without the reference
+      context — we now pass ``HF_TOKEN`` as a bearer token and retry with
+      exponential backoff);
+    - an absolute filesystem path or ``file://`` URL — copied directly with
+      ``shutil.copy2``, bypassing the urllib retry loop. Benchmarks whose
+      reference files already live on the agent's filesystem (rather than on
+      the HuggingFace Hub) use this path.
     """
     import shutil as _shutil
     import time
@@ -79,6 +85,15 @@ def _download_reference_files(
         rel_path = file_path.lstrip("/")
         local_path = dest_dir / rel_path
         local_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if not (url.startswith("http://") or url.startswith("https://")):
+            src = url[len("file://") :] if url.startswith("file://") else url
+            try:
+                _shutil.copy2(src, local_path)
+                downloaded.append(rel_path)
+            except Exception as e:
+                print(f"Warning: failed to copy local file {src} -> {rel_path}: {e}", flush=True)
+            continue
 
         req = urllib.request.Request(url)
         if token:

--- a/responses_api_agents/stirrup_agent/tests/test_tasks_gdpval.py
+++ b/responses_api_agents/stirrup_agent/tests/test_tasks_gdpval.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+
+from responses_api_agents.stirrup_agent.tasks.gdpval import _download_reference_files
+
+
+class TestDownloadReferenceFilesLocal:
+    """The local-path / ``file://`` branch of ``_download_reference_files``."""
+
+    def test_absolute_path_is_copied(self, tmp_path: Path) -> None:
+        src = tmp_path / "src" / "input.xlsx"
+        src.parent.mkdir()
+        src.write_bytes(b"hello")
+
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        downloaded = _download_reference_files(["input.xlsx"], [str(src)], dest_dir)
+
+        assert downloaded == ["input.xlsx"]
+        assert (dest_dir / "input.xlsx").read_bytes() == b"hello"
+
+    def test_file_url_is_copied(self, tmp_path: Path) -> None:
+        src = tmp_path / "src" / "input.txt"
+        src.parent.mkdir()
+        src.write_bytes(b"world")
+
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        downloaded = _download_reference_files(["input.txt"], [f"file://{src}"], dest_dir)
+
+        assert downloaded == ["input.txt"]
+        assert (dest_dir / "input.txt").read_bytes() == b"world"
+
+    def test_missing_local_file_does_not_raise(self, tmp_path: Path) -> None:
+        """A bad local path should be logged but not abort the whole batch."""
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        downloaded = _download_reference_files(["missing.bin"], [str(tmp_path / "does-not-exist.bin")], dest_dir)
+
+        assert downloaded == []
+        assert not (dest_dir / "missing.bin").exists()
+
+    def test_nested_dest_path_is_created(self, tmp_path: Path) -> None:
+        """``reference_files`` may contain nested paths; parent dirs are created."""
+        src = tmp_path / "src.bin"
+        src.write_bytes(b"data")
+
+        dest_dir = tmp_path / "dest"
+        dest_dir.mkdir()
+
+        downloaded = _download_reference_files(["sub/dir/file.bin"], [str(src)], dest_dir)
+
+        assert downloaded == ["sub/dir/file.bin"]
+        assert (dest_dir / "sub" / "dir" / "file.bin").read_bytes() == b"data"


### PR DESCRIPTION
## Summary

- Adds a copy-from-disk fast path to `_download_reference_files` so any entry in `reference_file_urls` that isn't an `http://` / `https://` URL (i.e. an absolute filesystem path or a `file://` URL) is materialized via `shutil.copy2` instead of going through the urllib download + retry loop.
- All existing GDPVal HF URLs continue to take the unchanged urllib + HF-token path; behaviour is strictly additive.
- Motivated by benchmarks whose reference files already live on the agent's filesystem rather than on the HuggingFace Hub — currently those entries crash with a URL parse error inside `urllib.request.Request`.

## Test plan

- [x] `pytest responses_api_agents/stirrup_agent/tests/test_tasks_gdpval.py -v` — 4 new tests pass:
  - absolute path → copied
  - `file://` URL → copied
  - missing local file → logged, returns `[]`, doesn't abort the batch
  - nested `reference_files` path → parent dirs created
- [x] `ruff check` / `ruff format --check` clean
- [x] Manual end-to-end: 5-task smoke + 140-task run on an internal benchmark whose `reference_file_urls` are absolute lustre paths — agents materialize the reference files into their sandboxes and produce non-zero rewards.