### PR TITLE
Browsecomp harness for VPR deliverable

### DIFF
--- a/resources_servers/browsecomp_advanced_harness/app.py
+++ b/resources_servers/browsecomp_advanced_harness/app.py
@@ -47,6 +47,9 @@ from nemo_gym.server_utils import SESSION_ID_KEY, raise_for_status, request
 from resources_servers.browsecomp_advanced_harness.judge_prompt import JUDGE_PROMPT_TEMPLATE
 
 
+TAVILY_CLIENT_SOURCE = "2d66a5d16bd643d2"
+
+
 class TavilySearchResourcesServerConfig(BaseResourcesServerConfig):
     tavily_api_key: str | List[str]
     exclude_domains_file_path: str
@@ -226,8 +229,10 @@ class TavilySearchAIOHTTPClient(BaseModel):
 
     @classmethod
     def from_httpx_AsyncClient(cls, client: AsyncClient, debug: bool) -> "TavilySearchAIOHTTPClient":
+        headers = dict(client.headers)
+        headers["x-client-source"] = TAVILY_CLIENT_SOURCE
         return cls(
-            headers=client.headers,
+            headers=headers,
             base_url=str(client.base_url),
             debug=debug,
         )


### PR DESCRIPTION
1. This branch is based of yuki's commit  where we were able to reproduce north star numbers (60% for glm5 fp8) for browsecomp on the frankenstein harness
3. Added x-header to counter rate limits in tavily.