### PR TITLE
[GDPVal] Add opt-in persistence of raw judge responses

### DIFF
--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -47,6 +47,19 @@ _DEFAULT_JUDGE_PROMPT_FPATH = str(Path(__file__).parent / "prompts" / "judge_pro
 _DEFAULT_REFERENCE_ELO = 1000.0
 
 
+def _resolve_repeat_dir(task_dir: Path) -> Optional[Path]:
+    """Pick a deliverable dir for a task, supporting both layouts.
+
+    New: ``task_<id>/repeat_<n>/`` — return the lowest-numbered repeat that
+    exists. Old: flat ``task_<id>/`` — return as-is for backwards compat with
+    pre-existing reference dirs.
+    """
+    if not task_dir.is_dir():
+        return None
+    repeats = sorted(p for p in task_dir.iterdir() if p.is_dir() and p.name.startswith("repeat_"))
+    return repeats[0] if repeats else task_dir
+
+
 def _safe_output_text(response: Any) -> str:
     """Extract concatenated assistant text from a response without relying on
     ``response.output_text`` — that property raises ``AttributeError`` when
@@ -225,10 +238,10 @@ class GDPValResourcesServer(SimpleResourcesServer):
         from resources_servers.gdpval.preconvert import preconvert_dir_async
 
         ref_root = Path(self.config.reference_deliverables_dir)
-        ref_task_dir = ref_root / f"task_{body.task_id}"
+        ref_task_dir = _resolve_repeat_dir(ref_root / f"task_{body.task_id}")
         eval_task_dir = Path(body.deliverables_dir) if body.deliverables_dir else None
 
-        if not task_attempted(str(ref_task_dir)):
+        if ref_task_dir is None or not task_attempted(str(ref_task_dir)):
             print(f"[gdpval] no reference deliverable for task {body.task_id}", flush=True)
             return GDPValVerifyResponse(
                 **body.model_dump(),

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -47,17 +47,21 @@ _DEFAULT_JUDGE_PROMPT_FPATH = str(Path(__file__).parent / "prompts" / "judge_pro
 _DEFAULT_REFERENCE_ELO = 1000.0
 
 
-def _resolve_repeat_dir(task_dir: Path) -> Optional[Path]:
-    """Pick a deliverable dir for a task, supporting both layouts.
+def _iter_ref_repeat_dirs(task_dir: Path) -> List[Path]:
+    """All reference deliverable dirs for a task, supporting both layouts.
 
-    New: ``task_<id>/repeat_<n>/`` — return the lowest-numbered repeat that
-    exists. Old: flat ``task_<id>/`` — return as-is for backwards compat with
-    pre-existing reference dirs.
+    New: ``task_<id>/repeat_<n>/`` — return every repeat dir, sorted. Old:
+    flat ``task_<id>/`` — return ``[task_dir]``. Missing → ``[]``.
+
+    Returning every repeat lets the comparison verifier judge each eval
+    rollout against *all* reference rollouts so the win rate (and ELO)
+    averages over reference variance instead of being anchored to a single
+    sample.
     """
     if not task_dir.is_dir():
-        return None
+        return []
     repeats = sorted(p for p in task_dir.iterdir() if p.is_dir() and p.name.startswith("repeat_"))
-    return repeats[0] if repeats else task_dir
+    return repeats or [task_dir]
 
 
 def _safe_output_text(response: Any) -> str:
@@ -129,9 +133,17 @@ class GDPValVerifyResponse(GDPValVerifyRequest, BaseVerifyResponse):
     verify_mode: Literal["rubric", "comparison"] = "rubric"
     judge_response: Optional[Dict[str, Any]] = None
     invalid_judge_response: Optional[bool] = None
+    # Majority-decision flags across all (ref_repeat × trial) judge votes —
+    # kept for back-compat with older verify responses (still bool-valued).
     win: Optional[bool] = None
     loss: Optional[bool] = None
     tie: Optional[bool] = None
+    # Raw judge vote counts aggregated over every reference repeat × trial.
+    # ``aggregate_metrics`` prefers these so the win rate reflects all
+    # comparisons rather than treating each verify call as a single vote.
+    total_wins: Optional[int] = None
+    total_losses: Optional[int] = None
+    total_ties: Optional[int] = None
 
 
 class GDPValResourcesServer(SimpleResourcesServer):
@@ -231,17 +243,17 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         from resources_servers.gdpval.comparison import (
             build_file_section,
-            compute_comparison_reward,
             run_trials,
             task_attempted,
         )
         from resources_servers.gdpval.preconvert import preconvert_dir_async
 
         ref_root = Path(self.config.reference_deliverables_dir)
-        ref_task_dir = _resolve_repeat_dir(ref_root / f"task_{body.task_id}")
+        ref_task_root = ref_root / f"task_{body.task_id}"
+        ref_task_dirs = [d for d in _iter_ref_repeat_dirs(ref_task_root) if task_attempted(str(d))]
         eval_task_dir = Path(body.deliverables_dir) if body.deliverables_dir else None
 
-        if ref_task_dir is None or not task_attempted(str(ref_task_dir)):
+        if not ref_task_dirs:
             print(f"[gdpval] no reference deliverable for task {body.task_id}", flush=True)
             return GDPValVerifyResponse(
                 **body.model_dump(),
@@ -262,39 +274,71 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         if self.config.preconvert_office_to_pdf:
             await preconvert_dir_async(eval_task_dir, max_concurrent=self.config.preconvert_max_concurrent)
-            await preconvert_dir_async(ref_task_dir, max_concurrent=self.config.preconvert_max_concurrent)
+            for ref_dir in ref_task_dirs:
+                await preconvert_dir_async(ref_dir, max_concurrent=self.config.preconvert_max_concurrent)
 
-        refs_dir = ref_task_dir / "reference_files"
-        refs = build_file_section(str(refs_dir) if refs_dir.is_dir() else None)
-        ref_submission = build_file_section(str(ref_task_dir))
         eval_submission = build_file_section(str(eval_task_dir))
 
         overrides = dict(self.config.judge_responses_create_params_overrides or {})
         judge_base_url = get_server_url(self.config.judge_model_server.name) + "/v1"
         judge_model_name = overrides.get("model", "judge")
         judge_api_key = overrides.get("api_key", "dummy")
-
         client = OpenAI(base_url=judge_base_url, api_key=judge_api_key)
-        result = await asyncio.to_thread(
-            run_trials,
-            client=client,
-            model=judge_model_name,
-            task_prompt=body.prompt or "",
-            refs=refs,
-            submission_a=ref_submission,
-            submission_b=eval_submission,
-            num_trials=self.config.num_comparison_trials,
-        )
 
-        reward = compute_comparison_reward(result["winner"])
+        # Judge eval submission against every available reference repeat. Raw
+        # vote counts (not just per-matchup majority) are summed so the win
+        # rate averages over reference variance — see ``_iter_ref_repeat_dirs``.
+        total_wins = 0
+        total_losses = 0
+        total_ties = 0
+        per_ref_results: List[Dict[str, Any]] = []
+        for ref_dir in ref_task_dirs:
+            refs_subdir = ref_dir / "reference_files"
+            refs = build_file_section(str(refs_subdir) if refs_subdir.is_dir() else None)
+            ref_submission = build_file_section(str(ref_dir))
+            result = await asyncio.to_thread(
+                run_trials,
+                client=client,
+                model=judge_model_name,
+                task_prompt=body.prompt or "",
+                refs=refs,
+                submission_a=ref_submission,
+                submission_b=eval_submission,
+                num_trials=self.config.num_comparison_trials,
+            )
+            # ``run_trials`` casts submission_a=ref, submission_b=eval, so
+            # ``win_count_b`` is eval wins.
+            total_wins += result["win_count_b"]
+            total_losses += result["win_count_a"]
+            total_ties += result["tie_count"]
+            per_ref_results.append({"ref_repeat": ref_dir.name, **result})
+
+        total_judged = total_wins + total_losses + total_ties
+        if total_wins > total_losses:
+            reward = 1.0
+        elif total_losses > total_wins:
+            reward = 0.0
+        else:
+            reward = 0.5
+
         return GDPValVerifyResponse(
             **body.model_dump(),
             reward=reward,
             verify_mode="comparison",
-            judge_response=result,
+            judge_response={
+                "per_ref_repeat": per_ref_results,
+                "total_wins": total_wins,
+                "total_losses": total_losses,
+                "total_ties": total_ties,
+                "total_judged": total_judged,
+                "ref_repeat_count": len(ref_task_dirs),
+            },
             win=reward == 1.0,
             loss=reward == 0.0,
             tie=reward == 0.5,
+            total_wins=total_wins,
+            total_losses=total_losses,
+            total_ties=total_ties,
         )
 
     async def aggregate_metrics(self, body: AggregateMetricsRequest) -> AggregateMetrics:
@@ -303,9 +347,23 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         from resources_servers.gdpval.comparison import calculate_elo
 
-        wins = sum(1 for vr in body.verify_responses if vr.get("win"))
-        losses = sum(1 for vr in body.verify_responses if vr.get("loss"))
-        ties = sum(1 for vr in body.verify_responses if vr.get("tie"))
+        # Prefer the raw judge vote counts (``total_wins``/``total_losses``/
+        # ``total_ties``) when present so the win rate reflects every
+        # eval×ref_repeat×trial comparison. Fall back to the bool flags for
+        # verify responses produced before this field existed — those count as
+        # one vote each.
+        def _votes(vr: Dict[str, Any]) -> tuple[int, int, int]:
+            tw, tl, tt = vr.get("total_wins"), vr.get("total_losses"), vr.get("total_ties")
+            if tw is not None or tl is not None or tt is not None:
+                return int(tw or 0), int(tl or 0), int(tt or 0)
+            return int(bool(vr.get("win"))), int(bool(vr.get("loss"))), int(bool(vr.get("tie")))
+
+        wins = losses = ties = 0
+        for vr in body.verify_responses:
+            w, ls, t = _votes(vr)
+            wins += w
+            losses += ls
+            ties += t
         judged = wins + losses + ties
 
         if judged == 0:

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -281,8 +281,9 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         overrides = dict(self.config.judge_responses_create_params_overrides or {})
         judge_base_url = get_server_url(self.config.judge_model_server.name) + "/v1"
-        judge_model_name = overrides.get("model", "judge")
-        judge_api_key = overrides.get("api_key", "dummy")
+        judge_model_name = overrides.pop("model", "judge")
+        judge_api_key = overrides.pop("api_key", "dummy")
+        judge_create_overrides = overrides or None
         client = OpenAI(base_url=judge_base_url, api_key=judge_api_key)
 
         # Judge eval submission against every available reference repeat. Raw
@@ -305,6 +306,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 submission_a=ref_submission,
                 submission_b=eval_submission,
                 num_trials=self.config.num_comparison_trials,
+                create_overrides=judge_create_overrides,
             )
             # ``run_trials`` casts submission_a=ref, submission_b=eval, so
             # ``win_count_b`` is eval wins.

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -117,6 +117,23 @@ class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     judge_responses_create_params_overrides: Dict[str, Any] = {}
     judge_prompt_template_fpath: Optional[str] = None
 
+    # Rubric-mode scoring backend:
+    # - ``"binary"`` (default, legacy): judge emits a JSON ``{criteria_scores:
+    #   [{score: 0|1, ...}], overall_score: float}``; reward is the overall
+    #   score (0-1). Treats every criterion as equal weight.
+    # - ``"structured"``: judge emits ``CRITERION_NUMBER[N]: GRADE[X] out of
+    #   MAX_POSSIBLE_POINTS[Y]`` tagged output and ``FINAL_SCORE[…] / MAX_POSSIBLE_SCORE[…]``.
+    #   Honors per-criterion point weights when the rubric carries them in
+    #   ``rubric_json[i].score`` or ``rubric_json[i].weight``. For datasets
+    #   without weights, every criterion contributes max-points 1, giving a
+    #   signal equivalent to binary mode. Multi-trial averaged for stability.
+    #   The tagged output is also more compact than the JSON-with-rationale
+    #   format used by binary mode, so it rarely runs into the judge's
+    #   ``finish_reason: length`` truncation on rubrics with many criteria.
+    rubric_scoring_mode: Literal["binary", "structured"] = "binary"
+    rubric_structured_num_trials: int = 2
+    rubric_structured_formatting_retries: int = 3
+
 
 class GDPValVerifyRequest(BaseVerifyRequest):
     task_id: str
@@ -201,7 +218,22 @@ class GDPValResourcesServer(SimpleResourcesServer):
         # the judge model is expected to be multimodal (configured via
         # ``judge_model_server`` in the benchmark YAML). Falls back to text
         # scoring only when no content blocks could be built.
-        if deliverable_content_blocks:
+        if self.config.rubric_scoring_mode == "structured":
+            from resources_servers.gdpval.scoring import score_with_rubric_structured
+
+            reward, judge_result = await score_with_rubric_structured(
+                deliverable_text=deliverable_text,
+                rubric_json=body.rubric_json,
+                rubric_pretty=rubric_pretty,
+                task_prompt=task_prompt,
+                model_base_url=judge_base_url,
+                model_name=judge_model_name,
+                api_key=judge_api_key,
+                num_trials=self.config.rubric_structured_num_trials,
+                formatting_retries=self.config.rubric_structured_formatting_retries,
+                deliverable_content_blocks=deliverable_content_blocks,
+            )
+        elif deliverable_content_blocks:
             from resources_servers.gdpval.scoring import score_with_rubric_visual
 
             reward, judge_result = await score_with_rubric_visual(

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -134,6 +134,14 @@ class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     rubric_structured_num_trials: int = 2
     rubric_structured_formatting_retries: int = 3
 
+    # When True, every judge call's raw response text is preserved on
+    # ``verify_response.judge_response`` (per-trial in comparison mode under
+    # ``per_ref_repeat[i].raw_responses``; under top-level ``raw_responses``
+    # in rubric modes). Off by default — raw responses are 10-50 KB each and
+    # multiply by num_trials × num_ref_repeats × num_tasks. Turn on for debug
+    # runs to post-mortem judge verdicts.
+    persist_raw_judge_responses: bool = False
+
 
 class GDPValVerifyRequest(BaseVerifyRequest):
     task_id: str
@@ -232,6 +240,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 num_trials=self.config.rubric_structured_num_trials,
                 formatting_retries=self.config.rubric_structured_formatting_retries,
                 deliverable_content_blocks=deliverable_content_blocks,
+                include_raw_responses=self.config.persist_raw_judge_responses,
             )
         elif deliverable_content_blocks:
             from resources_servers.gdpval.scoring import score_with_rubric_visual
@@ -246,6 +255,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 model_name=judge_model_name,
                 api_key=judge_api_key,
                 create_overrides=judge_create_overrides,
+                include_raw_responses=self.config.persist_raw_judge_responses,
             )
         else:
             from resources_servers.gdpval.scoring import score_with_rubric
