### PR TITLE
fix(stirrup_agent): reasoning fallback + surface tool-arg validation errors

### DIFF
--- a/responses_api_agents/stirrup_agent/finish_tool_coercing.py
+++ b/responses_api_agents/stirrup_agent/finish_tool_coercing.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Gym-side replacement for stirrup's SIMPLE_FINISH_TOOL with `paths` coercion.
+
+Upstream stirrup's FinishParams expects ``paths: list[str]``. DSv4-Pro served
+by vLLM 0.20.0 (the wedu image ``vllm-deepseekv4-v0200-cu130-ray-arm64.sqsh``)
+emits non-string-typed tool-call args as JSON-encoded strings: the model emits
+``<｜DSML｜parameter ... string="false">[...]</｜DSML｜parameter>`` per its
+chat-template, but vLLM's ``--tool-call-parser deepseek_v4`` in 0.20.0 doesn't
+honor the ``string="false"`` flag and forwards the inner JSON as a literal
+string. The Gym client therefore receives ``"paths": "[\\"foo.txt\\"]"``
+(string) instead of ``"paths": ["foo.txt"]`` (list). Stirrup's pydantic
+validator rejects with ``Input should be a valid list (type=list_type)`` and
+the agent loops forever on the same broken shape.
+
+Upstream vLLM PR #41801 (merged 2026-05-06) fixes this, but the wedu image
+predates the merge. This module bypasses the parser bug at the Gym schema
+layer with a ``@field_validator(mode="before")`` that:
+
+1. Passes through real lists unchanged.
+2. JSON-decodes a string that looks like a JSON array (``"[...]"``).
+3. Wraps a bare filename string into a single-element list.
+4. Leaves other types alone so pydantic raises a clean structural error.
+
+Observed broken shapes from the r5 GDPVal client log (verbatim):
+
+  "paths": "[]"
+  "paths": "[\\"article.txt\\"]"
+  "paths": "[\\"article.txt\\", \\"chart.jpg\\"]"
+  "paths": "Case Feedback.docx"            # bare filename
+  "paths": {...}                            # rare; pydantic will reject
+
+Once the wedu image is rebuilt against vLLM main ≥ #41801, this coercion is
+a no-op (the first ``isinstance(v, list)`` branch will always take) and the
+module can be removed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated
+
+from pydantic import BaseModel, Field, field_validator
+from stirrup.constants import FINISH_TOOL_NAME
+from stirrup.core.models import Tool, ToolUseCountMetadata
+from stirrup.tools.finish import _validating_finish_executor
+
+
+class CoercingFinishParams(BaseModel):
+    """Same shape as stirrup.tools.finish.FinishParams, with ``paths`` coercion."""
+
+    reason: Annotated[str, Field(description="Reason for finishing.")]
+    paths: Annotated[
+        list[str],
+        Field(description=("List of file paths created or modified. Do not include directories, only files.")),
+    ]
+
+    @field_validator("paths", mode="before")
+    @classmethod
+    def _coerce_paths(cls, v):
+        if isinstance(v, list):
+            return [str(p) for p in v]
+        if isinstance(v, str):
+            stripped = v.strip()
+            if stripped.startswith("[") and stripped.endswith("]"):
+                try:
+                    parsed = json.loads(stripped)
+                except json.JSONDecodeError:
+                    parsed = None
+                if isinstance(parsed, list):
+                    return [str(p) for p in parsed]
+            if stripped:
+                return [stripped]
+            return []
+        return v
+
+
+COERCING_FINISH_TOOL: Tool[CoercingFinishParams, ToolUseCountMetadata] = Tool[
+    CoercingFinishParams, ToolUseCountMetadata
+](
+    name=FINISH_TOOL_NAME,
+    description=(
+        "Signal task completion with a reason. Use when the task is finished "
+        "or cannot proceed further. Note that you will need a separate turn "
+        "to finish."
+    ),
+    parameters=CoercingFinishParams,
+    executor=_validating_finish_executor,
+)

--- a/responses_api_agents/stirrup_agent/nemo_client.py
+++ b/responses_api_agents/stirrup_agent/nemo_client.py
@@ -299,6 +299,10 @@ class DynamicMaxTokensChatCompletionsClient(ChatCompletionsClient):
         reasoning: Optional[Reasoning] = None
         if hasattr(msg, "reasoning_content") and msg.reasoning_content:
             reasoning = Reasoning(content=msg.reasoning_content)
