### PR TITLE
Support sharded rollout aggregation via ng_aggregate_rollouts

### DIFF
--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -538,7 +538,12 @@ class RolloutAggregationConfig(BaseNeMoGymCLIConfig):
     """
 
     input_glob: str = Field(
-        description="Glob pattern matching the rollout shards to aggregate (e.g. 'results/rollouts-rs*-chunk*.jsonl')."
+        description=(
+            "Glob pattern or comma-separated list of glob patterns matching the rollout shards "
+            "to aggregate (e.g. 'results/rollouts-rs*-chunk*.jsonl' or "
+            "'results/run1/rollouts.jsonl,results/run2/rollouts.jsonl'). Whitespace around "
+            "commas is stripped. Duplicate matches across patterns are deduplicated."
+        )
     )
     output_jsonl_fpath: str = Field(
         description=(
@@ -553,9 +558,24 @@ class RolloutAggregationConfig(BaseNeMoGymCLIConfig):
     )
 
 
+def _expand_input_glob(input_glob: str) -> List[str]:
+    """Expand a glob-or-comma-separated-globs string into a sorted, deduplicated list of paths.
+
+    Examples:
+      'results/rollouts.jsonl' -> ['results/rollouts.jsonl'] (if it exists)
+      'a/*.jsonl, b/*.jsonl'   -> matches of both patterns, deduplicated
+    """
+    patterns = [p.strip() for p in input_glob.split(",") if p.strip()]
+    seen: Dict[str, None] = {}  # preserve insertion order while deduping
+    for pattern in patterns:
+        for path in sorted(glob_module.glob(pattern)):
+            seen.setdefault(path, None)
+    return list(seen)
+
+
 class RolloutAggregationHelper(BaseModel):
     async def run_from_config(self, config: RolloutAggregationConfig) -> Optional[Path]:
-        input_paths = sorted(glob_module.glob(config.input_glob))
+        input_paths = _expand_input_glob(config.input_glob)
         if not input_paths:
             raise FileNotFoundError(f"No shards matched input_glob={config.input_glob!r}")
         print(f"Aggregating {len(input_paths)} shard(s):")

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import glob as glob_module
 import json
 from asyncio import Future, Semaphore
 from collections import Counter
@@ -63,6 +64,14 @@ class SharedRolloutCollectionConfig(BaseNeMoGymCLIConfig):
     upload_rollouts_to_wandb: bool = Field(
         default=True,
         description="Upload the rollouts to W&B. Sometimes this should be off because the rollouts are massive. Default: True",
+    )
+    disable_aggregation: bool = Field(
+        default=False,
+        description=(
+            "Skip the post-rollout aggregate-metrics computation and file write. "
+            "Used when sharding rollouts across multiple jobs that will be aggregated together "
+            "afterward by `ng_aggregate_rollouts`."
+        ),
     )
 
 
@@ -207,8 +216,12 @@ class RolloutCollectionHelper(BaseModel):
                 row[RESPONSES_CREATE_PARAMS_KEY_NAME] | responses_create_params_overrides
             )
 
-            # Resolve task index
-            row[TASK_INDEX_KEY_NAME] = row_to_task_idx.setdefault(row_str, len(row_to_task_idx))
+            # Resolve task index. Honor a caller-provided value when present (e.g. when an
+            # upstream slicer has stamped a globally-stable index across chunks so that
+            # subsequent /aggregate_metrics groupby unions chunks correctly); otherwise dedupe
+            # identical input rows to the same task index as before.
+            if TASK_INDEX_KEY_NAME not in row:
+                row[TASK_INDEX_KEY_NAME] = row_to_task_idx.setdefault(row_str, len(row_to_task_idx))
 
             for _ in range(num_repeats):
                 row = deepcopy(row)
@@ -342,8 +355,15 @@ class RolloutCollectionHelper(BaseModel):
         results.sort(key=lambda r: (r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME]))
 
         # Compute and write aggregate metrics via /aggregate_metrics on each agent server
-        print("Computing aggregate metrics")
-        aggregate_metrics_fpath = await self._call_aggregate_metrics(results, rows, output_fpath)
+        if config.disable_aggregation:
+            print(
+                "Skipping aggregate-metrics computation because disable_aggregation=True. "
+                "Run `ng_aggregate_rollouts` after all shards finish to compute the global metrics."
+            )
+            aggregate_metrics_fpath = None
+        else:
+            print("Computing aggregate metrics")
+            aggregate_metrics_fpath = await self._call_aggregate_metrics(results, rows, output_fpath)
 
         print(f"""Finished rollout collection! View results at:
 Fully materialized inputs: {config.materialized_jsonl_fpath}
