### PR TITLE
feat: [GDPval-AA v2 Updates 2 / n] - Task Execution Only Mode

### DIFF
--- a/benchmarks/gdpval/config.yaml
+++ b/benchmarks/gdpval/config.yaml
@@ -65,6 +65,10 @@ gdpval_stirrup_agent:
       user_prompt_template: ${oc.env:USER_PROMPT_TEMPLATE,null}
       gdpval_container_path: ${oc.env:GDPVAL_CONTAINER_PATH,null}
       persist_deliverables_dir: ${oc.env:PERSIST_DELIVERABLES_DIR,output/gdpval/deliverables}
+      # Task-only execution mode. When true, runs each task and caches deliverables
+      # to persist_deliverables_dir but skips the judge /verify call (no reward).
+      # Requires persist_deliverables_dir to be an absolute path.
+      execute_only: ${oc.env:EXECUTE_ONLY,false}
       resources_server:
         type: resources_servers
         name: gdpval_resources_server

--- a/responses_api_agents/stirrup_agent/README.md
+++ b/responses_api_agents/stirrup_agent/README.md
@@ -206,6 +206,40 @@ To give the agent web access (some GDPVal tasks benefit from fresh facts), set
 `TAVILY_API_KEY` in the environment. The agent automatically exposes `web_search` and
 `web_fetch` tools backed by the [Tavily Search API](https://tavily.com).
 
+### Task-Only Execution Mode
+
+Sometimes you want to *run* the tasks and keep their deliverables without judging
+them — e.g. to build a reference set for later pairwise comparison, to defer
+scoring to a separate pass, or to inspect raw model outputs. Set `execute_only:
+true` (or export `EXECUTE_ONLY=true` with the benchmark config) to do exactly
+that:
+
+- Each task runs through the Stirrup agent and its deliverables are cached to
+  `persist_deliverables_dir/task_<task_id>/repeat_<n>/` (the same layout used by
+  comparison mode's `reference_deliverables_dir`).
+- The judge `/verify` call is **skipped entirely** — no judgement is made or
+  sent, and no LLM-judge tokens are spent.
+- Each rollout row carries the `response`, the `deliverables_dir`, and
+  `execute_only: true`, but **no `reward`** and **no `judge_response`**.
+- `aggregate_metrics` returns baseline (reward-free) stats instead of proxying
+  to the judge server.
+
+`execute_only: true` **requires** `persist_deliverables_dir` to be set to an
+absolute path — without it nothing is saved and the mode is rejected at startup.
+
+```bash
+EXECUTE_ONLY=true \
+PERSIST_DELIVERABLES_DIR=/abs/path/to/output/gdpval/my-model \
+HF_TOKEN=... \
+ng_e2e_collect_rollouts \
+  "+config_paths=[responses_api_models/vllm_model/configs/vllm_model.yaml,benchmarks/gdpval/config.yaml]" \
+  ++split=benchmark \
+  ++output_jsonl_fpath=results/gdpval_execute_only.jsonl
+```
+
+The cached deliverables can later be scored with a separate rubric or
+comparison run by pointing the resources server at the same directory.
+
 ## Extending to New Tasks
 
 To add a benchmark `my_bench`:

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -723,6 +723,14 @@ class StirrupAgentWrapperConfig(BaseResponsesAPIAgentConfig):
         "When set, each task's artifacts land in <dir>/task_<task_id>/; the resources server "
         "reads deliverables_dir from the verify request to score them.",
     )
+    execute_only: bool = Field(
+        default=False,
+        description="Task-only execution mode. When True, the agent runs each task and persists "
+        "deliverables to persist_deliverables_dir, but skips the resources server /verify judge "
+        "call and the aggregate_metrics proxy. No judgement is made or sent and no reward is "
+        "produced; the cached deliverables on disk are the only output. Requires "
+        "persist_deliverables_dir to be set.",
+    )
     model_id: Optional[str] = Field(
         default=None,
         description="HuggingFace model ID (or local checkpoint path) used to load a tokenizer "
@@ -821,6 +829,19 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 f"persist_deliverables_dir must be an absolute path "
                 f"(got {self.config.persist_deliverables_dir!r}). Relative paths "
                 f"resolve differently in the agent vs. the resources server."
+            )
+        # Task-only mode is meaningless without a place to cache deliverables —
+        # nothing is judged or returned, so the persisted files are the sole output.
+        if self.config.execute_only and not self.config.persist_deliverables_dir:
+            raise ValueError(
+                "execute_only=True requires persist_deliverables_dir to be set so deliverables "
+                "are cached to disk (nothing is judged or returned otherwise)."
+            )
+        if self.config.execute_only:
+            print(
+                "Stirrup agent running in execute_only (task-only) mode: deliverables will be "
+                f"cached to {self.config.persist_deliverables_dir!r}; no judgement will be made or sent.",
+                flush=True,
             )
         print(f"Stirrup agent initialized with task={self.config.task!r}", flush=True)
 
@@ -1028,6 +1049,22 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     (Path(self.config.persist_deliverables_dir) / f"task_{task_id}" / repeat_name).absolute()
                 )
 
