### PR TITLE
perf(responses_api_agents): bypass HTTP self-calls in all agents

### DIFF
--- a/responses_api_agents/browsecomp_agent/app.py
+++ b/responses_api_agents/browsecomp_agent/app.py
@@ -20,7 +20,7 @@ import time
 import traceback
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Mapping, Optional, Tuple
 
 from fastapi import Request, Response
 from pydantic import ConfigDict, ValidationError
@@ -126,6 +126,17 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        result, set_cookies = await self._responses(body, request.cookies)
+        for k, v in set_cookies.items():
+            response.set_cookie(k, v)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        cookies: Optional[Mapping[str, str]] = None,
+    ) -> Tuple[NeMoGymResponse, dict]:
+        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -142,7 +153,9 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
         step = 0
         num_tool_calls = 0
         model_server_cookies = None  # update the cookies on every model response
-        resources_server_cookies = request.cookies  # update the cookies on every resources server response
+        resources_server_cookies = (
+            dict(cookies) if cookies else {}
+        )  # update the cookies on every resources server response
 
         reset_threshold = 0
         reset_count = 0
@@ -636,8 +649,9 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
             pass  # best-effort; a stale ckpt won't be re-read because the driver caches this sample
 
         # Propogate any extra cookies necessary for downstream verification
+        set_cookies: dict[str, str] = {}
         for k, v in (*resources_server_cookies.items(), *model_server_cookies.items()):
-            response.set_cookie(k, v)
+            set_cookies[k] = v
 
         print(
             f"{user_query[:20]}... | FINISHED | Step {step} | Time: {time.monotonic() - time_taken:.2f}s (model {time_taken_model_call:.2f}s, tool {time_taken_tool_call:.2f}s) | Max output tokens: {max_output_tokens} | Missing end thinks: {missing_end_think_count}"
@@ -648,7 +662,7 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
         model_response.reset_count = reset_count
         model_response.num_tool_calls = num_tool_calls
         model_response.metadata = {"missing_end_think_count": str(missing_end_think_count)}
-        return model_response
+        return model_response, set_cookies
 
     async def run(self, request: Request, body: BrowsecompAgentRunRequest) -> BrowsecompAgentVerifyResponse:
         cookies = request.cookies
@@ -668,16 +682,9 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
             body.responses_create_params.metadata["task_index"] = str(body._ng_task_index)
             body.responses_create_params.metadata["attempt"] = str(0)
 
-        response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path="/v1/responses",
-            json=body.responses_create_params,
-            cookies=cookies,
-        )
-        await raise_for_status(response)
-        cookies = response.cookies
-
-        response_json = await get_response_json(response)
+        inproc_response, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
+        response_json = inproc_response.model_dump()
 
         verify_request = BrowsecompAgentVerifyRequest.model_validate(body.model_dump() | {"response": response_json})
 

--- a/responses_api_agents/browsecomp_agent/app.py
+++ b/responses_api_agents/browsecomp_agent/app.py
@@ -17,7 +17,7 @@ import json
 import re
 import traceback
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Mapping, Optional, Tuple
 
 import aiohttp
 from fastapi import Request, Response
@@ -259,7 +259,14 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
         # RE-RAISE unchanged so run()'s containment behaves exactly as before.
         # Grep the next run for [browsecomp][responses_exc].
         try:
-            return await self._responses_impl(request, response, body)
+            result, set_cookies = await self._responses_impl(
+                body,
+                model_url_path=self.url_path_for_request("/v1/responses", request),
+                cookies=request.cookies,
+            )
+            for k, v in set_cookies.items():
+                response.set_cookie(k, v)
+            return result
         except Exception as e:
             print(f"[browsecomp][responses_exc] error_type={type(e).__name__} error={str(e)[:300]}", flush=True)
             traceback.print_exc()
@@ -267,10 +274,12 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
 
     async def _responses_impl(
         self,
-        request: Request,
-        response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming,
-    ) -> NeMoGymResponse:
+        *,
+        model_url_path: str,
+        cookies: Optional[Mapping[str, str]] = None,
+    ) -> Tuple[NeMoGymResponse, dict]:
+        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -283,7 +292,9 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
         usage = None
         step = 0
         model_server_cookies = None  # update the cookies on every model response
-        resources_server_cookies = request.cookies  # update the cookies on every resources server response
+        resources_server_cookies = (
+            dict(cookies) if cookies else {}
+        )  # update the cookies on every resources server response
 
         reset_threshold = self._reset_threshold(self.config)
 
@@ -421,7 +432,7 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
 
             model_response = await self.server_client.post(
                 server_name=self.config.model_server.name,
-                url_path=self.url_path_for_request("/v1/responses", request),
+                url_path=model_url_path,
                 json=new_body,
                 cookies=model_server_cookies,
             )
@@ -720,8 +731,9 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
             )
 
         # Propogate any extra cookies necessary for downstream verification
+        set_cookies: dict[str, str] = {}
         for k, v in (*resources_server_cookies.items(), *model_server_cookies.items()):
-            response.set_cookie(k, v)
+            set_cookies[k] = v
 
         model_response.output = full_trajectory
         model_response.usage = usage
@@ -730,7 +742,7 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
         model_response.reset_count = reset_count
         model_response.num_tool_calls = num_tool_calls
         model_response.pre_reset_warning_steps = pre_reset_warning_steps
-        return model_response
+        return model_response, set_cookies
 
     async def run(self, request: Request, body: BrowsecompAgentRunRequest) -> BrowsecompAgentVerifyResponse:
         cookies = request.cookies
@@ -769,19 +781,17 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
                     rollout_index = getattr(body, "_ng_rollout_index", None)
                     if rollout_index is not None:
                         body.responses_create_params.metadata["rollout_index"] = str(rollout_index)
-                response = await self.server_client.post(
-                    server_name=self.config.name,
-                    url_path=self.url_path_for_run("/v1/responses", body),
-                    json=body.responses_create_params,
+                inproc_response, set_cookies = await self._responses_impl(
+                    body.responses_create_params,
+                    model_url_path=self.url_path_for_run("/v1/responses", body),
                     cookies=cookies,
                 )
-                await raise_for_status(response)
-                cookies = response.cookies
+                cookies = set_cookies
 
                 # Retry if the model's LAST content-bearing turn was empty after <think>-strip.
                 # (Keyed on the last assistant message, matching the reference harness, NOT the concatenated
                 # output_text — a final think-only turn retries even if an earlier turn had text.)
-                response_json = await get_response_json(response)
+                response_json = inproc_response.model_dump(mode="json")
                 last_response_json = response_json
                 raw_output_text = self._last_message_text(NeMoGymResponse.model_validate(response_json))
                 cleaned_output_text = re.sub(r"<think>.*?</think>", "", raw_output_text, flags=re.DOTALL).strip()

--- a/responses_api_agents/claude_code_agent/app.py
+++ b/responses_api_agents/claude_code_agent/app.py
@@ -345,6 +345,13 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
         request: Request,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        return await self._responses(body)
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+    ) -> NeMoGymResponse:
+        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         body = body.model_copy(deep=True)
         if isinstance(body.input, str):
             body.input = [NeMoGymEasyInputMessage(role="user", content=body.input)]
@@ -405,15 +412,8 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
             await raise_for_status(seed_resp)
             cookies = seed_resp.cookies
 
-            agent_resp = await self.server_client.post(
-                server_name=self.config.name,
-                url_path="/v1/responses",
-                json=body.responses_create_params,
-                cookies=cookies,
-            )
-            await raise_for_status(agent_resp)
-            cookies = agent_resp.cookies
-            agent_resp_json = await get_response_json(agent_resp)
+            inproc_resp = await self._responses(body.responses_create_params)
+            agent_resp_json = inproc_resp.model_dump()
 
             verify_resp = await self.server_client.post(
                 server_name=self.config.resources_server.name,

--- a/responses_api_agents/claude_code_agent/app.py
+++ b/responses_api_agents/claude_code_agent/app.py
@@ -598,6 +598,13 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
         rollout_id: Optional[str] = None,
         observation_collector: Optional[Callable[[Path, dict[str, Any]], None]] = None,
     ) -> NeMoGymResponse:
+        return await self._responses(body)
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+    ) -> NeMoGymResponse:
+        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         body = body.model_copy(deep=True)
         if isinstance(body.input, str):
             body.input = [NeMoGymEasyInputMessage(role="user", content=body.input)]

--- a/responses_api_agents/claude_code_agent/app.py
+++ b/responses_api_agents/claude_code_agent/app.py
@@ -598,13 +598,6 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
         rollout_id: Optional[str] = None,
         observation_collector: Optional[Callable[[Path, dict[str, Any]], None]] = None,
     ) -> NeMoGymResponse:
-        return await self._responses(body)
-
-    async def _responses(
-        self,
-        body: NeMoGymResponseCreateParamsNonStreaming,
-    ) -> NeMoGymResponse:
-        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         body = body.model_copy(deep=True)
         if isinstance(body.input, str):
             body.input = [NeMoGymEasyInputMessage(role="user", content=body.input)]

--- a/responses_api_agents/cline_agent/app.py
+++ b/responses_api_agents/cline_agent/app.py
@@ -647,6 +647,14 @@ class ClineAgent(SimpleResponsesAPIAgent):
         request: Request,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        return await self._responses(body, rollout_id=request.path_params.get("rollout_id"))
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        rollout_id: Optional[str] = None,
+    ) -> NeMoGymResponse:
         body = body.model_copy(deep=True)
         if isinstance(body.input, str):
             body.input = [NeMoGymEasyInputMessage(role="user", content=body.input)]
@@ -655,10 +663,6 @@ class ClineAgent(SimpleResponsesAPIAgent):
         system_parts = [p for p in [self.config.system_prompt, input_system] if p]
         system_prompt = "\n\n".join(system_parts) if system_parts else None
 
