### PR TITLE
Add tau2-synth-library reward-profiling config + tau2 deps

### DIFF
--- a/responses_api_agents/verifiers_agent/configs/tau2-synth-library-kimi.yaml
+++ b/responses_api_agents/verifiers_agent/configs/tau2-synth-library-kimi.yaml
@@ -1,0 +1,23 @@
+verifiers_agent:
+  responses_api_agents:
+    verifiers_agent:
+      entrypoint: app.py
+      domain: agent
+      description: Prime Intellect tau2-synth library domain (customer-support tool-use). Used for reward profiling of Nemotron Nano v3.5.
+      value: Profile per-task difficulty for tau2-synth-library.
+      model_server:
+        type: responses_api_models
+        name: policy_model
+      model_name: ""
+      vf_env_id: tau2-synth
+      vf_env_args:
+        domain: library
+        user_model: openai/nvidia/moonshotai/kimi-k2.6
+        user_base_url: https://inference-api.nvidia.com/v1
+        user_api_key_var: OPENAI_API_KEY
+      group_size: 1
+      max_concurrent_generation: -1
+      max_concurrent_scoring: -1
+      max_tokens: 16384
+      temperature: 1.0
+      top_p: 1.0

--- a/responses_api_agents/verifiers_agent/requirements.txt
+++ b/responses_api_agents/verifiers_agent/requirements.txt
@@ -2,3 +2,6 @@
 verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@v0.1.14
 --extra-index-url https://hub.primeintellect.ai/primeintellect/simple/
 acereason-math
+--extra-index-url https://hub.primeintellect.ai/prime/simple/
+tau2 @ git+https://github.com/eligotts/tau2-bench.git@4839dd6
+tau2-synth==0.2.0


### PR DESCRIPTION
Adds a tau2-synth (library domain) config for the verifiers_agent and the tau2 / tau2-synth dependencies so the agent can run the tau2-synth env. Used for reward profiling of Nemotron Nano v3.5 on Polyphe.