### PR TITLE
[GDPVal] Align rubric judge max_tokens default with comparison mode

### DIFF
--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -281,8 +281,9 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         overrides = dict(self.config.judge_responses_create_params_overrides or {})
         judge_base_url = get_server_url(self.config.judge_model_server.name) + "/v1"
-        judge_model_name = overrides.get("model", "judge")
-        judge_api_key = overrides.get("api_key", "dummy")
+        judge_model_name = overrides.pop("model", "judge")
+        judge_api_key = overrides.pop("api_key", "dummy")
+        judge_create_overrides = overrides or None
         client = OpenAI(base_url=judge_base_url, api_key=judge_api_key)
 
         # Judge eval submission against every available reference repeat. Raw
@@ -305,6 +306,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 submission_a=ref_submission,
                 submission_b=eval_submission,
                 num_trials=self.config.num_comparison_trials,
+                create_overrides=judge_create_overrides,
             )
             # ``run_trials`` casts submission_a=ref, submission_b=eval, so
             # ``win_count_b`` is eval wins.

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -291,18 +291,27 @@ def send_judge_request(
     model: str,
     messages: list[dict],
     max_output_tokens: int = 65535,
+    create_overrides: dict | None = None,
 ) -> str:
-    """Send a judge request with exponential-backoff retry.  Returns response text."""
+    """Send a judge request with exponential-backoff retry.  Returns response text.
+
+    *create_overrides* is merged into the kwargs passed to
+    ``client.chat.completions.create``; user-supplied keys win over defaults.
+    Mirrors the override mechanism used by ``scoring.score_with_rubric``.
+    """
     backoff = REQUEST_INITIAL_BACKOFF_SECONDS
 
     for attempt in range(1, REQUEST_MAX_ATTEMPTS + 1):
         try:
-            response = client.chat.completions.create(
-                model=model,
-                messages=messages,
-                max_tokens=max_output_tokens,
-                temperature=1.0,
-            )
+            create_kwargs: dict = {
+                "model": model,
+                "messages": messages,
+                "max_tokens": max_output_tokens,
+                "temperature": 1.0,
+            }
+            if create_overrides:
+                create_kwargs.update(create_overrides)
+            response = client.chat.completions.create(**create_kwargs)
             return (response.choices[0].message.content or "").strip()
         except Exception as error:
             retryable = _is_retryable(error)
@@ -375,11 +384,16 @@ def run_trials(
     submission_b: list[dict],
     num_trials: int = 4,
     max_output_tokens: int = 65535,
+    create_overrides: dict | None = None,
 ) -> dict:
     """Run ``num_trials`` judge calls, alternating swapped/unswapped positions.
 
     Returns a dict with ``winner``, ``win_count_a``, ``win_count_b``,
     ``tie_count``, and ``task_count``.
+
+    *create_overrides* flows through to ``send_judge_request`` and lets the
+    caller override any ``chat.completions.create`` kwarg (``max_tokens``,
+    ``temperature``, …).
     """
     win_count_a = 0
     win_count_b = 0
@@ -396,7 +410,9 @@ def run_trials(
             submission_a=current_a,
             submission_b=current_b,
         )
-        response_text = send_judge_request(client, model, messages, max_output_tokens)
+        response_text = send_judge_request(
+            client, model, messages, max_output_tokens, create_overrides=create_overrides
+        )
         judgement = parse_judgement(response_text)
         win_count_a, win_count_b, tie_count = tally_result(judgement, swapped, win_count_a, win_count_b, tie_count)
 

--- a/resources_servers/gdpval/scoring.py
+++ b/resources_servers/gdpval/scoring.py
@@ -102,7 +102,7 @@ async def score_with_rubric(
 
     *create_overrides* is merged into the kwargs passed to
     ``client.chat.completions.create``; user-supplied keys win over defaults.
-    Use it to bump ``max_tokens`` (default 8192), tweak ``temperature``, etc.
+    Use it to bump ``max_tokens`` (default 65535), tweak ``temperature``, etc.
     """
     from openai import AsyncOpenAI
 
@@ -134,7 +134,7 @@ async def score_with_rubric(
                         {"role": "user", "content": judge_prompt},
                     ],
                     "temperature": 0.1,
-                    "max_tokens": 8192,
+                    "max_tokens": 65535,
                 }
                 if create_overrides:
                     create_kwargs.update(create_overrides)
@@ -237,7 +237,7 @@ async def score_with_rubric_visual(
 
     *create_overrides* is merged into the kwargs passed to
     ``client.chat.completions.create``; user-supplied keys win over defaults.
-    Use it to bump ``max_tokens`` (default 8192), tweak ``temperature``, etc.
+    Use it to bump ``max_tokens`` (default 65535), tweak ``temperature``, etc.
 
     Returns ``(score, judge_response)`` — same contract as ``score_with_rubric``.
     """
@@ -275,7 +275,7 @@ async def score_with_rubric_visual(
                         {"role": "user", "content": content},
                     ],
                     "temperature": 0.1,
-                    "max_tokens": 8192,
+                    "max_tokens": 65535,
                 }
                 if create_overrides:
                     create_kwargs.update(create_overrides)


### PR DESCRIPTION
## Summary

Two related fixes to make rubric and comparison judging share one consistent override mechanism + sane defaults.

### 1. Bump rubric default ``max_tokens`` 8192 → 65535

| Mode | File | Old default | New default |
|------|------|-------------|-------------|
| Rubric (text) | ``resources_servers/gdpval/scoring.py::score_with_rubric`` | 8192 | 65535 |
| Rubric (visual / multimodal) | ``resources_servers/gdpval/scoring.py::score_with_rubric_visual`` | 8192 | 65535 |
| Comparison (pairwise) | ``resources_servers/gdpval/comparison.py::send_judge_request`` | 65535 | unchanged |

8192 was a footgun for multi-criterion rubric tasks: the judge has to emit one ``score`` + ``rationale`` per criterion as JSON, which routinely truncated and forced the regex-fallback path. Historically that surfaced as ~50% ``invalid_judge_response`` on the 220-task GDPVal validation and ~44% on 140-task Mercor pre-override; bumping the cap drops it to <1%.

### 2. Plumb ``judge_responses_create_params_overrides`` through comparison mode

Rubric mode already merges ``create_overrides`` over the request kwargs in ``scoring.py``. Comparison mode read the same config dict but only consumed ``model`` and ``api_key`` — every other override (``max_tokens``, ``temperature``, ``top_p``, …) was silently dropped on the way to ``send_judge_request``.

This PR threads ``create_overrides`` through ``run_trials`` → ``send_judge_request`` and switches ``app.py::_verify_comparison`` to ``pop`` model/api_key (mirroring rubric) so the rest of the dict reaches the judge call.

After this, ``judge_responses_create_params_overrides.max_tokens=N`` (and any other create kwarg) applies symmetrically in both modes.

## Compatibility

- ``create_overrides`` is added with ``default=None`` on both ``run_trials`` and ``send_judge_request``; existing callers that pass only the positional args continue to work.
- The override merge is ``dict.update`` (overrides win) — same pattern as rubric — so any caller already passing ``judge_responses_create_params_overrides.max_tokens`` continues to win over the new default.

## Test plan

- [x] Existing tests in ``resources_servers/gdpval/tests/test_app.py`` pass an explicit ``max_tokens=16384`` and assert it lands in ``create_overrides``; that contract is unchanged.
- [ ] CI green.