### PR TITLE
feat(vllm_model): chunk long single-clip audio in chat_completions

### DIFF
--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -65,6 +65,14 @@ from nemo_gym.openai_utils import (
 )
 from nemo_gym.server_utils import SESSION_ID_KEY, is_nemo_gym_fastapi_entrypoint
 
+from .audio_utils import (
+    audio_duration_seconds,
+    chunk_audio_array,
+    encode_audio_chunk_to_data_uri,
+    load_audio_from_data_uri,
+    load_audio_from_path,
+)
+
 
 class VLLMModelConfig(BaseResponsesAPIModelConfig):
     base_url: Union[str, List[str]]
@@ -94,6 +102,18 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
     # ``data:audio/<fmt>;base64,...`` URI at request time — keeps the JSONL
     # small without depending on vLLM's ``--allowed-local-media-path``.
     audio_root: Optional[str] = None
+
+    # Audio chunking: long single-clip audio (``metadata.audio_data`` or
+    # ``metadata.audio_path``) is split into fixed-duration windows and each
+    # window is run through chat completions independently; the textual
+    # outputs are space-joined and usage tokens summed. Mirrors NeMo Skills'
+    # ``VLLMMultimodalModel`` chunking so audio benchmarks ported from Skills
+    # don't fall off a cliff when the input exceeds the model's audio limit
+    # (e.g. Qwen2-Audio at 30s). ``audio_paths`` (multi-clip) is left alone
+    # because chunking semantics across clips are ambiguous.
+    enable_audio_chunking: bool = True
+    chunk_audio_threshold_sec: float = 30.0
+    min_audio_chunk_duration_sec: float = 0.5
 
     def model_post_init(self, context):
         if isinstance(self.base_url, str):
@@ -236,18 +256,14 @@ class VLLMModel(SimpleResponsesAPIModel):
         ".opus": "opus",
     }
 
-    def _resolve_audio_path_to_url(self, audio_path: str) -> str:
-        """Turn an ``audio_path`` reference into a ``data:audio/...;base64`` URI.
-
-        Reads the file and inlines it as a base64 data URI at request time
-        — same strategy NeMo Skills' ``VLLMMultimodalModel.content_text_to_list``
-        uses (read once per request, hand vLLM a self-contained content
-        block). Keeps the on-disk JSONL small without requiring any vLLM
-        server-side flag.
+    def _resolve_audio_path_to_absolute(self, audio_path: str) -> str:
+        """Resolve a possibly-relative ``audio_path`` to an existing absolute path.
 
         Relative paths are resolved against ``config.audio_root``; without
         it, relative paths raise so the failure mode is loud rather than