@@ -496,3 +516,87 @@ def collect_rollouts():  # pragma: no cover
     rch = RolloutCollectionHelper()
 
     asyncio.run(rch.run_from_config(config))
+
+
+class RolloutAggregationConfig(BaseNeMoGymCLIConfig):
+    """
+    Aggregate metrics across rollout shards produced by `ng_collect_rollouts +disable_aggregation=true`.
+
+    Reads every JSONL file matching `input_glob`, computes aggregate metrics by POSTing to each
+    agent server's `/aggregate_metrics` endpoint over the global union of records, and writes a
+    single `<output_jsonl_fpath stem>_aggregate_metrics.json` next to the rollouts. By default
+    also concatenates all shards into `output_jsonl_fpath`.
+
+    Examples:
+
+    ```bash
+    ng_aggregate_rollouts \
+        "+config_paths=[benchmarks/aime24/config.yaml,responses_api_models/vllm_model/configs/vllm_model.yaml]" \
+        +input_glob='results/rollouts-rs*-chunk*.jsonl' \
+        +output_jsonl_fpath=results/rollouts.jsonl
+    ```
+    """
+
+    input_glob: str = Field(
+        description="Glob pattern matching the rollout shards to aggregate (e.g. 'results/rollouts-rs*-chunk*.jsonl')."
+    )
+    output_jsonl_fpath: str = Field(
+        description=(
+            "Path used to derive the aggregate-metrics output location "
+            "('<stem>_aggregate_metrics.json' next to this path) and, when merge_shards=True, "
+            "the merged-rollouts file."
+        ),
+    )
+    merge_shards: bool = Field(
+        default=True,
+        description="Concatenate the matched shard JSONLs into output_jsonl_fpath alongside the metrics file.",
+    )
+
+
+class RolloutAggregationHelper(BaseModel):
+    async def run_from_config(self, config: RolloutAggregationConfig) -> Optional[Path]:
+        input_paths = sorted(glob_module.glob(config.input_glob))
+        if not input_paths:
+            raise FileNotFoundError(f"No shards matched input_glob={config.input_glob!r}")
+        print(f"Aggregating {len(input_paths)} shard(s):")
+        for p in input_paths:
+            print(f"  - {p}")
+
+        results: List[Dict] = []
+        for shard_path in input_paths:
+            with open(shard_path, "rb") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    results.append(orjson.loads(line))
+        print(f"Loaded {len(results)} rollout record(s) from {len(input_paths)} shard(s)")
+
+        # Sort for deterministic aggregation ordering (matches run_from_config's post-collection sort)
+        results.sort(key=lambda r: (r.get(TASK_INDEX_KEY_NAME), r.get(ROLLOUT_INDEX_KEY_NAME)))
+
+        output_fpath = Path(config.output_jsonl_fpath)
+        output_fpath.parent.mkdir(parents=True, exist_ok=True)
+
+        if config.merge_shards:
+            print(f"Merging shards into {output_fpath}")
+            with output_fpath.open("wb") as out:
+                for r in results:
+                    out.write(orjson.dumps(r) + b"\n")
+
+        # `_call_aggregate_metrics` only inspects each row's AGENT_REF_KEY_NAME, which results already carry.
+        helper = RolloutCollectionHelper()
+        aggregate_metrics_fpath = await helper._call_aggregate_metrics(results, results, output_fpath)
+
+        print(f"""Finished rollout aggregation! View results at:
+Merged rollouts: {output_fpath if config.merge_shards else "<not merged>"}
+Aggregate metrics: {aggregate_metrics_fpath}""")
+
+        return aggregate_metrics_fpath
+
+
+def aggregate_rollouts():  # pragma: no cover
+    config = RolloutAggregationConfig.model_validate(get_global_config_dict())
+    rah = RolloutAggregationHelper()
+
+    asyncio.run(rah.run_from_config(config))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -331,6 +331,8 @@ nemo_gym_collect_rollouts = "nemo_gym.rollout_collection:collect_rollouts"
 ng_collect_rollouts = "nemo_gym.rollout_collection:collect_rollouts"
 nemo_gym_e2e_collect_rollouts = "nemo_gym.cli:e2e_rollout_collection"
 ng_e2e_collect_rollouts = "nemo_gym.cli:e2e_rollout_collection"
