### PR TITLE
fix(longmt_eval): use valid 'Apache 2.0' license literal

### DIFF
--- a/resources_servers/longmt_eval/configs/longmt_eval.yaml
+++ b/resources_servers/longmt_eval/configs/longmt_eval.yaml
@@ -28,4 +28,4 @@ longmt_eval_simple_agent:
         type: example
         jsonl_fpath: resources_servers/longmt_eval/data/example.jsonl
         num_repeats: 1
-        license: Apache-2.0
+        license: Apache 2.0

--- a/resources_servers/longmt_eval/configs/longmt_pg19.yaml
+++ b/resources_servers/longmt_eval/configs/longmt_pg19.yaml
@@ -30,4 +30,4 @@ longmt_pg19_simple_agent:
         type: example
         jsonl_fpath: resources_servers/longmt_eval/data/example.jsonl
         num_repeats: 1
-        license: Apache-2.0
+        license: Apache 2.0


### PR DESCRIPTION
## What

`resources_servers/longmt_eval/configs/longmt_eval.yaml` and `longmt_pg19.yaml` set
`license: Apache-2.0` (hyphen). That is **not** a valid `DatasetConfig.license` literal — the
allowed value is `Apache 2.0` (with a space), which the sibling `longmt_wmt24pp.yaml` already
uses correctly. This aligns all three configs.

Loading either of the two affected configs through `get_global_config_dict()` currently raises
a pydantic `ValidationError`:

```
'Apache 2.0':  OK
'Apache-2.0':  REJECTED (ValidationError)
```

## ⚠️ This does not fully green the `longmt_eval` data-validation CI

While investigating the `Test` job failure that shows up on every open PR, I found **two**
separate issues in `longmt_eval` (added in #1458):

1. **This PR** — the invalid `Apache-2.0` license literal (a latent config-parse bug).
2. **Still outstanding** — the `Test` job's data validation (`_validate_data_single` in `cli.py`)
   requires `resources_servers/longmt_eval/data/example_metrics.json`, but the server only ships
   `example_rollouts_agent_metrics.json`. The missing file is what actually reds the `Test` job
   for **all** PRs (it validates all 114 servers), e.g. on #1561.

@jeffwillette — could you regenerate and commit `data/example_metrics.json` for `longmt_eval`?
It comes from:

```bash
ng_prepare_data "+config_paths=[resources_servers/longmt_eval/configs/longmt_eval.yaml]" \
    +output_dirpath=data/longmt_eval \
    +mode=example_validation
```

That step needs the server's GPU/SEGALE/COMET environment, which is why it's best done on your
side. Happy to fold it into this PR or you can land it separately — whichever is easier.

## Testing

`Apache 2.0` validates against `DatasetConfig`; pre-commit clean (verified-flag + README hooks
pass with no changes).