### PR TITLE
perf(server_utils): avoid repeated config work in agent runs

### DIFF
--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -474,10 +474,6 @@ class ServerClient(BaseModel):
 
 
 def _has_local_global_config() -> bool:
-    from nemo_gym import global_config as _gc
-
-    if _gc._GLOBAL_CONFIG_DICT is not None:
-        return True
     return getenv(NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME) is not None
 
 

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -327,8 +327,8 @@ class ServerClient(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    # Cached server_name -> base_url lookup populated lazily by request()
-    _server_base_urls: dict = PrivateAttr(default_factory=dict)
+    # Resolved base URLs, cached by server name.
+    _server_base_urls: dict[str, str] = PrivateAttr(default_factory=dict)
 
     @classmethod
     def load_head_server_config(cls) -> BaseServerConfig:
@@ -339,15 +339,15 @@ class ServerClient(BaseModel):
 
     @classmethod
     def load_from_global_config(cls, head_server_config: Optional[BaseServerConfig] = None) -> "ServerClient":
-        """Build a `ServerClient` from the merged global config dict.
+        """Build a client from the fully resolved global config.
 
-        Uses the in-process global config dict when available.
-        Otherwise falls back to fetching the YAML from the head server over HTTP.
+        Gym-launched server processes reuse the config injected by their parent.
+        Other processes fetch the config from the head server.
         """
         if head_server_config is None:
             head_server_config = cls.load_head_server_config()
 
-        if _has_local_global_config():
+        if _has_injected_global_config_env():
             return cls(
                 head_server_config=head_server_config,
                 global_config_dict=get_global_config_dict(),
@@ -473,7 +473,7 @@ class ServerClient(BaseModel):
         return f"http://{server_config_dict.host}:{server_config_dict.port}"
 
 
-def _has_local_global_config() -> bool:
+def _has_injected_global_config_env() -> bool:
     return getenv(NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME) is not None
 
 
@@ -826,7 +826,7 @@ Full body: {json.dumps(exc.body, indent=4)}
 class HeadServer(BaseServer):
     config: BaseServerConfig
     _server_instances: List[dict] = []
-    # Cached YAML serialization of the global config dict, which is immutable post-startup
+    # Serialized global config returned to clients.
     _cached_yaml: Optional[str] = None
 
     def setup_webserver(self) -> FastAPI:
@@ -845,7 +845,7 @@ class HeadServer(BaseServer):
         self._server_instances = instances
 
     def invalidate_global_config_dict_yaml_cache(self) -> None:
-        """Forget the cached YAML; the next call to `global_config_dict_yaml will re-serialize."""
+        """Clear the serialized global config cache."""
         self._cached_yaml = None
 
     @classmethod

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -49,7 +49,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from multidict import CIMultiDict
 from omegaconf import DictConfig, OmegaConf, open_dict
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 from requests.exceptions import ConnectionError
 from starlette.middleware.sessions import SessionMiddleware
 
@@ -63,6 +63,7 @@ from nemo_gym.config_types import (
 from nemo_gym.global_config import (
     DRY_RUN_KEY_NAME,
     HEAD_SERVER_KEY_NAME,
+    NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME,
     NEMO_GYM_CONFIG_PATH_ENV_VAR_NAME,
     OBSERVABILITY_ENABLED_KEY_NAME,
     RAY_HEAD_NODE_ADDRESS_KEY_NAME,
@@ -326,6 +327,9 @@ class ServerClient(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
+    # Cached server_name -> base_url lookup populated lazily by request()
+    _server_base_urls: dict = PrivateAttr(default_factory=dict)
+
     @classmethod
     def load_head_server_config(cls) -> BaseServerConfig:
         global_config_dict = get_global_config_dict()
@@ -335,8 +339,19 @@ class ServerClient(BaseModel):
 
     @classmethod
     def load_from_global_config(cls, head_server_config: Optional[BaseServerConfig] = None) -> "ServerClient":
+        """Build a `ServerClient` from the merged global config dict.
+
+        Uses the in-process global config dict when available.
+        Otherwise falls back to fetching the YAML from the head server over HTTP.
+        """
         if head_server_config is None:
             head_server_config = cls.load_head_server_config()
+
+        if _has_local_global_config():
+            return cls(
+                head_server_config=head_server_config,
+                global_config_dict=get_global_config_dict(),
+            )
 
         # It's critical we use requests here instead of the global httpx client since a FastAPI server may be run downstream of this function call.
         head_server_url = f"http://{head_server_config.host}:{head_server_config.port}"
@@ -354,14 +369,10 @@ class ServerClient(BaseModel):
 
         return cls(head_server_config=head_server_config, global_config_dict=global_config_dict)
 
-    def _build_server_base_url(self, server_config_dict: OmegaConf) -> str:
-        return f"http://{server_config_dict.host}:{server_config_dict.port}"
-
     async def request(
         self, server_name: str, url_path: str, method: str, **kwargs: Unpack[_RequestOptions]
     ) -> ClientResponse:
-        server_config_dict = get_first_server_config_dict(self.global_config_dict, server_name)
-        base_url = self._build_server_base_url(server_config_dict)
+        base_url = self._resolve_base_url(server_name)
 
         json_obj = kwargs.get("json")
         if "json" in kwargs:
@@ -448,6 +459,26 @@ class ServerClient(BaseModel):
             return "timeout"
         except Exception:
             return "unknown_error"
+
+    def _resolve_base_url(self, server_name: str) -> str:
+        cached = self._server_base_urls.get(server_name)
+        if cached is not None:
+            return cached
+        server_config_dict = get_first_server_config_dict(self.global_config_dict, server_name)
+        base_url = self._build_server_base_url(server_config_dict)
+        self._server_base_urls[server_name] = base_url
+        return base_url
+
+    def _build_server_base_url(self, server_config_dict: OmegaConf) -> str:
+        return f"http://{server_config_dict.host}:{server_config_dict.port}"
+
+
+def _has_local_global_config() -> bool:
+    from nemo_gym import global_config as _gc
+
+    if _gc._GLOBAL_CONFIG_DICT is not None:
+        return True
+    return getenv(NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME) is not None
 
 
 SESSION_ID_KEY = "session_id"
@@ -799,6 +830,8 @@ Full body: {json.dumps(exc.body, indent=4)}
 class HeadServer(BaseServer):
     config: BaseServerConfig
     _server_instances: List[dict] = []
+    # Cached YAML serialization of the global config dict, which is immutable post-startup
+    _cached_yaml: Optional[str] = None
 
     def setup_webserver(self) -> FastAPI:
         app = FastAPI()
@@ -814,6 +847,10 @@ class HeadServer(BaseServer):
 
     def set_server_instances(self, instances: List) -> None:
         self._server_instances = instances
+
+    def invalidate_global_config_dict_yaml_cache(self) -> None:
+        """Forget the cached YAML; the next call to `global_config_dict_yaml will re-serialize."""
+        self._cached_yaml = None
 
     @classmethod
     def run_webserver(cls) -> Tuple[uvicorn.Server, Thread, "HeadServer"]:  # pragma: no cover
@@ -835,7 +872,9 @@ class HeadServer(BaseServer):
         return uvicorn_server, thread, server
 
     async def global_config_dict_yaml(self) -> str:
-        return OmegaConf.to_yaml(get_global_config_dict())
+        if self._cached_yaml is None:
+            self._cached_yaml = OmegaConf.to_yaml(get_global_config_dict())
+        return self._cached_yaml
 
 
 class ServerInstanceDisplayConfig(BaseModel):

--- a/responses_api_agents/mini_swe_agent/app.py
+++ b/responses_api_agents/mini_swe_agent/app.py
@@ -43,7 +43,6 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
 )
 from nemo_gym.server_utils import (
-    ServerClient,
     get_first_server_config_dict,
 )
 from responses_api_agents.mini_swe_agent.utils import MiniSWEAgentUtils
@@ -110,7 +109,7 @@ class MiniSWEAgent(SimpleResponsesAPIAgent):
     async def run(self, body: MiniSWEAgentRunRequest) -> MiniSWEAgentVerifyResponse:
         async with self.sem:
             model_server_name = self.config.model_server.name
-            global_config_dict = ServerClient.load_from_global_config().global_config_dict
+            global_config_dict = self.server_client.global_config_dict
 
             model_server_config = get_first_server_config_dict(
                 global_config_dict,

--- a/responses_api_agents/mini_swe_agent/tests/test_app.py
+++ b/responses_api_agents/mini_swe_agent/tests/test_app.py
@@ -113,10 +113,8 @@ def create_test_config(
     )
 
 
-def setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict):
-    mock_server_client_instance = MagicMock()
-    mock_server_client_instance.global_config_dict = {"policy_model_name": "test_model"}
-    mock_load_from_global_config.return_value = mock_server_client_instance
+def setup_server_client_mocks(mock_server_client, mock_get_first_server_config_dict):
+    mock_server_client.global_config_dict = {"policy_model_name": "test_model"}
 
     mock_get_first_server_config_dict.return_value = {
         "host": "0.0.0.0",
@@ -220,7 +218,6 @@ class TestApp:
         config = create_test_config(model_name="", cache_dir_template="/")
         MiniSWEAgent(config=config, server_client=MagicMock(spec=ServerClient))
 
-    @patch("responses_api_agents.mini_swe_agent.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.mini_swe_agent.app.get_first_server_config_dict")
     @patch("responses_api_agents.mini_swe_agent.app.get_config_path")
     @patch("responses_api_agents.mini_swe_agent.app.runner_ray_remote")
@@ -231,7 +228,6 @@ class TestApp:
         mock_runner_ray_remote,
         mock_get_config_path,
         mock_get_first_server_config_dict,
-        mock_load_from_global_config,
     ) -> None:
         """Test successful execution of the run method with mocked run_swegym."""
 
@@ -239,7 +235,7 @@ class TestApp:
         mock_server_client = MagicMock(spec=ServerClient)
         server = MiniSWEAgent(config=config, server_client=mock_server_client)
 
-        setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict)
+        setup_server_client_mocks(mock_server_client, mock_get_first_server_config_dict)
         setup_config_path_mock(mock_get_config_path)
         setup_run_swegym_mock(mock_to_thread, mock_runner_ray_remote)
 
@@ -276,7 +272,6 @@ class TestApp:
 
         assert output[1]["routed_experts"] == routed_experts
 
-    @patch("responses_api_agents.mini_swe_agent.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.mini_swe_agent.app.get_first_server_config_dict")
     @patch("responses_api_agents.mini_swe_agent.app.get_config_path")
     @patch("responses_api_agents.mini_swe_agent.app.runner_ray_remote")
@@ -287,7 +282,6 @@ class TestApp:
         mock_runner_ray_remote,
         mock_get_config_path,
         mock_get_first_server_config_dict,
-        mock_load_from_global_config,
     ) -> None:
         """Test run method when run_swegym fails."""
 
@@ -295,7 +289,7 @@ class TestApp:
         mock_server_client = MagicMock(spec=ServerClient)
         server = MiniSWEAgent(config=config, server_client=mock_server_client)
 
-        setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict)
+        setup_server_client_mocks(mock_server_client, mock_get_first_server_config_dict)
         setup_config_path_mock(mock_get_config_path)
 
         # Mock Ray remote function
@@ -319,7 +313,6 @@ class TestApp:
 
         assert_run_swegym_called(mock_to_thread, instance_id="test_instance_456")
 
-    @patch("responses_api_agents.mini_swe_agent.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.mini_swe_agent.app.get_first_server_config_dict")
     @patch("responses_api_agents.mini_swe_agent.app.get_config_path")
     @patch("responses_api_agents.mini_swe_agent.app.runner_ray_remote")
@@ -330,13 +323,12 @@ class TestApp:
         mock_runner_ray_remote,
         mock_get_config_path,
         mock_get_first_server_config_dict,
-        mock_load_from_global_config,
     ) -> None:
         config = create_test_config(env="docker")
         mock_server_client = MagicMock(spec=ServerClient)
         server = MiniSWEAgent(config=config, server_client=mock_server_client)
 
-        setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict)
+        setup_server_client_mocks(mock_server_client, mock_get_first_server_config_dict)
         setup_config_path_mock(mock_get_config_path)
 
         # Mock Ray remote function

--- a/responses_api_agents/mini_swe_agent_2/app.py
+++ b/responses_api_agents/mini_swe_agent_2/app.py
@@ -49,7 +49,6 @@ from nemo_gym.openai_utils import (
 from nemo_gym.reward_profile import compute_pass_majority_metrics, highest_k_metrics
 from nemo_gym.sandbox import resolve_provider_config, resolve_provider_metadata
 from nemo_gym.server_utils import (
-    ServerClient,
     get_first_server_config_dict,
 )
 
@@ -728,7 +727,7 @@ class MiniSWEAgent(SimpleResponsesAPIAgent):
     async def run(self, body: MiniSWEAgentRunRequest) -> MiniSWEAgentVerifyResponse:
         async with self.sem:
             model_server_name = self.config.model_server.name
-            global_config_dict = ServerClient.load_from_global_config().global_config_dict
+            global_config_dict = self.server_client.global_config_dict
 
             model_server_config = get_first_server_config_dict(
                 global_config_dict,

--- a/responses_api_agents/mini_swe_agent_2/tests/test_app.py
+++ b/responses_api_agents/mini_swe_agent_2/tests/test_app.py
@@ -150,11 +150,8 @@ def create_test_config(
     )
 
 
-def setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict):
-    mock_server_client_instance = MagicMock()
-    mock_server_client_instance.global_config_dict = {"policy_model_name": "test_model"}
-    mock_load_from_global_config.return_value = mock_server_client_instance
-
+def setup_server_client_mocks(mock_server_client, mock_get_first_server_config_dict):
+    mock_server_client.global_config_dict = {"policy_model_name": "test_model"}
     mock_get_first_server_config_dict.return_value = {
         "host": "0.0.0.0",
         "port": 8080,
@@ -710,7 +707,6 @@ class TestApp:
         with pytest.raises(ValueError, match="instance_dict"):
             _run_mini_swe_v2(**(params | {"instance_dict": None}))
 
-    @patch("responses_api_agents.mini_swe_agent_2.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.mini_swe_agent_2.app.get_first_server_config_dict")
     @patch("responses_api_agents.mini_swe_agent_2.app.get_config_path")
     @patch("responses_api_agents.mini_swe_agent_2.app.runner_ray_remote")
@@ -719,17 +715,16 @@ class TestApp:
         mock_runner_ray_remote,
         mock_get_config_path,
         mock_get_first_server_config_dict,
-        mock_load_from_global_config,
     ) -> None:
         """Test successful execution of the run method with mocked run_mini_swe."""
 
         config = create_test_config()
         mock_server_client = MagicMock(spec=ServerClient)
-        # The rollout prefix is only applied when model-call capture is enabled.
-        mock_server_client.global_config_dict = {"observability_enabled": True}
         server = MiniSWEAgent(config=config, server_client=mock_server_client)
 
-        setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict)
+        setup_server_client_mocks(mock_server_client, mock_get_first_server_config_dict)
+        # The rollout prefix is only applied when model-call capture is enabled.
+        mock_server_client.global_config_dict["observability_enabled"] = True
         setup_config_path_mock(mock_get_config_path)
         setup_run_mini_swe_mock(mock_runner_ray_remote)
 
@@ -744,7 +739,6 @@ class TestApp:
         assert_run_mini_swe_called(mock_runner_ray_remote)
         assert mock_runner_ray_remote.remote.call_args.args[1]["base_url"] == ("http://0.0.0.0:8080/ng-rollout/2-1/v1")
 
-    @patch("responses_api_agents.mini_swe_agent_2.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.mini_swe_agent_2.app.get_first_server_config_dict")
     @patch("responses_api_agents.mini_swe_agent_2.app.get_config_path")
     @patch("responses_api_agents.mini_swe_agent_2.app.runner_ray_remote")
@@ -753,7 +747,6 @@ class TestApp:
         mock_runner_ray_remote,
         mock_get_config_path,
         mock_get_first_server_config_dict,
-        mock_load_from_global_config,
         tmp_path,
         monkeypatch,
     ) -> None:
@@ -771,7 +764,7 @@ class TestApp:
         mock_server_client = MagicMock(spec=ServerClient)
         server = MiniSWEAgent(config=config, server_client=mock_server_client)
 
-        setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict)
+        setup_server_client_mocks(mock_server_client, mock_get_first_server_config_dict)
         setup_config_path_mock(mock_get_config_path)
         setup_run_mini_swe_mock(mock_runner_ray_remote)
 
@@ -807,7 +800,6 @@ class TestApp:
             "chat_template_kwargs": {"enable_thinking": True},
         }
 
-    @patch("responses_api_agents.mini_swe_agent_2.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.mini_swe_agent_2.app.get_first_server_config_dict")
     @patch("responses_api_agents.mini_swe_agent_2.app.get_config_path")
     @patch("responses_api_agents.mini_swe_agent_2.app.runner_ray_remote")
@@ -816,7 +808,6 @@ class TestApp:
         mock_runner_ray_remote,
         mock_get_config_path,
         mock_get_first_server_config_dict,
-        mock_load_from_global_config,
         tmp_path,
         monkeypatch,
     ) -> None:
@@ -826,8 +817,7 @@ class TestApp:
         mock_server_client = MagicMock(spec=ServerClient)
         server = MiniSWEAgent(config=config, server_client=mock_server_client)
 
-        mock_server_client_instance = MagicMock()
-        mock_server_client_instance.global_config_dict = {
+        mock_server_client.global_config_dict = {
             "policy_model_name": "test_model",
             "sandbox": {
                 "default_metadata": {"sandbox-api": "opensandbox-sdk"},
@@ -839,7 +829,6 @@ class TestApp:
                 },
             },
         }
-        mock_load_from_global_config.return_value = mock_server_client_instance
         mock_get_first_server_config_dict.return_value = {"host": "0.0.0.0", "port": 8080}
         setup_config_path_mock(mock_get_config_path)
         setup_run_mini_swe_mock(mock_runner_ray_remote)
@@ -857,7 +846,6 @@ class TestApp:
         # Provider default_metadata flows into the sandbox spec metadata.
         assert generated_config["environment"]["spec"]["metadata"]["sandbox-api"] == "opensandbox-sdk"
 
-    @patch("responses_api_agents.mini_swe_agent_2.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.mini_swe_agent_2.app.get_first_server_config_dict")
     @patch("responses_api_agents.mini_swe_agent_2.app.get_config_path")
     @patch("responses_api_agents.mini_swe_agent_2.app.runner_ray_remote")
@@ -866,7 +854,6 @@ class TestApp:
         mock_runner_ray_remote,
         mock_get_config_path,
         mock_get_first_server_config_dict,
-        mock_load_from_global_config,
     ) -> None:
         """Test run method when run_mini_swe fails."""
 
@@ -874,7 +861,7 @@ class TestApp:
         mock_server_client = MagicMock(spec=ServerClient)
         server = MiniSWEAgent(config=config, server_client=mock_server_client)
 
-        setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict)
+        setup_server_client_mocks(mock_server_client, mock_get_first_server_config_dict)
         setup_config_path_mock(mock_get_config_path)
 
         # Awaiting the Ray result raises, standing in for a failed rollout task.
@@ -894,7 +881,6 @@ class TestApp:
 
         assert_run_mini_swe_called(mock_runner_ray_remote, instance_id="test_instance_456")
 
-    @patch("responses_api_agents.mini_swe_agent_2.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.mini_swe_agent_2.app.get_first_server_config_dict")
     @patch("responses_api_agents.mini_swe_agent_2.app.get_config_path")
     @patch("responses_api_agents.mini_swe_agent_2.app.runner_ray_remote")
@@ -903,13 +889,12 @@ class TestApp:
         mock_runner_ray_remote,
         mock_get_config_path,
         mock_get_first_server_config_dict,
-        mock_load_from_global_config,
     ) -> None:
         config = create_test_config()
         mock_server_client = MagicMock(spec=ServerClient)
         server = MiniSWEAgent(config=config, server_client=mock_server_client)
 
-        setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict)
+        setup_server_client_mocks(mock_server_client, mock_get_first_server_config_dict)
         setup_config_path_mock(mock_get_config_path)
 
         mock_runner_ray_remote.remote.return_value = FakeObjectRef(error=FileNotFoundError("run_mini_swe not found"))

--- a/responses_api_agents/osworld_agent/app.py
+++ b/responses_api_agents/osworld_agent/app.py
@@ -45,7 +45,6 @@ from nemo_gym.openai_utils import (
 )
 from nemo_gym.sandbox import resolve_provider_config, resolve_provider_metadata
 from nemo_gym.server_utils import (
-    ServerClient,
     get_first_server_config_dict,
 )
 from responses_api_agents.osworld_agent.proxy import (
@@ -832,7 +831,7 @@ class OSWorldAgent(SimpleResponsesAPIAgent):
                     )
 
             model_server_name = self.config.model_server.name
-            global_config_dict = ServerClient.load_from_global_config().global_config_dict
+            global_config_dict = self.server_client.global_config_dict
             model_server_config = get_first_server_config_dict(global_config_dict, model_server_name)
             policy_model_name = _resolve_policy_model_name(global_config_dict, self.config.runner_name)
             policy_api_key = global_config_dict.get("policy_api_key", "")

--- a/responses_api_agents/osworld_agent/tests/test_app.py
+++ b/responses_api_agents/osworld_agent/tests/test_app.py
@@ -452,13 +452,12 @@ def make_run_request(
     )
 
 
-def setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict):
-    mock_client = MagicMock()
-    mock_client.global_config_dict = {
+def setup_server_client_mocks(mock_server_client, mock_get_first_server_config_dict, extra_global_config=None):
+    mock_server_client.global_config_dict = {
         "policy_model_name": "test-policy",
         "policy_api_key": "test-key",  # pragma: allowlist secret
+        **(extra_global_config or {}),
     }
-    mock_load_from_global_config.return_value = mock_client
     mock_get_first_server_config_dict.return_value = {"host": "127.0.0.1", "port": 8000}
 
 
@@ -577,7 +576,6 @@ class TestApp:
         assert "osworld_error" in response.verifier_metadata
         assert "No 'osworld_task'" in response.verifier_metadata["osworld_error"]
 
-    @patch("responses_api_agents.osworld_agent.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.osworld_agent.app.get_first_server_config_dict")
     @patch("responses_api_agents.osworld_agent.app._run_osworld_task_remote")
     @patch("asyncio.to_thread")
@@ -586,10 +584,8 @@ class TestApp:
         mock_to_thread,
         mock_remote,
         mock_get_first_server_config_dict,
-        mock_load_from_global_config,
         monkeypatch,
     ) -> None:
-        setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict)
         monkeypatch.setenv("RUN_TAG", "run-001")
 
         # Mock the Ray-remote ``.options(...).remote(...)`` call chain.
@@ -598,7 +594,11 @@ class TestApp:
         mock_to_thread.return_value = DEFAULT_RUN_RESULT
 
         server_client = MagicMock(spec=ServerClient)
-        server_client.global_config_dict = {"observability_enabled": True}
+        setup_server_client_mocks(
+            server_client,
+            mock_get_first_server_config_dict,
+            extra_global_config={"observability_enabled": True},
+        )
         agent = OSWorldAgent(config=make_config(), server_client=server_client)
         request = make_run_request(osworld_task=DEFAULT_OSWORLD_TASK, temperature=0.7, top_p=0.95)
         request = OSWorldRunRequest.model_validate(
@@ -644,7 +644,6 @@ class TestApp:
             "task_attempt": 1,
         }
 
-    @patch("responses_api_agents.osworld_agent.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.osworld_agent.app.get_first_server_config_dict")
     @patch("responses_api_agents.osworld_agent.app._run_osworld_task_remote")
     @patch("asyncio.to_thread")
@@ -653,16 +652,20 @@ class TestApp:
         mock_to_thread,
         mock_remote,
         mock_get_first_server_config_dict,
-        mock_load_from_global_config,
     ) -> None:
-        setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict)
-        global_config = mock_load_from_global_config.return_value.global_config_dict
-        global_config["osworld_sandbox"] = {
-            "default_metadata": {"sandbox-api": "docker-cli", "owner": "provider"},
-            "docker": {"create": {"use_init": False}},
-        }
         mock_remote.options.return_value.remote.return_value = MagicMock()
         mock_to_thread.return_value = DEFAULT_RUN_RESULT
+        server_client = MagicMock(spec=ServerClient)
+        setup_server_client_mocks(
+            server_client,
+            mock_get_first_server_config_dict,
+            extra_global_config={
+                "osworld_sandbox": {
+                    "default_metadata": {"sandbox-api": "docker-cli", "owner": "provider"},
+                    "docker": {"create": {"use_init": False}},
+                }
+            },
+        )
         agent = OSWorldAgent(
             config=make_config(
                 sandbox_provider="osworld_sandbox",
@@ -672,7 +675,7 @@ class TestApp:
                 },
                 vm_path="/assets/Ubuntu.qcow2",
             ),
-            server_client=MagicMock(spec=ServerClient),
+            server_client=server_client,
         )
 
         response = await agent.run(make_run_request(osworld_task=DEFAULT_OSWORLD_TASK))
@@ -689,7 +692,6 @@ class TestApp:
         assert runner_kwargs["vm_path"] == "/assets/Ubuntu.qcow2"
         assert runner_kwargs["sandbox_vm_path"] is None
 
-    @patch("responses_api_agents.osworld_agent.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.osworld_agent.app.get_first_server_config_dict")
     @patch("responses_api_agents.osworld_agent.app._run_osworld_task_remote")
     @patch("asyncio.to_thread")
@@ -698,15 +700,15 @@ class TestApp:
         mock_to_thread,
         mock_remote,
         mock_get_first_server_config_dict,
-        mock_load_from_global_config,
         monkeypatch,
     ) -> None:
-        setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict)
         monkeypatch.setenv("PROXY_CONFIG_FILE", "/unused/proxy.json")
         mock_remote.options.return_value.remote.return_value = MagicMock()
         mock_to_thread.return_value = DEFAULT_RUN_RESULT
         task = {**DEFAULT_OSWORLD_TASK, "proxy": True}
-        agent = OSWorldAgent(config=make_config(enable_proxy=False), server_client=MagicMock(spec=ServerClient))
+        server_client = MagicMock(spec=ServerClient)
+        setup_server_client_mocks(server_client, mock_get_first_server_config_dict)
+        agent = OSWorldAgent(config=make_config(enable_proxy=False), server_client=server_client)
 
         response = await agent.run(make_run_request(osworld_task=task))
 
@@ -718,7 +720,6 @@ class TestApp:
         assert response.verifier_metadata["osworld_proxy_enabled"] is False
         assert response.verifier_metadata["osworld_proxy_configured"] is False
 
-    @patch("responses_api_agents.osworld_agent.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.osworld_agent.app.get_first_server_config_dict")
     @patch("responses_api_agents.osworld_agent.app._run_osworld_task_remote")
     @patch("asyncio.to_thread")
@@ -727,11 +728,9 @@ class TestApp:
         mock_to_thread,
         mock_remote,
         mock_get_first_server_config_dict,
-        mock_load_from_global_config,
         monkeypatch,
         tmp_path,
     ) -> None:
-        setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict)
         proxy_path = tmp_path / "proxy.json"
         proxy_path.write_text('[{"host":"proxy.example.com","port":3128}]\n', encoding="utf-8")
         monkeypatch.setenv("OSWORLD_ENABLE_PROXY", "1")
@@ -739,7 +738,9 @@ class TestApp:
         mock_remote.options.return_value.remote.return_value = MagicMock()
         mock_to_thread.return_value = DEFAULT_RUN_RESULT
         task = {**DEFAULT_OSWORLD_TASK, "proxy": True}
-        agent = OSWorldAgent(config=make_config(), server_client=MagicMock(spec=ServerClient))
+        server_client = MagicMock(spec=ServerClient)
+        setup_server_client_mocks(server_client, mock_get_first_server_config_dict)
+        agent = OSWorldAgent(config=make_config(), server_client=server_client)
 
         response = await agent.run(make_run_request(osworld_task=task))
 
@@ -760,7 +761,6 @@ class TestApp:
         assert response.mask_sample is True
         assert response.verifier_metadata["osworld_termination_reason"] == "proxy_configuration_error"
 
-    @patch("responses_api_agents.osworld_agent.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.osworld_agent.app.get_first_server_config_dict")
     @patch("responses_api_agents.osworld_agent.app._run_osworld_task_remote")
     @patch("asyncio.to_thread")
@@ -769,13 +769,13 @@ class TestApp:
         mock_to_thread,
         mock_remote,
         mock_get_first_server_config_dict,
-        mock_load_from_global_config,
     ) -> None:
-        setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict)
         mock_remote.options.return_value.remote.return_value = MagicMock()
         mock_to_thread.side_effect = RuntimeError("docker daemon unreachable")
 
-        agent = OSWorldAgent(config=make_config(), server_client=MagicMock(spec=ServerClient))
+        server_client = MagicMock(spec=ServerClient)
+        setup_server_client_mocks(server_client, mock_get_first_server_config_dict)
+        agent = OSWorldAgent(config=make_config(), server_client=server_client)
         request = make_run_request(osworld_task=DEFAULT_OSWORLD_TASK)
 
         response = await agent.run(request)
@@ -784,7 +784,6 @@ class TestApp:
         assert "RuntimeError" in response.verifier_metadata["osworld_error"]
         assert "docker daemon unreachable" in response.verifier_metadata["osworld_error"]
 
-    @patch("responses_api_agents.osworld_agent.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.osworld_agent.app.get_first_server_config_dict")
     @patch("responses_api_agents.osworld_agent.app._run_osworld_task_remote")
     @patch("asyncio.to_thread")
@@ -793,10 +792,8 @@ class TestApp:
         mock_to_thread,
         mock_remote,
         mock_get_first_server_config_dict,
-        mock_load_from_global_config,
     ) -> None:
         """Score < 1.0 -> reward 0.0 (matches gym's 0/1 reward convention)."""
-        setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict)
         mock_remote.options.return_value.remote.return_value = MagicMock()
         mock_to_thread.return_value = {
             "reward": 0.0,
@@ -806,7 +803,9 @@ class TestApp:
             "steps": [],
         }
 
-        agent = OSWorldAgent(config=make_config(), server_client=MagicMock(spec=ServerClient))
+        server_client = MagicMock(spec=ServerClient)
+        setup_server_client_mocks(server_client, mock_get_first_server_config_dict)
+        agent = OSWorldAgent(config=make_config(), server_client=server_client)
         response = await agent.run(make_run_request(osworld_task=DEFAULT_OSWORLD_TASK))
 
         assert response.reward == 0.0

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -166,8 +166,8 @@ class TestServerUtils:
         actual_client = ServerClient.load_from_global_config()
         assert {"a": 2} == actual_client.global_config_dict
 
-    def test_ServerClient_load_from_global_config_prefers_local_cache(self, monkeypatch: MonkeyPatch) -> None:
-        """When `_GLOBAL_CONFIG_DICT` is populated locally, no HTTP fetch happens."""
+    def test_ServerClient_load_from_global_config_ignores_unscoped_local_cache(self, monkeypatch: MonkeyPatch) -> None:
+        """A local singleton without the worker env var may contain only CLI config."""
         global_config_dict = DictConfig(
             {
                 "head_server": {"host": "", "port": 0},
@@ -177,22 +177,21 @@ class TestServerUtils:
         get_global_config_dict_mock = MagicMock(return_value=global_config_dict)
         monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", get_global_config_dict_mock)
 
-        # Simulate a worker process: the global config dict is cached locally.
+        # `gym eval run --no-serve` initializes a partial local config.
+        # It must still fetch the full config from the running head server.
         monkeypatch.setattr(nemo_gym.global_config, "_GLOBAL_CONFIG_DICT", global_config_dict)
+        monkeypatch.delenv(NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME, raising=False)
 
-        # If the fast path is taken, requests.get is never called. Make it loud
-        # if it does get called so the test fails clearly.
-        def boom(*args, **kwargs):
-            raise AssertionError("requests.get should not be called on the fast path")
-
-        monkeypatch.setattr(nemo_gym.server_utils.requests, "get", boom)
+        response = MagicMock(content=b'"remote_server: {host: remote, port: 1234}"')
+        get_mock = MagicMock(return_value=response)
+        monkeypatch.setattr(nemo_gym.server_utils.requests, "get", get_mock)
 
         client = ServerClient.load_from_global_config()
-        assert client.global_config_dict is global_config_dict
+        assert client.global_config_dict == {"remote_server": {"host": "remote", "port": 1234}}
+        get_mock.assert_called_once()
 
     def test_ServerClient_load_from_global_config_fast_path_via_env(self, monkeypatch: MonkeyPatch) -> None:
-        """`NEMO_GYM_CONFIG_DICT` env var alone is enough to trigger the fast path
-        (covers the first call inside a fresh worker before the singleton is hit)."""
+        """The worker config env var triggers the fast path before the singleton is populated."""
         global_config_dict = DictConfig({"head_server": {"host": "", "port": 0}})
         get_global_config_dict_mock = MagicMock(return_value=global_config_dict)
         monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", get_global_config_dict_mock)

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -19,12 +19,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 from aiohttp import ClientOSError, ClientResponseError, RequestInfo
 from multidict import CIMultiDict, CIMultiDictProxy
+from omegaconf import OmegaConf
 from pytest import MonkeyPatch, raises
 from yarl import URL
 
 import nemo_gym.global_config
 import nemo_gym.server_utils
 from nemo_gym.global_config import (
+    NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME,
     NEMO_GYM_CONFIG_PATH_ENV_VAR_NAME,
 )
 from nemo_gym.server_utils import (
@@ -138,6 +140,7 @@ class TestServerUtils:
         assert actual_config.port == 0
 
     def test_ServerClient_load_from_global_config(self, monkeypatch: MonkeyPatch) -> None:
+        """HTTP fallback path: simulate an ad-hoc client.py with no local cache."""
         global_config_dict = DictConfig(
             {
                 "head_server": {
@@ -150,6 +153,10 @@ class TestServerUtils:
         get_global_config_dict_mock.return_value = global_config_dict
         monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", get_global_config_dict_mock)
 
+        # Force the slow path: no local cache and no env var.
+        monkeypatch.setattr(nemo_gym.global_config, "_GLOBAL_CONFIG_DICT", None)
+        monkeypatch.delenv(NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME, raising=False)
+
         httpx_client_mock = MagicMock()
         httpx_response_mock = MagicMock()
         httpx_client_mock.return_value = httpx_response_mock
@@ -158,6 +165,48 @@ class TestServerUtils:
 
         actual_client = ServerClient.load_from_global_config()
         assert {"a": 2} == actual_client.global_config_dict
+
+    def test_ServerClient_load_from_global_config_prefers_local_cache(self, monkeypatch: MonkeyPatch) -> None:
+        """When `_GLOBAL_CONFIG_DICT` is populated locally, no HTTP fetch happens."""
+        global_config_dict = DictConfig(
+            {
+                "head_server": {"host": "", "port": 0},
+                "my_server": {"a": {"b": {"host": "x", "port": 1}}},
+            }
+        )
+        get_global_config_dict_mock = MagicMock(return_value=global_config_dict)
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", get_global_config_dict_mock)
+
+        # Simulate a worker process: the global config dict is cached locally.
+        monkeypatch.setattr(nemo_gym.global_config, "_GLOBAL_CONFIG_DICT", global_config_dict)
+
+        # If the fast path is taken, requests.get is never called. Make it loud
+        # if it does get called so the test fails clearly.
+        def boom(*args, **kwargs):
+            raise AssertionError("requests.get should not be called on the fast path")
+
+        monkeypatch.setattr(nemo_gym.server_utils.requests, "get", boom)
+
+        client = ServerClient.load_from_global_config()
+        assert client.global_config_dict is global_config_dict
+
+    def test_ServerClient_load_from_global_config_fast_path_via_env(self, monkeypatch: MonkeyPatch) -> None:
+        """`NEMO_GYM_CONFIG_DICT` env var alone is enough to trigger the fast path
+        (covers the first call inside a fresh worker before the singleton is hit)."""
+        global_config_dict = DictConfig({"head_server": {"host": "", "port": 0}})
+        get_global_config_dict_mock = MagicMock(return_value=global_config_dict)
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", get_global_config_dict_mock)
+
+        monkeypatch.setattr(nemo_gym.global_config, "_GLOBAL_CONFIG_DICT", None)
+        monkeypatch.setenv(NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME, "head_server: {host: '', port: 0}")
+
+        def boom(*args, **kwargs):
+            raise AssertionError("requests.get should not be called on the fast path")
+
+        monkeypatch.setattr(nemo_gym.server_utils.requests, "get", boom)
+
+        client = ServerClient.load_from_global_config()
+        assert client.global_config_dict is global_config_dict
 
     def test_ServerClient_load_from_global_config_propogate_ConnectionError(self, monkeypatch: MonkeyPatch) -> None:
         global_config_dict = DictConfig(
@@ -171,6 +220,10 @@ class TestServerUtils:
         get_global_config_dict_mock = MagicMock()
         get_global_config_dict_mock.return_value = global_config_dict
         monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", get_global_config_dict_mock)
+
+        # Force the slow path so the ConnectionError can fire.
+        monkeypatch.setattr(nemo_gym.global_config, "_GLOBAL_CONFIG_DICT", None)
+        monkeypatch.delenv(NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME, raising=False)
 
         httpx_client_mock = MagicMock()
         httpx_client_mock.side_effect = ConnectionError
@@ -244,6 +297,63 @@ class TestServerUtils:
         resp = await head_server.global_config_dict_yaml()
 
         assert "a: 2\n" == resp
+
+    async def test_HeadServer_global_config_dict_yaml_caches(self, monkeypatch: MonkeyPatch) -> None:
+        """Step 2: the immutable config dict is serialized to YAML at most once."""
+        global_config_dict = DictConfig({"a": 2})
+        get_global_config_dict_mock = MagicMock(return_value=global_config_dict)
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", get_global_config_dict_mock)
+
+        to_yaml_mock = MagicMock(wraps=OmegaConf.to_yaml)
+        monkeypatch.setattr(nemo_gym.server_utils.OmegaConf, "to_yaml", to_yaml_mock)
+
+        head_server = HeadServer(config=BaseServerConfig(host="", port=0))
+        first = await head_server.global_config_dict_yaml()
+        second = await head_server.global_config_dict_yaml()
+
+        # Same string object — proves the cache, not just value-equal.
+        assert first is second
+        assert to_yaml_mock.call_count == 1
+
+        # Explicit invalidation re-serializes.
+        head_server.invalidate_global_config_dict_yaml_cache()
+        third = await head_server.global_config_dict_yaml()
+        assert third == first  # value
+        assert to_yaml_mock.call_count == 2
+
+    async def test_ServerClient_request_uses_base_url_table(self, monkeypatch: MonkeyPatch) -> None:
+        """Step 3: after the first request to a server_name, `request()` no longer
+        walks the OmegaConf DictConfig — the base URL comes from the cached
+        `_server_base_urls` table."""
+        server_client = ServerClient(
+            head_server_config=BaseServerConfig(host="head", port=11000),
+            global_config_dict=DictConfig({"my_server": {"a": {"b": {"host": "xyz", "port": 54321}}}}),
+        )
+
+        httpx_client_mock = MagicMock()
+        httpx_client_request_mock = AsyncMock()
+        httpx_client_request_mock.return_value = "ok"
+        httpx_client_mock.return_value.request = httpx_client_request_mock
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", httpx_client_mock)
+
+        # First call: populates the table.
+        await server_client.post(server_name="my_server", url_path="/x")
+        assert server_client._server_base_urls == {"my_server": "http://xyz:54321"}
+
+        # Second call: must not touch the OmegaConf walker. Make
+        # `get_first_server_config_dict` loud to prove the fast path.
+        def boom(*_args, **_kwargs):
+            raise AssertionError("get_first_server_config_dict should not be called once the URL is cached")
+
+        monkeypatch.setattr(nemo_gym.server_utils, "get_first_server_config_dict", boom)
+
+        await server_client.post(server_name="my_server", url_path="/y")
+        await server_client.get(server_name="my_server", url_path="/z")
+
+        # All three calls dispatched to the same precomputed URL.
+        assert httpx_client_request_mock.call_count == 3
+        for call in httpx_client_request_mock.call_args_list:
+            assert call.kwargs["url"].startswith("http://xyz:54321")
 
     def _mock_ray_return_value(self, monkeypatch: MonkeyPatch, return_value: bool) -> MagicMock:
         ray_is_initialized_mock = MagicMock()

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -140,7 +140,7 @@ class TestServerUtils:
         assert actual_config.port == 0
 
     def test_ServerClient_load_from_global_config(self, monkeypatch: MonkeyPatch) -> None:
-        """HTTP fallback path: simulate an ad-hoc client.py with no local cache."""
+        """Fetch the config from the head server when no config was injected."""
         global_config_dict = DictConfig(
             {
                 "head_server": {
@@ -153,7 +153,6 @@ class TestServerUtils:
         get_global_config_dict_mock.return_value = global_config_dict
         monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", get_global_config_dict_mock)
 
-        # Force the slow path: no local cache and no env var.
         monkeypatch.setattr(nemo_gym.global_config, "_GLOBAL_CONFIG_DICT", None)
         monkeypatch.delenv(NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME, raising=False)
 
@@ -166,8 +165,10 @@ class TestServerUtils:
         actual_client = ServerClient.load_from_global_config()
         assert {"a": 2} == actual_client.global_config_dict
 
-    def test_ServerClient_load_from_global_config_ignores_unscoped_local_cache(self, monkeypatch: MonkeyPatch) -> None:
-        """A local singleton without the worker env var may contain only CLI config."""
+    def test_ServerClient_load_from_global_config_fetches_when_config_was_not_injected(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """Do not treat an unrelated process-local config as the server config."""
         global_config_dict = DictConfig(
             {
                 "head_server": {"host": "", "port": 0},
@@ -191,7 +192,7 @@ class TestServerUtils:
         get_mock.assert_called_once()
 
     def test_ServerClient_load_from_global_config_fast_path_via_env(self, monkeypatch: MonkeyPatch) -> None:
-        """The worker config env var triggers the fast path before the singleton is populated."""
+        """Use the config injected into a Gym-launched server process."""
         global_config_dict = DictConfig({"head_server": {"host": "", "port": 0}})
         get_global_config_dict_mock = MagicMock(return_value=global_config_dict)
         monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", get_global_config_dict_mock)
@@ -220,7 +221,6 @@ class TestServerUtils:
         get_global_config_dict_mock.return_value = global_config_dict
         monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", get_global_config_dict_mock)
 
-        # Force the slow path so the ConnectionError can fire.
         monkeypatch.setattr(nemo_gym.global_config, "_GLOBAL_CONFIG_DICT", None)
         monkeypatch.delenv(NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME, raising=False)
 
@@ -298,7 +298,7 @@ class TestServerUtils:
         assert "a: 2\n" == resp
 
     async def test_HeadServer_global_config_dict_yaml_caches(self, monkeypatch: MonkeyPatch) -> None:
-        """Step 2: the immutable config dict is serialized to YAML at most once."""
+        """Serialize the global config once until the cache is cleared."""
         global_config_dict = DictConfig({"a": 2})
         get_global_config_dict_mock = MagicMock(return_value=global_config_dict)
         monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", get_global_config_dict_mock)
@@ -310,20 +310,16 @@ class TestServerUtils:
         first = await head_server.global_config_dict_yaml()
         second = await head_server.global_config_dict_yaml()
 
-        # Same string object — proves the cache, not just value-equal.
         assert first is second
         assert to_yaml_mock.call_count == 1
 
-        # Explicit invalidation re-serializes.
         head_server.invalidate_global_config_dict_yaml_cache()
         third = await head_server.global_config_dict_yaml()
-        assert third == first  # value
+        assert third == first
         assert to_yaml_mock.call_count == 2
 
     async def test_ServerClient_request_uses_base_url_table(self, monkeypatch: MonkeyPatch) -> None:
-        """Step 3: after the first request to a server_name, `request()` no longer
-        walks the OmegaConf DictConfig — the base URL comes from the cached
-        `_server_base_urls` table."""
+        """Resolve each server's base URL once."""
         server_client = ServerClient(
             head_server_config=BaseServerConfig(host="head", port=11000),
             global_config_dict=DictConfig({"my_server": {"a": {"b": {"host": "xyz", "port": 54321}}}}),
@@ -335,12 +331,9 @@ class TestServerUtils:
         httpx_client_mock.return_value.request = httpx_client_request_mock
         monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", httpx_client_mock)
 
-        # First call: populates the table.
         await server_client.post(server_name="my_server", url_path="/x")
         assert server_client._server_base_urls == {"my_server": "http://xyz:54321"}
 
-        # Second call: must not touch the OmegaConf walker. Make
-        # `get_first_server_config_dict` loud to prove the fast path.
         def boom(*_args, **_kwargs):
             raise AssertionError("get_first_server_config_dict should not be called once the URL is cached")
 
@@ -349,7 +342,6 @@ class TestServerUtils:
         await server_client.post(server_name="my_server", url_path="/y")
         await server_client.get(server_name="my_server", url_path="/z")
 
-        # All three calls dispatched to the same precomputed URL.
         assert httpx_client_request_mock.call_count == 3
         for call in httpx_client_request_mock.call_args_list:
             assert call.kwargs["url"].startswith("http://xyz:54321")


### PR DESCRIPTION
## Summary

- Reuse the parent-injected global config in Gym-launched server processes instead of fetching and reparsing it from the HeadServer for each affected agent `/run` request.
- Preserve the HeadServer fallback for standalone processes, including `gym eval run --no-serve`, that were not launched with `NEMO_GYM_CONFIG_DICT`.
- Cache the HeadServer's serialized global config and each `ServerClient` server-name-to-base-URL resolution.
- Reuse the initialized `self.server_client` in `mini_swe_agent`, `mini_swe_agent_2`, and `osworld_agent` rather than constructing another client during each rollout.

This change targets `/global_config_dict_yaml` traffic and config resolution. It does not remove `/server_instances` readiness polling.

## Config flow

Before this change, affected agents reconstructed config state inside every `/run` request:

```mermaid
sequenceDiagram
    participant R as Rollout callers
    participant A as Agent server /run
    participant H as HeadServer

    loop Every affected rollout
        R->>A: POST /run
        A->>H: GET /global_config_dict_yaml
        H->>H: Serialize global config
        H-->>A: Serialized YAML
        A->>A: Decode JSON, parse YAML, construct ServerClient
        A->>A: Resolve downstream server URL from DictConfig
    end
```

Gym already injects the resolved config into each server process. The updated flow uses that process-scoped state:

```mermaid
sequenceDiagram
    participant P as Gym parent process
    participant A as Agent server process
    participant R as RLVR rollout callers
    participant H as HeadServer

    P->>P: Resolve global config once
    P->>A: Spawn with NEMO_GYM_CONFIG_DICT
    A->>A: Cache injected config and initialize ServerClient

    loop Concurrent rollouts
        R->>A: POST /run
        A->>A: Reuse self.server_client.global_config_dict
        A->>A: Reuse cached downstream base URL
    end

    opt Standalone process without injected config
        A->>H: Fetch global config while constructing a client
        H-->>A: Serialized YAML
    end
```

## Assumptions

- The resolved global config is immutable after server startup. This matches the existing lifecycle: the parent resolves it once, injects it into child processes, and each process caches it.
- Configured server host and port values remain stable for the lifetime of a server process. A future runtime-reconfiguration feature would need to invalidate the serialized-config and base-URL caches.
- `ServerClient` contains process-scoped routing state, not rollout-scoped state. Rollout correlation remains context-local, so concurrent requests do not share rollout identity through the client.
- Each server worker has its own `ServerClient`; the object is not shared across processes.
- This PR reuses the existing `NEMO_GYM_CONFIG_DICT` injection mechanism. It does not increase the environment-variable payload or change its startup-time size constraints.

## Performance simulation

Ran using the `mcqa` and `vllm_model`, 16,384 config accesses, and 32 concurrent caller threads against one HeadServer. The HTTP path used the new HeadServer serialization cache, so its result is a conservative lower bound for the original uncached behavior.

| Path | Throughput | p50 | p95 | p99 |
| --- | ---: | ---: | ---: | ---: |
| HeadServer HTTP fetch and client YAML parse | 136.7 calls/s | 230,964 µs | 268,920 µs | 299,029 µs |
| Injected config with a newly constructed client | 18,743.6 calls/s | 28.02 µs | 142.12 µs | 287.09 µs |
| Reused `self.server_client` attribute | 101,410.0 calls/s | 0.11 µs | 0.46 µs | 0.83 µs |

In the same simulation, the serial p50 fell from 5.57 ms for the HTTP path to 26.25 µs for injected-config reconstruction and 0.05 µs for direct client reuse. At 32 callers, the shared HeadServer path took about 120 seconds for 16,384 accesses; client reconstruction took about 0.87 seconds, and client reuse took about 0.16 seconds.

These measurements isolate config-dispatch overhead. They do not claim the same multiplier for complete rollouts, where model inference and environment execution usually dominate. The benefit grows with rollout concurrency because the removed HTTP path otherwise contends on one HeadServer and performs repeated client-side parsing.

## Test plan

- [x] Run the server utility unit tests.
- [x] Run the `mini_swe_agent_2` application tests.
- [x] Run the `osworld_agent` application tests.
- [x] Run scoped pre-commit checks for all changed product and test files.