### PR TITLE
fix: Fern preview build

### DIFF
--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -29,6 +29,7 @@ on:
     paths:
       - 'fern/**'
       - '.github/workflows/fern-docs-preview-build.yml'
+      - '.github/workflows/fern-docs-preview-comment.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -29,7 +29,6 @@ on:
     paths:
       - 'fern/**'
       - '.github/workflows/fern-docs-preview-build.yml'
-      - '.github/workflows/fern-docs-preview-comment.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -64,76 +64,77 @@ jobs:
           HEAD_REF: ${{ steps.metadata.outputs.head_ref }}
         working-directory: ./fern
         run: |
-          OUTPUT=$(npx -y fern-api@latest generate --docs --preview --id "$HEAD_REF" 2>&1)
-          echo "$OUTPUT"
-          URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
-          if [ -z "$URL" ]; then
-            echo "::error::Failed to generate preview URL. See fern output above."
-            exit 1
-          fi
-          echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
+          npx -y fern-api@latest generate --docs --preview --id "$HEAD_REF"
+          # OUTPUT=$(npx -y fern-api@latest generate --docs --preview --id "$HEAD_REF" 2>&1)
+          # echo "$OUTPUT"
+          # URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
+          # if [ -z "$URL" ]; then
+          #   echo "::error::Failed to generate preview URL. See fern output above."
+          #   exit 1
+          # fi
+          # echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
 
-      - name: Build page links for changed MDX files
-        id: page-links
-        env:
-          FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
-          PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
-        run: |
-          CHANGED_FILES=""
-          if [ -f preview-metadata/changed_mdx_files ]; then
-            CHANGED_FILES=$(cat preview-metadata/changed_mdx_files)
-          fi
+      # - name: Build page links for changed MDX files
+      #   id: page-links
+      #   env:
+      #     FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
+      #     PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
+      #   run: |
+      #     CHANGED_FILES=""
+      #     if [ -f preview-metadata/changed_mdx_files ]; then
+      #       CHANGED_FILES=$(cat preview-metadata/changed_mdx_files)
+      #     fi
 
-          if [ -z "$CHANGED_FILES" ] || [ -z "$PREVIEW_URL" ]; then
-            echo "page_links=" >> "$GITHUB_OUTPUT"; exit 0
-          fi
+      #     if [ -z "$CHANGED_FILES" ] || [ -z "$PREVIEW_URL" ]; then
+      #       echo "page_links=" >> "$GITHUB_OUTPUT"; exit 0
+      #     fi
 
-          BASE_URL=$(echo "$PREVIEW_URL" | grep -oP 'https?://[^/]+')
-          FILES_PARAM=$(echo "$CHANGED_FILES" | tr '\n' ',' | sed 's/,$//' \
-            | python3 -c "import sys, urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=',/'))")
-          RESPONSE=$(curl -sf -H "FERN_TOKEN: $FERN_TOKEN" "${PREVIEW_URL}/api/fern-docs/get-slug-for-file?files=${FILES_PARAM}" 2>/dev/null) || {
-            echo "page_links=" >> "$GITHUB_OUTPUT"; exit 0
-          }
+      #     BASE_URL=$(echo "$PREVIEW_URL" | grep -oP 'https?://[^/]+')
+      #     FILES_PARAM=$(echo "$CHANGED_FILES" | tr '\n' ',' | sed 's/,$//' \
+      #       | python3 -c "import sys, urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=',/'))")
+      #     RESPONSE=$(curl -sf -H "FERN_TOKEN: $FERN_TOKEN" "${PREVIEW_URL}/api/fern-docs/get-slug-for-file?files=${FILES_PARAM}" 2>/dev/null) || {
+      #       echo "page_links=" >> "$GITHUB_OUTPUT"; exit 0
+      #     }
 
