### PR TITLE
feat(adapters): observability interceptors

### DIFF
--- a/fern/versions/latest/pages/model-server/adapters-observability.mdx
+++ b/fern/versions/latest/pages/model-server/adapters-observability.mdx
@@ -1,0 +1,62 @@
+---
+title: "Observability Interceptors"
+description: "Passive (or mildly-normalizing) interceptors for inspecting traffic without changing semantics."
+position: 4
+---
+
+Passive (or mildly-normalizing) interceptors for inspecting traffic without changing semantics.
+
+| Name | Stage | Purpose |
+|------|-------|---------|
+| `log_tokens` | response | Log `usage` token counts and latency. |
+| `response_stats` | response | Accumulate request count / total tokens / total latency; periodic summary. |
+| `progress_tracking` | response | Optional webhook ping every N completed responses. |
+| `reasoning` | response | Normalize `<think>...</think>` content or a `reasoning` field into `reasoning_content`. |
+| `raise_client_errors` | response | Convert non-retriable 4xx responses into `RuntimeError`. 429/408 pass through (retriable). |
+
+### `log_tokens`
+
+```yaml
+- name: log_tokens
+  config: {}
+```
+
+### `response_stats`
+
+```yaml
+- name: response_stats
+  config:
+    every: 100
+```
+
+### `progress_tracking`
+
+```yaml
+- name: progress_tracking
+  config:
+    webhook_url: http://progress-endpoint/ping
+    every: 10
+```
+
+Webhook errors are logged and swallowed (`best_effort = True`).
+
+### `reasoning`
+
+```yaml
+- name: reasoning
+  config: {}
+```
+
+Handles three response shapes:
+- already has `reasoning_content` → no-op
+- has a `reasoning` field → renamed to `reasoning_content`
+- `content` starts with `<think>...</think>` → extracted into `reasoning_content`
+
+### `raise_client_errors`
+
+```yaml
+- name: raise_client_errors
+  config: {}
+```
+
+429 and 408 are treated as retriable and pass through.

--- a/nemo_gym/adapters/interceptors/log_tokens.py
+++ b/nemo_gym/adapters/interceptors/log_tokens.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import logging
+
+from nemo_gym.adapters.types import AdapterResponse, ResponseInterceptor
+
+
+logger = logging.getLogger(__name__)
+
+
+class Interceptor(ResponseInterceptor):
+    stream_safe = False
+    best_effort = True
+
+    async def intercept_response(self, resp: AdapterResponse) -> AdapterResponse:
+        body = resp.body
+        if not isinstance(body, dict):
+            return resp
+        usage = body.get("usage")
+        if not isinstance(usage, dict):
+            return resp
+        model = body.get("model", "?")
+        pt = usage.get("prompt_tokens")
+        ct = usage.get("completion_tokens")
+        tt = usage.get("total_tokens")
+        logger.info(
+            "tokens model=%s prompt=%s completion=%s total=%s latency_ms=%.2f",
+            model,
+            pt,
+            ct,
+            tt,
+            resp.latency_ms,
+        )
+        return resp

--- a/nemo_gym/adapters/interceptors/progress_tracking.py
+++ b/nemo_gym/adapters/interceptors/progress_tracking.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import aiohttp
+
+from nemo_gym.adapters.types import AdapterResponse, ResponseInterceptor
+from nemo_gym.server_utils import request as global_request
+
+
+logger = logging.getLogger(__name__)
+
+
+class Interceptor(ResponseInterceptor):
+    best_effort = True
+
+    def __init__(
+        self,
+        *,
+        webhook_url: str | None = None,
+        every: int = 10,
+    ) -> None:
+        self._webhook_url = webhook_url
+        self._every = max(every, 1)
+        self._completed = 0
+        self._lock = asyncio.Lock()
+
+    async def intercept_response(self, resp: AdapterResponse) -> AdapterResponse:
+        async with self._lock:
+            self._completed += 1
+            n = self._completed
+        if n % self._every == 0:
+            logger.info("progress completed=%d", n)
+            if self._webhook_url:
+                try:
+                    webhook_resp = await global_request(
+                        method="POST",
+                        url=self._webhook_url,
+                        json={"completed": n},
+                        timeout=aiohttp.ClientTimeout(total=30),
+                    )
+                    async with webhook_resp:
+                        webhook_resp.raise_for_status()
+                except Exception:
+                    logger.warning("progress webhook failed", exc_info=True)
+        return resp

