### PR TITLE
Codex/equiv judge extraction

### DIFF
--- a/resources_servers/equivalence_llm_judge/app.py
+++ b/resources_servers/equivalence_llm_judge/app.py
@@ -76,6 +76,7 @@ class LLMJudgeResourcesServerConfig(BaseResourcesServerConfig):
     # The last match is used. If capture groups exist, the first non-empty group is
     # returned; otherwise, the entire last match is used.
     response_extract_regex: Optional[str] = None
+    msg_extraction_failure: str = "[NO VALID ANSWER EXTRACTED]"
 
     # Swap check: Run second judge pass with swapped expected/generated to detect positional bias
     check_twice_swap: bool = False
@@ -140,13 +141,15 @@ class LLMJudgeVerifyResponse(BaseVerifyResponse):
     judge_evaluations: list[JudgeEvaluation]
 
 
-def _extract_last_assistant_text(body: BaseVerifyRequest, extract_regex: Optional[str]) -> str:
+def _extract_last_assistant_text(
+    body: BaseVerifyRequest, extract_regex: Optional[str], extraction_failure_message: str = ""
+) -> str:
     """Extract the last assistant message text from the response.
 
     - If the assistant message has multiple text blocks, they are joined with newlines.
     - If ``extract_regex`` is provided, the last regex match is used; if capture
       groups exist, the first non-empty group is returned, otherwise the full match.
-    - Returns an empty string when no assistant text is available.
+    - Returns ``extraction_failure_message`` when no assistant text is available.
     """
     # Return only the last assistant message's text content.
     for o in reversed(body.response.output):