+nemo_gym_aggregate_rollouts = "nemo_gym.rollout_collection:aggregate_rollouts"
+ng_aggregate_rollouts = "nemo_gym.rollout_collection:aggregate_rollouts"
 
 # Prompt materialization
 nemo_gym_materialize_prompts = "nemo_gym.prompt:materialize_prompts_cli"

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -27,6 +27,8 @@ from nemo_gym.global_config import AGENT_REF_KEY_NAME, ROLLOUT_INDEX_KEY_NAME, T
 from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
 from nemo_gym.reward_profile import compute_aggregate_metrics
 from nemo_gym.rollout_collection import (
+    RolloutAggregationConfig,
+    RolloutAggregationHelper,
     RolloutCollectionConfig,
     RolloutCollectionHelper,
     _expand_input_glob,
@@ -732,3 +734,191 @@ class TestExpandInputGlob:
         a.write_text("{}\n")
         result = _expand_input_glob(f",{a},,")
         assert result == [str(a)]
+
+
+class TestDisableAggregationAndCallerTaskIndex:
+    """Branches added for sharded rollouts: `disable_aggregation` flag and
+    caller-provided `_ng_task_index`. Both must be backward-compatible with
+    the existing default-on aggregation + auto-numbering behaviour.
+    """
+
+    async def test_run_from_config_disable_aggregation_skips_call(self, tmp_path: Path) -> None:
+        """When disable_aggregation=True, _call_aggregate_metrics MUST NOT run.
+
+        Shows up in chunked-rollouts flows where the aggregation pass is deferred
+        to a single ng_aggregate_rollouts run over the union of shards.
+        """
+        input_jsonl_fpath = tmp_path / "input.jsonl"
+        input_jsonl_fpath.write_text(
+            json.dumps({"responses_create_params": {"input": []}, "agent_ref": {"name": "a"}, "x": 0}) + "\n"
+        )
+        output_jsonl_fpath = tmp_path / "output.jsonl"
+
+        config = RolloutCollectionConfig(
+            input_jsonl_fpath=str(input_jsonl_fpath),
+            output_jsonl_fpath=str(output_jsonl_fpath),
+            disable_aggregation=True,
+            num_repeats=1,
+        )
+
+        class Helper(RolloutCollectionHelper):
+            def run_examples(self, examples, *args, **kwargs):
+                futures = []
+                for ex in examples:
+                    fut = Future()
+                    fut.set_result((ex, {"response": {"usage": {}}}))
+                    futures.append(fut)
+                return futures
+
+            async def _call_aggregate_metrics(self, results, rows, output_fpath):
+                raise AssertionError("aggregator must not run when disable_aggregation=True")
+
+        await Helper().run_from_config(config)
+
+        # Rollouts file written (proves the rollout phase ran); aggregator file absent.
+        assert output_jsonl_fpath.exists()
+        assert not (tmp_path / "output_aggregate_metrics.json").exists()
+
+    def test_preprocess_honors_caller_task_index(self, tmp_path: Path) -> None:
+        """A row arriving with `_ng_task_index` pre-set is used verbatim — the
+        original `row_to_task_idx` auto-numbering is bypassed. This is the seam
+        an upstream slicer relies on to keep task identifiers globally-stable
+        across shards.
+        """
+        fpath = tmp_path / "input.jsonl"
+        rows = [
+            # Same prompt twice with *different* caller-stamped indices — must
+            # NOT be collapsed to one task by the row_str dedup path.
+            {"responses_create_params": {"input": []}, "agent_ref": {"name": "a"}, TASK_INDEX_KEY_NAME: 42},
+            {"responses_create_params": {"input": []}, "agent_ref": {"name": "a"}, TASK_INDEX_KEY_NAME: 99},
+            # And a third row with no caller index — auto-numbering still applies.
+            {"responses_create_params": {"input": []}, "agent_ref": {"name": "a"}, "diff": "row"},
+        ]
+        fpath.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+        config = RolloutCollectionConfig(
+            agent_name="a",
+            input_jsonl_fpath=str(fpath),
+            output_jsonl_fpath=str(tmp_path / "out.jsonl"),
+            num_repeats=1,
+        )
+
+        result = RolloutCollectionHelper._preprocess_rows_from_config(None, config)
+        indices = [r[TASK_INDEX_KEY_NAME] for r in result]
+
+        # Caller-provided indices preserved; the no-index row gets an auto-generated
+        # one starting at 0 (the row_to_task_idx counter is independent of caller stamps).
+        assert indices[:2] == [42, 99]
+        assert indices[2] == 0  # auto-assigned; not 100 or 43
+
+
+class TestRolloutAggregationHelper:
+    """End-to-end shape of `ng_aggregate_rollouts`: glob → load → sort → aggregate."""
+
+    async def test_run_from_config_full_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Two shards. Records have globally-stamped task indices (out of order)
+        # — the helper should sort by (task_index, rollout_index) before calling
+        # _call_aggregate_metrics so downstream groupby is deterministic.
+        shard0 = tmp_path / "rollouts-chunk0.jsonl"
+        shard1 = tmp_path / "rollouts-chunk1.jsonl"
+        records_shard0 = [
+            {
+                AGENT_REF_KEY_NAME: {"name": "a"},
+                TASK_INDEX_KEY_NAME: 1,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                "response": {"usage": {"x": 2}},
+                "reward": 1.0,
+            },
+            {
+                AGENT_REF_KEY_NAME: {"name": "a"},
+                TASK_INDEX_KEY_NAME: 0,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                "response": {"usage": {"x": 1}},
+                "reward": 0.0,
+            },
+        ]
+        records_shard1 = [
+            {
+                AGENT_REF_KEY_NAME: {"name": "a"},
+                TASK_INDEX_KEY_NAME: 2,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                "response": {"usage": {"x": 3}},
+                "reward": 1.0,
+            },
+        ]
+        shard0.write_text("\n".join(json.dumps(r) for r in records_shard0) + "\n")
+        shard1.write_text("\n".join(json.dumps(r) for r in records_shard1) + "\n")
+
+        output_fpath = tmp_path / "rollouts.jsonl"
+
+        captured: dict[str, list] = {}
+
+        async def fake_call(self, results, rows, output_fpath):
+            captured["results"] = results
+            captured["rows"] = rows
+            captured["output_fpath"] = output_fpath
+            # Touch a sentinel file so the helper's return value is meaningful.
+            metrics_fpath = output_fpath.with_stem(output_fpath.stem + "_aggregate_metrics").with_suffix(".json")
+            metrics_fpath.write_text("[]")
+            return metrics_fpath
+
+        monkeypatch.setattr(RolloutCollectionHelper, "_call_aggregate_metrics", fake_call)
+
+        cfg = RolloutAggregationConfig(
+            input_glob=f"{shard0},{shard1}",
+            output_jsonl_fpath=str(output_fpath),
+            merge_shards=True,
+        )
+        metrics_fpath = await RolloutAggregationHelper().run_from_config(cfg)
+
+        # 3 records total, sorted by (task_index, rollout_index): tasks 0, 1, 2.
+        assert [r[TASK_INDEX_KEY_NAME] for r in captured["results"]] == [0, 1, 2]
+        # rows passed twice == results (helper uses results both ways since each
+        # row already carries AGENT_REF_KEY_NAME).
+        assert captured["rows"] is captured["results"]
+        # Merged shard concatenation honoured (merge_shards=True).
+        assert output_fpath.exists()
+        assert sum(1 for _ in output_fpath.open()) == 3
+        # Metrics file path returned and points next to the merged JSONL.
+        assert metrics_fpath == tmp_path / "rollouts_aggregate_metrics.json"
+        assert metrics_fpath.exists()
+
+    async def test_run_from_config_no_matches_raises(self, tmp_path: Path) -> None:
+        cfg = RolloutAggregationConfig(
+            input_glob=str(tmp_path / "nothing-matches-*.jsonl"),
+            output_jsonl_fpath=str(tmp_path / "out.jsonl"),
+        )
+        with pytest.raises(FileNotFoundError, match="No shards matched"):
+            await RolloutAggregationHelper().run_from_config(cfg)
+
+    async def test_run_from_config_merge_shards_false_skips_concat(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        shard = tmp_path / "shard.jsonl"
+        record = {
+            AGENT_REF_KEY_NAME: {"name": "a"},
+            TASK_INDEX_KEY_NAME: 0,
+            ROLLOUT_INDEX_KEY_NAME: 0,
+            "response": {"usage": {}},
+            "reward": 0.5,
+        }
+        shard.write_text(json.dumps(record) + "\n")
+        output_fpath = tmp_path / "rollouts.jsonl"
+
+        async def _noop(self, results, rows, output_fpath):
+            m = output_fpath.with_stem(output_fpath.stem + "_aggregate_metrics").with_suffix(".json")
+            m.write_text("[]")
+            return m
+
+        monkeypatch.setattr(RolloutCollectionHelper, "_call_aggregate_metrics", _noop)
+        cfg = RolloutAggregationConfig(
+            input_glob=str(shard),
+            output_jsonl_fpath=str(output_fpath),
+            merge_shards=False,
+        )
+        await RolloutAggregationHelper().run_from_config(cfg)
+
+        # merge_shards=False ⇒ no concatenated rollouts file is written, even
+        # though output_jsonl_fpath is used to derive the metrics path.
+        assert not output_fpath.exists()
+        assert (tmp_path / "rollouts_aggregate_metrics.json").exists()

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -29,6 +29,7 @@ from nemo_gym.reward_profile import compute_aggregate_metrics
 from nemo_gym.rollout_collection import (
     RolloutCollectionConfig,
     RolloutCollectionHelper,
+    _expand_input_glob,
     _rollout_request_debug_summary,
 )
 
@@ -668,3 +669,66 @@ class TestRolloutCollection:
         output_fpath = tmp_path / "output.jsonl"
         result = await helper._call_aggregate_metrics([], [], output_fpath)
         assert result is None
+
+
+class TestExpandInputGlob:
+    """`_expand_input_glob` accepts a single glob, a comma-separated list of globs, or a mix.
+
+    Mirrors the multi-pattern conventions used elsewhere in NeMo Skills
+    (e.g. comma-separated `config_paths` on `ns nemo_gym_rollouts`).
+    """
+
+    def test_single_path(self, tmp_path: Path) -> None:
+        a = tmp_path / "a.jsonl"
+        a.write_text("{}\n")
+        assert _expand_input_glob(str(a)) == [str(a)]
+
+    def test_single_glob(self, tmp_path: Path) -> None:
+        for i in range(3):
+            (tmp_path / f"rollouts-chunk{i}.jsonl").write_text("{}\n")
+        result = _expand_input_glob(str(tmp_path / "rollouts-chunk*.jsonl"))
+        assert result == sorted(str(tmp_path / f"rollouts-chunk{i}.jsonl") for i in range(3))
+
+    def test_comma_separated_paths(self, tmp_path: Path) -> None:
+        a = tmp_path / "a.jsonl"
+        b = tmp_path / "b.jsonl"
+        a.write_text("{}\n")
+        b.write_text("{}\n")
+        result = _expand_input_glob(f"{a},{b}")
+        assert set(result) == {str(a), str(b)}
+
+    def test_comma_separated_globs(self, tmp_path: Path) -> None:
+        for sub in ("run1", "run2"):
+            (tmp_path / sub).mkdir()
+            (tmp_path / sub / "rollouts.jsonl").write_text("{}\n")
+            (tmp_path / sub / "extra.txt").write_text("ignore me")
+        result = _expand_input_glob(f"{tmp_path / 'run1' / 'rollouts*.jsonl'},{tmp_path / 'run2' / 'rollouts*.jsonl'}")
+        assert set(result) == {
+            str(tmp_path / "run1" / "rollouts.jsonl"),
+            str(tmp_path / "run2" / "rollouts.jsonl"),
+        }
+
+    def test_whitespace_around_commas_is_stripped(self, tmp_path: Path) -> None:
+        a = tmp_path / "a.jsonl"
+        b = tmp_path / "b.jsonl"
+        a.write_text("{}\n")
+        b.write_text("{}\n")
+        result = _expand_input_glob(f"  {a}  ,  {b}  ")
+        assert set(result) == {str(a), str(b)}
+
+    def test_overlapping_patterns_dedup(self, tmp_path: Path) -> None:
+        """A file matched by two patterns appears once in the output."""
+        a = tmp_path / "a.jsonl"
+        a.write_text("{}\n")
+        result = _expand_input_glob(f"{tmp_path / '*.jsonl'},{a}")
+        assert result == [str(a)]
+
+    def test_no_matches_returns_empty(self, tmp_path: Path) -> None:
+        assert _expand_input_glob(str(tmp_path / "nonexistent-*.jsonl")) == []
+
+    def test_empty_strings_in_csv_are_dropped(self, tmp_path: Path) -> None:
+        """Trailing/leading commas don't produce an empty-pattern glob that matches everything."""
+        a = tmp_path / "a.jsonl"
+        a.write_text("{}\n")
+        result = _expand_input_glob(f",{a},,")
+        assert result == [str(a)]


### PR DESCRIPTION
## Summary

- Add `disable_aggregation: bool = False` to `ng_collect_rollouts`. When `true`, the rollouts write the per-sample rollouts JSONL as usual but skips the post-rollout `/aggregate_metrics` call and the `_aggregate_metrics.json` write. Default behaviour is unchanged.
- New `ng_aggregate_rollouts` CLI (`nemo_gym.rollout_collection:aggregate_rollouts`) that reads rollout shards from a glob, sorts records by `(_ng_task_index, _ng_rollout_index)`, and runs the same `_call_aggregate_metrics` helper `ng_collect_rollouts` already uses. Writes the standard `<output_stem>_aggregate_metrics.json` next to the rollouts; optionally concatenates the shards into `output_jsonl_fpath` (`merge_shards`, default true).
- `input_glob` accepts a single glob, a comma-separated list of globs, or a mix. 
- Honour a caller-provided `_ng_task_index` on input rows. When present, the existing `row_to_task_idx` auto-numbering is bypassed and the value is used verbatim. Lets upstream slicers stamp a globally-stable task identifier so a subsequent `/aggregate_metrics` groupby unions rollouts from sharded runs correctly.

## Motivation

For non-decomposable metrics (`pass@k`, `majority@k`, Arena-Elo MLE+bootstrap, classification F1, ...) the post-rollout aggregation must see every record exactly once. A multi-job sharded rollout collection therefore needs:

1. Each shard collects rollouts without computing local-only metrics.
2. After every shard finishes, a single aggregation pass over the union runs the agent server's `compute_metrics`.

These changes give the orchestrator a flag to skip inline aggregation, and a CLI that runs the existing aggregation logic over a glob of shards while keeping `ng_collect_rollouts`'s default behavior unchanged.


So e.g.,
```
ng_collect_rollouts(X)
  ≡ ng_collect_rollouts(X, disable_aggregation=true)
  + ng_aggregate_rollouts(<its output>)
```

## Example usage

```bash
# Step 1 — N shards collect with inline aggregation disabled
ng_collect_rollouts \
    "+config_paths=[benchmarks/aime24/config.yaml,responses_api_models/vllm_model/configs/vllm_model.yaml]" \
    +input_jsonl_fpath=shard_0.jsonl \
    +output_jsonl_fpath=results/rollouts-chunk0.jsonl \
    +disable_aggregation=true \
    +num_repeats=4

# ... (one ng_collect_rollouts per shard) ...

# Step 2 — global aggregation
ng_aggregate_rollouts \
    "+config_paths=[benchmarks/aime24/config.yaml,responses_api_models/vllm_model/configs/vllm_model.yaml]" \
    +input_glob='results/rollouts-chunk*.jsonl' \
    +output_jsonl_fpath=results/rollouts.jsonl
```

`input_glob` also accepts a comma-separated list of patterns:

```bash
ng_aggregate_rollouts ... \
    +input_glob='run1/rollouts-rs*-chunk*.jsonl, run2/rollouts-rs*-chunk*.jsonl' \
    +output_jsonl_fpath=combined/rollouts.jsonl
```

## Validation

Validated end-to-end on `math_with_judge` and `arena_judge`.