### PR TITLE
feat(openai_model): opt-in concurrency cap via per-server semaphore

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -12,10 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import asyncio
 import json
 from asyncio import sleep
-from contextlib import nullcontext
 from typing import (
     Any,
     Dict,
@@ -470,8 +468,6 @@ RETRY_ERROR_CODES = RATE_LIMIT_ERROR_CODES + [500]
 class NeMoGymAsyncOpenAI(BaseModel):  # pragma: no cover
     """This is just a stub class that wraps around aiohttp"""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
     base_url: str
     api_key: str
 
@@ -479,23 +475,6 @@ class NeMoGymAsyncOpenAI(BaseModel):  # pragma: no cover
         default=False,
         description="Set this to true if this particular client is only used to call internal NeMo Gym servers.",
     )
-    max_concurrent_requests: Optional[int] = Field(
-        default=None,
-        description=(
-            "Cap on in-flight upstream requests from this client (process-local "
-            "asyncio.Semaphore). Set on rate-limited endpoints (e.g. Gemini) to "
-            "stay under quota regardless of caller fan-out. None = unlimited."
-        ),
-    )
-    _semaphore: Optional[asyncio.Semaphore] = None
-
-    def _get_semaphore(self) -> Optional[asyncio.Semaphore]:
-        # Lazy init: asyncio.Semaphore needs a running event loop.
-        if self.max_concurrent_requests is None:
-            return None
-        if self._semaphore is None:
-            self._semaphore = asyncio.Semaphore(self.max_concurrent_requests)
-        return self._semaphore
 
     default_headers: Dict[str, str] = Field(
         default_factory=dict,
@@ -545,43 +524,39 @@ class NeMoGymAsyncOpenAI(BaseModel):  # pragma: no cover
         await raise_for_status(response)
 
     async def create_models(self):
-        async with self._get_semaphore() or nullcontext():
-            request_kwargs = dict(url=f"{self.base_url}/models")
-            response = await self._request(method="GET", **request_kwargs)
+        request_kwargs = dict(url=f"{self.base_url}/models")
+        response = await self._request(method="GET", **request_kwargs)
 
-            await self._raise_for_status(response, request_kwargs)
-            return await get_response_json(response)
+        await self._raise_for_status(response, request_kwargs)
+        return await get_response_json(response)
 
     async def create_chat_completion(self, **kwargs):
-        async with self._get_semaphore() or nullcontext():
-            request_kwargs = dict(
-                url=f"{self.base_url}/chat/completions",
-                json=kwargs,
-            )
-            response = await self._request(method="POST", **request_kwargs)
+        request_kwargs = dict(
+            url=f"{self.base_url}/chat/completions",
+            json=kwargs,
+        )
+        response = await self._request(method="POST", **request_kwargs)
 
-            await self._raise_for_status(response, request_kwargs)
-            return await get_response_json(response)
+        await self._raise_for_status(response, request_kwargs)
+        return await get_response_json(response)
 
     async def create_response(self, **kwargs):
-        async with self._get_semaphore() or nullcontext():
-            request_kwargs = dict(
-                url=f"{self.base_url}/responses",
-                json=kwargs,
-            )
-            response = await self._request(method="POST", **request_kwargs)
+        request_kwargs = dict(
+            url=f"{self.base_url}/responses",
+            json=kwargs,
+        )
+        response = await self._request(method="POST", **request_kwargs)
 
-            await self._raise_for_status(response, request_kwargs)
-            return await get_response_json(response)
+        await self._raise_for_status(response, request_kwargs)
+        return await get_response_json(response)
 
     async def create_tokenize(self, **kwargs):
-        async with self._get_semaphore() or nullcontext():
-            base_url = self.base_url.removesuffix("/v1")
-            request_kwargs = dict(
-                url=f"{base_url}/tokenize",
-                json=kwargs,
-            )
-            response = await self._request(method="POST", **request_kwargs)
+        base_url = self.base_url.removesuffix("/v1")
+        request_kwargs = dict(
+            url=f"{base_url}/tokenize",
+            json=kwargs,
+        )
+        response = await self._request(method="POST", **request_kwargs)
 
-            await self._raise_for_status(response, request_kwargs)
-            return await get_response_json(response)
+        await self._raise_for_status(response, request_kwargs)
+        return await get_response_json(response)

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -12,8 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import json
 from asyncio import sleep
+from contextlib import nullcontext
 from typing import (
     Any,
     Dict,
@@ -468,6 +470,8 @@ RETRY_ERROR_CODES = RATE_LIMIT_ERROR_CODES + [500]
 class NeMoGymAsyncOpenAI(BaseModel):  # pragma: no cover
     """This is just a stub class that wraps around aiohttp"""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     base_url: str
     api_key: str
 
@@ -475,6 +479,23 @@ class NeMoGymAsyncOpenAI(BaseModel):  # pragma: no cover
         default=False,
         description="Set this to true if this particular client is only used to call internal NeMo Gym servers.",
     )
+    max_concurrent_requests: Optional[int] = Field(
+        default=None,
+        description=(
+            "Cap on in-flight upstream requests from this client (process-local "
+            "asyncio.Semaphore). Set on rate-limited endpoints (e.g. Gemini) to "
+            "stay under quota regardless of caller fan-out. None = unlimited."
+        ),
+    )
+    _semaphore: Optional[asyncio.Semaphore] = None
+
+    def _get_semaphore(self) -> Optional[asyncio.Semaphore]:
+        # Lazy init: asyncio.Semaphore needs a running event loop.
+        if self.max_concurrent_requests is None:
+            return None
+        if self._semaphore is None:
+            self._semaphore = asyncio.Semaphore(self.max_concurrent_requests)
+        return self._semaphore
 
     default_headers: Dict[str, str] = Field(
         default_factory=dict,
@@ -489,7 +510,9 @@ class NeMoGymAsyncOpenAI(BaseModel):  # pragma: no cover
             },
             "_internal": self.internal,
         }