+            # Task-only execution mode: the deliverables are already cached to
+            # ``deliverables_dir`` by ``responses()``. Skip the /verify judge
+            # call entirely and return a judgement-free payload (no reward,
+            # no judge_response). Mirrors the verify_request_body shape so the
+            # rollout JSONL row still carries the response + deliverables_dir.
+            if self.config.execute_only:
+                execute_only_payload = dict(body_dict)
+                execute_only_payload["response"] = response_clean.model_dump(mode="json")
+                if deliverables_dir is not None:
+                    execute_only_payload["deliverables_dir"] = deliverables_dir
+                execute_only_payload.setdefault(
+                    "elapsed_seconds", float(response_metadata.get("elapsed_seconds", 0))
+                )
+                execute_only_payload["execute_only"] = True
+                return execute_only_payload
+
             verify_request_body = dict(body_dict)
             verify_request_body["response"] = response_clean.model_dump(mode="json")
             if deliverables_dir is not None:
@@ -1146,6 +1183,11 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         this proxy those extras are lost because the framework dispatches
         ``/aggregate_metrics`` to the agent, not the resources server.
         """
+        # Task-only mode produces no rewards/judge votes, so there is nothing
+        # for the resources server to aggregate. Use the base (non-proxy)
+        # implementation to avoid a needless judge-server round trip.
+        if self.config.execute_only:
+            return await SimpleResponsesAPIAgent.aggregate_metrics(self, body)
         response = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/aggregate_metrics",

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -1059,9 +1059,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 execute_only_payload["response"] = response_clean.model_dump(mode="json")
                 if deliverables_dir is not None:
                     execute_only_payload["deliverables_dir"] = deliverables_dir
-                execute_only_payload.setdefault(
-                    "elapsed_seconds", float(response_metadata.get("elapsed_seconds", 0))
-                )
+                execute_only_payload.setdefault("elapsed_seconds", float(response_metadata.get("elapsed_seconds", 0)))
                 execute_only_payload["execute_only"] = True
                 return execute_only_payload
 

--- a/responses_api_agents/stirrup_agent/configs/stirrup_gdpval.yaml
+++ b/responses_api_agents/stirrup_agent/configs/stirrup_gdpval.yaml
@@ -33,6 +33,12 @@ stirrup_agent:
       # falls back to ``response.output_text``.
       persist_deliverables_dir: null
 
+      # Task-only execution mode. When true, runs each task and caches deliverables
+      # to persist_deliverables_dir but skips the resources server /verify judge
+      # call and aggregate_metrics proxy (no judgement is made or sent, no reward).
+      # Requires persist_deliverables_dir to be set to an absolute path.
+      execute_only: false
+
       # Resources server reference (scores deliverables via /verify).
       resources_server:
         type: resources_servers

--- a/responses_api_agents/stirrup_agent/tests/test_app.py
+++ b/responses_api_agents/stirrup_agent/tests/test_app.py
@@ -13,16 +13,23 @@
 # limitations under the License.
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from stirrup.core.models import AssistantMessage, TokenUsage, ToolCall
 
 from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
+from nemo_gym.openai_utils import (
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseOutputMessage,
+    NeMoGymResponseOutputText,
+)
 from nemo_gym.server_utils import ServerClient
 from responses_api_agents.stirrup_agent.app import (
     StirrupAgentWrapper,
     StirrupAgentWrapperConfig,
+    StirrupRunRequest,
     _load_task_registry,
     get_task_strategy,
 )
@@ -32,6 +39,20 @@ from responses_api_agents.stirrup_agent.task_strategy import TaskStrategy
 
 
 STIRRUP_AGENT_DIR = Path(__file__).resolve().parent.parent
+
+
+def _make_config(*, execute_only: bool = False, persist_deliverables_dir=None) -> StirrupAgentWrapperConfig:
+    return StirrupAgentWrapperConfig(
+        host="0.0.0.0",
+        port=8080,
+        entrypoint="",
+        name="stirrup_agent",
+        task="gdpval",
+        model_server=ModelServerRef(type="responses_api_models", name="policy_model"),
+        resources_server=ResourcesServerRef(type="resources_servers", name="gdpval_resources_server"),
+        execute_only=execute_only,
+        persist_deliverables_dir=persist_deliverables_dir,
+    )
 
 
 class TestTaskRegistry:
@@ -90,6 +111,69 @@ class TestApp:
         assert output_items[1].type == "function_call_output"
         assert output_items[1].call_id == "call_1"
         assert output_items[1].output == "ok"
+
+
+class TestExecuteOnlyMode:
+    def test_execute_only_requires_persist_dir(self) -> None:
+        """execute_only without a persist dir is useless — nothing is saved."""
+        config = _make_config(execute_only=True, persist_deliverables_dir=None)
+        with pytest.raises(ValueError, match="execute_only=True requires persist_deliverables_dir"):
+            StirrupAgentWrapper(config=config, server_client=MagicMock(spec=ServerClient))
+
+    @pytest.mark.asyncio
+    async def test_run_execute_only_skips_verify(self, tmp_path) -> None:
+        """In execute_only mode, run() must not POST /verify and must return a
+        judgement-free payload (no reward / judge_response) carrying the
+        response + deliverables_dir."""
+        config = _make_config(execute_only=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        # seed_session is the only legitimate POST; make it fail so the
+        # non-fatal except branch is exercised and we'd notice any /verify POST.
+        server_client.post = AsyncMock(side_effect=RuntimeError("no server in unit test"))
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        fake_response = NeMoGymResponse(
+            id="gdpval-task-1",
+            created_at=0,
+            model="policy",
+            object="response",
+            output=[
+                NeMoGymResponseOutputMessage(
+                    id="msg-1",
+                    content=[NeMoGymResponseOutputText(type="output_text", text="done", annotations=[])],
+                    role="assistant",
+                    status="completed",
+                    type="message",
+                )
+            ],
+            parallel_tool_calls=False,
+            tool_choice="auto",
+            tools=[],
+            metadata={"elapsed_seconds": "12.5"},
+        )
+
+        params = NeMoGymResponseCreateParamsNonStreaming(
+            input="ignored",
+            metadata={"task_id": "task-1", "prompt": "do the thing", "_ng_rollout_index": "0"},
+        )
+        body = StirrupRunRequest(responses_create_params=params, task_id="task-1", prompt="do the thing")
+        request = MagicMock()
+        request.cookies = {}
+
+        # ``responses`` is a pydantic-model method, so patch it on the class.
+        with patch.object(StirrupAgentWrapper, "responses", AsyncMock(return_value=fake_response)):
+            result = await wrapper.run(request, body)
+
+        # No /verify (or any non-seed) POST should have been issued.
+        for call in server_client.post.await_args_list:
+            assert call.kwargs.get("url_path") == "/seed_session"
+
+        assert result["execute_only"] is True
+        assert "reward" not in result
+        assert "judge_response" not in result
+        assert result["response"]["id"] == "gdpval-task-1"
+        assert result["deliverables_dir"].endswith(str(Path("task_task-1") / "repeat_0"))
+        assert result["elapsed_seconds"] == 12.5
 
 
 class TestExampleDataset:


### PR DESCRIPTION
Adds the ability to only collect rollouts and deliverables for each task, skipping judgement verification. Useful for synthetic data generation or generating reference model deliverable files.