--- a/nemo_gym/adapters/interceptors/raise_client_errors.py
+++ b/nemo_gym/adapters/interceptors/raise_client_errors.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from nemo_gym.adapters.types import AdapterResponse, ResponseInterceptor
+
+
+logger = logging.getLogger(__name__)
+
+_RETRIABLE = {408, 429}
+
+
+class Interceptor(ResponseInterceptor):
+    async def intercept_response(self, resp: AdapterResponse) -> AdapterResponse:
+        if 400 <= resp.status_code < 500 and resp.status_code not in _RETRIABLE:
+            body: Any = resp.body
+            detail = body if isinstance(body, (str, bytes)) else body.get("error", body)
+            logger.error(
+                "client error %d: %s",
+                resp.status_code,
+                detail,
+            )
+            raise RuntimeError(f"Upstream returned {resp.status_code}: {detail}")
+        return resp

--- a/nemo_gym/adapters/interceptors/reasoning.py
+++ b/nemo_gym/adapters/interceptors/reasoning.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import logging
+import re
+
+from nemo_gym.adapters.types import AdapterResponse, ResponseInterceptor
+
+
+logger = logging.getLogger(__name__)
+
+_THINK = re.compile(r"^\s*<think>(.*?)</think>", re.DOTALL)
+
+
+class Interceptor(ResponseInterceptor):
+    best_effort = True
+
+    @staticmethod
+    def _normalize_message(msg: dict) -> bool:
+        if "reasoning_content" in msg:
+            return False
+        if "reasoning" in msg:
+            msg["reasoning_content"] = msg.pop("reasoning")
+            return True
+        content = msg.get("content")
+        if not isinstance(content, str):
+            return False
+        m = _THINK.match(content)
+        if m:
+            msg["reasoning_content"] = m.group(1).strip()
+            msg["content"] = content[m.end() :].lstrip()
+            return True
+        return False
+
+    async def intercept_response(self, resp: AdapterResponse) -> AdapterResponse:
+        body = resp.body
+        if not isinstance(body, dict):
+            return resp
+        changed = 0
+        for ch in body.get("choices") or []:
+            if not isinstance(ch, dict):
+                continue
+            msg = ch.get("message")
+            if isinstance(msg, dict) and self._normalize_message(msg):
+                changed += 1
+        if changed:
+            logger.debug("reasoning normalized choices=%d", changed)
+        return resp

--- a/nemo_gym/adapters/interceptors/response_stats.py
+++ b/nemo_gym/adapters/interceptors/response_stats.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from nemo_gym.adapters.types import AdapterResponse, ResponseInterceptor
+
+
+logger = logging.getLogger(__name__)
+
+
+class Interceptor(ResponseInterceptor):
+    stream_safe = False
+    best_effort = True
+
+    def __init__(self, *, every: int = 100) -> None:
+        self._every = max(every, 1)
+        self._n = 0
+        self._tokens = 0
+        self._latency_ms = 0.0
+        self._lock = asyncio.Lock()
+
+    async def intercept_response(self, resp: AdapterResponse) -> AdapterResponse:
+        body = resp.body
+        tokens = 0
+        if isinstance(body, dict):
+            u = body.get("usage")
+            if isinstance(u, dict):
+                tokens = int(u.get("total_tokens") or 0)
+        async with self._lock:
+            self._n += 1
+            self._tokens += tokens
+            self._latency_ms += resp.latency_ms
+            n = self._n
+            tot_tok = self._tokens
+            tot_lat = self._latency_ms
+        if n % self._every == 0:
+            logger.info(
+                "response_stats requests=%d total_tokens=%d total_latency_ms=%.2f",
+                n,
+                tot_tok,
+                tot_lat,
+            )
+        return resp

