### PR TITLE
ship `environments/` and `example_environments/` in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -395,7 +395,7 @@ ng_reinstall = "nemo_gym.cli:reinstall"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["benchmarks", "resources_servers", "responses_api_agents", "responses_api_models", "nemo_gym"]
+include = ["benchmarks", "environments", "example_environments", "nemo_gym", "resources_servers", "responses_api_agents", "responses_api_models"]
 
 ################################################
 # Testing


### PR DESCRIPTION
The new top-level `environments/` and `example_environments/` added in #1324 are not currently included in `[tool.setuptools.packages.find]`, so a `pip install nemo-gym` user would not be able to launch those environments since their config and example data never shipped. R

This PR add both top-level packages to the wheel include list, matching the existing benchmarks/resources_servers/etc. packaging