### PR TITLE
feat: [GDPval-AA v2 Updates 5 / n] - Multi-Judge Panel

### DIFF
--- a/benchmarks/gdpval/config.yaml
+++ b/benchmarks/gdpval/config.yaml
@@ -11,7 +11,9 @@
 #   ++gdpval_resources_server.resources_servers.gdpval.reward_mode=comparison \
 #   ++gdpval_resources_server.resources_servers.gdpval.reference_deliverables_dir=/path/to/fork
 
-# Judge model — proxy to NVIDIA inference API for Gemini 3.1 Pro.
+# Judge model — proxy to the NVIDIA inference API. A single proxy server fronts
+# every frontier judge (Gemini, GPT, Claude); panel members below select among
+# them by model id, so one server is enough.
 gdpval_judge_model:
   responses_api_models:
     openai_model:
@@ -37,6 +39,24 @@ gdpval_resources_server:
         type: responses_api_models
         name: gdpval_judge_model
       judge_responses_create_params_overrides: {}
+      # Multi-judge panel (applies to both rubric and comparison modes): a panel
+      # of frontier judges, one sampled per comparison/scoring call. This is the
+      # default. All three route through the single gdpval_judge_model proxy and
+      # differ only by model id + reasoning knobs; set a per-member model_server
+      # to point at distinct endpoints. To fall back to a single judge, override
+      # ++gdpval_resources_server.resources_servers.gdpval.judge_panel=null
+      # (the lone judge then comes from judge_model_server above).
+      judge_panel:
+        - name: gpt-5.5
+          model: ${oc.env:JUDGE_GPT_MODEL,openai/gpt-5.5}
+          create_params_overrides: { reasoning_effort: medium }
+        - name: gemini-3.1-pro
+          model: ${oc.env:JUDGE_GEMINI_MODEL,gcp/google/gemini-3.1-pro-preview}
+          create_params_overrides: { extra_body: { reasoning_effort: high } }
+        - name: claude-opus-4.8
+          model: ${oc.env:JUDGE_CLAUDE_MODEL,anthropic/claude-opus-4.8}
+          create_params_overrides: { extra_body: { thinking: { type: enabled } } }
+      judge_sampling_seed: null
 
 # Stirrup agent paired with the resources server above.
 gdpval_stirrup_agent:

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -25,6 +25,13 @@ selected via ``reward_mode`` config:
 
 Scoring internals live in ``scoring.py`` (rubric) and ``comparison.py``
 (pairwise judge + ELO math).
