### PR TITLE
fix(docs): replace generic "Index" link text with actual page titles

### DIFF
--- a/fern/versions/latest/pages/environment-tutorials/llm-as-judge-verification.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/llm-as-judge-verification.mdx
@@ -361,6 +361,6 @@ Done looks like:
 ## See also
 
 - [task-verification](/latest/about/concepts/task-verification) — verification patterns and reward design
-- [Index](/latest/resources-server) — role of `verify()`
+- [Resources Server](/latest/resources-server) — role of `verify()`
 - [Deployment Topology](/latest/infrastructure/deployment-topology) — cluster layout and GPUs
 - [New Environment](/latest/contribute/environments/new-environment) — scaffolding a new resources server

--- a/fern/versions/latest/pages/get-started/detailed-setup.mdx
+++ b/fern/versions/latest/pages/get-started/detailed-setup.mdx
@@ -403,6 +403,6 @@ You've confirmed that NeMo Gym is working — the agent can call tools and retur
 <NavButton href="/latest/get-started/rollout-collection" label="Continue to Rollout Collection" direction="next" />
 
 <Note>
-Rollout collection is required before proceeding to tutorials like [Index](/latest/environment-tutorials) or training workflows. Complete it next.
+Rollout collection is required before proceeding to tutorials like [Environment Tutorials](/latest/environment-tutorials) or training workflows. Complete it next.
 
 </Note>

--- a/fern/versions/latest/pages/infrastructure/deployment-topology.mdx
+++ b/fern/versions/latest/pages/infrastructure/deployment-topology.mdx
@@ -7,7 +7,7 @@ position: 2
 
 When NeMo Gym is used for RL training (not standalone rollout collection), it runs alongside a training framework. NeMo Gym's Model Server acts as an HTTP proxy for policy model inference — it translates between the Responses API and Chat Completions API formats, forwarding requests to the training framework's generation endpoint (e.g., vLLM). NeMo Gym can also run other models on GPU (e.g., reward models, judge models) through its own resources servers.
 