@@ -260,6 +270,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 model_name=judge_model_name,
                 api_key=judge_api_key,
                 create_overrides=judge_create_overrides,
+                include_raw_responses=self.config.persist_raw_judge_responses,
             )
 
         return GDPValVerifyResponse(
@@ -339,6 +350,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 submission_b=eval_submission,
                 num_trials=self.config.num_comparison_trials,
                 create_overrides=judge_create_overrides,
+                return_raw_responses=self.config.persist_raw_judge_responses,
             )
             # ``run_trials`` casts submission_a=ref, submission_b=eval, so
             # ``win_count_b`` is eval wins.

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -291,18 +291,27 @@ def send_judge_request(
     model: str,
     messages: list[dict],
     max_output_tokens: int = 65535,
+    create_overrides: dict | None = None,
 ) -> str:
-    """Send a judge request with exponential-backoff retry.  Returns response text."""
+    """Send a judge request with exponential-backoff retry.  Returns response text.
+
+    *create_overrides* is merged into the kwargs passed to
+    ``client.chat.completions.create``; user-supplied keys win over defaults.
+    Mirrors the override mechanism used by ``scoring.score_with_rubric``.
+    """
     backoff = REQUEST_INITIAL_BACKOFF_SECONDS
 
     for attempt in range(1, REQUEST_MAX_ATTEMPTS + 1):
         try:
