### PR TITLE
ci: add evals scaffolding and license for NVSkills CI signing

### DIFF
--- a/.claude/skills/add-benchmark/SKILL.md
+++ b/.claude/skills/add-benchmark/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: add-benchmark
+license: Apache-2.0
 description: >
   Guide for adding a new benchmark or training environment to NeMo-Gym.
   Use when the user asks to add, create, or integrate a benchmark, evaluation,

--- a/.claude/skills/add-benchmark/evals/evals.json
+++ b/.claude/skills/add-benchmark/evals/evals.json
@@ -1,0 +1,63 @@
+[
+  {
+    "id": "add-benchmark-positive-001",
+    "question": "I want to add the HumanEval+ benchmark to NeMo-Gym. How do I scaffold the resources server and wire it up?",
+    "expected_skill": "add-benchmark",
+    "ground_truth": "The agent loads the add-benchmark skill, classifies HumanEval+ as a native code-gen benchmark, runs ng_init_resources_server to scaffold the directory, converts the source data to Gym JSONL with verifier_metadata, implements verify() with subprocess execution, wires the YAML config, and runs ng_test plus ng_collect_rollouts for smoke testing before baselining.",
+    "expected_behavior": [
+      "The agent read add-benchmark/SKILL.md before acting",
+      "The agent classified the benchmark as native vs external",
+      "The agent ran ng_init_resources_server to scaffold the server directory",
+      "The agent described converting the source dataset to Gym JSONL with responses_create_params.input and verifier_metadata",
+      "The agent mentioned reward as binary 0.0 or 1.0 and graceful handling of empty model output"
+    ]
+  },
+  {
+    "id": "add-benchmark-positive-002",
+    "question": "Wrap the SWE-bench library as a NeMo-Gym agent server so we can run it against our policy model.",
+    "expected_skill": "add-benchmark",
+    "ground_truth": "The agent loads the add-benchmark skill, classifies SWE-bench as an external benchmark wrapped at the agent-server level, creates the agent under responses_api_agents/, pre-processes from Gym schema to the SWE-bench input and post-processes back to BaseVerifyResponse, adds the dependency, and reproduces the published numbers with the original repo first before reproducing post-integration.",
+    "expected_behavior": [
+      "The agent read add-benchmark/SKILL.md before acting",
+      "The agent classified SWE-bench as an external benchmark (not a native resources server)",
+      "The agent placed the wrapper under responses_api_agents/ rather than resources_servers/",
+      "The agent mentioned reproducing the original repo's numbers first, then reproducing after integration",
+      "The agent added the dependency to requirements.txt"
+    ]
+  },
+  {
+    "id": "add-benchmark-positive-003",
+    "question": "Add a new training environment for grade-school math word problems with binary reward, ready for reward profiling.",
+    "expected_skill": "add-benchmark",
+    "ground_truth": "The agent loads the add-benchmark skill, scaffolds a native resources server, prepares example.jsonl plus train/validation datasets uploaded to the GitLab dataset registry, implements verify() returning 0.0 or 1.0, wires the YAML config with the train dataset entry and gitlab_identifier, runs ng_test, smoke tests with ng_collect_rollouts, and baselines against multiple models including at least one closed-source model.",
+    "expected_behavior": [
+      "The agent read add-benchmark/SKILL.md before acting",
+      "The agent ran ng_init_resources_server to scaffold the server",
+      "The agent uploaded train/validation datasets to GitLab via ng_upload_dataset_to_gitlab rather than committing them to git",
+      "The agent added gitlab_identifier alongside jsonl_fpath in the YAML for train datasets",
+      "The agent ran the baselining suite across an open-source instruct, open-source thinking, and closed-source model"
+    ]
+  },
+  {
+    "id": "add-benchmark-negative-001",
+    "question": "Debug why my existing ng_reward_profile job is producing empty profile rows even though rollouts.jsonl has 100 lines.",
+    "expected_skill": null,
+    "should_trigger": false,
+    "ground_truth": "The agent should not activate the add-benchmark skill for a debugging task on an existing benchmark. It should use the nemo-gym-debugging skill instead.",
+    "expected_behavior": [
+      "The agent did not read or activate add-benchmark/SKILL.md",
+      "The agent recognized this as a debugging task for an existing benchmark"
+    ]
+  },
+  {
+    "id": "add-benchmark-negative-002",
+    "question": "Update the quickstart page in the Gym Fern docs to mention the new ng_run --port flag.",
+    "expected_skill": null,
+    "should_trigger": false,
+    "ground_truth": "The agent should not activate the add-benchmark skill for a documentation update. It should use the nemo-gym-docs skill instead.",
+    "expected_behavior": [
+      "The agent did not read or activate add-benchmark/SKILL.md",
+      "The agent recognized this as a docs edit, not a benchmark integration"
+    ]
+  }
+]

