### PR TITLE
[Draft] Add Anthropic Messages API (/v1/messages) support to model server

### DIFF
--- a/nemo_gym/anthropic_utils.py
+++ b/nemo_gym/anthropic_utils.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""NeMo Gym wrappers for the Anthropic Messages API (``POST /v1/messages``).
+
+This mirrors ``nemo_gym/openai_utils.py``: we copy the Anthropic SDK schemas into
+NeMo Gym ``BaseModel`` / ``TypedDict`` subclasses so that we can do strict server-side
+validation, override the SDK's lazy ``Iterable`` annotations with ``List`` (which
+Pydantic validates eagerly), and attach the training mixins (token IDs + log probs).
+
+Types are prefixed ``NeMoGymAnthropic*`` to avoid colliding with the OpenAI Responses
+API wrappers in ``openai_utils.py`` (e.g. ``NeMoGymMessage`` already exists there).
+"""
+
+from typing import (
+    List,
+    Literal,
+    Optional,
+    TypeAlias,
+    Union,
+)
+
+from anthropic.types import (
+    CacheControlEphemeralParam,
+    DocumentBlockParam,
+    ImageBlockParam,
+    Message,
+    MetadataParam,
+    ModelParam,
+    RedactedThinkingBlock,
+    RedactedThinkingBlockParam,
+    TextBlock,
+    TextBlockParam,
+    ThinkingBlock,
+    ThinkingBlockParam,
+    ThinkingConfigParam,
+    ToolChoiceParam,
+    ToolResultBlockParam,
+    ToolUnionParam,
+    ToolUseBlock,
+    ToolUseBlockParam,
+    Usage,
+)
+from anthropic.types.message_create_params import OutputConfigParam
+from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import Required, TypedDict
+
+from nemo_gym.openai_utils import (
+    TokenIDLogProbMixin,
+    TokenIDLogProbTypedDictMixin,
+)
+
+
+########################################
+# Messages API inputs (request params)
+########################################
+
+# We deliberately narrow the input content-block surface to the blocks that show up
+# in text + tool-calling rollouts (mirroring how openai_utils only wraps text/image
+# content parts). Add more blocks here if an environment needs them.
+
+
+class NeMoGymAnthropicTextBlockParam(TextBlockParam):
+    pass
+
+
+class NeMoGymAnthropicImageBlockParam(ImageBlockParam):
+    pass
+
+
+class NeMoGymAnthropicDocumentBlockParam(DocumentBlockParam):
+    pass
+
+
+class NeMoGymAnthropicToolUseBlockParam(ToolUseBlockParam):
+    pass
+
+
+class NeMoGymAnthropicToolResultBlockParam(ToolResultBlockParam):
+    pass
+
+
+class NeMoGymAnthropicThinkingBlockParam(ThinkingBlockParam):
+    pass
+
+
+class NeMoGymAnthropicRedactedThinkingBlockParam(RedactedThinkingBlockParam):
+    pass
+
+
+NeMoGymAnthropicContentBlockParam: TypeAlias = Union[
+    NeMoGymAnthropicTextBlockParam,
+    NeMoGymAnthropicImageBlockParam,
+    NeMoGymAnthropicDocumentBlockParam,
+    NeMoGymAnthropicToolUseBlockParam,
+    NeMoGymAnthropicToolResultBlockParam,
+    NeMoGymAnthropicThinkingBlockParam,
+    NeMoGymAnthropicRedactedThinkingBlockParam,
+]
+
+
+class NeMoGymAnthropicMessageParam(TypedDict):
+    # Override the SDK's Iterable content annotation with List to avoid lazy
+    # iterators in Pydantic validation.
+    content: Required[Union[str, List[NeMoGymAnthropicContentBlockParam]]]
+    role: Required[Literal["user", "assistant", "system"]]
+
+
+class NeMoGymAnthropicMessageForTrainingParam(NeMoGymAnthropicMessageParam, TokenIDLogProbTypedDictMixin):
+    pass
+
+
+NeMoGymAnthropicMessageParamUnion: TypeAlias = Union[
+    NeMoGymAnthropicMessageParam,
+    # For training (assistant turns carry token IDs + log probs):
+    NeMoGymAnthropicMessageForTrainingParam,
+]
+
+
+class NeMoGymAnthropicMessageCreateParamsNonStreaming(BaseModel):
+    """A copy of ``anthropic.types.message_create_params.MessageCreateParamsNonStreaming``.
+
+    The SDK type is a ``TypedDict`` with no strict validation; we copy it here as a
+    Pydantic ``BaseModel`` (``extra="forbid"``) so the model server validates request
+    bodies server-side, the same way ``NeMoGymResponseCreateParamsNonStreaming`` does.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_tokens: int
+    # Override the Iterable to avoid lazy iterators in Pydantic validation.
+    messages: List[NeMoGymAnthropicMessageParamUnion]
+    # model is optional here so the model server can fill it in from its own config,
+    # matching NeMoGymResponseCreateParamsNonStreaming.
+    model: Optional[ModelParam] = None
+    cache_control: Optional[CacheControlEphemeralParam] = None
+    container: Optional[str] = None
+    inference_geo: Optional[str] = None
+    metadata: Optional[MetadataParam] = None
+    output_config: Optional[OutputConfigParam] = None
+    service_tier: Optional[Literal["auto", "standard_only"]] = None
+    stop_sequences: Optional[List[str]] = None
+    system: Optional[Union[str, List[NeMoGymAnthropicTextBlockParam]]] = None
+    temperature: Optional[float] = None
+    thinking: Optional[ThinkingConfigParam] = None
+    tool_choice: Optional[ToolChoiceParam] = None
+    # Override the Iterable to avoid lazy iterators in Pydantic validation.
+    tools: List[ToolUnionParam] = Field(default_factory=list)
+    top_k: Optional[int] = None
+    top_p: Optional[float] = None
+    stream: Optional[Literal[False]] = None
+
+
+########################################
+# Messages API outputs (response)
+########################################
+
+
+class NeMoGymAnthropicTextBlock(TextBlock):
+    pass
+
+
+class NeMoGymAnthropicToolUseBlock(ToolUseBlock):
+    pass
+
+
+class NeMoGymAnthropicThinkingBlock(ThinkingBlock):
+    pass
+
+
+class NeMoGymAnthropicRedactedThinkingBlock(RedactedThinkingBlock):
+    pass
+
+
+NeMoGymAnthropicContentBlock: TypeAlias = Union[
+    NeMoGymAnthropicTextBlock,
+    NeMoGymAnthropicToolUseBlock,
+    NeMoGymAnthropicThinkingBlock,
+    NeMoGymAnthropicRedactedThinkingBlock,
+]
+
+
+class NeMoGymAnthropicUsage(Usage):
+    pass
+
+
+class NeMoGymAnthropicMessage(Message):
+    # Override the Iterable to avoid lazy iterators in Pydantic validation.
+    content: List[NeMoGymAnthropicContentBlock]
+    usage: NeMoGymAnthropicUsage
+
+
+class NeMoGymAnthropicMessageForTraining(NeMoGymAnthropicMessage, TokenIDLogProbMixin):
+    pass

