### PR TITLE
Add particle MCP tool config

### DIFF
--- a/resources_servers/ns_tools/configs/ns_tools_particle.yaml
+++ b/resources_servers/ns_tools/configs/ns_tools_particle.yaml
@@ -1,0 +1,13 @@
+ns_tools_particle:
+  resources_servers:
+    ns_tools_particle:
+      entrypoint: app.py
+      default_verifier: math_with_judge
+      verifiers: {}
+      nemo_skills_tools:
+        - nemo_skills.mcp.servers.particle_tool.ParticleTool
+      domain: agent
+      verified: false
+      description: NeMo Skills particle physics lookup tool
+      value: Enable PDG particle lookup through NeMo Skills MCP tools
+

--- a/resources_servers/ns_tools/tests/test_particle_mcp_config.py
+++ b/resources_servers/ns_tools/tests/test_particle_mcp_config.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+import yaml
+
+from app import NSToolsConfig
+
+
+def test_particle_mcp_config_loads() -> None:
+    config_path = Path(__file__).parents[1] / "configs" / "ns_tools_particle.yaml"
+    data = yaml.safe_load(config_path.read_text())
+
+    server = data["ns_tools_particle"]["resources_servers"]["ns_tools_particle"]
+    assert server["entrypoint"] == "app.py"
+    assert server["nemo_skills_tools"] == ["nemo_skills.mcp.servers.particle_tool.ParticleTool"]
+
+    config = NSToolsConfig(
+        host="0.0.0.0",
+        port=8080,
+        entrypoint=server["entrypoint"],
+        name="ns_tools_particle",
+        nemo_skills_tools=server["nemo_skills_tools"],
+    )
+    assert config.nemo_skills_tools == server["nemo_skills_tools"]


### PR DESCRIPTION
## Summary
- Add a NeMo-Gym `ns_tools` config that exposes `ParticleTool` through the existing NeMo-Skills ToolManager bridge.
- Add a focused config test to keep the resource-server wiring valid.
- This is the Gym-side companion to NVIDIA-NeMo/Skills#1422.

## Test plan
- `PYTHONPATH=. python -m pytest resources_servers/ns_tools/tests/test_particle_mcp_config.py -q --tb=short`