### PR TITLE
fix: process cleanup in CLI / `rdkit_chemistry` / `ns_tools` / `code_gen`

### DIFF
--- a/nemo_gym/cli.py
+++ b/nemo_gym/cli.py
@@ -65,6 +65,12 @@ from nemo_gym.server_utils import (
 from nemo_gym.train_data_utils import TrainDataProcessor
 
 
+# Grace period after SIGINT before escalating to SIGKILL. Kept short so Ctrl-C is responsive.
+_GRACEFUL_SHUTDOWN_TIMEOUT_SEC: int = 1
+# Grace period after SIGKILL for the kernel to reap the child and avoid <defunct> entries.
+_FORCE_KILL_REAP_TIMEOUT_SEC: int = 2
+
+
 class RunConfig(BaseNeMoGymCLIConfig):
     """
     Start NeMo Gym servers for agents, models, and resources.
@@ -322,20 +328,32 @@ Process `{process_name}` stderr:
 
         print("Waiting for processes to finish...")
         killed_process_names: List[str] = []
+        unreaped_process_names: List[str] = []
         for process_name, process in self._processes.items():
             try:
-                process.wait(timeout=1)
+                process.wait(timeout=_GRACEFUL_SHUTDOWN_TIMEOUT_SEC)
             except TimeoutExpired:
                 process.kill()
                 killed_process_names.append(process_name)
+                # Reap the child after SIGKILL to avoid leaving a <defunct> entry.
+                try:
+                    process.wait(timeout=_FORCE_KILL_REAP_TIMEOUT_SEC)
+                except TimeoutExpired:
+                    unreaped_process_names.append(process_name)
 
         if killed_process_names:
             print(
-                f"""Some processes ({", ".join(killed_process_names)}) didn't shutdown within the 5s timeout, killing instead. You may see messages like:
+                f"""Some processes ({", ".join(killed_process_names)}) didn't shutdown within the {_GRACEFUL_SHUTDOWN_TIMEOUT_SEC}s timeout, killing instead. You may see messages like:
 ```bash
 rpc_client.h:203: Failed to connect to GCS within 60 seconds. GCS may have been killed. It's either GCS is terminated by `ray stop` or is killed unexpectedly. If it is killed unexpectedly, see the log file gcs_server.out. https://docs.ray.io/en/master/ray-observability/user-guides/configure-logging.html#logging-directory-structure. The program will terminate.
 ```
 """
+            )
+        if unreaped_process_names:
+            print(
+                f"WARNING: processes ({', '.join(unreaped_process_names)}) did not exit "
+                f"within {_FORCE_KILL_REAP_TIMEOUT_SEC}s after SIGKILL; "
+                "they may remain as zombies until this process exits."
             )
         self._processes = dict()
 

--- a/resources_servers/code_gen/lcb_integration/compute_code_generation_metrics.py
+++ b/resources_servers/code_gen/lcb_integration/compute_code_generation_metrics.py
@@ -75,23 +75,39 @@ def check_correctness(sample, generation, timeout, debug=True):
         return [-1], None
 
     manager = multiprocessing.Manager()
-    result = manager.list()
-    metadata_list = manager.list()
-    p = multiprocessing.Process(
-        target=_temp_run,
-        args=(in_outs, generation, debug, result, metadata_list, timeout),
-    )
-    p.start()
-    p.join(timeout=(timeout + 1) * len(in_outs["inputs"]) + 5)
-    if p.is_alive():
-        p.kill()
-    if not result:
-        # consider that all tests failed
-        result = [[-1 for i in range(len(in_outs["inputs"]))]]
-        metadata_list = [None]
+    p: multiprocessing.Process | None = None
+    try:
+        result = manager.list()
+        metadata_list = manager.list()
+        p = multiprocessing.Process(
+            target=_temp_run,
+            args=(in_outs, generation, debug, result, metadata_list, timeout),
+        )
+        p.start()
+        p.join(timeout=(timeout + 1) * len(in_outs["inputs"]) + 5)
+        if p.is_alive():
+            p.kill()
+            # Reap the worker after SIGKILL to release joinable resources.
+            p.join(timeout=5)
+
+        # Drain ListProxy values into plain lists before Manager shutdown, since access
+        # raises once the Manager helper process exits.
+        if result:
+            result_local: list = list(result)
+            metadata_local: list = list(metadata_list)
+            return result_local[0], metadata_local[0]
+
         if debug:
             print("global timeout")
