### PR TITLE
ci(fern): generate library reference before publishing docs

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -53,6 +53,12 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Generate library reference
+        env:
+          FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
+        working-directory: ./fern
+        run: npm run generate:library
+
       - name: Publish Docs
         env:
           FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}


### PR DESCRIPTION
## Summary
- Publish workflow was failing with `Folder not found: ../product-docs/nemo-gym/Full-Library-Reference` because `fern/product-docs/` is gitignored and only exists after `fern docs md generate` runs.
- Adds a `Generate library reference` step (runs `npm run generate:library`) before `Publish Docs` so the library reference is populated when Fern resolves the docs definition.
- Not an auth issue — `FERN_TOKEN` was wired correctly; the publish step just had nothing to publish for the library section.

## Test plan
- [ ] Trigger the workflow via `workflow_dispatch` and confirm the `Generate library reference` step populates `fern/product-docs/nemo-gym/Full-Library-Reference` and the subsequent `Publish Docs` step succeeds.
- [ ] Verify the published site shows the Full Library Reference section under each version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)