### PR TITLE
Add sandbox coverage unit tests

### DIFF
--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -186,9 +186,14 @@ async def test_direct_create_passes_platform_to_sdk_create(
 def test_provider_validation_and_retry_helpers() -> None:
     with pytest.raises(ValueError, match="image_pull_policy"):
         opensandbox_provider.validate_image_pull_policy("Sometimes")
+    with pytest.raises(TypeError, match="extensions"):
+        opensandbox_provider._spec_extensions(
+            SandboxSpec(image="image:tag", provider_options={"extensions": ["not", "a", "mapping"]})
+        )
     with pytest.raises(TypeError, match="must be a bool"):
         opensandbox_provider._provider_option_bool({"skip_health_check": "true"}, "skip_health_check")
 
+    assert opensandbox_provider._resource_map(SandboxResources(cpu=2.0))["cpu"] == "2"
     assert opensandbox_provider._to_sandbox_status("starting") == SandboxStatus.STARTING
     assert opensandbox_provider._to_sandbox_status("terminated") == SandboxStatus.STOPPED
     assert opensandbox_provider._to_sandbox_status("failed") == SandboxStatus.ERROR
@@ -665,6 +670,35 @@ async def test_retry_classification_and_await_sdk_helpers(monkeypatch: pytest.Mo
             sandbox_id="sandbox-1",
             timeout_s=None,
         )
+
+
+async def test_retry_loop_empty_iterator_guards(monkeypatch: pytest.MonkeyPatch) -> None:
+    class EmptyAsyncRetrying:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def __aiter__(self) -> "EmptyAsyncRetrying":
+            return self
+
+        async def __anext__(self) -> Any:
+            raise StopAsyncIteration
+
+    monkeypatch.setattr(
+        opensandbox_provider,
+        "_require_tenacity",
+        lambda: (EmptyAsyncRetrying, lambda predicate: predicate, lambda attempts: attempts, lambda **kwargs: kwargs),
+    )
+
+    provider = opensandbox_provider.OpenSandboxProvider(probe={"command": None})
+    with pytest.raises(RuntimeError, match="SDK operation retry loop did not run"):
+        await provider._await_sdk_operation(
+            lambda: _return_value("ok"),
+            operation="noop",
+            sandbox_id="sandbox-1",
+            timeout_s=None,
+        )
+    with pytest.raises(opensandbox_provider.OpenSandboxCreateError, match="create retry loop did not run"):
+        await provider._create_with_retries(SandboxSpec(image="image:tag"))
 
 
 async def _return_value(value: Any) -> Any:

--- a/tests/unit_tests/test_sandbox.py
+++ b/tests/unit_tests/test_sandbox.py
@@ -333,6 +333,17 @@ async def _assert_async_sandbox_initial_file_error_paths() -> None:
         await started.start(SandboxSpec(image="image:tag"))
 
 
+def test_async_sandbox_requires_spec_and_reports_unknown_status() -> None:
+    asyncio.run(_assert_async_sandbox_requires_spec_and_reports_unknown_status())
+
+
+async def _assert_async_sandbox_requires_spec_and_reports_unknown_status() -> None:
+    sandbox = AsyncSandbox(FakeSandboxProvider())
+    assert await sandbox.status() == SandboxStatus.UNKNOWN
+    with pytest.raises(ValueError, match="requires a SandboxSpec"):
+        await sandbox.start()
+
+
 def test_rewrite_image_validation() -> None:
     assert rewrite_image(None, []) is None
     assert rewrite_image("image:tag", [{"from": "other/", "to": "mirror/"}]) == "image:tag"
@@ -350,6 +361,7 @@ def test_provider_registry_validation_and_listing(monkeypatch: pytest.MonkeyPatc
     provider_name = f"fake-{uuid4().hex}"
     register_provider(provider_name, FakeSandboxProvider)
 
+    assert get_provider_class("opensandbox").__name__ == "OpenSandboxProvider"
     assert get_provider_class(provider_name) is FakeSandboxProvider
     assert "opensandbox" in list_providers()
     assert provider_name in list_providers()
@@ -495,6 +507,24 @@ def test_sync_loop_runner_times_out_waits_and_skips_running_loop_close() -> None
         runner._thread.join(timeout=1)
         if not runner._loop.is_closed():
             runner._loop.close()
+
+
+def test_sync_loop_runner_times_out_async_operations() -> None:
+    runner = _AsyncLoopRunner(wait_timeout_s=0.01)
+    cancelled = threading.Event()
+
+    async def never_finishes() -> None:
+        try:
+            await asyncio.get_running_loop().create_future()
+        finally:
+            cancelled.set()
+
+    try:
+        with pytest.raises(TimeoutError, match="timed out waiting for the sync loop"):
+            runner.run("blocked", never_finishes)
+        assert cancelled.wait(timeout=1)
+    finally:
+        runner.close()
 
 
 def test_sync_sandbox_file_operations(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add OpenSandbox provider tests for extension validation, float resource normalization, and retry-loop guard branches
- add public sandbox/registry tests for missing-spec status, builtin provider loading, and sync async-operation timeouts
- raises focused sandbox coverage from 98.34% to 99.86%, leaving only an unreachable defensive OpenSandbox create fallback uncovered

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pre-commit run --files tests/unit_tests/test_opensandbox_provider.py tests/unit_tests/test_sandbox.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit_tests/test_opensandbox_provider.py tests/unit_tests/test_sandbox.py --cov=nemo_gym.sandbox.providers.opensandbox --cov=nemo_gym.sandbox.providers.registry --cov=nemo_gym.sandbox.api --cov-report=term-missing`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit_tests/ -x`