### PR TITLE
[GDPVal] Add opt-in persistence of raw judge responses

### DIFF
--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -117,6 +117,23 @@ class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     judge_responses_create_params_overrides: Dict[str, Any] = {}
     judge_prompt_template_fpath: Optional[str] = None
 
+    # Rubric-mode scoring backend:
+    # - ``"binary"`` (default, legacy): judge emits a JSON ``{criteria_scores:
+    #   [{score: 0|1, ...}], overall_score: float}``; reward is the overall
+    #   score (0-1). Treats every criterion as equal weight.
+    # - ``"structured"``: judge emits ``CRITERION_NUMBER[N]: GRADE[X] out of
+    #   MAX_POSSIBLE_POINTS[Y]`` tagged output and ``FINAL_SCORE[…] / MAX_POSSIBLE_SCORE[…]``.
+    #   Honors per-criterion point weights when the rubric carries them in
+    #   ``rubric_json[i].score`` or ``rubric_json[i].weight``. For datasets
+    #   without weights, every criterion contributes max-points 1, giving a
+    #   signal equivalent to binary mode. Multi-trial averaged for stability.
+    #   The tagged output is also more compact than the JSON-with-rationale
+    #   format used by binary mode, so it rarely runs into the judge's
+    #   ``finish_reason: length`` truncation on rubrics with many criteria.
+    rubric_scoring_mode: Literal["binary", "structured"] = "binary"
+    rubric_structured_num_trials: int = 2
+    rubric_structured_formatting_retries: int = 3
+
 
 class GDPValVerifyRequest(BaseVerifyRequest):
     task_id: str
@@ -201,7 +218,22 @@ class GDPValResourcesServer(SimpleResourcesServer):
         # the judge model is expected to be multimodal (configured via
         # ``judge_model_server`` in the benchmark YAML). Falls back to text
         # scoring only when no content blocks could be built.
-        if deliverable_content_blocks:
+        if self.config.rubric_scoring_mode == "structured":
+            from resources_servers.gdpval.scoring import score_with_rubric_structured
+
+            reward, judge_result = await score_with_rubric_structured(
+                deliverable_text=deliverable_text,
+                rubric_json=body.rubric_json,
+                rubric_pretty=rubric_pretty,
+                task_prompt=task_prompt,
+                model_base_url=judge_base_url,
+                model_name=judge_model_name,
+                api_key=judge_api_key,
+                num_trials=self.config.rubric_structured_num_trials,
+                formatting_retries=self.config.rubric_structured_formatting_retries,
+                deliverable_content_blocks=deliverable_content_blocks,
+            )
+        elif deliverable_content_blocks:
             from resources_servers.gdpval.scoring import score_with_rubric_visual
 
             reward, judge_result = await score_with_rubric_visual(

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -134,6 +134,14 @@ class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     rubric_structured_num_trials: int = 2
     rubric_structured_formatting_retries: int = 3
 
+    # When True, every judge call's raw response text is preserved on
+    # ``verify_response.judge_response`` (per-trial in comparison mode under
+    # ``per_ref_repeat[i].raw_responses``; under top-level ``raw_responses``
+    # in rubric modes). Off by default — raw responses are 10-50 KB each and
+    # multiply by num_trials × num_ref_repeats × num_tasks. Turn on for debug
+    # runs to post-mortem judge verdicts.
+    persist_raw_judge_responses: bool = False
+
 
 class GDPValVerifyRequest(BaseVerifyRequest):
     task_id: str
@@ -232,6 +240,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 num_trials=self.config.rubric_structured_num_trials,
                 formatting_retries=self.config.rubric_structured_formatting_retries,
                 deliverable_content_blocks=deliverable_content_blocks,
+                include_raw_responses=self.config.persist_raw_judge_responses,
             )
         elif deliverable_content_blocks:
             from resources_servers.gdpval.scoring import score_with_rubric_visual
@@ -246,6 +255,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 model_name=judge_model_name,
                 api_key=judge_api_key,
                 create_overrides=judge_create_overrides,
+                include_raw_responses=self.config.persist_raw_judge_responses,
             )
         else:
             from resources_servers.gdpval.scoring import score_with_rubric
@@ -260,6 +270,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 model_name=judge_model_name,
                 api_key=judge_api_key,
                 create_overrides=judge_create_overrides,
