### PR TITLE
fix(gdpval): make Office→PDF preconvert actually work in comparison mode

### DIFF
--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -114,7 +114,7 @@ class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     # Most office docs render poorly as raw text; PDFs let multimodal judges
     # read tables/charts. Costs ~5-30s per Office file.
     preconvert_office_to_pdf: bool = True
-    preconvert_max_concurrent: int = 1
+    preconvert_max_concurrent: int = 4
 
     judge_model_server: ModelServerRef
     judge_responses_create_params_overrides: Dict[str, Any] = {}
@@ -184,7 +184,13 @@ class GDPValResourcesServer(SimpleResourcesServer):
         if self.config.preconvert_office_to_pdf:
             from resources_servers.gdpval.setup_libreoffice import ensure_libreoffice
 
-            ensure_libreoffice()
+            if not ensure_libreoffice() and self.config.reward_mode == "comparison":
+                raise RuntimeError(
+                    "preconvert_office_to_pdf=True and reward_mode='comparison' but libreoffice "
+                    "could not be ensured on the host. Office deliverables would reach the multimodal "
+                    "judge as filename-only stubs, biasing the win rate. Install libreoffice in the "
+                    "deployment container, or set preconvert_office_to_pdf=false to opt out."
+                )
         super().model_post_init(context)
 
     async def verify(self, body: GDPValVerifyRequest) -> GDPValVerifyResponse:

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -181,6 +181,10 @@ class GDPValResourcesServer(SimpleResourcesServer):
         self._judge_prompt_fpath: str = self.config.judge_prompt_template_fpath or _DEFAULT_JUDGE_PROMPT_FPATH
         if self.config.reward_mode == "comparison" and not self.config.reference_deliverables_dir:
             raise ValueError("reward_mode=comparison requires reference_deliverables_dir to be set")
+        if self.config.preconvert_office_to_pdf:
+            from resources_servers.gdpval.setup_libreoffice import ensure_libreoffice
+
+            ensure_libreoffice()
         super().model_post_init(context)
 
     async def verify(self, body: GDPValVerifyRequest) -> GDPValVerifyResponse:

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -30,6 +30,7 @@ Scoring internals live in ``scoring.py`` (rubric) and ``comparison.py``
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
@@ -42,6 +43,8 @@ from nemo_gym.base_resources_server import (
 from nemo_gym.config_types import AggregateMetrics, AggregateMetricsRequest, ModelServerRef
 from nemo_gym.server_utils import get_server_url
 
+
+LOGGER = logging.getLogger(__name__)
 
 _DEFAULT_JUDGE_PROMPT_FPATH = str(Path(__file__).parent / "prompts" / "judge_prompt.j2")
 _DEFAULT_REFERENCE_ELO = 1000.0
@@ -281,6 +284,18 @@ class GDPValResourcesServer(SimpleResourcesServer):
             invalid_judge_response=(judge_result is None),
         )
 
+    async def _preconvert_and_log(self, target_dir: Path, *, label: str) -> None:
+        from resources_servers.gdpval.preconvert import preconvert_dir_async
+
+        n_ok, n_fail, errors = await preconvert_dir_async(
+            target_dir, max_concurrent=self.config.preconvert_max_concurrent
+        )
+        if n_ok or n_fail:
+            LOGGER.info("preconvert %s: ok=%d fail=%d", label, n_ok, n_fail)
+        if n_fail:
+            for msg in errors[:5]:
+                LOGGER.warning("preconvert %s: %s", label, msg)
+
     async def _verify_comparison(self, body: GDPValVerifyRequest) -> GDPValVerifyResponse:
         from openai import OpenAI
 
@@ -289,7 +304,6 @@ class GDPValResourcesServer(SimpleResourcesServer):
             run_trials,
             task_attempted,
         )
-        from resources_servers.gdpval.preconvert import preconvert_dir_async
 
         ref_root = Path(self.config.reference_deliverables_dir)
         ref_task_root = ref_root / f"task_{body.task_id}"
@@ -316,9 +330,9 @@ class GDPValResourcesServer(SimpleResourcesServer):
             )
 
         if self.config.preconvert_office_to_pdf:
-            await preconvert_dir_async(eval_task_dir, max_concurrent=self.config.preconvert_max_concurrent)
+            await self._preconvert_and_log(eval_task_dir, label=f"eval/{body.task_id}")
             for ref_dir in ref_task_dirs:
-                await preconvert_dir_async(ref_dir, max_concurrent=self.config.preconvert_max_concurrent)
+                await self._preconvert_and_log(ref_dir, label=f"ref/{body.task_id}/{ref_dir.name}")
 
         eval_submission = build_file_section(str(eval_task_dir))
 

