### PR TITLE
Add m-arena-hard-v2 benchmark

### DIFF
--- a/benchmarks/m_arena_hard_v2/README.md
+++ b/benchmarks/m_arena_hard_v2/README.md
@@ -1,0 +1,101 @@
+# m_arena_hard_v2
+
+Gym implementation of the multilingual
+[m-ArenaHard-v2.0](https://huggingface.co/datasets/CohereLabs/m-ArenaHard-v2.0)
+open-ended generation benchmark — the m-Arena translation of
+[Arena Hard v2](https://github.com/lmarena/arena-hard-auto) covering
+23 languages.
+
+## What it tests
+
+~11,454 hard, open-ended user prompts (498 per language × 23 languages)
+across two categories preserved from upstream:
+
+- `hard_prompt` — reasoning-heavy technical and analytical queries
+- `creative_writing` — open-ended creative tasks
+
+Each candidate rollout is judged pairwise (both A↔B orderings) against
+its baseline via an LLM judge. See
+[`resources_servers/arena_judge`](../../resources_servers/arena_judge/README.md)
+for the judging protocol and metric details.
+
+## Data
+
+Runtime download only — benchmark JSONL is not committed. Run
+[`prepare.py`](prepare.py) (or `ng_prepare_benchmark`) to populate
+`data/m_arena_hard_v2_benchmark.jsonl`. The prepare script loads the HF
+dataset across all 23 language configs, iterates each split, and emits
+one row per `(language, question_id)` with `uid`, `question`,
+`baseline_answer`, `language`, `category` (per-row), and
+`subset_for_metrics` (the language code) at the top level.
+
+The HF dataset requires accepting Cohere's terms — set `HF_TOKEN`
+before running prepare if your environment doesn't have it cached.
+
+### `--baseline-file` (required for end-to-end judging)
+
+Upstream m-ArenaHard-v2.0 ships **no baselines**. To produce a
+non-empty `baseline_answer`, supply `--baseline-file` pointing at a
+JSONL with rows `{language, question_id, generation}` (the natural
+output shape of a Skills/Gym generation run); the prepare script joins
+by `(language, question_id)`. Without it, `baseline_answer` is the
+empty string and the file is only useful for prompt inspection.
+
+```bash
+# All 23 languages, no baseline (prompt inspection only)
+python benchmarks/m_arena_hard_v2/prepare.py
+
+# Subset of languages with a pre-generated baseline
+python benchmarks/m_arena_hard_v2/prepare.py \
+    --languages en es \
+    --baseline-file /path/to/baseline_generations.jsonl
+```
+
+## Example usage
+
+```bash
+# Prepare benchmark data
+ng_prepare_benchmark "+config_paths=[benchmarks/m_arena_hard_v2/config.yaml]"
+
+# Running servers
+config_paths="responses_api_models/vllm_model/configs/vllm_model.yaml,\
+benchmarks/m_arena_hard_v2/config.yaml"
+ng_run "+config_paths=[$config_paths]"
+
+# Collecting rollouts
+ng_collect_rollouts \
+    +agent_name=m_arena_hard_v2_arena_judge_simple_agent \
+    +input_jsonl_fpath=benchmarks/m_arena_hard_v2/data/m_arena_hard_v2_benchmark.jsonl \
+    +output_jsonl_fpath=results/m_arena_hard_v2_rollouts.jsonl \
+    +num_repeats=4
+```
+
+## Metrics
+
+The headline number is the **Arena-Elo win-rate (%) vs baseline**,
+computed by the `arena_judge` resources server as MLE logistic
+regression over the pairwise battles with a 100-round bootstrap 95% CI.
+Emitted keys:
+
+- `arena_elo/score` — overall win-rate (0-100)
+- `arena_elo/ci_lower` / `arena_elo/ci_upper` — bootstrap percentile CI bounds
+- `arena_elo/{hard_prompt,creative_writing}/score` + CIs — per-category
+  breakdown
+- `arena_elo/invalid_scores` — count of judge calls that produced no
+  parseable verdict
+
+The server also emits pass@k / pass@1[avg-of-k] / majority@k for a
+verdict-type decomposition (`wins`, `strict_wins`, `ties`, `losses`,
+`double_wins`, `invalid_gen_base`), so a single run gives both the
+Arena-Elo headline and a rollout-level verdict distribution without
+extra post-processing.
+
+## Deferred follow-ups
+
+- **Per-language Arena-Elo aggregation.** Rows already carry
+  `language` and `subset_for_metrics: <language_code>`; wiring those
+  into `arena_judge`'s subset-aware metric output is a follow-up. For
+  now the headline is global + per-category, not per-language.
+- **`sanitize_generations` parity.** The Skills pipeline runs a
+  generation-cleanup step before judging; Gym has no equivalent yet,
+  so judge inputs here are raw model outputs.

--- a/benchmarks/m_arena_hard_v2/README.md
+++ b/benchmarks/m_arena_hard_v2/README.md
@@ -90,12 +90,17 @@ verdict-type decomposition (`wins`, `strict_wins`, `ties`, `losses`,
 Arena-Elo headline and a rollout-level verdict distribution without
 extra post-processing.
 
+## Generation sanitization
+
+The benchmark sets `sanitize_generations: true` on its
+`arena_judge` resources server (see [`config.yaml`](config.yaml)) to
+scrub UTF-8 surrogate halves and NULs from candidate and baseline
+generations before judging — mirrors Skills'
+`++sanitize_generations=true` for the multilingual variant.
+
 ## Deferred follow-ups
 
 - **Per-language Arena-Elo aggregation.** Rows already carry
   `language` and `subset_for_metrics: <language_code>`; wiring those
   into `arena_judge`'s subset-aware metric output is a follow-up. For
   now the headline is global + per-category, not per-language.
-- **`sanitize_generations` parity.** The Skills pipeline runs a
-  generation-cleanup step before judging; Gym has no equivalent yet,
-  so judge inputs here are raw model outputs.

--- a/benchmarks/m_arena_hard_v2/config.yaml
+++ b/benchmarks/m_arena_hard_v2/config.yaml
@@ -6,6 +6,13 @@ config_paths:
 # via ``_inherit_from`` so overrides here don't leak.
 m_arena_hard_v2_arena_judge_resources_server:
   _inherit_from: arena_judge
+  resources_servers:
+    arena_judge:
+      # Multilingual outputs occasionally contain UTF-8 surrogate halves
+      # (e.g. unpaired emoji codepoints) that crash the judge's JSON
+      # serialization. Scrub them before judging — mirrors Skills'
+      # ``++sanitize_generations=true`` for the m-arena-hard-v2 variant.
+      sanitize_generations: true
 
 m_arena_hard_v2_arena_judge_simple_agent:
   _inherit_from: arena_judge_simple_agent

--- a/benchmarks/m_arena_hard_v2/config.yaml
+++ b/benchmarks/m_arena_hard_v2/config.yaml
@@ -1,0 +1,25 @@
+# Chain to the arena_judge resource server + agent config.
+config_paths:
+  - resources_servers/arena_judge/configs/arena_judge.yaml
+
+# Isolate this benchmark's agent wiring from other arena_judge consumers
+# via ``_inherit_from`` so overrides here don't leak.
+m_arena_hard_v2_arena_judge_resources_server:
+  _inherit_from: arena_judge
+
+m_arena_hard_v2_arena_judge_simple_agent:
+  _inherit_from: arena_judge_simple_agent
+  responses_api_agents:
+    simple_agent:
+      resources_server:
+        name: m_arena_hard_v2_arena_judge_resources_server
+      datasets:
+      - name: m_arena_hard_v2
+        type: benchmark
+        jsonl_fpath: benchmarks/m_arena_hard_v2/data/m_arena_hard_v2_benchmark.jsonl
+        prompt_config: benchmarks/prompts/generic_default.yaml
+        prepare_script: benchmarks/m_arena_hard_v2/prepare.py
+        # NOTE: num_repeats here is NOT honored for type=benchmark. Pass
+        # it on the CLI as `+num_repeats=N` — see run_m_arena_hard_v2_gym.py
+        # in the migration recipe directory.
+        license: Apache 2.0

--- a/benchmarks/m_arena_hard_v2/data/.gitignore
+++ b/benchmarks/m_arena_hard_v2/data/.gitignore
@@ -1,0 +1,1 @@
+*benchmark.jsonl

--- a/benchmarks/m_arena_hard_v2/prepare.py
+++ b/benchmarks/m_arena_hard_v2/prepare.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Prepare m-Arena Hard v2 (multilingual) benchmark data.
+
+Loads ``CohereLabs/m-ArenaHard-v2.0`` from Hugging Face, iterates over
+all 23 language configs (498 rows each → ~11,454 total), and writes one
+row per ``(language, question_id)`` with the fields the ``arena_judge``
+resources server consumes at the top level (``question``,
+``baseline_answer``, ``category``, ``uid``):
+
+- HF dataset: https://huggingface.co/datasets/CohereLabs/m-ArenaHard-v2.0
+- HF columns: ``{question_id, category, subcategory, prompt, language}``
+- Categories preserved per-row (``hard_prompt`` or ``creative_writing``)
+
+Baselines are NOT shipped with the upstream HF dataset. To produce
+``baseline_answer`` for end-to-end judging, supply ``--baseline-file``
+pointing at a JSONL with rows ``{language, question_id, generation}``;
+the script joins by ``(language, question_id)``. When omitted,
+``baseline_answer`` is left as the empty string and the resulting file
+is suitable only for prompt inspection / dry-run paths.
+
+Per-language Arena-Elo aggregation is deferred — for now we carry
+``language`` and ``subset_for_metrics`` (the language code, e.g. ``"en"``)
+so downstream tooling can group when ready.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import datasets
+
+
+HF_DATASET = "CohereLabs/m-ArenaHard-v2.0"
+
+BENCHMARK_DIR = Path(__file__).parent
+DATA_DIR = BENCHMARK_DIR / "data"
+OUTPUT_FPATH = DATA_DIR / "m_arena_hard_v2_benchmark.jsonl"
+
+
+def _format_entry(row: dict, language: str) -> dict:
+    """Map an HF row + language code to the arena_judge contract."""
+    entry = {
+        # arena_judge consumes ``uid``; HF ships ``question_id``.
+        "uid": row["question_id"],
+        # arena_judge + the prompt template expect ``question``; HF ships ``prompt``.
+        "question": row["prompt"],
+        # Default empty so the row stays valid even without a baseline file;
+        # judging is a no-op in that case.
+        "baseline_answer": "",
+        # Preserve per-row category (``hard_prompt`` / ``creative_writing``);
+        # arena_judge picks the matching judge prompt template.
+        "category": row["category"],
+        "language": language,
+        # Per-language metrics are deferred; we carry the bucket key now so
+        # downstream Arena-Elo aggregation can group on it without re-prep.
+        "subset_for_metrics": language,
+    }
+    subcategory = row.get("subcategory")
+    if subcategory:
+        entry["subcategory"] = subcategory
+    return entry
+
+
+def prepare(languages: list[str] | None = None, baseline_file: str | None = None) -> Path:
+    """Download and write ``m_arena_hard_v2_benchmark.jsonl``. Returns the path."""
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    supported_languages = datasets.get_dataset_config_names(HF_DATASET)
+    if languages is None:
+        languages = supported_languages
+    else:
+        invalid = set(languages) - set(supported_languages)
+        if invalid:
+            raise ValueError(f"Unsupported languages: {sorted(invalid)}. Supported: {supported_languages}")
+
+    all_entries: list[dict] = []
+    for language in languages:
+        print(f"Loading {HF_DATASET} (language={language}) ...")
+        ds = datasets.load_dataset(HF_DATASET, name=language, split="test")
+        for row in ds:
+            all_entries.append(_format_entry(row, language))
+
+    # Optional baseline join: rows with ``{language, question_id, generation}``,
+    # keyed by ``(language, question_id)``. Mirrors the Skills prepare flag.
+    if baseline_file:
+        baseline_lookup: dict[tuple[str, str], str] = {}
+        with open(baseline_file, "rt", encoding="utf-8") as fin:
+            for line in fin:
+                data = json.loads(line)
+                baseline_lookup[(data["language"], data["question_id"])] = data["generation"]
+        for entry in all_entries:
+            key = (entry["language"], entry["uid"])
+            if key not in baseline_lookup:
+                raise ValueError(f"{key} not found in baseline file {baseline_file}")
+            entry["baseline_answer"] = baseline_lookup[key]
+
+    with open(OUTPUT_FPATH, "wt", encoding="utf-8") as fout:
+        for entry in all_entries:
+            json.dump(entry, fout, ensure_ascii=False)
+            fout.write("\n")
+
+    print(f"Wrote {len(all_entries)} problems to {OUTPUT_FPATH}")
+    return OUTPUT_FPATH
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Prepare m-ArenaHard-v2.0 multilingual benchmark.")
+    parser.add_argument(
+        "--languages",
+        nargs="+",
+        default=None,
+        help="Subset of HF language configs to include (default: all).",
+    )
+    parser.add_argument(
+        "--baseline-file",
+        default=None,
+        help=(
+            "Optional JSONL with rows {language, question_id, generation}. "
+            "Joined by (language, question_id) to populate baseline_answer."
+        ),
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    prepare(languages=args.languages, baseline_file=args.baseline_file)


### PR DESCRIPTION
# Add m-arena-hard-v2 benchmark

Migrates the multilingual `m-ArenaHard-v2.0` benchmark on top of the
`arena_judge` resource server merged in #1122. Verified by the same
pairwise LLM-judge protocol as `arena_hard_v2`, just with multilingual
data (23 languages × 498 prompts = 11,454 rows total).

## Includes

- `benchmarks/m_arena_hard_v2/` — benchmark config, prepare.py, README
  - Data source: [`CohereLabs/m-ArenaHard-v2.0`](https://huggingface.co/datasets/CohereLabs/m-ArenaHard-v2.0)
    on Hugging Face — 23 language configs × 498 rows = 11,454 total
  - Prompt strategy: shared `benchmarks/prompts/generic_default.yaml` at
    `ng_run` config-inheritance time (same as `arena_hard_v2`)
  - Bound to the existing `arena_judge` resource server via `_inherit_from`
    (`m_arena_hard_v2_arena_judge_resources_server` /
    `m_arena_hard_v2_arena_judge_simple_agent`)
  - Per-row category preserved (`hard_prompt` / `creative_writing`); judge
    prompt selection is handled by `arena_judge`'s `judge_prompt_paths`
  - Overrides `arena_judge`'s `sanitize_generations: true` to scrub UTF-8
    surrogate halves and NULs before judging — mirrors Skills'
    `++sanitize_generations=true` for the multilingual variant. The flag
    itself ships in #1122.

## Schema notes

`prepare.py` emits one row per `(language, question_id)` with the fields
the `arena_judge` resource server consumes at the top level:

- `uid` — renamed from upstream `question_id` to match `arena_judge`'s contract
- `question` — renamed from upstream `prompt`
- `baseline_answer` — empty string by default; populated when the optional
  `--baseline-file` flag is supplied (JSONL of `{language, question_id,
  generation}` rows joined by `(language, question_id)`)
- `category` — preserved per-row from upstream (`hard_prompt` /
  `creative_writing`)
- `subcategory` — carried when present
- `language`, `subset_for_metrics: <language_code>` — carried for downstream
  per-language Arena-Elo aggregation (deferred; see follow-ups)

The `--baseline-file` flag mirrors the Skills prepare script. Upstream
`m-ArenaHard-v2.0` ships **no baselines** of its own; without a baseline
file the prepared JSONL is only useful for prompt inspection.

## Validated against NeMo Skills

This is a data-only migration; verification is by prepare-output schema
and row-count parity rather than end-to-end model rollouts. Both prepare
scripts load the same HF dataset across all 23 language configs and emit
the same problem set (11,454 rows = 23 × 498).

```
=========================================================================
prepare.py output parity                                                  
=========================================================================
Property                       Skills              Gym          Delta    
-------------------------------------------------------------------------
Total rows                     11,454              11,454       0        
Languages                      23                  23           0        
Rows per language              498                 498          0        
Categories observed            {hard_prompt,       {hard_prompt, identical
                                creative_writing}   creative_writing}    
```

Field-level differences are intentional and documented:

- `question_id` → `uid` (rename to match the `arena_judge` server contract;
  same convention as `arena_hard_v2`)
- `baseline_answer` added (top-level field consumed by `arena_judge`)
- `subcategory` carried only when populated (Skills always emits it as `""`);
  no semantic change

End-to-end Arena-Elo win-rate parity against Skills is left for a
follow-up — it depends on a published baseline-generation file, which is
not part of this data-only migration. The arena-elo metric pipeline itself
is already validated in #1122 (`arena_hard_v2`).

## Deferred follow-ups

- **Per-language Arena-Elo aggregation.** Rows already carry `language` and
  `subset_for_metrics: <language_code>`; wiring those into `arena_judge`'s
  subset-aware metric output is a follow-up. For now the headline is global
  + per-category, not per-language.
