### PR TITLE
Add mbpp benchmark

### DIFF
--- a/benchmarks/mbpp/README.md
+++ b/benchmarks/mbpp/README.md
@@ -1,0 +1,52 @@
+# MBPP+ benchmark
+
+378 Python function-completion tasks from the EvalPlus-curated subset of
+MBPP, verified with EvalPlus base + plus tests. Mirrors NeMo-Skills'
+`mbpp` dataset — same data source, same transformation (4-space → `\t`
+in `prompt`), same per-task verification (EvalPlus base + plus
+subprocess execution).
+
+Two named scores per task:
+- `passing_base_tests` — passes the base MBPP tests
+- `passing_plus_tests` — passes base + EvalPlus extra tests (strict)
+
+Reward (`= 1.0` iff plus pass) is the strict verdict. Both scores produce
+their own pass@k / majority@k via the `evalplus` resource server's
+`compute_metrics()`.
+
+Verification runs in the `evalplus` resource server (shared with
+`human_eval`); this directory only holds the dataset definition + prompt
++ prepare script.
+
+### Example usage
+
+```bash
+# Prepare benchmark data
+ng_prepare_benchmark "+config_paths=[benchmarks/mbpp/config.yaml]"
+
+# Running servers
+config_paths="responses_api_models/vllm_model/configs/vllm_model.yaml,\
+benchmarks/mbpp/config.yaml"
+ng_run "+config_paths=[$config_paths]"
+
+# Collecting rollouts. The +prompt_config= override is required because
+# the prepared JSONL stores raw `question` rows (no `responses_create_params.input`);
+# ng_collect_rollouts does not pick up the `prompt_config:` field on the dataset
+# entry in config.yaml the way ng_run does.
+ng_collect_rollouts \
+    +agent_name=mbpp_evalplus_simple_agent \
+    +input_jsonl_fpath=benchmarks/mbpp/data/mbpp_benchmark.jsonl \
+    +prompt_config=benchmarks/mbpp/prompts/default.yaml \
+    +output_jsonl_fpath=results/mbpp_rollouts.jsonl \
+    +num_repeats=4
+```
+
+Start vLLM with `--reasoning-parser <name>` (e.g. `deepseek_r1` for
+Nemotron-3) so `<think>…</think>` is stripped before the verifier sees
+the model output. Without this, the last-fence extractor will skip
+trailing reasoning blocks but `no_answer` rates will diverge from
+Skills' `eval_type=evalplus` baseline (which strips reasoning at the
+evaluator layer).
+
+## Licensing information
+MIT (MBPP+ is MIT-licensed; see https://github.com/evalplus/evalplus).

--- a/benchmarks/mbpp/__init__.py
+++ b/benchmarks/mbpp/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/benchmarks/mbpp/config.yaml
+++ b/benchmarks/mbpp/config.yaml
@@ -1,0 +1,22 @@
+config_paths:
+  - resources_servers/evalplus/configs/evalplus.yaml
+
+mbpp_evalplus_resources_server:
+  _inherit_from: evalplus
+  resources_servers:
+    evalplus:
+      dataset: mbpp
+
+mbpp_evalplus_simple_agent:
+  _inherit_from: evalplus_simple_agent
+  responses_api_agents:
+    simple_agent:
+      resources_server:
+        name: mbpp_evalplus_resources_server
+      datasets:
+      - name: mbpp
+        type: benchmark
+        jsonl_fpath: benchmarks/mbpp/data/mbpp_benchmark.jsonl
+        prompt_config: benchmarks/mbpp/prompts/default.yaml
+        prepare_script: benchmarks/mbpp/prepare.py
+        license: MIT

--- a/benchmarks/mbpp/data/.gitignore
+++ b/benchmarks/mbpp/data/.gitignore
@@ -1,0 +1,1 @@
+*benchmark.jsonl

--- a/benchmarks/mbpp/prepare.py
+++ b/benchmarks/mbpp/prepare.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prepare MBPP+ benchmark data for NeMo Gym.
+
+Mirrors NeMo-Skills' `nemo_skills/dataset/mbpp/prepare.py`:
+  - Source: `evalplus.data.get_mbpp_plus()` (MBPP+, default version).
+  - Per-row transform: replace 4-space indentation with `\\t` in `prompt`
+    (Skills comment: "models like tabs more than spaces").
+  - Drop `base_input` / `plus_input` (re-fetched at eval time by the
+    EvalPlus library — keeping them here just bloats the JSONL).
+
+Per-row schema written:
+  - question        : prompt with 4-space → \\t replacement (the field
+                      the prompt template's `{question}` placeholder binds to)
+  - entry_point     : str (informational; not consumed by the verifier)
+  - canonical_solution : str (informational)
+  - verifier_metadata.task_id : str (e.g. "Mbpp/2") — the ONLY field
+                                the `evalplus` resource server reads
+                                beyond the model output. The server looks
+                                up base + plus tests via
+                                `evalplus.data.get_mbpp_plus()` at
+                                runtime using this id.
+"""
+
+import json
+from pathlib import Path
+
+
+BENCHMARK_DIR = Path(__file__).parent
+DATA_DIR = BENCHMARK_DIR / "data"
+OUTPUT_FPATH = DATA_DIR / "mbpp_benchmark.jsonl"
+
+
+def prepare() -> Path:
+    """Download MBPP+ and write a Gym-format JSONL."""
+    from evalplus.data import get_mbpp_plus
+
+    print("Downloading MBPP+ via evalplus.data.get_mbpp_plus()...")
+    problems = get_mbpp_plus()
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    for problem in problems.values():
+        # Skills' transform: problem["question"] = problem["prompt"].replace("    ", "\t")
+        question = problem["prompt"].replace("    ", "\t")
+        row = {
+            "question": question,
+            "entry_point": problem["entry_point"],
+            "canonical_solution": problem["canonical_solution"],
+            "verifier_metadata": {"task_id": problem["task_id"]},
+        }
+        rows.append(json.dumps(row) + "\n")
+
+    with open(OUTPUT_FPATH, "w") as f:
+        f.writelines(rows)
+
+    print(f"Wrote {len(rows)} problems to {OUTPUT_FPATH}")
+    if len(rows) != 378:
+        # MBPP+ has exactly 378 tasks (the EvalPlus-curated subset of MBPP);
+        # a different count means the upstream dataset shifted and parity to
+        # Skills is no longer guaranteed.
+        raise RuntimeError(f"Expected 378 MBPP+ problems, got {len(rows)}")
+    return OUTPUT_FPATH
+
+
+if __name__ == "__main__":
+    prepare()

--- a/benchmarks/mbpp/prompts/default.yaml
+++ b/benchmarks/mbpp/prompts/default.yaml
@@ -1,0 +1,10 @@
+user: |-
+  Here is a problem for which you need to generate/complete code:
+  {question}
+
+  Please continue to complete the function with python programming language. You are not allowed to modify the given code and do the completion only.
+
+  The solution should be in the following format:
+  ```python
+  # Your code here
+  ```


### PR DESCRIPTION
# Add mbpp benchmark

## Summary

Migrates the MBPP+ benchmark (378 Python function-completion tasks)
from NeMo Skills into Gym as a data-only follow-up to the HumanEval+
migration (#1201). Reuses the `evalplus` resource server unchanged —
its `dataset: humaneval | mbpp` knob was already in place — so this
PR adds only the new `benchmarks/mbpp/` directory.

## Includes

- `benchmarks/mbpp/` — benchmark dataset binding
  - Data source: MBPP+ via `evalplus.data.get_mbpp_plus()`
    (378 tasks, MIT license).
  - `prepare.py` mirrors NeMo-Skills' `nemo_skills/dataset/mbpp/prepare.py`:
    same `evalplus` source, same per-row `prompt.replace("    ", "\t")`
    (Skills comment: "models like tabs more than spaces"), drops
    `base_input` / `plus_input` (re-fetched at eval time by EvalPlus).
  - `prompts/default.yaml` is character-for-character identical to
    Skills' `nemo_skills/prompt/config/generic/codegen.yaml`.
  - `config.yaml` inherits the `evalplus` resource server with
    `dataset: mbpp`; reuses the `evalplus_simple_agent` configuration.

## Validation (data-only / Mode 2)

Skills-vs-Gym prepare-output parity, run on the same `evalplus==0.3.1`
upstream:

```
Skills file: nemo_skills/dataset/mbpp/test.jsonl
Gym file:    benchmarks/mbpp/data/mbpp_benchmark.jsonl

Row count:   378 (Skills)  ==  378 (Gym)
Field-level mismatches across 378 rows on the 4 retained fields
(question, entry_point, canonical_solution, task_id):  0
```

Documented schema rename: Skills' top-level `task_id` is moved into
`verifier_metadata.task_id` to match the `evalplus` resource server's
verifier contract; Skills' extra informational fields (`assertion`,
`atol`, `contract`, `prompt`) are dropped (not consumed by either
evaluator). This mirrors the schema convention adopted in the
`benchmarks/human_eval/` sibling.

The `evalplus` resource server's existing test suite (24 tests,
including `TestLoadDatasetAndExpected.test_mbpp_path`) continues to
pass without modification.

## Licensing

MBPP+ is MIT-licensed (https://github.com/evalplus/evalplus).