--- a/resources_servers/gdpval/preconvert.py
+++ b/resources_servers/gdpval/preconvert.py
@@ -6,19 +6,12 @@
 # You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 """Pre-convert Office documents to PDF for GDPVal judging.
 
-Defensive fallback. Primary path is the agent-side Apptainer preconvert
-in ``responses_api_agents/stirrup_agent/preconvert.py``; this layer only
-fires when the agent didn't produce a sibling PDF (e.g. for the
-reference deliverables tree, or when the agent ran with a non-Apptainer
-exec provider).
+Each invocation gets its own ``-env:UserInstallation`` profile dir, so
+concurrent libreoffice subprocesses don't race on the shared default
+profile lock (``$HOME/.config/libreoffice``) — that race is the reason
+the previous default ``max_concurrent=1`` existed.
 """
 
 from __future__ import annotations
@@ -26,7 +19,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import shutil
 import subprocess
+import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
@@ -34,6 +29,8 @@ from pathlib import Path
 LOGGER = logging.getLogger(__name__)
 
 OFFICE_EXTENSIONS = {".docx", ".pptx", ".xlsx"}
+
+DEFAULT_MAX_CONCURRENT = 4
 
 
 def needs_conversion(path: Path) -> bool:
@@ -43,11 +40,17 @@ def needs_conversion(path: Path) -> bool:
 def convert_to_pdf(path: Path) -> tuple[Path, bool, str]:
     """Convert one file to PDF via host LibreOffice. Returns ``(path, ok, msg)``."""
     output_dir = str(path.parent)
+    profile_dir = Path(tempfile.mkdtemp(prefix="lo-profile-"))
     try:
         result = subprocess.run(
             [
                 "libreoffice",
                 "--headless",
+                "--nologo",
+                "--nolockcheck",
+                "--nodefault",
+                "--norestore",
+                f"-env:UserInstallation=file://{profile_dir.as_posix()}",
                 "--convert-to",
                 "pdf",
                 "--outdir",
@@ -72,6 +75,8 @@ def convert_to_pdf(path: Path) -> tuple[Path, bool, str]:
         return path, False, "libreoffice not found on host PATH (install with: apt install libreoffice)"
     except Exception as exc:
         return path, False, f"error converting {path.name}: {exc!r}"
+    finally:
+        shutil.rmtree(profile_dir, ignore_errors=True)
 
 
 def find_convertible_files(root_dir: str | os.PathLike) -> list[Path]:
@@ -84,12 +89,14 @@ def find_convertible_files(root_dir: str | os.PathLike) -> list[Path]:
     return sorted(files)
 
 
-def preconvert_dir(root_dir: str | os.PathLike, max_concurrent: int = 1) -> tuple[int, int, list[str]]:
+def preconvert_dir(
+    root_dir: str | os.PathLike,
+    max_concurrent: int = DEFAULT_MAX_CONCURRENT,
+) -> tuple[int, int, list[str]]:
     """Convert every pending Office file under ``root_dir`` to PDF.
 
     Returns ``(num_success, num_failed, error_messages)``. Caller should log
-    a sample at WARNING when ``num_failed > 0``; this used to swallow the
-    messages and produce silent no-ops in production.
+    a sample at WARNING when ``num_failed > 0``.
     """
     files = find_convertible_files(root_dir)
     if not files:
@@ -110,5 +117,8 @@ def preconvert_dir(root_dir: str | os.PathLike, max_concurrent: int = 1) -> tupl
     return success_count, fail_count, error_messages
 
 
-async def preconvert_dir_async(root_dir: str | os.PathLike, max_concurrent: int = 1) -> tuple[int, int, list[str]]:
+async def preconvert_dir_async(
+    root_dir: str | os.PathLike,
+    max_concurrent: int = DEFAULT_MAX_CONCURRENT,
+) -> tuple[int, int, list[str]]:
     return await asyncio.to_thread(preconvert_dir, root_dir, max_concurrent)

--- a/resources_servers/gdpval/preconvert.py
+++ b/resources_servers/gdpval/preconvert.py
@@ -14,34 +14,34 @@
 # limitations under the License.
 """Pre-convert Office documents to PDF for GDPVal judging.
 