-    return result[0], metadata_list[0]
+        # consider that all tests failed
+        return [-1 for _ in range(len(in_outs["inputs"]))], None
+    finally:
+        if p is not None and p.is_alive():
+            # Defensive: reap the worker if an exception bypassed the join above.
+            p.kill()
+            p.join(timeout=5)
+        # Always shut down the Manager so its helper process doesn't leak under stress.
+        manager.shutdown()
 
 
 def evaluate_generations_by_problem(args):

--- a/resources_servers/code_gen/tests/test_compute_code_generation_metrics.py
+++ b/resources_servers/code_gen/tests/test_compute_code_generation_metrics.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+"""Tests for `check_correctness` worker + Manager lifecycle."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from lcb_integration import compute_code_generation_metrics
+from lcb_integration.compute_code_generation_metrics import check_correctness
+
+
+_SAMPLE: dict[str, str] = {"input_output": json.dumps({"inputs": ["1", "2"], "outputs": ["1", "4"]})}
+
+
+@pytest.fixture
+def patched_mp(monkeypatch):
+    """Replace multiprocessing.Manager + Process so we can assert lifecycle ordering."""
+    manager: MagicMock = MagicMock(name="Manager")
+    manager.list.side_effect = lambda: []
+    manager_factory: MagicMock = MagicMock(return_value=manager)
+    process_instance: MagicMock = MagicMock(name="Process")
+    process_factory: MagicMock = MagicMock(return_value=process_instance)
+
+    monkeypatch.setattr(compute_code_generation_metrics.multiprocessing, "Manager", manager_factory)
+    monkeypatch.setattr(compute_code_generation_metrics.multiprocessing, "Process", process_factory)
+
+    return manager, manager_factory, process_instance, process_factory
+
+
+class TestCheckCorrectnessReap:
+    """check_correctness must reap its worker and shut down its Manager on every exit path."""
+
+    def test_kill_is_followed_by_reap_join(self, patched_mp):
+        manager, _manager_factory, process, _process_factory = patched_mp
+        process.is_alive.side_effect = [True, False]
+
+        result, metadata = check_correctness(_SAMPLE, generation="ignored", timeout=1, debug=False)
+
+        process.start.assert_called_once()
+        assert process.join.call_count == 2
+        process.kill.assert_called_once()
+        first_join_timeout = process.join.call_args_list[0].kwargs.get("timeout")
+        second_join_timeout = process.join.call_args_list[1].kwargs.get("timeout")
+        assert first_join_timeout is not None
+        assert second_join_timeout is not None
+        assert result == [-1, -1]
+        assert metadata is None
+        manager.shutdown.assert_called_once()
+
+    def test_manager_shutdown_runs_when_process_start_raises(self, patched_mp):
+        manager, _manager_factory, process, _process_factory = patched_mp
+        process.start.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            check_correctness(_SAMPLE, generation="ignored", timeout=1, debug=False)
+
+        manager.shutdown.assert_called_once()
+
+    def test_happy_path_drains_results_before_manager_shutdown(self, patched_mp):
+        manager, _manager_factory, process, _process_factory = patched_mp
+        process.is_alive.return_value = False
+
+        captured_lists: list[list] = []
+
+        def _make_list() -> list:
+            new_list: list = []
+            captured_lists.append(new_list)
+            return new_list
+
+        manager.list.side_effect = _make_list
+
+        def _start_side_effect() -> None:
+            assert len(captured_lists) >= 2
+            captured_lists[0].append([1, 1])
+            captured_lists[1].append({"ok": True})
+
+        process.start.side_effect = _start_side_effect
+
+        result, metadata = check_correctness(_SAMPLE, generation="ignored", timeout=1, debug=False)
+
+        assert result == [1, 1]
+        assert metadata == {"ok": True}
+        manager.shutdown.assert_called_once()
+
+    def test_invalid_input_output_short_circuits(self, patched_mp):
+        _manager, manager_factory, process, _process_factory = patched_mp
+
+        result, metadata = check_correctness({"input_output": "not-json"}, generation="g", timeout=1, debug=False)
+
+        assert result == [-1]
+        assert metadata is None
+        manager_factory.assert_not_called()
+        process.start.assert_not_called()

--- a/resources_servers/ns_tools/app.py
+++ b/resources_servers/ns_tools/app.py
@@ -450,13 +450,19 @@ class NSToolsResourcesServer(SimpleResourcesServer):
 
         # Terminate the python_tool subprocess if one was started.
         if self._python_tool_process:
-            logger.info(f"Terminating python_tool server (PID: {self._python_tool_process.pid})")
+            pid: int = self._python_tool_process.pid
+            logger.info(f"Terminating python_tool server (PID: {pid})")
             self._python_tool_process.terminate()
             try:
                 self._python_tool_process.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 logger.warning("python_tool server did not terminate gracefully, killing...")
                 self._python_tool_process.kill()
+                # Reap the child after SIGKILL so it doesn't linger as <defunct>.
+                try:
+                    self._python_tool_process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    logger.error(f"python_tool server (PID: {pid}) did not exit after SIGKILL; may leak as a zombie")
             self._python_tool_process = None
 
 

--- a/resources_servers/ns_tools/tests/test_app.py
+++ b/resources_servers/ns_tools/tests/test_app.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from app import (
@@ -266,3 +267,54 @@ class TestApp:
         assert "expected_answer" in json_data
         assert "responses_create_params" in json_data
         assert "response" in json_data
+
+
+class TestPythonToolShutdownReap:
+    """Shutdown must reap the python_tool subprocess on every exit path."""
+
+    def _make_server(self) -> NSToolsResourcesServer:
+        config = NSToolsConfig(host="0.0.0.0", port=8080, entrypoint="", name="ns_tools")
+        return NSToolsResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+
+    async def test_kill_is_followed_by_reap_wait(self) -> None:
+        server = self._make_server()
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.pid = 12345
+        proc.wait.side_effect = [subprocess.TimeoutExpired(cmd="python_tool", timeout=5), 0]
+        server._python_tool_process = proc
+
+        await server.shutdown()
+
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
+        assert proc.wait.call_count == 2
+        assert server._python_tool_process is None
+
+    async def test_unreaped_child_after_sigkill_is_logged(self) -> None:
+        server = self._make_server()
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.pid = 12345
+        proc.wait.side_effect = subprocess.TimeoutExpired(cmd="python_tool", timeout=5)
+        server._python_tool_process = proc
+
+        with patch("app.logger") as mock_logger:
+            await server.shutdown()
+
+        proc.kill.assert_called_once()
+        assert proc.wait.call_count == 2
+        mock_logger.error.assert_called_once()
+        assert server._python_tool_process is None
+
+    async def test_graceful_termination_does_not_kill(self) -> None:
+        server = self._make_server()
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.pid = 12345
+        proc.wait.return_value = 0
+        server._python_tool_process = proc
+
+        await server.shutdown()
+
+        proc.terminate.assert_called_once()
+        proc.kill.assert_not_called()
+        proc.wait.assert_called_once_with(timeout=5)
+        assert server._python_tool_process is None

--- a/resources_servers/rdkit_chemistry/sandbox_launcher.py
+++ b/resources_servers/rdkit_chemistry/sandbox_launcher.py
@@ -501,11 +501,17 @@ def _stop_sandbox() -> None:
     global _sandbox_proc
     with _lock:
         if _sandbox_proc is not None:
+            pid: int = _sandbox_proc.pid
             _sandbox_proc.terminate()
             try:
                 _sandbox_proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 _sandbox_proc.kill()
+                # Reap the child after SIGKILL so it doesn't linger as <defunct>.
+                try:
+                    _sandbox_proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    logger.error("Sandbox (pid=%d) did not exit after SIGKILL; may leak as a zombie", pid)
             _sandbox_proc = None
             logger.info("Sandbox stopped")
 

--- a/resources_servers/rdkit_chemistry/tests/test_app.py
+++ b/resources_servers/rdkit_chemistry/tests/test_app.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for the rdkit_chemistry resources server."""
 
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -403,3 +404,63 @@ class TestSandboxStartupProbe:
 
         with pytest.raises(RuntimeError, match="Sandbox startup probe failed"):
             sandbox_launcher._run_startup_probe(6001, timeout_s=9.0)
