### PR TITLE
fix: process lifecycle for apptainer & nstools

### DIFF
--- a/resources_servers/ns_tools/app.py
+++ b/resources_servers/ns_tools/app.py
@@ -148,9 +148,11 @@ class NSToolsResourcesServer(SimpleResourcesServer):
 
         @asynccontextmanager
         async def lifespan_wrapper(app):
-            async with main_app_lifespan(app) as maybe_state:
-                yield maybe_state
-            await self.shutdown()
+            try:
+                async with main_app_lifespan(app) as maybe_state:
+                    yield maybe_state
+            finally:
+                await self.shutdown()
 
         app.router.lifespan_context = lifespan_wrapper
 

--- a/resources_servers/ns_tools/app.py
+++ b/resources_servers/ns_tools/app.py
@@ -29,6 +29,7 @@ import subprocess
 import sys
 import time
 import uuid
+from contextlib import asynccontextmanager
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -138,6 +139,20 @@ class NSToolsResourcesServer(SimpleResourcesServer):
 
     def setup_webserver(self) -> FastAPI:
         app = super().setup_webserver()
+
+        # Wire shutdown() into the lifespan so a normal server stop reaps the
+        # python_tool sidecar and ToolManager. The base runner only starts
+        # Uvicorn and never calls it, otherwise leaving the sidecar bound to
+        # its fixed port.
+        main_app_lifespan = app.router.lifespan_context
+
+        @asynccontextmanager
+        async def lifespan_wrapper(app):
+            async with main_app_lifespan(app) as maybe_state:
+                yield maybe_state
+            await self.shutdown()
+
+        app.router.lifespan_context = lifespan_wrapper
 
         # Initialize nemo_skills ToolManager if tools are configured
         if self.config.nemo_skills_tools:

--- a/resources_servers/ns_tools/tests/test_app.py
+++ b/resources_servers/ns_tools/tests/test_app.py
@@ -318,3 +318,50 @@ class TestPythonToolShutdownReap:
         proc.kill.assert_not_called()
         proc.wait.assert_called_once_with(timeout=5)
         assert server._python_tool_process is None
+
+
+class TestSidecarTeardownWiredToLifespan:
+    """shutdown() must be connected to the server lifetime, not just defined.
+
+    The base runner only starts Uvicorn; nothing calls shutdown() on its own.
+    setup_webserver() must register it so a normal server stop reaps the
+    python_tool sidecar instead of leaving it bound to its fixed port.
+    """
+
+    def _make_server(self) -> NSToolsResourcesServer:
+        config = NSToolsConfig(host="0.0.0.0", port=8080, entrypoint="", name="ns_tools")
+        return NSToolsResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+
+    async def test_lifespan_context_invokes_shutdown(self) -> None:
+        server = self._make_server()
+        app = server.setup_webserver()
+
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.pid = 12345
+        proc.wait.return_value = 0
+        server._python_tool_process = proc
+
+        # Exiting the app lifespan context must reap the sidecar.
+        async with app.router.lifespan_context(app):
+            pass
+
+        proc.terminate.assert_called_once()
+        assert server._python_tool_process is None
+
+    def test_lifespan_shutdown_reaps_sidecar_via_testclient(self) -> None:
+        from fastapi.testclient import TestClient
+
+        server = self._make_server()
+        app = server.setup_webserver()
+
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.pid = 12345
+        proc.wait.return_value = 0
+        server._python_tool_process = proc
+
+        # Entering/exiting TestClient drives the app startup/shutdown lifespan.
+        with TestClient(app):
+            pass
+
+        proc.terminate.assert_called_once()
+        assert server._python_tool_process is None

--- a/resources_servers/ns_tools/tests/test_app.py
+++ b/resources_servers/ns_tools/tests/test_app.py
@@ -13,14 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import subprocess
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from app import (
     NSToolsConfig,
     NSToolsResourcesServer,
     NSToolsVerifyRequest,
 )
+from fastapi import FastAPI
 
+from nemo_gym.base_resources_server import SimpleResourcesServer
 from nemo_gym.config_types import ResourcesServerRef
 from nemo_gym.openai_utils import NeMoGymResponse
 from nemo_gym.server_utils import ServerClient
@@ -362,6 +366,58 @@ class TestSidecarTeardownWiredToLifespan:
         # Entering/exiting TestClient drives the app startup/shutdown lifespan.
         with TestClient(app):
             pass