@@ -162,7 +165,7 @@ def _extract_last_assistant_text(body: BaseVerifyRequest, extract_regex: Optiona
                         texts.append(t)
                 text = "\n".join(texts).strip()
                 if not text:
-                    return text
+                    return extraction_failure_message
                 if extract_regex:
                     try:
                         matches = list(re.finditer(extract_regex, text, flags=re.MULTILINE | re.DOTALL))
@@ -181,7 +184,7 @@ def _extract_last_assistant_text(body: BaseVerifyRequest, extract_regex: Optiona
             elif isinstance(content, str):
                 text = content.strip()
                 if not text:
-                    return text
+                    return extraction_failure_message
                 if extract_regex:
                     try:
                         matches = list(re.finditer(extract_regex, text, flags=re.MULTILINE | re.DOTALL))
@@ -198,7 +201,7 @@ def _extract_last_assistant_text(body: BaseVerifyRequest, extract_regex: Optiona
                         return m.group(0).strip()
                 return text
             break
-    return ""
+    return extraction_failure_message
 
 
 def _extract_expected_answer(req: LLMJudgeRunRequest) -> Optional[str]:
@@ -353,7 +356,9 @@ class LLMJudgeResourcesServer(SimpleResourcesServer):
             and body.template_metadata.get("output_regex")
         ):
             # Retry with full generation (no regex) - rescue from regex extraction failure
-            generated_full = _extract_last_assistant_text(body, extract_regex=None)
+            generated_full = _extract_last_assistant_text(
+                body, extract_regex=None, extraction_failure_message=self.config.msg_extraction_failure
+            )
             second_equal, second_eval = await self._generate_judge_evaluation(
                 question=question, expected_answer=expected, generated_answer=generated_full
             )
@@ -415,7 +420,9 @@ class LLMJudgeResourcesServer(SimpleResourcesServer):
         # Step 3: Extract answer to judge
         # - If extract_regex is not None → regex-extracted answer
         # - If extract_regex is None (long answer) → full generation
-        generated = _extract_last_assistant_text(body, extract_regex)
+        generated = _extract_last_assistant_text(
+            body, extract_regex, extraction_failure_message=self.config.msg_extraction_failure
+        )
 
         # Step 4: Run first judge evaluation
         first_equal, first_eval = await self._generate_judge_evaluation(

--- a/resources_servers/equivalence_llm_judge/configs/equivalence_llm_judge.yaml
+++ b/resources_servers/equivalence_llm_judge/configs/equivalence_llm_judge.yaml
@@ -25,6 +25,7 @@ equivalence_llm_judge:
       # group is returned; otherwise, the entire last match is used.
       # Example: "^Answer:\\s*(.*)$"
       response_extract_regex: null
+      msg_extraction_failure: "[NO VALID ANSWER EXTRACTED]"
       
       # Swap check: Run second judge pass with swapped expected/generated to detect positional bias
       check_twice_swap: false

--- a/resources_servers/equivalence_llm_judge/configs/lc_judge.yaml
+++ b/resources_servers/equivalence_llm_judge/configs/lc_judge.yaml
@@ -16,6 +16,7 @@ lc_judge:
       reward_if_swap_fails: 0.0
       question_extract_regex: ^QUESTION:\s*(.*)$|</text>\n\n(.*)$
       response_extract_regex: null
+      msg_extraction_failure: "[NO VALID ANSWER EXTRACTED]"
       domain: knowledge
       verified: false
 lc_judge_simple_agent:

--- a/resources_servers/equivalence_llm_judge/configs/lc_judge.yaml
+++ b/resources_servers/equivalence_llm_judge/configs/lc_judge.yaml
@@ -16,7 +16,7 @@ lc_judge:
       reward_if_swap_fails: 0.0
       question_extract_regex: ^QUESTION:\s*(.*)$|</text>\n\n(.*)$
       response_extract_regex: null
-      msg_extraction_failure: "[NO VALID ANSWER EXTRACTED]"
+      msg_extraction_failure: ""
       domain: knowledge
       verified: false
 lc_judge_simple_agent:

--- a/resources_servers/equivalence_llm_judge/configs/nl2bash-equivalency.yaml
+++ b/resources_servers/equivalence_llm_judge/configs/nl2bash-equivalency.yaml
@@ -82,7 +82,7 @@ equivalence_llm_judge:
       # group is returned; otherwise, the entire last match is used.
       # Example: "^Answer:\\s*(.*)$"
       response_extract_regex: Answer:\s*```(?:\w+)?\s*([\s\S]*?)\s*```(?=[\s\S]*$)
-      msg_extraction_failure: "[NO VALID ANSWER EXTRACTED]"
+      msg_extraction_failure: ""
 
       # Swap check: Run second judge pass with swapped expected/generated to detect positional bias
       check_twice_swap: true

--- a/resources_servers/equivalence_llm_judge/configs/nl2bash-equivalency.yaml
+++ b/resources_servers/equivalence_llm_judge/configs/nl2bash-equivalency.yaml
@@ -82,6 +82,7 @@ equivalence_llm_judge:
       # group is returned; otherwise, the entire last match is used.
       # Example: "^Answer:\\s*(.*)$"
       response_extract_regex: Answer:\s*```(?:\w+)?\s*([\s\S]*?)\s*```(?=[\s\S]*$)
+      msg_extraction_failure: "[NO VALID ANSWER EXTRACTED]"
 
       # Swap check: Run second judge pass with swapped expected/generated to detect positional bias
       check_twice_swap: true
@@ -148,5 +149,3 @@ equivalence_llm_judge_simple_agent:
           version: 0.0.1
           artifact_fpath: nl2bash-super-validation-0901.jsonl
         license: GNU General Public License v3.0
-
-

--- a/resources_servers/equivalence_llm_judge/tests/test_app.py
+++ b/resources_servers/equivalence_llm_judge/tests/test_app.py
@@ -186,6 +186,39 @@ class TestApp:
         res = await rs.verify(req)
         assert res.reward == approx(0.0)
 
+    async def test_missing_assistant_text_uses_configured_failure_message(
+        self, config: LLMJudgeResourcesServerConfig
+    ) -> None:
+        server_mock = MagicMock(spec=ServerClient)
+        cfg = config.model_copy(deep=True)
+        cfg.msg_extraction_failure = "[CUSTOM EXTRACTION FAILURE]"
+        rs = LLMJudgeResourcesServer(config=cfg, server_client=server_mock)
+
+        post_mock = MagicMock()
+        post_mock.read = AsyncMock(return_value=self._create_response("f", self._msg("[[A!=B]]")))
+        server_mock.post = AsyncMock(return_value=post_mock)
+
+        req = LLMJudgeVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=NeMoGymResponse(
+                id="r",
+                created_at=0.0,
+                model="m",
+                object="response",
+                output=[],
+                parallel_tool_calls=False,
+                tool_choice="none",
+                tools=[],
+            ),
+            expected_answer="x",
+        )
+
+        res = await rs.verify(req)
+
+        judge_prompt = res.judge_evaluations[0].responses_create_params.input[-1].content
+        assert cfg.msg_extraction_failure in judge_prompt
+        assert res.reward == approx(0.0)
+
     async def test_swap_fails_uses_configured_reward(self, config: LLMJudgeResourcesServerConfig) -> None:
         server_mock = MagicMock(spec=ServerClient)
         cfg = config.model_copy(deep=True)


### PR DESCRIPTION
  - Adds configurable `msg_extraction_failure` support to the equivalence LLM judge.
  - Uses the configured failure message when assistant text cannot be extracted, instead of silently judging an empty string.
  - Applies the default failure message to the equivalence judge, LC judge, and NL2Bash equivalency configs.
  - Adds test coverage for missing assistant text using a custom configured failure message.

  lc_judge.yaml and nl2bash-equivalency.yaml set so the behavior did not change:
  ```msg_extraction_failure: ""```

  equivalence_llm_judge.yaml  uses:
  ```msg_extraction_failure: "[NO VALID ANSWER EXTRACTED]"```

replacement of https://github.com/NVIDIA-NeMo/Gym/pull/1272