### PR TITLE
feat(stirrup_agent): per-task timeout + walltime-resilient failure routing

### DIFF
--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -15,6 +15,7 @@
 import asyncio
 import glob as glob_module
 import json
+import os
 from asyncio import Future, Semaphore
 from collections import Counter
 from contextlib import nullcontext
@@ -50,6 +51,63 @@ from nemo_gym.server_utils import (
     raise_for_status,
     set_global_aiohttp_client,
 )
+
+
+# ---------------------------------------------------------------------------
+# Failure-routing sentinels (set by agent servers, read by the dispatcher).
+#
+# Background:
+#   The historical contract was "every dispatched task produces one row in
+#   the main rollouts jsonl, succeeded or failed." That contract broke
+#   resume-after-walltime: synthetic ``-failed`` rows written during a
+#   SIGTERM grace window look identical to real successes to the dedup in
+#   ``_load_from_cache`` (which keys only on (task_index, rollout_index)),
+#   so chain-hop 2 thinks failed tasks are done and never retries them.
+#
+# New contract:
+#   - Successes go to the main jsonl (``output_jsonl_fpath``).
+#   - Failures go to a sidecar (``<output_stem>_failures.jsonl``), one row
+#     per attempt, with ``_ng_failure_class`` set.
+#   - ``kill_shaped`` failures (Slurm SIGTERM, Ray actor died, OOM, ...) go
+#     NOWHERE: the absence of a row is the canonical signal. Resume's
+#     set-difference re-dispatches them naturally; per-task timeout bounds
+#     the chain-hop wallclock.
+#   - On resume, ``_load_from_cache`` reads BOTH files: main jsonl tells
+#     it what's permanently done, sidecar tells it how many attempts each
+#     non-success has consumed (capped at NEMO_GYM_MAX_ROLLOUT_ATTEMPTS,
+#     default 3). Rows flagged ``_ng_failure_terminal=True`` are never
+#     retried regardless of attempt count.
+# ---------------------------------------------------------------------------
+
+NG_FAILURE_CLASS_KEY = "_ng_failure_class"
+NG_NO_PERSIST_KEY = "_ng_no_persist"
+NG_TERMINAL_KEY = "_ng_failure_terminal"
+
+_DEFAULT_MAX_ROLLOUT_ATTEMPTS = 3
+
+
+def _get_max_rollout_attempts() -> int:
+    """Read ``NEMO_GYM_MAX_ROLLOUT_ATTEMPTS`` (positive int) or default to 3."""
+    raw = os.environ.get("NEMO_GYM_MAX_ROLLOUT_ATTEMPTS")
+    if raw is None or raw == "":
+        return _DEFAULT_MAX_ROLLOUT_ATTEMPTS
+    try:
+        n = int(raw)
+        if n < 1:
+            raise ValueError(f"must be >= 1, got {n}")
+        return n
+    except (TypeError, ValueError) as e:
+        print(
+            f"WARNING: could not parse NEMO_GYM_MAX_ROLLOUT_ATTEMPTS={raw!r} ({e}); "
+            f"falling back to default {_DEFAULT_MAX_ROLLOUT_ATTEMPTS}.",
+            flush=True,
+        )
+        return _DEFAULT_MAX_ROLLOUT_ATTEMPTS
+
+
+def _failures_path_for(output_fpath: Path) -> Path:
+    """Sidecar path used by the dispatcher and ``_load_from_cache``."""
+    return output_fpath.with_name(output_fpath.stem + "_failures.jsonl")
 
 
 class SharedRolloutCollectionConfig(BaseNeMoGymCLIConfig):
@@ -256,8 +314,34 @@ class RolloutCollectionHelper(BaseModel):
 
         get_key = lambda r: (r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME])
 
-        seen_rows = set(map(get_key, results))
-        input_rows = [row for row in original_input_rows if get_key(row) not in seen_rows]
+        # Successes (and any legacy '-failed' rows written by pre-fix Gym
+        # builds) live in the main jsonl. They short-circuit dispatch.
+        successes_seen = set(map(get_key, results))
+
+        # Sidecar: one row per non-kill_shaped failure attempt. Count attempts
+        # per key + flag terminal rows so chain-hop 2 retries the right ones.
+        failures_fpath = _failures_path_for(Path(config.output_jsonl_fpath))
+        attempts_by_key: Counter = Counter()
+        terminal_keys: set = set()
+        if failures_fpath.exists():
+            with failures_fpath.open("rb") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    fr = orjson.loads(line)
+                    if TASK_INDEX_KEY_NAME not in fr or ROLLOUT_INDEX_KEY_NAME not in fr:
+                        continue
+                    k = (fr[TASK_INDEX_KEY_NAME], fr[ROLLOUT_INDEX_KEY_NAME])
+                    attempts_by_key[k] += 1
+                    if fr.get(NG_TERMINAL_KEY):
+                        terminal_keys.add(k)
+
+        max_attempts = _get_max_rollout_attempts()
+        maxed_out = {k for k, n in attempts_by_key.items() if n >= max_attempts}
+        gated = successes_seen | terminal_keys | maxed_out
+
+        input_rows = [row for row in original_input_rows if get_key(row) not in gated]
 
         key_to_row = dict(zip(map(get_key, original_input_rows), original_input_rows))
         rows = [key_to_row[get_key(result)] for result in results]
