### PR TITLE
fix(stirrup_agent): parse Tavily key list + rotate on 401/403/429

### DIFF
--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -28,7 +28,7 @@ import tempfile
 import time
 from asyncio import Semaphore
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import ray
 from fastapi import Request
@@ -151,6 +151,7 @@ async def _run_stirrup_agent(
     top_p: float = 0.95,
     enable_thinking: bool = True,
     max_completion_tokens_cap: int = 64000,
+    tavily_api_key: Optional[Union[str, List[str]]] = None,
 ) -> Dict[str, Any]:
     """Run a Stirrup agent session and return history + metadata.
 
@@ -230,15 +231,17 @@ async def _run_stirrup_agent(
 
     tools = [exec_provider if isinstance(t, CodeExecToolProvider) else t for t in DEFAULT_TOOLS]
 
-    # Replace Stirrup's WebToolProvider with TavilyToolProvider when TAVILY_API_KEY is set
+    # Replace Stirrup's WebToolProvider with TavilyToolProvider when keys are available
+    # (either via the ``tavily_api_key`` config field or the legacy ``TAVILY_API_KEY``
+    # env var fallback). The provider parses bracketed comma-lists and rotates per call.
     import os as _os
 
     from stirrup.tools.web import WebToolProvider
 
-    if _os.environ.get("TAVILY_API_KEY"):
+    if tavily_api_key or _os.environ.get("TAVILY_API_KEY"):
         from responses_api_agents.stirrup_agent.tavily_search import TavilyToolProvider
 
-        tools = [TavilyToolProvider() if isinstance(t, WebToolProvider) else t for t in tools]
+        tools = [TavilyToolProvider(api_keys=tavily_api_key) if isinstance(t, WebToolProvider) else t for t in tools]
 
     agent_kwargs: Dict[str, Any] = {
         "client": client,
@@ -524,6 +527,15 @@ class StirrupAgentWrapperConfig(BaseResponsesAPIAgentConfig):
         "context_window - input_tokens - completion_token_buffer, then caps to this value. "
         "Set to match the training-side response-length budget for RL.",
     )
+    tavily_api_key: Optional[Union[str, List[str]]] = Field(
+        default=None,
+        description="Tavily API key(s) for the ``web_search`` / ``fetch_web_page`` tools. "
+        "Accepts a single key, a Python list of keys, or a comma-separated string with optional "
+        "surrounding ``[...]`` brackets (the format EFB injects via ``host:TAVILY_API_KEY``). "
+        "When multiple keys are present, the provider rotates round-robin per call AND retries "
+        "on key-specific failures (401/403/429) with the next key. Falls back to the "
+        "``TAVILY_API_KEY`` env var when None.",
+    )
 
 
 class StirrupRunRequest(BaseRunRequest):
@@ -641,6 +653,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 "top_p": getattr(body, "top_p", None) or self.config.top_p,
                 "enable_thinking": self.config.enable_thinking,
                 "max_completion_tokens_cap": self.config.max_completion_tokens_cap,
+                "tavily_api_key": self.config.tavily_api_key,
             }
 
             future = run_stirrup_agent_remote.remote(params)

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -152,6 +152,7 @@ async def _run_stirrup_agent(
     enable_thinking: bool = True,
     max_completion_tokens_cap: int = 64000,
     tavily_api_key: Optional[Union[str, List[str]]] = None,
+    tavily_max_sweeps: int = 1,
 ) -> Dict[str, Any]:
     """Run a Stirrup agent session and return history + metadata.
 
@@ -241,7 +242,12 @@ async def _run_stirrup_agent(
     if tavily_api_key or _os.environ.get("TAVILY_API_KEY"):
         from responses_api_agents.stirrup_agent.tavily_search import TavilyToolProvider
 
-        tools = [TavilyToolProvider(api_keys=tavily_api_key) if isinstance(t, WebToolProvider) else t for t in tools]
+        tools = [
+            TavilyToolProvider(api_keys=tavily_api_key, max_sweeps=tavily_max_sweeps)
+            if isinstance(t, WebToolProvider)
+            else t
+            for t in tools
+        ]
 
     agent_kwargs: Dict[str, Any] = {
         "client": client,
@@ -533,8 +539,17 @@ class StirrupAgentWrapperConfig(BaseResponsesAPIAgentConfig):
         "Accepts a single key, a Python list of keys, or a comma-separated string with optional "
         "surrounding ``[...]`` brackets (the format EFB injects via ``host:TAVILY_API_KEY``). "
         "When multiple keys are present, the provider rotates round-robin per call AND retries "
-        "on key-specific failures (401/403/429) with the next key. Falls back to the "
+        "on key-specific failures (401/403/429/5xx) with the next key. Falls back to the "
         "``TAVILY_API_KEY`` env var when None.",
+    )
+    tavily_max_sweeps: int = Field(
+        default=1,
+        description="Number of full passes through the Tavily key list before giving up on a "
+        "single tool call. Total attempts per call = ``max_sweeps × len(api_keys)``. Default 1 "
+        "exhausts cleanly after one sweep and lets the model decide whether to retry on the "
+        "next turn. Bump to 2-3 for endurance against a flaky upstream at the cost of more "
+        "wallclock per stuck call.",
+        ge=1,
     )
 
 
@@ -654,6 +669,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 "enable_thinking": self.config.enable_thinking,
                 "max_completion_tokens_cap": self.config.max_completion_tokens_cap,
                 "tavily_api_key": self.config.tavily_api_key,
+                "tavily_max_sweeps": self.config.tavily_max_sweeps,
             }
 
             future = run_stirrup_agent_remote.remote(params)

