### PR TITLE
feat(adapters): request-rewriting interceptors

### DIFF
--- a/fern/versions/latest/pages/model-server/adapters-rewrites.mdx
+++ b/fern/versions/latest/pages/model-server/adapters-rewrites.mdx
@@ -1,0 +1,74 @@
+---
+title: "Request-Rewriting Interceptors"
+description: "Interceptors that mutate the outbound request body before it reaches the upstream."
+position: 6
+---
+
+Interceptors that mutate the outbound request body before it reaches the upstream. Run in the REQUEST stage.
+
+| Name | Stage | Purpose |
+|------|-------|---------|
+| `drop_params` | request | Remove named parameters from the outbound body. |
+| `payload_modifier` | request | Add, remove, and rename body fields. |
+| `system_message` | request | Inject a system message (prepend / append / replace). |
+| `consolidate_system` | request | Merge displaced system messages into one at position 0. |
+| `modify_tools` | request | Strip or add properties on `tools[].function.parameters`. |
+| `turn_counter` | request | Per-session turn budget; raises `GracefulError` (→ 429) on exhaustion. |
+
+### `drop_params`
+
+```yaml
+- name: drop_params
+  config:
+    params: ["top_k", "frequency_penalty"]
+```
+
+### `payload_modifier`
+
+```yaml
+- name: payload_modifier
+  config:
+    params_to_remove: ["secret_field"]
+    params_to_add: { "max_completion_tokens": 4096 }
+    params_to_rename: { "old_name": "new_name" }
+```
+
+### `system_message`
+
+```yaml
+- name: system_message
+  config:
+    system_message: "You are a careful assistant."
+    strategy: prepend   # one of: prepend | append | replace
+```
+
+### `consolidate_system`
+
+```yaml
+- name: consolidate_system
+  config:
+    separator: "\n\n"
+```
+
+### `modify_tools`
+
+```yaml
+- name: modify_tools
+  config:
+    strip_properties: ["internal_flag"]
+    add_properties:
+      reasoning:
+        type: string
+        description: "model's chain-of-thought"
+```
+
+### `turn_counter`
+
+```yaml
+- name: turn_counter
+  config:
+    every: 1            # log on every Nth turn
+    max_turns: 20       # null disables the budget
+```
+
+The session key is taken from `ctx.extra["session_id"]` (set by the middleware when the path matches `/s/<hex>/...`); otherwise a body-hash fallback is used.

