### PR TITLE
feat: [GDPval-AA v2 Updates 4 / n] - Re-Run Failed Judgements Only

### DIFF
--- a/benchmarks/gdpval/config.yaml
+++ b/benchmarks/gdpval/config.yaml
@@ -10,6 +10,15 @@
 # Comparison mode (pairwise ELO vs a reference model's deliverables):
 #   ++gdpval_resources_server.resources_servers.gdpval.reward_mode=comparison \
 #   ++gdpval_resources_server.resources_servers.gdpval.reference_deliverables_dir=/path/to/fork
+#
+# Multi-reference comparison mode (anchored Bradley-Terry MLE ELO over N
+# references — each reference is judged separately and the eval model's rating
+# is fit globally, with per-reference + total win stats reported):
+#   ++gdpval_resources_server.resources_servers.gdpval.reward_mode=comparison \
+#   ++gdpval_resources_server.resources_servers.gdpval.reference_models.kimi.deliverables_dir=/gdpval/refs/kimi \
+#   ++gdpval_resources_server.resources_servers.gdpval.reference_models.kimi.elo=1290 \
+#   ++gdpval_resources_server.resources_servers.gdpval.reference_models.gpt5.deliverables_dir=/gdpval/refs/gpt5 \
+#   ++gdpval_resources_server.resources_servers.gdpval.reference_models.gpt5.elo=1320
 
 # Judge model — proxy to NVIDIA inference API for Gemini 3.1 Pro.
 gdpval_judge_model:
@@ -28,9 +37,14 @@ gdpval_resources_server:
       domain: other
       verified: false
       reward_mode: rubric
+      # Single-reference (legacy) comparison fields.
       reference_deliverables_dir: null
-      num_comparison_trials: 4
       reference_elo: 1000.0
+      # Multi-reference comparison: map of reference id -> {deliverables_dir, elo}.
+      # When set, the eval model's ELO is fit via anchored Bradley-Terry MLE
+      # across all references and per-reference win stats are reported.
+      reference_models: {}
+      num_comparison_trials: 4
       preconvert_office_to_pdf: true
       preconvert_max_concurrent: 1
       judge_model_server:

--- a/benchmarks/gdpval/config.yaml
+++ b/benchmarks/gdpval/config.yaml
@@ -65,6 +65,7 @@ gdpval_stirrup_agent:
       user_prompt_template: ${oc.env:USER_PROMPT_TEMPLATE,null}
       gdpval_container_path: ${oc.env:GDPVAL_CONTAINER_PATH,null}
       persist_deliverables_dir: ${oc.env:PERSIST_DELIVERABLES_DIR,output/gdpval/deliverables}