@@ -265,7 +349,10 @@ class RolloutCollectionHelper(BaseModel):
         print(
             f"""Resumed from cache. Found:
 - {len(original_input_rows)} original input rows
-- {len(rows)} rows that have already been run
+- {len(rows)} rows already done (in main jsonl)
+- {sum(attempts_by_key.values())} prior failure attempts ({len(attempts_by_key)} unique tasks) in sidecar
+- {len(terminal_keys)} sidecar-terminal (timeout_exceeded / skipped) → not retried
+- {len(maxed_out)} hit max_attempts={max_attempts} → not retried
 - {len(input_rows)} rows that still need to be run"""
         )
 
@@ -311,10 +398,12 @@ class RolloutCollectionHelper(BaseModel):
             semaphore = Semaphore(config.num_samples_in_parallel)
 
         output_fpath.parent.mkdir(exist_ok=True, parents=True)
+        failures_fpath = _failures_path_for(output_fpath)
 
         pcts_to_print = [20, 40, 60, 80, 90, 95, 98, 99, 100]
         counts_left = Counter(r[AGENT_REF_KEY_NAME]["name"] for r in input_rows)
         results_file = output_fpath.open("ab")
+        failures_file = failures_fpath.open("ab")
         for future in self.run_examples(input_rows, semaphore=semaphore):
             row, result = await future
 
@@ -322,11 +411,27 @@ class RolloutCollectionHelper(BaseModel):
             result[ROLLOUT_INDEX_KEY_NAME] = row[ROLLOUT_INDEX_KEY_NAME]
             result[AGENT_REF_KEY_NAME] = row[AGENT_REF_KEY_NAME]
 
+            no_persist = bool(result.get(NG_NO_PERSIST_KEY))
+            failure_class = result.get(NG_FAILURE_CLASS_KEY)
+
             rows.append(row)
             results.append(result)
-            result_strs.append([orjson.dumps(result)])
-            results_file.write(result_strs[-1][0] + b"\n")
-            results_file.flush()
+            serialized = orjson.dumps(result)
+            result_strs.append([serialized])
+
+            if no_persist:
+                # kill_shaped: don't write anywhere. Set-difference on resume
+                # naturally re-dispatches; per-task timeout bounds wallclock.
+                pass
+            elif failure_class is not None:
+                # Non-kill_shaped failure → sidecar. The aggregator only reads
+                # the main jsonl, so this keeps win-rate uncontaminated.
+                failures_file.write(serialized + b"\n")
+                failures_file.flush()
+            else:
+                # Success → main jsonl.
+                results_file.write(serialized + b"\n")
+                results_file.flush()
 
             counts_left[row[AGENT_REF_KEY_NAME]["name"]] -= 1
             if counts_left[row[AGENT_REF_KEY_NAME]["name"]] <= 0:
@@ -344,6 +449,7 @@ class RolloutCollectionHelper(BaseModel):
                     tqdm.write(f"Examples left:\n{top_left_str}")
 
         results_file.close()
+        failures_file.close()
 
         if config.upload_rollouts_to_wandb and get_wandb_run():  # pragma: no cover
             print("Uploading rollouts to W&B. This may take a few minutes if your data is large.")

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -175,10 +175,12 @@ def _classify_rollout_failure(exc: BaseException) -> str:
         from ray.exceptions import (
             LocalRayletDiedError,
             NodeDiedError,
-            OutOfMemoryError as RayOutOfMemoryError,
             RayActorError,
             RayTaskError,
             WorkerCrashedError,
+        )
+        from ray.exceptions import (
+            OutOfMemoryError as RayOutOfMemoryError,
         )
     except ImportError:
         # ray.exceptions surface drifted; fail open to bounded retry.

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -22,6 +22,7 @@ construction, scoring, response building) is delegated to a
 from __future__ import annotations
 
 import asyncio
+import os
 import shutil
 import sys
 import tempfile
