### PR TITLE
feat: Make vLLM reasoning tags configurable from YAML

### DIFF
--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -638,23 +638,21 @@ class VLLMConverter(BaseModel):
     # =======================================================
 
     def model_post_init(self, context) -> None:
+        """Pre-compile the configured reasoning-tag regex once at initialization time."""
+
         self._reasoning_tag_regex = re.compile(
             rf"{re.escape(self.reasoning_start_tag)}(.*?){re.escape(self.reasoning_end_tag)}",
             re.DOTALL,
         )
-
-    def _reasoning_tag_pattern(self) -> re.Pattern:
-        return self._reasoning_tag_regex
 
     def _wrap_reasoning_in_tags(self, texts: List[str]) -> str:
         return "".join(f"{self.reasoning_start_tag}{t}{self.reasoning_end_tag}" for t in texts if t)
 
     def _parse_reasoning_tags(self, content: str) -> Tuple[List[str], str]:
         # Extract reasoning content from between the configured reasoning tags.
-        pattern = self._reasoning_tag_pattern()
-        matches = pattern.findall(content)
+        matches = self._reasoning_tag_regex.findall(content)
         # Remove reasoning from main content
-        cleaned = pattern.sub("", content)
+        cleaned = self._reasoning_tag_regex.sub("", content)
         return matches, cleaned
 
     # =======================================================

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -23,7 +23,7 @@ from uuid import uuid4
 
 from aiohttp.client_exceptions import ClientResponseError
 from fastapi import Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 from nemo_gym.base_responses_api_model import (
     BaseResponsesAPIModelConfig,
@@ -67,6 +67,8 @@ from nemo_gym.server_utils import SESSION_ID_KEY, is_nemo_gym_fastapi_entrypoint
 
 
 class ReasoningTagsConfig(BaseModel):
+    """Configures the tag pair used to wrap and parse reasoning content in assistant messages."""
+
     start: str = "<think>"
     end: str = "</think>"
 
@@ -629,16 +631,20 @@ class VLLMConverter(BaseModel):
     return_token_id_information: bool
     reasoning_start_tag: str = "<think>"
     reasoning_end_tag: str = "</think>"
+    _reasoning_tag_regex: re.Pattern = PrivateAttr()
 
     # =======================================================
     # Reasoning handling. This may change across models and model families
     # =======================================================
 
-    def _reasoning_tag_pattern(self) -> re.Pattern:
-        return re.compile(
+    def model_post_init(self, context) -> None:
+        self._reasoning_tag_regex = re.compile(
             rf"{re.escape(self.reasoning_start_tag)}(.*?){re.escape(self.reasoning_end_tag)}",
             re.DOTALL,
         )
+
+    def _reasoning_tag_pattern(self) -> re.Pattern:
+        return self._reasoning_tag_regex
 
     def _wrap_reasoning_in_tags(self, texts: List[str]) -> str:
         return "".join(f"{self.reasoning_start_tag}{t}{self.reasoning_end_tag}" for t in texts if t)

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -66,6 +66,11 @@ from nemo_gym.openai_utils import (
 from nemo_gym.server_utils import SESSION_ID_KEY, is_nemo_gym_fastapi_entrypoint
 
 
+class ReasoningTagsConfig(BaseModel):
+    start: str = "<think>"
+    end: str = "</think>"
+
+
 class VLLMModelConfig(BaseResponsesAPIModelConfig):
     base_url: Union[str, List[str]]
     api_key: str
@@ -94,6 +99,7 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
     # ``data:audio/<fmt>;base64,...`` URI at request time — keeps the JSONL
     # small without depending on vLLM's ``--allowed-local-media-path``.
     audio_root: Optional[str] = None
+    reasoning_tags: ReasoningTagsConfig = Field(default_factory=ReasoningTagsConfig)
 
     def model_post_init(self, context):
         if isinstance(self.base_url, str):
@@ -111,6 +117,8 @@ class VLLMModel(SimpleResponsesAPIModel):
         """
         return VLLMConverter(
             return_token_id_information=self.config.return_token_id_information,
+            reasoning_start_tag=self.config.reasoning_tags.start,
+            reasoning_end_tag=self.config.reasoning_tags.end,
         )
 
     def model_post_init(self, context):
@@ -489,8 +497,9 @@ class VLLMModel(SimpleResponsesAPIModel):
                 # See the TODO wrt reasoning_content above
                 choice_dict["message"].pop("reasoning", None)
 
-                # We wrap this here in think tags for Gym's sake and to return a valid OpenAI Chat Completions response.
-                choice_dict["message"]["content"] = self._converter._wrap_reasoning_in_think_tags(
+                # We wrap this here in the configured reasoning tags for Gym's sake and to return a valid OpenAI Chat
+                # Completions response.
+                choice_dict["message"]["content"] = self._converter._wrap_reasoning_in_tags(
                     [reasoning_content]
                 ) + (choice_dict["message"].get("content") or "")
         else:
@@ -618,23 +627,28 @@ class VLLMConverterResponsesToChatCompletionsState(BaseModel):
 
 class VLLMConverter(BaseModel):
     return_token_id_information: bool
+    reasoning_start_tag: str = "<think>"
+    reasoning_end_tag: str = "</think>"
 
     # =======================================================
     # Reasoning handling. This may change across models and model families
     # =======================================================
 
-    THINK_TAG_PATTERN: ClassVar = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+    def _reasoning_tag_pattern(self) -> re.Pattern:
+        return re.compile(
+            rf"{re.escape(self.reasoning_start_tag)}(.*?){re.escape(self.reasoning_end_tag)}",
+            re.DOTALL,
+        )
 
-    @staticmethod
-    def _wrap_reasoning_in_think_tags(texts: List[str]) -> str:
-        return "".join(f"<think>{t}</think>" for t in texts if t)
+    def _wrap_reasoning_in_tags(self, texts: List[str]) -> str:
+        return "".join(f"{self.reasoning_start_tag}{t}{self.reasoning_end_tag}" for t in texts if t)
 
-    @classmethod
-    def _parse_think_tags(cls, content: str) -> Tuple[List[str], str]:
-        # Extract reasoning content from between <think></think> tags.
-        matches = cls.THINK_TAG_PATTERN.findall(content)
+    def _parse_reasoning_tags(self, content: str) -> Tuple[List[str], str]:
+        # Extract reasoning content from between the configured reasoning tags.
+        pattern = self._reasoning_tag_pattern()
+        matches = pattern.findall(content)
         # Remove reasoning from main content
-        cleaned = cls.THINK_TAG_PATTERN.sub("", content)
+        cleaned = pattern.sub("", content)
         return matches, cleaned
 
     # =======================================================
@@ -822,7 +836,7 @@ class VLLMConverter(BaseModel):
         """
         if "summary" in m and m["summary"]:
             texts = [s["text"] for s in m["summary"]]
-            state.content_buffer += self._wrap_reasoning_in_think_tags(texts)
+            state.content_buffer += self._wrap_reasoning_in_tags(texts)
 
     def _format_function_call(
         self,
@@ -913,9 +927,8 @@ class VLLMConverter(BaseModel):
         return response_output
 
     def _extract_reasoning_from_content(self, content: str) -> Tuple[List[str], str]:
-        # TODO: Currently only parses reasoning wrapped in <think>...</think> tags.
-        # Maybe parameterize to support other model formats in the future.
-        return self._parse_think_tags(content)
+        # Parse reasoning wrapped in the configured reasoning tags.
+        return self._parse_reasoning_tags(content)
 
     def chat_completions_messages_to_responses_items(
         self, messages: List[Dict[str, Any]]

--- a/responses_api_models/vllm_model/configs/vllm_model.yaml
+++ b/responses_api_models/vllm_model/configs/vllm_model.yaml
@@ -8,6 +8,9 @@ policy_model:
       return_token_id_information: false
       uses_reasoning_parser: true
       uses_interleaved_reasoning: true
+      reasoning_tags:
+        start: "<think>"
+        end: "</think>"
       chat_template_kwargs: null
       extra_body: null
       default_headers: {}

--- a/responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
+++ b/responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
@@ -7,3 +7,6 @@ policy_model:
       model: ${policy_model_name}
       return_token_id_information: true
       uses_reasoning_parser: true
+      reasoning_tags:
+        start: "<think>"
+        end: "</think>"

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -683,6 +683,29 @@ class TestApp:
     async def test_sanity(self, monkeypatch: MonkeyPatch) -> None:
         self._setup_server(monkeypatch)
 
+    def test_get_converter_uses_configured_reasoning_tags(self, monkeypatch: MonkeyPatch) -> None:
+        config = VLLMModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            base_url="http://api.openai.com/v1",
+            api_key="dummy_key",  # pragma: allowlist secret
+            model="dummy_model",
+            entrypoint="",
+            name="",
+            return_token_id_information=False,
+            uses_reasoning_parser=True,
+            reasoning_tags={"start": "<reasoning>", "end": "</reasoning>"},
+        )
+
+        get_global_config_dict_mock = MagicMock()
+        get_global_config_dict_mock.return_value = dict()
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", get_global_config_dict_mock)
+
+        server = VLLMModel(config=config, server_client=MagicMock(spec=ServerClient))
+
+        assert server._converter.reasoning_start_tag == "<reasoning>"
+        assert server._converter.reasoning_end_tag == "</reasoning>"
+
     def test_responses_multistep(self, monkeypatch: MonkeyPatch):
         server = self._setup_server(monkeypatch)
         app = server.setup_webserver()
@@ -2725,6 +2748,57 @@ class TestVLLMConverter:
         reasoning_none, main_content_none = self.converter._extract_reasoning_from_content(content_none)
         assert reasoning_none == []
         assert main_content_none == "Just plain content here."
+
+    def test_extract_reasoning_from_content_custom_tags(self):
+        converter = VLLMConverter(
+            return_token_id_information=False,
+            reasoning_start_tag="<reasoning>",
+            reasoning_end_tag="</reasoning>",
+        )
+
+        content = "First.<reasoning>Thought 1.</reasoning>Second.<reasoning>Thought 2.</reasoning>Done."
+        reasoning, main_content = converter._extract_reasoning_from_content(content)
+
+        assert reasoning == ["Thought 1.", "Thought 2."]
+        assert main_content == "First.Second.Done."
+
+    def test_responses_to_chat_completion_create_params_uses_configured_reasoning_tags(self):
+        converter = VLLMConverter(
+            return_token_id_information=False,
+            reasoning_start_tag="<reasoning>",
+            reasoning_end_tag="</reasoning>",
+        )
+        responses_create_params = NeMoGymResponseCreateParamsNonStreaming(
+            input=[
+                NeMoGymResponseReasoningItem(
+                    id="rs_123",
+                    type="reasoning",
+                    summary=[
+                        NeMoGymSummary(type="summary_text", text="Thought 1."),
+                        NeMoGymSummary(type="summary_text", text="Thought 2."),
+                    ],
+                ),
+                NeMoGymResponseOutputMessage(
+                    id="msg_123",
+                    role="assistant",
+                    type="message",
+                    content=[NeMoGymResponseOutputText(type="output_text", text="Hello!", annotations=[])],
+                    status="completed",
+                ),
+            ]
+        )
+
+        actual_chat_completion_create_params = converter.responses_to_chat_completion_create_params(
+            responses_create_params
+        )
+
+        assert actual_chat_completion_create_params.messages == [
+            NeMoGymChatCompletionAssistantMessageParam(
+                role="assistant",
+                content="<reasoning>Thought 1.</reasoning><reasoning>Thought 2.</reasoning>Hello!",
+                tool_calls=[],
+            )
+        ]
 
     def test_postprocess_chat_response_multiple_reasoning_items(self, monkeypatch: MonkeyPatch):
         monkeypatch.setattr("responses_api_models.vllm_model.app.uuid4", lambda: FakeUUID())

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -683,7 +683,7 @@ class TestApp:
     async def test_sanity(self, monkeypatch: MonkeyPatch) -> None:
         self._setup_server(monkeypatch)
 
-    def test_get_converter_uses_configured_reasoning_tags(self, monkeypatch: MonkeyPatch) -> None:
+    def test_converter_initialization_uses_configured_reasoning_tags(self, monkeypatch: MonkeyPatch) -> None:
         config = VLLMModelConfig(
             host="0.0.0.0",
             port=8081,


### PR DESCRIPTION
This updates `responses_api_models/vllm_model/app.py` so reasoning wrappers/parsers no longer assume `<think>...</think>`. The tag pair is now configurable via model YAML while preserving the current `<think>` defaults for existing configs.
