### PR TITLE
chore (local_vllm_model): bump vllm 0.17.0 -> 0.20.0

### DIFF
--- a/responses_api_models/genrm_model/setup.py
+++ b/responses_api_models/genrm_model/setup.py
@@ -22,10 +22,9 @@ dependencies = [
     "nemo-gym[dev]",
 
     # We specifically pin the vllm dependency because we have tested on this version.
-    # Updated Tue Jun 23, 2026 to vllm==0.20.0 to match the version NeMo-RL main pins in its
-    # [vllm] extra (https://github.com/NVIDIA-NeMo/RL/blob/main/pyproject.toml), so the local
-    # vLLM model server runs the same engine NeMo-RL trains/evaluates against.
-    # License: Apache 2.0 https://github.com/vllm-project/vllm/blob/v0.20.0/LICENSE
+    # Updated Tue Jun 23, 2026 with vllm==0.20.0
+    # License: Apache 2.0 https://github.com/vllm-project/vllm/blob/88d34c6409e9fb3c7b8ca0c04756f061d2099eb1/LICENSE
+    # "vllm==0.20.0",
     # VLLM is resolved below since installation on Macs requires special workarounds.
 
     # hf_transfer for faster model download from HuggingFace

--- a/responses_api_models/genrm_model/setup.py
+++ b/responses_api_models/genrm_model/setup.py
@@ -22,9 +22,10 @@ dependencies = [
     "nemo-gym[dev]",
 
     # We specifically pin the vllm dependency because we have tested on this version.
-    # Updated Thu Dec 11, 2025 with vllm==0.11.2
-    # License: Apache 2.0 https://github.com/vllm-project/vllm/blob/89988ec8c2a0c3e18e63767d9df5ca8f6b8ff21c/LICENSE
-    # "vllm==0.11.2",
+    # Updated Tue Jun 23, 2026 to vllm==0.20.0 to match the version NeMo-RL main pins in its
+    # [vllm] extra (https://github.com/NVIDIA-NeMo/RL/blob/main/pyproject.toml), so the local
+    # vLLM model server runs the same engine NeMo-RL trains/evaluates against.
+    # License: Apache 2.0 https://github.com/vllm-project/vllm/blob/v0.20.0/LICENSE
     # VLLM is resolved below since installation on Macs requires special workarounds.
 
     # hf_transfer for faster model download from HuggingFace
@@ -47,7 +48,7 @@ dependencies = [
 if platform == "darwin":
     dependencies.append("vllm==0.11.0")
 else:
-    dependencies.append("vllm==0.17.0")
+    dependencies.append("vllm==0.20.0")
 
 
 setuptools.setup(install_requires=dependencies)

--- a/responses_api_models/local_vllm_model/app.py
+++ b/responses_api_models/local_vllm_model/app.py
@@ -149,8 +149,10 @@ class LocalVLLMModel(VLLMModel):
         final_args = parser.parse_args(namespace=Namespace(**server_args))
         validate_parsed_serve_args(final_args)
 
-        # @bxyu-nvidia: TODO remove, specific to Nemotron 3 Ultra vLLM version
-        # this return_routed_experts argument isn't present in 0.17.0, so this must be from 0.16.x
+        # @bxyu-nvidia: TODO remove, specific to Nemotron 3 Ultra vLLM version.
+        # The Nemotron 3 Ultra build expects `return_routed_experts`, whereas upstream vLLM
+        # (verified on 0.20.0, engine/arg_utils.py) only exposes `enable_return_routed_experts`,
+        # so we alias the parsed arg across.
         final_args.return_routed_experts = final_args.enable_return_routed_experts
 
         if self.config.debug:

--- a/responses_api_models/local_vllm_model/app.py
+++ b/responses_api_models/local_vllm_model/app.py
@@ -150,9 +150,7 @@ class LocalVLLMModel(VLLMModel):
         validate_parsed_serve_args(final_args)
 
         # @bxyu-nvidia: TODO remove, specific to Nemotron 3 Ultra vLLM version.
-        # The Nemotron 3 Ultra build expects `return_routed_experts`, whereas upstream vLLM
-        # (verified on 0.20.0, engine/arg_utils.py) only exposes `enable_return_routed_experts`,
-        # so we alias the parsed arg across.
+        # Upstream vLLM only exposes `enable_return_routed_experts`, so alias it across.
         final_args.return_routed_experts = final_args.enable_return_routed_experts
 
         if self.config.debug:

--- a/responses_api_models/local_vllm_model/setup.py
+++ b/responses_api_models/local_vllm_model/setup.py
@@ -19,9 +19,10 @@ dependencies = [
     "nemo-gym[dev]",
 
     # We specifically pin the vllm dependency because we have tested on this version.
-    # Updated Thu Dec 11, 2025 with vllm==0.11.2
-    # License: Apache 2.0 https://github.com/vllm-project/vllm/blob/89988ec8c2a0c3e18e63767d9df5ca8f6b8ff21c/LICENSE
-    # "vllm==0.11.2",
+    # Updated Tue Jun 23, 2026 to vllm==0.20.0 to match the version NeMo-RL main pins in its
+    # [vllm] extra (https://github.com/NVIDIA-NeMo/RL/blob/main/pyproject.toml), so the local
+    # vLLM model server runs the same engine NeMo-RL trains/evaluates against.
+    # License: Apache 2.0 https://github.com/vllm-project/vllm/blob/v0.20.0/LICENSE
     # VLLM is resolved below since installation on Macs requires special workarounds.
 
     # hf_transfer for faster model download from HuggingFace
@@ -44,7 +45,7 @@ dependencies = [
 if platform == "darwin":
     dependencies.append("vllm==0.11.0")
 else:
-    dependencies.append("vllm==0.17.0")
+    dependencies.append("vllm==0.20.0")
 
 
 setuptools.setup(install_requires=dependencies)

--- a/responses_api_models/local_vllm_model/setup.py
+++ b/responses_api_models/local_vllm_model/setup.py
@@ -19,10 +19,9 @@ dependencies = [
     "nemo-gym[dev]",
 
     # We specifically pin the vllm dependency because we have tested on this version.
-    # Updated Tue Jun 23, 2026 to vllm==0.20.0 to match the version NeMo-RL main pins in its
-    # [vllm] extra (https://github.com/NVIDIA-NeMo/RL/blob/main/pyproject.toml), so the local
-    # vLLM model server runs the same engine NeMo-RL trains/evaluates against.
-    # License: Apache 2.0 https://github.com/vllm-project/vllm/blob/v0.20.0/LICENSE
+    # Updated Tue Jun 23, 2026 with vllm==0.20.0
+    # License: Apache 2.0 https://github.com/vllm-project/vllm/blob/88d34c6409e9fb3c7b8ca0c04756f061d2099eb1/LICENSE
+    # "vllm==0.20.0",
     # VLLM is resolved below since installation on Macs requires special workarounds.
 
     # hf_transfer for faster model download from HuggingFace


### PR DESCRIPTION
## Summary
- Bumps the pinned vLLM version in `responses_api_models/local_vllm_model` (and its GenRM subclass `responses_api_models/genrm_model`) from `0.17.0` → `0.20.0`. This matches the matching the version [NeMo-RL `main` pins in its `[vllm]` extra](https://github.com/NVIDIA-NeMo/RL/blob/main/pyproject.toml). This keeps the in-process vLLM engine Gym spins up for local eval/rollout on the same engine NeMo-RL trains and evaluates against.
- Mac pin left at `0.11.0` (latest cleanly pip-installable on macOS; the local vLLM model realistically only runs on Linux GPU hosts).
- Updates a stale `0.17.0`-version comment in `app.py` around the `enable_return_routed_experts` → `return_routed_experts` alias (verified the arg still exists in 0.20.0).

## Test plan
Validated in a `vllm/vllm-openai:v0.20.x` container with this worktree mounted

- [x] `local_vllm_model` unit tests pass (incl. `_configure_vllm_serve` / arg-parser path)
- [x] `ng_run` builds the isolated per-server venv installing **exactly `vllm==0.20.0`** and reaches "servers ready"
- [x] **DP1/TP1** dense (`Qwen3-0.6B`): spinup + end-to-end chat completion
- [x] **TP=2 + MoE** (`Qwen3-30B-A3B`): weights sharded across both GPUs, server up, inference works
- [x] **DP=2** dense (`Qwen3-0.6B`): two `EngineCoreActor` ranks (one per GPU) via the `create_dp_placement_groups` loop + per-rank `_init_data_parallel`, inference works