-          PAGE_LINKS=$(echo "$RESPONSE" | jq -r --arg url "$BASE_URL" \
-            '.mappings[] | select(.slug != null) | "- [\(.slug)](\($url)/\(.slug))"')
+      #     PAGE_LINKS=$(echo "$RESPONSE" | jq -r --arg url "$BASE_URL" \
+      #       '.mappings[] | select(.slug != null) | "- [\(.slug)](\($url)/\(.slug))"')
 
-          if [ -n "$PAGE_LINKS" ]; then
-            { echo "page_links<<EOF"; echo "$PAGE_LINKS"; echo "EOF"; } >> "$GITHUB_OUTPUT"
-          else
-            echo "page_links=" >> "$GITHUB_OUTPUT"
-          fi
+      #     if [ -n "$PAGE_LINKS" ]; then
+      #       { echo "page_links<<EOF"; echo "$PAGE_LINKS"; echo "EOF"; } >> "$GITHUB_OUTPUT"
+      #     else
+      #       echo "page_links=" >> "$GITHUB_OUTPUT"
+      #     fi
 
-      - name: Post or update PR comment
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
-          PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
-          PAGE_LINKS: ${{ steps.page-links.outputs.page_links }}
-        run: |
-          # Build comment body
-          BODY=":herb: **Preview your docs:** <${PREVIEW_URL}>"
-          if [ -n "${PAGE_LINKS}" ]; then
-            BODY="${BODY}
+      # - name: Post or update PR comment
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+      #     PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
+      #     PAGE_LINKS: ${{ steps.page-links.outputs.page_links }}
+      #   run: |
+      #     # Build comment body
+      #     BODY=":herb: **Preview your docs:** <${PREVIEW_URL}>"
+      #     if [ -n "${PAGE_LINKS}" ]; then
+      #       BODY="${BODY}
 
-          Here are the markdown pages you've updated:
-          ${PAGE_LINKS}"
-          fi
+      #     Here are the markdown pages you've updated:
+      #     ${PAGE_LINKS}"
+      #     fi
 
-          # Hidden marker for upsert
-          MARKER="<!-- preview-docs -->"
-          BODY="${BODY}
+      #     # Hidden marker for upsert
+      #     MARKER="<!-- preview-docs -->"
+      #     BODY="${BODY}
 
-          ${MARKER}"
+      #     ${MARKER}"
 
-          # Find existing comment with marker
-          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | tr -d '\r' | head -1)
+      #     # Find existing comment with marker
+      #     COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+      #       --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | tr -d '\r' | head -1)
 
-          if [ -n "$COMMENT_ID" ]; then
-            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
-              -X PATCH -f body="$BODY"
-          else
-            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-              -f body="$BODY"
-          fi
+      #     if [ -n "$COMMENT_ID" ]; then
+      #       gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+      #         -X PATCH -f body="$BODY"
+      #     else
+      #       gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+      #         -f body="$BODY"
+      #     fi

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -39,20 +39,20 @@ permissions:
 jobs:
   preview:
     runs-on: ubuntu-latest
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download fern sources and metadata
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: fern-preview
-          run-id: "27616516542"
+          run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read PR metadata
         id: metadata
         run: |
-          echo "pr_number=1610" >> "$GITHUB_OUTPUT"
-          echo "head_ref=chtruong/debug-fern" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$(cat preview-metadata/pr_number)" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(cat preview-metadata/head_ref)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -26,9 +26,11 @@
 name: "Preview Fern Docs: Comment"
 
 on:
-  workflow_run:
-    workflows: ["Preview Fern Docs: Build"]
-    types: [completed]
+  pull_request:
+    paths:
+      - 'fern/**'
+      - '.github/workflows/fern-docs-preview-build.yml'
+      - '.github/workflows/fern-docs-preview-comment.yml'
 
 permissions:
   pull-requests: write
@@ -37,7 +39,7 @@ permissions:
 jobs:
   preview:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download fern sources and metadata
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -49,8 +51,8 @@ jobs:
       - name: Read PR metadata
         id: metadata
         run: |
