### PR TITLE
fix(stirrup_agent): libreoffice whitespace + reference_files double-nest

### DIFF
--- a/resources_servers/gdpval/preconvert.py
+++ b/resources_servers/gdpval/preconvert.py
@@ -98,19 +98,40 @@ def needs_conversion(path: Path) -> bool:
     return path.suffix.lower() in OFFICE_EXTENSIONS and not path.with_suffix(".pdf").exists()
 
 
+def _safe_basename(name: str) -> str:
+    """Sanitize a filename's stem for LibreOffice's batch-convert mode.
+
+    Whitespace in the input path makes LibreOffice's internal URI handling
+    drop arguments mid-flight, producing ``source file could not be loaded``
+    with rc=0. Replacing whitespace in the stem (extension preserved) and
+    staging via tempdir sidesteps the bug.
+    """
+    p = Path(name)
+    return re.sub(r"\s+", "_", p.stem) + p.suffix
+
+
 def convert_to_pdf(path: Path) -> tuple[Path, bool, str]:
     """Convert one file to PDF via host LibreOffice. Returns ``(path, ok, msg)``."""
-    output_dir = str(path.parent)
     profile_dir = Path(tempfile.mkdtemp(prefix="lo-profile-"))
-    norm_dir: Path | None = None
+    stage_dir: Path | None = None
     input_path = path
     normalized = False
+    needs_ns0_normalization = _ooxml_has_ns0_prefix(path)
+    has_whitespace = any(c.isspace() for c in path.name)
+    needs_stage = needs_ns0_normalization or has_whitespace
     try:
-        if _ooxml_has_ns0_prefix(path):
-            norm_dir = Path(tempfile.mkdtemp(prefix="gdpval-norm-"))
-            input_path = norm_dir / path.name
-            _normalize_ooxml_zip(path, input_path)
-            normalized = True
+        if needs_stage:
+            stage_dir = Path(tempfile.mkdtemp(prefix="gdpval-stage-"))
+            staged_name = _safe_basename(path.name) if has_whitespace else path.name
+            input_path = stage_dir / staged_name
+            if needs_ns0_normalization:
+                _normalize_ooxml_zip(path, input_path)
+                normalized = True
+            else:
+                shutil.copy2(path, input_path)
+            lo_outdir = str(stage_dir)
+        else:
+            lo_outdir = str(path.parent)
 
         result = subprocess.run(
             [
@@ -124,21 +145,25 @@ def convert_to_pdf(path: Path) -> tuple[Path, bool, str]:
                 "--convert-to",
                 "pdf",
                 "--outdir",
-                output_dir,
+                lo_outdir,
                 str(input_path),
             ],
             capture_output=True,
             text=True,
             timeout=120,
         )
-        pdf_path = path.with_suffix(".pdf")
-        if pdf_path.exists():
+        final_pdf = path.with_suffix(".pdf")
+        if needs_stage:
+            staged_pdf = Path(lo_outdir) / (input_path.stem + ".pdf")
+            if staged_pdf.exists():
+                shutil.move(str(staged_pdf), str(final_pdf))
+        if final_pdf.exists():
             suffix = " (after ns0 normalization)" if normalized else ""
             return path, True, f"converted {path.name}{suffix}"
         return (
             path,
             False,
-            f"libreoffice rc={result.returncode} did not produce {pdf_path.name}: {result.stderr.strip()[:300]}",
+            f"libreoffice rc={result.returncode} did not produce {final_pdf.name}: {result.stderr.strip()[:300]}",
         )
     except subprocess.TimeoutExpired:
         return path, False, f"timeout converting {path.name}"
@@ -148,8 +173,8 @@ def convert_to_pdf(path: Path) -> tuple[Path, bool, str]:
         return path, False, f"error converting {path.name}: {exc!r}"
     finally:
         shutil.rmtree(profile_dir, ignore_errors=True)
-        if norm_dir is not None:
-            shutil.rmtree(norm_dir, ignore_errors=True)
+        if stage_dir is not None:
+            shutil.rmtree(stage_dir, ignore_errors=True)
 
 
 def find_convertible_files(root_dir: str | os.PathLike) -> list[Path]:

--- a/resources_servers/gdpval/tests/test_preconvert.py
+++ b/resources_servers/gdpval/tests/test_preconvert.py
@@ -291,8 +291,11 @@ class TestConvertToPdfNormalization:
 
         def _run(cmd, *_a, **_kw):
             captured.append(cmd)