--- a/nemo_gym/adapters/registry.py
+++ b/nemo_gym/adapters/registry.py
@@ -52,6 +52,13 @@ _BUILTIN: dict[str, str] = {
 # Each family adds entries under its own family-named comment marker so
 # different families don't fight for the same diff context.
 
+# Observability family — passive (or mildly-normalizing) interceptors.
+_BUILTIN["log_tokens"] = "nemo_gym.adapters.interceptors.log_tokens"
+_BUILTIN["response_stats"] = "nemo_gym.adapters.interceptors.response_stats"
+_BUILTIN["progress_tracking"] = "nemo_gym.adapters.interceptors.progress_tracking"
+_BUILTIN["reasoning"] = "nemo_gym.adapters.interceptors.reasoning"
+_BUILTIN["raise_client_errors"] = "nemo_gym.adapters.interceptors.raise_client_errors"
+
 # External / plugin registrations at runtime.
 _EXTRA: dict[str, str] = {}
 

--- a/tests/unit_tests/adapter_fixtures/log_tokens_does_not_alter_the_response_body.json
+++ b/tests/unit_tests/adapter_fixtures/log_tokens_does_not_alter_the_response_body.json
@@ -1,0 +1,72 @@
+{
+  "expected_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "ok",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "x",
+      "usage": {
+        "completion_tokens": 2,
+        "prompt_tokens": 1,
+        "total_tokens": 3
+      }
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  },
+  "interceptor_specs": [
+    {
+      "config": {},
+      "name": "log_tokens"
+    }
+  ],
+  "request": {
+    "body": {
+      "messages": [
+        {
+          "content": "hi",
+          "role": "user"
+        }
+      ],
+      "model": "m"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "path": "/v1/chat/completions"
+  },
+  "scenario": "log_tokens does not alter the response body",
+  "upstream_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "ok",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "x",
+      "usage": {
+        "completion_tokens": 2,
+        "prompt_tokens": 1,
+        "total_tokens": 3
+      }
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  }
+}

