### PR TITLE
Add m-arena-hard benchmark

### DIFF
--- a/benchmarks/m_arena_hard/README.md
+++ b/benchmarks/m_arena_hard/README.md
@@ -81,6 +81,14 @@ verdict-type decomposition (`wins`, `strict_wins`, `ties`, `losses`,
 Arena-Elo headline and a rollout-level verdict distribution without
 extra post-processing.
 
+## Generation sanitization
+
+This benchmark sets `sanitize_generations: true` on the inherited
+`arena_judge` resources server (see `config.yaml`) so the judge scrubs
+UTF-8 surrogate halves and embedded NULs out of multilingual rollouts
+before serializing them into the judge prompt. Mirrors Skills'
+`++sanitize_generations=true` for the multilingual variant.
+
 ## Deferred follow-ups
 
 - **Per-language Arena-Elo aggregation.** Rows already carry
@@ -88,8 +96,3 @@ extra post-processing.
   server does not split Arena-Elo by `subset_key=language`. Adding
   per-language breakdowns is a future `arena_judge` change and is
   intentionally out of scope here.
-- **`sanitize_generations` parity.** Skills sets
-  `++sanitize_generations=true` for multilingual variants to strip
-  reasoning traces from rollouts before judging. Gym has no equivalent
-  knob yet; this is a deferred follow-up rather than a Gym-side
-  prepare change.

--- a/benchmarks/m_arena_hard/README.md
+++ b/benchmarks/m_arena_hard/README.md
@@ -1,0 +1,95 @@
+# m_arena_hard
+
+Gym implementation of
+[m-ArenaHard](https://huggingface.co/datasets/CohereLabs/m-ArenaHard),
+the multilingual extension of Arena-Hard v0.1 published by CohereLabs.
+
+## What it tests
+
+Hard, open-ended user prompts translated into many languages. Each
+candidate rollout is judged pairwise (both A↔B orderings) against a
+fixed baseline answer via an LLM judge. See
+[`resources_servers/arena_judge`](../../resources_servers/arena_judge/README.md)
+for the judging protocol and metric details.
+
+The HF dataset only ships `{question_id, cluster, category, prompt}`
+per language config — there is **no built-in baseline answer**. To
+judge end-to-end you must supply your own baseline answers via
+`--baseline-file` (see below); this matches NeMo Skills, which
+generates the baseline with a separate `ns generate` run and joins
+it back into the prepared JSONL.
+
+## Data
+
+Runtime download only — benchmark JSONL is not committed. Run
+[`prepare.py`](prepare.py) (or `ng_prepare_benchmark`) to populate
+`data/m_arena_hard_benchmark.jsonl`. The prepare script:
+
+1. Calls `datasets.load_dataset("CohereLabs/m-ArenaHard", lang, split="test")`
+   for every language config.
+2. Emits one row per `(language, question_id)` with `uid`,
+   `question`, `language`, `category` (always `"hard_prompt"`),
+   `original_category`, `cluster`, and `subset_for_metrics: <lang>`.
+3. If `--baseline-file <path.jsonl>` is supplied, joins by
+   `(language, question_id)` and emits `baseline_answer` from
+   `generation`. Otherwise `baseline_answer` is set to `""` and a full
+   `arena_judge` run will not be useful (the judge needs both
+   answers). Use the no-baseline path only for question-set inspection
+   or prepare-output parity checks.
+
+Loading the HF dataset requires a Hugging Face token — set
+`HF_TOKEN` in your environment (or `huggingface-cli login`) before
+running `prepare.py`.
+
+## Example usage
+
+```bash
+# Prepare benchmark data (no baseline -> baseline_answer is empty string)
+ng_prepare_benchmark "+config_paths=[benchmarks/m_arena_hard/config.yaml]"
+
+# Or call prepare.py directly with a baseline JSONL
+python benchmarks/m_arena_hard/prepare.py --baseline-file path/to/baselines.jsonl
+
+# Running servers
+config_paths="responses_api_models/vllm_model/configs/vllm_model.yaml,\
+benchmarks/m_arena_hard/config.yaml"
+ng_run "+config_paths=[$config_paths]"
+
+# Collecting rollouts
+ng_collect_rollouts \
+    +agent_name=m_arena_hard_arena_judge_simple_agent \
+    +input_jsonl_fpath=benchmarks/m_arena_hard/data/m_arena_hard_benchmark.jsonl \
+    +output_jsonl_fpath=results/m_arena_hard_rollouts.jsonl \
+    +num_repeats=4
+```
+
+## Metrics
+
+The headline number is the **Arena-Elo win-rate (%) vs baseline**,
+computed by the `arena_judge` resources server as MLE logistic
+regression over the pairwise battles with a 100-round bootstrap 95% CI.
+Emitted keys:
+
+- `arena_elo/score` — overall win-rate (0-100)
+- `arena_elo/ci_lower` / `arena_elo/ci_upper` — bootstrap percentile CI bounds
+- `arena_elo/invalid_scores` — count of judge calls that produced no
+  parseable verdict
+
+The server also emits pass@k / pass@1[avg-of-k] / majority@k for a
+verdict-type decomposition (`wins`, `strict_wins`, `ties`, `losses`,
+`double_wins`, `invalid_gen_base`), so a single run gives both the
+Arena-Elo headline and a rollout-level verdict distribution without
+extra post-processing.
+
+## Deferred follow-ups
+
+- **Per-language Arena-Elo aggregation.** Rows already carry
+  `subset_for_metrics: <language>`, but the current `arena_judge`
+  server does not split Arena-Elo by `subset_key=language`. Adding
+  per-language breakdowns is a future `arena_judge` change and is
+  intentionally out of scope here.
+- **`sanitize_generations` parity.** Skills sets
+  `++sanitize_generations=true` for multilingual variants to strip
+  reasoning traces from rollouts before judging. Gym has no equivalent
+  knob yet; this is a deferred follow-up rather than a Gym-side
+  prepare change.

--- a/benchmarks/m_arena_hard/config.yaml
+++ b/benchmarks/m_arena_hard/config.yaml
@@ -6,6 +6,11 @@ config_paths:
 # via ``_inherit_from`` so overrides here don't leak.
 m_arena_hard_arena_judge_resources_server:
   _inherit_from: arena_judge
+  resources_servers:
+    arena_judge:
+      # Multilingual rollouts emit UTF-8 surrogate halves / embedded NULs
+      # that break the judge's JSON serialization; scrub them before judging.
+      sanitize_generations: true
 
 m_arena_hard_arena_judge_simple_agent:
   _inherit_from: arena_judge_simple_agent

--- a/benchmarks/m_arena_hard/config.yaml
+++ b/benchmarks/m_arena_hard/config.yaml
@@ -1,0 +1,25 @@
+# Chain to the arena_judge resource server + agent config.
+config_paths:
+  - resources_servers/arena_judge/configs/arena_judge.yaml
+
+# Isolate this benchmark's agent wiring from other arena_judge consumers
+# via ``_inherit_from`` so overrides here don't leak.
+m_arena_hard_arena_judge_resources_server:
+  _inherit_from: arena_judge
+
+m_arena_hard_arena_judge_simple_agent:
+  _inherit_from: arena_judge_simple_agent
+  responses_api_agents:
+    simple_agent:
+      resources_server:
+        name: m_arena_hard_arena_judge_resources_server
+      datasets:
+      - name: m_arena_hard
+        type: benchmark
+        jsonl_fpath: benchmarks/m_arena_hard/data/m_arena_hard_benchmark.jsonl
+        prompt_config: benchmarks/prompts/generic_default.yaml
+        prepare_script: benchmarks/m_arena_hard/prepare.py
+        # NOTE: num_repeats here is NOT honored for type=benchmark. Pass
+        # it on the CLI as `+num_repeats=N` — see run_m_arena_hard_gym.py
+        # in the migration recipe directory.
+        license: Apache 2.0

--- a/benchmarks/m_arena_hard/data/.gitignore
+++ b/benchmarks/m_arena_hard/data/.gitignore
@@ -1,0 +1,3 @@
+*benchmark.jsonl
+question.jsonl
+baseline_*.jsonl

--- a/benchmarks/m_arena_hard/prepare.py
+++ b/benchmarks/m_arena_hard/prepare.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Prepare m-ArenaHard multilingual benchmark data.
+
+Loads the
+[``CohereLabs/m-ArenaHard``](https://huggingface.co/datasets/CohereLabs/m-ArenaHard)
+HuggingFace dataset across every language config and writes one row per
+``(language, question_id)`` with the fields the ``arena_judge``
+resources server consumes at the top level (``question``, ``uid``,
+``category``, ``baseline_answer``).
+
+The HF dataset only ships ``{question_id, cluster, category, prompt}``
+columns and does **not** include any baseline model answer. To run the
+full Arena-Elo judging end-to-end, supply ``--baseline-file``: a JSONL
+with rows ``{"language", "question_id", "generation"}`` joined in by
+``(language, question_id)``. This mirrors NeMo Skills, which generates
+the baseline with a separate ``ns generate`` run and feeds the
+resulting JSONL back into ``prepare`` via ``--baseline-file``.
+
+When ``--baseline-file`` is omitted, ``baseline_answer`` is set to the
+empty string so the JSONL is still well-formed for tooling that only
+needs the question set (e.g. data exploration or Skills-vs-Gym prepare
+parity checks). ``ng_prepare_benchmark`` calls ``prepare()`` with no
+arguments and so always takes this no-baseline path; use the script
+entry-point (``python prepare.py --baseline-file ...``) for full
+arena_judge runs.
+
+The HF dataset's ``category`` column is preserved as
+``original_category`` for traceability; ``category`` itself is
+overwritten with the literal ``"hard_prompt"`` to route every prompt
+through ``arena_judge``'s standard hard-prompt judge template (matches
+Skills' ``m-arena-hard/prepare.py``). The per-row ``language`` is also
+emitted under ``subset_for_metrics`` to set up future per-language
+Arena-Elo aggregation (deferred — needs ``arena_judge`` to honour
+``subset_key=language``).
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import datasets
+
+
+HF_DATASET = "CohereLabs/m-ArenaHard"
+
+BENCHMARK_DIR = Path(__file__).parent
+DATA_DIR = BENCHMARK_DIR / "data"
+OUTPUT_FPATH = DATA_DIR / "m_arena_hard_benchmark.jsonl"
+
+
+def _format_entry(row: dict, language: str) -> dict:
+    return {
+        # arena_judge expects the question identifier under ``uid``.
+        "uid": row["question_id"],
+        "question": row["prompt"],
+        "language": language,
+        # arena_judge expects "hard_prompt" or "creative_writing"; m-ArenaHard
+        # has no creative_writing split, so route everything through the
+        # standard hard-prompt judge template (matches Skills).
+        "category": "hard_prompt",
+        "original_category": row["category"],
+        "cluster": row["cluster"],
+        # Carries the language code (e.g. "en", "de") for future per-language
+        # Arena-Elo aggregation in arena_judge.
+        "subset_for_metrics": language,
+    }
+
+
+def prepare(languages: list[str] | None = None, baseline_file: str | None = None) -> Path:
+    """Download m-ArenaHard from HF, optionally join baselines, write JSONL.
+
+    Called with no arguments by ``ng_prepare_benchmark``. Returns the
+    path to the written JSONL.
+    """
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    supported = datasets.get_dataset_config_names(HF_DATASET)
+    if languages is None:
+        languages = supported
+    invalid = set(languages) - set(supported)
+    if invalid:
+        raise ValueError(f"Unsupported languages: {sorted(invalid)}. Supported: {supported}")
+
+    all_entries: list[dict] = []
+    for language in languages:
+        print(f"Loading {HF_DATASET} ({language}) ...")
+        ds = datasets.load_dataset(HF_DATASET, name=language, split="test")
+        for row in ds:
+            all_entries.append(_format_entry(row, language))
+
+    if baseline_file:
+        # Mirror Skills: external JSONL with rows {language, question_id, generation}.
+        baseline_lookup: dict[tuple[str, str], str] = {}
+        with open(baseline_file, "rt", encoding="utf-8") as fin:
+            for line in fin:
+                data = json.loads(line)
+                baseline_lookup[(data["language"], data["question_id"])] = data["generation"]
+        for entry in all_entries:
+            key = (entry["language"], entry["uid"])
+            if key not in baseline_lookup:
+                raise ValueError(f"({key[0]}, {key[1]}) not found in baseline file {baseline_file}")
+            entry["baseline_answer"] = baseline_lookup[key]
+    else:
+        # No baseline supplied — emit empty string so the JSONL is still
+        # well-formed. Full arena_judge runs require --baseline-file; see README.
+        for entry in all_entries:
+            entry["baseline_answer"] = ""
+
+    with open(OUTPUT_FPATH, "wt", encoding="utf-8") as fout:
+        for entry in all_entries:
+            json.dump(entry, fout, ensure_ascii=False)
+            fout.write("\n")
+    print(f"Wrote {len(all_entries)} problems to {OUTPUT_FPATH}")
+    return OUTPUT_FPATH
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Prepare m-ArenaHard multilingual benchmark.")
+    parser.add_argument(
+        "--languages",
+        default=None,
+        nargs="+",
+        help="Language configs to include (default: all supported by the HF dataset).",
+    )
+    parser.add_argument(
+        "--baseline-file",
+        default=None,
+        help=(
+            "Path to JSONL with baseline answers (rows must include 'language', "
+            "'question_id', and 'generation'). When omitted, baseline_answer is set to "
+            "the empty string."
+        ),
+    )
+    args = parser.parse_args()
+    prepare(languages=args.languages, baseline_file=args.baseline_file)


### PR DESCRIPTION
# Add m-arena-hard benchmark

Migrates the `m-arena-hard` multilingual benchmark from NeMo Skills into
Gym on top of the `arena_judge` resource server merged in #1122.
End-to-end Arena-Elo judging requires a baseline answer JSONL passed via
`--baseline-file`, mirroring how Skills generates the baseline with a
separate `ns generate` run.

## Includes

- `benchmarks/m_arena_hard/` — benchmark config, prepare.py, prompt template
  - Data source: [`CohereLabs/m-ArenaHard`](https://huggingface.co/datasets/CohereLabs/m-ArenaHard)
    on HuggingFace (23 language configs × 500 prompts = 11,500 rows total).
  - Prompt strategy: `prompt_config` at rollout time → `benchmarks/prompts/generic_default.yaml`
    (shared with `arena_hard` and `arena_hard_v2`).
  - Bound to the existing `arena_judge` resource server via `_inherit_from`,
    namespaced as `m_arena_hard_arena_judge_resources_server` /
    `m_arena_hard_arena_judge_simple_agent` so overrides here don't leak.
  - Sets `sanitize_generations: true` on the inherited `arena_judge` server
    (overriding the default of `false`) so the judge scrubs UTF-8 surrogate
    halves and embedded NULs out of multilingual candidate and baseline
    generations before judging — mirrors Skills' `++sanitize_generations=true`
    for the multilingual variant. The flag itself ships in #1122.
  - Every row carries `subset_for_metrics: <language_code>` to set up future
    per-language Arena-Elo aggregation in `arena_judge`.
  - `category` is overwritten with `"hard_prompt"` for every row — m-ArenaHard
    has no `creative_writing` split, so all prompts route through the
    standard hard-prompt judge template (matches Skills'
    `m-arena-hard/prepare.py`). The upstream `category` is preserved as
    `original_category` for traceability.

## Baselines

The HF dataset only ships `{question_id, cluster, category, prompt}` per
language config — there is **no built-in baseline answer**. To judge
end-to-end the user supplies their own baseline answers via
`--baseline-file`, a JSONL with rows `{"language", "question_id",
"generation"}`. This matches Skills, which runs an external `ns generate`
step to produce the baseline and joins it back into `prepare` via the
same flag.

When `--baseline-file` is omitted (e.g. `ng_prepare_benchmark`),
`baseline_answer` is set to the empty string so the JSONL is still
well-formed for tooling that only needs the question set (data
exploration, prepare-output parity checks). A full `arena_judge` run
requires populated baselines.

## Deferred follow-ups

These were explicitly scoped out of this PR; opening them as separate
issues once this lands:

- **Per-language Arena-Elo aggregation.** Rows already carry
  `subset_for_metrics: <language>`, but `arena_judge` does not yet split
  Arena-Elo by `subset_key=language`. Adding per-language breakdowns is a
  future `arena_judge` enhancement.

## Validated against NeMo Skills

Schema parity verified against
`nemo_skills/dataset/m-arena-hard/prepare.py`:

```
Field            Skills                         Gym
---------------  -----------------------------  --------------------
question         row["prompt"]                  same
question_id      row["question_id"]             renamed to `uid`
category         "hard_prompt"                  same
original_category row["category"]               same
cluster          row["cluster"]                 same
language         <lang code>                    same
subset_for_metrics <lang code>                  same
baseline_answer  joined from --baseline-file    joined from --baseline-file
                                                (or "" when omitted)
```

End-to-end model-output parity is **not** included here because Skills'
full m-arena-hard pipeline depends on a separate baseline-generation run;
the `sanitize_generations` knob is now wired in Gym (see "Includes"
above) so that piece no longer blocks parity. This PR is intentionally a
data-only migration — model-output parity will follow once the
baseline-generation pipeline is wired up.

`prepare()` is called with no arguments by `ng_prepare_benchmark` and
produces 11,500 rows across 23 language configs, all
`category: "hard_prompt"`, with empty `baseline_answer`. Calling
`python benchmarks/m_arena_hard/prepare.py --baseline-file <path>` joins
externally-generated baseline answers in by `(language, question_id)`.

## How to run

```bash
# Prepare benchmark data (no baseline -> baseline_answer is empty string)
ng_prepare_benchmark "+config_paths=[benchmarks/m_arena_hard/config.yaml]"

# Or call prepare.py directly with a baseline JSONL
python benchmarks/m_arena_hard/prepare.py --baseline-file path/to/baselines.jsonl

# Running servers
config_paths="responses_api_models/vllm_model/configs/vllm_model.yaml,\
benchmarks/m_arena_hard/config.yaml"
ng_run "+config_paths=[$config_paths]"

# Collecting rollouts
ng_collect_rollouts \
    +agent_name=m_arena_hard_arena_judge_simple_agent \
    +input_jsonl_fpath=benchmarks/m_arena_hard/data/m_arena_hard_benchmark.jsonl \
    +output_jsonl_fpath=results/m_arena_hard_rollouts.jsonl \
    +num_repeats=4
```

Loading the HF dataset requires a Hugging Face token; set `HF_TOKEN` (or
`huggingface-cli login`) before running `prepare.py`.
