### PR TITLE
docs: document use_absolute_ip config option (supersedes #595)

### DIFF
--- a/fern/versions/latest/pages/reference/configuration.mdx
+++ b/fern/versions/latest/pages/reference/configuration.mdx
@@ -127,9 +127,20 @@ my_config_paths:
   - responses_api_models/openai_model/configs/openai_model.yaml
   - resources_servers/example_single_tool_call/configs/example_single_tool_call.yaml
 
+# Optional: multi-node setups
+use_absolute_ip: true           # Bind servers to the host's IP instead of 127.0.0.1 (default: false)
+
 # Optional: validation behavior
 error_on_almost_servers: true   # Exit on invalid configs (default: true)
 ```
+
+### Multi-Node Configuration
+
+**`use_absolute_ip`** — Controls the default host servers bind to.
+
+- **Default:** `false` — servers use `127.0.0.1` (localhost).
+- **When to use:** Set to `true` for multi-node setups (e.g. multi-node Ray clusters) where servers must communicate across machines.
+- **Effect:** Resolves and uses the host's IP address (`gethostbyname(gethostname())`) instead of localhost.
 
 ---
 


### PR DESCRIPTION
## Changes

Documents the `use_absolute_ip` global config option on the Fern **Configuration** reference page (`fern/versions/latest/pages/reference/configuration.mdx`):

- Adds it to the `env.yaml` example block.
- Adds a short **Multi-Node Configuration** subsection explaining default (`127.0.0.1`), when to use it (multi-node / Ray clusters), and its effect (`gethostbyname(gethostname())`).

## Why a fresh PR

This supersedes #595, which documented the same option but targeted `docs/reference/configuration.md` — a path that no longer exists after the docs migration to Fern. The option itself is still live (`nemo_gym/global_config.py`) and was undocumented in the current docs. Content ported and adapted to the Fern page.

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)
