### PR TITLE
chore: bump version to 0.4.0rc0 for next dev cycle

### DIFF
--- a/nemo_gym/package_info.py
+++ b/nemo_gym/package_info.py
@@ -15,7 +15,7 @@
 
 
 MAJOR = 0
-MINOR = 3
+MINOR = 4
 PATCH = 0
 PRE_RELEASE = "rc0"
 


### PR DESCRIPTION
## Summary
- Bumps `MINOR` version from 3 → 4 in `nemo_gym/package_info.py` (`0.3.0rc0` → `0.4.0rc0`)
- Part of the `r0.3.0` code freeze — main now targets the next release

## Test plan
- [ ] CI passes (lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)