--- a/nemo_gym/anthropic_utils.py
+++ b/nemo_gym/anthropic_utils.py
@@ -53,8 +53,9 @@ from anthropic.types import (
     Usage,
 )
 from anthropic.types.message_create_params import OutputConfigParam
+from anthropic.types.tool_result_block_param import Content as ToolResultContentBlockParam
 from pydantic import BaseModel, ConfigDict, Field
-from typing_extensions import Required, TypedDict
+from typing_extensions import NotRequired, Required, TypedDict
 
 from nemo_gym.openai_utils import (
     TokenIDLogProbMixin,
@@ -88,7 +89,10 @@ class NeMoGymAnthropicToolUseBlockParam(ToolUseBlockParam):
 
 
 class NeMoGymAnthropicToolResultBlockParam(ToolResultBlockParam):
-    pass
+    # Override the SDK's Iterable content annotation with List so Pydantic
+    # materializes it eagerly instead of leaving a lazy ValidatorIterator
+    # (same reason openai_utils overrides Iterable -> List throughout).
+    content: NotRequired[Union[str, List[ToolResultContentBlockParam]]]
 
 
 class NeMoGymAnthropicThinkingBlockParam(ThinkingBlockParam):

--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -14,8 +14,12 @@
 # limitations under the License.
 from abc import abstractmethod
 
-from fastapi import Body, FastAPI
+from fastapi import Body, FastAPI, HTTPException
 
+from nemo_gym.anthropic_utils import (
+    NeMoGymAnthropicMessage,
+    NeMoGymAnthropicMessageCreateParamsNonStreaming,
+)
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
     NeMoGymChatCompletionCreateParamsNonStreaming,
@@ -43,6 +47,8 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
 
         app.post("/v1/responses")(self.responses)
 
+        app.post("/v1/messages")(self.messages)
+
         return app
 
     @abstractmethod
@@ -54,3 +60,15 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
     @abstractmethod
     async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:
         pass
+
+    async def messages(
+        self, body: NeMoGymAnthropicMessageCreateParamsNonStreaming = Body()
+    ) -> NeMoGymAnthropicMessage:
+        # Anthropic Messages API endpoint. Unlike chat_completions() and responses(),
+        # this is not abstract: existing model servers predate it and shouldn't be
+        # forced to implement it. Servers that support Anthropic-format inference
+        # override this method; the rest return 501.
+        raise HTTPException(
+            status_code=501,
+            detail=f"{type(self).__name__} does not implement the /v1/messages (Anthropic Messages API) endpoint.",
+        )

--- a/nemo_gym/claude_converter.py
+++ b/nemo_gym/claude_converter.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Converter between the Anthropic Messages API (``/v1/messages``) and the OpenAI
+Chat Completions API.
+
+Mirrors the structure of ``VLLMConverter`` (Responses <-> Chat Completions) in
+``responses_api_models/vllm_model/app.py``: a small Pydantic ``BaseModel`` with one
+method per direction plus private ``_convert_*`` helpers. The field mappings follow
+``nemo_switchyard``'s ``anthropic_openai`` translation module.
+
+Two directions, both non-streaming:
+
+- ``messages_to_chat_completion_create_params``: an Anthropic Messages request
+  (``NeMoGymAnthropicMessageCreateParamsNonStreaming``) ->
+  ``NeMoGymChatCompletionCreateParamsNonStreaming``.
+- ``chat_completion_to_message``: a Chat Completions response
+  (``NeMoGymChatCompletion``) -> ``NeMoGymAnthropicMessage``.
+
+Mapping summary:
+- Anthropic ``system`` param -> OpenAI system message
+- Anthropic ``text`` block -> OpenAI content string
+- Anthropic ``tool_use`` block -> OpenAI assistant ``tool_calls`` entry
+- Anthropic ``tool_result`` block -> OpenAI ``tool`` role message
+- Anthropic tool definitions -> OpenAI ``tools`` (JSON schema under ``parameters``)
+- Anthropic ``tool_choice`` <-> OpenAI ``tool_choice``
+- OpenAI ``finish_reason`` -> Anthropic ``stop_reason``
+
+Out of scope for now (raise / drop rather than silently mishandle): streaming,
+training token-id/logprob threading, image/document content blocks. ``thinking`` /
+``redacted_thinking`` blocks are dropped on the request path.
+"""
+
+import json
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from uuid import uuid4
+
+from anthropic.types import StopReason
+from pydantic import BaseModel
+
+from nemo_gym.anthropic_utils import (
+    NeMoGymAnthropicContentBlock,
+    NeMoGymAnthropicMessage,
+    NeMoGymAnthropicMessageCreateParamsNonStreaming,
+    NeMoGymAnthropicTextBlock,
+    NeMoGymAnthropicToolUseBlock,
+    NeMoGymAnthropicUsage,
+)
+from nemo_gym.openai_utils import (
+    NeMoGymChatCompletion,
+    NeMoGymChatCompletionAssistantMessageParam,
+    NeMoGymChatCompletionCreateParamsNonStreaming,
+    NeMoGymChatCompletionMessage,
+    NeMoGymChatCompletionMessageParam,
+    NeMoGymChatCompletionMessageToolCallFunctionParam,
+    NeMoGymChatCompletionMessageToolCallParam,
+    NeMoGymChatCompletionSystemMessageParam,
+    NeMoGymChatCompletionToolMessageParam,
+    NeMoGymChatCompletionToolParam,
+    NeMoGymChatCompletionUserMessageParam,
+    NeMoGymFunctionDefinition,
+)
+
+
+class ClaudeConverter(BaseModel):
+    # Anthropic tool_choice (string or {"type": ...}) -> OpenAI tool_choice string.
+    _TOOL_CHOICE_MAP: ClassVar[Dict[str, str]] = {
+        "auto": "auto",
+        "any": "required",
+        "none": "none",
+    }
+
+    # OpenAI finish_reason -> Anthropic stop_reason.
+    _FINISH_REASON_MAP: ClassVar[Dict[str, StopReason]] = {
+        "stop": "end_turn",
+        "length": "max_tokens",
+        "tool_calls": "tool_use",
+        "content_filter": "end_turn",
+        "function_call": "tool_use",  # legacy
+    }
+
+    # =======================================================
+    # Messages create params -> Chat Completion create params
+    # =======================================================
+
+    def messages_to_chat_completion_create_params(
+        self,
+        body: NeMoGymAnthropicMessageCreateParamsNonStreaming,
+    ) -> NeMoGymChatCompletionCreateParamsNonStreaming:
+        """Convert an Anthropic Messages request to a Chat Completions request."""
+        messages: List[NeMoGymChatCompletionMessageParam] = []
+
+        # Anthropic carries the system prompt as a top-level param; Chat
+        # Completions carries it as the first message.
+        system_message = self._convert_system(body.system)
+        if system_message is not None:
+            messages.append(system_message)
+
+        # body.messages entries are validated TypedDicts, i.e. plain dicts here.
+        for message in body.messages:
+            messages.extend(self._convert_message(message))
+
+        kwargs: Dict[str, Any] = {"messages": messages, "max_tokens": body.max_tokens}
+        if body.model is not None:
+            kwargs["model"] = body.model
+        if body.temperature is not None:
+            kwargs["temperature"] = body.temperature
+        if body.top_p is not None:
+            kwargs["top_p"] = body.top_p
+        if body.stop_sequences:
+            kwargs["stop"] = body.stop_sequences
+        if body.tools:
+            kwargs["tools"] = self._convert_tools(body.tools)
+        if body.tool_choice:
+            kwargs["tool_choice"] = self._convert_tool_choice(body.tool_choice)
+        # Note: Anthropic `top_k` has no Chat Completions equivalent and is dropped.
+
+        return NeMoGymChatCompletionCreateParamsNonStreaming(**kwargs)
+
+    def _convert_system(
+        self,
+        system: Optional[Union[str, List[Dict[str, Any]]]],
+    ) -> Optional[NeMoGymChatCompletionSystemMessageParam]:
+        if not system:
+            return None
+        if isinstance(system, str):
+            text = system
+        else:
+            # A validated Anthropic system list contains only text blocks.
+            text = " ".join(block.get("text", "") for block in system)
+        return NeMoGymChatCompletionSystemMessageParam(role="system", content=text)
+
+    def _convert_message(self, message: Dict[str, Any]) -> List[NeMoGymChatCompletionMessageParam]:
+        # ``message`` is a validated Anthropic MessageParam: ``role`` is one of
+        # user/assistant/system and ``content`` is a str or a list of typed blocks.
+        role = message["role"]
+        content = message["content"]
+
+        if isinstance(content, str):
+            return [self._simple_message(role, content)]
+
+        text_parts: List[str] = []
+        tool_calls: List[NeMoGymChatCompletionMessageToolCallParam] = []
+        tool_messages: List[NeMoGymChatCompletionMessageParam] = []
+
+        for block in content:
+            block_type = block.get("type")
+
+            if block_type == "text":
+                text_parts.append(block.get("text", ""))
+            elif block_type in ("thinking", "redacted_thinking"):
+                # Dropped on the request path for now.
+                continue
+            elif block_type == "tool_use":
+                # Anthropic tool_use input is always an object; serialize it to
+                # the JSON string OpenAI tool_calls expect.
+                tool_calls.append(
+                    NeMoGymChatCompletionMessageToolCallParam(
+                        id=block["id"],
+                        type="function",
+                        function=NeMoGymChatCompletionMessageToolCallFunctionParam(
+                            name=block["name"],
+                            arguments=json.dumps(block["input"]),
+                        ),
+                    )
+                )
+            elif block_type == "tool_result":
+                tool_messages.append(
+                    NeMoGymChatCompletionToolMessageParam(
+                        role="tool",
+                        tool_call_id=block.get("tool_use_id", ""),
+                        content=self._flatten_tool_result_content(block.get("content", "")),
+                    )
+                )
+            else:
+                # image / document blocks have no Chat Completions equivalent yet.
+                raise NotImplementedError(f"Unsupported Anthropic content block type: {block_type!r}")
+
+        # An assistant turn requesting tools becomes a single assistant message
+        # carrying both any text and the tool_calls.
+        if tool_calls:
+            return [
+                NeMoGymChatCompletionAssistantMessageParam(
+                    role="assistant",
+                    content=" ".join(text_parts) if text_parts else None,
+                    tool_calls=tool_calls,
+                )
+            ]
+
+        # Otherwise emit any tool_result messages, then a text message. In
+        # Anthropic format tool_use and tool_result don't share a message, so
+        # these branches are mutually exclusive in practice.
+        result: List[NeMoGymChatCompletionMessageParam] = list(tool_messages)
+        if text_parts:
+            result.append(self._simple_message(role, " ".join(text_parts)))
+        elif not result:
+            result.append(self._simple_message(role, ""))
+        return result
+
+    def _simple_message(self, role: str, content: str) -> NeMoGymChatCompletionMessageParam:
+        match role:
+            case "user":
+                return NeMoGymChatCompletionUserMessageParam(role="user", content=content)
+            case "assistant":
+                return NeMoGymChatCompletionAssistantMessageParam(role="assistant", content=content)
+            case "system":
+                return NeMoGymChatCompletionSystemMessageParam(role="system", content=content)
+            case _:
+                raise NotImplementedError(f"Unsupported Anthropic message role: {role!r}")
+
+    def _flatten_tool_result_content(self, content: Any) -> str:
+        """Flatten Anthropic tool_result content (string or block list) to a string.
+
+        Text blocks contribute their text; non-text blocks are JSON-encoded so their
+        data is preserved rather than silently dropped.
+        """
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: List[str] = []
+            for block in content:
+                if block.get("type") == "text":
+                    parts.append(block.get("text", ""))
+                else:
+                    parts.append(json.dumps(block))
+            return " ".join(parts)
+        return str(content)
+
+    def _convert_tools(self, tools: List[Dict[str, Any]]) -> List[NeMoGymChatCompletionToolParam]:
+        converted: List[NeMoGymChatCompletionToolParam] = []
+        for tool in tools:
+            # Custom tools carry an input_schema; Anthropic server tools (web_search,
+            # bash, ...) don't and have no Chat Completions equivalent.
+            if "input_schema" not in tool:
+                raise NotImplementedError(f"Unsupported Anthropic tool (no input_schema): {tool.get('name', tool)!r}")
+            converted.append(
+                NeMoGymChatCompletionToolParam(
+                    type="function",
+                    function=NeMoGymFunctionDefinition(
+                        name=tool.get("name", ""),
+                        description=tool.get("description", ""),
+                        parameters=tool["input_schema"],
+                    ),
+                )
+            )
+        return converted
+
+    def _convert_tool_choice(self, tool_choice: Union[str, Dict[str, Any]]) -> Union[str, Dict[str, Any]]:
+        if isinstance(tool_choice, str):
+            return self._TOOL_CHOICE_MAP.get(tool_choice, tool_choice)
+        choice_type = tool_choice.get("type")
+        if choice_type == "tool":
+            return {"type": "function", "function": {"name": tool_choice.get("name", "")}}
+        return self._TOOL_CHOICE_MAP.get(choice_type, "auto")
+
+    # =======================================================
+    # Chat Completion -> Messages response
+    # =======================================================
+
+    def chat_completion_to_message(
+        self,
+        chat_completion: NeMoGymChatCompletion,
+        model: Optional[str] = None,
+    ) -> NeMoGymAnthropicMessage:
+        """Convert a Chat Completions response to an Anthropic Messages response."""
+        choice = chat_completion.choices[0]
+        content_blocks = self._message_to_content_blocks(choice.message)
+        stop_reason = self._FINISH_REASON_MAP.get(choice.finish_reason or "stop", "end_turn")
+
+        usage = chat_completion.usage
+        input_tokens = usage.prompt_tokens if usage else 0
+        output_tokens = usage.completion_tokens if usage else 0
+
+        return NeMoGymAnthropicMessage(
+            id=f"msg_{uuid4().hex}",
+            type="message",
+            role="assistant",
+            model=model or chat_completion.model,
+            content=content_blocks,
+            stop_reason=stop_reason,
+            stop_sequence=None,
+            usage=NeMoGymAnthropicUsage(input_tokens=input_tokens, output_tokens=output_tokens),
+        )
+
+    def _message_to_content_blocks(
+        self,
+        message: NeMoGymChatCompletionMessage,
+    ) -> List[NeMoGymAnthropicContentBlock]:
+        blocks: List[NeMoGymAnthropicContentBlock] = []
+
+        content = message.content
+        if content:
+            blocks.append(NeMoGymAnthropicTextBlock(type="text", text=content))
+
+        for tool_call in message.tool_calls or []:
+            arguments = tool_call.function.arguments
+            try:
+                tool_input = json.loads(arguments) if isinstance(arguments, str) else arguments
+            except json.JSONDecodeError:
+                # Preserve the raw arguments rather than dropping the tool call.
+                tool_input = {"raw": arguments}
+            blocks.append(
+                NeMoGymAnthropicToolUseBlock(
+                    type="tool_use",
+                    id=tool_call.id,
+                    name=tool_call.function.name,
+                    input=tool_input,
+                )
+            )
+
+        # Anthropic responses always carry at least one content block.
+        if not blocks:
+            blocks.append(NeMoGymAnthropicTextBlock(type="text", text=""))
+
+        return blocks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,12 @@ dependencies = [
     # License: Apache 2.0 https://github.com/openai/openai-python/blob/a8258744cbecf51321587fc870e8920bd2c07809/LICENSE
     "openai<=2.7.2",
 
+    # Anthropic: We leverage the Anthropic Messages API schemas for Nemo Gym abstractions (the /v1/messages endpoint). It may also be used to directly query endpoints.
+    # We upper bound this Anthropic dependency since the version bumps frequently, mirroring how we pin openai.
+    # Updated Mon Jun 16, 2026 with anthropic<=0.109.2
+    # License: MIT https://github.com/anthropics/anthropic-sdk-python/blob/v0.109.2/LICENSE
+    "anthropic<=0.109.2",
+
     # tqdm: Used for progress tracking on batch operations.
     # Updated Fri Jul 25, 2025 with tqdm==4.67.1
     # License: MIT https://github.com/tqdm/tqdm/blob/0ed5d7f18fa3153834cbac0aa57e8092b217cc16/LICENCE

--- a/tests/unit_tests/test_anthropic_utils.py
+++ b/tests/unit_tests/test_anthropic_utils.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+from pydantic import ValidationError
+
+from nemo_gym.anthropic_utils import (
+    NeMoGymAnthropicMessage,
+    NeMoGymAnthropicMessageCreateParamsNonStreaming,
+    NeMoGymAnthropicMessageForTraining,
+)
+
+
+class TestNeMoGymAnthropicMessageCreateParamsNonStreaming:
+    def test_minimal_request(self) -> None:
+        params = NeMoGymAnthropicMessageCreateParamsNonStreaming(
+            max_tokens=16, messages=[{"role": "user", "content": "hi"}]
+        )
+        # model is optional so the model server can fill it from its own config.
+        assert params.model is None
+        assert params.tools == []
+
+    def test_tool_calling_history(self) -> None:
+        """A text + tool_use + tool_result conversation round-trips through the strict schema."""
+        params = NeMoGymAnthropicMessageCreateParamsNonStreaming(
+            max_tokens=1024,
+            system="You are helpful.",
+            messages=[
+                {"role": "user", "content": "What's the weather in Paris?"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "Let me check."},
+                        {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"location": "Paris"}},
+                    ],
+                },
+                {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_1", "content": "72F"}]},
+            ],
+            tools=[
+                {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                }
+            ],
+            thinking={"type": "adaptive"},
+            tool_choice={"type": "auto"},
+        )
+        assert len(params.messages) == 3
+        assert len(params.tools) == 1
+
+    def test_unknown_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            NeMoGymAnthropicMessageCreateParamsNonStreaming(
+                max_tokens=16, messages=[{"role": "user", "content": "hi"}], not_a_real_field=1
+            )
+
+    def test_max_tokens_required(self) -> None:
+        with pytest.raises(ValidationError):
+            NeMoGymAnthropicMessageCreateParamsNonStreaming(messages=[{"role": "user", "content": "hi"}])
+
+    def test_training_input_message(self) -> None:
+        """Assistant turns in history may carry token IDs + log probs for training."""
+        params = NeMoGymAnthropicMessageCreateParamsNonStreaming(
+            max_tokens=16,
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "hi"}],
+                    "prompt_token_ids": [1, 2],
+                    "generation_token_ids": [3],
+                    "generation_log_probs": [-0.1],
+                }
+            ],
+        )
+        assert params.messages[0]["generation_token_ids"] == [3]
+
+
+class TestNeMoGymAnthropicMessage:
+    _RESPONSE = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-opus-4-8",
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "content": [{"type": "text", "text": "Sunny, 72F."}],
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+    def test_response_round_trip(self) -> None:
+        resp = NeMoGymAnthropicMessage.model_validate(self._RESPONSE)
+        assert resp.content[0].type == "text"
+        assert resp.content[0].text == "Sunny, 72F."
+        assert resp.usage.output_tokens == 5
+
+    def test_response_training_variant(self) -> None:
+        resp = NeMoGymAnthropicMessageForTraining.model_validate(
+            self._RESPONSE | {"prompt_token_ids": [1], "generation_token_ids": [2], "generation_log_probs": [-0.2]}
+        )
+        assert resp.generation_token_ids == [2]

--- a/tests/unit_tests/test_base_responses_api_model.py
+++ b/tests/unit_tests/test_base_responses_api_model.py
@@ -14,6 +14,10 @@
 # limitations under the License.
 from unittest.mock import MagicMock
 
+import pytest
+from fastapi import HTTPException
+
+from nemo_gym.anthropic_utils import NeMoGymAnthropicMessageCreateParamsNonStreaming
 from nemo_gym.base_responses_api_model import (
     BaseResponsesAPIModel,
     BaseResponsesAPIModelConfig,
@@ -46,3 +50,24 @@ class TestBaseResponsesAPIModel:
 
         model = TestSimpleResponsesAPIModel(config=config, server_client=MagicMock(spec=ServerClient))
         model.setup_webserver()
+
+    async def test_messages_default_returns_501(self) -> None:
+        """The /v1/messages endpoint is not abstract: servers that don't implement it return 501."""
+        config = BaseResponsesAPIModelConfig(host="", port=0, openai_api_key="123", entrypoint="", name="")
+
+        class TestSimpleResponsesAPIModel(SimpleResponsesAPIModel):
+            async def chat_completions(
+                self, request: NeMoGymResponseCreateParamsNonStreaming
+            ) -> NeMoGymChatCompletion:
+                raise NotImplementedError
+
+            async def responses(self, request: NeMoGymResponseCreateParamsNonStreaming) -> NeMoGymResponse:
+                raise NotImplementedError
+
+        model = TestSimpleResponsesAPIModel(config=config, server_client=MagicMock(spec=ServerClient))
+        body = NeMoGymAnthropicMessageCreateParamsNonStreaming(
+            max_tokens=16, messages=[{"role": "user", "content": "hi"}]
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await model.messages(body)
+        assert exc_info.value.status_code == 501

--- a/tests/unit_tests/test_claude_converter.py
+++ b/tests/unit_tests/test_claude_converter.py
@@ -1,0 +1,384 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from nemo_gym.anthropic_utils import NeMoGymAnthropicMessageCreateParamsNonStreaming
+from nemo_gym.claude_converter import ClaudeConverter
+from nemo_gym.openai_utils import NeMoGymChatCompletion
+
+
+def _req(**kwargs) -> NeMoGymAnthropicMessageCreateParamsNonStreaming:
+    kwargs.setdefault("max_tokens", 1024)
+    kwargs.setdefault("messages", [])
+    return NeMoGymAnthropicMessageCreateParamsNonStreaming.model_validate(kwargs)
+
+
+def _roles(cc) -> list[str]:
+    return [m["role"] for m in cc.messages]
+
+
+class TestMessagesToChatCompletion:
+    def setup_method(self) -> None:
+        self.c = ClaudeConverter()
+
+    def test_simple_text_message(self) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(_req(messages=[{"role": "user", "content": "hello"}]))
+        assert cc.messages == [{"role": "user", "content": "hello"}]
+        assert cc.max_tokens == 1024
+
+    def test_system_string(self) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(system="be brief", messages=[{"role": "user", "content": "hi"}])
+        )
+        assert cc.messages[0] == {"role": "system", "content": "be brief"}
+
+    def test_system_block_list_joined(self) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(
+                system=[{"type": "text", "text": "a"}, {"type": "text", "text": "b"}],
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        )
+        assert cc.messages[0] == {"role": "system", "content": "a b"}
+
+    def test_system_block_list_without_text_is_dropped(self) -> None:
+        # A system list carrying no text blocks yields no system message.
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(system=[], messages=[{"role": "user", "content": "hi"}])
+        )
+        assert "system" not in _roles(cc)
+
+    def test_system_role_message(self) -> None:
+        # Anthropic also allows "system" as a message role (not just the top-level param).
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(messages=[{"role": "system", "content": "stay terse"}])
+        )
+        assert cc.messages == [{"role": "system", "content": "stay terse"}]
+
+    def test_assistant_text_via_block_list(self) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(messages=[{"role": "assistant", "content": [{"type": "text", "text": "ok"}]}])
+        )
+        assert cc.messages == [{"role": "assistant", "content": "ok"}]
+
+    def test_assistant_tool_use_with_text(self) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(
+                messages=[
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "checking"},
+                            {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"city": "Paris"}},
+                        ],
+                    }
+                ]
+            )
+        )
+        msg = cc.messages[0]
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "checking"
+        assert msg["tool_calls"][0]["id"] == "toolu_1"
+        assert msg["tool_calls"][0]["type"] == "function"
+        assert msg["tool_calls"][0]["function"] == {"name": "get_weather", "arguments": '{"city": "Paris"}'}
+
+    def test_tool_use_only_has_null_content(self) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(
+                messages=[
+                    {"role": "assistant", "content": [{"type": "tool_use", "id": "t", "name": "f", "input": {}}]}
+                ]
+            )
+        )
+        assert cc.messages[0]["content"] is None
+
+    def test_tool_result_block_list_flattened(self) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "toolu_1",
+                                "content": [{"type": "text", "text": "72F"}, {"type": "text", "text": "sunny"}],
+                            }
+                        ],
+                    }
+                ]
+            )
+        )
+        assert cc.messages == [{"role": "tool", "tool_call_id": "toolu_1", "content": "72F sunny"}]
+
+    def test_tool_result_string_content(self) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(
+                messages=[
+                    {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t", "content": "done"}]}
+                ]
+            )
+        )
+        assert cc.messages[0] == {"role": "tool", "tool_call_id": "t", "content": "done"}
+
+    def test_tool_result_non_text_block_json_encoded(self) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "t",
+                                "content": [
+                                    {"type": "image", "source": {"type": "url", "url": "http://x/y.png"}},
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            )
+        )
+        # Non-text blocks are JSON-encoded so their data survives the flatten.
+        assert '"type": "image"' in cc.messages[0]["content"]
+
+    def test_thinking_blocks_dropped(self) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(
+                messages=[
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "thinking", "thinking": "secret", "signature": "s"},
+                            {"type": "redacted_thinking", "data": "xxx"},
+                            {"type": "text", "text": "answer"},
+                        ],
+                    }
+                ]
+            )
+        )
+        assert cc.messages == [{"role": "assistant", "content": "answer"}]
+
+    def test_empty_content_list_falls_back_to_empty_message(self) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(_req(messages=[{"role": "user", "content": []}]))
+        assert cc.messages == [{"role": "user", "content": ""}]
+
+    def test_unsupported_block_type_raises(self) -> None:
+        with pytest.raises(NotImplementedError):
+            self.c.messages_to_chat_completion_create_params(
+                _req(
+                    messages=[{"role": "user", "content": [{"type": "image", "source": {"type": "url", "url": "u"}}]}]
+                )
+            )
+
+    def test_tools_converted(self) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[
+                    {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "input_schema": {"type": "object", "properties": {"loc": {"type": "string"}}},
+                    }
+                ],
+            )
+        )
+        assert cc.tools[0]["type"] == "function"
+        assert cc.tools[0]["function"]["name"] == "get_weather"
+        assert cc.tools[0]["function"]["description"] == "Get weather"
+        assert cc.tools[0]["function"]["parameters"]["properties"]["loc"] == {"type": "string"}
+
+    def test_tool_without_input_schema_raises(self) -> None:
+        with pytest.raises(NotImplementedError):
+            self.c.messages_to_chat_completion_create_params(
+                _req(
+                    messages=[{"role": "user", "content": "hi"}],
+                    tools=[{"type": "web_search_20250305", "name": "web_search"}],
+                )
+            )
+
+    @pytest.mark.parametrize(
+        "anthropic_choice,openai_choice",
+        [("auto", "auto"), ("any", "required"), ("none", "none")],
+    )
+    def test_tool_choice_string(self, anthropic_choice: str, openai_choice: str) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(messages=[{"role": "user", "content": "hi"}], tool_choice={"type": anthropic_choice})
+        )
+        assert cc.tool_choice == openai_choice
+
+    def test_tool_choice_specific_tool(self) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(messages=[{"role": "user", "content": "hi"}], tool_choice={"type": "tool", "name": "get_weather"})
+        )
+        assert cc.tool_choice == {"type": "function", "function": {"name": "get_weather"}}
+
+    def test_tool_choice_unknown_dict_defaults_auto(self) -> None:
+        assert self.c._convert_tool_choice({"type": "mystery"}) == "auto"
+
+    def test_tool_choice_bare_string(self) -> None:
+        # Anthropic also accepts a bare string tool_choice.
+        assert self.c._convert_tool_choice("any") == "required"
+
+    def test_scalar_params_mapped(self) -> None:
+        cc = self.c.messages_to_chat_completion_create_params(
+            _req(
+                model="claude-opus-4-8",
+                temperature=0.5,
+                top_p=0.9,
+                top_k=40,
+                stop_sequences=["STOP"],
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        )
+        assert cc.model == "claude-opus-4-8"
+        assert cc.temperature == 0.5
+        assert cc.top_p == 0.9
+        assert cc.stop == ["STOP"]
+        # top_k has no Chat Completions equivalent and is dropped.
+        assert not hasattr(cc, "top_k") or cc.model_dump().get("top_k") is None
+
+    def test_simple_message_unsupported_role_raises(self) -> None:
+        # Defensive branch: Anthropic message roles are constrained to
+        # user/assistant/system by validation, so exercise it directly.
+        with pytest.raises(NotImplementedError):
+            self.c._simple_message("developer", "x")
+
+    def test_flatten_tool_result_scalar_fallback(self) -> None:
+        assert self.c._flatten_tool_result_content(123) == "123"
+
+
+def _chat_completion(message: dict, finish_reason: str = "stop", usage: dict | None = None) -> NeMoGymChatCompletion:
+    return NeMoGymChatCompletion.model_validate(
+        {
+            "id": "cmpl-1",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "backend-model",
+            "choices": [{"index": 0, "finish_reason": finish_reason, "message": message}],
+            "usage": usage,
+        }
+    )
+
+
+class TestChatCompletionToMessage:
+    def setup_method(self) -> None:
+        self.c = ClaudeConverter()
+
+    def test_text_response(self) -> None:
+        msg = self.c.chat_completion_to_message(
+            _chat_completion(
+                {"role": "assistant", "content": "hello"},
+                usage={"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
+            )
+        )
+        assert msg.type == "message"
+        assert msg.role == "assistant"
+        assert msg.model == "backend-model"
+        assert msg.stop_reason == "end_turn"
+        assert msg.stop_sequence is None
+        assert [b.type for b in msg.content] == ["text"]
+        assert msg.content[0].text == "hello"
+        assert (msg.usage.input_tokens, msg.usage.output_tokens) == (3, 4)
+        assert msg.id.startswith("msg_")
+
+    def test_model_override(self) -> None:
+        msg = self.c.chat_completion_to_message(
+            _chat_completion({"role": "assistant", "content": "x"}), model="claude-opus-4-8"
+        )
+        assert msg.model == "claude-opus-4-8"
+
+    def test_tool_calls_response(self) -> None:
+        msg = self.c.chat_completion_to_message(
+            _chat_completion(
+                {
+                    "role": "assistant",
+                    "content": "let me check",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                        }
+                    ],
+                },
+                finish_reason="tool_calls",
+            )
+        )
+        assert [b.type for b in msg.content] == ["text", "tool_use"]
+        tool_use = msg.content[1]
+        assert tool_use.id == "call_1"
+        assert tool_use.name == "get_weather"
+        assert tool_use.input == {"city": "Paris"}
+        assert msg.stop_reason == "tool_use"
+
+    def test_tool_call_with_invalid_json_arguments(self) -> None:
+        msg = self.c.chat_completion_to_message(
+            _chat_completion(
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {"id": "c", "type": "function", "function": {"name": "f", "arguments": "not json"}}
+                    ],
+                },
+                finish_reason="tool_calls",
+            )
+        )
+        assert msg.content[0].type == "tool_use"
+        assert msg.content[0].input == {"raw": "not json"}
+
+    def test_empty_message_gets_empty_text_block(self) -> None:
+        msg = self.c.chat_completion_to_message(_chat_completion({"role": "assistant", "content": None}))
+        assert [b.type for b in msg.content] == ["text"]
+        assert msg.content[0].text == ""
+
+    def test_usage_absent_defaults_to_zero(self) -> None:
+        msg = self.c.chat_completion_to_message(_chat_completion({"role": "assistant", "content": "x"}, usage=None))
+        assert (msg.usage.input_tokens, msg.usage.output_tokens) == (0, 0)
+
+    @pytest.mark.parametrize(
+        "finish_reason,stop_reason",
+        [
+            ("stop", "end_turn"),
+            ("length", "max_tokens"),
+            ("tool_calls", "tool_use"),
+            ("content_filter", "end_turn"),
+            ("function_call", "tool_use"),
+        ],
+    )
+    def test_finish_reason_mapping(self, finish_reason: str, stop_reason: str) -> None:
+        msg = self.c.chat_completion_to_message(
+            _chat_completion({"role": "assistant", "content": "x"}, finish_reason=finish_reason)
+        )
+        assert msg.stop_reason == stop_reason
+
+
+class TestRoundTrip:
+    def test_request_then_response(self) -> None:
+        c = ClaudeConverter()
+        # Anthropic request -> Chat Completions request.
+        cc_req = c.messages_to_chat_completion_create_params(
+            _req(system="be helpful", messages=[{"role": "user", "content": "hi"}])
+        )
+        assert _roles(cc_req) == ["system", "user"]
+        # A backend Chat Completions response -> Anthropic Messages response.
+        msg = c.chat_completion_to_message(
+            _chat_completion({"role": "assistant", "content": "hi there"}), model="claude-opus-4-8"
+        )
+        assert msg.content[0].text == "hi there"
+        assert msg.role == "assistant"

