### PR TITLE
docs: NVIDIA style-guide fixes for model-server pages (on top of #1289)

### DIFF
--- a/fern/versions/latest/pages/model-server/azure-openai.mdx
+++ b/fern/versions/latest/pages/model-server/azure-openai.mdx
@@ -7,7 +7,7 @@ position: 3
 The `azure_openai_model` server connects NeMo Gym to models hosted on [Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/). It calls Azure's Chat Completions endpoint and converts to and from NeMo Gym's native [Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create) — so, like [Inference Providers](/model-server/inference-providers), it translates between the two formats (unlike [OpenAI](/model-server/openai), which forwards Responses requests natively). Azure also requires an explicit `api-version`.
 
 <Info>
-For **training** workloads that require token IDs and log probabilities, use [vLLM](/model-server/vllm) instead. Hosted endpoints don't expose the token-level information needed for RL training.
+For **training** workloads that require token IDs and log probabilities, use [vLLM](/model-server/vllm) instead. Hosted endpoints do not expose the token-level information needed for RL training.
 
 </Info>
 
@@ -37,7 +37,7 @@ Azure requires an API version (for example `2024-10-21`). Set it on the `default
 | `openai_base_url` | `str` | — | **Required.** Azure OpenAI endpoint. |
 | `openai_api_key` | `str` | — | **Required.** Azure API key. |
 | `openai_model` | `str` | — | **Required.** Azure deployment name. |
-| `default_query` | `dict` | — | **Required.** Must include `api-version` (e.g. `2024-10-21`). |
+| `default_query` | `dict` | — | **Required.** Must include `api-version` (for example, `2024-10-21`). |
 | `num_concurrent_requests` | `int` | — | **Required.** Maximum concurrent requests to Azure. |
 
 <Note>

--- a/fern/versions/latest/pages/model-server/index.mdx
+++ b/fern/versions/latest/pages/model-server/index.mdx
@@ -6,7 +6,7 @@ position: 1
 
 Configure your model with the inference backend of your choice.
 
-NeMo Gym uses the [Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create) as its native schema because it natively represents tool calls, multi-turn conversations, and structured outputs. NeMo Gym provides middleware to automatically convert other protocols, e.g. Chat Completions into Responses format.
+NeMo Gym uses the [Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create) as its native schema because it natively represents tool calls, multi-turn conversations, and structured outputs. NeMo Gym provides middleware to automatically convert other protocols, for example, Chat Completions, into Responses format.
 
 For training, use a backend that returns token IDs and log probabilities (marked with <Badge minimal outlined>training</Badge> below).
 
@@ -27,7 +27,7 @@ Use models hosted on Azure OpenAI deployments.
 </Card>
 
 <Card title="Inference Providers" href="/model-server/inference-providers">
-Use models via cloud API.
+Use models through a cloud API.
 
 <Badge minimal outlined>cloud</Badge>
 </Card>

--- a/fern/versions/latest/pages/model-server/inference-providers.mdx
+++ b/fern/versions/latest/pages/model-server/inference-providers.mdx
@@ -7,7 +7,7 @@ position: 4
 The `inference_provider` server connects NeMo Gym to any hosted inference provider. The server manages the conversion to and from the Responses API: it translates incoming Responses requests to Chat Completions for the provider and converts the reply back into a Responses object — so your agent code stays the same across backends.
 
 <Info>
-For **training** workloads that require token IDs and log probabilities, use [vLLM](/model-server/vllm) instead. Hosted providers don't expose the token-level information needed for RL training.
+For **training** workloads that require token IDs and log probabilities, use [vLLM](/model-server/vllm) instead. Hosted providers do not expose the token-level information needed for RL training.
 
 </Info>
 
@@ -41,7 +41,7 @@ policy_api_key: your-api-key
 policy_model_name: nvidia/Nemotron-3-Nano-30B-A3B
 ```
 
-If your provider isn't in the table above, also set the base URL:
+If your provider is not in the table above, also set the base URL:
 
 ```yaml
 # env.yaml
@@ -68,7 +68,7 @@ policy_base_url: https://your-provider.com/v1
 
 ### 1. Set model and environment config
 
-In this example we use Together.ai:
+In this example, we use Together.ai:
 
 ```bash
 environment_config="resources_servers/mcqa/configs/mcqa.yaml"

--- a/fern/versions/latest/pages/model-server/openai.mdx
+++ b/fern/versions/latest/pages/model-server/openai.mdx
@@ -6,10 +6,10 @@ position: 2
 
 The `openai_model` server connects NeMo Gym to OpenAI. It forwards requests straight through with no conversion in either direction: a Responses request goes to OpenAI's [Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create) and returns a Responses object, and a Chat Completions request goes to OpenAI's Chat Completions and returns a chat completion — OpenAI serves both natively.
 
-Because it's a pass-through, the Responses endpoint also works with any other backend that implements the Responses API natively — point `openai_base_url` at it. In practice that's rare: most hosted backends only expose Chat Completions and instead go through [Inference Providers](/model-server/inference-providers), which translates between the two formats.
+Because it is a pass-through, the Responses endpoint also works with any other backend that implements the Responses API natively — point `openai_base_url` at it. In practice that is rare: most hosted backends only expose Chat Completions and instead go through [Inference Providers](/model-server/inference-providers), which translates between the two formats.
 
 <Info>
-For **training** workloads that require token IDs and log probabilities, use [vLLM](/model-server/vllm) instead. Hosted endpoints don't expose the token-level information needed for RL training.
+For **training** workloads that require token IDs and log probabilities, use [vLLM](/model-server/vllm) instead. Hosted endpoints do not expose the token-level information needed for RL training.
 
 </Info>
 
@@ -38,7 +38,7 @@ Point `policy_base_url` at any OpenAI-compatible Responses endpoint to reuse thi
 |-----------|------|---------|-------------|
 | `openai_base_url` | `str` | — | **Required.** Base URL of an endpoint that serves the Responses API. |
 | `openai_api_key` | `str` | — | **Required.** API key for the endpoint. |
-| `openai_model` | `str` | — | **Required.** Model identifier (e.g. `gpt-4o-mini`). |
+| `openai_model` | `str` | — | **Required.** Model identifier (for example, `gpt-4o-mini`). |
 | `openai_default_headers` | `dict` | `{}` | Extra headers sent on every request. |
 | `extra_body` | `dict` | `{}` | Default parameters merged into every request body. Values set on the incoming request take precedence. |
 | `max_concurrent_requests` | `int` | `null` | Cap on in-flight upstream requests (per-process). `null` = unlimited; set it on rate-limited endpoints. |


### PR DESCRIPTION
## Summary

Stacked on top of #1289. Applies an NVIDIA technical-writing style-guide sweep (`::r` / `doc-style-guide`) to the model-server pages that PR adds or updates.

### Fixes (8)

| File | Fix |
|------|-----|
| `index.mdx` | `e.g.` → `for example`; `via` → `through` (cloud API card) |
| `inference-providers.mdx` | `don't` → `do not`; `isn't` → `is not`; added introductory comma in usage example |
| `azure-openai.mdx` | `don't` → `do not`; `e.g.` → `for example` (config table) |
| `openai.mdx` | `it's`/`that's` → `it is`/`that is`; `don't` → `do not`; `e.g.` → `for example` (config table) |

Two categories: **Latinisms** (`e.g.`) and **contractions**, both disallowed by NVIDIA technical style. No semantic changes.

### Not changed (intentional)

- Spaced em dashes — consistent house style across the pages; left as-is.
- `RL` left unexpanded — minor, deferred.

## Test plan

- [ ] `fern docs dev` renders all four pages
- [ ] No broken links / component regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)