### PR TITLE
docs(config): document the Domain enum (#1205 friction #9 / FEP-1023)

### DIFF
--- a/nemo_gym/config_types.py
+++ b/nemo_gym/config_types.py
@@ -409,22 +409,22 @@ class Domain(str, Enum):
     """The capability a resources server primarily evaluates or trains.
 
     Pick the single domain that best fits the task. If several seem to apply, choose the most
-    specific one (e.g. prefer ``math`` or ``coding`` over ``agent``); use ``other`` only when none
+    specific one (e.g. prefer `math` or `coding` over `agent`); use `other` only when none
     of the specific values fit. The values:
 
-    - ``math``                  — mathematical problem solving (e.g. AIME, MATH, GSM8K).
-    - ``coding``                — code generation, repair, or execution (e.g. SWE-bench, LiveCodeBench).
-    - ``agent``                 — multi-step, tool-using / environment-interacting tasks (e.g. tau2,
+    - `math`                  — mathematical problem solving (e.g. AIME, MATH, GSM8K).
+    - `coding`                — code generation, repair, or execution (e.g. SWE-bench, LiveCodeBench).
+    - `agent`                 — multi-step, tool-using / environment-interacting tasks (e.g. tau2,
       workplace_assistant). Prefer a more specific value when the task is really math/coding/etc.
-    - ``knowledge``             — factual or domain-knowledge question answering (e.g. GPQA, MMLU).
-    - ``instruction_following`` — adherence to explicit formatting/constraints (e.g. IFEval).
-    - ``long_context``          — reasoning over long inputs (e.g. RULER, long-document QA).
-    - ``safety``                — refusing harmful content / resisting jailbreaks & prompt injection.
-    - ``games``                 — interactive game environments (e.g. blackjack, tetris).
-    - ``translation``           — machine translation quality (e.g. WMT).
-    - ``e2e``                   — end-to-end pipelines spanning multiple capabilities at once.
-    - ``rlhf``                  — preference / reward-model / LLM-as-judge evaluations.
-    - ``other``                 — catch-all when no specific domain above applies.
+    - `knowledge`             — factual or domain-knowledge question answering (e.g. GPQA, MMLU).
+    - `instruction_following` — adherence to explicit formatting/constraints (e.g. IFEval).
+    - `long_context`          — reasoning over long inputs (e.g. RULER, long-document QA).
+    - `safety`                — refusing harmful content / resisting jailbreaks & prompt injection.
+    - `games`                 — interactive game environments (e.g. blackjack, tetris).
+    - `translation`           — machine translation quality (e.g. WMT).
+    - `e2e`                   — end-to-end pipelines spanning multiple capabilities at once.
+    - `rlhf`                  — preference / reward-model / LLM-as-judge evaluations.
+    - `other`                 — catch-all when no specific domain above applies.
     """
 
     MATH = "math"

--- a/nemo_gym/config_types.py
+++ b/nemo_gym/config_types.py
@@ -406,6 +406,27 @@ class BenchmarkDatasetConfig(BaseModel):
 
 
 class Domain(str, Enum):
+    """The capability a resources server primarily evaluates or trains.
+
+    Pick the single domain that best fits the task. If several seem to apply, choose the most
+    specific one (e.g. prefer ``math`` or ``coding`` over ``agent``); use ``other`` only when none
+    of the specific values fit. The values:
+
+    - ``math``                  — mathematical problem solving (e.g. AIME, MATH, GSM8K).
+    - ``coding``                — code generation, repair, or execution (e.g. SWE-bench, LiveCodeBench).
+    - ``agent``                 — multi-step, tool-using / environment-interacting tasks (e.g. tau2,
+      workplace_assistant). Prefer a more specific value when the task is really math/coding/etc.
+    - ``knowledge``             — factual or domain-knowledge question answering (e.g. GPQA, MMLU).
+    - ``instruction_following`` — adherence to explicit formatting/constraints (e.g. IFEval).
+    - ``long_context``          — reasoning over long inputs (e.g. RULER, long-document QA).
+    - ``safety``                — refusing harmful content / resisting jailbreaks & prompt injection.
+    - ``games``                 — interactive game environments (e.g. blackjack, tetris).
+    - ``translation``           — machine translation quality (e.g. WMT).
+    - ``e2e``                   — end-to-end pipelines spanning multiple capabilities at once.
+    - ``rlhf``                  — preference / reward-model / LLM-as-judge evaluations.
+    - ``other``                 — catch-all when no specific domain above applies.
+    """
+
     MATH = "math"
     CODING = "coding"
     AGENT = "agent"

--- a/tests/unit_tests/test_config_types_help.py
+++ b/tests/unit_tests/test_config_types_help.py
@@ -197,3 +197,13 @@ class TestHelpOutput:
         # Validate parameters section
         assert "param" in parsed["parameters"]
         assert "[required]" in parsed["parameters"]["param"]
+
+
+def test_domain_enum_documents_every_value() -> None:
+    # Each Domain value must be documented in the enum docstring, so newly-added domains can't
+    # ship without guidance (the docstring is the source of truth surfaced in IDEs / on hover).
+    from nemo_gym.config_types import Domain
+
+    doc = Domain.__doc__ or ""
+    for member in Domain:
+        assert f"``{member.value}``" in doc, f"Domain.{member.name} ('{member.value}') is undocumented"

--- a/tests/unit_tests/test_config_types_help.py
+++ b/tests/unit_tests/test_config_types_help.py
@@ -206,4 +206,4 @@ def test_domain_enum_documents_every_value() -> None:
 
     doc = Domain.__doc__ or ""
     for member in Domain:
-        assert f"``{member.value}``" in doc, f"Domain.{member.name} ('{member.value}') is undocumented"
+        assert f"`{member.value}`" in doc, f"Domain.{member.name} ('{member.value}') is undocumented"


### PR DESCRIPTION
## What

Adds a docstring to the `Domain` enum in `config_types.py` — a one-line description per value with a recognizable example benchmark, plus guidance to **pick the most specific domain** and use `other` only as a catch-all (addresses the [#600](https://github.com/NVIDIA-NeMo/Gym/issues/600) 'agent is too broad / no guidance' concern **without** redefining the taxonomy).

```
math   — mathematical problem solving (e.g. AIME, MATH, GSM8K).
coding — code generation, repair, or execution (e.g. SWE-bench, LiveCodeBench).
agent  — multi-step, tool-using tasks (e.g. tau2, workplace_assistant). Prefer a more specific value when it fits.
... (knowledge, instruction_following, long_context, safety, games, translation, e2e, rlhf, other)
```

## Why

Epic [#1205](https://github.com/NVIDIA-NeMo/Gym/issues/1205) friction 9 (naming confusion). Surfaces on IDE hover and when reading `config_types`; complements the inline `domain` comment added in #1597.

## Tests

`test_domain_enum_documents_every_value` asserts every `Domain` value appears in the docstring, so a newly-added domain can't ship undocumented. 