--- a/tests/unit_tests/adapter_fixtures/logging_interceptor_does_not_mutate_the_request.json
+++ b/tests/unit_tests/adapter_fixtures/logging_interceptor_does_not_mutate_the_request.json
@@ -1,0 +1,64 @@
+{
+  "expected_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  },
+  "interceptor_specs": [
+    {
+      "config": {},
+      "name": "logging"
+    }
+  ],
+  "request": {
+    "body": {
+      "messages": [
+        {
+          "content": "hi",
+          "role": "user"
+        }
+      ],
+      "model": "m"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "path": "/v1/chat/completions"
+  },
+  "scenario": "logging interceptor does not mutate the request",
+  "upstream_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  }
+}

--- a/tests/unit_tests/adapter_fixtures/progress_tracking_does_not_mutate_the_request.json
+++ b/tests/unit_tests/adapter_fixtures/progress_tracking_does_not_mutate_the_request.json
@@ -1,0 +1,64 @@
+{
+  "expected_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  },
+  "interceptor_specs": [
+    {
+      "config": {},
+      "name": "progress_tracking"
+    }
+  ],
+  "request": {
+    "body": {
+      "messages": [
+        {
+          "content": "hi",
+          "role": "user"
+        }
+      ],
+      "model": "m"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "path": "/v1/chat/completions"
+  },
+  "scenario": "progress_tracking does not mutate the request",
+  "upstream_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  }
+}

--- a/tests/unit_tests/adapter_fixtures/raise_client_errors_passes_429_through_unchanged.json
+++ b/tests/unit_tests/adapter_fixtures/raise_client_errors_passes_429_through_unchanged.json
@@ -1,0 +1,37 @@
+{
+  "expected_response": {
+    "body": {
+      "error": "rate limited"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 429
+  },
+  "interceptor_specs": [
+    {
+      "config": {},
+      "name": "raise_client_errors"
+    }
+  ],
+  "request": {
+    "body": {
+      "messages": [],
+      "model": "m"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "path": "/v1/chat/completions"
+  },
+  "scenario": "raise_client_errors passes 429 through unchanged",
+  "upstream_response": {
+    "body": {
+      "error": "rate limited"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 429
+  }
+}

--- a/tests/unit_tests/adapter_fixtures/reasoning_normalizes__think______think__into_reasoning_content.json
+++ b/tests/unit_tests/adapter_fixtures/reasoning_normalizes__think______think__into_reasoning_content.json
@@ -1,0 +1,63 @@
+{
+  "expected_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "a",
+            "reasoning_content": "r",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "x"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  },
+  "interceptor_specs": [
+    {
+      "config": {},
+      "name": "reasoning"
+    }
+  ],
+  "request": {
+    "body": {
+      "messages": [
+        {
+          "content": "hi",
+          "role": "user"
+        }
+      ],
+      "model": "m"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "path": "/v1/chat/completions"
+  },
+  "scenario": "reasoning normalizes <think>...</think> into reasoning_content",
+  "upstream_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "<think>r</think>a",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "x"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  }
+}

--- a/tests/unit_tests/adapter_fixtures/response_stats_does_not_alter_the_response_body.json
+++ b/tests/unit_tests/adapter_fixtures/response_stats_does_not_alter_the_response_body.json
@@ -1,0 +1,62 @@
+{
+  "expected_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "ok",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "x"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  },
+  "interceptor_specs": [
+    {
+      "config": {},
+      "name": "response_stats"
+    }
+  ],
+  "request": {
+    "body": {
+      "messages": [
+        {
+          "content": "hi",
+          "role": "user"
+        }
+      ],
+      "model": "m"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "path": "/v1/chat/completions"
+  },
+  "scenario": "response_stats does not alter the response body",
+  "upstream_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "ok",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "x"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  }
+}

--- a/tests/unit_tests/test_adapter_interceptors_observability.py
+++ b/tests/unit_tests/test_adapter_interceptors_observability.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Per-interceptor behavior tests — ported from NEL ``tests/test_adapters/test_interceptors.py``
+and ``test_interceptors_extended.py``.
+
+Mechanical port from ``nemo_evaluator.adapters.*`` to ``nemo_gym.adapters.*``;
+``GracefulError`` re-rooted at ``nemo_gym.adapters.types``.
+"""
+
+import pytest
+
+from nemo_gym.adapters.registry import InterceptorRegistry
+from nemo_gym.adapters.types import (
+    AdapterRequest,
+    AdapterResponse,
+    InterceptorContext,
+)
+
+
+def _req(body=None, **kw):
+    return AdapterRequest(
+        method="POST",
+        path="/v1/chat/completions",
+        headers={"content-type": "application/json"},
+        body=body or {"model": "test", "messages": [{"role": "user", "content": "hi"}]},
+        ctx=InterceptorContext(),
+    )
+
+
+def _resp(body=None, status_code=200):
+    return AdapterResponse(
+        status_code=status_code,
+        headers={},
+        body=body or {},
+        ctx=InterceptorContext(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Request-side interceptors
+# ---------------------------------------------------------------------------
+
+
+async def test_raise_client_errors_4xx():
+    ic = InterceptorRegistry.create("raise_client_errors")
+    resp = _resp({"error": "bad request"}, status_code=400)
+    with pytest.raises(RuntimeError, match="Upstream returned 400"):
+        await ic.intercept_response(resp)
+
+
+async def test_raise_client_errors_429_passes():
+    ic = InterceptorRegistry.create("raise_client_errors")
+    resp = _resp({"error": "rate limited"}, status_code=429)
+    result = await ic.intercept_response(resp)
+    assert result.status_code == 429
+
+
+async def test_reasoning_normalize():
+    ic = InterceptorRegistry.create("reasoning")
+    resp = _resp(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": "<think>reason</think>answer",
+                    },
+                }
+            ],
+        }
+    )
+    result = await ic.intercept_response(resp)
+    msg = result.body["choices"][0]["message"]
+    assert msg["reasoning_content"] == "reason"
+    assert msg["content"] == "answer"
+
+
+class TestProgressTrackingBehavior:
+    async def test_counter_increments_on_each_call(self):
+        from nemo_gym.adapters.interceptors.progress_tracking import Interceptor
+
+        i = Interceptor(every=100)  # avoid log emission in the assert window
+        for _ in range(5):
+            await i.intercept_response(_resp())
+        assert i._completed == 5
+
+    async def test_emits_log_at_every_boundary(self, caplog):
+        import logging as _logging
+
+        from nemo_gym.adapters.interceptors.progress_tracking import Interceptor
+
+        i = Interceptor(every=3)
+        with caplog.at_level(_logging.INFO, logger="nemo_gym.adapters.interceptors.progress_tracking"):
+            for _ in range(7):
+                await i.intercept_response(_resp())
+
+        # Should log at completion #3 and #6 only (every=3, count=7 → 3, 6).
+        progress_logs = [r for r in caplog.records if r.message.startswith("progress completed=")]
+        assert len(progress_logs) == 2
+        assert "progress completed=3" in progress_logs[0].message
+        assert "progress completed=6" in progress_logs[1].message
+
+    async def test_webhook_fires_with_completed_payload(self, monkeypatch):
+        from nemo_gym.adapters.interceptors import progress_tracking as pt
+
+        captured: list[dict] = []
+
+        class _FakeResp:
+            def __init__(self, payload):
+                self._payload = payload
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            def raise_for_status(self):
+                return None
+
+        async def _fake_global_request(method, url, **kw):
+            captured.append({"method": method, "url": url, "json": kw.get("json")})
+            return _FakeResp(kw.get("json"))
+
+        monkeypatch.setattr(pt, "global_request", _fake_global_request)
+
+        i = pt.Interceptor(webhook_url="http://hook.example/post", every=2)
+        for _ in range(4):
+            await i.intercept_response(_resp())
+
+        # Webhook fires twice (at completed=2 and completed=4) with the running
+        # ``completed`` counter as the only payload field.
+        assert len(captured) == 2
+        assert captured[0] == {"method": "POST", "url": "http://hook.example/post", "json": {"completed": 2}}
+        assert captured[1] == {"method": "POST", "url": "http://hook.example/post", "json": {"completed": 4}}
+
+
+class TestResponseStatsBehavior:
+    async def test_token_total_accumulates_from_usage(self):
+        from nemo_gym.adapters.interceptors.response_stats import Interceptor
+
+        i = Interceptor(every=1000)
+        await i.intercept_response(_resp(body={"usage": {"total_tokens": 12}}))
+        await i.intercept_response(_resp(body={"usage": {"total_tokens": 30}}))
+        await i.intercept_response(_resp(body={"usage": {"total_tokens": 5}}))
+        assert i._n == 3
+        assert i._tokens == 47
+
+    async def test_missing_usage_field_counts_zero_tokens(self):
+        from nemo_gym.adapters.interceptors.response_stats import Interceptor
+
+        i = Interceptor(every=1000)
+        await i.intercept_response(_resp(body={}))  # no usage
+        await i.intercept_response(_resp(body={"usage": None}))  # null usage
+        await i.intercept_response(_resp(body={"usage": {"total_tokens": 7}}))
+        assert i._n == 3
+        assert i._tokens == 7
+
+    async def test_emits_aggregate_log_at_every_boundary(self, caplog):
+        import logging as _logging
+
+        from nemo_gym.adapters.interceptors.response_stats import Interceptor
+
+        i = Interceptor(every=2)
+        with caplog.at_level(_logging.INFO, logger="nemo_gym.adapters.interceptors.response_stats"):
+            await i.intercept_response(_resp(body={"usage": {"total_tokens": 4}}))
+            await i.intercept_response(_resp(body={"usage": {"total_tokens": 6}}))
+            await i.intercept_response(_resp(body={"usage": {"total_tokens": 1}}))
+            await i.intercept_response(_resp(body={"usage": {"total_tokens": 2}}))
+
+        stats_logs = [r for r in caplog.records if r.message.startswith("response_stats requests=")]
+        # every=2 with 4 calls → logs at #2 and #4
+        assert len(stats_logs) == 2
+        assert "requests=2" in stats_logs[0].message and "total_tokens=10" in stats_logs[0].message
+        assert "requests=4" in stats_logs[1].message and "total_tokens=13" in stats_logs[1].message
+
+
+class TestRequestLoggingBehavior:
+    async def test_request_log_records_method_path_and_body_keys(self, caplog):
+        import logging as _logging
+
+        from nemo_gym.adapters.interceptors.request_logging import Interceptor
+
+        i = Interceptor()
+        req = AdapterRequest(
+            method="POST",
+            path="/v1/chat/completions",
+            headers={},
+            body={"model": "m", "messages": [], "temperature": 0.3},
+            ctx=InterceptorContext(),
+        )
+        with caplog.at_level(_logging.INFO, logger="nemo_gym.adapters.interceptors.request_logging"):
+            await i.intercept_request(req)
+
+        request_logs = [r for r in caplog.records if r.message.startswith("request POST ")]
+        assert len(request_logs) == 1
+        msg = request_logs[0].message
+        assert "POST" in msg
+        assert "/v1/chat/completions" in msg
+        # body_keys must reflect the request body's top-level keys
+        assert "'model'" in msg and "'messages'" in msg and "'temperature'" in msg
+
+    async def test_response_log_records_status_and_latency(self, caplog):
+        import logging as _logging
+
+        from nemo_gym.adapters.interceptors.request_logging import Interceptor
+
+        i = Interceptor()
+        resp = AdapterResponse(
+            status_code=503,
+            headers={},
+            body={"error": "boom"},
+            latency_ms=12.5,
+            ctx=InterceptorContext(),
+        )
+        with caplog.at_level(_logging.INFO, logger="nemo_gym.adapters.interceptors.request_logging"):
+            await i.intercept_response(resp)
+
+        response_logs = [r for r in caplog.records if r.message.startswith("response status=")]
+        assert len(response_logs) == 1
+        msg = response_logs[0].message
+        assert "status=503" in msg
+        assert "latency_ms=12.50" in msg
+
+    async def test_long_body_preview_is_truncated(self, caplog):
+        import logging as _logging
+
+        from nemo_gym.adapters.interceptors.request_logging import _MAX, Interceptor
+
+        i = Interceptor()
+        # Build a body whose JSON representation exceeds _MAX so the preview
+        # exercises the truncation branch.
+        long_value = "x" * (_MAX + 200)
+        req = AdapterRequest(
+            method="POST",
+            path="/v1/chat/completions",
+            headers={},
+            body={"model": "m", "messages": [{"role": "user", "content": long_value}]},
+            ctx=InterceptorContext(),
+        )
+        with caplog.at_level(_logging.INFO, logger="nemo_gym.adapters.interceptors.request_logging"):
+            await i.intercept_request(req)
+
+        request_logs = [r for r in caplog.records if r.message.startswith("request POST ")]
+        assert len(request_logs) == 1
+        # Truncated previews end with the "..." sentinel from request_logging._trunc_preview.
+        assert "body_preview=" in request_logs[0].message
+        assert request_logs[0].message.endswith("...")

--- a/tests/unit_tests/test_adapter_parity_replay_observability.py
+++ b/tests/unit_tests/test_adapter_parity_replay_observability.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Parity replay test for the adapter middleware.
+
+Loads every JSON fixture under ``adapter_fixtures/`` and asserts that the
+recorded ``request`` → ``expected_response`` pair still holds when the
+middleware is installed with the recorded ``interceptor_specs`` and the
+(mocked) upstream returns the recorded ``upstream_response``. ``caching``
+is covered by a dedicated round-trip test below since its parity behavior
+is "second hit ≡ first response".
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from nemo_gym.adapters import install_middleware
+
+
+FIXTURE_DIR = Path(__file__).parent / "adapter_fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_fixtures() -> list[tuple[str, dict[str, Any]]]:
+    """Return ``[(fixture_name, fixture_data), ...]`` sorted by name."""
+    if not FIXTURE_DIR.exists():
+        return []
+    fixtures: list[tuple[str, dict[str, Any]]] = []
+    for path in sorted(FIXTURE_DIR.glob("*.json")):
+        with path.open() as f:
+            fixtures.append((path.stem, json.load(f)))
+    return fixtures
+
+
+_FIXTURES = _load_fixtures()
+
+
+def _build_replay_app(interceptor_specs: list[dict[str, Any]], upstream: dict[str, Any]) -> FastAPI:
+    """FastAPI app whose chat-completions route returns ``upstream`` verbatim,
+    with the adapter middleware installed on top."""
+    app = FastAPI()
+
+    @app.post("/v1/chat/completions")
+    async def _chat(body: dict):
+        return JSONResponse(
+            content=upstream["body"],
+            status_code=upstream["status_code"],
+            headers=upstream.get("headers") or {},
+        )
+
+    install_middleware(app, interceptor_specs)
+    return app
+
+
+_VOLATILE_HEADERS = {"date", "server", "content-length"}
+
+
+def _normalise_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Drop headers whose values are non-deterministic.
+
+    Matches the normalisation in ``generate_adapter_fixtures.py``. Without this,
+    replays would fail because ``content-length`` is recomputed per-response
+    by Starlette and ``date`` / ``server`` vary across runs.
+    """
+    return {k: v for k, v in headers.items() if k.lower() not in _VOLATILE_HEADERS}
+
+
+# ---------------------------------------------------------------------------
+# Parametrised replay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _FIXTURES, reason="no fixtures recorded yet (run generate_adapter_fixtures.py)")
+@pytest.mark.parametrize("name,fixture", _FIXTURES, ids=[name for name, _ in _FIXTURES])
+def test_parity_replay(name: str, fixture: dict[str, Any]) -> None:
+    """Each fixture must replay byte-equal through the middleware chain."""
+    request = fixture["request"]
+    upstream = fixture["upstream_response"]
+    expected = fixture["expected_response"]
+
+    app = _build_replay_app(fixture["interceptor_specs"], upstream)
+    with TestClient(app) as client:
+        resp = client.post(request["path"], json=request["body"], headers=request["headers"])
+
+    assert resp.status_code == expected["status_code"], (
+        f"fixture {name!r}: status mismatch (got {resp.status_code}, expected {expected['status_code']})"
+    )
+
+    actual_body = resp.json()
+    assert actual_body == expected["body"], (
+        f"fixture {name!r}: body mismatch\n  got: {actual_body!r}\n  expected: {expected['body']!r}"
+    )
+
+    actual_headers = _normalise_headers(dict(resp.headers))
+    expected_headers = _normalise_headers(expected["headers"])
+    assert actual_headers == expected_headers, (
+        f"fixture {name!r}: headers mismatch\n  got: {actual_headers!r}\n  expected: {expected_headers!r}"
+    )


### PR DESCRIPTION
Adapter interceptor follow-up on `feat/adapter-base`. Adds 5 passive / mildly-normalizing interceptors:
- **`log_tokens`** — log usage token counts + latency
- **`response_stats`** — accumulate counts / tokens / latency
- **`progress_tracking`** — optional webhook ping every N responses
- **`reasoning`** — normalize `<think>…</think>` / reasoning field into `reasoning_content`
- **`raise_client_errors`** — non-retriable 4xx → `RuntimeError`; 429/408 pass through

All registered as builtins in the interceptor registry. **Tests:** per-interceptor behavior + parity replay (5 scenarios) — 18 added.

Supersedes Glorf/Gym#3 (fork discontinued; rebased clean onto upstream `feat/adapter-base`).