### PR TITLE
docs: generalize training card links to all training tutorials

### DIFF
--- a/fern/versions/latest/pages/data/download-huggingface.mdx
+++ b/fern/versions/latest/pages/data/download-huggingface.mdx
@@ -289,9 +289,9 @@ rm -rf ~/.cache/huggingface/hub/datasets--<org>--<dataset>
 Preprocess raw data, run `ng_prepare_data`, and add `agent_ref` routing.
 </Card>
 
-<Card title="Train with NeMo RL" href="/training-tutorials/nemo-rl-grpo">
+<Card title="Training Tutorials" href="/training-tutorials">
 
-Use validated data with NeMo RL for GRPO training.
+Use validated data to train with your preferred RL framework.
 </Card>
 
 </Cards>

--- a/fern/versions/latest/pages/data/prepare-validate.mdx
+++ b/fern/versions/latest/pages/data/prepare-validate.mdx
@@ -382,6 +382,6 @@ datasets:
 
 ## Next Steps
 
-<Card title="NeMo RL Integration" href="/training-tutorials/nemo-rl-grpo">
-Use validated data with NeMo RL for GRPO training.
+<Card title="Training Tutorials" href="/training-tutorials">
+Use validated data for RL training or fine-tuning.
 </Card>


### PR DESCRIPTION
## Summary

- The download-huggingface and prepare-validate "Next Steps" cards linked specifically to NeMo RL GRPO training. Users may train with other frameworks (OpenRLHF, Unsloth, etc.), so these now link to the training tutorials index instead.

Supersedes #1312 (rebased cleanly on main).

## Test plan

- [ ] Verify links resolve correctly in `fern docs dev`