### PR TITLE
fix: fail fast with clear errors for invalid +config_paths

### DIFF
--- a/nemo_gym/cli.py
+++ b/nemo_gym/cli.py
@@ -51,6 +51,7 @@ from nemo_gym.global_config import (
     NEMO_GYM_RESERVED_TOP_LEVEL_KEYS,
     GlobalConfigDictParserConfig,
     get_global_config_dict,
+    require_configured_servers,
 )
 from nemo_gym.rollout_collection import E2ERolloutCollectionConfig, RolloutCollectionConfig, RolloutCollectionHelper
 from nemo_gym.server_status import StatusCommand
@@ -129,6 +130,10 @@ class RunHelper:  # pragma: no cover
 
     def start(self, global_config_dict_parser_config: GlobalConfigDictParserConfig) -> None:
         global_config_dict = get_global_config_dict(global_config_dict_parser_config=global_config_dict_parser_config)
+
+        # Fail fast before Ray / head-server startup if nothing is configured to run,
+        # otherwise the process spins up with zero servers and hangs until killed.
+        require_configured_servers(global_config_dict)
 
         # Initialize Ray cluster in the main process
         # Note: This function will modify the global config dict - update `ray_head_node_address`

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -209,10 +209,9 @@ class GlobalConfigDictParser(BaseModel):
             # recursively from another config's `config_paths`.
             if not config_path.exists():
                 raise SystemExit(
-                    f"Config file not found: {config_path}\n"
-                    f"Checked relative to cwd ({Path.cwd()}) and install root ({PARENT_DIR}).\n"
-                    f"Check the `{CONFIG_PATHS_KEY_NAME}` entries (passed via `+{CONFIG_PATHS_KEY_NAME}=[...]` "
-                    f"or referenced from another config)."
+                    f"""Config file not found: {config_path}
+Checked relative to cwd ({Path.cwd()}) and install root ({PARENT_DIR}).
+Check the `{CONFIG_PATHS_KEY_NAME}` entries (passed via `+{CONFIG_PATHS_KEY_NAME}=[...]` or referenced from another config)."""
                 )
 
             extra_config = OmegaConf.load(config_path)
@@ -423,13 +422,13 @@ Duplicate config paths:
         config_paths = merged_config_for_config_paths.get(CONFIG_PATHS_KEY_NAME) or []
         try:
             config_paths = ta.validate_python(config_paths)
-        except ValidationError:
+        except ValidationError as e:
             # A malformed value (e.g. a scalar instead of a list) should explain the
             # expected Hydra syntax rather than surface a raw Pydantic traceback.
             raise SystemExit(
                 f"`+{CONFIG_PATHS_KEY_NAME}` must be a list of config paths, e.g. "
                 f"`+{CONFIG_PATHS_KEY_NAME}=[a.yaml,b.yaml]` (got: {config_paths!r})."
-            )
+            ) from e
 
         config_paths, extra_configs = self.load_extra_config_paths(config_paths)
 

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -203,6 +203,18 @@ class GlobalConfigDictParser(BaseModel):
                 cwd_path = Path.cwd() / config_path
                 config_path = cwd_path if cwd_path.exists() else PARENT_DIR / config_path
 
+            # Fail fast with an actionable message instead of an opaque OmegaConf
+            # FileNotFoundError traceback when a config path is mistyped or missing.
+            # Paths may come from `+config_paths` on the CLI or be referenced
+            # recursively from another config's `config_paths`.
+            if not config_path.exists():
+                raise SystemExit(
+                    f"Config file not found: {config_path}\n"
+                    f"Checked relative to cwd ({Path.cwd()}) and install root ({PARENT_DIR}).\n"
+                    f"Check the `{CONFIG_PATHS_KEY_NAME}` entries (passed via `+{CONFIG_PATHS_KEY_NAME}=[...]` "
+                    f"or referenced from another config)."
+                )
+
             extra_config = OmegaConf.load(config_path)
             for new_config_path in extra_config.get(CONFIG_PATHS_KEY_NAME) or []:
                 if new_config_path not in config_paths:
@@ -409,7 +421,15 @@ Duplicate config paths:
         merged_config_for_config_paths = OmegaConf.merge(dotenv_extra_config, global_config_dict)
         ta = TypeAdapter(List[str])
         config_paths = merged_config_for_config_paths.get(CONFIG_PATHS_KEY_NAME) or []
-        config_paths = ta.validate_python(config_paths)
+        try:
+            config_paths = ta.validate_python(config_paths)
+        except ValidationError:
+            # A malformed value (e.g. a scalar instead of a list) should explain the
+            # expected Hydra syntax rather than surface a raw Pydantic traceback.
+            raise SystemExit(
+                f"`+{CONFIG_PATHS_KEY_NAME}` must be a list of config paths, e.g. "
+                f"`+{CONFIG_PATHS_KEY_NAME}=[a.yaml,b.yaml]` (got: {config_paths!r})."
+            )
 
         config_paths, extra_configs = self.load_extra_config_paths(config_paths)
 