-            response = client.chat.completions.create(
-                model=model,
-                messages=messages,
-                max_tokens=max_output_tokens,
-                temperature=1.0,
-            )
+            create_kwargs: dict = {
+                "model": model,
+                "messages": messages,
+                "max_tokens": max_output_tokens,
+                "temperature": 1.0,
+            }
+            if create_overrides:
+                create_kwargs.update(create_overrides)
+            response = client.chat.completions.create(**create_kwargs)
             return (response.choices[0].message.content or "").strip()
         except Exception as error:
             retryable = _is_retryable(error)
@@ -375,11 +384,16 @@ def run_trials(
     submission_b: list[dict],
     num_trials: int = 4,
     max_output_tokens: int = 65535,
+    create_overrides: dict | None = None,
 ) -> dict:
     """Run ``num_trials`` judge calls, alternating swapped/unswapped positions.
 
     Returns a dict with ``winner``, ``win_count_a``, ``win_count_b``,
     ``tie_count``, and ``task_count``.
+
+    *create_overrides* flows through to ``send_judge_request`` and lets the
+    caller override any ``chat.completions.create`` kwarg (``max_tokens``,
+    ``temperature``, …).
     """
     win_count_a = 0
     win_count_b = 0
@@ -396,7 +410,9 @@ def run_trials(
             submission_a=current_a,
             submission_b=current_b,
         )
-        response_text = send_judge_request(client, model, messages, max_output_tokens)
+        response_text = send_judge_request(
+            client, model, messages, max_output_tokens, create_overrides=create_overrides
+        )
         judgement = parse_judgement(response_text)
         win_count_a, win_count_b, tie_count = tally_result(judgement, swapped, win_count_a, win_count_b, tie_count)
 

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -385,6 +385,7 @@ def run_trials(
     num_trials: int = 4,
     max_output_tokens: int = 65535,
     create_overrides: dict | None = None,
+    return_raw_responses: bool = False,
 ) -> dict:
     """Run ``num_trials`` judge calls, alternating swapped/unswapped positions.
 
@@ -394,10 +395,15 @@ def run_trials(
     *create_overrides* flows through to ``send_judge_request`` and lets the
     caller override any ``chat.completions.create`` kwarg (``max_tokens``,
     ``temperature``, …).
+
+    When ``return_raw_responses`` is True, the dict also carries
+    ``raw_responses``: a list of the per-trial judge completion strings,
+    ordered by trial index (so trial ``i`` was swapped iff ``i % 2 != 0``).
     """
     win_count_a = 0
     win_count_b = 0
     tie_count = 0
+    raw_responses: list[str] = []
 
     for i in range(num_trials):
         swapped = i % 2 != 0