+        return await self._request_with_retry(**request_kwargs)
 
+    async def _request_with_retry(self, **request_kwargs: Dict) -> ClientResponse:
         max_num_tries = MAX_NUM_TRIES
         tries = 0
         while tries < max_num_tries:
@@ -522,39 +545,43 @@ class NeMoGymAsyncOpenAI(BaseModel):  # pragma: no cover
         await raise_for_status(response)
 
     async def create_models(self):
-        request_kwargs = dict(url=f"{self.base_url}/models")
-        response = await self._request(method="GET", **request_kwargs)
+        async with self._get_semaphore() or nullcontext():
+            request_kwargs = dict(url=f"{self.base_url}/models")
+            response = await self._request(method="GET", **request_kwargs)
 
-        await self._raise_for_status(response, request_kwargs)
-        return await get_response_json(response)
+            await self._raise_for_status(response, request_kwargs)
+            return await get_response_json(response)
 
     async def create_chat_completion(self, **kwargs):
-        request_kwargs = dict(
-            url=f"{self.base_url}/chat/completions",
-            json=kwargs,
-        )
-        response = await self._request(method="POST", **request_kwargs)
+        async with self._get_semaphore() or nullcontext():
+            request_kwargs = dict(
+                url=f"{self.base_url}/chat/completions",
+                json=kwargs,
+            )
+            response = await self._request(method="POST", **request_kwargs)
 
-        await self._raise_for_status(response, request_kwargs)
-        return await get_response_json(response)
+            await self._raise_for_status(response, request_kwargs)
+            return await get_response_json(response)
 
     async def create_response(self, **kwargs):
-        request_kwargs = dict(
-            url=f"{self.base_url}/responses",
-            json=kwargs,
-        )
-        response = await self._request(method="POST", **request_kwargs)
+        async with self._get_semaphore() or nullcontext():
+            request_kwargs = dict(
+                url=f"{self.base_url}/responses",
+                json=kwargs,
+            )
+            response = await self._request(method="POST", **request_kwargs)
 
-        await self._raise_for_status(response, request_kwargs)
-        return await get_response_json(response)
+            await self._raise_for_status(response, request_kwargs)
+            return await get_response_json(response)
 
     async def create_tokenize(self, **kwargs):