--- a/.claude/skills/nemo-gym-debugging/SKILL.md
+++ b/.claude/skills/nemo-gym-debugging/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: nemo-gym-debugging
+license: Apache-2.0
 description: >-
   Use when debugging a Nemo Gym run or reward profiling job. Covers rollout collection failures,
   empty or partial JSONL outputs, stale materialized inputs, verifier/schema errors, Ray or Slurm

--- a/.claude/skills/nemo-gym-debugging/evals/evals.json
+++ b/.claude/skills/nemo-gym-debugging/evals/evals.json
@@ -1,0 +1,73 @@
+[
+  {
+    "id": "nemo-gym-debugging-positive-001",
+    "question": "My ng_collect_rollouts job finished but rollouts.jsonl only has 2 rows even though my input has 100 tasks. The reward profile is empty. What's going on?",
+    "expected_skill": "nemo-gym-debugging",
+    "ground_truth": "The agent loads the nemo-gym-debugging skill, classifies the symptom as a partial-output + verifier issue, inspects the first real verifier exception (not shutdown noise), checks for stale materialized inputs if resume_from_cache was on, and compares the failing row schema against the resource-server request model.",
+    "expected_behavior": [
+      "The agent read nemo-gym-debugging/SKILL.md before acting",
+      "The agent classified the failing layer (data/schema, verifier, or cache) rather than guessing",
+      "The agent inspected the first real verifier exception rather than shutdown noise",
+      "The agent considered stale materialized inputs as a first-class suspect if resume_from_cache was enabled",
+      "The agent checked rollout output and profiling row counts"
+    ]
+  },
+  {
+    "id": "nemo-gym-debugging-positive-002",
+    "question": "All my Gym servers are up and vLLM is ready, but the resources server keeps returning 422 errors from the verifier endpoint. Help me figure out why.",
+    "expected_skill": "nemo-gym-debugging",
+    "ground_truth": "The agent loads the nemo-gym-debugging skill, recognizes that ready servers + 422 means a data/schema mismatch, compares the request body against the resources server's Pydantic request model, and inspects the first real verifier exception before touching infra or model settings.",
+    "expected_behavior": [
+      "The agent read nemo-gym-debugging/SKILL.md before acting",
+      "The agent classified the failure as data/schema rather than infra or model serving",
+      "The agent compared the failing row schema against the resources-server request model",
+      "The agent did not chase infra or vLLM tuning before checking the request body"
+    ]
+  },
+  {
+    "id": "nemo-gym-debugging-positive-003",
+    "question": "My tool-call rollouts hang almost immediately with vLLM grammar/schema errors before any generation happens. What should I check?",
+    "expected_skill": "nemo-gym-debugging",
+    "ground_truth": "The agent loads the nemo-gym-debugging skill, reads references/vllm-tool-call-schema-checks.md, and runs a static tool-schema check against the dataset before changing Gym wrappers or model settings.",
+    "expected_behavior": [
+      "The agent read nemo-gym-debugging/SKILL.md before acting",
+      "The agent loaded references/vllm-tool-call-schema-checks.md for the tool-call schema check",
+      "The agent ran a static tool-schema check before changing Gym wrappers",
+      "The agent did not change model settings as the first move"
+    ]
+  },
+  {
+    "id": "nemo-gym-debugging-positive-004",
+    "question": "I'm only seeing nested 'inner server' 500s in my logs and I can't tell which row or provider call actually failed. How do I get the real error?",
+    "expected_skill": "nemo-gym-debugging",
+    "ground_truth": "The agent loads the nemo-gym-debugging skill, enables ++global_aiohttp_client_request_debug=True to surface request-boundary visibility, and reads references/request-boundary-visibility.md before changing code.",
+    "expected_behavior": [
+      "The agent read nemo-gym-debugging/SKILL.md before acting",
+      "The agent enabled ++global_aiohttp_client_request_debug=True instead of editing code first",
+      "The agent loaded references/request-boundary-visibility.md",
+      "The agent did not start changing wrappers or provider code as a first move"
+    ]
+  },
+  {
+    "id": "nemo-gym-debugging-negative-001",
+    "question": "Add a new benchmark called wmt-comet to NeMo-Gym, including data prep and the resources server.",
+    "expected_skill": null,
+    "should_trigger": false,
+    "ground_truth": "The agent should not activate the nemo-gym-debugging skill for a benchmark integration task. It should use the add-benchmark skill instead.",
+    "expected_behavior": [
+      "The agent did not read or activate nemo-gym-debugging/SKILL.md",
+      "The agent recognized this as a benchmark integration task"
+    ]
+  },
+  {
+    "id": "nemo-gym-debugging-negative-002",
+    "question": "Document the new ng_reward_profile --pass_threshold flag in the Fern docs under the reward profiling section.",
+    "expected_skill": null,
+    "should_trigger": false,
+    "ground_truth": "The agent should not activate the nemo-gym-debugging skill for a documentation task. It should use the nemo-gym-docs skill instead.",
+    "expected_behavior": [
+      "The agent did not read or activate nemo-gym-debugging/SKILL.md",
+      "The agent recognized this as a docs edit"
+    ]
+  }
+]

