### PR TITLE
docs(fern): remove duplicate H1 on main home landing page

### DIFF
--- a/fern/versions/latest/pages/about/index.mdx
+++ b/fern/versions/latest/pages/about/index.mdx
@@ -4,8 +4,6 @@ description: "NeMo Gym is a library for evaluating and improving models and agen
 position: 1
 ---
 
-# NeMo Gym
-
 NeMo Gym is a library for evaluating and improving models and agents using environments. NeMo Gym provides infrastructure to develop environments, scalably run evaluation and training, and a collection of popular benchmarks and training environments.
 
 ## When to Use NeMo Gym


### PR DESCRIPTION
## Summary
- Fern auto-renders the frontmatter `title` as the page's H1. `fern/versions/latest/pages/about/index.mdx` (the `main` home landing per #1320) also has an explicit `# NeMo Gym` heading in the body, producing two stacked H1s.
- Remove the body heading; let the frontmatter title stand alone.

## Test plan
- [x] Confirmed frontmatter `title: "NeMo Gym"` is intact.
- [ ] Post-merge + republish: visit `https://nvidia-gym.docs.buildwithfern.com/nemo/gym/main` and confirm exactly one "NeMo Gym" H1 renders.