### PR TITLE
chore(deps): bump gitpython 3.1.45 → 3.1.50 to address GHSA-x2qx-6953-8485 and GHSA-rpm5-65cw-6hj4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -717,14 +717,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.45"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/c8/dd58967d119baab745caec2f9d853297cec1989ec1d63f677d3880632b88/gitpython-3.1.45.tar.gz", hash = "sha256:85b0ee964ceddf211c41b9f27a49086010a190fd8132a24e21f362a4b36a791c", size = 215076, upload-time = "2025-07-24T03:45:54.871Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/61/d4b89fec821f72385526e1b9d9a3a0385dda4a72b206d28049e2c7cd39b8/gitpython-3.1.45-py3-none-any.whl", hash = "sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77", size = 208168, upload-time = "2025-07-24T03:45:52.517Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps gitpython from 3.1.45 to 3.1.50 to address two security advisories:

GHSA-x2qx-6953-8485 (NVD: Critical) — Unsafe option check validates multi_options before shlex.split transformation
GHSA-rpm5-65cw-6hj4 (High) — Command Injection via Git options bypass

Both are fixed in gitpython 3.1.47+. This is a security-only change with no API breakage.

Changes

uv.lock: gitpython 3.1.45 → 3.1.50

Verification

uv lock --check ✅
uv sync --extra dev ✅
uv run pytest ✅ (223/223 passed in 12.29s)
uv run python -c "import git; print(git.__version__)" → 3.1.50

Context

gitpython is a transitive dependency pulled in by wandb and mlflow-skinny. Neither pins an upper bound, so the bump is safe.