### PR TITLE
docs(fern): add SEO meta descriptions + headlines to nightly docs (#1589)

### DIFF
--- a/fern/versions/latest/pages/about/concepts/key-terminology.mdx
+++ b/fern/versions/latest/pages/about/concepts/key-terminology.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Key Terminology"
-description: ""
+headline: "NeMo Gym Glossary: RL & Training Terminology"
+description: "Definitions of NeMo Gym terms for RL and model training, including rollouts, trajectories, environments, tasks, verifiers, SFT, DPO, GRPO, and the Responses API."
 ---
 Essential vocabulary for model training, RL workflows, and NeMo Gym. This glossary defines terms you'll encounter throughout the tutorials and documentation.
 

--- a/fern/versions/latest/pages/about/concepts/training.mdx
+++ b/fern/versions/latest/pages/about/concepts/training.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Training"
-description: "Post-training techniques and how environments are used for training."
+headline: "Training Models with Environments: SFT, RL, GRPO"
+description: "Compare post-training techniques (SFT, RL, GRPO, DAPO, GSPO) and learn how NeMo Gym environments act as RL reward signals and synthetic data generators."
 position: 1.7
 ---
 

--- a/fern/versions/latest/pages/about/ecosystem.mdx
+++ b/fern/versions/latest/pages/about/ecosystem.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Ecosystem"
-description: ""
+headline: "NeMo Gym Ecosystem Integrations"
+description: "Explore NeMo Gym integrations: environment libraries like Aviary and Verifiers, training frameworks NeMo RL, Unsloth, and VeRL, and agent harnesses."
 position: 3
 ---
 NeMo Gym is integrated with the broader agentic ecosystem. We would love your contribution! Open a PR to add an integration, or [file an issue](https://github.com/NVIDIA-NeMo/Gym/issues/new/choose) to share what would be valuable for you.

--- a/fern/versions/latest/pages/about/release-notes.mdx
+++ b/fern/versions/latest/pages/about/release-notes.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Release Notes"
-description: ""
+headline: "NeMo Gym Release Notes & Changelog by Version"
+description: "Browse NeMo Gym release notes by version, from v0.3.0 back to v0.1.1, covering new environments, agent harnesses, integrations, bug fixes, and deprecations."
 position: 4
 ---
 

--- a/fern/versions/latest/pages/agent-server/index.mdx
+++ b/fern/versions/latest/pages/agent-server/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent Server"
-description: ""
+description: "The NeMo Gym Agent server orchestrates rollouts: it runs the agent loop, calls the Model server, routes tool calls to Resources, and collects the final reward."
 position: 1
 ---
 The Agent server is the central component of environment design. It defines whether a rollout is single-step or multi-step, single-turn or multi-turn, and orchestrates all interaction logic — calling the model, executing tool calls through resources, and collecting the final reward. The Agent server does not run an LLM itself, it is orchestration code that delegates all text generation to the Model server.

--- a/fern/versions/latest/pages/api-reference/index.mdx
+++ b/fern/versions/latest/pages/api-reference/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "API Reference"
-description: "Auto-generated Python API reference for the nemo_gym library."
+headline: "nemo_gym Python API Reference: Modules, Classes, Functions"
+description: "Browse the auto-generated nemo_gym Python API reference, built from source docstrings, covering base server classes, config types, and server utilities."
 ---
 
 Auto-generated reference documentation for the `nemo_gym` Python package.

--- a/fern/versions/latest/pages/contribute/development-setup.mdx
+++ b/fern/versions/latest/pages/contribute/development-setup.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Development Setup"
-description: ""
+headline: "NeMo Gym Development Setup and Contributor Guide"
+description: "Set up a NeMo Gym dev environment with uv and pre-commit, run tests, configure DCO commit signing, and fix common CI and contribution issues."
 position: 2
 ---
 This guide covers everything you need to set up your development environment and submit contributions to NeMo Gym.

--- a/fern/versions/latest/pages/contribute/environments/index.mdx
+++ b/fern/versions/latest/pages/contribute/environments/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Environments"
-description: ""
+headline: "Contribute Environments to NeMo Gym"
+description: "Start contributing new RL training environments to NeMo Gym, with a guide for adding your own novel environments to benefit the wider community."
 position: 3
 ---
 Help advance RL training for the community by contributing new environments. There are several ways to get involved:

--- a/fern/versions/latest/pages/contribute/environments/new-environment.mdx
+++ b/fern/versions/latest/pages/contribute/environments/new-environment.mdx
@@ -1,6 +1,7 @@
 ---
 title: "New Environment"
-description: ""
+headline: "Contribute a New NeMo Gym Training Environment / Server"
+description: "Contribute a new NeMo Gym training environment: curate tasks, build a resources server, test, reward profile, validate with GRPO, and submit your PR."
 ---
 An environment consists of three components: Agents, Models, and Resources. Most contributors will create new resources servers while using existing agent server and model server implementations. If you need to create custom agents or models, you can reference the implementations in `responses_api_agents/` and `responses_api_models/`.
 

--- a/fern/versions/latest/pages/contribute/index.mdx
+++ b/fern/versions/latest/pages/contribute/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Overview"
-description: ""
+headline: "Contribute to NeMo Gym: Environments, RL Frameworks, Docs"
+description: "Ways to contribute to NeMo Gym: add training environments and benchmarks, integrate RL frameworks, improve docs, and report or fix bugs, plus signing requirements."
 position: 1
 ---
 Welcome! We are excited to have you contribute to NeMo Gym. Whether you are adding new training environments, integrating RL frameworks, improving documentation, or fixing bugs, your contributions help advance RL training.

--- a/fern/versions/latest/pages/contribute/rl-framework-integration/generation-backend-and-openai-compatible-http-server.mdx
+++ b/fern/versions/latest/pages/contribute/rl-framework-integration/generation-backend-and-openai-compatible-http-server.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Generation Backend"
-description: ""
+description: "Expose an OpenAI-compatible HTTP server for Gym RL training generation, with reference vLLM and SGLang implementations from NeMo RL, VeRL, TRL, Slime, and ART."
 ---
 Gym requires an OpenAI-compatible HTTP server to handle model generations during training. This page covers the server requirements and existing implementations across popular RL frameworks.
 

--- a/fern/versions/latest/pages/contribute/rl-framework-integration/gym-integration-footprint-and-form-factor.mdx
+++ b/fern/versions/latest/pages/contribute/rl-framework-integration/gym-integration-footprint-and-form-factor.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Integration Footprint"
-description: ""
+description: "Reference for the five components required to integrate NeMo Gym into your RL training framework, with NeMo RL reference implementations, tests, and a checklist."
 ---
 This page provides a reference for the components required to integrate Gym into your training framework. Each component includes links to the NeMo RL reference implementation and corresponding tests.
 

--- a/fern/versions/latest/pages/contribute/rl-framework-integration/gym-rl-framework-integration-success-criteria.mdx
+++ b/fern/versions/latest/pages/contribute/rl-framework-integration/gym-rl-framework-integration-success-criteria.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Success Criteria"
-description: ""
+headline: "Validate Your Gym RL Framework Integration"
+description: "Validate your RL framework integration with Gym by checking required components and training Qwen3-4B on the DAPO17k math and workplace assistant benchmarks."
 ---
 Use these criteria to validate that your Gym integration is working correctly. A successful integration must pass all validation benchmarks.
 

--- a/fern/versions/latest/pages/contribute/rl-framework-integration/index.mdx
+++ b/fern/versions/latest/pages/contribute/rl-framework-integration/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Integrate RL Frameworks"
-description: ""
+description: "Add NeMo Gym support to your RL training framework: wire up an OpenAI-compatible generation backend, on-policy corrections, the integration, and validation."
 position: 4
 ---
 These guides cover how to integrate NeMo Gym into a new RL training framework. Use them if you are:

--- a/fern/versions/latest/pages/contribute/rl-framework-integration/openai-compatible-http-server-on-policy-correction.mdx
+++ b/fern/versions/latest/pages/contribute/rl-framework-integration/openai-compatible-http-server-on-policy-correction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "On-Policy Corrections"
-description: ""
+description: "Why OpenAI-compatible HTTP servers cause train-generation logprob mismatch in multi-turn RL rollouts, and the token ID fixes that keep training on-policy."
 ---
 When using an OpenAI-compatible HTTP server for RL training, fundamental issues arise in **multi-step** and **multi-turn** scenarios. This page explains these problems and the corrections required for on-policy training.
 

--- a/fern/versions/latest/pages/data/download-huggingface.mdx
+++ b/fern/versions/latest/pages/data/download-huggingface.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Download from Hugging Face"
-description: ""
+description: "Download Hugging Face Hub datasets as JSONL for NeMo Gym training with ng_download_dataset_from_hf, covering structured, raw-file, and private-repo modes."
 position: 3
 ---
 Download JSONL datasets from Hugging Face Hub for NeMo Gym training.

--- a/fern/versions/latest/pages/data/index.mdx
+++ b/fern/versions/latest/pages/data/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Data"
-description: ""
+headline: "NeMo Gym JSONL Dataset Format and Fields for RL Training"
+description: "Build NeMo Gym JSONL datasets for RL training: the required responses_create_params and agent_ref fields, dataset types, YAML config, and ng_prepare_data."
 position: 1
 ---
 NeMo Gym datasets use JSONL format for reinforcement learning (RL) training. Each dataset connects to an **agent server** (orchestrates agent-environment interactions) which routes requests to a **resources server** (provides tools and computes rewards).

--- a/fern/versions/latest/pages/data/prepare-validate.mdx
+++ b/fern/versions/latest/pages/data/prepare-validate.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Prepare and Validate"
-description: ""
+headline: "Prepare and Validate JSONL Datasets with ng_prepare_data"
+description: "Use ng_prepare_data to validate JSONL datasets against the Responses API format, generate train and validation splits, and compute dataset metrics."
 position: 2
 ---
 Format and validate JSONL datasets for NeMo Gym training using `ng_prepare_data`.

--- a/fern/versions/latest/pages/data/prompt-config.mdx
+++ b/fern/versions/latest/pages/data/prompt-config.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Prompt Config"
-description: ""
+description: "Use YAML prompt configs to build responses_create_params.input from raw JSONL fields at rollout time, enabling prompt sweeps without re-preparing data."
 position: 4
 ---
 Apply YAML-based prompt templates at rollout time to build `responses_create_params.input` on the fly. This enables prompt sweeps without re-preparing JSONL data.

--- a/fern/versions/latest/pages/environment-tutorials/adding-a-benchmark.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/adding-a-benchmark.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Add a benchmark"
-description: ""
+description: "Add a benchmark to NeMo Gym with fidelity: reward-profile against open and closed models, analyze failure cases, reproduce original scores, and reduce variance."
 position: 7
 ---
 The most important principle when adding benchmarks into NeMo Gym is ensuring the fidelity of the benchmark. As a result, there are additional steps and best practices to adding a benchmark that are required on top of adding just a training environment (although the steps below are still suggested for training environments).

--- a/fern/versions/latest/pages/environment-tutorials/aggregate-metrics.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/aggregate-metrics.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Aggregate Metrics"
-description: ""
+description: "Compute aggregate metrics across rollouts per agent in NeMo Gym, write per-agent stats to an _aggregate_metrics.json file, and add custom metrics like pass@k."
 position: 9
 ---
 After rollout collection, NeMo Gym computes **aggregate metrics** for each agent by calling the `/aggregate_metrics` endpoint on the agent server. The results are written to a single `_aggregate_metrics.json` file.

--- a/fern/versions/latest/pages/environment-tutorials/index.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/index.mdx
@@ -1,7 +1,8 @@
 ---
 title: "Overview"
+headline: "Build Custom NeMo Gym Training & Eval Environments"
 subtitle: "Build your own custom environment"
-description: ""
+description: "Build custom NeMo Gym environments through tutorials covering single-step, multi-step, stateful, and real-world patterns, verification, benchmarks, and metrics."
 position: 1
 ---
 Learn how to build custom environments for training or evaluation using NeMo Gym.

--- a/fern/versions/latest/pages/environment-tutorials/integrate-external-environments.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/integrate-external-environments.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Integrate external libraries"
-description: ""
+description: "Wrap a third-party benchmark, agent, or training library inside a NeMo Gym agent server's /run endpoint, with token ID passthrough for training."
 position: 6
 ---
 Fundamentally, a training environment in NeMo Gym is some Python logic that performs a sequence or graph of model calls and tool calls. For native NeMo Gym environments, all of the model and tool calls are present within an agent server like [`simple_agent`](https://github.com/NVIDIA-NeMo/Gym/blob/main/responses_api_agents/simple_agent/app.py). For environments that we consider "external", the orchestration of model and tool calls is offloaded to a third-party library rather than implemented within NeMo Gym itself.

--- a/fern/versions/latest/pages/environment-tutorials/multi-step-environment.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/multi-step-environment.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multi-Step Environment"
-description: ""
+description: "Build a NeMo Gym Resources Server for a multi-step tool-calling environment, where the agent chains sequential tool calls and verify() grades the result."
 position: 3
 ---
 import { NavButton } from "../../../../components/NavButton";

--- a/fern/versions/latest/pages/environment-tutorials/real-world-environment/generating-training-data.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/real-world-environment/generating-training-data.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Generating Training Data"
-description: ""
+description: "Generate synthetic multi-step user queries for the Workplace Assistant environment with NeMo Data Designer, then filter and export them as NeMo Gym task JSONL."
 position: 1
 ---
 import { NavButton } from "../../../../../components/NavButton";

--- a/fern/versions/latest/pages/environment-tutorials/real-world-environment/index.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/real-world-environment/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Real-World Environment"
-description: ""
+description: "Build the Workplace Assistant environment: an office simulation with email, calendar, analytics, project, and CRM tools graded by state-based verification."
 position: 5
 ---
 import { NavButton } from "../../../../../components/NavButton";

--- a/fern/versions/latest/pages/environment-tutorials/real-world-environment/resources-server-implementation.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/real-world-environment/resources-server-implementation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Resources Server Implementation"
-description: ""
+description: "Build the Workplace Assistant Resources Server with dynamic tool routing, per-session toolkit state, and state-matching verification that replays tool calls."
 position: 2
 ---
 import { NavButton } from "../../../../../components/NavButton";

--- a/fern/versions/latest/pages/environment-tutorials/single-step-environment.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/single-step-environment.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Single-Step Environment"
-description: ""
+description: "Build a single-step tool-calling environment in NeMo Gym: scaffold a resources server, prepare JSONL tasks, write a verify() reward, test, and collect rollouts."
 position: 2
 ---
 import { NavButton } from "../../../../components/NavButton";

--- a/fern/versions/latest/pages/environment-tutorials/stateful-environment.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/stateful-environment.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Stateful Environment"
-description: ""
+description: "Build a NeMo Gym Resources Server that keeps per-episode state across tool calls, using session middleware and SESSION_ID_KEY to store state by session ID."
 position: 4
 ---
 import { NavButton } from "../../../../components/NavButton";

--- a/fern/versions/latest/pages/environment-tutorials/verification-patterns/index.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/verification-patterns/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Verification Patterns"
-description: "Patterns for evaluating agent behavior and computing scores."
+description: "Choose a verification pattern to score agent behavior in your environment: equivalence match, execution and state match, LLM-as-judge, or reward model."
 position: 8
 ---
 

--- a/fern/versions/latest/pages/get-started/installation.mdx
+++ b/fern/versions/latest/pages/get-started/installation.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Installation"
-description: "Install NeMo Gym and verify your setup."
+headline: "Install NeMo Gym from Git or the NGC Container"
+description: "Install NeMo Gym from a Git clone with uv on Python 3.12, or pull the NGC container for NeMo RL, then verify the setup with ng_version."
 position: 2
 ---
 

--- a/fern/versions/latest/pages/get-started/prerequisites.mdx
+++ b/fern/versions/latest/pages/get-started/prerequisites.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Prerequisites"
-description: "What you need to install and run NeMo Gym."
+headline: "NeMo Gym Prerequisites: Python, OS, and Hardware"
+description: "Check the hardware and software you need before installing NeMo Gym: Python 3.12+, uv, a supported Linux, macOS, or WSL2 OS, and 8 GB RAM."
 position: 1
 ---
 

--- a/fern/versions/latest/pages/get-started/quickstart.mdx
+++ b/fern/versions/latest/pages/get-started/quickstart.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Quickstart"
-description: "Run your first agent evaluation with NeMo Gym."
+headline: "NeMo Gym Quickstart: Run Your First Agent Evaluation"
+description: "Run your first NeMo Gym agent evaluation: configure a model in env.yaml, start the servers, score rollouts on the mcqa tasks, and list benchmarks."
 position: 3
 ---
 

--- a/fern/versions/latest/pages/infrastructure/deployment-topology.mdx
+++ b/fern/versions/latest/pages/infrastructure/deployment-topology.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Deployment Topology"
-description: ""
+description: "Deploy NeMo Gym alongside an RL training framework: compare single Ray cluster, own Ray cluster, and separate HTTP-connected cluster topologies."
 position: 2
 ---
 ## Training Framework Deployment

--- a/fern/versions/latest/pages/infrastructure/engineering-notes/aiohttp-vs-httpx.mdx
+++ b/fern/versions/latest/pages/infrastructure/engineering-notes/aiohttp-vs-httpx.mdx
@@ -1,6 +1,6 @@
 ---
 title: "aiohttp vs httpx"
-description: ""
+description: "Why NeMo Gym swapped its async HTTP backend from httpx to aiohttp: httpcore's O(n^2) connection pooling hung a 16,000-concurrent-request rollout run."
 ---
 TL;DR: httpx is O(n^2) runtime where n is the number of queued requests (that is, for each request, we check all other queued requests). This is terribly inefficient and results in major slowdowns.
 

--- a/fern/versions/latest/pages/infrastructure/engineering-notes/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/engineering-notes/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Engineering Notes"
-description: ""
+headline: "NeMo Gym Engineering Notes: Infrastructure & Design Decisions"
+description: "Read the technical notes behind NeMo Gym: system design, why it uses the Responses API and aiohttp, and the SWE RL infrastructure case study."
 position: 3
 ---
 Technical notes that document infrastructure decisions, performance investigations, and design rationale behind NeMo Gym.

--- a/fern/versions/latest/pages/infrastructure/engineering-notes/responses-api-evolution.mdx
+++ b/fern/versions/latest/pages/infrastructure/engineering-notes/responses-api-evolution.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Responses API"
-description: ""
+headline: "Why NeMo Gym Uses the OpenAI Responses API"
+description: "Learn why NeMo Gym adopts the OpenAI Responses API as its native schema, how it evolved from Completions and Chat Completions, and how the two schemas differ."
 ---
 This engineering note explains why NeMo Gym uses the OpenAI Responses API as its native schema and how it differs from the older Chat Completions API.
 

--- a/fern/versions/latest/pages/infrastructure/engineering-notes/swe-rl-case-study.mdx
+++ b/fern/versions/latest/pages/infrastructure/engineering-notes/swe-rl-case-study.mdx
@@ -1,6 +1,6 @@
 ---
 title: "SWE RL Case Study"
-description: ""
+description: "How we run SWE RL training in NeMo Gym: the Slurm, Ray, and Apptainer deployment topology, CPU resources per task instance, and long-horizon scaling challenges."
 ---
 This case study was written on February 13, 2026. The information below may be outdated.
 

--- a/fern/versions/latest/pages/infrastructure/engineering-notes/system-design.mdx
+++ b/fern/versions/latest/pages/infrastructure/engineering-notes/system-design.mdx
@@ -1,6 +1,7 @@
 ---
 title: "System Design"
-description: ""
+headline: "NeMo Gym System Design: Server Startup & Request Flow"
+description: "Trace how NeMo Gym starts up on ng_run and how its Model, Resources, and Agent servers communicate over HTTP during a rollout, plus shutdown and parallel collection."
 ---
 This section describes how NeMo Gym components interact during startup and execution. For an overview of the three server types (Model, Resources, Agent), see [Environment Components](/about/architecture).
 

--- a/fern/versions/latest/pages/infrastructure/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Infrastructure"
-description: ""
+headline: "NeMo Gym Infrastructure: Deployment & Cluster Planning"
+description: "Deploy NeMo Gym servers, plan cluster resources for training, and read engineering notes on the infrastructure decisions behind its design."
 position: 1
 ---
 Learn how to deploy NeMo Gym and plan cluster resources for training.

--- a/fern/versions/latest/pages/model-recipes/index.mdx
+++ b/fern/versions/latest/pages/model-recipes/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Model Recipes"
-description: ""
+description: "Model recipes that run Gym with the data recipes used to train models, including distributed Nemotron 3 Nano and Super training on Slurm and Ray."
 position: 1
 ---
 Model recipes are tutorials to run Gym with various data recipes that were used to train models.

--- a/fern/versions/latest/pages/model-recipes/nemotron-3-nano.mdx
+++ b/fern/versions/latest/pages/model-recipes/nemotron-3-nano.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Nemotron 3 Nano"
-description: ""
+description: "Train Nemotron 3 Nano 30B with GRPO across multiple Slurm nodes: set up NeMo RL, prepare data, launch a multi-node Ray job, and monitor it."
 position: 2
 ---
 This tutorial walks through the complete setup for distributed training of Nemotron 3 Nano 30B across multiple nodes using Slurm and Ray.

--- a/fern/versions/latest/pages/model-recipes/nemotron-3-super.mdx
+++ b/fern/versions/latest/pages/model-recipes/nemotron-3-super.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Nemotron 3 Super"
-description: ""
+description: "Train Nemotron 3 Super with NeMo Gym and NeMo RL: follow the linked NeMo RL guide, with steps that mirror the Nemotron 3 Nano recipe."
 position: 3
 ---
 The recipe for training Nemotron 3 Super with NeMo Gym and NeMo RL can be found in this [NeMo RL guide](https://github.com/NVIDIA-NeMo/RL/blob/super-v3/docs/guides/nemotron-3-super.md).

--- a/fern/versions/latest/pages/model-server/index.mdx
+++ b/fern/versions/latest/pages/model-server/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Model Server"
-description: ""
+description: "Model servers are stateless LLM inference endpoints in NeMo Gym that return the next output and expose OpenAI Responses and Chat Completions endpoints."
 position: 1
 ---
 Model servers are stateless LLM inference endpoints. They receive a conversation and return the model's next output (text, tool calls, or code) with no memory or orchestration logic. During training, you will typically have at least one active Model server: the "policy" model being trained.

--- a/fern/versions/latest/pages/model-server/vllm.mdx
+++ b/fern/versions/latest/pages/model-server/vllm.mdx
@@ -1,6 +1,7 @@
 ---
 title: "vLLM"
-description: ""
+headline: "vLLM Model Server: serve open models in NeMo Gym"
+description: "Serve open-source models with the NeMo Gym VLLMModel server, which wraps vLLM's Chat Completions endpoint and maps it to the native Responses API format."
 position: 2
 ---
 [vLLM](https://docs.vllm.ai/) is a popular LLM inference engine. The NeMo Gym VLLMModel server wraps vLLM's Chat Completions endpoint and converts requests and responses to NeMo Gym's native format, the OpenAI [Responses API](https://platform.openai.com/docs/api-reference/responses) schema.

--- a/fern/versions/latest/pages/reference/cli-commands.mdx
+++ b/fern/versions/latest/pages/reference/cli-commands.mdx
@@ -1,6 +1,6 @@
 ---
 title: "CLI Commands"
-description: ""
+description: "Reference for every NeMo Gym CLI command (ng_ short and nemo_gym_ full forms) to run servers, collect rollouts, prepare data, manage datasets, and check status."
 position: 3
 ---
 This page documents all available NeMo Gym CLI commands.

--- a/fern/versions/latest/pages/reference/configuration.mdx
+++ b/fern/versions/latest/pages/reference/configuration.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Configuration"
-description: ""
+headline: "NeMo Gym Configuration Reference: YAML Fields & ng_run"
+description: "Reference for NeMo Gym config files: server YAML structure, model, resources, and agent server fields, dataset and env.yaml settings, and ng_run usage."
 position: 1
 ---
 Complete syntax and field specifications for NeMo Gym configuration files.

--- a/fern/versions/latest/pages/reference/faq.mdx
+++ b/fern/versions/latest/pages/reference/faq.mdx
@@ -1,6 +1,7 @@
 ---
 title: "FAQ"
-description: ""
+headline: "NeMo Gym FAQ: datasets, data prep, profiling, Ray, training"
+description: "Answers for uploading and downloading Hugging Face datasets, preparing data with ng_prepare_data, profiling resources servers, using Ray, and SFT vs RL."
 position: 4
 ---
 <Note>

--- a/fern/versions/latest/pages/reference/index.mdx
+++ b/fern/versions/latest/pages/reference/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Reference"
-description: ""
+headline: "NeMo Gym Reference: Config, CLI, FAQ"
+description: "Look up NeMo Gym reference material: YAML configuration schema, CLI commands, the RL training framework compatibility matrix, and an FAQ for debugging."
 ---
 Quick lookup for configuration syntax, options, and specifications.
 

--- a/fern/versions/latest/pages/resources-server/index.mdx
+++ b/fern/versions/latest/pages/resources-server/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Resources Server"
-description: ""
+description: "The NeMo Gym Resources server defines an agent's task, tools, and per-session state, plus the verify() logic that scores rollouts and returns reward signals."
 position: 1
 ---
 The Resources server is the "world" the agent interacts with. It defines the task, the tools and actions available to the agent, and the verification logic that evaluates performance and returns reward signals for training.

--- a/fern/versions/latest/pages/training-tutorials/index.mdx
+++ b/fern/versions/latest/pages/training-tutorials/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Training Tutorials"
-description: ""
+description: "Train models on NeMo Gym environments with hands-on tutorials for GRPO, SFT, and DPO using NeMo RL, Unsloth, and VeRL, including multi-environment runs."
 position: 1
 ---
 We have hands-on tutorials with supported training frameworks to help you train with NeMo Gym environments. If you're interested in integrating another training framework, see the [Training Framework Integration Guide](/contribute/rl-framework-integration).

--- a/fern/versions/latest/pages/training-tutorials/multi-environment-training.mdx
+++ b/fern/versions/latest/pages/training-tutorials/multi-environment-training.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multi-Environment Training"
-description: ""
+description: "Train on multiple NeMo Gym environments at once: combine resources server configs in one ng_run, route tasks with agent_ref, and collect rollouts."
 position: 4
 ---
 NeMo Gym supports training on multiple environments simultaneously. Multi-verifier training is another term for this concept.

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/about-workplace-assistant.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/about-workplace-assistant.mdx
@@ -1,6 +1,6 @@
 ---
 title: "About Workplace Assistant"
-description: ""
+description: "Understand the Workplace Assistant training environment: multi-step tool calling across 5 simulated databases, scored by state-matching verification."
 ---
 import { NavButton } from "../../../../../components/NavButton";
 

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/gym-configuration.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/gym-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Gym Configuration"
-description: ""
+description: "Configure the data and env sections of your NeMo RL GRPO training config to connect NeMo Gym: dataset paths, config_paths, and max tool-calling steps."
 ---
 import { NavButton } from "../../../../../components/NavButton";
 

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/index.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: "NeMo RL"
-description: ""
+headline: "GRPO Training with NeMo RL: Tool-Calling Tutorial"
+description: "Train Nemotron Nano 9B v2 for multi-step tool calling with GRPO, using NeMo RL and the Workplace Assistant environment on single- and multi-node setups."
 position: 2
 ---
 This tutorial trains NVIDIA [Nemotron Nano 9B v2](https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2) to improve its **multi-step tool-calling** capability using the **GRPO (Group Relative Policy Optimization)** algorithm on the **Workplace Assistant** environment.

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/multi-node-training.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/multi-node-training.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Multi-Node Training"
-description: ""
+description: "Scale GRPO training to multiple nodes with a Slurm batch job, track reward and validation accuracy in Weights & Biases, and measure tool-calling gains on BFCL v3."
 ---
 import { NavButton } from "../../../../../components/NavButton";
 

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/nemo-rl-configuration.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/nemo-rl-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "NeMo RL Configuration"
-description: ""
+description: "Reference for the NeMo RL GRPO training config: model parameters, GRPO hyperparameters, and optimizer settings that control how your model learns."
 ---
 import { NavButton } from "../../../../../components/NavButton";
 

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/setup.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/setup.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Setup"
-description: ""
+headline: "Set Up the NeMo RL GRPO Training Environment"
+description: "Set up your GRPO training environment: authenticate with NGC, launch a Slurm GPU node, install NeMo RL and NeMo Gym, run sanity tests, and prepare the dataset."
 ---
 import { NavButton } from "../../../../../components/NavButton";
 

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/single-node-training.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/single-node-training.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Single Node Training"
-description: ""
+description: "Validate your GRPO environment with a single-node test run: download Nemotron Nano 9B v2, patch its chat template, and launch a 3-step training session."
 ---
 import { NavButton } from "../../../../../components/NavButton";
 

--- a/fern/versions/latest/pages/training-tutorials/offline-training-w-rollouts.mdx
+++ b/fern/versions/latest/pages/training-tutorials/offline-training-w-rollouts.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Offline Training (SFT/DPO)"
-description: ""
+description: "Turn collected rollouts into SFT and DPO training data: filter by reward, format into conversation and preference-pair datasets, then train and evaluate."
 position: 5
 ---
 <Warning>

--- a/fern/versions/latest/pages/training-tutorials/unsloth.mdx
+++ b/fern/versions/latest/pages/training-tutorials/unsloth.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Unsloth"
-description: ""
+headline: "Fine-tune models with Unsloth and NeMo Gym"
+description: "Fine-tune models with Unsloth and NeMo Gym environments using ready-made Colab notebooks for Sudoku and multi-environment reinforcement learning."
 position: 3
 ---
 This tutorial demonstrates how to use [Unsloth](https://github.com/unslothai/unsloth) to fine-tune models with NeMo Gym environments.

--- a/fern/versions/latest/pages/troubleshooting/configuration.mdx
+++ b/fern/versions/latest/pages/troubleshooting/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration Errors"
-description: ""
+description: "Fix NeMo Gym configuration errors at ng_run startup: missing mandatory values, server reference not found, and invalid field values from almost-server validation."
 position: 1
 ---
 These errors appear when running `ng_run` or `ng_collect_rollouts`. NeMo Gym validates configuration at startup before launching servers.

--- a/fern/versions/latest/pages/troubleshooting/index.mdx
+++ b/fern/versions/latest/pages/troubleshooting/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshooting"
-description: ""
+headline: "NeMo Gym Troubleshooting: Fix Common Errors and Issues"
+description: "Troubleshoot NeMo Gym: solutions to common errors and issues, including configuration problems that surface when you run ng_run or collect rollouts."
 ---
 Solutions for common errors and issues.


### PR DESCRIPTION
## What

Fills in per-page SEO `description` frontmatter for the **main/latest (nightly)** docs and adds `headline` SEO-title overrides for generic titles. Scoped to `fern/versions/latest/pages` only.

Closes #1589.

## Why

Investigating the live site (`docs.nvidia.com/nemo/gym`) showed the issue's suspected problems are **already handled by Fern's defaults**:

- ✅ `sitemap.xml` published (108 URLs) and listed in `robots.txt`
- ✅ Googlebot/Bingbot allowed; only tracking-param URLs disallowed
- ✅ Cross-version duplicate content collapsed via auto `rel=canonical` (`/main/…` and `/v0.3.0/…` both canonical to the un-prefixed URL)
- ✅ Old version `/v0.2.1/*` already `noindex`

The actual gap was **per-page metadata**: **57 of 71 indexed pages had `description: ""`**. With no meta description, search engines fall back to generic body snippets, so deep pages have weak SERP relevance and the landing page outranks them for specific queries — exactly the user-reported "I only land on the main page."

## Changes

- **63 pages** updated under `fern/versions/latest/pages` (the indexed default "Main"/nightly version).
- **Descriptions**: 74–165 chars, unique across all pages, each adversarially verified against the page body (no fabricated features, flags, or numbers).
- **28 `headline` overrides** give query-matching `<title>` tags to generic titles (Overview, FAQ, Setup, …) without changing the visible H1.
- The v0.3.0 mirror and noindex'd v0.2.1 are intentionally **not** touched.

## Verification

- `fern check` → 0 errors.
- Diff is frontmatter-only (only `description`/`headline` lines added; only empty/thin `description` lines removed); no body edits.
- Independent re-scan: 0 empty, 0 thin (<70 chars), 0 duplicate descriptions.

## Follow-ups (not in this PR)

- Add a site-level `metadata:` block in `docs.yml` (`og:image`, `og:site_name`, `twitter:site`) for richer social-share cards.
- Confirm the docs property is verified in Google Search Console and the Fern sitemap is submitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