--- a/responses_api_agents/stirrup_agent/tavily_search.py
+++ b/responses_api_agents/stirrup_agent/tavily_search.py
@@ -42,11 +42,23 @@ from stirrup.utils.text import truncate_msg
 MAX_LENGTH = 40_000
 TIMEOUT = 60 * 3
 
-# HTTP statuses that indicate the *current key* is the problem (auth or quota).
-# On these, we rotate to the next key and retry. Other failures (404, 5xx,
-# network errors) aren't key-specific so retrying with another key wouldn't
-# help — they fail through to the model after one attempt.
+# HTTP statuses that indicate the *current key* is the problem (auth or
+# quota). On these, we rotate to the next key and retry.
 KEY_ROTATION_RETRY_STATUSES = frozenset({401, 403, 429})
+
+
+def _should_rotate_on_status(status: int) -> bool:
+    """Whether to rotate to the next key after seeing this HTTP status.
+
+    Rotates on key-specific 4xx (auth/quota) AND any 5xx. The 5xx rationale
+    is conservative: even though all keys hit the same upstream
+    (api.tavily.com), Tavily fronts multiple backends and occasional 5xx
+    are observed for individual requests; a free retry with the next key
+    costs nothing and often succeeds. Non-rotating failures (404, 4xx that
+    aren't auth/quota, malformed-query) bail after one attempt — rotating
+    wouldn't help and would mask the real issue.
+    """
+    return status in KEY_ROTATION_RETRY_STATUSES or 500 <= status < 600
 
 
 # ---------------------------------------------------------------------------
@@ -82,7 +94,7 @@ async def _search_executor(
                 metadata=ToolUseCountMetadata(),
             )
 
-        if resp.status_code in KEY_ROTATION_RETRY_STATUSES:
+        if _should_rotate_on_status(resp.status_code):
             last_status = resp.status_code
             continue  # rotate to next key
 
@@ -114,11 +126,11 @@ async def _search_executor(
             metadata=ToolUseCountMetadata(),
         )
 
