### PR TITLE
fix(gdpval): also apt-install JRE when libreoffice is pre-baked into image

### DIFF
--- a/resources_servers/gdpval/setup_libreoffice.py
+++ b/resources_servers/gdpval/setup_libreoffice.py
@@ -47,23 +47,48 @@ def _run(cmd: list[str], *, timeout: int) -> tuple[int, str, str]:
     return p.returncode, p.stdout, p.stderr
 
 
+def _java_runs() -> bool:
+    """Return True iff `java -version` runs successfully (rc=0).
+
+    `shutil.which("java")` is necessary but not sufficient — the
+    deployment image may have a `java` binary on PATH that's
+    non-functional for libreoffice's `javaldx` helper (e.g. partially-
+    installed openjdk, broken symlink, missing libjvm.so). The only way
+    to know if the JRE is *usable* is to actually try to invoke it.
+    """
+    if not shutil.which("java"):
+        return False
+    try:
+        rc, _, _ = _run(["java", "-version"], timeout=15)
+    except Exception:
+        return False
+    return rc == 0
+
+
 def ensure_libreoffice() -> bool:
-    """Make sure ``libreoffice`` *and* a JRE are on PATH; apt-install on Linux if missing.
+    """Make sure ``libreoffice`` *and* a *functional* JRE are present; apt-install on Linux if missing.
 
     Returns True if libreoffice is available after the call, False otherwise.
-    Idempotent: when both the libreoffice binary AND a Java runtime are
-    already on PATH, returns immediately. When libreoffice is present but
-    Java is missing (e.g. the deployment image bakes libreoffice in
-    without a JRE), still runs apt-install — without a JRE, libreoffice
-    silently exits rc=0 with `Warning: failed to launch javaldx` for any
-    chart/formula/embedded-object doc, so we'd produce filename-only
-    stubs in comparison mode.
+    Idempotent: when libreoffice is on PATH AND `java -version` runs
+    cleanly, returns immediately. When libreoffice is present but Java is
+    missing or broken (e.g. the deployment image bakes libreoffice in
+    without a usable JRE), still runs apt-install — without a working
+    JRE, libreoffice silently exits rc=0 with `Warning: failed to launch
+    javaldx` for any chart/formula/embedded-object doc, producing
+    filename-only stubs in comparison mode.
+
+    A previous version of this function gated the early-exit on
+    `shutil.which("java")` alone; that wasn't enough — the deployment
+    image had *some* `java` binary on PATH that satisfied `which()` but
+    couldn't actually execute (`java -version` failed), so apt-install
+    was skipped and the JRE was never landed. The functional probe in
+    `_java_runs()` catches that case.
 
     Logs a WARNING (not raise) on install failure so the server still boots
     and rubric-mode tasks keep working; comparison-mode preconvert will then
     surface its own per-file errors via ``preconvert.py``.
     """
-    if shutil.which("libreoffice") and shutil.which("java"):
+    if shutil.which("libreoffice") and _java_runs():
         return True
 
     if not sys.platform.startswith("linux"):
@@ -107,9 +132,9 @@ def ensure_libreoffice() -> bool:
     if not shutil.which("libreoffice"):
         LOGGER.warning("apt-get install reported success but libreoffice still not on PATH")
         return False
-    if not shutil.which("java"):
+    if not _java_runs():
         LOGGER.warning(
-            "apt-get install reported success but java still not on PATH "
+            "apt-get install reported success but `java -version` still fails "
             "(libreoffice will fail on chart/formula docs)"
         )
         return False

--- a/resources_servers/gdpval/setup_libreoffice.py
+++ b/resources_servers/gdpval/setup_libreoffice.py
@@ -32,6 +32,15 @@ _APT_PACKAGES = (
     # complex formulas, embedded objects, or pivot tables. Headless JRE
     # is enough — we never display a GUI.
     "default-jre-headless",
+    # `javaldx` (the helper libreoffice uses to locate the JRE via JNI)
+    # ships in `libreoffice-java-common`, which is NOT a dependency of
+    # the `libreoffice` metapackage on Ubuntu 24.04. Without it,
+    # `/usr/lib/libreoffice/program/javaldx` simply doesn't exist —
+    # libreoffice can't discover the JRE no matter how many JRE
+    # packages are installed. Without this entry, every attempt at
+    # the JRE-prebaked fix (v1–v4) silently failed because the bridge
+    # between libreoffice and the JRE was missing.
+    "libreoffice-java-common",
 )
 
 _APT_INSTALL_TIMEOUT_S = 600

--- a/resources_servers/gdpval/setup_libreoffice.py
+++ b/resources_servers/gdpval/setup_libreoffice.py
@@ -48,15 +48,22 @@ def _run(cmd: list[str], *, timeout: int) -> tuple[int, str, str]:
 
 
 def ensure_libreoffice() -> bool:
-    """Make sure ``libreoffice`` is on PATH; apt-install on Linux if missing.
+    """Make sure ``libreoffice`` *and* a JRE are on PATH; apt-install on Linux if missing.
 
     Returns True if libreoffice is available after the call, False otherwise.
-    Idempotent: when the binary is already on PATH, returns immediately.
+    Idempotent: when both the libreoffice binary AND a Java runtime are
+    already on PATH, returns immediately. When libreoffice is present but
+    Java is missing (e.g. the deployment image bakes libreoffice in
+    without a JRE), still runs apt-install — without a JRE, libreoffice
+    silently exits rc=0 with `Warning: failed to launch javaldx` for any
+    chart/formula/embedded-object doc, so we'd produce filename-only
+    stubs in comparison mode.
+
     Logs a WARNING (not raise) on install failure so the server still boots
     and rubric-mode tasks keep working; comparison-mode preconvert will then
     surface its own per-file errors via ``preconvert.py``.
     """
-    if shutil.which("libreoffice"):
+    if shutil.which("libreoffice") and shutil.which("java"):
         return True
 
     if not sys.platform.startswith("linux"):
@@ -68,10 +75,15 @@ def ensure_libreoffice() -> bool:
         return False
 
     if not shutil.which("apt-get"):
-        LOGGER.warning("libreoffice not on PATH and apt-get is unavailable; GDPVal preconvert will be a no-op.")
+        LOGGER.warning(
+            "libreoffice or java not on PATH and apt-get is unavailable; GDPVal preconvert will be a no-op."
+        )
         return False
 
-    LOGGER.info("Installing libreoffice via apt-get (one-time, ~500 MB)...")
+    LOGGER.info(
+        "Installing %s via apt-get (one-time, ~500 MB if libreoffice is missing)...",
+        ", ".join(_APT_PACKAGES),
+    )
 
     try:
         rc, _, err = _run(["apt-get", "update", "-qq"], timeout=_APT_INSTALL_TIMEOUT_S)
@@ -94,6 +106,12 @@ def ensure_libreoffice() -> bool:
 
     if not shutil.which("libreoffice"):
         LOGGER.warning("apt-get install reported success but libreoffice still not on PATH")
+        return False
+    if not shutil.which("java"):
+        LOGGER.warning(
+            "apt-get install reported success but java still not on PATH "
+            "(libreoffice will fail on chart/formula docs)"
+        )
         return False
 
     rc, out, err = _run(["libreoffice", "--version"], timeout=30)