--- a/.claude/skills/nemo-gym-docs/SKILL.md
+++ b/.claude/skills/nemo-gym-docs/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: nemo-gym-docs
+license: Apache-2.0
 description: >
   Maintain the NeMo Gym Fern docs site — add, update, move, or remove pages
   under fern/. Use for any documentation change. Triggered by: "edit docs",

--- a/.claude/skills/nemo-gym-docs/evals/evals.json
+++ b/.claude/skills/nemo-gym-docs/evals/evals.json
@@ -1,0 +1,60 @@
+[
+  {
+    "id": "nemo-gym-docs-positive-001",
+    "question": "Add a how-to page for collecting rollouts under the Get Started section of the NeMo Gym docs.",
+    "expected_skill": "nemo-gym-docs",
+    "ground_truth": "The agent loads the nemo-gym-docs skill, creates fern/versions/latest/pages/get-started/rollout-collection.mdx with the required frontmatter (title, description, position), and confirms the folder uses title-source: frontmatter so no main.yml edit is needed.",
+    "expected_behavior": [
+      "The agent read nemo-gym-docs/SKILL.md before acting",
+      "The agent created the new page under fern/versions/latest/pages/get-started/ (the bleeding-edge tree), not under v0.2.1/",
+      "The agent added the required frontmatter (title, description) to the MDX",
+      "The agent did not mirror the change into a frozen GA snapshot folder"
+    ]
+  },
+  {
+    "id": "nemo-gym-docs-positive-002",
+    "question": "Rename /main/get-started/setup to /main/get-started/detailed-setup and make sure the old URL still works.",
+    "expected_skill": "nemo-gym-docs",
+    "ground_truth": "The agent loads the nemo-gym-docs skill, runs git mv on the MDX file under fern/versions/latest/pages/get-started/, adds a redirect entry in fern/docs.yml, and updates incoming links inside fern/versions/latest/.",
+    "expected_behavior": [
+      "The agent read nemo-gym-docs/SKILL.md before acting",
+      "The agent used git mv on the MDX file under fern/versions/latest/pages/",
+      "The agent added a redirect entry to fern/docs.yml for the old URL",
+      "The agent searched for and updated incoming links"
+    ]
+  },
+  {
+    "id": "nemo-gym-docs-positive-003",
+    "question": "Publish the Gym docs to docs.nvidia.com as a new versioned release. What tag do I push?",
+    "expected_skill": "nemo-gym-docs",
+    "ground_truth": "The agent loads the nemo-gym-docs skill and explains that a tag matching docs/v<MAJOR>.<MINOR>.<PATCH> pushed to origin triggers publish-fern-docs.yml, and reminds the user not to push the tag without explicit user approval.",
+    "expected_behavior": [
+      "The agent read nemo-gym-docs/SKILL.md before acting",
+      "The agent gave the docs/v<MAJOR>.<MINOR>.<PATCH> tag format",
+      "The agent referenced publish-fern-docs.yml as the workflow that publishes",
+      "The agent did not push the tag without explicit user confirmation"
+    ]
+  },
+  {
+    "id": "nemo-gym-docs-negative-001",
+    "question": "Implement the verify() function for a new code-generation benchmark resources server.",
+    "expected_skill": null,
+    "should_trigger": false,
+    "ground_truth": "The agent should not activate the nemo-gym-docs skill for benchmark implementation. It should use the add-benchmark skill instead.",
+    "expected_behavior": [
+      "The agent did not read or activate nemo-gym-docs/SKILL.md",
+      "The agent recognized this as a benchmark integration task"
+    ]
+  },
+  {
+    "id": "nemo-gym-docs-negative-002",
+    "question": "My Slurm job for ng_collect_rollouts is failing with OOM mid-run. Help me debug it.",
+    "expected_skill": null,
+    "should_trigger": false,
+    "ground_truth": "The agent should not activate the nemo-gym-docs skill for a job-debugging task. It should use the nemo-gym-debugging skill instead.",
+    "expected_behavior": [
+      "The agent did not read or activate nemo-gym-docs/SKILL.md",
+      "The agent recognized this as a job-debugging task"
+    ]
+  }
+]