-        silently reading from the server CWD.
+        silently reading from the server CWD. Shared by the data-URI splice
+        path and the chunking path so both observe the same audio_root /
+        extension rules.
         """
         if os.path.isabs(audio_path):
             resolved = audio_path
@@ -263,11 +279,23 @@ class VLLMModel(SimpleResponsesAPIModel):
             raise FileNotFoundError(f"metadata.audio_path resolved to {resolved!r}, which does not exist.")
 
         ext = os.path.splitext(resolved)[1].lower()
-        mime = self._AUDIO_EXT_TO_MIME.get(ext)
-        if mime is None:
+        if ext not in self._AUDIO_EXT_TO_MIME:
             raise ValueError(
                 f"Unsupported audio extension {ext!r} for {resolved!r}. Supported: {sorted(self._AUDIO_EXT_TO_MIME)}."
             )
+        return resolved
+
+    def _resolve_audio_path_to_url(self, audio_path: str) -> str:
+        """Turn an ``audio_path`` reference into a ``data:audio/...;base64`` URI.
+
+        Reads the file and inlines it as a base64 data URI at request time
+        — same strategy NeMo Skills' ``VLLMMultimodalModel.content_text_to_list``
+        uses (read once per request, hand vLLM a self-contained content
+        block). Keeps the on-disk JSONL small without requiring any vLLM
+        server-side flag.
+        """
+        resolved = self._resolve_audio_path_to_absolute(audio_path)
+        mime = self._AUDIO_EXT_TO_MIME[os.path.splitext(resolved)[1].lower()]
         with open(resolved, "rb") as f:
             encoded = base64.b64encode(f.read()).decode("ascii")
         return f"data:audio/{mime};base64,{encoded}"
@@ -441,6 +469,21 @@ class VLLMModel(SimpleResponsesAPIModel):
         self, request: Request, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
     ) -> NeMoGymChatCompletion:
         body_dict = body.model_dump(exclude_unset=True)
+
+        chunked_bodies = self._maybe_chunk_audio_for_request(body_dict)
+        if chunked_bodies is not None:
+            return await self._run_chunked_chat_completion(request, chunked_bodies)
+
+        return await self._run_single_chat_completion(request, body_dict)
+
+    async def _run_single_chat_completion(self, request: Request, body_dict: Dict[str, Any]) -> NeMoGymChatCompletion:
+        """Run one chat completion call end-to-end on a pre-dump body dict.
+
+        Extracted so the chunked-audio fan-out can reuse the full preprocess
+        → vLLM → reasoning/token post-processing pipeline per chunk without
+        duplicating the request shape, error handling, or reasoning-parser
+        rewrites.
+        """
         body_dict = self._preprocess_chat_completion_create_params(request, body_dict)
 
         client = self._resolve_client(request)
@@ -546,6 +589,125 @@ class VLLMModel(SimpleResponsesAPIModel):
             # choice_dict.pop("token_ids")
 
         return NeMoGymChatCompletion.model_validate(chat_completion_dict)
+
+    # =====================
+    # Audio chunking
+    # =====================
+
+    def _maybe_chunk_audio_for_request(self, body_dict: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
+        """Return per-chunk body dicts if the request needs audio chunking, else ``None``.
+
+        Triggers when ``enable_audio_chunking`` is on, the request carries a
+        single-clip audio source (``metadata.audio_data`` or
+        ``metadata.audio_path``), and the audio duration exceeds
+        ``chunk_audio_threshold_sec``. ``metadata.audio_paths`` (multi-clip)
+        is left alone — chunking semantics across clips are ambiguous and no
+        current benchmark exercises long multi-clip audio.
+
+        Each returned body dict is a deep copy of ``body_dict`` with
+        ``metadata.audio_data`` replaced by that chunk's WAV data URI and
+        any other audio keys stripped, so the existing splice path in
+        ``_preprocess_chat_completion_create_params`` handles them as if
+        the JSONL had carried inline data-URIs.
+        """
+        if not self.config.enable_audio_chunking:
+            return None
+
+        metadata = body_dict.get("metadata") or {}
+
+        # ``audio_paths`` (multi-clip) is intentionally not chunked. The
+        # other two keys are mutually exclusive (enforced in the splice
+        # path), so the dispatch here is straightforward.
+        if metadata.get("audio_paths"):
+            return None
+
+        audio_data = metadata.get("audio_data")
+        audio_path = metadata.get("audio_path")
+        if not audio_data and not audio_path:
+            return None
+
+        if audio_data:
+            audio_array, sampling_rate = load_audio_from_data_uri(audio_data)
+        else:
+            resolved = self._resolve_audio_path_to_absolute(audio_path)
+            audio_array, sampling_rate = load_audio_from_path(resolved)
+
+        duration = audio_duration_seconds(audio_array, sampling_rate)
+        if duration <= self.config.chunk_audio_threshold_sec:
+            return None
+
+        # Token-ID training mode wants a single contiguous prompt/generation
+        # token stream — concatenating per-chunk token ids loses the
+        # alignment the trainer relies on, so refuse rather than silently
+        # produce a malformed training row.
+        if self.config.return_token_id_information:
+            raise ValueError(
+                "Audio chunking is incompatible with return_token_id_information=True; "
+                "per-chunk prompts have different token streams that cannot be aggregated. "
+                "Disable enable_audio_chunking or use shorter audio (≤ chunk_audio_threshold_sec)."
+            )
+
+        chunks = chunk_audio_array(
+            audio_array,
+            sampling_rate,
+            chunk_duration_sec=self.config.chunk_audio_threshold_sec,
+            min_chunk_duration_sec=self.config.min_audio_chunk_duration_sec,
+        )
+
+        chunked_bodies: List[Dict[str, Any]] = []
+        for chunk in chunks:
+            chunk_body = deepcopy(body_dict)
+            chunk_metadata = chunk_body.setdefault("metadata", {})
+            # Re-emit each chunk through the ``audio_data`` channel so the
+            # splice path doesn't need a special "I am a chunk" branch.
+            chunk_metadata.pop("audio_path", None)
+            chunk_metadata.pop("audio_paths", None)
+            chunk_metadata["audio_data"] = encode_audio_chunk_to_data_uri(chunk, sampling_rate)
+            chunked_bodies.append(chunk_body)
+
+        return chunked_bodies
+
+    async def _run_chunked_chat_completion(
+        self, request: Request, chunked_bodies: List[Dict[str, Any]]
+    ) -> NeMoGymChatCompletion:
+        """Run each per-chunk body through ``_run_single_chat_completion`` and aggregate.
+
+        Aggregation mirrors NeMo Skills' ``_generate_with_chunking``:
+        * ``message.content`` is the space-joined per-chunk content
+          (each chunk stripped of leading/trailing whitespace). ``None``
+          contents (e.g. an out-of-context chunk) are dropped from the join
+          rather than becoming the literal string "None".
+        * ``usage.prompt_tokens`` / ``completion_tokens`` / ``total_tokens``
+          are summed across chunks. Other usage fields take the last
+          chunk's value.
+        * ``finish_reason`` propagates ``"length"`` if any chunk truncated,
+          otherwise the last chunk's reason. ``"length"`` here means the
+          rollout hit a hard limit on at least one chunk — surfacing it
+          lets downstream code (e.g. the verifier) treat the aggregated
+          output as incomplete instead of complete.
+        """
+        sub_completions: List[NeMoGymChatCompletion] = []
+        for chunk_body in chunked_bodies:
+            sub_completions.append(await self._run_single_chat_completion(request, chunk_body))
+
+        aggregate = sub_completions[-1]
+
+        joined = " ".join(
+            (c.choices[0].message.content or "").strip() for c in sub_completions if c.choices[0].message.content
+        )
+        aggregate.choices[0].message.content = joined or None
+
+        if any(c.choices[0].finish_reason == "length" for c in sub_completions):
+            aggregate.choices[0].finish_reason = "length"
+
+        if all(c.usage is not None for c in sub_completions):
+            total_prompt = sum(c.usage.prompt_tokens for c in sub_completions)
+            total_completion = sum(c.usage.completion_tokens for c in sub_completions)
+            aggregate.usage.prompt_tokens = total_prompt
+            aggregate.usage.completion_tokens = total_completion
+            aggregate.usage.total_tokens = total_prompt + total_completion
+
+        return aggregate
 
     def _create_empty_chat_completion(self) -> NeMoGymChatCompletion:
         return NeMoGymChatCompletion(

--- a/responses_api_models/vllm_model/audio_utils.py
+++ b/responses_api_models/vllm_model/audio_utils.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Audio chunking helpers for the ``vllm_model`` server.
+
+Used only when ``VLLMModelConfig.enable_audio_chunking`` is on AND the inbound
+row carries a single-clip audio source longer than the configured threshold.
+The chunking semantics (fixed-duration windows, undersized-tail merge) mirror
+NeMo Skills' ``nemo_skills/inference/model/audio_utils.chunk_audio`` so ports
+of audio benchmarks see byte-identical chunk boundaries on the wire.
+
+``soundfile`` and ``numpy`` are imported lazily so non-chunking deployments
+keep working even if the extras aren't installed.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import re
+from typing import TYPE_CHECKING, List, Tuple
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    import numpy as np
+
+
+# WAV is the only re-encode target for chunk URIs — every audio-capable vLLM
+# backend accepts 16-bit PCM WAV, and pinning a single output format keeps the
+# data URI's MIME stable regardless of the source extension.
+_CHUNK_OUTPUT_MIME = "wav"
+
+_DATA_URI_RE = re.compile(r"^data:audio/[^;]+;base64,(.+)$", re.IGNORECASE | re.DOTALL)
+
+
+def load_audio_from_path(path: str) -> Tuple["np.ndarray", int]:
+    """Read a file from disk and return ``(audio_array, sampling_rate)``."""
+    import soundfile as sf
+
+    array, sampling_rate = sf.read(path)
+    return array, sampling_rate
+
+
+def load_audio_from_data_uri(data_uri: str) -> Tuple["np.ndarray", int]:
+    """Decode a ``data:audio/<fmt>;base64,...`` URI to ``(audio_array, sampling_rate)``."""
+    import soundfile as sf
+
+    match = _DATA_URI_RE.match(data_uri)
+    if match is None:
+        raise ValueError(f"Expected 'data:audio/<fmt>;base64,...' URI for chunking; got prefix {data_uri[:32]!r}.")
+    raw = base64.b64decode(match.group(1))
+    array, sampling_rate = sf.read(io.BytesIO(raw))
+    return array, sampling_rate
+
+
+def audio_duration_seconds(audio_array, sampling_rate: int) -> float:
+    if sampling_rate <= 0:
+        raise ValueError(f"sampling_rate must be positive, got {sampling_rate!r}.")
+    return len(audio_array) / float(sampling_rate)
+
+
+def chunk_audio_array(
+    audio_array,
+    sampling_rate: int,
+    chunk_duration_sec: float = 30.0,
+    min_chunk_duration_sec: float = 0.5,
+) -> List["np.ndarray"]:
+    """Split audio into fixed-duration windows, merging an undersized tail.
+
+    Mirrors NeMo Skills' ``chunk_audio`` so a benchmark ported from Skills to
+    Gym produces the same chunk boundaries (and therefore the same per-chunk
+    model output, when paired with deterministic decoding).
+    """
+    import numpy as np
+
+    if chunk_duration_sec <= 0:
+        raise ValueError(f"chunk_duration_sec must be positive, got {chunk_duration_sec!r}.")
+    if min_chunk_duration_sec <= 0:
+        raise ValueError(f"min_chunk_duration_sec must be positive, got {min_chunk_duration_sec!r}.")
+
+    chunk_samples = int(chunk_duration_sec * sampling_rate)
+    min_chunk_samples = int(min_chunk_duration_sec * sampling_rate)
+
+    if len(audio_array) < min_chunk_samples:
+        raise ValueError(
+            f"Audio too short to chunk: {len(audio_array) / sampling_rate:.2f}s < minimum {min_chunk_duration_sec}s"
+        )
+
+    num_chunks = int(np.ceil(len(audio_array) / chunk_samples))
+    chunks: List["np.ndarray"] = []
+    for i in range(num_chunks):
+        start = i * chunk_samples
+        end = min((i + 1) * chunk_samples, len(audio_array))
+        chunk = audio_array[start:end]
+
+        # Merge tiny trailing chunks with the previous chunk to avoid emitting
+        # near-empty audio (which some audio models reject outright).
+        if len(chunk) < min_chunk_samples and chunks:
+            chunks[-1] = np.concatenate([chunks[-1], chunk])
+        else:
+            chunks.append(chunk)
+
+    return chunks
+
+
+def encode_audio_chunk_to_data_uri(audio_array, sampling_rate: int) -> str:
+    """Serialize one chunk as a ``data:audio/wav;base64,...`` URI.
+
+    Always WAV (PCM_16) regardless of the source format — the splice path in
+    ``VLLMModel._preprocess_chat_completion_create_params`` already accepts
+    ``audio_data`` URIs verbatim, so re-emitting chunks as ``audio_data``
+    keeps the rest of the request shape unchanged.
+    """
+    import soundfile as sf
+
+    buf = io.BytesIO()
+    sf.write(buf, audio_array, sampling_rate, format="WAV", subtype="PCM_16")
+    encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+    return f"data:audio/{_CHUNK_OUTPUT_MIME};base64,{encoded}"

--- a/responses_api_models/vllm_model/pyproject.toml
+++ b/responses_api_models/vllm_model/pyproject.toml
@@ -19,6 +19,12 @@ version = "0.2.0rc0"
 requires-python = ">=3.12"
 dependencies = [
     "nemo-gym[dev]",
+    # Needed by audio_utils.py when enable_audio_chunking is True. Imports
+    # are lazy inside audio_utils so non-chunking deployments aren't forced
+    # to drag soundfile/numpy in, but listing them here makes the chunking
+    # path work out-of-the-box for audio benchmarks (asr_with_pc et al.).
+    "numpy",
+    "soundfile",
 ]
 
 [build-system]

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -3621,3 +3621,335 @@ class TestAudioPathSplice:
                 assert "mutually exclusive" in str(e)
             else:
                 raise AssertionError(f"expected ValueError for metadata={metadata}")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Audio chunking (long single-clip audio → N sequential chat completions whose
+# textual outputs are space-joined and token counts summed). Mirrors NeMo
+# Skills' ``VLLMMultimodalModel._generate_with_chunking`` so audio benchmarks
+# ported from Skills retain their long-audio behaviour after the move to Gym.
+# ──────────────────────────────────────────────────────────────────────────────
+
+import io as _io  # noqa: E402
+
+import numpy as _np  # noqa: E402
+import soundfile as _sf  # noqa: E402
+from openai.types.completion_usage import CompletionUsage as _CompletionUsage  # noqa: E402
+
+from nemo_gym.server_utils import SESSION_ID_KEY as _SESSION_ID_KEY  # noqa: E402
+
+
+_SAMPLE_RATE = 16000
+
+
+def _make_wav_data_uri(duration_sec: float, sample_rate: int = _SAMPLE_RATE) -> str:
+    """Build a ``data:audio/wav;base64,...`` URI for ``duration_sec`` of silence."""
+    audio = _np.zeros(int(duration_sec * sample_rate), dtype=_np.int16)
+    buf = _io.BytesIO()
+    _sf.write(buf, audio, sample_rate, format="WAV", subtype="PCM_16")
+    return f"data:audio/wav;base64,{_b64.b64encode(buf.getvalue()).decode('ascii')}"
+
+
+def _write_wav_file(path, duration_sec: float, sample_rate: int = _SAMPLE_RATE) -> None:
+    audio = _np.zeros(int(duration_sec * sample_rate), dtype=_np.int16)
+    _sf.write(str(path), audio, sample_rate, format="WAV", subtype="PCM_16")
+
+
+def _make_chunking_model(
+    *,
+    enable_audio_chunking: bool = True,
+    chunk_audio_threshold_sec: float = 2.0,
+    return_token_id_information: bool = False,
+    audio_root: str | None = None,
+) -> VLLMModel:
+    """Minimal VLLMModel wired for chunking tests.
+
+    Threshold defaults to 2s (not the production 30s) so a few-second WAV is
+    enough to exercise the chunk fan-out without inflating test data size.
+    """
+    config = VLLMModelConfig(
+        host="0.0.0.0",
+        port=8080,
+        entrypoint="",
+        name="vllm_model",
+        base_url="http://localhost:9999/v1",
+        api_key="dummy_key",  # pragma: allowlist secret
+        model="dummy-model",
+        return_token_id_information=return_token_id_information,
+        uses_reasoning_parser=False,
+        uses_interleaved_reasoning=False,
+        audio_root=audio_root,
+        enable_audio_chunking=enable_audio_chunking,
+        chunk_audio_threshold_sec=chunk_audio_threshold_sec,
+        min_audio_chunk_duration_sec=0.5,
+    )
+    return VLLMModel(config=config, server_client=MagicMock(spec=ServerClient))
+
+
+def _make_chat_completion(content: str, finish_reason: str = "stop", usage=None):
+    """Build a ``NeMoGymChatCompletion`` carrying a single assistant message."""
+    return NeMoGymChatCompletion(
+        id="chtcmpl-x",
+        object="chat.completion",
+        created=FIXED_TIME,
+        model="dummy-model",
+        choices=[
+            NeMoGymChoice(
+                index=0,
+                finish_reason=finish_reason,
+                message=NeMoGymChatCompletionMessage(
+                    role="assistant",
+                    content=content,
+                    tool_calls=[],
+                ),
+            )
+        ],
+        usage=usage,
+    )
+
+
+def _attach_mock_client(model: VLLMModel, responses: list) -> AsyncMock:
+    """Wire ``model._clients[0]`` to return ``responses`` round-robin per call.
+
+    Tests exercising the chunk fan-out need each ``create_chat_completion``
+    invocation to yield a different completion (one per chunk) so the
+    aggregator's space-join and usage-sum can be observed.
+    """
+    mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+    iterator = iter(responses)
+    mock_client.create_chat_completion = AsyncMock(side_effect=lambda **_: next(iterator).model_dump())
+    model._clients = [mock_client]
+    return mock_client
+
+
+def _make_request_with_session(session_id: str = "test-session"):
+    request = MagicMock()
+    request.session = {_SESSION_ID_KEY: session_id}
+    return request
+
+
+class TestMaybeChunkAudioForRequest:
+    """Direct tests for ``VLLMModel._maybe_chunk_audio_for_request``.
+
+    Keeps the chunking decision logic separable from the chat-completions
+    fan-out so regressions in either layer surface independently.
+    """
+
+    def test_no_audio_returns_none(self) -> None:
+        model = _make_chunking_model()
+        body = {"model": "dummy-model", "messages": [{"role": "user", "content": "hi"}]}
+        assert model._maybe_chunk_audio_for_request(body) is None
+
+    def test_short_audio_is_passthrough(self) -> None:
+        """Under-threshold audio sidesteps the chunker entirely."""
+        model = _make_chunking_model(chunk_audio_threshold_sec=10.0)
+        body = {
+            "model": "dummy-model",
+            "messages": [{"role": "user", "content": "Transcribe."}],
+            "metadata": {"audio_data": _make_wav_data_uri(duration_sec=1.0)},
+        }
+        assert model._maybe_chunk_audio_for_request(body) is None
+
+    def test_disabled_chunking_is_passthrough(self) -> None:
+        """``enable_audio_chunking=False`` defeats chunking even on long audio."""
+        model = _make_chunking_model(enable_audio_chunking=False, chunk_audio_threshold_sec=1.0)
+        body = {
+            "model": "dummy-model",
+            "messages": [{"role": "user", "content": "Transcribe."}],
+            "metadata": {"audio_data": _make_wav_data_uri(duration_sec=5.0)},
+        }
+        assert model._maybe_chunk_audio_for_request(body) is None
+
+    def test_long_audio_data_splits_into_chunks(self) -> None:
+        """5s audio @ 2s threshold → 3 chunks (2s + 2s + 1s, tail kept since >= min)."""
+        model = _make_chunking_model(chunk_audio_threshold_sec=2.0)
+        body = {
+            "model": "dummy-model",
+            "messages": [{"role": "user", "content": "Transcribe."}],
+            "metadata": {"audio_data": _make_wav_data_uri(duration_sec=5.0)},
+        }
+        chunked = model._maybe_chunk_audio_for_request(body)
+        assert chunked is not None
+        assert len(chunked) == 3
+        # Every chunk body should carry its OWN audio_data URI (different
+        # from the original — the original held 5s, each chunk holds ≤ 2s).
+        original_uri = body["metadata"]["audio_data"]
+        for sub in chunked:
+            assert sub["metadata"]["audio_data"].startswith("data:audio/wav;base64,")
+            assert sub["metadata"]["audio_data"] != original_uri
+            # Other audio keys must be cleared so the splice path's
+            # mutual-exclusion guard doesn't trip.
+            assert "audio_path" not in sub["metadata"]
+            assert "audio_paths" not in sub["metadata"]
+
+    def test_long_audio_path_splits_into_chunks(self, tmp_path) -> None:
+        wav = tmp_path / "clip.wav"
+        _write_wav_file(wav, duration_sec=5.0)
+
+        model = _make_chunking_model(chunk_audio_threshold_sec=2.0)
+        body = {
+            "model": "dummy-model",
+            "messages": [{"role": "user", "content": "Transcribe."}],
+            "metadata": {"audio_path": str(wav)},
+        }
+        chunked = model._maybe_chunk_audio_for_request(body)
+        assert chunked is not None
+        assert len(chunked) == 3
+        for sub in chunked:
+            # audio_path channel got rewritten to audio_data (chunk URI).
+            assert "audio_path" not in sub["metadata"]
+            assert sub["metadata"]["audio_data"].startswith("data:audio/wav;base64,")
+
+    def test_audio_paths_multiclip_skips_chunking(self, tmp_path) -> None:
+        """Multi-clip audio is left for the splice path; chunking only owns single-clip."""
+        wav = tmp_path / "clip.wav"
+        _write_wav_file(wav, duration_sec=5.0)
+
+        model = _make_chunking_model(chunk_audio_threshold_sec=2.0)
+        body = {
+            "model": "dummy-model",
+            "messages": [{"role": "user", "content": "Compare."}],
+            "metadata": {"audio_paths": [str(wav), str(wav)]},
+        }
+        assert model._maybe_chunk_audio_for_request(body) is None
+
+    def test_token_id_training_with_long_audio_raises(self) -> None:
+        """Concatenating per-chunk token streams is meaningless — bail out loudly."""
+        model = _make_chunking_model(
+            chunk_audio_threshold_sec=1.0,
+            return_token_id_information=True,
+        )
+        body = {
+            "model": "dummy-model",
+            "messages": [{"role": "user", "content": "Transcribe."}],
+            "metadata": {"audio_data": _make_wav_data_uri(duration_sec=3.0)},
+        }
+        try:
+            model._maybe_chunk_audio_for_request(body)
+        except ValueError as e:
+            assert "return_token_id_information" in str(e)
+        else:
+            raise AssertionError("expected ValueError for chunking + token-id training mode")
+
+    def test_token_id_training_with_short_audio_passes_through(self) -> None:
+        """Token-id mode only conflicts when chunking actually fires — short audio is fine."""
+        model = _make_chunking_model(
+            chunk_audio_threshold_sec=10.0,
+            return_token_id_information=True,
+        )
+        body = {
+            "model": "dummy-model",
+            "messages": [{"role": "user", "content": "Transcribe."}],
+            "metadata": {"audio_data": _make_wav_data_uri(duration_sec=1.0)},
+        }
+        assert model._maybe_chunk_audio_for_request(body) is None
+
+
+class TestChunkedChatCompletion:
+    """End-to-end tests for chunked ``chat_completions``.
+
+    Mocks ``client.create_chat_completion`` to return distinct content per
+    call so the aggregator's space-join, usage-sum, and finish_reason rules
+    can be asserted.
+    """
+
+    async def test_chunks_join_with_space_and_sum_usage(self) -> None:
+        model = _make_chunking_model(chunk_audio_threshold_sec=2.0)
+        responses = [
+            _make_chat_completion(
+                "chunk one.",
+                usage=_CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            ),
+            _make_chat_completion(
+                "chunk two.",
+                usage=_CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17),
+            ),
+            _make_chat_completion(
+                "chunk three.",
+                usage=_CompletionUsage(prompt_tokens=10, completion_tokens=4, total_tokens=14),
+            ),
+        ]
+        mock_client = _attach_mock_client(model, responses)
+
+        body = NeMoGymChatCompletionCreateParamsNonStreaming(
+            model="dummy-model",
+            messages=[
+                NeMoGymChatCompletionUserMessageParam(role="user", content="Transcribe."),
+            ],
+            metadata={"audio_data": _make_wav_data_uri(duration_sec=5.0)},
+        )
+
+        result = await model.chat_completions(_make_request_with_session(), body)
+
+        # 5s audio / 2s threshold → 3 chunks → 3 mock client calls.
+        assert mock_client.create_chat_completion.await_count == 3
+
+        # Each chunk's content is space-joined (after strip) in order.
+        assert result.choices[0].message.content == "chunk one. chunk two. chunk three."
+
+        # Usage is summed across chunks; non-summed fields stay None.
+        assert result.usage.prompt_tokens == 30
+        assert result.usage.completion_tokens == 16
+        assert result.usage.total_tokens == 46
+
+        # finish_reason is "stop" since no chunk truncated.
+        assert result.choices[0].finish_reason == "stop"
+
+    async def test_length_finish_reason_propagates_from_any_chunk(self) -> None:
+        """If any chunk truncates we mark the aggregated rollout as truncated."""
+        model = _make_chunking_model(chunk_audio_threshold_sec=2.0)
+        responses = [
+            _make_chat_completion("first."),
+            _make_chat_completion("second.", finish_reason="length"),
+        ]
+        _attach_mock_client(model, responses)
+
+        body = NeMoGymChatCompletionCreateParamsNonStreaming(
+            model="dummy-model",
+            messages=[
+                NeMoGymChatCompletionUserMessageParam(role="user", content="Transcribe."),
+            ],
+            metadata={"audio_data": _make_wav_data_uri(duration_sec=3.0)},
+        )
+
+        result = await model.chat_completions(_make_request_with_session(), body)
+        assert result.choices[0].finish_reason == "length"
+
+    async def test_chunk_with_none_content_is_dropped_from_join(self) -> None:
+        """``content is None`` (e.g. out-of-context chunk) skips the join cleanly."""
+        model = _make_chunking_model(chunk_audio_threshold_sec=2.0)
+        responses = [
+            _make_chat_completion("kept."),
+            _make_chat_completion(None, finish_reason="length"),
+        ]
+        _attach_mock_client(model, responses)
+
+        body = NeMoGymChatCompletionCreateParamsNonStreaming(
+            model="dummy-model",
+            messages=[
+                NeMoGymChatCompletionUserMessageParam(role="user", content="Transcribe."),
+            ],
+            metadata={"audio_data": _make_wav_data_uri(duration_sec=3.0)},
+        )
+
+        result = await model.chat_completions(_make_request_with_session(), body)
+        # Empty/None chunk doesn't leak the literal "None" into the output.
+        assert result.choices[0].message.content == "kept."
+
+    async def test_short_audio_runs_once(self) -> None:
+        """Under-threshold audio takes the regular (single-call) path."""
+        model = _make_chunking_model(chunk_audio_threshold_sec=10.0)
+        responses = [_make_chat_completion("once.")]
+        mock_client = _attach_mock_client(model, responses)
+
+        body = NeMoGymChatCompletionCreateParamsNonStreaming(
+            model="dummy-model",
+            messages=[
+                NeMoGymChatCompletionUserMessageParam(role="user", content="Transcribe."),
+            ],
+            metadata={"audio_data": _make_wav_data_uri(duration_sec=1.0)},
+        )
+
+        result = await model.chat_completions(_make_request_with_session(), body)
+        assert mock_client.create_chat_completion.await_count == 1
+        assert result.choices[0].message.content == "once."


### PR DESCRIPTION
# feat(vllm_model): chunk long single-clip audio in chat_completions

Audio rows whose duration exceeds the model's input limit (e.g. Qwen2-Audio at 30s) currently fail outright in `vllm_model` — the audio is inlined whole on `metadata.audio_data` / `metadata.audio_path` and the request bounces. This adds an opt-in chunking pipeline that splits long single-clip audio into fixed-duration windows, runs each window as its own chat completion through the existing preprocess → vLLM → reasoning-parser path, then space-joins the textual outputs and sums the usage tokens. Mirrors the chunking already shipping in NeMo Skills' `VLLMMultimodalModel`, so audio benchmarks ported from Skills retain their long-audio behaviour on Gym.

## Config

Three new fields on `VLLMModelConfig`:

- `enable_audio_chunking: bool = True` — master switch. Chunking only fires if it's also possible to chunk the inbound audio (see below); short audio is a no-op regardless.
- `chunk_audio_threshold_sec: float = 30.0` — both the trigger threshold (audio under this duration is passed through whole) AND the per-chunk window size.
- `min_audio_chunk_duration_sec: float = 0.5` — the trailing chunk is merged into the previous chunk if it falls below this duration. Avoids emitting near-empty audio that some audio models reject.

When chunking does fire and `return_token_id_information: true` is also set, the request raises rather than producing a malformed training row — per-chunk prompts have different token streams that can't be meaningfully aggregated. Disable chunking or constrain audio length if you need exact token IDs.

## Behaviour

Chunking only owns the **single-clip** audio sources:

- `metadata.audio_data` — decoded from the `data:audio/<fmt>;base64,...` URI.
- `metadata.audio_path` — resolved through the existing `audio_root` rules.

`metadata.audio_paths` (multi-clip) is left alone — chunking semantics across multiple clips are ambiguous and no current benchmark exercises long multi-clip audio. Existing splice behaviour for `audio_paths` is unchanged.

Each chunk runs through `_run_single_chat_completion` (the existing `chat_completions` body, extracted as a helper) with its `metadata.audio_data` replaced by a fresh `data:audio/wav;base64,...` URI for that window. The aggregator then:

- Space-joins per-chunk `choices[0].message.content` after `.strip()` (matches Skills).
- Sums `usage.prompt_tokens` / `completion_tokens` / `total_tokens` across chunks.
- Propagates `finish_reason="length"` if **any** chunk truncated — downstream code (verifier, training data filter) should treat aggregated output as incomplete when any window hit a hard limit.

## Parity with NeMo Skills

The Skills implementation of audio chunking lives in `nemo_skills/inference/model/{audio_utils.py, vllm_multimodal.py}` and is the reference for this port. Two layers were verified before this PR:

1. **Chunk function parity.** Gym's `chunk_audio_array` and Skills' `chunk_audio` produce identical output across 40 cases (9 durations × 2 thresholds × 2 minimums, plus 4 explicit tail-merge edge cases including the boundary at exactly `min_chunk_duration_sec`).
2. **Aggregation parity.** Skills' `VLLMMultimodalModel._generate_with_chunking` and Gym's `VLLMModel._run_chunked_chat_completion` produce identical aggregated text on the same 5-second WAV + same per-chunk LLM outputs across 3 cases (clean text, whitespace-padded chunks, whitespace-only middle chunk — verifies both sides `.strip()` per chunk and that the whitespace-only artifact is preserved identically).
