### PR TITLE
fix(vllm_model): prefer inline token metadata over prompt tokenization

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -148,14 +148,14 @@ class TokenIDLogProbTypedDictMixin(TypedDict):
     routed_experts: NotRequired[RoutedExperts]
 
 
-_REQUIRED_TOKEN_METADATA_FIELDS = frozenset(
+REQUIRED_TOKEN_METADATA_FIELDS = frozenset(
     {
         "prompt_token_ids",
         "generation_token_ids",
         "generation_log_probs",
     }
 )
-_TOKEN_METADATA_FIELDS = _REQUIRED_TOKEN_METADATA_FIELDS | {"routed_experts"}
+TOKEN_METADATA_FIELDS = REQUIRED_TOKEN_METADATA_FIELDS | {"routed_experts"}
 
 
 def _validate_atomic_token_metadata(value: Any) -> Any:
@@ -163,11 +163,11 @@ def _validate_atomic_token_metadata(value: Any) -> Any:
     if not isinstance(value, dict):
         return value
 
-    present_fields = _TOKEN_METADATA_FIELDS.intersection(value)
+    present_fields = TOKEN_METADATA_FIELDS.intersection(value)
     if not present_fields:
         return value
 
-    missing_fields = _REQUIRED_TOKEN_METADATA_FIELDS.difference(present_fields)
+    missing_fields = REQUIRED_TOKEN_METADATA_FIELDS.difference(present_fields)
     if missing_fields:
         missing = ", ".join(sorted(missing_fields))
         raise ValueError(f"Token metadata must include all required fields; missing: {missing}")

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -150,6 +150,7 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
     api_key: str
     model: str
     return_token_id_information: bool
+    request_prompt_and_generation_token_ids: bool = False
 
     uses_reasoning_parser: bool
     uses_interleaved_reasoning: bool = True
@@ -606,6 +607,8 @@ class VLLMModel(SimpleResponsesAPIModel):
                 # Typically passed via OpenAI client extra_body.
                 return_tokens_as_token_ids=True,
             )
+            if self.config.request_prompt_and_generation_token_ids:
+                body_dict["return_token_ids"] = True
 
         if self.config.uses_reasoning_parser and not self.config.preserve_reasoning_in_assistant_content:
             for message_dict in body_dict["messages"]:

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -282,125 +282,6 @@ class VLLMModel(SimpleResponsesAPIModel):
         if self.config.use_completions_api and self.config.render_chat_template:
             self._chat_template_tokenizer = self._load_chat_template_tokenizer()
 
