### PR TITLE
feat(code_gen): add per-language subset metrics for livecodebench-x

### DIFF
--- a/resources_servers/code_gen/app.py
+++ b/resources_servers/code_gen/app.py
@@ -150,7 +150,6 @@ class CompCodingResourcesServer(SimpleResourcesServer):
     async def verify(self, body: CompCodingVerifyRequest) -> CompCodingVerifyResponse:
         model_out = body.response.output_text
         difficulty = (body.verifier_metadata or {}).get("difficulty")
-        target_language = body.target_language
 
         if not model_out or not model_out.strip():
             # A response existed but had no usable text -> model failure
@@ -158,7 +157,6 @@ class CompCodingResourcesServer(SimpleResourcesServer):
                 **body.model_dump(),
                 reward=0.0,
                 difficulty=difficulty,
-                target_language=target_language,
             )
 
         tests = UnitTests.model_validate(body.verifier_metadata["unit_tests"])
@@ -171,7 +169,6 @@ class CompCodingResourcesServer(SimpleResourcesServer):
                 reward=0.0,
                 extracted_model_output=model_out,
                 difficulty=difficulty,
-                target_language=target_language,
             )
 
         # 4) run (no sandbox)
@@ -230,7 +227,6 @@ class CompCodingResourcesServer(SimpleResourcesServer):
             unit_tests_time_taken=unit_tests_time_taken,
             reasoning_format_violation_rate=1.0 if has_violation else 0.0,
             difficulty=difficulty,
-            target_language=target_language,
         )
 
 

--- a/resources_servers/code_gen/app.py
+++ b/resources_servers/code_gen/app.py
@@ -64,6 +64,7 @@ class CompCodingRunRequest(BaseRunRequest):
 
 class CompCodingVerifyRequest(CompCodingRunRequest, BaseVerifyRequest):
     verifier_metadata: Optional[Dict[str, Any]] = None
+    target_language: Optional[str] = None
 
 
 class CompCodingVerifyResponse(BaseVerifyResponse):
@@ -149,7 +150,7 @@ class CompCodingResourcesServer(SimpleResourcesServer):
     async def verify(self, body: CompCodingVerifyRequest) -> CompCodingVerifyResponse:
         model_out = body.response.output_text
         difficulty = (body.verifier_metadata or {}).get("difficulty")
-        target_language = (body.verifier_metadata or {}).get("target_language")
+        target_language = body.target_language
 
         if not model_out or not model_out.strip():
             # A response existed but had no usable text -> model failure

--- a/resources_servers/code_gen/app.py
+++ b/resources_servers/code_gen/app.py
@@ -74,6 +74,7 @@ class CompCodingVerifyResponse(BaseVerifyResponse):
     unit_tests_time_taken: Optional[float] = None
     reasoning_format_violation_rate: float = 0.0
     difficulty: Optional[str] = None
+    target_language: Optional[str] = None
 
 
 # ----------------------------
@@ -124,6 +125,7 @@ class CompCodingResourcesServer(SimpleResourcesServer):
         )
         add_avg_sample_std_dev(metrics, all_score_dicts, score_names, max_k)
         metrics.update(compute_subset_metrics(tasks, "difficulty", self._code_score_fn, "extracted_model_code"))
+        metrics.update(compute_subset_metrics(tasks, "target_language", self._code_score_fn, "extracted_model_code"))
         return metrics
 
     def get_key_metrics(self, agent_metrics: Dict[str, Any]) -> Dict[str, Any]:
@@ -147,6 +149,7 @@ class CompCodingResourcesServer(SimpleResourcesServer):
     async def verify(self, body: CompCodingVerifyRequest) -> CompCodingVerifyResponse:
         model_out = body.response.output_text
         difficulty = (body.verifier_metadata or {}).get("difficulty")
+        target_language = (body.verifier_metadata or {}).get("target_language")
 
         if not model_out or not model_out.strip():
             # A response existed but had no usable text -> model failure
