### PR TITLE
[codex] Add sandbox API docs guide

### DIFF
--- a/fern/versions/latest/pages/api-reference/index.mdx
+++ b/fern/versions/latest/pages/api-reference/index.mdx
@@ -17,3 +17,4 @@ This reference is built from docstrings in the [source code](https://github.com/
 | `nemo_gym.config_types` | Pydantic configuration models for servers, datasets, and CLI |
 | `nemo_gym.server_utils` | Server utilities, HTTP client, and middleware |
 | `nemo_gym.openai_utils` | OpenAI API client wrapper |
+| `nemo_gym.sandbox` | Provider-neutral sandbox API for isolated command execution and file transfer |

--- a/fern/versions/latest/pages/infrastructure/engineering-notes/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/engineering-notes/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Engineering Notes"
 description: ""
-position: 3
+position: 4
 ---
 Technical notes that document infrastructure decisions, performance investigations, and design rationale behind NeMo Gym.
 

--- a/fern/versions/latest/pages/infrastructure/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/index.mdx
@@ -13,6 +13,12 @@ Server deployment patterns and training framework integration.
 <Badge minimal outlined>deployment</Badge> <Badge minimal outlined>topology</Badge> <Badge minimal outlined>training-integration</Badge>
 </Card>
 
+<Card title="Sandbox API" href="/infrastructure/sandbox">
+Provider-neutral isolated execution for agents, resources servers, and benchmark harnesses.
+
+<Badge minimal outlined>execution</Badge> <Badge minimal outlined>sandbox</Badge> <Badge minimal outlined>providers</Badge>
+</Card>
+
 <Card title="Engineering Notes" href="/infrastructure/engineering-notes">
 Technical notes on infrastructure decisions and design rationale.
 

--- a/fern/versions/latest/pages/infrastructure/sandbox/adding-a-provider.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/adding-a-provider.mdx
@@ -1,0 +1,190 @@
+---
+title: "Adding a Sandbox Provider"
+description: "Implement and register a sandbox runtime backend for NeMo Gym."
+position: 3
+---
+
+Add a provider when NeMo Gym needs to create sandboxes through a new runtime backend, such as a container service, HPC isolation layer, or in-house execution platform. The public `AsyncSandbox` and `Sandbox` facades stay the same; the provider owns runtime-specific create, command, file transfer, status, and cleanup behavior.
+
+## Provider Contract
+
+Providers implement the `SandboxProvider` protocol from `nemo_gym.sandbox.providers.base`. Keep common caller fields on `SandboxSpec`; put backend-specific options in `SandboxSpec.provider_options`.
+
+```python
+from pathlib import Path
+
+from nemo_gym.sandbox.providers.base import (
+    SandboxExecResult,
+    SandboxHandle,
+    SandboxSpec,
+    SandboxStatus,
+)
+
+
+class MySandboxProvider:
+    name = "my_provider"
+
+    async def create(self, spec: SandboxSpec) -> SandboxHandle:
+        raw = await my_runtime_create(spec)
+        return SandboxHandle(sandbox_id=raw.id, provider_name=self.name, raw=raw)
+
+    async def exec(
+        self,
+        handle: SandboxHandle,
+        command: str,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_s: int | float | None = None,
+        user: str | int | None = None,
+    ) -> SandboxExecResult:
+        result = await handle.raw.run(command, cwd=cwd, env=env, timeout_s=timeout_s, user=user)
+        return SandboxExecResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            return_code=result.return_code,
+        )
+
+    async def upload_file(self, handle: SandboxHandle, source_path: Path, target_path: str) -> None:
+        await handle.raw.upload(source_path, target_path)
+
+    async def download_file(self, handle: SandboxHandle, source_path: str, target_path: Path) -> None:
+        await handle.raw.download(source_path, target_path)
+
+    async def status(self, handle: SandboxHandle) -> SandboxStatus:
+        return SandboxStatus.RUNNING
+
+    async def close(self, handle: SandboxHandle) -> None:
+        await handle.raw.stop()
+
+    async def aclose(self) -> None:
+        return None
+```
+
+Provider implementations should preserve the same lifecycle contract as the built-in providers:
+
+- Return a `SandboxHandle` from `create()` only after the sandbox is ready enough to run commands and transfer files.
+- Return command status through `SandboxExecResult` for process exits, including nonzero exits.
+- Raise `SandboxCreateError` or `SandboxCreateVerificationError` for sandbox allocation and readiness failures.
+- Make `close()` safe to call from cleanup paths.
+- Use `aclose()` for provider-scoped resources such as SDK clients.
+
+## Provider Config
+
+Provider constructors receive the single provider-specific mapping from a named sandbox block:
+
+```yaml
+sandbox:
+  default_metadata:
+    sandbox-api: my-runtime
+  my_provider:
+    connection:
+      endpoint: https://sandbox.example
+    operations:
+      retries: 3
+```
+
+`resolve_provider_config("sandbox", global_config_dict)` returns only the single provider mapping:
+
+```python
+{"my_provider": {"connection": {"endpoint": "https://sandbox.example"}, "operations": {"retries": 3}}}
+```
+
+`resolve_provider_metadata("sandbox", global_config_dict)` returns the optional `default_metadata` block. Agents merge those values into `SandboxSpec.metadata` before provider create, with agent-level metadata taking precedence.
+
+Each named block must contain exactly one non-reserved provider key. The only reserved key today is `default_metadata`.
+
+## Provider Options
+
+Use `SandboxSpec.provider_options` for per-sandbox options that do not belong in the neutral schema. Validate that mapping before allocating runtime resources so bad configs fail early.
+
+```python
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class MyProviderOptions:
+    snapshot_id: str | None = None
+    labels: dict[str, str] | None = None
+
+    @classmethod
+    def from_mapping(cls, options: Mapping[str, Any] | None) -> "MyProviderOptions":
+        if options is None:
+            return cls()
+        allowed = set(cls.__dataclass_fields__)
+        unknown = set(options) - allowed
+        if unknown:
+            raise ValueError(f"Unknown provider option(s): {', '.join(sorted(unknown))}")
+        return cls(**dict(options))
+```
+
+Then resolve it inside `create()`:
+
+```python
+async def create(self, spec: SandboxSpec) -> SandboxHandle:
+    options = MyProviderOptions.from_mapping(spec.provider_options)
+    ...
+```
+
+This keeps common fields such as `image`, `env`, `files`, `metadata`, and `resources` portable while still giving a provider room for runtime-specific behavior.
+
+## Registry
+
+The registry in `nemo_gym.sandbox.providers.registry` maps provider names from config to provider classes. Lookup order is:
+
+1. Explicit in-process registration with `register_provider()`.
+2. Built-in providers shipped with NeMo Gym.
+3. Installed Python entry points in the `nemo_gym.sandbox_providers` group.
+
+External packages and tests can register a provider directly:
+
+```python
+from nemo_gym.sandbox.providers.registry import register_provider
+
+
+register_provider("my_provider", MySandboxProvider)
+```
+
+In-tree built-in providers should use a lazy loader in `registry.py` so importing `nemo_gym.sandbox` does not eagerly import optional provider dependencies.
+
+```python
+def _load_my_provider() -> ProviderClass:
+    from nemo_gym.sandbox.providers.my_provider import MySandboxProvider
+
+    return MySandboxProvider
+
+
+_BUILTIN_PROVIDER_LOADERS["my_provider"] = _load_my_provider
+```
+
+Out-of-tree packages can publish a provider entry point in their `pyproject.toml`:
+
+```toml
+[project.entry-points."nemo_gym.sandbox_providers"]
+my_provider = "my_pkg.provider:MyProvider"
+```
+
+Two entry points with the same provider name raise an error because selection would be nondeterministic. An entry point shadowed by a registered provider or a built-in provider is warned and ignored.
+
+After registration, callers select the provider with a single-key provider config:
+
+```python
+provider_config = {
+    "my_provider": {
+        "provider_setting": "value",
+    }
+}
+```
+
+## Provider Pages
+
+Each provider page should use the same shape so users can compare backends quickly:
+
+- Setup and optional dependencies
+- Named provider config block
+- `provider_options` accepted by `SandboxSpec`
+- Resource mapping and isolation properties
+- Minimal `gym env start` or local first-run example
+- Provider-specific operational notes

--- a/fern/versions/latest/pages/infrastructure/sandbox/apptainer.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/apptainer.mdx
@@ -1,0 +1,135 @@
+---
+title: "Apptainer Provider"
+description: "Configure NeMo Gym sandboxes backed by local Apptainer instances."
+position: 2
+---
+
+The `apptainer` provider runs each sandbox as a persistent local Apptainer instance. It shells out to the `apptainer` binary, so it does not require a daemon, Kubernetes, or a network sandbox service.
+
+## Setup
+
+Install Apptainer on the host and make sure the `apptainer` binary is on `PATH`. The provider does not auto-install it; constructing the provider raises an error if the binary is missing.
+
+Images can be local `.sif` files, Apptainer-compatible URIs such as `docker://ubuntu:22.04`, or bare Docker image names such as `ubuntu:22.04`. Bare names are resolved to `docker://...` before instance start.
+
+## Provider Config
+
+Define a named provider block in a YAML config file that you own, such as `configs/apptainer-sandbox.yaml` in your checkout or application repo. Put the `sandbox:` block at the top level of that file, then reference it from an agent with `sandbox_provider: sandbox`.
+
+<Note>
+NeMo Gym does not ship a default Apptainer provider config file. Create this file next to the other configs you pass to `gym env start`.
+</Note>
+
+```yaml
+sandbox:
+  default_metadata:
+    sandbox-api: apptainer-cli
+  apptainer:
+    exec:
+      fakeroot_for_root: true
+      default_binds: ["/tmp"]
+      extra_exec_args: ["--writable-tmpfs"]
+      default_timeout_s: 180
+      concurrency: 32
+    create:
+      mount_point: /sandbox
+      start_timeout_s: 600
+      extra_start_args: []
+      apply_resource_limits: true
+    probe:
+      command: printf apptainer-sandbox-ready
+      expected_stdout: apptainer-sandbox-ready
+      timeout_s: 30
+      deadline_s: 120
+```
+
+The provider constructor accepts three optional config sections:
+
+| Section | Purpose |
+| --- | --- |
+| `exec` | Per-command timeout, fakeroot behavior, default bind mounts, extra `apptainer exec` flags, and subprocess concurrency. |
+| `create` | Instance mount point, start timeout, extra `apptainer instance start` flags, and CPU/memory limit behavior. |
+| `probe` | Post-create command probe used to verify command execution before the sandbox is returned. |
+
+Pass that config file alongside the agent and model configs:
+
+```bash
+gym env start \
+  --config responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml \
+  --config configs/apptainer-sandbox.yaml \
+  --config responses_api_models/vllm_model/configs/vllm_model.yaml
+```
+
+## SandboxSpec Provider Options
+
+Use `provider_options.binds` for per-sandbox bind mounts. It accepts either a single bind string or a list of bind strings, using the Apptainer `host:container[:opts]` format.
+
+```yaml
+sandbox_spec:
+  provider_options:
+    binds:
+      - /datasets/swebench:/datasets/swebench:ro
+```
+
+These binds are added on top of the provider's staging mount and `exec.default_binds`.
+
+## Relevant SandboxSpec Fields
+
+| Field | Apptainer behavior |
+| --- | --- |
+| `image` | Required. Local `.sif`, Apptainer URI, or Docker image name. |
+| `env` | Passed as `--env KEY=VALUE` at instance start and on each `exec()`. |
+| `workdir` | Used as the default command working directory through `--pwd`. |
+| `files` | Seed files uploaded before the first command. |
+| `resources` | Mapped to cgroup and GPU flags when supported by the host. |
+| `provider_options.binds` | Extra per-sandbox bind mounts. |
+| `ttl_s` | Not supported by Apptainer; the provider logs a warning and ignores it. |
+
+## Resource Mapping
+
+`SandboxResources` is translated into Apptainer CLI flags:
+
+| SandboxResources field | Apptainer flag |
+| --- | --- |
+| `cpu` | `--cpus <value>` |
+| `memory_mib` | `--memory <value>m` |
+| `gpu` | `--nv` when truthy |
+| `disk_gib` | No direct flag; ignored. |
+| `gpu_type` | No direct flag; ignored. |
+
+CPU and memory enforcement requires cgroups support from the host. Set `create.apply_resource_limits: false` if the cluster does not delegate those controls.
+
+## Lifecycle
+
+The provider creates one persistent Apptainer instance per sandbox:
+
+| Operation | Apptainer command |
+| --- | --- |
+| Create | `apptainer instance start --bind <staging>:<mount_point> ... <image> <name>` |
+| Exec | `apptainer exec ... instance://<name> sh -c <command>` |
+| Status | `apptainer instance list --json` |
+| Close | `apptainer instance stop <name>` |
+
+Instances are named `nemo-gym-<uuid>`. State written by one command is visible to later commands in the same sandbox.
+
+## File Transfer
+
+On create, the provider makes a temporary host staging directory and bind-mounts it into the container at `create.mount_point`, which defaults to `/sandbox`.
+
+If a transfer path is under that mount point, uploads and downloads use the host-side staging directory directly. For paths outside the mount point, the provider stages bytes in the shared directory and runs an in-container copy command as root.
+
+Download any files you need before stopping the sandbox. Stopping an Apptainer sandbox stops the instance and deletes the host staging directory.
+
+## User and Runtime Notes
+
+The neutral `user` argument to `exec()` maps onto Apptainer behavior:
+
+| `user` value | Behavior |
+| --- | --- |
+| `None` | Run as the launching user. |
+| `"root"` or `0` | Add `--fakeroot` when `exec.fakeroot_for_root` is enabled. |
+| Other user or uid | Add `--fakeroot` and wrap the command with `su`. |
+
+Running as root or another user depends on host fakeroot support. Numeric UIDs may not resolve inside the container; prefer named users when switching users.
+
+Command failures return `SandboxExecResult` with the command's exit code. Provider runtime failures such as a missing instance return code `125` with `error_type="sandbox"`, and timeouts return code `125` with `error_type="timeout"`.

--- a/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
@@ -1,0 +1,311 @@
+---
+title: "Sandbox API"
+description: "Use the provider-neutral sandbox module for isolated execution in NeMo Gym agents and environments."
+position: 3
+---
+
+The `nemo_gym.sandbox` module is the provider-neutral interface for creating isolated execution environments, running commands, and moving files in or out of those environments. Agents and resources servers call the same API while provider pages document backend-specific setup, configuration, and isolation properties.
+
+Import caller-facing APIs from the public package boundary:
+
+```python
+from nemo_gym.sandbox import AsyncSandbox, Sandbox, SandboxResources, SandboxSpec
+```
+
+<Note>
+Treat `nemo_gym.sandbox` as the stable caller-facing API. Provider modules under `nemo_gym.sandbox.providers` are implementation details unless you are adding or configuring a provider.
+</Note>
+
+<Cards>
+
+<Card title="OpenSandbox Provider" href="/infrastructure/sandbox/opensandbox">
+Run sandboxes through an OpenSandbox server and SDK.
+
+<Badge minimal outlined>provider</Badge> <Badge minimal outlined>opensandbox</Badge>
+</Card>
+
+<Card title="Apptainer Provider" href="/infrastructure/sandbox/apptainer">
+Run sandboxes as local Apptainer instances on a host or HPC node.
+
+<Badge minimal outlined>provider</Badge> <Badge minimal outlined>apptainer</Badge>
+</Card>
+
+<Card title="Adding a Provider" href="/infrastructure/sandbox/adding-a-provider">
+Implement the `SandboxProvider` protocol and register a new runtime backend.
+
+<Badge minimal outlined>contributors</Badge> <Badge minimal outlined>providers</Badge>
+</Card>
+
+</Cards>
+
+## Install Provider Dependencies
+
+The public API is part of `nemo-gym`. Runtime backends can have optional dependencies, so install the extras or system packages required by the provider you configure in your agent or resources server.
+
+## Core Types
+
+| API | Purpose |
+| --- | --- |
+| `AsyncSandbox` | Async facade for FastAPI servers, async agents, and rollout code. Use this inside async code. |
+| `Sandbox` | Sync facade for synchronous harnesses. It owns a private event loop and rejects calls from an already-running async loop. |
+| `SandboxSpec` | Provider-neutral sandbox creation request. Includes image, TTL, working directory, files, metadata, resources, entrypoint, and provider options. |
+| `SandboxResources` | Typed resource request with CPU, memory, disk, and GPU fields. |
+| `SandboxExecResult` | Command result with `stdout`, `stderr`, `return_code`, and optional `error_type`. |
+| `SandboxStatus` | Provider-neutral lifecycle status: `starting`, `running`, `stopped`, `error`, or `unknown`. |
+| `SandboxCreateError` | Base create-time failure for provider allocation and readiness errors. |
+| `SandboxCreateVerificationError` | Create-time failure raised when a new sandbox cannot pass provider readiness checks. |
+
+## First-Run Example
+
+Create a small local script after your provider is available. Replace the provider name and settings with the backend configured for your environment.
+
+```python
+import asyncio
+
+from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
+
+
+provider_config = {"apptainer": {}}
+
+spec = SandboxSpec(
+    image="docker://python:3.12-slim",
+    ttl_s=1800,
+    ready_timeout_s=300,
+    workdir="/sandbox",
+    files={
+        "/sandbox/hello.py": "print('hello from sandbox')\n",
+    },
+    resources=SandboxResources(cpu=1, memory_mib=1024, disk_gib=5),
+    metadata={"example": "first-run"},
+)
+
+
+async def main() -> None:
+    async with AsyncSandbox(provider_config, spec) as sandbox:
+        await sandbox.start()
+        result = await sandbox.exec("python /sandbox/hello.py", timeout_s=60)
+        print(result.stdout or result.stderr)
+        raise SystemExit(result.return_code)
+
+
+asyncio.run(main())
+```
+
+Run it from your local checkout or application environment:
+
+```bash
+python first_sandbox.py
+```
+
+`exec()` returns a `SandboxExecResult`. Nonzero process exits are reported in `return_code`; providers should reserve exceptions for sandbox runtime failures such as allocation, transport, or lifecycle errors.
+
+## Provider Config Blocks
+
+Agents can refer to a named provider block instead of embedding provider credentials or backend settings in the agent config. The `sandbox_provider` field names a top-level config block, and that block contains exactly one provider key plus optional reserved keys:
+
+```yaml
+sandbox:
+  default_metadata:
+    sandbox-api: opensandbox-sdk
+  opensandbox:
+    connection:
+      domain: ${oc.env:OPENSANDBOX_DOMAIN}
+      api_key: ${oc.env:OPENSANDBOX_API_KEY}
+      protocol: http
+```
+
+The agent then references that block by name:
+
+```yaml
+mini_swe_agent_2:
+  responses_api_agents:
+    mini_swe_agent_2:
+      sandbox_provider: sandbox
+      sandbox_spec:
+        resources:
+          cpu: 2
+          memory_mib: 8192
+        provider_options:
+          platform:
+            os: linux
+            arch: amd64
+```
+
+Every provider config can bind the same name, such as `sandbox`, so swapping backends is swapping the provider config path passed to `gym env start`. If one run needs multiple sandboxes, give each block a distinct name and reference each one separately.
+
+`default_metadata` is merged into `SandboxSpec.metadata` before create. The agent's own `sandbox_spec.metadata` wins on key conflicts.
+
+The helpers used by agents are public:
+
+```python
+from nemo_gym.sandbox import resolve_provider_config, resolve_provider_metadata
+
+
+provider_config = resolve_provider_config("sandbox", global_config_dict)
+provider_metadata = resolve_provider_metadata("sandbox", global_config_dict)
+```
+
+Inline single-key mappings are also accepted when a caller does not use Hydra config:
+
+```python
+provider_config = {"opensandbox": {"connection": {"domain": "sandbox.example"}}}
+```
+
+## Lifecycle
+
+`AsyncSandbox` and `Sandbox` are lifecycle objects. Construct one with a provider config and optional `SandboxSpec`, call `start()`, run commands or transfer files, then call `stop()`. Context managers close the provider on exit, but they do not start the sandbox automatically.
+
+```python
+from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
+
+
+spec = SandboxSpec(
+    image="ghcr.io/example/eval-image:py312",
+    ttl_s=18000,
+    ready_timeout_s=1200,
+    workdir="/workspace",
+    resources=SandboxResources(cpu=2, memory_mib=8192, disk_gib=20),
+    metadata={"benchmark": "my-benchmark", "task_id": "task-001"},
+)
+
+async with AsyncSandbox(provider_config, spec) as sandbox:
+    await sandbox.start()
+    result = await sandbox.exec(
+        "python -m pytest -q",
+        timeout_s=600,
+        user="root",
+    )
+    passed = result.return_code == 0
+```
+
+## Sync vs. Async
+
+Use `AsyncSandbox` inside FastAPI handlers, async resources servers, async agents, and rollout collection code.
+
+Use `Sandbox` only in synchronous code, such as a third-party harness adapter that does not expose async hooks.
+
+```python
+from nemo_gym.sandbox import Sandbox, SandboxSpec
+
+
+with Sandbox(provider_config, SandboxSpec(image="ghcr.io/example/eval-image:py312")) as sandbox:
+    sandbox.start()
+    result = sandbox.exec("python --version", timeout_s=30)
+    output = "\n".join(part for part in (result.stdout, result.stderr) if part)
+```
+
+<Warning>
+Do not call `Sandbox` from FastAPI handlers, async resources servers, or async agents. It blocks the caller by design. Use `AsyncSandbox` in async code.
+</Warning>
+
+## SandboxSpec Fields
+
+`SandboxSpec` is intentionally provider-neutral. Providers map these fields onto their own runtime primitives.
+
+| Field | Description |
+| --- | --- |
+| `image` | Container image to create. |
+| `ttl_s` | Sandbox lifetime in seconds, when supported by the provider. |
+| `ready_timeout_s` | Time to wait for sandbox readiness. |
+| `workdir` | Default working directory for `exec()` calls. |
+| `env` | Environment variables injected into the sandbox. Forward only values required by the task. |
+| `files` | Text files to upload at startup, keyed by remote target path. |
+| `metadata` | String metadata for tracing, debugging, and backend labels. Providers may normalize values for their runtime. |
+| `resources` | `SandboxResources` or a mapping with `cpu`, `memory_mib`, `disk_gib`, `gpu`, and `gpu_type`. |
+| `entrypoint` | Optional container entrypoint override. |
+| `provider_options` | Provider-specific options that do not fit the common schema. |
+
+You can pass resources as either a `SandboxResources` instance or a mapping:
+
+```python
+spec = SandboxSpec(
+    image="ghcr.io/example/eval-image:py312",
+    resources={
+        "cpu": 2,
+        "memory_mib": 8192,
+        "disk_gib": 20,
+    },
+)
+```
+
+Unknown resource keys raise a `ValueError`, which catches config drift early.
+
+## Startup Files and File Transfer
+
+Use `files` for small text files that should exist before the first command runs:
+
+```python
+spec = SandboxSpec(
+    image="ghcr.io/example/eval-image:py312",
+    workdir="/workspace",
+    files={
+        "/workspace/input.txt": "hello\n",
+    },
+)
+```
+
+Use `upload()` and `download()` for local files:
+
+```python
+await sandbox.upload(local_path, "/workspace/archive.tar.gz")
+await sandbox.download("/workspace/log.txt", output_path)
+```
+
+`upload()` and `download()` operate on files. If you need structured values, serialize them locally before uploading and parse the downloaded file locally after the sandbox command completes.
+
+## Status and Cleanup
+
+Call `status()` when a runner needs to distinguish a stopped sandbox from a provider error:
+
+```python
+status = await sandbox.status()
+if status.value == "error":
+    ...
+```
+
+Always stop sandboxes in cleanup paths. `stop()` is idempotent on the public facade and closes provider-scoped resources after ending the sandbox lifecycle.
+
+```python
+sandbox = AsyncSandbox(provider_config, spec)
+try:
+    await sandbox.start()
+    result = await sandbox.exec("pytest -q", timeout_s=600)
+finally:
+    await sandbox.stop()
+```
+
+## Image Rewrites
+
+Use `rewrite_image()` when a benchmark's upstream image needs to run through an internal registry mirror.
+
+```python
+from nemo_gym.sandbox import rewrite_image
+
+
+image = rewrite_image(
+    "docker.io/library/python:3.12-slim",
+    [{"from": "docker.io/", "to": "mirror.example.com/dockerhub/"}],
+)
+```
+
+Rewrites are ordered. The first matching `from` prefix wins.
+
+## Error Handling
+
+Sandbox create failures use provider-neutral exception classes:
+
+- `SandboxCreateError` for sandbox allocation or readiness failures.
+- `SandboxCreateVerificationError` when a created sandbox fails Gym readiness verification.
+
+In resources servers and agents, catch these errors close to the sandbox operation and return a meaningful verifier or rollout error. Do not let one bad sandbox allocation crash a long-running server.
+
+```python
+from nemo_gym.sandbox import AsyncSandbox, SandboxCreateError
+
+
+sandbox = AsyncSandbox(provider_config, spec)
+try:
+    await sandbox.start()
+except SandboxCreateError as error:
+    return {"reward": 0.0, "error": f"sandbox_create_failed: {error}"}
+```

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
@@ -1,0 +1,175 @@
+---
+title: "OpenSandbox Provider"
+description: "Configure NeMo Gym sandboxes backed by an OpenSandbox server."
+position: 1
+---
+
+The `opensandbox` provider creates sandboxes through the OpenSandbox SDK and server API. It is the Kubernetes-backed provider used by agentic software engineering environments such as `mini_swe_agent_2`.
+
+## Setup
+
+Install the sandbox extra in the runtime image or virtual environment that creates sandboxes:
+
+```bash
+uv sync --extra sandbox
+```
+
+For package installs, use:
+
+```bash
+pip install "nemo-gym[sandbox]"
+```
+
+Set connection values through the provider config. The shipped config reads these environment variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `OPENSANDBOX_DOMAIN` | OpenSandbox server domain. Defaults to the in-cluster service name in the shipped config. |
+| `OPENSANDBOX_API_KEY` | API key passed to the OpenSandbox SDK connection config. |
+
+## Provider Config
+
+NeMo Gym ships an OpenSandbox provider config at `nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml`. It defines a top-level `sandbox` block that agents reference with `sandbox_provider: sandbox`.
+
+```yaml
+sandbox:
+  default_metadata:
+    sandbox-api: opensandbox-sdk
+  opensandbox:
+    connection:
+      domain: ${oc.env:OPENSANDBOX_DOMAIN,opensandbox-server.opensandbox-system.svc.cluster.local}
+      api_key: ${oc.env:OPENSANDBOX_API_KEY}
+      protocol: http
+      request_timeout_s: 300
+      use_server_proxy: true
+    create:
+      request_timeout_s: 1200
+      timeout_s: 1200
+      skip_health_check: true
+      retries: 10
+      retry_delay_s: 5.0
+      retry_max_delay_s: 90.0
+    probe:
+      timeout_s: 60
+      deadline_s: 180
+      stable_count: 2
+      stable_delay_s: 1.0
+    operations:
+      retries: 5
+      retry_delay_s: 1.0
+      retry_max_delay_s: 45.0
+      command_retries: 0
+      close_timeout_s: 30
+```
+
+Run an agent with the provider config by passing it alongside the agent and model configs:
+
+```bash
+gym env start \
+  --config responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml \
+  --config nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml \
+  --config responses_api_models/vllm_model/configs/vllm_model.yaml
+```
+
+The provider constructor accepts four optional config sections:
+
+| Section | Purpose |
+| --- | --- |
+| `connection` | OpenSandbox SDK connection settings: domain, API key, protocol, request timeout, and server proxy mode. |
+| `create` | Sandbox create timeout, retry, image pull policy, and health-check behavior. |
+| `probe` | Post-create command probe used to verify command execution before the sandbox is returned. |
+| `operations` | Retry and timeout behavior for SDK operations after create, including command retries and close timeout. |
+
+## SandboxSpec Provider Options
+
+Set OpenSandbox-specific create options under `SandboxSpec.provider_options`, or under `sandbox_spec.provider_options` in an agent config:
+
+```yaml
+sandbox_spec:
+  provider_options:
+    platform:
+      os: linux
+      arch: amd64
+    skip_health_check: false
+    extensions:
+      imagePullPolicy: IfNotPresent
+```
+
+Supported options are:
+
+| Option | Purpose |
+| --- | --- |
+| `platform` | Mapping passed to the OpenSandbox SDK `PlatformSpec`, such as `os` and `arch`. |
+| `snapshot_id` | OpenSandbox snapshot ID to create from instead of only an image. |
+| `volumes` | List of mappings passed to the OpenSandbox SDK `Volume` model. |
+| `skip_health_check` | Per-sandbox override for SDK create health checking unless the provider config forces it on. |
+| `extensions` | String map passed to OpenSandbox create extensions. |
+
+Unknown provider option keys raise `ValueError`; values with the wrong type raise `TypeError`. This catches config drift before a sandbox allocation is attempted.
+
+## Relevant SandboxSpec Fields
+
+| Field | OpenSandbox behavior |
+| --- | --- |
+| `image` | Container image passed to OpenSandbox create. |
+| `ttl_s` | Converted to an OpenSandbox sandbox timeout. |
+| `ready_timeout_s` | Converted to an OpenSandbox ready timeout. |
+| `env` | Passed to OpenSandbox create and command execution. |
+| `files` | Seed files uploaded before the first command. |
+| `metadata` | Passed to OpenSandbox create after provider-specific normalization. |
+| `resources` | Mapped to OpenSandbox resource quantities. |
+| `entrypoint` | Passed to OpenSandbox create when set. |
+| `provider_options` | Per-sandbox OpenSandbox options such as `platform`, `snapshot_id`, `volumes`, `skip_health_check`, and `extensions`. |
+
+## Resource Mapping
+
+`SandboxResources` is translated into OpenSandbox resource quantities:
+
+| SandboxResources field | OpenSandbox resource key |
+| --- | --- |
+| `cpu` | `cpu` |
+| `memory_mib` | `memory`, formatted as `<value>Mi` |
+| `disk_gib` | `ephemeral-storage`, formatted as `<value>Gi` |
+| `gpu` | `gpu` |
+| `gpu_type` | `gpu_type` |
+
+The provider also normalizes metadata values for backend labels by replacing unsupported characters and truncating values to the provider limit.
+
+## Lifecycle
+
+The provider creates one OpenSandbox sandbox per Gym sandbox:
+
+| Operation | OpenSandbox behavior |
+| --- | --- |
+| Create | `opensandbox.Sandbox.create(...)` with normalized `SandboxSpec` fields. |
+| Exec | `handle.raw.commands.run(...)` with command options derived from `exec()` arguments. |
+| Status | `handle.raw.get_info()` mapped onto `SandboxStatus`. |
+| Close | `handle.raw.kill()` followed by local SDK handle cleanup. |
+
+If `create.skip_health_check` is enabled, the provider reconnects to the sandbox before running the NeMo Gym readiness probe so follow-up operations use a fresh SDK handle.
+
+## File Transfer
+
+The provider uses the OpenSandbox SDK file API for uploads and downloads:
+
+- `upload()` reads the local file and writes bytes to the target sandbox path.
+- `download()` reads bytes from the sandbox path and writes them to the local target path.
+
+Startup files from `SandboxSpec.files` use the same provider file path semantics before the first command runs.
+
+## User and Runtime Notes
+
+The neutral `user` argument to `exec()` maps onto OpenSandbox command options:
+
+| `user` value | Behavior |
+| --- | --- |
+| `None` | Use the sandbox default user. |
+| `"root"` | Run the command as provided. |
+| Integer uid | Pass the uid through the OpenSandbox command options. |
+| Other string | Wrap the command with `su -s /bin/sh -c ... <user>`. |
+
+Command failures return `SandboxExecResult` with the command's exit code. If OpenSandbox reports an execution error without an exit code, the provider returns code `125` with `error_type="sandbox"`.
+
+The provider's `create.image_pull_policy` defaults to `IfNotPresent`. Valid values are `Always`, `IfNotPresent`, and `Never`. The resolved policy is written into OpenSandbox create extensions as both `imagePullPolicy` and `opensandbox.extensions.image-pull-policy` unless those keys are already present in `provider_options.extensions`.
+
+Create retries handle transient allocation, connection, image pull, and server-side errors. Command retries are controlled separately by `operations.command_retries`.


### PR DESCRIPTION
## Summary
- Add a Fern guide for the provider-neutral `nemo_gym.sandbox` API.
- Link the guide from the Infrastructure docs and include `nemo_gym.sandbox` in the API reference index.
- Adjust Engineering Notes ordering so the new Sandbox API page appears in the Infrastructure section.

## Validation
- `npm run check -- --warnings` passed with 0 errors.
- Remaining Fern warning: redirects check skipped because the local session is not authenticated with Fern.