--- a/.claude/skills/nemo-gym-pivot-datasets/SKILL.md
+++ b/.claude/skills/nemo-gym-pivot-datasets/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: nemo-gym-pivot-datasets
+license: Apache-2.0
 description: >-
   Use when creating, validating, or documenting Nemo Gym pivot datasets from rollout,
   trajectory, chat-completion, Responses API, or tool-call artifacts. Covers Gym

--- a/.claude/skills/nemo-gym-pivot-datasets/evals/evals.json
+++ b/.claude/skills/nemo-gym-pivot-datasets/evals/evals.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "nemo-gym-pivot-datasets-positive-001",
+    "question": "Convert these tool-call trajectories in a JSONL file into a NeMo Gym pivot dataset I can use for single-step training.",
+    "expected_skill": "nemo-gym-pivot-datasets",
+    "ground_truth": "The agent loads the nemo-gym-pivot-datasets skill, inspects representative source rows and the target resource server before writing a converter, identifies the semantic fields needed per pivot, converts each accepted decision point to one row with responses_create_params, expected_action, and agent_ref, and runs the bundled validator against the output.",
+    "expected_behavior": [
+      "The agent read nemo-gym-pivot-datasets/SKILL.md before acting",
+      "The agent inspected representative source rows before writing a converter",
+      "The agent emitted one pivot row per accepted decision point with responses_create_params, expected_action, and agent_ref",
+      "The agent filtered out source turns with more than one tool call rather than emitting multi-action rows",
+      "The agent ran scripts/validate_pivot_dataset.py on the output"
+    ]
+  },
+  {
+    "id": "nemo-gym-pivot-datasets-positive-002",
+    "question": "Validate this pivot.jsonl file against the resources-server request models and the agent_ref I expect — is it usable for training?",
+    "expected_skill": "nemo-gym-pivot-datasets",
+    "ground_truth": "The agent loads the nemo-gym-pivot-datasets skill and runs the bundled validator with both --agent-ref and --gym-repo, checks that agent_ref matches the config's agent block, and confirms the row contract for single_step_tool_use_with_argument_comparison.",
+    "expected_behavior": [
+      "The agent read nemo-gym-pivot-datasets/SKILL.md before acting",
+      "The agent ran scripts/validate_pivot_dataset.py with --agent-ref",
+      "The agent passed --gym-repo to validate against the resources-server Pydantic models when the Gym repo is available",
+      "The agent confirmed agent_ref.name matches the agent block used by the config"
+    ]
+  },
+  {
+    "id": "nemo-gym-pivot-datasets-positive-003",
+    "question": "I have a batch of chat-completion rollouts from a different framework. Build me a NeMo Gym pivot dataset and the matching Gym YAML config.",
+    "expected_skill": "nemo-gym-pivot-datasets",
+    "ground_truth": "The agent loads the nemo-gym-pivot-datasets skill, normalizes the chat-completion rows into Gym Responses-style pivot rows (one expected_action per row), uses tool_choice: auto in the generated config, points the train dataset entry at the pivot JSONL, and aligns agent_ref with the agent block before validating.",
+    "expected_behavior": [
+      "The agent read nemo-gym-pivot-datasets/SKILL.md before acting",
+      "The agent normalized the chat-completion rows into Responses-style pivot rows",
+      "The agent set tool_choice: auto in the generated config rather than required",
+      "The agent pointed the config's train dataset entry directly at the pivot JSONL",
+      "The agent ensured row-level agent_ref matches the config's agent block"
+    ]
+  },
+  {
+    "id": "nemo-gym-pivot-datasets-negative-001",
+    "question": "Add the cuOpt vehicle-routing benchmark to NeMo-Gym, including data prep and the resources server.",
+    "expected_skill": null,
+    "should_trigger": false,
+    "ground_truth": "The agent should not activate the nemo-gym-pivot-datasets skill for a new-benchmark integration task. It should use the add-benchmark skill instead.",
+    "expected_behavior": [
+      "The agent did not read or activate nemo-gym-pivot-datasets/SKILL.md",
+      "The agent recognized this as a benchmark integration task"
+    ]
+  },
+  {
+    "id": "nemo-gym-pivot-datasets-negative-002",
+    "question": "My ng_reward_profile job is producing empty profile rows for half the tasks. Help me figure out what's wrong.",
+    "expected_skill": null,
+    "should_trigger": false,
+    "ground_truth": "The agent should not activate the nemo-gym-pivot-datasets skill for a debugging task on an existing reward profiling run. It should use the nemo-gym-debugging skill instead.",
+    "expected_behavior": [
+      "The agent did not read or activate nemo-gym-pivot-datasets/SKILL.md",
+      "The agent recognized this as a debugging task"
+    ]
+  }
+]

