### PR TITLE
[StirrupAgent] Add structured rubric scoring mode

### DIFF
--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -117,6 +117,23 @@ class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     judge_responses_create_params_overrides: Dict[str, Any] = {}
     judge_prompt_template_fpath: Optional[str] = None
 
+    # Rubric-mode scoring backend:
+    # - ``"binary"`` (default, legacy): judge emits a JSON ``{criteria_scores:
+    #   [{score: 0|1, ...}], overall_score: float}``; reward is the overall
+    #   score (0-1). Treats every criterion as equal weight.
+    # - ``"structured"``: judge emits ``CRITERION_NUMBER[N]: GRADE[X] out of
+    #   MAX_POSSIBLE_POINTS[Y]`` tagged output and ``FINAL_SCORE[…] / MAX_POSSIBLE_SCORE[…]``.
+    #   Honors per-criterion point weights when the rubric carries them in
+    #   ``rubric_json[i].score`` or ``rubric_json[i].weight``. For datasets
+    #   without weights, every criterion contributes max-points 1, giving a
+    #   signal equivalent to binary mode. Multi-trial averaged for stability.
+    #   The tagged output is also more compact than the JSON-with-rationale
+    #   format used by binary mode, so it rarely runs into the judge's
+    #   ``finish_reason: length`` truncation on rubrics with many criteria.
+    rubric_scoring_mode: Literal["binary", "structured"] = "binary"
+    rubric_structured_num_trials: int = 2
+    rubric_structured_formatting_retries: int = 3
+
 
 class GDPValVerifyRequest(BaseVerifyRequest):
     task_id: str
@@ -201,7 +218,22 @@ class GDPValResourcesServer(SimpleResourcesServer):
         # the judge model is expected to be multimodal (configured via
         # ``judge_model_server`` in the benchmark YAML). Falls back to text
         # scoring only when no content blocks could be built.
-        if deliverable_content_blocks:
+        if self.config.rubric_scoring_mode == "structured":
+            from resources_servers.gdpval.scoring import score_with_rubric_structured
+
+            reward, judge_result = await score_with_rubric_structured(
+                deliverable_text=deliverable_text,
+                rubric_json=body.rubric_json,
+                rubric_pretty=rubric_pretty,
+                task_prompt=task_prompt,
+                model_base_url=judge_base_url,
+                model_name=judge_model_name,
+                api_key=judge_api_key,
+                num_trials=self.config.rubric_structured_num_trials,
+                formatting_retries=self.config.rubric_structured_formatting_retries,
+                deliverable_content_blocks=deliverable_content_blocks,
+            )
+        elif deliverable_content_blocks:
             from resources_servers.gdpval.scoring import score_with_rubric_visual
 
             reward, judge_result = await score_with_rubric_visual(

--- a/resources_servers/gdpval/scoring.py
+++ b/resources_servers/gdpval/scoring.py
@@ -375,13 +375,25 @@ async def score_with_rubric_structured(
     """
     from openai import AsyncOpenAI
 
-    # Compute max possible score from rubric
+    # Compute max possible score from rubric. Different upstream formats name
+    # the per-criterion point field differently — accept either ``score`` or
+    # ``weight`` so multiple datasets can mix in the same training run without
+    # a per-source pre-pass.
+    def _criterion_points(item: Any) -> float:
+        if not isinstance(item, dict):
+            return 0
+        for key in ("score", "weight"):
+            v = item.get(key)
+            if isinstance(v, (int, float)):
+                return v
+        return 0
+
     if isinstance(rubric_json, str):
         rubric_json = json.loads(rubric_json) if rubric_json else []
     if isinstance(rubric_json, list):
-        max_possible = sum(item.get("score", 0) for item in rubric_json)
+        max_possible = sum(_criterion_points(item) for item in rubric_json)
     elif isinstance(rubric_json, dict) and "criteria" in rubric_json:
-        max_possible = sum(c.get("score", 0) for c in rubric_json["criteria"])
+        max_possible = sum(_criterion_points(c) for c in rubric_json["criteria"])
     else:
         max_possible = 0
 


### PR DESCRIPTION
## Summary

Adds an opt-in ``structured`` rubric scoring backend on the GDPVal resources server, alongside the existing ``binary`` (default) backend. ``score_with_rubric_structured`` already lived in ``scoring.py`` but wasn't reachable from a config; this PR wires the dispatch.

## Why

The current ``binary`` rubric path has two failure modes on rubrics with many criteria and per-criterion point weights:

1. **Reward magnitude is wrong** when the rubric carries integer point weights (``rubric_json[i].score`` / ``rubric_json[i].weight``). The binary judge emits ``score: 0|1`` per criterion and averages, treating ``+5`` and ``+1`` criteria the same.
2. **Output truncation**. Multi-criterion rubrics with detailed JSON ``rationale`` strings push the judge response past ``max_tokens``, producing partial JSON and the regex-fallback partial-score path. Observed up to 25% ``invalid_judge_response`` rate on heavy rubrics.

The structured path replaces the JSON-with-rationale output with a tagged ``CRITERION_NUMBER[N]: GRADE[X] out of MAX_POSSIBLE_POINTS[Y]`` format and ``FINAL_SCORE[…] / MAX_POSSIBLE_SCORE[…]`` at the end. Reward = ``FINAL_SCORE / MAX_POSSIBLE_SCORE``, multi-trial averaged.

On a 10-task pipecleaning run on a heavy-rubric dataset:

| Mode | mean/reward | invalid_judge_response |
|------|------------:|-----------------------:|
| binary (default) | 0.652 | 25% |
| structured | 0.733 | **0%** |

Reward distribution went from clustered around 0.6 (regex fallback noise) to a clean 0.47–1.00 spread, with the harder tasks correctly scoring lower.

## What changed

- ``GDPValResourcesServerConfig``: new ``rubric_scoring_mode: Literal[\"binary\", \"structured\"] = \"binary\"`` (default keeps existing behavior). ``rubric_structured_num_trials`` (default 2) and ``rubric_structured_formatting_retries`` (default 3) tune the structured path.
- ``GDPValResourcesServer._verify_rubric``: dispatches to ``score_with_rubric_structured`` when ``rubric_scoring_mode == \"structured\"``. Existing ``score_with_rubric`` / ``score_with_rubric_visual`` paths are unchanged for the default ``binary`` mode.
- ``score_with_rubric_structured``: ``max_possible`` now reads either ``score`` or ``weight`` per criterion (different upstream rubric formats use different field names), so multiple sources can mix in the same training run without per-source pre-processing.

## Compatibility

- ``rubric_scoring_mode`` defaults to ``binary``. Existing benchmark configs (``benchmarks/gdpval/config.yaml``, etc.) get exactly the same behavior they have today — no opt-out needed.
- For datasets with no per-criterion weights, the structured path falls back to ``MAX_POSSIBLE_POINTS=1`` per criterion, so reward is equivalent to binary in that case.

## Test plan

- [x] 10-task pipecleaning run on a weighted-rubric dataset (binary 0.65 / 25% invalid → structured 0.73 / 0% invalid).
- [ ] CI green.