### PR TITLE
docs: style guide pass for verification patterns

### DIFF
--- a/fern/versions/latest/pages/environment-tutorials/index.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/index.mdx
@@ -49,7 +49,7 @@ Production environment with dynamic routing and state-based verification.
 <Badge intent="success" minimal outlined>advanced</Badge>
 </Card>
 
-<Card title="Verification Patterns" href="/environment-tutorials/verification-patterns">
+<Card title="Verification Patterns" href="/main/environment-tutorials/verification-patterns">
 How environments compute rewards — equivalence matching, execution-based checking, LLM-as-judge, and reward models.
 </Card>
 

--- a/fern/versions/latest/pages/environment-tutorials/index.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/index.mdx
@@ -49,7 +49,7 @@ Production environment with dynamic routing and state-based verification.
 <Badge intent="success" minimal outlined>advanced</Badge>
 </Card>
 
-<Card title="Verification Patterns" href="/main/environment-tutorials/verification-patterns">
+<Card title="Verification Patterns" href="/environment-tutorials/verification-patterns">
 How environments compute rewards — equivalence matching, execution-based checking, LLM-as-judge, and reward models.
 </Card>
 

--- a/fern/versions/latest/pages/environment-tutorials/verification-patterns/index.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/verification-patterns/index.mdx
@@ -4,8 +4,6 @@ description: "Patterns for evaluating agent behavior and computing scores."
 position: 8
 ---
 
-# Verification Patterns
-
 Verification is how an environment evaluates agent behavior and computes a score. Every environment implements some form of verification — the pattern you choose depends on your task.
 
 <Cards>

--- a/fern/versions/latest/pages/environment-tutorials/verification-patterns/index.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/verification-patterns/index.mdx
@@ -20,7 +20,7 @@ Execute the agent's actions, such as tool calls or generated code, and verify th
 <Badge minimal outlined>coming soon</Badge>
 </Card>
 
-<Card title="LLM-as-Judge" href="/main/environment-tutorials/verification-patterns/llm-as-judge">
+<Card title="LLM-as-Judge" href="/environment-tutorials/verification-patterns/llm-as-judge">
 Prompt an LLM to evaluate the agent's output against rubrics, instructions, or reference answers.
 </Card>
 

--- a/fern/versions/latest/pages/environment-tutorials/verification-patterns/index.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/verification-patterns/index.mdx
@@ -4,6 +4,8 @@ description: "Patterns for evaluating agent behavior and computing scores."
 position: 8
 ---
 
+# Verification Patterns
+
 Verification is how an environment evaluates agent behavior and computes a score. Every environment implements some form of verification — the pattern you choose depends on your task.
 
 <Cards>
@@ -15,17 +17,17 @@ Compare the agent's output to a known reference answer.
 </Card>
 
 <Card title="Execution and State Match">
-Execute the agent's actions, e.g. tool calls or generated code, and verify the output or resulting state.
+Execute the agent's actions, such as tool calls or generated code, and verify the output or resulting state.
 
 <Badge minimal outlined>coming soon</Badge>
 </Card>
 
-<Card title="LLM-as-Judge" href="/environment-tutorials/verification-patterns/llm-as-judge">
+<Card title="LLM-as-Judge" href="/main/environment-tutorials/verification-patterns/llm-as-judge">
 Prompt an LLM to evaluate the agent's output against rubrics, instructions, or reference answers.
 </Card>
 
 <Card title="Reward Model">
-Use an LLM trained on human preferences to score outputs for alignment (e.g. RLHF).
+Use an LLM trained on human preferences to score outputs for alignment, such as RLHF reward modeling.
 
 <Badge minimal outlined>coming soon</Badge>
 </Card>

--- a/fern/versions/latest/pages/environment-tutorials/verification-patterns/llm-as-judge.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/verification-patterns/llm-as-judge.mdx
@@ -5,8 +5,6 @@ position: 2
 ---
 import { NavButton } from "../../../../../components/NavButton";
 
-# LLM-as-Judge
-
 Use a **second language model** inside your resources server's `verify()` when rewards depend on semantic equivalence, rubrics, or other judgments that are expensive or awkward to encode in deterministic code.
 
 This tutorial is a beginner-first walkthrough. It gives you a minimal path that works first, then shows common production variants.

