### PR TITLE
docs: remove model recipe column from RL framework compatibility table

### DIFF
--- a/fern/versions/latest/pages/reference/rl-framework-compatibility.mdx
+++ b/fern/versions/latest/pages/reference/rl-framework-compatibility.mdx
@@ -11,11 +11,11 @@ Reference for NeMo Gym version compatibility with supported training frameworks.
 
 The following table maps NeMo Gym versions to compatible NeMo RL containers. Use the latest version when possible; the table provides historical compatibility for users who cannot upgrade.
 
-| NeMo Gym Version | Container / Docker File | Recipe |
-| --- | --- | --- |
-| v0.1.1 | [`nvcr.io/nvidia/nemo-rl:v0.4.0.nemotron_3_nano`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-rl/tags?version=v0.4.0) | [Nemotron 3 Nano](/model-recipes/nemotron-3-nano) |
-| v0.2.0 | [`nvcr.io/nvidia/nemo-rl:v0.5.0.nemotron_3_super`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-rl/tags?version=v0.5.0) | [Nemotron 3 Super](/model-recipes/nemotron-3-super) |
-| v0.3.0 | [Dockerfile](https://github.com/NVIDIA-NeMo/RL/blob/ultra-v3/docker/Dockerfile) | [Nemotron 3 Ultra](https://github.com/NVIDIA-NeMo/RL/blob/ultra-v3/docs/guides/nemotron-3-ultra.md) |
+| NeMo Gym Version | Container / Docker File |
+| --- | --- |
+| v0.1.1 | [`nvcr.io/nvidia/nemo-rl:v0.4.0.nemotron_3_nano`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-rl/tags?version=v0.4.0) |
+| v0.2.0 | [`nvcr.io/nvidia/nemo-rl:v0.5.0.nemotron_3_super`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-rl/tags?version=v0.5.0) |
+| v0.3.0 | [Dockerfile](https://github.com/NVIDIA-NeMo/RL/blob/ultra-v3/docker/Dockerfile) |
 
 <Note>
 [NeMo RL GRPO](/training-tutorials/nemo-rl-grpo) for the NeMo RL training tutorial.


### PR DESCRIPTION
## What

Removes the **Recipe** column from the NeMo RL Container table in `fern/versions/latest/pages/reference/rl-framework-compatibility.mdx`.

Per #1527, this table should map NeMo Gym versions to compatible NeMo RL containers only. The model-recipe links are out of scope for this table.

## Before

| NeMo Gym Version | Container / Docker File | Recipe |
| --- | --- | --- |

## After

| NeMo Gym Version | Container / Docker File |
| --- | --- |

Only the `latest` (Main) docs are changed; the frozen `v0.2.1` and `v0.3.0` snapshots are intentionally left untouched.

## Notes

- Docs-only change; no code or behavior affected.

Closes #1527