-Library form (no CLI). ``verify()`` calls ``preconvert_dir`` on a task's
-deliverable directory; the resulting PDFs land alongside the originals so
-the multimodal judge can read them.
+Defensive fallback. Primary path is the agent-side Apptainer preconvert
+in ``responses_api_agents/stirrup_agent/preconvert.py``; this layer only
+fires when the agent didn't produce a sibling PDF (e.g. for the
+reference deliverables tree, or when the agent ran with a non-Apptainer
+exec provider).
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 
+LOGGER = logging.getLogger(__name__)
+
 OFFICE_EXTENSIONS = {".docx", ".pptx", ".xlsx"}
 
 
 def needs_conversion(path: Path) -> bool:
-    """Return True if this Office file has no corresponding PDF yet."""
     return path.suffix.lower() in OFFICE_EXTENSIONS and not path.with_suffix(".pdf").exists()
 
 
 def convert_to_pdf(path: Path) -> tuple[Path, bool, str]:
-    """Convert a single file to PDF via LibreOffice headless.
-
-    Returns ``(path, success, message)``. ``success=False`` on missing
-    libreoffice, timeout, or non-zero exit without a produced PDF.
-    """
+    """Convert one file to PDF via host LibreOffice. Returns ``(path, ok, msg)``."""
     output_dir = str(path.parent)
     try:
         result = subprocess.run(
@@ -60,18 +60,21 @@ def convert_to_pdf(path: Path) -> tuple[Path, bool, str]:
         )
         pdf_path = path.with_suffix(".pdf")
         if pdf_path.exists():
-            return path, True, f"Converted: {path} -> {pdf_path}"
-        return path, False, f"LibreOffice ran but PDF not created: {result.stderr.strip()}"
+            return path, True, f"converted {path.name}"
+        return (
+            path,
+            False,
+            f"libreoffice rc={result.returncode} did not produce {pdf_path.name}: {result.stderr.strip()[:300]}",
+        )
     except subprocess.TimeoutExpired:
-        return path, False, f"Timeout converting {path}"
+        return path, False, f"timeout converting {path.name}"
     except FileNotFoundError:
-        return path, False, "LibreOffice not found — install with: apt install libreoffice"
-    except Exception as e:
-        return path, False, f"Error converting {path}: {e}"
+        return path, False, "libreoffice not found on host PATH (install with: apt install libreoffice)"
+    except Exception as exc:
+        return path, False, f"error converting {path.name}: {exc!r}"
 
 
 def find_convertible_files(root_dir: str | os.PathLike) -> list[Path]:
-    """Walk *root_dir* for Office files that still need PDF conversion."""
     files: list[Path] = []
     for dirpath, _, filenames in os.walk(root_dir):
         for filename in filenames:
@@ -81,35 +84,31 @@ def find_convertible_files(root_dir: str | os.PathLike) -> list[Path]:
     return sorted(files)
 
 
-def preconvert_dir(root_dir: str | os.PathLike, max_concurrent: int = 1) -> tuple[int, int]:
-    """Convert every pending Office file under *root_dir* to PDF.
+def preconvert_dir(root_dir: str | os.PathLike, max_concurrent: int = 1) -> tuple[int, int, list[str]]:
+    """Convert every pending Office file under ``root_dir`` to PDF.
 