+      judge_only: ${oc.env:JUDGE_ONLY,false}
       resources_server:
         type: resources_servers
         name: gdpval_resources_server

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -77,11 +77,27 @@ from nemo_gym.server_utils import (
 #     non-success has consumed (capped at NEMO_GYM_MAX_ROLLOUT_ATTEMPTS,
 #     default 3). Rows flagged ``_ng_failure_terminal=True`` are never
 #     retried regardless of attempt count.
+#   - ``_ng_verify_failed=True`` (NG_VERIFY_FAILED_KEY) additionally marks a
+#     sidecar row whose rollout succeeded but whose verification/scoring step
+#     failed, so the rollout output is cached on disk. The row still routes to
+#     the sidecar as a normal retryable failure; ``reverify_failed_from_cache``
+#     selects rows carrying this flag to re-verify from cache without
+#     re-executing. Like the other sentinels here this is a boolean KEY — the
+#     dispatcher never inspects specific ``_ng_failure_class`` *values*.
 # ---------------------------------------------------------------------------
 
-NG_FAILURE_CLASS_KEY = "_ng_failure_class"
-NG_NO_PERSIST_KEY = "_ng_no_persist"
-NG_TERMINAL_KEY = "_ng_failure_terminal"
+# Sentinel KEY names (set by agent servers, read by the dispatcher). The
+# dispatcher routes purely on these keys: it treats ``_ng_failure_class`` as an
+# opaque label (its presence ⇒ sidecar) and never matches specific class values.
+NG_FAILURE_CLASS_KEY = "_ng_failure_class"  # str: opaque failure label
+NG_NO_PERSIST_KEY = "_ng_no_persist"  # bool: don't write anywhere
+NG_TERMINAL_KEY = "_ng_failure_terminal"  # bool: never retry on resume
+# bool: rollout succeeded but its verification/scoring step failed, so the
+# rollout output is cached and can be re-verified from disk. Set alongside
+# ``_ng_failure_class`` (the row still routes to the sidecar as a normal
+# retryable failure); ``reverify_failed_from_cache`` selects rows with this flag
+# to re-verify without re-executing.
+NG_VERIFY_FAILED_KEY = "_ng_verify_failed"
 
 _DEFAULT_MAX_ROLLOUT_ATTEMPTS = 3
 
@@ -188,6 +204,17 @@ class RolloutCollectionConfig(SharedRolloutCollectionConfig):
     resume_from_cache: bool = Field(
         default=False,
         description="If the same command is run multiple times, check the materialized inputs and current outputs and remove the inputs that have already been run",
+    )
+    reverify_failed_from_cache: bool = Field(
+        default=False,
+        description="Redo only the tasks whose verification/scoring step failed in a prior run. "
+        "Instead of the normal resume set-difference, dispatch exactly the failures-sidecar rows "
+        f"flagged '{NG_VERIFY_FAILED_KEY}' (minus any that later succeeded), ignoring the "
+        "NEMO_GYM_MAX_ROLLOUT_ATTEMPTS cap so a deliberate redo is never blocked by prior "
+        "attempts. Pair with an agent running in a verify-only mode (one that re-verifies its "
+        "cached rollout output instead of re-executing) so the rollout is not re-run. Requires the "
+        "prior run's materialized inputs + failures sidecar; reuses its main jsonl to skip tasks "
+        "that already succeeded.",
     )
     prompt_config: Optional[str] = Field(
         default=None,
@@ -358,10 +385,87 @@ class RolloutCollectionHelper(BaseModel):
 
         return input_rows, rows, results, result_strs
 
+    def _load_verify_failed_from_cache(
+        self, config: RolloutCollectionConfig
+    ) -> Tuple[List[Dict], List[Dict], List[Dict], List[List[str]]]:
+        """Select only the tasks whose verification step failed previously.
+
+        Unlike :meth:`_load_from_cache` (which re-dispatches everything not
+        gated), this re-dispatches exactly the failures-sidecar rows flagged
+        ``_ng_verify_failed`` that did not later succeed — ignoring the
+        ``max_attempts`` cap. The existing main-jsonl successes are preserved
+        (returned as already-done rows so the final output keeps them).
+        """
+        with config.materialized_jsonl_fpath.open() as f:
+            original_input_rows = list(map(orjson.loads, f))
+
+        get_key = lambda r: (r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME])
+
+        # Preserve prior successes (main jsonl) and gate them out of the redo set.
+        output_fpath = Path(config.output_jsonl_fpath)
+        results: List[Dict] = []
+        result_strs: List[List[str]] = []
+        successes_seen: set = set()
+        if output_fpath.exists():
+            with output_fpath.open("rb") as f:
+                result_strs = [[line.strip()] for line in f if line.strip()]
+            results = [orjson.loads(p[0]) for p in result_strs]
+            successes_seen = set(map(get_key, results))
+
+        # Collect the verify-failed tasks from the failures sidecar.
+        failures_fpath = _failures_path_for(output_fpath)
+        verify_failed_keys: set = set()
+        total_verify_failed_rows = 0
+        if failures_fpath.exists():
+            with failures_fpath.open("rb") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    fr = orjson.loads(line)
+                    if TASK_INDEX_KEY_NAME not in fr or ROLLOUT_INDEX_KEY_NAME not in fr:
+                        continue
+                    if bool(fr.get(NG_VERIFY_FAILED_KEY)):
+                        total_verify_failed_rows += 1
+                        verify_failed_keys.add((fr[TASK_INDEX_KEY_NAME], fr[ROLLOUT_INDEX_KEY_NAME]))
+
+        # Don't redo ones that later succeeded; ignore attempt-count gating.
+        to_redo = verify_failed_keys - successes_seen
+        key_to_row = {get_key(r): r for r in original_input_rows}
+        input_rows = [key_to_row[k] for k in to_redo if k in key_to_row]
+        rows = [key_to_row[get_key(result)] for result in results if get_key(result) in key_to_row]
+
+        print(
+            f"""Re-verify-failed-from-cache. Found:
+- {len(original_input_rows)} original input rows
+- {len(results)} prior successes (in main jsonl) → kept, not redone
+- {total_verify_failed_rows} '{NG_VERIFY_FAILED_KEY}' sidecar attempts ({len(verify_failed_keys)} unique tasks)
+- {len(verify_failed_keys & successes_seen)} of those later succeeded → skipped
+- {len(input_rows)} tasks to re-verify (attempt cap ignored)"""
+        )
+
+        return input_rows, rows, results, result_strs
+
     async def run_from_config(self, config: RolloutCollectionConfig) -> Tuple[List[Dict]]:
         output_fpath = Path(config.output_jsonl_fpath)
 
-        if config.resume_from_cache and config.materialized_jsonl_fpath.exists() and output_fpath.exists():
+        if config.reverify_failed_from_cache and not config.materialized_jsonl_fpath.exists():
+            # Fail loud rather than silently clearing the output and re-running
+            # the whole benchmark from scratch (which would re-execute rollouts).
+            raise FileNotFoundError(
+                f"reverify_failed_from_cache=True but the prior run's materialized inputs were not "
+                f"found at {config.materialized_jsonl_fpath}. Point output_jsonl_fpath at the prior "
+                f"run (so its *_materialized_inputs.jsonl and *_failures.jsonl are reused)."
+            )
+
+        if config.reverify_failed_from_cache and config.materialized_jsonl_fpath.exists():
+            (
+                input_rows,
+                rows,
+                results,
+                result_strs,
+            ) = self._load_verify_failed_from_cache(config)
+        elif config.resume_from_cache and config.materialized_jsonl_fpath.exists() and output_fpath.exists():
             (
                 input_rows,
                 rows,

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -34,6 +34,8 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
+from pydantic import BaseModel
+
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
     BaseVerifyRequest,
@@ -92,22 +94,49 @@ def _safe_output_text(response: Any) -> str:
     return "\n".join(p for p in parts if p)
 
 
+class ReferenceModelConfig(BaseModel):
+    """A single reference model for comparison-mode pairwise ELO.
+
+    ``deliverables_dir`` is a directory tree of the reference model's
+    deliverables, laid out as ``<deliverables_dir>/task_<task_id>/`` (optionally
+    with ``repeat_<n>/`` subdirs) containing the same files the agent would
+    persist (deliverable artifacts + finish_params.json + reference_files/).
+    ``elo`` is the reference's known rating (e.g. a published Arena/AA number),
+    held fixed when the eval model's MLE rating is fit.
+    """
+
+    deliverables_dir: str
+    elo: float = _DEFAULT_REFERENCE_ELO
+
+
 class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     reward_mode: Literal["rubric", "comparison"] = "rubric"
 
-    # Comparison-mode: directory tree containing the reference model's
-    # deliverables, laid out as ``<reference_deliverables_dir>/task_<task_id>/``
-    # with the same files the agent would persist (deliverable artifacts +
-    # finish_params.json + reference_files/). Required when
-    # ``reward_mode=comparison``.
+    # Comparison-mode: one or more reference models the eval deliverable is
+    # pairwise-judged against. The eval model's ELO is then estimated globally
+    # via an anchored Bradley-Terry MLE over all references (see
+    # ``comparison.calculate_mle_elo``). Keyed by an arbitrary reference id used
+    # in the per-reference aggregate metrics.
+    #
+    #   reference_models:
+    #     kimi_k2.5_thinking: {deliverables_dir: /gdpval/refs/kimi, elo: 1290}
+    #     glm5.1:            {deliverables_dir: /gdpval/refs/glm5.1, elo: 1535}
+    #
+    # For back-compat the legacy single-reference fields
+    # ``reference_deliverables_dir`` + ``reference_elo`` are still honored when
+    # ``reference_models`` is empty (treated as a single reference id
+    # ``"reference"``).
+    reference_models: Dict[str, ReferenceModelConfig] = {}
+
+    # Legacy single-reference fields. Prefer ``reference_models``.
     reference_deliverables_dir: Optional[str] = None
 
     # Pairwise judge trials per task. 4 is the historical default; alternates
     # swap/no-swap to debias position effects.
     num_comparison_trials: int = 4
 
-    # ELO assigned to the reference model in pairwise mode. ``aggregate_metrics``
-    # reports the eval model's ELO relative to this anchor.
+    # ELO assigned to the (legacy single) reference model in pairwise mode.
+    # Ignored when ``reference_models`` is set (each carries its own ``elo``).
     reference_elo: float = _DEFAULT_REFERENCE_ELO
 
     # Office→PDF preconversion for deliverables before pairwise judging.
@@ -166,12 +195,17 @@ class GDPValVerifyResponse(GDPValVerifyRequest, BaseVerifyResponse):
     win: Optional[bool] = None
     loss: Optional[bool] = None
     tie: Optional[bool] = None
-    # Raw judge vote counts aggregated over every reference repeat × trial.
-    # ``aggregate_metrics`` prefers these so the win rate reflects all
+    # Raw judge vote counts aggregated over every reference (model × repeat ×
+    # trial). ``aggregate_metrics`` prefers these so the win rate reflects all
     # comparisons rather than treating each verify call as a single vote.
     total_wins: Optional[int] = None
     total_losses: Optional[int] = None
     total_ties: Optional[int] = None
+    # Per-reference-model vote breakdown for multi-reference comparison mode.
+    # Maps reference id -> {wins, losses, ties, reference_elo, ref_repeat_count}.
+    # ``aggregate_metrics`` uses these to build the per-reference battle table
+    # that the anchored Bradley-Terry MLE is fit over.
+    per_reference: Optional[Dict[str, Dict[str, Any]]] = None
 
 
 class GDPValResourcesServer(SimpleResourcesServer):
@@ -179,8 +213,24 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
     def model_post_init(self, context: Any) -> None:
         self._judge_prompt_fpath: str = self.config.judge_prompt_template_fpath or _DEFAULT_JUDGE_PROMPT_FPATH
-        if self.config.reward_mode == "comparison" and not self.config.reference_deliverables_dir:
-            raise ValueError("reward_mode=comparison requires reference_deliverables_dir to be set")
+        # Normalize the reference-model set: prefer the multi-reference
+        # ``reference_models`` mapping; fall back to the legacy single-reference
+        # fields (treated as a single reference id ``"reference"``).
+        self._references: Dict[str, ReferenceModelConfig] = {}
+        if self.config.reward_mode == "comparison":
+            if self.config.reference_models:
+                self._references = dict(self.config.reference_models)
+            elif self.config.reference_deliverables_dir:
+                self._references = {
+                    "reference": ReferenceModelConfig(
+                        deliverables_dir=self.config.reference_deliverables_dir,
+                        elo=self.config.reference_elo,
+                    )
+                }
+            else:
+                raise ValueError(
+                    "reward_mode=comparison requires reference_deliverables_dir or reference_models to be set"
+                )
         if self.config.preconvert_office_to_pdf:
             from resources_servers.gdpval.setup_libreoffice import ensure_libreoffice
 
@@ -317,12 +367,19 @@ class GDPValResourcesServer(SimpleResourcesServer):
             task_attempted,
         )
 
-        ref_root = Path(self.config.reference_deliverables_dir)
-        ref_task_root = ref_root / f"task_{body.task_id}"
-        ref_task_dirs = [d for d in _iter_ref_repeat_dirs(ref_task_root) if task_attempted(str(d))]
         eval_task_dir = Path(body.deliverables_dir) if body.deliverables_dir else None
 
-        if not ref_task_dirs:
+        # Resolve, per reference model, the available (attempted) repeat dirs
+        # for this task. A reference that has no deliverable for this task is
+        # simply skipped — the eval model just isn't judged against it here.
+        ref_dirs_by_id: Dict[str, List[Path]] = {}
+        for ref_id, ref_cfg in self._references.items():
+            ref_task_root = Path(ref_cfg.deliverables_dir) / f"task_{body.task_id}"
+            dirs = [d for d in _iter_ref_repeat_dirs(ref_task_root) if task_attempted(str(d))]
+            if dirs:
+                ref_dirs_by_id[ref_id] = dirs
+
+        if not ref_dirs_by_id:
             print(f"[gdpval] no reference deliverable for task {body.task_id}", flush=True)
             return GDPValVerifyResponse(
                 **body.model_dump(),
@@ -343,8 +400,9 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         if self.config.preconvert_office_to_pdf:
             await self._preconvert_and_log(eval_task_dir, label=f"eval/{body.task_id}")
-            for ref_dir in ref_task_dirs:
-                await self._preconvert_and_log(ref_dir, label=f"ref/{body.task_id}/{ref_dir.name}")
+            for ref_id, dirs in ref_dirs_by_id.items():
+                for ref_dir in dirs:
+                    await self._preconvert_and_log(ref_dir, label=f"ref/{ref_id}/{body.task_id}/{ref_dir.name}")
 
         clean_up_list: List[Path] = []
         overrides = dict(self.config.judge_responses_create_params_overrides or {})
@@ -360,37 +418,54 @@ class GDPValResourcesServer(SimpleResourcesServer):
         total_wins = 0
         total_losses = 0
         total_ties = 0
+        # Per-reference-model vote tallies + a flat list of every (ref × repeat)
+        # matchup for back-compat with the single-reference judge_response shape.
+        per_reference: Dict[str, Dict[str, Any]] = {}
         per_ref_results: List[Dict[str, Any]] = []
         try:
             eval_submission = build_file_section(str(eval_task_dir), clean_up_list)
 
-            # Judge eval submission against every available reference repeat. Raw
-            # vote counts (not just per-matchup majority) are summed so the win
-            # rate averages over reference variance — see ``_iter_ref_repeat_dirs``.
-            for ref_dir in ref_task_dirs:
-                refs_subdir = ref_dir / "reference_files"
-                refs = build_file_section(
-                    str(refs_subdir) if refs_subdir.is_dir() else None,
-                    clean_up_list,
-                )
-                ref_submission = build_file_section(str(ref_dir), clean_up_list)
-                result = await asyncio.to_thread(
-                    run_trials,
-                    client=client,
-                    model=judge_model_name,
-                    task_prompt=body.prompt or "",
-                    refs=refs,
-                    submission_a=ref_submission,
-                    submission_b=eval_submission,
-                    num_trials=self.config.num_comparison_trials,
-                    return_raw_responses=self.config.persist_raw_judge_responses,
-                )
-                # ``run_trials`` casts submission_a=ref, submission_b=eval, so
-                # ``win_count_b`` is eval wins.
-                total_wins += result["win_count_b"]
-                total_losses += result["win_count_a"]
-                total_ties += result["tie_count"]
-                per_ref_results.append({"ref_repeat": ref_dir.name, **result})
+            # Judge the eval submission against every reference model, and within
+            # each model against every available reference repeat. Raw vote
+            # counts (not just per-matchup majority) are summed so the win rate
+            # averages over reference variance — see ``_iter_ref_repeat_dirs``.
+            for ref_id, dirs in ref_dirs_by_id.items():
+                ref_wins = ref_losses = ref_ties = 0
+                for ref_dir in dirs:
+                    refs_subdir = ref_dir / "reference_files"
+                    refs = build_file_section(
+                        str(refs_subdir) if refs_subdir.is_dir() else None,
+                        clean_up_list,
+                    )
+                    ref_submission = build_file_section(str(ref_dir), clean_up_list)
+                    result = await asyncio.to_thread(
+                        run_trials,
+                        client=client,
+                        model=judge_model_name,
+                        task_prompt=body.prompt or "",
+                        refs=refs,
+                        submission_a=ref_submission,
+                        submission_b=eval_submission,
+                        num_trials=self.config.num_comparison_trials,
+                        return_raw_responses=self.config.persist_raw_judge_responses,
+                    )
+                    # ``run_trials`` casts submission_a=ref, submission_b=eval, so
+                    # ``win_count_b`` is eval wins.
+                    ref_wins += result["win_count_b"]
+                    ref_losses += result["win_count_a"]
+                    ref_ties += result["tie_count"]
+                    per_ref_results.append({"ref_id": ref_id, "ref_repeat": ref_dir.name, **result})
+
+                per_reference[ref_id] = {
+                    "wins": ref_wins,
+                    "losses": ref_losses,
+                    "ties": ref_ties,
+                    "reference_elo": self._references[ref_id].elo,
+                    "ref_repeat_count": len(dirs),
+                }
+                total_wins += ref_wins
+                total_losses += ref_losses
+                total_ties += ref_ties
         finally:
             clean_up_paths(clean_up_list)
 
@@ -407,12 +482,15 @@ class GDPValResourcesServer(SimpleResourcesServer):
             reward=reward,
             verify_mode="comparison",
             judge_response={
+                "per_reference": per_reference,
                 "per_ref_repeat": per_ref_results,
                 "total_wins": total_wins,
                 "total_losses": total_losses,
                 "total_ties": total_ties,
                 "total_judged": total_judged,
-                "ref_repeat_count": len(ref_task_dirs),
+                "reference_count": len(per_reference),
+                # Back-compat: total matchups across all references × repeats.
+                "ref_repeat_count": len(per_ref_results),
             },
             win=reward == 1.0,
             loss=reward == 0.0,
@@ -420,17 +498,22 @@ class GDPValResourcesServer(SimpleResourcesServer):
             total_wins=total_wins,
             total_losses=total_losses,
             total_ties=total_ties,
+            per_reference=per_reference,
         )
 
     async def aggregate_metrics(self, body: AggregateMetricsRequest) -> AggregateMetrics:
         if self.config.reward_mode != "comparison":
             return await super().aggregate_metrics(body)
 
-        from resources_servers.gdpval.comparison import calculate_elo
+        from resources_servers.gdpval.comparison import (
+            calculate_elo,
+            calculate_mle_elo,
+            predict_win_rate,
+        )
 
         # Prefer the raw judge vote counts (``total_wins``/``total_losses``/
         # ``total_ties``) when present so the win rate reflects every
-        # eval×ref_repeat×trial comparison. Fall back to the bool flags for
+        # eval×ref×repeat×trial comparison. Fall back to the bool flags for
         # verify responses produced before this field existed — those count as
         # one vote each.
         def _votes(vr: Dict[str, Any]) -> tuple[int, int, int]:
@@ -439,31 +522,85 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 return int(tw or 0), int(tl or 0), int(tt or 0)
             return int(bool(vr.get("win"))), int(bool(vr.get("loss"))), int(bool(vr.get("tie")))
 
+        # Pooled (total) win stats across all references.
         wins = losses = ties = 0
+        # Per-reference-model win stats: ref_id -> [wins, losses, ties, ref_elo].
+        per_ref_totals: Dict[str, List[Any]] = {}
         for vr in body.verify_responses:
             w, ls, t = _votes(vr)
             wins += w
             losses += ls
             ties += t
-        judged = wins + losses + ties
 
+            per_reference = vr.get("per_reference") or {}
+            for ref_id, counts in per_reference.items():
+                entry = per_ref_totals.setdefault(ref_id, [0, 0, 0, None])
+                entry[0] += int(counts.get("wins", 0) or 0)
+                entry[1] += int(counts.get("losses", 0) or 0)
+                entry[2] += int(counts.get("ties", 0) or 0)
+                if entry[3] is None:
+                    # Prefer the ELO from config; fall back to whatever the
+                    # verify response recorded at judging time.
+                    cfg_ref = self._references.get(ref_id)
+                    entry[3] = cfg_ref.elo if cfg_ref is not None else counts.get("reference_elo")
+
+        judged = wins + losses + ties
         if judged == 0:
             return await super().aggregate_metrics(body)
 
         win_rate = (wins + 0.5 * ties) / judged
-        eval_elo, normalized_elo = calculate_elo(win_rate, self.config.reference_elo)
 
         base = await super().aggregate_metrics(body)
-        extra = {
+        # Total win stats (always emitted).
+        extra: Dict[str, Any] = {
             "comparison/wins": wins,
             "comparison/losses": losses,
             "comparison/ties": ties,
             "comparison/judged": judged,
             "comparison/win_rate": win_rate,
-            "comparison/eval_elo": eval_elo,
-            "comparison/normalized_elo": normalized_elo,
-            "comparison/reference_elo": self.config.reference_elo,
         }
+
+        # Per-reference win stats (always emitted when present).
+        for ref_id, (rw, rl, rt, ref_elo) in per_ref_totals.items():
+            r_judged = rw + rl + rt
+            r_win_rate = (rw + 0.5 * rt) / r_judged if r_judged else float("nan")
+            extra[f"comparison/ref/{ref_id}/wins"] = rw
+            extra[f"comparison/ref/{ref_id}/losses"] = rl
+            extra[f"comparison/ref/{ref_id}/ties"] = rt
+            extra[f"comparison/ref/{ref_id}/judged"] = r_judged
+            extra[f"comparison/ref/{ref_id}/win_rate"] = r_win_rate
+            if ref_elo is not None:
+                extra[f"comparison/ref/{ref_id}/reference_elo"] = ref_elo
+
+        # ELO estimate. With per-reference battles we fit an anchored
+        # Bradley-Terry MLE across all references; otherwise fall back to the
+        # legacy single-anchor closed form.
+        battles = [
+            (float(ref_elo), rw, rl, rt)
+            for (rw, rl, rt, ref_elo) in per_ref_totals.values()
+            if ref_elo is not None and (rw + rl + rt) > 0
+        ]
+        mle = calculate_mle_elo(battles) if battles else None
+        if mle is not None:
+            eval_elo, normalized_elo = mle
+            extra["comparison/eval_elo"] = eval_elo
+            extra["comparison/normalized_elo"] = normalized_elo
+            extra["comparison/num_references"] = len(battles)
+            extra["comparison/elo_method"] = "bradley_terry_mle"
+            # Predicted (model-implied) win rate vs each reference, useful to
+            # eyeball MLE fit against the observed per-reference win rate.
+            for ref_id, (rw, rl, rt, ref_elo) in per_ref_totals.items():
+                if ref_elo is not None:
+                    extra[f"comparison/ref/{ref_id}/predicted_win_rate"] = predict_win_rate(
+                        eval_elo, float(ref_elo)
+                    )
+        else:
+            eval_elo, normalized_elo = calculate_elo(win_rate, self.config.reference_elo)
+            extra["comparison/eval_elo"] = eval_elo
+            extra["comparison/normalized_elo"] = normalized_elo
+            extra["comparison/reference_elo"] = self.config.reference_elo
+            extra["comparison/elo_method"] = "single_reference"
+
         merged_agent = {**base.agent_metrics, **extra}
         merged_key = {**base.key_metrics, **extra}
         return AggregateMetrics(

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -422,6 +422,13 @@ class GDPValResourcesServer(SimpleResourcesServer):
         # matchup for back-compat with the single-reference judge_response shape.
         per_reference: Dict[str, Dict[str, Any]] = {}
         per_ref_results: List[Dict[str, Any]] = []
+        # Per-reference judge failures (timeouts, upstream 5xx, oversize/context
+        # payloads). With multiple references a single failed matchup must NOT
+        # discard the whole rollout — we skip just that (ref × repeat) and keep
+        # every reference that judged successfully.
+        ref_errors: Dict[str, List[str]] = {}
+        attempted_matchups = 0
+        last_error: Optional[Exception] = None
         try:
             eval_submission = build_file_section(str(eval_task_dir), clean_up_list)
 
@@ -431,6 +438,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
             # averages over reference variance — see ``_iter_ref_repeat_dirs``.
             for ref_id, dirs in ref_dirs_by_id.items():
                 ref_wins = ref_losses = ref_ties = 0
+                ref_judged_repeats = 0
                 for ref_dir in dirs:
                     refs_subdir = ref_dir / "reference_files"
                     refs = build_file_section(
@@ -438,36 +446,60 @@ class GDPValResourcesServer(SimpleResourcesServer):
                         clean_up_list,
                     )
                     ref_submission = build_file_section(str(ref_dir), clean_up_list)
-                    result = await asyncio.to_thread(
-                        run_trials,
-                        client=client,
-                        model=judge_model_name,
-                        task_prompt=body.prompt or "",
-                        refs=refs,
-                        submission_a=ref_submission,
-                        submission_b=eval_submission,
-                        num_trials=self.config.num_comparison_trials,
-                        return_raw_responses=self.config.persist_raw_judge_responses,
-                    )
+                    attempted_matchups += 1
+                    try:
+                        result = await asyncio.to_thread(
+                            run_trials,
+                            client=client,
+                            model=judge_model_name,
+                            task_prompt=body.prompt or "",
+                            refs=refs,
+                            submission_a=ref_submission,
+                            submission_b=eval_submission,
+                            num_trials=self.config.num_comparison_trials,
+                            return_raw_responses=self.config.persist_raw_judge_responses,
+                        )
+                    except Exception as e:  # noqa: BLE001 — isolate per-matchup judge failures
+                        last_error = e
+                        ref_errors.setdefault(ref_id, []).append(f"{ref_dir.name}: {e!r}")
+                        print(
+                            f"[gdpval] judge failed for task {body.task_id} ref {ref_id}/{ref_dir.name}: {e!r}",
+                            flush=True,
+                        )
+                        continue
                     # ``run_trials`` casts submission_a=ref, submission_b=eval, so
                     # ``win_count_b`` is eval wins.
                     ref_wins += result["win_count_b"]
                     ref_losses += result["win_count_a"]
                     ref_ties += result["tie_count"]
+                    ref_judged_repeats += 1
                     per_ref_results.append({"ref_id": ref_id, "ref_repeat": ref_dir.name, **result})
 
-                per_reference[ref_id] = {
-                    "wins": ref_wins,
-                    "losses": ref_losses,
-                    "ties": ref_ties,
-                    "reference_elo": self._references[ref_id].elo,
-                    "ref_repeat_count": len(dirs),
-                }
-                total_wins += ref_wins
-                total_losses += ref_losses
-                total_ties += ref_ties
+                # Only record references that produced at least one valid matchup;
+                # a reference whose every repeat failed contributes no votes (and
+                # must not appear as a 0/0/0 battle in aggregate_metrics).
+                if ref_judged_repeats > 0:
+                    per_reference[ref_id] = {
+                        "wins": ref_wins,
+                        "losses": ref_losses,
+                        "ties": ref_ties,
+                        "reference_elo": self._references[ref_id].elo,
+                        "ref_repeat_count": ref_judged_repeats,
+                    }
+                    total_wins += ref_wins
+                    total_losses += ref_losses
+                    total_ties += ref_ties
         finally:
             clean_up_paths(clean_up_list)
+
+        # Every matchup failed → this rollout is genuinely unjudgeable. Surface
+        # it as a failure (matches pre-resilience behavior) rather than emitting
+        # a fake neutral reward that would pollute the metrics.
+        if attempted_matchups > 0 and not per_reference:
+            raise RuntimeError(
+                f"all {attempted_matchups} judge matchup(s) failed for task {body.task_id}; "
+                f"last error: {last_error!r}"
+            )
 
         total_judged = total_wins + total_losses + total_ties
         if total_wins > total_losses:
@@ -491,6 +523,9 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 "reference_count": len(per_reference),
                 # Back-compat: total matchups across all references × repeats.
                 "ref_repeat_count": len(per_ref_results),
+                # References (and their repeats) whose judge calls failed and
+                # were skipped. Empty when every matchup succeeded.
+                "ref_errors": ref_errors,
             },
             win=reward == 1.0,
             loss=reward == 0.0,
@@ -563,7 +598,9 @@ class GDPValResourcesServer(SimpleResourcesServer):
         # Per-reference win stats (always emitted when present).
         for ref_id, (rw, rl, rt, ref_elo) in per_ref_totals.items():
             r_judged = rw + rl + rt
-            r_win_rate = (rw + 0.5 * rt) / r_judged if r_judged else float("nan")
+            # Keep every emitted metric numeric (downstream coerces each metric
+            # into a float ``Score``): use 0.0 rather than NaN when unjudged.
+            r_win_rate = (rw + 0.5 * rt) / r_judged if r_judged else 0.0
             extra[f"comparison/ref/{ref_id}/wins"] = rw
             extra[f"comparison/ref/{ref_id}/losses"] = rl
             extra[f"comparison/ref/{ref_id}/ties"] = rt
@@ -585,8 +622,11 @@ class GDPValResourcesServer(SimpleResourcesServer):
             eval_elo, normalized_elo = mle
             extra["comparison/eval_elo"] = eval_elo
             extra["comparison/normalized_elo"] = normalized_elo
+            # Number of references the MLE was fit over (>1 ⇒ multi-reference
+            # Bradley-Terry). All metric values must stay numeric — downstream
+            # coerces each into a float ``Score`` — so we encode the method as a
+            # count rather than a descriptive string.
             extra["comparison/num_references"] = len(battles)
-            extra["comparison/elo_method"] = "bradley_terry_mle"
             # Predicted (model-implied) win rate vs each reference, useful to
             # eyeball MLE fit against the observed per-reference win rate.
             for ref_id, (rw, rl, rt, ref_elo) in per_ref_totals.items():
@@ -599,7 +639,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
             extra["comparison/eval_elo"] = eval_elo
             extra["comparison/normalized_elo"] = normalized_elo
             extra["comparison/reference_elo"] = self.config.reference_elo
-            extra["comparison/elo_method"] = "single_reference"
+            extra["comparison/num_references"] = 1
 
         merged_agent = {**base.agent_metrics, **extra}
         merged_key = {**base.key_metrics, **extra}

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -497,8 +497,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
         # a fake neutral reward that would pollute the metrics.
         if attempted_matchups > 0 and not per_reference:
             raise RuntimeError(
-                f"all {attempted_matchups} judge matchup(s) failed for task {body.task_id}; "
-                f"last error: {last_error!r}"
+                f"all {attempted_matchups} judge matchup(s) failed for task {body.task_id}; last error: {last_error!r}"
             )
 
         total_judged = total_wins + total_losses + total_ties
@@ -631,9 +630,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
             # eyeball MLE fit against the observed per-reference win rate.
             for ref_id, (rw, rl, rt, ref_elo) in per_ref_totals.items():
                 if ref_elo is not None:
-                    extra[f"comparison/ref/{ref_id}/predicted_win_rate"] = predict_win_rate(
-                        eval_elo, float(ref_elo)
-                    )
+                    extra[f"comparison/ref/{ref_id}/predicted_win_rate"] = predict_win_rate(eval_elo, float(ref_elo))
         else:
             eval_elo, normalized_elo = calculate_elo(win_rate, self.config.reference_elo)
             extra["comparison/eval_elo"] = eval_elo

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -496,6 +496,87 @@ def calculate_elo(win_rate: float, ref_elo: float) -> tuple[float, float]:
     return elo, normalized_elo
 
 
+def calculate_mle_elo(
+    battles: list[tuple[float, float, float, float]],
+    scale: float = 400.0,
+    base: float = 10.0,
+) -> tuple[float, float] | None:
+    """Anchored Bradley-Terry MLE ELO for one eval model vs N fixed references.
+
+    This is the multi-reference generalization of ``calculate_elo``. It applies
+    the traditional ELO rating system (logistic / Bradley-Terry) to the pooled
+    pairwise comparisons, estimating the eval model's rating globally rather
+    than inverting a single win rate against a single anchor.
+
+    ``battles`` is a list of ``(reference_elo, wins, losses, ties)`` where the
+    counts are the eval model's win / loss / tie vote totals against that
+    reference model (ties counted as half a win). The reference ratings are
+    held **fixed** at their known ELOs (e.g. published Arena/AA numbers); the
+    eval model's rating ``R`` is the single free parameter, found by maximizing
+    the Bradley-Terry log-likelihood
+
+        L(R) = sum_i [ s_i * log(p_i) + (n_i - s_i) * log(1 - p_i) ]
+
+    with ``p_i = 1 / (1 + base**((reference_elo_i - R) / scale))``, ``n_i`` the
+    number of games vs reference ``i`` and ``s_i = wins_i + 0.5 * ties_i``.
+
+    For a single reference this reduces exactly to ``calculate_elo``. Returns
+    ``(elo, normalized_elo)`` with ``normalized_elo = (elo - 500) / 2000``, or
+    ``None`` when there are no games to fit.
+    """
+    data: list[tuple[float, float, float]] = []
+    for ref_elo, wins, losses, ties in battles:
+        n = float(wins) + float(losses) + float(ties)
+        if n <= 0:
+            continue
+        s = float(wins) + 0.5 * float(ties)
+        data.append((float(ref_elo), s, n))
+
+    if not data:
+        return None
+
+    total_s = sum(s for _, s, _ in data)
+    total_n = sum(n for _, _, n in data)
+    eps = 1e-3
+
+    overall_win_rate = total_s / total_n
+    if overall_win_rate <= eps or overall_win_rate >= 1.0 - eps:
+        # Degenerate: the eval model won (or lost) every battle, so the MLE
+        # rating diverges to ±inf. Clamp exactly like ``calculate_elo`` does,
+        # anchored to the game-weighted mean reference ELO.
+        clamped = min(max(overall_win_rate, eps), 1.0 - eps)
+        mean_ref = sum(ref_elo * n for ref_elo, _, n in data) / total_n
+        elo = mean_ref - scale * (math.log10(1.0 - clamped) - math.log10(clamped))
+        return elo, (elo - 500.0) / 2000.0
+
+    def gradient(rating: float) -> float:
+        # dL/dR up to the positive constant ln(base)/scale: sum_i (s_i - n_i*p_i).
+        # Strictly decreasing in ``rating``, so the root is unique.
+        total = 0.0
+        for ref_elo, s, n in data:
+            p = 1.0 / (1.0 + base ** ((ref_elo - rating) / scale))
+            total += s - n * p
+        return total
+
+    # gradient(lo) > 0 and gradient(hi) < 0 are guaranteed once the overall win
+    # rate is strictly inside (0, 1); bisect for the unique root.
+    lo = min(ref_elo for ref_elo, _, _ in data) - 4000.0
+    hi = max(ref_elo for ref_elo, _, _ in data) + 4000.0
+    for _ in range(100):
+        mid = 0.5 * (lo + hi)
+        if gradient(mid) > 0.0:
+            lo = mid
+        else:
+            hi = mid
+    elo = 0.5 * (lo + hi)
+    return elo, (elo - 500.0) / 2000.0
+
+
+def predict_win_rate(eval_elo: float, ref_elo: float, scale: float = 400.0, base: float = 10.0) -> float:
+    """Expected eval-model win probability vs a reference at ``ref_elo``."""
+    return 1.0 / (1.0 + base ** ((ref_elo - eval_elo) / scale))
+
+
 def compute_comparison_reward(winner: str) -> float:
     """Convert a BOXED winner string to a reward float.
 

--- a/resources_servers/gdpval/configs/gdpval.yaml
+++ b/resources_servers/gdpval/configs/gdpval.yaml
@@ -6,6 +6,7 @@ gdpval_resources_server:
       verified: false
       reward_mode: rubric
       reference_deliverables_dir: null
+      reference_models: {}
       judge_model_server:
         type: responses_api_models
         name: gdpval_judge_model

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -486,6 +486,167 @@ class TestApp:
         assert abs(result.agent_metrics["comparison/win_rate"] - (13.0 / 24.0)) < 1e-6
 
 
+class TestMleElo:
+    def test_single_reference_matches_closed_form(self) -> None:
+        """For one reference the anchored MLE reduces exactly to ``calculate_elo``."""
+        from resources_servers.gdpval.comparison import calculate_elo, calculate_mle_elo
+
+        # 7 wins, 2 losses, 1 tie vs a single reference at ELO 1000 → win_rate 0.75.
+        closed_elo, closed_norm = calculate_elo(0.75, 1000.0)
+        mle = calculate_mle_elo([(1000.0, 7, 2, 1)])
+        assert mle is not None
+        mle_elo, mle_norm = mle
+        assert abs(mle_elo - closed_elo) < 0.5
+        assert abs(mle_norm - closed_norm) < 1e-3
+
+    def test_two_references_fits_midpoint(self) -> None:
+        """50% win rate vs two references at 1000 and 1400 ⇒ eval ELO ≈ 1200."""
+        from resources_servers.gdpval.comparison import calculate_mle_elo
+
+        mle = calculate_mle_elo([(1000.0, 5, 5, 0), (1400.0, 5, 5, 0)])
+        assert mle is not None
+        eval_elo, _ = mle
+        assert abs(eval_elo - 1200.0) < 1.0
+
+    def test_stronger_eval_gets_higher_rating(self) -> None:
+        from resources_servers.gdpval.comparison import calculate_mle_elo
+
+        weak = calculate_mle_elo([(1200.0, 2, 8, 0)])
+        strong = calculate_mle_elo([(1200.0, 8, 2, 0)])
+        assert weak is not None and strong is not None
+        assert strong[0] > 1200.0 > weak[0]
+
+    def test_degenerate_all_wins_is_finite_and_high(self) -> None:
+        from resources_servers.gdpval.comparison import calculate_mle_elo
+
+        mle = calculate_mle_elo([(1000.0, 10, 0, 0), (1100.0, 10, 0, 0)])
+        assert mle is not None
+        eval_elo, _ = mle
+        import math as _math
+
+        assert _math.isfinite(eval_elo)
+        assert eval_elo > 1100.0
+
+    def test_no_games_returns_none(self) -> None:
+        from resources_servers.gdpval.comparison import calculate_mle_elo
+
+        assert calculate_mle_elo([]) is None
+        assert calculate_mle_elo([(1000.0, 0, 0, 0)]) is None
+
+
+class TestMultiReference:
+    @pytest.mark.asyncio
+    async def test_verify_judges_every_reference_model(self, tmp_path) -> None:
+        """Each eval rollout is judged against every configured reference model,
+        and per-reference vote tallies are recorded on the response."""
+        eval_dir = tmp_path / "eval" / "task_task-1" / "repeat_0"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "finish_params.json").write_text("{}")
+
+        ref_roots = {}
+        for ref_id in ("kimi", "gpt5"):
+            root = tmp_path / ref_id
+            td = root / "task_task-1"
+            td.mkdir(parents=True)
+            (td / "finish_params.json").write_text("{}")
+            ref_roots[ref_id] = root
+
+        server = _server(
+            reward_mode="comparison",
+            reference_models={
+                "kimi": {"deliverables_dir": str(ref_roots["kimi"]), "elo": 1290.0},
+                "gpt5": {"deliverables_dir": str(ref_roots["gpt5"]), "elo": 1320.0},
+            },
+            preconvert_office_to_pdf=False,
+            num_comparison_trials=4,
+        )
+
+        def fake_run_trials(**_kwargs):
+            # 3 eval wins (B), 1 ref win (A) per matchup.
+            return {
+                "winner": "[[B]]",
+                "win_count_a": 1,
+                "win_count_b": 3,
+                "tie_count": 0,
+                "task_count": 4,
+            }
+
+        body = _verify_request(deliverables_dir=str(eval_dir))
+
+        with (
+            patch("resources_servers.gdpval.comparison.run_trials", side_effect=fake_run_trials),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+            patch("resources_servers.gdpval.comparison.build_file_section", return_value=[]),
+            patch("openai.OpenAI", return_value=MagicMock()),
+        ):
+            resp = await server.verify(body)
+
+        assert set(resp.per_reference) == {"kimi", "gpt5"}
+        assert resp.per_reference["kimi"] == {
+            "wins": 3,
+            "losses": 1,
+            "ties": 0,
+            "reference_elo": 1290.0,
+            "ref_repeat_count": 1,
+        }
+        assert resp.per_reference["gpt5"]["reference_elo"] == 1320.0
+        # Totals are pooled across both references.
+        assert resp.total_wins == 6
+        assert resp.total_losses == 2
+        assert resp.judge_response["reference_count"] == 2
+
+    def test_aggregate_metrics_mle_and_per_reference_stats(self) -> None:
+        from nemo_gym.config_types import AggregateMetricsRequest
+
+        server = _server(
+            reward_mode="comparison",
+            reference_models={
+                "low": {"deliverables_dir": "/tmp/low", "elo": 1000.0},
+                "high": {"deliverables_dir": "/tmp/high", "elo": 1400.0},
+            },
+        )
+
+        # One verify response carrying a per-reference breakdown: 50% vs each
+        # reference ⇒ MLE eval ELO ≈ 1200 (midpoint).
+        responses = [
+            {
+                "_ng_task_index": 0,
+                "_ng_rollout_index": 0,
+                "reward": 0.5,
+                "total_wins": 10,
+                "total_losses": 10,
+                "total_ties": 0,
+                "per_reference": {
+                    "low": {"wins": 5, "losses": 5, "ties": 0, "reference_elo": 1000.0},
+                    "high": {"wins": 5, "losses": 5, "ties": 0, "reference_elo": 1400.0},
+                },
+                "response": {},
+            }
+        ]
+        import asyncio as _asyncio
+
+        body = AggregateMetricsRequest(verify_responses=responses)
+        result = _asyncio.run(server.aggregate_metrics(body))
+        m = result.agent_metrics
+
+        # Total win stats.
+        assert m["comparison/wins"] == 10
+        assert m["comparison/losses"] == 10
+        assert m["comparison/judged"] == 20
+
+        # Per-reference win stats.
+        assert m["comparison/ref/low/wins"] == 5
+        assert m["comparison/ref/low/judged"] == 10
+        assert abs(m["comparison/ref/low/win_rate"] - 0.5) < 1e-9
+        assert m["comparison/ref/low/reference_elo"] == 1000.0
+        assert m["comparison/ref/high/reference_elo"] == 1400.0
+
+        # MLE ELO over both references.
+        assert m["comparison/elo_method"] == "bradley_terry_mle"
+        assert m["comparison/num_references"] == 2
+        assert abs(m["comparison/eval_elo"] - 1200.0) < 1.0
+
+
 class TestComparisonPayloadHardening:
     """Three protections against multi-hour /verify stalls observed on the
     multimodal-heavy long-tail tasks (task_a941b6d8 video, task_4b894ae3

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -595,6 +595,85 @@ class TestMultiReference:
         assert resp.total_losses == 2
         assert resp.judge_response["reference_count"] == 2
 
+    @staticmethod
+    def _two_ref_server_and_body(tmp_path):
+        eval_dir = tmp_path / "eval" / "task_task-1" / "repeat_0"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "finish_params.json").write_text("{}")
+        ref_roots = {}
+        for ref_id in ("kimi", "gpt5"):
+            root = tmp_path / ref_id
+            td = root / "task_task-1"
+            td.mkdir(parents=True)
+            (td / "finish_params.json").write_text("{}")
+            ref_roots[ref_id] = root
+        server = _server(
+            reward_mode="comparison",
+            reference_models={
+                "kimi": {"deliverables_dir": str(ref_roots["kimi"]), "elo": 1284.0},
+                "gpt5": {"deliverables_dir": str(ref_roots["gpt5"]), "elo": 1320.0},
+            },
+            preconvert_office_to_pdf=False,
+            num_comparison_trials=4,
+        )
+        return server, _verify_request(deliverables_dir=str(eval_dir))
+
+    @pytest.mark.asyncio
+    async def test_verify_skips_failed_reference_keeps_others(self, tmp_path) -> None:
+        """A judge failure on one reference is isolated: that reference is
+        skipped (recorded under ``ref_errors``) while the others still score."""
+        server, body = self._two_ref_server_and_body(tmp_path)
+
+        calls = {"n": 0}
+
+        def flaky_run_trials(**_kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # First matchup (kimi) blows up the way a judge timeout would.
+                raise RuntimeError("openai.APITimeoutError: Request timed out.")
+            return {
+                "winner": "[[B]]",
+                "win_count_a": 1,
+                "win_count_b": 3,
+                "tie_count": 0,
+                "task_count": 4,
+            }
+
+        with (
+            patch("resources_servers.gdpval.comparison.run_trials", side_effect=flaky_run_trials),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+            patch("resources_servers.gdpval.comparison.build_file_section", return_value=[]),
+            patch("openai.OpenAI", return_value=MagicMock()),
+        ):
+            resp = await server.verify(body)
+
+        # Only the surviving reference contributes votes.
+        assert set(resp.per_reference) == {"gpt5"}
+        assert resp.total_wins == 3
+        assert resp.total_losses == 1
+        assert resp.reward == 1.0
+        # The failed reference is recorded but does not abort the rollout.
+        assert "kimi" in resp.judge_response["ref_errors"]
+        assert resp.judge_response["reference_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_verify_all_references_fail_raises(self, tmp_path) -> None:
+        """When every matchup fails the rollout is genuinely unjudgeable and
+        verify raises (surfacing as a failure) rather than faking a reward."""
+        server, body = self._two_ref_server_and_body(tmp_path)
+
+        def always_fail(**_kwargs):
+            raise RuntimeError("500 Internal Server Error")
+
+        with (
+            patch("resources_servers.gdpval.comparison.run_trials", side_effect=always_fail),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+            patch("resources_servers.gdpval.comparison.build_file_section", return_value=[]),
+            patch("openai.OpenAI", return_value=MagicMock()),
+        ):
+            with pytest.raises(RuntimeError, match="all .* judge matchup"):
+                await server.verify(body)
+
     def test_aggregate_metrics_mle_and_per_reference_stats(self) -> None:
         from nemo_gym.config_types import AggregateMetricsRequest
 
@@ -642,9 +721,11 @@ class TestMultiReference:
         assert m["comparison/ref/high/reference_elo"] == 1400.0
 
         # MLE ELO over both references.
-        assert m["comparison/elo_method"] == "bradley_terry_mle"
         assert m["comparison/num_references"] == 2
         assert abs(m["comparison/eval_elo"] - 1200.0) < 1.0
+        # Every emitted metric value must be numeric (downstream coerces each
+        # into a float Score — a string value fails parsing and fails the run).
+        assert all(isinstance(v, (int, float)) for v in m.values())
 
 
 class TestComparisonPayloadHardening:

--- a/responses_api_agents/stirrup_agent/README.md
+++ b/responses_api_agents/stirrup_agent/README.md
@@ -201,6 +201,33 @@ or as a Hydra override:
 ++gdpval_stirrup_agent.responses_api_agents.stirrup_agent.judge_only=true
 ```
 
+#### Redoing only the judgements that failed
+
+A normal run records every `/verify` failure in the failures sidecar
+(`<output_stem>_failures.jsonl`) with the `_ng_verify_failed=true` flag and the
+`deliverables_dir` of the (already-cached) deliverable. Because the deliverables
+are persisted *before* `/verify`, a judge failure always leaves a re-verifiable
+artifact on disk.
+
+To re-judge **only** those failed-judgement tasks — without re-executing
+anything and without being blocked by the per-task attempt cap — combine
+judge-only mode with the dispatcher's general `reverify_failed_from_cache`:
+
+```bash
+ng_e2e_collect_rollouts ... \
+  ++output_jsonl_fpath=/prior/run/evaluator_rollouts.jsonl \
+  ++reverify_failed_from_cache=true \
+  ++gdpval_stirrup_agent.responses_api_agents.stirrup_agent.judge_only=true
+```
+
+`reverify_failed_from_cache` reads the prior run's `*_materialized_inputs.jsonl`
+and `*_failures.jsonl`, selects exactly the `_ng_verify_failed` tasks that did **not**
+later succeed, and re-dispatches just those (ignoring
+`NEMO_GYM_MAX_ROLLOUT_ATTEMPTS`). Prior successes in the main jsonl are kept as-is.
+`PERSIST_DELIVERABLES_DIR` must point at the same cache the prior run wrote.
+Re-judgements that pass move to the main jsonl; ones that fail again append a new
+sidecar attempt, so the pass is idempotent and repeatable.
+
 ### Apptainer Sandboxing
 
 Some GDPVal tasks ask the model to install packages or run untrusted code. By default the

--- a/responses_api_agents/stirrup_agent/README.md
+++ b/responses_api_agents/stirrup_agent/README.md
@@ -125,6 +125,7 @@ The agent reads its Hydra config at `configs/stirrup_gdpval.yaml`. Notable keys:
 | `resources_server` | required | Reference to the GDPVal resources server (which scores the deliverable via `/verify`). |
 | `gdpval_container_path` | `null` | Path to an Apptainer `.sif` (see below). |
 | `persist_deliverables_dir` | `null` | If set, each task's artifacts land in `<dir>/task_<task_id>/`. The resources server reads this dir to score the deliverable. |
+| `judge_only` | `false` | If true, skip task execution and score the deliverables already cached under `persist_deliverables_dir` (see [Judge-Only Mode](#judge-only-mode)). |
 | `model_id` | `null` | HF model id or local path used to load a tokenizer for dynamic output sizing. |
 | `completion_token_buffer` | `1000` | Safety margin (in tokens) reserved when sizing `max_completion_tokens` per call. |
 
@@ -159,6 +160,46 @@ default `1000` works in practice; raise it (e.g. 2000–5000) if you see
 sporadic HTTP 400 responses at the vLLM proxy.
 
 ## Advanced Features
+
+### Judge-Only Mode
+
+`judge_only` re-scores a set of deliverables that an earlier run already
+produced, **without** re-executing the (expensive) agent task. It is the
+counterpart to a plain execute-then-judge run: the agent loop is skipped
+entirely and only the resources server `/verify` step runs.
+
+How it works:
+
+- For each task, the agent locates the cached deliverable directory at
+  `persist_deliverables_dir/task_<task_id>/repeat_<rollout_index>/` — the same
+  layout a normal run writes when `persist_deliverables_dir` is set.
+- If the directory exists, a placeholder response is built and `/verify` is
+  called with `deliverables_dir` pointing at the cached files, so the judge
+  scores the on-disk deliverables (not fresh model output).
+- If no cached directory exists for a task, that task is reported as
+  **skipped** (terminal — re-dispatching it would not create the files) and
+  `/verify` is never called.
+
+Requirements / notes:
+
+- `persist_deliverables_dir` must be set (and absolute); it is the source of
+  the deliverables to score. The agent raises at startup otherwise.
+- Run judge-only over the same benchmark / `num_repeats` that produced the
+  cache so the `task_<id>/repeat_<n>` directories line up.
+
+Enable it via the config key or the `JUDGE_ONLY` env var honored by
+`benchmarks/gdpval/config.yaml`:
+
+```bash
+JUDGE_ONLY=true PERSIST_DELIVERABLES_DIR=/abs/path/to/cached/deliverables \
+  ng_e2e_collect_rollouts ...
+```
+
+or as a Hydra override:
+
+```bash
+++gdpval_stirrup_agent.responses_api_agents.stirrup_agent.judge_only=true
+```
 
 ### Apptainer Sandboxing
 

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -112,12 +112,16 @@ def _log_timeout_once(timeout_s: float) -> None:
 #   timeout_exceeded  TaskPerAttemptTimeoutError. Sidecar entry with
 #                     _ng_failure_terminal=True so chain-hop 2 does NOT retry.
 #   skipped           TaskSampleSkipError. Sidecar entry with terminal=True.
-#   transient         verify-side ClientResponseError 5xx / connection /
-#                     asyncio.TimeoutError. Sidecar entry per attempt; retry
-#                     up to max_attempts.
-#   legitimate        Everything else (real Python exception with user code
-#                     in the traceback). Sidecar entry per attempt; retry
-#                     up to max_attempts.
+#   verify_failed     Any verify-side (/verify) failure. The rollout succeeded
+#                     and (with persist_deliverables_dir) its deliverables are
+#                     cached, so only verification failed. Sidecar entry per
+#                     attempt; retried up to max_attempts on a normal resume.
+#                     The row also carries the _ng_verify_failed boolean
+#                     sentinel: the dispatcher routes reverify_failed_from_cache
+#                     on that flag, not on this (agent-internal) class name.
+#   legitimate        Rollout-side Python exception with user code in the
+#                     traceback. Sidecar entry per attempt; retry up to
+#                     max_attempts.
 # ---------------------------------------------------------------------------
 
 # Sentinel keys the dispatcher (nemo_gym.rollout_collection) reads to route a
@@ -125,6 +129,7 @@ def _log_timeout_once(timeout_s: float) -> None:
 NG_FAILURE_CLASS_KEY = "_ng_failure_class"  # str: one of the 5 class names
 NG_NO_PERSIST_KEY = "_ng_no_persist"  # bool: don't write anywhere
 NG_TERMINAL_KEY = "_ng_failure_terminal"  # bool: never retry on resume
+NG_VERIFY_FAILED_KEY = "_ng_verify_failed"  # bool: rollout ok, only /verify failed; reverifiable from cache
 
 _USER_CODE_PATH_SUBSTRINGS = (
     "responses_api_agents/",
@@ -204,22 +209,52 @@ def _classify_rollout_failure(exc: BaseException) -> str:
 
 
 def _classify_verify_failure(exc: BaseException) -> str:
-    """Classify an exception raised by the ``/verify`` POST. Verify-side
-    failures are never ``kill_shaped`` (we had a rollout response in hand)
-    and never ``timeout_exceeded`` (that's a rollout-side class).
+    """Classify an exception raised by the ``/verify`` POST.
+
+    Every verify-side failure is a ``verify_failed``: the rollout itself
+    succeeded (we had a response in hand and, when ``persist_deliverables_dir``
+    is set, the deliverables are already on disk) — only the verification step
+    failed. This is an agent-internal label; the dispatcher never reads it.
+    What the dispatcher routes on is the ``_ng_verify_failed`` boolean sentinel
+    that ``_build_failed_run_payload`` sets for this class, which lets
+    ``reverify_failed_from_cache`` (in ``nemo_gym.rollout_collection``) re-verify
+    just these tasks from the cached deliverables without re-executing the agent.
+
+    A ``verify_failed`` is written to the failures sidecar, one row per attempt,
+    and retried up to ``max_attempts`` on a normal chain resume.
+
+    This is the *routing* class. For triage of *why* the verify failed (e.g. a
+    flaky judge endpoint vs. a deterministic bad request) see the companion
+    :func:`_verify_failure_kind`, whose label is surfaced in the log line and
+    the failed-row ``error_message``.
+    """
+    return "verify_failed"
+
+
+def _verify_failure_kind(exc: BaseException) -> str:
+    """Best-effort sub-classification of a ``/verify`` failure, for triage only.
+
+    Routing always treats verify failures as ``verify_failed`` (see
+    :func:`_classify_verify_failure`); this label is purely diagnostic. It
+    names the exception that caused the judge call to fail so a later reader
+    can tell an overloaded/flaky judge endpoint (5xx response, dropped
+    connection, timeout — usually worth retrying) apart from a deterministic
+    failure (4xx response / a bug in our request — retrying won't help). For
+    HTTP errors the response status is appended (e.g. ``503`` ⇒ 5xx ⇒ flaky,
+    ``400`` ⇒ 4xx ⇒ deterministic).
     """
     try:
         import aiohttp
 
         if isinstance(exc, aiohttp.ClientResponseError):
-            return "transient" if 500 <= exc.status < 600 else "legitimate"
+            return f"client_response_error_http_{exc.status}"
         if isinstance(exc, aiohttp.ClientConnectionError):
-            return "transient"
+            return "client_connection_error"
     except ImportError:
         pass
     if isinstance(exc, asyncio.TimeoutError):
-        return "transient"
-    return "legitimate"
+        return "timeout_error"
+    return f"other_{type(exc).__name__}"
 
 
 # ---------------------------------------------------------------------------
@@ -1094,18 +1129,21 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
             except Exception as exc:
                 task_info = self.task_strategy.extract_task_info(existing_metadata)
                 failure_class = _classify_verify_failure(exc)
+                failure_kind = _verify_failure_kind(exc)
                 instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
                 print(
-                    f"[stirrup-verify-{failure_class}] {instance_hint}: {type(exc).__name__}: {exc}",
+                    f"[stirrup-verify-{failure_class}: {failure_kind}] {instance_hint}: "
+                    f"{type(exc).__name__}: {exc}",
                     flush=True,
                 )
                 return self._build_failed_run_payload(
                     body_dict=body_dict,
                     fixed_params=fixed_params,
                     task_info=task_info,
-                    reason=f"verify failed: {type(exc).__name__}: {exc}",
+                    reason=f"verify failed ({failure_kind}): {type(exc).__name__}: {exc}",
                     skipped=False,
                     error_class=failure_class,
+                    deliverables_dir=deliverables_dir,
                 )
 
     def _build_judge_only_response(
@@ -1157,6 +1195,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         reason: str,
         skipped: bool,
         error_class: Optional[str] = None,
+        deliverables_dir: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Return a verify-response-shaped dict for runs that never produced a deliverable.
 
@@ -1167,8 +1206,15 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
           resume's set-difference on the main jsonl re-dispatches the task.
         - ``_ng_failure_terminal=True`` for ``timeout_exceeded`` / ``skipped``:
           one sidecar entry, never retried.
-        - Otherwise (``legitimate``, ``transient``): sidecar entry per attempt;
-          retried up to ``NEMO_GYM_MAX_ROLLOUT_ATTEMPTS`` on chain resume.
+        - Otherwise (``legitimate``, ``verify_failed``): sidecar entry per
+          attempt; retried up to ``NEMO_GYM_MAX_ROLLOUT_ATTEMPTS`` on chain
+          resume.
+
+        For ``verify_failed`` (a verify-side failure), the rollout's deliverables
+        are already cached, so the row records ``deliverables_dir`` and the
+        ``_ng_verify_failed=True`` boolean sentinel. ``reverify_failed_from_cache``
+        selects rows with that flag to re-verify just those tasks from disk
+        without re-executing.
         """
         if error_class == "timeout_exceeded":
             suffix = "timeout"
@@ -1211,6 +1257,15 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         payload["reward"] = 0.0
         payload["skipped"] = skipped
         payload["error_message"] = reason
+        # Record the cached deliverables location for verify-side failures so a
+        # later reverify-from-cache pass knows where to read without re-running.
+        if deliverables_dir is not None:
+            payload["deliverables_dir"] = deliverables_dir
+        if error_class == "verify_failed":
+            # The rollout itself succeeded; only /verify failed. Flag the cached
+            # sidecar row with the boolean sentinel the dispatcher routes on so
+            # reverify_failed_from_cache can re-verify it without re-executing.
+            payload[NG_VERIFY_FAILED_KEY] = True
         if error_class is not None:
             payload["error_class"] = error_class
             payload[NG_FAILURE_CLASS_KEY] = error_class

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -723,6 +723,15 @@ class StirrupAgentWrapperConfig(BaseResponsesAPIAgentConfig):
         "When set, each task's artifacts land in <dir>/task_<task_id>/; the resources server "
         "reads deliverables_dir from the verify request to score them.",
     )
+    judge_only: bool = Field(
+        default=False,
+        description="Judge-only mode. When True, the Stirrup agent task is NOT executed; instead "
+        "the resources server scores pre-existing cached deliverables found under "
+        "persist_deliverables_dir/task_<task_id>/repeat_<rollout_index>/ via /verify. Requires "
+        "persist_deliverables_dir to be set and the cached deliverables to already exist (a task "
+        "with no cached deliverable directory is reported as skipped). Use this to (re)score a "
+        "deliverable set produced by an earlier run without paying the rollout cost again.",
+    )
     model_id: Optional[str] = Field(
         default=None,
         description="HuggingFace model ID (or local checkpoint path) used to load a tokenizer "
@@ -821,6 +830,19 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 f"persist_deliverables_dir must be an absolute path "
                 f"(got {self.config.persist_deliverables_dir!r}). Relative paths "
                 f"resolve differently in the agent vs. the resources server."
+            )
+        # Judge-only mode scores cached deliverables in place, so it needs a
+        # populated persist_deliverables_dir to read them from.
+        if self.config.judge_only and not self.config.persist_deliverables_dir:
+            raise ValueError(
+                "judge_only=True requires persist_deliverables_dir to be set — it is the source "
+                "of the cached deliverables to score (no task is executed in judge-only mode)."
+            )
+        if self.config.judge_only:
+            print(
+                "Stirrup agent running in judge_only mode: tasks will NOT be executed; the resources "
+                f"server will score cached deliverables under {self.config.persist_deliverables_dir!r}.",
+                flush=True,
             )
         print(f"Stirrup agent initialized with task={self.config.task!r}", flush=True)
 
@@ -993,29 +1015,6 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
             except Exception as exc:
                 print(f"[stirrup] seed_session failed (non-fatal): {exc}", flush=True)
 
-            # Run the Stirrup agent
-            try:
-                response = await self.responses(fixed_params)
-            except Exception as exc:
-                task_info = self.task_strategy.extract_task_info(existing_metadata)
-                failure_class = _classify_rollout_failure(exc)
-                instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
-                print(
-                    f"[stirrup-{failure_class}] {instance_hint}: {type(exc).__name__}: {exc}",
-                    flush=True,
-                )
-                return self._build_failed_run_payload(
-                    body_dict=body_dict,
-                    fixed_params=fixed_params,
-                    task_info=task_info,
-                    reason=f"{type(exc).__name__}: {exc}",
-                    skipped=(failure_class == "skipped"),
-                    error_class=failure_class,
-                )
-
-            response_clean = response.model_copy(update={"metadata": None})
-            response_metadata = response.metadata or {}
-
             # Locate the persisted deliverables dir for this task. Unset if
             # persist_deliverables_dir is null or task_id is missing (the
             # resources server will fall back to response.output_text).
@@ -1027,6 +1026,54 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 deliverables_dir = str(
                     (Path(self.config.persist_deliverables_dir) / f"task_{task_id}" / repeat_name).absolute()
                 )
+
+            if self.config.judge_only:
+                # Judge-only mode: do NOT run the agent. Score the pre-existing
+                # cached deliverables at ``deliverables_dir``. A task whose
+                # deliverable directory is missing can't be scored — report it
+                # as skipped (terminal; re-dispatch won't create the files).
+                if deliverables_dir is None or not Path(deliverables_dir).is_dir():
+                    task_info = self.task_strategy.extract_task_info(existing_metadata)
+                    reason = (
+                        f"judge_only: no cached deliverables at {deliverables_dir}"
+                        if deliverables_dir
+                        else "judge_only: persist_deliverables_dir or task_id unavailable"
+                    )
+                    instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
+                    print(f"[stirrup-judge_only-missing] {instance_hint}: {reason}", flush=True)
+                    return self._build_failed_run_payload(
+                        body_dict=body_dict,
+                        fixed_params=fixed_params,
+                        task_info=task_info,
+                        reason=reason,
+                        skipped=True,
+                        error_class="skipped",
+                    )
+                response_clean = self._build_judge_only_response(existing_metadata, fixed_params.model)
+                response_metadata = {}
+            else:
+                # Run the Stirrup agent
+                try:
+                    response = await self.responses(fixed_params)
+                except Exception as exc:
+                    task_info = self.task_strategy.extract_task_info(existing_metadata)
+                    failure_class = _classify_rollout_failure(exc)
+                    instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
+                    print(
+                        f"[stirrup-{failure_class}] {instance_hint}: {type(exc).__name__}: {exc}",
+                        flush=True,
+                    )
+                    return self._build_failed_run_payload(
+                        body_dict=body_dict,
+                        fixed_params=fixed_params,
+                        task_info=task_info,
+                        reason=f"{type(exc).__name__}: {exc}",
+                        skipped=(failure_class == "skipped"),
+                        error_class=failure_class,
+                    )
+
+                response_clean = response.model_copy(update={"metadata": None})
+                response_metadata = response.metadata or {}
 
             verify_request_body = dict(body_dict)
             verify_request_body["response"] = response_clean.model_dump(mode="json")
@@ -1060,6 +1107,46 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     skipped=False,
                     error_class=failure_class,
                 )
+
+    def _build_judge_only_response(
+        self,
+        metadata: Dict[str, Any],
+        model_name: Optional[str],
+    ) -> NeMoGymResponse:
+        """Build a placeholder response for judge-only mode.
+
+        No agent ran, so there is no fresh model output. The resources server
+        scores the cached deliverable files read from ``deliverables_dir``; the
+        response text is only the fallback the rubric judge uses when no
+        deliverable files are found. This placeholder keeps the rollout row
+        well-formed for downstream parsing.
+        """
+        task_info = self.task_strategy.extract_task_info(metadata)
+        return NeMoGymResponse(
+            id=self.task_strategy.response_id(task_info),
+            created_at=int(time.time()),
+            model=model_name or "judge_only",
+            object="response",
+            output=[
+                NeMoGymResponseOutputMessage(
+                    id=self.task_strategy.fallback_message_id(task_info),
+                    content=[
+                        NeMoGymResponseOutputText(
+                            type="output_text",
+                            text="Judge-only mode: scoring pre-existing cached deliverables.",
+                            annotations=[],
+                        )
+                    ],
+                    role="assistant",
+                    status="completed",
+                    type="message",
+                )
+            ],
+            parallel_tool_calls=False,
+            tool_choice="none",
+            tools=[],
+            metadata=None,
+        )
 
     def _build_failed_run_payload(
         self,

--- a/responses_api_agents/stirrup_agent/configs/stirrup_gdpval.yaml
+++ b/responses_api_agents/stirrup_agent/configs/stirrup_gdpval.yaml
@@ -33,6 +33,13 @@ stirrup_agent:
       # falls back to ``response.output_text``.
       persist_deliverables_dir: null
 
+      # Judge-only mode: when true, the agent task is NOT executed; instead the
+      # resources server scores the deliverables already cached under
+      # persist_deliverables_dir/task_<task_id>/repeat_<rollout_index>/ via
+      # /verify. Requires persist_deliverables_dir to point at an existing
+      # cached deliverable set. Default false (normal execute-then-judge run).
+      judge_only: false
+
       # Resources server reference (scores deliverables via /verify).
       resources_server:
         type: resources_servers

--- a/responses_api_agents/stirrup_agent/tests/test_app.py
+++ b/responses_api_agents/stirrup_agent/tests/test_app.py
@@ -13,16 +13,20 @@
 # limitations under the License.
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from stirrup.core.models import AssistantMessage, TokenUsage, ToolCall
 
 from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
+from nemo_gym.openai_utils import (
+    NeMoGymResponseCreateParamsNonStreaming,
+)
 from nemo_gym.server_utils import ServerClient
 from responses_api_agents.stirrup_agent.app import (
     StirrupAgentWrapper,
     StirrupAgentWrapperConfig,
+    StirrupRunRequest,
     _load_task_registry,
     get_task_strategy,
 )
@@ -32,6 +36,20 @@ from responses_api_agents.stirrup_agent.task_strategy import TaskStrategy
 
 
 STIRRUP_AGENT_DIR = Path(__file__).resolve().parent.parent
+
+
+def _make_config(*, judge_only: bool = False, persist_deliverables_dir=None) -> StirrupAgentWrapperConfig:
+    return StirrupAgentWrapperConfig(
+        host="0.0.0.0",
+        port=8080,
+        entrypoint="",
+        name="stirrup_agent",
+        task="gdpval",
+        model_server=ModelServerRef(type="responses_api_models", name="policy_model"),
+        resources_server=ResourcesServerRef(type="resources_servers", name="gdpval_resources_server"),
+        judge_only=judge_only,
+        persist_deliverables_dir=persist_deliverables_dir,
+    )
 
 
 class TestTaskRegistry:
@@ -90,6 +108,82 @@ class TestApp:
         assert output_items[1].type == "function_call_output"
         assert output_items[1].call_id == "call_1"
         assert output_items[1].output == "ok"
+
+
+class TestJudgeOnlyMode:
+    def test_judge_only_requires_persist_dir(self) -> None:
+        """judge_only without a persist dir has no cached deliverables to score."""
+        config = _make_config(judge_only=True, persist_deliverables_dir=None)
+        with pytest.raises(ValueError, match="judge_only=True requires persist_deliverables_dir"):
+            StirrupAgentWrapper(config=config, server_client=MagicMock(spec=ServerClient))
+
+    @pytest.mark.asyncio
+    async def test_run_judge_only_scores_cached_deliverables(self, tmp_path) -> None:
+        """When cached deliverables exist, run() must NOT execute the agent and
+        must POST /verify with the cached deliverables_dir."""
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "answer.txt").write_text("cached deliverable")
+
+        config = _make_config(judge_only=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        params = NeMoGymResponseCreateParamsNonStreaming(
+            input="ignored",
+            metadata={"task_id": "task-1", "prompt": "do the thing", "_ng_rollout_index": "0"},
+        )
+        body = StirrupRunRequest(responses_create_params=params, task_id="task-1", prompt="do the thing")
+        request = MagicMock()
+        request.cookies = {}
+
+        responses_mock = AsyncMock()
+        with patch.object(StirrupAgentWrapper, "responses", responses_mock), patch(
+            "responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()
+        ), patch(
+            "responses_api_agents.stirrup_agent.app.get_response_json",
+            AsyncMock(return_value={"reward": 0.9, "judge_response": "ok"}),
+        ):
+            result = await wrapper.run(request, body)
+
+        # The agent task must never run in judge-only mode.
+        responses_mock.assert_not_awaited()
+
+        verify_calls = [c for c in server_client.post.await_args_list if c.kwargs.get("url_path") == "/verify"]
+        assert len(verify_calls) == 1
+        verify_json = verify_calls[0].kwargs["json"]
+        assert verify_json["deliverables_dir"].endswith(str(Path("task_task-1") / "repeat_0"))
+        assert result == {"reward": 0.9, "judge_response": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_run_judge_only_missing_deliverables_is_skipped(self, tmp_path) -> None:
+        """A task with no cached deliverable dir is reported skipped and never
+        reaches /verify."""
+        config = _make_config(judge_only=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        params = NeMoGymResponseCreateParamsNonStreaming(
+            input="ignored",
+            metadata={"task_id": "missing-task", "prompt": "do the thing", "_ng_rollout_index": "0"},
+        )
+        body = StirrupRunRequest(responses_create_params=params, task_id="missing-task", prompt="do the thing")
+        request = MagicMock()
+        request.cookies = {}
+
+        responses_mock = AsyncMock()
+        with patch.object(StirrupAgentWrapper, "responses", responses_mock), patch(
+            "responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()
+        ):
+            result = await wrapper.run(request, body)
+
+        responses_mock.assert_not_awaited()
+        verify_calls = [c for c in server_client.post.await_args_list if c.kwargs.get("url_path") == "/verify"]
+        assert verify_calls == []
+        assert result["skipped"] is True
+        assert result["reward"] == 0.0
 
 
 class TestExampleDataset:

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -28,11 +28,14 @@ from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
 from nemo_gym.reward_profile import compute_aggregate_metrics
 from nemo_gym.rollout_collection import (
     _DEFAULT_MAX_ROLLOUT_ATTEMPTS,
+    NG_FAILURE_CLASS_KEY,
+    NG_VERIFY_FAILED_KEY,
     RolloutAggregationConfig,
     RolloutAggregationHelper,
     RolloutCollectionConfig,
     RolloutCollectionHelper,
     _expand_input_glob,
+    _failures_path_for,
     _get_max_rollout_attempts,
     _rollout_request_debug_summary,
 )
@@ -563,6 +566,60 @@ class TestRolloutCollection:
         )
 
         assert expected_results == actual_returned_results
+
+    def test_load_verify_failed_from_cache(self, tmp_path: Path, monkeypatch) -> None:
+        input_jsonl_fpath = tmp_path / "input.jsonl"
+        materialized_inputs_jsonl_fpath = tmp_path / "output_materialized_inputs.jsonl"
+
+        materialized_inputs = [
+            {"_ng_task_index": 0, "_ng_rollout_index": 0, "input": True},
+            {"_ng_task_index": 0, "_ng_rollout_index": 1, "input": True},
+            {"_ng_task_index": 1, "_ng_rollout_index": 0, "input": True},
+            {"_ng_task_index": 1, "_ng_rollout_index": 1, "input": True},
+            {"_ng_task_index": 2, "_ng_rollout_index": 0, "input": True},
+        ]
+        materialized_inputs_jsonl_fpath.write_bytes(b"\n".join(map(orjson.dumps, materialized_inputs)) + b"\n")
+
+        # Prior successes: (0,0) and (1,1). (1,1) failed verify once then passed.
+        outputs = [
+            {"_ng_task_index": 0, "_ng_rollout_index": 0, "output": True},
+            {"_ng_task_index": 1, "_ng_rollout_index": 1, "output": True},
+        ]
+        output_jsonl_fpath = tmp_path / "output.jsonl"
+        output_jsonl_fpath.write_bytes(b"\n".join(map(orjson.dumps, outputs)) + b"\n")
+
+        # Failures sidecar: verify_failed for (0,1) once, (1,0) three times
+        # (maxed out — must still be redone), (1,1) once (later succeeded —
+        # skip), and a non-verify 'legitimate' rollout failure for (2,0) (skip).
+        vf = {NG_FAILURE_CLASS_KEY: "verify_failed", NG_VERIFY_FAILED_KEY: True}
+        failures = [
+            {"_ng_task_index": 0, "_ng_rollout_index": 1, **vf},
+            {"_ng_task_index": 1, "_ng_rollout_index": 0, **vf},
+            {"_ng_task_index": 1, "_ng_rollout_index": 0, **vf},
+            {"_ng_task_index": 1, "_ng_rollout_index": 0, **vf},
+            {"_ng_task_index": 1, "_ng_rollout_index": 1, **vf},
+            {"_ng_task_index": 2, "_ng_rollout_index": 0, NG_FAILURE_CLASS_KEY: "legitimate"},
+        ]
+        _failures_path_for(output_jsonl_fpath).write_bytes(b"\n".join(map(orjson.dumps, failures)) + b"\n")
+
+        # Even with the attempt cap at 1, the maxed-out (1,0) must be redone.
+        monkeypatch.setenv("NEMO_GYM_MAX_ROLLOUT_ATTEMPTS", "1")
+
+        config = RolloutCollectionConfig(
+            input_jsonl_fpath=str(input_jsonl_fpath),
+            output_jsonl_fpath=str(output_jsonl_fpath),
+            reverify_failed_from_cache=True,
+        )
+
+        input_rows, rows, results, result_strs = RolloutCollectionHelper()._load_verify_failed_from_cache(config)
+
+        get_key = lambda r: (r["_ng_task_index"], r["_ng_rollout_index"])
+        # Only verify_failed-and-not-yet-succeeded tasks are redone.
+        assert sorted(map(get_key, input_rows)) == [(0, 1), (1, 0)]
+        # Prior successes are preserved untouched.
+        assert sorted(map(get_key, rows)) == [(0, 0), (1, 1)]
+        assert results == outputs
+        assert result_strs == [[orjson.dumps(o)] for o in outputs]
 
     async def test_call_aggregate_metrics(self, tmp_path: Path) -> None:
         """Test _call_aggregate_metrics with a mocked server client."""


### PR DESCRIPTION
In GDPval evals, we've been having a lot of judge related failures. This adds the ability to re-run judgements only on tasks whose judgements previously failed, rather than re-judging on every task and spamming the remote or local judge unnecessarily. This is a complement, not a replacement, for the judge retries already implemented for GDPval. 


***Needs the judge only mode PR to be merged in first: https://github.com/NVIDIA-NeMo/Gym/pull/1693