-        # run() reaches this handler through the /ng-rollout/<id> self-call route, which carries
-        # the correlation id Cline's model calls are tagged with. Absent on a direct
-        # /v1/responses call.
-        rollout_id = request.path_params.get("rollout_id")
         output_items, metadata, model_name = await self._run_cline(user_message, system_prompt, rollout_id)
 
         if not any(
@@ -711,15 +715,11 @@ class ClineAgent(SimpleResponsesAPIAgent):
             await raise_for_status(seed_resp)
             cookies = seed_resp.cookies
 
-            agent_resp = await self.server_client.post(
-                server_name=self.config.name,
-                url_path=self.url_path_for_run("/v1/responses", body),
-                json=body.responses_create_params,
-                cookies=cookies,
+            agent_response = await self._responses(
+                body.responses_create_params,
+                rollout_id=self.rollout_id_from_run(body),
             )
-            await raise_for_status(agent_resp)
-            cookies = agent_resp.cookies
-            agent_resp_json = await get_response_json(agent_resp)
+            agent_resp_json = agent_response.model_dump(mode="json")
 
             verify_resp = await self.server_client.post(
                 server_name=self.config.resources_server.name,

--- a/responses_api_agents/conversational_tool_use/simulation/app.py
+++ b/responses_api_agents/conversational_tool_use/simulation/app.py
@@ -132,11 +132,29 @@ class ConversationalToolUseAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        result, resources_server_cookies, model_server_cookies = await self._responses(
+            body,
+            resources_server_cookies=request.cookies,
+            model_url_path=self.url_path_for_request("/v1/responses", request),
+        )
+        for cookie_source in (resources_server_cookies, model_server_cookies):
+            if cookie_source is None:
+                continue
+            for key, value in cookie_source.items():
+                response.set_cookie(key, value)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        resources_server_cookies: Dict[str, str],
+        model_url_path: str,
+    ) -> tuple[NeMoGymResponse, Dict[str, str], Optional[Dict[str, str]]]:
         body = body.model_copy(deep=True)
         if isinstance(body.input, str):
             body.input = [NeMoGymEasyInputMessage(role="user", content=body.input)]
 
-        resources_server_cookies = request.cookies
         model_server_cookies = None
         new_outputs: List[Any] = []
         usage = None
@@ -200,7 +218,7 @@ class ConversationalToolUseAgent(SimpleResponsesAPIAgent):
             model_payload["input"] = self._normalize_response_input_items(body.input + new_outputs)
             model_response_http = await self.server_client.post(
                 server_name=self.config.model_server.name,
-                url_path=self.url_path_for_request("/v1/responses", request),
+                url_path=model_url_path,
                 json=model_payload,
                 cookies=model_server_cookies,
             )
@@ -295,17 +313,11 @@ class ConversationalToolUseAgent(SimpleResponsesAPIAgent):
                     resources_server_cookies = terminal["cookies"]
                     break
 
-        for cookie_source in (resources_server_cookies, model_server_cookies):
-            if cookie_source is None:
-                continue
-            for key, value in cookie_source.items():
-                response.set_cookie(key, value)
-
         if last_model_response is None:
             last_model_response = self._empty_response()
         last_model_response.output = new_outputs
         last_model_response.usage = usage
-        return last_model_response
+        return last_model_response, resources_server_cookies, model_server_cookies
 
     async def run(
         self, request: Request, body: ConversationalToolUseAgentRunRequest
@@ -333,15 +345,13 @@ class ConversationalToolUseAgent(SimpleResponsesAPIAgent):
         try:
             responses_create_params = body.responses_create_params.model_copy(deep=True)
             try:
-                response = await self.server_client.post(
-                    server_name=self.config.name,
-                    url_path=self.url_path_for_run("/v1/responses", body),
-                    json=responses_create_params,
-                    cookies=cookies,
+                response, resources_cookies, model_cookies = await self._responses(
+                    responses_create_params,
+                    resources_server_cookies=cookies,
+                    model_url_path=self.url_path_for_run("/v1/responses", body),
                 )
-                await raise_for_status(response)
-                cookies = self._merge_cookies(cookies, response.cookies)
-                response_payload = await get_response_json(response)
+                cookies = self._merge_cookies(resources_cookies, model_cookies)
+                response_payload = response.model_dump(mode="json", exclude_unset=True)
                 responses_create_params, response_payload = self._canonicalize_run_transcript(
                     responses_create_params,
                     response_payload,

--- a/responses_api_agents/conversational_tool_use/simulation/tests/test_app.py
+++ b/responses_api_agents/conversational_tool_use/simulation/tests/test_app.py
@@ -26,6 +26,7 @@ from nemo_gym.global_config import ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymFunctionCallOutput,
+    NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCall,
 )
@@ -990,12 +991,11 @@ async def test_final_agent_tool_calls_terminate_without_tool_simulation_or_dummy
 
 async def test_run_routes_rollout_5xx_to_transient_failure_sidecar_contract() -> None:
     agent = make_agent()
+    agent._responses = AsyncMock(side_effect=http_error(503))
 
     async def route_post(**kwargs):
         if kwargs["url_path"] == "/seed_session":
             return JsonResponseStub({}, cookies={"session_id": "session-1"})
-        if kwargs["url_path"] == "/v1/responses":
-            raise http_error(503)
         if kwargs["url_path"] == "/discard_session":
             assert kwargs["cookies"] == {"session_id": "session-1"}
             return JsonResponseStub({"discarded": True})
@@ -1016,11 +1016,18 @@ async def test_run_routes_rollout_5xx_to_transient_failure_sidecar_contract() ->
     assert "503" in result_payload["error_message"]
     assert result.instance_config == {"mask_sample": True}
     assert result.response.id == "conversational_tool_use_rollout_failed"
-    assert agent.server_client.post.await_count == 3
+    assert agent.server_client.post.await_count == 2
 
 
 async def test_run_correlates_self_and_resource_model_calls_with_rollout_identity() -> None:
     agent = make_agent(observability=True)
+    agent._responses = AsyncMock(
+        return_value=(
+            NeMoGymResponse.model_validate(response_payload([assistant_message("msg_1", "Done.")])),
+            {"session_id": "session-1"},
+            None,
+        )
+    )
     requests = []
 
     async def route_post(**kwargs):
@@ -1028,8 +1035,6 @@ async def test_run_correlates_self_and_resource_model_calls_with_rollout_identit
         if kwargs["url_path"] == "/seed_session":
             assert kwargs["json"]["rollout_id"] == "7-2"
             return JsonResponseStub({}, cookies={"session_id": "session-1"})
-        if kwargs["url_path"] == "/ng-rollout/7-2/v1/responses":
-            return JsonResponseStub(response_payload([assistant_message("msg_1", "Done.")]))
         if kwargs["url_path"] == "/verify":
             return JsonResponseStub(
                 kwargs["json"]
@@ -1053,9 +1058,9 @@ async def test_run_correlates_self_and_resource_model_calls_with_rollout_identit
     assert result.reward == 1.0
     assert [request["url_path"] for request in requests] == [
         "/seed_session",
-        "/ng-rollout/7-2/v1/responses",
         "/verify",
     ]
+    assert agent._responses.await_args.kwargs["model_url_path"] == "/ng-rollout/7-2/v1/responses"
 
 
 async def test_run_routes_seed_rate_limit_to_transient_failure_sidecar_contract() -> None:
@@ -1077,12 +1082,17 @@ async def test_run_routes_seed_rate_limit_to_transient_failure_sidecar_contract(
 
 async def test_run_routes_verify_5xx_to_transient_failure_sidecar_contract() -> None:
     agent = make_agent()
+    agent._responses = AsyncMock(
+        return_value=(
+            NeMoGymResponse.model_validate(response_payload([assistant_message("msg_1", "Done.")])),
+            {"session_id": "session-1"},
+            None,
+        )
+    )
 
     async def route_post(**kwargs):
         if kwargs["url_path"] == "/seed_session":
             return JsonResponseStub({}, cookies={"session_id": "session-1"})
-        if kwargs["url_path"] == "/v1/responses":
-            return JsonResponseStub(response_payload([assistant_message("msg_1", "Done.")]))
         if kwargs["url_path"] == "/verify":
             raise http_error(502)
         if kwargs["url_path"] == "/discard_session":
@@ -1102,17 +1112,22 @@ async def test_run_routes_verify_5xx_to_transient_failure_sidecar_contract() -> 
     assert result_payload["error_stage"] == "verify"
     assert "502" in result_payload["error_message"]
     assert result.instance_config == {"mask_sample": True}
-    assert agent.server_client.post.await_count == 4
+    assert agent.server_client.post.await_count == 3
 
 
 async def test_run_preserves_verified_semantic_zero_as_scored_result() -> None:
     agent = make_agent()
+    agent._responses = AsyncMock(
+        return_value=(
+            NeMoGymResponse.model_validate(response_payload([assistant_message("msg_1", "Incorrect answer.")])),
+            {"session_id": "session-1"},
+            None,
+        )
+    )
 
     async def route_post(**kwargs):
         if kwargs["url_path"] == "/seed_session":
             return JsonResponseStub({}, cookies={"session_id": "session-1"})
-        if kwargs["url_path"] == "/v1/responses":
-            return JsonResponseStub(response_payload([assistant_message("msg_1", "Incorrect answer.")]))
         if kwargs["url_path"] == "/verify":
             return JsonResponseStub(
                 kwargs["json"]
@@ -1140,12 +1155,11 @@ async def test_run_preserves_verified_semantic_zero_as_scored_result() -> None:
 
 async def test_run_does_not_convert_non_retryable_4xx_to_transient_failure() -> None:
     agent = make_agent()
+    agent._responses = AsyncMock(side_effect=http_error(400))
 
     async def route_post(**kwargs):
         if kwargs["url_path"] == "/seed_session":
             return JsonResponseStub({}, cookies={"session_id": "session-1"})
-        if kwargs["url_path"] == "/v1/responses":
-            raise http_error(400)
         if kwargs["url_path"] == "/discard_session":
             return JsonResponseStub({"discarded": True})
         raise AssertionError(f"Unexpected request: {kwargs}")

--- a/responses_api_agents/critpt_agent/app.py
+++ b/responses_api_agents/critpt_agent/app.py
@@ -68,16 +68,30 @@ class CritPtAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
-        model_response = await self.server_client.post(
-            server_name=self.config.model_server.name,
-            url_path=self.url_path_for_request("/v1/responses", request),
-            json=body,
+        result, cookies = await self._responses(
+            body,
+            model_url_path=self.url_path_for_request("/v1/responses", request),
             cookies=request.cookies,
         )
+        for key, value in cookies.items():
+            response.set_cookie(key, value)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        model_url_path: str,
+        cookies: Any = None,
+    ) -> tuple[NeMoGymResponse, Any]:
+        model_response = await self.server_client.post(
+            server_name=self.config.model_server.name,
+            url_path=model_url_path,
+            json=body,
+            cookies=cookies,
+        )
         await raise_for_status(model_response)
-        for k, v in model_response.cookies.items():
-            response.set_cookie(k, v)
-        return NeMoGymResponse.model_validate(await get_response_json(model_response))
+        return NeMoGymResponse.model_validate(await get_response_json(model_response)), model_response.cookies
 
     async def run(self, request: Request, body: CritPtAgentRunRequest) -> CritPtAgentVerifyResponse:
         cookies = request.cookies
@@ -94,15 +108,12 @@ class CritPtAgent(SimpleResponsesAPIAgent):
         self_responses_url_path = self.url_path_for_run("/v1/responses", body)
 
         # Turn 1: solve the problem
-        turn1_response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path=self_responses_url_path,
-            json=body.responses_create_params,
+        turn1_response, cookies = await self._responses(
+            body.responses_create_params,
+            model_url_path=self_responses_url_path,
             cookies=cookies,
         )
-        await raise_for_status(turn1_response)
-        cookies = turn1_response.cookies
-        turn1_json = await get_response_json(turn1_response)
+        turn1_json = turn1_response.model_dump(mode="json")
         # Strip reasoning blocks: the Turn 2 user message asks the model not to reason again, so
         # the Turn 2 assistant context should contain only the conclusion, not the thinking trace.
         turn1_text = _strip_thinking_blocks(_extract_output_text(turn1_json))
@@ -115,15 +126,12 @@ class CritPtAgent(SimpleResponsesAPIAgent):
         ]
         turn2_params = body.responses_create_params.model_copy(update={"input": turn2_input})
 
-        turn2_response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path=self_responses_url_path,
-            json=turn2_params,
+        turn2_response, cookies = await self._responses(
+            turn2_params,
+            model_url_path=self_responses_url_path,
             cookies=cookies,
         )
-        await raise_for_status(turn2_response)
-        cookies = turn2_response.cookies
-        turn2_json = await get_response_json(turn2_response)
+        turn2_json = turn2_response.model_dump(mode="json")
 
         # Verify Turn 2 output against the Artificial Analysis API
         verify_request_data = body.model_dump() | {"response": turn2_json}

--- a/responses_api_agents/cvdp_agent/app.py
+++ b/responses_api_agents/cvdp_agent/app.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-from typing import List
+from typing import List, Mapping, Optional, Tuple
 
 from fastapi import Request, Response
 from pydantic import ConfigDict, ValidationError
@@ -68,6 +68,17 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        result, set_cookies = await self._responses(body, request.cookies)
+        for k, v in set_cookies.items():
+            response.set_cookie(k, v)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        cookies: Optional[Mapping[str, str]] = None,
+    ) -> Tuple[NeMoGymResponse, dict]:
+        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -77,7 +88,9 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         usage = None
         step = 0
         model_server_cookies = None  # update the cookies on every model response
-        resources_server_cookies = request.cookies  # update the cookies on every resources server response
+        resources_server_cookies = (
+            dict(cookies) if cookies else {}
+        )  # update the cookies on every resources server response
 
         while True:
             step += 1
@@ -148,12 +161,13 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 break
 
         # Propogate any extra cookies necessary for downstream verification
+        set_cookies: dict[str, str] = {}
         for k, v in (*resources_server_cookies.items(), *model_server_cookies.items()):
-            response.set_cookie(k, v)
+            set_cookies[k] = v
 
         model_response.output = new_outputs
         model_response.usage = usage
-        return model_response
+        return model_response, set_cookies
 
     async def run(self, request: Request, body: SimpleAgentRunRequest) -> SimpleAgentVerifyResponse:
         cookies = request.cookies
@@ -179,24 +193,18 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         retries_left = self.config.llm_parse_retries
         while True:
             try:
-                response = await self.server_client.post(
-                    server_name=self.config.name,
-                    url_path="/v1/responses",
-                    json=body.responses_create_params,
-                    cookies=cookies,
-                )
-                await raise_for_status(response)
-                cookies = response.cookies
+                inproc_response, set_cookies = await self._responses(body.responses_create_params, cookies)
+                attempt_cookies = set_cookies
 
                 verify_request = SimpleAgentVerifyRequest.model_validate(
-                    body.model_dump() | {"response": await get_response_json(response)}
+                    body.model_dump() | {"response": inproc_response.model_dump()}
                 )
 
                 verify_response = await self.server_client.post(
                     server_name=self.config.resources_server.name,
                     url_path="/verify",
                     json=verify_request.model_dump(),
-                    cookies=cookies,
+                    cookies=attempt_cookies,
                 )
                 await raise_for_status(verify_response)
                 result = SimpleAgentVerifyResponse.model_validate(await get_response_json(verify_response))

--- a/responses_api_agents/cvdp_agent/app.py
+++ b/responses_api_agents/cvdp_agent/app.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
@@ -278,6 +279,23 @@ class CVDPAgent(SimpleResponsesAPIAgent):
         if self.config.model_server is None:
             raise RuntimeError("simple_agent mode requires model_server to be configured")
 
+        result, set_cookies = await self._responses(
+            body,
+            model_url_path=self.url_path_for_request("/v1/responses", request),
+            cookies=request.cookies,
+        )
+        for k, v in set_cookies.items():
+            response.set_cookie(k, v)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        model_url_path: str,
+        cookies: Optional[Mapping[str, str]] = None,
+    ) -> tuple[NeMoGymResponse, dict[str, str]]:
+        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -287,7 +305,9 @@ class CVDPAgent(SimpleResponsesAPIAgent):
         usage = None
         step = 0
         model_server_cookies = None  # update the cookies on every model response
-        resources_server_cookies = request.cookies  # update the cookies on every resources server response
+        resources_server_cookies = (
+            dict(cookies) if cookies else {}
+        )  # update the cookies on every resources server response
 
         while True:
             step += 1
@@ -295,7 +315,7 @@ class CVDPAgent(SimpleResponsesAPIAgent):
 
             model_response = await self.server_client.post(
                 server_name=self.config.model_server.name,
-                url_path=self.url_path_for_request("/v1/responses", request),
+                url_path=model_url_path,
                 json=new_body,
                 cookies=model_server_cookies,
             )
@@ -347,12 +367,13 @@ class CVDPAgent(SimpleResponsesAPIAgent):
                 break
 
         # Propogate any extra cookies necessary for downstream verification
+        set_cookies: dict[str, str] = {}
         for k, v in (*resources_server_cookies.items(), *model_server_cookies.items()):
-            response.set_cookie(k, v)
+            set_cookies[k] = v
 
         model_response.output = new_outputs
         model_response.usage = usage
-        return model_response
+        return model_response, set_cookies
 
     async def _run_simple(self, request: Request, body: CVDPAgentRunRequest) -> CVDPAgentVerifyResponse:
         cookies = request.cookies
@@ -378,24 +399,22 @@ class CVDPAgent(SimpleResponsesAPIAgent):
         retries_left = self.config.llm_parse_retries
         while True:
             try:
-                response = await self.server_client.post(
-                    server_name=self.config.name,
-                    url_path=self.url_path_for_run("/v1/responses", body),
-                    json=body.responses_create_params,
+                inproc_response, set_cookies = await self._responses(
+                    body.responses_create_params,
+                    model_url_path=self.url_path_for_run("/v1/responses", body),
                     cookies=cookies,
                 )
-                await raise_for_status(response)
-                cookies = response.cookies
+                attempt_cookies = set_cookies
 
                 verify_request = CVDPAgentVerifyRequest.model_validate(
-                    body.model_dump() | {"response": await get_response_json(response)}
+                    body.model_dump() | {"response": inproc_response.model_dump()}
                 )
 
                 verify_response = await self.server_client.post(
                     server_name=self.config.resources_server.name,
                     url_path="/verify",
                     json=verify_request.model_dump(),
-                    cookies=cookies,
+                    cookies=attempt_cookies,
                 )
                 await raise_for_status(verify_response)
                 result = CVDPAgentVerifyResponse.model_validate(await get_response_json(verify_response))

--- a/responses_api_agents/finance_agent/app.py
+++ b/responses_api_agents/finance_agent/app.py
@@ -16,7 +16,7 @@ import asyncio
 import json
 import logging
 import re
-from typing import Any, List, Optional
+from typing import Any, List, Mapping, Optional, Tuple
 
 from fastapi import Request, Response
 from pydantic import ConfigDict, Field
@@ -161,6 +161,17 @@ class FinanceAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        result, set_cookies = await self._responses(body, request.cookies)
+        for k, v in set_cookies.items():
+            response.set_cookie(k, v)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        cookies: Optional[Mapping[str, str]] = None,
+    ) -> Tuple[NeMoGymResponse, dict]:
+        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -171,7 +182,7 @@ class FinanceAgent(SimpleResponsesAPIAgent):
         step = 0
         last_model_response: Optional[NeMoGymResponse] = None
         model_server_cookies = None
-        resources_server_cookies = request.cookies
+        resources_server_cookies = dict(cookies) if cookies else {}
 
         done_tools_set = set(self.config.done_tools)
         max_steps = self.config.max_steps
@@ -316,15 +327,16 @@ class FinanceAgent(SimpleResponsesAPIAgent):
                 tool_choice="auto",
             )
 
-        cookie_items = list(resources_server_cookies.items())
+        set_cookies: dict[str, str] = {}
+        for k, v in resources_server_cookies.items():
+            set_cookies[k] = v
         if model_server_cookies:
-            cookie_items.extend(model_server_cookies.items())
-        for k, v in cookie_items:
-            response.set_cookie(k, v)
+            for k, v in model_server_cookies.items():
+                set_cookies[k] = v
 
         last_model_response.output = new_outputs
         last_model_response.usage = usage
-        return last_model_response
+        return last_model_response, set_cookies
 
     async def run(self, request: Request, body: FinanceAgentRunRequest) -> FinanceAgentVerifyResponse:
         try:
@@ -359,17 +371,11 @@ class FinanceAgent(SimpleResponsesAPIAgent):
         await raise_for_status(seed_session_response)
         cookies = seed_session_response.cookies
 
-        response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path="/v1/responses",
-            json=body.responses_create_params,
-            cookies=cookies,
-        )
-        await raise_for_status(response)
-        cookies = response.cookies
+        inproc_response, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
         verify_request = FinanceAgentVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(response)}
+            body.model_dump() | {"response": inproc_response.model_dump()}
         )
 
         verify_response = await self.server_client.post(

--- a/responses_api_agents/finance_agent/app.py
+++ b/responses_api_agents/finance_agent/app.py
@@ -31,6 +31,7 @@ import json
 import logging
 import re
 import time
+from collections.abc import Mapping
 from enum import Enum
 from typing import Any, List, Optional
 
@@ -260,6 +261,17 @@ class FinanceAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        result, set_cookies = await self._responses(body, request.cookies)
+        for k, v in set_cookies.items():
+            response.set_cookie(k, v)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        cookies: Optional[Mapping[str, str]] = None,
+    ) -> tuple[NeMoGymResponse, dict[str, str]]:
+        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -270,7 +282,7 @@ class FinanceAgent(SimpleResponsesAPIAgent):
         step = 0
         last_model_response: Optional[NeMoGymResponse] = None
         model_server_cookies = None