-    Uses a ``ThreadPoolExecutor`` bounded by *max_concurrent* (LibreOffice
-    spawns its own processes; parallelism above ~4 tends to deadlock).
-
-    Returns ``(num_success, num_failed)``.
+    Returns ``(num_success, num_failed, error_messages)``. Caller should log
+    a sample at WARNING when ``num_failed > 0``; this used to swallow the
+    messages and produce silent no-ops in production.
     """
     files = find_convertible_files(root_dir)
     if not files:
-        return 0, 0
+        return 0, 0, []
 
     success_count = 0
     fail_count = 0
+    error_messages: list[str] = []
     with ThreadPoolExecutor(max_workers=max_concurrent) as executor:
         futures = {executor.submit(convert_to_pdf, f): f for f in files}
         for future in as_completed(futures):
-            _, success, _ = future.result()
+            _, success, message = future.result()
             if success:
                 success_count += 1
             else:
                 fail_count += 1
-    return success_count, fail_count
+                error_messages.append(message)
+    return success_count, fail_count, error_messages
 
 
-async def preconvert_dir_async(root_dir: str | os.PathLike, max_concurrent: int = 1) -> tuple[int, int]:
-    """Async wrapper over :func:`preconvert_dir`.
-
-    Delegates to a worker thread so the asyncio event loop stays
-    responsive while LibreOffice subprocesses run.
-    """
+async def preconvert_dir_async(root_dir: str | os.PathLike, max_concurrent: int = 1) -> tuple[int, int, list[str]]:
     return await asyncio.to_thread(preconvert_dir, root_dir, max_concurrent)

--- a/resources_servers/gdpval/setup_libreoffice.py
+++ b/resources_servers/gdpval/setup_libreoffice.py
@@ -26,6 +26,12 @@ LOGGER = logging.getLogger(__name__)
 _APT_PACKAGES = (
     "libreoffice",
     "fonts-liberation",
+    # libreoffice's chart/formula rendering needs Java; without a JRE it
+    # logs `Warning: failed to launch javaldx` and silently exits rc=0
+    # without producing the expected PDF for any doc with charts,
+    # complex formulas, embedded objects, or pivot tables. Headless JRE
+    # is enough — we never display a GUI.
+    "default-jre-headless",
 )
 
 _APT_INSTALL_TIMEOUT_S = 600

--- a/resources_servers/gdpval/setup_libreoffice.py
+++ b/resources_servers/gdpval/setup_libreoffice.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+"""Idempotent host-side libreoffice install for GDPVal preconvert.
+
+The deployment container (where the gdpval resources server runs) does
+not ship libreoffice. We install on first server start so Office → PDF
+preconversion in ``preconvert.py`` actually produces sibling PDFs.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import sys
+
+
+LOGGER = logging.getLogger(__name__)
+
+_APT_PACKAGES = (
+    "libreoffice",
+    "fonts-liberation",
+)
+
+_APT_INSTALL_TIMEOUT_S = 600
+
+
+def _run(cmd: list[str], *, timeout: int) -> tuple[int, str, str]:
+    p = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return p.returncode, p.stdout, p.stderr
+
+
+def ensure_libreoffice() -> bool:
+    """Make sure ``libreoffice`` is on PATH; apt-install on Linux if missing.
+
+    Returns True if libreoffice is available after the call, False otherwise.
+    Idempotent: when the binary is already on PATH, returns immediately.
+    Logs a WARNING (not raise) on install failure so the server still boots
+    and rubric-mode tasks keep working; comparison-mode preconvert will then
+    surface its own per-file errors via ``preconvert.py``.
+    """
+    if shutil.which("libreoffice"):
+        return True
+
+    if not sys.platform.startswith("linux"):
+        LOGGER.warning(
+            "libreoffice not on PATH and auto-install only supports Linux (sys.platform=%s); "
+            "GDPVal preconvert will be a no-op.",
+            sys.platform,
+        )
+        return False
+
+    if not shutil.which("apt-get"):
+        LOGGER.warning("libreoffice not on PATH and apt-get is unavailable; GDPVal preconvert will be a no-op.")
+        return False
+
+    LOGGER.info("Installing libreoffice via apt-get (one-time, ~500 MB)...")
+
+    try:
+        rc, _, err = _run(["apt-get", "update", "-qq"], timeout=_APT_INSTALL_TIMEOUT_S)
+        if rc != 0:
+            LOGGER.warning("apt-get update failed (rc=%d): %s", rc, (err or "").strip()[:500])
+            return False
+        rc, _, err = _run(
+            ["apt-get", "install", "-y", "--no-install-recommends", *_APT_PACKAGES],
+            timeout=_APT_INSTALL_TIMEOUT_S,
+        )
+        if rc != 0:
+            LOGGER.warning("apt-get install libreoffice failed (rc=%d): %s", rc, (err or "").strip()[:500])
+            return False
+    except subprocess.TimeoutExpired:
+        LOGGER.warning("apt-get timed out after %ds while installing libreoffice", _APT_INSTALL_TIMEOUT_S)
+        return False
+    except Exception as exc:
+        LOGGER.warning("Unexpected error installing libreoffice: %r", exc)
+        return False
+
+    if not shutil.which("libreoffice"):
+        LOGGER.warning("apt-get install reported success but libreoffice still not on PATH")
+        return False
+
+    rc, out, err = _run(["libreoffice", "--version"], timeout=30)
+    if rc != 0:
+        LOGGER.warning("libreoffice --version failed after install (rc=%d): %s", rc, (err or "").strip()[:200])
+        return False
+
+    LOGGER.info("libreoffice ready: %s", out.strip())
+    return True
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    ok = ensure_libreoffice()
+    sys.exit(0 if ok else 1)

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -39,6 +39,10 @@ def _server(reward_mode: str = "rubric", **extra) -> GDPValResourcesServer:
         name="",
         reward_mode=reward_mode,
         judge_model_server={"type": "responses_api_models", "name": "judge"},