+                include_raw_responses=self.config.persist_raw_judge_responses,
             )
 
         return GDPValVerifyResponse(
@@ -337,6 +348,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 submission_a=ref_submission,
                 submission_b=eval_submission,
                 num_trials=self.config.num_comparison_trials,
+                return_raw_responses=self.config.persist_raw_judge_responses,
             )
             # ``run_trials`` casts submission_a=ref, submission_b=eval, so
             # ``win_count_b`` is eval wins.

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -375,15 +375,21 @@ def run_trials(
     submission_b: list[dict],
     num_trials: int = 4,
     max_output_tokens: int = 65535,
+    return_raw_responses: bool = False,
 ) -> dict:
     """Run ``num_trials`` judge calls, alternating swapped/unswapped positions.
 
     Returns a dict with ``winner``, ``win_count_a``, ``win_count_b``,
     ``tie_count``, and ``task_count``.
+
+    When ``return_raw_responses`` is True, the dict also carries
+    ``raw_responses``: a list of the per-trial judge completion strings,
+    ordered by trial index (so trial ``i`` was swapped iff ``i % 2 != 0``).
     """
     win_count_a = 0
     win_count_b = 0
     tie_count = 0
+    raw_responses: list[str] = []
 
     for i in range(num_trials):
         swapped = i % 2 != 0
@@ -397,6 +403,8 @@ def run_trials(
             submission_b=current_b,
         )
         response_text = send_judge_request(client, model, messages, max_output_tokens)
+        if return_raw_responses:
+            raw_responses.append(response_text)
         judgement = parse_judgement(response_text)
         win_count_a, win_count_b, tie_count = tally_result(judgement, swapped, win_count_a, win_count_b, tie_count)
 
