### PR TITLE
fix: unblock CI from incomplete critpt landing (resilient gym list + missing critpt_agent README)

### DIFF
--- a/nemo_gym/benchmarks.py
+++ b/nemo_gym/benchmarks.py
@@ -23,6 +23,7 @@ from typing import Dict, List, Optional, Tuple
 import rich
 from omegaconf import DictConfig, OmegaConf
 from pydantic import BaseModel, Field
+from rich.markup import escape
 from rich.table import Table
 from tqdm.auto import tqdm
 
@@ -98,7 +99,15 @@ def _load_benchmarks_from_config_paths(config_paths: List[Path]) -> Dict[str, Be
     for config_path in config_paths:
         config_path = Path(config_path)
 
-        maybe_bc = BenchmarkConfig.from_config_path(config_path)
+        # Listing is best-effort: a single benchmark whose config can't be loaded in the current
+        # environment (e.g. it references an interpolation/API key that isn't set right now) must
+        # not break listing the rest. Skip it with a warning instead of crashing.
+        try:
+            maybe_bc = BenchmarkConfig.from_config_path(config_path)
+        except Exception as e:
+            rich.print(f"[yellow]Skipping benchmark config {config_path}: {escape(str(e))}[/yellow]")
+            continue
+
         if not maybe_bc:
             continue
 

--- a/responses_api_agents/critpt_agent/README.md
+++ b/responses_api_agents/critpt_agent/README.md
@@ -1,0 +1,24 @@
+# CritPt Agent
+
+Custom two-turn agent for the [CritPt](https://huggingface.co/datasets/CritPt-Benchmark/CritPt)
+research-level physics benchmark. The built-in `simple_agent` does not work for CritPt; this agent
+drives the two LLM calls required per problem:
+
+- **Turn 1 — solve:** the policy model reasons about the physics problem.
+- **Turn 2 — populate template:** the model fills the problem's code template from its Turn 1
+  solution (`turn2_prompt_fpath`). The result is submitted to the resources server for batched
+  evaluation via the [Artificial Analysis API](https://artificialanalysis.ai/documentation#critpt-api).
+
+## Composition
+
+Wired together in [`benchmarks/critpt/config.yaml`](../../benchmarks/critpt/config.yaml):
+
+- `responses_api_agents/critpt_agent` — this agent
+- `responses_api_models/*` — typically `policy_model`
+- `resources_servers/critpt` — the verifier (see [its README](../../resources_servers/critpt/README.md))
+
+## Tests
+
+```bash
+ng_test +entrypoint=responses_api_agents/critpt_agent
+```

--- a/tests/unit_tests/test_benchmarks.py
+++ b/tests/unit_tests/test_benchmarks.py
@@ -19,7 +19,7 @@ import pytest
 from omegaconf import OmegaConf
 from yaml import safe_load
 
-from nemo_gym.benchmarks import list_benchmarks, prepare_benchmark
+from nemo_gym.benchmarks import BenchmarkConfig, _load_benchmarks_from_config_paths, list_benchmarks, prepare_benchmark
 
 
 def _mock_global_config(config: dict = None):
@@ -40,6 +40,20 @@ class TestListBenchmarks:
         ):
             list_benchmarks()
         assert "No benchmarks found" in capsys.readouterr().out
+
+    def test_load_benchmarks_skips_unloadable_config(self, capsys) -> None:
+        # A benchmark config that can't be loaded in the current environment (e.g. it references an
+        # interpolation/API key that isn't set) must be skipped with a warning, not crash listing.
+        from omegaconf.errors import InterpolationKeyError
+
+        def boom(cls, config_path):
+            raise InterpolationKeyError("Interpolation key 'some_api_key' not found")
+
+        with patch.object(BenchmarkConfig, "from_config_path", classmethod(boom)):
+            result = _load_benchmarks_from_config_paths([Path("benchmarks/needs_key/config.yaml")])
+
+        assert result == {}
+        assert "Skipping benchmark config" in capsys.readouterr().out
 
 
 class TestPrepareBenchmark:


### PR DESCRIPTION
Two pre-existing `main` CI failures, both caused by the `critpt` benchmark landing incomplete. They're entangled at the CI level — you need **both** fixes to go green (a fix for one alone still fails the other job), so they're together here.

## 1. Unit `Test` job — `gym list` crash (benchmarks.py)
[`benchmarks/critpt/config.yaml`](https://github.com/NVIDIA-NeMo/Gym/blob/main/benchmarks/critpt/config.yaml) has `api_key: ${artificial_analysis_api_key}` (unset in CI). `test_lists_found_benchmarks` resolved it → `InterpolationKeyError`, crashing the whole listing and dragging coverage under the gate.
**Fix:** `_load_benchmarks_from_config_paths` is now best-effort — it skips a config it can't resolve in the current env, with a warning, instead of crashing. Other benchmarks still list.

## 2. Server-suite (all 8 shards) — module-count mismatch
[`responses_api_agents/critpt_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/critpt_agent) shipped **without a README**, so `ng_test_all +fail_on_total_and_test_mismatch=true` failed (120 modules found, 119 with a README). That check runs on the full list before sharding, so **every shard failed identically**.
**Fix:** added the missing `README.md`. critpt_agent's tests are fully mocked and pass (15/15); it now joins the suite and the count matches (120/120).

## Verified
- `tests/unit_tests/test_benchmarks.py`: 8/8 on the real `main` tree (incl. `test_lists_found_benchmarks`, which fails without fix #1) + new `test_load_benchmarks_skips_unloadable_config`.
- `responses_api_agents/critpt_agent/tests`: 15/15.
- Module count 120/120 → mismatch gate passes.
- ruff + pre-commit clean.

Reproduces on `main` HEAD; independent of the config-friction PRs. Unblocks CI for all open PRs.