+
+
+class TestStopSandboxReap:
+    """_stop_sandbox must reap the sandbox subprocess on every exit path."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_sandbox_proc(self):
+        original = sandbox_launcher._sandbox_proc
+        try:
+            yield
+        finally:
+            sandbox_launcher._sandbox_proc = original
+
+    def test_kill_is_followed_by_reap_wait(self, monkeypatch):
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.pid = 9999
+        proc.wait.side_effect = [subprocess.TimeoutExpired(cmd="sandbox", timeout=10), 0]
+        monkeypatch.setattr(sandbox_launcher, "_sandbox_proc", proc)
+
+        sandbox_launcher._stop_sandbox()
+
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
+        assert proc.wait.call_count == 2
+        assert sandbox_launcher._sandbox_proc is None
+
+    def test_unreaped_child_after_sigkill_is_logged(self, monkeypatch):
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.pid = 9999
+        proc.wait.side_effect = subprocess.TimeoutExpired(cmd="sandbox", timeout=10)
+        monkeypatch.setattr(sandbox_launcher, "_sandbox_proc", proc)
+
+        mock_logger = MagicMock()
+        monkeypatch.setattr(sandbox_launcher, "logger", mock_logger)
+
+        sandbox_launcher._stop_sandbox()
+
+        proc.kill.assert_called_once()
+        assert proc.wait.call_count == 2
+        mock_logger.error.assert_called_once()
+        assert 9999 in mock_logger.error.call_args[0]
+        assert sandbox_launcher._sandbox_proc is None
+
+    def test_graceful_termination_does_not_kill(self, monkeypatch):
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.pid = 9999
+        proc.wait.return_value = 0
+        monkeypatch.setattr(sandbox_launcher, "_sandbox_proc", proc)
+
+        sandbox_launcher._stop_sandbox()
+
+        proc.terminate.assert_called_once()
+        proc.kill.assert_not_called()
+        proc.wait.assert_called_once_with(timeout=10)
+        assert sandbox_launcher._sandbox_proc is None
+
+    def test_noop_when_no_sandbox_running(self, monkeypatch):
+        monkeypatch.setattr(sandbox_launcher, "_sandbox_proc", None)
+        sandbox_launcher._stop_sandbox()
+        assert sandbox_launcher._sandbox_proc is None

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -18,14 +18,22 @@ import tomllib
 from importlib import import_module
 from io import StringIO
 from pathlib import Path
-from unittest.mock import patch
+from subprocess import TimeoutExpired
+from unittest.mock import MagicMock, patch
 
 from omegaconf import OmegaConf
 from pytest import MonkeyPatch, raises
 
 import nemo_gym.global_config
 from nemo_gym import PARENT_DIR
-from nemo_gym.cli import RunConfig, display_help, init_resources_server
+from nemo_gym.cli import (
+    _FORCE_KILL_REAP_TIMEOUT_SEC,
+    _GRACEFUL_SHUTDOWN_TIMEOUT_SEC,
+    RunConfig,
+    RunHelper,
+    display_help,
+    init_resources_server,
+)
 from nemo_gym.config_types import ResourcesServerInstanceConfig
 
 
@@ -154,3 +162,68 @@ class TestCLI:
             dir_path = _cwd_path if _cwd_path.exists() else PARENT_DIR / Path("resources_servers", "arc_agi")
 
         assert dir_path == PARENT_DIR / "resources_servers" / "arc_agi"
+
+
+class TestRunHelperShutdownReap:
+    """RunHelper.shutdown must reap every server subprocess on every exit path."""
+
+    def _make_runner_with_processes(self, processes: dict) -> RunHelper:
+        runner = RunHelper()
+        runner._processes = processes
+        runner._head_server = MagicMock()
+        runner._head_server_thread = MagicMock()
+        return runner
+
+    def test_kill_is_followed_by_reap_wait(self) -> None:
+        good = MagicMock()
+        good.wait.return_value = 0
+        bad = MagicMock()
+        bad.wait.side_effect = [TimeoutExpired(cmd="bad", timeout=_GRACEFUL_SHUTDOWN_TIMEOUT_SEC), 0]
+
+        runner = self._make_runner_with_processes({"good_server": good, "bad_server": bad})
+        runner.shutdown()
+
+        good.send_signal.assert_called_once()
+        bad.send_signal.assert_called_once()
+        good.kill.assert_not_called()
+        bad.kill.assert_called_once()
+        assert good.wait.call_count == 1
+        assert bad.wait.call_count == 2
+        assert runner._processes == {}
+
+    def test_unreaped_server_after_sigkill_is_warned(self, capsys) -> None:
+        zombie = MagicMock()
+        zombie.wait.side_effect = TimeoutExpired(cmd="zombie", timeout=_GRACEFUL_SHUTDOWN_TIMEOUT_SEC)
+
+        runner = self._make_runner_with_processes({"zombie_server": zombie})
+        runner.shutdown()
+
+        zombie.kill.assert_called_once()
+        assert zombie.wait.call_count == 2
+        out: str = capsys.readouterr().out
+        assert "zombie_server" in out
+        assert f"{_GRACEFUL_SHUTDOWN_TIMEOUT_SEC}s timeout" in out
+        assert f"{_FORCE_KILL_REAP_TIMEOUT_SEC}s after SIGKILL" in out
+
+    def test_shutdown_message_matches_actual_timeout(self, capsys) -> None:
+        bad = MagicMock()
+        bad.wait.side_effect = [TimeoutExpired(cmd="bad", timeout=_GRACEFUL_SHUTDOWN_TIMEOUT_SEC), 0]
+        runner = self._make_runner_with_processes({"bad": bad})
+        runner.shutdown()
+
+        out: str = capsys.readouterr().out
+        assert f"{_GRACEFUL_SHUTDOWN_TIMEOUT_SEC}s timeout" in out
+
+    def test_graceful_termination_does_not_kill(self) -> None:
+        a = MagicMock()
+        a.wait.return_value = 0
+        b = MagicMock()
+        b.wait.return_value = 0
+        runner = self._make_runner_with_processes({"a": a, "b": b})
+        runner.shutdown()
+
+        a.kill.assert_not_called()
+        b.kill.assert_not_called()
+        assert a.wait.call_count == 1
+        assert b.wait.call_count == 1
+        assert runner._processes == {}


### PR DESCRIPTION
Pair `kill()` with a reap `wait()` / `join()` in four shutdown paths so `SIGKILL`-ed children don't linger as defunct until the parent exits.

`Popen.kill()` and `multiprocessing.Process.kill()` only send `SIGKILL`. The kernel keeps the PID in the process table until the parent calls waitpid(). Without that follow-up, every escalated shutdown leaks a zombie. Under multi-server CI shutdowns (CLI), per-call benchmark loops (code_gen LCB metrics), or sandbox restart cycles (rdkit_chemistry, ns_tools), this saturates the PID table and pins joinable resources.

Other servers already follow this pattern