--- a/.claude/skills/nemo-gym-reward-profiling/SKILL.md
+++ b/.claude/skills/nemo-gym-reward-profiling/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: nemo-gym-reward-profiling
+license: Apache-2.0
 description: >-
   Use to help users get started with Nemo Gym reward profiling. Covers the basic
   ng_run, ng_collect_rollouts, and ng_reward_profile workflow, repeated rollouts,

--- a/.claude/skills/nemo-gym-reward-profiling/evals/evals.json
+++ b/.claude/skills/nemo-gym-reward-profiling/evals/evals.json
@@ -1,0 +1,60 @@
+[
+  {
+    "id": "nemo-gym-reward-profiling-positive-001",
+    "question": "How do I run reward profiling on the math benchmark? I want pass@5 numbers.",
+    "expected_skill": "nemo-gym-reward-profiling",
+    "ground_truth": "The agent loads the nemo-gym-reward-profiling skill, walks through the ng_run / ng_collect_rollouts / ng_reward_profile sequence, sets num_repeats=5 for pass@5, and explains that ng_reward_profile is the step that writes the *_reward_profiling.jsonl.",
+    "expected_behavior": [
+      "The agent read nemo-gym-reward-profiling/SKILL.md before acting",
+      "The agent walked through the ng_run → ng_collect_rollouts → ng_reward_profile sequence",
+      "The agent set num_repeats=5 to match the pass@5 ask",
+      "The agent identified ng_reward_profile (not ng_collect_rollouts) as the step that produces the reward profiling JSONL"
+    ]
+  },
+  {
+    "id": "nemo-gym-reward-profiling-positive-002",
+    "question": "Can you explain what the *_materialized_inputs.jsonl file is and how it relates to rollouts.jsonl and the reward profile output?",
+    "expected_skill": "nemo-gym-reward-profiling",
+    "ground_truth": "The agent loads the nemo-gym-reward-profiling skill and explains materialized_inputs as the expanded collection inputs after repeat expansion plus agent defaults and task/rollout id assignment, rollouts.jsonl as one completed rollout per materialized input row, and *_reward_profiling.jsonl as one summarized profile row per original task with rollout_infos.",
+    "expected_behavior": [
+      "The agent read nemo-gym-reward-profiling/SKILL.md before acting",
+      "The agent explained that *_materialized_inputs.jsonl holds the expanded collection inputs after repeat expansion",
+      "The agent explained the role of _ng_task_index and _ng_rollout_index for keying analysis",
+      "The agent mentioned rollout_infos as the compact per-rollout info inside each task profile row"
+    ]
+  },
+  {
+    "id": "nemo-gym-reward-profiling-positive-003",
+    "question": "Rollout collection stopped early so I have partial output. How do I still run reward profiling on the rollouts that did complete?",
+    "expected_skill": "nemo-gym-reward-profiling",
+    "ground_truth": "The agent loads the nemo-gym-reward-profiling skill and uses ++allow_partial_rollouts=True on ng_reward_profile to profile only the completed rollouts and drop original input rows with no completed rollout.",
+    "expected_behavior": [
+      "The agent read nemo-gym-reward-profiling/SKILL.md before acting",
+      "The agent passed ++allow_partial_rollouts=True to ng_reward_profile",
+      "The agent confirmed that ng_reward_profile (not ng_collect_rollouts) is the step being modified",
+      "The agent noted the default is strict profiling"
+    ]
+  },
+  {
+    "id": "nemo-gym-reward-profiling-negative-001",
+    "question": "Add a new GSM8K-style benchmark to NeMo-Gym, including data prep and a verify() implementation.",
+    "expected_skill": null,
+    "should_trigger": false,
+    "ground_truth": "The agent should not activate the nemo-gym-reward-profiling skill for a benchmark integration task. It should use the add-benchmark skill instead.",
+    "expected_behavior": [
+      "The agent did not read or activate nemo-gym-reward-profiling/SKILL.md",
+      "The agent recognized this as a benchmark integration task"
+    ]
+  },
+  {
+    "id": "nemo-gym-reward-profiling-negative-002",
+    "question": "My ng_collect_rollouts crashed with a Ray actor stack trace and no rollouts.jsonl was written. Help me find the root cause.",
+    "expected_skill": null,
+    "should_trigger": false,
+    "ground_truth": "The agent should not activate the nemo-gym-reward-profiling skill for a failed-job debugging task. It should use the nemo-gym-debugging skill instead.",
+    "expected_behavior": [
+      "The agent did not read or activate nemo-gym-reward-profiling/SKILL.md",
+      "The agent recognized this as a debugging task and deferred to nemo-gym-debugging"
+    ]
+  }
+]