--- a/nemo_gym/adapters/interceptors/consolidate_system.py
+++ b/nemo_gym/adapters/interceptors/consolidate_system.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Merge all system messages into one at position 0.
+
+Models like Qwen3 reject system messages that appear mid-conversation
+(``System message must be at the beginning``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from nemo_gym.adapters.types import AdapterRequest, RequestInterceptor
+
+
+logger = logging.getLogger(__name__)
+
+
+def _content_to_str(content) -> str:
+    """Extract plain text from either a string or OpenAI list-format content."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict):
+                parts.append(item.get("text", ""))
+            elif isinstance(item, str):
+                parts.append(item)
+        return "\n".join(parts)
+    return str(content) if content else ""
+
+
+class Interceptor(RequestInterceptor):
+    def __init__(self, *, separator: str = "\n\n") -> None:
+        self._sep = separator
+        self._fix_count = 0
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        messages: list[dict] = req.body.get("messages", [])
+        if not messages:
+            return req
+
+        system_indices: list[int] = []
+        system_parts: list[str] = []
+        non_system: list[dict] = []
+        for i, msg in enumerate(messages):
+            if msg.get("role") == "system":
+                system_indices.append(i)
+                text = _content_to_str(msg.get("content", ""))
+                if text:
+                    system_parts.append(text)
+            else:
+                non_system.append(msg)
+
+        if len(system_indices) <= 1 and (not system_indices or system_indices[0] == 0):
+            return req
+
+        self._fix_count += 1
+        session = req.ctx.extra.get("session_id", "?")
+
+        role_seq = [m.get("role", "?") for m in messages]
+        displaced = [i for i in system_indices if i > 0]
+        diag_parts: list[str] = []
+        for idx in displaced:
+            lo = max(0, idx - 2)
+            hi = min(len(role_seq), idx + 3)
+            window = " ".join(f"[{j}]={role_seq[j]}" for j in range(lo, hi))
+            content_preview = _content_to_str(messages[idx].get("content", ""))[:300]
+            diag_parts.append(f"system@{idx} window=({window}) content_preview={content_preview!r}")
+
+        logger.warning(
+            "consolidate_system: fix #%d session=%s n_msgs=%d system_at=%s n_system=%d roles_head=%s | %s",
+            self._fix_count,
+            session,
+            len(messages),
+            system_indices,
+            len(system_parts),
+            role_seq[:8],
+            " | ".join(diag_parts) if diag_parts else "system missing from pos 0",
+        )
+
+        merged: list[dict] = []
+        if system_parts:
+            merged.append({"role": "system", "content": self._sep.join(system_parts)})
+        merged.extend(non_system)
+        req.body["messages"] = merged
+        return req

--- a/nemo_gym/adapters/interceptors/drop_params.py
+++ b/nemo_gym/adapters/interceptors/drop_params.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import logging
+
+from nemo_gym.adapters.types import AdapterRequest, RequestInterceptor
+
+
+logger = logging.getLogger(__name__)
+
+
+class Interceptor(RequestInterceptor):
+    def __init__(self, *, params: list[str]) -> None:
+        self._params = set(params)
+        self._logged_once = False
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        for p in self._params:
+            req.body.pop(p, None)
+
+        if not self._logged_once:
+            logger.info("drop_params: removing %s", sorted(self._params))
+            self._logged_once = True
+
+        return req

--- a/nemo_gym/adapters/interceptors/modify_tools.py
+++ b/nemo_gym/adapters/interceptors/modify_tools.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any
+
+from nemo_gym.adapters.types import AdapterRequest, RequestInterceptor
+
+
+logger = logging.getLogger(__name__)
+
+
+def _apply_modifications(
+    tools: list[dict[str, Any]],
+    strip: frozenset[str],
+    add: dict[str, dict[str, Any]],
+) -> int:
+    count = 0
+    for tool in tools:
+        fn = tool.get("function") or tool
+        params = fn.get("parameters") or {}
+        props = params.get("properties")
+        if not isinstance(props, dict):
+            continue
+
+        req: list[str] | None = params.get("required")
+
+        for field in strip:
+            if field in props:
+                del props[field]
+                count += 1
+            if isinstance(req, list) and field in req:
+                req.remove(field)
+
+        for field, schema in add.items():
+            if field not in props:
+                props[field] = copy.deepcopy(schema)
+                count += 1
+    return count
+
+
+class Interceptor(RequestInterceptor):
+    def __init__(
+        self,
+        *,
+        strip_properties: list[str] | None = None,
+        add_properties: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        self._strip = frozenset(strip_properties or [])
+        self._add: dict[str, dict[str, Any]] = add_properties or {}
+        self._logged_once = False
+
+        if not self._strip and not self._add:
+            logger.warning("modify_tools: no modifications configured — interceptor is a no-op")
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        tools = req.body.get("tools")
+        if tools:
+            n = _apply_modifications(tools, self._strip, self._add)
+            if n and not self._logged_once:
+                logger.info(
+                    "modify_tools: applied %d change(s) (strip=%s, add=%s)",
+                    n,
+                    sorted(self._strip),
+                    sorted(self._add),
+                )
+                self._logged_once = True
+        return req

--- a/nemo_gym/adapters/interceptors/payload_modifier.py
+++ b/nemo_gym/adapters/interceptors/payload_modifier.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from nemo_gym.adapters.types import AdapterRequest, RequestInterceptor
+
+
+logger = logging.getLogger(__name__)
+
+
+def _remove_keys(obj: Any, keys: set[str]) -> Any:
+    if isinstance(obj, dict):
+        return {k: _remove_keys(v, keys) for k, v in obj.items() if k not in keys}
+    if isinstance(obj, list):
+        return [_remove_keys(item, keys) for item in obj]
+    return obj
+
+
+def _rename_keys(obj: Any, mapping: dict[str, str]) -> Any:
+    if isinstance(obj, dict):
+        return {mapping.get(k, k): _rename_keys(v, mapping) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_rename_keys(item, mapping) for item in obj]
+    return obj
+
+
+class Interceptor(RequestInterceptor):
+    def __init__(
+        self,
+        *,
+        params_to_remove: list[str] | None = None,
+        params_to_add: dict[str, Any] | None = None,
+        params_to_rename: dict[str, str] | None = None,
+    ) -> None:
+        self._remove = set(params_to_remove or [])
+        self._add: dict[str, Any] = params_to_add or {}
+        self._rename: dict[str, str] = params_to_rename or {}
+        self._logged_once = False
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        if self._remove:
+            req.body = _remove_keys(req.body, self._remove)
+
+        if self._rename:
+            req.body = _rename_keys(req.body, self._rename)
+
+        if self._add:
+            req.body.update(self._add)
+
+        if not self._logged_once:
+            logger.info(
+                "payload_modifier: remove=%s, add=%s, rename=%s",
+                sorted(self._remove),
+                sorted(self._add),
+                sorted(self._rename),
+            )
+            self._logged_once = True
+
+        return req

--- a/nemo_gym/adapters/interceptors/system_message.py
+++ b/nemo_gym/adapters/interceptors/system_message.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import logging
+
+from nemo_gym.adapters.types import AdapterRequest, RequestInterceptor
+
+
+logger = logging.getLogger(__name__)
+
+_VALID_STRATEGIES = {"replace", "append", "prepend"}
+
+
+class Interceptor(RequestInterceptor):
+    def __init__(
+        self,
+        *,
+        system_message: str,
+        strategy: str = "prepend",
+    ) -> None:
+        if strategy not in _VALID_STRATEGIES:
+            raise ValueError(f"Invalid strategy {strategy!r}, must be one of {_VALID_STRATEGIES}")
+        self._message = system_message
+        self._strategy = strategy
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        messages: list = req.body.setdefault("messages", [])
+        sys_msg = {"role": "system", "content": self._message}
+
+        if self._strategy == "replace":
+            non_system = [m for m in messages if m.get("role") != "system"]
+            req.body["messages"] = [sys_msg] + non_system
+
+        elif self._strategy == "append":
+            messages.append(sys_msg)
+
+        else:  # prepend
+            messages.insert(0, sys_msg)
+
+        return req

--- a/nemo_gym/adapters/interceptors/turn_counter.py
+++ b/nemo_gym/adapters/interceptors/turn_counter.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from nemo_gym.adapters.types import AdapterRequest, RequestInterceptor
+
+
+logger = logging.getLogger(__name__)
+
+_WARN_THRESHOLD = 0.80
+_URGENT_THRESHOLD = 0.95
+_STALE_SESSION_SEC = 900.0
+_GC_INTERVAL_SEC = 300.0
+
+
+def _session_key_from_body(body: dict[str, Any]) -> str:
+    """Fallback: derive a session key from the first non-system message."""
+    messages = body.get("messages") or []
+    for msg in messages:
+        if msg.get("role") == "system":
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            content = "".join(part.get("text", "") for part in content if isinstance(part, dict))
+        if content:
+            return hashlib.sha256(content.encode()).hexdigest()[:8]
+    return "unknown"
+
+
+@dataclass
+class _Session:
+    count: int = 0
+    last_time: float = field(default_factory=time.monotonic)
+
+
+class Interceptor(RequestInterceptor):
+    def __init__(
+        self,
+        *,
+        every: int = 1,
+        max_turns: int | None = None,
+    ) -> None:
+        self._every = max(every, 1)
+        self._max = max_turns
+        self._sessions: dict[str, _Session] = {}
+        self._lock = asyncio.Lock()
+        self._last_gc = time.monotonic()
+
+    async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        key = req.ctx.extra.get("session_id")
+        if not key:
+            key = _session_key_from_body(req.body)
+            logger.warning("no session_id in context — falling back to body-hash key %s", key)
+
+        async with self._lock:
+            now = time.monotonic()
+            if now - self._last_gc > _GC_INTERVAL_SEC:
+                self._gc(now)
+                self._last_gc = now
+
+            sess = self._sessions.setdefault(key, _Session())
+            sess.count += 1
+            n = sess.count
+            dt = now - sess.last_time if sess.count > 1 else 0.0
+            sess.last_time = now
+            active = len(self._sessions)
+
+        if n % self._every == 0 or n == 1:
+            cap = f"/{self._max}" if self._max else ""
+            elapsed = f" (+{dt:.1f}s)" if dt > 0 else ""
+            logger.info(
+                "task %s turn %d%s%s (%d active)",
+                key,
+                n,
+                cap,
+                elapsed,
+                active,
+            )
+
+        if self._max is None:
+            return req
+
+        if n > self._max:
+            logger.warning(
+                "task %s REJECTED turn %d (max_turns=%d exceeded)",
+                key,
+                n,
+                self._max,
+            )
+            from nemo_gym.adapters.types import GracefulError
+
+            raise GracefulError(
+                f"Turn budget exhausted: {n}/{self._max} turns used. "
+                f"The evaluation framework has terminated this agent session."
+            )
+
+        remaining = self._max - n
+        messages = req.body.get("messages")
+        if not isinstance(messages, list):
+            return req
+
+        ratio = n / self._max
+        if ratio >= _URGENT_THRESHOLD:
+            messages.append(
+                {
+                    "role": "system",
+                    "content": (
+                        f"[SYSTEM] URGENT: Turn {n}/{self._max} — only {remaining} turn(s) left. "
+                        f"You MUST provide your final answer NOW. Do not start new work."
+                    ),
+                }
+            )
+        elif ratio >= _WARN_THRESHOLD:
+            messages.append(
+                {
+                    "role": "system",
+                    "content": (
+                        f"[SYSTEM] Turn {n}/{self._max} — {remaining} turns remaining. "
+                        f"Begin wrapping up: finish current work and prepare your final answer."
+                    ),
+                }
+            )
+
+        return req
+
+    def _gc(self, now: float) -> None:
+        """Remove sessions idle longer than ``_STALE_SESSION_SEC``."""
+        stale = [k for k, s in self._sessions.items() if now - s.last_time > _STALE_SESSION_SEC]
+        for k in stale:
+            del self._sessions[k]
+        if stale:
+            logger.debug("turn_counter GC: removed %d stale sessions, %d remaining", len(stale), len(self._sessions))

--- a/nemo_gym/adapters/registry.py
+++ b/nemo_gym/adapters/registry.py
@@ -52,6 +52,15 @@ _BUILTIN: dict[str, str] = {
 # Each family adds entries under its own family-named comment marker so
 # different families don't fight for the same diff context.
 
+# Request-rewriting family — mutate the outbound request body before
+# upstream sees it.
+_BUILTIN["drop_params"] = "nemo_gym.adapters.interceptors.drop_params"
+_BUILTIN["payload_modifier"] = "nemo_gym.adapters.interceptors.payload_modifier"
+_BUILTIN["system_message"] = "nemo_gym.adapters.interceptors.system_message"
+_BUILTIN["consolidate_system"] = "nemo_gym.adapters.interceptors.consolidate_system"
+_BUILTIN["modify_tools"] = "nemo_gym.adapters.interceptors.modify_tools"
+_BUILTIN["turn_counter"] = "nemo_gym.adapters.interceptors.turn_counter"
+
 # External / plugin registrations at runtime.
 _EXTRA: dict[str, str] = {}
 

--- a/tests/unit_tests/adapter_fixtures/consolidate_system_moves_system_to_front_and_merges.json
+++ b/tests/unit_tests/adapter_fixtures/consolidate_system_moves_system_to_front_and_merges.json
@@ -1,0 +1,72 @@
+{
+  "expected_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  },
+  "interceptor_specs": [
+    {
+      "config": {},
+      "name": "consolidate_system"
+    }
+  ],
+  "request": {
+    "body": {
+      "messages": [
+        {
+          "content": "q1",
+          "role": "user"
+        },
+        {
+          "content": "A",
+          "role": "system"
+        },
+        {
+          "content": "B",
+          "role": "system"
+        }
+      ],
+      "model": "m"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "path": "/v1/chat/completions"
+  },
+  "scenario": "consolidate_system moves system to front and merges",
+  "upstream_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  }
+}

--- a/tests/unit_tests/adapter_fixtures/drop_params_drops_temperature_and_top_p.json
+++ b/tests/unit_tests/adapter_fixtures/drop_params_drops_temperature_and_top_p.json
@@ -1,0 +1,72 @@
+{
+  "expected_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  },
+  "interceptor_specs": [
+    {
+      "config": {
+        "params": [
+          "temperature",
+          "top_p"
+        ]
+      },
+      "name": "drop_params"
+    }
+  ],
+  "request": {
+    "body": {
+      "max_tokens": 16,
+      "messages": [
+        {
+          "content": "hi",
+          "role": "user"
+        }
+      ],
+      "model": "m",
+      "temperature": 0.7,
+      "top_p": 0.95
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "path": "/v1/chat/completions"
+  },
+  "scenario": "drop_params drops temperature and top_p",
+  "upstream_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  }
+}

--- a/tests/unit_tests/adapter_fixtures/modify_tools_strips_a_property___required_entry.json
+++ b/tests/unit_tests/adapter_fixtures/modify_tools_strips_a_property___required_entry.json
@@ -1,0 +1,86 @@
+{
+  "expected_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  },
+  "interceptor_specs": [
+    {
+      "config": {
+        "strip_properties": [
+          "debug_flag"
+        ]
+      },
+      "name": "modify_tools"
+    }
+  ],
+  "request": {
+    "body": {
+      "messages": [],
+      "model": "m",
+      "tools": [
+        {
+          "function": {
+            "name": "f",
+            "parameters": {
+              "properties": {
+                "debug_flag": {
+                  "type": "boolean"
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "debug_flag",
+                "value"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "function"
+        }
+      ]
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "path": "/v1/chat/completions"
+  },
+  "scenario": "modify_tools strips a property + required entry",
+  "upstream_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  }
+}

--- a/tests/unit_tests/adapter_fixtures/payload_modifier_removes_one_param_and_adds_another.json
+++ b/tests/unit_tests/adapter_fixtures/payload_modifier_removes_one_param_and_adds_another.json
@@ -1,0 +1,67 @@
+{
+  "expected_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  },
+  "interceptor_specs": [
+    {
+      "config": {
+        "params_to_add": {
+          "temperature": 0.0
+        },
+        "params_to_remove": [
+          "stream"
+        ]
+      },
+      "name": "payload_modifier"
+    }
+  ],
+  "request": {
+    "body": {
+      "messages": [],
+      "model": "m",
+      "stream": true
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "path": "/v1/chat/completions"
+  },
+  "scenario": "payload_modifier removes one param and adds another",
+  "upstream_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  }
+}

--- a/tests/unit_tests/adapter_fixtures/system_message_prepends_a_system_message.json
+++ b/tests/unit_tests/adapter_fixtures/system_message_prepends_a_system_message.json
@@ -1,0 +1,67 @@
+{
+  "expected_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  },
+  "interceptor_specs": [
+    {
+      "config": {
+        "strategy": "prepend",
+        "system_message": "be terse"
+      },
+      "name": "system_message"
+    }
+  ],
+  "request": {
+    "body": {
+      "messages": [
+        {
+          "content": "hi",
+          "role": "user"
+        }
+      ],
+      "model": "m"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "path": "/v1/chat/completions"
+  },
+  "scenario": "system_message prepends a system message",
+  "upstream_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  }
+}

--- a/tests/unit_tests/adapter_fixtures/turn_counter_passes_through_under_the_budget.json
+++ b/tests/unit_tests/adapter_fixtures/turn_counter_passes_through_under_the_budget.json
@@ -1,0 +1,66 @@
+{
+  "expected_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  },
+  "interceptor_specs": [
+    {
+      "config": {
+        "max_turns": 5
+      },
+      "name": "turn_counter"
+    }
+  ],
+  "request": {
+    "body": {
+      "messages": [
+        {
+          "content": "hi",
+          "role": "user"
+        }
+      ],
+      "model": "m"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "path": "/v1/chat/completions"
+  },
+  "scenario": "turn_counter passes through under the budget",
+  "upstream_response": {
+    "body": {
+      "choices": [
+        {
+          "finish_reason": "stop",
+          "index": 0,
+          "message": {
+            "content": "fixture-canned",
+            "role": "assistant"
+          }
+        }
+      ],
+      "id": "chatcmpl-fixture",
+      "object": "chat.completion"
+    },
+    "headers": {
+      "content-type": "application/json"
+    },
+    "status_code": 200
+  }
+}

--- a/tests/unit_tests/test_adapter_consolidate_system.py
+++ b/tests/unit_tests/test_adapter_consolidate_system.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the consolidate_system interceptor — ported from NEL."""
+
+from __future__ import annotations
+
+from nemo_gym.adapters.interceptors.consolidate_system import Interceptor, _content_to_str
+from nemo_gym.adapters.types import AdapterRequest, InterceptorContext
+
+
+def _req(messages: list[dict], session_id: str = "test-session") -> AdapterRequest:
+    ctx = InterceptorContext()
+    ctx.extra["session_id"] = session_id
+    return AdapterRequest(
+        method="POST",
+        path="/v1/chat/completions",
+        headers={"content-type": "application/json"},
+        body={"model": "test", "messages": messages},
+        ctx=ctx,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _content_to_str helper
+# ---------------------------------------------------------------------------
+
+
+class TestContentToStr:
+    def test_string_passthrough(self):
+        assert _content_to_str("hello") == "hello"
+
+    def test_list_of_dicts(self):
+        content = [{"type": "text", "text": "part1"}, {"type": "text", "text": "part2"}]
+        assert _content_to_str(content) == "part1\npart2"
+
+    def test_list_of_strings(self):
+        assert _content_to_str(["a", "b"]) == "a\nb"
+
+    def test_mixed_list(self):
+        content = [{"type": "text", "text": "dict-part"}, "str-part"]
+        assert _content_to_str(content) == "dict-part\nstr-part"
+
+    def test_none(self):
+        assert _content_to_str(None) == ""
+
+    def test_empty_string(self):
+        assert _content_to_str("") == ""
+
+    def test_empty_list(self):
+        assert _content_to_str([]) == ""
+
+    def test_dict_without_text_key(self):
+        assert _content_to_str([{"type": "image_url", "image_url": "x"}]) == ""
+
+
+# ---------------------------------------------------------------------------
+# No-op cases: interceptor should return the request unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestNoOp:
+    async def test_empty_messages(self):
+        ic = Interceptor()
+        req = _req([])
+        result = await ic.intercept_request(req)
+        assert result.body["messages"] == []
+
+    async def test_no_messages_key(self):
+        ic = Interceptor()
+        ctx = InterceptorContext()
+        req = AdapterRequest(
+            method="POST",
+            path="/v1/chat/completions",
+            headers={},
+            body={"model": "test"},
+            ctx=ctx,
+        )
+        result = await ic.intercept_request(req)
+        assert "messages" not in result.body
+
+    async def test_single_system_at_pos_0(self):
+        ic = Interceptor()
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hi"},
+        ]
+        req = _req(messages)
+        result = await ic.intercept_request(req)
+        assert result.body["messages"] == messages
+        assert ic._fix_count == 0
+
+    async def test_no_system_messages(self):
+        ic = Interceptor()
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        req = _req(messages)
+        result = await ic.intercept_request(req)
+        assert result.body["messages"] == messages
+        assert ic._fix_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Fix cases: interceptor should consolidate system messages
+# ---------------------------------------------------------------------------
+
+
+class TestConsolidate:
+    async def test_system_not_at_pos_0(self):
+        """Single system message at position > 0 gets moved to front."""
+        ic = Interceptor()
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "Be helpful."},
+            {"role": "assistant", "content": "hello"},
+        ]
+        result = await ic.intercept_request(_req(messages))
+        msgs = result.body["messages"]
+        assert msgs[0] == {"role": "system", "content": "Be helpful."}
+        assert msgs[1] == {"role": "user", "content": "hi"}
+        assert msgs[2] == {"role": "assistant", "content": "hello"}
+        assert ic._fix_count == 1
+
+    async def test_duplicate_system_messages(self):
+        """Two system messages get merged into one at position 0."""
+        ic = Interceptor()
+        messages = [
+            {"role": "system", "content": "First."},
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "Second."},
+            {"role": "assistant", "content": "hello"},
+        ]
+        result = await ic.intercept_request(_req(messages))
+        msgs = result.body["messages"]
+        assert len(msgs) == 3
+        assert msgs[0] == {"role": "system", "content": "First.\n\nSecond."}
+        assert msgs[1] == {"role": "user", "content": "hi"}
+        assert msgs[2] == {"role": "assistant", "content": "hello"}
+
+    async def test_empty_system_at_0_real_system_later(self):
+        """Empty system at pos 0 + real system later triggers fix."""
+        ic = Interceptor()
+        messages = [
+            {"role": "system", "content": ""},
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "Real prompt."},
+        ]
+        result = await ic.intercept_request(_req(messages))
+        msgs = result.body["messages"]
+        assert msgs[0] == {"role": "system", "content": "Real prompt."}
+        assert msgs[1] == {"role": "user", "content": "hi"}
+        assert len(msgs) == 2
+
+    async def test_list_format_content(self):
+        """System message with OpenAI list-format content is handled."""
+        ic = Interceptor()
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": [{"type": "text", "text": "Be helpful."}]},
+        ]
+        result = await ic.intercept_request(_req(messages))
+        msgs = result.body["messages"]
+        assert msgs[0] == {"role": "system", "content": "Be helpful."}
+        assert msgs[1] == {"role": "user", "content": "hi"}
+
+    async def test_three_system_messages(self):
+        """Three system messages scattered across conversation."""
+        ic = Interceptor()
+        messages = [
+            {"role": "system", "content": "A"},
+            {"role": "user", "content": "q1"},
+            {"role": "system", "content": "B"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "system", "content": "C"},
+        ]
+        result = await ic.intercept_request(_req(messages))
+        msgs = result.body["messages"]
+        assert msgs[0] == {"role": "system", "content": "A\n\nB\n\nC"}
+        assert [m["role"] for m in msgs[1:]] == ["user", "assistant"]
+
+    async def test_system_without_content_key(self):
+        """System message with no content key at all doesn't crash."""
+        ic = Interceptor()
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "system"},
+        ]
+        result = await ic.intercept_request(_req(messages))
+        msgs = result.body["messages"]
+        assert len(msgs) == 1
+        assert msgs[0] == {"role": "user", "content": "hi"}
+
+
+# ---------------------------------------------------------------------------
+# Non-system message ordering is preserved
+# ---------------------------------------------------------------------------
+
+
+class TestOrderPreservation:
+    async def test_non_system_order_preserved(self):
+        ic = Interceptor()
+        messages = [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+        ]
+        result = await ic.intercept_request(_req(messages))
+        msgs = result.body["messages"]
+        assert msgs[0]["role"] == "system"
+        non_system = msgs[1:]
+        assert [m["content"] for m in non_system] == ["u1", "a1", "u2", "a2"]
+
+    async def test_extra_message_fields_preserved(self):
+        """Fields like tool_calls, name, etc. are not lost."""
+        ic = Interceptor()
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": "ok", "tool_calls": [{"id": "1"}]},
+        ]
+        result = await ic.intercept_request(_req(messages))
+        msgs = result.body["messages"]
+        assert msgs[2]["tool_calls"] == [{"id": "1"}]
+
+
+# ---------------------------------------------------------------------------
+# Custom separator
+# ---------------------------------------------------------------------------
+
+
+class TestCustomSeparator:
+    async def test_custom_separator(self):
+        ic = Interceptor(separator=" | ")
+        messages = [
+            {"role": "system", "content": "A"},
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "B"},
+        ]
+        result = await ic.intercept_request(_req(messages))
+        assert result.body["messages"][0]["content"] == "A | B"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency and fix counter
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    async def test_idempotent_after_fix(self):
+        """Running the interceptor twice on the fixed output is a no-op."""
+        ic = Interceptor()
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "sys"},
+        ]
+        result1 = await ic.intercept_request(_req(messages))
+        assert ic._fix_count == 1
+
+        result2 = await ic.intercept_request(_req(result1.body["messages"]))
+        assert ic._fix_count == 1
+        assert result2.body["messages"] == result1.body["messages"]
+
+    async def test_fix_counter_increments(self):
+        ic = Interceptor()
+        for i in range(3):
+            messages = [
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": f"sys-{i}"},
+            ]
+            await ic.intercept_request(_req(messages))
+        assert ic._fix_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    async def test_create_via_registry(self):
+        from nemo_gym.adapters.registry import InterceptorRegistry
+
+        ic = InterceptorRegistry.create("consolidate_system", {})
+        assert isinstance(ic, Interceptor)
+
+    async def test_create_with_separator(self):
+        from nemo_gym.adapters.registry import InterceptorRegistry
+
+        ic = InterceptorRegistry.create("consolidate_system", {"separator": "---"})
+        assert ic._sep == "---"