+
+        proc.terminate.assert_called_once()
+        assert server._python_tool_process is None
+
+    async def test_shutdown_runs_when_lifespan_body_raises(self) -> None:
+        """The try/finally must reap the sidecar even if the running app errors/cancels.
+
+        An exception raised inside the lifespan body is thrown into the wrapper at
+        the `yield`. Without the finally, shutdown() is skipped and the sidecar leaks.
+        """
+        server = self._make_server()
+        app = server.setup_webserver()
+
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.pid = 12345
+        proc.wait.return_value = 0
+        server._python_tool_process = proc
+
+        with pytest.raises(RuntimeError, match="boom"):
+            async with app.router.lifespan_context(app):
+                raise RuntimeError("boom")
+
+        proc.terminate.assert_called_once()
+        assert server._python_tool_process is None
+
+    async def test_shutdown_runs_when_inner_lifespan_teardown_raises(self) -> None:
+        """The try/finally must reap the sidecar even if the inner lifespan teardown raises.
+
+        The wrapper wraps the base app's lifespan; if that inner teardown raises on a
+        clean exit, the finally still runs shutdown() before the error propagates.
+        """
+
+        @asynccontextmanager
+        async def raising_inner_lifespan(app):
+            yield None
+            raise RuntimeError("inner lifespan teardown failed")
+
+        base_app = FastAPI()
+        base_app.router.lifespan_context = raising_inner_lifespan
+
+        server = self._make_server()
+        with patch.object(SimpleResourcesServer, "setup_webserver", return_value=base_app):
+            app = server.setup_webserver()
+
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.pid = 12345
+        proc.wait.return_value = 0
+        server._python_tool_process = proc
+
+        with pytest.raises(RuntimeError, match="inner lifespan teardown failed"):
+            async with app.router.lifespan_context(app):
+                pass
 
         proc.terminate.assert_called_once()
         assert server._python_tool_process is None

--- a/responses_api_agents/stirrup_agent/apptainer_provider.py
+++ b/responses_api_agents/stirrup_agent/apptainer_provider.py
@@ -35,6 +35,7 @@ import shutil
 import tempfile
 import uuid
 from pathlib import Path