-        base_url = self.base_url.removesuffix("/v1")
-        request_kwargs = dict(
-            url=f"{base_url}/tokenize",
-            json=kwargs,
-        )
-        response = await self._request(method="POST", **request_kwargs)
+        async with self._get_semaphore() or nullcontext():
+            base_url = self.base_url.removesuffix("/v1")
+            request_kwargs = dict(
+                url=f"{base_url}/tokenize",
+                json=kwargs,
+            )
+            response = await self._request(method="POST", **request_kwargs)
 
-        await self._raise_for_status(response, request_kwargs)
-        return await get_response_json(response)
+            await self._raise_for_status(response, request_kwargs)
+            return await get_response_json(response)

--- a/responses_api_models/openai_model/app.py
+++ b/responses_api_models/openai_model/app.py
@@ -62,18 +62,15 @@ class SimpleModelServer(SimpleResponsesAPIModel):
         self._semaphore = (
             asyncio.Semaphore(self.config.max_concurrent_requests)
             if self.config.max_concurrent_requests is not None
-            else None
+            else nullcontext()
         )
 
         return super().model_post_init(context)
 
-    def _bound(self):
-        return self._semaphore if self._semaphore is not None else nullcontext()
-
     async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:
         body_dict = self.config.extra_body | body.model_dump(exclude_unset=True)
         body_dict.setdefault("model", self.config.openai_model)
-        async with self._bound():
+        async with self._semaphore:
             openai_response_dict = await self._client.create_response(**body_dict)
         return NeMoGymResponse.model_validate(openai_response_dict)
 
@@ -82,7 +79,7 @@ class SimpleModelServer(SimpleResponsesAPIModel):
     ) -> NeMoGymChatCompletion:
         body_dict = self.config.extra_body | body.model_dump(exclude_unset=True)
         body_dict.setdefault("model", self.config.openai_model)
-        async with self._bound():
+        async with self._semaphore:
             openai_response_dict = await self._client.create_chat_completion(**body_dict)
         return NeMoGymChatCompletion.model_validate(openai_response_dict)
 

--- a/responses_api_models/openai_model/app.py
+++ b/responses_api_models/openai_model/app.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
+from contextlib import nullcontext
 from typing import Any, Dict, Optional
 
 from pydantic import Field
@@ -56,15 +58,23 @@ class SimpleModelServer(SimpleResponsesAPIModel):
             base_url=self.config.openai_base_url,
             api_key=self.config.openai_api_key,
             default_headers=self.config.openai_default_headers,
-            max_concurrent_requests=self.config.max_concurrent_requests,
+        )
+        self._semaphore = (
+            asyncio.Semaphore(self.config.max_concurrent_requests)
+            if self.config.max_concurrent_requests is not None
+            else None
         )
 
         return super().model_post_init(context)
 
+    def _bound(self):
+        return self._semaphore if self._semaphore is not None else nullcontext()
+
     async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:
         body_dict = self.config.extra_body | body.model_dump(exclude_unset=True)
         body_dict.setdefault("model", self.config.openai_model)
-        openai_response_dict = await self._client.create_response(**body_dict)
+        async with self._bound():
+            openai_response_dict = await self._client.create_response(**body_dict)
         return NeMoGymResponse.model_validate(openai_response_dict)
 
     async def chat_completions(
@@ -72,7 +82,8 @@ class SimpleModelServer(SimpleResponsesAPIModel):
     ) -> NeMoGymChatCompletion:
         body_dict = self.config.extra_body | body.model_dump(exclude_unset=True)
         body_dict.setdefault("model", self.config.openai_model)
-        openai_response_dict = await self._client.create_chat_completion(**body_dict)
+        async with self._bound():
+            openai_response_dict = await self._client.create_chat_completion(**body_dict)
         return NeMoGymChatCompletion.model_validate(openai_response_dict)
 
 

--- a/responses_api_models/openai_model/app.py
+++ b/responses_api_models/openai_model/app.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pydantic import Field
 
@@ -38,6 +38,15 @@ class SimpleModelServerConfig(BaseResponsesAPIModelConfig):
     extra_body: Dict[str, Any] = Field(default_factory=dict)
     openai_default_headers: Dict[str, str] = Field(default_factory=dict)
 