-    @staticmethod
-    def _require_token_id_list(value: Any, field_name: str) -> List[Any]:
-        """Check the container without scanning or copying token IDs."""
-        if not isinstance(value, list):
-            raise RuntimeError(f"`{field_name}` must be a list of integer token IDs.")
-        return value
-
-    @staticmethod
-    def _require_log_prob_list(value: Any, field_name: str) -> List[Any]:
-        """Check the container without scanning or copying log probabilities."""
-        if not isinstance(value, list):
-            raise RuntimeError(f"`{field_name}` must be a list of numeric log probabilities.")
-        return value
-
-    @classmethod
-    def _validate_token_bundle(cls, bundle: Dict[str, Any], source: str) -> Dict[str, Any]:
-        present_fields = TOKEN_METADATA_FIELDS.intersection(bundle)
-        missing_fields = REQUIRED_TOKEN_METADATA_FIELDS.difference(present_fields)
-        if missing_fields:
-            missing = ", ".join(sorted(missing_fields))
-            raise RuntimeError(f"{source} returned partial token metadata; missing: {missing}.")
-
-        normalized = {
-            "prompt_token_ids": cls._require_token_id_list(bundle["prompt_token_ids"], f"{source}.prompt_token_ids"),
-            "generation_token_ids": cls._require_token_id_list(
-                bundle["generation_token_ids"], f"{source}.generation_token_ids"
-            ),
-            "generation_log_probs": cls._require_log_prob_list(
-                bundle["generation_log_probs"], f"{source}.generation_log_probs"
-            ),
-        }
-        if "routed_experts" in bundle:
-            normalized["routed_experts"] = bundle["routed_experts"]
-
-        if len(normalized["generation_token_ids"]) != len(normalized["generation_log_probs"]):
-            raise RuntimeError(
-                f"{source} returned mismatched generation token IDs and log probabilities: "
-                f"{len(normalized['generation_token_ids'])} token IDs and "
-                f"{len(normalized['generation_log_probs'])} log probabilities."
-            )
-
-        return normalized
-
-    @classmethod
-    def _extract_message_token_bundle(cls, message_dict: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-        required_fields = REQUIRED_TOKEN_METADATA_FIELDS.intersection(message_dict)
-        if not required_fields:
-            return None
-        present_fields = TOKEN_METADATA_FIELDS.intersection(message_dict)
-        return cls._validate_token_bundle(
-            {field: message_dict[field] for field in present_fields},
-            "choice.message",
-        )
-
-    @classmethod
-    def _extract_vllm_response_token_ids(
-        cls,
-        chat_completion_dict: Dict[str, Any],
-        choice_dict: Dict[str, Any],
-    ) -> Optional[tuple[List[Any], List[Any]]]:
-        prompt_value = chat_completion_dict.get("prompt_token_ids")
-        generation_value = choice_dict.get("token_ids")
-        prompt_present = prompt_value is not None
-        generation_present = generation_value is not None
-
-        if prompt_present != generation_present:
-            missing = "choice.token_ids" if prompt_present else "prompt_token_ids"
-            raise RuntimeError(f"vLLM response returned partial token metadata; missing: {missing}.")
-        if not prompt_present:
-            return None
-
-        return (
-            cls._require_token_id_list(prompt_value, "prompt_token_ids"),
-            cls._require_token_id_list(generation_value, "choice.token_ids"),
-        )
-
-    def _extract_choice_logprobs(self, choice_dict: Dict[str, Any]) -> tuple[List[int], List[float]]:
-        logprobs_block = choice_dict.get("logprobs")
-        if not isinstance(logprobs_block, dict) or not isinstance(logprobs_block.get("content"), list):
-            raise RuntimeError(
-                f"`{self.config.name}` requested per-token logprobs from vLLM "
-                "(return_token_id_information=True, logprobs=True, top_logprobs=0), "
-                f"but the response had none (choice.logprobs={logprobs_block!r}). "
-                "Cannot extract token ids or logprobs."
-            )
-
-        generation_token_ids: List[int] = []
-        generation_log_probs: List[float] = []
-        for index, entry in enumerate(logprobs_block["content"]):
-            if not isinstance(entry, dict):
-                raise RuntimeError(f"choice.logprobs.content[{index}] must be an object.")
-            token = entry.get("token")
-            if not isinstance(token, str) or not token.startswith("token_id:"):
-                raise RuntimeError(f"choice.logprobs.content[{index}].token must use the `token_id:<int>` format.")
-            try:
-                token_id = int(token.removeprefix("token_id:"))
-            except ValueError as e:
-                raise RuntimeError(
-                    f"choice.logprobs.content[{index}].token must use the `token_id:<int>` format."
-                ) from e
-            log_prob = entry.get("logprob")
-            if not isinstance(log_prob, (int, float)) or isinstance(log_prob, bool):
-                raise RuntimeError(f"choice.logprobs.content[{index}].logprob must be numeric.")
-            generation_token_ids.append(token_id)
-            generation_log_probs.append(float(log_prob))
-
-        return generation_token_ids, generation_log_probs
-
-    @classmethod
-    def _get_tokenize_chat_body(cls, body_dict: Dict[str, Any]) -> Dict[str, Any]:
-        """Keep every known prompt-affecting field aligned with generation."""
-        return {field: body_dict[field] for field in cls._TOKENIZE_CHAT_FIELDS if field in body_dict}
-
-    def _validate_single_choice_token_request(self, body_dict: Dict[str, Any]) -> None:
-        if self.config.return_token_id_information and body_dict.get("n") not in (None, 1):
-            raise ValueError(
-                f"NeMo Gym server `{self.config.name}` requires n=1 when return_token_id_information=true."
-            )
-
     def _load_chat_template_tokenizer(self):
         """Load an HF AutoTokenizer for client-side chat-template rendering.
 
@@ -926,6 +807,125 @@ class VLLMModel(SimpleResponsesAPIModel):
             choice_dict["message"] = NeMoGymChatCompletionMessageForTraining.model_validate(message_dict)
 
         return NeMoGymChatCompletion.model_validate(chat_completion_dict)
+
+    @staticmethod
+    def _require_token_id_list(value: Any, field_name: str) -> List[Any]:
+        """Check the container without scanning or copying token IDs."""
+        if not isinstance(value, list):
+            raise RuntimeError(f"`{field_name}` must be a list of integer token IDs.")
+        return value
+
+    @staticmethod
+    def _require_log_prob_list(value: Any, field_name: str) -> List[Any]:
+        """Check the container without scanning or copying log probabilities."""
+        if not isinstance(value, list):
+            raise RuntimeError(f"`{field_name}` must be a list of numeric log probabilities.")
+        return value
+
+    @classmethod
+    def _validate_token_bundle(cls, bundle: Dict[str, Any], source: str) -> Dict[str, Any]:
+        present_fields = TOKEN_METADATA_FIELDS.intersection(bundle)
+        missing_fields = REQUIRED_TOKEN_METADATA_FIELDS.difference(present_fields)
+        if missing_fields:
+            missing = ", ".join(sorted(missing_fields))
+            raise RuntimeError(f"{source} returned partial token metadata; missing: {missing}.")
+
+        normalized = {
+            "prompt_token_ids": cls._require_token_id_list(bundle["prompt_token_ids"], f"{source}.prompt_token_ids"),
+            "generation_token_ids": cls._require_token_id_list(
+                bundle["generation_token_ids"], f"{source}.generation_token_ids"
+            ),
+            "generation_log_probs": cls._require_log_prob_list(
+                bundle["generation_log_probs"], f"{source}.generation_log_probs"
+            ),
+        }
+        if "routed_experts" in bundle:
+            normalized["routed_experts"] = bundle["routed_experts"]
+
+        if len(normalized["generation_token_ids"]) != len(normalized["generation_log_probs"]):
+            raise RuntimeError(
+                f"{source} returned mismatched generation token IDs and log probabilities: "
+                f"{len(normalized['generation_token_ids'])} token IDs and "
+                f"{len(normalized['generation_log_probs'])} log probabilities."
+            )
+
+        return normalized
+
+    @classmethod
+    def _extract_message_token_bundle(cls, message_dict: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        required_fields = REQUIRED_TOKEN_METADATA_FIELDS.intersection(message_dict)
+        if not required_fields:
+            return None
+        present_fields = TOKEN_METADATA_FIELDS.intersection(message_dict)
+        return cls._validate_token_bundle(
+            {field: message_dict[field] for field in present_fields},
+            "choice.message",
+        )
+
+    @classmethod
+    def _extract_vllm_response_token_ids(
+        cls,
+        chat_completion_dict: Dict[str, Any],
+        choice_dict: Dict[str, Any],
+    ) -> Optional[tuple[List[Any], List[Any]]]:
+        prompt_value = chat_completion_dict.get("prompt_token_ids")
+        generation_value = choice_dict.get("token_ids")
+        prompt_present = prompt_value is not None
+        generation_present = generation_value is not None
+
+        if prompt_present != generation_present:
+            missing = "choice.token_ids" if prompt_present else "prompt_token_ids"
+            raise RuntimeError(f"vLLM response returned partial token metadata; missing: {missing}.")
+        if not prompt_present:
+            return None
+
+        return (
+            cls._require_token_id_list(prompt_value, "prompt_token_ids"),
+            cls._require_token_id_list(generation_value, "choice.token_ids"),
+        )
+
+    def _extract_choice_logprobs(self, choice_dict: Dict[str, Any]) -> tuple[List[int], List[float]]:
+        logprobs_block = choice_dict.get("logprobs")
+        if not isinstance(logprobs_block, dict) or not isinstance(logprobs_block.get("content"), list):
+            raise RuntimeError(
+                f"`{self.config.name}` requested per-token logprobs from vLLM "
+                "(return_token_id_information=True, logprobs=True, top_logprobs=0), "
+                f"but the response had none (choice.logprobs={logprobs_block!r}). "
+                "Cannot extract token ids or logprobs."
+            )
+
+        generation_token_ids: List[int] = []
+        generation_log_probs: List[float] = []
+        for index, entry in enumerate(logprobs_block["content"]):
+            if not isinstance(entry, dict):
+                raise RuntimeError(f"choice.logprobs.content[{index}] must be an object.")
+            token = entry.get("token")
+            if not isinstance(token, str) or not token.startswith("token_id:"):
+                raise RuntimeError(f"choice.logprobs.content[{index}].token must use the `token_id:<int>` format.")
+            try:
+                token_id = int(token.removeprefix("token_id:"))
+            except ValueError as e:
+                raise RuntimeError(
+                    f"choice.logprobs.content[{index}].token must use the `token_id:<int>` format."
+                ) from e
+            log_prob = entry.get("logprob")
+            if not isinstance(log_prob, (int, float)) or isinstance(log_prob, bool):
+                raise RuntimeError(f"choice.logprobs.content[{index}].logprob must be numeric.")
+            generation_token_ids.append(token_id)
+            generation_log_probs.append(float(log_prob))
+
+        return generation_token_ids, generation_log_probs
+
+    @classmethod
+    def _get_tokenize_chat_body(cls, body_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """Keep every known prompt-affecting field aligned with generation."""
+        return {field: body_dict[field] for field in cls._TOKENIZE_CHAT_FIELDS if field in body_dict}
+
+    def _validate_single_choice_token_request(self, body_dict: Dict[str, Any]) -> None:
+        if self.config.return_token_id_information and body_dict.get("n") not in (None, 1):
+            raise ValueError(
+                f"NeMo Gym server `{self.config.name}` requires n=1 when return_token_id_information=true."
+            )
 
     async def _chat_completions_via_completions_api(
         self, request: Request, body: NeMoGymChatCompletionCreateParamsNonStreaming

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -32,14 +32,16 @@ from nemo_gym.base_responses_api_model import (
     SimpleResponsesAPIModel,
 )
 from nemo_gym.openai_utils import (
+    REQUIRED_TOKEN_METADATA_FIELDS,
+    TOKEN_METADATA_FIELDS,
     NeMoGymAsyncOpenAI,
     NeMoGymChatCompletion,
     NeMoGymChatCompletionCreateParamsNonStreaming,
     NeMoGymChatCompletionMessage,
+    NeMoGymChatCompletionMessageForTraining,
     NeMoGymChoice,
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
-    TokenIDLogProbMixin,
 )
 from nemo_gym.responses_converter import (
     VLLMConverter,
@@ -150,6 +152,7 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
     api_key: str
     model: str
     return_token_id_information: bool
+    # Request inline prompt and generation token IDs from compatible vLLM endpoints.
     request_prompt_and_generation_token_ids: bool = False
 
     uses_reasoning_parser: bool
@@ -230,10 +233,6 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
 class VLLMModel(SimpleResponsesAPIModel):
     config: VLLMModelConfig
 
-    _REQUIRED_TOKEN_METADATA_FIELDS: ClassVar[frozenset[str]] = frozenset(
-        {"prompt_token_ids", "generation_token_ids", "generation_log_probs"}
-    )
-    _TOKEN_METADATA_FIELDS: ClassVar[frozenset[str]] = _REQUIRED_TOKEN_METADATA_FIELDS | {"routed_experts"}
     _TOKENIZE_CHAT_FIELDS: ClassVar[tuple[str, ...]] = (
         "model",
         "messages",
@@ -284,35 +283,33 @@ class VLLMModel(SimpleResponsesAPIModel):
             self._chat_template_tokenizer = self._load_chat_template_tokenizer()
 
     @staticmethod
-    def _coerce_token_ids(value: Any, field_name: str) -> List[int]:
-        if not isinstance(value, list) or any(
-            not isinstance(token_id, int) or isinstance(token_id, bool) for token_id in value
-        ):
+    def _require_token_id_list(value: Any, field_name: str) -> List[Any]:
+        """Check the container without scanning or copying token IDs."""
+        if not isinstance(value, list):
             raise RuntimeError(f"`{field_name}` must be a list of integer token IDs.")
-        return list(value)
+        return value
 
     @staticmethod
-    def _coerce_log_probs(value: Any, field_name: str) -> List[float]:
-        if not isinstance(value, list) or any(
-            not isinstance(log_prob, (int, float)) or isinstance(log_prob, bool) for log_prob in value
-        ):
+    def _require_log_prob_list(value: Any, field_name: str) -> List[Any]:
+        """Check the container without scanning or copying log probabilities."""
+        if not isinstance(value, list):
             raise RuntimeError(f"`{field_name}` must be a list of numeric log probabilities.")
-        return [float(log_prob) for log_prob in value]
+        return value
 
     @classmethod
     def _validate_token_bundle(cls, bundle: Dict[str, Any], source: str) -> Dict[str, Any]:
-        present_fields = cls._TOKEN_METADATA_FIELDS.intersection(bundle)
-        missing_fields = cls._REQUIRED_TOKEN_METADATA_FIELDS.difference(present_fields)
+        present_fields = TOKEN_METADATA_FIELDS.intersection(bundle)
+        missing_fields = REQUIRED_TOKEN_METADATA_FIELDS.difference(present_fields)
         if missing_fields:
             missing = ", ".join(sorted(missing_fields))
             raise RuntimeError(f"{source} returned partial token metadata; missing: {missing}.")
 
         normalized = {
-            "prompt_token_ids": cls._coerce_token_ids(bundle["prompt_token_ids"], f"{source}.prompt_token_ids"),
-            "generation_token_ids": cls._coerce_token_ids(
+            "prompt_token_ids": cls._require_token_id_list(bundle["prompt_token_ids"], f"{source}.prompt_token_ids"),
+            "generation_token_ids": cls._require_token_id_list(
                 bundle["generation_token_ids"], f"{source}.generation_token_ids"
             ),
-            "generation_log_probs": cls._coerce_log_probs(
+            "generation_log_probs": cls._require_log_prob_list(
                 bundle["generation_log_probs"], f"{source}.generation_log_probs"
             ),
         }
@@ -326,25 +323,25 @@ class VLLMModel(SimpleResponsesAPIModel):
                 f"{len(normalized['generation_log_probs'])} log probabilities."
             )
 
-        return TokenIDLogProbMixin.model_validate(normalized).model_dump(exclude_none=True)
+        return normalized
 
     @classmethod
     def _extract_message_token_bundle(cls, message_dict: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-        required_fields = cls._REQUIRED_TOKEN_METADATA_FIELDS.intersection(message_dict)
+        required_fields = REQUIRED_TOKEN_METADATA_FIELDS.intersection(message_dict)
         if not required_fields:
             return None
-        present_fields = cls._TOKEN_METADATA_FIELDS.intersection(message_dict)
+        present_fields = TOKEN_METADATA_FIELDS.intersection(message_dict)
         return cls._validate_token_bundle(
             {field: message_dict[field] for field in present_fields},
             "choice.message",
         )
 
     @classmethod
-    def _extract_standard_vllm_ids(
+    def _extract_vllm_response_token_ids(
         cls,
         chat_completion_dict: Dict[str, Any],
         choice_dict: Dict[str, Any],
-    ) -> Optional[tuple[List[int], List[int]]]:
+    ) -> Optional[tuple[List[Any], List[Any]]]:
         prompt_value = chat_completion_dict.get("prompt_token_ids")
         generation_value = choice_dict.get("token_ids")
         prompt_present = prompt_value is not None
@@ -352,13 +349,13 @@ class VLLMModel(SimpleResponsesAPIModel):
 
         if prompt_present != generation_present:
             missing = "choice.token_ids" if prompt_present else "prompt_token_ids"
-            raise RuntimeError(f"Standard vLLM returned partial token metadata; missing: {missing}.")
+            raise RuntimeError(f"vLLM response returned partial token metadata; missing: {missing}.")
         if not prompt_present:
             return None
 
         return (
-            cls._coerce_token_ids(prompt_value, "prompt_token_ids"),
-            cls._coerce_token_ids(generation_value, "choice.token_ids"),
+            cls._require_token_id_list(prompt_value, "prompt_token_ids"),
+            cls._require_token_id_list(generation_value, "choice.token_ids"),
         )
 
     def _extract_choice_logprobs(self, choice_dict: Dict[str, Any]) -> tuple[List[int], List[float]]:
@@ -866,29 +863,39 @@ class VLLMModel(SimpleResponsesAPIModel):
 
         if self.config.return_token_id_information:
             message_dict = choice_dict["message"]
+
+            # Token metadata uses this source order:
+            # 1. A complete bundle on the assistant message.
+            # 2. Prompt IDs at the response top level and generation IDs on the choice.
+            # 3. Generation data from choice logprobs and prompt IDs from `/tokenize`.
+            #
+            # An earlier source supplies the normalized bundle.
+            # Later inline sources are still checked when present.
+            # A partially present source is invalid.
+            # Duplicate token IDs must agree.
             message_bundle = self._extract_message_token_bundle(message_dict)
-            standard_ids = self._extract_standard_vllm_ids(chat_completion_dict, choice_dict)
+            response_token_ids = self._extract_vllm_response_token_ids(chat_completion_dict, choice_dict)
 
             if message_bundle is not None:
-                if standard_ids is not None:
-                    standard_prompt_ids, standard_generation_ids = standard_ids
+                if response_token_ids is not None:
+                    response_prompt_token_ids, response_generation_token_ids = response_token_ids
                     if (
-                        message_bundle["prompt_token_ids"] != standard_prompt_ids
-                        or message_bundle["generation_token_ids"] != standard_generation_ids
+                        message_bundle["prompt_token_ids"] != response_prompt_token_ids
+                        or message_bundle["generation_token_ids"] != response_generation_token_ids
                     ):
-                        raise RuntimeError("Message-level token metadata disagrees with standard vLLM token IDs.")
+                        raise RuntimeError("Message-level token metadata disagrees with vLLM response token IDs.")
                 message_dict.update(message_bundle)
             else:
                 logprob_token_ids, generation_log_probs = self._extract_choice_logprobs(choice_dict)
-                if standard_ids is not None:
-                    prompt_token_ids, generation_token_ids = standard_ids
+                if response_token_ids is not None:
+                    prompt_token_ids, generation_token_ids = response_token_ids
                     if generation_token_ids != logprob_token_ids:
                         raise RuntimeError(
-                            "Standard vLLM generation token IDs disagree with choice logprob token IDs."
+                            "vLLM response generation token IDs disagree with choice logprob token IDs."
                         )
                 else:
                     tokenize_response = await client.create_tokenize(**self._get_tokenize_chat_body(body_dict))
-                    prompt_token_ids = self._coerce_token_ids(
+                    prompt_token_ids = self._require_token_id_list(
                         tokenize_response.get("tokens"),
                         "tokenize.tokens",
                     )
@@ -913,9 +920,10 @@ class VLLMModel(SimpleResponsesAPIModel):
                 # The adapter consumed this compatibility payload.
                 choice_dict.pop("logprobs", None)
 
-            # Standard token-ID fields are transport details.
+            # Top-level and choice-level token-ID fields are transport details.
             chat_completion_dict.pop("prompt_token_ids", None)
             choice_dict.pop("token_ids", None)
+            choice_dict["message"] = NeMoGymChatCompletionMessageForTraining.model_validate(message_dict)
 
         return NeMoGymChatCompletion.model_validate(chat_completion_dict)
 

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -39,6 +39,7 @@ from nemo_gym.openai_utils import (
     NeMoGymChoice,
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
+    TokenIDLogProbMixin,
 )
 from nemo_gym.responses_converter import (
     VLLMConverter,
@@ -228,6 +229,19 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
 class VLLMModel(SimpleResponsesAPIModel):
     config: VLLMModelConfig
 
+    _REQUIRED_TOKEN_METADATA_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {"prompt_token_ids", "generation_token_ids", "generation_log_probs"}
+    )
+    _TOKEN_METADATA_FIELDS: ClassVar[frozenset[str]] = _REQUIRED_TOKEN_METADATA_FIELDS | {"routed_experts"}
+    _TOKENIZE_CHAT_FIELDS: ClassVar[tuple[str, ...]] = (
+        "model",
+        "messages",
+        "tools",
+        "chat_template_kwargs",
+        "mm_processor_kwargs",
+        "required_prefix_token_ids",
+    )
+
     def get_converter(self) -> "VLLMConverter":
         """Return the converter used for Responses API <-> Chat Completions mapping.
 
@@ -267,6 +281,127 @@ class VLLMModel(SimpleResponsesAPIModel):
         self._chat_template_tokenizer = None
         if self.config.use_completions_api and self.config.render_chat_template:
             self._chat_template_tokenizer = self._load_chat_template_tokenizer()
+
+    @staticmethod
+    def _coerce_token_ids(value: Any, field_name: str) -> List[int]:
+        if not isinstance(value, list) or any(
+            not isinstance(token_id, int) or isinstance(token_id, bool) for token_id in value
+        ):
+            raise RuntimeError(f"`{field_name}` must be a list of integer token IDs.")
+        return list(value)
+
+    @staticmethod
+    def _coerce_log_probs(value: Any, field_name: str) -> List[float]:
+        if not isinstance(value, list) or any(
+            not isinstance(log_prob, (int, float)) or isinstance(log_prob, bool) for log_prob in value
+        ):
+            raise RuntimeError(f"`{field_name}` must be a list of numeric log probabilities.")
+        return [float(log_prob) for log_prob in value]
+
+    @classmethod
+    def _validate_token_bundle(cls, bundle: Dict[str, Any], source: str) -> Dict[str, Any]:
+        present_fields = cls._TOKEN_METADATA_FIELDS.intersection(bundle)
+        missing_fields = cls._REQUIRED_TOKEN_METADATA_FIELDS.difference(present_fields)
+        if missing_fields:
+            missing = ", ".join(sorted(missing_fields))
+            raise RuntimeError(f"{source} returned partial token metadata; missing: {missing}.")
+
+        normalized = {
+            "prompt_token_ids": cls._coerce_token_ids(bundle["prompt_token_ids"], f"{source}.prompt_token_ids"),
+            "generation_token_ids": cls._coerce_token_ids(
+                bundle["generation_token_ids"], f"{source}.generation_token_ids"
+            ),
+            "generation_log_probs": cls._coerce_log_probs(
+                bundle["generation_log_probs"], f"{source}.generation_log_probs"
+            ),
+        }
+        if "routed_experts" in bundle:
+            normalized["routed_experts"] = bundle["routed_experts"]
+
+        if len(normalized["generation_token_ids"]) != len(normalized["generation_log_probs"]):
+            raise RuntimeError(
+                f"{source} returned mismatched generation token IDs and log probabilities: "
+                f"{len(normalized['generation_token_ids'])} token IDs and "
+                f"{len(normalized['generation_log_probs'])} log probabilities."
+            )
+
+        return TokenIDLogProbMixin.model_validate(normalized).model_dump(exclude_none=True)
+
+    @classmethod
+    def _extract_message_token_bundle(cls, message_dict: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        required_fields = cls._REQUIRED_TOKEN_METADATA_FIELDS.intersection(message_dict)
+        if not required_fields:
+            return None
+        present_fields = cls._TOKEN_METADATA_FIELDS.intersection(message_dict)
+        return cls._validate_token_bundle(
+            {field: message_dict[field] for field in present_fields},
+            "choice.message",
+        )
+
+    @classmethod
+    def _extract_standard_vllm_ids(
+        cls,
+        chat_completion_dict: Dict[str, Any],
+        choice_dict: Dict[str, Any],
+    ) -> Optional[tuple[List[int], List[int]]]:
+        prompt_value = chat_completion_dict.get("prompt_token_ids")
+        generation_value = choice_dict.get("token_ids")
+        prompt_present = prompt_value is not None
+        generation_present = generation_value is not None
+
+        if prompt_present != generation_present:
+            missing = "choice.token_ids" if prompt_present else "prompt_token_ids"
+            raise RuntimeError(f"Standard vLLM returned partial token metadata; missing: {missing}.")
+        if not prompt_present:
+            return None
+
+        return (
+            cls._coerce_token_ids(prompt_value, "prompt_token_ids"),
+            cls._coerce_token_ids(generation_value, "choice.token_ids"),
+        )
+
+    def _extract_choice_logprobs(self, choice_dict: Dict[str, Any]) -> tuple[List[int], List[float]]:
+        logprobs_block = choice_dict.get("logprobs")
+        if not isinstance(logprobs_block, dict) or not isinstance(logprobs_block.get("content"), list):
+            raise RuntimeError(
+                f"`{self.config.name}` requested per-token logprobs from vLLM "
+                "(return_token_id_information=True, logprobs=True, top_logprobs=0), "
+                f"but the response had none (choice.logprobs={logprobs_block!r}). "
+                "Cannot extract token ids or logprobs."
+            )
+
+        generation_token_ids: List[int] = []
+        generation_log_probs: List[float] = []
+        for index, entry in enumerate(logprobs_block["content"]):
+            if not isinstance(entry, dict):
+                raise RuntimeError(f"choice.logprobs.content[{index}] must be an object.")
+            token = entry.get("token")
+            if not isinstance(token, str) or not token.startswith("token_id:"):
+                raise RuntimeError(f"choice.logprobs.content[{index}].token must use the `token_id:<int>` format.")
+            try:
+                token_id = int(token.removeprefix("token_id:"))
+            except ValueError as e:
+                raise RuntimeError(
+                    f"choice.logprobs.content[{index}].token must use the `token_id:<int>` format."
+                ) from e
+            log_prob = entry.get("logprob")
+            if not isinstance(log_prob, (int, float)) or isinstance(log_prob, bool):
+                raise RuntimeError(f"choice.logprobs.content[{index}].logprob must be numeric.")
+            generation_token_ids.append(token_id)
+            generation_log_probs.append(float(log_prob))
+
+        return generation_token_ids, generation_log_probs
+
+    @classmethod
+    def _get_tokenize_chat_body(cls, body_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """Keep every known prompt-affecting field aligned with generation."""
+        return {field: body_dict[field] for field in cls._TOKENIZE_CHAT_FIELDS if field in body_dict}
+
+    def _validate_single_choice_token_request(self, body_dict: Dict[str, Any]) -> None:
+        if self.config.return_token_id_information and body_dict.get("n") not in (None, 1):
+            raise ValueError(
+                f"NeMo Gym server `{self.config.name}` requires n=1 when return_token_id_information=true."
+            )
 
     def _load_chat_template_tokenizer(self):
         """Load an HF AutoTokenizer for client-side chat-template rendering.
@@ -470,11 +605,9 @@ class VLLMModel(SimpleResponsesAPIModel):
                 top_logprobs=0,
                 # Typically passed via OpenAI client extra_body.
                 return_tokens_as_token_ids=True,
-                # TODO add this when NeMo RL upgrades to vLLM 0.10.2 support for prompt token ids
-                # For prompt and generation token IDs
-                # return_token_ids=True,
-                # For prompt token IDs
-                # prompt_logprobs=0,
+                # Standard vLLM returns exact prompt and generation IDs in the
+                # same response when this extension is enabled.
+                return_token_ids=True,
             )
 
         if self.config.uses_reasoning_parser and not self.config.preserve_reasoning_in_assistant_content:
@@ -590,7 +723,9 @@ class VLLMModel(SimpleResponsesAPIModel):
                 # No user message found — create one with just the audio blocks.
                 body_dict.setdefault("messages", []).append({"role": "user", "content": list(audio_blocks)})
 
-        return self._apply_sampling_overrides(body_dict)
+        self._apply_sampling_overrides(body_dict)
+        self._validate_single_choice_token_request(body_dict)
+        return body_dict
 
     async def chat_completions(
         self, request: Request, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
@@ -729,63 +864,58 @@ class VLLMModel(SimpleResponsesAPIModel):
                 f"NeMo Gym server `{self.config.name}` config has explicitly been set to not use a reasoning parser i.e. `uses_reasoning_parser: false`. Please do not use a reasoning parser in your vLLM endpoint, or fix the `{self.config.name}` server config!"
             )
 
-        if self.config.return_token_id_information and "prompt_token_ids" not in choice_dict["message"]:
-            # Check vLLM honored the logprobs request.
-            # It returns choice.logprobs=None when it computed none.
-            # That happens when a null top_logprobs reached it, or the contract changed across versions.
-            # Without this check the code below raises a TypeError or emits empty token ids that zero the loss mask.
-            # An empty content list is a valid zero-token generation and passes through.
-            logprobs_block = choice_dict.get("logprobs")
-            if not logprobs_block or logprobs_block.get("content") is None:
-                raise RuntimeError(
-                    f"`{self.config.name}` requested per-token logprobs from vLLM "
-                    f"(return_token_id_information=True, logprobs=True, top_logprobs=0), but the response "
-                    f"had none (choice.logprobs={logprobs_block!r}). Cannot extract token ids or logprobs."
-                )
-            log_probs = logprobs_block["content"]
-            generation_log_probs = [log_prob["logprob"] for log_prob in log_probs]
-
-            """
-            START TODO remove this when NeMo RL upgrades to vLLM 0.10.2 support for prompt token ids
-            """
-            # Looks like `"token_id:151667"`
-            generation_token_ids = [log_prob["token"].removeprefix("token_id:") for log_prob in log_probs]
-
-            # The tokenize endpoint doesn't accept any sampling parameters
-            # The only relevant params are model, messages, and tools.
-            #
-            # IMPORTANT: pass through chat-template knobs (e.g. enable_thinking)
-            # when tokenizing, otherwise `prompt_token_ids` (and therefore logged
-            # `prompt_str`) can be built with different chat template settings than
-            # the actual generation request.
-            tokenize_body_dict = dict()
-            for key in ("model", "messages", "tools", "chat_template_kwargs"):
-                if key in body_dict:
-                    tokenize_body_dict[key] = body_dict[key]
-
-            # The base url has /v1 at the end but vLLM's tokenize endpoint does not have v1, hence the ..
-            tokenize_response = await client.create_tokenize(**tokenize_body_dict)
-            """
-            END
-            """
-
+        if self.config.return_token_id_information:
             message_dict = choice_dict["message"]
-            message_dict.update(
-                dict(
-                    # TODO add this when NeMo RL upgrades to vLLM 0.10.2 support for prompt token ids
-                    # prompt_token_ids=chat_completion_dict["prompt_token_ids"],
-                    prompt_token_ids=tokenize_response["tokens"],
-                    # generation_token_ids=choice_dict["token_ids"],
-                    generation_token_ids=generation_token_ids,
-                    generation_log_probs=generation_log_probs,
-                )
-            )
+            message_bundle = self._extract_message_token_bundle(message_dict)
+            standard_ids = self._extract_standard_vllm_ids(chat_completion_dict, choice_dict)
 
-            # Clean the duplicated information
-            choice_dict.pop("logprobs")
-            # TODO add this when NeMo RL upgrades to vLLM 0.10.2 support for prompt token ids
-            # chat_completion_dict.pop("prompt_token_ids")
-            # choice_dict.pop("token_ids")
+            if message_bundle is not None:
+                if standard_ids is not None:
+                    standard_prompt_ids, standard_generation_ids = standard_ids
+                    if (
+                        message_bundle["prompt_token_ids"] != standard_prompt_ids
+                        or message_bundle["generation_token_ids"] != standard_generation_ids
+                    ):
+                        raise RuntimeError("Message-level token metadata disagrees with standard vLLM token IDs.")
+                message_dict.update(message_bundle)
+            else:
+                logprob_token_ids, generation_log_probs = self._extract_choice_logprobs(choice_dict)
+                if standard_ids is not None:
+                    prompt_token_ids, generation_token_ids = standard_ids
+                    if generation_token_ids != logprob_token_ids:
+                        raise RuntimeError(
+                            "Standard vLLM generation token IDs disagree with choice logprob token IDs."
+                        )
+                else:
+                    tokenize_response = await client.create_tokenize(**self._get_tokenize_chat_body(body_dict))
+                    prompt_token_ids = self._coerce_token_ids(
+                        tokenize_response.get("tokens"),
+                        "tokenize.tokens",
+                    )
+                    generation_token_ids = logprob_token_ids
+
+                message_dict.update(
+                    self._validate_token_bundle(
+                        {
+                            "prompt_token_ids": prompt_token_ids,
+                            "generation_token_ids": generation_token_ids,
+                            "generation_log_probs": generation_log_probs,
+                            **(
+                                {"routed_experts": message_dict["routed_experts"]}
+                                if message_dict.get("routed_experts") is not None
+                                else {}
+                            ),
+                        },
+                        "vLLM token transport",
+                    )
+                )
+
+                # The adapter consumed this compatibility payload.
+                choice_dict.pop("logprobs", None)
+
+            # Standard token-ID fields are transport details.
+            chat_completion_dict.pop("prompt_token_ids", None)
+            choice_dict.pop("token_ids", None)
 
         return NeMoGymChatCompletion.model_validate(chat_completion_dict)
 
@@ -841,6 +971,7 @@ class VLLMModel(SimpleResponsesAPIModel):
             prompt = self._render_messages_to_prompt(messages)
 
         completion_body = self._build_completion_body_from_chat_body(body_dict, prompt)
+        self._validate_single_choice_token_request(completion_body)
 
         client = self._resolve_client(request)
 

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -605,9 +605,6 @@ class VLLMModel(SimpleResponsesAPIModel):
                 top_logprobs=0,
                 # Typically passed via OpenAI client extra_body.
                 return_tokens_as_token_ids=True,
-                # Standard vLLM returns exact prompt and generation IDs in the
-                # same response when this extension is enabled.
-                return_token_ids=True,
             )
 
         if self.config.uses_reasoning_parser and not self.config.preserve_reasoning_in_assistant_content:

--- a/responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
+++ b/responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
@@ -6,4 +6,6 @@ policy_model:
       api_key: ${policy_api_key}
       model: ${policy_model_name}
       return_token_id_information: true
+      # Enable this for endpoints that return prompt and generation token IDs inline.
+      request_prompt_and_generation_token_ids: false
       uses_reasoning_parser: true

--- a/responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
+++ b/responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
@@ -6,6 +6,5 @@ policy_model:
       api_key: ${policy_api_key}
       model: ${policy_model_name}
       return_token_id_information: true
-      # Enable this for endpoints that return prompt and generation token IDs inline.
       request_prompt_and_generation_token_ids: false
       uses_reasoning_parser: true

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -4745,7 +4745,7 @@ class TestTopLogprobsHandling:
         assert message["generation_log_probs"] == [-0.1, -0.2]
         assert message["prompt_token_ids"] == [10, 20, 30]
 
-    def test_capture_path_prefers_standard_inline_token_ids(self) -> None:
+    def test_capture_path_prefers_vllm_response_token_ids(self) -> None:
         model = _make_top_logprobs_model(
             return_token_id_information=True,
             request_prompt_and_generation_token_ids=True,
@@ -4842,7 +4842,7 @@ class TestTopLogprobsHandling:
         mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
         model._clients = [mock_client]
 
-        with raises(RuntimeError, match="disagrees with standard vLLM token IDs"):
+        with raises(RuntimeError, match="disagrees with vLLM response token IDs"):
             TestClient(app).post(
                 "/v1/chat/completions",
                 json={"messages": [{"role": "user", "content": "hi"}]},

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -4564,6 +4564,7 @@ def _make_top_logprobs_model(
     return_token_id_information: bool,
     *,
     extra_body: dict[str, Any] | None = None,
+    request_prompt_and_generation_token_ids: bool = False,
 ) -> VLLMModel:
     """A VLLMModel with the minimum config needed to exercise top_logprobs handling."""
     config = VLLMModelConfig(
@@ -4575,6 +4576,7 @@ def _make_top_logprobs_model(
         api_key="dummy_key",  # pragma: allowlist secret
         model="dummy_model",
         return_token_id_information=return_token_id_information,
+        request_prompt_and_generation_token_ids=request_prompt_and_generation_token_ids,
         uses_reasoning_parser=False,
         uses_interleaved_reasoning=False,
         extra_body=extra_body,
@@ -4610,6 +4612,19 @@ class TestTopLogprobsHandling:
             {"model": "dummy_model", "messages": [{"role": "user", "content": "hi"}], "top_logprobs": 5},
         )
         assert result["top_logprobs"] == 0
+
+    def test_capture_path_can_request_prompt_and_generation_token_ids(self) -> None:
+        model = _make_top_logprobs_model(
+            return_token_id_information=True,
+            request_prompt_and_generation_token_ids=True,
+        )
+
+        result = model._preprocess_chat_completion_create_params(
+            MagicMock(),
+            {"model": "dummy_model", "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert result["return_token_ids"] is True
 
     def test_capture_path_rejects_multiple_choices(self) -> None:
         model = _make_top_logprobs_model(return_token_id_information=True)
@@ -4731,11 +4746,14 @@ class TestTopLogprobsHandling:
         assert message["prompt_token_ids"] == [10, 20, 30]
 
     def test_capture_path_prefers_standard_inline_token_ids(self) -> None:
-        model = _make_top_logprobs_model(return_token_id_information=True)
+        model = _make_top_logprobs_model(
+            return_token_id_information=True,
+            request_prompt_and_generation_token_ids=True,
+        )
         app = model.setup_webserver()
 
         async def mock_create_chat_completion(**kwargs):
-            assert "return_token_ids" not in kwargs
+            assert kwargs["return_token_ids"] is True
             return self._capture_chat_completion_dict(
                 logprobs={
                     "content": [

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -4602,7 +4602,7 @@ class TestTopLogprobsHandling:
         assert result["top_logprobs"] == 0
         assert result["logprobs"] is True
         assert result["return_tokens_as_token_ids"] is True
-        assert result["return_token_ids"] is True
+        assert "return_token_ids" not in result
 
         # Inbound non-zero value must also be overridden, not inherited.
         result = model._preprocess_chat_completion_create_params(
@@ -4735,7 +4735,7 @@ class TestTopLogprobsHandling:
         app = model.setup_webserver()
 
         async def mock_create_chat_completion(**kwargs):
-            assert kwargs["return_token_ids"] is True
+            assert "return_token_ids" not in kwargs
             return self._capture_chat_completion_dict(
                 logprobs={
                     "content": [

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -4560,7 +4560,11 @@ class TestCompletionsBackendChatTemplateRender:
         assert "<|user|>hi" in captured["kwargs"]["prompt"]
 
 
-def _make_top_logprobs_model(return_token_id_information: bool) -> VLLMModel:
+def _make_top_logprobs_model(
+    return_token_id_information: bool,
+    *,
+    extra_body: dict[str, Any] | None = None,
+) -> VLLMModel:
     """A VLLMModel with the minimum config needed to exercise top_logprobs handling."""
     config = VLLMModelConfig(
         host="0.0.0.0",
@@ -4573,6 +4577,7 @@ def _make_top_logprobs_model(return_token_id_information: bool) -> VLLMModel:
         return_token_id_information=return_token_id_information,
         uses_reasoning_parser=False,
         uses_interleaved_reasoning=False,
+        extra_body=extra_body,
     )
     return VLLMModel(config=config, server_client=MagicMock(spec=ServerClient, global_config_dict={}))
 
@@ -4597,6 +4602,7 @@ class TestTopLogprobsHandling:
         assert result["top_logprobs"] == 0
         assert result["logprobs"] is True
         assert result["return_tokens_as_token_ids"] is True
+        assert result["return_token_ids"] is True
 
         # Inbound non-zero value must also be overridden, not inherited.
         result = model._preprocess_chat_completion_create_params(
@@ -4604,6 +4610,19 @@ class TestTopLogprobsHandling:
             {"model": "dummy_model", "messages": [{"role": "user", "content": "hi"}], "top_logprobs": 5},
         )
         assert result["top_logprobs"] == 0
+
+    def test_capture_path_rejects_multiple_choices(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+
+        with raises(ValueError, match="requires n=1"):
+            model._preprocess_chat_completion_create_params(
+                MagicMock(),
+                {
+                    "model": "dummy_model",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "n": 2,
+                },
+            )
 
     def test_noncapture_path_strips_null_top_logprobs(self) -> None:
         """On the non-capture path a null top_logprobs is dropped (letting vLLM apply its
@@ -4641,25 +4660,33 @@ class TestTopLogprobsHandling:
         assert "top_logprobs" not in result
 
     def _capture_chat_completion_dict(
-        self, logprobs: Union[dict, None], message_extra: Union[dict, None] = None
+        self,
+        logprobs: Union[dict, None],
+        message_extra: Union[dict, None] = None,
+        choice_extra: Union[dict, None] = None,
+        response_extra: Union[dict, None] = None,
     ) -> dict:
         message = {"role": "assistant", "content": "hi", "tool_calls": None}
         if message_extra:
             message.update(message_extra)
-        return {
+        choice = {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": message,
+            "logprobs": logprobs,
+        }
+        if choice_extra:
+            choice.update(choice_extra)
+        response = {
             "id": "chtcmpl",
             "object": "chat.completion",
             "created": FIXED_TIME,
             "model": "dummy_model",
-            "choices": [
-                {
-                    "index": 0,
-                    "finish_reason": "stop",
-                    "message": message,
-                    "logprobs": logprobs,
-                }
-            ],
+            "choices": [choice],
         }
+        if response_extra:
+            response.update(response_extra)
+        return response
 
     def test_capture_path_succeeds_with_inbound_null_top_logprobs(self) -> None:
         """End-to-end regression: a request with top_logprobs=null no longer empties capture;
@@ -4702,6 +4729,187 @@ class TestTopLogprobsHandling:
         assert message["generation_token_ids"] == [123, 456]
         assert message["generation_log_probs"] == [-0.1, -0.2]
         assert message["prompt_token_ids"] == [10, 20, 30]
+
+    def test_capture_path_prefers_standard_inline_token_ids(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            assert kwargs["return_token_ids"] is True
+            return self._capture_chat_completion_dict(
+                logprobs={
+                    "content": [
+                        {"token": "token_id:123", "logprob": -0.1, "bytes": None, "top_logprobs": []},
+                        {"token": "token_id:456", "logprob": -0.2, "bytes": None, "top_logprobs": []},
+                    ]
+                },
+                choice_extra={"token_ids": [123, 456]},
+                response_extra={"prompt_token_ids": [10, 20, 30]},
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock(
+            side_effect=AssertionError("create_tokenize must not be called when inline IDs are present")
+        )
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        mock_client.create_tokenize.assert_not_awaited()
+        data = response.json()
+        message = data["choices"][0]["message"]
+        assert message["prompt_token_ids"] == [10, 20, 30]
+        assert message["generation_token_ids"] == [123, 456]
+        assert message["generation_log_probs"] == [-0.1, -0.2]
+        assert "prompt_token_ids" not in data
+        assert "token_ids" not in data["choices"][0]
+
+    def test_capture_path_accepts_framework_message_bundle(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+        token_bundle = {
+            "prompt_token_ids": [10, 20],
+            "generation_token_ids": [123],
+            "generation_log_probs": [-0.1],
+        }
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                message_extra=token_bundle,
+                choice_extra={"token_ids": [123]},
+                response_extra={"prompt_token_ids": [10, 20]},
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock(
+            side_effect=AssertionError("create_tokenize must not be called for a framework token bundle")
+        )
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        message = response.json()["choices"][0]["message"]
+        for field, value in token_bundle.items():
+            assert message[field] == value
+        mock_client.create_tokenize.assert_not_awaited()
+
+    def test_capture_path_rejects_disagreeing_duplicate_ids(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                message_extra={
+                    "prompt_token_ids": [10, 20],
+                    "generation_token_ids": [123],
+                    "generation_log_probs": [-0.1],
+                },
+                choice_extra={"token_ids": [999]},
+                response_extra={"prompt_token_ids": [10, 20]},
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        model._clients = [mock_client]
+
+        with raises(RuntimeError, match="disagrees with standard vLLM token IDs"):
+            TestClient(app).post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+
+    def test_capture_path_forwards_prompt_affecting_fields_to_tokenize(self) -> None:
+        model = _make_top_logprobs_model(
+            return_token_id_information=True,
+            extra_body={
+                "mm_processor_kwargs": {"fps": 2},
+                "required_prefix_token_ids": [1, 2, 3],
+            },
+        )
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs={
+                    "content": [
+                        {"token": "token_id:123", "logprob": -0.1, "bytes": None, "top_logprobs": []},
+                    ]
+                }
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock(return_value={"tokens": [10, 20]})
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        mock_client.create_tokenize.assert_awaited_once_with(
+            model="dummy_model",
+            messages=[{"role": "user", "content": "hi"}],
+            mm_processor_kwargs={"fps": 2},
+            required_prefix_token_ids=[1, 2, 3],
+        )
+
+    def test_capture_path_rejects_partial_message_bundle(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                message_extra={"prompt_token_ids": [10, 20]},
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        model._clients = [mock_client]
+
+        with raises(RuntimeError, match="partial token metadata"):
+            TestClient(app).post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+
+    def test_capture_path_rejects_mismatched_generation_lengths(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                message_extra={
+                    "prompt_token_ids": [10, 20],
+                    "generation_token_ids": [123, 456],
+                    "generation_log_probs": [-0.1],
+                },
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        model._clients = [mock_client]
+
+        with raises(RuntimeError, match="mismatched generation token IDs"):
+            TestClient(app).post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
 
     def test_capture_path_preserves_routed_experts(self) -> None:
         model = _make_top_logprobs_model(return_token_id_information=True)


### PR DESCRIPTION
## Summary

- Consume a complete token bundle from `choice.message` without making a second `/tokenize` request.
- Support opt-in vLLM response token IDs for endpoints that return top-level `prompt_token_ids` and choice-level `token_ids`.
- Retain `/tokenize` for integrations that return neither inline representation.
- Reject partial or conflicting sources. Token capture supports one completion choice per request (`n` omitted or set to `1`).

## Why

Gym needs the prompt token IDs, generated token IDs, and selected-token log probabilities used during generation. The previous adapter reconstructed prompt IDs through a second awaited `/tokenize` request. That request adds inter-turn latency and can reproduce a different prompt when prompt-affecting inputs are omitted.

NeMo RL [#3390](https://github.com/NVIDIA-NeMo/RL/pull/3390) attaches the token bundle to the assistant message. Gym reads that bundle directly and does not request duplicate response-level IDs by default.

Gym cannot require that message shape from every training integration. Other integrations, including Verl, can request vLLM's response token IDs or continue using the compatibility fallback.

## Source precedence

1. A complete token bundle on `choice.message`.
2. Top-level `prompt_token_ids`, choice-level `token_ids`, and `choice.logprobs` from the vLLM response.
3. Generation metadata from `choice.logprobs` and prompt IDs from `/tokenize`.

`request_prompt_and_generation_token_ids: true` enables the second source by sending `return_token_ids=true` to compatible vLLM endpoints. The option defaults to `false`. If both inline sources are present, their token IDs must agree. The selected training message is validated once to avoid repeated list scans and copies at long sequence lengths.

The fallback forwards `model`, `messages`, `tools`, `chat_template_kwargs`, `mm_processor_kwargs`, and `required_prefix_token_ids`. This keeps fallback tokenization aligned with the generation prompt.

`prompt_logprobs` is not requested. vLLM returns prompt IDs independently when `return_token_ids` is enabled, and Gym does not consume prompt-token log probabilities.

## Related work

- Gym [#700](https://github.com/NVIDIA-NeMo/Gym/pull/700) is superseded by this change.
- Gym [#2576](https://github.com/NVIDIA-NeMo/Gym/pull/2576) is superseded by this change.
- NeMo RL [#3390](https://github.com/NVIDIA-NeMo/RL/pull/3390) produces the message-level token bundle consumed by the first source.
- NeMo RL [#3581](https://github.com/NVIDIA-NeMo/RL/pull/3581) reuses replayed token metadata across turns.
- Gym [#1784](https://github.com/NVIDIA-NeMo/Gym/pull/1784) can add the Dynamo `nvext.engine_data` source independently.
- Gym [#2324](https://github.com/NVIDIA-NeMo/Gym/pull/2324) can retain its video-specific schema, conversion, and adapter behavior independently.