### PR TITLE
ci: exclude .oms.sig from secrets-detector baseline

### DIFF
--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -124,7 +124,7 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "pyproject\\.toml|\\.github/workflows/config/\\.secrets\\.baseline"
+        "pyproject\\.toml|\\.github/workflows/config/\\.secrets\\.baseline|\\.oms\\.sig$"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

- Add `\.oms\.sig$` to the `should_exclude_file` regex in `.github/workflows/config/.secrets.baseline` so NVSkills cryptographic signature blobs (high-entropy by design) are not flagged as accidental secrets by detect-secrets.

## Motivation

NVSkills CI signing attaches `skill.oms.sig` files under each signed skill (a Sigstore/OMS signature bundle). These have very high entropy and trip the secrets detector unless excluded. Prerequisite for the per-skill NVSkills signing PRs (mirrors the equivalent change in NVIDIA-NeMo/RL#2595).

## Test plan

- [ ] After merge, per-skill NVSkills signing PRs that contain `skill.oms.sig` artifacts pass the secrets-detector check.