### PR TITLE
ci: add request-nvskills-ci workflow

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -1,0 +1,22 @@
+name: Request NVSkills CI
+
+on:
+  issue_comment:
+    types: [created]
+  push:
+
+jobs:
+  request:
+    if: >
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/nvskills-ci')) ||
+      (github.event_name == 'push' &&
+        github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]') &&
+        startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: NVIDIA/skills/.github/workflows/team-request.yml@main
+    secrets:
+      NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/request-nvskills-ci.yml`, copied from the NVIDIA/skills onboarding template. Calls the central reusable workflow `NVIDIA/skills/.github/workflows/team-request.yml@main`.
- Enables `/nvskills-ci` PR comments to dispatch the central NVSkills CI pipeline for skill validation and signing.

## Motivation

NeMo-Gym is already onboarded centrally: `components.d/nemo-gym.yml` in NVIDIA/skills declares `.claude/skills/` as the canonical skill source. The remaining onboarding step is adding this workflow file so the central pipeline can be triggered on PRs that touch skills. 

The follow-up PR will add licensing information and an evals json to each skill along with an evals jso

## Test plan

- [ ] Workflow file syntax validates (no `act` lint errors)
- [ ] After merge, `/nvskills-ci` comment on the follow-up scaffolding PR successfully dispatches the central pipeline