### PR TITLE
fix: verifiers agent ToolEnv downstream use

### DIFF
--- a/responses_api_agents/verifiers_agent/README.md
+++ b/responses_api_agents/verifiers_agent/README.md
@@ -65,7 +65,7 @@ python3 scripts/create_dataset.py --env-id primeintellect/ascii-tree --size 5 --
 ### Update agent server requirements
 ```
 -e nemo-gym[dev] @ ../../
-verifiers==0.1.9.post3
+verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@main
 --extra-index-url https://hub.primeintellect.ai/primeintellect/simple/
 ascii-tree
 ```
@@ -110,7 +110,7 @@ ng_collect_rollouts \
 
 ## Integration notes
 
-The patch to include prompt and generation token ids for preventing retokenization error when training with NeMo RL works specifically with the pinned verifiers version. In newer version of verifiers, this may have change. Thus, we need to make sure to use the pinned version of verifiers and environments that are compatible with this version.
+The patch to include prompt and generation token ids for preventing retokenization error when training with NeMo RL has been upstreamed into verifiers' `NeMoRLChatCompletionsClient`. We currently track verifiers `main` (`git+https://github.com/PrimeIntellect-ai/verifiers.git@main`) for this support; once verifiers `0.1.13` is released, the requirements pin will move to that tagged version.
 
 For installing new prime environments and generating datasets, use a separate venv (outside of Gym) to avoid dependency conflicts with the `exclude-dependencies` section of Gym `pyproject.toml` and the server's pinned verifiers version. After generating your dataset, deactivate the separate venv and return to the Gym venv for running servers. Make sure to restart NeMo Gym servers with `ng_run` after any environment changes to ensure the pinned version of verifiers is used.
 

--- a/responses_api_agents/verifiers_agent/app.py
+++ b/responses_api_agents/verifiers_agent/app.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import traceback
 from typing import Any
@@ -30,8 +31,11 @@ from nemo_gym.config_types import ModelServerRef
 from nemo_gym.global_config import get_first_server_config_dict
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
+    NeMoGymFunctionCallOutput,
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseFunctionToolCall,
+    NeMoGymResponseFunctionToolCallForTraining,
     NeMoGymResponseOutputMessage,
     NeMoGymResponseOutputMessageForTraining,
     NeMoGymResponseOutputText,
