### PR TITLE
ci: Add community bot labeler

### DIFF
--- a/.github/workflows/community-bot.yml
+++ b/.github/workflows/community-bot.yml
@@ -1,0 +1,15 @@
+name: Community Bot
+
+on:
+  issues:
+    types: [opened, edited, reopened, closed, deleted]
+  issue_comment:
+    types: [created, edited, deleted]
+
+jobs:
+  community-bot:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_community_bot.yml@v1.4.3
+    with:
+      community_project_id: ${{ vars.COMMUNITY_PROJECT_ID }}
+    secrets:
+      GH_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/community-bot.yml
+++ b/.github/workflows/community-bot.yml
@@ -8,8 +8,9 @@ on:
 
 jobs:
   community-bot:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_community_bot.yml@v1.4.3
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_community_bot.yml@v1.5.0
     with:
       community_project_id: ${{ vars.COMMUNITY_PROJECT_ID }}
+      app-id: ${{ vars.BOT_ID }}
     secrets:
-      GH_TOKEN: ${{ secrets.PAT }}
+      BOT_KEY: ${{ secrets.BOT_KEY }}


### PR DESCRIPTION
ci: Add community bot labeler

Adds a "community" label if an issue author is not a member of the Nvidia or Nvidia-NeMo org