-          echo "pr_number=$(cat preview-metadata/pr_number)" >> "$GITHUB_OUTPUT"
-          echo "head_ref=$(cat preview-metadata/head_ref)" >> "$GITHUB_OUTPUT"
+          echo "pr_number=1610" >> "$GITHUB_OUTPUT"
+          echo "head_ref=chtruong/debug-fern" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -67,77 +67,76 @@ jobs:
         working-directory: ./fern
         run: |
           npm run generate:library
-          npx -y fern-api@latest generate --docs --preview --id "$HEAD_REF"
-          # OUTPUT=$(npx -y fern-api@latest generate --docs --preview --id "$HEAD_REF" 2>&1)
-          # echo "$OUTPUT"
-          # URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
-          # if [ -z "$URL" ]; then
-          #   echo "::error::Failed to generate preview URL. See fern output above."
-          #   exit 1
-          # fi
-          # echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
+          OUTPUT=$(npx -y fern-api@latest generate --docs --preview --id "$HEAD_REF" 2>&1)
+          echo "$OUTPUT"
+          URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
+          if [ -z "$URL" ]; then
+            echo "::error::Failed to generate preview URL. See fern output above."
+            exit 1
+          fi
+          echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
 
-      # - name: Build page links for changed MDX files
-      #   id: page-links
-      #   env:
-      #     FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
-      #     PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
-      #   run: |
-      #     CHANGED_FILES=""
-      #     if [ -f preview-metadata/changed_mdx_files ]; then
-      #       CHANGED_FILES=$(cat preview-metadata/changed_mdx_files)
-      #     fi
+      - name: Build page links for changed MDX files
+        id: page-links
+        env:
+          FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
+          PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
+        run: |
+          CHANGED_FILES=""
+          if [ -f preview-metadata/changed_mdx_files ]; then
+            CHANGED_FILES=$(cat preview-metadata/changed_mdx_files)
+          fi
 
-      #     if [ -z "$CHANGED_FILES" ] || [ -z "$PREVIEW_URL" ]; then
-      #       echo "page_links=" >> "$GITHUB_OUTPUT"; exit 0
-      #     fi
+          if [ -z "$CHANGED_FILES" ] || [ -z "$PREVIEW_URL" ]; then
+            echo "page_links=" >> "$GITHUB_OUTPUT"; exit 0
+          fi
 
-      #     BASE_URL=$(echo "$PREVIEW_URL" | grep -oP 'https?://[^/]+')
-      #     FILES_PARAM=$(echo "$CHANGED_FILES" | tr '\n' ',' | sed 's/,$//' \
-      #       | python3 -c "import sys, urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=',/'))")
-      #     RESPONSE=$(curl -sf -H "FERN_TOKEN: $FERN_TOKEN" "${PREVIEW_URL}/api/fern-docs/get-slug-for-file?files=${FILES_PARAM}" 2>/dev/null) || {
-      #       echo "page_links=" >> "$GITHUB_OUTPUT"; exit 0
-      #     }
+          BASE_URL=$(echo "$PREVIEW_URL" | grep -oP 'https?://[^/]+')
+          FILES_PARAM=$(echo "$CHANGED_FILES" | tr '\n' ',' | sed 's/,$//' \
+            | python3 -c "import sys, urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=',/'))")
+          RESPONSE=$(curl -sf -H "FERN_TOKEN: $FERN_TOKEN" "${PREVIEW_URL}/api/fern-docs/get-slug-for-file?files=${FILES_PARAM}" 2>/dev/null) || {
+            echo "page_links=" >> "$GITHUB_OUTPUT"; exit 0
+          }
 
-      #     PAGE_LINKS=$(echo "$RESPONSE" | jq -r --arg url "$BASE_URL" \
-      #       '.mappings[] | select(.slug != null) | "- [\(.slug)](\($url)/\(.slug))"')
+          PAGE_LINKS=$(echo "$RESPONSE" | jq -r --arg url "$BASE_URL" \
+            '.mappings[] | select(.slug != null) | "- [\(.slug)](\($url)/\(.slug))"')
 
