### PR TITLE
fix: don't crash rollouts on malformed tool-call arguments and missing message content

### DIFF
--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -138,7 +138,9 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                     tool_response = NeMoGymFunctionCallOutput(
                         type="function_call_output",
                         call_id=output_function_call.call_id,
-                        output=json.dumps({"error": f"Invalid tool call arguments: {e}"}),
+                        # Use repr(e) so the exception type name is always
+                        # included even when str(e) would be empty.
+                        output=json.dumps({"error": f"Invalid tool call arguments: {e!r}"}),
                     )
                     new_outputs.append(tool_response)
                     continue

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -128,10 +128,25 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 break
 
             for output_function_call in all_fn_calls:
+                try:
+                    parsed_arguments = json.loads(output_function_call.arguments)
+                except (json.JSONDecodeError, TypeError) as e:
+                    # Model produced malformed tool-call arguments. Surface the
+                    # error back as a tool response so the rollout can continue
+                    # (or terminate with a low reward) instead of crashing the
+                    # whole batch on json.loads.
+                    tool_response = NeMoGymFunctionCallOutput(
+                        type="function_call_output",
+                        call_id=output_function_call.call_id,
+                        output=json.dumps({"error": f"Invalid tool call arguments: {e}"}),
+                    )
+                    new_outputs.append(tool_response)
+                    continue
+
                 api_response = await self.server_client.post(
                     server_name=self.config.resources_server.name,
                     url_path=f"/{output_function_call.name}",
-                    json=json.loads(output_function_call.arguments),
+                    json=parsed_arguments,
                     cookies=resources_server_cookies,
                 )
                 # We don't raise for status here since it's a valid return for the API to error e.g. if the model outputs an invalid call or something.

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -20,7 +20,9 @@ from pytest import MonkeyPatch
 
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
+    NeMoGymFunctionCallOutput,
     NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseFunctionToolCall,
     NeMoGymResponseReasoningItem,
     NeMoGymSummary,
 )
@@ -161,6 +163,111 @@ class TestApp:
             "safety_identifier": None,
         }
         assert expected_responses_dict == actual_responses_dict
+
+    async def test_responses_continues_on_malformed_tool_call_arguments(self, monkeypatch: MonkeyPatch) -> None:
+        """Malformed JSON in a tool-call's arguments must not crash the rollout.
+
+        The agent should surface the parse error back to the model as a
+        function_call_output and let the loop continue (ultimately terminating
+        on a normal assistant message).
+        """
+        config = SimpleAgentConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            model_server=ModelServerRef(
+                type="responses_api_models",
+                name="my server name",
+            ),
+            resources_server=ResourcesServerRef(
+                type="resources_servers",
+                name="my resources server",
+            ),
+        )
+        server = SimpleAgent(config=config, server_client=MagicMock(spec=ServerClient))
+        app = server.setup_webserver()
+        client = TestClient(app)
+
+        mock_response_bad_tool_call = {
+            "id": "resp_bad_tool_call",
+            "created_at": 1753983920.0,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [
+                {
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "my_tool",
+                    # Not valid JSON.
+                    "arguments": "{not json",
+                    "type": "function_call",
+                    "status": "completed",
+                }
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+
+        mock_response_chat_data = {
+            "id": "resp_final",
+            "created_at": 1753983921.0,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [
+                {
+                    "id": "msg_final",
+                    "content": [
+                        {
+                            "annotations": [],
+                            "text": "Sorry, I'll stop calling that tool.",
+                            "type": "output_text",
+                        }
+                    ],
+                    "role": "assistant",
+                    "status": "completed",
+                    "type": "message",
+                }
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+
+        dotjson_mock = AsyncMock()
+        dotjson_mock.read.side_effect = [
+            json.dumps(mock_response_bad_tool_call),
+            json.dumps(mock_response_chat_data),
+        ]
+        dotjson_mock.cookies = MagicMock()
+        server.server_client.post.return_value = dotjson_mock
+
+        res = client.post("/v1/responses", json={"input": [{"role": "user", "content": "hello"}]})
+        assert res.status_code == 200
+
+        # The resources server must not be called for a malformed tool call —
+        # only the two model calls should hit server_client.post.
+        post_call_kwargs = [c.kwargs for c in server.server_client.post.call_args_list]
+        server_names_called = [kw["server_name"] for kw in post_call_kwargs]
+        assert server_names_called == ["my server name", "my server name"]
+
+        # The second model call's input must include the original function_call
+        # plus a function_call_output describing the parse error.
+        second_call_input = post_call_kwargs[1]["json"].input
+        assert any(
+            isinstance(item, NeMoGymResponseFunctionToolCall) and item.call_id == "call_1"
+            for item in second_call_input
+        )
+        error_outputs = [
+            item
+            for item in second_call_input
+            if isinstance(item, NeMoGymFunctionCallOutput) and item.call_id == "call_1"
+        ]
+        assert len(error_outputs) == 1
+        error_payload = json.loads(error_outputs[0].output)
+        assert "error" in error_payload
+        assert "Invalid tool call arguments" in error_payload["error"]
 
     async def test_responses_continues_on_reasoning_only(self, monkeypatch: MonkeyPatch) -> None:
         config = SimpleAgentConfig(

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -268,6 +268,9 @@ class TestApp:
         error_payload = json.loads(error_outputs[0].output)
         assert "error" in error_payload
         assert "Invalid tool call arguments" in error_payload["error"]
+        # The exception type must be visible to the model — repr(e) on a
+        # JSONDecodeError starts with the class name.
+        assert "JSONDecodeError" in error_payload["error"]
 
     async def test_responses_continues_on_reasoning_only(self, monkeypatch: MonkeyPatch) -> None:
         config = SimpleAgentConfig(

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -490,7 +490,7 @@ class VLLMModel(SimpleResponsesAPIModel):
                 # We wrap this here in think tags for Gym's sake and to return a valid OpenAI Chat Completions response.
                 choice_dict["message"]["content"] = self._converter._wrap_reasoning_in_think_tags(
                     [reasoning_content]
-                ) + (choice_dict["message"]["content"] or "")
+                ) + (choice_dict["message"].get("content") or "")
         else:
             # See the TODO wrt reasoning_content above
             assert not (choice_dict["message"].get("reasoning_content") or choice_dict["message"].get("reasoning")), (


### PR DESCRIPTION
## Summary

Two small defensive fixes that came up while running rollouts; both were triggering crashes on otherwise-recoverable model outputs.

- **`simple_agent`**: when the model emits tool-call `arguments` that aren't valid JSON, the agent crashed the whole rollout batch on `json.loads(output_function_call.arguments)`. Catch `JSONDecodeError`/`TypeError`, surface the parse error back to the model as a `function_call_output`, and let the loop continue (it will either self-correct on the next turn or terminate naturally with a low reward). Adds a unit test exercising this path.
- **`vllm_model`**: in the reasoning-parser branch, `choice_dict["message"]["content"] or ""` would `KeyError` if the upstream response omitted the `content` key entirely (some vLLM responses do this when only `reasoning_content` is set). Switched to `choice_dict["message"].get("content") or ""` so a missing key behaves the same as `None`.

Both are pulled out of a longer-running branch as standalone, isolated fixes; no behavior changes for the happy paths.

## Test plan

- [x] `pytest responses_api_agents/simple_agent/tests/test_app.py` — all 6 tests pass, including the new `test_responses_continues_on_malformed_tool_call_arguments`.
- [x] `pytest responses_api_models/vllm_model/tests/test_app.py` — all 66 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)