### PR TITLE
docs: define Resources/Agent/Model Server in the glossary (#1205 friction #9, #395)

### DIFF
--- a/fern/versions/latest/pages/about/concepts/key-terminology.mdx
+++ b/fern/versions/latest/pages/about/concepts/key-terminology.mdx
@@ -57,6 +57,18 @@ Training data format for DPO consisting of the same prompt with two different re
 
 The primary LLM being trained or evaluated - the "decision-making brain" you want to improve.
 
+**Resources Server**
+
+The FastAPI service (one directory per environment under `resources_servers/`) that *is* the environment: it holds per-task state, exposes the environment's tools, and implements `verify()` to score a rollout into a reward. If the name "Resources Server" feels abstract, read it as "the environment + verifier service." Every benchmark or training environment has exactly one.
+
+**Agent Server (Responses API Agent)**
+
+The FastAPI service (under `responses_api_agents/`) that drives the model through a task - the harness that runs the multi-step / tool-calling loop against a resources server. `simple_agent` is the built-in default; bring your own for custom control flow.
+
+**Model Server (Responses API Model)**
+
+The FastAPI service (under `responses_api_models/`) that wraps an LLM endpoint (vLLM, OpenAI, etc.) behind NeMo Gym's Responses API and manages the token IDs needed for training. Agents refer to it by name (commonly `policy_model`).
+
 **Orchestration**
 
 Coordination logic that manages when to call models, which tools to use, and how to sequence multi-step operations.

--- a/fern/versions/latest/pages/about/concepts/key-terminology.mdx
+++ b/fern/versions/latest/pages/about/concepts/key-terminology.mdx
@@ -59,11 +59,11 @@ The primary LLM being trained or evaluated - the "decision-making brain" you wan
 
 **Resources Server**
 
-The FastAPI service (one directory per environment under `resources_servers/`) that *is* the environment: it holds per-task state, exposes the environment's tools, and implements `verify()` to score a rollout into a reward. If the name "Resources Server" feels abstract, read it as "the environment + verifier service." Every benchmark or training environment has exactly one.
+The FastAPI service (under `resources_servers/`) that holds per-task state, exposes the environment's tools, and implements `verify()` to score a rollout into a reward — the verifier-and-state component of an environment. (In Gym an *environment* is a resources server together with an agent and dataset(s); see the `environments/` directory.) Every environment has exactly one resources server.
 
 **Agent Server (Responses API Agent)**
 
-The FastAPI service (under `responses_api_agents/`) that drives the model through a task - the harness that runs the multi-step / tool-calling loop against a resources server. `simple_agent` is the built-in default; bring your own for custom control flow.
+The FastAPI service (under `responses_api_agents/`) that drives the model through a task — the harness that runs the multi-step / tool-calling loop against a resources server. Gym ships several built-in harnesses (e.g. `simple_agent`, `aviary_agent`, and others under `responses_api_agents/`); pick whichever fits your control flow, or bring your own.
 
 **Model Server (Responses API Model)**
 

--- a/fern/versions/v0.3.0/pages/about/concepts/key-terminology.mdx
+++ b/fern/versions/v0.3.0/pages/about/concepts/key-terminology.mdx
@@ -57,6 +57,18 @@ Training data format for DPO consisting of the same prompt with two different re
 
 The primary LLM being trained or evaluated - the "decision-making brain" you want to improve.
 
+**Resources Server**
+
+The FastAPI service (one directory per environment under `resources_servers/`) that *is* the environment: it holds per-task state, exposes the environment's tools, and implements `verify()` to score a rollout into a reward. If the name "Resources Server" feels abstract, read it as "the environment + verifier service." Every benchmark or training environment has exactly one.
+
+**Agent Server (Responses API Agent)**
+
+The FastAPI service (under `responses_api_agents/`) that drives the model through a task - the harness that runs the multi-step / tool-calling loop against a resources server. `simple_agent` is the built-in default; bring your own for custom control flow.
+
+**Model Server (Responses API Model)**
+
+The FastAPI service (under `responses_api_models/`) that wraps an LLM endpoint (vLLM, OpenAI, etc.) behind NeMo Gym's Responses API and manages the token IDs needed for training. Agents refer to it by name (commonly `policy_model`).
+
 **Orchestration**
 
 Coordination logic that manages when to call models, which tools to use, and how to sequence multi-step operations.

--- a/fern/versions/v0.3.0/pages/about/concepts/key-terminology.mdx
+++ b/fern/versions/v0.3.0/pages/about/concepts/key-terminology.mdx
@@ -59,11 +59,11 @@ The primary LLM being trained or evaluated - the "decision-making brain" you wan
 
 **Resources Server**
 
-The FastAPI service (one directory per environment under `resources_servers/`) that *is* the environment: it holds per-task state, exposes the environment's tools, and implements `verify()` to score a rollout into a reward. If the name "Resources Server" feels abstract, read it as "the environment + verifier service." Every benchmark or training environment has exactly one.
+The FastAPI service (under `resources_servers/`) that holds per-task state, exposes the environment's tools, and implements `verify()` to score a rollout into a reward — the verifier-and-state component of an environment. (In Gym an *environment* is a resources server together with an agent and dataset(s); see the `environments/` directory.) Every environment has exactly one resources server.
 
 **Agent Server (Responses API Agent)**
 
-The FastAPI service (under `responses_api_agents/`) that drives the model through a task - the harness that runs the multi-step / tool-calling loop against a resources server. `simple_agent` is the built-in default; bring your own for custom control flow.
+The FastAPI service (under `responses_api_agents/`) that drives the model through a task — the harness that runs the multi-step / tool-calling loop against a resources server. Gym ships several built-in harnesses (e.g. `simple_agent`, `aviary_agent`, and others under `responses_api_agents/`); pick whichever fits your control flow, or bring your own.
 
 **Model Server (Responses API Model)**
 


### PR DESCRIPTION
## What

The key-terminology glossary (`fern/.../about/concepts/key-terminology.mdx`) defined `Verifier`, `Policy Model`, etc. but **not** the three FastAPI server types — so "Resources Server" was never actually defined ([#395](https://github.com/NVIDIA-NeMo/Gym/issues/395): the name is nebulous). Added clear Architecture-Terms entries:

- **Resources Server** — *is* the environment: per-task state + tools + `verify()` → reward. "Read it as the environment + verifier service."
- **Agent Server (Responses API Agent)** — the harness that drives the model through the task.
- **Model Server (Responses API Model)** — wraps an LLM endpoint behind the Responses API.

Each ties the term to its directory (`resources_servers/`, `responses_api_agents/`, `responses_api_models/`). Mirrored into `latest` and `v0.3.0`.

## Why

Epic [#1205](https://github.com/NVIDIA-NeMo/Gym/issues/1205) friction 9 (naming confusion), RFC milestone M6e. Docs-only.