-      #     if [ -n "$PAGE_LINKS" ]; then
-      #       { echo "page_links<<EOF"; echo "$PAGE_LINKS"; echo "EOF"; } >> "$GITHUB_OUTPUT"
-      #     else
-      #       echo "page_links=" >> "$GITHUB_OUTPUT"
-      #     fi
+          if [ -n "$PAGE_LINKS" ]; then
+            { echo "page_links<<EOF"; echo "$PAGE_LINKS"; echo "EOF"; } >> "$GITHUB_OUTPUT"
+          else
+            echo "page_links=" >> "$GITHUB_OUTPUT"
+          fi
 
-      # - name: Post or update PR comment
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
-      #     PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
-      #     PAGE_LINKS: ${{ steps.page-links.outputs.page_links }}
-      #   run: |
-      #     # Build comment body
-      #     BODY=":herb: **Preview your docs:** <${PREVIEW_URL}>"
-      #     if [ -n "${PAGE_LINKS}" ]; then
-      #       BODY="${BODY}
+      - name: Post or update PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
+          PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
+          PAGE_LINKS: ${{ steps.page-links.outputs.page_links }}
+        run: |
+          # Build comment body
+          BODY=":herb: **Preview your docs:** <${PREVIEW_URL}>"
+          if [ -n "${PAGE_LINKS}" ]; then
+            BODY="${BODY}
 
-      #     Here are the markdown pages you've updated:
-      #     ${PAGE_LINKS}"
-      #     fi
+          Here are the markdown pages you've updated:
+          ${PAGE_LINKS}"
+          fi
 
-      #     # Hidden marker for upsert
-      #     MARKER="<!-- preview-docs -->"
-      #     BODY="${BODY}
+          # Hidden marker for upsert
+          MARKER="<!-- preview-docs -->"
+          BODY="${BODY}
 
-      #     ${MARKER}"
+          ${MARKER}"
 
-      #     # Find existing comment with marker
-      #     COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-      #       --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | tr -d '\r' | head -1)
+          # Find existing comment with marker
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | tr -d '\r' | head -1)
 
-      #     if [ -n "$COMMENT_ID" ]; then
-      #       gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
-      #         -X PATCH -f body="$BODY"
-      #     else
-      #       gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-      #         -f body="$BODY"
-      #     fi
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -f body="$BODY"
+          else
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+              -f body="$BODY"
+          fi

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -66,6 +66,7 @@ jobs:
           HEAD_REF: ${{ steps.metadata.outputs.head_ref }}
         working-directory: ./fern
         run: |
+          npm run generate:library
           npx -y fern-api@latest generate --docs --preview --id "$HEAD_REF"
           # OUTPUT=$(npx -y fern-api@latest generate --docs --preview --id "$HEAD_REF" 2>&1)
           # echo "$OUTPUT"

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -26,11 +26,9 @@
 name: "Preview Fern Docs: Comment"
 
 on:
-  pull_request:
-    paths:
-      - 'fern/**'
-      - '.github/workflows/fern-docs-preview-build.yml'
-      - '.github/workflows/fern-docs-preview-comment.yml'
+  workflow_run:
+    workflows: ["Preview Fern Docs: Build"]
+    types: [completed]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: fern-preview
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: "27616516542"
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read PR metadata


### PR DESCRIPTION
fix: Fern preview build

The Fern preview build was failing:
https://github.com/NVIDIA-NeMo/Gym/actions/runs/27614358362

It doesn't seem like it ever worked. The fix is to ensure we generate the fern library first. I forced a preview by hard coding variables and was able to complete the preview job successfully:
https://github.com/NVIDIA-NeMo/Gym/pull/1610#issuecomment-4718885602
https://github.com/NVIDIA-NeMo/Gym/actions/runs/27618537512