-            # libreoffice would write the PDF to the original outdir using the input stem.
-            (src.with_suffix(".pdf")).write_bytes(b"%PDF-1.4 fake\n")
+            # libreoffice writes <--outdir>/<input_stem>.pdf — convert_to_pdf
+            # now stages into a tempdir and moves the PDF back.
+            outdir = Path(cmd[cmd.index("--outdir") + 1])
+            input_arg = Path(cmd[-1])
+            (outdir / (input_arg.stem + ".pdf")).write_bytes(b"%PDF-1.4 fake\n")
             return _Completed()
 
         monkeypatch.setattr(subprocess, "run", _run)
@@ -300,12 +303,14 @@ class TestConvertToPdfNormalization:
         assert ok is True
         assert "(after ns0 normalization)" in msg
         # The input arg passed to libreoffice should NOT be the original file: it must come
-        # from the gdpval-norm- tempdir, but with the same basename so output stem is preserved.
+        # from the gdpval-stage- tempdir, but with the same basename so output stem is preserved.
         assert len(captured) == 1
         input_arg = captured[0][-1]
         assert input_arg.endswith("/src.docx")
-        assert "/gdpval-norm-" in input_arg
+        assert "/gdpval-stage-" in input_arg
         assert input_arg != str(src)
+        # PDF should land at the caller's expected location after stage→move.
+        assert src.with_suffix(".pdf").exists()
 
     def test_calls_libreoffice_with_original_when_not_ns0(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -335,3 +340,40 @@ class TestConvertToPdfNormalization:
         assert ok is True
         assert "(after ns0 normalization)" not in msg
         assert captured[0][-1] == str(src)
+
+    def test_stages_when_path_has_whitespace(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # GDPVal HF filenames such as ``Population v2.xlsx`` make LibreOffice's
+        # batch-convert mode silently drop the input; ``convert_to_pdf`` must
+        # stage to a tempdir with a sanitized basename and move the PDF back.
+        src = _make_zip(
+            tmp_path / "Population v2.xlsx",
+            {
+                "[Content_Types].xml": DEFAULT_NS_CONTENT_TYPES,
+                "_rels/.rels": DEFAULT_NS_RELS,
+                "word/document.xml": DOCUMENT_XML,
+            },
+        )
+        captured: list[list[str]] = []
+
+        class _Completed:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _run(cmd, *_a, **_kw):
+            captured.append(cmd)
+            outdir = Path(cmd[cmd.index("--outdir") + 1])
+            input_arg = Path(cmd[-1])
+            (outdir / (input_arg.stem + ".pdf")).write_bytes(b"%PDF-1.4 fake\n")
+            return _Completed()
+
+        monkeypatch.setattr(subprocess, "run", _run)
+        path, ok, msg = pcv.convert_to_pdf(src)
+        assert ok is True
+        assert len(captured) == 1
+        input_arg = captured[0][-1]
+        assert " " not in Path(input_arg).name
+        assert Path(input_arg).name == "Population_v2.xlsx"
+        assert "/gdpval-stage-" in input_arg
+        # PDF must end up next to the original with the original stem.
+        assert (tmp_path / "Population v2.pdf").exists()

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -409,8 +409,22 @@ async def _run_stirrup_agent(
 
             # 6. Reference files
             if input_files_dir and Path(input_files_dir).is_dir():
-                ref_dest = task_dir / "reference_files"
-                shutil.copytree(input_files_dir, ref_dest, dirs_exist_ok=True)
+                # ``_download_reference_files`` writes each ``file_path`` from the
+                # dataset row directly under ``input_files_dir``. The GDPVal HF
+                # corpus prefixes every entry with ``reference_files/`` (matching
+                # the dataset's directory layout), so ``input_files_dir`` already
+                # contains a top-level ``reference_files/`` subdir. Copying into
+                # another ``task_dir/reference_files/`` produced double-nested
+                # ``task_dir/reference_files/reference_files/...`` which made
+                # comparison.py's non-recursive ``build_file_section`` see zero
+                # references. Merge contents directly when the prefix is present;
+                # otherwise fall back to wrapping in ``reference_files/`` for
+                # datasets that don't bake the prefix into the file paths.
+                src = Path(input_files_dir)
+                if (src / "reference_files").is_dir():
+                    shutil.copytree(src, task_dir, dirs_exist_ok=True)
+                else:
+                    shutil.copytree(src, task_dir / "reference_files", dirs_exist_ok=True)
 
             print(f"[stirrup] persisted task artifacts to {task_dir}", flush=True)
     finally:

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import base64
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -179,12 +180,29 @@ def _convert_office_to_pdf(fpath: Path) -> Path | None:
 
     Returns the path to the generated PDF, or None on failure.
     Uses a unique user profile to avoid lock conflicts in concurrent workers.
+
+    Whitespace in the input filename makes LibreOffice's batch-convert mode
+    silently drop the file (the URI it builds isn't percent-encoded), so we
+    stage the input to a tempdir with a sanitized basename and move the PDF
+    back to the original location.
     """
     profile_dir = Path(tempfile.mkdtemp(prefix="lo-profile-"))
     user_install = f"file://{profile_dir.as_posix()}"
     out_pdf = fpath.with_suffix(".pdf")
+    stage_dir: Path | None = None
+    input_path = fpath
+    has_whitespace = any(c.isspace() for c in fpath.name)
 
     try:
+        if has_whitespace:
+            stage_dir = Path(tempfile.mkdtemp(prefix="lo-stage-"))
+            safe_name = re.sub(r"\s+", "_", fpath.stem) + fpath.suffix
+            input_path = stage_dir / safe_name
+            shutil.copy2(fpath, input_path)
+            lo_outdir = str(stage_dir)
+        else:
+            lo_outdir = str(fpath.parent)
+
         cmd = [
             "libreoffice",
             "--headless",
@@ -196,10 +214,14 @@ def _convert_office_to_pdf(fpath: Path) -> Path | None:
             "--convert-to",
             "pdf",
             "--outdir",
-            str(fpath.parent),
-            str(fpath),
+            lo_outdir,
+            str(input_path),
         ]
         p = subprocess.run(cmd, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=120)
+        if stage_dir is not None:
+            staged_pdf = stage_dir / (input_path.stem + ".pdf")
+            if staged_pdf.exists():
+                shutil.move(str(staged_pdf), str(out_pdf))
         if p.returncode != 0 or not out_pdf.exists():
             print(f"[file_reader] LibreOffice conversion failed for {fpath.name}: {p.stderr[:200]}", flush=True)
             return None
@@ -209,6 +231,8 @@ def _convert_office_to_pdf(fpath: Path) -> Path | None:
         return None
     finally:
         shutil.rmtree(profile_dir, ignore_errors=True)
+        if stage_dir is not None:
+            shutil.rmtree(stage_dir, ignore_errors=True)
 
 
 def convert_deliverables_to_content_blocks(output_dir: str) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

Two related GDPVal bugs that bias comparison-mode scoring.

### 1. LibreOffice preconvert silently drops files with whitespace in the filename

`convert_to_pdf` in `resources_servers/gdpval/preconvert.py` (and the sibling `_convert_office_to_pdf` in `responses_api_agents/stirrup_agent/file_reader.py`) passes `str(input_path)` straight to `libreoffice --convert-to pdf`. The GDPVal HF corpus includes filenames like `Population v2.xlsx`; libreoffice's batch-convert URI handling drops these on the floor (`source file could not be loaded`, rc=0), so every Office doc with a space in its name silently reaches the multimodal judge as a filename-only stub — same failure mode as the missing-JRE case fixed in #1268, but driven by the path instead of the runtime.

**Fix:** generalize the existing ns0-staging path to also stage when the name contains whitespace. Copy to a tempdir with a sanitized basename, run libreoffice there, move the resulting PDF back to the caller's expected location.

### 2. Persisted reference files are double-nested as `reference_files/reference_files/`

`_download_reference_files` materializes each row's reference files at `input_files_dir/<file_path>`, and every GDPVal row has `file_path` prefixed with `reference_files/` (matching the HF dataset's directory layout). The persistence step in `app.py` then did `shutil.copytree(input_files_dir, task_dir / "reference_files")`, so artifacts ended up at `task_dir/reference_files/reference_files/<hash>/<file>` — double nested.

This is **not just cosmetic**: `comparison.py`'s `build_file_section` lists `<ref_dir>/reference_files/` with `os.listdir` (no recursion), so it saw only the inner `reference_files/` subdir and **zero actual reference files**, biasing every pairwise judgment against whichever side actually had references.

Evidence: `/lustre/.../ultra-v3/moonshotai/Kimi-K2.6/20260509_231553-df9e2fbb2daff866/nemo_gym.0` — every task directory has `reference_files/reference_files/...`.

**Fix:** when `input_files_dir` already carries a top-level `reference_files/` subdir (the HF GDPVal layout), merge contents straight into `task_dir` so the persisted layout is the expected single-level `task_dir/reference_files/<hash>/<file>`. Fall back to the previous wrapping behavior when the prefix isn't present (non-GDPVal datasets).

## Test plan
- [x] `pytest resources_servers/gdpval/tests/ responses_api_agents/stirrup_agent/tests/` → 127/127 pass
- [x] New `test_stages_when_path_has_whitespace` uses a `Population v2.xlsx` fixture, asserts the staged input has no whitespace, and verifies the PDF ends up at the original path
- [x] Existing ns0-normalization test updated for the unified stage→move flow
- [x] `ruff check` + `ruff format --check` clean
- [ ] Validate end-to-end on a GDPVal pipeclean run via the pr-train

🤖 Generated with [Claude Code](https://claude.com/claude-code)