### PR TITLE
feat(cli): run an environment by name — 'gym env run --env <name>' (#1205 friction #8 / FEP-1022)

### DIFF
--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -279,11 +279,17 @@ def _env_run(args: argparse.Namespace, overrides: list[str]) -> None:
             config_paths += resolve_environment_config_paths(args.env)
         except EnvironmentNotFoundError as error:
             raise SystemExit(f"error: {error}")
-    if args.config:
-        config_paths += list(args.config)
+    # Merge --env's resolved config(s) with any +config_paths the router already emitted — from
+    # --config or from an asset-selector name (e.g. `gym env run mcqa`) — into a single token,
+    # preserving order. Pulling paths out of the existing token (rather than re-reading args.config)
+    # means asset-selector resolution is not discarded.
+    rest: list[str] = []
+    for token in overrides:
+        if token.startswith("+config_paths=[") and token.endswith("]"):
+            config_paths += [path for path in token[len("+config_paths=[") : -1].split(",") if path]
+        else:
+            rest.append(token)
 
-    # CONFIG already emitted its own +config_paths token; drop it and emit the merged list instead.
-    rest = [token for token in overrides if not token.startswith("+config_paths=")]
     merged = ([f"+config_paths=[{','.join(config_paths)}]"] if config_paths else []) + rest
     dispatch("nemo_gym.cli.env:run", merged)
 

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -108,6 +108,16 @@ CONFIG = Flag(
     translate_to_hydra=lambda args: [f"+config_paths=[{','.join(args.config)}]"] if args.config else [],
 )
 
+# Shared flag: select an environment by name (run-by-name). Resolved to its config via the registry
+# in `_env_run` rather than statically, then merged with any --config into a single +config_paths.
+ENV = Flag(
+    register=lambda p: p.add_argument(
+        "--env",
+        metavar="NAME",
+        help="Environment to run, by name (see `gym list environments`); combined with --config / --model-* for the model.",
+    ),
+)
+
 # Shared flag: select the storage backend. Reused by `dataset upload` and `dataset download`.
 STORAGE = Flag(
     register=lambda p: p.add_argument(
@@ -254,6 +264,28 @@ def _merge_config_paths(overrides: list[str]) -> list[str]:
 def _eval_run(args: argparse.Namespace, overrides: list[str]) -> None:
     target = "nemo_gym.cli.eval:collect_rollouts" if args.no_serve else "nemo_gym.cli.eval:e2e_rollout_collection"
     dispatch(target, overrides)
+
+
+def _env_run(args: argparse.Namespace, overrides: list[str]) -> None:
+    # Run an environment by name: resolve --env to its config via the registry and merge it with any
+    # --config files into a single +config_paths token (the env references its model server, so pair
+    # it with --config / --model-* for the model). Other overrides (model flags, passthrough) flow
+    # through unchanged.
+    config_paths: list[str] = []
+    if getattr(args, "env", None):
+        from nemo_gym.registry import EnvironmentNotFoundError, resolve_environment_config_paths
+
+        try:
+            config_paths += resolve_environment_config_paths(args.env)
+        except EnvironmentNotFoundError as error:
+            raise SystemExit(f"error: {error}")
+    if args.config:
+        config_paths += list(args.config)
+
+    # CONFIG already emitted its own +config_paths token; drop it and emit the merged list instead.
+    rest = [token for token in overrides if not token.startswith("+config_paths=")]
+    merged = ([f"+config_paths=[{','.join(config_paths)}]"] if config_paths else []) + rest
+    dispatch("nemo_gym.cli.env:run", merged)
 
 
 def _env_test(args: argparse.Namespace, overrides: list[str]) -> None:
@@ -409,9 +441,9 @@ COMMANDS = {
         flags=(RESOURCE_SERVER,),
     ),
     "env run": Command(
-        target="nemo_gym.cli.env:run",
-        summary="Start the servers.",
-        flags=(CONFIG, BENCHMARK, RESOURCE_SERVER_CONFIG, MODEL_TYPE, SEARCH_DIR, MODEL, MODEL_URL, MODEL_API_KEY),
+        target=_env_run,
+        summary="Start the servers (by --env name and/or --config).",
+        flags=(ENV, CONFIG, BENCHMARK, RESOURCE_SERVER_CONFIG, MODEL_TYPE, SEARCH_DIR, MODEL, MODEL_URL, MODEL_API_KEY),
     ),
     "env status": Command(target="nemo_gym.cli.env:status", summary="Print the server status.", flags=(JSON,)),
     "eval prepare": Command(

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -449,7 +449,17 @@ COMMANDS = {
     "env run": Command(
         target=_env_run,
         summary="Start the servers (by --env name and/or --config).",
-        flags=(ENV, CONFIG, BENCHMARK, RESOURCE_SERVER_CONFIG, MODEL_TYPE, SEARCH_DIR, MODEL, MODEL_URL, MODEL_API_KEY),
+        flags=(
+            ENV,
+            CONFIG,
+            BENCHMARK,
+            RESOURCE_SERVER_CONFIG,
+            MODEL_TYPE,
+            SEARCH_DIR,
+            MODEL,
+            MODEL_URL,
+            MODEL_API_KEY,
+        ),
     ),
     "env status": Command(target="nemo_gym.cli.env:status", summary="Print the server status.", flags=(JSON,)),
     "eval prepare": Command(

--- a/tests/unit_tests/test_cli_main.py
+++ b/tests/unit_tests/test_cli_main.py
@@ -901,6 +901,18 @@ class TestEnvRunByName:
         assert target == "nemo_gym.cli.env:run"
         assert overrides == ["+config_paths=[a.yaml]"]
 
+    def test_existing_config_paths_token_is_preserved(self, monkeypatch: MonkeyPatch) -> None:
+        # An asset-selector name (or passthrough) reaches _env_run as a +config_paths token with no
+        # --env/--config; it must survive rather than be stripped.
+        target, overrides = _dispatch_for(monkeypatch, ["env", "run", "+config_paths=[foo.yaml]"])
+        assert target == "nemo_gym.cli.env:run"
+        assert overrides == ["+config_paths=[foo.yaml]"]
+
+    def test_env_merges_with_existing_config_paths_token(self, monkeypatch: MonkeyPatch) -> None:
+        self._patch_resolve(monkeypatch)
+        _, overrides = _dispatch_for(monkeypatch, ["env", "run", "--env", "alpha", "+config_paths=[foo.yaml]"])
+        assert overrides == ["+config_paths=[environments/alpha/config.yaml,foo.yaml]"]
+
     def test_unknown_env_exits_cleanly(self, monkeypatch: MonkeyPatch) -> None:
         import nemo_gym.registry
         from nemo_gym.registry import EnvironmentNotFoundError

--- a/tests/unit_tests/test_cli_main.py
+++ b/tests/unit_tests/test_cli_main.py
@@ -892,7 +892,7 @@ class TestEnvRunByName:
 
     def test_model_flags_pass_through(self, monkeypatch: MonkeyPatch) -> None:
         self._patch_resolve(monkeypatch)
-        _, overrides = _dispatch_for(monkeypatch, ["env", "run", "--env", "alpha", "--model-name", "gpt"])
+        _, overrides = _dispatch_for(monkeypatch, ["env", "run", "--env", "alpha", "--model", "gpt"])
         assert "+config_paths=[environments/alpha/config.yaml]" in overrides
         assert "+policy_model_name=gpt" in overrides
 

--- a/tests/unit_tests/test_cli_main.py
+++ b/tests/unit_tests/test_cli_main.py
@@ -866,3 +866,50 @@ class TestListEnvironmentsRouting:
         target, overrides = _dispatch_for(monkeypatch, ["list", "environments"])
         assert target == "nemo_gym.cli.env:list_environments"
         assert overrides == []
+
+
+class TestEnvRunByName:
+    def _patch_resolve(self, monkeypatch: MonkeyPatch) -> None:
+        import nemo_gym.registry
+
+        monkeypatch.setattr(
+            nemo_gym.registry,
+            "resolve_environment_config_paths",
+            lambda name, *a, **k: [f"environments/{name}/config.yaml"],
+        )
+
+    def test_env_name_resolves_to_config_path(self, monkeypatch: MonkeyPatch) -> None:
+        self._patch_resolve(monkeypatch)
+        target, overrides = _dispatch_for(monkeypatch, ["env", "run", "--env", "alpha"])
+        assert target == "nemo_gym.cli.env:run"
+        assert overrides == ["+config_paths=[environments/alpha/config.yaml]"]
+
+    def test_env_and_config_merge_into_one_config_paths(self, monkeypatch: MonkeyPatch) -> None:
+        self._patch_resolve(monkeypatch)
+        _, overrides = _dispatch_for(monkeypatch, ["env", "run", "--env", "alpha", "--config", "model.yaml"])
+        config_paths = [o for o in overrides if o.startswith("+config_paths=")]
+        assert config_paths == ["+config_paths=[environments/alpha/config.yaml,model.yaml]"]
+
+    def test_model_flags_pass_through(self, monkeypatch: MonkeyPatch) -> None:
+        self._patch_resolve(monkeypatch)
+        _, overrides = _dispatch_for(monkeypatch, ["env", "run", "--env", "alpha", "--model-name", "gpt"])
+        assert "+config_paths=[environments/alpha/config.yaml]" in overrides
+        assert "+policy_model_name=gpt" in overrides
+
+    def test_config_only_is_unchanged(self, monkeypatch: MonkeyPatch) -> None:
+        target, overrides = _dispatch_for(monkeypatch, ["env", "run", "--config", "a.yaml"])
+        assert target == "nemo_gym.cli.env:run"
+        assert overrides == ["+config_paths=[a.yaml]"]
+
+    def test_unknown_env_exits_cleanly(self, monkeypatch: MonkeyPatch) -> None:
+        import nemo_gym.registry
+        from nemo_gym.registry import EnvironmentNotFoundError
+
+        def boom(name, *a, **k):
+            raise EnvironmentNotFoundError(f"No environment named '{name}'")
+
+        monkeypatch.setattr(nemo_gym.registry, "resolve_environment_config_paths", boom)
+        monkeypatch.setattr(cli_main, "dispatch", lambda target, overrides: None)
+        monkeypatch.setattr(sys, "argv", ["gym", "env", "run", "--env", "nope"])
+        with pytest.raises(SystemExit):
+            main()


### PR DESCRIPTION
## What

The run-by-name half of M2 (the discovery half is the base PR #1635): run an environment by its short name instead of an internal config path.

```bash
gym env run --env workplace_assistant --config responses_api_models/openai_model/configs/openai_model.yaml
# or:  gym env run --env workplace_assistant --model-url ... --model-name ... --model-api-key ...
```

`--env <name>` resolves to the environment's config via the registry (`resolve_environment_config_paths`) and is **merged with any `--config`** into a single `+config_paths`. Because an environment references its model server by name, you pair `--env` with `--config` / `--model-*` to supply the model.

- Unknown name → exits cleanly with the registry's "did you mean?" message (no traceback).
- Model flags (`--model-name/url/api-key`) pass through unchanged.
- `env run` becomes a callable router target (`_env_run`); **config-only behavior is unchanged**.

## Why

Epic [#1205](https://github.com/NVIDIA-NeMo/Gym/issues/1205) friction 8. Completes the registry payoff: **discover** (`gym list environments`, #1635) **+ run** by name.

## Tests

`TestEnvRunByName` (5): name→config resolution; `--env`+`--config` merge into one `+config_paths`; model-flag passthrough; config-only unchanged; unknown env exits cleanly. 91/91 router+cli+registry tests pass; ruff + pre-commit clean.