### PR TITLE
fix(gdpval): bound /verify wallclock on multimodal long-tail tasks

### DIFF
--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -285,7 +285,9 @@ class GDPValResourcesServer(SimpleResourcesServer):
         from openai import OpenAI
 
         from resources_servers.gdpval.comparison import (
+            JUDGE_REQUEST_TIMEOUT_SECONDS,
             build_file_section,
+            clean_up_paths,
             run_trials,
             task_attempted,
         )
@@ -320,42 +322,53 @@ class GDPValResourcesServer(SimpleResourcesServer):
             for ref_dir in ref_task_dirs:
                 await preconvert_dir_async(ref_dir, max_concurrent=self.config.preconvert_max_concurrent)
 
-        eval_submission = build_file_section(str(eval_task_dir))
-
+        clean_up_list: List[Path] = []
         overrides = dict(self.config.judge_responses_create_params_overrides or {})
         judge_base_url = get_server_url(self.config.judge_model_server.name) + "/v1"
         judge_model_name = overrides.get("model", "judge")
         judge_api_key = overrides.get("api_key", "dummy")
-        client = OpenAI(base_url=judge_base_url, api_key=judge_api_key)
+        client = OpenAI(
+            base_url=judge_base_url,
+            api_key=judge_api_key,
+            timeout=JUDGE_REQUEST_TIMEOUT_SECONDS,
+        )
 
-        # Judge eval submission against every available reference repeat. Raw
-        # vote counts (not just per-matchup majority) are summed so the win
-        # rate averages over reference variance — see ``_iter_ref_repeat_dirs``.
         total_wins = 0
         total_losses = 0
         total_ties = 0
         per_ref_results: List[Dict[str, Any]] = []
-        for ref_dir in ref_task_dirs:
-            refs_subdir = ref_dir / "reference_files"
-            refs = build_file_section(str(refs_subdir) if refs_subdir.is_dir() else None)
-            ref_submission = build_file_section(str(ref_dir))
-            result = await asyncio.to_thread(
-                run_trials,
-                client=client,
-                model=judge_model_name,
-                task_prompt=body.prompt or "",
-                refs=refs,
-                submission_a=ref_submission,
-                submission_b=eval_submission,
-                num_trials=self.config.num_comparison_trials,
-                return_raw_responses=self.config.persist_raw_judge_responses,
-            )
-            # ``run_trials`` casts submission_a=ref, submission_b=eval, so
-            # ``win_count_b`` is eval wins.
-            total_wins += result["win_count_b"]
-            total_losses += result["win_count_a"]
-            total_ties += result["tie_count"]
-            per_ref_results.append({"ref_repeat": ref_dir.name, **result})
+        try:
+            eval_submission = build_file_section(str(eval_task_dir), clean_up_list)
+
+            # Judge eval submission against every available reference repeat. Raw
+            # vote counts (not just per-matchup majority) are summed so the win
+            # rate averages over reference variance — see ``_iter_ref_repeat_dirs``.
+            for ref_dir in ref_task_dirs:
+                refs_subdir = ref_dir / "reference_files"
+                refs = build_file_section(
+                    str(refs_subdir) if refs_subdir.is_dir() else None,
+                    clean_up_list,
+                )
+                ref_submission = build_file_section(str(ref_dir), clean_up_list)
+                result = await asyncio.to_thread(
+                    run_trials,
+                    client=client,
+                    model=judge_model_name,
+                    task_prompt=body.prompt or "",
+                    refs=refs,
+                    submission_a=ref_submission,
+                    submission_b=eval_submission,
+                    num_trials=self.config.num_comparison_trials,
+                    return_raw_responses=self.config.persist_raw_judge_responses,
+                )
+                # ``run_trials`` casts submission_a=ref, submission_b=eval, so
+                # ``win_count_b`` is eval wins.
+                total_wins += result["win_count_b"]
+                total_losses += result["win_count_a"]
+                total_ties += result["tie_count"]
+                per_ref_results.append({"ref_repeat": ref_dir.name, **result})
+        finally:
+            clean_up_paths(clean_up_list)
 
         total_judged = total_wins + total_losses + total_ties
         if total_wins > total_losses:

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -24,10 +24,13 @@ import base64
 import math
 import os
 import shutil
+import tempfile
 import time
 import zipfile
 from pathlib import Path
 from typing import Any