@@ -41,14 +45,102 @@ from nemo_gym.openai_utils import (
 logger = logging.getLogger(__name__)
 
 
+def _as_dict(msg: Any) -> dict:
+    if isinstance(msg, dict):
+        return msg
+    return {k: getattr(msg, k, None) for k in ("role", "content", "tool_calls", "tool_call_id", "tokens")}
+
+
+def _text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if content is None:
+        return ""
+    return json.dumps(content, default=str)
+
+
+def _tok_kwargs(tokens: dict | None) -> dict:
+    if not tokens:
+        return {}
+    return {
+        "prompt_token_ids": tokens.get("prompt_ids", []),
+        "generation_token_ids": tokens.get("completion_ids", []),
+        "generation_log_probs": tokens.get("completion_logprobs", []),
+    }
+
+
+def _normalize_tool_call(tool_call: Any) -> dict:
+    if isinstance(tool_call, str):
+        try:
+            return json.loads(tool_call)
+        except json.JSONDecodeError:
+            return {"arguments": tool_call}
+    return tool_call
+
+
+def _build_tool_result_item(msg: dict, raw: Any) -> dict:
+    call_id = msg.get("tool_call_id") or f"call_{id(raw)}"
+    return NeMoGymFunctionCallOutput(
+        call_id=call_id,
+        id=call_id,
+        output=_text(msg.get("content")),
+        status="completed",
+    ).model_dump()
+
+
+def _build_function_call_item(tool_call: Any, tokens: dict | None) -> dict:
+    tc = _normalize_tool_call(tool_call)
+    function = tc.get("function") if isinstance(tc.get("function"), dict) else {}
+    call_id = tc.get("id") or tc.get("call_id") or f"call_{id(tool_call)}"
+    name = tc.get("name") or function.get("name", "")
+    arguments = _text(tc.get("arguments") or function.get("arguments") or "{}")
+
+    cls = NeMoGymResponseFunctionToolCallForTraining if tokens else NeMoGymResponseFunctionToolCall
+    return cls(
+        id=call_id,
+        call_id=call_id,
+        name=name,
+        arguments=arguments,
+        status="completed",
+        **_tok_kwargs(tokens),
+    ).model_dump()
+
+
+def _build_message_item(raw: Any, body: str, tokens: dict | None) -> dict:
+    cls = NeMoGymResponseOutputMessageForTraining if tokens else NeMoGymResponseOutputMessage
+    return cls(
+        id=f"msg_{id(raw)}",
+        content=[NeMoGymResponseOutputText(text=body, annotations=[])],
+        **_tok_kwargs(tokens),
+    ).model_dump()
+
+
+def _build_assistant_items(msg: dict, raw: Any, tokens: dict | None) -> list[dict]:
+    tool_calls = msg.get("tool_calls") or []
+    body = _text(msg.get("content"))
+    items: list[dict] = []
+
+    if body:
+        items.append(_build_message_item(raw, body, tokens if not tool_calls else None))
+
+    for i, tool_call in enumerate(tool_calls):
+        is_last = i == len(tool_calls) - 1
+        items.append(_build_function_call_item(tool_call, tokens if is_last else None))
+
+    if not items:
+        items.append(_build_message_item(raw, "", tokens))
+
+    return items
+
+
 class VerifiersNeMoGymResponse(NeMoGymResponse):
     env_id: str
     group_id: str
     output: list[dict[str, Any]]
     reward: float
     metrics: dict[str, Any] = Field(default_factory=dict)
-    parallel_tool_calls: bool = False
-    tool_choice: str = "none"
+    parallel_tool_calls: bool = True
+    tool_choice: str = "auto"
     tools: list = Field(default_factory=list)
 
 
@@ -119,60 +211,54 @@ class VerifiersAgent(SimpleResponsesAPIAgent):
         return self.client_cache[cache_key]
 
     def _convert_trajectory_to_output(self, rollout_output: dict) -> list:
-        output = []
-        trajectory = rollout_output.get("trajectory", [])
+        assistant_tokens = self._collect_assistant_tokens(rollout_output.get("trajectory") or [])
 
-        # Build steps from trajectory if present, otherwise fall back to
-        # top-level prompt/completion (single-turn environments).
-        if trajectory:
-            steps = trajectory
-        else:
-            steps = [
-                {
-                    "prompt": rollout_output.get("prompt", []),
-                    "completion": rollout_output.get("completion", []),
-                    "tokens": None,
-                }
-            ]
+        output: list[dict] = []
+        assist_idx = 0
+        for raw in rollout_output.get("completion") or []:
+            msg = _as_dict(raw)
+            role = msg.get("role", "user")
 
-        for step in steps:
-            for msg in step.get("prompt", []) or []:
-                # Handle both plain dicts (serialized RolloutOutput) and
-                # Pydantic CustomBaseModel messages (which support .get()).
-                if hasattr(msg, "get"):
-                    role = msg.get("role", "user")
-                    content = msg.get("content", "")
-                    output.append(NeMoGymEasyInputMessage(role=role, content=content).model_dump())
+            if role == "tool":
+                output.append(_build_tool_result_item(msg, raw))
+            elif role == "assistant":
+                tokens = assistant_tokens[assist_idx] if assist_idx < len(assistant_tokens) else None
+                assist_idx += 1
+                output.extend(_build_assistant_items(msg, raw, tokens))
+            else:
+                output.append(NeMoGymEasyInputMessage(role=role, content=_text(msg.get("content"))).model_dump())
 
-            step_tokens = step.get("tokens") if hasattr(step, "get") else None
-            for msg in step.get("completion", []) or []:
-                if hasattr(msg, "get"):
-                    content = msg.get("content", "")
-                    # For trajectory steps, tokens are on the step.
-                    # For single-turn fallback, tokens may be on the message
-                    # (ResponseMessage.tokens from verifiers).
-                    tokens = step_tokens
-                    if tokens is None:
-                        tokens = msg.get("tokens") if hasattr(msg, "get") else getattr(msg, "tokens", None)
-                    if tokens:
-                        output.append(
-                            NeMoGymResponseOutputMessageForTraining(
-                                id=f"msg_{id(msg)}",
-                                content=[NeMoGymResponseOutputText(text=content, annotations=[])],
-                                prompt_token_ids=tokens.get("prompt_ids", []),
-                                generation_token_ids=tokens.get("completion_ids", []),
-                                generation_log_probs=tokens.get("completion_logprobs", []),
-                            ).model_dump()
-                        )
-                    else:
-                        output.append(
-                            NeMoGymResponseOutputMessage(
-                                id=f"msg_{id(msg)}",
-                                content=[NeMoGymResponseOutputText(text=content, annotations=[])],
-                            ).model_dump()
-                        )
+        if not any(item.get("generation_token_ids") for item in output):
+            err = rollout_output.get("error") or {}
+            err_msg = err.get("error") or err.get("error_chain_repr") or "unknown (no error info on rollout_output)"
+            logger.warning(
+                "[verifiers_agent] rollout produced no trainable tokens. This can happen when sandbox concurrency quota is exceeded. Returning empty trajectory. "
+                "Underlying error: %s",
+                err_msg,
+            )
+            output.append(
+                NeMoGymResponseOutputMessageForTraining(
+                    id="msg_empty",
+                    content=[NeMoGymResponseOutputText(text="", annotations=[])],
+                    prompt_token_ids=[0],
+                    generation_token_ids=[0],
+                    generation_log_probs=[0.0],
+                ).model_dump()
+            )
 
         return output
+
+    @staticmethod
+    def _collect_assistant_tokens(trajectory: list) -> list[dict | None]:
+        tokens_per_turn: list[dict | None] = []
+        for step in trajectory:
+            if not isinstance(step, dict):
+                continue
+            step_tokens = step.get("tokens")
+            for m in step.get("completion") or []:
+                if _as_dict(m).get("role") == "assistant":
+                    tokens_per_turn.append(step_tokens)
+        return tokens_per_turn
 
     async def responses(
         self,
@@ -182,6 +268,8 @@ class VerifiersAgent(SimpleResponsesAPIAgent):
     ) -> VerifiersNeMoGymResponse:
         try:
             vf_env_id = body.vf_env_id or self.config.vf_env_id
+            if not vf_env_id:
+                raise ValueError("vf_env_id must be set on the request or in the agent config")
             vf_env = self._get_env(vf_env_id)
             task_idx = body.task_idx
 

--- a/responses_api_agents/verifiers_agent/configs/acereason-math.yaml
+++ b/responses_api_agents/verifiers_agent/configs/acereason-math.yaml
@@ -14,6 +14,6 @@ verifiers_agent:
       group_size: 1
       max_concurrent_generation: -1
       max_concurrent_scoring: -1
-      max_tokens: 8192
+      max_tokens: 16000
       temperature: 1.0
       top_p: 1.0

--- a/responses_api_agents/verifiers_agent/requirements.txt
+++ b/responses_api_agents/verifiers_agent/requirements.txt
@@ -1,4 +1,4 @@
 -e nemo-gym[dev] @ ../../
-verifiers
+verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@main
 --extra-index-url https://hub.primeintellect.ai/primeintellect/simple/
 acereason-math

--- a/responses_api_agents/verifiers_agent/scripts/create_dataset.py
+++ b/responses_api_agents/verifiers_agent/scripts/create_dataset.py
@@ -28,7 +28,10 @@ def load_verifiers_dataset(vf_env: vf.Environment, n: int = -1, seed: int | None
     try:
         dataset = vf_env.get_dataset(n=n, seed=seed)
     except ValueError:
-        dataset = None
+        try:
+            dataset = vf_env.get_eval_dataset(n=n, seed=seed)
+        except ValueError:
+            dataset = None
         for attr in ["dataset", "train_dataset", "eval_dataset"]:
             ds = getattr(vf_env, attr, None)
             if ds is not None:

--- a/responses_api_agents/verifiers_agent/tests/test_app.py
+++ b/responses_api_agents/verifiers_agent/tests/test_app.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from unittest.mock import MagicMock
 
 from nemo_gym.config_types import ModelServerRef
@@ -32,3 +33,76 @@ class TestApp:
             model_server=ModelServerRef(type="responses_api_models", name=""),
         )
         VerifiersAgent(config=config, server_client=MagicMock(spec=ServerClient))
+
+    def test_convert_completion_keeps_tool_outputs_as_response_items(self) -> None:
+        config = VerifiersAgentConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            model_server=ModelServerRef(type="responses_api_models", name=""),
+        )
+        agent = VerifiersAgent(config=config, server_client=MagicMock(spec=ServerClient))
+
+        rollout_output = {
+            "prompt": [{"role": "user", "content": "q"}],
+            "completion": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        json.dumps(
+                            {
+                                "id": "call_1",
+                                "name": "python",
+                                "arguments": json.dumps({"expr": "2+2"}),
+                            }
+                        )
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "4"},
+                {"role": "assistant", "content": "answer"},
+            ],
+            "trajectory": [
+                {
+                    "completion": [
+                        {
+                            "role": "assistant",
+                            "content": "",
+                            "tool_calls": [
+                                {
+                                    "id": "call_1",
+                                    "name": "python",
+                                    "arguments": json.dumps({"expr": "2+2"}),
+                                }
+                            ],
+                        }
+                    ],
+                    "tokens": {
+                        "prompt_ids": [1],
+                        "completion_ids": [2],
+                        "completion_logprobs": [0.0],
+                    },
+                },
+                {
+                    "completion": [{"role": "assistant", "content": "answer"}],
+                    "tokens": {
+                        "prompt_ids": [3],
+                        "completion_ids": [4],
+                        "completion_logprobs": [-0.1],
+                    },
+                },
+            ],
+        }
+
+        output = agent._convert_trajectory_to_output(rollout_output)
+
+        assert [item["type"] for item in output] == ["function_call", "function_call_output", "message"]
+        assert output[0]["call_id"] == "call_1"
+        assert output[0]["name"] == "python"
+        assert output[0]["arguments"] == json.dumps({"expr": "2+2"})
+        assert output[0]["prompt_token_ids"] == [1]
+        assert output[1]["call_id"] == "call_1"
+        assert output[1]["output"] == "4"
+        assert output[2]["content"][0]["text"] == "answer"
+        assert output[2]["prompt_token_ids"] == [3]


### PR DESCRIPTION
the current verifiers agent preserves token ids for training but loses verifiers ToolEnv output format tools in the rollouts stored for downstream use such as a judge or user inspection

#1200 #1204 