### PR TITLE
fix(vllm_model): auto-derive required_prefix_token_ids on chat + toke…

### DIFF
--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -447,9 +447,8 @@ class VLLMModel(SimpleResponsesAPIModel):
         if "required_prefix_token_ids" not in body_dict:
             for message in reversed(body_dict.get("messages", [])):
                 if "prompt_token_ids" in message:
-                    body_dict["required_prefix_token_ids"] = (
-                        list(message["prompt_token_ids"])
-                        + list(message["generation_token_ids"])
+                    body_dict["required_prefix_token_ids"] = list(message["prompt_token_ids"]) + list(
+                        message["generation_token_ids"]
                     )
                     break
 

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -450,9 +450,8 @@ class VLLMModel(SimpleResponsesAPIModel):
         if "required_prefix_token_ids" not in body_dict:
             for message in reversed(body_dict.get("messages", [])):
                 if "prompt_token_ids" in message:
-                    body_dict["required_prefix_token_ids"] = (
-                        list(message["prompt_token_ids"])
-                        + list(message["generation_token_ids"])
+                    body_dict["required_prefix_token_ids"] = list(message["prompt_token_ids"]) + list(
+                        message["generation_token_ids"]
                     )
                     break
 

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -88,6 +88,11 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
     extra_body: Optional[Dict[str, Any]] = None
 
     default_headers: Dict[str, str] = Field(default_factory=dict)
+
+    # Dynamo consumes token-prefix splicing at message granularity. When enabled,
+    # rewrite Gym's training token fields into Dynamo's message-level extension.
+    send_required_prefix_token_ids_dynamo: bool = False
+
     # Optional prefix for resolving relative ``metadata.audio_path`` (or
     # entries in ``metadata.audio_paths``) against. Absolute paths are used
     # as-is. When unset, relative paths raise. Audio is always inlined as a
@@ -436,24 +441,17 @@ class VLLMModel(SimpleResponsesAPIModel):
                 # No user message found — create one with just the audio blocks.
                 body_dict.setdefault("messages", []).append({"role": "user", "content": list(audio_blocks)})
 
-        # Auto-derive `required_prefix_token_ids` from the latest assistant
-        # message that has per-message token IDs attached. Both Dynamo's
-        # Rust preprocessor and NeMo-RL's custom vLLM serving mixin honor
-        # this field to splice verbatim model-emitted tokens into the
-        # template-tokenized prefix, preserving byte-level token continuity
-        # across multi-turn replays. The vLLM mixin auto-derives from
-        # per-message `prompt_token_ids` itself (see
-        # `nemo_rl/models/generation/vllm/vllm_worker_async.py`
-        # `NeMoRLOpenAIChatRequestMixin.model_post_init`); Dynamo does not,
-        # so we set it server-agnostically here. When the vLLM mixin sees
-        # the field already populated, its auto-derive short-circuits.
-        if "required_prefix_token_ids" not in body_dict:
-            for message in reversed(body_dict.get("messages", [])):
-                if "prompt_token_ids" in message:
-                    body_dict["required_prefix_token_ids"] = list(message["prompt_token_ids"]) + list(
-                        message["generation_token_ids"]
+        if self.config.send_required_prefix_token_ids_dynamo:
+            # NeMo-RL's vLLM worker still derives request-level
+            # `required_prefix_token_ids` from these per-message fields:
+            # https://github.com/NVIDIA-NeMo/RL/blob/d9ba460fa63e0e079fd18eb207e1febf6485b5e2/nemo_rl/models/generation/vllm/vllm_worker_async.py#L350-L360
+            # Dynamo uses a message-level extension instead, so avoid sending
+            # both representations on the Dynamo path.
+            for message in body_dict.get("messages", []):
+                if "prompt_token_ids" in message and "generation_token_ids" in message:
+                    message["required_prefix_token_ids"] = list(message.pop("prompt_token_ids")) + list(
+                        message.pop("generation_token_ids")
                     )
-                    break
 
         return body_dict
 
@@ -537,12 +535,7 @@ class VLLMModel(SimpleResponsesAPIModel):
             # `prompt_str`) can be built with different chat template settings than
             # the actual generation request.
             tokenize_body_dict = dict()
-            # `required_prefix_token_ids` is forwarded here too: the gym's
-            # contiguity assert reads `prompt_token_ids` from this tokenize
-            # response (not from the chat response), so the splice must
-            # happen on this leg as well — otherwise the chat-side fix above
-            # is invisible to the assert.
-            for key in ("model", "messages", "tools", "chat_template_kwargs", "required_prefix_token_ids"):
+            for key in ("model", "messages", "tools", "chat_template_kwargs"):
                 if key in body_dict:
                     tokenize_body_dict[key] = body_dict[key]
 

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -436,6 +436,26 @@ class VLLMModel(SimpleResponsesAPIModel):
                 # No user message found — create one with just the audio blocks.
                 body_dict.setdefault("messages", []).append({"role": "user", "content": list(audio_blocks)})
 
+        # Auto-derive `required_prefix_token_ids` from the latest assistant
+        # message that has per-message token IDs attached. Both Dynamo's
+        # Rust preprocessor and NeMo-RL's custom vLLM serving mixin honor
+        # this field to splice verbatim model-emitted tokens into the
+        # template-tokenized prefix, preserving byte-level token continuity
+        # across multi-turn replays. The vLLM mixin auto-derives from
+        # per-message `prompt_token_ids` itself (see
+        # `nemo_rl/models/generation/vllm/vllm_worker_async.py`
+        # `NeMoRLOpenAIChatRequestMixin.model_post_init`); Dynamo does not,
+        # so we set it server-agnostically here. When the vLLM mixin sees
+        # the field already populated, its auto-derive short-circuits.
+        if "required_prefix_token_ids" not in body_dict:
+            for message in reversed(body_dict.get("messages", [])):
+                if "prompt_token_ids" in message:
+                    body_dict["required_prefix_token_ids"] = (
+                        list(message["prompt_token_ids"])
+                        + list(message["generation_token_ids"])
+                    )
+                    break
+
         return body_dict
 
     async def chat_completions(
@@ -518,7 +538,12 @@ class VLLMModel(SimpleResponsesAPIModel):
             # `prompt_str`) can be built with different chat template settings than
             # the actual generation request.
             tokenize_body_dict = dict()
-            for key in ("model", "messages", "tools", "chat_template_kwargs"):
+            # `required_prefix_token_ids` is forwarded here too: the gym's
+            # contiguity assert reads `prompt_token_ids` from this tokenize
+            # response (not from the chat response), so the splice must
+            # happen on this leg as well — otherwise the chat-side fix above
+            # is invisible to the assert.
+            for key in ("model", "messages", "tools", "chat_template_kwargs", "required_prefix_token_ids"):
                 if key in body_dict:
                     tokenize_body_dict[key] = body_dict[key]
 

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -433,6 +433,26 @@ class VLLMModel(SimpleResponsesAPIModel):
                 # No user message found — create one with just the audio blocks.
                 body_dict.setdefault("messages", []).append({"role": "user", "content": list(audio_blocks)})
 
+        # Auto-derive `required_prefix_token_ids` from the latest assistant
+        # message that has per-message token IDs attached. Both Dynamo's
+        # Rust preprocessor and NeMo-RL's custom vLLM serving mixin honor
+        # this field to splice verbatim model-emitted tokens into the
+        # template-tokenized prefix, preserving byte-level token continuity
+        # across multi-turn replays. The vLLM mixin auto-derives from
+        # per-message `prompt_token_ids` itself (see
+        # `nemo_rl/models/generation/vllm/vllm_worker_async.py`
+        # `NeMoRLOpenAIChatRequestMixin.model_post_init`); Dynamo does not,
+        # so we set it server-agnostically here. When the vLLM mixin sees
+        # the field already populated, its auto-derive short-circuits.
+        if "required_prefix_token_ids" not in body_dict:
+            for message in reversed(body_dict.get("messages", [])):
+                if "prompt_token_ids" in message:
+                    body_dict["required_prefix_token_ids"] = (
+                        list(message["prompt_token_ids"])
+                        + list(message["generation_token_ids"])
+                    )
+                    break
+
         return body_dict
 
     async def chat_completions(
@@ -515,7 +535,12 @@ class VLLMModel(SimpleResponsesAPIModel):
             # `prompt_str`) can be built with different chat template settings than
             # the actual generation request.
             tokenize_body_dict = dict()
-            for key in ("model", "messages", "tools", "chat_template_kwargs"):
+            # `required_prefix_token_ids` is forwarded here too: the gym's
+            # contiguity assert reads `prompt_token_ids` from this tokenize
+            # response (not from the chat response), so the splice must
+            # happen on this leg as well — otherwise the chat-side fix above
+            # is invisible to the assert.
+            for key in ("model", "messages", "tools", "chat_template_kwargs", "required_prefix_token_ids"):
                 if key in body_dict:
                     tokenize_body_dict[key] = body_dict[key]
 

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -3307,6 +3307,81 @@ class TestVLLMConverter:
         assert captured_kwargs["new_param"] == "value"
 
 
+def _make_required_prefix_token_ids_model(send_required_prefix_token_ids_dynamo: bool = False) -> VLLMModel:
+    config = VLLMModelConfig(
+        host="0.0.0.0",
+        port=8080,
+        entrypoint="",
+        name="vllm_model",
+        base_url="http://localhost:9999/v1",
+        api_key="dummy_key",  # pragma: allowlist secret
+        model="dummy-model",
+        return_token_id_information=False,
+        uses_reasoning_parser=False,
+        uses_interleaved_reasoning=False,
+        send_required_prefix_token_ids_dynamo=send_required_prefix_token_ids_dynamo,
+    )
+    return VLLMModel(config=config, server_client=MagicMock(spec=ServerClient))
+
+
+class TestRequiredPrefixTokenIdsDynamo:
+    def test_default_keeps_gym_token_fields(self) -> None:
+        model = _make_required_prefix_token_ids_model()
+        body = {
+            "model": "dummy-model",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {
+                    "role": "assistant",
+                    "content": "first",
+                    "prompt_token_ids": [1, 2],
+                    "generation_token_ids": [3, 4],
+                    "generation_log_probs": [0.1, 0.2],
+                },
+            ],
+        }
+
+        result = model._preprocess_chat_completion_create_params(MagicMock(), body)
+
+        assert "required_prefix_token_ids" not in result
+        assert result["messages"][1]["prompt_token_ids"] == [1, 2]
+        assert result["messages"][1]["generation_token_ids"] == [3, 4]
+        assert "required_prefix_token_ids" not in result["messages"][1]
+
+    def test_dynamo_flag_rewrites_token_ids_per_message(self) -> None:
+        model = _make_required_prefix_token_ids_model(send_required_prefix_token_ids_dynamo=True)
+        body = {
+            "model": "dummy-model",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {
+                    "role": "assistant",
+                    "content": "first",
+                    "prompt_token_ids": [1, 2],
+                    "generation_token_ids": [3, 4],
+                    "generation_log_probs": [0.1, 0.2],
+                },
+                {"role": "user", "content": "again"},
+                {
+                    "role": "assistant",
+                    "content": "second",
+                    "prompt_token_ids": [10],
+                    "generation_token_ids": [11],
+                    "generation_log_probs": [0.3],
+                },
+            ],
+        }
+
+        result = model._preprocess_chat_completion_create_params(MagicMock(), body)
+
+        assert "required_prefix_token_ids" not in result
+        assert result["messages"][1]["required_prefix_token_ids"] == [1, 2, 3, 4]
+        assert result["messages"][3]["required_prefix_token_ids"] == [10, 11]
+        assert "prompt_token_ids" not in result["messages"][1]
+        assert "generation_token_ids" not in result["messages"][1]
+        assert result["messages"][1]["generation_log_probs"] == [0.1, 0.2]
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Audio sidechannel splice (metadata.audio_data → user-message content block)
 #


### PR DESCRIPTION
…nize

When per-message prompt_token_ids/generation_token_ids are attached to assistant messages (training mode), populate the top-level required_prefix_token_ids field on both the chat-completion request and the separate tokenize request. Mirrors NeMoRLOpenAIChatRequestMixin auto-derive in nemo-rl's custom vLLM serving (vllm_worker_async.py).

Without this, Dynamo - which has the splice machinery server-side but no auto-derive - re-tokenizes the chat history each turn, breaking the byte-level token-contiguity invariant on multi-turn rollouts. The fix must apply to BOTH endpoints because the contiguity assert in nemo_rl/environments/nemo_gym.py reads prompt_token_ids from the tokenize response, not the chat response. Patching only chat fails at the tokenize step.