+        # Default off in tests: avoids triggering the host-libreoffice install
+        # check in model_post_init. Tests that exercise the preconvert path
+        # set this back to True explicitly.
+        preconvert_office_to_pdf=False,
     )
     kwargs.update(extra)
     config = GDPValResourcesServerConfig(**kwargs)
@@ -110,6 +114,29 @@ class TestApp:
 
         with _pytest.raises(ValueError, match="reference_deliverables_dir"):
             _server(reward_mode="comparison")
+
+    def test_comparison_fails_fast_when_libreoffice_unavailable(self) -> None:
+        with patch("resources_servers.gdpval.setup_libreoffice.ensure_libreoffice", return_value=False):
+            with pytest.raises(RuntimeError, match="libreoffice"):
+                _server(
+                    reward_mode="comparison",
+                    reference_deliverables_dir="/tmp/fork-deliverables",
+                    preconvert_office_to_pdf=True,
+                )
+
+    def test_rubric_does_not_fail_when_libreoffice_unavailable(self) -> None:
+        with patch("resources_servers.gdpval.setup_libreoffice.ensure_libreoffice", return_value=False):
+            # Rubric mode tolerates missing libreoffice; the rubric path has its own
+            # text-extraction fallback. Should not raise.
+            _server(reward_mode="rubric", preconvert_office_to_pdf=True)
+
+    def test_comparison_passes_when_libreoffice_available(self) -> None:
+        with patch("resources_servers.gdpval.setup_libreoffice.ensure_libreoffice", return_value=True):
+            _server(
+                reward_mode="comparison",
+                reference_deliverables_dir="/tmp/fork-deliverables",
+                preconvert_office_to_pdf=True,
+            )
 
     @pytest.mark.asyncio
     async def test_verify_rubric_no_rubric_returns_zero(self) -> None:

--- a/resources_servers/gdpval/tests/test_preconvert.py
+++ b/resources_servers/gdpval/tests/test_preconvert.py
@@ -68,6 +68,31 @@ class TestConvertToPdfErrors:
         assert "did not produce" in msg
         assert "Some libreoffice error" in msg
 
+    def test_passes_user_installation_flag(self, tmp_path: Path, monkeypatch) -> None:
+        f = tmp_path / "a.docx"
+        f.write_text("x")
+        captured: list[list[str]] = []
+
+        class _Completed:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _run(cmd, *_a, **_kw):
+            captured.append(cmd)
+            f.with_suffix(".pdf").write_bytes(b"%PDF-1.4 fake\n")
+            return _Completed()
+
+        monkeypatch.setattr(subprocess, "run", _run)
+        path, ok, _ = pcv.convert_to_pdf(f)
+        assert ok is True
+        assert len(captured) == 1
+        env_flags = [arg for arg in captured[0] if arg.startswith("-env:UserInstallation=")]
+        assert len(env_flags) == 1, f"expected one -env:UserInstallation flag, got {env_flags}"
+        assert env_flags[0].startswith("-env:UserInstallation=file://")
+        # The path should be a unique tempdir (one per call); just sanity-check it points to a path.
+        assert "/lo-profile-" in env_flags[0]
+
 
 class TestPreconvertDirSurfacesFailures:
     def test_returns_error_messages(self, tmp_path: Path, monkeypatch) -> None:

--- a/resources_servers/gdpval/tests/test_preconvert.py
+++ b/resources_servers/gdpval/tests/test_preconvert.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from resources_servers.gdpval import preconvert as pcv
+
+
+class TestNeedsConversion:
+    def test_office_without_pdf_needs_conversion(self, tmp_path: Path) -> None:
+        f = tmp_path / "a.docx"
+        f.write_text("x")
+        assert pcv.needs_conversion(f) is True
+
+    def test_office_with_sibling_pdf_does_not(self, tmp_path: Path) -> None:
+        f = tmp_path / "a.docx"
+        f.write_text("x")
+        (tmp_path / "a.pdf").write_text("p")
+        assert pcv.needs_conversion(f) is False
+
+    def test_non_office_skipped(self, tmp_path: Path) -> None:
+        f = tmp_path / "a.txt"
+        f.write_text("x")
+        assert pcv.needs_conversion(f) is False
+
+
+class TestFindConvertibleFiles:
+    def test_finds_recursively_and_sorted(self, tmp_path: Path) -> None:
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "b.docx").write_text("b")
+        (tmp_path / "sub" / "a.xlsx").write_text("a")
+        (tmp_path / "ignore.txt").write_text("t")
+        # already-converted should be skipped
+        (tmp_path / "c.pptx").write_text("c")
+        (tmp_path / "c.pdf").write_text("p")
+        files = pcv.find_convertible_files(str(tmp_path))
+        # Sorted by full path: top-level b.docx < sub/a.xlsx; c.pptx skipped (sibling .pdf exists).
+        assert [p.name for p in files] == ["b.docx", "a.xlsx"]
+
+
+class TestConvertToPdfErrors:
+    def test_returns_message_when_libreoffice_not_found(self, tmp_path: Path, monkeypatch) -> None:
+        f = tmp_path / "a.docx"
+        f.write_text("x")
+
+        def _raise(*_a, **_kw):
+            raise FileNotFoundError("libreoffice")
+
+        monkeypatch.setattr(subprocess, "run", _raise)
+        path, ok, msg = pcv.convert_to_pdf(f)
+        assert ok is False
+        assert "libreoffice not found" in msg
+
+    def test_returns_message_when_libreoffice_runs_but_no_pdf(self, tmp_path: Path, monkeypatch) -> None:
+        f = tmp_path / "a.docx"
+        f.write_text("x")
+
+        class _CompletedNoPdf:
+            returncode = 1
+            stdout = ""
+            stderr = "Some libreoffice error"
+
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _CompletedNoPdf())
+        path, ok, msg = pcv.convert_to_pdf(f)
+        assert ok is False
+        assert "did not produce" in msg
+        assert "Some libreoffice error" in msg
+
+
+class TestPreconvertDirSurfacesFailures:
+    def test_returns_error_messages(self, tmp_path: Path, monkeypatch) -> None:
+        (tmp_path / "a.docx").write_text("x")
+        (tmp_path / "b.xlsx").write_text("x")
+
+        def _convert(path: Path) -> tuple[Path, bool, str]:
+            return path, False, f"forced fail on {path.name}"
+
+        monkeypatch.setattr(pcv, "convert_to_pdf", _convert)
+
+        ok, fail, errors = pcv.preconvert_dir(str(tmp_path))
+        assert ok == 0
+        assert fail == 2
+        assert sorted(errors) == sorted(["forced fail on a.docx", "forced fail on b.xlsx"])
+
+    def test_empty_dir_returns_zeros(self, tmp_path: Path) -> None:
+        ok, fail, errors = pcv.preconvert_dir(str(tmp_path))
+        assert (ok, fail, errors) == (0, 0, [])
+
+    def test_success_path_returns_no_errors(self, tmp_path: Path, monkeypatch) -> None:
+        (tmp_path / "a.docx").write_text("x")
+
+        def _convert(path: Path) -> tuple[Path, bool, str]:
+            (path.with_suffix(".pdf")).write_text("p")
+            return path, True, "ok"
+
+        monkeypatch.setattr(pcv, "convert_to_pdf", _convert)
+
+        ok, fail, errors = pcv.preconvert_dir(str(tmp_path))
+        assert (ok, fail, errors) == (1, 0, [])
+
+
+@pytest.mark.asyncio
+async def test_preconvert_dir_async_propagates_results(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "a.docx").write_text("x")
+
+    monkeypatch.setattr(pcv, "convert_to_pdf", lambda p: (p, False, "boom"))
+    ok, fail, errors = await pcv.preconvert_dir_async(str(tmp_path))
+    assert (ok, fail) == (0, 1)
+    assert errors == ["boom"]