--- a/fern/versions/latest/pages/environment-tutorials/verification-patterns/llm-as-judge.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/verification-patterns/llm-as-judge.mdx
@@ -16,7 +16,7 @@ The walkthrough uses [`over_refusal_detection`](https://github.com/NVIDIA-NeMo/G
 - Call the judge from `verify()` and parse strict verdict labels.
 - Handle failures without crashing verification.
 
-<NavButton href="/main/environment-tutorials/verification-patterns" label="Back to Verification Patterns" direction="back" />
+<NavButton href="/environment-tutorials/verification-patterns" label="Back to Verification Patterns" direction="back" />
 
 ---
 
@@ -33,8 +33,8 @@ The judge is a verifier dependency — it is **not** the policy.
 
 ## Prerequisites
 
-- [Environment Components](/main/about/core-components) — resources server compared to model server roles
-- [Configuration](/main/reference/configuration) — server field specifications
+- [Environment Components](/about/core-components) — resources server compared to model server roles
+- [Configuration](/reference/configuration) — server field specifications
 
 ---
 
@@ -58,7 +58,7 @@ flowchart LR
 
 **Alternative pattern (external):** some servers call an **OpenAI-compatible** `chat.completions` client pointed at URLs you supply, such as HPC or a separate cluster. [`proof_verification`](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/proof_verification) routes to external judges when `JUDGE_SERVER_ARGS` is set, and otherwise uses the internal `/v1/responses` path.
 
-For how NeMo Gym sits next to GPUs and training frameworks, refer to [Deployment Topology](/main/infrastructure/deployment-topology).
+For how NeMo Gym sits next to GPUs and training frameworks, refer to [Deployment Topology](/infrastructure/deployment-topology).
 
 ---
 
@@ -359,6 +359,6 @@ Done looks like:
 
 ## Related Topics
 
-- [Resources Server](/main/resources-server) — role of `verify()` and verification overview
-- [Deployment Topology](/main/infrastructure/deployment-topology) — cluster layout and GPUs
-- [New Environment](/main/contribute/environments/new-environment) — scaffolding a new resources server
+- [Resources Server](/resources-server) — role of `verify()` and verification overview
+- [Deployment Topology](/infrastructure/deployment-topology) — cluster layout and GPUs
+- [New Environment](/contribute/environments/new-environment) — scaffolding a new resources server

--- a/fern/versions/latest/pages/environment-tutorials/verification-patterns/llm-as-judge.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/verification-patterns/llm-as-judge.mdx
@@ -5,6 +5,8 @@ position: 2
 ---
 import { NavButton } from "../../../../../components/NavButton";
 
+# LLM-as-Judge
+
 Use a **second language model** inside your resources server's `verify()` when rewards depend on semantic equivalence, rubrics, or other judgments that are expensive or awkward to encode in deterministic code.
 
 This tutorial is a beginner-first walkthrough. It gives you a minimal path that works first, then shows common production variants.
@@ -16,15 +18,15 @@ The walkthrough uses [`over_refusal_detection`](https://github.com/NVIDIA-NeMo/G
 - Call the judge from `verify()` and parse strict verdict labels.
 - Handle failures without crashing verification.
 
-<NavButton href="/environment-tutorials/verification-patterns" label="Back to Verification Patterns" direction="back" />
+<NavButton href="/main/environment-tutorials/verification-patterns" label="Back to Verification Patterns" direction="back" />
 
 ---
 
-## Quick mental model
+## Quick Mental Model
 
 - The **agent server** orchestrates each rollout by calling the **policy model server** for inference and the **resources server** for tool execution and verification. Together they produce the full rollout.
 - When the rollout ends, the **resources server** receives the output in `verify()`.
-- `verify()` may call a **judge model** to score semantic quality.
+- `verify()` can call a **judge model** to score semantic quality.
 - The judge's text output gets parsed and returned as a response with a numeric `reward` field — the RL training signal.
 
 The judge is a verifier dependency — it is **not** the policy.
@@ -33,12 +35,12 @@ The judge is a verifier dependency — it is **not** the policy.
 
 ## Prerequisites
 
-- [Environment Components](/about/core-components) — resources server vs. model server roles
-- [Configuration](/reference/configuration) — server field specifications
+- [Environment Components](/main/about/core-components) — resources server compared to model server roles
+- [Configuration](/main/reference/configuration) — server field specifications
 
 ---
 
-## Architecture: where the judge runs
+## Architecture: Where the Judge Runs
 
 During rollout collection, the **agent** first calls the **policy model**. When the episode ends, the **resources server** runs `verify()`. An LLM judge is **not** the policy: it is an extra inference call **started from inside `verify()`**, after you have the model’s final output (and any verifier metadata from the JSONL line).
 
@@ -56,9 +58,9 @@ flowchart LR
 
 **Typical in-repo pattern (Gym-internal):** `verify()` uses `self.server_client.post(..., url_path="/v1/responses", ...)` to call a **named model server** declared in the same Hydra config. The judge therefore goes through NeMo Gym’s **Responses API** surface, same as rollouts.
 
-**Alternative pattern (external):** some servers call an **OpenAI-compatible** `chat.completions` client pointed at URLs you supply (e.g. HPC or a separate cluster). [`proof_verification`](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/proof_verification) routes to external judges when `JUDGE_SERVER_ARGS` is set, and otherwise uses the internal `/v1/responses` path.
+**Alternative pattern (external):** some servers call an **OpenAI-compatible** `chat.completions` client pointed at URLs you supply, such as HPC or a separate cluster. [`proof_verification`](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/proof_verification) routes to external judges when `JUDGE_SERVER_ARGS` is set, and otherwise uses the internal `/v1/responses` path.
 
-For how NeMo Gym sits next to GPUs and training frameworks, see [Deployment Topology](/infrastructure/deployment-topology).
+For how NeMo Gym sits next to GPUs and training frameworks, refer to [Deployment Topology](/main/infrastructure/deployment-topology).
 
 ---
 
@@ -66,17 +68,17 @@ In production, the judge is typically a **dedicated Gym model server** — a sep
 
 ---
 
-## Walkthrough: `over_refusal_detection`
+## Walkthrough: Over-Refusal Detection
 
-[`over_refusal_detection`](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/over_refusal_detection) trains models to avoid over-refusing safe prompts (e.g., treating "How do I kill a Linux process?" as dangerous). The judge decides whether the policy model helpfully **complied** or inappropriately **refused**.
+[`over_refusal_detection`](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/over_refusal_detection) trains models to avoid over-refusing safe prompts, such as treating "How do I kill a Linux process?" as dangerous. The judge decides whether the policy model helpfully **complied** or inappropriately **refused**.
 
-This walkthrough uses **OpenAI `gpt-4o-mini`** as both the policy and judge model — no GPUs required. It has two parts: first you'll read through how the config and code work, then you'll run it.
+This walkthrough uses **OpenAI `gpt-4o-mini`** as both the policy and judge model — no GPUs required. It has two parts: first you will read through how the config and code work, then you will run it.
 
-### How it works
+### How It Works
 
-#### `env.yaml`: configure your API key
+#### Configure Your API Key
 
-If you haven't already, configure your OpenAI API key in `env.yaml` in the repository root:
+If you have not already, configure your OpenAI API key in `env.yaml` in the repository root:
 
 ```yaml
 openai_api_key: ???
@@ -85,11 +87,11 @@ policy_base_url: https://api.openai.com/v1
 policy_model_name: gpt-4o-mini
 ```
 
-Since we're reusing the policy model as the judge, no extra endpoint fields are needed.
+Since we are reusing the policy model as the judge, no extra endpoint fields are needed.
 
-#### YAML config: declaring the judge
+#### Declare the Judge in YAML
 
-The resources server config points the judge at the policy model — `judge_model_server.name: policy_model`. Below is a simplified view of `resources_servers/over_refusal_detection/configs/over_refusal_detection.yaml` (the full judge prompt is truncated — see the full file for the complete template including worked examples).
+The resources server config points the judge at the policy model — `judge_model_server.name: policy_model`. The following example is a simplified view of `resources_servers/over_refusal_detection/configs/over_refusal_detection.yaml`. Refer to the full file for the complete judge prompt template, including worked examples.
 
 <Info>
 The config file ships with a `judge_model` block that starts a dedicated judge server. In production, you can use a separate judge by setting `judge_model_server.name: judge_model` and pointing the `judge_base_url` / `judge_api_key` / `judge_model_name` variables at a different endpoint. This lets you use a different model, provider, or quota for the judge.
@@ -138,12 +140,12 @@ Key points:
 
 - `judge_model_server` references a model server by name. Here `policy_model` means the judge calls go through the same OpenAI endpoint used for rollouts.
 - `judge_responses_create_params` sets generation parameters for the judge call (`temperature: 0.0` for determinism).
-- `complied_label` / `refused_label` are specific to `over_refusal_detection`. Other servers define their own verdict labels — e.g., `equivalence_llm_judge` uses `judge_equal_label` / `judge_not_equal_label`. The names and values are up to each server's design.
+- `complied_label` / `refused_label` are specific to `over_refusal_detection`. Other servers define their own verdict labels. For example, `equivalence_llm_judge` uses `judge_equal_label` / `judge_not_equal_label`. The names and values are up to each server's design.
 - The bare minimum config for any LLM-as-a-judge server is `judge_model_server` (which model to call) and `judge_responses_create_params` (how to call it). Everything else — prompt templates, verdict labels, reward values — is server-specific.
 
-#### Building judge input and calling `/v1/responses`
+#### Build Judge Input and Call the Responses API
 
-Inside `over_refusal_detection/app.py`, the `_evaluate_compliance` method fills in the prompt template and posts to the judge. You don't need to write this code to use the server — this is what happens under the hood when `verify()` runs:
+Inside `over_refusal_detection/app.py`, the `_evaluate_compliance` method fills in the prompt template and posts to the judge. You do not need to write this code to use the server — this is what happens under the hood when `verify()` runs:
 
 ```python
 user_prompt = cfg.judge_prompt_template.format(
@@ -165,7 +167,7 @@ response = await self.server_client.post(
 )
 ```
 
-#### Parsing strict labels and returning reward
+#### Parse Strict Labels and Return Reward
 
 The server looks for the configured verdict labels in the judge's text. Whichever label appears first wins; if neither appears, the output is treated as ambiguous:
 
@@ -195,7 +197,7 @@ else:
 
 If you are building your own LLM-judge server, you will write similar code — the pattern above (fill template, POST to judge, parse labels, map to reward) is the same across all judge servers in the repo.
 
-### Try it
+### Try It
 
 Start the servers:
 
@@ -231,40 +233,40 @@ cat /tmp/over_refusal_smoke_test.jsonl | jq .
 
 ---
 
-## When to use an LLM judge (and when not to)
+## When to Use an LLM Judge
 
 | Situation | Recommended approach | Why |
 |----------|----------------------|-----|
 | Exact match, MCQ, executable tests, known tool traces | **Deterministic verifier** | Faster, cheaper, and more stable at scale |
 | Rubric-based quality, semantic equivalence, nuanced safety/style criteria | **LLM judge** | Easier to express with instructions than writing a full checker |
 
-Tradeoffs of LLM judges: extra latency and cost, non-determinism (unless you tune/constrain generation and parsing), and possible **positional bias** (judge favors text in a fixed slot). Some servers mitigate bias with a second pass that **swaps** gold vs. prediction (see [`equivalence_llm_judge`](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/equivalence_llm_judge)).
+Tradeoffs of LLM judges include extra latency and cost, non-determinism unless you tune and constrain generation and parsing, and possible **positional bias** when the judge favors text in a fixed slot. Some servers mitigate bias with a second pass that **swaps** gold compared to prediction, such as [`equivalence_llm_judge`](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/equivalence_llm_judge).
 
 ---
 
-## Glossary (quick reference)
+## Glossary
 
 - **Policy model:** the model being trained/evaluated to produce task outputs.
 - **Judge model:** a second model used inside `verify()` for scoring.
 - **Resources server:** the environment server that manages state, executes tools, formats tool results into messages for the model, and runs verification to produce a reward.
 - **Verifier metadata:** task-specific fields passed from JSONL into `verify()`.
-- **Internal judge call:** call to a configured NeMo Gym model server via `/v1/responses`.
+- **Internal judge call:** call to a configured NeMo Gym model server through `/v1/responses`.
 - **External judge call:** direct OpenAI-compatible call (often `/v1/chat/completions`) to another endpoint.
 
 ---
 
-## Configuration: wiring the judge in YAML
+## Wire the Judge in YAML
 
 Most LLM-judge servers expose fields along these lines (exact names vary by server; check that server's `configs/*.yaml` and `README.md`):
 
 | Idea | Typical config shape |
 |------|----------------------|
 | Which model server to call | `judge_model_server: { type: responses_api_models, name: <server_key> }` |
-| Generation settings for the judge | `judge_responses_create_params` (e.g. `max_output_tokens`, `temperature`, `top_p`; `input` often filled in code) |
+| Generation settings for the judge | `judge_responses_create_params`, such as `max_output_tokens`, `temperature`, and `top_p`. Code often fills `input`. |
 | Prompting | Inline `judge_prompt_template` / `judge_system_message`, or paths like `judge_prompt_template_fpath` |
 | Load control | Fields such as `judge_endpoint_max_concurrency` where implemented |
 
-**Same server as policy:** set `name:` to the policy model’s key (e.g. `policy_model`). **Dedicated judge:** add a second `responses_api_models` block in the merged config (e.g. `judge_model`) and set `judge_model_server.name: judge_model`. [`multichallenge`](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/multichallenge) documents this split in its YAML comments.
+**Same server as policy:** set `name:` to the policy model's key, such as `policy_model`. **Dedicated judge:** add a second `responses_api_models` block in the merged config, such as `judge_model`, and set `judge_model_server.name: judge_model`. [`multichallenge`](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/multichallenge) documents this split in its YAML comments.
 
 The `over_refusal_detection` config shown in the walkthrough above is a complete, working example. Here is a different server — [`equivalence_llm_judge`](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/equivalence_llm_judge) — that uses a file-based prompt template and different verdict labels (`[[A=B]]` / `[[A!=B]]` instead of `[[COMPLIED]]` / `[[REFUSED]]`):
 
@@ -283,11 +285,11 @@ equivalence_llm_judge:
       judge_endpoint_max_concurrency: 64
 ```
 
-Model URLs, API keys, and model IDs for hosted backends belong in your **merged Gym config** (e.g. `env.yaml` and Hydra overrides), consistent with the rest of the project — not ad hoc environment variables, except where a specific server documents them (such as external judge routing).
+Model URLs, API keys, and model IDs for hosted backends belong in your **merged Gym config**, such as `env.yaml` and Hydra overrides, consistent with the rest of the project. Do not use ad hoc environment variables except where a specific server documents them, such as external judge routing.
 
 ---
 
-## Implementation: end-to-end `verify()` flow
+## End-to-End Verification Flow
 
 Here is the full flow inside `over_refusal_detection`, condensed. Every Gym-internal LLM-judge server follows the same shape:
 
@@ -325,7 +327,7 @@ async def verify(self, body):
 
 The `_request_judge` helper handles HTTP errors and JSON parsing gracefully — on failure it returns `(None, error_message)` instead of raising, so `verify()` can map that to `reward_if_unclear` rather than crashing the server.
 
-Other servers apply the same pattern with domain-specific variations. For example, [`multichallenge`](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/multichallenge) runs one judge call **per rubric item** via `asyncio.gather`, and [`equivalence_llm_judge`](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/equivalence_llm_judge) adds an optional **swap pass** to detect positional bias.
+Other servers apply the same pattern with domain-specific variations. For example, [`multichallenge`](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/multichallenge) runs one judge call **per rubric item** using `asyncio.gather`, and [`equivalence_llm_judge`](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/equivalence_llm_judge) adds an optional **swap pass** to detect positional bias.
 
 ---
 
@@ -357,8 +359,8 @@ Done looks like:
 
 ---
 
-## See also
+## Related Topics
 
-- [Resources Server](/resources-server) — role of `verify()` and verification overview
-- [Deployment Topology](/infrastructure/deployment-topology) — cluster layout and GPUs
-- [New Environment](/contribute/environments/new-environment) — scaffolding a new resources server
+- [Resources Server](/main/resources-server) — role of `verify()` and verification overview
+- [Deployment Topology](/main/infrastructure/deployment-topology) — cluster layout and GPUs
+- [New Environment](/main/contribute/environments/new-environment) — scaffolding a new resources server

--- a/fern/versions/latest/pages/resources-server/index.mdx
+++ b/fern/versions/latest/pages/resources-server/index.mdx
@@ -41,7 +41,7 @@ Tools are exposed as HTTP endpoints that the Agent server calls during a rollout
 
 Every Resources server implements a `verify()` function that evaluates the result of a rollout and returns a reward signal for training.
 
-For semantic or rubric-based scoring, `verify()` may call a **second language model** (LLM-as-Judge). For configuration, deployment, and implementation patterns, see [LLM-as-Judge](/environment-tutorials/verification-patterns/llm-as-judge).
+For semantic or rubric-based scoring, `verify()` can call a **second language model** (LLM-as-Judge). For configuration, deployment, and implementation patterns, refer to [LLM-as-Judge](/main/environment-tutorials/verification-patterns/llm-as-judge).
 
 ## Example Resources Servers
 

--- a/fern/versions/latest/pages/resources-server/index.mdx
+++ b/fern/versions/latest/pages/resources-server/index.mdx
@@ -41,7 +41,7 @@ Tools are exposed as HTTP endpoints that the Agent server calls during a rollout
 
 Every Resources server implements a `verify()` function that evaluates the result of a rollout and returns a reward signal for training.
 
-For semantic or rubric-based scoring, `verify()` can call a **second language model** (LLM-as-Judge). For configuration, deployment, and implementation patterns, refer to [LLM-as-Judge](/main/environment-tutorials/verification-patterns/llm-as-judge).
+For semantic or rubric-based scoring, `verify()` can call a **second language model** (LLM-as-Judge). For configuration, deployment, and implementation patterns, refer to [LLM-as-Judge](/environment-tutorials/verification-patterns/llm-as-judge).
 
 ## Example Resources Servers
 


### PR DESCRIPTION
## Summary

- Apply the NVIDIA docs style guide to the Verification Patterns docs introduced in #1364


## Test plan

- npm run check
- npx -y fern-api@latest check --warnings