@@ -407,13 +415,16 @@ def run_trials(
     else:
         winner = TIE_RESPONSE
 
-    return {
+    result: dict = {
         "winner": winner,
         "win_count_a": win_count_a,
         "win_count_b": win_count_b,
         "tie_count": tie_count,
         "task_count": num_trials,
     }
+    if return_raw_responses:
+        result["raw_responses"] = raw_responses
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/resources_servers/gdpval/scoring.py
+++ b/resources_servers/gdpval/scoring.py
@@ -93,6 +93,7 @@ async def score_with_rubric(
     model_name: str,
     api_key: str = "dummy",
     create_overrides: dict | None = None,
+    include_raw_responses: bool = False,
 ) -> tuple[float, dict | None]:
     """Score a deliverable against a rubric using an LLM judge.
 
@@ -164,6 +165,7 @@ async def score_with_rubric(
             return 0.0, None
 
         response_text = content.strip()
+        raw_response_text = response_text
         print(
             f"Rubric judge response length: {len(response_text)} chars, "
             f"finish_reason: {response.choices[0].finish_reason}",
@@ -206,6 +208,8 @@ async def score_with_rubric(
             score = 0.0
 
         print(f"Rubric final score: {score}", flush=True)
+        if include_raw_responses and isinstance(result, dict):
+            result["raw_responses"] = [raw_response_text]
         return max(0.0, min(1.0, score)), result
 
     except Exception as e:
@@ -226,6 +230,7 @@ async def score_with_rubric_visual(
     model_name: str,
     api_key: str = "dummy",
     create_overrides: dict | None = None,
+    include_raw_responses: bool = False,
 ) -> tuple[float, dict | None]:
     """Score deliverables visually using a multimodal judge (e.g., Gemini 3 Pro).
 
@@ -295,6 +300,7 @@ async def score_with_rubric_visual(
                     raise
 
         response_text = (response.choices[0].message.content or "").strip()
+        raw_response_text = response_text
         print(
             f"Visual judge response length: {len(response_text)} chars, "
             f"finish_reason: {response.choices[0].finish_reason}, "
@@ -337,6 +343,8 @@ async def score_with_rubric_visual(
             score = 0.0
 
         print(f"Visual judge final score: {score}", flush=True)
+        if include_raw_responses and isinstance(result, dict):
+            result["raw_responses"] = [raw_response_text]
         return max(0.0, min(1.0, score)), result
 
     except Exception as e:
@@ -363,6 +371,7 @@ async def score_with_rubric_structured(
     num_trials: int = 2,
     formatting_retries: int = 3,
     deliverable_content_blocks: list[dict] | None = None,
+    include_raw_responses: bool = False,
 ) -> tuple[float, dict | None]:
     """Score a deliverable using structured tagged output format.
 
@@ -488,7 +497,10 @@ async def score_with_rubric_structured(
 
     if not scores:
         print("[structured-rubric] no valid scores from any trial", flush=True)
-        return 0.0, {"error": "no_valid_scores", "num_trials": num_trials}
+        no_valid_metadata: dict = {"error": "no_valid_scores", "num_trials": num_trials}
+        if include_raw_responses:
+            no_valid_metadata["raw_responses"] = trial_responses
+        return 0.0, no_valid_metadata
 
     avg_score = sum(scores) / len(scores)
     avg_pct = sum(percentages) / len(percentages)
@@ -509,6 +521,8 @@ async def score_with_rubric_structured(
         "num_trials_completed": len(scores),
         "num_trials_requested": num_trials,
     }
+    if include_raw_responses:
+        metadata["raw_responses"] = trial_responses
 
     print(
         f"[structured-rubric] final: avg={avg_score:.1f}/{effective_max} ({avg_pct:.1f}%), "

--- a/resources_servers/gdpval/scoring.py
+++ b/resources_servers/gdpval/scoring.py
@@ -375,13 +375,25 @@ async def score_with_rubric_structured(
     """
     from openai import AsyncOpenAI
 
-    # Compute max possible score from rubric
+    # Compute max possible score from rubric. Different upstream formats name
+    # the per-criterion point field differently — accept either ``score`` or
+    # ``weight`` so multiple datasets can mix in the same training run without
+    # a per-source pre-pass.
+    def _criterion_points(item: Any) -> float:
+        if not isinstance(item, dict):
+            return 0
+        for key in ("score", "weight"):
+            v = item.get(key)
+            if isinstance(v, (int, float)):
+                return v
+        return 0
+
     if isinstance(rubric_json, str):
         rubric_json = json.loads(rubric_json) if rubric_json else []
     if isinstance(rubric_json, list):
-        max_possible = sum(item.get("score", 0) for item in rubric_json)
+        max_possible = sum(_criterion_points(item) for item in rubric_json)
     elif isinstance(rubric_json, dict) and "criteria" in rubric_json:
-        max_possible = sum(c.get("score", 0) for c in rubric_json["criteria"])
+        max_possible = sum(_criterion_points(c) for c in rubric_json["criteria"])
     else:
         max_possible = 0
 

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -297,6 +297,77 @@ class TestApp:
         assert resp.reward == 0.0
         assert resp.loss is True
 
+    @pytest.mark.asyncio
+    async def test_persist_raw_judge_responses_comparison(self, tmp_path) -> None:
+        """When persist_raw_judge_responses=True, raw judge text per trial flows
+        through ``run_trials`` and lands on ``per_ref_repeat[i].raw_responses``."""
+        ref_root = tmp_path / "ref"
+        task_dir = ref_root / "task_task-1" / "repeat_0"
+        task_dir.mkdir(parents=True)
+        (task_dir / "finish_params.json").write_text("{}")
+        eval_dir = tmp_path / "eval" / "task_task-1" / "repeat_0"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "finish_params.json").write_text("{}")
+
+        server = _server(
+            reward_mode="comparison",
+            reference_deliverables_dir=str(ref_root),
+            preconvert_office_to_pdf=False,
+            num_comparison_trials=2,
+            persist_raw_judge_responses=True,
+        )
+
+        captured_kwargs: dict = {}
+        canned_raw = ["Trial 0 verdict: BOXED[B]", "Trial 1 (swapped) verdict: BOXED[A]"]
+
+        def fake_run_trials(**kwargs):
+            captured_kwargs.update(kwargs)
+            return {
+                "winner": "[[B]]",
+                "win_count_a": 1,
+                "win_count_b": 1,
+                "tie_count": 0,
+                "task_count": 2,
+                "raw_responses": canned_raw,
+            }
+
+        body = _verify_request(deliverables_dir=str(eval_dir))
+
+        with (
+            patch("resources_servers.gdpval.comparison.run_trials", side_effect=fake_run_trials),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+            patch("resources_servers.gdpval.comparison.build_file_section", return_value=[]),
+            patch("openai.OpenAI", return_value=MagicMock()),
+        ):
+            resp = await server.verify(body)
+
+        assert captured_kwargs["return_raw_responses"] is True
+        assert resp.judge_response["per_ref_repeat"][0]["raw_responses"] == canned_raw
+
+    @pytest.mark.asyncio
+    async def test_persist_raw_judge_responses_rubric(self) -> None:
+        """When persist_raw_judge_responses=True, the structured-rubric scorer
+        gets ``include_raw_responses=True`` and the resulting metadata reaches
+        ``judge_response``."""
+        server = _server(reward_mode="rubric", rubric_scoring_mode="structured", persist_raw_judge_responses=True)
+
+        captured_kwargs: dict = {}
+
+        async def fake_score_structured(**kwargs):
+            captured_kwargs.update(kwargs)
+            return 0.7, {"scoring_method": "structured_rubric", "raw_responses": ["FINAL_SCORE[7]\nMAX_POSSIBLE_SCORE[10]"]}
+
+        body = _verify_request(rubric_json=[{"criterion": "clarity", "score": 1}])
+
+        with (
+            patch("resources_servers.gdpval.scoring.score_with_rubric_structured", side_effect=fake_score_structured),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+        ):
+            resp = await server.verify(body)
+
+        assert captured_kwargs["include_raw_responses"] is True
+        assert resp.judge_response["raw_responses"] == ["FINAL_SCORE[7]\nMAX_POSSIBLE_SCORE[10]"]
+
     def test_aggregate_metrics_comparison_elo(self) -> None:
         from nemo_gym.config_types import AggregateMetricsRequest
 

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -355,7 +355,10 @@ class TestApp:
 
         async def fake_score_structured(**kwargs):
             captured_kwargs.update(kwargs)
-            return 0.7, {"scoring_method": "structured_rubric", "raw_responses": ["FINAL_SCORE[7]\nMAX_POSSIBLE_SCORE[10]"]}
+            return 0.7, {
+                "scoring_method": "structured_rubric",
+                "raw_responses": ["FINAL_SCORE[7]\nMAX_POSSIBLE_SCORE[10]"],
+            }
 
         body = _verify_request(rubric_json=[{"criterion": "clarity", "score": 1}])
 


### PR DESCRIPTION
## Summary

Adds a config flag `persist_raw_judge_responses: bool = False` on `GDPValResourcesServerConfig`. When True, the raw judge completion text from every trial is preserved on `verify_response.judge_response`:

- **Comparison mode** — under `judge_response.per_ref_repeat[i].raw_responses: list[str]` (one per trial, ordered by trial index; trial `i` was swapped iff `i % 2 != 0`).
- **Rubric modes** (binary / visual / structured) — under top-level `judge_response.raw_responses: list[str]`.

Off by default. Raw responses are 10–50 KB × `num_trials` × `num_ref_repeats` × `num_tasks`, so always-on would meaningfully bloat rollout JSONLs and W&B uploads. Turn on for debug runs to post-mortem judge verdicts (e.g. understanding why a comparison-mode run lost 87% of pairwise comparisons).

## Why

When a comparison-mode or rubric run produces unexpected scores, the only persisted signal today is parsed counts/numbers — the judge's actual rationale, criterion-by-criterion grades, and verdict text are fetched and discarded. With this flag, those raw strings survive into the rollout JSONL so post-mortem analysis is possible without re-running.

## Dependency

The structured-rubric scorer modified here is added by #1222. Until #1222 lands, this PR's diff includes its commit; after #1222 merges, a rebase against main auto-drops the duplicate (patch-id match).

## Test plan

- [x] Unit tests added: `test_persist_raw_judge_responses_comparison`, `test_persist_raw_judge_responses_rubric` — verify both modes pass the flag through to the underlying scorers and that returned raw text appears in the response.
- [x] Smoke run on a small AfterQuery sample with the flag on, inspect resulting JSONL for `raw_responses` field shape (in flight on HSG).

## Replaces #1224

Supersedes draft #1224 which carried 9 commits / 826 lines from a stale Kh4L:dev stack (5 already-merged-to-main with different SHAs). Closing that one.