--- a/resources_servers/gdpval/tests/test_setup_libreoffice.py
+++ b/resources_servers/gdpval/tests/test_setup_libreoffice.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import shutil
+import subprocess
+import sys
+from unittest.mock import patch
+
+from resources_servers.gdpval import setup_libreoffice as setup
+
+
+def test_returns_true_when_libreoffice_already_on_path() -> None:
+    with patch.object(shutil, "which", return_value="/usr/bin/libreoffice") as which:
+        with patch.object(setup, "_run") as run_mock:
+            assert setup.ensure_libreoffice() is True
+    which.assert_called_once_with("libreoffice")
+    run_mock.assert_not_called()
+
+
+def test_returns_false_on_non_linux_when_missing() -> None:
+    with patch.object(shutil, "which", return_value=None):
+        with patch.object(sys, "platform", "darwin"):
+            with patch.object(setup, "_run") as run_mock:
+                assert setup.ensure_libreoffice() is False
+    run_mock.assert_not_called()
+
+
+def test_returns_false_when_apt_get_unavailable() -> None:
+    def _which(name: str) -> str | None:
+        return None
+
+    with patch.object(shutil, "which", side_effect=_which):
+        with patch.object(sys, "platform", "linux"):
+            with patch.object(setup, "_run") as run_mock:
+                assert setup.ensure_libreoffice() is False
+    run_mock.assert_not_called()
+
+
+def test_returns_false_when_apt_get_update_fails() -> None:
+    which_calls = {"libreoffice": None, "apt-get": "/usr/bin/apt-get"}
+
+    def _which(name: str) -> str | None:
+        return which_calls[name]
+
+    with patch.object(shutil, "which", side_effect=_which):
+        with patch.object(sys, "platform", "linux"):
+            with patch.object(setup, "_run", return_value=(1, "", "Network down")) as run_mock:
+                assert setup.ensure_libreoffice() is False
+    # Only the apt-get update call before bailing
+    assert run_mock.call_count == 1
+    assert run_mock.call_args_list[0][0][0][:2] == ["apt-get", "update"]
+
+
+def test_returns_false_when_apt_install_fails() -> None:
+    which_seq = iter([None, "/usr/bin/apt-get"])
+
+    def _which(name: str) -> str | None:
+        return next(which_seq)
+
+    runs = iter([(0, "", ""), (100, "", "E: Unable to fetch some archives")])
+    with patch.object(shutil, "which", side_effect=_which):
+        with patch.object(sys, "platform", "linux"):
+            with patch.object(setup, "_run", side_effect=lambda *a, **kw: next(runs)) as run_mock:
+                assert setup.ensure_libreoffice() is False
+    # update + install were both attempted
+    assert run_mock.call_count == 2
+    assert run_mock.call_args_list[1][0][0][:3] == ["apt-get", "install", "-y"]
+
+
+def test_returns_false_when_install_succeeds_but_binary_still_missing() -> None:
+    # which returns: 1) initial check -> None, 2) apt-get -> /usr/bin, 3) post-install -> None
+    which_seq = iter([None, "/usr/bin/apt-get", None])
+
+    def _which(name: str) -> str | None:
+        return next(which_seq)
+
+    runs = iter([(0, "", ""), (0, "", "")])
+    with patch.object(shutil, "which", side_effect=_which):
+        with patch.object(sys, "platform", "linux"):
+            with patch.object(setup, "_run", side_effect=lambda *a, **kw: next(runs)):
+                assert setup.ensure_libreoffice() is False
+
+
+def test_full_success_path() -> None:
+    # which: initial None, apt-get yes, post-install yes; --version returns 0
+    which_seq = iter([None, "/usr/bin/apt-get", "/usr/bin/libreoffice"])
+
+    def _which(name: str) -> str | None:
+        return next(which_seq)
+
+    runs = iter([(0, "", ""), (0, "", ""), (0, "LibreOffice 24.2", "")])
+    with patch.object(shutil, "which", side_effect=_which):
+        with patch.object(sys, "platform", "linux"):
+            with patch.object(setup, "_run", side_effect=lambda *a, **kw: next(runs)):
+                assert setup.ensure_libreoffice() is True
+
+
+def test_handles_subprocess_timeout_gracefully() -> None:
+    which_seq = iter([None, "/usr/bin/apt-get"])
+
+    def _which(name: str) -> str | None:
+        return next(which_seq)
+
+    def _raise_timeout(*_a, **_kw):
+        raise subprocess.TimeoutExpired(cmd="apt-get", timeout=1)
+
+    with patch.object(shutil, "which", side_effect=_which):
+        with patch.object(sys, "platform", "linux"):
+            with patch.object(setup, "_run", side_effect=_raise_timeout):
+                assert setup.ensure_libreoffice() is False
+
+
+def test_install_command_uses_no_install_recommends() -> None:
+    which_seq = iter([None, "/usr/bin/apt-get", "/usr/bin/libreoffice"])
+
+    def _which(name: str) -> str | None:
+        return next(which_seq)
+
+    captured: list[list[str]] = []
+
+    def _capture(cmd, **kw):
+        captured.append(cmd)
+        if cmd[:2] == ["apt-get", "update"]:
+            return 0, "", ""
+        if cmd[:3] == ["apt-get", "install", "-y"]:
+            return 0, "", ""
+        if cmd == ["libreoffice", "--version"]:
+            return 0, "LibreOffice 24.2", ""
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    with patch.object(shutil, "which", side_effect=_which):
+        with patch.object(sys, "platform", "linux"):
+            with patch.object(setup, "_run", side_effect=_capture):
+                assert setup.ensure_libreoffice() is True
+
+    install_cmd = next(c for c in captured if c[:3] == ["apt-get", "install", "-y"])
+    assert "--no-install-recommends" in install_cmd
+    assert "libreoffice" in install_cmd
+    assert "fonts-liberation" in install_cmd