+
+Both modes grade with a multi-judge *panel* (``judge_panel``): a set of frontier
+judges (e.g. GPT-5.5, Gemini 3.1 Pro Preview, Claude Opus 4.8, each at their own
+reasoning settings) that are sampled per comparison/scoring call. Panel
+sampling + seeding lives in ``judge_panel.py``. A single judge is just the
+degenerate one-member panel synthesized from ``judge_model_server`` when
+``judge_panel`` is unset — there is one panel-based code path either way.
 """
 
 from __future__ import annotations
@@ -34,6 +41,8 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
+from pydantic import BaseModel
+
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
     BaseVerifyRequest,
@@ -42,6 +51,7 @@ from nemo_gym.base_resources_server import (
 )
 from nemo_gym.config_types import AggregateMetrics, AggregateMetricsRequest, ModelServerRef
 from nemo_gym.server_utils import get_server_url
+from resources_servers.gdpval.judge_panel import ResolvedJudge, make_rng, panel_summary
 
 
 LOGGER = logging.getLogger(__name__)
@@ -92,6 +102,32 @@ def _safe_output_text(response: Any) -> str:
     return "\n".join(p for p in parts if p)
 
 
+class JudgePanelMember(BaseModel):
+    """One judge in a multi-judge panel.
+
+    Each member is a distinct frontier model + reasoning configuration. For
+    every comparison/scoring call one member is sampled (see
+    ``judge_panel.sample_judge``). Members may share the single
+    ``judge_model_server`` proxy and differ only by ``model`` + reasoning
+    knobs, or point at distinct servers via ``model_server``.
+    """
+
+    # Human-readable label used in logs and the per-judge metrics breakdown,
+    # e.g. "gpt-5.5", "gemini-3.1-pro", "claude-opus-4.8". Defaults to ``model``.
+    name: Optional[str] = None
+    # Upstream model id as the judge endpoint expects (e.g. "openai/gpt-5.5").
+    # Falls back to ``create_params_overrides.model`` then the legacy default.
+    model: Optional[str] = None
+    # Defaults to the server-level ``judge_model_server`` when omitted.
+    model_server: Optional[ModelServerRef] = None
+    # Provider-specific generation/reasoning knobs merged into
+    # ``chat.completions.create`` (e.g. ``{reasoning_effort: high}`` or
+    # ``{extra_body: {...}}``). A ``None`` value drops the matching default.
+    create_params_overrides: Dict[str, Any] = {}
+    # Relative sampling weight; defaults to equal weighting across the panel.
+    weight: float = 1.0
+
+
 class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     reward_mode: Literal["rubric", "comparison"] = "rubric"
 
@@ -119,6 +155,19 @@ class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     judge_model_server: ModelServerRef
     judge_responses_create_params_overrides: Dict[str, Any] = {}
     judge_prompt_template_fpath: Optional[str] = None
+
+    # Multi-judge panel. Every comparison/scoring call samples one member. A
+    # single judge is just the degenerate case: when this is None a one-member
+    # panel is synthesized from ``judge_model_server`` +
+    # ``judge_responses_create_params_overrides`` (see ``_effective_panel``), so
+    # there is a single panel-based code path with no separate single-judge
+    # branch.
+    judge_panel: Optional[List[JudgePanelMember]] = None
+    # Seed for reproducible per-comparison judge sampling. The RNG is seeded per
+    # (task_id, ref_repeat/mode) so reruns of the same task draw the same
+    # judges. Leave None to seed only on those identity parts (still stable per
+    # task); set an int to additionally shift the whole stream.
+    judge_sampling_seed: Optional[int] = None
 
     # Rubric-mode scoring backend:
     # - ``"binary"`` (default, legacy): judge emits a JSON ``{criteria_scores:
@@ -193,6 +242,54 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 )
         super().model_post_init(context)
 
+    def _effective_panel(self) -> List[JudgePanelMember]:
+        """The panel to grade with — always a non-empty list of members.
+
+        A single judge is just the degenerate case: when ``judge_panel`` is
+        unset we synthesize a one-member panel from the legacy single-judge
+        fields (``judge_model_server`` + ``judge_responses_create_params_overrides``),
+        so every code path downstream is panel-based.
+        """
+        if self.config.judge_panel:
+            return self.config.judge_panel
+        # Degenerate 1-member panel: inherit the legacy create-params overrides
+        # (model/api_key are split out during resolution, the rest become the
+        # member's reasoning/generation knobs).
+        return [JudgePanelMember(create_params_overrides=dict(self.config.judge_responses_create_params_overrides or {}))]
+
+    def _resolve_judges(self) -> List[ResolvedJudge]:
+        """Resolve the (always non-empty) panel to concrete upstream coordinates.
+
+        Every judge — including the single-judge special case (see
+        :meth:`_effective_panel`) — is resolved through this one loop. Members
+        may share ``judge_model_server`` (differing only by model + reasoning)
+        or point at their own ``model_server``. Per-member ``model`` / ``api_key``
+        fall back to the legacy ``judge_responses_create_params_overrides`` then
+        to sane defaults.
+        """
+        legacy_overrides = dict(self.config.judge_responses_create_params_overrides or {})
+
+        def _url(server: ModelServerRef) -> str:
+            return get_server_url(server.name) + "/v1"
+
+        judges: List[ResolvedJudge] = []
+        for i, member in enumerate(self._effective_panel()):
+            server = member.model_server or self.config.judge_model_server
+            overrides = dict(member.create_params_overrides or {})
+            model = member.model or overrides.pop("model", None) or legacy_overrides.get("model", "judge")
+            api_key = overrides.pop("api_key", None) or legacy_overrides.get("api_key", "dummy")
+            judges.append(
+                ResolvedJudge(
+                    name=member.name or model or f"judge_{i}",
+                    base_url=_url(server),
+                    model=model,
+                    api_key=api_key,
+                    create_overrides=overrides,
+                    weight=member.weight,
+                )
+            )
+        return judges
+
     async def verify(self, body: GDPValVerifyRequest) -> GDPValVerifyResponse:
         if self.config.reward_mode == "comparison":
             return await self._verify_comparison(body)
@@ -208,13 +305,10 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 invalid_judge_response=True,
             )
 
-        overrides = dict(self.config.judge_responses_create_params_overrides or {})
-        judge_base_url = get_server_url(self.config.judge_model_server.name) + "/v1"
-        judge_model_name = overrides.pop("model", "judge")
-        judge_api_key = overrides.pop("api_key", "dummy")
-        # Anything left in `overrides` (max_tokens, temperature, top_p, …) is
-        # merged into the judge's chat.completions.create kwargs.
-        judge_create_overrides = overrides or None
+        judges = self._resolve_judges()
+        # Seed per task so a rerun samples the same judge(s); ``rubric`` tag
+        # keeps the stream distinct from the comparison path.
+        rng = make_rng(self.config.judge_sampling_seed, body.task_id, "rubric")
 
         deliverable_text = _safe_output_text(body.response)
         deliverable_content_blocks: Optional[List[Dict[str, Any]]] = None
@@ -247,9 +341,8 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 rubric_json=body.rubric_json,
                 rubric_pretty=rubric_pretty,
                 task_prompt=task_prompt,
-                model_base_url=judge_base_url,
-                model_name=judge_model_name,
-                api_key=judge_api_key,
+                judges=judges,
+                rng=rng,
                 num_trials=self.config.rubric_structured_num_trials,
                 formatting_retries=self.config.rubric_structured_formatting_retries,
                 deliverable_content_blocks=deliverable_content_blocks,
@@ -264,10 +357,8 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 rubric_pretty=rubric_pretty,
                 task_prompt=task_prompt,
                 judge_prompt_template=self._judge_prompt_fpath,
-                model_base_url=judge_base_url,
-                model_name=judge_model_name,
-                api_key=judge_api_key,
-                create_overrides=judge_create_overrides,
+                judges=judges,
+                rng=rng,
                 include_raw_responses=self.config.persist_raw_judge_responses,
             )
         else:
@@ -279,10 +370,8 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 rubric_pretty=rubric_pretty,
                 task_prompt=task_prompt,
                 judge_prompt_template=self._judge_prompt_fpath,
-                model_base_url=judge_base_url,
-                model_name=judge_model_name,
-                api_key=judge_api_key,
-                create_overrides=judge_create_overrides,
+                judges=judges,
+                rng=rng,
                 include_raw_responses=self.config.persist_raw_judge_responses,
             )
 
@@ -311,6 +400,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         from resources_servers.gdpval.comparison import (
             JUDGE_REQUEST_TIMEOUT_SECONDS,
+            Judge,
             build_file_section,
             clean_up_paths,
             run_trials,
@@ -347,20 +437,39 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 await self._preconvert_and_log(ref_dir, label=f"ref/{body.task_id}/{ref_dir.name}")
 
         clean_up_list: List[Path] = []
-        overrides = dict(self.config.judge_responses_create_params_overrides or {})
-        judge_base_url = get_server_url(self.config.judge_model_server.name) + "/v1"
-        judge_model_name = overrides.get("model", "judge")
-        judge_api_key = overrides.get("api_key", "dummy")
-        client = OpenAI(
-            base_url=judge_base_url,
-            api_key=judge_api_key,
-            timeout=JUDGE_REQUEST_TIMEOUT_SECONDS,
-        )
+        # Build the judge panel. Members may share a single proxy server (so we
+        # reuse one OpenAI client per distinct upstream) and differ only by
+        # model + reasoning settings. run_trials samples one member per trial.
+        resolved_judges = self._resolve_judges()
+        client_cache: Dict[tuple, Any] = {}
+
+        def _client_for(judge: ResolvedJudge) -> Any:
+            key = (judge.base_url, judge.api_key)
+            if key not in client_cache:
+                client_cache[key] = OpenAI(
+                    base_url=judge.base_url,
+                    api_key=judge.api_key,
+                    timeout=JUDGE_REQUEST_TIMEOUT_SECONDS,
+                )
+            return client_cache[key]
+
+        judges = [
+            Judge(
+                name=rj.name,
+                client=_client_for(rj),
+                model=rj.model,
+                create_overrides=rj.create_overrides or None,
+                weight=rj.weight,
+            )
+            for rj in resolved_judges
+        ]
 
         total_wins = 0
         total_losses = 0
         total_ties = 0
         per_ref_results: List[Dict[str, Any]] = []
+        # eval-perspective per-judge tally pooled across reference repeats.
+        per_judge_totals: Dict[str, Dict[str, int]] = {}
         try:
             eval_submission = build_file_section(str(eval_task_dir), clean_up_list)
 
@@ -374,22 +483,31 @@ class GDPValResourcesServer(SimpleResourcesServer):
                     clean_up_list,
                 )
                 ref_submission = build_file_section(str(ref_dir), clean_up_list)
+                # Seed per (task, ref_repeat) so judge sampling is reproducible.
+                rng = make_rng(self.config.judge_sampling_seed, body.task_id, ref_dir.name)
                 result = await asyncio.to_thread(
                     run_trials,
-                    client=client,
-                    model=judge_model_name,
+                    judges=judges,
                     task_prompt=body.prompt or "",
                     refs=refs,
                     submission_a=ref_submission,
                     submission_b=eval_submission,
                     num_trials=self.config.num_comparison_trials,
                     return_raw_responses=self.config.persist_raw_judge_responses,
+                    rng=rng,
                 )
                 # ``run_trials`` casts submission_a=ref, submission_b=eval, so
                 # ``win_count_b`` is eval wins.
                 total_wins += result["win_count_b"]
                 total_losses += result["win_count_a"]
                 total_ties += result["tie_count"]
+                # Fold per-judge counts into eval-perspective totals.
+                for jname, jc in (result.get("per_judge") or {}).items():
+                    agg = per_judge_totals.setdefault(jname, {"wins": 0, "losses": 0, "ties": 0, "trials": 0})
+                    agg["wins"] += jc.get("win_count_b", 0)
+                    agg["losses"] += jc.get("win_count_a", 0)
+                    agg["ties"] += jc.get("tie_count", 0)
+                    agg["trials"] += jc.get("trials", 0)
                 per_ref_results.append({"ref_repeat": ref_dir.name, **result})
         finally:
             clean_up_paths(clean_up_list)
@@ -413,6 +531,8 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 "total_ties": total_ties,
                 "total_judged": total_judged,
                 "ref_repeat_count": len(ref_task_dirs),
+                "judge_panel": panel_summary(judges),
+                "per_judge": per_judge_totals,
             },
             win=reward == 1.0,
             loss=reward == 0.0,

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -23,14 +23,18 @@ from __future__ import annotations
 import base64
 import math
 import os
+import random
 import shutil
 import tempfile
 import time
 import zipfile
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from openai import APITimeoutError
+
+from resources_servers.gdpval.judge_panel import merge_create_kwargs, sample_judge
 
 
 JUDGE_PROMPT = (
@@ -343,18 +347,27 @@ def send_judge_request(
     model: str,
     messages: list[dict],
     max_output_tokens: int = 65535,
+    create_overrides: Optional[dict] = None,
 ) -> str:
-    """Send a judge request with exponential-backoff retry.  Returns response text."""
+    """Send a judge request with exponential-backoff retry.  Returns response text.
+
+    *create_overrides* (a panel member's reasoning/generation knobs) is merged
+    over the default create kwargs; a ``None`` value removes the default key.
+    """
     backoff = REQUEST_INITIAL_BACKOFF_SECONDS
+    create_kwargs = merge_create_kwargs(
+        {
+            "model": model,
+            "messages": messages,
+            "max_tokens": max_output_tokens,
+            "temperature": 1.0,
+        },
+        create_overrides,
+    )
 
     for attempt in range(1, REQUEST_MAX_ATTEMPTS + 1):
         try:
-            response = client.chat.completions.create(
-                model=model,
-                messages=messages,
-                max_tokens=max_output_tokens,
-                temperature=1.0,
-            )
+            response = client.chat.completions.create(**create_kwargs)
             return (response.choices[0].message.content or "").strip()
         except Exception as error:
             retryable = _is_retryable(error)
@@ -418,9 +431,24 @@ def tally_result(
 # ---------------------------------------------------------------------------
 
 
+@dataclass
+class Judge:
+    """A panel member bound to a live (sync) OpenAI client for the trial loop.
+
+    Built by the resources server from a
+    ``resources_servers.gdpval.judge_panel.ResolvedJudge`` (one client per
+    distinct upstream). ``run_trials`` samples one of these per trial.
+    """
+
+    name: str
+    client: Any
+    model: str
+    create_overrides: Optional[dict] = None
+    weight: float = 1.0
+
+
 def run_trials(
-    client: Any,
-    model: str,
+    judges: list[Judge],
     task_prompt: str,
     refs: list[dict],
     submission_a: list[dict],
@@ -428,22 +456,40 @@ def run_trials(
     num_trials: int = 4,
     max_output_tokens: int = 65535,
     return_raw_responses: bool = False,
+    rng: Optional[random.Random] = None,
 ) -> dict:
     """Run ``num_trials`` judge calls, alternating swapped/unswapped positions.
 
+    For each trial one member of *judges* is sampled (see
+    ``judge_panel.sample_judge``) — this is the "sample between the judges for
+    each comparison" panel behavior. With a single-member panel this reduces to
+    the historical single-judge loop. Pass *rng* (a seeded ``random.Random``)
+    for reproducible judge selection.
+
     Returns a dict with ``winner``, ``win_count_a``, ``win_count_b``,
-    ``tie_count``, and ``task_count``.
+    ``tie_count``, ``task_count``, ``per_judge`` (per-member a/b/tie/trial
+    counts, keyed by judge name), and ``trial_judges`` (the judge name that
+    graded each trial, ordered by trial index — always present so the grader
+    of every match is documented).
 
     When ``return_raw_responses`` is True, the dict also carries
-    ``raw_responses``: a list of the per-trial judge completion strings,
-    ordered by trial index (so trial ``i`` was swapped iff ``i % 2 != 0``).
+    ``raw_responses`` (per-trial judge completion strings, same ordering as
+    ``trial_judges`` — trial ``i`` was swapped iff ``i % 2 != 0``).
     """
+    if not judges:
+        raise ValueError("run_trials requires a non-empty judge panel")
+    rng = rng or random.Random()
+
     win_count_a = 0
     win_count_b = 0
     tie_count = 0
     raw_responses: list[str] = []
+    trial_judges: list[str] = []
+    per_judge: dict[str, dict] = {}
 
     for i in range(num_trials):
+        judge = sample_judge(judges, rng)
+        trial_judges.append(judge.name)
         swapped = i % 2 != 0
         current_a = submission_b if swapped else submission_a
         current_b = submission_a if swapped else submission_b
@@ -454,11 +500,23 @@ def run_trials(
             submission_a=current_a,
             submission_b=current_b,
         )
-        response_text = send_judge_request(client, model, messages, max_output_tokens)
+        response_text = send_judge_request(
+            judge.client, judge.model, messages, max_output_tokens, judge.create_overrides
+        )
         if return_raw_responses:
             raw_responses.append(response_text)
         judgement = parse_judgement(response_text)
         win_count_a, win_count_b, tie_count = tally_result(judgement, swapped, win_count_a, win_count_b, tie_count)
+
+        # Per-judge tally (same A=submission_a / B=submission_b convention as
+        # the global counts) so the panel's per-member balance is auditable.
+        jc = per_judge.setdefault(
+            judge.name, {"win_count_a": 0, "win_count_b": 0, "tie_count": 0, "trials": 0}
+        )
+        jc["win_count_a"], jc["win_count_b"], jc["tie_count"] = tally_result(
+            judgement, swapped, jc["win_count_a"], jc["win_count_b"], jc["tie_count"]
+        )
+        jc["trials"] += 1
 
     if win_count_a > win_count_b:
         winner = A_WIN_RESPONSE
@@ -473,6 +531,10 @@ def run_trials(
         "win_count_b": win_count_b,
         "tie_count": tie_count,
         "task_count": num_trials,
+        "per_judge": per_judge,
+        # Always recorded (just judge names, ordered by trial) so every match's
+        # per-trial grader is documented even when raw responses aren't kept.
+        "trial_judges": trial_judges,
     }
     if return_raw_responses:
         result["raw_responses"] = raw_responses

--- a/resources_servers/gdpval/judge_panel.py
+++ b/resources_servers/gdpval/judge_panel.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Multi-judge panel support shared by the GDPVal rubric and comparison scorers.
+
+A *panel* is a set of LLM judges (each a distinct upstream model + reasoning
+settings, e.g. GPT-5.5 medium, Gemini 3.1 Pro Preview high, Claude Opus 4.8
+high). For every individual scoring/comparison we *sample* one panel member —
+the per-trial grader is drawn here. Sampling is seeded (via :func:`make_rng`)
+so a rerun of the same task lands on the same judges and the result is
+reproducible.
+
+This module is intentionally connection-agnostic: a :class:`ResolvedJudge`
+carries only the upstream coordinates (base URL / model / api key / create
+overrides). The rubric scorers build an ``AsyncOpenAI`` client from these; the
+comparison scorer wraps them in its own client-bearing ``Judge`` for the
+threaded sync path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Protocol, Sequence, TypeVar
+
+
+@dataclass
+class ResolvedJudge:
+    """A single panel member resolved to concrete upstream coordinates.
+
+    ``create_overrides`` holds provider-specific generation/reasoning knobs
+    (e.g. ``reasoning_effort``, ``extra_body``, ``temperature``) that are merged
+    into the ``chat.completions.create`` kwargs via :func:`merge_create_kwargs`.
+    A ``None`` value there *removes* the default key (so a reasoning model can
+    drop ``temperature``).
+    """
+
+    name: str
+    base_url: str
+    model: str
+    api_key: str = "dummy"
+    create_overrides: Dict[str, Any] = field(default_factory=dict)
+    weight: float = 1.0
+
+
+class _HasWeight(Protocol):
+    name: str
+    weight: float
+
+
+_J = TypeVar("_J", bound=_HasWeight)
+
+
+def make_rng(seed: Optional[int], *parts: str) -> random.Random:
+    """Return a ``random.Random`` seeded deterministically from *seed* + *parts*.
+
+    Used to make per-comparison judge sampling reproducible: callers seed with
+    a stable identity (e.g. the task id and reference repeat) so the same task
+    always draws the same judges across reruns. When *seed* is ``None`` the
+    parts alone determine the stream (still reproducible per task); pass no
+    parts for a fully fresh stream.
+    """
+    payload = "|".join([repr(seed), *parts])
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return random.Random(int(digest[:16], 16))
+
+
+def sample_judge(judges: Sequence[_J], rng: random.Random) -> _J:
+    """Sample one judge from the panel using each member's ``weight``.
+
+    Duck-typed on ``.weight`` / ``.name`` so it works for both
+    :class:`ResolvedJudge` (rubric path) and the comparison scorer's
+    client-bearing ``Judge``. Non-positive total weight falls back to a uniform
+    choice.
+    """
+    if not judges:
+        raise ValueError("sample_judge requires a non-empty judge panel")
+    if len(judges) == 1:
+        return judges[0]
+    weights = [j.weight if (j.weight and j.weight > 0) else 0.0 for j in judges]
+    if sum(weights) <= 0:
+        return rng.choice(list(judges))
+    return rng.choices(list(judges), weights=weights, k=1)[0]
+
+
+def merge_create_kwargs(base: Dict[str, Any], overrides: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Merge per-judge ``create_overrides`` onto *base* create kwargs.
+
+    A ``None`` override value deletes the key from the result (lets a reasoning
+    judge drop ``temperature``); any other value replaces the default.
+    """
+    merged = dict(base)
+    for key, value in (overrides or {}).items():
+        if value is None:
+            merged.pop(key, None)
+        else:
+            merged[key] = value
+    return merged
+
+
+def panel_summary(judges: Sequence[_HasWeight]) -> List[Dict[str, Any]]:
+    """A small JSON-friendly description of the panel for verify responses."""
+    return [{"name": j.name, "weight": j.weight} for j in judges]

--- a/resources_servers/gdpval/scoring.py
+++ b/resources_servers/gdpval/scoring.py
@@ -26,9 +26,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import random
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
+
+from resources_servers.gdpval.judge_panel import ResolvedJudge, merge_create_kwargs, sample_judge
 
 
 # ---------------------------------------------------------------------------
@@ -89,10 +92,8 @@ async def score_with_rubric(
     rubric_pretty: str,
     task_prompt: str,
     judge_prompt_template: str,
-    model_base_url: str,
-    model_name: str,
-    api_key: str = "dummy",
-    create_overrides: dict | None = None,
+    judges: list[ResolvedJudge],
+    rng: Optional[random.Random] = None,
     include_raw_responses: bool = False,
 ) -> tuple[float, dict | None]:
     """Score a deliverable against a rubric using an LLM judge.
@@ -101,11 +102,14 @@ async def score_with_rubric(
     and *judge_response* is the parsed JSON dict from the judge (or ``None``
     on failure).
 
-    *create_overrides* is merged into the kwargs passed to
-    ``client.chat.completions.create``; user-supplied keys win over defaults.
-    Use it to bump ``max_tokens`` (default 8192), tweak ``temperature``, etc.
+    One member of *judges* is sampled for this scoring call (see
+    ``judge_panel.sample_judge``); its ``create_overrides`` (reasoning settings,
+    ``max_tokens``, etc.) are merged into ``client.chat.completions.create``.
+    Pass *rng* (a seeded ``random.Random``) for reproducible selection.
     """
     from openai import AsyncOpenAI
+
+    judge = sample_judge(judges, rng or random.Random())
 
     rubric_str = rubric_pretty if rubric_pretty else json.dumps(rubric_json, indent=2)
 
@@ -116,7 +120,7 @@ async def score_with_rubric(
         deliverable_text=deliverable_text,
     )
 
-    client = AsyncOpenAI(base_url=model_base_url, api_key=api_key)
+    client = AsyncOpenAI(base_url=judge.base_url, api_key=judge.api_key)
 
     max_retries = 5
     base_delay = 2.0
@@ -125,20 +129,21 @@ async def score_with_rubric(
         response = None
         for attempt in range(max_retries + 1):
             try:
-                create_kwargs: dict = {
-                    "model": model_name,
-                    "messages": [
-                        {
-                            "role": "system",
-                            "content": "You are an expert evaluator. You must respond with valid JSON only.",
-                        },
-                        {"role": "user", "content": judge_prompt},
-                    ],
-                    "temperature": 0.1,
-                    "max_tokens": 8192,
-                }
-                if create_overrides:
-                    create_kwargs.update(create_overrides)
+                create_kwargs: dict = merge_create_kwargs(
+                    {
+                        "model": judge.model,
+                        "messages": [
+                            {
+                                "role": "system",
+                                "content": "You are an expert evaluator. You must respond with valid JSON only.",
+                            },
+                            {"role": "user", "content": judge_prompt},
+                        ],
+                        "temperature": 0.1,
+                        "max_tokens": 8192,
+                    },
+                    judge.create_overrides,
+                )
                 response = await client.chat.completions.create(**create_kwargs)
                 break
             except Exception as retry_err:
@@ -207,9 +212,11 @@ async def score_with_rubric(
             print(f"Could not extract score. Full result: {json.dumps(result)[:1000]}", flush=True)
             score = 0.0
 
-        print(f"Rubric final score: {score}", flush=True)
-        if include_raw_responses and isinstance(result, dict):
-            result["raw_responses"] = [raw_response_text]
+        print(f"Rubric final score: {score} (judge: {judge.name})", flush=True)
+        if isinstance(result, dict):
+            result["judge_name"] = judge.name
+            if include_raw_responses:
+                result["raw_responses"] = [raw_response_text]
         return max(0.0, min(1.0, score)), result
 
     except Exception as e:
@@ -226,10 +233,8 @@ async def score_with_rubric_visual(
     rubric_pretty: str,
     task_prompt: str,
     judge_prompt_template: str,
-    model_base_url: str,
-    model_name: str,
-    api_key: str = "dummy",
-    create_overrides: dict | None = None,
+    judges: list[ResolvedJudge],
+    rng: Optional[random.Random] = None,
     include_raw_responses: bool = False,
 ) -> tuple[float, dict | None]:
     """Score deliverables visually using a multimodal judge (e.g., Gemini 3 Pro).
@@ -240,13 +245,14 @@ async def score_with_rubric_visual(
     *deliverable_content_blocks* is a list of OpenAI-compatible content blocks
     (text and image_url) produced by ``file_reader.convert_deliverables_to_content_blocks()``.
 
-    *create_overrides* is merged into the kwargs passed to
-    ``client.chat.completions.create``; user-supplied keys win over defaults.
-    Use it to bump ``max_tokens`` (default 8192), tweak ``temperature``, etc.
+    One member of *judges* is sampled for this scoring call; its
+    ``create_overrides`` are merged into ``client.chat.completions.create``.
 
     Returns ``(score, judge_response)`` — same contract as ``score_with_rubric``.
     """
     from openai import AsyncOpenAI
+
+    judge = sample_judge(judges, rng or random.Random())
 
     rubric_str = rubric_pretty if rubric_pretty else json.dumps(rubric_json, indent=2)
 
@@ -261,7 +267,7 @@ async def score_with_rubric_visual(
     content: list[dict] = [{"type": "text", "text": judge_text}]
     content.extend(deliverable_content_blocks)
 
-    client = AsyncOpenAI(base_url=model_base_url, api_key=api_key)
+    client = AsyncOpenAI(base_url=judge.base_url, api_key=judge.api_key)
 
     max_retries = 5
     base_delay = 2.0
@@ -270,20 +276,21 @@ async def score_with_rubric_visual(
         response = None
         for attempt in range(max_retries + 1):
             try:
-                create_kwargs: dict = {
-                    "model": model_name,
-                    "messages": [
-                        {
-                            "role": "system",
-                            "content": "You are an expert evaluator. You must respond with valid JSON only.",
-                        },
-                        {"role": "user", "content": content},
-                    ],
-                    "temperature": 0.1,
-                    "max_tokens": 8192,
-                }
-                if create_overrides:
-                    create_kwargs.update(create_overrides)
+                create_kwargs: dict = merge_create_kwargs(
+                    {
+                        "model": judge.model,
+                        "messages": [
+                            {
+                                "role": "system",
+                                "content": "You are an expert evaluator. You must respond with valid JSON only.",
+                            },
+                            {"role": "user", "content": content},
+                        ],
+                        "temperature": 0.1,
+                        "max_tokens": 8192,
+                    },
+                    judge.create_overrides,
+                )
                 response = await client.chat.completions.create(**create_kwargs)
                 break
             except Exception as retry_err:
@@ -342,9 +349,11 @@ async def score_with_rubric_visual(
             print(f"Could not extract score. Full result: {json.dumps(result)[:1000]}", flush=True)
             score = 0.0
 
-        print(f"Visual judge final score: {score}", flush=True)
-        if include_raw_responses and isinstance(result, dict):
-            result["raw_responses"] = [raw_response_text]
+        print(f"Visual judge final score: {score} (judge: {judge.name})", flush=True)
+        if isinstance(result, dict):
+            result["judge_name"] = judge.name
+            if include_raw_responses:
+                result["raw_responses"] = [raw_response_text]
         return max(0.0, min(1.0, score)), result
 
     except Exception as e:
@@ -365,9 +374,8 @@ async def score_with_rubric_structured(
     rubric_json: Any,
     rubric_pretty: str,
     task_prompt: str,
-    model_base_url: str,
-    model_name: str,
-    api_key: str = "dummy",
+    judges: list[ResolvedJudge],
+    rng: Optional[random.Random] = None,
     num_trials: int = 2,
     formatting_retries: int = 3,
     deliverable_content_blocks: list[dict] | None = None,
@@ -378,11 +386,24 @@ async def score_with_rubric_structured(
     Uses ``FINAL_SCORE[x] out of MAX_POSSIBLE_SCORE[y]`` tags for reliable
     parsing.  Runs *num_trials* scoring rounds (each with up to
     *formatting_retries* retries on parse failure) and averages the results.
+    A judge is sampled from *judges* per trial ("sample between the judges"),
+    so the averaged score pools the panel; pass *rng* for reproducibility.
 
     Returns ``(normalized_score, metadata)`` where *normalized_score* is in
     [0, 1] and *metadata* contains per-trial scores and percentages.
     """
     from openai import AsyncOpenAI
+
+    rng = rng or random.Random()
+    # One AsyncOpenAI client per distinct upstream (base_url, api_key), reused
+    # across trials that sample the same judge.
+    client_cache: dict[tuple[str, str], Any] = {}
+
+    def _client_for(judge: ResolvedJudge) -> Any:
+        key = (judge.base_url, judge.api_key)
+        if key not in client_cache:
+            client_cache[key] = AsyncOpenAI(base_url=judge.base_url, api_key=judge.api_key)
+        return client_cache[key]
 
     # Compute max possible score from rubric. Different upstream formats name
     # the per-criterion point field differently — accept either ``score`` or
@@ -430,25 +451,25 @@ async def score_with_rubric_structured(
 
     messages = [{"role": "user", "content": content}]
 
-    client = AsyncOpenAI(base_url=model_base_url, api_key=api_key)
-
     scores: list[float] = []
     max_scores: list[float] = []
     percentages: list[float] = []
     trial_responses: list[str] = []
+    trial_judges: list[str] = []
 
     for trial in range(num_trials):
         trial_num = trial + 1
         parsed_ok = False
+        judge = sample_judge(judges, rng)
+        client = _client_for(judge)
+        create_kwargs = merge_create_kwargs(
+            {"model": judge.model, "messages": messages, "temperature": 0.3, "max_tokens": 65535},
+            judge.create_overrides,
+        )
 
         for retry in range(formatting_retries):
             try:
-                response = await client.chat.completions.create(
-                    model=model_name,
-                    messages=messages,
-                    temperature=0.3,
-                    max_tokens=65535,
-                )
+                response = await client.chat.completions.create(**create_kwargs)
                 resp_text = (response.choices[0].message.content or "").strip()
             except Exception as e:
                 err_str = str(e).lower()
@@ -479,6 +500,7 @@ async def score_with_rubric_structured(
                 max_scores.append(parsed_max)
                 percentages.append((score / parsed_max) * 100 if parsed_max > 0 else 0)
                 trial_responses.append(resp_text)
+                trial_judges.append(judge.name)
                 parsed_ok = True
                 print(
                     f"[structured-rubric] trial {trial_num}: score={score}/{parsed_max} ({percentages[-1]:.1f}%)",
@@ -520,6 +542,7 @@ async def score_with_rubric_structured(
         "max_possible_score": effective_max,
         "num_trials_completed": len(scores),
         "num_trials_requested": num_trials,
+        "trial_judges": trial_judges,
     }
     if include_raw_responses:
         metadata["raw_responses"] = trial_responses

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -176,9 +176,11 @@ class TestApp:
     async def test_verify_rubric_passes_create_overrides_through(self) -> None:
         """``judge_responses_create_params_overrides`` must reach the scoring fn.
 
-        ``model`` and ``api_key`` are pulled out as their own kwargs; everything
-        else (e.g. ``max_tokens``, ``temperature``) flows through as
-        ``create_overrides`` and gets merged into ``client.chat.completions.create``.
+        With no ``judge_panel`` the server resolves a single judge from
+        ``judge_model_server`` + the legacy overrides: ``model`` and ``api_key``
+        become the judge's own fields; everything else (``max_tokens``,
+        ``temperature``, …) is its ``create_overrides``, merged into
+        ``client.chat.completions.create``.
         """
         server = _server(
             reward_mode="rubric",
@@ -204,9 +206,54 @@ class TestApp:
         ):
             await server.verify(body)
 
-        assert captured["model_name"] == "custom-judge"
-        assert captured["api_key"] == "sk-custom"  # pragma: allowlist secret
-        assert captured["create_overrides"] == {"max_tokens": 16384, "temperature": 0.0}
+        judges = captured["judges"]
+        assert len(judges) == 1
+        judge = judges[0]
+        assert judge.model == "custom-judge"
+        assert judge.api_key == "sk-custom"  # pragma: allowlist secret
+        assert judge.base_url == "http://localhost:9999/v1"
+        assert judge.create_overrides == {"max_tokens": 16384, "temperature": 0.0}
+
+    @pytest.mark.asyncio
+    async def test_verify_rubric_panel_resolves_members(self) -> None:
+        """A configured ``judge_panel`` reaches the scoring fn as resolved judges
+        carrying each member's model + reasoning overrides."""
+        server = _server(
+            reward_mode="rubric",
+            judge_panel=[
+                {"name": "gpt-5.5", "model": "openai/gpt-5.5",
+                 "create_params_overrides": {"reasoning_effort": "medium"}},
+                {"name": "gemini-3.1-pro", "model": "gcp/google/gemini-3.1-pro-preview",
+                 "create_params_overrides": {"extra_body": {"reasoning_effort": "high"}}},
+                {"name": "claude-opus-4.8", "model": "anthropic/claude-opus-4.8"},
+            ],
+        )
+
+        captured: dict = {}
+
+        async def fake_score_with_rubric(**kwargs):
+            captured.update(kwargs)
+            return 0.5, {"overall_score": 0.5}
+
+        body = _verify_request(rubric_json=[{"criterion": "clarity", "score": 1}])
+
+        with (
+            patch("resources_servers.gdpval.scoring.score_with_rubric", side_effect=fake_score_with_rubric),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+        ):
+            await server.verify(body)
+
+        judges = captured["judges"]
+        assert [j.name for j in judges] == ["gpt-5.5", "gemini-3.1-pro", "claude-opus-4.8"]
+        assert [j.model for j in judges] == [
+            "openai/gpt-5.5",
+            "gcp/google/gemini-3.1-pro-preview",
+            "anthropic/claude-opus-4.8",
+        ]
+        assert judges[0].create_overrides == {"reasoning_effort": "medium"}
+        assert judges[1].create_overrides == {"extra_body": {"reasoning_effort": "high"}}
+        # A seeded RNG must be threaded through for reproducible sampling.
+        assert captured["rng"] is not None
 
     @pytest.mark.asyncio
     async def test_verify_comparison_missing_reference(self, tmp_path) -> None:
@@ -484,6 +531,126 @@ class TestApp:
         assert result.agent_metrics["comparison/judged"] == 24
         # win_rate = (12 + 0.5*2) / 24 = 13/24 ≈ 0.5417
         assert abs(result.agent_metrics["comparison/win_rate"] - (13.0 / 24.0)) < 1e-6
+
+
+class _FakeOpenAIClient:
+    """Minimal stand-in for an OpenAI client that records the model used and
+    returns a fixed BOXED verdict so run_trials can be exercised offline."""
+
+    def __init__(self, verdict: str, record: list) -> None:
+        self._verdict = verdict
+        self._record = record
+
+        outer = self
+
+        class _Completions:
+            def create(self, **kwargs):
+                outer._record.append(kwargs["model"])
+
+                class _Msg:
+                    content = outer._verdict
+
+                class _Choice:
+                    message = _Msg()
+
+                class _Resp:
+                    choices = [_Choice()]
+
+                return _Resp()
+
+        class _Chat:
+            completions = _Completions()
+
+        self.chat = _Chat()
+
+
+class TestJudgePanel:
+    def test_make_rng_is_deterministic(self) -> None:
+        from resources_servers.gdpval.judge_panel import make_rng
+
+        a = make_rng(7, "task-1", "repeat_0")
+        b = make_rng(7, "task-1", "repeat_0")
+        c = make_rng(7, "task-1", "repeat_1")
+        seq_a = [a.random() for _ in range(5)]
+        seq_b = [b.random() for _ in range(5)]
+        seq_c = [c.random() for _ in range(5)]
+        assert seq_a == seq_b
+        assert seq_a != seq_c
+
+    def test_sample_judge_respects_weight(self) -> None:
+        from resources_servers.gdpval.judge_panel import ResolvedJudge, make_rng, sample_judge
+
+        heavy = ResolvedJudge(name="heavy", base_url="u", model="m", weight=9.0)
+        light = ResolvedJudge(name="light", base_url="u", model="m", weight=1.0)
+        rng = make_rng(0, "x")
+        picks = [sample_judge([heavy, light], rng).name for _ in range(200)]
+        assert picks.count("heavy") > picks.count("light")
+        # Single-member panel always returns that member.
+        only = ResolvedJudge(name="solo", base_url="u", model="m")
+        assert sample_judge([only], rng).name == "solo"
+
+    def test_merge_create_kwargs_drops_none(self) -> None:
+        from resources_servers.gdpval.judge_panel import merge_create_kwargs
+
+        merged = merge_create_kwargs(
+            {"model": "m", "temperature": 1.0, "max_tokens": 10},
+            {"temperature": None, "reasoning_effort": "high"},
+        )
+        assert "temperature" not in merged
+        assert merged["reasoning_effort"] == "high"
+        assert merged["max_tokens"] == 10
+
+    def test_run_trials_samples_panel_and_tallies_per_judge(self) -> None:
+        from resources_servers.gdpval.comparison import Judge, run_trials
+        from resources_servers.gdpval.judge_panel import make_rng
+
+        used_models: list = []
+        judges = [
+            Judge(name="gpt-5.5", client=_FakeOpenAIClient("BOXED[B]", used_models), model="openai/gpt-5.5"),
+            Judge(name="gemini", client=_FakeOpenAIClient("BOXED[B]", used_models), model="gcp/gemini"),
+            Judge(name="claude", client=_FakeOpenAIClient("BOXED[B]", used_models), model="anthropic/claude"),
+        ]
+        result = run_trials(
+            judges=judges,
+            task_prompt="t",
+            refs=[],
+            submission_a=[{"type": "text", "text": "ref"}],
+            submission_b=[{"type": "text", "text": "eval"}],
+            num_trials=6,
+            return_raw_responses=False,
+            rng=make_rng(123, "task-1", "repeat_0"),
+        )
+        # Per-trial grader is documented even when raw responses are NOT kept.
+        assert "trial_judges" in result
+        assert "raw_responses" not in result
+        assert len(result["trial_judges"]) == 6
+        assert all(name in {"gpt-5.5", "gemini", "claude"} for name in result["trial_judges"])
+        # Every trial graded; per_judge trial counts sum to num_trials.
+        assert sum(j["trials"] for j in result["per_judge"].values()) == 6
+        assert len(used_models) == 6
+        # Vote counts are internally consistent (a + b + tie == trials). A
+        # constant verdict nets to a tie under position-swap debiasing — the
+        # point of this test is panel sampling + per-judge accounting, not the
+        # winner.
+        assert result["win_count_a"] + result["win_count_b"] + result["tie_count"] == 6
+        # More than one panel member was sampled across 6 trials.
+        assert len(result["per_judge"]) >= 2
+
+    def test_run_trials_judge_sampling_is_reproducible(self) -> None:
+        from resources_servers.gdpval.comparison import Judge, run_trials
+        from resources_servers.gdpval.judge_panel import make_rng
+
+        def _judges():
+            rec: list = []
+            return [
+                Judge(name="a", client=_FakeOpenAIClient("BOXED[TIE]", rec), model="a"),
+                Judge(name="b", client=_FakeOpenAIClient("BOXED[TIE]", rec), model="b"),
+            ]
+
+        kwargs = dict(task_prompt="t", refs=[], submission_a=[], submission_b=[], num_trials=8)
+        r1 = run_trials(judges=_judges(), rng=make_rng(42, "task-1"), return_raw_responses=True, **kwargs)
+        r2 = run_trials(judges=_judges(), rng=make_rng(42, "task-1"), return_raw_responses=True, **kwargs)
+        assert r1["trial_judges"] == r2["trial_judges"]
 
 
 class TestComparisonPayloadHardening:


### PR DESCRIPTION
Implements a multi-judge panel during task verification to match the GDPval-AA v2 benchmark methodology described here [GDPval-AA v2](https://artificialanalysis.ai/methodology/intelligence-benchmarking#gdpval-aa)[GDPval-AA v2](https://artificialanalysis.ai/methodology/intelligence-benchmarking#gdpval-aa)

> Matches are graded by a panel of three frontier LLM judges from leading labs, each run at its default reasoning settings: GPT-5.5 (medium reasoning), Gemini 3.1 Pro Preview (high reasoning), and Claude Opus 4.8 (high effort). We sample between the judges for each comparison. The initial task, all reference files, and all submission files are parsed and provided as context to the judge.



***Still needs testing