--- a/uv.lock
+++ b/uv.lock
@@ -197,6 +197,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.109.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/b7/9a8e2f79011e89dd6eeb599c27332aed765dac9d6fbee3a55e68e4e3ec25/anthropic-0.109.2.tar.gz", hash = "sha256:d37db299597c7bc124b49b767ff135f1e6456b64af2b2fad4b63b2a1df333cf0", size = 927559, upload-time = "2026-06-15T17:30:25.024Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/f2/bee5de8a2699fc8a3cce34d61c7a2626a2c310ddde7ea5611327eb0ddbe9/anthropic-0.109.2-py3-none-any.whl", hash = "sha256:e0fb4ca5df0ed983248c9c6c3242adc81d9cfddb8725902da53698554117abac", size = 923800, upload-time = "2026-06-15T17:30:23.124Z" },
+]
+
+[[package]]
 name = "antlr4-python3-runtime"
 version = "4.9.3"
 source = { registry = "https://pypi.org/simple" }
@@ -534,6 +553,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -1374,6 +1402,7 @@ name = "nemo-gym"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "anthropic" },
     { name = "datasets" },
     { name = "devtools" },
     { name = "fastapi" },
@@ -1432,6 +1461,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
+    { name = "anthropic", specifier = "<=0.109.2" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "datasets" },
     { name = "devtools" },


### PR DESCRIPTION
Add NeMoGymAnthropic* wrapper schemas mirroring openai_utils, wire a non-abstract /v1/messages endpoint that returns 501 by default, and add the anthropic dependency.