--- a/tests/unit_tests/test_adapter_interceptors_rewrites.py
+++ b/tests/unit_tests/test_adapter_interceptors_rewrites.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Per-interceptor behavior tests — ported from NEL ``tests/test_adapters/test_interceptors.py``
+and ``test_interceptors_extended.py``.
+
+Mechanical port from ``nemo_evaluator.adapters.*`` to ``nemo_gym.adapters.*``;
+``GracefulError`` re-rooted at ``nemo_gym.adapters.types``.
+"""
+
+import pytest
+
+from nemo_gym.adapters.registry import InterceptorRegistry
+from nemo_gym.adapters.types import (
+    AdapterRequest,
+    AdapterResponse,
+    GracefulError,
+    InterceptorContext,
+)
+
+
+def _req(body=None, **kw):
+    return AdapterRequest(
+        method="POST",
+        path="/v1/chat/completions",
+        headers={"content-type": "application/json"},
+        body=body or {"model": "test", "messages": [{"role": "user", "content": "hi"}]},
+        ctx=InterceptorContext(),
+    )
+
+
+def _resp(body=None, status_code=200):
+    return AdapterResponse(
+        status_code=status_code,
+        headers={},
+        body=body or {},
+        ctx=InterceptorContext(),
+    )
+
+
+async def test_drop_params():
+    ic = InterceptorRegistry.create("drop_params", {"params": ["temperature", "top_p"]})
+    req = _req({"model": "test", "messages": [], "temperature": 0.7, "top_p": 0.9, "max_tokens": 100})
+    result = await ic.intercept_request(req)
+    assert "temperature" not in result.body
+    assert "top_p" not in result.body
+    assert result.body["max_tokens"] == 100
+
+
+async def test_modify_tools():
+    ic = InterceptorRegistry.create("modify_tools", {"strip_properties": ["x"]})
+    req = _req(
+        {
+            "model": "test",
+            "messages": [],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "f",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "x": {"type": "string"},
+                                "y": {"type": "integer"},
+                            },
+                            "required": ["x", "y"],
+                        },
+                    },
+                }
+            ],
+        }
+    )
+    result = await ic.intercept_request(req)
+    props = result.body["tools"][0]["function"]["parameters"]["properties"]
+    assert "x" not in props
+    assert "y" in props
+    assert "x" not in result.body["tools"][0]["function"]["parameters"]["required"]
+
+
+async def test_system_message_prepend():
+    ic = InterceptorRegistry.create(
+        "system_message",
+        {
+            "system_message": "Be helpful",
+            "strategy": "prepend",
+        },
+    )
+    req = _req({"model": "test", "messages": [{"role": "user", "content": "hi"}]})
+    result = await ic.intercept_request(req)
+    assert result.body["messages"][0] == {"role": "system", "content": "Be helpful"}
+    assert result.body["messages"][1] == {"role": "user", "content": "hi"}
+
+
+async def test_system_message_replace():
+    ic = InterceptorRegistry.create(
+        "system_message",
+        {
+            "system_message": "New system",
+            "strategy": "replace",
+        },
+    )
+    req = _req(
+        {
+            "model": "test",
+            "messages": [
+                {"role": "system", "content": "Old system"},
+                {"role": "user", "content": "hi"},
+            ],
+        }
+    )
+    result = await ic.intercept_request(req)
+    sys_msgs = [m for m in result.body["messages"] if m["role"] == "system"]
+    assert len(sys_msgs) == 1
+    assert sys_msgs[0]["content"] == "New system"
+
+
+async def test_payload_modifier_remove():
+    ic = InterceptorRegistry.create("payload_modifier", {"params_to_remove": ["stream"]})
+    req = _req({"model": "test", "messages": [], "stream": True})
+    result = await ic.intercept_request(req)
+    assert "stream" not in result.body
+
+
+async def test_payload_modifier_add():
+    ic = InterceptorRegistry.create("payload_modifier", {"params_to_add": {"temperature": 0.5}})
+    req = _req({"model": "test", "messages": []})
+    result = await ic.intercept_request(req)
+    assert result.body["temperature"] == 0.5
+
+
+async def test_turn_counter_basic():
+    ic = InterceptorRegistry.create("turn_counter", {"max_turns": 5})
+    for _ in range(5):
+        req = _req({"model": "test", "messages": [{"role": "user", "content": "hi"}]})
+        await ic.intercept_request(req)
+
+    with pytest.raises(GracefulError, match="Turn budget exhausted"):
+        await ic.intercept_request(_req({"model": "test", "messages": [{"role": "user", "content": "hi"}]}))
+
+
+async def test_turn_counter_session_isolation():
+    """Repeats of the same problem get independent turn budgets when
+    the proxy injects distinct session_id values."""
+    ic = InterceptorRegistry.create("turn_counter", {"max_turns": 3})
+    body = {"model": "test", "messages": [{"role": "user", "content": "same prompt"}]}
+
+    for session_id in ("aaa", "bbb"):
+        for _ in range(3):
+            r = _req(body)
+            r.ctx.extra["session_id"] = session_id
+            await ic.intercept_request(r)
+
+    r = _req(body)
+    r.ctx.extra["session_id"] = "aaa"
+    with pytest.raises(GracefulError, match="Turn budget exhausted"):
+        await ic.intercept_request(r)
+
+    r = _req(body)
+    r.ctx.extra["session_id"] = "ccc"
+    await ic.intercept_request(r)

--- a/tests/unit_tests/test_adapter_parity_replay_rewrites.py
+++ b/tests/unit_tests/test_adapter_parity_replay_rewrites.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Parity replay test for the adapter middleware.
+
+Loads every JSON fixture under ``adapter_fixtures/`` and asserts that the
+recorded ``request`` → ``expected_response`` pair still holds when the
+middleware is installed with the recorded ``interceptor_specs`` and the
+(mocked) upstream returns the recorded ``upstream_response``. ``caching``
+is covered by a dedicated round-trip test below since its parity behavior
+is "second hit ≡ first response".
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from nemo_gym.adapters import install_middleware
+
+
+FIXTURE_DIR = Path(__file__).parent / "adapter_fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_fixtures() -> list[tuple[str, dict[str, Any]]]:
+    """Return ``[(fixture_name, fixture_data), ...]`` sorted by name."""
+    if not FIXTURE_DIR.exists():
+        return []
+    fixtures: list[tuple[str, dict[str, Any]]] = []
+    for path in sorted(FIXTURE_DIR.glob("*.json")):
+        with path.open() as f:
+            fixtures.append((path.stem, json.load(f)))
+    return fixtures
+
+
+_FIXTURES = _load_fixtures()
+
+
+def _build_replay_app(interceptor_specs: list[dict[str, Any]], upstream: dict[str, Any]) -> FastAPI:
+    """FastAPI app whose chat-completions route returns ``upstream`` verbatim,
+    with the adapter middleware installed on top."""
+    app = FastAPI()
+
+    @app.post("/v1/chat/completions")
+    async def _chat(body: dict):
+        return JSONResponse(
+            content=upstream["body"],
+            status_code=upstream["status_code"],
+            headers=upstream.get("headers") or {},
+        )
+
+    install_middleware(app, interceptor_specs)
+    return app
+
+
+_VOLATILE_HEADERS = {"date", "server", "content-length"}
+
+
+def _normalise_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Drop headers whose values are non-deterministic.
+
+    Matches the normalisation in ``generate_adapter_fixtures.py``. Without this,
+    replays would fail because ``content-length`` is recomputed per-response
+    by Starlette and ``date`` / ``server`` vary across runs.
+    """
+    return {k: v for k, v in headers.items() if k.lower() not in _VOLATILE_HEADERS}
+
+
+# ---------------------------------------------------------------------------
+# Parametrised replay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _FIXTURES, reason="no fixtures recorded yet (run generate_adapter_fixtures.py)")
+@pytest.mark.parametrize("name,fixture", _FIXTURES, ids=[name for name, _ in _FIXTURES])
+def test_parity_replay(name: str, fixture: dict[str, Any]) -> None:
+    """Each fixture must replay byte-equal through the middleware chain."""
+    request = fixture["request"]
+    upstream = fixture["upstream_response"]
+    expected = fixture["expected_response"]
+
+    app = _build_replay_app(fixture["interceptor_specs"], upstream)
+    with TestClient(app) as client:
+        resp = client.post(request["path"], json=request["body"], headers=request["headers"])
+
+    assert resp.status_code == expected["status_code"], (
+        f"fixture {name!r}: status mismatch (got {resp.status_code}, expected {expected['status_code']})"
+    )
+
+    actual_body = resp.json()
+    assert actual_body == expected["body"], (
+        f"fixture {name!r}: body mismatch\n  got: {actual_body!r}\n  expected: {expected['body']!r}"
+    )
+
+    actual_headers = _normalise_headers(dict(resp.headers))
+    expected_headers = _normalise_headers(expected["headers"])
+    assert actual_headers == expected_headers, (
+        f"fixture {name!r}: headers mismatch\n  got: {actual_headers!r}\n  expected: {expected_headers!r}"
+    )


### PR DESCRIPTION
Adapter interceptor follow-up on `feat/adapter-base`. Adds 6 interceptors that mutate the outbound request body:
- **`drop_params`** — remove named parameters
- **`payload_modifier`** — add / remove / rename body fields
- **`system_message`** — inject a system message (prepend / append / replace)
- **`consolidate_system`** — merge displaced system messages to position 0 (required by Qwen3)
- **`modify_tools`** — strip / add `tools[].function.parameters` properties
- **`turn_counter`** — per-session turn budget; raises `GracefulError` (→429) on exhaustion; warn/urgent system messages at 80%/95%

All registered as builtins. **Tests:** per-interceptor behavior, consolidate-system edge cases, parity replay (6 scenarios) — 39 added.

Supersedes Glorf/Gym#4 (fork discontinued; rebased clean onto upstream `feat/adapter-base`).