@@ -154,6 +157,7 @@ class CompCodingResourcesServer(SimpleResourcesServer):
                 **body.model_dump(),
                 reward=0.0,
                 difficulty=difficulty,
+                target_language=target_language,
             )
 
         tests = UnitTests.model_validate(body.verifier_metadata["unit_tests"])
@@ -166,6 +170,7 @@ class CompCodingResourcesServer(SimpleResourcesServer):
                 reward=0.0,
                 extracted_model_output=model_out,
                 difficulty=difficulty,
+                target_language=target_language,
             )
 
         # 4) run (no sandbox)
@@ -224,6 +229,7 @@ class CompCodingResourcesServer(SimpleResourcesServer):
             unit_tests_time_taken=unit_tests_time_taken,
             reasoning_format_violation_rate=1.0 if has_violation else 0.0,
             difficulty=difficulty,
+            target_language=target_language,
         )
 
 

--- a/resources_servers/code_gen/tests/test_app.py
+++ b/resources_servers/code_gen/tests/test_app.py
@@ -146,6 +146,10 @@ class TestApp:
                 verifier_metadata={"unit_tests": {"inputs": ["1\n"], "outputs": ["1"]}},
             )
 
+    def test_verify_target_language_field(self) -> None:
+        resp = CompCodingVerifyResponse(reward=0.0, target_language="ja")
+        assert resp.target_language == "ja"
+
     async def test_verify_no_code_block(self, code_gen_resources_server_client: TestClient) -> None:
         """Test when response contains no code block - should extract raw text"""
         response = NeMoGymResponse(
@@ -326,6 +330,23 @@ class TestComputeMetrics:
         m = server.compute_metrics(tasks)
         assert "pass@1[avg-of-2]/no_answer" in m
         assert m["pass@1[avg-of-2]/no_answer"] == pytest.approx(50.0)
+
+    def test_produces_per_language_subsets(self):
+        server = _make_server()
+        tasks = [
+            [
+                {"reward": 1.0, "extracted_model_code": "print(1)", "target_language": "de"},
+                {"reward": 1.0, "extracted_model_code": "print(1)", "target_language": "de"},
+            ],
+            [
+                {"reward": 0.0, "extracted_model_code": "print(2)", "target_language": "fr"},
+                {"reward": 0.0, "extracted_model_code": "print(2)", "target_language": "fr"},
+            ],
+        ]
+        m = server.compute_metrics(tasks)
+        assert "de/pass@1/accuracy" in m
+        assert "fr/pass@1/accuracy" in m
+        assert m["de/pass@1/accuracy"] > m["fr/pass@1/accuracy"]
 
 
 class TestGetKeyMetrics:


### PR DESCRIPTION
`compute_metrics()` currently groups by `difficulty` only. livecodebench-x benchmark rows include a `target_language` field (`de`, `es`, `fr`, `ja`) as a top-level data row field (adjacent to `verifier_metadata`, not inside it), but the field was never declared on `CompCodingVerifyRequest` — Pydantic silently dropped it — and therefore never reached `CompCodingVerifyResponse` or `compute_subset_metrics`. As a result, per-language pass@k values never appear in `rollouts_aggregate_metrics.json`.

This PR fixes that by mirroring the existing `difficulty` pattern:

- Adds `target_language: Optional[str] = None` to `CompCodingVerifyRequest` so Pydantic preserves the top-level field through routing
- Adds `target_language: Optional[str] = None` to `CompCodingVerifyResponse`
- Reads `body.target_language` in `verify()` and propagates it through all three return sites via `**body.model_dump()`
- Calls `compute_subset_metrics(tasks, "target_language", ...)` alongside the existing difficulty call
- Confirms `get_key_metrics()` already handles the new prefixes generically — no change needed there
- Adds focused tests for the new metric keys and field propagation

Closes #1171

## Checklist
- [ ] Targeted tests pass: `uv run pytest resources_servers/code_gen/tests/test_app.py -x -v`
- [ ] No changes to benchmark data files, config YAML, or `nemo_gym/reward_profile.py`
- [ ] DCO sign-off on all commits