-        resources_server_cookies = request.cookies
+        resources_server_cookies = dict(cookies) if cookies else {}
 
         done_tools_set = set(self.config.done_tools)
         max_steps = self.config.max_steps
@@ -444,11 +456,12 @@ class FinanceAgent(SimpleResponsesAPIAgent):
                 tool_choice="auto",
             )
 
-        cookie_items = list(resources_server_cookies.items())
+        set_cookies: dict[str, str] = {}
+        for k, v in resources_server_cookies.items():
+            set_cookies[k] = v
         if model_server_cookies:
-            cookie_items.extend(model_server_cookies.items())
-        for k, v in cookie_items:
-            response.set_cookie(k, v)
+            for k, v in model_server_cookies.items():
+                set_cookies[k] = v
 
         last_model_response.output = new_outputs
         last_model_response.usage = usage
@@ -462,7 +475,7 @@ class FinanceAgent(SimpleResponsesAPIAgent):
             "stop_reason": stop_reason.value,
             "steps": str(step),
         }
-        return last_model_response
+        return last_model_response, set_cookies
 
     async def run(self, request: Request, body: FinanceAgentRunRequest) -> FinanceAgentVerifyResponse:
         try:
@@ -498,17 +511,11 @@ class FinanceAgent(SimpleResponsesAPIAgent):
         await raise_for_status(seed_session_response)
         cookies = seed_session_response.cookies
 
-        response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path="/v1/responses",
-            json=body.responses_create_params,
-            cookies=cookies,
-        )
-        await raise_for_status(response)
-        cookies = response.cookies
+        inproc_response, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
         verify_request = FinanceAgentVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(response)}
+            body.model_dump() | {"response": inproc_response.model_dump()}
         )
 
         verify_response = await self.server_client.post(

--- a/responses_api_agents/hermes_agent/app.py
+++ b/responses_api_agents/hermes_agent/app.py
@@ -197,6 +197,13 @@ class HermesAgent(SimpleResponsesAPIAgent):
         request: Request,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        return await self._responses(body)
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+    ) -> NeMoGymResponse:
+        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         from run_agent import AIAgent  # from hermes-agent on path
 
         body = body.model_copy(deep=True)
@@ -315,15 +322,8 @@ class HermesAgent(SimpleResponsesAPIAgent):
             await raise_for_status(seed_resp)
             cookies = seed_resp.cookies
 
-            agent_resp = await self.server_client.post(
-                server_name=self.config.name,
-                url_path="/v1/responses",
-                json=body.responses_create_params,
-                cookies=cookies,
-            )
-            await raise_for_status(agent_resp)
-            cookies = agent_resp.cookies
-            agent_resp_json = await get_response_json(agent_resp)
+            inproc_resp = await self._responses(body.responses_create_params)
+            agent_resp_json = inproc_resp.model_dump()
 
             verify_resp = await self.server_client.post(
                 server_name=self.config.resources_server.name,

--- a/responses_api_agents/hermes_agent/app.py
+++ b/responses_api_agents/hermes_agent/app.py
@@ -487,21 +487,14 @@ class HermesAgent(SimpleResponsesAPIAgent):
             cookies = seed_resp.cookies
 
             rollout_id = self.rollout_id_from_run(body)
-            agent_resp = await self.server_client.post(
-                server_name=self.config.name,
-                url_path=self.url_path_for_run("/v1/responses", body),
-                json=body.responses_create_params,
-                cookies=cookies,
-            )
-            await raise_for_status(agent_resp)
-            cookies = agent_resp.cookies
-            agent_resp_json = await get_response_json(agent_resp)
-            raw_observations = (
-                agent_resp_json.pop(_INTERNAL_OBSERVATIONS_KEY, None) if rollout_id is not None else None
-            )
-            observations = (
-                AgentObservationBundle.model_validate(raw_observations) if isinstance(raw_observations, dict) else None
-            )
+            if rollout_id is not None:
+                episode = await self._create_episode(body.responses_create_params, rollout_id=rollout_id)
+                agent_resp = episode.response
+                observations = episode.observations
+            else:
+                agent_resp = await self._create_response(body.responses_create_params)
+                observations = None
+            agent_resp_json = agent_resp.model_dump(mode="json")
 
             verify_resp = await self.server_client.post(
                 server_name=self.config.resources_server.name,

--- a/responses_api_agents/kilocode_agent/app.py
+++ b/responses_api_agents/kilocode_agent/app.py
@@ -468,6 +468,14 @@ class KiloCodeAgent(SimpleResponsesAPIAgent):
         request: Request,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        return await self._responses(body, rollout_id=request.path_params.get("rollout_id"))
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        rollout_id: Optional[str] = None,
+    ) -> NeMoGymResponse:
         body = body.model_copy(deep=True)
         if isinstance(body.input, str):
             body.input = [NeMoGymEasyInputMessage(role="user", content=body.input)]
@@ -476,9 +484,6 @@ class KiloCodeAgent(SimpleResponsesAPIAgent):
         system_parts = [p for p in [self.config.system_prompt, input_system] if p]
         system_prompt = "\n\n".join(system_parts) if system_parts else None
 
-        # run() reaches this handler through the /ng-rollout/<id> self-call route, which carries the
-        # correlation id kilo's model calls are tagged with. Absent on a direct /v1/responses call.
-        rollout_id = request.path_params.get("rollout_id")
         output_items, usage, model_name = await self._run_kilo(user_message, system_prompt, rollout_id)
 
         if not any(
@@ -530,15 +535,11 @@ class KiloCodeAgent(SimpleResponsesAPIAgent):
             await raise_for_status(seed_resp)
             cookies = seed_resp.cookies
 
-            agent_resp = await self.server_client.post(
-                server_name=self.config.name,
-                url_path=self.url_path_for_run("/v1/responses", body),
-                json=body.responses_create_params,
-                cookies=cookies,
+            agent_response = await self._responses(
+                body.responses_create_params,
+                rollout_id=self.rollout_id_from_run(body),
             )
-            await raise_for_status(agent_resp)
-            cookies = agent_resp.cookies
-            agent_resp_json = await get_response_json(agent_resp)
+            agent_resp_json = agent_response.model_dump(mode="json")
 
             verify_resp = await self.server_client.post(
                 server_name=self.config.resources_server.name,

--- a/responses_api_agents/langgraph_agent/app.py
+++ b/responses_api_agents/langgraph_agent/app.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import abstractmethod
-from typing import Any
+from typing import Any, Mapping, Optional, Tuple
 
 from fastapi import Body, Request, Response
 from pydantic import ConfigDict
@@ -58,17 +58,29 @@ class LangGraphAgentAdapter(SimpleResponsesAPIAgent):
     async def responses(
         self, request: Request, response: Response, body: NeMoGymResponseCreateParamsNonStreaming = Body()
     ) -> NeMoGymResponse:
-        initial_state = await self.get_initial_state(body, request.cookies)
+        result, set_cookies = await self._responses(body, request.cookies)
+        for k, v in set_cookies.items():
+            response.set_cookie(k, v)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        cookies: Optional[Mapping[str, str]] = None,
+    ) -> Tuple[NeMoGymResponse, dict]:
+        """Implementation of `/v1/responses`; subclass `run` methods invoke this in-process."""
+        initial_state = await self.get_initial_state(body, dict(cookies) if cookies else {})
         final_state = await self.graph.ainvoke(initial_state)
 
+        set_cookies: dict[str, str] = {}
         if "cookies" in final_state:
             for k, v in final_state["cookies"].items():
-                response.set_cookie(k, v)
+                set_cookies[k] = v
 
         model_response = self.extract_model_response(final_state)
         outputs = self.extract_outputs(final_state)
         model_response.output = outputs
-        return model_response
+        return model_response, set_cookies
 
     async def run(self, request: Request, body: BaseRunRequest) -> BaseVerifyResponse:
         cookies = request.cookies
@@ -82,18 +94,16 @@ class LangGraphAgentAdapter(SimpleResponsesAPIAgent):
         await raise_for_status(seed)
         cookies = seed.cookies
 
-        resp = await self.server_client.post(
-            server_name=self.config.name, url_path="/v1/responses", json=body.responses_create_params, cookies=cookies
-        )
-        await raise_for_status(resp)
+        inproc_resp, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
-        verify_request_dict = body.model_dump() | {"response": await get_response_json(resp)}
+        verify_request_dict = body.model_dump() | {"response": inproc_resp.model_dump()}
 
         verify = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",
             json=verify_request_dict,
-            cookies=resp.cookies,
+            cookies=cookies,
         )
         await raise_for_status(verify)
         return BaseVerifyResponse.model_validate(await get_response_json(verify))

--- a/responses_api_agents/langgraph_agent/app.py
+++ b/responses_api_agents/langgraph_agent/app.py
@@ -98,19 +98,31 @@ class LangGraphAgentAdapter(SimpleResponsesAPIAgent):
     async def responses(
         self, request: Request, response: Response, body: NeMoGymResponseCreateParamsNonStreaming = Body()
     ) -> NeMoGymResponse:
-        initial_state = await self.get_initial_state(body, request.cookies)
+        result, set_cookies = await self._responses(body, request.cookies)
+        for k, v in set_cookies.items():
+            response.set_cookie(k, v)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        cookies: Mapping[str, str] | None = None,
+    ) -> tuple[NeMoGymResponse, dict[str, str]]:
+        """Implementation of `/v1/responses`; subclass `run` methods invoke this in-process."""
+        initial_state = await self.get_initial_state(body, dict(cookies) if cookies else {})
         final_state = await self.graph.ainvoke(initial_state)
 
+        set_cookies: dict[str, str] = {}
         if "cookies" in final_state:
             for k, v in final_state["cookies"].items():
-                response.set_cookie(k, v)
+                set_cookies[k] = v
 
         model_response = self.extract_model_response(final_state)
         outputs = self.extract_outputs(final_state)
         model_response.output = outputs
         if "policy_usages" in final_state:
             model_response.usage = aggregate_response_usage(final_state["policy_usages"])
-        return model_response
+        return model_response, set_cookies
 
     async def run(self, request: Request, body: BaseRunRequest) -> LangGraphVerifyResponse:
         cookies = request.cookies
@@ -124,18 +136,16 @@ class LangGraphAgentAdapter(SimpleResponsesAPIAgent):
         await raise_for_status(seed)
         cookies = seed.cookies
 
-        resp = await self.server_client.post(
-            server_name=self.config.name, url_path="/v1/responses", json=body.responses_create_params, cookies=cookies
-        )
-        await raise_for_status(resp)
+        inproc_resp, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
-        verify_request_dict = body.model_dump() | {"response": await get_response_json(resp)}
+        verify_request_dict = body.model_dump() | {"response": inproc_resp.model_dump()}
 
         verify = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",
             json=verify_request_dict,
-            cookies=resp.cookies,
+            cookies=cookies,
         )
         await raise_for_status(verify)
         return LangGraphVerifyResponse.model_validate(await get_response_json(verify))

