### PR TITLE
[Stirrup] Lift LLM kwargs from config and clear stale deliverables

### DIFF
--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -148,6 +148,9 @@ async def _run_stirrup_agent(
     is_gdpval: bool = False,
     model_id: Optional[str] = None,
     completion_token_buffer: int = 1000,
+    top_p: float = 0.95,
+    enable_thinking: bool = True,
+    max_completion_tokens_cap: int = 64000,
 ) -> Dict[str, Any]:
     """Run a Stirrup agent session and return history + metadata.
 
@@ -209,6 +212,10 @@ async def _run_stirrup_agent(
         max_tokens=max_tokens,
         model_id=model_id,
         completion_token_buffer=completion_token_buffer,
+        temperature=temperature,
+        top_p=top_p,
+        enable_thinking=enable_thinking,
+        max_completion_tokens_cap=max_completion_tokens_cap,
     )
 
     if exec_provider_class:
@@ -341,10 +348,14 @@ async def _run_stirrup_agent(
             import uuid
 
             # ``<persist>/task_<task_id>/repeat_<rollout_index>/`` so concurrent
-            # repeats of the same task don't clobber each other.
+            # repeats of the same task don't clobber each other. Clear the
+            # directory first so a re-visit of the same (task, repeat) — e.g.
+            # across RL training steps — doesn't leak stale files from a prior
+            # run into the judge's input set.
             dir_name = f"task_{task_id}" if task_id else f"task_{uuid.uuid4().hex[:8]}"
             repeat_name = f"repeat_{rollout_index}" if rollout_index is not None else "repeat_0"
             task_dir = Path(persist_deliverables_dir) / dir_name / repeat_name
+            shutil.rmtree(task_dir, ignore_errors=True)
             task_dir.mkdir(parents=True, exist_ok=True)
 
             # 1. Deliverable files
@@ -498,6 +509,21 @@ class StirrupAgentWrapperConfig(BaseResponsesAPIAgentConfig):
         "(messages + tool-schema JSON) and the exact prompt the server sees after chat-template "
         "rendering. See ``nemo_client.DynamicMaxTokensChatCompletionsClient``.",
     )
+    top_p: float = Field(
+        default=0.95,
+        description="Top-p sampling cutoff for the policy model. Forwarded to the LLM client.",
+    )
+    enable_thinking: bool = Field(
+        default=True,
+        description="Whether to enable reasoning tokens (sets "
+        "``extra_body.chat_template_kwargs.enable_thinking``). Reasoning-trained models default to True.",
+    )
+    max_completion_tokens_cap: int = Field(
+        default=64000,
+        description="Hard ceiling on per-call ``max_completion_tokens``. Dynamic sizing computes "
+        "context_window - input_tokens - completion_token_buffer, then caps to this value. "
+        "Set to match the training-side response-length budget for RL.",
+    )
 
 
 class StirrupRunRequest(BaseRunRequest):
@@ -612,6 +638,9 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 "is_gdpval": self.config.task == "gdpval",
                 "model_id": self.config.model_id,
                 "completion_token_buffer": self.config.completion_token_buffer,
+                "top_p": getattr(body, "top_p", None) or self.config.top_p,
+                "enable_thinking": self.config.enable_thinking,
+                "max_completion_tokens_cap": self.config.max_completion_tokens_cap,
             }
 
             future = run_stirrup_agent_remote.remote(params)

--- a/responses_api_agents/stirrup_agent/nemo_client.py
+++ b/responses_api_agents/stirrup_agent/nemo_client.py
@@ -71,7 +71,7 @@ _MIN_COMPLETION_TOKENS = 1024
 
 # Hard cap on per-call max_completion_tokens.  Oversized completion budgets
 # on long-context servers can degrade output quality for reasoning models.
-_MAX_COMPLETION_TOKENS = 64000
+_DEFAULT_MAX_COMPLETION_TOKENS_CAP = 64000
 
 
 def _load_tokenizer(model_id: Optional[str]):
@@ -124,10 +124,18 @@ class DynamicMaxTokensChatCompletionsClient(ChatCompletionsClient):
         *args: Any,
         model_id: Optional[str] = None,
         completion_token_buffer: int = 1000,
+        temperature: float = 1.0,
+        top_p: float = 0.95,
+        enable_thinking: bool = True,
+        max_completion_tokens_cap: int = _DEFAULT_MAX_COMPLETION_TOKENS_CAP,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
         self._completion_token_buffer = completion_token_buffer
+        self._temperature = temperature
+        self._top_p = top_p
+        self._enable_thinking = enable_thinking
+        self._max_completion_tokens_cap = max_completion_tokens_cap
         self._tokenizer = _load_tokenizer(model_id)
         if model_id and self._tokenizer is None:
             LOGGER.warning(
@@ -236,18 +244,17 @@ class DynamicMaxTokensChatCompletionsClient(ChatCompletionsClient):
             context_window - input_tokens - self._completion_token_buffer,
             _MIN_COMPLETION_TOKENS,
         )
-        capped_max = min(dynamic_max, _MAX_COMPLETION_TOKENS)
+        capped_max = min(dynamic_max, self._max_completion_tokens_cap)
 
-        # Defaults tuned for reasoning-trained models: thinking enabled,
-        # temperature=1.0, top_p=0.95, capped completion budget.
-        # ``self._kwargs`` is spread last so explicit config overrides win.
+        # ``self._kwargs`` is spread last so explicit per-request kwargs override
+        # the agent-level defaults.
         request_kwargs: dict[str, Any] = {
             "model": self._model,
             "messages": to_openai_messages(messages),
-            "temperature": 1.0,
-            "top_p": 0.95,
+            "temperature": self._temperature,
+            "top_p": self._top_p,
             "max_completion_tokens": capped_max,
-            "extra_body": {"chat_template_kwargs": {"enable_thinking": True}},
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": self._enable_thinking}},
             **self._kwargs,
         }
         if tools:

--- a/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
+++ b/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ``DynamicMaxTokensChatCompletionsClient``.
+
+Covers per-call sampling kwargs (``temperature``, ``top_p``,
+``enable_thinking``) and the configurable per-call completion cap
+(``max_completion_tokens_cap``) — all of which used to be hardcoded.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from stirrup.core.models import AssistantMessage, SystemMessage, UserMessage
+
+from responses_api_agents.stirrup_agent.nemo_client import (
+    DynamicMaxTokensChatCompletionsClient,
+)
+
+
+def _make_response(content: str = "ok"):
+    """Build a fake openai chat.completions response shape."""
+    response = MagicMock()
+    choice = MagicMock()
+    choice.finish_reason = "stop"
+    choice.message = MagicMock()
+    choice.message.content = content
+    choice.message.tool_calls = []
+    choice.message.reasoning_content = None
+    response.choices = [choice]
+    response.usage = MagicMock()
+    response.usage.prompt_tokens = 10
+    response.usage.completion_tokens = 5
+    response.usage.completion_tokens_details = None
+    return response
+
+
+@pytest.mark.asyncio
+async def test_generate_forwards_configured_sampling_kwargs() -> None:
+    """``temperature``, ``top_p``, ``enable_thinking``, and the cap on
+    ``max_completion_tokens`` should land on the wire request_kwargs."""
+    client = DynamicMaxTokensChatCompletionsClient(
+        model="m",
+        max_tokens=10_000,
+        base_url="http://test",
+        api_key="k",
+        temperature=0.42,
+        top_p=0.7,
+        enable_thinking=False,
+        max_completion_tokens_cap=2048,
+    )
+    fake_create = AsyncMock(return_value=_make_response())
+    client._client = MagicMock()
+    client._client.chat.completions.create = fake_create
+
+    messages = [SystemMessage(content="sys"), UserMessage(content="hi")]
+    await client.generate(messages, tools={})
+
+    fake_create.assert_awaited_once()
+    sent = fake_create.await_args.kwargs
+
+    assert sent["temperature"] == pytest.approx(0.42)
+    assert sent["top_p"] == pytest.approx(0.7)
+    assert sent["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False
+    assert sent["max_completion_tokens"] <= 2048
+
+
+@pytest.mark.asyncio
+async def test_max_completion_tokens_cap_overrides_dynamic_size() -> None:
+    """When the dynamic computation exceeds the cap, the cap should win."""
+    client = DynamicMaxTokensChatCompletionsClient(
+        model="m",
+        max_tokens=1_000_000,  # huge context window → dynamic_max would exceed cap
+        base_url="http://test",
+        api_key="k",
+        max_completion_tokens_cap=512,
+    )
+    fake_create = AsyncMock(return_value=_make_response())
+    client._client = MagicMock()
+    client._client.chat.completions.create = fake_create
+
+    await client.generate([UserMessage(content="hi")], tools={})
+
+    sent = fake_create.await_args.kwargs
+    assert sent["max_completion_tokens"] == 512
+
+
+def test_defaults_match_pre_lift_behaviour() -> None:
+    """Sanity: omitting the new kwargs must keep the historical defaults
+    (temperature=1.0, top_p=0.95, enable_thinking=True, cap=64000) so existing
+    deployments that don't set the new config fields are unaffected."""
+    client = DynamicMaxTokensChatCompletionsClient(
+        model="m",
+        max_tokens=10_000,
+        base_url="http://test",
+        api_key="k",
+    )
+    assert client._temperature == 1.0
+    assert client._top_p == 0.95
+    assert client._enable_thinking is True
+    assert client._max_completion_tokens_cap == 64000

