### PR TITLE
feat: add '/' endpoint to SimpleServer and HeadServer

### DIFF
--- a/nemo_gym/cli.py
+++ b/nemo_gym/cli.py
@@ -304,7 +304,7 @@ Process `{process_name}` stderr:
             if len(successful_servers) != total_servers:
                 if poll_count % 10 == 0:  # Print every sleep_interval * poll_count = 3 * 10 = 30s
                     print(
-                        f"""Checking for HTTP server statuses (you should see some HTTP requests to `/` that may 404. This is expected.
+                        f"""Checking for HTTP server statuses.
 {len(successful_servers)} / {total_servers} servers ready. Waiting for servers to spin up: {waiting}"""
                     )
                 poll_count += 1

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -626,6 +626,11 @@ repr(e): {repr(e)}"""
             return
 
         app = server.setup_webserver()
+
+        @app.get("/", include_in_schema=False)
+        async def _liveness():
+            return {"status": "ok"}
+
         server.set_ulimit()
         server.prefix_server_logs()
         server.setup_exception_middleware(app)
@@ -698,10 +703,14 @@ class HeadServer(BaseServer):
     def setup_webserver(self) -> FastAPI:
         app = FastAPI()
 
+        app.get("/", include_in_schema=False)(self._liveness)
         app.get("/global_config_dict_yaml")(self.global_config_dict_yaml)
         app.get("/server_instances")(self.get_server_instances)
 
         return app
+
+    async def _liveness(self) -> dict:
+        return {"status": "ok"}
 
     def get_server_instances(self) -> List[dict]:
         return self._server_instances

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -377,6 +377,11 @@ class BaseServer(BaseModel):
 
         return server_config
 
+    def setup_liveness(self, app: FastAPI) -> None:
+        @app.get("/", include_in_schema=False)
+        async def _liveness():
+            return {"status": "ok"}
+
 
 class ProfilingMiddlewareInputConfig(BaseModel):
     # Relative to the Gym root dir.
@@ -626,11 +631,7 @@ repr(e): {repr(e)}"""
             return
 
         app = server.setup_webserver()
-
-        @app.get("/", include_in_schema=False)
-        async def _liveness():
-            return {"status": "ok"}
-
+        server.setup_liveness(app)
         server.set_ulimit()
         server.prefix_server_logs()
         server.setup_exception_middleware(app)
@@ -703,14 +704,11 @@ class HeadServer(BaseServer):
     def setup_webserver(self) -> FastAPI:
         app = FastAPI()
 
-        app.get("/", include_in_schema=False)(self._liveness)
+        self.setup_liveness(app)
         app.get("/global_config_dict_yaml")(self.global_config_dict_yaml)
         app.get("/server_instances")(self.get_server_instances)
 
         return app
-
-    async def _liveness(self) -> dict:
-        return {"status": "ok"}
 
     def get_server_instances(self) -> List[dict]:
         return self._server_instances


### PR DESCRIPTION
In the current code, the server readiness is checked through a request to the '/' endpoint. This endpoint does not exist, thus return 404 (expected behavior). Although this is not an issue, for a new user (like myself) it might be scary and confusing. I missed the `"This is expected."` message in the logs, noticed the red error codes and thought that I mis-configured something.

This PR adds an explicit '/' endpoint to the `SimpleServer` and `HeadServer` classes and changes logs from:

```
(mcqa) Adding a uvicorn logging filter so that the logs aren't spammed with 200 OK messages. This is to help errors pop up better and filter out noise.
(mcqa) INFO:     Started server process [871128]
(mcqa) INFO:     Waiting for application startup.
(mcqa) INFO:     Application startup complete.
(mcqa) INFO:     Uvicorn running on http://127.0.0.1:19298 (Press CTRL+C to quit)
INFO:     127.0.0.1:58256 - "GET / HTTP/1.1" 404 Not Found
Waiting for servers to spin up
(mcqa) INFO:     127.0.0.1:60176 - "GET / HTTP/1.1" 404 Not Found
```
to:

```
(mcqa) Adding a uvicorn logging filter so that the logs aren't spammed with 200 OK messages. This is to help errors pop up better and filter out noise.
(mcqa) INFO:     Started server process [877195]
(mcqa) INFO:     Waiting for application startup.
(mcqa) INFO:     Application startup complete.
(mcqa) INFO:     Uvicorn running on http://127.0.0.1:16602 (Press CTRL+C to quit)
INFO:     127.0.0.1:41560 - "GET / HTTP/1.1" 200 OK
```