### PR TITLE
fix: resolve CritPt benchmark config interpolation and add critpt_agent README

### DIFF
--- a/resources_servers/critpt/configs/critpt.yaml
+++ b/resources_servers/critpt/configs/critpt.yaml
@@ -3,7 +3,7 @@ critpt_resources_server:
     critpt:
       entrypoint: app.py
       domain: other
-      api_key: ${artificial_analysis_api_key}
+      api_key: ${oc.select:artificial_analysis_api_key,null}
       verified: false
       description: Research-level physics problems scored by the Artificial Analysis API
       value: Evaluate model performance on research-level physics reasoning

--- a/responses_api_agents/critpt_agent/README.md
+++ b/responses_api_agents/critpt_agent/README.md
@@ -1,0 +1,22 @@
+# CritPt Agent
+
+Custom two-turn agent for the CritPt benchmark (research-level physics problems). For each problem it:
+
+1. **Turn 1 — solve:** sends the problem to the model and collects its reasoning and conclusion.
+2. **Turn 2 — fill the template:** strips the Turn 1 thinking blocks (`<think>` / `<thinking>`), then asks
+   the model to populate the problem's `code_template` using the Turn 1 conclusion as context (the Turn 2
+   prompt instructs the model not to reason again).
+
+The accumulated Turn 2 output is submitted to the CritPt resources server's `/verify`, which scores it via
+the Artificial Analysis API.
+
+## Configuration
+
+- `resources_server`: the CritPt resources server instance to seed sessions and verify against
+- `model_server`: the model server used for generation
+- `turn2_prompt_fpath`: the Turn 2 user-prompt template filled with the problem's `code_template`
+  (e.g. `benchmarks/critpt/prompts/turn2.yaml`)
+
+The full wiring (resources server + this agent + example dataset) lives in
+`resources_servers/critpt/configs/critpt.yaml`; the benchmark dataset is narrowed in
+`benchmarks/critpt/config.yaml`.


### PR DESCRIPTION
## Summary

Fixes two CI breakages on `main` introduced by the CritPt benchmark (#1588). Both fail unit/server CI for any PR once it is merged with current `main`:

1. **`resources_servers/critpt/configs/critpt.yaml`** referenced `${artificial_analysis_api_key}` with no definition or default. `list_benchmarks()` (chained via `benchmarks/critpt/config.yaml`) cannot resolve it, failing `tests/unit_tests/test_benchmarks.py::TestListBenchmarks::test_lists_found_benchmarks` and dropping unit-test coverage below the 96% gate (the errored test stops covering `benchmarks.py`). Changed to `${oc.select:artificial_analysis_api_key,null}` so it resolves to `null` when unset — matching the default-bearing pattern used by sibling configs (e.g. `labbench2_vlm`'s `${oc.select:judge_api_key,unset}`, `frontierscience_judge`'s `${oc.env:NVIDIA_API_KEY,null}`). The override key name is unchanged, so any existing `artificial_analysis_api_key` config/env override still applies.

2. **`responses_api_agents/critpt_agent`** shipped without a `README.md`. `ng_test_all` counts it as a candidate module but not a testable one, failing the total-vs-tested assertion (`Mismatch on the number of total modules found (120) ... (119)`) on **every** server-suite shard. Added a `README.md` describing the two-turn agent.

## Testing

- `pytest tests/unit_tests/` → 290 passed; coverage **96.20%** (was 95.87%)
- Module discovery: **120 candidates == 120 testable**
- `critpt` server test is unaffected (it constructs its config directly with a dummy key and never resolves the YAML interpolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)