### PR TITLE
fix: Compatibility with vllm 0.20 tool-calling

### DIFF
--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -706,7 +706,7 @@ class VLLMConverter(BaseModel):
             responses_create_params["max_tokens"] = max_output_tokens
 
         tools = responses_create_params.pop("tools", None)
-        if tools is not None:
+        if tools:
             responses_create_params["tools"] = []
             for tool_dict in tools:
                 tool_dict = tool_dict.copy()


### PR DESCRIPTION
vllm 0.20 has stricter Pydantic checking that does not allow for the `tools` field to be an empty list.

The official published Nemotron-3-Nano-RL training blend contains entries with `tools: []`. This causes errors.

This change prevents `tools: []` entries from being propagated to vllm, preventing any such errors.