@@ -413,6 +419,8 @@ def run_trials(
         response_text = send_judge_request(
             client, model, messages, max_output_tokens, create_overrides=create_overrides
         )
+        if return_raw_responses:
+            raw_responses.append(response_text)
         judgement = parse_judgement(response_text)
         win_count_a, win_count_b, tie_count = tally_result(judgement, swapped, win_count_a, win_count_b, tie_count)
 
@@ -423,13 +431,16 @@ def run_trials(
     else:
         winner = TIE_RESPONSE
 
-    return {
+    result: dict = {
         "winner": winner,
         "win_count_a": win_count_a,
         "win_count_b": win_count_b,
         "tie_count": tie_count,
         "task_count": num_trials,
     }
+    if return_raw_responses:
+        result["raw_responses"] = raw_responses
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/resources_servers/gdpval/scoring.py
+++ b/resources_servers/gdpval/scoring.py
@@ -93,6 +93,7 @@ async def score_with_rubric(
     model_name: str,
     api_key: str = "dummy",
     create_overrides: dict | None = None,
+    include_raw_responses: bool = False,
 ) -> tuple[float, dict | None]:
     """Score a deliverable against a rubric using an LLM judge.
 
@@ -164,6 +165,7 @@ async def score_with_rubric(
             return 0.0, None
 
         response_text = content.strip()
+        raw_response_text = response_text
         print(
             f"Rubric judge response length: {len(response_text)} chars, "
             f"finish_reason: {response.choices[0].finish_reason}",
@@ -206,6 +208,8 @@ async def score_with_rubric(
             score = 0.0
 
         print(f"Rubric final score: {score}", flush=True)
+        if include_raw_responses and isinstance(result, dict):
+            result["raw_responses"] = [raw_response_text]
         return max(0.0, min(1.0, score)), result
 
     except Exception as e:
@@ -226,6 +230,7 @@ async def score_with_rubric_visual(
     model_name: str,
     api_key: str = "dummy",
     create_overrides: dict | None = None,
+    include_raw_responses: bool = False,
 ) -> tuple[float, dict | None]:
     """Score deliverables visually using a multimodal judge (e.g., Gemini 3 Pro).
 
@@ -295,6 +300,7 @@ async def score_with_rubric_visual(
                     raise
 
         response_text = (response.choices[0].message.content or "").strip()
+        raw_response_text = response_text
         print(
             f"Visual judge response length: {len(response_text)} chars, "
             f"finish_reason: {response.choices[0].finish_reason}, "
@@ -337,6 +343,8 @@ async def score_with_rubric_visual(
             score = 0.0
 
         print(f"Visual judge final score: {score}", flush=True)
+        if include_raw_responses and isinstance(result, dict):
+            result["raw_responses"] = [raw_response_text]
         return max(0.0, min(1.0, score)), result
 
     except Exception as e:
@@ -363,6 +371,7 @@ async def score_with_rubric_structured(
     num_trials: int = 2,
     formatting_retries: int = 3,
     deliverable_content_blocks: list[dict] | None = None,
+    include_raw_responses: bool = False,
 ) -> tuple[float, dict | None]:
     """Score a deliverable using structured tagged output format.
 
@@ -488,7 +497,10 @@ async def score_with_rubric_structured(
 
     if not scores:
         print("[structured-rubric] no valid scores from any trial", flush=True)
-        return 0.0, {"error": "no_valid_scores", "num_trials": num_trials}
+        no_valid_metadata: dict = {"error": "no_valid_scores", "num_trials": num_trials}
+        if include_raw_responses:
+            no_valid_metadata["raw_responses"] = trial_responses
+        return 0.0, no_valid_metadata
 
     avg_score = sum(scores) / len(scores)
     avg_pct = sum(percentages) / len(percentages)
@@ -509,6 +521,8 @@ async def score_with_rubric_structured(
         "num_trials_completed": len(scores),
         "num_trials_requested": num_trials,
     }
+    if include_raw_responses:
+        metadata["raw_responses"] = trial_responses
 
     print(
         f"[structured-rubric] final: avg={avg_score:.1f}/{effective_max} ({avg_pct:.1f}%), "

--- a/resources_servers/gdpval/scoring.py
+++ b/resources_servers/gdpval/scoring.py
@@ -102,7 +102,7 @@ async def score_with_rubric(
 
     *create_overrides* is merged into the kwargs passed to
     ``client.chat.completions.create``; user-supplied keys win over defaults.
-    Use it to bump ``max_tokens`` (default 8192), tweak ``temperature``, etc.
+    Use it to bump ``max_tokens`` (default 65535), tweak ``temperature``, etc.
     """
     from openai import AsyncOpenAI
 
@@ -134,7 +134,7 @@ async def score_with_rubric(
                         {"role": "user", "content": judge_prompt},
                     ],
                     "temperature": 0.1,
-                    "max_tokens": 8192,
+                    "max_tokens": 65535,
                 }
                 if create_overrides:
                     create_kwargs.update(create_overrides)
@@ -237,7 +237,7 @@ async def score_with_rubric_visual(
 
     *create_overrides* is merged into the kwargs passed to
     ``client.chat.completions.create``; user-supplied keys win over defaults.
-    Use it to bump ``max_tokens`` (default 8192), tweak ``temperature``, etc.
+    Use it to bump ``max_tokens`` (default 65535), tweak ``temperature``, etc.
 
     Returns ``(score, judge_response)`` — same contract as ``score_with_rubric``.
     """
@@ -275,7 +275,7 @@ async def score_with_rubric_visual(
                         {"role": "user", "content": content},
                     ],
                     "temperature": 0.1,
-                    "max_tokens": 8192,
+                    "max_tokens": 65535,
                 }
                 if create_overrides:
                     create_kwargs.update(create_overrides)

--- a/resources_servers/gdpval/scoring.py
+++ b/resources_servers/gdpval/scoring.py
@@ -375,13 +375,25 @@ async def score_with_rubric_structured(
     """
     from openai import AsyncOpenAI
 
-    # Compute max possible score from rubric
+    # Compute max possible score from rubric. Different upstream formats name
+    # the per-criterion point field differently — accept either ``score`` or
+    # ``weight`` so multiple datasets can mix in the same training run without
+    # a per-source pre-pass.
+    def _criterion_points(item: Any) -> float:
+        if not isinstance(item, dict):
+            return 0
+        for key in ("score", "weight"):
+            v = item.get(key)
+            if isinstance(v, (int, float)):
+                return v
+        return 0
+
     if isinstance(rubric_json, str):
         rubric_json = json.loads(rubric_json) if rubric_json else []
     if isinstance(rubric_json, list):
-        max_possible = sum(item.get("score", 0) for item in rubric_json)
+        max_possible = sum(_criterion_points(item) for item in rubric_json)
     elif isinstance(rubric_json, dict) and "criteria" in rubric_json:
-        max_possible = sum(c.get("score", 0) for c in rubric_json["criteria"])
+        max_possible = sum(_criterion_points(c) for c in rubric_json["criteria"])
     else:
         max_possible = 0
 

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -27,6 +27,7 @@ from resources_servers.gdpval.app import (
     GDPValResourcesServer,
     GDPValResourcesServerConfig,
     GDPValVerifyRequest,
+    _resolve_repeat_dir,
 )
 
 
@@ -73,6 +74,24 @@ def _verify_request(**fields) -> GDPValVerifyRequest:
         rubric_pretty=fields.pop("rubric_pretty", ""),
         **fields,
     )
+
+
+class TestResolveRepeatDir:
+    def test_picks_lowest_repeat(self, tmp_path) -> None:
+        td = tmp_path / "task_x"
+        (td / "repeat_1").mkdir(parents=True)
+        (td / "repeat_0").mkdir()
+        (td / "repeat_2").mkdir()
+        assert _resolve_repeat_dir(td) == td / "repeat_0"
+
+    def test_falls_back_to_flat_layout(self, tmp_path) -> None:
+        td = tmp_path / "task_x"
+        td.mkdir()
+        (td / "deliverable.docx").write_text("x")
+        assert _resolve_repeat_dir(td) == td
+
+    def test_missing_dir_returns_none(self, tmp_path) -> None:
+        assert _resolve_repeat_dir(tmp_path / "does-not-exist") is None
 
 
 class TestApp:

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -27,7 +27,7 @@ from resources_servers.gdpval.app import (
     GDPValResourcesServer,
     GDPValResourcesServerConfig,
     GDPValVerifyRequest,
-    _resolve_repeat_dir,
+    _iter_ref_repeat_dirs,
 )
 
 
@@ -76,22 +76,26 @@ def _verify_request(**fields) -> GDPValVerifyRequest:
     )
 
 
-class TestResolveRepeatDir:
-    def test_picks_lowest_repeat(self, tmp_path) -> None:
+class TestIterRefRepeatDirs:
+    def test_returns_all_repeats_sorted(self, tmp_path) -> None:
         td = tmp_path / "task_x"
         (td / "repeat_1").mkdir(parents=True)
         (td / "repeat_0").mkdir()
         (td / "repeat_2").mkdir()
-        assert _resolve_repeat_dir(td) == td / "repeat_0"
+        assert _iter_ref_repeat_dirs(td) == [
+            td / "repeat_0",
+            td / "repeat_1",
+            td / "repeat_2",
+        ]
 
     def test_falls_back_to_flat_layout(self, tmp_path) -> None:
         td = tmp_path / "task_x"
         td.mkdir()
         (td / "deliverable.docx").write_text("x")
-        assert _resolve_repeat_dir(td) == td
+        assert _iter_ref_repeat_dirs(td) == [td]
 
-    def test_missing_dir_returns_none(self, tmp_path) -> None:
-        assert _resolve_repeat_dir(tmp_path / "does-not-exist") is None
+    def test_missing_dir_returns_empty(self, tmp_path) -> None:
+        assert _iter_ref_repeat_dirs(tmp_path / "does-not-exist") == []
 
 
 class TestApp:
@@ -189,6 +193,110 @@ class TestApp:
         assert resp.verify_mode == "comparison"
         assert resp.judge_response == {"error": "reference_missing"}
 
+    @pytest.mark.asyncio
+    async def test_verify_comparison_iterates_all_ref_repeats(self, tmp_path) -> None:
+        """Each eval rollout is judged against every reference repeat and the
+        raw vote counts are summed — not just one matchup against repeat_0."""
+        ref_root = tmp_path / "ref"
+        task_dir = ref_root / "task_task-1"
+        for i in range(3):
+            r = task_dir / f"repeat_{i}"
+            r.mkdir(parents=True)
+            (r / "finish_params.json").write_text("{}")
+        eval_dir = tmp_path / "eval" / "task_task-1" / "repeat_0"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "finish_params.json").write_text("{}")
+
+        server = _server(
+            reward_mode="comparison",
+            reference_deliverables_dir=str(ref_root),
+            preconvert_office_to_pdf=False,
+            num_comparison_trials=4,
+        )
+
+        seen_ref_dirs: list[str] = []
+
+        def fake_run_trials(*, submission_a, **_kwargs):
+            # ``build_file_section`` includes a ``"role": "user"`` text block
+            # whose text is "Submission:\n" followed by the dir contents — we
+            # just need to record which ref dir was passed.
+            seen_ref_dirs.append(str(submission_a))
+            # 3 eval wins (B), 1 ref win (A), 0 ties per ref repeat.
+            return {
+                "winner": "[[B]]",
+                "win_count_a": 1,
+                "win_count_b": 3,
+                "tie_count": 0,
+                "task_count": 4,
+            }
+
+        body = _verify_request(deliverables_dir=str(eval_dir))
+
+        with (
+            patch("resources_servers.gdpval.comparison.run_trials", side_effect=fake_run_trials),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+            patch("resources_servers.gdpval.comparison.build_file_section", return_value=[]),
+            patch("resources_servers.gdpval.app.OpenAI" if False else "openai.OpenAI", return_value=MagicMock()),
+        ):
+            resp = await server.verify(body)
+
+        # All three reference repeats must be judged.
+        assert len(seen_ref_dirs) == 3
+        # Vote totals: 3 ref repeats × (3 wins, 1 loss, 0 ties).
+        assert resp.total_wins == 9
+        assert resp.total_losses == 3
+        assert resp.total_ties == 0
+        assert resp.reward == 1.0
+        assert resp.win is True
+        assert resp.judge_response["ref_repeat_count"] == 3
+        assert len(resp.judge_response["per_ref_repeat"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_verify_comparison_flat_layout_back_compat(self, tmp_path) -> None:
+        """Old ``task_<id>/`` flat reference layouts still work — one matchup."""
+        ref_root = tmp_path / "ref"
+        task_dir = ref_root / "task_task-1"
+        task_dir.mkdir(parents=True)
+        (task_dir / "finish_params.json").write_text("{}")
+        eval_dir = tmp_path / "eval" / "task_task-1" / "repeat_0"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "finish_params.json").write_text("{}")
+
+        server = _server(
+            reward_mode="comparison",
+            reference_deliverables_dir=str(ref_root),
+            preconvert_office_to_pdf=False,
+            num_comparison_trials=4,
+        )
+
+        call_count = {"n": 0}
+
+        def fake_run_trials(**_kwargs):
+            call_count["n"] += 1
+            return {
+                "winner": "[[A]]",
+                "win_count_a": 4,
+                "win_count_b": 0,
+                "tie_count": 0,
+                "task_count": 4,
+            }
+
+        body = _verify_request(deliverables_dir=str(eval_dir))
+
+        with (
+            patch("resources_servers.gdpval.comparison.run_trials", side_effect=fake_run_trials),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+            patch("resources_servers.gdpval.comparison.build_file_section", return_value=[]),
+            patch("openai.OpenAI", return_value=MagicMock()),
+        ):
+            resp = await server.verify(body)
+
+        assert call_count["n"] == 1
+        assert resp.total_wins == 0
+        assert resp.total_losses == 4
+        assert resp.reward == 0.0
+        assert resp.loss is True
+
     def test_aggregate_metrics_comparison_elo(self) -> None:
         from nemo_gym.config_types import AggregateMetricsRequest
 
@@ -225,3 +333,53 @@ class TestApp:
         assert abs(result.agent_metrics["comparison/win_rate"] - 0.75) < 1e-6
         # win_rate=0.75 → ELO = 1000 - 400 * (log10(0.25) - log10(0.75)) ≈ 1190.85
         assert 1180 < result.agent_metrics["comparison/eval_elo"] < 1200
+
+    def test_aggregate_metrics_uses_raw_vote_counts(self) -> None:
+        """When verify responses carry ``total_wins``/``total_losses``/
+        ``total_ties`` (multi-ref-repeat path), they're summed as raw judge
+        votes rather than treated as one matchup each."""
+        from nemo_gym.config_types import AggregateMetricsRequest
+
+        server = _server(
+            reward_mode="comparison",
+            reference_deliverables_dir="/tmp/fork-deliverables",
+            reference_elo=1000.0,
+        )
+        # Two verify responses, each representing one eval_repeat × 3 ref
+        # repeats × 4 trials = 12 judge votes.
+        responses = [
+            {
+                "_ng_task_index": 0,
+                "_ng_rollout_index": 0,
+                "reward": 1.0,
+                "win": True,
+                "loss": False,
+                "tie": False,
+                "total_wins": 9,
+                "total_losses": 2,
+                "total_ties": 1,
+                "response": {},
+            },
+            {
+                "_ng_task_index": 0,
+                "_ng_rollout_index": 1,
+                "reward": 0.0,
+                "win": False,
+                "loss": True,
+                "tie": False,
+                "total_wins": 3,
+                "total_losses": 8,
+                "total_ties": 1,
+                "response": {},
+            },
+        ]
+        import asyncio as _asyncio
+
+        body = AggregateMetricsRequest(verify_responses=responses)
+        result = _asyncio.run(server.aggregate_metrics(body))
+        assert result.agent_metrics["comparison/wins"] == 12
+        assert result.agent_metrics["comparison/losses"] == 10
+        assert result.agent_metrics["comparison/ties"] == 2
+        assert result.agent_metrics["comparison/judged"] == 24
+        # win_rate = (12 + 0.5*2) / 24 = 13/24 ≈ 0.5417
+        assert abs(result.agent_metrics["comparison/win_rate"] - (13.0 / 24.0)) < 1e-6

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -297,6 +297,77 @@ class TestApp:
         assert resp.reward == 0.0
         assert resp.loss is True
 
+    @pytest.mark.asyncio
+    async def test_persist_raw_judge_responses_comparison(self, tmp_path) -> None:
+        """When persist_raw_judge_responses=True, raw judge text per trial flows
+        through ``run_trials`` and lands on ``per_ref_repeat[i].raw_responses``."""
+        ref_root = tmp_path / "ref"
+        task_dir = ref_root / "task_task-1" / "repeat_0"
+        task_dir.mkdir(parents=True)
+        (task_dir / "finish_params.json").write_text("{}")
+        eval_dir = tmp_path / "eval" / "task_task-1" / "repeat_0"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "finish_params.json").write_text("{}")
+
+        server = _server(
+            reward_mode="comparison",
+            reference_deliverables_dir=str(ref_root),
+            preconvert_office_to_pdf=False,
+            num_comparison_trials=2,
+            persist_raw_judge_responses=True,
+        )
+
+        captured_kwargs: dict = {}
+        canned_raw = ["Trial 0 verdict: BOXED[B]", "Trial 1 (swapped) verdict: BOXED[A]"]
+
+        def fake_run_trials(**kwargs):
+            captured_kwargs.update(kwargs)
+            return {
+                "winner": "[[B]]",
+                "win_count_a": 1,
+                "win_count_b": 1,
+                "tie_count": 0,
+                "task_count": 2,
+                "raw_responses": canned_raw,
+            }
+
+        body = _verify_request(deliverables_dir=str(eval_dir))
+
+        with (
+            patch("resources_servers.gdpval.comparison.run_trials", side_effect=fake_run_trials),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+            patch("resources_servers.gdpval.comparison.build_file_section", return_value=[]),
+            patch("openai.OpenAI", return_value=MagicMock()),
+        ):
+            resp = await server.verify(body)
+
+        assert captured_kwargs["return_raw_responses"] is True
+        assert resp.judge_response["per_ref_repeat"][0]["raw_responses"] == canned_raw
+
+    @pytest.mark.asyncio
+    async def test_persist_raw_judge_responses_rubric(self) -> None:
+        """When persist_raw_judge_responses=True, the structured-rubric scorer
+        gets ``include_raw_responses=True`` and the resulting metadata reaches
+        ``judge_response``."""
+        server = _server(reward_mode="rubric", rubric_scoring_mode="structured", persist_raw_judge_responses=True)
+
+        captured_kwargs: dict = {}
+
+        async def fake_score_structured(**kwargs):
+            captured_kwargs.update(kwargs)
+            return 0.7, {"scoring_method": "structured_rubric", "raw_responses": ["FINAL_SCORE[7]\nMAX_POSSIBLE_SCORE[10]"]}
+
+        body = _verify_request(rubric_json=[{"criterion": "clarity", "score": 1}])
+
+        with (
+            patch("resources_servers.gdpval.scoring.score_with_rubric_structured", side_effect=fake_score_structured),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+        ):
+            resp = await server.verify(body)
+
+        assert captured_kwargs["include_raw_responses"] is True
+        assert resp.judge_response["raw_responses"] == ["FINAL_SCORE[7]\nMAX_POSSIBLE_SCORE[10]"]
+
     def test_aggregate_metrics_comparison_elo(self) -> None:
         from nemo_gym.config_types import AggregateMetricsRequest
 

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -148,6 +148,9 @@ async def _run_stirrup_agent(
     is_gdpval: bool = False,
     model_id: Optional[str] = None,
     completion_token_buffer: int = 1000,
+    top_p: float = 0.95,
+    enable_thinking: bool = True,
+    max_completion_tokens_cap: int = 64000,
 ) -> Dict[str, Any]:
     """Run a Stirrup agent session and return history + metadata.
 
@@ -209,6 +212,10 @@ async def _run_stirrup_agent(
         max_tokens=max_tokens,
         model_id=model_id,
         completion_token_buffer=completion_token_buffer,
+        temperature=temperature,
+        top_p=top_p,
+        enable_thinking=enable_thinking,
+        max_completion_tokens_cap=max_completion_tokens_cap,
     )
 
     if exec_provider_class:
@@ -341,10 +348,14 @@ async def _run_stirrup_agent(
             import uuid
 
             # ``<persist>/task_<task_id>/repeat_<rollout_index>/`` so concurrent
-            # repeats of the same task don't clobber each other.
+            # repeats of the same task don't clobber each other. Clear the
+            # directory first so a re-visit of the same (task, repeat) — e.g.
+            # across RL training steps — doesn't leak stale files from a prior
+            # run into the judge's input set.
             dir_name = f"task_{task_id}" if task_id else f"task_{uuid.uuid4().hex[:8]}"
             repeat_name = f"repeat_{rollout_index}" if rollout_index is not None else "repeat_0"
             task_dir = Path(persist_deliverables_dir) / dir_name / repeat_name
+            shutil.rmtree(task_dir, ignore_errors=True)
             task_dir.mkdir(parents=True, exist_ok=True)
 
             # 1. Deliverable files
@@ -498,6 +509,21 @@ class StirrupAgentWrapperConfig(BaseResponsesAPIAgentConfig):
         "(messages + tool-schema JSON) and the exact prompt the server sees after chat-template "
         "rendering. See ``nemo_client.DynamicMaxTokensChatCompletionsClient``.",
     )
+    top_p: float = Field(
+        default=0.95,
+        description="Top-p sampling cutoff for the policy model. Forwarded to the LLM client.",
+    )
+    enable_thinking: bool = Field(
+        default=True,
+        description="Whether to enable reasoning tokens (sets "
+        "``extra_body.chat_template_kwargs.enable_thinking``). Reasoning-trained models default to True.",
+    )
+    max_completion_tokens_cap: int = Field(
+        default=64000,
+        description="Hard ceiling on per-call ``max_completion_tokens``. Dynamic sizing computes "
+        "context_window - input_tokens - completion_token_buffer, then caps to this value. "
+        "Set to match the training-side response-length budget for RL.",
+    )
 
 
 class StirrupRunRequest(BaseRunRequest):
@@ -612,6 +638,9 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 "is_gdpval": self.config.task == "gdpval",
                 "model_id": self.config.model_id,
                 "completion_token_buffer": self.config.completion_token_buffer,
+                "top_p": getattr(body, "top_p", None) or self.config.top_p,
+                "enable_thinking": self.config.enable_thinking,
+                "max_completion_tokens_cap": self.config.max_completion_tokens_cap,
             }
 
             future = run_stirrup_agent_remote.remote(params)

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -144,6 +144,7 @@ async def _run_stirrup_agent(
     exec_provider_kwargs: Optional[Dict[str, Any]] = None,
     persist_deliverables_dir: Optional[str] = None,
     task_id: Optional[str] = None,
+    rollout_index: Optional[int] = None,
     is_gdpval: bool = False,
     model_id: Optional[str] = None,
     completion_token_buffer: int = 1000,
@@ -339,8 +340,11 @@ async def _run_stirrup_agent(
             import pickle as _persist_pickle
             import uuid
 
+            # ``<persist>/task_<task_id>/repeat_<rollout_index>/`` so concurrent
+            # repeats of the same task don't clobber each other.
             dir_name = f"task_{task_id}" if task_id else f"task_{uuid.uuid4().hex[:8]}"
-            task_dir = Path(persist_deliverables_dir) / dir_name
+            repeat_name = f"repeat_{rollout_index}" if rollout_index is not None else "repeat_0"
+            task_dir = Path(persist_deliverables_dir) / dir_name / repeat_name
             task_dir.mkdir(parents=True, exist_ok=True)
 
             # 1. Deliverable files
@@ -514,6 +518,7 @@ _TASK_METADATA_FIELDS = (
     "rubric_json",
     "rubric_pretty",
     "instance_id",
+    "_ng_rollout_index",
 )
 
 
@@ -603,6 +608,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 "exec_provider_kwargs": exec_provider_kwargs,
                 "persist_deliverables_dir": self.config.persist_deliverables_dir,
                 "task_id": task_info.get("task_id"),
+                "rollout_index": (body.metadata or {}).get("_ng_rollout_index"),
                 "is_gdpval": self.config.task == "gdpval",
                 "model_id": self.config.model_id,
                 "completion_token_buffer": self.config.completion_token_buffer,
@@ -728,10 +734,12 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
             # resources server will fall back to response.output_text).
             deliverables_dir: Optional[str] = None
             task_id = existing_metadata.get("task_id")
+            rollout_index = existing_metadata.get("_ng_rollout_index")
             if self.config.persist_deliverables_dir and task_id:
-                # Absolute path so the resources server (which runs from its
-                # own subdir) resolves to the same filesystem location.
-                deliverables_dir = str((Path(self.config.persist_deliverables_dir) / f"task_{task_id}").absolute())
+                repeat_name = f"repeat_{rollout_index}" if rollout_index is not None else "repeat_0"
+                deliverables_dir = str(
+                    (Path(self.config.persist_deliverables_dir) / f"task_{task_id}" / repeat_name).absolute()
+                )
 
             verify_request_body = dict(body_dict)
             verify_request_body["response"] = response_clean.model_dump(mode="json")

--- a/responses_api_agents/stirrup_agent/apptainer_provider.py
+++ b/responses_api_agents/stirrup_agent/apptainer_provider.py
@@ -128,17 +128,27 @@ class ApptainerCodeExecToolProvider(CodeExecToolProvider):
             mount_args.append(extra)
         mount_str = " ".join(mount_args)
 
+        # NOTE: ``HOME`` inside the container is set via the ``--home`` flag
+        # (not ``--env HOME=...``). Apptainer 1.4+ rejects setting HOME via
+        # ``--env`` because that flag forwards values through the
+        # ``APPTAINERENV_HOME`` mechanism, which it explicitly disallows for
+        # HOME with a startup-time stderr warning. That warning is harmless
+        # in isolation but our ``echo ready`` health-check below treats any
+        # non-empty stderr as fatal, so the agent fails to enter the shell
+        # even though apptainer would otherwise run fine. ``--home`` is the
+        # supported way to set ``$HOME`` in the container.
         env_args = " ".join(
             f"--env {var}={shlex.quote(os.environ.get(var, ''))}"
             for var in self._env_passthrough
             if os.environ.get(var)
         )
-        env_section = f"--env HOME=/root {env_args}" if env_args else "--env HOME=/root"
+        env_section = env_args
 
         exec_cmd = (
             f"apptainer exec "
             f"--writable-tmpfs --cleanenv --pid "
             f"--no-mount home,tmp,bind-paths "
+            f"--home /root "
             f"{env_section} "
             f"{mount_str} "
             f"{shlex.quote(self._sif_path)} "

--- a/responses_api_agents/stirrup_agent/containers/gdpval.def
+++ b/responses_api_agents/stirrup_agent/containers/gdpval.def
@@ -19,7 +19,18 @@ From: python:3.12-bookworm
     Description GDPVal Apptainer container with all document generation dependencies
 
 %post
-    apt-get update && apt-get install -y --no-install-recommends \
+    set -ex
+
+    # System packages.  The previous version chained these with ``&&`` and let
+    # ``pip install`` run on a separate line, so an apt failure (e.g. a build
+    # host with no DNS, or an ARM-only Debian variant where one package isn't
+    # in the default mirrors) silently skipped to the pip block — producing a
+    # sif missing libreoffice/tesseract/etc. while still appearing to build.
+    # ``set -ex`` aborts on the first failure, and the ``command -v`` checks
+    # below fail loud if any binary we expect didn't actually install.
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y --no-install-recommends \
         git \
         build-essential \
         gcc \
@@ -43,9 +54,18 @@ From: python:3.12-bookworm
         ffmpeg \
         graphviz \
         curl \
-        wget \
-        && rm -rf /var/lib/apt/lists/*
+        wget
+    rm -rf /var/lib/apt/lists/*
 
+    command -v libreoffice
+    command -v tesseract
+    command -v pandoc
+    command -v pdftotext
+    command -v gs
+    command -v ffmpeg
+    command -v dot
+
+    # Python packages matching GDPVal deliverable + agent needs.
     pip install --no-cache-dir \
         python-docx fpdf2 reportlab weasyprint PyPDF2 beautifulsoup4 \
         seaborn python-pptx markdown2 pdfminer.six openpyxl lxml Pillow \

--- a/responses_api_agents/stirrup_agent/nemo_client.py
+++ b/responses_api_agents/stirrup_agent/nemo_client.py
@@ -71,7 +71,7 @@ _MIN_COMPLETION_TOKENS = 1024
 
 # Hard cap on per-call max_completion_tokens.  Oversized completion budgets
 # on long-context servers can degrade output quality for reasoning models.
-_MAX_COMPLETION_TOKENS = 64000
+_DEFAULT_MAX_COMPLETION_TOKENS_CAP = 64000
 
 
 def _load_tokenizer(model_id: Optional[str]):
@@ -124,10 +124,18 @@ class DynamicMaxTokensChatCompletionsClient(ChatCompletionsClient):
         *args: Any,
         model_id: Optional[str] = None,
         completion_token_buffer: int = 1000,
+        temperature: float = 1.0,
+        top_p: float = 0.95,
+        enable_thinking: bool = True,
+        max_completion_tokens_cap: int = _DEFAULT_MAX_COMPLETION_TOKENS_CAP,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
         self._completion_token_buffer = completion_token_buffer
+        self._temperature = temperature
+        self._top_p = top_p
+        self._enable_thinking = enable_thinking
+        self._max_completion_tokens_cap = max_completion_tokens_cap
         self._tokenizer = _load_tokenizer(model_id)
         if model_id and self._tokenizer is None:
             LOGGER.warning(
@@ -236,18 +244,17 @@ class DynamicMaxTokensChatCompletionsClient(ChatCompletionsClient):
             context_window - input_tokens - self._completion_token_buffer,
             _MIN_COMPLETION_TOKENS,
         )
-        capped_max = min(dynamic_max, _MAX_COMPLETION_TOKENS)
+        capped_max = min(dynamic_max, self._max_completion_tokens_cap)
 
-        # Defaults tuned for reasoning-trained models: thinking enabled,
-        # temperature=1.0, top_p=0.95, capped completion budget.
-        # ``self._kwargs`` is spread last so explicit config overrides win.
+        # ``self._kwargs`` is spread last so explicit per-request kwargs override
+        # the agent-level defaults.
         request_kwargs: dict[str, Any] = {
             "model": self._model,
             "messages": to_openai_messages(messages),
-            "temperature": 1.0,
-            "top_p": 0.95,
+            "temperature": self._temperature,
+            "top_p": self._top_p,
             "max_completion_tokens": capped_max,
-            "extra_body": {"chat_template_kwargs": {"enable_thinking": True}},
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": self._enable_thinking}},
             **self._kwargs,
         }
         if tools:

--- a/responses_api_agents/stirrup_agent/stirrup_utils.py
+++ b/responses_api_agents/stirrup_agent/stirrup_utils.py
@@ -41,14 +41,37 @@ def convert_stirrup_history_to_output_items(
     system/user messages and *output_items* are assistant messages +
     tool calls/results.
     """
+    from stirrup.core.models import (
+        AssistantMessage,
+        SystemMessage,
+        ToolMessage,
+        UserMessage,
+    )
+
     input_items: list = []
     output_items: list = []
 
     for turn in history:
         for msg in turn:
-            msg_type = type(msg).__name__
+            # Tool result. ``ToolMessage`` is the canonical case; ``NeMoUserMessage``
+            # (a ``UserMessage`` subclass produced by ``NeMoAgent.run_tool`` when
+            # ``tool_response_as_user=True``) carries the same metadata but
+            # serialises as ``role=user`` for the LLM. Detect both via the
+            # ``tool_call_id`` attribute so the rollout always retains a
+            # ``function_call_output`` paired with the upstream ``function_call``.
+            tool_call_id = getattr(msg, "tool_call_id", None)
+            if isinstance(msg, ToolMessage) or tool_call_id:
+                call_id = tool_call_id or f"call-{uuid.uuid4().hex[:8]}"
+                content = msg.content if isinstance(msg.content, str) else str(msg.content)
+                output_items.append(
+                    NeMoGymFunctionCallOutput(
+                        call_id=call_id,
+                        output=content,
+                        type="function_call_output",
+                    )
+                )
 
-            if msg_type == "SystemMessage":
+            elif isinstance(msg, SystemMessage):
                 input_items.append(
                     NeMoGymEasyInputMessage(
                         role="system",
@@ -56,7 +79,7 @@ def convert_stirrup_history_to_output_items(
                     )
                 )
 
-            elif msg_type == "UserMessage":
+            elif isinstance(msg, UserMessage):
                 content_text = ""
                 if isinstance(msg.content, str):
                     content_text = msg.content
@@ -67,7 +90,7 @@ def convert_stirrup_history_to_output_items(
 
                 input_items.append(NeMoGymEasyInputMessage(role="user", content=content_text))
 
-            elif msg_type == "AssistantMessage":
+            elif isinstance(msg, AssistantMessage):
                 content_text = msg.content if isinstance(msg.content, str) else ""
                 if content_text:
                     output_items.append(
@@ -88,7 +111,11 @@ def convert_stirrup_history_to_output_items(
 
                 if hasattr(msg, "tool_calls") and msg.tool_calls:
                     for tc in msg.tool_calls:
-                        call_id = tc.id if hasattr(tc, "id") else f"call-{uuid.uuid4().hex[:8]}"
+                        # Stirrup ``ToolCall`` exposes ``tool_call_id``; preserve it so the
+                        # downstream ``function_call_output`` (keyed on the same id) pairs.
+                        call_id = (
+                            getattr(tc, "tool_call_id", None) or getattr(tc, "id", None) or f"call-{uuid.uuid4().hex[:8]}"
+                        )
                         output_items.append(
                             NeMoGymResponseFunctionToolCall(
                                 id=f"fc-{uuid.uuid4().hex[:8]}",
@@ -99,17 +126,6 @@ def convert_stirrup_history_to_output_items(
                                 status="completed",
                             )
                         )
-
-            elif msg_type == "ToolMessage":
-                call_id = msg.tool_call_id if hasattr(msg, "tool_call_id") else f"call-{uuid.uuid4().hex[:8]}"
-                content = msg.content if isinstance(msg.content, str) else str(msg.content)
-                output_items.append(
-                    NeMoGymFunctionCallOutput(
-                        call_id=call_id,
-                        output=content,
-                        type="function_call_output",
-                    )
-                )
 
     return input_items, output_items
 

--- a/responses_api_agents/stirrup_agent/tasks/gdpval.py
+++ b/responses_api_agents/stirrup_agent/tasks/gdpval.py
@@ -160,7 +160,13 @@ class GDPValTask(TaskStrategy):
         if not ref_files or not ref_urls:
             return None
 
-        input_files_dir = tempfile.mkdtemp(prefix="gdpval_ref_files_")
+        # Default ``tempfile.mkdtemp`` lands in the agent host's local /tmp,
+        # which Ray actors on other nodes can't read. Honor a shared-FS
+        # override so multi-node Ray works.
+        ref_root = os.environ.get("GDPVAL_REF_FILES_DIR")
+        if ref_root:
+            Path(ref_root).mkdir(parents=True, exist_ok=True)
+        input_files_dir = tempfile.mkdtemp(prefix="gdpval_ref_files_", dir=ref_root)
         downloaded = _download_reference_files(ref_files, ref_urls, Path(input_files_dir))
         if downloaded:
             print(f"Downloaded {len(downloaded)} reference files to {input_files_dir}", flush=True)
@@ -186,9 +192,15 @@ class GDPValTask(TaskStrategy):
             f"[gdpval] Using Apptainer container {container_path} for task {task_info.get('task_id', '?')}", flush=True
         )
 
+        # ``working_dir="/root"`` rather than ``/workspace``: ``/root`` is
+        # guaranteed by the ``--home /root`` flag we pass to apptainer, while
+        # ``/workspace`` only exists if the container's ``%post`` actually ran
+        # ``mkdir -p /workspace`` — and the previous ``%post`` could silently
+        # skip that step on apt failure. Using ``/root`` makes the per-task
+        # apptainer flow robust to a partial container build.
         return ApptainerCodeExecToolProvider(
             sif_path=container_path,
-            working_dir="/workspace",
+            working_dir="/root",
             memory_limit_mb=getattr(config, "apptainer_memory_limit_mb", None),
             capture_git_diff=False,
             env_passthrough=["HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY", "https_proxy", "http_proxy", "no_proxy"],

--- a/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
+++ b/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ``DynamicMaxTokensChatCompletionsClient``.
+
+Covers per-call sampling kwargs (``temperature``, ``top_p``,
+``enable_thinking``) and the configurable per-call completion cap
+(``max_completion_tokens_cap``) — all of which used to be hardcoded.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from stirrup.core.models import AssistantMessage, SystemMessage, UserMessage
+
+from responses_api_agents.stirrup_agent.nemo_client import (
+    DynamicMaxTokensChatCompletionsClient,
+)
+
+
+def _make_response(content: str = "ok"):
+    """Build a fake openai chat.completions response shape."""
+    response = MagicMock()
+    choice = MagicMock()
+    choice.finish_reason = "stop"
+    choice.message = MagicMock()
+    choice.message.content = content
+    choice.message.tool_calls = []
+    choice.message.reasoning_content = None
+    response.choices = [choice]
+    response.usage = MagicMock()
+    response.usage.prompt_tokens = 10
+    response.usage.completion_tokens = 5
+    response.usage.completion_tokens_details = None
+    return response
+
+
+@pytest.mark.asyncio
+async def test_generate_forwards_configured_sampling_kwargs() -> None:
+    """``temperature``, ``top_p``, ``enable_thinking``, and the cap on
+    ``max_completion_tokens`` should land on the wire request_kwargs."""
+    client = DynamicMaxTokensChatCompletionsClient(
+        model="m",
+        max_tokens=10_000,
+        base_url="http://test",
+        api_key="k",
+        temperature=0.42,
+        top_p=0.7,
+        enable_thinking=False,
+        max_completion_tokens_cap=2048,
+    )
+    fake_create = AsyncMock(return_value=_make_response())
+    client._client = MagicMock()
+    client._client.chat.completions.create = fake_create
+
+    messages = [SystemMessage(content="sys"), UserMessage(content="hi")]
+    await client.generate(messages, tools={})
+
+    fake_create.assert_awaited_once()
+    sent = fake_create.await_args.kwargs
+
+    assert sent["temperature"] == pytest.approx(0.42)
+    assert sent["top_p"] == pytest.approx(0.7)
+    assert sent["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False
+    assert sent["max_completion_tokens"] <= 2048
+
+
+@pytest.mark.asyncio
+async def test_max_completion_tokens_cap_overrides_dynamic_size() -> None:
+    """When the dynamic computation exceeds the cap, the cap should win."""
+    client = DynamicMaxTokensChatCompletionsClient(
+        model="m",
+        max_tokens=1_000_000,  # huge context window → dynamic_max would exceed cap
+        base_url="http://test",
+        api_key="k",
+        max_completion_tokens_cap=512,
+    )
+    fake_create = AsyncMock(return_value=_make_response())
+    client._client = MagicMock()
+    client._client.chat.completions.create = fake_create
+
+    await client.generate([UserMessage(content="hi")], tools={})
+
+    sent = fake_create.await_args.kwargs
+    assert sent["max_completion_tokens"] == 512
+
+
+def test_defaults_match_pre_lift_behaviour() -> None:
+    """Sanity: omitting the new kwargs must keep the historical defaults
+    (temperature=1.0, top_p=0.95, enable_thinking=True, cap=64000) so existing
+    deployments that don't set the new config fields are unaffected."""
+    client = DynamicMaxTokensChatCompletionsClient(
+        model="m",
+        max_tokens=10_000,
+        base_url="http://test",
+        api_key="k",
+    )
+    assert client._temperature == 1.0
+    assert client._top_p == 0.95
+    assert client._enable_thinking is True
+    assert client._max_completion_tokens_cap == 64000

--- a/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
+++ b/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from stirrup.core.models import AssistantMessage, SystemMessage, UserMessage
+from stirrup.core.models import SystemMessage, UserMessage
 
 from responses_api_agents.stirrup_agent.nemo_client import (
     DynamicMaxTokensChatCompletionsClient,

--- a/responses_api_agents/stirrup_agent/tests/test_stirrup_utils.py
+++ b/responses_api_agents/stirrup_agent/tests/test_stirrup_utils.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ``stirrup_utils.convert_stirrup_history_to_output_items``.
+
+Focuses on the rollout-output coverage of tool results: ``ToolMessage``
+and ``NeMoUserMessage`` (the ``UserMessage`` subclass produced when
+``tool_response_as_user=True``) must both materialise as
+``function_call_output`` items, with ``call_id`` paired to the
+upstream ``function_call``.
+"""
+
+from __future__ import annotations
+
+from stirrup.core.models import (
+    AssistantMessage,
+    SystemMessage,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+)
+
+from responses_api_agents.stirrup_agent.nemo_agent import NeMoUserMessage
+from responses_api_agents.stirrup_agent.stirrup_utils import (
+    convert_stirrup_history_to_output_items,
+)
+
+
+def _types(items):
+    return [it.type for it in items]
+
+
+def _call_ids(items, item_type):
+    return [it.call_id for it in items if it.type == item_type]
+
+
+def test_tool_message_emits_function_call_output_paired_with_call() -> None:
+    history = [
+        [
+            SystemMessage(content="sys"),
+            UserMessage(content="user prompt"),
+        ],
+        [
+            AssistantMessage(
+                content="thinking",
+                tool_calls=[ToolCall(name="code_exec", arguments='{"code": "1+1"}', tool_call_id="abc123")],
+            ),
+            ToolMessage(content="2", tool_call_id="abc123", name="code_exec", success=True),
+        ],
+    ]
+    input_items, output_items = convert_stirrup_history_to_output_items(history)
+
+    assert _types(input_items) == ["message", "message"]
+    assert _types(output_items) == ["message", "function_call", "function_call_output"]
+    assert _call_ids(output_items, "function_call") == ["abc123"]
+    assert _call_ids(output_items, "function_call_output") == ["abc123"]
+
+
+def test_nemo_user_message_with_tool_call_id_emits_function_call_output() -> None:
+    """``NeMoUserMessage`` is a ``UserMessage`` subclass; without the
+    tool_call_id-based dispatch its tool output would either be dropped or
+    misclassified as a regular user message."""
+    history = [
+        [
+            AssistantMessage(
+                content="",
+                tool_calls=[ToolCall(name="code_exec", arguments="{}", tool_call_id="tc-1")],
+            ),
+            NeMoUserMessage(content="stdout: ok", tool_call_id="tc-1", name="code_exec", success=True),
+        ],
+    ]
+    _, output_items = convert_stirrup_history_to_output_items(history)
+
+    assert _types(output_items) == ["function_call", "function_call_output"]
+    assert _call_ids(output_items, "function_call") == ["tc-1"]
+    assert _call_ids(output_items, "function_call_output") == ["tc-1"]
+    fco = output_items[1]
+    assert fco.output == "stdout: ok"
+
+
+def test_plain_user_message_routes_to_input_items() -> None:
+    """A regular ``UserMessage`` (no ``tool_call_id``) must land in input_items,
+    not be misclassified as a tool result."""
+    history = [[UserMessage(content="hello")]]
+    input_items, output_items = convert_stirrup_history_to_output_items(history)
+
+    assert len(input_items) == 1
+    assert input_items[0].role == "user"
+    assert input_items[0].content == "hello"
+    assert output_items == []
+
+
+def test_assistant_tool_call_uses_stirrup_tool_call_id() -> None:
+    """``ToolCall.tool_call_id`` is the canonical id field; verify that the
+    function_call output uses it (rather than falling back to a random uuid)
+    so it pairs with the corresponding function_call_output."""
+    history = [
+        [
+            AssistantMessage(
+                content="",
+                tool_calls=[ToolCall(name="run", arguments="{}", tool_call_id="real-id-7")],
+            ),
+        ],
+    ]
+    _, output_items = convert_stirrup_history_to_output_items(history)
+    assert _call_ids(output_items, "function_call") == ["real-id-7"]


### PR DESCRIPTION
## Summary

Adds a config flag `persist_raw_judge_responses: bool = False` on `GDPValResourcesServerConfig`. When True, the raw judge completion text from every trial is preserved on `verify_response.judge_response`:

- **Comparison mode** — under `judge_response.per_ref_repeat[i].raw_responses: list[str]` (one per trial, ordered by trial index; trial `i` was swapped iff `i % 2 != 0`).
- **Rubric modes** (binary / visual / structured) — under top-level `judge_response.raw_responses: list[str]`.

Off by default. Raw responses are 10–50 KB × `num_trials` × `num_ref_repeats` × `num_tasks`, so always-on would meaningfully bloat rollout JSONLs and W&B uploads. Turn on for debug runs to post-mortem judge verdicts (e.g. understanding why a comparison-mode run lost 87% of pairwise comparisons).

## Why

When a comparison-mode or rubric run produces unexpected scores, the only persisted signal today is parsed counts/numbers — the judge's actual rationale, criterion-by-criterion grades, and verdict text are fetched and discarded. With this flag, those raw strings survive into the rollout JSONL so post-mortem analysis is possible without re-running.

## Stacking

Builds on PR #1222 (`[GDPVal] Add structured rubric scoring mode`); the structured-rubric kwarg additions only make sense once that lands. Once #1222 merges, this PR will rebase to a single commit cleanly.

## Test plan

- [x] Unit tests added: `test_persist_raw_judge_responses_comparison`, `test_persist_raw_judge_responses_rubric` — verify both modes pass the flag through to the underlying scorers and that returned raw text appears in the response.
- [ ] Smoke run on a small AfterQuery sample with the flag on, inspect resulting JSONL for `raw_responses` field shape.