--- a/responses_api_agents/langgraph_agent/orchestrator_agent.py
+++ b/responses_api_agents/langgraph_agent/orchestrator_agent.py
@@ -234,20 +234,18 @@ class OrchestratorAgent(LangGraphAgentAdapter):
         await raise_for_status(seed)
         cookies = seed.cookies
 
-        resp = await self.server_client.post(
-            server_name=self.config.name, url_path="/v1/responses", json=body.responses_create_params, cookies=cookies
-        )
-        await raise_for_status(resp)
+        inproc_resp, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
         verify_request = OrchestratorVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(resp)}
+            body.model_dump() | {"response": inproc_resp.model_dump()}
         )
 
         verify = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",
             json=verify_request.model_dump(),
-            cookies=resp.cookies,
+            cookies=cookies,
         )
         await raise_for_status(verify)
         return OrchestratorVerifyResponse.model_validate(await get_response_json(verify))

--- a/responses_api_agents/langgraph_agent/orchestrator_agent.py
+++ b/responses_api_agents/langgraph_agent/orchestrator_agent.py
@@ -239,20 +239,18 @@ class OrchestratorAgent(LangGraphAgentAdapter):
         await raise_for_status(seed)
         cookies = seed.cookies
 
-        resp = await self.server_client.post(
-            server_name=self.config.name, url_path="/v1/responses", json=body.responses_create_params, cookies=cookies
-        )
-        await raise_for_status(resp)
+        inproc_resp, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
         verify_request = OrchestratorVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(resp)}
+            body.model_dump() | {"response": inproc_resp.model_dump()}
         )
 
         verify = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",
             json=verify_request.model_dump(),
-            cookies=resp.cookies,
+            cookies=cookies,
         )
         await raise_for_status(verify)
         return OrchestratorVerifyResponse.model_validate(await get_response_json(verify))

--- a/responses_api_agents/langgraph_agent/parallel_thinking_agent.py
+++ b/responses_api_agents/langgraph_agent/parallel_thinking_agent.py
@@ -210,20 +210,18 @@ class ParallelThinkingAgent(LangGraphAgentAdapter):
         await raise_for_status(seed)
         cookies = seed.cookies
 
-        resp = await self.server_client.post(
-            server_name=self.config.name, url_path="/v1/responses", json=body.responses_create_params, cookies=cookies
-        )
-        await raise_for_status(resp)
+        inproc_resp, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
         verify_request = ParallelThinkingVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(resp)}
+            body.model_dump() | {"response": inproc_resp.model_dump()}
         )
 
         verify = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",
             json=verify_request.model_dump(),
-            cookies=resp.cookies,
+            cookies=cookies,
         )
         await raise_for_status(verify)
         return ParallelThinkingVerifyResponse.model_validate(await get_response_json(verify))

--- a/responses_api_agents/langgraph_agent/parallel_thinking_agent.py
+++ b/responses_api_agents/langgraph_agent/parallel_thinking_agent.py
@@ -217,20 +217,18 @@ class ParallelThinkingAgent(LangGraphAgentAdapter):
         await raise_for_status(seed)
         cookies = seed.cookies
 
-        resp = await self.server_client.post(
-            server_name=self.config.name, url_path="/v1/responses", json=body.responses_create_params, cookies=cookies
-        )
-        await raise_for_status(resp)
+        inproc_resp, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
         verify_request = ParallelThinkingVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(resp)}
+            body.model_dump() | {"response": inproc_resp.model_dump()}
         )
 
         verify = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",
             json=verify_request.model_dump(),
-            cookies=resp.cookies,
+            cookies=cookies,
         )
         await raise_for_status(verify)
         return ParallelThinkingVerifyResponse.model_validate(await get_response_json(verify))

--- a/responses_api_agents/langgraph_agent/reflection_agent.py
+++ b/responses_api_agents/langgraph_agent/reflection_agent.py
@@ -211,20 +211,18 @@ class ReflectionAgent(LangGraphAgentAdapter):
         await raise_for_status(seed)
         cookies = seed.cookies
 
-        resp = await self.server_client.post(
-            server_name=self.config.name, url_path="/v1/responses", json=body.responses_create_params, cookies=cookies
-        )
-        await raise_for_status(resp)
+        inproc_resp, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
         verify_request = ReflectionAgentVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(resp)}
+            body.model_dump() | {"response": inproc_resp.model_dump()}
         )
 
         verify = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",
             json=verify_request.model_dump(),
-            cookies=resp.cookies,
+            cookies=cookies,
         )
         await raise_for_status(verify)
         return ReflectionAgentVerifyResponse.model_validate(await get_response_json(verify))

--- a/responses_api_agents/langgraph_agent/reflection_agent.py
+++ b/responses_api_agents/langgraph_agent/reflection_agent.py
@@ -212,20 +212,18 @@ class ReflectionAgent(LangGraphAgentAdapter):
         await raise_for_status(seed)
         cookies = seed.cookies
 
-        resp = await self.server_client.post(
-            server_name=self.config.name, url_path="/v1/responses", json=body.responses_create_params, cookies=cookies
-        )
-        await raise_for_status(resp)
+        inproc_resp, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
         verify_request = ReflectionAgentVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(resp)}
+            body.model_dump() | {"response": inproc_resp.model_dump()}
         )
 
         verify = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",
             json=verify_request.model_dump(),
-            cookies=resp.cookies,
+            cookies=cookies,
         )
         await raise_for_status(verify)
         return ReflectionAgentVerifyResponse.model_validate(await get_response_json(verify))

--- a/responses_api_agents/langgraph_agent/rewoo_agent.py
+++ b/responses_api_agents/langgraph_agent/rewoo_agent.py
@@ -256,20 +256,16 @@ class ReWOOAgent(LangGraphAgentAdapter):
         await raise_for_status(seed)
         cookies = seed.cookies
 
-        resp = await self.server_client.post(
-            server_name=self.config.name, url_path="/v1/responses", json=body.responses_create_params, cookies=cookies
-        )
-        await raise_for_status(resp)
+        inproc_resp, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
-        verify_request = ReWOOVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(resp)}
-        )
+        verify_request = ReWOOVerifyRequest.model_validate(body.model_dump() | {"response": inproc_resp.model_dump()})
 
         verify = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",
             json=verify_request.model_dump(),
-            cookies=resp.cookies,
+            cookies=cookies,
         )
         await raise_for_status(verify)
         return ReWOOVerifyResponse.model_validate(await get_response_json(verify))

--- a/responses_api_agents/langgraph_agent/rewoo_agent.py
+++ b/responses_api_agents/langgraph_agent/rewoo_agent.py
@@ -261,20 +261,16 @@ class ReWOOAgent(LangGraphAgentAdapter):
         await raise_for_status(seed)
         cookies = seed.cookies
 
-        resp = await self.server_client.post(
-            server_name=self.config.name, url_path="/v1/responses", json=body.responses_create_params, cookies=cookies
-        )
-        await raise_for_status(resp)
+        inproc_resp, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
-        verify_request = ReWOOVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(resp)}
-        )
+        verify_request = ReWOOVerifyRequest.model_validate(body.model_dump() | {"response": inproc_resp.model_dump()})
 
         verify = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",
             json=verify_request.model_dump(),
-            cookies=resp.cookies,
+            cookies=cookies,
         )
         await raise_for_status(verify)
         return ReWOOVerifyResponse.model_validate(await get_response_json(verify))

--- a/responses_api_agents/non_executing_simple_agent/app.py
+++ b/responses_api_agents/non_executing_simple_agent/app.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+from typing import Mapping, Optional, Tuple
 
 from fastapi import Request, Response
 from pydantic import ConfigDict, ValidationError
@@ -64,6 +65,17 @@ class NonExecutingSimpleAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        result, set_cookies = await self._responses(body, request.cookies)
+        for k, v in set_cookies.items():
+            response.set_cookie(k, v)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        cookies: Optional[Mapping[str, str]] = None,
+    ) -> Tuple[NeMoGymResponse, dict]:
+        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -85,10 +97,14 @@ class NonExecutingSimpleAgent(SimpleResponsesAPIAgent):
             ) from e
 
         # Preserve session cookies for /run verification, but do not inspect or execute tool calls.
-        for k, v in (*request.cookies.items(), *model_response.cookies.items()):
-            response.set_cookie(k, v)
+        set_cookies: dict[str, str] = {}
+        if cookies:
+            for k, v in cookies.items():
+                set_cookies[k] = v
+        for k, v in model_response.cookies.items():
+            set_cookies[k] = v
 
-        return parsed_response
+        return parsed_response, set_cookies
 
     async def run(
         self,
@@ -106,17 +122,11 @@ class NonExecutingSimpleAgent(SimpleResponsesAPIAgent):
         await raise_for_status(seed_session_response)
         cookies = seed_session_response.cookies
 
-        response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path="/v1/responses",
-            json=body.responses_create_params,
-            cookies=cookies,
-        )
-        await raise_for_status(response)
-        cookies = response.cookies
+        inproc_response, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
         verify_request = NonExecutingSimpleAgentVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(response)}
+            body.model_dump() | {"response": inproc_response.model_dump()}
         )
 
         verify_response = await self.server_client.post(

--- a/responses_api_agents/non_executing_simple_agent/app.py
+++ b/responses_api_agents/non_executing_simple_agent/app.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+from typing import Mapping, Optional, Tuple
 
 from fastapi import Request, Response
 from pydantic import ConfigDict, ValidationError
@@ -64,6 +65,23 @@ class NonExecutingSimpleAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        result, set_cookies = await self._responses(
+            body,
+            model_url_path=self.url_path_for_request("/v1/responses", request),
+            cookies=request.cookies,
+        )
+        for k, v in set_cookies.items():
+            response.set_cookie(k, v)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        model_url_path: str,
+        cookies: Optional[Mapping[str, str]] = None,
+    ) -> Tuple[NeMoGymResponse, dict]:
+        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -71,7 +89,7 @@ class NonExecutingSimpleAgent(SimpleResponsesAPIAgent):
 
         model_response = await self.server_client.post(
             server_name=self.config.model_server.name,
-            url_path=self.url_path_for_request("/v1/responses", request),
+            url_path=model_url_path,
             json=body,
         )
         await raise_for_status(model_response)