@@ -651,6 +671,24 @@ def get_first_server_config_dict(global_config_dict: DictConfig, top_level_path:
     server_config_dict = list(server_config_dict.values())[0]
 
     return server_config_dict
+
+
+def require_configured_servers(global_config_dict: DictConfig) -> None:
+    """Fail fast if no servers are configured.
+
+    Without this guard, running with no config (e.g. `+config_paths` omitted)
+    starts Ray and the head server with nothing to do; the process never
+    converges and is eventually killed with low-level signal noise. Raise a
+    clean, actionable error before any startup instead.
+    """
+    server_keys = [k for k in global_config_dict if k not in NEMO_GYM_RESERVED_TOP_LEVEL_KEYS]
+    if not server_keys:
+        raise SystemExit(
+            f"No servers configured. Pass at least one config via "
+            f"`+{CONFIG_PATHS_KEY_NAME}=[...]`, e.g. "
+            f"`+{CONFIG_PATHS_KEY_NAME}=[resources_servers/example_single_tool_call/configs/"
+            f"example_single_tool_call.yaml]`. See `ng_help` for usage."
+        )
 
 
 def find_open_port(

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -31,6 +31,7 @@ from nemo_gym.global_config import (
     find_open_port,
     get_first_server_config_dict,
     get_global_config_dict,
+    require_configured_servers,
 )
 from nemo_gym.server_utils import (
     DictConfig,
@@ -977,3 +978,47 @@ class TestGlobalConfig:
 
         # Without the help override, this will SystemExit.
         GlobalConfigDictParser.parse_global_config_dict_from_cli(None)
+
+    def test_load_extra_config_paths_missing_path_fails_fast(self, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+        # A mistyped / nonexistent config path should fail fast with a clear message
+        # instead of an opaque FileNotFoundError traceback from OmegaConf.load().
+        parser = GlobalConfigDictParser()
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(nemo_gym.global_config, "PARENT_DIR", tmp_path)
+
+        with raises(SystemExit) as exc_info:
+            parser.load_extra_config_paths(["does_not_exist/configs/nope.yaml"])
+
+        assert "Config file not found" in str(exc_info.value)
+
+    def test_parse_rejects_non_list_config_paths(self, monkeypatch: MonkeyPatch) -> None:
+        # A scalar instead of a list should explain the expected Hydra list syntax
+        # instead of surfacing a raw Pydantic ValidationError traceback.
+        parser = GlobalConfigDictParser()
+
+        with raises(SystemExit) as exc_info:
+            parser.parse(
+                GlobalConfigDictParserConfig(
+                    initial_global_config_dict=DictConfig({"config_paths": "a.yaml"}),
+                    skip_load_from_cli=True,
+                    skip_load_from_dotenv=True,
+                )
+            )
+
+        assert "config_paths" in str(exc_info.value)
+        assert "must be a list" in str(exc_info.value)
+
+    def test_require_configured_servers_raises_when_empty(self) -> None:
+        with raises(SystemExit) as exc_info:
+            require_configured_servers(DictConfig({}))
+        assert "No servers configured" in str(exc_info.value)
+
+    def test_require_configured_servers_raises_with_only_reserved_keys(self) -> None:
+        # Only reserved (non-server) keys present, e.g. an empty `+config_paths`.
+        with raises(SystemExit):
+            require_configured_servers(DictConfig({"config_paths": []}))
+
+    def test_require_configured_servers_passes_with_server(self) -> None:
+        # A configured server key present -> no error.
+        require_configured_servers(DictConfig({"config_paths": ["a.yaml"], "my_server": {"a": 1}}))


### PR DESCRIPTION
## What & Why

Routine user mistakes when starting servers via `ng_run` currently surface
low-level library internals instead of actionable guidance. This hardens
`+config_paths` handling so each failure mode fails fast with a concise,
user-facing message (no traceback) before any expensive startup.

Addresses three filed usability bugs:

| Issue | Symptom today | After |
|-------|---------------|-------|
| #1488 | A mistyped/nonexistent config path dumps a raw `OmegaConf` `FileNotFoundError` traceback | Clear "Config file not found" message with the resolved path and where it was checked |
| #1490 | A malformed (non-list) `+config_paths` value surfaces a raw Pydantic `ValidationError` (incl. a `pydantic.dev` URL) | Clear message explaining the expected Hydra list syntax |
| #1489 | Omitting `+config_paths` starts Ray + the head server with **zero** configured servers; the process hangs until killed with a native `SIGTERM` dump | Fails fast before any Ray / head-server startup with a message pointing at `+config_paths` |

## Approach

- **#1488** — in `GlobalConfigDictParser.load_extra_config_paths()`, check the
  resolved path exists before `OmegaConf.load()`. The check uses the already
  cwd→install-root-resolved path, so existing resolution behaviour (absolute
  paths, cwd preference, recursive `config_paths`) is unchanged.
- **#1490** — wrap the `TypeAdapter(List[str]).validate_python(...)` call and
  re-raise with the expected syntax. Only `ValidationError` is caught, so valid
  lists / `ListConfig` values pass through untouched.
- **#1489** — add `require_configured_servers()` and call it inside
  `RunHelper.start()` *before* `initialize_ray()`. Placing it in `start()` (rather
  than only `run()`) means every entrypoint that starts servers — including
  `ng_e2e_collect_rollouts` — is covered by the same guard.

Each path raises `SystemExit(<message>)`, which prints only the message to
stderr and exits non-zero — no traceback — matching the behaviour requested in
the issues. Valid inputs are entirely unaffected.

## Why is the "no servers" signal correct?

`require_configured_servers()` keys off the presence of any non-reserved
top-level config key — the same notion of "server paths" that `RunHelper.start()`
already uses (`[k for k in global_config_dict if k not in NEMO_GYM_RESERVED_TOP_LEVEL_KEYS]`).
An empty/omitted `+config_paths` yields only reserved keys, which is exactly the
hang case in #1489.

## Tests

Added unit tests in `tests/unit_tests/test_global_config.py` covering all three
cases (missing path, non-list value, no-servers guard). Each is red on `main`
(raw `FileNotFoundError` / Pydantic `ValidationError` / no guard) and green here.

```
uv run pytest tests/unit_tests/ -q   # 233 passed
```

Closes #1488
Closes #1489
Closes #1490