+        elif hasattr(msg, "reasoning") and msg.reasoning:
+            # vLLM >= 0.16.0 emits `reasoning` (Responses-API convention) instead of
+            # `reasoning_content`; e.g. DeepSeek-V4's `--reasoning-parser deepseek_v4`.
+            reasoning = Reasoning(content=msg.reasoning)
 
         tool_calls = [
             ToolCall(

--- a/responses_api_agents/stirrup_agent/nemo_client.py
+++ b/responses_api_agents/stirrup_agent/nemo_client.py
@@ -87,7 +87,12 @@ def _install_tool_arg_error_surfacing() -> None:
     async def run_tool_with_error_surfacing(self, tool_call, run_metadata):
         result_msg = await _orig_run_tool(self, tool_call, run_metadata)
         if (not getattr(result_msg, "args_was_valid", True)) and result_msg.content == "Tool arguments are not valid":
-            tool = next((t for t in self._tools if t.name == tool_call.name), None)
+            # Mirror upstream stirrup's lookup: self._active_tools is the {name: Tool}
+            # dict built from self._tools filtered by isinstance(Tool). Looking up
+            # via the dict avoids iterating self._tools which mixes Tool instances
+            # with provider objects (e.g. ApptainerCodeExecToolProvider) that don't
+            # have a .name attribute and crash a naive `t.name` lookup.
+            tool = self._active_tools.get(tool_call.name)
             if tool is not None:
                 args = tool_call.arguments if tool_call.arguments and tool_call.arguments.strip() else "{}"
                 try:

--- a/responses_api_agents/stirrup_agent/nemo_client.py
+++ b/responses_api_agents/stirrup_agent/nemo_client.py
@@ -48,6 +48,8 @@ import logging
 from time import perf_counter
 from typing import Any, Optional
 
+import stirrup.core.agent as _stirrup_agent_mod
+from pydantic import ValidationError as _PydanticValidationError
 from stirrup.clients.chat_completions_client import ChatCompletionsClient
 from stirrup.clients.utils import to_openai_tools
 from stirrup.core.models import (
@@ -64,6 +66,52 @@ from responses_api_agents.stirrup_agent.stirrup_utils import to_provider_openai_
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+# Monkey-patch stirrup.core.agent.Agent.run_tool to surface pydantic
+# ValidationError detail into the ToolResult content. Upstream stirrup
+# returns the bare string "Tool arguments are not valid", hiding the
+# pydantic error detail (e.g., "paths: Input should be a valid list,
+# input_type=str"). Without that detail the agent has no signal to
+# self-correct and just retries the same broken shape forever.
+#
+# Observed on DSv4-Pro GDPVal r5/r7: the model emitted `paths` as a JSON
+# string literal ("[]") instead of a JSON array ([]). All ~660 finish
+# attempts in r5 failed with the same bare-string error; the agent
+# never learned what was wrong.
+def _install_tool_arg_error_surfacing() -> None:
+    _orig_run_tool = _stirrup_agent_mod.Agent.run_tool
+    if getattr(_orig_run_tool, "_gym_surfacing_patched", False):
+        return
+
+    async def run_tool_with_error_surfacing(self, tool_call, run_metadata):
+        result_msg = await _orig_run_tool(self, tool_call, run_metadata)
+        if (not getattr(result_msg, "args_was_valid", True)) and result_msg.content == "Tool arguments are not valid":
+            tool = next((t for t in self._tools if t.name == tool_call.name), None)
+            if tool is not None:
+                args = tool_call.arguments if tool_call.arguments and tool_call.arguments.strip() else "{}"
+                try:
+                    tool.parameters.model_validate_json(args)
+                except _PydanticValidationError as exc:
+                    errors_str = "; ".join(
+                        f"{'.'.join(str(p) for p in e['loc']) or '<root>'}: {e['msg']} (type={e.get('type', '?')})"
+                        for e in exc.errors()
+                    )
+                    args_preview = (tool_call.arguments or "")[:500]
+                    detailed = (
+                        f"Tool arguments are not valid: {errors_str}. "
+                        f"Submitted arguments (first 500 chars): {args_preview!r}"
+                    )
+                    result_msg = result_msg.model_copy(update={"content": detailed})
+                except Exception:
+                    pass
+        return result_msg
+
+    run_tool_with_error_surfacing._gym_surfacing_patched = True
+    _stirrup_agent_mod.Agent.run_tool = run_tool_with_error_surfacing
+
+
+_install_tool_arg_error_surfacing()
 
 # Floor for per-call max_completion_tokens.  Below this the model basically
 # cannot produce a useful answer — treat as a hard minimum.

--- a/responses_api_agents/stirrup_agent/nemo_client.py
+++ b/responses_api_agents/stirrup_agent/nemo_client.py
@@ -118,6 +118,41 @@ def _install_tool_arg_error_surfacing() -> None:
 
 _install_tool_arg_error_surfacing()
 
+
+# Replace stirrup's SIMPLE_FINISH_TOOL with a coercing variant whose
+# FinishParams accepts `paths` as a JSON-encoded string and normalizes to
+# list[str]. vLLM 0.20.0's --tool-call-parser deepseek_v4 forwards DSv4's
+# string="false" args as JSON strings (the unwrap landed upstream in vLLM
+# PR #41801, merged 2026-05-06, but the wedu image predates the merge).
+# See responses_api_agents/stirrup_agent/finish_tool_coercing.py for the
+# coerced schema. The override happens at module-import time so any Agent
+# constructed after this point picks up the coercing variant via the
+# default-arg path in stirrup.core.agent.Agent.__init__.
+def _install_coercing_finish_tool() -> None:
+    import stirrup.tools as _tools_mod
+    import stirrup.tools.finish as _finish_mod
+
+    if getattr(_finish_mod.SIMPLE_FINISH_TOOL, "_gym_coercing_finish_patched", False):
+        return
+
+    from responses_api_agents.stirrup_agent.finish_tool_coercing import (
+        COERCING_FINISH_TOOL,
+    )
+
+    # Tag for idempotency.
+    setattr(COERCING_FINISH_TOOL, "_gym_coercing_finish_patched", True)
+
+    # Patch the canonical binding plus every place stirrup or its callers
+    # captured a reference via `from ... import SIMPLE_FINISH_TOOL`.
+    _finish_mod.SIMPLE_FINISH_TOOL = COERCING_FINISH_TOOL
+    if hasattr(_tools_mod, "SIMPLE_FINISH_TOOL"):
+        _tools_mod.SIMPLE_FINISH_TOOL = COERCING_FINISH_TOOL
+    if hasattr(_stirrup_agent_mod, "SIMPLE_FINISH_TOOL"):
+        _stirrup_agent_mod.SIMPLE_FINISH_TOOL = COERCING_FINISH_TOOL
+
+
+_install_coercing_finish_tool()
+
 # Floor for per-call max_completion_tokens.  Below this the model basically
 # cannot produce a useful answer — treat as a hard minimum.
 _MIN_COMPLETION_TOKENS = 1024

--- a/responses_api_agents/stirrup_agent/tests/test_finish_tool_coercing.py
+++ b/responses_api_agents/stirrup_agent/tests/test_finish_tool_coercing.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Round-trip tests for CoercingFinishParams.
+
+Covers the 4 known broken `paths` shapes observed in the DSv4-Pro GDPVal r5
+client log (vLLM 0.20.0 + --tool-call-parser deepseek_v4, pre-PR #41801) plus
+the canonical correct shapes that should round-trip unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from responses_api_agents.stirrup_agent.finish_tool_coercing import (
+    COERCING_FINISH_TOOL,
+    CoercingFinishParams,
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Empty list as JSON-encoded string — the most common bad shape.
+        ('{"reason":"ok","paths":"[]"}', []),
+        # Single-element JSON-encoded array.
+        ('{"reason":"ok","paths":"[\\"a.txt\\"]"}', ["a.txt"]),
+        # Multi-element JSON-encoded array, with whitespace.
+        (
+            '{"reason":"ok","paths":"[\\"a.txt\\", \\"b.pdf\\"]"}',
+            ["a.txt", "b.pdf"],
+        ),
+        # Bare filename string — wrap into single-element list.
+        ('{"reason":"ok","paths":"single.docx"}', ["single.docx"]),
+        # Correct list shape — passthrough.
+        ('{"reason":"ok","paths":[]}', []),
+        ('{"reason":"ok","paths":["a.txt"]}', ["a.txt"]),
+        ('{"reason":"ok","paths":["a.txt","b.pdf"]}', ["a.txt", "b.pdf"]),
+    ],
+)
+def test_paths_coercion(raw: str, expected: list[str]) -> None:
+    """Each known-bad and known-good shape round-trips to a clean list[str]."""
+    p = CoercingFinishParams.model_validate_json(raw)
+    assert p.paths == expected
+    assert all(isinstance(x, str) for x in p.paths)
+
+
+def test_reason_required() -> None:
+    """`reason` is still required — coercion only changes `paths` semantics."""
+    with pytest.raises(ValidationError):
+        CoercingFinishParams.model_validate_json('{"paths":[]}')
+
+
+def test_paths_required() -> None:
+    """`paths` is still required — coercion has no default."""
+    with pytest.raises(ValidationError):
+        CoercingFinishParams.model_validate_json('{"reason":"ok"}')
+
+
+def test_paths_dict_rejected_loudly() -> None:
+    """An object for `paths` (not list / str) raises a clean pydantic error
+    instead of silently coercing."""
+    with pytest.raises(ValidationError):
+        CoercingFinishParams.model_validate_json('{"reason":"ok","paths":{"a":1}}')
+
+
+def test_paths_with_non_string_items_stringified() -> None:
+    """A real list with non-string items gets stringified (defensive)."""
+    p = CoercingFinishParams.model_validate({"reason": "ok", "paths": [1, "b.txt"]})
+    assert p.paths == ["1", "b.txt"]
+
+
+def test_tool_carries_coercing_params() -> None:
+    """The exported tool references CoercingFinishParams as its parameters
+    schema — sanity check that the wire-up doesn't fall back to upstream."""
+    assert COERCING_FINISH_TOOL.parameters is CoercingFinishParams
+    assert COERCING_FINISH_TOOL.name == "finish"

--- a/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
+++ b/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
@@ -44,6 +44,7 @@ def _make_response(content: str = "ok"):
     choice.message.content = content
     choice.message.tool_calls = []
     choice.message.reasoning_content = None
+    choice.message.reasoning = None
     response.choices = [choice]
     response.usage = MagicMock()
     response.usage.prompt_tokens = 10


### PR DESCRIPTION
## Summary

Three Gym-side fixes for DSv4-Pro (and any vLLM ≥ 0.16 model) running through the Stirrup agent. (2) and (3) are workarounds for the wedu vLLM image (`vllm-deepseekv4-v0200`) predating upstream [vllm-project/vllm#41801](https://github.com/vllm-project/vllm/pull/41801) (merged 2026-05-06), which fixes `--tool-call-parser deepseek_v4` to honor DSv4's `string="false"` flag. Once the image is rebuilt against vLLM main ≥ #41801, (2) becomes diagnostic-only and (3) becomes a no-op.

### 1) Reasoning-field fallback (`nemo_client.py:299`)

vLLM ≥ 0.16.0 emits `msg.reasoning` (Responses-API convention) instead of `msg.reasoning_content`. Add an `elif` branch so reasoning is threaded back into the next-turn request instead of silently dropped.

### 2) Surface pydantic ValidationError in failed tool-call results

Upstream stirrup returns the bare string `"Tool arguments are not valid"` as `ToolResult.content`, hiding the pydantic detail. The agent has no signal to self-correct and retries the same broken shape forever.

Fix: one-shot monkey-patch on `stirrup.core.agent.Agent.run_tool` at module import time — on the failure path, re-run `tool.parameters.model_validate_json` and rebuild the `ToolMessage` with field-by-field error detail + a 500-char preview of the submitted args. Guarded by `_gym_surfacing_patched` for idempotency.

### 3) Coercing `finish` tool — accept `paths` as JSON-encoded string

Pre-#41801 vLLM forwards non-string tool-call args as JSON-encoded strings, so the Gym client receives `"paths": "[\"foo.txt\"]"` (string) instead of `"paths": ["foo.txt"]` (list). New `finish_tool_coercing.py` defines `CoercingFinishParams` with a `@field_validator("paths", mode="before")` that passes real lists through, JSON-decodes `"[...]"` strings, wraps bare filename strings into single-element lists, and lets other types fall to a clean pydantic structural error. Wired in as `COERCING_FINISH_TOOL` replacing `SIMPLE_FINISH_TOOL` at module-import time across `stirrup.tools.finish`, `stirrup.tools`, and `stirrup.core.agent` import-aliases.

Round-trip tests in `tests/test_finish_tool_coercing.py` cover the four broken shapes observed in the DSv4-Pro GDPVal client log.