-This section covers resource requirements, cluster strategies, and how to choose between them. For a detailed integration walkthrough from the training framework side, see how [NeMo RL integrated with NeMo Gym](https://github.com/NVIDIA-NeMo/RL/blob/main/docs/design-docs/nemo-gym-integration.md). For guidance on integrating a new training framework, see [Index](/latest/contribute/rl-framework-integration).
+This section covers resource requirements, cluster strategies, and how to choose between them. For a detailed integration walkthrough from the training framework side, see how [NeMo RL integrated with NeMo Gym](https://github.com/NVIDIA-NeMo/RL/blob/main/docs/design-docs/nemo-gym-integration.md). For guidance on integrating a new training framework, see [Integrate RL Frameworks](/latest/contribute/rl-framework-integration).
 
 ### Resource Requirements
 

--- a/fern/versions/latest/pages/reference/rl-framework-compatibility.mdx
+++ b/fern/versions/latest/pages/reference/rl-framework-compatibility.mdx
@@ -6,7 +6,7 @@ position: 2
 Reference for NeMo Gym version compatibility with supported training frameworks.
 
 <Note>
-[Ecosystem](/latest/about/ecosystem) for training framework integrations and [Index](/latest/training-tutorials/nemo-rl-grpo) for NeMo RL GRPO training with NeMo Gym.
+[Ecosystem](/latest/about/ecosystem) for training framework integrations and [NeMo RL GRPO](/latest/training-tutorials/nemo-rl-grpo) for training with NeMo Gym.
 
 </Note>
 

--- a/fern/versions/latest/pages/training-tutorials/unsloth.mdx
+++ b/fern/versions/latest/pages/training-tutorials/unsloth.mdx
@@ -10,7 +10,7 @@ This tutorial demonstrates how to use [Unsloth](https://github.com/unslothai/uns
 ## Prerequisites
 
 - A Google account (for Colab) or a local GPU with 16GB+ VRAM
-- Familiarity with NeMo Gym concepts ([Index](/latest/get-started))
+- Familiarity with NeMo Gym concepts ([Get Started](/latest/get-started))
 
 The NeMo Gym integration with Unsloth is tested on `unsloth==2026.1.4` and `unsloth_zoo==2026.1.4`. Other versions are not guaranteed to work.
 

--- a/fern/versions/v0.2/pages/environment-tutorials/llm-as-judge-verification.mdx
+++ b/fern/versions/v0.2/pages/environment-tutorials/llm-as-judge-verification.mdx
@@ -359,6 +359,6 @@ Done looks like:
 ## See also
 
 - [task-verification](/v0.2/about/concepts/task-verification) — verification patterns and reward design
-- [Index](/v0.2/resources-server) — role of `verify()`
+- [Resources Server](/v0.2/resources-server) — role of `verify()`
 - [Deployment Topology](/v0.2/infrastructure/deployment-topology) — cluster layout and GPUs
 - [New Environment](/v0.2/contribute/environments/new-environment) — scaffolding a new resources server

--- a/fern/versions/v0.2/pages/get-started/detailed-setup.mdx
+++ b/fern/versions/v0.2/pages/get-started/detailed-setup.mdx
@@ -403,6 +403,6 @@ You've confirmed that NeMo Gym is working — the agent can call tools and retur
 <NavButton href="/v0.2/get-started/rollout-collection" label="Continue to Rollout Collection" direction="next" />
 
 <Note>
-Rollout collection is required before proceeding to tutorials like [Index](/v0.2/environment-tutorials) or training workflows. Complete it next.
+Rollout collection is required before proceeding to tutorials like [Environment Tutorials](/v0.2/environment-tutorials) or training workflows. Complete it next.
 
 </Note>

--- a/fern/versions/v0.2/pages/infrastructure/deployment-topology.mdx
+++ b/fern/versions/v0.2/pages/infrastructure/deployment-topology.mdx
@@ -7,7 +7,7 @@ position: 2
 
 When NeMo Gym is used for RL training (not standalone rollout collection), it runs alongside a training framework. NeMo Gym's Model Server acts as an HTTP proxy for policy model inference — it translates between the Responses API and Chat Completions API formats, forwarding requests to the training framework's generation endpoint (e.g., vLLM). NeMo Gym can also run other models on GPU (e.g., reward models, judge models) through its own resources servers.
 
-This section covers resource requirements, cluster strategies, and how to choose between them. For a detailed integration walkthrough from the training framework side, see how [NeMo RL integrated with NeMo Gym](https://github.com/NVIDIA-NeMo/RL/blob/main/docs/design-docs/nemo-gym-integration.md). For guidance on integrating a new training framework, see [Index](/v0.2/contribute/rl-framework-integration).
+This section covers resource requirements, cluster strategies, and how to choose between them. For a detailed integration walkthrough from the training framework side, see how [NeMo RL integrated with NeMo Gym](https://github.com/NVIDIA-NeMo/RL/blob/main/docs/design-docs/nemo-gym-integration.md). For guidance on integrating a new training framework, see [Integrate RL Frameworks](/v0.2/contribute/rl-framework-integration).
 
 ### Resource Requirements
 

--- a/fern/versions/v0.2/pages/reference/rl-framework-compatibility.mdx
+++ b/fern/versions/v0.2/pages/reference/rl-framework-compatibility.mdx
@@ -8,7 +8,7 @@ position: 2
 Reference for NeMo Gym version compatibility with supported training frameworks.
 
 <Note>
-[Ecosystem](/v0.2/about/ecosystem) for training framework integrations and [Index](/v0.2/training-tutorials/nemo-rl-grpo) for NeMo RL GRPO training with NeMo Gym.
+[Ecosystem](/v0.2/about/ecosystem) for training framework integrations and [NeMo RL GRPO](/v0.2/training-tutorials/nemo-rl-grpo) for training with NeMo Gym.
 
 </Note>
 

--- a/fern/versions/v0.2/pages/training-tutorials/unsloth.mdx
+++ b/fern/versions/v0.2/pages/training-tutorials/unsloth.mdx
@@ -10,7 +10,7 @@ This tutorial demonstrates how to use [Unsloth](https://github.com/unslothai/uns
 ## Prerequisites
 
 - A Google account (for Colab) or a local GPU with 16GB+ VRAM
-- Familiarity with NeMo Gym concepts ([Index](/v0.2/get-started))
+- Familiarity with NeMo Gym concepts ([Get Started](/v0.2/get-started))
 
 The NeMo Gym integration with Unsloth is tested on `unsloth==2026.1.4` and `unsloth_zoo==2026.1.4`. Other versions are not guaranteed to work.
 


### PR DESCRIPTION
## Summary
- Links to `index.mdx` pages across the docs were rendering with the literal text "Index" instead of the target page's actual title (e.g., "Integrate RL Frameworks", "Resources Server", "Get Started", etc.)
- Fixed all 10 occurrences across both `latest` and `v0.2` doc versions

## Test plan
- [ ] Verify links render with correct text on the docs site