@@ -49,6 +50,174 @@ from nemo_gym.openai_utils import (
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
 from responses_api_agents.stirrup_agent.task_strategy import TaskSampleSkipError, TaskStrategy
+
+
+# ---------------------------------------------------------------------------
+# Per-task timeout (caps a single Ray rollout attempt's wallclock).
+# Without a per-attempt budget, a single pathological task that exceeds Slurm
+# walltime can permanently consume every chain-hop's compute and never
+# complete.
+# ---------------------------------------------------------------------------
+
+STIRRUP_PER_TASK_TIMEOUT_DEFAULT = 3 * 3600 + 30 * 60  # 3h30m = 12600s
+
+_TIMEOUT_LOGGED = False
+
+
+class TaskPerAttemptTimeoutError(Exception):
+    """Raised when a single Ray rollout attempt exceeds the per-task timeout."""
+
+
+def _get_per_task_timeout() -> float:
+    """Read STIRRUP_PER_TASK_TIMEOUT_S (seconds, float) or fall back to default."""
+    raw = os.environ.get("STIRRUP_PER_TASK_TIMEOUT_S")
+    if raw is None or raw == "":
+        return float(STIRRUP_PER_TASK_TIMEOUT_DEFAULT)
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        print(
+            f"[gdpval_stirrup_agent] WARNING: could not parse STIRRUP_PER_TASK_TIMEOUT_S={raw!r} "
+            f"as float, falling back to default {STIRRUP_PER_TASK_TIMEOUT_DEFAULT} s.",
+            flush=True,
+        )
+        return float(STIRRUP_PER_TASK_TIMEOUT_DEFAULT)
+
+
+def _log_timeout_once(timeout_s: float) -> None:
+    """Emit a single INFO line on the first per-task await of this process."""
+    global _TIMEOUT_LOGGED
+    if _TIMEOUT_LOGGED:
+        return
+    _TIMEOUT_LOGGED = True
+    total = int(timeout_s)
+    hours, rem = divmod(total, 3600)
+    minutes, seconds = divmod(rem, 60)
+    print(
+        f"[gdpval_stirrup_agent] per-task timeout set to {hours}h{minutes}m{seconds}s "
+        f"({timeout_s:g} s). Override with env var STIRRUP_PER_TASK_TIMEOUT_S.",
+        flush=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Failure classification (drives whether a failure is persisted to the main
+# rollouts jsonl, the failures sidecar, or nowhere at all).
+#
+# Five classes:
+#   kill_shaped       Ray worker died (SIGTERM/walltime/OOM/node loss). NO row
+#                     written anywhere; resume's set-difference on the main
+#                     jsonl naturally re-dispatches, capped per-attempt by
+#                     the per-task timeout above.
+#   timeout_exceeded  TaskPerAttemptTimeoutError. Sidecar entry with
+#                     _ng_failure_terminal=True so chain-hop 2 does NOT retry.
+#   skipped           TaskSampleSkipError. Sidecar entry with terminal=True.
+#   transient         verify-side ClientResponseError 5xx / connection /
+#                     asyncio.TimeoutError. Sidecar entry per attempt; retry
+#                     up to max_attempts.
+#   legitimate        Everything else (real Python exception with user code
+#                     in the traceback). Sidecar entry per attempt; retry
+#                     up to max_attempts.
+# ---------------------------------------------------------------------------
+
+# Sentinel keys the dispatcher (nemo_gym.rollout_collection) reads to route a
+# returned payload between the main jsonl, the failures sidecar, or /dev/null.
+NG_FAILURE_CLASS_KEY = "_ng_failure_class"  # str: one of the 5 class names
+NG_NO_PERSIST_KEY = "_ng_no_persist"  # bool: don't write anywhere
+NG_TERMINAL_KEY = "_ng_failure_terminal"  # bool: never retry on resume
+
+_USER_CODE_PATH_SUBSTRINGS = (
+    "responses_api_agents/",
+    "/stirrup/",
+)
+
+
+def _has_user_code_frame(exc: BaseException) -> bool:
+    """Return True iff *exc* (or any cause/context in its chain) has a
+    traceback frame originating in user code (stirrup_agent or Stirrup).
+
+    A ``RayTaskError`` wrapping a user-code failure has those frames present.
+    A ``RayTaskError`` raised purely from Ray's internal post-mortem (e.g.
+    formatting a worker stdout log that Slurm's epilogue already scrubbed)
+    has only Ray internals and ``<frozen genericpath>`` — that's the
+    walltime / SIGTERM signature.
+    """
+    seen: set = set()
+
+    def _walk(e: Optional[BaseException]) -> bool:
+        if e is None or id(e) in seen:
+            return False
+        seen.add(id(e))
+        tb = e.__traceback__
+        while tb is not None:
+            fname = tb.tb_frame.f_code.co_filename
+            for sub in _USER_CODE_PATH_SUBSTRINGS:
+                if sub in fname:
+                    return True
+            tb = tb.tb_next
+        return _walk(e.__cause__) or _walk(e.__context__)
+
+    return _walk(exc)
+
+
+def _classify_rollout_failure(exc: BaseException) -> str:
+    """Classify an exception raised by ``self.responses(...)``.
+
+    Returns one of: 'kill_shaped', 'timeout_exceeded', 'skipped', 'legitimate'.
+    The 'transient' class only applies to verify-side failures and is
+    produced by :func:`_classify_verify_failure`.
+    """
+    if isinstance(exc, TaskPerAttemptTimeoutError):
+        return "timeout_exceeded"
+    if isinstance(exc, TaskSampleSkipError):
+        return "skipped"
+    try:
+        from ray.exceptions import (
+            LocalRayletDiedError,
+            NodeDiedError,
+            OutOfMemoryError as RayOutOfMemoryError,
+            RayActorError,
+            RayTaskError,
+            WorkerCrashedError,
+        )
+    except ImportError:
+        # ray.exceptions surface drifted; fail open to bounded retry.
+        return "legitimate"
+    if isinstance(
+        exc,
+        (
+            RayActorError,
+            WorkerCrashedError,
+            NodeDiedError,
+            RayOutOfMemoryError,
+            LocalRayletDiedError,
+        ),
+    ):
+        return "kill_shaped"
+    if isinstance(exc, RayTaskError):
+        # No user-code frame ⇒ Ray internals (e.g. summary-builder hitting
+        # a vanished worker log after Slurm's epilogue scrubbed /tmp/ray).
+        return "legitimate" if _has_user_code_frame(exc) else "kill_shaped"
+    return "legitimate"
+
+
+def _classify_verify_failure(exc: BaseException) -> str:
+    """Classify an exception raised by the ``/verify`` POST. Verify-side
+    failures are never ``kill_shaped`` (we had a rollout response in hand)
+    and never ``timeout_exceeded`` (that's a rollout-side class).
+    """
+    try:
+        import aiohttp
+
+        if isinstance(exc, aiohttp.ClientResponseError):
+            return "transient" if 500 <= exc.status < 600 else "legitimate"
+        if isinstance(exc, aiohttp.ClientConnectionError):
+            return "transient"
+    except ImportError:
+        pass
+    if isinstance(exc, asyncio.TimeoutError):
+        return "transient"
+    return "legitimate"
 
 
 # ---------------------------------------------------------------------------
@@ -721,7 +890,19 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         }
 
         future = run_stirrup_agent_remote.remote(params)
-        result = await future
+        per_task_timeout = _get_per_task_timeout()
+        _log_timeout_once(per_task_timeout)
+        try:
+            result = await asyncio.wait_for(future, timeout=per_task_timeout)
+        except asyncio.TimeoutError:
+            try:
+                ray.cancel(future, force=True)
+            except Exception as _cancel_exc:
+                print(
+                    f"[gdpval_stirrup_agent] WARNING: ray.cancel failed after timeout: {_cancel_exc!r}",
+                    flush=True,
+                )
+            raise TaskPerAttemptTimeoutError(f"per-task timeout exceeded ({per_task_timeout:g} s)") from None
 
         input_items = result["input_items"]
         output_items = result["output_items"]
@@ -815,10 +996,10 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 response = await self.responses(fixed_params)
             except Exception as exc:
                 task_info = self.task_strategy.extract_task_info(existing_metadata)
-                label = "skipped" if isinstance(exc, TaskSampleSkipError) else "failed"
+                failure_class = _classify_rollout_failure(exc)
                 instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
                 print(
-                    f"[stirrup-{label}] {instance_hint}: {type(exc).__name__}: {exc}",
+                    f"[stirrup-{failure_class}] {instance_hint}: {type(exc).__name__}: {exc}",
                     flush=True,
                 )
                 return self._build_failed_run_payload(
@@ -826,7 +1007,8 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     fixed_params=fixed_params,
                     task_info=task_info,
                     reason=f"{type(exc).__name__}: {exc}",
-                    skipped=label == "skipped",
+                    skipped=(failure_class == "skipped"),
+                    error_class=failure_class,
                 )
 
             response_clean = response.model_copy(update={"metadata": None})
@@ -862,9 +1044,10 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 return await get_response_json(verify_response)
             except Exception as exc:
                 task_info = self.task_strategy.extract_task_info(existing_metadata)
+                failure_class = _classify_verify_failure(exc)
                 instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
                 print(
-                    f"[stirrup-verify-failed] {instance_hint}: {type(exc).__name__}: {exc}",
+                    f"[stirrup-verify-{failure_class}] {instance_hint}: {type(exc).__name__}: {exc}",
                     flush=True,
                 )
                 return self._build_failed_run_payload(
@@ -873,6 +1056,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     task_info=task_info,
                     reason=f"verify failed: {type(exc).__name__}: {exc}",
                     skipped=False,
+                    error_class=failure_class,
                 )
 
     def _build_failed_run_payload(
@@ -883,10 +1067,34 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         task_info: Dict[str, Any],
         reason: str,
         skipped: bool,
+        error_class: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Return a verify-response-shaped dict for runs that never produced a deliverable."""
+        """Return a verify-response-shaped dict for runs that never produced a deliverable.
+
+        The returned payload carries routing flags read by the rollout
+        dispatcher (``nemo_gym.rollout_collection``):
+
+        - ``_ng_no_persist=True`` for ``kill_shaped``: not written anywhere;
+          resume's set-difference on the main jsonl re-dispatches the task.
+        - ``_ng_failure_terminal=True`` for ``timeout_exceeded`` / ``skipped``:
+          one sidecar entry, never retried.
+        - Otherwise (``legitimate``, ``transient``): sidecar entry per attempt;
+          retried up to ``NEMO_GYM_MAX_ROLLOUT_ATTEMPTS`` on chain resume.
+        """
+        if error_class == "timeout_exceeded":
+            suffix = "timeout"
+            status_word = "Timed out"
+        elif error_class == "kill_shaped":
+            suffix = "killed"
+            status_word = "Killed"
+        elif skipped or error_class == "skipped":
+            suffix = "skipped"
+            status_word = "Skipped"
+        else:
+            suffix = "failed"
+            status_word = "Failed"
         placeholder = NeMoGymResponse(
-            id=f"{self.task_strategy.response_id(task_info)}-{'skipped' if skipped else 'failed'}",
+            id=f"{self.task_strategy.response_id(task_info)}-{suffix}",
             created_at=int(time.time()),
             model=fixed_params.model or "unknown",
             object="response",
@@ -896,7 +1104,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     content=[
                         NeMoGymResponseOutputText(
                             type="output_text",
-                            text=f"{'Skipped' if skipped else 'Failed'}: {reason}",
+                            text=f"{status_word}: {reason}",
                             annotations=[],
                         )
                     ],
@@ -914,6 +1122,18 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         payload["reward"] = 0.0
         payload["skipped"] = skipped
         payload["error_message"] = reason
+        if error_class is not None:
+            payload["error_class"] = error_class
+            payload[NG_FAILURE_CLASS_KEY] = error_class
+            if error_class == "kill_shaped":
+                # Don't persist: resume's set-difference on the main jsonl
+                # naturally re-dispatches. Bounded across hops by per-task timeout.
+                payload[NG_NO_PERSIST_KEY] = True
+            elif error_class in ("timeout_exceeded", "skipped"):
+                # Sidecar entry written once; chain-hop 2 will not retry.
+                payload[NG_TERMINAL_KEY] = True
+            # 'legitimate' / 'transient': sidecar entry per attempt; retried
+            # by chain-hop up to NEMO_GYM_MAX_ROLLOUT_ATTEMPTS (default 3).
         return payload
 
     async def aggregate_metrics(self, body: AggregateMetricsRequest = Body()) -> AggregateMetrics:

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -22,6 +22,7 @@ construction, scoring, response building) is delegated to a
 from __future__ import annotations
 
 import asyncio
+import os
 import shutil
 import sys
 import tempfile
@@ -49,6 +50,174 @@ from nemo_gym.openai_utils import (
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
 from responses_api_agents.stirrup_agent.task_strategy import TaskSampleSkipError, TaskStrategy
+
+
+# ---------------------------------------------------------------------------
+# Per-task timeout (caps a single Ray rollout attempt's wallclock).
+# Without a per-attempt budget, a single pathological task that exceeds Slurm
+# walltime can permanently consume every chain-hop's compute and never
+# complete.
+# ---------------------------------------------------------------------------
+
+STIRRUP_PER_TASK_TIMEOUT_DEFAULT = 3 * 3600 + 30 * 60  # 3h30m = 12600s
+
+_TIMEOUT_LOGGED = False
+
+
+class TaskPerAttemptTimeoutError(Exception):
+    """Raised when a single Ray rollout attempt exceeds the per-task timeout."""
+
+
+def _get_per_task_timeout() -> float:
+    """Read STIRRUP_PER_TASK_TIMEOUT_S (seconds, float) or fall back to default."""
+    raw = os.environ.get("STIRRUP_PER_TASK_TIMEOUT_S")
+    if raw is None or raw == "":
+        return float(STIRRUP_PER_TASK_TIMEOUT_DEFAULT)
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        print(
+            f"[gdpval_stirrup_agent] WARNING: could not parse STIRRUP_PER_TASK_TIMEOUT_S={raw!r} "
+            f"as float, falling back to default {STIRRUP_PER_TASK_TIMEOUT_DEFAULT} s.",
+            flush=True,
+        )
+        return float(STIRRUP_PER_TASK_TIMEOUT_DEFAULT)
+
+
+def _log_timeout_once(timeout_s: float) -> None:
+    """Emit a single INFO line on the first per-task await of this process."""
+    global _TIMEOUT_LOGGED
+    if _TIMEOUT_LOGGED:
+        return
+    _TIMEOUT_LOGGED = True
+    total = int(timeout_s)
+    hours, rem = divmod(total, 3600)
+    minutes, seconds = divmod(rem, 60)
+    print(
+        f"[gdpval_stirrup_agent] per-task timeout set to {hours}h{minutes}m{seconds}s "
+        f"({timeout_s:g} s). Override with env var STIRRUP_PER_TASK_TIMEOUT_S.",
+        flush=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Failure classification (drives whether a failure is persisted to the main
+# rollouts jsonl, the failures sidecar, or nowhere at all).
+#
+# Five classes:
+#   kill_shaped       Ray worker died (SIGTERM/walltime/OOM/node loss). NO row
+#                     written anywhere; resume's set-difference on the main
+#                     jsonl naturally re-dispatches, capped per-attempt by
+#                     the per-task timeout above.
+#   timeout_exceeded  TaskPerAttemptTimeoutError. Sidecar entry with
+#                     _ng_failure_terminal=True so chain-hop 2 does NOT retry.
+#   skipped           TaskSampleSkipError. Sidecar entry with terminal=True.
+#   transient         verify-side ClientResponseError 5xx / connection /
+#                     asyncio.TimeoutError. Sidecar entry per attempt; retry
+#                     up to max_attempts.
+#   legitimate        Everything else (real Python exception with user code
+#                     in the traceback). Sidecar entry per attempt; retry
+#                     up to max_attempts.
+# ---------------------------------------------------------------------------
+
+# Sentinel keys the dispatcher (nemo_gym.rollout_collection) reads to route a
+# returned payload between the main jsonl, the failures sidecar, or /dev/null.
+NG_FAILURE_CLASS_KEY = "_ng_failure_class"  # str: one of the 5 class names
+NG_NO_PERSIST_KEY = "_ng_no_persist"  # bool: don't write anywhere
+NG_TERMINAL_KEY = "_ng_failure_terminal"  # bool: never retry on resume
+
+_USER_CODE_PATH_SUBSTRINGS = (
+    "responses_api_agents/",
+    "/stirrup/",
+)
+
+
+def _has_user_code_frame(exc: BaseException) -> bool:
+    """Return True iff *exc* (or any cause/context in its chain) has a
+    traceback frame originating in user code (stirrup_agent or Stirrup).
+
+    A ``RayTaskError`` wrapping a user-code failure has those frames present.
+    A ``RayTaskError`` raised purely from Ray's internal post-mortem (e.g.
+    formatting a worker stdout log that Slurm's epilogue already scrubbed)
+    has only Ray internals and ``<frozen genericpath>`` — that's the
+    walltime / SIGTERM signature.
+    """
+    seen: set = set()
+
+    def _walk(e: Optional[BaseException]) -> bool:
+        if e is None or id(e) in seen:
+            return False
+        seen.add(id(e))
+        tb = e.__traceback__
+        while tb is not None:
+            fname = tb.tb_frame.f_code.co_filename
+            for sub in _USER_CODE_PATH_SUBSTRINGS:
+                if sub in fname:
+                    return True
+            tb = tb.tb_next
+        return _walk(e.__cause__) or _walk(e.__context__)
+
+    return _walk(exc)
+
+
+def _classify_rollout_failure(exc: BaseException) -> str:
+    """Classify an exception raised by ``self.responses(...)``.
+
+    Returns one of: 'kill_shaped', 'timeout_exceeded', 'skipped', 'legitimate'.
+    The 'transient' class only applies to verify-side failures and is
+    produced by :func:`_classify_verify_failure`.
+    """
+    if isinstance(exc, TaskPerAttemptTimeoutError):
+        return "timeout_exceeded"
+    if isinstance(exc, TaskSampleSkipError):
+        return "skipped"
+    try:
+        from ray.exceptions import (
+            LocalRayletDiedError,
+            NodeDiedError,
+            OutOfMemoryError as RayOutOfMemoryError,
+            RayActorError,
+            RayTaskError,
+            WorkerCrashedError,
+        )
+    except ImportError:
+        # ray.exceptions surface drifted; fail open to bounded retry.
+        return "legitimate"
+    if isinstance(
+        exc,
+        (
+            RayActorError,
+            WorkerCrashedError,
+            NodeDiedError,
+            RayOutOfMemoryError,
+            LocalRayletDiedError,
+        ),
+    ):
+        return "kill_shaped"
+    if isinstance(exc, RayTaskError):
+        # No user-code frame ⇒ Ray internals (e.g. summary-builder hitting
+        # a vanished worker log after Slurm's epilogue scrubbed /tmp/ray).
+        return "legitimate" if _has_user_code_frame(exc) else "kill_shaped"
+    return "legitimate"
+
+
+def _classify_verify_failure(exc: BaseException) -> str:
+    """Classify an exception raised by the ``/verify`` POST. Verify-side
+    failures are never ``kill_shaped`` (we had a rollout response in hand)
+    and never ``timeout_exceeded`` (that's a rollout-side class).
+    """
+    try:
+        import aiohttp
+
+        if isinstance(exc, aiohttp.ClientResponseError):
+            return "transient" if 500 <= exc.status < 600 else "legitimate"
+        if isinstance(exc, aiohttp.ClientConnectionError):
+            return "transient"
+    except ImportError:
+        pass
+    if isinstance(exc, asyncio.TimeoutError):
+        return "transient"
+    return "legitimate"
 
 
 # ---------------------------------------------------------------------------
@@ -687,7 +856,19 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
             }
 
             future = run_stirrup_agent_remote.remote(params)
-            result = await future
+            per_task_timeout = _get_per_task_timeout()
+            _log_timeout_once(per_task_timeout)
+            try:
+                result = await asyncio.wait_for(future, timeout=per_task_timeout)
+            except asyncio.TimeoutError:
+                try:
+                    ray.cancel(future, force=True)
+                except Exception as _cancel_exc:
+                    print(
+                        f"[gdpval_stirrup_agent] WARNING: ray.cancel failed after timeout: {_cancel_exc!r}",
+                        flush=True,
+                    )
+                raise TaskPerAttemptTimeoutError(f"per-task timeout exceeded ({per_task_timeout:g} s)") from None
         finally:
             if input_files_dir:
                 shutil.rmtree(input_files_dir, ignore_errors=True)
@@ -784,10 +965,10 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 response = await self.responses(fixed_params)
             except Exception as exc:
                 task_info = self.task_strategy.extract_task_info(existing_metadata)
-                label = "skipped" if isinstance(exc, TaskSampleSkipError) else "failed"
+                failure_class = _classify_rollout_failure(exc)
                 instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
                 print(
-                    f"[stirrup-{label}] {instance_hint}: {type(exc).__name__}: {exc}",
+                    f"[stirrup-{failure_class}] {instance_hint}: {type(exc).__name__}: {exc}",
                     flush=True,
                 )
                 return self._build_failed_run_payload(
@@ -795,7 +976,8 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     fixed_params=fixed_params,
                     task_info=task_info,
                     reason=f"{type(exc).__name__}: {exc}",
-                    skipped=label == "skipped",
+                    skipped=(failure_class == "skipped"),
+                    error_class=failure_class,
                 )
 
             response_clean = response.model_copy(update={"metadata": None})
@@ -831,9 +1013,10 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 return await get_response_json(verify_response)
             except Exception as exc:
                 task_info = self.task_strategy.extract_task_info(existing_metadata)
+                failure_class = _classify_verify_failure(exc)
                 instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
                 print(
-                    f"[stirrup-verify-failed] {instance_hint}: {type(exc).__name__}: {exc}",
+                    f"[stirrup-verify-{failure_class}] {instance_hint}: {type(exc).__name__}: {exc}",
                     flush=True,
                 )
                 return self._build_failed_run_payload(
@@ -842,6 +1025,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     task_info=task_info,
                     reason=f"verify failed: {type(exc).__name__}: {exc}",
                     skipped=False,
+                    error_class=failure_class,
                 )
 
     def _build_failed_run_payload(
@@ -852,10 +1036,34 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         task_info: Dict[str, Any],
         reason: str,
         skipped: bool,
+        error_class: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Return a verify-response-shaped dict for runs that never produced a deliverable."""
+        """Return a verify-response-shaped dict for runs that never produced a deliverable.
+
+        The returned payload carries routing flags read by the rollout
+        dispatcher (``nemo_gym.rollout_collection``):
+
+        - ``_ng_no_persist=True`` for ``kill_shaped``: not written anywhere;
+          resume's set-difference on the main jsonl re-dispatches the task.
+        - ``_ng_failure_terminal=True`` for ``timeout_exceeded`` / ``skipped``:
+          one sidecar entry, never retried.
+        - Otherwise (``legitimate``, ``transient``): sidecar entry per attempt;
+          retried up to ``NEMO_GYM_MAX_ROLLOUT_ATTEMPTS`` on chain resume.
+        """
+        if error_class == "timeout_exceeded":
+            suffix = "timeout"
+            status_word = "Timed out"
+        elif error_class == "kill_shaped":
+            suffix = "killed"
+            status_word = "Killed"
+        elif skipped or error_class == "skipped":
+            suffix = "skipped"
+            status_word = "Skipped"
+        else:
+            suffix = "failed"
+            status_word = "Failed"
         placeholder = NeMoGymResponse(
-            id=f"{self.task_strategy.response_id(task_info)}-{'skipped' if skipped else 'failed'}",
+            id=f"{self.task_strategy.response_id(task_info)}-{suffix}",
             created_at=int(time.time()),
             model=fixed_params.model or "unknown",
             object="response",
@@ -865,7 +1073,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     content=[
                         NeMoGymResponseOutputText(
                             type="output_text",
-                            text=f"{'Skipped' if skipped else 'Failed'}: {reason}",
+                            text=f"{status_word}: {reason}",
                             annotations=[],
                         )
                     ],
@@ -883,6 +1091,18 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         payload["reward"] = 0.0
         payload["skipped"] = skipped
         payload["error_message"] = reason
+        if error_class is not None:
+            payload["error_class"] = error_class
+            payload[NG_FAILURE_CLASS_KEY] = error_class
+            if error_class == "kill_shaped":
+                # Don't persist: resume's set-difference on the main jsonl
+                # naturally re-dispatches. Bounded across hops by per-task timeout.
+                payload[NG_NO_PERSIST_KEY] = True
+            elif error_class in ("timeout_exceeded", "skipped"):
+                # Sidecar entry written once; chain-hop 2 will not retry.
+                payload[NG_TERMINAL_KEY] = True
+            # 'legitimate' / 'transient': sidecar entry per attempt; retried
+            # by chain-hop up to NEMO_GYM_MAX_ROLLOUT_ATTEMPTS (default 3).
         return payload
 
     async def aggregate_metrics(self, body: AggregateMetricsRequest = Body()) -> AggregateMetrics:


### PR DESCRIPTION
## Summary

Two coupled changes that together fix walltime-induced rollout loss on multi-node GDPVal runs.

**1. Per-task timeout** — default 3h30m, env `STIRRUP_PER_TASK_TIMEOUT_S` overrides. Wraps `await future` in `asyncio.wait_for`; on timeout, `ray.cancel(future, force=True)` + raises `TaskPerAttemptTimeoutError`. Logs once per process at first dispatch.

**2. Failure classification + sidecar routing** — at the two `_build_failed_run_payload` callsites, every failure is classified into one of five classes and persisted accordingly:

| class | persist | retry on chain-hop 2 |
|---|---|---|
| `kill_shaped` (Ray actor died, SIGTERM, OOM, node failure) | NO row anywhere | yes, unbounded (per-attempt timeout bounds wallclock) |
| `timeout_exceeded` | 1 sidecar entry, `_ng_failure_terminal=True` | no |
| `skipped` (TaskSampleSkipError) | 1 sidecar entry, terminal | no |
| `transient` (verify-side 5xx, ConnectionError, asyncio.TimeoutError) | sidecar entry per attempt | yes, up to `NEMO_GYM_MAX_ROLLOUT_ATTEMPTS` (default 3) |
| `legitimate` (real Python exception with user code in traceback) | sidecar entry per attempt | yes, up to max_attempts |

Successes still write to `<output_jsonl_fpath>`; failures write to `<stem>_failures.jsonl`. `_load_from_cache` reads both: main jsonl is the success ledger, sidecar tracks attempts + terminal flags. The retry set is `materialized_inputs − (successes ∪ terminal ∪ maxed_out)`.

## Why this matters

Without #1, a single pathological task that exceeds Slurm walltime can permanently consume every chain-hop's compute and never complete.

Without #2, walltime-killed in-flight rollouts permanently disappear on chain-hop 2. The old `_load_from_cache` dedup keyed on `(task_index, rollout_index)` regardless of `-failed` status, so synthetic `-failed` rows written during the SIGTERM grace window looked already-done to the resumer. Worse, under harsh kills (SIGKILL, OOM) the `-failed` row write itself is non-atomic — we couldn't depend on it being there to filter. Using "row absent from main jsonl" as the canonical "needs retry" signal sidesteps both problems: kill_shaped writes nothing at all, so the disk state survives arbitrary kill timing.

See the debug write-up for the production incident and design rationale: https://gitlab-master.nvidia.com/agronskiy/idea/-/blob/main/reports/debug/20260519T1011-gdpval-missing-histories.md

## Kill-shaped detection

`_classify_rollout_failure` uses Ray's actor-died classes (`RayActorError`, `WorkerCrashedError`, `NodeDiedError`, `OutOfMemoryError`, `LocalRayletDiedError`) plus a user-code-in-traceback fallback for `RayTaskError`. The fallback distinguishes a real user exception (frames under \`responses_api_agents/\` or \`stirrup/\`) from Ray's internal post-mortem (e.g. summary-builder hitting a vanished worker log after Slurm's epilogue scrubbed `/tmp/ray`) — the latter is the walltime / SIGTERM signature and routes to `kill_shaped`. Detection fails open: if Ray's exception surface drifts, everything goes to bounded-retry `legitimate` instead of unbounded-retry `kill_shaped` — safe, not catastrophic.

## Knobs

- `STIRRUP_PER_TASK_TIMEOUT_S` — per-attempt timeout (default 12600 s = 3h30m).
- `NEMO_GYM_MAX_ROLLOUT_ATTEMPTS` — max retries per `(task_index, rollout_index)` (default 3).

## Test plan

- \`python -m py_compile\` clean for both edited files.
- ruff format clean.
- Suggested smoke: run a GDPVal eval with `STIRRUP_PER_TASK_TIMEOUT_S=60`, confirm the log line is emitted once and that long-running rollouts get cancelled cleanly with `_ng_failure_class=timeout_exceeded` in `<stem>_failures.jsonl`.
- Suggested integration: deliberately kill the deployment srun mid-run (`scancel -s TERM`), verify `_failures.jsonl` is unchanged (kill_shaped writes nothing) and that on chain-hop 2 the killed rollouts re-dispatch.