@@ -85,10 +103,14 @@ class NonExecutingSimpleAgent(SimpleResponsesAPIAgent):
             ) from e
 
         # Preserve session cookies for /run verification, but do not inspect or execute tool calls.
-        for k, v in (*request.cookies.items(), *model_response.cookies.items()):
-            response.set_cookie(k, v)
+        set_cookies: dict[str, str] = {}
+        if cookies:
+            for k, v in cookies.items():
+                set_cookies[k] = v
+        for k, v in model_response.cookies.items():
+            set_cookies[k] = v
 
-        return parsed_response
+        return parsed_response, set_cookies
 
     async def run(
         self,
@@ -106,17 +128,15 @@ class NonExecutingSimpleAgent(SimpleResponsesAPIAgent):
         await raise_for_status(seed_session_response)
         cookies = seed_session_response.cookies
 
-        response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path=self.url_path_for_run("/v1/responses", body),
-            json=body.responses_create_params,
+        inproc_response, set_cookies = await self._responses(
+            body.responses_create_params,
+            model_url_path=self.url_path_for_run("/v1/responses", body),
             cookies=cookies,
         )
-        await raise_for_status(response)
-        cookies = response.cookies
+        cookies = set_cookies
 
         verify_request = NonExecutingSimpleAgentVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(response)}
+            body.model_dump() | {"response": inproc_response.model_dump()}
         )
 
         verify_response = await self.server_client.post(

--- a/responses_api_agents/non_executing_simple_agent/tests/test_app.py
+++ b/responses_api_agents/non_executing_simple_agent/tests/test_app.py
@@ -136,11 +136,14 @@ class TestApp:
             json={"responses_create_params": responses_create_params.model_dump()},
             cookies={},
         )
+        # `run` calls `_responses` in-process; call[1] is the model_server
+        # call that `_responses` makes.
         assert server.server_client.post.call_args_list[1] == call(
-            server_name="non_executing_agent",
+            server_name="model",
             url_path="/v1/responses",
-            json=responses_create_params,
-            cookies={"session": "seeded"},
+            json=NeMoGymResponseCreateParamsNonStreaming(
+                input=[NeMoGymEasyInputMessage(content="hello", role="user", type="message")]
+            ),
         )
         assert server.server_client.post.call_args_list[2].kwargs["server_name"] == "resource"
         assert server.server_client.post.call_args_list[2].kwargs["url_path"] == "/verify"

--- a/responses_api_agents/openclaw_agent/app.py
+++ b/responses_api_agents/openclaw_agent/app.py
@@ -749,6 +749,14 @@ class OpenClawAgent(SimpleResponsesAPIAgent):
     ) -> NeMoGymResponse:
         path_params = getattr(request, "path_params", None)
         rollout_id = path_params.get("rollout_id") if isinstance(path_params, Mapping) else None
+        return await self._responses(body, rollout_id=rollout_id)
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        rollout_id: Optional[str] = None,
+    ) -> NeMoGymResponse:
         if not isinstance(rollout_id, str):
             return await self._create_response(body)
         episode = await self._create_episode(body, rollout_id=rollout_id)
@@ -849,15 +857,8 @@ class OpenClawAgent(SimpleResponsesAPIAgent):
             cookies = seed_resp.cookies
 
             rollout_id = self.rollout_id_from_run(body)
-            agent_resp = await self.server_client.post(
-                server_name=self.config.name,
-                url_path=self.url_path_for_run("/v1/responses", body),
-                json=body.responses_create_params,
-                cookies=cookies,
-            )
-            await raise_for_status(agent_resp)
-            cookies = agent_resp.cookies
-            agent_resp_json = await get_response_json(agent_resp)
+            agent_response = await self._responses(body.responses_create_params, rollout_id=rollout_id)
+            agent_resp_json = agent_response.model_dump(mode="json")
             raw_observations = (
                 agent_resp_json.pop(_INTERNAL_OBSERVATIONS_KEY, None) if rollout_id is not None else None
             )

--- a/responses_api_agents/opencode_agent/app.py
+++ b/responses_api_agents/opencode_agent/app.py
@@ -760,6 +760,14 @@ class OpenCodeAgent(SimpleResponsesAPIAgent):
     ) -> NeMoGymResponse:
         path_params = getattr(request, "path_params", None)
         rollout_id = path_params.get("rollout_id") if isinstance(path_params, Mapping) else None
+        return await self._responses(body, rollout_id=rollout_id)
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        rollout_id: Optional[str] = None,
+    ) -> NeMoGymResponse:
         episode = await self._create_episode(
             body,
             rollout_id=rollout_id,
@@ -785,15 +793,8 @@ class OpenCodeAgent(SimpleResponsesAPIAgent):
             cookies = seed_resp.cookies
 
             rollout_id = self.rollout_id_from_run(body)
-            agent_resp = await self.server_client.post(
-                server_name=self.config.name,
-                url_path=self.url_path_for_run("/v1/responses", body),
-                json=body.responses_create_params,
-                cookies=cookies,
-            )
-            await raise_for_status(agent_resp)
-            cookies = agent_resp.cookies
-            agent_resp_json = await get_response_json(agent_resp)
+            agent_response = await self._responses(body.responses_create_params, rollout_id=rollout_id)
+            agent_resp_json = agent_response.model_dump(mode="json")
             raw_observations = (
                 agent_resp_json.pop(_INTERNAL_OBSERVATIONS_KEY, None) if rollout_id is not None else None
             )

--- a/responses_api_agents/opencode_agent/tests/test_app.py
+++ b/responses_api_agents/opencode_agent/tests/test_app.py
@@ -472,8 +472,7 @@ class TestRolloutObservability:
         assert result.ng_agent_observations is not None
         assert _invocations(result.ng_agent_observations)[0].conversation
         assert agent._run_opencode.await_args.kwargs["rollout_id"] == "1-2"
-        assert agent.server_client.post.await_args_list[1].kwargs["url_path"] == "/ng-rollout/1-2/v1/responses"
-        verify_json = agent.server_client.post.await_args_list[2].kwargs["json"]
+        verify_json = agent.server_client.post.await_args_list[1].kwargs["json"]
         assert "_ng_agent_observations" not in verify_json["response"]
 
 

--- a/responses_api_agents/pi_agent/app.py
+++ b/responses_api_agents/pi_agent/app.py
@@ -660,6 +660,14 @@ class PiAgent(SimpleResponsesAPIAgent):
     ) -> NeMoGymResponse:
         path_params = getattr(request, "path_params", None)
         rollout_id = path_params.get("rollout_id") if isinstance(path_params, Mapping) else None
+        return await self._responses(body, rollout_id=rollout_id)
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        rollout_id: Optional[str] = None,
+    ) -> NeMoGymResponse:
         episode = await self._create_episode(
             body,
             rollout_id=rollout_id,
@@ -685,15 +693,8 @@ class PiAgent(SimpleResponsesAPIAgent):
             cookies = seed_resp.cookies
 
             rollout_id = self.rollout_id_from_run(body)
-            agent_resp = await self.server_client.post(
-                server_name=self.config.name,
-                url_path=self.url_path_for_run("/v1/responses", body),
-                json=body.responses_create_params,
-                cookies=cookies,
-            )
-            await raise_for_status(agent_resp)
-            cookies = agent_resp.cookies
-            agent_resp_json = await get_response_json(agent_resp)
+            agent_response = await self._responses(body.responses_create_params, rollout_id=rollout_id)
+            agent_resp_json = agent_response.model_dump(mode="json")
             raw_observations = (
                 agent_resp_json.pop(_INTERNAL_OBSERVATIONS_KEY, None) if rollout_id is not None else None
             )

--- a/responses_api_agents/pi_agent/tests/test_app.py
+++ b/responses_api_agents/pi_agent/tests/test_app.py
@@ -454,7 +454,7 @@ class TestRolloutObservability:
         assert tool.tool_call_id == "call-1"
         assert tool.status == "incomplete"
 
-    def test_run_uses_prefixed_response_boundary(self) -> None:
+    def test_run_preserves_rollout_identity_in_process(self) -> None:
         agent = _make_agent()
         agent.server_client.global_config_dict = {"observability_enabled": True}
         agent._run_pi = AsyncMock(return_value=([], {"input_tokens": 0, "output_tokens": 0}, "model", []))
@@ -484,9 +484,8 @@ class TestRolloutObservability:
         result = asyncio.run(agent.run(MagicMock(cookies={}), body))
 
         assert result.ng_agent_observations is not None
-        assert agent.server_client.post.await_args_list[1].kwargs["url_path"] == "/ng-rollout/1-2/v1/responses"
         assert agent._run_pi.await_args.kwargs["rollout_id"] == "1-2"
-        verify_json = agent.server_client.post.await_args_list[2].kwargs["json"]
+        verify_json = agent.server_client.post.await_args_list[1].kwargs["json"]
         assert "_ng_agent_observations" not in verify_json["response"]
 
     def test_prefixed_responses_preserves_observations_through_fastapi(self) -> None:

--- a/responses_api_agents/prime_agent/app.py
+++ b/responses_api_agents/prime_agent/app.py
@@ -426,6 +426,14 @@ class PrimeAgent(SimpleResponsesAPIAgent):
         request: Request,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        return await self._responses(body, rollout_id=request.path_params.get("rollout_id"))
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        rollout_id: Optional[str] = None,
+    ) -> NeMoGymResponse:
         body = body.model_copy(deep=True)
         if isinstance(body.input, str):
             body.input = [NeMoGymEasyInputMessage(role="user", content=body.input)]
@@ -433,8 +441,6 @@ class PrimeAgent(SimpleResponsesAPIAgent):
         user_message, input_system = _extract_instruction(body.input)
         system_parts = [part for part in [self.config.system_prompt, body.instructions, input_system] if part]
         system_prompt = "\n\n".join(system_parts) if system_parts else None