+
+from openai import APITimeoutError
 
 
 JUDGE_PROMPT = (
@@ -64,6 +67,19 @@ REQUEST_MAX_ATTEMPTS = 5
 REQUEST_INITIAL_BACKOFF_SECONDS = 5.0
 REQUEST_BACKOFF_MULTIPLIER = 2.0
 REQUEST_MAX_BACKOFF_SECONDS = 60.0
+# Per-request OpenAI client timeout. Multimodal payloads through a flaky
+# proxy have historically taken hours when this defaulted to 600 s × 5
+# retries (50 min/trial × 4 trials = 200 min/verify worst case). 120 s here,
+# combined with non-retryable ``APITimeoutError`` below, bounds wall-clock
+# damage to ~8 min/verify when the upstream is genuinely down.
+JUDGE_REQUEST_TIMEOUT_SECONDS = 120.0
+# Per-file size cap on multimodal content blocks. Above this the file is
+# replaced with a one-line text marker so the judge still knows what was
+# claimed without us pushing 100s of MB of base64 through the proxy.
+# Set high enough (250 MB) that normal multi-stem audio and reference
+# videos in the GDPVal task set still go through; only catches the truly
+# pathological cases (e.g. ``task_a941b6d8`` 657 MB overlay clip).
+MAX_FILE_BYTES_FOR_JUDGE = 250 * 1024 * 1024
 RETRYABLE_ERROR_MARKERS = (
     "429",
     "502",
@@ -80,8 +96,6 @@ RETRYABLE_ERROR_MARKERS = (
     "service unavailable",
     "upstream",
     "temporarily unavailable",
-    "timeout",
-    "timed out",
     "connection error",
 )
 
@@ -114,17 +128,25 @@ def _convert_to_pdf(path: str | Path) -> bytes | None:
     return None
 
 
-def _maybe_unzip(path: str | Path) -> list[Path]:
+def _maybe_unzip(path: str | Path) -> tuple[Path | None, list[Path]]:
+    """Extract a zip into a per-call tempdir; never write into ``path.parent``.
+
+    The reference deliverables tree is mounted read-only in production, so the
+    previous behaviour of ``extractall(path.parent)`` raised ``PermissionError``
+    and failed /verify outright. Returns ``(extract_dir, member_paths)`` —
+    callers are responsible for ``shutil.rmtree(extract_dir)`` after they're
+    done reading the members.
+    """
     path = Path(path)
-    extracted_paths: list[Path] = []
     try:
         with zipfile.ZipFile(path, "r") as zip_ref:
+            extract_dir = Path(tempfile.mkdtemp(prefix="gdpval_unzip_"))
+            zip_ref.extractall(extract_dir)
             members = zip_ref.namelist()
-            zip_ref.extractall(path.parent)
-            extracted_paths = [path.parent / Path(member) for member in members if member]
-    except (zipfile.BadZipFile, zipfile.LargeZipFile, FileNotFoundError):
-        pass
-    return extracted_paths
+            extracted_paths = [extract_dir / Path(member) for member in members if member]
+        return extract_dir, extracted_paths
+    except (zipfile.BadZipFile, zipfile.LargeZipFile, FileNotFoundError, OSError):
+        return None, []
 
 
 FILE_TYPE_MAP: dict[str, dict[str, Any]] = {
@@ -188,6 +210,17 @@ def get_file_content_block(file_dir: str, file_name: str) -> dict | None:
     full_path = os.path.join(file_dir, file_name)
 
     try:
+        size_bytes = os.path.getsize(full_path)
+    except OSError:
+        return None
+    if size_bytes > MAX_FILE_BYTES_FOR_JUDGE:
+        size_mb = size_bytes / (1024 * 1024)
+        return {
+            "type": "text",
+            "text": f"[oversize: {file_name} {size_mb:.1f}MB — not included]",
+        }
+
+    try:
         if file_type == "TXT":
             raw_text = file_converter(full_path)
             return {"type": "text", "text": raw_text}
@@ -215,8 +248,9 @@ def get_file_content_block(file_dir: str, file_name: str) -> dict | None:
 def build_file_section(file_dir: str | None, clean_up_list: list[Path] | None = None) -> list[dict]:
     """Build OpenAI content blocks from all files in a directory.
 
-    Skips files in ``IGNORE_FILES``.  Extracts zips first.  Returns a list
-    of content block dicts suitable for OpenAI messages.
+    Skips files in ``IGNORE_FILES``. Extracts zips into per-call tempdirs
+    (the dirs are appended to ``clean_up_list`` for the caller to ``rmtree``).
+    Returns a list of content block dicts suitable for OpenAI messages.
     """
     if clean_up_list is None:
         clean_up_list = []
@@ -224,24 +258,37 @@ def build_file_section(file_dir: str | None, clean_up_list: list[Path] | None = 
     section: list[dict] = []
     no_files = True
 
+    extracted_dirs: list[Path] = []
     if file_dir is not None and os.path.exists(file_dir):
         for file_name in os.listdir(file_dir):
             if file_name.lower().endswith(".zip"):
-                extracted_paths = _maybe_unzip(os.path.join(file_dir, file_name))
-                clean_up_list.extend(extracted_paths)
+                extract_dir, _ = _maybe_unzip(os.path.join(file_dir, file_name))
+                if extract_dir is not None:
+                    clean_up_list.append(extract_dir)
+                    extracted_dirs.append(extract_dir)
+
+    def _emit(directory: str, file_name: str) -> None:
+        nonlocal no_files
+        if file_name in IGNORE_FILES:
+            return
+        section.append({"type": "text", "text": f"\n{file_name}:\n"})
+        block = get_file_content_block(directory, file_name)
+        if block is not None:
+            section.append(block)
+            no_files = False
 
     if file_dir is not None and os.path.exists(file_dir):
         for file_name in sorted(os.listdir(file_dir)):
             full_path = os.path.join(file_dir, file_name)
             if os.path.isdir(full_path) or file_name.lower().endswith(".zip"):
                 continue
-            if file_name in IGNORE_FILES:
+            _emit(file_dir, file_name)
+
+    for extract_dir in extracted_dirs:
+        for member in sorted(extract_dir.rglob("*")):
+            if not member.is_file():
                 continue
-            section.append({"type": "text", "text": f"\n{file_name}:\n"})
-            block = get_file_content_block(file_dir, file_name)
-            if block is not None:
-                section.append(block)
-                no_files = False
+            _emit(str(member.parent), member.name)
 
     if no_files:
         section.append({"type": "text", "text": "None"})
@@ -282,6 +329,11 @@ def construct_judge_messages(
 
 
 def _is_retryable(error: Exception) -> bool:
+    # Timeouts on multimodal payloads are deterministic — the payload is too
+    # large for the judge endpoint to digest in time, and retrying just burns
+    # another full timeout window per attempt. Fail the trial fast instead.
+    if isinstance(error, APITimeoutError):
+        return False
     error_text = str(error).lower()
     return any(marker in error_text for marker in RETRYABLE_ERROR_MARKERS)
 

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -457,3 +457,136 @@ class TestApp:
         assert result.agent_metrics["comparison/judged"] == 24
         # win_rate = (12 + 0.5*2) / 24 = 13/24 ≈ 0.5417
         assert abs(result.agent_metrics["comparison/win_rate"] - (13.0 / 24.0)) < 1e-6
+
+
+class TestComparisonPayloadHardening:
+    """Three protections against multi-hour /verify stalls observed on the
+    multimodal-heavy long-tail tasks (task_a941b6d8 video, task_4b894ae3
+    multi-stem audio): tmpdir zip extraction, per-file size cap, and
+    APITimeoutError treated as non-retryable."""
+
+    def test_maybe_unzip_extracts_to_tempdir_not_parent(self, tmp_path) -> None:
+        """``_maybe_unzip`` must never write back into the zip's parent dir —
+        the reference deliverables tree is read-only on the production bind
+        mount, and ``extractall(path.parent)`` raised PermissionError."""
+        import zipfile
+
+        from resources_servers.gdpval.comparison import _maybe_unzip
+
+        ref_dir = tmp_path / "ref"
+        ref_dir.mkdir()
+        zip_path = ref_dir / "stems.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("stem_a.txt", "hello")
+            zf.writestr("nested/stem_b.txt", "world")
+
+        before = sorted(p.name for p in ref_dir.iterdir())
+        extract_dir, members = _maybe_unzip(zip_path)
+        after = sorted(p.name for p in ref_dir.iterdir())
+
+        assert extract_dir is not None
+        assert extract_dir.is_dir()
+        assert extract_dir != ref_dir
+        # Original ref dir must be unchanged.
+        assert before == after == ["stems.zip"]
+        # Extracted members live under the tmpdir.
+        assert (extract_dir / "stem_a.txt").read_text() == "hello"
+        assert (extract_dir / "nested" / "stem_b.txt").read_text() == "world"
+        assert {p.name for p in members} >= {"stem_a.txt"}
+
+    def test_maybe_unzip_handles_bad_zip(self, tmp_path) -> None:
+        from resources_servers.gdpval.comparison import _maybe_unzip
+
+        bad = tmp_path / "broken.zip"
+        bad.write_bytes(b"not a zip")
+        extract_dir, members = _maybe_unzip(bad)
+        assert extract_dir is None
+        assert members == []
+
+    def test_get_file_content_block_rejects_oversize(self, tmp_path) -> None:
+        """Files > MAX_FILE_BYTES_FOR_JUDGE are returned as a one-line text
+        marker, not base64-encoded into the judge payload."""
+        import os as _os
+
+        from resources_servers.gdpval.comparison import (
+            MAX_FILE_BYTES_FOR_JUDGE,
+            get_file_content_block,
+        )
+
+        big = tmp_path / "huge.mp4"
+        # Sparse file (truncate to size, no real disk/RAM cost) so this
+        # stays cheap even when the cap is hundreds of MB.
+        big.touch()
+        _os.truncate(big, MAX_FILE_BYTES_FOR_JUDGE + 1)
+
+        block = get_file_content_block(str(tmp_path), "huge.mp4")
+        assert block == {
+            "type": "text",
+            "text": f"[oversize: huge.mp4 {(MAX_FILE_BYTES_FOR_JUDGE + 1) / (1024 * 1024):.1f}MB — not included]",
+        }
+
+    def test_get_file_content_block_includes_under_threshold(self, tmp_path) -> None:
+        from resources_servers.gdpval.comparison import get_file_content_block
+
+        small = tmp_path / "note.txt"
+        small.write_text("hello world")
+        block = get_file_content_block(str(tmp_path), "note.txt")
+        assert block == {"type": "text", "text": "hello world"}
+
+    def test_build_file_section_emits_zip_members_from_tempdir_and_cleans_up(self, tmp_path) -> None:
+        """End-to-end: a zip in the source dir is extracted to tmp, its members
+        appear as content blocks, and the tmpdir is registered for cleanup."""
+        import zipfile
+
+        from resources_servers.gdpval.comparison import build_file_section, clean_up_paths
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "top_level.txt").write_text("top")
+        with zipfile.ZipFile(src / "bundle.zip", "w") as zf:
+            zf.writestr("inside.txt", "inner")
+
+        clean_up_list: list = []
+        section = build_file_section(str(src), clean_up_list)
+
+        # both files appear (top_level.txt directly, inside.txt from zip).
+        texts = [b.get("text", "") for b in section if b.get("type") == "text"]
+        assert any("top_level.txt" in t for t in texts)
+        assert any("inside.txt" in t for t in texts)
+        assert any(t == "top" for t in texts)
+        assert any(t == "inner" for t in texts)
+
+        assert len(clean_up_list) == 1
+        tmp_extract = clean_up_list[0]
+        assert tmp_extract.exists()
+        # Source dir is untouched.
+        assert sorted(p.name for p in src.iterdir()) == ["bundle.zip", "top_level.txt"]
+
+        clean_up_paths(clean_up_list)
+        assert not tmp_extract.exists()
+
+    def test_is_retryable_treats_apitimeout_as_non_retryable(self) -> None:
+        """APITimeoutError must NOT be retried — multimodal payload timeouts
+        are deterministic, not transient, and retrying burns 5×120s = 10 min
+        per /verify with no chance of recovery."""
+        from openai import APITimeoutError
+
+        from resources_servers.gdpval.comparison import _is_retryable
+
+        # Construct a minimal APITimeoutError. SDK signature is
+        # ``APITimeoutError(request)`` since v1.x.
+        try:
+            err = APITimeoutError(request=object())
+        except TypeError:
+            # Older SDKs allow positional/no-arg.
+            err = APITimeoutError("Request timed out.")
+        assert _is_retryable(err) is False
+
+    def test_is_retryable_still_retries_502_and_rate_limit(self) -> None:
+        from resources_servers.gdpval.comparison import _is_retryable
+
+        assert _is_retryable(RuntimeError("502 Bad Gateway")) is True
+        assert _is_retryable(RuntimeError("429 Too Many Requests")) is True
+        assert _is_retryable(RuntimeError("rate limit exceeded")) is True
+        # ``timeout`` substring no longer triggers a blind retry.
+        assert _is_retryable(RuntimeError("Request timed out")) is False


### PR DESCRIPTION
## Summary

Three protections against the multi-hour `/verify` stalls that pin GDPVal runs near walltime on the multimodal-heavy long-tail tasks. Observed on the in-flight 2026-05-05 run (slurm 2569421): `task_a941b6d8` has both repeats stuck in retry > 2 h, `task_4b894ae3 repeat_1` stuck > 2 h, plus the deterministic 8 PermissionError tasks lose 16 rollouts/run before judging.

| Task | Eval payload (this run) | Symptom |
|---|---:|---|
| `task_a941b6d8 / r1` | 879 MB (overlay 657 MB + base 220 MB) | stuck in retry > 2h24m |
| `task_4b894ae3 / r1` | 232 MB (5× stem WAVs) | stuck in retry > 2h31m |
| `task_38889c3b / r0` | 156 MB zip | PermissionError 500 (read-only ref mount) |
| `task_75401f7c / r1` | 60 MB mp4 | PermissionError 500 |
| 8 task IDs total | varies | deterministic PermissionError each run |

## Changes

### 1. Zip extraction → tmpdir (not into the reference tree)

`_maybe_unzip` was calling `extractall(path.parent)`, where `path.parent` is the reference deliverables mount. That mount is read-only in production, so any reference dir containing a `.zip` raised:

```
PermissionError: [Errno 13] Permission denied:
  '/gdpval/refs/test_ref/task_38889c3b-.../MASTER_TRACK.wav'
```

…and 500'd `/verify` outright (16 rollouts × 1 run = ~3.6% of trial volume lost).

New return shape `(extract_dir, members)` extracts into a per-call `tempfile.mkdtemp()`. `build_file_section` collects the tmpdirs into the existing `clean_up_list` parameter, and `_verify_comparison` `rmtree`s them in a `finally`. The reference tree is never written to.

### 2. Per-file size cap in the judge payload (250 MB)

`comparison.py:get_file_content_block` returns `[oversize: <name> <size>MB — not included]` instead of base64 for any file > `MAX_FILE_BYTES_FOR_JUDGE = 250 MB`. The judge still sees what `finish.paths` claimed but we don't push GBs of base64 through the proxy.

250 MB is set high enough that normal multi-stem audio and reference videos in the GDPVal task set still go through (largest Kimi reference is 205 MB; eval-side stems max ~56 MB each). Only catches truly pathological cases — e.g. `task_a941b6d8 r1`'s 657 MB overlay clip + 220 MB base clip → ~1.91 GB of base64 per trial × 4 trials in the absence of a cap.

### 3. APITimeoutError non-retryable + 120 s client timeout

`OpenAI(timeout=600)` (SDK default) × 5 retry attempts × 4 trials = up to **200 min/verify** when the upstream is degraded. We now use:

```python
client = OpenAI(..., timeout=JUDGE_REQUEST_TIMEOUT_SECONDS)  # 120 s
```

…and `_is_retryable` short-circuits on `isinstance(error, APITimeoutError)`. Multimodal payload timeouts are deterministic (the request is too large for the endpoint to digest), not transient — retrying just burns another full window. Bounds wall-clock damage to **~8 min/verify** worst case.

`"timeout"` and `"timed out"` substrings also removed from `RETRYABLE_ERROR_MARKERS` so a wrapped timeout doesn't sneak through as a retryable string match.

## Tests

7 new unit tests in `TestComparisonPayloadHardening`:

- `_maybe_unzip` extracts to tempdir, leaves the source dir untouched
- `_maybe_unzip` handles bad/missing zips
- `get_file_content_block` returns the oversize marker above the cap (sparse file via `os.truncate` so the test stays cheap regardless of cap value)
- `get_file_content_block` returns normal content below the cap
- `build_file_section` emits zip members from the tmpdir and registers it for cleanup
- `_is_retryable` returns False on `APITimeoutError`
- `_is_retryable` still retries 502 / 429 / "rate limit" but no longer matches "timed out" substring

All 23 gdpval tests pass.

## Test plan

- [x] Unit tests
- [x] `ruff check` / `ruff format --check` pass
- [ ] Next GDPVal run (planned with `install_on_the_fly` tracking this branch) should show:
  - 0 `PermissionError` traces in `gdpval_resources_server.log`
  - The oversize multimodal tasks (a941b6d8, 4b894ae3) judged within normal /verify wallclock
  - `evaluator_rollouts.jsonl` reaches 440 / 440
  - Recovers ~3.6% of trial volume from the PermissionError class alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)