--- a/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
+++ b/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from stirrup.core.models import AssistantMessage, SystemMessage, UserMessage
+from stirrup.core.models import SystemMessage, UserMessage
 
 from responses_api_agents.stirrup_agent.nemo_client import (
     DynamicMaxTokensChatCompletionsClient,


### PR DESCRIPTION
## Summary

Two issues surfaced while validating the agent against an RL training loop:

### 1. Stale deliverables leak across rollouts

`responses_api_agents/stirrup_agent/app.py:347` does `task_dir.mkdir(parents=True, exist_ok=True)` and then copies the current run's output files into `task_dir`. It never clears the directory first, and only same-named files are overwritten by `shutil.copy2`. When an agent revisits the same `(task_id, rollout_index)` (e.g. across RL training steps that reuse `persist_deliverables_dir`), files from the prior visit linger in `repeat_<n>/`. The judge in `resources_servers/gdpval/app.py::_verify_rubric` calls `read_deliverable_files(body.deliverables_dir)` and `convert_deliverables_to_content_blocks(...)` against the whole directory, so stale artifacts from a prior step contaminate the reward signal.

Fix: `shutil.rmtree(task_dir, ignore_errors=True)` immediately before the `mkdir`. Each visit gets a clean directory.

### 2. Hardcoded LLM sampling kwargs and per-call completion cap

`nemo_client.DynamicMaxTokensChatCompletionsClient.generate` hardcoded `temperature=1.0`, `top_p=0.95`, `extra_body.chat_template_kwargs.enable_thinking=True`, and `_MAX_COMPLETION_TOKENS = 64000`. Although `temperature` is plumbed all the way through `_run_stirrup_agent`, the client never consumed it — every call ignored the configured value and ran at 1.0. The 64K cap on per-call `max_completion_tokens` similarly couldn't be tuned to match a training-side response-length budget.

Fix: expose the four values as constructor params, with the historical hardcoded values as defaults, and surface them on `StirrupAgentWrapperConfig`:

- `temperature` — already a config field; now actually reaches the client.
- `top_p: float = 0.95` (new field)
- `enable_thinking: bool = True` (new field)
- `max_completion_tokens_cap: int = 64000` (new field)

`top_p` also accepts a per-request override via `body.top_p`, mirroring how `temperature` and `max_output_tokens` already work.

## Test plan

- [x] New unit tests in `responses_api_agents/stirrup_agent/tests/test_nemo_client.py` cover the kwargs landing on the wire request, the `max_completion_tokens_cap` ceiling, and the unchanged defaults.
- [ ] CI green.