### PR TITLE
feat(litellm): block compromised proxy versions on startup

### DIFF
--- a/responses_api_models/litellm_model/README.md
+++ b/responses_api_models/litellm_model/README.md
@@ -1,0 +1,14 @@
+# Description
+
+LiteLLM model server for use with LiteLLM proxy endpoints that expose the OpenAI Responses API (`/v1/responses`).
+
+LiteLLM proxies may return non-standard response formats (e.g. `object="chat.completion"` instead of `"response"`, or `reasoning.effort = "none"` as a string instead of `null`). This server normalizes those responses so downstream NeMo Gym validation succeeds.
+
+Extends `openai_model`'s `SimpleModelServer`.
+
+# Licensing information
+Code: Apache 2.0
+Data: N/A
+
+Dependencies
+- nemo_gym: Apache 2.0

--- a/responses_api_models/litellm_model/app.py
+++ b/responses_api_models/litellm_model/app.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import re
+from typing import Any, Dict
+
+from nemo_gym.base_responses_api_model import Body
+from nemo_gym.openai_utils import (
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+)
+from responses_api_models.openai_model.app import SimpleModelServer, SimpleModelServerConfig
+
+
+logger = logging.getLogger(__name__)
+
+_SENSITIVE_HEADER_RE = re.compile(r"('Authorization': ')[^']*(')", re.IGNORECASE)
+_SENSITIVE_COOKIE_RE = re.compile(r"('(?:Set-)?Cookie': ')[^']*(')", re.IGNORECASE)
+
+
+def _sanitize_error(e: Exception) -> str:
+    """Strip sensitive headers (API keys, cookies) from error repr for safe logging."""
+    msg = repr(e)
+    msg = _SENSITIVE_HEADER_RE.sub(r"\1[REDACTED]\2", msg)
+    msg = _SENSITIVE_COOKIE_RE.sub(r"\1[REDACTED]\2", msg)
+    return msg
+
+
+def _normalize_to_response(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a LiteLLM proxy response to the Responses API format.
+
+    LiteLLM proxies have two known quirks when proxying /v1/responses:
+    1. They may return ``reasoning.effort = "none"`` (string) instead of ``null``.
+    2. They may downgrade the call to chat completions internally and return
+       ``object="chat.completion"`` instead of ``"response"``.
+    """
+    # Fix fields that cause validation errors even in native response format.
+    reasoning = data.get("reasoning")
+    if isinstance(reasoning, dict) and reasoning.get("effort") == "none":
+        reasoning["effort"] = None
+
+    if data.get("object") != "chat.completion":
+        return data
+
+    logger.info("Normalizing chat.completion response to Responses API format")
+
+    # LiteLLM proxies may return a hybrid format: object="chat.completion" but
+    # content in either choices[] (standard) or output[] (Responses API style).
+    text = ""
+
+    # Try output[] first (LiteLLM hybrid format)
+    for item in data.get("output", []):
+        if isinstance(item, dict):
+            for block in item.get("content", []):
+                if isinstance(block, dict) and block.get("type") == "output_text":
+                    text = block.get("text", "") or ""
+                    if text:
+                        break
+        if text:
+            break
+
+    # Fall back to choices[] (standard chat completion format)
+    if not text:
+        for choice in data.get("choices", []):
+            msg = choice.get("message", {})
+            text = msg.get("content", "") or ""
+            if text:
+                break
+
+    # Build a Responses API shaped dict
+    usage = data.get("usage", {}) or {}
+    return {
+        "id": data.get("id", ""),
+        "created_at": data.get("created", 0),
+        "model": data.get("model", ""),
+        "object": "response",
+        "output": [
+            {
+                "id": f"msg_{data.get('id', '')[-16:]}",
+                "content": [{"annotations": [], "text": text, "type": "output_text", "logprobs": None}],
+                "role": "assistant",
+                "status": "completed",
+                "type": "message",
+            }
+        ],
+        "parallel_tool_calls": False,
+        "tool_choice": "auto",
+        "tools": [],
+        "usage": {
+            "input_tokens": usage.get("input_tokens", 0) or usage.get("prompt_tokens", 0),
+            "output_tokens": usage.get("output_tokens", 0) or usage.get("completion_tokens", 0),
+            "total_tokens": usage.get("total_tokens", 0),
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens_details": {"reasoning_tokens": 0},
+        },
+    }
+
+
+class LiteLLMModelServerConfig(SimpleModelServerConfig):
+    pass
+
+
+class LiteLLMModelServer(SimpleModelServer):
+    config: LiteLLMModelServerConfig
+
+    async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:
+        body_dict = self.config.extra_body | body.model_dump(exclude_unset=True)
+        body_dict["model"] = self.config.openai_model
+        try:
+            openai_response_dict = await self._client.create_response(**body_dict)
+        except Exception as e:
+            logger.error("LiteLLM API call failed: %s", _sanitize_error(e))
+            raise
+        openai_response_dict = _normalize_to_response(openai_response_dict)
+        return NeMoGymResponse.model_validate(openai_response_dict)
+
+
+if __name__ == "__main__":
+    LiteLLMModelServer.run_webserver()

--- a/responses_api_models/litellm_model/app.py
+++ b/responses_api_models/litellm_model/app.py
@@ -14,13 +14,17 @@
 # limitations under the License.
 import logging
 import re
+from contextlib import asynccontextmanager
 from typing import Any, Dict
+
+from fastapi import FastAPI
 
 from nemo_gym.base_responses_api_model import Body
 from nemo_gym.openai_utils import (
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
 )
+from nemo_gym.server_utils import request
 from responses_api_models.openai_model.app import SimpleModelServer, SimpleModelServerConfig
 
 
@@ -108,12 +112,55 @@ def _normalize_to_response(data: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+# Versions with credential-harvesting malware (supply chain incident, March 2026).
+# https://docs.litellm.ai/blog/security-update-march-2026
+_COMPROMISED_VERSIONS = frozenset({"1.82.7", "1.82.8"})
+_MIN_SAFE_VERSION = "1.83.0"
+
+
 class LiteLLMModelServerConfig(SimpleModelServerConfig):
     pass
 
 
 class LiteLLMModelServer(SimpleModelServer):
     config: LiteLLMModelServerConfig
+
+    async def _check_proxy_version(self) -> None:
+        """Verify the LiteLLM proxy is not running a known-compromised version."""
+        base_url = re.sub(r"/v1/?$", "", self.config.openai_base_url.rstrip("/"))
+        health_url = f"{base_url}/health"
+        try:
+            resp = await request("GET", health_url, _internal=True)
+            data = await resp.json(content_type=None)
+            version = data.get("litellm_version", "")
+        except Exception as e:
+            logger.warning("Could not verify LiteLLM proxy version at %s: %s", health_url, e)
+            return
+
+        if version in _COMPROMISED_VERSIONS:
+            raise RuntimeError(
+                f"LiteLLM proxy is running a compromised version ({version}). "
+                f"Versions {sorted(_COMPROMISED_VERSIONS)} contain credential-harvesting malware "
+                f"(supply chain incident, March 2026 — see https://docs.litellm.ai/blog/security-update-march-2026). "
+                f"Upgrade the proxy to >= {_MIN_SAFE_VERSION}."
+            )
+
+        logger.info("LiteLLM proxy version check passed (version=%s)", version or "unknown")
+
+    def setup_webserver(self) -> FastAPI:
+        app = super().setup_webserver()
+
+        main_lifespan = app.router.lifespan_context
+        server = self
+
+        @asynccontextmanager
+        async def lifespan_with_version_check(app):
+            await server._check_proxy_version()
+            async with main_lifespan(app) as state:
+                yield state
+
+        app.router.lifespan_context = lifespan_with_version_check
+        return app
 
     async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:
         body_dict = self.config.extra_body | body.model_dump(exclude_unset=True)

--- a/responses_api_models/litellm_model/configs/litellm_model.yaml
+++ b/responses_api_models/litellm_model/configs/litellm_model.yaml
@@ -1,0 +1,7 @@
+policy_model:
+  responses_api_models:
+    litellm_model:
+      entrypoint: app.py
+      openai_base_url: ${policy_base_url}
+      openai_api_key: ${policy_api_key}
+      openai_model: ${policy_model_name}

--- a/responses_api_models/litellm_model/requirements.txt
+++ b/responses_api_models/litellm_model/requirements.txt
@@ -1,0 +1,1 @@
+-e nemo-gym[dev] @ ../../

--- a/responses_api_models/litellm_model/tests/test_app.py
+++ b/responses_api_models/litellm_model/tests/test_app.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from copy import deepcopy
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+from nemo_gym.openai_utils import NeMoGymAsyncOpenAI
+from nemo_gym.server_utils import ServerClient
+from responses_api_models.litellm_model.app import (
+    LiteLLMModelServer,
+    LiteLLMModelServerConfig,
+    _normalize_to_response,
+)
+
+
+# -- Fixtures / helpers -------------------------------------------------------
+
+NATIVE_RESPONSE = {
+    "id": "resp_abc123",
+    "created_at": 1700000000.0,
+    "model": "openai/openai/gpt-5.4",
+    "object": "response",
+    "output": [
+        {
+            "id": "msg_abc123",
+            "content": [{"annotations": [], "text": "Hello!", "type": "output_text"}],
+            "role": "assistant",
+            "status": "completed",
+            "type": "message",
+        }
+    ],
+    "parallel_tool_calls": True,
+    "tool_choice": "auto",
+    "tools": [],
+}
+
+CHAT_COMPLETION_RESPONSE = {
+    "id": "chatcmpl-xyz789",
+    "choices": [
+        {
+            "finish_reason": "stop",
+            "index": 0,
+            "message": {"content": "Hi from Opus!", "role": "assistant"},
+        }
+    ],
+    "created": 1700000000,
+    "model": "azure/anthropic/claude-opus-4-6",
+    "object": "chat.completion",
+    "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+}
+
+HYBRID_RESPONSE = {
+    "id": "chatcmpl-hybrid456",
+    "object": "chat.completion",
+    "created": 1700000000,
+    "model": "azure/anthropic/claude-opus-4-6",
+    "output": [
+        {
+            "id": "msg_hybrid",
+            "content": [{"annotations": [], "text": "Hybrid text!", "type": "output_text"}],
+            "role": "assistant",
+            "status": "completed",
+            "type": "message",
+        }
+    ],
+    "usage": {"input_tokens": 8, "output_tokens": 3, "total_tokens": 11},
+}
+
+
+def _make_server() -> LiteLLMModelServer:
+    config = LiteLLMModelServerConfig(
+        host="0.0.0.0",
+        port=8081,
+        openai_base_url="https://litellm.example.com/v1",
+        openai_api_key="dummy_key",  # pragma: allowlist secret
+        openai_model="dummy_model",
+        entrypoint="",
+        name="",
+    )
+    return LiteLLMModelServer(config=config, server_client=MagicMock(spec=ServerClient))
+
+
+# -- Unit tests for _normalize_to_response ------------------------------------
+
+
+class TestNormalizeToResponse:
+    def test_native_response_passthrough(self) -> None:
+        """Native response format passes through unchanged."""
+        data = deepcopy(NATIVE_RESPONSE)
+        result = _normalize_to_response(data)
+        assert result["object"] == "response"
+        assert result["output"][0]["content"][0]["text"] == "Hello!"
+
+    def test_reasoning_effort_none_fix(self) -> None:
+        """reasoning.effort = 'none' (string) is normalized to null."""
+        data = deepcopy(NATIVE_RESPONSE)
+        data["reasoning"] = {"effort": "none"}
+        result = _normalize_to_response(data)
+        assert result["reasoning"]["effort"] is None
+        # Still a native response, not converted
+        assert result["object"] == "response"
+
+    def test_reasoning_effort_valid_preserved(self) -> None:
+        """Valid reasoning.effort values are not touched."""
+        data = deepcopy(NATIVE_RESPONSE)
+        data["reasoning"] = {"effort": "high"}
+        result = _normalize_to_response(data)
+        assert result["reasoning"]["effort"] == "high"
+
+    def test_chat_completion_normalization(self) -> None:
+        """Standard chat.completion with choices[] is normalized."""
+        data = deepcopy(CHAT_COMPLETION_RESPONSE)
+        result = _normalize_to_response(data)
+        assert result["object"] == "response"
+        assert result["output"][0]["content"][0]["text"] == "Hi from Opus!"
+        assert result["usage"]["input_tokens"] == 10
+        assert result["usage"]["output_tokens"] == 5
+
+    def test_hybrid_format_normalization(self) -> None:
+        """chat.completion with output[] (LiteLLM hybrid) is normalized."""
+        data = deepcopy(HYBRID_RESPONSE)
+        result = _normalize_to_response(data)
+        assert result["object"] == "response"
+        assert result["output"][0]["content"][0]["text"] == "Hybrid text!"
+        assert result["usage"]["input_tokens"] == 8
+
+    def test_chat_completion_empty_content(self) -> None:
+        """chat.completion with empty content produces empty text."""
+        data = deepcopy(CHAT_COMPLETION_RESPONSE)
+        data["choices"][0]["message"]["content"] = None
+        result = _normalize_to_response(data)
+        assert result["object"] == "response"
+        assert result["output"][0]["content"][0]["text"] == ""
+
+
+# -- Integration tests for the server -----------------------------------------
+
+
+class TestLiteLLMModelServer:
+    async def test_responses_native_format(self) -> None:
+        """Server handles native response format from LiteLLM (e.g. GPT-5.4)."""
+        server = _make_server()
+        app = server.setup_webserver()
+        client = TestClient(app)
+
+        mock_data = deepcopy(NATIVE_RESPONSE)
+
+        server._client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        server._client.create_response = AsyncMock(return_value=mock_data)
+
+        resp = client.post("/v1/responses", json={"input": "hello"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["object"] == "response"
+        assert body["output"][0]["content"][0]["text"] == "Hello!"
+
+    async def test_responses_chat_completion_format(self) -> None:
+        """Server normalizes chat.completion format from LiteLLM (e.g. Opus via Azure)."""
+        server = _make_server()
+        app = server.setup_webserver()
+        client = TestClient(app)
+
+        mock_data = deepcopy(CHAT_COMPLETION_RESPONSE)
+
+        server._client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        server._client.create_response = AsyncMock(return_value=mock_data)
+
+        resp = client.post("/v1/responses", json={"input": "hello"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["object"] == "response"
+        assert body["output"][0]["content"][0]["text"] == "Hi from Opus!"
+
+    async def test_responses_reasoning_effort_fix(self) -> None:
+        """Server fixes reasoning.effort='none' before validation."""
+        server = _make_server()
+        app = server.setup_webserver()
+        client = TestClient(app)
+
+        mock_data = deepcopy(NATIVE_RESPONSE)
+        mock_data["reasoning"] = {"effort": "none"}
+
+        server._client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        server._client.create_response = AsyncMock(return_value=mock_data)
+
+        resp = client.post("/v1/responses", json={"input": "hello"})
+        assert resp.status_code == 200
+
+    async def test_chat_completions_passthrough(self) -> None:
+        """chat_completions() is inherited from SimpleModelServer and works unchanged."""
+        server = _make_server()
+        app = server.setup_webserver()
+        client = TestClient(app)
+
+        mock_chat_data = deepcopy(CHAT_COMPLETION_RESPONSE)
+
+        server._client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        server._client.create_chat_completion = AsyncMock(return_value=mock_chat_data)
+
+        resp = client.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hi"}]})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["object"] == "chat.completion"
+
+    async def test_model_override(self) -> None:
+        """Config model name is always used regardless of request body."""
+        server = _make_server()
+        app = server.setup_webserver()
+        client = TestClient(app)
+
+        mock_data = deepcopy(NATIVE_RESPONSE)
+        called_args = {}
+
+        async def mock_create_response(**kwargs):
+            nonlocal called_args
+            called_args = kwargs
+            return mock_data
+
+        server._client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        server._client.create_response = AsyncMock(side_effect=mock_create_response)
+
+        client.post("/v1/responses", json={"input": "hello", "model": "wrong_model"})
+        assert called_args.get("model") == "dummy_model"

--- a/responses_api_models/litellm_model/tests/test_app.py
+++ b/responses_api_models/litellm_model/tests/test_app.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from copy import deepcopy
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from nemo_gym.openai_utils import NeMoGymAsyncOpenAI

--- a/responses_api_models/openai_model/app.py
+++ b/responses_api_models/openai_model/app.py
@@ -12,9 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
-import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from pydantic import Field
 
@@ -32,95 +30,10 @@ from nemo_gym.openai_utils import (
 )
 
 
-logger = logging.getLogger(__name__)
-
-_SENSITIVE_HEADER_RE = re.compile(r"('Authorization': ')[^']*(')", re.IGNORECASE)
-_SENSITIVE_COOKIE_RE = re.compile(r"('(?:Set-)?Cookie': ')[^']*(')", re.IGNORECASE)
-
-
-def _sanitize_error(e: Exception) -> str:
-    """Strip sensitive headers (API keys, cookies) from error repr for safe logging."""
-    msg = repr(e)
-    msg = _SENSITIVE_HEADER_RE.sub(r"\1[REDACTED]\2", msg)
-    msg = _SENSITIVE_COOKIE_RE.sub(r"\1[REDACTED]\2", msg)
-    return msg
-
-
-def _normalize_to_response(data: Dict[str, Any]) -> Dict[str, Any]:
-    """Normalize a chat.completion response to the Responses API format.
-
-    Some LiteLLM proxies downgrade /v1/responses calls to chat completions
-    internally and return object='chat.completion' instead of 'response'.
-    """
-    # Fix fields that cause validation errors even in native response format.
-    reasoning = data.get("reasoning")
-    if isinstance(reasoning, dict) and reasoning.get("effort") == "none":
-        reasoning["effort"] = None
-
-    if data.get("object") not in ("chat.completion",):
-        return data
-
-    logger.info("Normalizing chat.completion response to Responses API format")
-
-    # LiteLLM proxies may return a hybrid format: object="chat.completion" but
-    # content in either choices[] (standard) or output[] (Responses API style).
-    text = ""
-
-    # Try output[] first (LiteLLM hybrid format)
-    for item in data.get("output", []):
-        if isinstance(item, dict):
-            for block in item.get("content", []):
-                if isinstance(block, dict) and block.get("type") == "output_text":
-                    text = block.get("text", "") or ""
-                    if text:
-                        break
-        if text:
-            break
-
-    # Fall back to choices[] (standard chat completion format)
-    if not text:
-        for choice in data.get("choices", []):
-            msg = choice.get("message", {})
-            text = msg.get("content", "") or ""
-            if text:
-                break
-
-    # Build a Responses API shaped dict
-    usage = data.get("usage", {}) or {}
-    return {
-        "id": data.get("id", ""),
-        "created_at": data.get("created", 0),
-        "model": data.get("model", ""),
-        "object": "response",
-        "output": [
-            {
-                "id": f"msg_{data.get('id', '')[-16:]}",
-                "content": [
-                    {"annotations": [], "text": text, "type": "output_text", "logprobs": None}
-                ],
-                "role": "assistant",
-                "status": "completed",
-                "type": "message",
-            }
-        ],
-        "parallel_tool_calls": False,
-        "tool_choice": "auto",
-        "tools": [],
-        "usage": {
-            "input_tokens": usage.get("input_tokens", 0) or usage.get("prompt_tokens", 0),
-            "output_tokens": usage.get("output_tokens", 0) or usage.get("completion_tokens", 0),
-            "total_tokens": usage.get("total_tokens", 0),
-            "input_tokens_details": {"cached_tokens": 0},
-            "output_tokens_details": {"reasoning_tokens": 0},
-        },
-    }
-
-
 class SimpleModelServerConfig(BaseResponsesAPIModelConfig):
     openai_base_url: str
     openai_api_key: str
     openai_model: str
-    openai_organization: Optional[str] = None
 
     extra_body: Dict[str, Any] = Field(default_factory=dict)
 
@@ -132,7 +45,6 @@ class SimpleModelServer(SimpleResponsesAPIModel):
         self._client = NeMoGymAsyncOpenAI(
             base_url=self.config.openai_base_url,
             api_key=self.config.openai_api_key,
-            organization=self.config.openai_organization,
         )
 
         return super().model_post_init(context)
@@ -140,19 +52,8 @@ class SimpleModelServer(SimpleResponsesAPIModel):
     async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:
         body_dict = self.config.extra_body | body.model_dump(exclude_unset=True)
         body_dict["model"] = self.config.openai_model
-        try:
-            openai_response_dict = await self._client.create_response(**body_dict)
-        except Exception as e:
-            logger.error("OpenAI API call failed: %s", _sanitize_error(e))
-            raise
-        try:
-            # Some LiteLLM proxies return chat.completion format instead of response format.
-            # Normalize to the expected Responses API shape so downstream validation succeeds.
-            openai_response_dict = _normalize_to_response(openai_response_dict)
-            return NeMoGymResponse.model_validate(openai_response_dict)
-        except Exception as e:
-            logger.error("NeMoGymResponse validation failed: %s", repr(e))
-            raise
+        openai_response_dict = await self._client.create_response(**body_dict)
+        return NeMoGymResponse.model_validate(openai_response_dict)
 
     async def chat_completions(
         self, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()

--- a/responses_api_models/openai_model/app.py
+++ b/responses_api_models/openai_model/app.py
@@ -12,7 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+import logging
+import re
+from typing import Any, Dict, Optional
 
 from pydantic import Field
 
@@ -30,10 +32,95 @@ from nemo_gym.openai_utils import (
 )
 
 
+logger = logging.getLogger(__name__)
+
+_SENSITIVE_HEADER_RE = re.compile(r"('Authorization': ')[^']*(')", re.IGNORECASE)
+_SENSITIVE_COOKIE_RE = re.compile(r"('(?:Set-)?Cookie': ')[^']*(')", re.IGNORECASE)
+
+
+def _sanitize_error(e: Exception) -> str:
+    """Strip sensitive headers (API keys, cookies) from error repr for safe logging."""
+    msg = repr(e)
+    msg = _SENSITIVE_HEADER_RE.sub(r"\1[REDACTED]\2", msg)
+    msg = _SENSITIVE_COOKIE_RE.sub(r"\1[REDACTED]\2", msg)
+    return msg
+
+
+def _normalize_to_response(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a chat.completion response to the Responses API format.
+
+    Some LiteLLM proxies downgrade /v1/responses calls to chat completions
+    internally and return object='chat.completion' instead of 'response'.
+    """
+    # Fix fields that cause validation errors even in native response format.
+    reasoning = data.get("reasoning")
+    if isinstance(reasoning, dict) and reasoning.get("effort") == "none":
+        reasoning["effort"] = None
+
+    if data.get("object") not in ("chat.completion",):
+        return data
+
+    logger.info("Normalizing chat.completion response to Responses API format")
+
+    # LiteLLM proxies may return a hybrid format: object="chat.completion" but
+    # content in either choices[] (standard) or output[] (Responses API style).
+    text = ""
+
+    # Try output[] first (LiteLLM hybrid format)
+    for item in data.get("output", []):
+        if isinstance(item, dict):
+            for block in item.get("content", []):
+                if isinstance(block, dict) and block.get("type") == "output_text":
+                    text = block.get("text", "") or ""
+                    if text:
+                        break
+        if text:
+            break
+
+    # Fall back to choices[] (standard chat completion format)
+    if not text:
+        for choice in data.get("choices", []):
+            msg = choice.get("message", {})
+            text = msg.get("content", "") or ""
+            if text:
+                break
+
+    # Build a Responses API shaped dict
+    usage = data.get("usage", {}) or {}
+    return {
+        "id": data.get("id", ""),
+        "created_at": data.get("created", 0),
+        "model": data.get("model", ""),
+        "object": "response",
+        "output": [
+            {
+                "id": f"msg_{data.get('id', '')[-16:]}",
+                "content": [
+                    {"annotations": [], "text": text, "type": "output_text", "logprobs": None}
+                ],
+                "role": "assistant",
+                "status": "completed",
+                "type": "message",
+            }
+        ],
+        "parallel_tool_calls": False,
+        "tool_choice": "auto",
+        "tools": [],
+        "usage": {
+            "input_tokens": usage.get("input_tokens", 0) or usage.get("prompt_tokens", 0),
+            "output_tokens": usage.get("output_tokens", 0) or usage.get("completion_tokens", 0),
+            "total_tokens": usage.get("total_tokens", 0),
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens_details": {"reasoning_tokens": 0},
+        },
+    }
+
+
 class SimpleModelServerConfig(BaseResponsesAPIModelConfig):
     openai_base_url: str
     openai_api_key: str
     openai_model: str
+    openai_organization: Optional[str] = None
 
     extra_body: Dict[str, Any] = Field(default_factory=dict)
 
@@ -45,6 +132,7 @@ class SimpleModelServer(SimpleResponsesAPIModel):
         self._client = NeMoGymAsyncOpenAI(
             base_url=self.config.openai_base_url,
             api_key=self.config.openai_api_key,
+            organization=self.config.openai_organization,
         )
 
         return super().model_post_init(context)
@@ -52,8 +140,19 @@ class SimpleModelServer(SimpleResponsesAPIModel):
     async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:
         body_dict = self.config.extra_body | body.model_dump(exclude_unset=True)
         body_dict["model"] = self.config.openai_model
-        openai_response_dict = await self._client.create_response(**body_dict)
-        return NeMoGymResponse.model_validate(openai_response_dict)
+        try:
+            openai_response_dict = await self._client.create_response(**body_dict)
+        except Exception as e:
+            logger.error("OpenAI API call failed: %s", _sanitize_error(e))
+            raise
+        try:
+            # Some LiteLLM proxies return chat.completion format instead of response format.
+            # Normalize to the expected Responses API shape so downstream validation succeeds.
+            openai_response_dict = _normalize_to_response(openai_response_dict)
+            return NeMoGymResponse.model_validate(openai_response_dict)
+        except Exception as e:
+            logger.error("NeMoGymResponse validation failed: %s", repr(e))
+            raise
 
     async def chat_completions(
         self, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()


### PR DESCRIPTION
## Summary

Adds a startup version check to `LiteLLMModelServer` that blocks known-compromised LiteLLM proxy versions.

- On startup, calls `GET /health` on the configured proxy and checks `litellm_version`
- Hard-fails if v1.82.7 or v1.82.8 is detected (supply chain compromise, March 2026)
- Logs a non-blocking warning if the proxy doesn't expose version info

## Context

Companion to #990. LiteLLM v1.82.7 and v1.82.8 contained credential-harvesting malware injected via a PyPI supply chain attack (~40 min window, March 24 2026). The malware exfiltrated env vars, SSH keys, and cloud credentials from the host running the proxy. See: https://docs.litellm.ai/blog/security-update-march-2026

Since `LiteLLMModelServer` makes real HTTP calls to a LiteLLM proxy at runtime, we have no control over which version the proxy operator runs. This check gives an early, loud failure rather than silently routing traffic through a compromised proxy.

## Test plan

- [ ] Existing tests still pass (mocked, no real proxy needed)
- [ ] Add test: compromised version → startup raises `RuntimeError`
- [ ] Add test: safe version → startup proceeds normally
- [ ] Add test: unreachable health endpoint → warning logged, startup proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)