-    # All keys exhausted on auth/quota errors.
+    # All keys exhausted on retryable errors (auth, quota, or 5xx).
     return ToolResult(
         content=(
-            f"<error>All {n_keys} Tavily key(s) returned auth/quota error "
-            f"(last status={last_status}). Rotate or refresh keys.</error>"
+            f"<error>All {n_keys} Tavily key(s) returned a retryable error "
+            f"(last status={last_status}). Refresh keys or check upstream.</error>"
         ),
         success=False,
         metadata=ToolUseCountMetadata(),

--- a/responses_api_agents/stirrup_agent/tavily_search.py
+++ b/responses_api_agents/stirrup_agent/tavily_search.py
@@ -78,7 +78,8 @@ async def _search_executor(
 ) -> ToolResult[ToolUseCountMetadata]:
     last_status: Optional[int] = None
     n_keys = max(1, len(provider._api_keys))
-    for _ in range(n_keys):
+    n_attempts = provider._max_sweeps * n_keys
+    for _ in range(n_attempts):
         api_key = provider._next_key()
         try:
             resp = await client.post(
@@ -126,10 +127,11 @@ async def _search_executor(
             metadata=ToolUseCountMetadata(),
         )
 
-    # All keys exhausted on retryable errors (auth, quota, or 5xx).
+    # All attempts exhausted on retryable errors (auth, quota, or 5xx).
     return ToolResult(
         content=(
-            f"<error>All {n_keys} Tavily key(s) returned a retryable error "
+            f"<error>Tavily exhausted {n_attempts} attempt(s) "
+            f"({n_keys} key(s) × {provider._max_sweeps} sweep(s)) on retryable errors "
             f"(last status={last_status}). Refresh keys or check upstream.</error>"
         ),
         success=False,
@@ -200,12 +202,21 @@ class TavilyToolProvider(ToolProvider):
         *,
         api_keys: Optional[Union[str, List[str]]] = None,
         timeout: float = TIMEOUT,
+        max_sweeps: int = 1,
     ) -> None:
         if api_keys is None:
             api_keys = os.getenv("TAVILY_API_KEY", "")
+        if max_sweeps < 1:
+            raise ValueError(f"max_sweeps must be >= 1, got {max_sweeps}")
         self._api_keys: List[str] = self._parse_keys(api_keys)
         self._key_idx: int = 0
         self._timeout = timeout
+        # Total attempts per tool call = ``max_sweeps × len(api_keys)``. With
+        # the default 1, a single sweep through the keys exits gracefully on
+        # full exhaustion — the model is the natural backoff for the next
+        # tool call. Bump to 2-3 if the upstream is flaky in short bursts and
+        # an extra wallclock minute or two is acceptable.
+        self._max_sweeps = max_sweeps
         self._client: httpx.AsyncClient | None = None
 
     @staticmethod

--- a/responses_api_agents/stirrup_agent/tavily_search.py
+++ b/responses_api_agents/stirrup_agent/tavily_search.py
@@ -17,7 +17,13 @@ Provides a ``ToolProvider`` that returns ``web_search`` and ``web_fetch``
 tools backed by the Tavily Search API (https://tavily.com).  Drop-in
 replacement for Stirrup's built-in ``WebToolProvider`` (Brave).
 
-Set ``TAVILY_API_KEY`` in the environment to enable.
+Configure via the agent's ``tavily_api_key`` config field (preferred) or
+``TAVILY_API_KEY`` env var (fallback). Both accept either a single key
+or a comma-separated list (with or without surrounding ``[...]`` brackets,
+to match the format EFB injects). When multiple keys are provided, the
+provider rotates round-robin per call AND retries on key-specific
+failures (401, 403, 429) with the next key, up to ``len(keys)`` total
+attempts per call.
 """
 
 from __future__ import annotations
@@ -25,7 +31,7 @@ from __future__ import annotations
 import os
 from html import escape
 from types import TracebackType
-from typing import Annotated, Any
+from typing import Annotated, Any, List, Optional, Union
 
 import httpx
 from pydantic import BaseModel, Field
@@ -35,6 +41,12 @@ from stirrup.utils.text import truncate_msg
 
 MAX_LENGTH = 40_000
 TIMEOUT = 60 * 3
+
+# HTTP statuses that indicate the *current key* is the problem (auth or quota).
+# On these, we rotate to the next key and retry. Other failures (404, 5xx,
+# network errors) aren't key-specific so retrying with another key wouldn't
+# help — they fail through to the model after one attempt.
+KEY_ROTATION_RETRY_STATUSES = frozenset({401, 403, 429})
 
 
 # ---------------------------------------------------------------------------
@@ -49,18 +61,41 @@ class _SearchParams(BaseModel):
 async def _search_executor(
     params: _SearchParams,
     *,
-    api_key: str,
+    provider: TavilyToolProvider,
     client: httpx.AsyncClient,
 ) -> ToolResult[ToolUseCountMetadata]:
-    try:
-        resp = await client.post(
-            "https://api.tavily.com/search",
-            json={"query": params.query, "max_results": 5, "include_answer": True},
-            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-        )
-        resp.raise_for_status()
-        data = resp.json()
+    last_status: Optional[int] = None
+    n_keys = max(1, len(provider._api_keys))
+    for _ in range(n_keys):
+        api_key = provider._next_key()
+        try:
+            resp = await client.post(
+                "https://api.tavily.com/search",
+                json={"query": params.query, "max_results": 5, "include_answer": True},
+                headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            )
+        except httpx.HTTPError as exc:
+            # Network-level failure — not key-specific. Bail with this error.
+            return ToolResult(
+                content=f"<error>{escape(str(exc))}</error>",
+                success=False,
+                metadata=ToolUseCountMetadata(),
+            )
 
+        if resp.status_code in KEY_ROTATION_RETRY_STATUSES:
+            last_status = resp.status_code
+            continue  # rotate to next key
+
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            return ToolResult(
+                content=f"<error>{escape(str(exc))}</error>",
+                success=False,
+                metadata=ToolUseCountMetadata(),
+            )
+
+        data = resp.json()
         parts: list[str] = []
         if data.get("answer"):
             parts.append(f"<answer>{escape(data['answer'])}</answer>")
@@ -78,12 +113,16 @@ async def _search_executor(
             content=truncate_msg("\n".join(parts), MAX_LENGTH),
             metadata=ToolUseCountMetadata(),
         )
-    except httpx.HTTPError as exc:
-        return ToolResult(
-            content=f"<error>{escape(str(exc))}</error>",
-            success=False,
-            metadata=ToolUseCountMetadata(),
-        )
+
+    # All keys exhausted on auth/quota errors.
+    return ToolResult(
+        content=(
+            f"<error>All {n_keys} Tavily key(s) returned auth/quota error "
+            f"(last status={last_status}). Rotate or refresh keys.</error>"
+        ),
+        success=False,
+        metadata=ToolUseCountMetadata(),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -133,16 +172,63 @@ async def _fetch_executor(
 class TavilyToolProvider(ToolProvider):
     """Provides ``web_search`` and ``fetch_web_page`` tools via Tavily API.
 
+    Accepts a single key, a list of keys, or a comma-separated string
+    (with or without surrounding ``[...]`` brackets — the format EFB
+    injects via ``host:TAVILY_API_KEY``). When multiple keys are present,
+    rotates round-robin and retries auth/quota failures with the next key.
+
     Usage::
 
-        tools = [TavilyToolProvider(), LocalCodeExecToolProvider()]
+        tools = [TavilyToolProvider(api_keys=["k1", "k2"]), LocalCodeExecToolProvider()]
         agent = Agent(client=client, name="agent", tools=tools)
     """
 
-    def __init__(self, *, api_key: str | None = None, timeout: float = TIMEOUT) -> None:
-        self._api_key = api_key or os.getenv("TAVILY_API_KEY", "")
+    def __init__(
+        self,
+        *,
+        api_keys: Optional[Union[str, List[str]]] = None,
+        timeout: float = TIMEOUT,
+    ) -> None:
+        if api_keys is None:
+            api_keys = os.getenv("TAVILY_API_KEY", "")
+        self._api_keys: List[str] = self._parse_keys(api_keys)
+        self._key_idx: int = 0
         self._timeout = timeout
         self._client: httpx.AsyncClient | None = None
+
+    @staticmethod
+    def _parse_keys(value: Union[str, List[str]]) -> List[str]:
+        """Normalise ``value`` into a deduplicated, non-empty list of keys.
+
+        Accepts:
+        - ``List[str]`` directly,
+        - ``"k1,k2,k3"`` (comma-separated string),
+        - ``"[k1,k2,k3]"`` (EFB env-var format with surrounding brackets),
+        - ``""`` or ``None`` → empty list.
+        """
+        if isinstance(value, list):
+            keys = value
+        else:
+            s = (value or "").strip()
+            if s.startswith("[") and s.endswith("]"):
+                s = s[1:-1]
+            keys = s.split(",") if s else []
+        out: List[str] = []
+        seen: set[str] = set()
+        for k in keys:
+            ks = k.strip()
+            if ks and ks not in seen:
+                seen.add(ks)
+                out.append(ks)
+        return out
+
+    def _next_key(self) -> str:
+        """Return the next key in round-robin order. Empty list → ``""``."""
+        if not self._api_keys:
+            return ""
+        k = self._api_keys[self._key_idx % len(self._api_keys)]
+        self._key_idx += 1
+        return k
 
     async def __aenter__(self) -> list[Tool[Any, Any]]:
         self._client = httpx.AsyncClient(timeout=self._timeout, follow_redirects=True)
@@ -161,11 +247,11 @@ class TavilyToolProvider(ToolProvider):
 
     def _get_tools(self) -> list[Tool[Any, Any]]:
         assert self._client is not None
-        api_key = self._api_key
+        provider = self
         client = self._client
 
         async def search_exec(p: _SearchParams) -> ToolResult[ToolUseCountMetadata]:
-            return await _search_executor(p, api_key=api_key, client=client)
+            return await _search_executor(p, provider=provider, client=client)
 
         async def fetch_exec(p: _FetchParams) -> ToolResult[ToolUseCountMetadata]:
             return await _fetch_executor(p, client=client)

--- a/responses_api_agents/stirrup_agent/tests/test_tavily_search.py
+++ b/responses_api_agents/stirrup_agent/tests/test_tavily_search.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Tavily key-list parsing, rotation, and rotation-on-retry."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from responses_api_agents.stirrup_agent.tavily_search import (
+    KEY_ROTATION_RETRY_STATUSES,
+    TavilyToolProvider,
+    _search_executor,
+    _SearchParams,
+)
+
+
+class TestParseKeys:
+    def test_single_string_key(self):
+        assert TavilyToolProvider._parse_keys("tvly-prod-abc") == ["tvly-prod-abc"]
+
+    def test_python_list(self):
+        assert TavilyToolProvider._parse_keys(["k1", "k2", "k3"]) == ["k1", "k2", "k3"]
+
+    def test_comma_separated_string(self):
+        assert TavilyToolProvider._parse_keys("k1,k2,k3") == ["k1", "k2", "k3"]
+
+    def test_efb_bracket_list_format(self):
+        # The actual format the EFB harness injects via host:TAVILY_API_KEY.
+        raw = "[tvly-prod-aaa,tvly-prod-bbb,tvly-prod-ccc]"
+        assert TavilyToolProvider._parse_keys(raw) == [
+            "tvly-prod-aaa",
+            "tvly-prod-bbb",
+            "tvly-prod-ccc",
+        ]
+
+    def test_strips_whitespace(self):
+        assert TavilyToolProvider._parse_keys("  k1 , k2 ,  k3  ") == ["k1", "k2", "k3"]
+
+    def test_dedupes_preserving_order(self):
+        assert TavilyToolProvider._parse_keys("k1,k2,k1,k3,k2") == ["k1", "k2", "k3"]
+
+    def test_empty_string(self):
+        assert TavilyToolProvider._parse_keys("") == []
+
+    def test_empty_list(self):
+        assert TavilyToolProvider._parse_keys([]) == []
+
+    def test_only_brackets(self):
+        # No keys inside the brackets — corner case, must not blow up.
+        assert TavilyToolProvider._parse_keys("[]") == []
+
+    def test_skips_blank_items(self):
+        assert TavilyToolProvider._parse_keys("k1,,k2,  ,k3") == ["k1", "k2", "k3"]
+
+
+class TestRotation:
+    def test_round_robin(self):
+        p = TavilyToolProvider(api_keys=["k1", "k2", "k3"])
+        assert [p._next_key() for _ in range(7)] == ["k1", "k2", "k3", "k1", "k2", "k3", "k1"]
+
+    def test_single_key_keeps_returning_same(self):
+        p = TavilyToolProvider(api_keys=["only_one"])
+        assert [p._next_key() for _ in range(3)] == ["only_one"] * 3
+
+    def test_empty_keys_returns_empty_string(self):
+        p = TavilyToolProvider(api_keys=[])
+        assert p._next_key() == ""
+
+
+class TestEnvVarFallback:
+    def test_env_var_fallback(self, monkeypatch):
+        monkeypatch.setenv("TAVILY_API_KEY", "[from-env-1,from-env-2]")
+        p = TavilyToolProvider(api_keys=None)
+        assert p._api_keys == ["from-env-1", "from-env-2"]
+
+    def test_explicit_api_keys_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("TAVILY_API_KEY", "[from-env]")
+        p = TavilyToolProvider(api_keys=["explicit"])
+        assert p._api_keys == ["explicit"]
+
+    def test_no_env_no_arg(self, monkeypatch):
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        p = TavilyToolProvider(api_keys=None)
+        assert p._api_keys == []
+
+
+# ---------------------------------------------------------------------------
+# Rotation-on-retry: send key-specific failures (401/403/429), verify the
+# executor rotates to the next key, and verify it stops after len(keys).
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(status_code: int, json_body: dict[str, Any] | None = None) -> AsyncMock:
+    resp = AsyncMock()
+    resp.status_code = status_code
+    resp.json = AsyncMock(return_value=json_body or {})
+    if status_code >= 400:
+
+        def _raise():
+            raise httpx.HTTPStatusError(
+                f"{status_code}", request=AsyncMock(), response=AsyncMock(status_code=status_code)
+            )
+
+        resp.raise_for_status = _raise
+    else:
+        resp.raise_for_status = lambda: None
+    # The executor calls .json() synchronously — wrap accordingly.
+    if json_body is not None:
+        resp.json = lambda: json_body
+    return resp
+
+
+class TestSearchExecutorRotation:
+    async def test_first_key_succeeds_no_rotation(self):
+        provider = TavilyToolProvider(api_keys=["k1", "k2", "k3"])
+        seen_keys: list[str] = []
+
+        async def fake_post(url, **kwargs):
+            seen_keys.append(kwargs["headers"]["Authorization"])
+            return _mock_response(200, {"answer": "hi", "results": []})
+
+        client = AsyncMock()
+        client.post = fake_post
+        result = await _search_executor(_SearchParams(query="x"), provider=provider, client=client)
+        assert result.success is True
+        assert seen_keys == ["Bearer k1"]
+        assert provider._key_idx == 1
+
+    async def test_rotates_on_401_then_succeeds_on_second_key(self):
+        provider = TavilyToolProvider(api_keys=["bad", "good", "unused"])
+        seen_keys: list[str] = []
+
+        async def fake_post(url, **kwargs):
+            seen_keys.append(kwargs["headers"]["Authorization"])
+            if "bad" in kwargs["headers"]["Authorization"]:
+                return _mock_response(401)
+            return _mock_response(200, {"answer": "hi", "results": []})
+
+        client = AsyncMock()
+        client.post = fake_post
+        result = await _search_executor(_SearchParams(query="x"), provider=provider, client=client)
+        assert result.success is True
+        # First key tried, got 401; rotated to second.
+        assert seen_keys == ["Bearer bad", "Bearer good"]
+
+    @pytest.mark.parametrize("status", sorted(KEY_ROTATION_RETRY_STATUSES))
+    async def test_rotates_on_each_key_specific_status(self, status):
+        provider = TavilyToolProvider(api_keys=["first", "second"])
+        seen_keys: list[str] = []
+
+        async def fake_post(url, **kwargs):
+            seen_keys.append(kwargs["headers"]["Authorization"])
+            if "first" in kwargs["headers"]["Authorization"]:
+                return _mock_response(status)
+            return _mock_response(200, {"answer": "ok", "results": []})
+
+        client = AsyncMock()
+        client.post = fake_post
+        result = await _search_executor(_SearchParams(query="x"), provider=provider, client=client)
+        assert result.success is True
+        assert seen_keys == ["Bearer first", "Bearer second"]
+
+    async def test_all_keys_fail_returns_error(self):
+        provider = TavilyToolProvider(api_keys=["k1", "k2", "k3"])
+        seen_keys: list[str] = []
+
+        async def fake_post(url, **kwargs):
+            seen_keys.append(kwargs["headers"]["Authorization"])
+            return _mock_response(401)
+
+        client = AsyncMock()
+        client.post = fake_post
+        result = await _search_executor(_SearchParams(query="x"), provider=provider, client=client)
+        assert result.success is False
+        # Tried each key exactly once.
+        assert seen_keys == ["Bearer k1", "Bearer k2", "Bearer k3"]
+        assert "All 3 Tavily key(s)" in result.content
+        assert "last status=401" in result.content
+
+    async def test_404_does_NOT_trigger_rotation(self):
+        # 404 isn't key-specific — should fail through after one attempt.
+        provider = TavilyToolProvider(api_keys=["k1", "k2"])
+        seen_keys: list[str] = []
+
+        async def fake_post(url, **kwargs):
+            seen_keys.append(kwargs["headers"]["Authorization"])
+            return _mock_response(404)
+
+        client = AsyncMock()
+        client.post = fake_post
+        result = await _search_executor(_SearchParams(query="x"), provider=provider, client=client)
+        assert result.success is False
+        # Only ONE key attempted — 404 isn't in KEY_ROTATION_RETRY_STATUSES.
+        assert seen_keys == ["Bearer k1"]
+
+    async def test_network_error_does_NOT_trigger_rotation(self):
+        provider = TavilyToolProvider(api_keys=["k1", "k2"])
+        seen_keys: list[str] = []
+
+        async def fake_post(url, **kwargs):
+            seen_keys.append(kwargs["headers"]["Authorization"])
+            raise httpx.ConnectError("dns failed")
+
+        client = AsyncMock()
+        client.post = fake_post
+        result = await _search_executor(_SearchParams(query="x"), provider=provider, client=client)
+        assert result.success is False
+        # Only one attempt — network errors aren't key-specific.
+        assert seen_keys == ["Bearer k1"]
+        assert "dns failed" in result.content

--- a/responses_api_agents/stirrup_agent/tests/test_tavily_search.py
+++ b/responses_api_agents/stirrup_agent/tests/test_tavily_search.py
@@ -204,7 +204,8 @@ class TestSearchExecutorRotation:
         assert result.success is False
         # Tried each key exactly once.
         assert seen_keys == ["Bearer k1", "Bearer k2", "Bearer k3"]
-        assert "All 3 Tavily key(s)" in result.content
+        assert "exhausted 3 attempt(s)" in result.content
+        assert "3 key(s) × 1 sweep(s)" in result.content
         assert "last status=401" in result.content
         assert "retryable error" in result.content
 
@@ -242,6 +243,53 @@ class TestSearchExecutorRotation:
         result = await _search_executor(_SearchParams(query="x"), provider=provider, client=client)
         assert result.success is True
         assert seen_keys == ["Bearer k1", "Bearer k2"]
+
+    async def test_max_sweeps_2_tries_each_key_twice(self):
+        # max_sweeps=2 should give us 2 × len(keys) = 4 attempts before giving up.
+        provider = TavilyToolProvider(api_keys=["k1", "k2"], max_sweeps=2)
+        seen_keys: list[str] = []
+
+        async def fake_post(url, **kwargs):
+            seen_keys.append(kwargs["headers"]["Authorization"])
+            return _mock_response(429)
+
+        client = AsyncMock()
+        client.post = fake_post
+        result = await _search_executor(_SearchParams(query="x"), provider=provider, client=client)
+        assert result.success is False
+        # Each key attempted twice in round-robin.
+        assert seen_keys == ["Bearer k1", "Bearer k2", "Bearer k1", "Bearer k2"]
+        assert "exhausted 4 attempt(s)" in result.content
+        assert "2 key(s) × 2 sweep(s)" in result.content
+
+    async def test_max_sweeps_3_succeeds_on_third_sweep(self):
+        # Single key, fails twice, succeeds on third attempt (third sweep).
+        provider = TavilyToolProvider(api_keys=["only"], max_sweeps=3)
+        call_count = {"n": 0}
+
+        async def fake_post(url, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] < 3:
+                return _mock_response(503)
+            return _mock_response(200, {"answer": "ok", "results": []})
+
+        client = AsyncMock()
+        client.post = fake_post
+        result = await _search_executor(_SearchParams(query="x"), provider=provider, client=client)
+        assert result.success is True
+        assert call_count["n"] == 3
+
+    def test_max_sweeps_default_is_1(self):
+        provider = TavilyToolProvider(api_keys=["k1", "k2", "k3"])
+        assert provider._max_sweeps == 1
+
+    def test_max_sweeps_zero_rejected(self):
+        with pytest.raises(ValueError, match="max_sweeps must be >= 1"):
+            TavilyToolProvider(api_keys=["k1"], max_sweeps=0)
+
+    def test_max_sweeps_negative_rejected(self):
+        with pytest.raises(ValueError, match="max_sweeps must be >= 1"):
+            TavilyToolProvider(api_keys=["k1"], max_sweeps=-1)
 
     async def test_4xx_400_does_NOT_trigger_rotation(self):
         # 400 (e.g. malformed query) isn't fixable by changing keys.

--- a/responses_api_agents/stirrup_agent/tests/test_tavily_search.py
+++ b/responses_api_agents/stirrup_agent/tests/test_tavily_search.py
@@ -26,6 +26,7 @@ from responses_api_agents.stirrup_agent.tavily_search import (
     TavilyToolProvider,
     _search_executor,
     _SearchParams,
+    _should_rotate_on_status,
 )
 
 
@@ -80,6 +81,20 @@ class TestRotation:
     def test_empty_keys_returns_empty_string(self):
         p = TavilyToolProvider(api_keys=[])
         assert p._next_key() == ""
+
+
+class TestShouldRotateOnStatus:
+    @pytest.mark.parametrize("status", [401, 403, 429])
+    def test_auth_quota_rotates(self, status):
+        assert _should_rotate_on_status(status) is True
+
+    @pytest.mark.parametrize("status", [500, 501, 502, 503, 504, 599])
+    def test_5xx_rotates(self, status):
+        assert _should_rotate_on_status(status) is True
+
+    @pytest.mark.parametrize("status", [200, 201, 301, 400, 404, 405, 410, 600])
+    def test_other_does_not_rotate(self, status):
+        assert _should_rotate_on_status(status) is False
 
 
 class TestEnvVarFallback:
@@ -191,9 +206,10 @@ class TestSearchExecutorRotation:
         assert seen_keys == ["Bearer k1", "Bearer k2", "Bearer k3"]
         assert "All 3 Tavily key(s)" in result.content
         assert "last status=401" in result.content
+        assert "retryable error" in result.content
 
     async def test_404_does_NOT_trigger_rotation(self):
-        # 404 isn't key-specific — should fail through after one attempt.
+        # 404 isn't a rotation-worthy status — should fail through after one attempt.
         provider = TavilyToolProvider(api_keys=["k1", "k2"])
         seen_keys: list[str] = []
 
@@ -205,7 +221,41 @@ class TestSearchExecutorRotation:
         client.post = fake_post
         result = await _search_executor(_SearchParams(query="x"), provider=provider, client=client)
         assert result.success is False
-        # Only ONE key attempted — 404 isn't in KEY_ROTATION_RETRY_STATUSES.
+        # Only ONE key attempted — 404 doesn't trigger rotation.
+        assert seen_keys == ["Bearer k1"]
+
+    @pytest.mark.parametrize("status", [500, 502, 503, 504, 599])
+    async def test_rotates_on_5xx(self, status):
+        # 5xx is also key-rotation-worthy: free retry costs nothing and often
+        # the next attempt lands on a healthy backend.
+        provider = TavilyToolProvider(api_keys=["k1", "k2"])
+        seen_keys: list[str] = []
+
+        async def fake_post(url, **kwargs):
+            seen_keys.append(kwargs["headers"]["Authorization"])
+            if "k1" in kwargs["headers"]["Authorization"]:
+                return _mock_response(status)
+            return _mock_response(200, {"answer": "ok", "results": []})
+
+        client = AsyncMock()
+        client.post = fake_post
+        result = await _search_executor(_SearchParams(query="x"), provider=provider, client=client)
+        assert result.success is True
+        assert seen_keys == ["Bearer k1", "Bearer k2"]
+
+    async def test_4xx_400_does_NOT_trigger_rotation(self):
+        # 400 (e.g. malformed query) isn't fixable by changing keys.
+        provider = TavilyToolProvider(api_keys=["k1", "k2"])
+        seen_keys: list[str] = []
+
+        async def fake_post(url, **kwargs):
+            seen_keys.append(kwargs["headers"]["Authorization"])
+            return _mock_response(400)
+
+        client = AsyncMock()
+        client.post = fake_post
+        result = await _search_executor(_SearchParams(query="x"), provider=provider, client=client)
+        assert result.success is False
         assert seen_keys == ["Bearer k1"]
 
     async def test_network_error_does_NOT_trigger_rotation(self):


### PR DESCRIPTION
## Summary


This PR brings the stirrup_agent's Tavily integration up to par with `resources_servers/browsecomp_advanced_harness` (which already supports a list + rotation), and adds rotation-on-retry so that a transiently-bad key auto-falls-over to the next one within a single tool call.

## Changes

1. **`tavily_search.py`** — accept key list in any reasonable format
   - `TavilyToolProvider(api_keys: str | List[str] | None = None, max_sweeps: int = 1)`
   - `_parse_keys()` normalises any of: single string, comma-separated string, EFB-style `"[k1,k2,...]"` bracketed list, Python list, empty/None
   - Falls back to `TAVILY_API_KEY` env var when the arg is `None`, preserving existing deployments
2. **Round-robin rotation per call** via `_next_key()` (counter persists across calls so consecutive `web_search` invocations don't re-test the same starting key)
3. **Rotation-on-retry** for `{401, 403, 429}` AND any `5xx` (via `_should_rotate_on_status` predicate); other failures (400, 404, network errors) bail immediately because rotating won't help
4. **`max_sweeps` knob** for endurance against bursts of upstream flakiness — total attempts per tool call = `max_sweeps × len(api_keys)`, default 1 (= previous behaviour). Bumping to 2-3 lets a single call retry the full key list multiple times.
5. **New `StirrupAgentWrapperConfig` fields** `tavily_api_key: Optional[str | List[str]]` and `tavily_max_sweeps: int = 1`, plumbed through `_run_stirrup_agent` and the Ray worker params. EFB configs can now pass keys (and tune the sweep count) via Hydra without env-var roundtripping


## Rotation policy

| Status | Rotate? | Rationale |
|---|---|---|
| 401 Unauthorized | yes | the current key is invalid |
| 403 Forbidden | yes | current key is blocked, others may still work |
| 429 Too Many Requests | yes | per-key quota; another key may have headroom |
| 5xx (500-599) | yes | upstream fronts multiple backends; free retry often hits a healthy one and gives natural inter-attempt jitter |
| 4xx (other, e.g. 400, 404) | no | not key-specific (malformed query, bad URL) |
| Network errors | no | DNS / connect failures aren't key-specific |

Cap at `max_sweeps × len(keys)` attempts per call so we never loop. On full exhaustion, return `<error>Tavily exhausted N attempt(s) (K key(s) × S sweep(s)) on retryable errors (last status=…)</error>` so the agent knows to give up rather than retrying again.

## Validation

- `pytest responses_api_agents/stirrup_agent/tests/test_tavily_search.py -q` → 52 passed
- `ruff check` → clean
- Manual smoke: `TavilyToolProvider(api_keys="[k1,k2,k3]")._next_key()` returns `k1, k2, k3, k1, ...` ✓

## Test plan

- [ ] Reviewers confirm the EFB config update path (separate MR I'll open after this lands): `++stirrup_agent.responses_api_agents.stirrup_agent.tavily_api_key=$TAVILY_API_KEY` in `ultra_v3_gym_agentic_gdpval.yaml`
- [ ] After merge, run a 1-task GDPVal smoke and verify `web_search` returns 200 in `eval_factory_metrics.json` rather than 401