### PR TITLE
chore: drop rc0 pre-release tag for 0.3.0 release

### DIFF
--- a/nemo_gym/package_info.py
+++ b/nemo_gym/package_info.py
@@ -17,7 +17,7 @@
 MAJOR = 0
 MINOR = 3
 PATCH = 0
-PRE_RELEASE = "rc0"
+PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)


### PR DESCRIPTION
## Summary
- Sets `PRE_RELEASE = ""` in `nemo_gym/package_info.py`, changing version from `0.3.0rc0` → `0.3.0`
- Required for the `r0.3.0` release branch to carry the stable version string

## Test plan
- [ ] CI passes (lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)