--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -124,7 +124,7 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "pyproject\\.toml|\\.github/workflows/config/\\.secrets\\.baseline"
+        "pyproject\\.toml|\\.github/workflows/config/\\.secrets\\.baseline|\\.oms\\.sig$"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

- Add `license: Apache-2.0` to the frontmatter of all 5 skills under `.claude/skills/` so NVSkills CI validation accepts them.
- Add `evals/evals.json` to each of the 5 skills, with 3-4 positive trigger cases and 2 negative non-trigger cases per skill, covering the main `when_to_use` surface of each SKILL.md.
- Exclude `.oms.sig` from the secrets-detector baseline so generated NVSkills signature blobs are not flagged as high-entropy secrets.

## Motivation

Prepare Gym for NVSkills CI signing once the request workflow PR lands: https://github.com/NVIDIA-NeMo/Gym/pull/1441
With this PR plus the workflow, commenting `/nvskills-ci` will run Tier 3 evaluation on the eval cases and, on pass, attach `skill-card.md` and `skill.oms.sig` per skill.

The 5 affected skills are:
- `.claude/skills/add-benchmark/`
- `.claude/skills/nemo-gym-debugging/`
- `.claude/skills/nemo-gym-docs/`
- `.claude/skills/nemo-gym-pivot-datasets/`
- `.claude/skills/nemo-gym-reward-profiling/`

## Test plan

- [ ] After the workflow PR lands, comment `/nvskills-ci` on this PR. Expect `svc-nvskills-signing` to push an `Attach NVSkills validation signatures` commit containing `skill-card.md` and `skill.oms.sig` under each skill directory.
- [ ] Verify generated `skill.oms.sig` files pass the secrets-detector scan with the updated baseline exclusion.
- [ ] Verify all 5 SKILL.md files still load correctly in Claude Code and Cursor with the new `license:` frontmatter field.