### PR TITLE
Disable on-disk cache by default for eval, surface retrieval context-window/HTTP errors and make retrieval_max_output_tokens Optional

### DIFF
--- a/resources_servers/finance_sec_search/README.md
+++ b/resources_servers/finance_sec_search/README.md
@@ -43,6 +43,15 @@ The `tavily_api_key` is referenced as `${tavily_api_key}` in
 The resource server caches SEC data locally to avoid redundant API calls and to
 enable offline operation after the first fetch.
 
+### Enabling / disabling the cache (`use_cache`)
+
+| `use_cache` | Behavior |
+|-------------|----------|
+| `false` (default) | The on-disk cache is fully bypassed — no cache directories are created and **every request fetches fresh filings live**. |
+| `true` | The on-disk cache under `cache_dir` is read and written: ticker mappings, filing metadata, and parsed filing content are cached and reused across requests/runs. |
+
+Keep `use_cache: false` (the default) for **eval**
+
 ### What is cached
 
 | Directory | Contents |

--- a/resources_servers/finance_sec_search/app.py
+++ b/resources_servers/finance_sec_search/app.py
@@ -68,10 +68,7 @@ class FinanceAgentResourcesServerConfig(BaseResourcesServerConfig):
         default=None,
         description="Path for caching ticker mappings and filing metadata. Defaults to ~/.cache/nemo_gym/finance_sec_search/ if not set. Relative paths are resolved from cwd.",
     )
-    use_cache: bool = Field(
-        default=False,
-        description="Keep False to always fetch fresh filings (used for eval)."
-    )
+    use_cache: bool = Field(default=False, description="Keep False to always fetch fresh filings (used for eval).")
     user_agent: str = Field(
         default="Gym-SEC-Search/1.0 (research@nvidia.com)", description="User-Agent header for SEC.gov requests"
     )
@@ -1083,9 +1080,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                 if error_field is not None:
                     diagnostic_parts.append(f"error={error_field}")
                 diagnostic = (" (" + ", ".join(diagnostic_parts) + ")") if diagnostic_parts else ""
-                return RetrieveInformationResponse(
-                    results=f"ERROR: Retrieval LLM returned no output.{diagnostic}"
-                )
+                return RetrieveInformationResponse(results=f"ERROR: Retrieval LLM returned no output.{diagnostic}")
 
             return RetrieveInformationResponse(results=result_text)
 

--- a/resources_servers/finance_sec_search/app.py
+++ b/resources_servers/finance_sec_search/app.py
@@ -68,6 +68,10 @@ class FinanceAgentResourcesServerConfig(BaseResourcesServerConfig):
         default=None,
         description="Path for caching ticker mappings and filing metadata. Defaults to ~/.cache/nemo_gym/finance_sec_search/ if not set. Relative paths are resolved from cwd.",
     )
+    use_cache: bool = Field(
+        default=False,
+        description="Keep False to always fetch fresh filings (used for eval)."
+    )
     user_agent: str = Field(
         default="Gym-SEC-Search/1.0 (research@nvidia.com)", description="User-Agent header for SEC.gov requests"
     )
@@ -110,9 +114,11 @@ class FinanceAgentResourcesServerConfig(BaseResourcesServerConfig):
         "'binary': only [[2]] → 1.0, else 0.0. "
         "'scaled': [[0]] → 0.0, [[1]] → 0.5, [[2]] → 1.0.",
     )