-        rollout_id = request.path_params.get("rollout_id") if request is not None else None
-
         output_items, usage, model_name, timed_out = await self._run_prime_agent(
             user_message,
             system_prompt,
@@ -492,15 +498,11 @@ class PrimeAgent(SimpleResponsesAPIAgent):
             await raise_for_status(seed_resp)
             cookies = seed_resp.cookies
 
-            agent_resp = await self.server_client.post(
-                server_name=self.config.name,
-                url_path=self.url_path_for_run("/v1/responses", body),
-                json=body.responses_create_params,
-                cookies=cookies,
+            agent_response = await self._responses(
+                body.responses_create_params,
+                rollout_id=self.rollout_id_from_run(body),
             )
-            await raise_for_status(agent_resp)
-            cookies = agent_resp.cookies
-            agent_resp_json = await get_response_json(agent_resp)
+            agent_resp_json = agent_response.model_dump(mode="json")
 
             verify_resp = await self.server_client.post(
                 server_name=self.config.resources_server.name,

--- a/responses_api_agents/proof_refinement_agent/app.py
+++ b/responses_api_agents/proof_refinement_agent/app.py
@@ -27,7 +27,7 @@ The agent controls the retry loop and turn counting.
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from fastapi import Request, Response
 from pydantic import ConfigDict
@@ -105,11 +105,17 @@ class ProofRefinementAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
-        """Generate a model response (single turn, no tool calls).
+        result, set_cookies = await self._responses(body, request.cookies)
+        for k, v in set_cookies.items():
+            response.set_cookie(k, v)
+        return result
 
-        This is called for each generation turn. The verify-correction loop
-        is handled in run().
-        """
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        cookies: Optional[Mapping[str, str]] = None,
+    ) -> Tuple[NeMoGymResponse, dict]:
+        """Implementation of `/v1/responses`; `run` invokes this in-process per correction turn."""
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -119,16 +125,16 @@ class ProofRefinementAgent(SimpleResponsesAPIAgent):
             server_name=self.config.model_server.name,
             url_path="/v1/responses",
             json=body,
-            cookies=request.cookies,
+            cookies=dict(cookies) if cookies else None,
         )
         await raise_for_status(model_response)
         model_response_json = await model_response.json()
 
-        # Propagate cookies
+        set_cookies: dict[str, str] = {}
         for k, v in model_response.cookies.items():
-            response.set_cookie(k, v)
+            set_cookies[k] = v
 
-        return NeMoGymResponse.model_validate(model_response_json)
+        return NeMoGymResponse.model_validate(model_response_json), set_cookies
 
     async def run(self, request: Request, body: ProofRefinementRunRequest) -> ProofRefinementVerifyResponse:
         """Execute the proof refinement loop.
@@ -165,15 +171,13 @@ class ProofRefinementAgent(SimpleResponsesAPIAgent):
             LOG.info("Turn %d: Generating proof attempt", turn_index)
 
             # 2. Generate proof attempt
-            gen_response = await self.server_client.post(
-                server_name=self.config.name,
-                url_path="/v1/responses",
-                json=current_input,
-                cookies=cookies,
-            )
-            await raise_for_status(gen_response)
-            cookies = gen_response.cookies
-            model_response_json = await gen_response.json()
+            if isinstance(current_input, NeMoGymResponseCreateParamsNonStreaming):
+                gen_input = current_input
+            else:
+                gen_input = NeMoGymResponseCreateParamsNonStreaming.model_validate(current_input)
+            gen_model_response, set_cookies = await self._responses(gen_input, cookies)
+            cookies = set_cookies
+            model_response_json = gen_model_response.model_dump()
 
             # 3. Verify the proof
             verify_request_data = body.model_dump()

--- a/responses_api_agents/proof_refinement_agent/app.py
+++ b/responses_api_agents/proof_refinement_agent/app.py
@@ -27,7 +27,7 @@ The agent controls the retry loop and turn counting.
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from fastapi import Request, Response
 from pydantic import ConfigDict
@@ -105,11 +105,23 @@ class ProofRefinementAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
-        """Generate a model response (single turn, no tool calls).
+        result, set_cookies = await self._responses(
+            body,
+            model_url_path=self.url_path_for_request("/v1/responses", request),
+            cookies=request.cookies,
+        )
+        for k, v in set_cookies.items():
+            response.set_cookie(k, v)
+        return result
 
-        This is called for each generation turn. The verify-correction loop
-        is handled in run().
-        """
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        model_url_path: str,
+        cookies: Optional[Mapping[str, str]] = None,
+    ) -> Tuple[NeMoGymResponse, dict]:
+        """Implementation of `/v1/responses`; `run` invokes this in-process per correction turn."""
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -117,18 +129,18 @@ class ProofRefinementAgent(SimpleResponsesAPIAgent):
 
         model_response = await self.server_client.post(
             server_name=self.config.model_server.name,
-            url_path=self.url_path_for_request("/v1/responses", request),
+            url_path=model_url_path,
             json=body,
-            cookies=request.cookies,
+            cookies=dict(cookies) if cookies else None,
         )
         await raise_for_status(model_response)
         model_response_json = await model_response.json()
 
-        # Propagate cookies
+        set_cookies: dict[str, str] = {}
         for k, v in model_response.cookies.items():
-            response.set_cookie(k, v)
+            set_cookies[k] = v
 
-        return NeMoGymResponse.model_validate(model_response_json)
+        return NeMoGymResponse.model_validate(model_response_json), set_cookies
 
     async def run(self, request: Request, body: ProofRefinementRunRequest) -> ProofRefinementVerifyResponse:
         """Execute the proof refinement loop.
@@ -165,15 +177,17 @@ class ProofRefinementAgent(SimpleResponsesAPIAgent):
             LOG.info("Turn %d: Generating proof attempt", turn_index)
 
             # 2. Generate proof attempt
-            gen_response = await self.server_client.post(
-                server_name=self.config.name,
-                url_path=self.url_path_for_run("/v1/responses", body),
-                json=current_input,
+            if isinstance(current_input, NeMoGymResponseCreateParamsNonStreaming):
+                gen_input = current_input
+            else:
+                gen_input = NeMoGymResponseCreateParamsNonStreaming.model_validate(current_input)
+            gen_model_response, set_cookies = await self._responses(
+                gen_input,
+                model_url_path=self.url_path_for_run("/v1/responses", body),
                 cookies=cookies,
             )
-            await raise_for_status(gen_response)
-            cookies = gen_response.cookies
-            model_response_json = await gen_response.json()
+            cookies = set_cookies
+            model_response_json = gen_model_response.model_dump()
 
             # 3. Verify the proof
             verify_request_data = body.model_dump()

--- a/responses_api_agents/remote_agent/app.py
+++ b/responses_api_agents/remote_agent/app.py
@@ -92,12 +92,7 @@ class RemoteAgentError(RuntimeError):
 
 
 class RemoteAgentTerminalError(RemoteAgentError):
-    """A failure that will not fix itself on retry (e.g. an invalid response shape).
-
-    run() reaches responses() over an HTTP self-post, so this class's NAME is the wire
-    contract: the exception middleware serializes it into the 500 body and run() matches
-    the name string to set the terminal routing flag.
-    """
+    """A failure that will not fix itself on retry (e.g. an invalid response shape)."""
 
 
 def normalize_remote_url(url: str) -> str:
@@ -165,6 +160,17 @@ class RemoteAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        result, resources_server_cookies = await self._responses(body, resources_server_cookies=request.cookies)
+        for key, value in resources_server_cookies.items():
+            response.set_cookie(key, value)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        resources_server_cookies: Dict[str, str],
+    ) -> Tuple[NeMoGymResponse, Dict[str, str]]:
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -174,7 +180,6 @@ class RemoteAgent(SimpleResponsesAPIAgent):
         usage = None
         step = 0
         agent_server_cookies = None  # the service's own cookies, round-tripped so it can keep per-rollout state
-        resources_server_cookies = request.cookies
 
         while True:
             step += 1
@@ -245,14 +250,9 @@ class RemoteAgent(SimpleResponsesAPIAgent):
             if self.config.max_steps and step >= self.config.max_steps:
                 break
 
-        # Resources-server cookies propagate for downstream verification; the service's own
-        # cookies are its private session and deliberately stay out.
-        for k, v in resources_server_cookies.items():
-            response.set_cookie(k, v)
-
         agent_response.output = new_outputs
         agent_response.usage = usage
-        return agent_response
+        return agent_response, resources_server_cookies
 
     async def _post_agent_responses(
         self, new_body: NeMoGymResponseCreateParamsNonStreaming, cookies: Optional[Dict[str, str]]
@@ -398,23 +398,15 @@ class RemoteAgent(SimpleResponsesAPIAgent):
             )
 
         try:
-            loop_response = await self.server_client.post(
-                server_name=self.config.name,
-                url_path=self.url_path_for_run("/v1/responses", body),
-                json=body.responses_create_params,
-                cookies=cookies,
+            loop_response, cookies = await self._responses(
+                body.responses_create_params,
+                resources_server_cookies=dict(cookies),
             )
-            await raise_for_status(loop_response)
-            response_json = await get_response_json(loop_response)
-            cookies = loop_response.cookies
+            response_json = loop_response.model_dump(mode="json")
+        except RemoteAgentTerminalError as e:
+            return self._failure_response(record, f"agent loop failed: {type(e).__name__}: {e}", terminal=True)
         except Exception as e:
-            content = getattr(e, "response_content", b"")
-            text = content.decode(errors="replace") if isinstance(content, (bytes, bytearray)) else str(content)
-            # Terminal classification crosses the HTTP self-post boundary by exception NAME:
-            # the middleware serialized the raised RemoteAgentTerminalError into the 500 body.
-            terminal = "RemoteAgentTerminalError" in text
-            detail = text or f"{type(e).__name__}: {e}"
-            return self._failure_response(record, f"agent loop failed: {detail[:500]}", terminal=terminal)
+            return self._failure_response(record, f"agent loop failed: {type(e).__name__}: {e}"[:500])
 
         self._warn_on_response_quality(response_json)
 

--- a/responses_api_agents/remote_agent/tests/test_app.py
+++ b/responses_api_agents/remote_agent/tests/test_app.py
@@ -314,11 +314,11 @@ class TestRunHappyPath:
         result = await agent.run(make_request(), RemoteAgentRunRequest.model_validate(row))
 
         paths = [c["url_path"] for c in server_client.calls]
-        assert paths == ["/seed_session", "/v1/responses", "/verify"]
+        assert paths == ["/seed_session", "/verify"]
         # Seeded cookies reach the loop and verify; verify carries the trajectory + row keys
         assert server_client.calls[1]["cookies"] == {"session": "s1"}
-        assert server_client.calls[2]["json"]["response"]["id"] == "traj_1"
-        assert server_client.calls[2]["json"]["verifier_metadata"] == {"expected_answer": "42"}
+        assert server_client.calls[1]["json"]["response"]["id"] == "traj_1"
+        assert server_client.calls[1]["json"]["verifier_metadata"] == {"expected_answer": "42"}
 
         # The remote service receives ONLY create-params: no verifier_metadata, no row keys
         assert service.received[0]["payload"] == row["responses_create_params"]
@@ -526,7 +526,7 @@ class TestRemoteFailuresBecomeSentinelRows:
         assert result[NG_FAILURE_CLASS_KEY] == REMOTE_AGENT_FAILURE_CLASS
         assert "Is your service running at http://localhost:9000?" in result["error"]
         # verify is never reached on a failed loop
-        assert [c["url_path"] for c in server_client.calls] == ["/seed_session", "/v1/responses"]
+        assert [c["url_path"] for c in server_client.calls] == ["/seed_session"]
 
     async def test_disconnect_then_success_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
         request_mock = AsyncMock(
@@ -578,10 +578,10 @@ class TestRemoteFailuresBecomeSentinelRows:
             monkeypatch, AsyncMock(return_value=FakeRemoteResponse(200, orjson.dumps(bad)))
         )
         assert result[NG_FAILURE_CLASS_KEY] == REMOTE_AGENT_FAILURE_CLASS
-        # Terminal classification survives the HTTP self-post boundary (exception-name match)
+        # Terminal classification survives in-process delegation.
         assert result[NG_TERMINAL_KEY] is True
         assert "invalid Responses API object" in result["error"]
-        assert [c["url_path"] for c in server_client.calls] == ["/seed_session", "/v1/responses"]
+        assert [c["url_path"] for c in server_client.calls] == ["/seed_session"]
 
     async def test_mid_loop_failure_becomes_sentinel(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Turn 1 succeeds with a tool ask; turn 2 the service dies — the whole rollout

--- a/responses_api_agents/scicode_agent/app.py
+++ b/responses_api_agents/scicode_agent/app.py
@@ -145,6 +145,17 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        result, cookies = await self._responses(body, cookies=request.cookies)
+        for key, value in cookies.items():
+            response.set_cookie(key, value)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        cookies: Any = None,
+    ) -> tuple[NeMoGymResponse, Any]:
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -154,15 +165,11 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
             server_name=self.config.model_server.name,
             url_path="/v1/responses",
             json=body,
-            cookies=request.cookies,
+            cookies=cookies,
         )
         await raise_for_status(model_response)
         model_response_json = await model_response.json()
-
-        for k, v in model_response.cookies.items():
-            response.set_cookie(k, v)
-
-        return NeMoGymResponse.model_validate(model_response_json)
+        return NeMoGymResponse.model_validate(model_response_json), model_response.cookies
 
     async def run(self, request: Request, body: ScicodeAgentRunRequest):
         """Generate code for each sub-step (accumulating prior code as context), then verify."""
@@ -193,13 +200,12 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
             )
 
             try:
-                gen_response = await self.server_client.post(
-                    server_name=self.config.name,
-                    url_path="/v1/responses",
-                    json={"input": [{"role": "user", "content": user_content}]},
+                agent_response, cookies = await self._responses(
+                    NeMoGymResponseCreateParamsNonStreaming(
+                        input=[NeMoGymEasyInputMessage(role="user", content=user_content)]
+                    ),
                     cookies=cookies,
                 )
-                await raise_for_status(gen_response)
             except Exception as error:
                 if is_context_window_error(error):
                     LOG.warning("SciCode step %s: context window exceeded; failing remaining steps.", cur_step)
@@ -208,9 +214,8 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
                     continue
                 raise
 
-            cookies = gen_response.cookies
-            last_response_json = await gen_response.json()
-            generation = NeMoGymResponse.model_validate(last_response_json).output_text
+            last_response_json = agent_response.model_dump(mode="json")
+            generation = agent_response.output_text
             extracted = extract_python_script(generation)
             previous_llm_code[cur_step] = extracted
             solutions[f"{body.problem_id}.{cur_step + 1}"] = f"{previous_code}\n{extracted}"

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-from typing import List
+from typing import List, Mapping, Optional, Tuple
 
 from fastapi import Request, Response
 from pydantic import ConfigDict, ValidationError
@@ -69,6 +69,17 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        result, set_cookies = await self._responses(body, request.cookies)
+        for k, v in set_cookies.items():
+            response.set_cookie(k, v)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        cookies: Optional[Mapping[str, str]] = None,
+    ) -> Tuple[NeMoGymResponse, dict]:
+        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -78,7 +89,9 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         usage = None
         step = 0
         model_server_cookies = None  # update the cookies on every model response
-        resources_server_cookies = request.cookies  # update the cookies on every resources server response
+        resources_server_cookies = (
+            dict(cookies) if cookies else {}
+        )  # update the cookies on every resources server response
 
         while True:
             step += 1
@@ -166,12 +179,13 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 break
 
         # Propogate any extra cookies necessary for downstream verification
+        set_cookies: dict[str, str] = {}
         for k, v in (*resources_server_cookies.items(), *model_server_cookies.items()):
-            response.set_cookie(k, v)
+            set_cookies[k] = v
 
         model_response.output = new_outputs
         model_response.usage = usage
-        return model_response
+        return model_response, set_cookies
 
     async def run(self, request: Request, body: SimpleAgentRunRequest) -> SimpleAgentVerifyResponse:
         cookies = request.cookies
@@ -185,17 +199,11 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         await raise_for_status(seed_session_response)
         cookies = seed_session_response.cookies
 
-        response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path="/v1/responses",
-            json=body.responses_create_params,
-            cookies=cookies,
-        )
-        await raise_for_status(response)
-        cookies = response.cookies
+        inproc_response, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
         verify_request = SimpleAgentVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(response)}