+    max_concurrent_requests: Optional[int] = Field(
+        default=None,
+        description=(
+            "Cap on in-flight upstream requests from this server (per-process "
+            "asyncio.Semaphore). Set on rate-limited endpoints (e.g. Gemini) "
+            "to stay under quota; None = unlimited."
+        ),
+    )
+
 
 class SimpleModelServer(SimpleResponsesAPIModel):
     config: SimpleModelServerConfig
@@ -47,6 +56,7 @@ class SimpleModelServer(SimpleResponsesAPIModel):
             base_url=self.config.openai_base_url,
             api_key=self.config.openai_api_key,
             default_headers=self.config.openai_default_headers,
+            max_concurrent_requests=self.config.max_concurrent_requests,
         )
 
         return super().model_post_init(context)

--- a/responses_api_models/openai_model/tests/test_app.py
+++ b/responses_api_models/openai_model/tests/test_app.py
@@ -158,20 +158,19 @@ class TestApp:
 
     def test_semaphore_disabled_by_default(self) -> None:
         server = self._setup_server()
-        assert server._semaphore is None
-        assert isinstance(server._bound(), type(nullcontext()))
+        assert isinstance(server._semaphore, type(nullcontext()))
 
     @pytest.mark.asyncio
     async def test_semaphore_caps_concurrency(self) -> None:
         server = self._setup_server(max_concurrent_requests=2)
-        assert server._semaphore is not None
+        assert isinstance(server._semaphore, asyncio.Semaphore)
 
         in_flight = 0
         peak = 0
 
         async def worker() -> None:
             nonlocal in_flight, peak
-            async with server._bound():
+            async with server._semaphore:
                 in_flight += 1
                 peak = max(peak, in_flight)
                 await asyncio.sleep(0.01)

