### PR TITLE
feat(adapters): adapter middleware framework (base)

### DIFF
--- a/fern/versions/latest/pages/model-server/adapters.mdx
+++ b/fern/versions/latest/pages/model-server/adapters.mdx
@@ -1,0 +1,68 @@
+---
+title: "Adapter Middleware"
+description: "Interceptor-based middleware framework for Model, Agent, and Resources servers."
+position: 3
+---
+
+Adapter middleware adds an interceptor chain to a server's request/response path. Each interceptor can observe or mutate the payload without the host server changing. Use it to inject system prompts, drop unsupported params, cache responses, count turns, normalize reasoning fields, log tokens, and so on.
+
+`adapters` is opt-in. It is declared on `BaseResponsesAPIModelConfig`, `BaseResponsesAPIAgentConfig`, and `BaseResourcesServerConfig`, so every in-tree server inheriting from `SimpleResponsesAPIModel` / `SimpleResponsesAPIAgent` / `SimpleResourcesServer` accepts an `adapters` block automatically. Omitting it leaves behavior identical to the base server.
+
+## Quickstart
+
+Add an `adapters` list to any server config:
+
+```yaml
+policy_model:
+  responses_api_models:
+    openai_model:
+      openai_base_url: https://api.openai.com/v1
+      openai_api_key: ...
+      openai_model: gpt-4.1
+      adapters:                       # ← toggle: omit or null = OFF
+        - {name: logging, config: {}}
+```
+
+This PR ships the **framework** (`AdapterPipeline`, `InterceptorRegistry`, `install_middleware`, `start_adapter_proxy`) plus two built-in interceptors:
+
+| Name | Stage | Purpose |
+|------|-------|---------|
+| `logging` | request + response | Log request body keys and response status/latency. Canonical "did the chain fire?" probe. |
+| `endpoint` | request → response | Drive the upstream HTTP call directly. **Only used by `start_adapter_proxy`** (standalone host mode); forbidden inside `install_middleware`. |
+
+Additional interceptor families (observability, caching, request rewriting) ship in follow-on PRs.
+
+## Host modes
+
+The same `AdapterPipeline` runs in either of two hosting modes:
+
+**Middleware mode** — `install_middleware(app, adapters)` attaches the pipeline to an existing FastAPI app via `app.middleware("http")`. The host server's own routing performs the upstream call via `call_next`. Used by every Model/Agent/Resources server when `adapters` is set on its config.
+
+**Proxy mode** — `start_adapter_proxy(upstream_url, adapters)` launches a localhost uvicorn that hosts the pipeline with its own forwarding logic. Used by agents that bring their own SDK client (e.g. `claude_code_agent` with `anthropic_base_url`); the agent points its SDK's `*_BASE_URL` at the proxy URL via the `adapter_proxy` field on `BaseResponsesAPIAgentConfig`.
+
+## Path-Based Session Scoping
+
+Posts to `/s/<hex-id>/<path>` have the prefix stripped before forwarding, and `<hex-id>` is recorded as `ctx.extra["session_id"]`. Follow-on interceptors that key per-session (e.g. `turn_counter`, `caching`) use this id.
+
+## Custom Interceptors
+
+Register a class at runtime via `InterceptorRegistry.register`:
+
+```python
+from nemo_gym.adapters import InterceptorRegistry
+
+InterceptorRegistry.register("my_interceptor", "myproject.adapters.my_interceptor")
+```
+
+The target module must expose a class named `Interceptor` that subclasses one of `RequestInterceptor`, `RequestToResponseInterceptor`, or `ResponseInterceptor` from `nemo_gym.adapters.types`. The class is instantiated with the YAML `config` dict as kwargs.
+
+## Configuration Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `adapters` | `list[dict] \| null` | `null` | Ordered interceptor specs on each server config. Each entry is `{name: <str>, config: <dict>}`. `null` or `[]` disables the middleware. |
+| `adapter_proxy` | `AdapterProxyConfig \| null` | `null` | On `BaseResponsesAPIAgentConfig` only. Configures a localhost proxy in front of an external inference upstream. Fields: `upstream_url`, `adapters`, `host` (default `127.0.0.1`), `port` (default `0` → kernel-assigned), `request_timeout`, `unsafe_allow_remote`. |
+
+<Warning>
+`start_adapter_proxy` refuses any `host` other than `127.0.0.1`/`localhost` unless you pass `unsafe_allow_remote=True`. The proxy forwards the client's `Authorization` header verbatim to the upstream, so binding to `0.0.0.0` would leak the upstream API key to any caller on the network.
+</Warning>