+            body.model_dump() | {"response": inproc_response.model_dump()}
         )
 
         verify_response = await self.server_client.post(

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -286,23 +286,19 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         await raise_for_status(seed_session_response)
         cookies = seed_session_response.cookies
 
-        response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path=self.url_path_for_run("/v1/responses", body),
-            json=body.responses_create_params,
-            cookies=cookies,
-        )
-        await raise_for_status(response)
-        model_response_json = await get_response_json(response)
-        cookies = response.cookies
-
-        trajectory = None
         expected_rollout_id = self.rollout_id_from_run(body)
-        raw_trajectory = (
-            model_response_json.pop(_INTERNAL_TRAJECTORY_KEY, None) if expected_rollout_id is not None else None
+        collect_trajectory = self._model_call_capture_enabled() and expected_rollout_id is not None
+        inproc_response, trajectory, model_server_cookies, resources_server_cookies = await self._create_episode(
+            body.responses_create_params,
+            model_url_path=self.url_path_for_run("/v1/responses", body),
+            resources_server_cookies=cookies,
+            rollout_id=expected_rollout_id or "unscoped",
+            collect_trajectory=collect_trajectory,
         )
-        if isinstance(raw_trajectory, dict):
-            trajectory = TrajectoryRecord.model_validate(raw_trajectory)
+        model_response_json = inproc_response.model_dump(mode="json")
+        cookies = dict(resources_server_cookies)
+        cookies.update(model_server_cookies)
+        if trajectory is not None:
             extra = body.model_extra or {}
             task_id = next(
                 (

--- a/responses_api_agents/simple_agent_with_compaction/app.py
+++ b/responses_api_agents/simple_agent_with_compaction/app.py
@@ -425,18 +425,41 @@ class SimpleAgentWithCompaction(SimpleResponsesAPIAgent):
     ) -> ContextCompactedResponse | NeMoGymResponse:
         path_params = getattr(request, "path_params", None)
         rollout_id = path_params.get("rollout_id") if isinstance(path_params, Mapping) else None
+        model_response, resources_server_cookies, model_server_cookies = await self._responses(
+            body,
+            model_url_path=self.url_path_for_request("/v1/responses", request),
+            request_cookies=request.cookies,
+            rollout_id=rollout_id,
+            request_session_id=str(request.session.get(SESSION_ID_KEY, "request")),
+        )
+        for cookie_source in (resources_server_cookies, model_server_cookies):
+            if cookie_source is None:
+                continue
+            for key, value in cookie_source.items():
+                response.set_cookie(key, value)
+        return model_response
+
+    async def _responses(
+        self,
+        body: ContextCompactionResponseCreateParams,
+        *,
+        model_url_path: str,
+        request_cookies: Any,
+        rollout_id: str | None,
+        request_session_id: str = "request",
+    ) -> tuple[ContextCompactedResponse | NeMoGymResponse, Any, Any]:
         collect_trajectory = self._model_call_capture_enabled() and isinstance(rollout_id, str)
-        seed_count_raw = request.cookies.get(_CONTEXT_COMPACTION_SEED_COUNT_COOKIE, "0")
+        seed_count_raw = request_cookies.get(_CONTEXT_COMPACTION_SEED_COUNT_COOKIE, "0")
         try:
             seed_count = int(seed_count_raw)
         except (TypeError, ValueError) as exc:
             raise RuntimeError("Invalid internal context-compaction seed count") from exc
-        context_compaction_rollout_id = request.cookies.get(_CONTEXT_COMPACTION_ROLLOUT_ID_COOKIE)
+        context_compaction_rollout_id = request_cookies.get(_CONTEXT_COMPACTION_ROLLOUT_ID_COOKIE)
         if context_compaction_rollout_id is None:
-            context_compaction_rollout_id = rollout_id or str(request.session.get(SESSION_ID_KEY, "request"))
+            context_compaction_rollout_id = rollout_id or request_session_id
         resources_server_cookies = {
             key: value
-            for key, value in request.cookies.items()
+            for key, value in request_cookies.items()
             if key
             not in {
                 _CONTEXT_COMPACTION_SEED_COUNT_COOKIE,
@@ -445,21 +468,18 @@ class SimpleAgentWithCompaction(SimpleResponsesAPIAgent):
         }
         model_response, trajectory, model_server_cookies, resources_server_cookies = await self._create_episode(
             body,
-            model_url_path=self.url_path_for_request("/v1/responses", request),
+            model_url_path=model_url_path,
             resources_server_cookies=resources_server_cookies,
             rollout_id=rollout_id or "unscoped",
             context_compaction_rollout_id=context_compaction_rollout_id,
             seed_count=seed_count,
             collect_trajectory=collect_trajectory,
         )
-        # Propogate any extra cookies necessary for downstream verification
-        for k, v in (*resources_server_cookies.items(), *model_server_cookies.items()):
-            response.set_cookie(k, v)
         if trajectory is not None:
             model_response = model_response.model_copy(
                 update={_INTERNAL_TRAJECTORY_KEY: trajectory.model_dump(mode="json")}
             )
-        return model_response
+        return model_response, resources_server_cookies, model_server_cookies
 
     async def run(
         self,
@@ -495,18 +515,17 @@ class SimpleAgentWithCompaction(SimpleResponsesAPIAgent):
             responses_body.input = [*responses_body.input, *seed_messages]
             cookies[_CONTEXT_COMPACTION_SEED_COUNT_COOKIE] = str(len(seed_messages))
 
-        response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path=self.url_path_for_run("/v1/responses", body),
-            json=responses_body,
-            cookies=cookies,
+        expected_rollout_id = self.rollout_id_from_run(body)
+        model_response, resources_server_cookies, model_server_cookies = await self._responses(
+            ContextCompactionResponseCreateParams.model_validate(responses_body.model_dump()),
+            model_url_path=self.url_path_for_run("/v1/responses", body),
+            request_cookies=cookies,
+            rollout_id=expected_rollout_id,
         )
-        await raise_for_status(response)
-        model_response_json = await get_response_json(response)
-        cookies = response.cookies
+        cookies = {**dict(resources_server_cookies or {}), **dict(model_server_cookies or {})}
+        model_response_json = model_response.model_dump(mode="json")
 
         trajectory = None
-        expected_rollout_id = self.rollout_id_from_run(body)
         raw_trajectory = (
             model_response_json.pop(_INTERNAL_TRAJECTORY_KEY, None) if expected_rollout_id is not None else None
         )

--- a/responses_api_agents/simple_agent_with_compaction/tests/test_app.py
+++ b/responses_api_agents/simple_agent_with_compaction/tests/test_app.py
@@ -730,8 +730,6 @@ class TestApp:
             assert not hasattr(result.response, "completion_evidence")
             assert not hasattr(result.response, "agent_input")
             assert not hasattr(result.response, "seed_obs")
-        inner_responses_call = server.server_client.post.call_args_list[1]
-        assert inner_responses_call.kwargs["cookies"][_CONTEXT_COMPACTION_ROLLOUT_ID_COOKIE] == "rollout-run"
 
     @pytest.mark.parametrize("resolved", [False, None])
     async def test_run_emits_standard_turns_and_tool_observation(self, resolved: bool | None) -> None:
@@ -817,7 +815,6 @@ class TestApp:
             (item.kwargs["server_name"], item.kwargs["url_path"]) for item in server_client.post.await_args_list
         ] == [
             ("resources", "/seed_session"),
-            ("simple", "/ng-rollout/4-1/v1/responses"),
             ("model", "/ng-rollout/4-1/v1/responses"),
             ("resources", "/lookup"),
             ("model", "/ng-rollout/4-1/v1/responses"),
@@ -872,12 +869,12 @@ class TestApp:
         assert tool.started_at is not None and tool.completed_at is not None and tool.duration_ms is not None
 
     @pytest.mark.parametrize(("capture_enabled", "override_responses"), ((False, False), (True, False), (True, True)))
-    async def test_run_preserves_self_dispatch(self, capture_enabled: bool, override_responses: bool) -> None:
+    async def test_run_dispatches_model_in_process(self, capture_enabled: bool, override_responses: bool) -> None:
         agent_type = SimpleAgentWithCompaction
         if override_responses:
 
             async def overridden_responses(*args, **kwargs):
-                raise AssertionError("run must preserve self-dispatch for responses overrides")
+                raise AssertionError("run must bypass the public HTTP adapter")
 
             agent_type = type(
                 "OverriddenSimpleAgentWithCompaction",
@@ -891,7 +888,15 @@ class TestApp:
             "created_at": 1.0,
             "model": "model",
             "object": "response",
-            "output": [],
+            "output": [
+                {
+                    "id": "message-1",
+                    "content": [{"annotations": [], "text": "done", "type": "output_text"}],
+                    "role": "assistant",
+                    "status": "completed",
+                    "type": "message",
+                }
+            ],
             "parallel_tool_calls": True,
             "tool_choice": "auto",
             "tools": [],
@@ -922,7 +927,8 @@ class TestApp:
             "/ng-rollout/0-0/v1/responses" if capture_enabled else "/v1/responses",
             "/verify",
         ]
-        assert "ng_trajectory" not in result.model_dump(mode="json")
+        assert server_client.post.await_args_list[1].kwargs["server_name"] == "model"
+        assert ("ng_trajectory" in result.model_dump(mode="json")) is capture_enabled
 
     async def test_responses_continues_on_malformed_tool_call_arguments(self, monkeypatch: MonkeyPatch) -> None:
         """Malformed JSON in a tool-call's arguments must not crash the rollout.
@@ -1140,7 +1146,6 @@ class TestApp:
             call().read(),
             call().cookies.items(),
             call().cookies.items().__iter__(),
-            call().cookies.items().__len__(),
         ]
         server.server_client.post.assert_has_calls(expected_calls)
 
@@ -1383,7 +1388,6 @@ class TestApp:
             call().read(),
             call().cookies.items(),
             call().cookies.items().__iter__(),
-            call().cookies.items().__len__(),
         ]
         server.server_client.post.assert_has_calls(expected_calls)
 
@@ -1465,7 +1469,15 @@ class TestApp:
             "created_at": 1,
             "model": "dummy_model",
             "object": "response",
-            "output": [],
+            "output": [
+                {
+                    "id": "message-1",
+                    "content": [{"annotations": [], "text": "done", "type": "output_text"}],
+                    "role": "assistant",
+                    "status": "completed",
+                    "type": "message",
+                }
+            ],
             "parallel_tool_calls": True,
             "tool_choice": "auto",
             "tools": [],
@@ -1494,5 +1506,5 @@ class TestApp:
             "/v1/responses",
         ]
         assert post_call_kwargs[0]["server_name"] == "my resources server"
-        assert post_call_kwargs[1]["server_name"] == "simple_agent"
-        assert post_call_kwargs[1]["cookies"] == {"session": "seeded"}
+        assert post_call_kwargs[1]["server_name"] == "my model server"
+        assert post_call_kwargs[1]["cookies"] is None

--- a/responses_api_agents/simple_strands_agent/app.py
+++ b/responses_api_agents/simple_strands_agent/app.py
@@ -245,13 +245,20 @@ class SimpleStrandsAgent(SimpleResponsesAPIAgent):
         request: Request,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        return await self._responses(body, rollout_id=request.path_params.get("rollout_id"))
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        rollout_id: Optional[str] = None,
+    ) -> NeMoGymResponse:
         body = body.model_copy(deep=True)
         if isinstance(body.input, str):
             body.input = [NeMoGymEasyInputMessage(role="user", content=body.input)]
         instruction, input_system = _extract_instruction(body.input)
         system_parts = [self.config.system_prompt, body.instructions, input_system]
         system_prompt = "\n\n".join(part for part in system_parts if part) or None
-        rollout_id = request.path_params.get("rollout_id") if request is not None else None
         work_dir = self._workspace()
         model_name = self.config.model or str(body.model or self.config.model_server.name)
         reasoning_effort = (body.reasoning or {}).get("effort") or self.config.reasoning_effort
@@ -322,15 +329,11 @@ class SimpleStrandsAgent(SimpleResponsesAPIAgent):
             )
             await raise_for_status(seed_response)
             cookies = seed_response.cookies
-            agent_response = await self.server_client.post(
-                server_name=self.config.name,
-                url_path=self.url_path_for_run("/v1/responses", body),
-                json=body.responses_create_params,
-                cookies=cookies,
+            agent_response = await self._responses(
+                body.responses_create_params,
+                rollout_id=self.rollout_id_from_run(body),
             )
-            await raise_for_status(agent_response)
-            cookies = agent_response.cookies
-            response_json = await get_response_json(agent_response)
+            response_json = agent_response.model_dump(mode="json")
             if self.config.skip_verification:
                 result = body.model_dump() | {
                     "response": response_json,

--- a/responses_api_agents/simple_strands_agent/tests/test_app.py
+++ b/responses_api_agents/simple_strands_agent/tests/test_app.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-import json
 import signal
 from pathlib import Path
 from types import SimpleNamespace
@@ -89,7 +88,7 @@ def test_trajectory_preserves_reasoning_and_tools() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_skips_verification() -> None:
+async def test_run_skips_verification(monkeypatch: pytest.MonkeyPatch) -> None:
     config = SimpleStrandsAgentConfig(
         host="0.0.0.0",
         port=8080,
@@ -102,21 +101,10 @@ async def test_run_skips_verification() -> None:
     )
     client = MagicMock(spec=ServerClient)
     seed_response = AsyncMock(cookies={"session": "seeded"})
-    agent_response = AsyncMock(cookies={"session": "agent"})
-    agent_response.read.return_value = json.dumps(
-        {
-            "id": "response_id",
-            "created_at": 1,
-            "model": "model",
-            "object": "response",
-            "output": [],
-            "parallel_tool_calls": True,
-            "tool_choice": "auto",
-            "tools": [],
-        }
-    ).encode()
-    client.post = AsyncMock(side_effect=[seed_response, agent_response])
+    client.post = AsyncMock(return_value=seed_response)
     agent = SimpleStrandsAgent(config=config, server_client=client)
+    monkeypatch.setattr(SimpleStrandsAgent, "resolve_model_base_url", MagicMock(return_value="http://policy/v1"))
+    agent._run_ssa = AsyncMock(return_value={"messages": [], "usage": {}})
 
     result = await agent.run(
         SimpleNamespace(cookies={}),
@@ -125,10 +113,7 @@ async def test_run_skips_verification() -> None:
 
     assert result.reward == 0.25
     assert result.model_extra["verification_skipped"] is True
-    assert [call.kwargs["url_path"] for call in client.post.call_args_list] == [
-        "/seed_session",
-        "/v1/responses",
-    ]
+    assert [call.kwargs["url_path"] for call in client.post.call_args_list] == ["/seed_session"]
 
 
 @pytest.mark.asyncio

--- a/responses_api_agents/speed_bench_agent/app.py
+++ b/responses_api_agents/speed_bench_agent/app.py
@@ -44,7 +44,7 @@ model call (same shape as simple_agent).
 
 import json
 import logging
-from typing import List
+from typing import List, Mapping, Optional, Tuple
 
 from fastapi import Request, Response
 from pydantic import ConfigDict, ValidationError
@@ -119,6 +119,17 @@ class SpeedBenchAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        result, set_cookies = await self._responses(body, request.cookies)
+        for k, v in set_cookies.items():
+            response.set_cookie(k, v)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        cookies: Optional[Mapping[str, str]] = None,
+    ) -> Tuple[NeMoGymResponse, dict]:
+        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -157,7 +168,7 @@ class SpeedBenchAgent(SimpleResponsesAPIAgent):
         usage = None
         last_response: NeMoGymResponse = None
         model_server_cookies = None
-        resources_server_cookies = request.cookies
+        resources_server_cookies = dict(cookies) if cookies else {}
 
         async def _call_model(turn_input):
             new_body = body.model_copy(update={"input": turn_input})
@@ -214,12 +225,13 @@ class SpeedBenchAgent(SimpleResponsesAPIAgent):
             last_response.usage = None
 
         # Propagate any cookies the resources server set so /verify sees them.
+        set_cookies: dict[str, str] = {}
         for k, v in (*resources_server_cookies.items(), *(model_server_cookies or {}).items()):
-            response.set_cookie(k, v)
+            set_cookies[k] = v
 
         last_response.output = accumulated_outputs
         last_response.usage = usage
-        return last_response
+        return last_response, set_cookies
 
     async def run(self, request: Request, body: SpeedBenchAgentRunRequest) -> SpeedBenchAgentVerifyResponse:
         cookies = request.cookies
@@ -233,17 +245,11 @@ class SpeedBenchAgent(SimpleResponsesAPIAgent):
         await raise_for_status(seed_session_response)
         cookies = seed_session_response.cookies
 
-        api_response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path="/v1/responses",
-            json=body.responses_create_params,
-            cookies=cookies,
-        )
-        await raise_for_status(api_response)
-        cookies = api_response.cookies
+        inproc_response, set_cookies = await self._responses(body.responses_create_params, cookies)
+        cookies = set_cookies
 
         verify_request = SpeedBenchAgentVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(api_response)}
+            body.model_dump() | {"response": inproc_response.model_dump()}
         )
         verify_response = await self.server_client.post(
             server_name=self.config.resources_server.name,

--- a/responses_api_agents/speed_bench_agent/app.py
+++ b/responses_api_agents/speed_bench_agent/app.py
@@ -44,7 +44,7 @@ model call (same shape as simple_agent).
 
 import json
 import logging
-from typing import List
+from typing import List, Mapping, Optional, Tuple
 
 from fastapi import Request, Response
 from pydantic import ConfigDict, ValidationError
@@ -120,6 +120,23 @@ class SpeedBenchAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        result, set_cookies = await self._responses(
+            body,
+            model_url_path=self.url_path_for_request("/v1/responses", request),
+            cookies=request.cookies,
+        )
+        for k, v in set_cookies.items():
+            response.set_cookie(k, v)
+        return result
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        model_url_path: str,
+        cookies: Optional[Mapping[str, str]] = None,
+    ) -> Tuple[NeMoGymResponse, dict]:
+        """Implementation of `/v1/responses`; `run` invokes this in-process."""
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -158,13 +175,13 @@ class SpeedBenchAgent(SimpleResponsesAPIAgent):
         usage = None
         last_response: NeMoGymResponse = None
         model_server_cookies = None
-        resources_server_cookies = request.cookies
+        resources_server_cookies = dict(cookies) if cookies else {}
 
         async def _call_model(turn_input):
             new_body = body.model_copy(update={"input": turn_input})
             model_response = await self.server_client.post(
                 server_name=self.config.model_server.name,
-                url_path=self.url_path_for_request("/v1/responses", request),
+                url_path=model_url_path,
                 json=new_body,
                 cookies=model_server_cookies,
             )
@@ -208,12 +225,13 @@ class SpeedBenchAgent(SimpleResponsesAPIAgent):
             last_response.usage = None
 
         # Propagate any cookies the resources server set so /verify sees them.
+        set_cookies: dict[str, str] = {}
         for k, v in (*resources_server_cookies.items(), *(model_server_cookies or {}).items()):
-            response.set_cookie(k, v)
+            set_cookies[k] = v
 
         last_response.output = accumulated_outputs
         last_response.usage = usage
-        return last_response
+        return last_response, set_cookies
 
     async def run(self, request: Request, body: SpeedBenchAgentRunRequest) -> SpeedBenchAgentVerifyResponse:
         cookies = request.cookies
@@ -227,17 +245,15 @@ class SpeedBenchAgent(SimpleResponsesAPIAgent):
         await raise_for_status(seed_session_response)
         cookies = seed_session_response.cookies
 
-        api_response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path=self.url_path_for_run("/v1/responses", body),
-            json=body.responses_create_params,
+        inproc_response, set_cookies = await self._responses(
+            body.responses_create_params,
+            model_url_path=self.url_path_for_run("/v1/responses", body),
             cookies=cookies,
         )
-        await raise_for_status(api_response)
-        cookies = api_response.cookies
+        cookies = set_cookies
 
         verify_request = SpeedBenchAgentVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(api_response)}
+            body.model_dump() | {"response": inproc_response.model_dump()}
         )
         verify_response = await self.server_client.post(
             server_name=self.config.resources_server.name,

--- a/responses_api_agents/terminus_2_agent/app.py
+++ b/responses_api_agents/terminus_2_agent/app.py
@@ -421,6 +421,14 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
         request: Request,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
+        return await self._responses(body, rollout_id=self._rollout_id(request))
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        rollout_id: Optional[str] = None,
+    ) -> NeMoGymResponse:
         body = body.model_copy(deep=True)
         if body.temperature is None:
             body.temperature = self.config.temperature
@@ -433,7 +441,7 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
 
         api_base = self.resolve_model_base_url(
             self.config.model_server.name,
-            self._rollout_id(request),
+            rollout_id,
         )
         async with self.sem:
             trajectory, context, flags, timed_out, finished_naturally = await self._run_terminus(
@@ -509,15 +517,11 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
         await raise_for_status(seed_response)
         cookies = seed_response.cookies
 
-        agent_response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path=self.url_path_for_run("/v1/responses", body),
-            json=body.responses_create_params,
-            cookies=cookies,
+        agent_response = await self._responses(
+            body.responses_create_params,
+            rollout_id=self.rollout_id_from_run(body),
         )
-        await raise_for_status(agent_response)
-        cookies = agent_response.cookies
-        response_json = await get_response_json(agent_response)
+        response_json = agent_response.model_dump(mode="json")
 
         verify_response = await self.server_client.post(
             server_name=self.config.resources_server.name,

--- a/responses_api_agents/tool_simulation_agent/app.py
+++ b/responses_api_agents/tool_simulation_agent/app.py
@@ -47,9 +47,17 @@ class ToolSimulationAgent(SimpleResponsesAPIAgent):
     async def responses(
         self, request: Request, body: NeMoGymResponseCreateParamsNonStreaming = Body()
     ) -> NeMoGymResponse:
+        return await self._responses(body, model_url_path=self.url_path_for_request("/v1/responses", request))
+
+    async def _responses(
+        self,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        model_url_path: str,
+    ) -> NeMoGymResponse:
         model_response = await self.server_client.post(
             server_name=self.config.model_server.name,
-            url_path=self.url_path_for_request("/v1/responses", request),
+            url_path=model_url_path,
             json=body,
         )
 
@@ -66,14 +74,12 @@ class ToolSimulationAgent(SimpleResponsesAPIAgent):
 
     async def run(self, body: ToolSimulationAgentRunRequest = Body()) -> ToolSimulationAgentVerifyResponse:
         config = self.config
-        response = await self.server_client.post(
-            server_name=config.name,
-            url_path=self.url_path_for_run("/v1/responses", body),
-            json=body.responses_create_params,
+        response = await self._responses(
+            body.responses_create_params,
+            model_url_path=self.url_path_for_run("/v1/responses", body),
         )
-        await raise_for_status(response)
 
-        response_json = await response.json()
+        response_json = response.model_dump(mode="json")
         if config.skip_verification:
             result = body.model_dump() | {
                 "response": response_json,

--- a/responses_api_agents/tool_simulation_agent/tests/test_app.py
+++ b/responses_api_agents/tool_simulation_agent/tests/test_app.py
@@ -234,7 +234,7 @@ class TestApp:
             "id": "no_model",
         }
         self._set_server_client_post_responses(server_client_post_mock, no_model_response_object)
-        with raises(ValidationError, match="ToolSimulationAgentVerifyRequest"):
+        with raises(RuntimeError, match="Received an invalid response from the model server"):
             test_client.post(
                 "/run",
                 json={
@@ -245,7 +245,7 @@ class TestApp:
             )
 
         server_client_post_mock.assert_called_once_with(
-            server_name="tool_agent",
+            server_name="model_server",
             url_path="/v1/responses",
             json=NeMoGymResponseCreateParamsNonStreaming(
                 input=[],
@@ -343,7 +343,7 @@ class TestApp:
         }
         expected_invalid_verify_response_calls = [
             call(
-                server_name="tool_agent",
+                server_name="model_server",
                 url_path="/v1/responses",
                 json=NeMoGymResponseCreateParamsNonStreaming(
                     input=[
@@ -519,7 +519,7 @@ class TestApp:
         assert response_json["verification_skipped"] is True
         assert response_json["response"]["id"] == "chat_response_id"
         server_client_post_mock.assert_called_once_with(
-            server_name="tool_agent",
+            server_name="model_server",
             url_path="/v1/responses",
             json=NeMoGymResponseCreateParamsNonStreaming(
                 input=[


### PR DESCRIPTION
## Summary

A production agent's `/run` path should not send an HTTP request back to that same agent's `/v1/responses` endpoint. The loopback request adds an aiohttp round trip, FastAPI middleware, Pydantic validation, and socket pressure to every rollout.

This change replaces every remaining production self-call with an in-process invocation. The public `responses(request, response, body)` endpoint remains unchanged for external callers.

The in-process helpers preserve request-specific behavior that was added after the original implementation, including cookies, rollout-scoped URL paths and IDs, trajectory capture, retry handling, metadata, and diagnostics.

## Scope

The optimization now covers:

- `simple_agent`, `non_executing_simple_agent`, `simple_agent_with_compaction`, and `simple_strands_agent`
- `proof_refinement_agent`, `speed_bench_agent`, `browsecomp_agent`, `cvdp_agent`, and `finance_agent`
- `cline_agent`, `kilocode_agent`, `openclaw_agent`, `opencode_agent`, `pi_agent`, and `prime_agent`
- `hermes_agent`, `remote_agent`, `scicode_agent`, `terminus_2_agent`, `critpt_agent`, and `tool_simulation_agent`
- `conversational_tool_use/simulation`
- the `langgraph_agent` base and its `rewoo`, `orchestrator`, `parallel_thinking`, and `reflection` implementations

Agents that already used an in-process path, including `claude_code_agent`, are unchanged. An audit of `responses_api_agents` found no remaining production posts from an agent to its own `/v1/responses` endpoint.

## Performance

Model inference remains the dominant latency. In the original end-to-end measurements with a real OpenAI model, removing the self-call improved throughput by 7.5% for `simple_agent` and 13.3% for `proof_refinement_agent`, which performs multiple response calls per rollout. The in-process path also avoids file-descriptor pressure from loopback connections at high concurrency.