-    retrieval_max_output_tokens: int = Field(
-        default=8192,
-        description="Max output tokens for retrieve_information LLM calls. Increase for thinking models.",
+    retrieval_max_output_tokens: Optional[int] = Field(
+        default=None,
+        description="Max output tokens for retrieve_information LLM calls. Increase for thinking models. "
+        "Set to null/None to leave it unset so the retrieval call inherits the full generation budget "
+        "(used for eval); set an integer to cap it (used for training).",
     )
     retrieval_model_context_length: int = Field(
         default=131072,
@@ -358,12 +364,15 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
             if not self._cache_dir.is_absolute():
                 self._cache_dir = Path.cwd() / self._cache_dir
                 logger.info("Resolved relative cache_dir to %s", self._cache_dir)
-        self._cache_dir.mkdir(parents=True, exist_ok=True)
         self._filings_metadata_dir = self._cache_dir / "filings_metadata"
-        self._filings_metadata_dir.mkdir(exist_ok=True)
         self._filings_dir = self._cache_dir / "filings"
-        self._filings_dir.mkdir(exist_ok=True)
         self._tickers_file = self._cache_dir / "tickers.json"
+        # Only materialize the on-disk cache when caching is enabled. With
+        # use_cache=False every request fetches live and no dirs are created.
+        if self.config.use_cache:
+            self._cache_dir.mkdir(parents=True, exist_ok=True)
+            self._filings_metadata_dir.mkdir(exist_ok=True)
+            self._filings_dir.mkdir(exist_ok=True)
 
         self._rate_limiter = RateLimiter(max_requests=self.config.requests_per_second, window_seconds=1.0)
 
@@ -544,7 +553,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
 
         raw = None
 
-        if self._tickers_file.exists():
+        if self.config.use_cache and self._tickers_file.exists():
             try:
                 with open(self._tickers_file, "r") as f:
                     raw = json.load(f)
@@ -559,8 +568,9 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                     with urllib.request.urlopen(req, timeout=30) as resp:
                         data = resp.read().decode("utf-8")
                     raw = json.loads(data)
-                    with open(self._tickers_file, "w") as f:
-                        json.dump(raw, f)
+                    if self.config.use_cache:
+                        with open(self._tickers_file, "w") as f:
+                            json.dump(raw, f)
                     break
                 except (urllib.error.URLError, json.JSONDecodeError, OSError) as e:
                     wait = 2**attempt
@@ -655,7 +665,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                 return self._filings_cache[cik_padded]
 
             cache_path = self._get_company_cache_path(cik)
-            if cache_path.exists():
+            if self.config.use_cache and cache_path.exists():
                 with open(cache_path, "r") as f:
                     filings = json.load(f)
                 self._filings_cache[cik_padded] = filings
@@ -684,7 +694,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                         except json.JSONDecodeError:
                             logger.warning("Failed to parse supplementary file %s for CIK %s", filename, cik)
 
-                if filings:
+                if filings and self.config.use_cache:
                     self._atomic_write(cache_path, json.dumps(filings))
                 self._filings_cache[cik_padded] = filings
                 return filings
@@ -777,6 +787,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
         cik, accession_number = parts["cik"], parts["accession_number"]
         cik_padded = str(cik).zfill(10)
         acc_nodash = accession_number.replace("-", "")
+        # TODO: this path assumes the URL is for the primary filing document only, which is true because of how sec_filing_search is constructed
         return self._filings_dir / cik_padded / f"{acc_nodash}.txt"
 
     # ========================================================================
@@ -891,12 +902,12 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
             raise ValueError(f"Invalid SEC URL format: {url}")
 
         text_content = None
-        if file_path.exists():
+        if self.config.use_cache and file_path.exists():
             text_content = file_path.read_text(encoding="utf-8")
 
         if text_content is None and self.config.sec_dump_path:
             text_content = await self._lookup_dump(url)
-            if text_content:
+            if text_content and self.config.use_cache:
                 self._atomic_write(file_path, text_content)
 
         if text_content is None:
@@ -909,7 +920,8 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
             text_content = await asyncio.get_running_loop().run_in_executor(
                 None, self._parse_html_to_text, html_content
             )
-            self._atomic_write(file_path, text_content)
+            if self.config.use_cache:
+                self._atomic_write(file_path, text_content)
 
         if not text_content:
             raise ValueError("Filing content was empty after parsing.")

--- a/resources_servers/finance_sec_search/configs/finance_sec_search.yaml
+++ b/resources_servers/finance_sec_search/configs/finance_sec_search.yaml
@@ -8,6 +8,7 @@ finance_sec_search_resources_server:
       description: SEC EDGAR filing search for financial analysis questions
       value: Enable LLMs to search and analyze SEC filings
       cache_dir: null  # defaults to ~/.cache/nemo_gym/finance_sec_search/ if not set
+      use_cache: false  # keep false for eval to fetch fresh filings, set to true for training to reuse cached filings
       tavily_api_key: ${tavily_api_key}
       retrieval_model_server:
         type: responses_api_models

--- a/resources_servers/finance_sec_search/tests/test_app.py
+++ b/resources_servers/finance_sec_search/tests/test_app.py
@@ -89,6 +89,10 @@ def server_config(temp_cache_dir):
         entrypoint="",
         name="finance_sec_search_test",
         cache_dir=temp_cache_dir,
+        # The default is use_cache=False (eval). The bulk of these tests exercise
+        # the on-disk cache, so the shared fixture pins it True; the use_cache=False
+        # bypass path is covered explicitly in TestUseCacheFlag.
+        use_cache=True,
         judge_prompt_template_fpath=str(_prompt_dir / "finance_sec_search_judge.yaml"),
         retrieval_system_prompt_fpath=str(_prompt_dir / "finance_sec_search_retrieval.yaml"),
     )
@@ -116,6 +120,96 @@ class TestServerInitialization:
         assert Path(temp_cache_dir).exists()
         assert (Path(temp_cache_dir) / "filings_metadata").exists()
         assert (Path(temp_cache_dir) / "filings").exists()
+
+
+# ============================================================================
+# Test: use_cache flag (on-disk cache enable/disable)
+# ============================================================================
+
+
+class TestUseCacheFlag:
+    """Tests that the use_cache flag fully gates the on-disk SEC cache."""
+
+    _SEC_URL = "https://www.sec.gov/Archives/edgar/data/320193/000032019325000008/aapl-20241228.htm"
+
+    @staticmethod
+    def _make_server(cache_dir: Path, use_cache: bool) -> FinanceAgentResourcesServer:
+        _pd = Path(__file__).resolve().parents[1] / "prompt_templates"
+        config = FinanceAgentResourcesServerConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="finance_sec_search_test",
+            cache_dir=str(cache_dir),
+            use_cache=use_cache,
+            judge_prompt_template_fpath=str(_pd / "finance_sec_search_judge.yaml"),
+            retrieval_system_prompt_fpath=str(_pd / "finance_sec_search_retrieval.yaml"),
+        )
+        return FinanceAgentResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+
+    def test_directories_created_when_enabled(self, tmp_path) -> None:
+        """use_cache=True creates the cache directories."""
+        cache_dir = tmp_path / "cache"
+        self._make_server(cache_dir, use_cache=True)
+        assert (cache_dir / "filings").exists()
+        assert (cache_dir / "filings_metadata").exists()
+
+    def test_directories_not_created_when_disabled(self, tmp_path) -> None:
+        """use_cache=False does not create any cache directories."""
+        cache_dir = tmp_path / "cache"
+        server = self._make_server(cache_dir, use_cache=False)
+        assert not (cache_dir / "filings").exists()
+        assert not (cache_dir / "filings_metadata").exists()
+        # The path is still derived so URL→path conversion keeps working.
+        assert server._url_to_filing_path(self._SEC_URL) is not None
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_served_when_enabled(self, tmp_path) -> None:
+        """use_cache=True serves a pre-populated filing from disk without fetching."""
+        server = self._make_server(tmp_path / "cache", use_cache=True)
+        path = server._url_to_filing_path(self._SEC_URL)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("CACHED CONTENT", encoding="utf-8")
+
+        fetch_mock = AsyncMock(return_value="<html><body><p>LIVE CONTENT</p></body></html>")
+        with patch.object(server, "_fetch_with_retry", fetch_mock):
+            text = await server._fetch_sec_filing_text(self._SEC_URL)
+
+        assert text == "CACHED CONTENT"
+        fetch_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_bypassed_when_disabled(self, tmp_path) -> None:
+        """use_cache=False ignores an existing cache file, fetches live, and never writes back."""
+        server = self._make_server(tmp_path / "cache", use_cache=False)
+        path = server._url_to_filing_path(self._SEC_URL)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("CACHED CONTENT", encoding="utf-8")
+
+        fetch_mock = AsyncMock(return_value="<html><body><p>LIVE CONTENT</p></body></html>")
+        with patch.object(server, "_fetch_with_retry", fetch_mock):
+            text = await server._fetch_sec_filing_text(self._SEC_URL)
+
+        assert "LIVE CONTENT" in text
+        assert "CACHED CONTENT" not in text
+        fetch_mock.assert_called_once()
+        # The live result must NOT overwrite the cache file when caching is disabled.
+        assert path.read_text(encoding="utf-8") == "CACHED CONTENT"
+
+    @pytest.mark.asyncio
+    async def test_cache_written_when_enabled(self, tmp_path) -> None:
+        """use_cache=True writes a freshly fetched filing to the cache file."""
+        server = self._make_server(tmp_path / "cache", use_cache=True)
+        path = server._url_to_filing_path(self._SEC_URL)
+        assert not path.exists()
+
+        fetch_mock = AsyncMock(return_value="<html><body><p>FRESH CONTENT</p></body></html>")
+        with patch.object(server, "_fetch_with_retry", fetch_mock):
+            text = await server._fetch_sec_filing_text(self._SEC_URL)
+
+        assert "FRESH CONTENT" in text
+        assert path.exists()
+        assert "FRESH CONTENT" in path.read_text(encoding="utf-8")
 
 
 # ============================================================================

--- a/responses_api_agents/finance_agent/tests/test_app.py
+++ b/responses_api_agents/finance_agent/tests/test_app.py
@@ -311,9 +311,7 @@ class TestResponses:
             "loop should have run max_steps=3 model calls instead of breaking after first text response"
         )
 
-        user_continues = [
-            o for o in output if o["type"] == "message" and o["role"] == "user"
-        ]
+        user_continues = [o for o in output if o["type"] == "message" and o["role"] == "user"]
         assert len(user_continues) >= 1, "no 'Continue.' user message injected"
         assert any(o["content"] == "Continue." for o in user_continues), (
             f"Continue. literal missing; got user contents: {[o['content'] for o in user_continues]}"


### PR DESCRIPTION
disable on-disk cache by default for eval, surface retrieval context-window/HTTP errors and make retrieval_max_output_tokens Optional

- add use_cache flag (default False) gating all disk reads/writes
- make retrieval_max_output_tokens Optional (None = uncapped for eval)
- surface retrieval LLM HTTP errors + empty-output incomplete_details diagnostic
- restore {{key_name}} worked example in retrieve_information prompt description