### PR DESCRIPTION
## Summary

The most recent GDPVal run on `nemotron-ultra-v3-rl-ea1-apr13-step108` showed that **96.6% of Office deliverables (.docx / .xlsx / .pptx) reach the multimodal judge as filename-only stubs** because the gym evaluation container doesn't ship libreoffice and `resources_servers/gdpval/preconvert.py` swallowed every failure silently. This PR removes every stage of the silent failure:

1. **Surface preconvert failures** — `preconvert_dir` now returns `(ok, fail, error_messages)`; both call sites log a sample at WARNING. (*commit 1*)
2. **Auto-install libreoffice** — `setup_libreoffice.ensure_libreoffice()` apt-installs at `GDPValResourcesServer.model_post_init` if the binary is missing. (*commit 2*)
3. **Isolate libreoffice profile per call** — each `convert_to_pdf` runs with its own `-env:UserInstallation=file://<tempdir>`, so concurrent invocations don't race on `$HOME/.config/libreoffice` (the reason the previous default `preconvert_max_concurrent` was 1). Default bumped to 4. (*commit 3*)
4. **Fail fast in comparison mode** — when `preconvert_office_to_pdf=True`, `reward_mode="comparison"`, and `ensure_libreoffice()` returns False, raise at startup. Comparison mode without working preconvert silently feeds Office deliverables to the judge as filename-only stubs and biases the win rate; loud failure beats degraded judging. (*commit 3*)

## Why

(Investigation context: gym `gdpval-thinking-summary.md` Chapter 2.) The deployment container's pre_cmd `apt install -y git-lfs rpm2cpio cpio squashfuse fuse3` does not include libreoffice. `gdpval/preconvert.py:101` discarded the per-file error messages and `app.py:319-321` ignored the `(success, fail)` tuple. Combined: a 100%-failed preconvert produced zero log lines and the run continued to a degraded judge.

Quantified impact on the most recent run:

```
                                  agronskiy (eval)        Kimi (reference)
total Office files                       357                     165
  with sibling .pdf                       12 (3.4%)              165 (100%)
  WITHOUT sibling .pdf                   345 (96.6%)               0 (0%)

build_file_section dispatch:
  files reaching judge as filename-only  363 / 768 (47.3%)         3 / 524 (0.6%)
```

The 12 sibling pairs on the eval side all had `mtime_pdf - mtime_office == 0.0s` (model wrote both formats simultaneously in one `code_exec` call); zero traced back to libreoffice. With this PR, the same setup either ships every Office file with a sibling PDF (libreoffice present or installable) or aborts at startup (comparison mode, libreoffice unavailable) instead of silently judging stubs.

## Commits

- `6bd8c21b` `fix(gdpval): surface silent failures in defensive preconvert`
- `f962ef62` `feat(gdpval): auto-install libreoffice for Office→PDF preconvert`
- `2273013d` `fix(gdpval): isolate libreoffice profile per call; fail fast in comparison mode`

## Test plan

- [x] `pytest resources_servers/gdpval/tests/` — 39 passed (13 new + 26 existing). New tests cover: profile-flag presence, error-list propagation, `ensure_libreoffice` apt-install branches (already-present, non-Linux, no apt-get, apt-get update fail, apt-get install fail, install reported success but binary missing, full success, timeout, `--no-install-recommends` enforcement), comparison-mode fail-fast, rubric-mode tolerance, comparison-mode passes when libreoffice available.
- [x] `ruff check` + `ruff format --check` clean.
- [x] `pre-commit run --files <changed>` clean.
- [ ] Smoke run on a small GDPVal subset to verify Office files now ship with sibling PDFs and the comparison judge sees PDF blocks.
- [ ] Full GDPVal run on `nemotron-ultra-v3-rl-ea1-apr13-step108` to validate the win-rate change vs the silent-failure baseline.

## Backward compatibility

- `preconvert_dir` return signature changed from `(ok, fail)` to `(ok, fail, errors)`. Internal API; only one in-repo caller.
- `preconvert_office_to_pdf` default stays `True` — existing behavior preserved when libreoffice is already on PATH (`shutil.which` early-return; no apt cost).
- Comparison-mode runs that previously silently degraded will now fail loudly until libreoffice is reachable. To keep the old (broken) behavior, set `preconvert_office_to_pdf=false`.
- `preconvert_max_concurrent` default raised from 1 → 4. Safe because of per-call profile isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)