### PR TITLE
fix(gdpval): compare each eval rollout against all reference repeats

### DIFF
--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -47,17 +47,21 @@ _DEFAULT_JUDGE_PROMPT_FPATH = str(Path(__file__).parent / "prompts" / "judge_pro
 _DEFAULT_REFERENCE_ELO = 1000.0
 
 
-def _resolve_repeat_dir(task_dir: Path) -> Optional[Path]:
-    """Pick a deliverable dir for a task, supporting both layouts.
+def _iter_ref_repeat_dirs(task_dir: Path) -> List[Path]:
+    """All reference deliverable dirs for a task, supporting both layouts.
 
-    New: ``task_<id>/repeat_<n>/`` — return the lowest-numbered repeat that
-    exists. Old: flat ``task_<id>/`` — return as-is for backwards compat with
-    pre-existing reference dirs.
+    New: ``task_<id>/repeat_<n>/`` — return every repeat dir, sorted. Old:
+    flat ``task_<id>/`` — return ``[task_dir]``. Missing → ``[]``.
+
+    Returning every repeat lets the comparison verifier judge each eval
+    rollout against *all* reference rollouts so the win rate (and ELO)
+    averages over reference variance instead of being anchored to a single
+    sample.
     """
     if not task_dir.is_dir():
-        return None
+        return []
     repeats = sorted(p for p in task_dir.iterdir() if p.is_dir() and p.name.startswith("repeat_"))
-    return repeats[0] if repeats else task_dir
+    return repeats or [task_dir]
 
 
 def _safe_output_text(response: Any) -> str:
@@ -129,9 +133,17 @@ class GDPValVerifyResponse(GDPValVerifyRequest, BaseVerifyResponse):
     verify_mode: Literal["rubric", "comparison"] = "rubric"
     judge_response: Optional[Dict[str, Any]] = None
     invalid_judge_response: Optional[bool] = None
+    # Majority-decision flags across all (ref_repeat × trial) judge votes —
+    # kept for back-compat with older verify responses (still bool-valued).
     win: Optional[bool] = None
     loss: Optional[bool] = None
     tie: Optional[bool] = None
+    # Raw judge vote counts aggregated over every reference repeat × trial.
+    # ``aggregate_metrics`` prefers these so the win rate reflects all
+    # comparisons rather than treating each verify call as a single vote.
+    total_wins: Optional[int] = None
+    total_losses: Optional[int] = None
+    total_ties: Optional[int] = None
 
 
 class GDPValResourcesServer(SimpleResourcesServer):
@@ -231,17 +243,17 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         from resources_servers.gdpval.comparison import (
             build_file_section,
-            compute_comparison_reward,
             run_trials,
             task_attempted,
         )
         from resources_servers.gdpval.preconvert import preconvert_dir_async
 
         ref_root = Path(self.config.reference_deliverables_dir)
-        ref_task_dir = _resolve_repeat_dir(ref_root / f"task_{body.task_id}")
+        ref_task_root = ref_root / f"task_{body.task_id}"
+        ref_task_dirs = [d for d in _iter_ref_repeat_dirs(ref_task_root) if task_attempted(str(d))]
         eval_task_dir = Path(body.deliverables_dir) if body.deliverables_dir else None
 
-        if ref_task_dir is None or not task_attempted(str(ref_task_dir)):
+        if not ref_task_dirs:
             print(f"[gdpval] no reference deliverable for task {body.task_id}", flush=True)
             return GDPValVerifyResponse(
                 **body.model_dump(),
@@ -262,39 +274,71 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         if self.config.preconvert_office_to_pdf:
             await preconvert_dir_async(eval_task_dir, max_concurrent=self.config.preconvert_max_concurrent)
-            await preconvert_dir_async(ref_task_dir, max_concurrent=self.config.preconvert_max_concurrent)
+            for ref_dir in ref_task_dirs:
+                await preconvert_dir_async(ref_dir, max_concurrent=self.config.preconvert_max_concurrent)
 
-        refs_dir = ref_task_dir / "reference_files"
-        refs = build_file_section(str(refs_dir) if refs_dir.is_dir() else None)
-        ref_submission = build_file_section(str(ref_task_dir))
         eval_submission = build_file_section(str(eval_task_dir))
 
         overrides = dict(self.config.judge_responses_create_params_overrides or {})
         judge_base_url = get_server_url(self.config.judge_model_server.name) + "/v1"
         judge_model_name = overrides.get("model", "judge")
         judge_api_key = overrides.get("api_key", "dummy")
-
         client = OpenAI(base_url=judge_base_url, api_key=judge_api_key)
-        result = await asyncio.to_thread(
-            run_trials,
-            client=client,
-            model=judge_model_name,
-            task_prompt=body.prompt or "",
-            refs=refs,
-            submission_a=ref_submission,
-            submission_b=eval_submission,
-            num_trials=self.config.num_comparison_trials,
-        )
 
-        reward = compute_comparison_reward(result["winner"])
+        # Judge eval submission against every available reference repeat. Raw
+        # vote counts (not just per-matchup majority) are summed so the win
+        # rate averages over reference variance — see ``_iter_ref_repeat_dirs``.
+        total_wins = 0
+        total_losses = 0
+        total_ties = 0
+        per_ref_results: List[Dict[str, Any]] = []
+        for ref_dir in ref_task_dirs:
+            refs_subdir = ref_dir / "reference_files"
+            refs = build_file_section(str(refs_subdir) if refs_subdir.is_dir() else None)
+            ref_submission = build_file_section(str(ref_dir))
+            result = await asyncio.to_thread(
+                run_trials,
+                client=client,
+                model=judge_model_name,
+                task_prompt=body.prompt or "",
+                refs=refs,
+                submission_a=ref_submission,
+                submission_b=eval_submission,
+                num_trials=self.config.num_comparison_trials,
+            )
+            # ``run_trials`` casts submission_a=ref, submission_b=eval, so
+            # ``win_count_b`` is eval wins.
+            total_wins += result["win_count_b"]
+            total_losses += result["win_count_a"]
+            total_ties += result["tie_count"]
+            per_ref_results.append({"ref_repeat": ref_dir.name, **result})
+
+        total_judged = total_wins + total_losses + total_ties
+        if total_wins > total_losses:
+            reward = 1.0
+        elif total_losses > total_wins:
+            reward = 0.0
+        else:
+            reward = 0.5
+
         return GDPValVerifyResponse(
             **body.model_dump(),
             reward=reward,
             verify_mode="comparison",
-            judge_response=result,
+            judge_response={
+                "per_ref_repeat": per_ref_results,
+                "total_wins": total_wins,
+                "total_losses": total_losses,
+                "total_ties": total_ties,
+                "total_judged": total_judged,
+                "ref_repeat_count": len(ref_task_dirs),
+            },
             win=reward == 1.0,
             loss=reward == 0.0,
             tie=reward == 0.5,
+            total_wins=total_wins,
+            total_losses=total_losses,
+            total_ties=total_ties,
         )
 
     async def aggregate_metrics(self, body: AggregateMetricsRequest) -> AggregateMetrics:
@@ -303,9 +347,23 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         from resources_servers.gdpval.comparison import calculate_elo
 
-        wins = sum(1 for vr in body.verify_responses if vr.get("win"))
-        losses = sum(1 for vr in body.verify_responses if vr.get("loss"))
-        ties = sum(1 for vr in body.verify_responses if vr.get("tie"))
+        # Prefer the raw judge vote counts (``total_wins``/``total_losses``/
+        # ``total_ties``) when present so the win rate reflects every
+        # eval×ref_repeat×trial comparison. Fall back to the bool flags for
+        # verify responses produced before this field existed — those count as
+        # one vote each.
+        def _votes(vr: Dict[str, Any]) -> tuple[int, int, int]:
+            tw, tl, tt = vr.get("total_wins"), vr.get("total_losses"), vr.get("total_ties")
+            if tw is not None or tl is not None or tt is not None:
+                return int(tw or 0), int(tl or 0), int(tt or 0)
+            return int(bool(vr.get("win"))), int(bool(vr.get("loss"))), int(bool(vr.get("tie")))
+
+        wins = losses = ties = 0
+        for vr in body.verify_responses:
+            w, ls, t = _votes(vr)
+            wins += w
+            losses += ls
+            ties += t
         judged = wins + losses + ties
 
         if judged == 0:

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -27,7 +27,7 @@ from resources_servers.gdpval.app import (
     GDPValResourcesServer,
     GDPValResourcesServerConfig,
     GDPValVerifyRequest,
-    _resolve_repeat_dir,
+    _iter_ref_repeat_dirs,
 )
 
 
@@ -76,22 +76,26 @@ def _verify_request(**fields) -> GDPValVerifyRequest:
     )
 
 
-class TestResolveRepeatDir:
-    def test_picks_lowest_repeat(self, tmp_path) -> None:
+class TestIterRefRepeatDirs:
+    def test_returns_all_repeats_sorted(self, tmp_path) -> None:
         td = tmp_path / "task_x"
         (td / "repeat_1").mkdir(parents=True)
         (td / "repeat_0").mkdir()
         (td / "repeat_2").mkdir()
-        assert _resolve_repeat_dir(td) == td / "repeat_0"
+        assert _iter_ref_repeat_dirs(td) == [
+            td / "repeat_0",
+            td / "repeat_1",
+            td / "repeat_2",
+        ]
 
     def test_falls_back_to_flat_layout(self, tmp_path) -> None:
         td = tmp_path / "task_x"
         td.mkdir()
         (td / "deliverable.docx").write_text("x")
-        assert _resolve_repeat_dir(td) == td
+        assert _iter_ref_repeat_dirs(td) == [td]
 
-    def test_missing_dir_returns_none(self, tmp_path) -> None:
-        assert _resolve_repeat_dir(tmp_path / "does-not-exist") is None
+    def test_missing_dir_returns_empty(self, tmp_path) -> None:
+        assert _iter_ref_repeat_dirs(tmp_path / "does-not-exist") == []
 
 
 class TestApp:
@@ -189,6 +193,110 @@ class TestApp:
         assert resp.verify_mode == "comparison"
         assert resp.judge_response == {"error": "reference_missing"}
 
+    @pytest.mark.asyncio
+    async def test_verify_comparison_iterates_all_ref_repeats(self, tmp_path) -> None:
+        """Each eval rollout is judged against every reference repeat and the
+        raw vote counts are summed — not just one matchup against repeat_0."""
+        ref_root = tmp_path / "ref"
+        task_dir = ref_root / "task_task-1"
+        for i in range(3):
+            r = task_dir / f"repeat_{i}"
+            r.mkdir(parents=True)
+            (r / "finish_params.json").write_text("{}")
+        eval_dir = tmp_path / "eval" / "task_task-1" / "repeat_0"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "finish_params.json").write_text("{}")
+
+        server = _server(
+            reward_mode="comparison",
+            reference_deliverables_dir=str(ref_root),
+            preconvert_office_to_pdf=False,
+            num_comparison_trials=4,
+        )
+
+        seen_ref_dirs: list[str] = []
+
+        def fake_run_trials(*, submission_a, **_kwargs):
+            # ``build_file_section`` includes a ``"role": "user"`` text block
+            # whose text is "Submission:\n" followed by the dir contents — we
+            # just need to record which ref dir was passed.
+            seen_ref_dirs.append(str(submission_a))
+            # 3 eval wins (B), 1 ref win (A), 0 ties per ref repeat.
+            return {
+                "winner": "[[B]]",
+                "win_count_a": 1,
+                "win_count_b": 3,
+                "tie_count": 0,
+                "task_count": 4,
+            }
+
+        body = _verify_request(deliverables_dir=str(eval_dir))
+
+        with (
+            patch("resources_servers.gdpval.comparison.run_trials", side_effect=fake_run_trials),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+            patch("resources_servers.gdpval.comparison.build_file_section", return_value=[]),
+            patch("resources_servers.gdpval.app.OpenAI" if False else "openai.OpenAI", return_value=MagicMock()),
+        ):
+            resp = await server.verify(body)
+
+        # All three reference repeats must be judged.
+        assert len(seen_ref_dirs) == 3
+        # Vote totals: 3 ref repeats × (3 wins, 1 loss, 0 ties).
+        assert resp.total_wins == 9
+        assert resp.total_losses == 3
+        assert resp.total_ties == 0
+        assert resp.reward == 1.0
+        assert resp.win is True
+        assert resp.judge_response["ref_repeat_count"] == 3
+        assert len(resp.judge_response["per_ref_repeat"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_verify_comparison_flat_layout_back_compat(self, tmp_path) -> None:
+        """Old ``task_<id>/`` flat reference layouts still work — one matchup."""
+        ref_root = tmp_path / "ref"
+        task_dir = ref_root / "task_task-1"
+        task_dir.mkdir(parents=True)
+        (task_dir / "finish_params.json").write_text("{}")
+        eval_dir = tmp_path / "eval" / "task_task-1" / "repeat_0"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "finish_params.json").write_text("{}")
+
+        server = _server(
+            reward_mode="comparison",
+            reference_deliverables_dir=str(ref_root),
+            preconvert_office_to_pdf=False,
+            num_comparison_trials=4,
+        )
+
+        call_count = {"n": 0}
+
+        def fake_run_trials(**_kwargs):
+            call_count["n"] += 1
+            return {
+                "winner": "[[A]]",
+                "win_count_a": 4,
+                "win_count_b": 0,
+                "tie_count": 0,
+                "task_count": 4,
+            }
+
+        body = _verify_request(deliverables_dir=str(eval_dir))
+
+        with (
+            patch("resources_servers.gdpval.comparison.run_trials", side_effect=fake_run_trials),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+            patch("resources_servers.gdpval.comparison.build_file_section", return_value=[]),
+            patch("openai.OpenAI", return_value=MagicMock()),
+        ):
+            resp = await server.verify(body)
+
+        assert call_count["n"] == 1
+        assert resp.total_wins == 0
+        assert resp.total_losses == 4
+        assert resp.reward == 0.0
+        assert resp.loss is True
+
     def test_aggregate_metrics_comparison_elo(self) -> None:
         from nemo_gym.config_types import AggregateMetricsRequest
 
@@ -225,3 +333,53 @@ class TestApp:
         assert abs(result.agent_metrics["comparison/win_rate"] - 0.75) < 1e-6
         # win_rate=0.75 → ELO = 1000 - 400 * (log10(0.25) - log10(0.75)) ≈ 1190.85
         assert 1180 < result.agent_metrics["comparison/eval_elo"] < 1200
+
+    def test_aggregate_metrics_uses_raw_vote_counts(self) -> None:
+        """When verify responses carry ``total_wins``/``total_losses``/
+        ``total_ties`` (multi-ref-repeat path), they're summed as raw judge
+        votes rather than treated as one matchup each."""
+        from nemo_gym.config_types import AggregateMetricsRequest
+
+        server = _server(
+            reward_mode="comparison",
+            reference_deliverables_dir="/tmp/fork-deliverables",
+            reference_elo=1000.0,
+        )
+        # Two verify responses, each representing one eval_repeat × 3 ref
+        # repeats × 4 trials = 12 judge votes.
+        responses = [
+            {
+                "_ng_task_index": 0,
+                "_ng_rollout_index": 0,
+                "reward": 1.0,
+                "win": True,
+                "loss": False,
+                "tie": False,
+                "total_wins": 9,
+                "total_losses": 2,
+                "total_ties": 1,
+                "response": {},
+            },
+            {
+                "_ng_task_index": 0,
+                "_ng_rollout_index": 1,
+                "reward": 0.0,
+                "win": False,
+                "loss": True,
+                "tie": False,
+                "total_wins": 3,
+                "total_losses": 8,
+                "total_ties": 1,
+                "response": {},
+            },
+        ]
+        import asyncio as _asyncio
+
+        body = AggregateMetricsRequest(verify_responses=responses)
+        result = _asyncio.run(server.aggregate_metrics(body))
+        assert result.agent_metrics["comparison/wins"] == 12
+        assert result.agent_metrics["comparison/losses"] == 10
+        assert result.agent_metrics["comparison/ties"] == 2
+        assert result.agent_metrics["comparison/judged"] == 24
+        # win_rate = (12 + 0.5*2) / 24 = 13/24 ≈ 0.5417
+        assert abs(result.agent_metrics["comparison/win_rate"] - (13.0 / 24.0)) < 1e-6


### PR DESCRIPTION
## Summary

- Follow-up to #1183. That PR persisted GDPVal deliverables under `task_<id>/repeat_<n>/` per rollout, but the comparison verifier's helper `_resolve_repeat_dir` only ever picked the **lowest-numbered** reference repeat. For N reference rollouts on disk, N-1 were silently ignored, so the win rate / ELO were anchored to a single reference sample instead of averaging over reference variance.
- Replace `_resolve_repeat_dir` with `_iter_ref_repeat_dirs`, which returns **every** `repeat_*` dir (and falls back to the flat `task_<id>/` layout for back-compat with pre-#1183 reference dirs).
- In `_verify_comparison`, run a full `num_comparison_trials` judge sweep against each reference repeat for the eval rollout under verification. Sum raw judge votes into new `total_wins` / `total_losses` / `total_ties` fields on `GDPValVerifyResponse`.
- `aggregate_metrics` now prefers those raw counts when present, so the comparison win rate (and ELO) reflect every (eval_repeat × ref_repeat × trial) judge vote rather than treating each verify call as a single matchup. Verify responses produced before this change (without the new fields) fall back to the existing one-vote-per-matchup counting.

The per-call cost goes up linearly with the number of reference repeats on disk — that is the intended tradeoff. `num_comparison_trials` is unchanged per matchup.

## Test plan

- [x] `pytest resources_servers/gdpval/tests/test_app.py -x` (14 passed)
- [x] `pytest tests/unit_tests/ -x` (206 passed, no regressions)
- [x] `pre-commit run --files resources_servers/gdpval/...`
- New tests cover:
  - `_iter_ref_repeat_dirs` returns all sorted repeats / falls back to flat layout / returns `[]` for missing.
  - Multi-ref-repeat path: every `repeat_*` is judged and raw votes are summed (`total_wins=9` for 3 repeats × 3 wins each).
  - Flat-layout back-compat: only one matchup is run when the reference uses the pre-#1183 layout.
  - `aggregate_metrics` sums raw vote counts when verify responses carry them.