### PR TITLE
docs: fix agent_ref description to reference agent server instead of resources server

### DIFF
--- a/docs/data/index.md
+++ b/docs/data/index.md
@@ -33,7 +33,7 @@ Additional fields like `expected_answer` vary by resources server—the componen
 | Field | Added By | Description |
 |-------|----------|-------------|
 | `responses_create_params` | User | Input to the model during training. Contains `input` (messages) and optional `tools`, `temperature`, etc. |
-| `agent_ref` | `ng_prepare_data` | Routes each row to its resources server. Auto-generated during data preparation. |
+| `agent_ref` | `ng_prepare_data` | Routes each row to its agent server. Auto-generated during data preparation. |
 
 ### Optional Fields
 
@@ -49,7 +49,7 @@ Check `resources_servers/<name>/README.md` for fields required by each resources
 
 ### The `agent_ref` Field
 
-The `agent_ref` field maps each row to a specific resources server. A training dataset can blend multiple resources servers in a single file—`agent_ref` tells NeMo Gym which server handles each row.
+The `agent_ref` field maps each row to a specific agent server, which in turn knows its resources server from the YAML config. A training dataset can blend multiple agent servers in a single file—`agent_ref` tells NeMo Gym which server handles each row.
 
 ```json
 {


### PR DESCRIPTION
Fixes #1348

## Summary
The `agent_ref` field description incorrectly stated it routes each row 
to a "resources server". Updated to accurately reflect that it routes to 
an **agent server**, which in turn knows its resources server from the 
YAML config.

## Changes
- `docs/data/index.md`: Fixed description in Required Fields table
- `docs/data/index.md`: Fixed description in "The agent_ref Field" section