--- a/fern/versions/latest/pages/model-server/index.mdx
+++ b/fern/versions/latest/pages/model-server/index.mdx
@@ -38,3 +38,9 @@ Let NeMo Gym launch and manage the vLLM server for you.
 [Model Server Fields](/reference/configuration#model-server-fields) for server configuration syntax and fields.
 
 </Note>
+
+## Middleware
+
+Model servers can attach an interceptor chain that observes or mutates request and response payloads — useful for logging, caching, system-prompt injection, turn budgeting, reasoning-field normalization, and similar cross-cutting hooks.
+
+See [Adapter Middleware](/model-server/adapters) for the framework, built-in interceptors, and configuration syntax.

--- a/nemo_gym/adapters/__init__.py
+++ b/nemo_gym/adapters/__init__.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Gym adapter framework — interceptor-based middleware for responses_api_models.
+
+Public API:
+    install_middleware(app, interceptor_specs)  — attach pipeline to a FastAPI app
+    start_adapter_proxy(upstream_url, adapters) — host pipeline as a localhost uvicorn
+    AdapterPipeline                             — the async interceptor chain
+    InterceptorRegistry                         — name → class resolution
+"""
+
+from nemo_gym.adapters.middleware import install_middleware
+from nemo_gym.adapters.pipeline import AdapterPipeline
+from nemo_gym.adapters.proxy import ProxyHandle, start_adapter_proxy
+from nemo_gym.adapters.registry import InterceptorRegistry
+from nemo_gym.adapters.types import (
+    AdapterProxyConfig,
+    AdapterRequest,
+    AdapterResponse,
+    GracefulError,
+    InterceptorContext,
+    InterceptorSpec,
+    RequestInterceptor,
+    RequestToResponseInterceptor,
+    ResponseInterceptor,
+    Stage,
+)
+
+
+__all__ = [
+    "AdapterPipeline",
+    "AdapterProxyConfig",
+    "AdapterRequest",
+    "AdapterResponse",
+    "GracefulError",
+    "InterceptorContext",
+    "InterceptorRegistry",
+    "InterceptorSpec",
+    "ProxyHandle",
+    "RequestInterceptor",
+    "RequestToResponseInterceptor",
+    "ResponseInterceptor",
+    "Stage",
+    "install_middleware",
+    "start_adapter_proxy",
+]

--- a/nemo_gym/adapters/interceptors/__init__.py
+++ b/nemo_gym/adapters/interceptors/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Built-in interceptors for the adapter pipeline."""

--- a/nemo_gym/adapters/interceptors/endpoint.py
+++ b/nemo_gym/adapters/interceptors/endpoint.py
@@ -50,6 +50,10 @@ class Interceptor(RequestToResponseInterceptor):
             if clean.endswith(suffix):
                 clean = clean[: -len(suffix)]
                 break
+        # ``req.path`` already carries the ``/v1/...`` prefix, so strip a trailing
+        # ``/v1`` from the base to avoid ``.../v1/v1/...`` double-prefixing.
+        if clean.endswith("/v1"):
+            clean = clean[: -len("/v1")]
         self._upstream_url = clean
         self._api_key = api_key
         self._extra_body = extra_body or {}
@@ -60,13 +64,6 @@ class Interceptor(RequestToResponseInterceptor):
         # ``max_concurrent`` is config-shape compatibility only; connector
         # limits live on the global aiohttp client.
         self._max_concurrent = max_concurrent
-
-    @staticmethod
-    def _normalize_content(body: dict[str, Any]) -> None:
-        for choice in body.get("choices", []):
-            msg = choice.get("message") or choice.get("delta") or {}
-            if "content" in msg and msg["content"] is None:
-                msg["content"] = ""
 
     async def intercept_request(
         self,
@@ -105,7 +102,11 @@ class Interceptor(RequestToResponseInterceptor):
 
                     if status in self._retry_on_status and attempt < self._max_retries:
                         retry_after = resp.headers.get("Retry-After")
-                        delay = float(retry_after) if retry_after else min(2**attempt, 60)
+                        try:
+                            # RFC 7231 allows an HTTP-date here; fall back on parse failure.
+                            delay = float(retry_after) if retry_after else min(2**attempt, 60)
+                        except ValueError:
+                            delay = min(2**attempt, 60)
                         logger.warning(
                             "endpoint: %s returned %d, retry %d/%d in %.1fs",
                             url,
@@ -122,9 +123,6 @@ class Interceptor(RequestToResponseInterceptor):
                         parsed = json.loads(raw)
                     except (json.JSONDecodeError, UnicodeDecodeError):
                         parsed = raw
-
-                    if isinstance(parsed, dict):
-                        self._normalize_content(parsed)
 
                     return AdapterResponse(
                         status_code=status,

--- a/nemo_gym/adapters/interceptors/endpoint.py
+++ b/nemo_gym/adapters/interceptors/endpoint.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any
+
+import aiohttp  # type-name imports only (ClientTimeout, ClientError); HTTP calls go through nemo_gym.server_utils.request
+
+from nemo_gym.adapters.types import (
+    AdapterRequest,
+    AdapterResponse,
+    RequestToResponseInterceptor,
+)
+from nemo_gym.server_utils import request as global_request
+
+
+logger = logging.getLogger(__name__)
+
+
+class Interceptor(RequestToResponseInterceptor):
+    def __init__(
+        self,
+        *,
+        upstream_url: str,
+        api_key: str | None = None,
+        extra_body: dict[str, Any] | None = None,
+        request_timeout: float = 120,
+        max_retries: int = 0,
+        retry_on_status: list[int] | None = None,
+        max_concurrent: int = 64,
+    ) -> None:
+        clean = upstream_url.rstrip("/")
+        for suffix in ("/chat/completions", "/completions", "/embeddings"):
+            if clean.endswith(suffix):
+                clean = clean[: -len(suffix)]
+                break
+        self._upstream_url = clean
+        self._api_key = api_key
+        self._extra_body = extra_body or {}
+        self._request_timeout = float(request_timeout)
+        self._timeout = aiohttp.ClientTimeout(total=request_timeout)
+        self._max_retries = max_retries
+        self._retry_on_status = set(retry_on_status or [429, 502, 503, 504])
+        # ``max_concurrent`` is config-shape compatibility only; connector
+        # limits live on the global aiohttp client.
+        self._max_concurrent = max_concurrent
+
+    @staticmethod
+    def _normalize_content(body: dict[str, Any]) -> None:
+        for choice in body.get("choices", []):
+            msg = choice.get("message") or choice.get("delta") or {}
+            if "content" in msg and msg["content"] is None:
+                msg["content"] = ""
+
+    async def intercept_request(
+        self,
+        req: AdapterRequest,
+    ) -> AdapterRequest | AdapterResponse:
+        url = f"{self._upstream_url}{req.path}"
+
+        body = {**req.body, **self._extra_body}
+        headers = {
+            k: v for k, v in req.headers.items() if k.lower() not in ("host", "content-length", "transfer-encoding")
+        }
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        headers.setdefault("Content-Type", "application/json")
+
+        attempt = 0
+        while True:
+            t0 = time.perf_counter()
+            try:
+                resp = await global_request(
+                    method="POST",
+                    url=url,
+                    data=json.dumps(body),
+                    headers=headers,
+                    timeout=self._timeout,
+                )
+                async with resp:
+                    raw = await resp.read()
+                    latency = (time.perf_counter() - t0) * 1000
+                    # Iterate ``resp.headers.items()`` to preserve multi-valued
+                    # keys (e.g. Set-Cookie) that a plain ``dict()`` collapses.
+                    resp_headers: list[tuple[bytes, bytes]] = [
+                        (k.encode("latin-1"), v.encode("latin-1")) for k, v in resp.headers.items()
+                    ]
+                    status = resp.status
+
+                    if status in self._retry_on_status and attempt < self._max_retries:
+                        retry_after = resp.headers.get("Retry-After")
+                        delay = float(retry_after) if retry_after else min(2**attempt, 60)
+                        logger.warning(
+                            "endpoint: %s returned %d, retry %d/%d in %.1fs",
+                            url,
+                            status,
+                            attempt + 1,
+                            self._max_retries,
+                            delay,
+                        )
+                        attempt += 1
+                        await asyncio.sleep(delay)
+                        continue
+
+                    try:
+                        parsed = json.loads(raw)
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        parsed = raw
+
+                    if isinstance(parsed, dict):
+                        self._normalize_content(parsed)
+
+                    return AdapterResponse(
+                        status_code=status,
+                        headers=resp_headers,
+                        body=parsed,
+                        latency_ms=latency,
+                        ctx=req.ctx,
+                    )
+
+            except asyncio.TimeoutError:
+                latency = (time.perf_counter() - t0) * 1000
+                if attempt < self._max_retries:
+                    delay = min(2**attempt, 60)
+                    logger.warning(
+                        "endpoint: %s timed out, retry %d/%d in %.1fs",
+                        url,
+                        attempt + 1,
+                        self._max_retries,
+                        delay,
+                    )
+                    attempt += 1
+                    await asyncio.sleep(delay)
+                    continue
+                logger.error("endpoint: %s timed out after %d attempts", url, attempt + 1)
+                return AdapterResponse(
+                    status_code=504,
+                    headers={},
+                    body={
+                        "error": {"message": f"Upstream timed out after {self._request_timeout}s", "type": "timeout"}
+                    },
+                    latency_ms=latency,
+                    ctx=req.ctx,
+                )
+
+            except aiohttp.ClientError as exc:
+                latency = (time.perf_counter() - t0) * 1000
+                if attempt < self._max_retries:
+                    delay = min(2**attempt, 60)
+                    logger.warning(
+                        "endpoint: %s failed (%s), retry %d/%d in %.1fs",
+                        url,
+                        exc,
+                        attempt + 1,
+                        self._max_retries,
+                        delay,
+                    )
+                    attempt += 1
+                    await asyncio.sleep(delay)
+                    continue
+                raise
+
+    async def close(self) -> None:
+        return None

--- a/nemo_gym/adapters/interceptors/request_logging.py
+++ b/nemo_gym/adapters/interceptors/request_logging.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import json
+import logging
+
+from nemo_gym.adapters.types import (
+    AdapterRequest,
+    AdapterResponse,
+    RequestInterceptor,
+    ResponseInterceptor,
+)
+
+
+logger = logging.getLogger(__name__)
+
+_MAX = 512
+
+
+def _trunc_preview(obj: object) -> str:
+    if isinstance(obj, bytes):
+        text = obj.decode(errors="replace")
+    elif isinstance(obj, dict):
+        text = json.dumps(obj, default=str, ensure_ascii=False)
+    else:
+        text = str(obj)
+    if len(text) <= _MAX:
+        return text
+    return text[:_MAX] + "..."
+
+
+class Interceptor(RequestInterceptor, ResponseInterceptor):
+    best_effort = True
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        keys = list(req.body.keys()) if isinstance(req.body, dict) else []
+        logger.info(
+            "request %s %s body_keys=%s body_preview=%s",
+            req.method,
+            req.path,
+            keys,
+            _trunc_preview(req.body),
+        )
+        return req
+
+    async def intercept_response(self, resp: AdapterResponse) -> AdapterResponse:
+        logger.info(
+            "response status=%d latency_ms=%.2f body_preview=%s",
+            resp.status_code,
+            resp.latency_ms,
+            _trunc_preview(resp.body),
+        )
+        return resp

--- a/nemo_gym/adapters/middleware.py
+++ b/nemo_gym/adapters/middleware.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Adapter pipeline middleware for responses_api_models FastAPI apps."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from fastapi import FastAPI, Request
+from starlette.responses import JSONResponse, Response
+
+from nemo_gym.adapters.pipeline import AdapterPipeline
+from nemo_gym.adapters.types import (
+    AdapterRequest,
+    AdapterResponse,
+    GracefulError,
+    InterceptorContext,
+)
+
+
+logger = logging.getLogger(__name__)
+
+# Hop-by-hop headers (RFC 7230 §6.1) plus framing/encoding fields the ASGI
+# layer rewrites itself. ``content-encoding`` is included because aiohttp
+# auto-decodes upstream bodies — re-emitting the original encoding would
+# mislead any gzip-aware client into trying to decompress plain bytes.
+_HOP_BY_HOP_HEADERS = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+        "content-length",
+        "content-encoding",
+        "server",
+    }
+)
+
+_SESSION_PATH_RE = re.compile(r"^/s/([a-f0-9]+)(/.*)?$")
+
+
+def _override_request_body(request: Request, new_body: bytes) -> None:
+    """Make downstream handlers see *new_body* instead of the original."""
+    request._body = new_body  # type: ignore[attr-defined]
+    if hasattr(request, "_json"):
+        delattr(request, "_json")
+
+    new_len = str(len(new_body)).encode("ascii")
+    scope_headers = [(k, v) for k, v in request.scope.get("headers", []) if k.lower() != b"content-length"]
+    scope_headers.append((b"content-length", new_len))
+    request.scope["headers"] = scope_headers
+
+
+async def _starlette_response_to_adapter(
+    starlette_resp: Response,
+    ctx: InterceptorContext,
+) -> AdapterResponse:
+    chunks: list[bytes] = []
+    body_iter = getattr(starlette_resp, "body_iterator", None)
+    if body_iter is not None:
+        async for chunk in body_iter:
+            if isinstance(chunk, str):
+                chunk = chunk.encode("utf-8")
+            chunks.append(chunk)
+    else:
+        raw = getattr(starlette_resp, "body", b"")
+        if isinstance(raw, str):
+            raw = raw.encode("utf-8")
+        chunks.append(raw)
+    raw_body = b"".join(chunks)
+
+    # Preserve duplicate header keys (e.g. multiple Set-Cookie) — dict
+    # collapse would drop all but the last value.
+    headers: list[tuple[bytes, bytes]] = list(starlette_resp.raw_headers)
+
+    content_type = ""
+    for name, value in headers:
+        if name.lower() == b"content-type":
+            content_type = value.decode("latin-1").lower()
+            break
+
+    body: dict[str, Any] | bytes
+    if "application/json" in content_type or content_type == "":
+        try:
+            body = json.loads(raw_body.decode("utf-8")) if raw_body else {}
+        except (ValueError, UnicodeDecodeError):
+            body = raw_body
+    else:
+        body = raw_body
+
+    return AdapterResponse(
+        status_code=starlette_resp.status_code,
+        headers=headers,
+        body=body,
+        latency_ms=0.0,
+        ctx=ctx,
+    )
+
+
+def _adapter_response_to_starlette(resp: AdapterResponse) -> Response:
+    raw = resp.headers or []
+    if isinstance(raw, dict):
+        header_pairs: list[tuple[bytes, bytes]] = [(k.encode("latin-1"), v.encode("latin-1")) for k, v in raw.items()]
+    else:
+        header_pairs = list(raw)
+
+    fwd_pairs: list[tuple[bytes, bytes]] = [
+        (name, value) for name, value in header_pairs if name.decode("latin-1").lower() not in _HOP_BY_HOP_HEADERS
+    ]
+
+    if isinstance(resp.body, bytes):
+        out = Response(content=resp.body, status_code=resp.status_code)
+    else:
+        out = JSONResponse(content=resp.body, status_code=resp.status_code)
+
+    # Keep Starlette's framing content-length; drop framing content-type
+    # only if the adapter chain supplied one.
+    fwd_keys_lower = {name.lower() for name, _ in fwd_pairs}
+    framing_kept = [
+        (k, v) for k, v in out.raw_headers if k.lower() == b"content-length" or k.lower() not in fwd_keys_lower
+    ]
+    out.raw_headers = framing_kept + fwd_pairs
+    return out
+
+
+def install_middleware(
+    app: FastAPI,
+    interceptor_specs: list[dict[str, Any]] | None,
+) -> None:
+    """Install the adapter pipeline as FastAPI middleware on *app*.
+
+    ``interceptor_specs`` is a list of ``{"name": ..., "config": ...}`` dicts.
+    Empty or ``None`` disables the middleware.
+    """
+    if not interceptor_specs:
+        return
+
+    # ``endpoint`` performs its own upstream call; inside a host server this
+    # would double-forward. The proxy host mode (``start_adapter_proxy``)
+    # appends it itself.
+    if any(s.get("name") == "endpoint" for s in interceptor_specs):
+        raise ValueError(
+            "install_middleware: the 'endpoint' interceptor cannot be used in a "
+            "middleware-hosted chain — the model server already forwards upstream. "
+            "Drop it from `adapters` or use start_adapter_proxy() instead."
+        )
+
+    pipeline = AdapterPipeline.from_config(interceptor_specs)
+
+    @app.middleware("http")
+    async def _adapter_middleware(request: Request, call_next):  # noqa: ANN202
+        if request.method != "POST":
+            return await call_next(request)
+
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse(
+                {"error": {"message": "Invalid JSON body", "type": "invalid_request_error"}},
+                status_code=400,
+            )
+
+        path = request.url.path
+        ctx = InterceptorContext()
+
+        m = _SESSION_PATH_RE.match(path)
+        if m:
+            ctx.extra["session_id"] = m.group(1)
+            path = m.group(2) or "/"
+
+        adapter_req = AdapterRequest(
+            method=request.method,
+            path=path,
+            headers=dict(request.headers),
+            body=body,
+            ctx=ctx,
+        )
+
+        async def _upstream(req: AdapterRequest) -> AdapterResponse:
+            new_body = json.dumps(req.body).encode("utf-8")
+            _override_request_body(request, new_body)
+            starlette_resp = await call_next(request)
+            return await _starlette_response_to_adapter(starlette_resp, req.ctx)
+
+        try:
+            resp = await pipeline.process(adapter_req, upstream_call=_upstream)
+        except GracefulError as exc:
+            logger.warning(
+                "Adapter middleware: graceful termination for session %s: %s",
+                ctx.extra.get("session_id", "?"),
+                exc,
+            )
+            return JSONResponse(
+                {
+                    "error": {
+                        "message": str(exc),
+                        "type": "invalid_request_error",
+                        "code": "session_budget_exhausted",
+                    },
+                },
+                status_code=429,
+            )
+        except Exception:
+            logger.exception("Adapter pipeline error")
+            return JSONResponse(
+                {"error": {"message": "Internal adapter middleware error", "type": "server_error"}},
+                status_code=500,
+            )
+
+        return _adapter_response_to_starlette(resp)

--- a/nemo_gym/adapters/middleware.py
+++ b/nemo_gym/adapters/middleware.py
@@ -198,6 +198,10 @@ def install_middleware(
         async def _upstream(req: AdapterRequest) -> AdapterResponse:
             new_body = json.dumps(req.body).encode("utf-8")
             _override_request_body(request, new_body)
+            # Re-point the ASGI scope at the prefix-stripped path so the router
+            # can match it (the /s/<hex>/ session prefix is middleware-only).
+            request.scope["path"] = req.path
+            request.scope["raw_path"] = req.path.encode("latin-1")
             starlette_resp = await call_next(request)
             return await _starlette_response_to_adapter(starlette_resp, req.ctx)
 

--- a/nemo_gym/adapters/pipeline.py
+++ b/nemo_gym/adapters/pipeline.py
@@ -23,7 +23,7 @@ from nemo_gym.adapters.registry import InterceptorRegistry
 from nemo_gym.adapters.types import (
     AdapterRequest,
     AdapterResponse,
-    InterceptorContext,
+    GracefulError,
     RequestInterceptor,
     RequestToResponseInterceptor,
     ResponseInterceptor,
@@ -100,8 +100,9 @@ class AdapterPipeline:
         is invoked with the (possibly mutated) request. Response interceptors
         then run in reverse order.
         """
-        ctx = InterceptorContext(request_id=request.ctx.request_id)
-        set_context(ctx)
+        # Reuse the request's own context so interceptors reading the global
+        # get_context() observe the same ctx.extra (e.g. session_id) as req.ctx.
+        set_context(request.ctx)
 
         current: AdapterRequest | AdapterResponse = request
 
@@ -113,6 +114,9 @@ class AdapterPipeline:
                 try:
                     result = await interceptor.intercept_request(current)  # type: ignore[arg-type]
                     current = result
+                except GracefulError:
+                    # Control-flow signal (-> 429); never swallowed by best_effort.
+                    raise
                 except Exception:
                     if getattr(interceptor, "best_effort", False):
                         logger.warning(
@@ -133,6 +137,8 @@ class AdapterPipeline:
         for interceptor in response_interceptors:
             try:
                 response = await interceptor.intercept_response(response)
+            except GracefulError:
+                raise
             except Exception:
                 if getattr(interceptor, "best_effort", False):
                     logger.warning(

--- a/nemo_gym/adapters/pipeline.py
+++ b/nemo_gym/adapters/pipeline.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Async adapter pipeline — ordered interceptor chain execution."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable
+
+from nemo_gym.adapters.registry import InterceptorRegistry
+from nemo_gym.adapters.types import (
+    AdapterRequest,
+    AdapterResponse,
+    InterceptorContext,
+    RequestInterceptor,
+    RequestToResponseInterceptor,
+    ResponseInterceptor,
+    Stage,
+    set_context,
+)
+
+
+UpstreamCall = Callable[[AdapterRequest], Awaitable[AdapterResponse]]
+
+logger = logging.getLogger(__name__)
+
+
+def _stage_of(
+    interceptor: RequestInterceptor | RequestToResponseInterceptor | ResponseInterceptor,
+) -> Stage:
+    return getattr(interceptor, "stage", Stage.REQUEST)
+
+
+class AdapterPipeline:
+    """Async interceptor chain: REQUEST → REQUEST_TO_RESPONSE → RESPONSE."""
+
+    def __init__(
+        self,
+        interceptors: list[RequestInterceptor | RequestToResponseInterceptor | ResponseInterceptor],
+    ) -> None:
+        self._chain = list(interceptors)
+        self._validate_order()
+        logger.info(
+            "AdapterPipeline ready (%d interceptors: %s)",
+            len(self._chain),
+            [getattr(i, "_registry_name", type(i).__name__) for i in self._chain],
+        )
+
+    @classmethod
+    def from_config(
+        cls,
+        interceptor_specs: list[dict[str, Any]],
+    ) -> AdapterPipeline:
+        chain: list[RequestInterceptor | RequestToResponseInterceptor | ResponseInterceptor] = []
+        for spec in interceptor_specs:
+            name = spec["name"]
+            config = spec.get("config") or {}
+            chain.append(InterceptorRegistry.create(name, config))
+        return cls(chain)
+
+    _STAGE_ORDER = [Stage.REQUEST, Stage.REQUEST_TO_RESPONSE, Stage.RESPONSE]
+
+    def _validate_order(self) -> None:
+        current_idx = 0
+        for interceptor in self._chain:
+            stage = _stage_of(interceptor)
+            try:
+                idx = self._STAGE_ORDER.index(stage)
+            except ValueError:
+                raise ValueError(f"Unknown stage {stage!r} on {type(interceptor).__name__}")
+            if idx < current_idx:
+                raise ValueError(
+                    f"Invalid interceptor order: {type(interceptor).__name__} "
+                    f"(stage={stage.value}) appears after stage "
+                    f"{self._STAGE_ORDER[current_idx].value}. "
+                    f"Required order: request → request_to_response → response"
+                )
+            current_idx = max(current_idx, idx)
+
+    async def process(
+        self,
+        request: AdapterRequest,
+        upstream_call: UpstreamCall | None = None,
+    ) -> AdapterResponse:
+        """Run *request* through the chain and return the response.
+
+        If no ``RequestToResponseInterceptor`` short-circuits, ``upstream_call``
+        is invoked with the (possibly mutated) request. Response interceptors
+        then run in reverse order.
+        """
+        ctx = InterceptorContext(request_id=request.ctx.request_id)
+        set_context(ctx)
+
+        current: AdapterRequest | AdapterResponse = request
+
+        for interceptor in self._chain:
+            if isinstance(current, AdapterResponse):
+                break
+
+            if isinstance(interceptor, (RequestInterceptor, RequestToResponseInterceptor)):
+                try:
+                    result = await interceptor.intercept_request(current)  # type: ignore[arg-type]
+                    current = result
+                except Exception:
+                    if getattr(interceptor, "best_effort", False):
+                        logger.warning(
+                            "Interceptor %s failed (best_effort=True), continuing",
+                            type(interceptor).__name__,
+                            exc_info=True,
+                        )
+                        continue
+                    raise
+
+        if not isinstance(current, AdapterResponse):
+            if upstream_call is None:
+                raise RuntimeError("No interceptor produced a response. Is 'endpoint' in the chain?")
+            current = await upstream_call(current)
+
+        response = current
+        response_interceptors = [ic for ic in reversed(self._chain) if isinstance(ic, ResponseInterceptor)]
+        for interceptor in response_interceptors:
+            try:
+                response = await interceptor.intercept_response(response)
+            except Exception:
+                if getattr(interceptor, "best_effort", False):
+                    logger.warning(
+                        "Response interceptor %s failed (best_effort=True), continuing",
+                        type(interceptor).__name__,
+                        exc_info=True,
+                    )
+                    continue
+                raise
+
+        return response

--- a/nemo_gym/adapters/proxy.py
+++ b/nemo_gym/adapters/proxy.py
@@ -41,7 +41,7 @@ from fastapi import FastAPI, Request
 from starlette.responses import JSONResponse, Response
 
 from nemo_gym.adapters.pipeline import AdapterPipeline
-from nemo_gym.adapters.types import AdapterRequest, AdapterResponse, InterceptorContext
+from nemo_gym.adapters.types import AdapterRequest, AdapterResponse, GracefulError, InterceptorContext
 
 
 logger = logging.getLogger(__name__)
@@ -212,6 +212,8 @@ async def _run_pipeline(request: Request, path: str) -> Response:
 
     async def _upstream(req: AdapterRequest) -> AdapterResponse:
         target = f"{upstream_url}{req.path}"
+        if request.url.query:
+            target = f"{target}?{request.url.query}"
         fwd_headers = {k: v for k, v in req.headers.items() if k.lower() not in ("host", "content-length")}
         import json as _json
 
@@ -228,12 +230,6 @@ async def _run_pipeline(request: Request, path: str) -> Response:
             except (ValueError, UnicodeDecodeError):
                 parsed = raw
 
-            if isinstance(parsed, dict):
-                for choice in parsed.get("choices", []):
-                    msg = choice.get("message") or choice.get("delta") or {}
-                    if isinstance(msg, dict) and msg.get("content") is None and "content" in msg:
-                        msg["content"] = ""
-
             return AdapterResponse(
                 status_code=resp.status,
                 headers=resp_headers,
@@ -244,6 +240,18 @@ async def _run_pipeline(request: Request, path: str) -> Response:
 
     try:
         resp = await pipeline.process(adapter_req, upstream_call=_upstream)
+    except GracefulError as exc:
+        # Mirror middleware mode: budget/control-flow termination -> 429 (not 500).
+        return JSONResponse(
+            {
+                "error": {
+                    "message": str(exc),
+                    "type": "invalid_request_error",
+                    "code": "session_budget_exhausted",
+                },
+            },
+            status_code=429,
+        )
     except Exception:
         logger.exception("adapter proxy pipeline error")
         return JSONResponse(

--- a/nemo_gym/adapters/proxy.py
+++ b/nemo_gym/adapters/proxy.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Localhost adapter proxy.
+
+Hosts the same ``AdapterPipeline`` as ``install_middleware`` in its own
+uvicorn server. Used by agents whose SDK clients respect a ``*_BASE_URL``
+env var (Anthropic / OpenAI / Cohere): the agent's outbound traffic is
+pointed at the proxy URL, the proxy applies the chain, the proxy's own
+upstream-call closure forwards to the real upstream.
+
+Non-chat paths (``/v1/models``, batches, health checks) pass through to
+the upstream verbatim so SDK pre-flight works.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+import threading
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import aiohttp
+import uvicorn
+from fastapi import FastAPI, Request
+from starlette.responses import JSONResponse, Response
+
+from nemo_gym.adapters.pipeline import AdapterPipeline
+from nemo_gym.adapters.types import AdapterRequest, AdapterResponse, InterceptorContext
+
+
+logger = logging.getLogger(__name__)
+
+# Routes whose POST traffic runs through the adapter pipeline. Everything
+# else (any method, any path) is forwarded upstream verbatim so SDK
+# pre-flight (model listing, batches, health checks) still works.
+_ADAPTED_ROUTES = frozenset(
+    {
+        "/v1/chat/completions",
+        "/v1/completions",
+        "/v1/responses",
+        "/v1/messages",
+        "/v1/embeddings",
+    }
+)
+
+
+@dataclass
+class ProxyHandle:
+    """Handle for a running adapter proxy."""
+
+    url: str
+    port: int
+    _server: uvicorn.Server
+    _thread: threading.Thread
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._server.should_exit = True
+        self._thread.join(timeout=timeout)
+
+    def __enter__(self) -> "ProxyHandle":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()
+
+
+def start_adapter_proxy(
+    upstream_url: str,
+    adapters: list[dict[str, Any]],
+    *,
+    host: str = "127.0.0.1",
+    port: int = 0,
+    request_timeout: float = 120.0,
+    health_timeout: float = 10.0,
+    unsafe_allow_remote: bool = False,
+) -> ProxyHandle:
+    """Launch a localhost uvicorn that hosts the adapter pipeline.
+
+    The proxy forwards adapted requests to ``upstream_url`` via its own
+    ``aiohttp.ClientSession`` (created inside the proxy thread's event loop).
+    Forwarding happens outside the user's interceptor chain via ``pipeline.
+    process(req, upstream_call=...)`` — symmetric to ``install_middleware``
+    using FastAPI's ``call_next``.
+    """
+    if host not in ("127.0.0.1", "localhost") and not unsafe_allow_remote:
+        raise ValueError(
+            f"start_adapter_proxy: refusing host={host!r} — the proxy forwards the "
+            "client's Authorization header upstream, so binding to a non-localhost "
+            "interface leaks credentials. Pass unsafe_allow_remote=True to override."
+        )
+
+    if any(s.get("name") == "endpoint" for s in adapters):
+        raise ValueError(
+            "start_adapter_proxy: the 'endpoint' interceptor cannot be used here — "
+            "the proxy performs upstream forwarding itself. Drop it from `adapters`."
+        )
+
+    pipeline = AdapterPipeline.from_config(list(adapters))
+
+    app = _build_app(pipeline, upstream_url.rstrip("/"), request_timeout)
+    actual_port = _bind_port(host, port)
+
+    config = uvicorn.Config(
+        app,
+        host=host,
+        port=actual_port,
+        log_level="warning",
+        access_log=False,
+    )
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    url = f"http://{host}:{actual_port}"
+    _wait_for_health(url, timeout=health_timeout)
+    logger.info("adapter proxy ready upstream=%s url=%s", upstream_url, url)
+
+    return ProxyHandle(url=url, port=actual_port, _server=server, _thread=thread)
+
+
+def _bind_port(host: str, preferred: int) -> int:
+    if preferred:
+        return preferred
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_health(url: str, timeout: float) -> None:
+    import urllib.request
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(f"{url}/_proxy_health", timeout=1) as r:
+                if r.status == 200:
+                    return
+        except Exception:
+            time.sleep(0.05)
+    raise RuntimeError(f"adapter proxy at {url} did not become healthy in {timeout:.1f}s")
+
+
+def _build_app(pipeline: AdapterPipeline, upstream_url: str, request_timeout: float) -> FastAPI:
+    @asynccontextmanager
+    async def _lifespan(app_: FastAPI):
+        app_.state.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=request_timeout))
+        try:
+            yield
+        finally:
+            await app_.state.session.close()
+
+    app = FastAPI(lifespan=_lifespan)
+    app.state.pipeline = pipeline
+    app.state.upstream_url = upstream_url
+    app.state.request_timeout = request_timeout
+
+    @app.get("/_proxy_health")
+    async def _health() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    async def _dispatch(path: str, request: Request) -> Response:
+        norm_path = "/" + path.lstrip("/")
+        if request.method == "POST" and norm_path in _ADAPTED_ROUTES:
+            return await _run_pipeline(request, norm_path)
+        return await _passthrough(request, norm_path)
+
+    app.add_api_route(
+        "/{path:path}",
+        _dispatch,
+        methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"],
+    )
+
+    return app
+
+
+async def _run_pipeline(request: Request, path: str) -> Response:
+    pipeline: AdapterPipeline = request.app.state.pipeline
+    session: aiohttp.ClientSession = request.app.state.session
+    upstream_url: str = request.app.state.upstream_url
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            {"error": {"message": "Invalid JSON body", "type": "invalid_request_error"}},
+            status_code=400,
+        )
+
+    adapter_req = AdapterRequest(
+        method=request.method,
+        path=path,
+        headers=dict(request.headers),
+        body=body,
+        ctx=InterceptorContext(),
+    )
+
+    async def _upstream(req: AdapterRequest) -> AdapterResponse:
+        target = f"{upstream_url}{req.path}"
+        fwd_headers = {k: v for k, v in req.headers.items() if k.lower() not in ("host", "content-length")}
+        import json as _json
+
+        t0 = time.perf_counter()
+        async with session.post(target, data=_json.dumps(req.body), headers=fwd_headers) as resp:
+            raw = await resp.read()
+            latency = (time.perf_counter() - t0) * 1000
+            # Preserve multi-valued response headers (Set-Cookie etc.)
+            resp_headers: list[tuple[bytes, bytes]] = [
+                (k.encode("latin-1"), v.encode("latin-1")) for k, v in resp.headers.items()
+            ]
+            try:
+                parsed: Any = _json.loads(raw) if raw else {}
+            except (ValueError, UnicodeDecodeError):
+                parsed = raw
+
+            if isinstance(parsed, dict):
+                for choice in parsed.get("choices", []):
+                    msg = choice.get("message") or choice.get("delta") or {}
+                    if isinstance(msg, dict) and msg.get("content") is None and "content" in msg:
+                        msg["content"] = ""
+
+            return AdapterResponse(
+                status_code=resp.status,
+                headers=resp_headers,
+                body=parsed,
+                latency_ms=latency,
+                ctx=req.ctx,
+            )
+
+    try:
+        resp = await pipeline.process(adapter_req, upstream_call=_upstream)
+    except Exception:
+        logger.exception("adapter proxy pipeline error")
+        return JSONResponse(
+            {"error": {"message": "Internal adapter proxy error", "type": "server_error"}},
+            status_code=500,
+        )
+
+    fwd_headers: list[tuple[bytes, bytes]] = []
+    if isinstance(resp.headers, list):
+        for name, value in resp.headers:
+            lname = name.decode("latin-1").lower()
+            if lname in ("content-length", "transfer-encoding", "content-encoding"):
+                continue
+            fwd_headers.append((name, value))
+    elif isinstance(resp.headers, dict):
+        for k, v in resp.headers.items():
+            if k.lower() in ("content-length", "transfer-encoding", "content-encoding"):
+                continue
+            fwd_headers.append((k.encode("latin-1"), v.encode("latin-1")))
+
+    if isinstance(resp.body, bytes):
+        out: Response = Response(content=resp.body, status_code=resp.status_code)
+    else:
+        out = JSONResponse(content=resp.body, status_code=resp.status_code)
+
+    fwd_keys_lower = {k.lower() for k, _ in fwd_headers}
+    framing_kept = [
+        (k, v) for k, v in out.raw_headers if k.lower() == b"content-length" or k.lower() not in fwd_keys_lower
+    ]
+    out.raw_headers = framing_kept + fwd_headers
+    return out
+
+
+async def _passthrough(request: Request, path: str) -> Response:
+    """Forward request to upstream verbatim — for SDK pre-flight paths."""
+    session: aiohttp.ClientSession = request.app.state.session
+    upstream_url: str = request.app.state.upstream_url
+    timeout: float = request.app.state.request_timeout
+
+    body = await request.body()
+    fwd_headers = {k: v for k, v in request.headers.items() if k.lower() not in ("host", "content-length")}
+
+    target = f"{upstream_url}{path}"
+    if request.url.query:
+        target = f"{target}?{request.url.query}"
+
+    try:
+        async with session.request(
+            method=request.method,
+            url=target,
+            data=body if body else None,
+            headers=fwd_headers,
+        ) as resp:
+            raw = await resp.read()
+            out_headers: list[tuple[bytes, bytes]] = []
+            for k, v in resp.headers.items():
+                if k.lower() in ("content-length", "transfer-encoding", "content-encoding"):
+                    continue
+                out_headers.append((k.encode("latin-1"), v.encode("latin-1")))
+            out = Response(content=raw, status_code=resp.status)
+            out.raw_headers = [(hk, hv) for hk, hv in out.raw_headers if hk.lower() == b"content-length"] + out_headers
+            return out
+    except asyncio.TimeoutError:
+        return JSONResponse(
+            {"error": {"message": f"Upstream timed out after {timeout}s", "type": "timeout"}},
+            status_code=504,
+        )
+    except aiohttp.ClientError as exc:
+        logger.warning("passthrough %s failed: %s", target, exc)
+        return JSONResponse(
+            {"error": {"message": f"Upstream error: {exc}", "type": "upstream_error"}},
+            status_code=502,
+        )
+
+
+__all__ = ["start_adapter_proxy", "ProxyHandle"]

--- a/nemo_gym/adapters/registry.py
+++ b/nemo_gym/adapters/registry.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Interceptor registry — maps short names to interceptor classes."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import Any, Type
+
+from nemo_gym.adapters.types import (
+    RequestInterceptor,
+    RequestToResponseInterceptor,
+    ResponseInterceptor,
+)
+
+
+logger = logging.getLogger(__name__)
+
+InterceptorClass = Type[RequestInterceptor | RequestToResponseInterceptor | ResponseInterceptor]
+
+# Each module must expose a class named ``Interceptor``.
+#
+# This dict holds only the framework-level builtins. Interceptor families
+# (observability / caching / request-rewriting) add themselves via plain
+# ``_BUILTIN[<name>] = <module_path>`` assignments below the dict literal,
+# so each follow-on PR touches its own anchor lines and merges cleanly with
+# the others.
+_BUILTIN: dict[str, str] = {
+    # ``endpoint`` drives the upstream HTTP call from inside the pipeline.
+    # Required for ``start_adapter_proxy`` (standalone host mode); forbidden
+    # inside ``install_middleware`` because the host server already forwards.
+    "endpoint": "nemo_gym.adapters.interceptors.endpoint",
+    # ``logging`` is the canonical "did the chain fire?" probe used by
+    # framework-level tests. Lightweight; logs request keys + response status.
+    "logging": "nemo_gym.adapters.interceptors.request_logging",
+}
+
+# Family extensions — follow-on PRs append entries to ``_BUILTIN`` here.
+# Each family adds entries under its own family-named comment marker so
+# different families don't fight for the same diff context.
+
+# External / plugin registrations at runtime.
+_EXTRA: dict[str, str] = {}
+
+
+class InterceptorRegistry:
+    @staticmethod
+    def register(name: str, module_path: str) -> None:
+        _EXTRA[name] = module_path
+
+    @staticmethod
+    def resolve_class(name: str) -> InterceptorClass:
+        module_path = _EXTRA.get(name) or _BUILTIN.get(name)
+        if module_path is None:
+            available = sorted(set(_BUILTIN) | set(_EXTRA))
+            raise ValueError(f"Unknown interceptor {name!r}. Available: {available}")
+        try:
+            mod = importlib.import_module(module_path)
+        except ImportError as exc:
+            raise ValueError(f"Cannot import interceptor module {module_path!r} for {name!r}: {exc}") from exc
+        cls = getattr(mod, "Interceptor", None)
+        if cls is None:
+            raise ValueError(f"Module {module_path!r} does not expose an 'Interceptor' class")
+        return cls
+
+    @staticmethod
+    def create(
+        name: str, config: dict[str, Any] | None = None
+    ) -> RequestInterceptor | RequestToResponseInterceptor | ResponseInterceptor:
+        cls = InterceptorRegistry.resolve_class(name)
+        instance = cls(**(config or {}))
+        instance._registry_name = name
+        return instance
+
+    @staticmethod
+    def available() -> list[str]:
+        return sorted(set(_BUILTIN) | set(_EXTRA))

--- a/nemo_gym/adapters/types.py
+++ b/nemo_gym/adapters/types.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Core types and ABCs for the adapter interceptor pipeline."""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from abc import ABC, abstractmethod
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+@dataclass
+class InterceptorContext:
+    """Per-request state shared across interceptors via ContextVar."""
+
+    request_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+_current_context: ContextVar[InterceptorContext] = ContextVar("adapter_ctx")
+
+
+def get_context() -> InterceptorContext:
+    try:
+        return _current_context.get()
+    except LookupError:
+        ctx = InterceptorContext()
+        _current_context.set(ctx)
+        return ctx
+
+
+def set_context(ctx: InterceptorContext) -> None:
+    _current_context.set(ctx)
+
+
+@dataclass
+class AdapterRequest:
+    method: str
+    path: str
+    headers: dict[str, str]
+    body: dict[str, Any]
+    ctx: InterceptorContext = field(default_factory=get_context)
+
+
+@dataclass
+class AdapterResponse:
+    # ``headers`` is a list of byte-tuples (Starlette's ``raw_headers`` shape)
+    # so multi-valued headers like ``Set-Cookie`` survive. A plain ``dict`` is
+    # also accepted for convenience.
+    status_code: int
+    headers: list[tuple[bytes, bytes]] | dict[str, str]
+    body: dict[str, Any] | bytes
+    latency_ms: float = 0.0
+    ctx: InterceptorContext = field(default_factory=get_context)
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status_code < 400
+
+
+class Stage(enum.Enum):
+    REQUEST = "request"
+    REQUEST_TO_RESPONSE = "request_to_response"
+    RESPONSE = "response"
+
+
+class RequestInterceptor(ABC):
+    stage: Stage = Stage.REQUEST
+    stream_safe: bool = True
+    best_effort: bool = False
+
+    @abstractmethod
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest: ...
+
+
+class RequestToResponseInterceptor(ABC):
+    """Request-phase interceptor that may short-circuit by returning a response."""
+
+    stage: Stage = Stage.REQUEST_TO_RESPONSE
+    stream_safe: bool = True
+    best_effort: bool = False
+
+    @abstractmethod
+    async def intercept_request(
+        self,
+        req: AdapterRequest,
+    ) -> AdapterRequest | AdapterResponse: ...
+
+
+class ResponseInterceptor(ABC):
+    stage: Stage = Stage.RESPONSE
+    stream_safe: bool = True
+    best_effort: bool = False
+
+    @abstractmethod
+    async def intercept_response(self, resp: AdapterResponse) -> AdapterResponse: ...
+
+
+class GracefulError(Exception):
+    """Terminate the request with a 429 (e.g. session budget exhausted)."""
+
+
+class InterceptorSpec(BaseModel):
+    """One entry in an ``adapters`` config list."""
+
+    name: str
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class AdapterProxyConfig(BaseModel):
+    """Configuration for a localhost adapter proxy in front of an external upstream.
+
+    Used by agents that bring their own inference (e.g. ``claude_code_agent``
+    with ``anthropic_base_url``). The agent server starts the proxy alongside
+    itself; the agent's SDK ``*_BASE_URL`` is rewritten to the proxy's URL so
+    all outbound model traffic flows through the adapter chain.
+    """
+
+    upstream_url: str
+    adapters: list[InterceptorSpec] = Field(default_factory=list)
+    host: str = "127.0.0.1"
+    port: int = 0
+    request_timeout: float = 120.0
+    unsafe_allow_remote: bool = False

--- a/nemo_gym/base_resources_server.py
+++ b/nemo_gym/base_resources_server.py
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import abstractmethod
+from typing import Any, Optional
 
 from fastapi import FastAPI
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
+from nemo_gym.adapters import install_middleware
 from nemo_gym.config_types import AggregateMetrics, AggregateMetricsRequest
 from nemo_gym.openai_utils import (
     NeMoGymResponse,
@@ -27,7 +29,10 @@ from nemo_gym.server_utils import BaseRunServerInstanceConfig, BaseServer, Simpl
 
 
 class BaseResourcesServerConfig(BaseRunServerInstanceConfig):
-    pass
+    adapters: Optional[list[dict[str, Any]]] = Field(
+        default=None,
+        description="Adapter middleware chain: list of {'name': ..., 'config': {...}}. None disables.",
+    )
 
 
 class BaseResourcesServer(BaseServer):
@@ -65,6 +70,8 @@ class SimpleResourcesServer(BaseResourcesServer, AggregateMetricsMixin, SimpleSe
         app.post("/seed_session")(self.seed_session)
         app.post("/verify")(self.verify)
         app.post("/aggregate_metrics")(self.aggregate_metrics)
+
+        install_middleware(app, self.config.adapters)
 
         return app
 

--- a/nemo_gym/base_responses_api_agent.py
+++ b/nemo_gym/base_responses_api_agent.py
@@ -12,10 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import atexit
 from abc import abstractmethod
+from typing import Any, Optional
 
 from fastapi import Body, FastAPI
+from pydantic import Field
 
+from nemo_gym.adapters import AdapterProxyConfig, ProxyHandle, install_middleware, start_adapter_proxy
 from nemo_gym.base_resources_server import (
     AggregateMetrics,
     AggregateMetricsRequest,
@@ -31,7 +35,18 @@ from nemo_gym.server_utils import BaseRunServerInstanceConfig, BaseServer, Simpl
 
 
 class BaseResponsesAPIAgentConfig(BaseRunServerInstanceConfig):
-    pass
+    adapters: Optional[list[dict[str, Any]]] = Field(
+        default=None,
+        description="Adapter middleware chain: list of {'name': ..., 'config': {...}}. None disables.",
+    )
+    adapter_proxy: Optional[AdapterProxyConfig] = Field(
+        default=None,
+        description=(
+            "Optional localhost proxy in front of an external inference upstream. "
+            "When set, the agent's SDK client should point its *_BASE_URL at "
+            "``self._proxy_handle.url`` so model traffic flows through the chain."
+        ),
+    )
 
 
 class BaseResponsesAPIAgent(BaseServer):
@@ -40,8 +55,21 @@ class BaseResponsesAPIAgent(BaseServer):
 
 class SimpleResponsesAPIAgent(BaseResponsesAPIAgent, AggregateMetricsMixin, SimpleServer):
     config: BaseResponsesAPIAgentConfig
+    _proxy_handle: Optional[ProxyHandle] = None
 
     def setup_webserver(self) -> FastAPI:
+        if self.config.adapter_proxy is not None:
+            cfg = self.config.adapter_proxy
+            self._proxy_handle = start_adapter_proxy(
+                upstream_url=cfg.upstream_url,
+                adapters=[spec.model_dump() for spec in cfg.adapters],
+                host=cfg.host,
+                port=cfg.port,
+                request_timeout=cfg.request_timeout,
+                unsafe_allow_remote=cfg.unsafe_allow_remote,
+            )
+            atexit.register(self._proxy_handle.stop)
+
         app = FastAPI()
 
         self.setup_session_middleware(app)
@@ -49,6 +77,8 @@ class SimpleResponsesAPIAgent(BaseResponsesAPIAgent, AggregateMetricsMixin, Simp
         app.post("/v1/responses")(self.responses)
         app.post("/run")(self.run)
         app.post("/aggregate_metrics")(self.aggregate_metrics)
+
+        install_middleware(app, self.config.adapters)
 
         return app
 

--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -13,9 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import abstractmethod
+from typing import Any, Optional
 
 from fastapi import Body, FastAPI
+from pydantic import Field
 
+from nemo_gym.adapters import install_middleware
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
     NeMoGymChatCompletionCreateParamsNonStreaming,
@@ -26,7 +29,10 @@ from nemo_gym.server_utils import BaseRunServerInstanceConfig, BaseServer, Simpl
 
 
 class BaseResponsesAPIModelConfig(BaseRunServerInstanceConfig):
-    pass
+    adapters: Optional[list[dict[str, Any]]] = Field(
+        default=None,
+        description="Adapter middleware chain: list of {'name': ..., 'config': {...}}. None disables.",
+    )
 
 
 class BaseResponsesAPIModel(BaseServer):
@@ -42,6 +48,8 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
         app.post("/v1/chat/completions")(self.chat_completions)
 
         app.post("/v1/responses")(self.responses)
+
+        install_middleware(app, self.config.adapters)
 
         return app
 

--- a/responses_api_agents/claude_code_agent/app.py
+++ b/responses_api_agents/claude_code_agent/app.py
@@ -330,8 +330,10 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
     async def _run_claude_code(self, instruction: str, system_prompt: Optional[str] = None) -> tuple[str, str]:
         """Run claude -p --output-format=stream-json and return (stdout, model_name)."""
         base_url = self._resolve_base_url()
-        # Keep full model name for local/custom endpoints; strip provider prefix for real Anthropic API.
-        model = self.config.model if base_url else self.config.model.split("/")[-1]
+        # Keep full model name for local/custom endpoints (proxy mode counts);
+        # strip provider prefix only for real Anthropic API.
+        custom_upstream = bool(base_url) or self._proxy_handle is not None
+        model = self.config.model if custom_upstream else self.config.model.split("/")[-1]
         api_key = self.config.anthropic_api_key
 
         claude_config_dir = self._setup_config_dir()
@@ -347,8 +349,17 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
                 "IS_SANDBOX": "1",
                 "CLAUDE_CONFIG_DIR": str(claude_config_dir),
             }
-            if base_url:
-                env["ANTHROPIC_BASE_URL"] = base_url
+            proxy_or_base = self._proxy_handle.url if self._proxy_handle is not None else base_url
+            if proxy_or_base:
+                # Custom upstream (proxy in front of an inference endpoint OR a
+                # direct non-Anthropic endpoint). The claude CLI sends Bearer
+                # auth via ANTHROPIC_AUTH_TOKEN whenever ANTHROPIC_BASE_URL is
+                # set; ANTHROPIC_API_KEY (x-api-key) is ignored in that mode.
+                # Falls back to "local" only when no api_key is configured —
+                # api.anthropic.com rejects Bearer for sk-ant-... keys, so
+                # users targeting Anthropic directly must use an OAuth-issued
+                # token or accept that this auth shape won't work there.
+                env["ANTHROPIC_BASE_URL"] = proxy_or_base
                 env["ANTHROPIC_AUTH_TOKEN"] = api_key or "local"
 
             cmd = self._build_command(model, instruction, system_prompt=system_prompt)

--- a/responses_api_agents/claude_code_agent/tests/test_app.py
+++ b/responses_api_agents/claude_code_agent/tests/test_app.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import json
+import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -50,12 +51,49 @@ def _config(**kwargs) -> ClaudeCodeAgentConfig:
 def _make_agent(**kwargs) -> ClaudeCodeAgent:
     with patch("responses_api_agents.claude_code_agent.app.ClaudeCodeAgent.model_post_init"):
         agent = ClaudeCodeAgent(config=_config(**kwargs), server_client=MagicMock(spec=ServerClient))
+    # Patching model_post_init also skips Pydantic's private-attr initialization,
+    # leaving __pydantic_private__ as None; restore declared private slots (e.g.
+    # _proxy_handle) to their defaults so agent methods can read them.
+    object.__setattr__(
+        agent,
+        "__pydantic_private__",
+        {name: pa.get_default() for name, pa in type(agent).__private_attributes__.items()},
+    )
     agent.sem = asyncio.Semaphore(agent.config.concurrency)
     return agent
 
 
 def _event(type_: str, **kwargs) -> str:
     return json.dumps({"type": type_, **kwargs})
+
+
+def _run_claude_code_capturing(agent: ClaudeCodeAgent, tmp_path: Path) -> tuple[str, str, dict]:
+    """Run ``_run_claude_code`` with the subprocess stubbed out, capturing the
+    child process ``env`` and ``argv`` so env-threading / model-name handling
+    can be asserted. Mirrors the ``TestRunClaudeCode`` fixtures."""
+    captured: dict = {}
+
+    class FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return b'{"type":"result","usage":{"input_tokens":1,"output_tokens":1}}\n', b""
+
+    async def fake_exec(*cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["env"] = kwargs["env"]
+        return FakeProc()
+
+    # Clear the ambient environment so absence assertions (e.g. no
+    # ANTHROPIC_BASE_URL in plain mode) are deterministic regardless of the
+    # developer's/CI shell. The subprocess is mocked, so env is never spawned.
+    with (
+        patch.dict("responses_api_agents.claude_code_agent.app.os.environ", {}, clear=True),
+        patch("responses_api_agents.claude_code_agent.app.Path.home", return_value=tmp_path),
+        patch("responses_api_agents.claude_code_agent.app.asyncio.create_subprocess_exec", fake_exec),
+    ):
+        stdout, model = asyncio.run(agent._run_claude_code("hello"))
+    return stdout, model, captured
 
 
 class TestSanity:
@@ -233,6 +271,59 @@ class TestRunClaudeCode:
         assert stdout == ""
         assert killed["called"] is True
         assert model == "claude-sonnet-4-6"
+
+    def test_proxy_mode_threads_base_url_and_preserves_full_model(self, tmp_path: Path) -> None:
+        # A running adapter proxy in front of the model server: the SDK is
+        # pointed at the proxy URL and the full (provider-prefixed) model name
+        # is preserved for the custom upstream.
+        agent = _make_agent(
+            model="anthropic/claude-sonnet-4-6",
+            anthropic_api_key="sk-test",  # pragma: allowlist secret
+        )
+        agent._proxy_handle = types.SimpleNamespace(url="http://127.0.0.1:9999")
+
+        _stdout, model, captured = _run_claude_code_capturing(agent, tmp_path)
+        env = captured["env"]
+
+        assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:9999"
+        assert env["ANTHROPIC_AUTH_TOKEN"] == "sk-test"  # pragma: allowlist secret
+        # Full model name (provider prefix kept) for a custom upstream.
+        assert model == "anthropic/claude-sonnet-4-6"
+        assert env["ANTHROPIC_MODEL"] == "anthropic/claude-sonnet-4-6"
+        assert captured["cmd"][captured["cmd"].index("--model") + 1] == "anthropic/claude-sonnet-4-6"
+
+    def test_explicit_base_url_preserves_full_model(self, tmp_path: Path) -> None:
+        # A direct non-Anthropic endpoint via anthropic_base_url (no proxy):
+        # base url is threaded through and the full model name is preserved.
+        agent = _make_agent(
+            model="anthropic/claude-sonnet-4-6",
+            anthropic_base_url="https://my-endpoint.example/v1",
+            anthropic_api_key="sk-direct",  # pragma: allowlist secret
+        )
+        assert agent._proxy_handle is None
+
+        _stdout, model, captured = _run_claude_code_capturing(agent, tmp_path)
+        env = captured["env"]
+
+        assert env["ANTHROPIC_BASE_URL"] == "https://my-endpoint.example/v1"
+        assert env["ANTHROPIC_AUTH_TOKEN"] == "sk-direct"  # pragma: allowlist secret
+        assert model == "anthropic/claude-sonnet-4-6"
+        assert env["ANTHROPIC_MODEL"] == "anthropic/claude-sonnet-4-6"
+
+    def test_plain_anthropic_mode_strips_provider_prefix(self, tmp_path: Path) -> None:
+        # Plain Anthropic API mode (no proxy, no base url): the provider prefix
+        # is stripped and no base-url/auth-token env is injected.
+        agent = _make_agent(model="anthropic/claude-sonnet-4-6")
+        assert agent._proxy_handle is None
+
+        _stdout, model, captured = _run_claude_code_capturing(agent, tmp_path)
+        env = captured["env"]
+
+        assert "ANTHROPIC_BASE_URL" not in env
+        assert "ANTHROPIC_AUTH_TOKEN" not in env
+        assert model == "claude-sonnet-4-6"
+        assert env["ANTHROPIC_MODEL"] == "claude-sonnet-4-6"
+        assert captured["cmd"][captured["cmd"].index("--model") + 1] == "claude-sonnet-4-6"
 
 
 class TestExtractInstruction:

--- a/responses_api_agents/harbor_agent/app.py
+++ b/responses_api_agents/harbor_agent/app.py
@@ -26,6 +26,7 @@ import ray
 from fastapi import Body, FastAPI
 from pydantic import BaseModel, ConfigDict
 
+from nemo_gym.adapters import install_middleware
 from nemo_gym.base_resources_server import (
     BaseRunRequest,
     BaseVerifyResponse,
@@ -200,6 +201,7 @@ class HarborAgent(SimpleResponsesAPIAgent):
         app = FastAPI()
         app.post("/v1/responses")(self.responses)
         app.post("/run")(self.run)
+        install_middleware(app, self.config.adapters)
         return app
 
     async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:

--- a/responses_api_agents/mini_swe_agent/app.py
+++ b/responses_api_agents/mini_swe_agent/app.py
@@ -28,6 +28,7 @@ from minisweagent.config import builtin_config_dir, get_config_path
 from minisweagent.run.extra.swegym_runner import _main as run_swegym
 from pydantic import ConfigDict
 
+from nemo_gym.adapters import install_middleware
 from nemo_gym.base_resources_server import (
     BaseRunRequest,
     BaseVerifyRequest,
@@ -96,6 +97,7 @@ class MiniSWEAgent(SimpleResponsesAPIAgent):
         app = FastAPI()
         app.post("/v1/responses")(self.responses)
         app.post("/run")(self.run)
+        install_middleware(app, self.config.adapters)
         return app
 
     async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:

--- a/tests/unit_tests/test_adapter_base_class_wiring.py
+++ b/tests/unit_tests/test_adapter_base_class_wiring.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration test for the adapters lift on Agent + Resources bases.
+
+Confirms that the same ``adapters`` config field + ``install_middleware``
+call shipped on ``BaseResponsesAPIModelConfig`` is now also live on
+``BaseResponsesAPIAgentConfig`` and ``BaseResourcesServerConfig``, so any
+server inheriting from ``SimpleResponsesAPIAgent`` or ``SimpleResourcesServer``
+picks up the middleware automatically.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+from fastapi import Body
+from fastapi.testclient import TestClient
+
+from nemo_gym.base_resources_server import (
+    BaseResourcesServerConfig,
+    BaseRunRequest,
+    BaseVerifyRequest,
+    BaseVerifyResponse,
+    SimpleResourcesServer,
+)
+from nemo_gym.base_responses_api_agent import (
+    BaseResponsesAPIAgentConfig,
+    SimpleResponsesAPIAgent,
+)
+from nemo_gym.openai_utils import (
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+)
+from nemo_gym.server_utils import ServerClient
+
+
+class _StubAgent(SimpleResponsesAPIAgent):
+    async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def run(self, body: BaseRunRequest = Body()) -> BaseVerifyResponse:  # type: ignore[override]
+        return BaseVerifyResponse(
+            responses_create_params=body.responses_create_params,
+            response={"id": "stub", "model": "stub", "usage": {"total_tokens": 7}},
+            reward=1.0,
+        )
+
+
+class _StubResources(SimpleResourcesServer):
+    async def verify(self, body: BaseVerifyRequest) -> BaseVerifyResponse:  # type: ignore[override]
+        return BaseVerifyResponse(
+            responses_create_params=body.responses_create_params,
+            response=body.response,
+            reward=0.5,
+        )
+
+
+def _agent_config(adapters: list[dict] | None) -> BaseResponsesAPIAgentConfig:
+    return BaseResponsesAPIAgentConfig(
+        host="0.0.0.0",
+        port=8080,
+        entrypoint="",
+        name="stub_agent",
+        adapters=adapters,
+    )
+
+
+def _resources_config(adapters: list[dict] | None) -> BaseResourcesServerConfig:
+    return BaseResourcesServerConfig(
+        host="0.0.0.0",
+        port=8081,
+        entrypoint="",
+        name="stub_resources",
+        adapters=adapters,
+    )
+
+
+def test_agent_base_installs_adapter_chain(caplog) -> None:
+    agent = _StubAgent(
+        config=_agent_config(adapters=[{"name": "logging", "config": {}}]),
+        server_client=MagicMock(spec=ServerClient),
+    )
+    app = agent.setup_webserver()
+
+    # POST to a path the agent server doesn't route — middleware fires
+    # before routing, so the logging interceptor records the request
+    # regardless of the 404 that follows.
+    with caplog.at_level(logging.INFO, logger="nemo_gym.adapters.interceptors.request_logging"):
+        TestClient(app).post("/_probe", json={"x": 1})
+
+    assert any("request POST /_probe" in rec.message for rec in caplog.records), [
+        rec.message for rec in caplog.records
+    ]
+
+
+def test_agent_base_skips_middleware_when_adapters_none(caplog) -> None:
+    agent = _StubAgent(
+        config=_agent_config(adapters=None),
+        server_client=MagicMock(spec=ServerClient),
+    )
+    app = agent.setup_webserver()
+
+    with caplog.at_level(logging.INFO, logger="nemo_gym.adapters.interceptors.request_logging"):
+        TestClient(app).post("/_probe", json={"x": 1})
+
+    assert not any("request POST /_probe" in rec.message for rec in caplog.records)
+
+
+def test_resources_base_installs_adapter_chain(caplog) -> None:
+    resources = _StubResources(
+        config=_resources_config(adapters=[{"name": "logging", "config": {}}]),
+        server_client=MagicMock(spec=ServerClient),
+    )
+    app = resources.setup_webserver()
+
+    with caplog.at_level(logging.INFO, logger="nemo_gym.adapters.interceptors.request_logging"):
+        TestClient(app).post("/_probe", json={"x": 1})
+
+    assert any("request POST /_probe" in rec.message for rec in caplog.records), [
+        rec.message for rec in caplog.records
+    ]
+
+
+class _StubAgentInlineMiddleware(SimpleResponsesAPIAgent):
+    """Mirrors the harbor_agent / mini_swe_agent override pattern: rebuilds
+    the FastAPI app from scratch but calls install_middleware inline so the
+    `adapters` field still applies.
+    """
+
+    async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def run(self, body: BaseRunRequest = Body()) -> BaseVerifyResponse:  # type: ignore[override]
+        raise NotImplementedError
+
+    def setup_webserver(self):
+        from fastapi import FastAPI
+
+        from nemo_gym.adapters import install_middleware
+
+        app = FastAPI()
+        app.post("/v1/responses")(self.responses)
+        app.post("/run")(self.run)
+        install_middleware(app, self.config.adapters)
+        return app
+
+
+def test_agent_override_with_inline_install_middleware(caplog) -> None:
+    """Regression test for the harbor/mini_swe override fix.
+
+    The override doesn't call super().setup_webserver(), so the base class's
+    install_middleware call doesn't fire. Per the fix, each override adds its
+    own install_middleware(app, self.config.adapters) call so the YAML
+    `adapters:` block still takes effect.
+    """
+    agent = _StubAgentInlineMiddleware(
+        config=_agent_config(adapters=[{"name": "logging", "config": {}}]),
+        server_client=MagicMock(spec=ServerClient),
+    )
+    app = agent.setup_webserver()
+
+    with caplog.at_level(logging.INFO, logger="nemo_gym.adapters.interceptors.request_logging"):
+        TestClient(app).post("/_probe", json={"x": 1})
+
+    assert any("request POST /_probe" in rec.message for rec in caplog.records), [
+        rec.message for rec in caplog.records
+    ]
+
+
+def test_resources_base_skips_middleware_when_adapters_none(caplog) -> None:
+    resources = _StubResources(
+        config=_resources_config(adapters=None),
+        server_client=MagicMock(spec=ServerClient),
+    )
+    app = resources.setup_webserver()
+
+    with caplog.at_level(logging.INFO, logger="nemo_gym.adapters.interceptors.request_logging"):
+        TestClient(app).post("/_probe", json={"x": 1})
+
+    assert not any("request POST /_probe" in rec.message for rec in caplog.records)

--- a/tests/unit_tests/test_adapter_endpoint.py
+++ b/tests/unit_tests/test_adapter_endpoint.py
@@ -63,27 +63,15 @@ def _req(body: dict | None = None, path: str = "/v1/chat/completions") -> Adapte
 
 
 def test_upstream_url_known_suffixes_stripped():
+    # API suffixes AND a trailing /v1 are stripped so the /v1/... prefix already
+    # carried on req.path does not double up.
     for suffix in ("/chat/completions", "/completions", "/embeddings"):
         ic = Interceptor(upstream_url=f"https://api.example.com/v1{suffix}/")
-        assert ic._upstream_url == "https://api.example.com/v1"
-    # A non-API suffix is left intact.
-    assert Interceptor(upstream_url="http://up/v1")._upstream_url == "http://up/v1"
-
-
-def test_normalize_content_replaces_none_only():
-    body = {
-        "choices": [
-            {"message": {"content": None}},
-            {"delta": {"content": None}},
-            {"message": {"content": "keep"}},
-            {"message": {}},  # no content key -> untouched
-        ]
-    }
-    Interceptor._normalize_content(body)
-    assert body["choices"][0]["message"]["content"] == ""
-    assert body["choices"][1]["delta"]["content"] == ""
-    assert body["choices"][2]["message"]["content"] == "keep"
-    assert "content" not in body["choices"][3]["message"]
+        assert ic._upstream_url == "https://api.example.com"
+    # A bare /v1 base is stripped to the host root.
+    assert Interceptor(upstream_url="http://up/v1")._upstream_url == "http://up"
+    # A host with no /v1 is left intact.
+    assert Interceptor(upstream_url="http://up")._upstream_url == "http://up"
 
 
 async def test_intercept_request_success_merges_body_and_headers():
@@ -107,9 +95,9 @@ async def test_intercept_request_success_merges_body_and_headers():
     assert kwargs["headers"]["Content-Type"] == "application/json"
     assert "Host" not in kwargs["headers"] and "Content-Length" not in kwargs["headers"]
     assert kwargs["headers"]["X-Keep"] == "1"
-    assert kwargs["url"] == "http://up/v1/v1/chat/completions"
-    # None content normalized to ""
-    assert resp.body["choices"][0]["message"]["content"] == ""
+    assert kwargs["url"] == "http://up/v1/chat/completions"
+    # content:null passes through unchanged (no proxy-side normalization)
+    assert resp.body["choices"][0]["message"]["content"] is None
     # response headers preserved (original case) as latin-1 byte tuples
     assert (b"Content-Type", b"application/json") in resp.headers
 
@@ -125,6 +113,26 @@ async def test_intercept_request_retries_on_status_then_succeeds():
     assert resp.status_code == 200
     assert resp.body == {"ok": True}
     sleep.assert_awaited()  # Retry-After honored
+
+
+async def test_intercept_request_http_date_retry_after_falls_back_to_backoff():
+    """An HTTP-date ``Retry-After`` (RFC 7231 allows it) is not a float, so the
+    parse must fall back to exponential backoff instead of crashing the retry
+    loop. The request must still retry and eventually succeed."""
+    ic = Interceptor(upstream_url="http://up/v1", max_retries=1, retry_on_status=[503])
+    seq = [
+        _FakeResp(503, {"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"}),
+        _FakeResp(200, {}, {"ok": True}),
+    ]
+    with (
+        patch(f"{_ENDPOINT}.global_request", new=AsyncMock(side_effect=seq)),
+        patch(f"{_ENDPOINT}.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        resp = await ic.intercept_request(_req())
+    assert resp.status_code == 200
+    assert resp.body == {"ok": True}
+    # Backoff path was taken (date header could not be parsed as a delay).
+    sleep.assert_awaited_once_with(1)
 
 
 async def test_intercept_request_non_json_response_passed_through_as_bytes():

--- a/tests/unit_tests/test_adapter_endpoint.py
+++ b/tests/unit_tests/test_adapter_endpoint.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the ``endpoint`` request-to-response interceptor.
+
+All upstream HTTP is faked by patching ``endpoint.global_request`` and
+``endpoint.asyncio.sleep`` so the tests are fast and offline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+import pytest
+
+from nemo_gym.adapters.interceptors.endpoint import Interceptor
+from nemo_gym.adapters.types import AdapterRequest, AdapterResponse, InterceptorContext
+
+
+_ENDPOINT = "nemo_gym.adapters.interceptors.endpoint"
+
+
+class _FakeResp:
+    """Minimal stand-in for the aiohttp response used as an async ctx manager."""
+
+    def __init__(self, status: int, headers: dict | None = None, body=b""):
+        self.status = status
+        self.headers = headers or {}
+        self._body = body if isinstance(body, bytes) else json.dumps(body).encode()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def read(self) -> bytes:
+        return self._body
+
+
+def _req(body: dict | None = None, path: str = "/v1/chat/completions") -> AdapterRequest:
+    return AdapterRequest(
+        method="POST",
+        path=path,
+        headers={"Host": "drop-me", "Content-Length": "3", "X-Keep": "1"},
+        body=body or {"model": "m"},
+        ctx=InterceptorContext(),
+    )
+
+
+def test_upstream_url_known_suffixes_stripped():
+    for suffix in ("/chat/completions", "/completions", "/embeddings"):
+        ic = Interceptor(upstream_url=f"https://api.example.com/v1{suffix}/")
+        assert ic._upstream_url == "https://api.example.com/v1"
+    # A non-API suffix is left intact.
+    assert Interceptor(upstream_url="http://up/v1")._upstream_url == "http://up/v1"
+
+
+def test_normalize_content_replaces_none_only():
+    body = {
+        "choices": [
+            {"message": {"content": None}},
+            {"delta": {"content": None}},
+            {"message": {"content": "keep"}},
+            {"message": {}},  # no content key -> untouched
+        ]
+    }
+    Interceptor._normalize_content(body)
+    assert body["choices"][0]["message"]["content"] == ""
+    assert body["choices"][1]["delta"]["content"] == ""
+    assert body["choices"][2]["message"]["content"] == "keep"
+    assert "content" not in body["choices"][3]["message"]
+
+
+async def test_intercept_request_success_merges_body_and_headers():
+    ic = Interceptor(upstream_url="http://up/v1", api_key="sekret", extra_body={"stream": False})
+    mock = AsyncMock(
+        return_value=_FakeResp(
+            200,
+            {"Content-Type": "application/json"},
+            {"choices": [{"message": {"content": None}}]},
+        )
+    )
+    with patch(f"{_ENDPOINT}.global_request", new=mock):
+        resp = await ic.intercept_request(_req(body={"model": "m"}))
+
+    assert isinstance(resp, AdapterResponse) and resp.status_code == 200
+    kwargs = mock.call_args.kwargs
+    # extra_body merged into the forwarded body
+    assert json.loads(kwargs["data"]) == {"model": "m", "stream": False}
+    # api key injected, content-type defaulted, hop-by-hop headers stripped
+    assert kwargs["headers"]["Authorization"] == "Bearer sekret"
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+    assert "Host" not in kwargs["headers"] and "Content-Length" not in kwargs["headers"]
+    assert kwargs["headers"]["X-Keep"] == "1"
+    assert kwargs["url"] == "http://up/v1/v1/chat/completions"
+    # None content normalized to ""
+    assert resp.body["choices"][0]["message"]["content"] == ""
+    # response headers preserved (original case) as latin-1 byte tuples
+    assert (b"Content-Type", b"application/json") in resp.headers
+
+
+async def test_intercept_request_retries_on_status_then_succeeds():
+    ic = Interceptor(upstream_url="http://up/v1", max_retries=2, retry_on_status=[503])
+    seq = [_FakeResp(503, {"Retry-After": "0"}), _FakeResp(200, {}, {"ok": True})]
+    with (
+        patch(f"{_ENDPOINT}.global_request", new=AsyncMock(side_effect=seq)),
+        patch(f"{_ENDPOINT}.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        resp = await ic.intercept_request(_req())
+    assert resp.status_code == 200
+    assert resp.body == {"ok": True}
+    sleep.assert_awaited()  # Retry-After honored
+
+
+async def test_intercept_request_non_json_response_passed_through_as_bytes():
+    ic = Interceptor(upstream_url="http://up/v1")
+    with patch(
+        f"{_ENDPOINT}.global_request",
+        new=AsyncMock(return_value=_FakeResp(200, {"Content-Type": "text/plain"}, b"not-json")),
+    ):
+        resp = await ic.intercept_request(_req())
+    assert resp.body == b"not-json"
+
+
+async def test_intercept_request_timeout_returns_504():
+    ic = Interceptor(upstream_url="http://up/v1", max_retries=0)
+    with patch(f"{_ENDPOINT}.global_request", new=AsyncMock(side_effect=asyncio.TimeoutError())):
+        resp = await ic.intercept_request(_req())
+    assert resp.status_code == 504
+    assert resp.body["error"]["type"] == "timeout"
+
+
+async def test_intercept_request_timeout_retries_then_504():
+    ic = Interceptor(upstream_url="http://up/v1", max_retries=1)
+    with (
+        patch(f"{_ENDPOINT}.global_request", new=AsyncMock(side_effect=asyncio.TimeoutError())),
+        patch(f"{_ENDPOINT}.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        resp = await ic.intercept_request(_req())
+    assert resp.status_code == 504
+    sleep.assert_awaited()
+
+
+async def test_intercept_request_client_error_raises_without_retries():
+    ic = Interceptor(upstream_url="http://up/v1", max_retries=0)
+    with patch(f"{_ENDPOINT}.global_request", new=AsyncMock(side_effect=aiohttp.ClientError("boom"))):
+        with pytest.raises(aiohttp.ClientError):
+            await ic.intercept_request(_req())
+
+
+async def test_intercept_request_client_error_retries_then_raises():
+    ic = Interceptor(upstream_url="http://up/v1", max_retries=1)
+    with (
+        patch(f"{_ENDPOINT}.global_request", new=AsyncMock(side_effect=aiohttp.ClientError("boom"))),
+        patch(f"{_ENDPOINT}.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        with pytest.raises(aiohttp.ClientError):
+            await ic.intercept_request(_req())
+    sleep.assert_awaited()
+
+
+async def test_close_is_noop():
+    ic = Interceptor(upstream_url="http://up/v1")
+    assert await ic.close() is None

--- a/tests/unit_tests/test_adapter_framework.py
+++ b/tests/unit_tests/test_adapter_framework.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Smoke test for the Gym adapter framework.
+
+Confirms the framework imports, an empty pipeline raises the expected
+no-response error, and the registry pre-lists every builtin name.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_gym.adapters import (
+    AdapterPipeline,
+    AdapterRequest,
+    InterceptorContext,
+    InterceptorRegistry,
+    install_middleware,
+)
+
+
+# Names this PR ships in ``nemo_gym.adapters.registry._BUILTIN``. Follow-on
+# PRs (observability / caching / request-rewriting) extend the set —
+# assertion below is a subset check so adding new builtins doesn't require
+# editing this file.
+_FRAMEWORK_BUILTINS = {
+    "endpoint",
+    "logging",
+}
+
+
+def test_framework_imports() -> None:
+    """All public symbols import cleanly from the package."""
+    assert callable(install_middleware)
+    assert AdapterPipeline is not None
+    assert InterceptorRegistry is not None
+
+
+@pytest.mark.asyncio
+async def test_empty_pipeline_raises_no_response_error() -> None:
+    """A pipeline with no interceptors cannot produce a response."""
+    pipeline = AdapterPipeline([])
+    req = AdapterRequest(
+        method="POST",
+        path="/v1/chat/completions",
+        headers={},
+        body={"model": "test"},
+        ctx=InterceptorContext(),
+    )
+
+    with pytest.raises(RuntimeError, match="No interceptor produced a response"):
+        await pipeline.process(req)
+
+
+def test_registry_pre_lists_framework_builtins() -> None:
+    """``available()`` includes every framework-level builtin name.
+
+    Subset check (not equality) so this assertion is stable as follow-on
+    interceptor families extend the builtin set without touching this file.
+    """
+    names = set(InterceptorRegistry.available())
+    missing = _FRAMEWORK_BUILTINS - names
+    assert not missing, f"Framework builtins missing from registry: {sorted(missing)}"

--- a/tests/unit_tests/test_adapter_interceptors_smoke.py
+++ b/tests/unit_tests/test_adapter_interceptors_smoke.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Smoke gate: every builtin interceptor resolves and instantiates.
+
+For every name in ``InterceptorRegistry.available()`` the class is resolved
+(import-correctness) and instantiated with ``config={}``. Interceptors that
+require non-default kwargs raise ``TypeError`` and are recorded as
+``requires_config`` rather than failed.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from nemo_gym.adapters import InterceptorRegistry
+
+
+logger = logging.getLogger(__name__)
+
+
+def test_all_builtins_resolve_and_instantiable_or_require_config(caplog) -> None:
+    caplog.set_level(logging.INFO)
+
+    names = InterceptorRegistry.available()
+    # Subset check — framework-level minimum, follow-on PRs add more.
+    assert "endpoint" in names and "logging" in names, f"framework builtins missing from {names}"
+    assert len(names) >= 2, f"Expected at least 2 builtins, got {len(names)}: {names}"
+
+    instantiates: list[str] = []
+    requires_config: list[tuple[str, str]] = []
+
+    for name in names:
+        cls = InterceptorRegistry.resolve_class(name)
+        assert isinstance(cls, type), f"{name!r} did not resolve to a class (got {cls!r})"
+
+        try:
+            InterceptorRegistry.create(name, config={})
+        except TypeError as exc:
+            requires_config.append((name, str(exc)))
+        else:
+            instantiates.append(name)
+
+    summary = (
+        f"{len(instantiates)}/{len(names)} instantiate with empty config; "
+        f"{len(requires_config)}/{len(names)} require config"
+    )
+    print(summary)
+    print("  empty-config OK:", sorted(instantiates))
+    print("  require config:")
+    for n, msg in sorted(requires_config):
+        print(f"    {n}: {msg}")
+
+    # Sanity: at least one of each side. If every interceptor took empty
+    # config the contract would be too loose; if none did, the registry
+    # is probably broken.
+    assert instantiates, "no interceptor accepted empty config — registry likely broken"
+    assert requires_config, "every interceptor accepted empty config — likely loss of required-arg validation"

--- a/tests/unit_tests/test_adapter_internals.py
+++ b/tests/unit_tests/test_adapter_internals.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit coverage for adapter internals: context vars, response helpers, the
+logging preview, middleware request/response conversion, proxy guards, and the
+registry/pipeline error paths."""
+
+from __future__ import annotations
+
+import contextvars
+import json
+
+import pytest
+from fastapi import FastAPI
+from starlette.responses import Response, StreamingResponse
+
+from nemo_gym.adapters import middleware as mw
+from nemo_gym.adapters import proxy
+from nemo_gym.adapters import registry as reg
+from nemo_gym.adapters.interceptors.request_logging import _MAX, _trunc_preview
+from nemo_gym.adapters.pipeline import AdapterPipeline
+from nemo_gym.adapters.registry import InterceptorRegistry
+from nemo_gym.adapters.types import (
+    AdapterRequest,
+    AdapterResponse,
+    InterceptorContext,
+    ResponseInterceptor,
+    get_context,
+)
+
+
+# ── types: context + response helpers ────────────────────────────────
+
+
+def test_get_context_creates_and_caches_in_fresh_context():
+    # A brand-new contextvars.Context has no value, exercising the LookupError
+    # branch that lazily creates and stores a context.
+    captured: dict = {}
+
+    def _run():
+        captured["first"] = get_context()
+        captured["second"] = get_context()
+
+    contextvars.Context().run(_run)
+    assert isinstance(captured["first"], InterceptorContext)
+    assert captured["first"] is captured["second"]
+
+
+def test_adapter_response_ok_property():
+    assert AdapterResponse(status_code=200, headers={}, body={}).ok is True
+    assert AdapterResponse(status_code=302, headers={}, body={}).ok is True
+    assert AdapterResponse(status_code=404, headers={}, body={}).ok is False
+    assert AdapterResponse(status_code=500, headers={}, body={}).ok is False
+
+
+# ── request_logging._trunc_preview branches ──────────────────────────
+
+
+def test_trunc_preview_decodes_bytes():
+    assert _trunc_preview(b"hello") == "hello"
+
+
+def test_trunc_preview_stringifies_other_types():
+    assert _trunc_preview(12345) == "12345"
+
+
+def test_trunc_preview_truncates_long_text():
+    out = _trunc_preview("x" * (_MAX + 50))
+    assert out.endswith("...")
+    assert len(out) == _MAX + 3
+
+
+# ── middleware response/request conversion helpers ───────────────────
+
+
+async def test_starlette_to_adapter_streaming_str_chunks_falls_back_to_bytes():
+    async def gen():
+        yield "he"
+        yield "llo"
+
+    # Streaming body declared json but not valid json -> raw bytes fallback,
+    # and str chunks get utf-8 encoded.
+    resp = StreamingResponse(gen(), media_type="application/json")
+    out = await mw._starlette_response_to_adapter(resp, InterceptorContext())
+    assert out.body == b"hello"
+
+
+async def test_starlette_to_adapter_plain_json_body():
+    resp = Response(content=json.dumps({"a": 1}), media_type="application/json")
+    out = await mw._starlette_response_to_adapter(resp, InterceptorContext())
+    assert out.body == {"a": 1}
+
+
+async def test_starlette_to_adapter_non_json_content_type_kept_as_bytes():
+    resp = Response(content=b"raw", media_type="text/plain")
+    out = await mw._starlette_response_to_adapter(resp, InterceptorContext())
+    assert out.body == b"raw"
+
+
+def test_adapter_response_to_starlette_bytes_body():
+    out = mw._adapter_response_to_starlette(AdapterResponse(status_code=200, headers={"X-A": "1"}, body=b"raw-bytes"))
+    assert isinstance(out, Response)
+    assert out.body == b"raw-bytes"
+
+
+def test_install_middleware_noop_when_empty():
+    app = FastAPI()
+    before = len(app.user_middleware)
+    mw.install_middleware(app, None)
+    mw.install_middleware(app, [])
+    assert len(app.user_middleware) == before
+
+
+def test_install_middleware_rejects_endpoint_interceptor():
+    with pytest.raises(ValueError, match="endpoint"):
+        mw.install_middleware(FastAPI(), [{"name": "endpoint", "config": {"upstream_url": "http://x"}}])
+
+
+# ── proxy guards / helpers ───────────────────────────────────────────
+
+
+def test_bind_port_returns_preferred():
+    assert proxy._bind_port("127.0.0.1", 54321) == 54321
+
+
+def test_bind_port_allocates_ephemeral_when_zero():
+    port = proxy._bind_port("127.0.0.1", 0)
+    assert isinstance(port, int) and port > 0
+
+
+def test_wait_for_health_raises_on_timeout():
+    # Nothing is listening; the loop should give up and raise.
+    with pytest.raises(RuntimeError, match="did not become healthy"):
+        proxy._wait_for_health("http://127.0.0.1:1", timeout=0.2)
+
+
+def test_start_adapter_proxy_rejects_remote_host():
+    with pytest.raises(ValueError, match="unsafe_allow_remote"):
+        proxy.start_adapter_proxy("http://up", [], host="0.0.0.0")
+
+
+def test_start_adapter_proxy_rejects_endpoint_interceptor():
+    with pytest.raises(ValueError, match="endpoint"):
+        proxy.start_adapter_proxy("http://up", [{"name": "endpoint"}])
+
+
+# ── registry error paths ─────────────────────────────────────────────
+
+
+@pytest.fixture
+def _restore_extra():
+    before = dict(reg._EXTRA)
+    yield
+    reg._EXTRA.clear()
+    reg._EXTRA.update(before)
+
+
+def test_resolve_class_import_error(_restore_extra):
+    InterceptorRegistry.register("badmod", "nemo_gym.adapters.interceptors.does_not_exist")
+    with pytest.raises(ValueError, match="Cannot import interceptor module"):
+        InterceptorRegistry.resolve_class("badmod")
+
+
+def test_resolve_class_missing_interceptor_attr(_restore_extra):
+    # stdlib json imports fine but has no ``Interceptor`` attribute.
+    InterceptorRegistry.register("nointercept", "json")
+    with pytest.raises(ValueError, match="does not expose an 'Interceptor' class"):
+        InterceptorRegistry.resolve_class("nointercept")
+
+
+# ── pipeline error/best-effort paths ─────────────────────────────────
+
+
+class _BogusStageInterceptor:
+    stage = "not-a-real-stage"
+
+    async def intercept_request(self, req):  # pragma: no cover - never called
+        return req
+
+
+def test_pipeline_rejects_unknown_stage():
+    with pytest.raises(ValueError, match="Unknown stage"):
+        AdapterPipeline([_BogusStageInterceptor()])
+
+
+class _BestEffortFailingResponse(ResponseInterceptor):
+    best_effort = True
+
+    async def intercept_response(self, resp: AdapterResponse) -> AdapterResponse:
+        raise RuntimeError("swallow me")
+
+
+class _HardFailingResponse(ResponseInterceptor):
+    best_effort = False
+
+    async def intercept_response(self, resp: AdapterResponse) -> AdapterResponse:
+        raise RuntimeError("propagate me")
+
+
+def _req() -> AdapterRequest:
+    return AdapterRequest(method="POST", path="/p", headers={}, body={}, ctx=InterceptorContext())
+
+
+async def _upstream(req: AdapterRequest) -> AdapterResponse:
+    return AdapterResponse(status_code=200, headers={}, body={"ok": True}, ctx=req.ctx)
+
+
+async def test_response_interceptor_best_effort_failure_is_swallowed():
+    pipe = AdapterPipeline([_BestEffortFailingResponse()])
+    resp = await pipe.process(_req(), upstream_call=_upstream)
+    assert resp.status_code == 200
+    assert resp.body == {"ok": True}
+
+
+async def test_response_interceptor_failure_propagates_when_not_best_effort():
+    pipe = AdapterPipeline([_HardFailingResponse()])
+    with pytest.raises(RuntimeError, match="propagate me"):
+        await pipe.process(_req(), upstream_call=_upstream)

--- a/tests/unit_tests/test_adapter_internals.py
+++ b/tests/unit_tests/test_adapter_internals.py
@@ -108,6 +108,18 @@ async def test_starlette_to_adapter_non_json_content_type_kept_as_bytes():
     assert out.body == b"raw"
 
 
+async def test_starlette_to_adapter_str_body_without_iterator_is_encoded():
+    # No ``body_iterator`` and a ``str`` body exercises the non-streaming
+    # str->bytes encode branch.
+    class _StrBodyResp:
+        status_code = 200
+        raw_headers: list = []
+        body = "plain-str-body"
+
+    out = await mw._starlette_response_to_adapter(_StrBodyResp(), InterceptorContext())
+    assert out.body == b"plain-str-body"
+
+
 def test_adapter_response_to_starlette_bytes_body():
     out = mw._adapter_response_to_starlette(AdapterResponse(status_code=200, headers={"X-A": "1"}, body=b"raw-bytes"))
     assert isinstance(out, Response)

--- a/tests/unit_tests/test_adapter_middleware_behaviors.py
+++ b/tests/unit_tests/test_adapter_middleware_behaviors.py
@@ -1,0 +1,362 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Middleware behavioral tests — replace NEL ``tests/test_adapters/test_proxy.py``.
+
+NEL's ``test_proxy.py`` exercised a standalone uvicorn proxy spun up by
+``start_adapter_proxy(...)``. Gym does not have a standalone proxy — the
+adapter pipeline is installed as FastAPI middleware on an existing model
+server's app via ``install_middleware``. The architectural shift means the
+proxy lifecycle / port-allocation tests do not port.
+
+What does port — and is exercised here against the middleware via a
+FastAPI ``TestClient`` — are the **behavioral invariants** that NEL's
+proxy guaranteed and that Gym's Phase-1.5 middleware also implements:
+
+* ``/s/<hex>/...`` session-id prefix is parsed off the path and exposed
+  to interceptors via ``ctx.extra["session_id"]``.
+* Hop-by-hop response headers (``transfer-encoding``, etc.) are stripped.
+* ``GracefulError`` raised inside an interceptor returns HTTP 429 with a
+  ``session_budget_exhausted`` error code.
+* Invalid JSON bodies return HTTP 400.
+* The pipeline runs only on POST; other methods pass through unchanged.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+from fastapi import Body, FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from starlette.middleware.sessions import SessionMiddleware
+
+from nemo_gym.adapters import install_middleware
+from nemo_gym.adapters.registry import InterceptorRegistry
+from nemo_gym.adapters.types import (
+    AdapterRequest,
+    AdapterResponse,
+    GracefulError,
+    RequestInterceptor,
+    RequestToResponseInterceptor,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper interceptors registered for use in these tests
+# ---------------------------------------------------------------------------
+
+
+class _HeaderCapture(RequestInterceptor):
+    """Captures the last request the pipeline saw so tests can introspect ctx."""
+
+    last_req: AdapterRequest | None = None
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        type(self).last_req = req
+        return req
+
+
+class _CapturingEcho(RequestToResponseInterceptor):
+    """Captures the request *and* short-circuits with a canned response.
+
+    Using a short-circuiting interceptor — rather than letting the request
+    fall through to the FastAPI route — lets us assert on what the pipeline
+    saw without depending on the route handler matching the session-prefixed
+    URL. (FastAPI's router doesn't know about session prefixes; that's the
+    middleware's job, and NEL's standalone proxy used to rewrite the URL
+    before forwarding. Gym's middleware annotates ctx instead, and trusts
+    the chain to handle routing semantics.)
+    """
+
+    last_req: AdapterRequest | None = None
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterResponse:
+        type(self).last_req = req
+        return AdapterResponse(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            body={"id": "chatcmpl-canned", "echo_path": req.path},
+            ctx=req.ctx,
+        )
+
+
+class _GracefulRaiser(RequestInterceptor):
+    """Always raises ``GracefulError`` to simulate session-budget exhaustion."""
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        raise GracefulError("turns up")
+
+
+def _install_helper_interceptors() -> None:
+    """Make the helpers above resolvable via the registry."""
+    mod = types.ModuleType("nemo_gym.adapters.interceptors._test_header_capture")
+    mod.Interceptor = _HeaderCapture
+    sys.modules[mod.__name__] = mod
+    InterceptorRegistry.register("_test_header_capture", mod.__name__)
+
+    mod2 = types.ModuleType("nemo_gym.adapters.interceptors._test_graceful_raiser")
+    mod2.Interceptor = _GracefulRaiser
+    sys.modules[mod2.__name__] = mod2
+    InterceptorRegistry.register("_test_graceful_raiser", mod2.__name__)
+
+    mod3 = types.ModuleType("nemo_gym.adapters.interceptors._test_capturing_echo")
+    mod3.Interceptor = _CapturingEcho
+    sys.modules[mod3.__name__] = mod3
+    InterceptorRegistry.register("_test_capturing_echo", mod3.__name__)
+
+
+# ---------------------------------------------------------------------------
+# App / client factory
+# ---------------------------------------------------------------------------
+
+
+def _route_handler_default(body: dict) -> dict:
+    """Default canned model-server response: echoes path and body."""
+    return {
+        "id": "chatcmpl-route",
+        "object": "chat.completion",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "from route"},
+            }
+        ],
+        "echo": body,
+    }
+
+
+def _build_test_app(
+    interceptor_specs: list[dict[str, Any]] | None,
+    *,
+    extra_response_headers: dict[str, str] | None = None,
+) -> FastAPI:
+    """Build a FastAPI app whose ``/v1/chat/completions`` POST route returns
+    a canned response, with the adapter middleware optionally installed on top.
+
+    ``extra_response_headers`` is appended to the model-server's reply so
+    tests can verify that hop-by-hop headers added by the (mock) upstream
+    are stripped by the middleware before reaching the client.
+    """
+    app = FastAPI()
+
+    @app.post("/v1/chat/completions")
+    async def _chat(body: dict):
+        return JSONResponse(
+            content=_route_handler_default(body),
+            headers=extra_response_headers or {},
+        )
+
+    install_middleware(app, interceptor_specs)
+    return app
+
+
+@pytest.fixture(autouse=True)
+def _setup_registry() -> None:
+    _install_helper_interceptors()
+    _HeaderCapture.last_req = None
+    _CapturingEcho.last_req = None
+
+
+# ---------------------------------------------------------------------------
+# Session-id parsing
+# ---------------------------------------------------------------------------
+
+
+def test_session_id_parsed_into_ctx_extra() -> None:
+    """``POST /s/<hex>/v1/...`` strips the prefix and exposes the id on ctx.
+
+    Uses a short-circuiting interceptor (``_test_capturing_echo``) so the
+    request never falls through to the FastAPI router — which doesn't know
+    about session-prefixed URLs. The middleware-side behavior being verified
+    is purely that the pipeline sees ``ctx.extra["session_id"]`` set to the
+    expected hex string and the stripped path.
+    """
+    app = _build_test_app([{"name": "_test_capturing_echo"}])
+    with TestClient(app) as client:
+        resp = client.post(
+            "/s/deadbeef1234/v1/chat/completions",
+            json={"model": "test", "messages": []},
+        )
+    assert resp.status_code == 200
+    assert _CapturingEcho.last_req is not None
+    assert _CapturingEcho.last_req.ctx.extra.get("session_id") == "deadbeef1234"
+    # The path the interceptor saw is the clean one with the prefix removed.
+    assert _CapturingEcho.last_req.path == "/v1/chat/completions"
+
+
+def test_no_session_id_for_plain_path() -> None:
+    """A plain ``/v1/...`` POST exposes no session_id on the interceptor ctx."""
+    app = _build_test_app([{"name": "_test_capturing_echo"}])
+    with TestClient(app) as client:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"model": "test", "messages": []},
+        )
+    assert resp.status_code == 200
+    assert _CapturingEcho.last_req is not None
+    assert "session_id" not in _CapturingEcho.last_req.ctx.extra
+    assert _CapturingEcho.last_req.path == "/v1/chat/completions"
+
+
+# ---------------------------------------------------------------------------
+# Hop-by-hop header filtering
+# ---------------------------------------------------------------------------
+
+
+def test_hop_by_hop_headers_stripped_from_response() -> None:
+    """Hop-by-hop headers added by the underlying handler are stripped
+    before being returned to the client."""
+    app = _build_test_app(
+        [{"name": "logging"}],
+        extra_response_headers={
+            "x-upstream-marker": "kept",
+            "transfer-encoding": "chunked",  # must be stripped
+            "connection": "keep-alive",  # must be stripped
+        },
+    )
+    with TestClient(app) as client:
+        resp = client.post("/v1/chat/completions", json={"model": "test", "messages": []})
+    assert resp.status_code == 200
+    keys = {k.lower() for k in resp.headers}
+    assert "transfer-encoding" not in keys
+    assert "connection" not in keys
+    # Non hop-by-hop custom headers must be preserved.
+    assert resp.headers.get("x-upstream-marker") == "kept"
+
+
+# ---------------------------------------------------------------------------
+# GracefulError → 429
+# ---------------------------------------------------------------------------
+
+
+def test_graceful_error_returns_429() -> None:
+    """When an interceptor raises ``GracefulError``, the middleware emits
+    HTTP 429 with a ``session_budget_exhausted`` error code."""
+    app = _build_test_app([{"name": "_test_graceful_raiser"}])
+    with TestClient(app) as client:
+        resp = client.post("/v1/chat/completions", json={"model": "test", "messages": []})
+    assert resp.status_code == 429
+    body = resp.json()
+    assert body["error"]["code"] == "session_budget_exhausted"
+    assert "turns up" in body["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Invalid JSON → 400
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_json_body_returns_400() -> None:
+    """A POST whose body is not valid JSON returns 400 before any
+    interceptor runs (the pipeline must never see malformed input)."""
+    app = _build_test_app([{"name": "_test_header_capture"}])
+    with TestClient(app) as client:
+        resp = client.post(
+            "/v1/chat/completions",
+            content=b"not-json",
+            headers={"content-type": "application/json"},
+        )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    # The pipeline must not have run.
+    assert _HeaderCapture.last_req is None
+
+
+# ---------------------------------------------------------------------------
+# Non-POST methods pass through (the pipeline only intercepts POST)
+# ---------------------------------------------------------------------------
+
+
+def test_get_request_passes_through_middleware() -> None:
+    """GET requests bypass the pipeline entirely — the model server's own
+    routes (e.g. /health) keep working unmodified.
+
+    The default app doesn't define a GET route, so we expect 405 (Method
+    Not Allowed) from the route handler — proving the middleware did not
+    intercept and short-circuit with its own response."""
+    app = _build_test_app([{"name": "_test_header_capture"}])
+    with TestClient(app) as client:
+        resp = client.get("/v1/chat/completions")
+    assert resp.status_code == 405  # Method Not Allowed from FastAPI
+    # Pipeline was not invoked for GET.
+    assert _HeaderCapture.last_req is None
+
+
+# ---------------------------------------------------------------------------
+# Multi-valued response headers (Set-Cookie / SessionMiddleware) — the
+# ecosystem-review blocker. ``SimpleResponsesAPIModel`` always has Starlette
+# ``SessionMiddleware`` attached; before the fix, ``_starlette_response_to_adapter``
+# rebuilt headers as a Python dict and silently collapsed duplicate
+# ``Set-Cookie`` headers. This test mounts the adapter middleware on top of
+# a FastAPI app that has ``SessionMiddleware`` installed plus an explicit
+# route that sets an additional ``Set-Cookie`` — and asserts both cookies
+# survive the round trip.
+# ---------------------------------------------------------------------------
+
+
+def test_set_cookie_headers_preserved_through_middleware() -> None:
+    """Multiple ``Set-Cookie`` headers survive the adapter middleware.
+
+    Pre-fix, ``_starlette_response_to_adapter`` collapsed response headers
+    into a Python ``dict``, so a response carrying two ``Set-Cookie``
+    headers (one from ``SessionMiddleware``, one from the route handler)
+    arrived at the client with only the last value. Post-fix, headers
+    flow as ``list[tuple[bytes, bytes]]`` end-to-end and duplicates are
+    preserved.
+    """
+    app = FastAPI()
+    # Match the order ``SimpleResponsesAPIModel.setup_webserver`` uses:
+    # session middleware first, then the route handlers, then (after this
+    # builder returns) the adapter middleware on top.
+    app.add_middleware(SessionMiddleware, secret_key="test-secret-key")  # pragma: allowlist secret
+
+    @app.post("/v1/chat/completions")
+    async def _chat(request: Request, body: dict = Body(...)):
+        # Mutate the session so SessionMiddleware actually emits its
+        # ``Set-Cookie`` on the response path (it skips otherwise).
+        request.session["test_key"] = "test_value"
+        resp = JSONResponse(content={"ok": True, "echo": body})
+        # Set a second cookie explicitly on top of the one SessionMiddleware
+        # will inject. Two cookies on the same response is the exact case
+        # the dict-collapse bug obliterated.
+        resp.set_cookie("explicit_cookie", "explicit_value")
+        return resp
+
+    install_middleware(app, [{"name": "logging"}])
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"model": "test", "messages": []},
+        )
+    assert resp.status_code == 200, f"body={resp.text!r}"
+    # httpx exposes multi-valued headers via ``.get_list``; iterating the
+    # underlying raw header list is the most portable cross-version check.
+    raw_set_cookies = [v for k, v in resp.headers.raw if k.lower() == b"set-cookie"]
+    assert len(raw_set_cookies) >= 2, (
+        f"expected ≥2 Set-Cookie headers (SessionMiddleware + explicit), got: {raw_set_cookies!r}"
+    )
+    assert any(b"explicit_cookie=explicit_value" in v for v in raw_set_cookies), (
+        f"explicit cookie missing from response: {raw_set_cookies!r}"
+    )
+    # SessionMiddleware's cookie is named "session" by default.
+    assert any(v.lower().startswith(b"session=") for v in raw_set_cookies), (
+        f"SessionMiddleware cookie missing from response: {raw_set_cookies!r}"
+    )

--- a/tests/unit_tests/test_adapter_middleware_behaviors.py
+++ b/tests/unit_tests/test_adapter_middleware_behaviors.py
@@ -53,6 +53,7 @@ from nemo_gym.adapters.types import (
     GracefulError,
     RequestInterceptor,
     RequestToResponseInterceptor,
+    get_context,
 )
 
 
@@ -102,6 +103,14 @@ class _GracefulRaiser(RequestInterceptor):
         raise GracefulError("turns up")
 
 
+class _BoomRaiser(RequestInterceptor):
+    """Raises a generic (non-graceful) exception to exercise the middleware's
+    500 arm."""
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        raise RuntimeError("kaboom")
+
+
 def _install_helper_interceptors() -> None:
     """Make the helpers above resolvable via the registry."""
     mod = types.ModuleType("nemo_gym.adapters.interceptors._test_header_capture")
@@ -118,6 +127,11 @@ def _install_helper_interceptors() -> None:
     mod3.Interceptor = _CapturingEcho
     sys.modules[mod3.__name__] = mod3
     InterceptorRegistry.register("_test_capturing_echo", mod3.__name__)
+
+    mod4 = types.ModuleType("nemo_gym.adapters.interceptors._test_boom_raiser")
+    mod4.Interceptor = _BoomRaiser
+    sys.modules[mod4.__name__] = mod4
+    InterceptorRegistry.register("_test_boom_raiser", mod4.__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -214,6 +228,37 @@ def test_no_session_id_for_plain_path() -> None:
     assert _CapturingEcho.last_req.path == "/v1/chat/completions"
 
 
+def test_session_prefixed_post_routes_to_real_route() -> None:
+    """A session-prefixed ``POST /s/<hex>/v1/chat/completions`` must route to the
+    real ``/v1/chat/completions`` handler — not 404.
+
+    The middleware rewrites ``request.scope['path']`` / ``raw_path`` to the
+    prefix-stripped path before ``call_next`` so the FastAPI router can match
+    it. The session id is still parsed onto the request ctx, which the routed
+    handler observes via the shared ``get_context()``.
+    """
+    captured: dict[str, Any] = {}
+    app = FastAPI()
+
+    @app.post("/v1/chat/completions")
+    async def _chat(body: dict):
+        captured["session_id"] = get_context().extra.get("session_id")
+        return JSONResponse(_route_handler_default(body))
+
+    install_middleware(app, [{"name": "logging"}])
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/s/deadbeef/v1/chat/completions",
+            json={"model": "test", "messages": []},
+        )
+    # Routed to the real handler (not a 404 from the unstripped /s/... path).
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["id"] == "chatcmpl-route"
+    # The session id was parsed off the prefix and is visible to the handler.
+    assert captured["session_id"] == "deadbeef"
+
+
 # ---------------------------------------------------------------------------
 # Hop-by-hop header filtering
 # ---------------------------------------------------------------------------
@@ -255,6 +300,21 @@ def test_graceful_error_returns_429() -> None:
     body = resp.json()
     assert body["error"]["code"] == "session_budget_exhausted"
     assert "turns up" in body["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Generic pipeline error → 500
+# ---------------------------------------------------------------------------
+
+
+def test_generic_pipeline_exception_returns_500() -> None:
+    """A non-graceful exception raised inside the pipeline is caught by the
+    middleware and surfaced as HTTP 500 (not propagated to the ASGI server)."""
+    app = _build_test_app([{"name": "_test_boom_raiser"}])
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.post("/v1/chat/completions", json={"model": "test", "messages": []})
+    assert resp.status_code == 500
+    assert resp.json()["error"]["type"] == "server_error"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_adapter_middleware_integration.py
+++ b/tests/unit_tests/test_adapter_middleware_integration.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Middleware integration tests (Phase 1.5 — wrap, don't replace).
+
+The middleware now layers on top of an existing FastAPI route handler:
+REQUEST interceptors mutate the body, REQUEST_TO_RESPONSE interceptors may
+short-circuit, otherwise ``call_next`` invokes the model server's own
+handler, and RESPONSE interceptors observe the result. These tests verify:
+
+* ``log_tokens`` (RESPONSE stage) observes the route handler's output when
+  the chain has no short-circuiting interceptor.
+* REQUEST-stage interceptors mutate the body the route handler sees.
+* A short-circuiting REQUEST_TO_RESPONSE interceptor prevents the route
+  handler from ever running.
+* ``adapters=None`` / ``adapters=[]`` keep the middleware uninstalled.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nemo_gym.adapters import install_middleware
+from nemo_gym.adapters.registry import InterceptorRegistry
+from nemo_gym.adapters.types import (
+    AdapterRequest,
+    AdapterResponse,
+    RequestToResponseInterceptor,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures: a minimal canned-response interceptor registered as a
+# RequestToResponseInterceptor. Used by the short-circuit assertion test.
+# ---------------------------------------------------------------------------
+
+
+_CANNED_BODY = {
+    "id": "chatcmpl-test",
+    "object": "chat.completion",
+    "created": 0,
+    "model": "test-model",
+    "choices": [
+        {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {"role": "assistant", "content": "hello from middleware"},
+        }
+    ],
+    "usage": {"prompt_tokens": 3, "completion_tokens": 5, "total_tokens": 8},
+}
+
+
+class _CannedInterceptor(RequestToResponseInterceptor):
+    """Returns ``_CANNED_BODY`` without touching the network."""
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest | AdapterResponse:
+        return AdapterResponse(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            body=dict(_CANNED_BODY),
+            latency_ms=1.0,
+            ctx=req.ctx,
+        )
+
+
+def _register_canned_interceptor() -> None:
+    """Make the canned interceptor resolvable by ``InterceptorRegistry``."""
+    module_name = "nemo_gym.adapters.interceptors._test_canned"
+    if module_name not in sys.modules:
+        mod = types.ModuleType(module_name)
+        mod.Interceptor = _CannedInterceptor
+        sys.modules[module_name] = mod
+    InterceptorRegistry.register("_test_canned", module_name)
+
+
+# A handler-visibility flag: the test route writes the request body it
+# actually received into this list so tests can assert what the model
+# server saw (e.g. mutated by REQUEST interceptors).
+_route_seen: list[dict] = []
+
+
+def _build_app() -> FastAPI:
+    """Minimal FastAPI app with a single ``/v1/chat/completions`` POST route.
+
+    The route stashes the parsed body into ``_route_seen`` and returns a
+    sentinel body so the test can distinguish whether the request reached
+    the underlying handler or was short-circuited by middleware.
+    """
+    app = FastAPI()
+
+    @app.post("/v1/chat/completions")
+    async def _chat_completions(body: dict) -> dict:
+        _route_seen.append(body)
+        return {
+            "id": "chatcmpl-route",
+            "object": "chat.completion",
+            "created": 0,
+            "model": body.get("model", "?"),
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {"role": "assistant", "content": "from route"},
+                }
+            ],
+            "usage": {"prompt_tokens": 7, "completion_tokens": 11, "total_tokens": 18},
+        }
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _register() -> None:
+    _register_canned_interceptor()
+    _route_seen.clear()
+
+
+_SAMPLE_BODY = {
+    "model": "test-model",
+    "messages": [{"role": "user", "content": "hi"}],
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_install_middleware_runs_pipeline_and_logging_emits_log(caplog) -> None:
+    """A POST flows through the pipeline → route handler → RESPONSE stage.
+
+    The model server's own route handler produces the response;
+    ``logging`` (a request+response interceptor) emits records on both
+    sides to prove the pipeline ran.
+    """
+    app = _build_app()
+    install_middleware(
+        app,
+        [
+            {"name": "logging", "config": {}},
+        ],
+    )
+
+    with caplog.at_level(logging.INFO, logger="nemo_gym.adapters.interceptors.request_logging"):
+        with TestClient(app) as client:
+            resp = client.post("/v1/chat/completions", json=_SAMPLE_BODY)
+
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+
+    # The route handler ran (not a canned short-circuit).
+    assert payload["choices"][0]["message"]["content"] == "from route"
+    assert _route_seen == [_SAMPLE_BODY]
+
+    # logging fires on both the request and response halves of the chain.
+    log_records = [rec for rec in caplog.records if rec.name == "nemo_gym.adapters.interceptors.request_logging"]
+    assert any("request POST /v1/chat/completions" in r.getMessage() for r in log_records)
+    assert any("response status=200" in r.getMessage() for r in log_records)
+
+
+def test_short_circuit_interceptor_prevents_route_handler() -> None:
+    """A short-circuiting REQUEST_TO_RESPONSE interceptor skips ``call_next``.
+
+    The route handler must never run, ``_route_seen`` stays empty, and the
+    client receives the canned body.
+    """
+    app = _build_app()
+    install_middleware(
+        app,
+        [
+            {"name": "logging", "config": {}},
+            {"name": "_test_canned", "config": {}},
+        ],
+    )
+
+    with TestClient(app) as client:
+        resp = client.post("/v1/chat/completions", json=_SAMPLE_BODY)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["choices"][0]["message"]["content"] == "hello from middleware"
+    # Crucial: the underlying route handler was bypassed.
+    assert _route_seen == [], "Route handler ran even though chain short-circuited"
+
+
+def test_install_middleware_defaults_off_when_specs_is_none() -> None:
+    """``adapters=None`` is a no-op: the route handler runs unchanged."""
+    app = _build_app()
+    install_middleware(app, None)
+
+    with TestClient(app) as client:
+        resp = client.post("/v1/chat/completions", json=_SAMPLE_BODY)
+
+    assert resp.status_code == 200
+    # Route handler reply (not the canned interceptor one) — proves no
+    # middleware was inserted.
+    assert resp.json()["choices"][0]["message"]["content"] == "from route"
+
+
+def test_install_middleware_defaults_off_when_specs_is_empty() -> None:
+    """``adapters=[]`` is also a no-op (mirrors the None case)."""
+    app = _build_app()
+    install_middleware(app, [])
+
+    with TestClient(app) as client:
+        resp = client.post("/v1/chat/completions", json=_SAMPLE_BODY)
+
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["message"]["content"] == "from route"

--- a/tests/unit_tests/test_adapter_pipeline.py
+++ b/tests/unit_tests/test_adapter_pipeline.py
@@ -27,10 +27,12 @@ from nemo_gym.adapters.pipeline import AdapterPipeline
 from nemo_gym.adapters.types import (
     AdapterRequest,
     AdapterResponse,
+    GracefulError,
     InterceptorContext,
     RequestInterceptor,
     RequestToResponseInterceptor,
     ResponseInterceptor,
+    get_context,
 )
 
 
@@ -306,3 +308,63 @@ async def test_library_import_request_stage_mutation_reaches_short_circuit():
     assert endpoint.last_request.headers["x-test"] == "1"
     assert resp.status_code == 200
     assert resp.body == {"result": "ok"}
+
+
+# ===========================================================================
+# Context sharing — ``process()`` reuses the request's own ``ctx`` so the
+# global ``get_context()`` observed by interceptors sees the same ``ctx.extra``
+# (e.g. a middleware-parsed ``session_id``) as ``request.ctx``.
+# ===========================================================================
+
+
+async def test_process_exposes_request_ctx_via_get_context():
+    """After ``process()``, ``get_context()`` returns the request's own ctx —
+    including any ``ctx.extra`` the caller populated (e.g. a session id)."""
+    req = _req()
+    req.ctx.extra["session_id"] = "sess-xyz"
+    pipeline = AdapterPipeline([FixedEndpoint()])
+
+    await pipeline.process(req)
+
+    ctx = get_context()
+    # Same object, not a fresh context — so extra (session_id etc.) is shared.
+    assert ctx is req.ctx
+    assert ctx.extra == req.ctx.extra
+    assert ctx.extra.get("session_id") == "sess-xyz"
+
+
+# ===========================================================================
+# GracefulError is a control-flow signal: it must propagate even from a
+# ``best_effort=True`` interceptor (which otherwise swallows exceptions),
+# in both the request phase and the response phase.
+# ===========================================================================
+
+
+class _BestEffortGracefulRequest(RequestInterceptor):
+    best_effort = True
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        raise GracefulError("budget exhausted (request)")
+
+
+class _BestEffortGracefulResponse(ResponseInterceptor):
+    best_effort = True
+
+    async def intercept_response(self, resp: AdapterResponse) -> AdapterResponse:
+        raise GracefulError("budget exhausted (response)")
+
+
+async def test_graceful_error_propagates_from_best_effort_request_interceptor():
+    """A ``best_effort=True`` request interceptor that raises ``GracefulError``
+    must NOT have it swallowed — the control-flow signal propagates."""
+    pipeline = AdapterPipeline([_BestEffortGracefulRequest(), FixedEndpoint()])
+    with pytest.raises(GracefulError, match="request"):
+        await pipeline.process(_req())
+
+
+async def test_graceful_error_propagates_from_best_effort_response_interceptor():
+    """A ``best_effort=True`` response interceptor that raises ``GracefulError``
+    must NOT have it swallowed — the control-flow signal propagates."""
+    pipeline = AdapterPipeline([FixedEndpoint(), _BestEffortGracefulResponse()])
+    with pytest.raises(GracefulError, match="response"):
+        await pipeline.process(_req())

--- a/tests/unit_tests/test_adapter_pipeline.py
+++ b/tests/unit_tests/test_adapter_pipeline.py
@@ -1,0 +1,308 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""AdapterPipeline behavior tests — ported from NEL ``tests/test_adapters/test_pipeline.py``.
+
+Mechanical port from ``nemo_evaluator.adapters.*`` to ``nemo_gym.adapters.*``
+plus one additional Phase-1.5 test for the ``upstream_call`` parameter on
+``AdapterPipeline.process()``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_gym.adapters.pipeline import AdapterPipeline
+from nemo_gym.adapters.types import (
+    AdapterRequest,
+    AdapterResponse,
+    InterceptorContext,
+    RequestInterceptor,
+    RequestToResponseInterceptor,
+    ResponseInterceptor,
+)
+
+
+def _req(**body_overrides):
+    body = {"model": "test", "messages": [{"role": "user", "content": "hi"}]}
+    body.update(body_overrides)
+    return AdapterRequest(
+        method="POST",
+        path="/v1/chat/completions",
+        headers={"content-type": "application/json"},
+        body=body,
+        ctx=InterceptorContext(),
+    )
+
+
+class AddHeaderInterceptor(RequestInterceptor):
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        req.headers["x-test"] = "1"
+        return req
+
+
+class FixedEndpoint(RequestToResponseInterceptor):
+    def __init__(self):
+        self.last_request = None
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest | AdapterResponse:
+        self.last_request = req
+        return AdapterResponse(
+            status_code=200,
+            headers={},
+            body={"result": "ok"},
+            ctx=req.ctx,
+        )
+
+
+class AppendBodyInterceptor(ResponseInterceptor):
+    async def intercept_response(self, resp: AdapterResponse) -> AdapterResponse:
+        if isinstance(resp.body, dict):
+            resp.body["appended"] = True
+        return resp
+
+
+class TrackingResponseInterceptor(ResponseInterceptor):
+    def __init__(self):
+        self.called = False
+
+    async def intercept_response(self, resp: AdapterResponse) -> AdapterResponse:
+        self.called = True
+        return resp
+
+
+class CacheHitInterceptor(RequestToResponseInterceptor):
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest | AdapterResponse:
+        return AdapterResponse(
+            status_code=200,
+            headers={},
+            body={"cached": True},
+            ctx=req.ctx,
+        )
+
+
+class FailingRequestInterceptor(RequestInterceptor):
+    def __init__(self, *, best_effort=False):
+        self.best_effort = best_effort
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        raise RuntimeError("boom")
+
+
+def test_stage_order_validation():
+    with pytest.raises(ValueError, match="Invalid interceptor order"):
+        AdapterPipeline([AppendBodyInterceptor(), AddHeaderInterceptor()])
+
+
+async def test_request_then_endpoint_then_response():
+    endpoint = FixedEndpoint()
+    pipeline = AdapterPipeline(
+        [
+            AddHeaderInterceptor(),
+            endpoint,
+        ]
+    )
+    resp = await pipeline.process(_req())
+    assert resp.status_code == 200
+    assert resp.body["result"] == "ok"
+    assert endpoint.last_request.headers["x-test"] == "1"
+
+
+async def test_short_circuit_skips_endpoint():
+    """When a RequestToResponseInterceptor short-circuits, later request-side
+    interceptors (like the endpoint) are skipped, but response interceptors
+    still run so they can inspect the short-circuited response."""
+    endpoint = FixedEndpoint()
+    tracker = TrackingResponseInterceptor()
+    pipeline = AdapterPipeline(
+        [
+            CacheHitInterceptor(),
+            endpoint,
+            tracker,
+        ]
+    )
+    resp = await pipeline.process(_req())
+    assert resp.body["cached"] is True
+    assert endpoint.last_request is None  # endpoint was skipped
+    assert tracker.called is True  # response interceptors still fire
+
+
+async def test_best_effort_continues_on_error():
+    pipeline = AdapterPipeline(
+        [
+            FailingRequestInterceptor(best_effort=True),
+            FixedEndpoint(),
+        ]
+    )
+    resp = await pipeline.process(_req())
+    assert resp.status_code == 200
+
+
+async def test_non_best_effort_raises():
+    pipeline = AdapterPipeline(
+        [
+            FailingRequestInterceptor(best_effort=False),
+            FixedEndpoint(),
+        ]
+    )
+    with pytest.raises(RuntimeError, match="boom"):
+        await pipeline.process(_req())
+
+
+async def test_response_interceptors_run_after_endpoint():
+    """Response interceptors placed after the endpoint in the chain must run."""
+    appender = AppendBodyInterceptor()
+    pipeline = AdapterPipeline(
+        [
+            AddHeaderInterceptor(),
+            FixedEndpoint(),
+            appender,
+        ]
+    )
+    resp = await pipeline.process(_req())
+    assert resp.body.get("appended") is True
+
+
+async def test_multiple_response_interceptors_run_in_reverse():
+    """Multiple response interceptors run in reverse chain order."""
+    order: list[str] = []
+
+    class First(ResponseInterceptor):
+        async def intercept_response(self, resp):
+            order.append("first")
+            return resp
+
+    class Second(ResponseInterceptor):
+        async def intercept_response(self, resp):
+            order.append("second")
+            return resp
+
+    pipeline = AdapterPipeline(
+        [
+            FixedEndpoint(),
+            First(),
+            Second(),
+        ]
+    )
+    await pipeline.process(_req())
+    assert order == ["second", "first"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 1.5 addition: upstream_call invoked when no interceptor short-circuits
+# ---------------------------------------------------------------------------
+
+
+async def test_upstream_call_invoked_when_chain_does_not_short_circuit():
+    """When ``upstream_call`` is provided and the chain has no
+    ``RequestToResponseInterceptor`` that short-circuits, the upstream is
+    called with the (post-REQUEST-stage) request and its response flows
+    through ``ResponseInterceptor`` instances in reverse order.
+
+    This is the Phase 1.5 wrap-not-replace contract: an ``endpoint``
+    interceptor is no longer required in every chain — the middleware can
+    supply the upstream via ``upstream_call`` instead.
+    """
+    upstream_seen: list[AdapterRequest] = []
+    appender = AppendBodyInterceptor()
+
+    async def _upstream(req: AdapterRequest) -> AdapterResponse:
+        upstream_seen.append(req)
+        return AdapterResponse(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            body={"result": "from-upstream"},
+            ctx=req.ctx,
+        )
+
+    pipeline = AdapterPipeline(
+        [
+            AddHeaderInterceptor(),  # REQUEST stage
+            appender,  # RESPONSE stage
+        ]
+    )
+    resp = await pipeline.process(_req(), upstream_call=_upstream)
+
+    # Upstream was invoked exactly once with the (mutated) request.
+    assert len(upstream_seen) == 1
+    assert upstream_seen[0].headers["x-test"] == "1"
+
+    # Response flowed back through the RESPONSE stage.
+    assert resp.status_code == 200
+    assert resp.body["result"] == "from-upstream"
+    assert resp.body["appended"] is True
+
+
+async def test_upstream_call_skipped_when_chain_short_circuits():
+    """A short-circuiting ``RequestToResponseInterceptor`` skips
+    ``upstream_call`` entirely — the upstream must never be invoked."""
+    upstream_seen: list[AdapterRequest] = []
+
+    async def _upstream(req: AdapterRequest) -> AdapterResponse:
+        upstream_seen.append(req)
+        return AdapterResponse(status_code=200, headers={}, body={"result": "from-upstream"}, ctx=req.ctx)
+
+    pipeline = AdapterPipeline(
+        [
+            CacheHitInterceptor(),  # short-circuits
+        ]
+    )
+    resp = await pipeline.process(_req(), upstream_call=_upstream)
+    assert upstream_seen == []
+    assert resp.body == {"cached": True}
+
+
+# ===========================================================================
+# Library-import path — explicit positive coverage that the NEL-style
+# ``AdapterPipeline.process(req)`` call shape (no ``upstream_call``, no
+# FastAPI middleware host) still works end-to-end when a
+# ``RequestToResponseInterceptor`` short-circuits the chain. This is the
+# shape an external library user would import; we pin it here so the
+# Phase-1.5 ``upstream_call`` parameter never silently becomes mandatory.
+# ===========================================================================
+
+
+async def test_library_import_no_upstream_call_no_middleware_short_circuits():
+    """A NEL-style library user instantiates ``AdapterPipeline`` directly and
+    calls ``process(req)`` with no ``upstream_call`` and no FastAPI host.
+    A short-circuiting interceptor must produce the response."""
+    endpoint = FixedEndpoint()  # short-circuits with status 200, body={"result": "ok"}
+    tracker = TrackingResponseInterceptor()
+    pipeline = AdapterPipeline([endpoint, tracker])
+
+    # Call without ``upstream_call`` — the library-import surface.
+    resp = await pipeline.process(_req())
+
+    assert isinstance(resp, AdapterResponse)
+    assert resp.status_code == 200
+    assert resp.body == {"result": "ok"}
+    assert endpoint.last_request is not None  # endpoint was the source of the response
+    assert tracker.called is True  # RESPONSE-stage interceptor still ran
+
+
+async def test_library_import_request_stage_mutation_reaches_short_circuit():
+    """Request-stage interceptors must mutate the request before the
+    short-circuiting endpoint sees it, even when no ``upstream_call`` is
+    provided. Pins the library-import contract end-to-end."""
+    endpoint = FixedEndpoint()
+    pipeline = AdapterPipeline([AddHeaderInterceptor(), endpoint])
+
+    resp = await pipeline.process(_req())
+
+    # The mutation from AddHeaderInterceptor must have landed on the request
+    # that FixedEndpoint observed.
+    assert endpoint.last_request is not None
+    assert endpoint.last_request.headers["x-test"] == "1"
+    assert resp.status_code == 200
+    assert resp.body == {"result": "ok"}

--- a/tests/unit_tests/test_adapter_proxy.py
+++ b/tests/unit_tests/test_adapter_proxy.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for ``start_adapter_proxy``.
+
+Drives a real uvicorn proxy thread against a stub upstream (a FastAPI app
+hosted by Starlette's ``TestClient``-equivalent in-thread) and asserts:
+
+  - adapted POST routes (``/v1/chat/completions``, ``/v1/messages``) run
+    the pipeline (logging interceptor fires)
+  - non-adapted paths (``/v1/models`` GET, ``/health``) pass through
+    without running the pipeline
+  - localhost-bind enforcement (``host="0.0.0.0"`` rejected)
+  - user-supplied ``endpoint`` interceptor rejected
+  - multi-Set-Cookie response headers survive the proxy
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+import pytest
+import uvicorn
+from fastapi import FastAPI, Request
+from starlette.responses import JSONResponse, Response
+
+from nemo_gym.adapters import start_adapter_proxy
+
+
+# ---------------------------------------------------------------------------
+# In-thread stub upstream — records requests, lets us inject responses
+# ---------------------------------------------------------------------------
+
+
+class _StubUpstream:
+    def __init__(self) -> None:
+        self.received: list[dict[str, Any]] = []
+        self._lock = threading.Lock()
+        self.app = FastAPI()
+        self._build_routes()
+        self.port: int | None = None
+        self._server: uvicorn.Server | None = None
+        self._thread: threading.Thread | None = None
+
+    def _build_routes(self) -> None:
+        @self.app.api_route(
+            "/{path:path}",
+            methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"],
+        )
+        async def echo(path: str, request: Request) -> Response:
+            try:
+                body = json.loads(await request.body() or b"{}")
+            except Exception:
+                body = None
+            with self._lock:
+                self.received.append({"method": request.method, "path": "/" + path, "body": body})
+            # Default: OpenAI-compat success
+            if request.method == "POST":
+                resp_body = {
+                    "id": "stub-1",
+                    "object": "chat.completion",
+                    "model": body.get("model", "stub") if isinstance(body, dict) else "stub",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "stub-ok"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                }
+                # Inject two Set-Cookie headers to exercise multi-cookie path
+                out = JSONResponse(resp_body, status_code=200)
+                out.raw_headers.append((b"set-cookie", b"a=1; Path=/"))
+                out.raw_headers.append((b"set-cookie", b"b=2; HttpOnly"))
+                return out
+            return JSONResponse({"path": "/" + path, "method": request.method})
+
+    def start(self) -> None:
+        import socket
+
+        s = socket.socket()
+        s.bind(("127.0.0.1", 0))
+        self.port = s.getsockname()[1]
+        s.close()
+        cfg = uvicorn.Config(self.app, host="127.0.0.1", port=self.port, log_level="warning", access_log=False)
+        self._server = uvicorn.Server(cfg)
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
+        self._thread.start()
+        # Wait until ready
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                with urllib.request.urlopen(f"http://127.0.0.1:{self.port}/healthcheck", timeout=1) as r:
+                    if r.status == 200:
+                        return
+            except Exception:
+                time.sleep(0.05)
+        raise RuntimeError("stub upstream did not become healthy")
+
+    def stop(self) -> None:
+        if self._server:
+            self._server.should_exit = True
+        if self._thread:
+            self._thread.join(timeout=3)
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+
+@pytest.fixture
+def upstream():
+    s = _StubUpstream()
+    s.start()
+    try:
+        yield s
+    finally:
+        s.stop()
+
+
+def _post_json(url: str, body: dict) -> tuple[int, bytes, list[tuple[str, str]]]:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as r:
+            return r.status, r.read(), list(r.headers.items())
+    except urllib.error.HTTPError as e:
+        return e.code, e.read(), list(e.headers.items())
+
+
+def _get(url: str) -> tuple[int, bytes]:
+    try:
+        with urllib.request.urlopen(url, timeout=5) as r:
+            return r.status, r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+def test_proxy_runs_pipeline_on_adapted_routes(upstream, caplog) -> None:
+    proxy = start_adapter_proxy(
+        upstream_url=upstream.url,
+        adapters=[{"name": "logging", "config": {}}, {"name": "logging", "config": {}}],
+    )
+    try:
+        with caplog.at_level(logging.INFO, logger="nemo_gym.adapters.interceptors.request_logging"):
+            status, body, _ = _post_json(
+                f"{proxy.url}/v1/chat/completions",
+                {"model": "stub", "messages": [{"role": "user", "content": "hi"}]},
+            )
+        assert status == 200, body
+        assert json.loads(body)["choices"][0]["message"]["content"] == "stub-ok"
+        assert any("request POST /v1/chat/completions" in r.message for r in caplog.records)
+    finally:
+        proxy.stop()
+
+
+def test_proxy_passthrough_does_not_run_pipeline(upstream, caplog) -> None:
+    proxy = start_adapter_proxy(
+        upstream_url=upstream.url,
+        adapters=[{"name": "logging", "config": {}}],
+    )
+    try:
+        with caplog.at_level(logging.INFO, logger="nemo_gym.adapters.interceptors.request_logging"):
+            status, _ = _get(f"{proxy.url}/v1/models")
+        # Stub upstream returns 200 for GET /v1/models (via its catch-all)
+        assert status == 200
+        # Crucially, the logging interceptor should NOT have fired for the passthrough
+        assert not any("request GET /v1/models" in r.message for r in caplog.records)
+    finally:
+        proxy.stop()
+
+
+def test_proxy_multi_set_cookie_preserved(upstream) -> None:
+    proxy = start_adapter_proxy(
+        upstream_url=upstream.url,
+        adapters=[{"name": "logging", "config": {}}],
+    )
+    try:
+        status, _body, headers = _post_json(
+            f"{proxy.url}/v1/chat/completions",
+            {"model": "stub", "messages": []},
+        )
+        assert status == 200
+        cookies = [v for k, v in headers if k.lower() == "set-cookie"]
+        assert len(cookies) == 2, f"expected 2 Set-Cookie headers, got {len(cookies)}: {cookies}"
+    finally:
+        proxy.stop()
+
+
+def test_proxy_rejects_remote_host_by_default() -> None:
+    with pytest.raises(ValueError, match="refusing host"):
+        start_adapter_proxy(upstream_url="http://x", adapters=[], host="0.0.0.0")
+
+
+def test_proxy_allows_remote_with_explicit_flag(upstream) -> None:
+    proxy = start_adapter_proxy(
+        upstream_url=upstream.url,
+        adapters=[],
+        host="0.0.0.0",
+        unsafe_allow_remote=True,
+        port=0,
+    )
+    try:
+        assert proxy.url.startswith("http://0.0.0.0:")
+    finally:
+        proxy.stop()
+
+
+def test_proxy_rejects_user_supplied_endpoint() -> None:
+    with pytest.raises(ValueError, match="endpoint.*cannot be used"):
+        start_adapter_proxy(
+            upstream_url="http://x",
+            adapters=[{"name": "endpoint", "config": {"upstream_url": "http://y"}}],
+        )
+
+
+def test_proxy_handle_context_manager(upstream) -> None:
+    with start_adapter_proxy(upstream_url=upstream.url, adapters=[]) as proxy:
+        status, _ = _get(f"{proxy.url}/_proxy_health")
+        assert status == 200
+    # After context exit, the server should be stopped — port should reject
+    # connections after a brief moment. We don't strictly assert this since
+    # uvicorn shutdown is async, but the context manager should have called stop().

--- a/tests/unit_tests/test_adapter_proxy.py
+++ b/tests/unit_tests/test_adapter_proxy.py
@@ -30,8 +30,10 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 import threading
 import time
+import types
 import urllib.error
 import urllib.request
 from typing import Any
@@ -42,6 +44,14 @@ from fastapi import FastAPI, Request
 from starlette.responses import JSONResponse, Response
 
 from nemo_gym.adapters import start_adapter_proxy
+from nemo_gym.adapters.registry import InterceptorRegistry
+from nemo_gym.adapters.types import (
+    AdapterRequest,
+    AdapterResponse,
+    GracefulError,
+    RequestInterceptor,
+    ResponseInterceptor,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -70,7 +80,13 @@ class _StubUpstream:
             except Exception:
                 body = None
             with self._lock:
-                self.received.append({"method": request.method, "path": "/" + path, "body": body})
+                self.received.append(
+                    {"method": request.method, "path": "/" + path, "body": body, "query": request.url.query}
+                )
+            # A sentinel model lets a test force a non-JSON (bytes) upstream body
+            # so the proxy's bytes-passthrough arm is exercised.
+            if request.method == "POST" and isinstance(body, dict) and body.get("model") == "_raw_bytes_":
+                return Response(content=b"raw-not-json-bytes", media_type="application/octet-stream")
             # Default: OpenAI-compat success
             if request.method == "POST":
                 resp_body = {
@@ -156,6 +172,76 @@ def _get(url: str) -> tuple[int, bytes]:
             return r.status, r.read()
     except urllib.error.HTTPError as e:
         return e.code, e.read()
+
+
+def _post_raw(url: str, data: bytes) -> tuple[int, bytes]:
+    """POST arbitrary (possibly malformed) bytes with a JSON content-type."""
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as r:
+            return r.status, r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+# ---------------------------------------------------------------------------
+# Helper interceptors (registered via the registry so they can be named in an
+# ``adapters`` chain). These drive the pipeline's control-flow arms inside the
+# real proxy thread.
+# ---------------------------------------------------------------------------
+
+
+class _GracefulRaiser(RequestInterceptor):
+    """Raises ``GracefulError`` to exercise the proxy's 429 (budget) arm."""
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        raise GracefulError("proxy budget exhausted")
+
+
+class _BoomRaiser(RequestInterceptor):
+    """Raises a generic exception to exercise the proxy's 500 arm."""
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        raise RuntimeError("kaboom")
+
+
+class _DictHeaderBytesResponse(ResponseInterceptor):
+    """Replaces the response with dict-shaped headers + a bytes body.
+
+    The proxy's upstream closure always produces *list* headers, so the
+    dict-header forwarding branch is only reachable when an interceptor swaps
+    them in. A bogus ``content-length`` verifies the framing header is dropped
+    and recomputed from the actual body.
+    """
+
+    async def intercept_response(self, resp: AdapterResponse) -> AdapterResponse:
+        return AdapterResponse(
+            status_code=200,
+            headers={"x-proxy-marker": "kept", "content-length": "999"},
+            body=b"raw-bytes-body",
+            ctx=resp.ctx,
+        )
+
+
+def _register_proxy_test_interceptors() -> None:
+    for short, cls in (
+        ("_proxy_test_graceful", _GracefulRaiser),
+        ("_proxy_test_boom", _BoomRaiser),
+        ("_proxy_test_dict_bytes", _DictHeaderBytesResponse),
+    ):
+        mod_name = f"nemo_gym.adapters.interceptors.{short}"
+        mod = types.ModuleType(mod_name)
+        mod.Interceptor = cls
+        sys.modules[mod_name] = mod
+        InterceptorRegistry.register(short, mod_name)
+
+
+_register_proxy_test_interceptors()
 
 
 # ---------------------------------------------------------------------------
@@ -248,3 +334,86 @@ def test_proxy_handle_context_manager(upstream) -> None:
     # After context exit, the server should be stopped — port should reject
     # connections after a brief moment. We don't strictly assert this since
     # uvicorn shutdown is async, but the context manager should have called stop().
+
+
+def test_proxy_invalid_json_body_returns_400(upstream) -> None:
+    """A non-JSON body on an adapted POST route is rejected with 400 before the
+    pipeline runs (proxy.py invalid-JSON arm)."""
+    proxy = start_adapter_proxy(upstream_url=upstream.url, adapters=[{"name": "logging"}])
+    try:
+        status, body = _post_raw(f"{proxy.url}/v1/chat/completions", b"not-json")
+        assert status == 400, body
+        assert json.loads(body)["error"]["type"] == "invalid_request_error"
+    finally:
+        proxy.stop()
+
+
+def test_proxy_graceful_error_returns_429(upstream) -> None:
+    """A ``GracefulError`` from an interceptor maps to HTTP 429 with the
+    documented ``session_budget_exhausted`` body (mirrors middleware mode)."""
+    proxy = start_adapter_proxy(upstream_url=upstream.url, adapters=[{"name": "_proxy_test_graceful"}])
+    try:
+        status, body, _ = _post_json(f"{proxy.url}/v1/chat/completions", {"model": "stub", "messages": []})
+        assert status == 429, body
+        err = json.loads(body)["error"]
+        assert err["code"] == "session_budget_exhausted"
+        assert err["type"] == "invalid_request_error"
+        assert "proxy budget exhausted" in err["message"]
+    finally:
+        proxy.stop()
+
+
+def test_proxy_generic_exception_returns_500(upstream) -> None:
+    """A non-graceful exception from an interceptor falls into the generic
+    handler and returns HTTP 500."""
+    proxy = start_adapter_proxy(upstream_url=upstream.url, adapters=[{"name": "_proxy_test_boom"}])
+    try:
+        status, body, _ = _post_json(f"{proxy.url}/v1/chat/completions", {"model": "stub", "messages": []})
+        assert status == 500, body
+        assert json.loads(body)["error"]["type"] == "server_error"
+    finally:
+        proxy.stop()
+
+
+def test_proxy_non_json_upstream_body_passed_through_as_bytes(upstream) -> None:
+    """When the upstream returns a non-JSON (bytes) body, the proxy forwards it
+    unchanged as bytes rather than trying to JSON-encode it."""
+    proxy = start_adapter_proxy(upstream_url=upstream.url, adapters=[{"name": "logging"}])
+    try:
+        status, body, _ = _post_json(f"{proxy.url}/v1/chat/completions", {"model": "_raw_bytes_", "messages": []})
+        assert status == 200, body
+        assert body == b"raw-not-json-bytes"
+    finally:
+        proxy.stop()
+
+
+def test_proxy_forwards_query_string_to_upstream(upstream) -> None:
+    """A query string on the inbound request is preserved on the upstream call."""
+    proxy = start_adapter_proxy(upstream_url=upstream.url, adapters=[{"name": "logging"}])
+    try:
+        status, body, _ = _post_json(
+            f"{proxy.url}/v1/chat/completions?api-version=2024-08-01",
+            {"model": "stub", "messages": []},
+        )
+        assert status == 200, body
+        assert any(r.get("query") == "api-version=2024-08-01" for r in upstream.received), upstream.received
+    finally:
+        proxy.stop()
+
+
+def test_proxy_dict_headers_and_bytes_body_response_forwarded(upstream) -> None:
+    """A response carrying dict-shaped headers + a bytes body is forwarded with
+    correct framing: the bogus content-length is dropped and recomputed, custom
+    headers survive, and the bytes body is returned verbatim."""
+    proxy = start_adapter_proxy(upstream_url=upstream.url, adapters=[{"name": "_proxy_test_dict_bytes"}])
+    try:
+        status, body, headers = _post_json(f"{proxy.url}/v1/chat/completions", {"model": "stub", "messages": []})
+        assert status == 200, body
+        assert body == b"raw-bytes-body"
+        hdrs = {k.lower(): v for k, v in headers}
+        assert hdrs.get("x-proxy-marker") == "kept"
+        # The interceptor's bogus content-length=999 must be dropped; framing
+        # reflects the real body length.
+        assert hdrs.get("content-length") == str(len(b"raw-bytes-body"))
+    finally:
+        proxy.stop()

--- a/tests/unit_tests/test_adapter_registry.py
+++ b/tests/unit_tests/test_adapter_registry.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""InterceptorRegistry tests."""
+
+import pytest
+
+from nemo_gym.adapters.registry import InterceptorRegistry
+
+
+def test_resolve_known_interceptor():
+    cls = InterceptorRegistry.resolve_class("logging")
+    assert cls.__name__ == "Interceptor"
+    assert cls.__module__ == "nemo_gym.adapters.interceptors.request_logging"
+
+
+def test_resolve_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown interceptor 'nonexistent'"):
+        InterceptorRegistry.resolve_class("nonexistent")
+
+
+def test_create_with_config():
+    instance = InterceptorRegistry.create("endpoint", {"upstream_url": "http://x"})
+    from nemo_gym.adapters.interceptors.endpoint import Interceptor
+
+    assert isinstance(instance, Interceptor)
+
+
+def test_available_list():
+    names = InterceptorRegistry.available()
+    assert isinstance(names, list)
+    for expected in ("endpoint", "logging"):
+        assert expected in names


### PR DESCRIPTION
Introduces an interceptor-based middleware framework that runs at every in-tree server's request/response boundary. PR 1 of 4 — base framework only. Follow-on PRs add observability / caching / request-rewriting interceptor families.

Framework

  nemo_gym/adapters/
    pipeline.py      AdapterPipeline + stage-order validation
                     (REQUEST → REQUEST_TO_RESPONSE → RESPONSE)
    middleware.py    install_middleware(app, specs) — FastAPI middleware
                     that wraps call_next; body replay, multi-Set-Cookie
                     preservation, /s/<hex>/... session-prefix routing,
                     GracefulError → 429
    proxy.py         start_adapter_proxy(upstream_url, adapters) —
                     localhost uvicorn host mode for external-inference
                     agents whose SDK respects *_BASE_URL env vars
    registry.py      short-name → Interceptor class + runtime register()
    types.py         AdapterRequest/Response, three Interceptor ABCs,
                     Stage enum, GracefulError, ContextVar-backed
                     per-request context, InterceptorSpec and
                     AdapterProxyConfig pydantic models
    interceptors/
      endpoint.py    Drives upstream HTTP call (required by proxy mode,
                     forbidden inside install_middleware)
      request_logging.py
                     Canonical "did the chain fire?" probe (logs body
                     keys + response status/latency)

Server wire-up

  adapters: list[dict] | None = None  on three base configs:
    BaseResponsesAPIModelConfig
    BaseResponsesAPIAgentConfig
    BaseResourcesServerConfig

  install_middleware(app, self.config.adapters)  at the tail of each
  base's setup_webserver. Every in-tree server inheriting from
  SimpleResponsesAPI{Model,Agent} or SimpleResourcesServer picks up
  the adapters knob automatically.

  adapter_proxy: AdapterProxyConfig | None = None  on
  BaseResponsesAPIAgentConfig. When set, SimpleResponsesAPIAgent.
  setup_webserver starts a localhost uvicorn proxy in a daemon thread,
  stores the ProxyHandle on self._proxy_handle, registers atexit cleanup.

Per-server override fixes

  harbor_agent and mini_swe_agent override setup_webserver without
  calling super(). Inline install_middleware(app, self.config.adapters)
  calls added to both so the adapters field still applies.

claude_code_agent integration

  Reads self._proxy_handle.url when adapter_proxy is set; threads the
  proxy URL into the claude CLI subprocess via ANTHROPIC_BASE_URL +
  ANTHROPIC_AUTH_TOKEN. Preserves the full model-name prefix in proxy
  mode (no .split("/")[-1] stripping).

Safety

  - Stage ordering validated at startup
  - Unknown interceptor name raises at config-validation time
  - install_middleware rejects `endpoint` in chain (host already forwards)
  - start_adapter_proxy rejects user-supplied `endpoint` AND refuses host="0.0.0.0" unless unsafe_allow_remote=True (otherwise leaks the upstream API key to any caller on the network)
  - best_effort=True interceptors swallow exceptions; strict ones propagate

Tests

  42 tests, framework-level coverage. Follow-on PRs add per-interceptor
  test suites.

Docs

  fern/versions/latest/pages/model-server/adapters.mdx       new
  fern/versions/latest/pages/model-server/index.mdx          link added


---
_Recreated with an upstream head so it can join the GitHub stack (supersedes #1518, which had a fork head)._