+from typing import TextIO
 
 from stirrup.core.models import ImageContentBlock, Tool, ToolUseCountMetadata
 from stirrup.tools.code_backends.base import (
@@ -95,6 +96,7 @@ class ApptainerCodeExecToolProvider(CodeExecToolProvider):
         self._temp_dir: Path | None = None
         self._patch: str | None = None
         self._stderr_log: Path | None = None
+        self._stderr_fh: TextIO | None = None
         self._has_timeout_cmd: bool = False
 
     def _serializable_kwargs(self) -> dict:
@@ -160,42 +162,76 @@ class ApptainerCodeExecToolProvider(CodeExecToolProvider):
             exec_cmd = f"ulimit -v {memory_kb} && {exec_cmd}"
 
         self._stderr_log = self._temp_dir / "apptainer_stderr.log"
-        stderr_fh = open(self._stderr_log, "w")
+        self._stderr_fh = open(self._stderr_log, "w")
 
         self._process = await asyncio.create_subprocess_shell(
             exec_cmd,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
-            stderr=stderr_fh,
+            stderr=self._stderr_fh,
         )
 
-        # Verify the shell is alive by running a trivial command
-        rc, _, _ = await self._exec("echo ready", timeout=30)
-        if rc != 0:
-            appt_stderr = ""
-            if self._stderr_log and self._stderr_log.exists():
-                appt_stderr = self._stderr_log.read_text(errors="replace")[:2000]
-            raise RuntimeError(f"Failed to start Apptainer shell for {self._sif_path}: {appt_stderr}")
+        # __aexit__ is skipped when __aenter__ raises, so a readiness failure
+        # here must release the subprocess, stderr handle, and temp dir itself.
+        try:
+            # Verify the shell is alive by running a trivial command
+            rc, _, _ = await self._exec("echo ready", timeout=30)
+            if rc != 0:
+                appt_stderr = ""
+                if self._stderr_log and self._stderr_log.exists():
+                    appt_stderr = self._stderr_log.read_text(errors="replace")[:2000]
+                raise RuntimeError(f"Failed to start Apptainer shell for {self._sif_path}: {appt_stderr}")
 
-        # Mark all directories as safe for git (needed because --cleanenv
-        # strips the environment, and the container user may differ from the
-        # owner of /testbed).
-        await self._exec("git config --global --add safe.directory '*'", timeout=10)
+            # Mark all directories as safe for git (needed because --cleanenv
+            # strips the environment, and the container user may differ from the
+            # owner of /testbed).
+            await self._exec("git config --global --add safe.directory '*'", timeout=10)
 
-        # Check if GNU `timeout` is available for per-command time limits.
-        # When present, each command is wrapped so that a hung command is
-        # killed by the OS instead of blocking all subsequent commands on the
-        # shared stdin/stdout stream.
-        rc_to, _, _ = await self._exec("command -v timeout >/dev/null 2>&1", timeout=5)
-        self._has_timeout_cmd = rc_to == 0
-        if not self._has_timeout_cmd:
-            logger.warning(
-                "timeout command not found in container — "
-                "in-shell time limits disabled; hung commands will block the stream"
-            )
+            # Check if GNU `timeout` is available for per-command time limits.
+            # When present, each command is wrapped so that a hung command is
+            # killed by the OS instead of blocking all subsequent commands on the
+            # shared stdin/stdout stream.
+            rc_to, _, _ = await self._exec("command -v timeout >/dev/null 2>&1", timeout=5)
+            self._has_timeout_cmd = rc_to == 0
+            if not self._has_timeout_cmd:
+                logger.warning(
+                    "timeout command not found in container — "
+                    "in-shell time limits disabled; hung commands will block the stream"
+                )
+        except BaseException:
+            await self._cleanup_failed_start()
+            raise
 
         logger.info("Started Apptainer shell (pid=%s) from %s", self._process.pid, self._sif_path)
         return self.get_code_exec_tool()
+
+    async def _cleanup_failed_start(self) -> None:
+        """Tear down a partially-started session: terminate -> wait -> kill ->
+        wait the shell, close the stderr log handle, and remove the temp dir."""
+        proc = self._process
+        if proc is not None and proc.returncode is None:
+            try:
+                if proc.stdin is not None:
+                    proc.stdin.close()
+                proc.terminate()
+                await asyncio.wait_for(proc.wait(), timeout=10)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                try:
+                    proc.kill()
+                    await proc.wait()
+                except ProcessLookupError:
+                    pass
+        self._process = None
+
+        if self._stderr_fh is not None:
+            try:
+                self._stderr_fh.close()
+            finally:
+                self._stderr_fh = None
+
+        if self._temp_dir is not None and self._temp_dir.exists():
+            shutil.rmtree(self._temp_dir, ignore_errors=True)
+        self._temp_dir = None
 
     async def __aexit__(
         self,
@@ -271,6 +307,12 @@ class ApptainerCodeExecToolProvider(CodeExecToolProvider):
             f"(len={len(self._patch) if self._patch else 0})",
             flush=True,
         )
+
+        if self._stderr_fh is not None:
+            try:
+                self._stderr_fh.close()
+            finally:
+                self._stderr_fh = None
 
         if self._temp_dir and self._temp_dir.exists():
             shutil.rmtree(self._temp_dir, ignore_errors=True)

--- a/responses_api_agents/stirrup_agent/tests/test_apptainer_provider.py
+++ b/responses_api_agents/stirrup_agent/tests/test_apptainer_provider.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Startup/teardown resource-safety tests for the Apptainer code-exec provider.
+
+A readiness failure in ``__aenter__`` (which skips ``__aexit__``) must not leak
+the subprocess, the stderr log handle, or the temp bind directory.
+"""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from responses_api_agents.stirrup_agent.apptainer_provider import ApptainerCodeExecToolProvider
+
+
+def _make_fake_process(wait_side_effect=None) -> MagicMock:
+    proc = MagicMock(spec=asyncio.subprocess.Process)
+    proc.returncode = None
+    proc.pid = 4242
+    proc.stdin = MagicMock()
+    proc.stdout = MagicMock()
+    proc.terminate = MagicMock()
+    proc.kill = MagicMock()
+    if wait_side_effect is not None:
+        proc.wait = AsyncMock(side_effect=wait_side_effect)
+    else:
+        proc.wait = AsyncMock(return_value=0)
+    return proc
+
+
+async def test_failed_readiness_cleans_up_process_handle_and_tempdir() -> None:
+    """A readiness failure must terminate the shell, close the log, and drop the temp dir."""
+    provider = ApptainerCodeExecToolProvider(sif_path="/fake.sif")
+    fake_proc = _make_fake_process()
+    create_mock = AsyncMock(return_value=fake_proc)
+
+    # `echo ready` returns non-zero -> __aenter__ raises before returning.
+    with (
+        patch("asyncio.create_subprocess_shell", new=create_mock),
+        patch.object(ApptainerCodeExecToolProvider, "_exec", new=AsyncMock(return_value=(1, b"", b""))),
+    ):
+        with pytest.raises(RuntimeError, match="Failed to start Apptainer shell"):
+            await provider.__aenter__()
+
+    # The graceful terminate path was taken and awaited (no leaked live shell).
+    fake_proc.terminate.assert_called_once()
+    fake_proc.wait.assert_awaited()
+    assert provider._process is None
+
+    # The stderr log handle handed to the subprocess is closed and its temp
+    # bind directory removed.
+    stderr_fh = create_mock.call_args.kwargs["stderr"]
+    assert stderr_fh.closed
+    assert not Path(stderr_fh.name).parent.exists()
+    assert provider._stderr_fh is None
+    assert provider._temp_dir is None
+
+
+async def test_failed_readiness_kills_when_terminate_times_out() -> None:
+    """If the shell ignores SIGTERM, the cleanup escalates to kill() and reaps it."""
+    provider = ApptainerCodeExecToolProvider(sif_path="/fake.sif")
+    # First wait (after terminate) times out; second wait (after kill) reaps.
+    fake_proc = _make_fake_process(wait_side_effect=[asyncio.TimeoutError(), 0])
+
+    with (
+        patch("asyncio.create_subprocess_shell", new=AsyncMock(return_value=fake_proc)),
+        patch.object(ApptainerCodeExecToolProvider, "_exec", new=AsyncMock(return_value=(1, b"", b""))),
+    ):
+        with pytest.raises(RuntimeError, match="Failed to start Apptainer shell"):
+            await provider.__aenter__()
+
+    fake_proc.terminate.assert_called_once()
+    fake_proc.kill.assert_called_once()
+    assert fake_proc.wait.await_count == 2
+    assert provider._process is None
+    assert provider._temp_dir is None
+
+
+async def test_normal_exit_closes_stderr_handle_and_tempdir() -> None:
+    """On a successful enter/exit the stderr handle and temp dir are released."""
+    provider = ApptainerCodeExecToolProvider(sif_path="/fake.sif", capture_git_diff=False)
+    fake_proc = _make_fake_process()
+
+    with (
+        patch("asyncio.create_subprocess_shell", new=AsyncMock(return_value=fake_proc)),
+        patch.object(ApptainerCodeExecToolProvider, "_exec", new=AsyncMock(return_value=(0, b"", b""))),
+        patch.object(ApptainerCodeExecToolProvider, "get_code_exec_tool", new=MagicMock(return_value=MagicMock())),
+    ):
+        await provider.__aenter__()
+        stderr_fh = provider._stderr_fh
+        temp_dir = provider._temp_dir
+        assert stderr_fh is not None and not stderr_fh.closed
+        assert temp_dir is not None and temp_dir.exists()
+
+        await provider.__aexit__(None, None, None)
+
+    assert stderr_fh.closed
+    assert provider._stderr_fh is None
+    assert not temp_dir.exists()
+    assert provider._temp_dir is None


### PR DESCRIPTION
1. Apptainer provider

`ApptainerCodeExecToolProvider.__aenter__` opens a stderr log handle and spawns a long-lived `apptainer exec ... bash` subprocess, then runs readiness checks. If a check failed, it raised before returning, so `__aexit__` never ran, leaking the live subprocess, the open log handle, and the temp bind dir. Repeated failed setups could exhaust process slots/FDs and leave stale overlays.

The fix is to wrap the post-spawn readiness checks for cleanup on error handling: close stdin → terminate → wait → kill → wait, close the stderr handle, remove the temp dir, then re-raise. On the normal exit path, the stderr handle is now closed too so it doesn't leak on success. 


2. ns_tools sidecar

`NSToolsResourcesServer.shutdown()` terminates the python_tool sidecar and ToolManager, but nothing ever called i. Tthe base runner only starts Uvicorn. A normal server stop left the sidecar alive on its fixed port, so a later `ng_run` could hit stale state or fail because the port was still bound.

The fix is to wrap the app's `lifespan_context` in `setup_webserver` so `shutdown()` runs on server exit