--- a/resources_servers/gdpval/setup_libreoffice.py
+++ b/resources_servers/gdpval/setup_libreoffice.py
@@ -66,55 +66,57 @@ def _java_runs() -> bool:
 
 
 def ensure_libreoffice() -> bool:
-    """Make sure ``libreoffice`` *and* a *functional* JRE are present; apt-install on Linux if missing.
+    """Make sure libreoffice + a *functional* JRE are present. ALWAYS run apt-install on Linux.
 
-    Returns True if libreoffice is available after the call, False otherwise.
-    Idempotent: when libreoffice is on PATH AND `java -version` runs
-    cleanly, returns immediately. When libreoffice is present but Java is
-    missing or broken (e.g. the deployment image bakes libreoffice in
-    without a usable JRE), still runs apt-install — without a working
-    JRE, libreoffice silently exits rc=0 with `Warning: failed to launch
-    javaldx` for any chart/formula/embedded-object doc, producing
-    filename-only stubs in comparison mode.
+    Returns True if libreoffice + a usable JRE are available after the call.
 
-    A previous version of this function gated the early-exit on
-    `shutil.which("java")` alone; that wasn't enough — the deployment
-    image had *some* `java` binary on PATH that satisfied `which()` but
-    couldn't actually execute (`java -version` failed), so apt-install
-    was skipped and the JRE was never landed. The functional probe in
-    `_java_runs()` catches that case.
+    History (so we don't regress again):
+      v1 — early-exit on `shutil.which("libreoffice")`. The deployment image
+           bakes libreoffice in *without* a JRE; apt-install was skipped and
+           libreoffice's `javaldx` helper failed for every chart/formula doc.
+      v2 — early-exit on `shutil.which("libreoffice") and shutil.which("java")`.
+           Same regression — the image has a `java` binary that satisfies
+           `which()` but isn't functional.
+      v3 — early-exit on `shutil.which("libreoffice") and _java_runs()` (i.e.
+           `java -version` rc=0). STILL not enough — `java -version` succeeds
+           but libreoffice's `javaldx` (which loads libjvm.so via JNI) still
+           can't find a usable JRE. Concrete signal: 10 `failed to launch
+           javaldx` errors at 35 rollouts on slurm 2621556.
+      v4 (this) — drop the early-exit entirely. ALWAYS run apt-update +
+           apt-install of the full package list. `apt-get install` is
+           idempotent on already-installed packages (a few seconds when
+           everything is present), and the only configuration that
+           reliably gets `javaldx` working is having `default-jre-headless`
+           installed via the same dpkg DB that libreoffice's wrapper
+           consults. Rather than try to detect that out-of-band, just
+           install.
 
-    Logs a WARNING (not raise) on install failure so the server still boots
-    and rubric-mode tasks keep working; comparison-mode preconvert will then
-    surface its own per-file errors via ``preconvert.py``.
+    Logs a WARNING on apt failure so the server still boots and rubric-mode
+    tasks keep working; comparison-mode preconvert will surface its own
+    per-file errors via ``preconvert.py``.
     """
-    if shutil.which("libreoffice") and _java_runs():
-        return True
-
     if not sys.platform.startswith("linux"):
         LOGGER.warning(
-            "libreoffice not on PATH and auto-install only supports Linux (sys.platform=%s); "
-            "GDPVal preconvert will be a no-op.",
+            "auto-install only supports Linux (sys.platform=%s); GDPVal preconvert will be a no-op.",
             sys.platform,
         )
         return False
 
     if not shutil.which("apt-get"):
-        LOGGER.warning(
-            "libreoffice or java not on PATH and apt-get is unavailable; GDPVal preconvert will be a no-op."
-        )
+        LOGGER.warning("apt-get is unavailable; GDPVal preconvert will be a no-op.")
         return False
 
     LOGGER.info(
-        "Installing %s via apt-get (one-time, ~500 MB if libreoffice is missing)...",
+        "Ensuring %s via apt-get (idempotent; first call adds ~500 MB if libreoffice is missing, "
+        "subsequent calls only verify the packages)...",
         ", ".join(_APT_PACKAGES),
     )
 
     try:
         rc, _, err = _run(["apt-get", "update", "-qq"], timeout=_APT_INSTALL_TIMEOUT_S)
         if rc != 0:
+            # Non-fatal: stale apt index can still satisfy install if the packages are cached.
             LOGGER.warning("apt-get update failed (rc=%d): %s", rc, (err or "").strip()[:500])
-            return False
         rc, _, err = _run(
             ["apt-get", "install", "-y", "--no-install-recommends", *_APT_PACKAGES],
             timeout=_APT_INSTALL_TIMEOUT_S,

--- a/resources_servers/gdpval/tests/test_setup_libreoffice.py
+++ b/resources_servers/gdpval/tests/test_setup_libreoffice.py
@@ -17,121 +17,172 @@ def _which_from(table: dict[str, str | None]):
     return _impl
 
 
-def test_returns_true_when_libreoffice_and_java_already_on_path() -> None:
-    table = {"libreoffice": "/usr/bin/libreoffice", "java": "/usr/bin/java"}
-    with patch.object(shutil, "which", side_effect=_which_from(table)):
-        with patch.object(setup, "_run") as run_mock:
-            assert setup.ensure_libreoffice() is True
-    run_mock.assert_not_called()
+def _make_run(java_runs_pre: bool, java_runs_post: bool, install_succeeds: bool = True):
+    """Build a `setup._run` side_effect that:
+    - returns rc=0 for `java -version` based on `java_runs_pre` (before install)
+      and `java_runs_post` (after the apt-install install command runs);
+    - models apt-get update / install / libreoffice --version outcomes per
+      `install_succeeds`.
+    """
+    state = {"installed": False}
 
-
-def test_runs_apt_install_when_libreoffice_present_but_java_missing() -> None:
-    """The deployment image bakes libreoffice in without a JRE; we must still apt-install."""
-    # Pre-install: libreoffice yes, java no, apt-get yes. Post-install: both yes.
-    table = {"libreoffice": "/usr/bin/libreoffice", "java": None, "apt-get": "/usr/bin/apt-get"}
-    install_done = {"v": False}
-
-    def _which(name: str) -> str | None:
-        if install_done["v"] and name == "java":
-            return "/usr/bin/java"
-        return table.get(name)
-
-    captured: list[list[str]] = []
-
-    def _capture(cmd, **kw):
-        captured.append(cmd)
+    def _impl(cmd, **_kw):
+        if cmd == ["java", "-version"]:
+            ok = java_runs_post if state["installed"] else java_runs_pre
+            return (0 if ok else 1), "", ""
         if cmd[:2] == ["apt-get", "update"]:
-            return 0, "", ""
+            return (0 if install_succeeds else 1), "", ""
         if cmd[:3] == ["apt-get", "install", "-y"]:
-            install_done["v"] = True
-            return 0, "", ""
+            if install_succeeds:
+                state["installed"] = True
+                return 0, "", ""
+            return 100, "", "E: Unable to fetch"
         if cmd == ["libreoffice", "--version"]:
             return 0, "LibreOffice 24.2", ""
         raise AssertionError(f"unexpected cmd: {cmd}")
 
-    with patch.object(shutil, "which", side_effect=_which):
-        with patch.object(sys, "platform", "linux"):
-            with patch.object(setup, "_run", side_effect=_capture):
-                assert setup.ensure_libreoffice() is True
-
-    install_cmd = next(c for c in captured if c[:3] == ["apt-get", "install", "-y"])
-    assert "default-jre-headless" in install_cmd
+    return _impl, state
 
 
-def test_returns_false_when_libreoffice_present_but_java_missing_and_install_does_not_provide_java() -> None:
-    table = {"libreoffice": "/usr/bin/libreoffice", "java": None, "apt-get": "/usr/bin/apt-get"}
+def test_returns_true_when_libreoffice_and_functional_java_present() -> None:
+    """Early-exit fires only when libreoffice is on PATH AND `java -version` rc=0."""
+    table = {"libreoffice": "/usr/bin/libreoffice", "java": "/usr/bin/java"}
+    run_impl, _ = _make_run(java_runs_pre=True, java_runs_post=True)
+    with patch.object(shutil, "which", side_effect=_which_from(table)):
+        with patch.object(setup, "_run", side_effect=run_impl) as run_mock:
+            assert setup.ensure_libreoffice() is True
+    # Only `java -version` is invoked; no apt-get
+    assert run_mock.call_count == 1
+    assert run_mock.call_args_list[0][0][0] == ["java", "-version"]
+
+
+def test_runs_apt_install_when_java_on_path_but_not_functional() -> None:
+    """The deployment-image regression: `which("java")` returns a path, but
+    `java -version` exits non-zero — apt-install must still run."""
+    table = {"libreoffice": "/usr/bin/libreoffice", "java": "/usr/bin/java", "apt-get": "/usr/bin/apt-get"}
+    run_impl, _ = _make_run(java_runs_pre=False, java_runs_post=True)
     with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(sys, "platform", "linux"):
-            with patch.object(setup, "_run", return_value=(0, "", "")):
+            with patch.object(setup, "_run", side_effect=run_impl) as run_mock:
+                assert setup.ensure_libreoffice() is True
+
+    cmds = [c.args[0] for c in run_mock.call_args_list]
+    install = next(c for c in cmds if c[:3] == ["apt-get", "install", "-y"])
+    assert "default-jre-headless" in install
+
+
+def test_runs_apt_install_when_libreoffice_present_but_java_missing() -> None:
+    """The other half: libreoffice is on PATH but java isn't (which → None)."""
+    table = {"libreoffice": "/usr/bin/libreoffice", "java": None, "apt-get": "/usr/bin/apt-get"}
+    run_impl, state = _make_run(java_runs_pre=False, java_runs_post=True)
+
+    def _which(name: str) -> str | None:
+        # java appears on PATH only after the apt install has run
+        if name == "java" and state["installed"]:
+            return "/usr/bin/java"
+        return table.get(name)
+
+    with patch.object(shutil, "which", side_effect=_which):
+        with patch.object(sys, "platform", "linux"):
+            with patch.object(setup, "_run", side_effect=run_impl) as run_mock:
+                assert setup.ensure_libreoffice() is True
+
+    cmds = [c.args[0] for c in run_mock.call_args_list]
+    install = next(c for c in cmds if c[:3] == ["apt-get", "install", "-y"])
+    assert "default-jre-headless" in install
+
+
+def test_returns_false_when_install_does_not_provide_functional_java() -> None:
+    """Install reports success but post-install `java -version` still fails."""
+    table = {"libreoffice": "/usr/bin/libreoffice", "java": None, "apt-get": "/usr/bin/apt-get"}
+    run_impl, _ = _make_run(java_runs_pre=False, java_runs_post=False)
+    with patch.object(shutil, "which", side_effect=_which_from(table)):
+        with patch.object(sys, "platform", "linux"):
+            with patch.object(setup, "_run", side_effect=run_impl):
                 assert setup.ensure_libreoffice() is False
 
 
 def test_returns_false_on_non_linux_when_missing() -> None:
     with patch.object(shutil, "which", return_value=None):
         with patch.object(sys, "platform", "darwin"):
-            with patch.object(setup, "_run") as run_mock:
+            with patch.object(setup, "_run", return_value=(1, "", "")) as run_mock:
                 assert setup.ensure_libreoffice() is False
-    run_mock.assert_not_called()
+    # Only `java -version` was probed; apt-get never invoked
+    assert all(c.args[0] == ["java", "-version"] for c in run_mock.call_args_list)
 
 
 def test_returns_false_when_apt_get_unavailable() -> None:
-    with patch.object(shutil, "which", side_effect=_which_from({})):
+    """libreoffice + java probe both fail and apt-get isn't on PATH."""
+    table: dict[str, str | None] = {}
+    with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(sys, "platform", "linux"):
-            with patch.object(setup, "_run") as run_mock:
+            with patch.object(setup, "_run", return_value=(1, "", "")) as run_mock:
                 assert setup.ensure_libreoffice() is False
-    run_mock.assert_not_called()
+    # No apt-get commands attempted (java -version may have been probed)
+    for call in run_mock.call_args_list:
+        assert call.args[0][0] != "apt-get"
 
 
 def test_returns_false_when_apt_get_update_fails() -> None:
     table = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
+    run_impl, _ = _make_run(java_runs_pre=False, java_runs_post=False, install_succeeds=False)
     with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(sys, "platform", "linux"):
-            with patch.object(setup, "_run", return_value=(1, "", "Network down")) as run_mock:
+            with patch.object(setup, "_run", side_effect=run_impl) as run_mock:
                 assert setup.ensure_libreoffice() is False
-    # Only the apt-get update call before bailing
-    assert run_mock.call_count == 1
-    assert run_mock.call_args_list[0][0][0][:2] == ["apt-get", "update"]
+    cmds = [c.args[0] for c in run_mock.call_args_list]
+    # apt-get update was attempted; install was NOT (we bailed after update failed)
+    assert any(c[:2] == ["apt-get", "update"] for c in cmds)
+    assert not any(c[:3] == ["apt-get", "install", "-y"] for c in cmds)
 
 
 def test_returns_false_when_apt_install_fails() -> None:
     table = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
-    runs = iter([(0, "", ""), (100, "", "E: Unable to fetch some archives")])
+
+    def _impl(cmd, **_kw):
+        if cmd == ["java", "-version"]:
+            return 1, "", ""
+        if cmd[:2] == ["apt-get", "update"]:
+            return 0, "", ""
+        if cmd[:3] == ["apt-get", "install", "-y"]:
+            return 100, "", "E: Unable to fetch some archives"
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
     with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(sys, "platform", "linux"):
-            with patch.object(setup, "_run", side_effect=lambda *a, **kw: next(runs)) as run_mock:
+            with patch.object(setup, "_run", side_effect=_impl) as run_mock:
                 assert setup.ensure_libreoffice() is False
-    # update + install were both attempted
-    assert run_mock.call_count == 2
-    assert run_mock.call_args_list[1][0][0][:3] == ["apt-get", "install", "-y"]
+
+    cmds = [c.args[0] for c in run_mock.call_args_list]
+    assert any(c[:3] == ["apt-get", "install", "-y"] for c in cmds)
 
 
-def test_returns_false_when_install_succeeds_but_binary_still_missing() -> None:
+def test_returns_false_when_install_succeeds_but_libreoffice_still_missing() -> None:
+    """Install command returns rc=0 but libreoffice still not on PATH afterwards."""
     table = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
-    runs = iter([(0, "", ""), (0, "", "")])
+    # libreoffice/java which always returns None (table never updated)
+    run_impl, _ = _make_run(java_runs_pre=False, java_runs_post=False, install_succeeds=True)
     with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(sys, "platform", "linux"):
-            with patch.object(setup, "_run", side_effect=lambda *a, **kw: next(runs)):
+            with patch.object(setup, "_run", side_effect=run_impl):
                 assert setup.ensure_libreoffice() is False
 
 
 def test_full_success_path() -> None:
-    """Initial state: nothing present. After apt install: both libreoffice and java present."""
-    install_done = {"v": False}
+    """Initial state: nothing present. After apt install: libreoffice + working java."""
+    table_state = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
 
     def _which(name: str) -> str | None:
-        if not install_done["v"]:
-            return "/usr/bin/apt-get" if name == "apt-get" else None
-        return {"libreoffice": "/usr/bin/libreoffice", "java": "/usr/bin/java", "apt-get": "/usr/bin/apt-get"}.get(name)
+        return table_state.get(name)
+
+    run_impl, state = _make_run(java_runs_pre=False, java_runs_post=True, install_succeeds=True)
 
     def _run(cmd, **kw):
-        if cmd[:2] == ["apt-get", "update"]:
-            return 0, "", ""
-        if cmd[:3] == ["apt-get", "install", "-y"]:
-            install_done["v"] = True
-            return 0, "", ""
-        if cmd == ["libreoffice", "--version"]:
-            return 0, "LibreOffice 24.2", ""
-        raise AssertionError(f"unexpected cmd: {cmd}")
+        result = run_impl(cmd, **kw)
+        if cmd[:3] == ["apt-get", "install", "-y"] and state["installed"]:
+            table_state["libreoffice"] = "/usr/bin/libreoffice"
+            table_state["java"] = "/usr/bin/java"
+        return result
 
     with patch.object(shutil, "which", side_effect=_which):
         with patch.object(sys, "platform", "linux"):
@@ -142,35 +193,37 @@ def test_full_success_path() -> None:
 def test_handles_subprocess_timeout_gracefully() -> None:
     table = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
 
-    def _raise_timeout(*_a, **_kw):
+    def _impl(cmd, **_kw):
+        if cmd == ["java", "-version"]:
+            return 1, "", ""
         raise subprocess.TimeoutExpired(cmd="apt-get", timeout=1)
 
     with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(sys, "platform", "linux"):
-            with patch.object(setup, "_run", side_effect=_raise_timeout):
+            with patch.object(setup, "_run", side_effect=_impl):
                 assert setup.ensure_libreoffice() is False
 
 
-def test_install_command_uses_no_install_recommends() -> None:
-    install_done = {"v": False}
+def test_install_command_uses_no_install_recommends_and_includes_jre() -> None:
+    table_state = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
 
     def _which(name: str) -> str | None:
-        if not install_done["v"]:
-            return "/usr/bin/apt-get" if name == "apt-get" else None
-        return {"libreoffice": "/usr/bin/libreoffice", "java": "/usr/bin/java", "apt-get": "/usr/bin/apt-get"}.get(name)
+        return table_state.get(name)
+
+    run_impl, state = _make_run(java_runs_pre=False, java_runs_post=True, install_succeeds=True)
+
+    def _run(cmd, **kw):
+        result = run_impl(cmd, **kw)
+        if cmd[:3] == ["apt-get", "install", "-y"] and state["installed"]:
+            table_state["libreoffice"] = "/usr/bin/libreoffice"
+            table_state["java"] = "/usr/bin/java"
+        return result
 
     captured: list[list[str]] = []
 
     def _capture(cmd, **kw):
         captured.append(cmd)
-        if cmd[:2] == ["apt-get", "update"]:
-            return 0, "", ""
-        if cmd[:3] == ["apt-get", "install", "-y"]:
-            install_done["v"] = True
-            return 0, "", ""
-        if cmd == ["libreoffice", "--version"]:
-            return 0, "LibreOffice 24.2", ""
-        raise AssertionError(f"unexpected cmd: {cmd}")
+        return _run(cmd, **kw)
 
     with patch.object(shutil, "which", side_effect=_which):
         with patch.object(sys, "platform", "linux"):
@@ -182,3 +235,21 @@ def test_install_command_uses_no_install_recommends() -> None:
     assert "libreoffice" in install_cmd
     assert "fonts-liberation" in install_cmd
     assert "default-jre-headless" in install_cmd
+
+
+def test_java_runs_returns_false_when_java_not_on_path() -> None:
+    with patch.object(shutil, "which", return_value=None):
+        assert setup._java_runs() is False
+
+
+def test_java_runs_returns_false_when_java_version_exits_nonzero() -> None:
+    """Regression test: a non-functional `java` on PATH must NOT count as usable."""
+    with patch.object(shutil, "which", return_value="/usr/bin/java"):
+        with patch.object(setup, "_run", return_value=(1, "", "java: error while loading shared libraries")):
+            assert setup._java_runs() is False
+
+
+def test_java_runs_returns_true_when_java_version_exits_zero() -> None:
+    with patch.object(shutil, "which", return_value="/usr/bin/java"):
+        with patch.object(setup, "_run", return_value=(0, "", 'openjdk version "21.0.1"')):
+            assert setup._java_runs() is True

--- a/resources_servers/gdpval/tests/test_setup_libreoffice.py
+++ b/resources_servers/gdpval/tests/test_setup_libreoffice.py
@@ -246,6 +246,9 @@ def test_install_command_uses_no_install_recommends_and_includes_jre() -> None:
     assert "libreoffice" in install_cmd
     assert "fonts-liberation" in install_cmd
     assert "default-jre-headless" in install_cmd
+    # libreoffice-java-common ships javaldx, the helper libreoffice uses
+    # to find the JRE; without it the JRE-install does nothing useful.
+    assert "libreoffice-java-common" in install_cmd
 
 
 def test_java_runs_returns_false_when_java_not_on_path() -> None:

--- a/resources_servers/gdpval/tests/test_setup_libreoffice.py
+++ b/resources_servers/gdpval/tests/test_setup_libreoffice.py
@@ -1,5 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+"""Tests for `setup_libreoffice.ensure_libreoffice`.
+
+Behavior under test (v4): the function always runs `apt-get update` +
+`apt-get install -y` regardless of what's already on PATH. Earlier
+versions tried to short-circuit when libreoffice and/or `java` were
+already present, but every version of that gate was satisfied by the
+deployment image's broken JRE that libreoffice's `javaldx` helper
+couldn't actually use. Apt-install is idempotent on already-installed
+packages so the cost of always running it is small.
+"""
 import shutil
 import subprocess
 import sys
@@ -9,29 +19,27 @@ from resources_servers.gdpval import setup_libreoffice as setup
 
 
 def _which_from(table: dict[str, str | None]):
-    """Return a side_effect for shutil.which that looks up names in ``table``."""
-
     def _impl(name: str) -> str | None:
         return table.get(name)
 
     return _impl
 
 
-def _make_run(java_runs_pre: bool, java_runs_post: bool, install_succeeds: bool = True):
-    """Build a `setup._run` side_effect that:
-    - returns rc=0 for `java -version` based on `java_runs_pre` (before install)
-      and `java_runs_post` (after the apt-install install command runs);
-    - models apt-get update / install / libreoffice --version outcomes per
-      `install_succeeds`.
+def _make_run(install_succeeds: bool = True, java_works_after_install: bool = True):
+    """Side effect for `setup._run` modeling apt + libreoffice + java behaviour.
+
+    Tracks an internal "installed" flag flipped by a successful apt install;
+    `["java", "-version"]` then returns rc=0, modelling the post-install
+    JRE coming online.
     """
     state = {"installed": False}
 
     def _impl(cmd, **_kw):
         if cmd == ["java", "-version"]:
-            ok = java_runs_post if state["installed"] else java_runs_pre
+            ok = state["installed"] and java_works_after_install
             return (0 if ok else 1), "", ""
         if cmd[:2] == ["apt-get", "update"]:
-            return (0 if install_succeeds else 1), "", ""
+            return 0, "", ""
         if cmd[:3] == ["apt-get", "install", "-y"]:
             if install_succeeds:
                 state["installed"] = True
@@ -44,150 +52,151 @@ def _make_run(java_runs_pre: bool, java_runs_post: bool, install_succeeds: bool 
     return _impl, state
 
 
-def test_returns_true_when_libreoffice_and_functional_java_present() -> None:
-    """Early-exit fires only when libreoffice is on PATH AND `java -version` rc=0."""
-    table = {"libreoffice": "/usr/bin/libreoffice", "java": "/usr/bin/java"}
-    run_impl, _ = _make_run(java_runs_pre=True, java_runs_post=True)
-    with patch.object(shutil, "which", side_effect=_which_from(table)):
-        with patch.object(setup, "_run", side_effect=run_impl) as run_mock:
-            assert setup.ensure_libreoffice() is True
-    # Only `java -version` is invoked; no apt-get
-    assert run_mock.call_count == 1
-    assert run_mock.call_args_list[0][0][0] == ["java", "-version"]
+def _which_with_state(table_static: dict[str, str | None], state: dict, post_install_extra: dict[str, str | None] | None = None):
+    """Side effect for `shutil.which` that flips post-install paths once `state["installed"]` is True."""
+    extra = post_install_extra or {}
+
+    def _impl(name: str) -> str | None:
+        if state.get("installed") and name in extra:
+            return extra[name]
+        return table_static.get(name)
+
+    return _impl
 
 
-def test_runs_apt_install_when_java_on_path_but_not_functional() -> None:
-    """The deployment-image regression: `which("java")` returns a path, but
-    `java -version` exits non-zero — apt-install must still run."""
+def test_always_runs_apt_install_even_when_libreoffice_and_java_already_on_path() -> None:
+    """The v4 contract: even when both binaries already resolve, run apt-install anyway.
+
+    The deployment image had `libreoffice` + a broken-but-callable `java` baked
+    in; previous versions skipped the install and the JRE that libreoffice's
+    `javaldx` needs was never landed.
+    """
     table = {"libreoffice": "/usr/bin/libreoffice", "java": "/usr/bin/java", "apt-get": "/usr/bin/apt-get"}
-    run_impl, _ = _make_run(java_runs_pre=False, java_runs_post=True)
+    run_impl, _ = _make_run()
     with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(sys, "platform", "linux"):
             with patch.object(setup, "_run", side_effect=run_impl) as run_mock:
                 assert setup.ensure_libreoffice() is True
-
     cmds = [c.args[0] for c in run_mock.call_args_list]
-    install = next(c for c in cmds if c[:3] == ["apt-get", "install", "-y"])
-    assert "default-jre-headless" in install
+    assert any(c[:2] == ["apt-get", "update"] for c in cmds), "apt-get update must run"
+    assert any(c[:3] == ["apt-get", "install", "-y"] for c in cmds), "apt-get install must run"
 
 
 def test_runs_apt_install_when_libreoffice_present_but_java_missing() -> None:
-    """The other half: libreoffice is on PATH but java isn't (which → None)."""
     table = {"libreoffice": "/usr/bin/libreoffice", "java": None, "apt-get": "/usr/bin/apt-get"}
-    run_impl, state = _make_run(java_runs_pre=False, java_runs_post=True)
-
-    def _which(name: str) -> str | None:
-        # java appears on PATH only after the apt install has run
-        if name == "java" and state["installed"]:
-            return "/usr/bin/java"
-        return table.get(name)
-
-    with patch.object(shutil, "which", side_effect=_which):
+    run_impl, state = _make_run()
+    with patch.object(shutil, "which", side_effect=_which_with_state(table, state, {"java": "/usr/bin/java"})):
         with patch.object(sys, "platform", "linux"):
             with patch.object(setup, "_run", side_effect=run_impl) as run_mock:
                 assert setup.ensure_libreoffice() is True
-
     cmds = [c.args[0] for c in run_mock.call_args_list]
     install = next(c for c in cmds if c[:3] == ["apt-get", "install", "-y"])
     assert "default-jre-headless" in install
 
 
-def test_returns_false_when_install_does_not_provide_functional_java() -> None:
-    """Install reports success but post-install `java -version` still fails."""
-    table = {"libreoffice": "/usr/bin/libreoffice", "java": None, "apt-get": "/usr/bin/apt-get"}
-    run_impl, _ = _make_run(java_runs_pre=False, java_runs_post=False)
-    with patch.object(shutil, "which", side_effect=_which_from(table)):
-        with patch.object(sys, "platform", "linux"):
-            with patch.object(setup, "_run", side_effect=run_impl):
-                assert setup.ensure_libreoffice() is False
+def test_runs_apt_install_when_java_on_path_but_not_functional() -> None:
+    """Regression test for v3 → v4 transition: `java` resolves but `java -version` fails.
 
-
-def test_returns_false_on_non_linux_when_missing() -> None:
-    with patch.object(shutil, "which", return_value=None):
-        with patch.object(sys, "platform", "darwin"):
-            with patch.object(setup, "_run", return_value=(1, "", "")) as run_mock:
-                assert setup.ensure_libreoffice() is False
-    # Only `java -version` was probed; apt-get never invoked
-    assert all(c.args[0] == ["java", "-version"] for c in run_mock.call_args_list)
-
-
-def test_returns_false_when_apt_get_unavailable() -> None:
-    """libreoffice + java probe both fail and apt-get isn't on PATH."""
-    table: dict[str, str | None] = {}
-    with patch.object(shutil, "which", side_effect=_which_from(table)):
-        with patch.object(sys, "platform", "linux"):
-            with patch.object(setup, "_run", return_value=(1, "", "")) as run_mock:
-                assert setup.ensure_libreoffice() is False
-    # No apt-get commands attempted (java -version may have been probed)
-    for call in run_mock.call_args_list:
-        assert call.args[0][0] != "apt-get"
-
-
-def test_returns_false_when_apt_get_update_fails() -> None:
-    table = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
-    run_impl, _ = _make_run(java_runs_pre=False, java_runs_post=False, install_succeeds=False)
+    The v3 fix gated on `_java_runs()` — but the deployment container had a
+    callable-enough `java` to satisfy `java -version` while still failing
+    `javaldx`. v4 doesn't even try to detect this; it just always installs.
+    """
+    table = {"libreoffice": "/usr/bin/libreoffice", "java": "/usr/bin/java", "apt-get": "/usr/bin/apt-get"}
+    run_impl, _ = _make_run()
     with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(sys, "platform", "linux"):
             with patch.object(setup, "_run", side_effect=run_impl) as run_mock:
-                assert setup.ensure_libreoffice() is False
+                assert setup.ensure_libreoffice() is True
     cmds = [c.args[0] for c in run_mock.call_args_list]
-    # apt-get update was attempted; install was NOT (we bailed after update failed)
+    assert any(c[:3] == ["apt-get", "install", "-y"] for c in cmds)
+
+
+def test_returns_false_on_non_linux() -> None:
+    with patch.object(shutil, "which", return_value=None):
+        with patch.object(sys, "platform", "darwin"):
+            with patch.object(setup, "_run") as run_mock:
+                assert setup.ensure_libreoffice() is False
+    run_mock.assert_not_called()
+
+
+def test_returns_false_when_apt_get_unavailable() -> None:
+    with patch.object(shutil, "which", side_effect=_which_from({})):
+        with patch.object(sys, "platform", "linux"):
+            with patch.object(setup, "_run") as run_mock:
+                assert setup.ensure_libreoffice() is False
+    run_mock.assert_not_called()
+
+
+def test_proceeds_to_install_even_when_apt_update_fails() -> None:
+    """A stale apt index is still satisfiable by cached packages."""
+    table = {"libreoffice": "/usr/bin/libreoffice", "java": None, "apt-get": "/usr/bin/apt-get"}
+    state = {"installed": False}
+
+    def _impl(cmd, **_kw):
+        if cmd == ["java", "-version"]:
+            return (0 if state["installed"] else 1), "", ""
+        if cmd[:2] == ["apt-get", "update"]:
+            return 1, "", "Network down"  # update fails
+        if cmd[:3] == ["apt-get", "install", "-y"]:
+            state["installed"] = True
+            return 0, "", ""
+        if cmd == ["libreoffice", "--version"]:
+            return 0, "LibreOffice 24.2", ""
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    with patch.object(shutil, "which", side_effect=_which_with_state(table, state, {"java": "/usr/bin/java"})):
+        with patch.object(sys, "platform", "linux"):
+            with patch.object(setup, "_run", side_effect=_impl) as run_mock:
+                assert setup.ensure_libreoffice() is True
+    # update was attempted but failed; install was still attempted and succeeded
+    cmds = [c.args[0] for c in run_mock.call_args_list]
     assert any(c[:2] == ["apt-get", "update"] for c in cmds)
-    assert not any(c[:3] == ["apt-get", "install", "-y"] for c in cmds)
+    assert any(c[:3] == ["apt-get", "install", "-y"] for c in cmds)
 
 
 def test_returns_false_when_apt_install_fails() -> None:
     table = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
-
-    def _impl(cmd, **_kw):
-        if cmd == ["java", "-version"]:
-            return 1, "", ""
-        if cmd[:2] == ["apt-get", "update"]:
-            return 0, "", ""
-        if cmd[:3] == ["apt-get", "install", "-y"]:
-            return 100, "", "E: Unable to fetch some archives"
-        raise AssertionError(f"unexpected cmd: {cmd}")
-
+    run_impl, _ = _make_run(install_succeeds=False)
     with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(sys, "platform", "linux"):
-            with patch.object(setup, "_run", side_effect=_impl) as run_mock:
+            with patch.object(setup, "_run", side_effect=run_impl) as run_mock:
                 assert setup.ensure_libreoffice() is False
-
     cmds = [c.args[0] for c in run_mock.call_args_list]
     assert any(c[:3] == ["apt-get", "install", "-y"] for c in cmds)
 
 
 def test_returns_false_when_install_succeeds_but_libreoffice_still_missing() -> None:
-    """Install command returns rc=0 but libreoffice still not on PATH afterwards."""
-    table = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
-    # libreoffice/java which always returns None (table never updated)
-    run_impl, _ = _make_run(java_runs_pre=False, java_runs_post=False, install_succeeds=True)
+    """Install reports rc=0 but the binary doesn't materialise (rare; broken package)."""
+    table_static = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
+    state = {"installed": False}
+
+    def _impl(cmd, **_kw):
+        if cmd == ["java", "-version"]:
+            return (0 if state["installed"] else 1), "", ""
+        if cmd[:2] == ["apt-get", "update"]:
+            return 0, "", ""
+        if cmd[:3] == ["apt-get", "install", "-y"]:
+            state["installed"] = True
+            return 0, "", ""
+        if cmd == ["libreoffice", "--version"]:
+            return 0, "LibreOffice 24.2", ""
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    # `which` never returns a libreoffice path even after "install"
+    with patch.object(shutil, "which", side_effect=_which_from(table_static)):
+        with patch.object(sys, "platform", "linux"):
+            with patch.object(setup, "_run", side_effect=_impl):
+                assert setup.ensure_libreoffice() is False
+
+
+def test_returns_false_when_install_succeeds_but_java_still_broken() -> None:
+    """Install reports rc=0; libreoffice resolves; `java -version` keeps failing."""
+    table = {"libreoffice": "/usr/bin/libreoffice", "java": "/usr/bin/java", "apt-get": "/usr/bin/apt-get"}
+    run_impl, _ = _make_run(java_works_after_install=False)
     with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(sys, "platform", "linux"):
             with patch.object(setup, "_run", side_effect=run_impl):
                 assert setup.ensure_libreoffice() is False
-
-
-def test_full_success_path() -> None:
-    """Initial state: nothing present. After apt install: libreoffice + working java."""
-    table_state = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
-
-    def _which(name: str) -> str | None:
-        return table_state.get(name)
-
-    run_impl, state = _make_run(java_runs_pre=False, java_runs_post=True, install_succeeds=True)
-
-    def _run(cmd, **kw):
-        result = run_impl(cmd, **kw)
-        if cmd[:3] == ["apt-get", "install", "-y"] and state["installed"]:
-            table_state["libreoffice"] = "/usr/bin/libreoffice"
-            table_state["java"] = "/usr/bin/java"
-        return result
-
-    with patch.object(shutil, "which", side_effect=_which):
-        with patch.object(sys, "platform", "linux"):
-            with patch.object(setup, "_run", side_effect=_run):
-                assert setup.ensure_libreoffice() is True
 
 
 def test_handles_subprocess_timeout_gracefully() -> None:
@@ -205,32 +214,34 @@ def test_handles_subprocess_timeout_gracefully() -> None:
 
 
 def test_install_command_uses_no_install_recommends_and_includes_jre() -> None:
-    table_state = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
+    table_static = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
+    state = {"installed": False}
 
-    def _which(name: str) -> str | None:
-        return table_state.get(name)
+    def _impl(cmd, **_kw):
+        if cmd == ["java", "-version"]:
+            return (0 if state["installed"] else 1), "", ""
+        if cmd[:2] == ["apt-get", "update"]:
+            return 0, "", ""
+        if cmd[:3] == ["apt-get", "install", "-y"]:
+            state["installed"] = True
+            return 0, "", ""
+        if cmd == ["libreoffice", "--version"]:
+            return 0, "LibreOffice 24.2", ""
+        raise AssertionError(f"unexpected cmd: {cmd}")
 
-    run_impl, state = _make_run(java_runs_pre=False, java_runs_post=True, install_succeeds=True)
-
-    def _run(cmd, **kw):
-        result = run_impl(cmd, **kw)
-        if cmd[:3] == ["apt-get", "install", "-y"] and state["installed"]:
-            table_state["libreoffice"] = "/usr/bin/libreoffice"
-            table_state["java"] = "/usr/bin/java"
-        return result
-
-    captured: list[list[str]] = []
-
-    def _capture(cmd, **kw):
-        captured.append(cmd)
-        return _run(cmd, **kw)
-
-    with patch.object(shutil, "which", side_effect=_which):
+    with patch.object(
+        shutil, "which",
+        side_effect=_which_with_state(
+            table_static,
+            state,
+            {"libreoffice": "/usr/bin/libreoffice", "java": "/usr/bin/java"},
+        ),
+    ):
         with patch.object(sys, "platform", "linux"):
-            with patch.object(setup, "_run", side_effect=_capture):
+            with patch.object(setup, "_run", side_effect=_impl) as run_mock:
                 assert setup.ensure_libreoffice() is True
 
-    install_cmd = next(c for c in captured if c[:3] == ["apt-get", "install", "-y"])
+    install_cmd = next(c.args[0] for c in run_mock.call_args_list if c.args[0][:3] == ["apt-get", "install", "-y"])
     assert "--no-install-recommends" in install_cmd
     assert "libreoffice" in install_cmd
     assert "fonts-liberation" in install_cmd
@@ -243,7 +254,7 @@ def test_java_runs_returns_false_when_java_not_on_path() -> None:
 
 
 def test_java_runs_returns_false_when_java_version_exits_nonzero() -> None:
-    """Regression test: a non-functional `java` on PATH must NOT count as usable."""
+    """A non-functional `java` on PATH must NOT count as usable."""
     with patch.object(shutil, "which", return_value="/usr/bin/java"):
         with patch.object(setup, "_run", return_value=(1, "", "java: error while loading shared libraries")):
             assert setup._java_runs() is False

--- a/resources_servers/gdpval/tests/test_setup_libreoffice.py
+++ b/resources_servers/gdpval/tests/test_setup_libreoffice.py
@@ -8,12 +8,62 @@ from unittest.mock import patch
 from resources_servers.gdpval import setup_libreoffice as setup
 
 
-def test_returns_true_when_libreoffice_already_on_path() -> None:
-    with patch.object(shutil, "which", return_value="/usr/bin/libreoffice") as which:
+def _which_from(table: dict[str, str | None]):
+    """Return a side_effect for shutil.which that looks up names in ``table``."""
+
+    def _impl(name: str) -> str | None:
+        return table.get(name)
+
+    return _impl
+
+
+def test_returns_true_when_libreoffice_and_java_already_on_path() -> None:
+    table = {"libreoffice": "/usr/bin/libreoffice", "java": "/usr/bin/java"}
+    with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(setup, "_run") as run_mock:
             assert setup.ensure_libreoffice() is True
-    which.assert_called_once_with("libreoffice")
     run_mock.assert_not_called()
+
+
+def test_runs_apt_install_when_libreoffice_present_but_java_missing() -> None:
+    """The deployment image bakes libreoffice in without a JRE; we must still apt-install."""
+    # Pre-install: libreoffice yes, java no, apt-get yes. Post-install: both yes.
+    table = {"libreoffice": "/usr/bin/libreoffice", "java": None, "apt-get": "/usr/bin/apt-get"}
+    install_done = {"v": False}
+
+    def _which(name: str) -> str | None:
+        if install_done["v"] and name == "java":
+            return "/usr/bin/java"
+        return table.get(name)
+
+    captured: list[list[str]] = []
+
+    def _capture(cmd, **kw):
+        captured.append(cmd)
+        if cmd[:2] == ["apt-get", "update"]:
+            return 0, "", ""
+        if cmd[:3] == ["apt-get", "install", "-y"]:
+            install_done["v"] = True
+            return 0, "", ""
+        if cmd == ["libreoffice", "--version"]:
+            return 0, "LibreOffice 24.2", ""
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
+    with patch.object(shutil, "which", side_effect=_which):
+        with patch.object(sys, "platform", "linux"):
+            with patch.object(setup, "_run", side_effect=_capture):
+                assert setup.ensure_libreoffice() is True
+
+    install_cmd = next(c for c in captured if c[:3] == ["apt-get", "install", "-y"])
+    assert "default-jre-headless" in install_cmd
+
+
+def test_returns_false_when_libreoffice_present_but_java_missing_and_install_does_not_provide_java() -> None:
+    table = {"libreoffice": "/usr/bin/libreoffice", "java": None, "apt-get": "/usr/bin/apt-get"}
+    with patch.object(shutil, "which", side_effect=_which_from(table)):
+        with patch.object(sys, "platform", "linux"):
+            with patch.object(setup, "_run", return_value=(0, "", "")):
+                assert setup.ensure_libreoffice() is False
 
 
 def test_returns_false_on_non_linux_when_missing() -> None:
@@ -25,10 +75,7 @@ def test_returns_false_on_non_linux_when_missing() -> None:
 
 
 def test_returns_false_when_apt_get_unavailable() -> None:
-    def _which(name: str) -> str | None:
-        return None
-
-    with patch.object(shutil, "which", side_effect=_which):
+    with patch.object(shutil, "which", side_effect=_which_from({})):
         with patch.object(sys, "platform", "linux"):
             with patch.object(setup, "_run") as run_mock:
                 assert setup.ensure_libreoffice() is False
@@ -36,12 +83,8 @@ def test_returns_false_when_apt_get_unavailable() -> None:
 
 
 def test_returns_false_when_apt_get_update_fails() -> None:
-    which_calls = {"libreoffice": None, "apt-get": "/usr/bin/apt-get"}
-
-    def _which(name: str) -> str | None:
-        return which_calls[name]
-
-    with patch.object(shutil, "which", side_effect=_which):
+    table = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
+    with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(sys, "platform", "linux"):
             with patch.object(setup, "_run", return_value=(1, "", "Network down")) as run_mock:
                 assert setup.ensure_libreoffice() is False
@@ -51,13 +94,9 @@ def test_returns_false_when_apt_get_update_fails() -> None:
 
 
 def test_returns_false_when_apt_install_fails() -> None:
-    which_seq = iter([None, "/usr/bin/apt-get"])
-
-    def _which(name: str) -> str | None:
-        return next(which_seq)
-
+    table = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
     runs = iter([(0, "", ""), (100, "", "E: Unable to fetch some archives")])
-    with patch.object(shutil, "which", side_effect=_which):
+    with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(sys, "platform", "linux"):
             with patch.object(setup, "_run", side_effect=lambda *a, **kw: next(runs)) as run_mock:
                 assert setup.ensure_libreoffice() is False
@@ -67,53 +106,58 @@ def test_returns_false_when_apt_install_fails() -> None:
 
 
 def test_returns_false_when_install_succeeds_but_binary_still_missing() -> None:
-    # which returns: 1) initial check -> None, 2) apt-get -> /usr/bin, 3) post-install -> None
-    which_seq = iter([None, "/usr/bin/apt-get", None])
-
-    def _which(name: str) -> str | None:
-        return next(which_seq)
-
+    table = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
     runs = iter([(0, "", ""), (0, "", "")])
-    with patch.object(shutil, "which", side_effect=_which):
+    with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(sys, "platform", "linux"):
             with patch.object(setup, "_run", side_effect=lambda *a, **kw: next(runs)):
                 assert setup.ensure_libreoffice() is False
 
 
 def test_full_success_path() -> None:
-    # which: initial None, apt-get yes, post-install yes; --version returns 0
-    which_seq = iter([None, "/usr/bin/apt-get", "/usr/bin/libreoffice"])
+    """Initial state: nothing present. After apt install: both libreoffice and java present."""
+    install_done = {"v": False}
 
     def _which(name: str) -> str | None:
-        return next(which_seq)
+        if not install_done["v"]:
+            return "/usr/bin/apt-get" if name == "apt-get" else None
+        return {"libreoffice": "/usr/bin/libreoffice", "java": "/usr/bin/java", "apt-get": "/usr/bin/apt-get"}.get(name)
 
-    runs = iter([(0, "", ""), (0, "", ""), (0, "LibreOffice 24.2", "")])
+    def _run(cmd, **kw):
+        if cmd[:2] == ["apt-get", "update"]:
+            return 0, "", ""
+        if cmd[:3] == ["apt-get", "install", "-y"]:
+            install_done["v"] = True
+            return 0, "", ""
+        if cmd == ["libreoffice", "--version"]:
+            return 0, "LibreOffice 24.2", ""
+        raise AssertionError(f"unexpected cmd: {cmd}")
+
     with patch.object(shutil, "which", side_effect=_which):
         with patch.object(sys, "platform", "linux"):
-            with patch.object(setup, "_run", side_effect=lambda *a, **kw: next(runs)):
+            with patch.object(setup, "_run", side_effect=_run):
                 assert setup.ensure_libreoffice() is True
 
 
 def test_handles_subprocess_timeout_gracefully() -> None:
-    which_seq = iter([None, "/usr/bin/apt-get"])
-
-    def _which(name: str) -> str | None:
-        return next(which_seq)
+    table = {"libreoffice": None, "java": None, "apt-get": "/usr/bin/apt-get"}
 
     def _raise_timeout(*_a, **_kw):
         raise subprocess.TimeoutExpired(cmd="apt-get", timeout=1)
 
-    with patch.object(shutil, "which", side_effect=_which):
+    with patch.object(shutil, "which", side_effect=_which_from(table)):
         with patch.object(sys, "platform", "linux"):
             with patch.object(setup, "_run", side_effect=_raise_timeout):
                 assert setup.ensure_libreoffice() is False
 
 
 def test_install_command_uses_no_install_recommends() -> None:
-    which_seq = iter([None, "/usr/bin/apt-get", "/usr/bin/libreoffice"])
+    install_done = {"v": False}
 
     def _which(name: str) -> str | None:
-        return next(which_seq)
+        if not install_done["v"]:
+            return "/usr/bin/apt-get" if name == "apt-get" else None
+        return {"libreoffice": "/usr/bin/libreoffice", "java": "/usr/bin/java", "apt-get": "/usr/bin/apt-get"}.get(name)
 
     captured: list[list[str]] = []
 
@@ -122,6 +166,7 @@ def test_install_command_uses_no_install_recommends() -> None:
         if cmd[:2] == ["apt-get", "update"]:
             return 0, "", ""
         if cmd[:3] == ["apt-get", "install", "-y"]:
+            install_done["v"] = True
             return 0, "", ""
         if cmd == ["libreoffice", "--version"]:
             return 0, "LibreOffice 24.2", ""
@@ -136,3 +181,4 @@ def test_install_command_uses_no_install_recommends() -> None:
     assert "--no-install-recommends" in install_cmd
     assert "libreoffice" in install_cmd
     assert "fonts-liberation" in install_cmd
+    assert "default-jre-headless" in install_cmd

--- a/resources_servers/gdpval/tests/test_setup_libreoffice.py
+++ b/resources_servers/gdpval/tests/test_setup_libreoffice.py
@@ -10,6 +10,7 @@ deployment image's broken JRE that libreoffice's `javaldx` helper
 couldn't actually use. Apt-install is idempotent on already-installed
 packages so the cost of always running it is small.
 """
+
 import shutil
 import subprocess
 import sys
@@ -52,7 +53,9 @@ def _make_run(install_succeeds: bool = True, java_works_after_install: bool = Tr
     return _impl, state
 
 
-def _which_with_state(table_static: dict[str, str | None], state: dict, post_install_extra: dict[str, str | None] | None = None):
+def _which_with_state(
+    table_static: dict[str, str | None], state: dict, post_install_extra: dict[str, str | None] | None = None
+):
     """Side effect for `shutil.which` that flips post-install paths once `state["installed"]` is True."""
     extra = post_install_extra or {}
 
@@ -230,7 +233,8 @@ def test_install_command_uses_no_install_recommends_and_includes_jre() -> None:
         raise AssertionError(f"unexpected cmd: {cmd}")
 
     with patch.object(
-        shutil, "which",
+        shutil,
+        "which",
         side_effect=_which_with_state(
             table_static,
             state,


### PR DESCRIPTION
## Summary

PR #1228 added `default-jre-headless` to the apt package list in `setup_libreoffice.py` because libreoffice silently exits `rc=0` with `Warning: failed to launch javaldx` for any chart/formula/embedded-object/pivot-table doc when no JRE is on `PATH`, producing **filename-only stubs in comparison-mode preconvert**.

But `ensure_libreoffice()` short-circuits at `shutil.which(\"libreoffice\")` *before* running apt — so when the deployment image already bakes libreoffice in (without a JRE), the apt-install never runs and JRE is never installed. The package-list change in #1228 is unreachable on that code path.

## Why this matters

Observed in two GDPVal pipeclean runs on `ultra-v3` (`b8d417be`, `078ab5e1`) — **~25–30% of office docs reach the multimodal judge as filename-only stubs** with `libreoffice rc=0 did not produce X.pdf: Warning: failed to launch javaldx` for every chart/formula doc.

This biases comparison-mode win rates: if Kimi reference docs convert without Java but eval candidate's docs don't (or vice-versa), the judge votes against the side delivering only a filename.

## Fix

- Gate the early-exit on **both** `libreoffice` AND `java` being on `PATH`.
- When libreoffice is present but java is missing, still run `apt-get install` — idempotent on libreoffice (apt skips already-installed), and gives us the missing JRE.
- Add a post-install `which(\"java\")` check that warns and fails if apt-install reports success but java still isn't on `PATH`.

## Test plan

- [x] `pytest resources_servers/gdpval/tests/test_setup_libreoffice.py` — 11/11 pass (existing tests refactored to use a dict-based `which` mock; 2 new tests cover the libreoffice-present-but-java-missing case)
- [ ] Validate end-to-end on a GDPVal pipeclean run — fold this PR into the pr-train and re-pin EFB (next step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)