--- a/responses_api_models/openai_model/tests/test_app.py
+++ b/responses_api_models/openai_model/tests/test_app.py
@@ -12,8 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
+from contextlib import nullcontext
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 
@@ -26,7 +29,7 @@ from responses_api_models.openai_model.app import (
 
 
 class TestApp:
-    def _setup_server(self):
+    def _setup_server(self, max_concurrent_requests=None):
         config = SimpleModelServerConfig(
             host="0.0.0.0",
             port=8081,
@@ -35,6 +38,7 @@ class TestApp:
             openai_model="dummy_model",
             entrypoint="",
             name="",
+            max_concurrent_requests=max_concurrent_requests,
         )
         return SimpleModelServer(config=config, server_client=MagicMock(spec=ServerClient))
 
@@ -151,3 +155,27 @@ class TestApp:
 
         server._client.create_response.assert_any_await(input="hello", model="dummy_model")
         server._client.create_response.assert_any_await(input="hello", model="override_model")
+
+    def test_semaphore_disabled_by_default(self) -> None:
+        server = self._setup_server()
+        assert server._semaphore is None
+        assert isinstance(server._bound(), type(nullcontext()))
+
+    @pytest.mark.asyncio
+    async def test_semaphore_caps_concurrency(self) -> None:
+        server = self._setup_server(max_concurrent_requests=2)
+        assert server._semaphore is not None
+
+        in_flight = 0
+        peak = 0
+
+        async def worker() -> None:
+            nonlocal in_flight, peak
+            async with server._bound():
+                in_flight += 1
+                peak = max(peak, in_flight)
+                await asyncio.sleep(0.01)
+                in_flight -= 1
+
+        await asyncio.gather(*(worker() for _ in range(8)))
+        assert peak == 2

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import asyncio
-
 import pytest
 from pydantic import ValidationError
 
@@ -23,37 +21,6 @@ from nemo_gym.openai_utils import NeMoGymAsyncOpenAI, NeMoGymResponseCreateParam
 class TestOpenAIUtils:
     async def test_NeMoGymAsyncOpenAI(self) -> None:
         NeMoGymAsyncOpenAI(api_key="abc", base_url="https://api.openai.com/v1")
-
-    def test_semaphore_disabled_by_default(self) -> None:
-        client = NeMoGymAsyncOpenAI(api_key="abc", base_url="https://api.openai.com/v1")
-        assert client.max_concurrent_requests is None
-        assert client._get_semaphore() is None
-
-    @pytest.mark.asyncio
-    async def test_semaphore_caps_concurrency(self) -> None:
-        client = NeMoGymAsyncOpenAI(
-            api_key="abc",
-            base_url="https://api.openai.com/v1",
-            max_concurrent_requests=2,
-        )
-        sem = client._get_semaphore()
-        assert sem is not None
-        # Same instance returned across calls (lazy init only fires once).
-        assert client._get_semaphore() is sem
-
-        in_flight = 0
-        peak = 0
-
-        async def worker() -> None:
-            nonlocal in_flight, peak
-            async with sem:
-                in_flight += 1
-                peak = max(peak, in_flight)
-                await asyncio.sleep(0.01)
-                in_flight -= 1
-
-        await asyncio.gather(*(worker() for _ in range(8)))
-        assert peak == 2
 
 
 class TestNeMoGymResponseCreateParamsNonStreaming:

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
+
 import pytest
 from pydantic import ValidationError
 
@@ -21,6 +23,37 @@ from nemo_gym.openai_utils import NeMoGymAsyncOpenAI, NeMoGymResponseCreateParam
 class TestOpenAIUtils:
     async def test_NeMoGymAsyncOpenAI(self) -> None:
         NeMoGymAsyncOpenAI(api_key="abc", base_url="https://api.openai.com/v1")
+
+    def test_semaphore_disabled_by_default(self) -> None:
+        client = NeMoGymAsyncOpenAI(api_key="abc", base_url="https://api.openai.com/v1")
+        assert client.max_concurrent_requests is None
+        assert client._get_semaphore() is None
+
+    @pytest.mark.asyncio
+    async def test_semaphore_caps_concurrency(self) -> None:
+        client = NeMoGymAsyncOpenAI(
+            api_key="abc",
+            base_url="https://api.openai.com/v1",
+            max_concurrent_requests=2,
+        )
+        sem = client._get_semaphore()
+        assert sem is not None
+        # Same instance returned across calls (lazy init only fires once).
+        assert client._get_semaphore() is sem
+
+        in_flight = 0
+        peak = 0
+
+        async def worker() -> None:
+            nonlocal in_flight, peak
+            async with sem:
+                in_flight += 1
+                peak = max(peak, in_flight)
+                await asyncio.sleep(0.01)
+                in_flight -= 1
+
+        await asyncio.gather(*(worker() for _ in range(8)))
+        assert peak == 2
 
 
 class TestNeMoGymResponseCreateParamsNonStreaming:


### PR DESCRIPTION
## Summary
Adds an opt-in `max_concurrent_requests` config to `responses_api_models/openai_model`. When set, the server wraps upstream `create_chat_completion` / `create_response` calls in a per-server `asyncio.Semaphore`, so a rate-limited endpoint (e.g. Gemini) stays under quota regardless of caller fan-out. Default `None` = unlimited; existing configs are unaffected.

Originally drafted with the cap on `NeMoGymAsyncOpenAI` itself; per review, moved to the model server so the transport class stays a thin aiohttp wrapper and other model servers (`vllm_model`, `azure_openai_model`) aren't forced to carry the field.

The only change in `nemo_gym/openai_utils.py` is a refactor splitting `_request` into `_request` (adds auth headers) + `_request_with_retry` (the retry loop) — no behavior change in the retry policy itself.

## Context (production GDPVal run, slurm 2488217)
`gdpval_judge_model.log` showed 311 retry events against the Gemini-via-proxy judge endpoint:
- 274 × `502 Bad Gateway` from upstream
- 37 × `429 RESOURCE_EXHAUSTED`
- Retry chains observed up to **try 41** for a single call, pinning quota into perpetual exhaustion.

A per-server in-flight cap lets the judge config stay under the upstream's concurrent-request budget instead of relying solely on retries.

## Test plan
- [x] `pytest tests/unit_tests/test_openai_utils.py responses_api_models/openai_model/tests/test_app.py` — 9 passing (existing tests + 2 new in `test_app.py`: `test_semaphore_disabled_by_default`, `test_semaphore_caps_concurrency`)
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)