### PR TITLE
[Stirrup] Emit function_call_output items in rollouts

### DIFF
--- a/responses_api_agents/stirrup_agent/stirrup_utils.py
+++ b/responses_api_agents/stirrup_agent/stirrup_utils.py
@@ -41,14 +41,37 @@ def convert_stirrup_history_to_output_items(
     system/user messages and *output_items* are assistant messages +
     tool calls/results.
     """
+    from stirrup.core.models import (
+        AssistantMessage,
+        SystemMessage,
+        ToolMessage,
+        UserMessage,
+    )
+
     input_items: list = []
     output_items: list = []
 
     for turn in history:
         for msg in turn:
-            msg_type = type(msg).__name__
+            # Tool result. ``ToolMessage`` is the canonical case; ``NeMoUserMessage``
+            # (a ``UserMessage`` subclass produced by ``NeMoAgent.run_tool`` when
+            # ``tool_response_as_user=True``) carries the same metadata but
+            # serialises as ``role=user`` for the LLM. Detect both via the
+            # ``tool_call_id`` attribute so the rollout always retains a
+            # ``function_call_output`` paired with the upstream ``function_call``.
+            tool_call_id = getattr(msg, "tool_call_id", None)
+            if isinstance(msg, ToolMessage) or tool_call_id:
+                call_id = tool_call_id or f"call-{uuid.uuid4().hex[:8]}"
+                content = msg.content if isinstance(msg.content, str) else str(msg.content)
+                output_items.append(
+                    NeMoGymFunctionCallOutput(
+                        call_id=call_id,
+                        output=content,
+                        type="function_call_output",
+                    )
+                )
 
-            if msg_type == "SystemMessage":
+            elif isinstance(msg, SystemMessage):
                 input_items.append(
                     NeMoGymEasyInputMessage(
                         role="system",
@@ -56,7 +79,7 @@ def convert_stirrup_history_to_output_items(
                     )
                 )
 
-            elif msg_type == "UserMessage":
+            elif isinstance(msg, UserMessage):
                 content_text = ""
                 if isinstance(msg.content, str):
                     content_text = msg.content
@@ -67,7 +90,7 @@ def convert_stirrup_history_to_output_items(
 
                 input_items.append(NeMoGymEasyInputMessage(role="user", content=content_text))
 
-            elif msg_type == "AssistantMessage":
+            elif isinstance(msg, AssistantMessage):
                 content_text = msg.content if isinstance(msg.content, str) else ""
                 if content_text:
                     output_items.append(
@@ -88,7 +111,11 @@ def convert_stirrup_history_to_output_items(
 
                 if hasattr(msg, "tool_calls") and msg.tool_calls:
                     for tc in msg.tool_calls:
-                        call_id = tc.id if hasattr(tc, "id") else f"call-{uuid.uuid4().hex[:8]}"
+                        # Stirrup ``ToolCall`` exposes ``tool_call_id``; preserve it so the
+                        # downstream ``function_call_output`` (keyed on the same id) pairs.
+                        call_id = (
+                            getattr(tc, "tool_call_id", None) or getattr(tc, "id", None) or f"call-{uuid.uuid4().hex[:8]}"
+                        )
                         output_items.append(
                             NeMoGymResponseFunctionToolCall(
                                 id=f"fc-{uuid.uuid4().hex[:8]}",
@@ -99,17 +126,6 @@ def convert_stirrup_history_to_output_items(
                                 status="completed",
                             )
                         )
-
-            elif msg_type == "ToolMessage":
-                call_id = msg.tool_call_id if hasattr(msg, "tool_call_id") else f"call-{uuid.uuid4().hex[:8]}"
-                content = msg.content if isinstance(msg.content, str) else str(msg.content)
-                output_items.append(
-                    NeMoGymFunctionCallOutput(
-                        call_id=call_id,
-                        output=content,
-                        type="function_call_output",
-                    )
-                )
 
     return input_items, output_items
 

--- a/responses_api_agents/stirrup_agent/tests/test_stirrup_utils.py
+++ b/responses_api_agents/stirrup_agent/tests/test_stirrup_utils.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ``stirrup_utils.convert_stirrup_history_to_output_items``.
+
+Focuses on the rollout-output coverage of tool results: ``ToolMessage``
+and ``NeMoUserMessage`` (the ``UserMessage`` subclass produced when
+``tool_response_as_user=True``) must both materialise as
+``function_call_output`` items, with ``call_id`` paired to the
+upstream ``function_call``.
+"""
+
+from __future__ import annotations
+
+from stirrup.core.models import (
+    AssistantMessage,
+    SystemMessage,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+)
+
+from responses_api_agents.stirrup_agent.nemo_agent import NeMoUserMessage
+from responses_api_agents.stirrup_agent.stirrup_utils import (
+    convert_stirrup_history_to_output_items,
+)
+
+
+def _types(items):
+    return [it.type for it in items]
+
+
+def _call_ids(items, item_type):
+    return [it.call_id for it in items if it.type == item_type]
+
+
+def test_tool_message_emits_function_call_output_paired_with_call() -> None:
+    history = [
+        [
+            SystemMessage(content="sys"),
+            UserMessage(content="user prompt"),
+        ],
+        [
+            AssistantMessage(
+                content="thinking",
+                tool_calls=[ToolCall(name="code_exec", arguments='{"code": "1+1"}', tool_call_id="abc123")],
+            ),
+            ToolMessage(content="2", tool_call_id="abc123", name="code_exec", success=True),
+        ],
+    ]
+    input_items, output_items = convert_stirrup_history_to_output_items(history)
+
+    assert _types(input_items) == ["message", "message"]
+    assert _types(output_items) == ["message", "function_call", "function_call_output"]
+    assert _call_ids(output_items, "function_call") == ["abc123"]
+    assert _call_ids(output_items, "function_call_output") == ["abc123"]
+
+
+def test_nemo_user_message_with_tool_call_id_emits_function_call_output() -> None:
+    """``NeMoUserMessage`` is a ``UserMessage`` subclass; without the
+    tool_call_id-based dispatch its tool output would either be dropped or
+    misclassified as a regular user message."""
+    history = [
+        [
+            AssistantMessage(
+                content="",
+                tool_calls=[ToolCall(name="code_exec", arguments="{}", tool_call_id="tc-1")],
+            ),
+            NeMoUserMessage(content="stdout: ok", tool_call_id="tc-1", name="code_exec", success=True),
+        ],
+    ]
+    _, output_items = convert_stirrup_history_to_output_items(history)
+
+    assert _types(output_items) == ["function_call", "function_call_output"]
+    assert _call_ids(output_items, "function_call") == ["tc-1"]
+    assert _call_ids(output_items, "function_call_output") == ["tc-1"]
+    fco = output_items[1]
+    assert fco.output == "stdout: ok"
+
+
+def test_plain_user_message_routes_to_input_items() -> None:
+    """A regular ``UserMessage`` (no ``tool_call_id``) must land in input_items,
+    not be misclassified as a tool result."""
+    history = [[UserMessage(content="hello")]]
+    input_items, output_items = convert_stirrup_history_to_output_items(history)
+
+    assert len(input_items) == 1
+    assert input_items[0].role == "user"
+    assert input_items[0].content == "hello"
+    assert output_items == []
+
+
+def test_assistant_tool_call_uses_stirrup_tool_call_id() -> None:
+    """``ToolCall.tool_call_id`` is the canonical id field; verify that the
+    function_call output uses it (rather than falling back to a random uuid)
+    so it pairs with the corresponding function_call_output."""
+    history = [
+        [
+            AssistantMessage(
+                content="",
+                tool_calls=[ToolCall(name="run", arguments="{}", tool_call_id="real-id-7")],
+            ),
+        ],
+    ]
+    _, output_items = convert_stirrup_history_to_output_items(history)
+    assert _call_ids(output_items, "function_call") == ["real-id-7"]


### PR DESCRIPTION
## Summary

The Stirrup agent's rollouts were missing all `function_call_output` items, leaving every `function_call` un-paired in `response.output`. This breaks downstream consumers that read the rollout transcript (RL training, trajectory inspection); GDPVal scoring is unaffected because it grades the persisted deliverable files, not the trace.

## Root cause

`responses_api_agents/stirrup_agent/stirrup_utils.py::convert_stirrup_history_to_output_items` dispatches on `type(msg).__name__` against literal strings (`"UserMessage"`, `"ToolMessage"`, …). When `tool_response_as_user=True` (the default in `app.py`), `NeMoAgent.run_tool` returns `NeMoUserMessage` — a `UserMessage` subclass that carries the tool metadata. `type(msg).__name__` is `"NeMoUserMessage"`, which matches neither branch, so the message was silently dropped.

The same function also read `tc.id` for the assistant's tool calls; Stirrup's `ToolCall` exposes `tool_call_id`, so the call_id fell through to a random `f"call-{uuid.uuid4().hex[:8]}"`. Even when a tool result was emitted, the upstream `function_call` and downstream `function_call_output` would not have shared an id.

## Fix

- Switch dispatch to `isinstance` checks against `stirrup.core.models` types.
- Detect tool results via `isinstance(msg, ToolMessage) or getattr(msg, "tool_call_id", None)` so `NeMoUserMessage` (a `UserMessage` subclass with `tool_call_id` set) routes to `function_call_output` instead of being misclassified or dropped.
- Read `ToolCall.tool_call_id` (with `.id` and a uuid fallback) so `function_call.call_id` matches the paired `function_call_output.call_id`.

## Test plan

- [x] Unit tests covering `ToolMessage`, `NeMoUserMessage` (with `tool_call_id`), plain `UserMessage`, and assistant-`tool_calls` id propagation (`responses_api_agents/stirrup_agent/tests/test_stirrup_utils.py`).
- [ ] CI to confirm all stirrup_agent tests pass on the runner.