### PR TITLE
feat: [GDPval-AA v2 Updates 3 / n] - Judge Only Mode

### DIFF
--- a/benchmarks/gdpval/config.yaml
+++ b/benchmarks/gdpval/config.yaml
@@ -65,6 +65,7 @@ gdpval_stirrup_agent:
       user_prompt_template: ${oc.env:USER_PROMPT_TEMPLATE,null}
       gdpval_container_path: ${oc.env:GDPVAL_CONTAINER_PATH,null}
       persist_deliverables_dir: ${oc.env:PERSIST_DELIVERABLES_DIR,output/gdpval/deliverables}
+      judge_only: ${oc.env:JUDGE_ONLY,false}
       resources_server:
         type: resources_servers
         name: gdpval_resources_server

--- a/responses_api_agents/stirrup_agent/README.md
+++ b/responses_api_agents/stirrup_agent/README.md
@@ -125,6 +125,7 @@ The agent reads its Hydra config at `configs/stirrup_gdpval.yaml`. Notable keys:
 | `resources_server` | required | Reference to the GDPVal resources server (which scores the deliverable via `/verify`). |
 | `gdpval_container_path` | `null` | Path to an Apptainer `.sif` (see below). |
 | `persist_deliverables_dir` | `null` | If set, each task's artifacts land in `<dir>/task_<task_id>/`. The resources server reads this dir to score the deliverable. |
+| `judge_only` | `false` | If true, skip task execution and score the deliverables already cached under `persist_deliverables_dir` (see [Judge-Only Mode](#judge-only-mode)). |
 | `model_id` | `null` | HF model id or local path used to load a tokenizer for dynamic output sizing. |
 | `completion_token_buffer` | `1000` | Safety margin (in tokens) reserved when sizing `max_completion_tokens` per call. |
 
@@ -159,6 +160,46 @@ default `1000` works in practice; raise it (e.g. 2000–5000) if you see
 sporadic HTTP 400 responses at the vLLM proxy.
 
 ## Advanced Features
+
+### Judge-Only Mode
+
+`judge_only` re-scores a set of deliverables that an earlier run already
+produced, **without** re-executing the (expensive) agent task. It is the
+counterpart to a plain execute-then-judge run: the agent loop is skipped
+entirely and only the resources server `/verify` step runs.
+
+How it works:
+
+- For each task, the agent locates the cached deliverable directory at
+  `persist_deliverables_dir/task_<task_id>/repeat_<rollout_index>/` — the same
+  layout a normal run writes when `persist_deliverables_dir` is set.
+- If the directory exists, a placeholder response is built and `/verify` is
+  called with `deliverables_dir` pointing at the cached files, so the judge
+  scores the on-disk deliverables (not fresh model output).
+- If no cached directory exists for a task, that task is reported as
+  **skipped** (terminal — re-dispatching it would not create the files) and
+  `/verify` is never called.
+
+Requirements / notes:
+
+- `persist_deliverables_dir` must be set (and absolute); it is the source of
+  the deliverables to score. The agent raises at startup otherwise.
+- Run judge-only over the same benchmark / `num_repeats` that produced the
+  cache so the `task_<id>/repeat_<n>` directories line up.
+
+Enable it via the config key or the `JUDGE_ONLY` env var honored by
+`benchmarks/gdpval/config.yaml`:
+
+```bash
+JUDGE_ONLY=true PERSIST_DELIVERABLES_DIR=/abs/path/to/cached/deliverables \
+  ng_e2e_collect_rollouts ...
+```
+
+or as a Hydra override:
+
+```bash
+++gdpval_stirrup_agent.responses_api_agents.stirrup_agent.judge_only=true
+```
 
 ### Apptainer Sandboxing
 

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -723,6 +723,15 @@ class StirrupAgentWrapperConfig(BaseResponsesAPIAgentConfig):
         "When set, each task's artifacts land in <dir>/task_<task_id>/; the resources server "
         "reads deliverables_dir from the verify request to score them.",
     )
+    judge_only: bool = Field(
+        default=False,
+        description="Judge-only mode. When True, the Stirrup agent task is NOT executed; instead "
+        "the resources server scores pre-existing cached deliverables found under "
+        "persist_deliverables_dir/task_<task_id>/repeat_<rollout_index>/ via /verify. Requires "
+        "persist_deliverables_dir to be set and the cached deliverables to already exist (a task "
+        "with no cached deliverable directory is reported as skipped). Use this to (re)score a "
+        "deliverable set produced by an earlier run without paying the rollout cost again.",
+    )
     model_id: Optional[str] = Field(
         default=None,
         description="HuggingFace model ID (or local checkpoint path) used to load a tokenizer "
@@ -821,6 +830,19 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 f"persist_deliverables_dir must be an absolute path "
                 f"(got {self.config.persist_deliverables_dir!r}). Relative paths "
                 f"resolve differently in the agent vs. the resources server."
+            )
+        # Judge-only mode scores cached deliverables in place, so it needs a
+        # populated persist_deliverables_dir to read them from.
+        if self.config.judge_only and not self.config.persist_deliverables_dir:
+            raise ValueError(
+                "judge_only=True requires persist_deliverables_dir to be set — it is the source "
+                "of the cached deliverables to score (no task is executed in judge-only mode)."
+            )
+        if self.config.judge_only:
+            print(
+                "Stirrup agent running in judge_only mode: tasks will NOT be executed; the resources "
+                f"server will score cached deliverables under {self.config.persist_deliverables_dir!r}.",
+                flush=True,
             )
         print(f"Stirrup agent initialized with task={self.config.task!r}", flush=True)
 
@@ -993,29 +1015,6 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
             except Exception as exc:
                 print(f"[stirrup] seed_session failed (non-fatal): {exc}", flush=True)
 
-            # Run the Stirrup agent
-            try:
-                response = await self.responses(fixed_params)
-            except Exception as exc:
-                task_info = self.task_strategy.extract_task_info(existing_metadata)
-                failure_class = _classify_rollout_failure(exc)
-                instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
-                print(
-                    f"[stirrup-{failure_class}] {instance_hint}: {type(exc).__name__}: {exc}",
-                    flush=True,
-                )
-                return self._build_failed_run_payload(
-                    body_dict=body_dict,
-                    fixed_params=fixed_params,
-                    task_info=task_info,
-                    reason=f"{type(exc).__name__}: {exc}",
-                    skipped=(failure_class == "skipped"),
-                    error_class=failure_class,
-                )
-
-            response_clean = response.model_copy(update={"metadata": None})
-            response_metadata = response.metadata or {}
-
             # Locate the persisted deliverables dir for this task. Unset if
             # persist_deliverables_dir is null or task_id is missing (the
             # resources server will fall back to response.output_text).
@@ -1027,6 +1026,54 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 deliverables_dir = str(
                     (Path(self.config.persist_deliverables_dir) / f"task_{task_id}" / repeat_name).absolute()
                 )
+
+            if self.config.judge_only:
+                # Judge-only mode: do NOT run the agent. Score the pre-existing
+                # cached deliverables at ``deliverables_dir``. A task whose
+                # deliverable directory is missing can't be scored — report it
+                # as skipped (terminal; re-dispatch won't create the files).
+                if deliverables_dir is None or not Path(deliverables_dir).is_dir():
+                    task_info = self.task_strategy.extract_task_info(existing_metadata)
+                    reason = (
+                        f"judge_only: no cached deliverables at {deliverables_dir}"
+                        if deliverables_dir
+                        else "judge_only: persist_deliverables_dir or task_id unavailable"
+                    )
+                    instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
+                    print(f"[stirrup-judge_only-missing] {instance_hint}: {reason}", flush=True)
+                    return self._build_failed_run_payload(
+                        body_dict=body_dict,
+                        fixed_params=fixed_params,
+                        task_info=task_info,
+                        reason=reason,
+                        skipped=True,
+                        error_class="skipped",
+                    )
+                response_clean = self._build_judge_only_response(existing_metadata, fixed_params.model)
+                response_metadata = {}
+            else:
+                # Run the Stirrup agent
+                try:
+                    response = await self.responses(fixed_params)
+                except Exception as exc:
+                    task_info = self.task_strategy.extract_task_info(existing_metadata)
+                    failure_class = _classify_rollout_failure(exc)
+                    instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
+                    print(
+                        f"[stirrup-{failure_class}] {instance_hint}: {type(exc).__name__}: {exc}",
+                        flush=True,
+                    )
+                    return self._build_failed_run_payload(
+                        body_dict=body_dict,
+                        fixed_params=fixed_params,
+                        task_info=task_info,
+                        reason=f"{type(exc).__name__}: {exc}",
+                        skipped=(failure_class == "skipped"),
+                        error_class=failure_class,
+                    )
+
+                response_clean = response.model_copy(update={"metadata": None})
+                response_metadata = response.metadata or {}
 
             verify_request_body = dict(body_dict)
             verify_request_body["response"] = response_clean.model_dump(mode="json")
@@ -1060,6 +1107,46 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     skipped=False,
                     error_class=failure_class,
                 )
+
+    def _build_judge_only_response(
+        self,
+        metadata: Dict[str, Any],
+        model_name: Optional[str],
+    ) -> NeMoGymResponse:
+        """Build a placeholder response for judge-only mode.
+
+        No agent ran, so there is no fresh model output. The resources server
+        scores the cached deliverable files read from ``deliverables_dir``; the
+        response text is only the fallback the rubric judge uses when no
+        deliverable files are found. This placeholder keeps the rollout row
+        well-formed for downstream parsing.
+        """
+        task_info = self.task_strategy.extract_task_info(metadata)
+        return NeMoGymResponse(
+            id=self.task_strategy.response_id(task_info),
+            created_at=int(time.time()),
+            model=model_name or "judge_only",
+            object="response",
+            output=[
+                NeMoGymResponseOutputMessage(
+                    id=self.task_strategy.fallback_message_id(task_info),
+                    content=[
+                        NeMoGymResponseOutputText(
+                            type="output_text",
+                            text="Judge-only mode: scoring pre-existing cached deliverables.",
+                            annotations=[],
+                        )
+                    ],
+                    role="assistant",
+                    status="completed",
+                    type="message",
+                )
+            ],
+            parallel_tool_calls=False,
+            tool_choice="none",
+            tools=[],
+            metadata=None,
+        )
 
     def _build_failed_run_payload(
         self,

--- a/responses_api_agents/stirrup_agent/configs/stirrup_gdpval.yaml
+++ b/responses_api_agents/stirrup_agent/configs/stirrup_gdpval.yaml
@@ -33,6 +33,13 @@ stirrup_agent:
       # falls back to ``response.output_text``.
       persist_deliverables_dir: null
 
+      # Judge-only mode: when true, the agent task is NOT executed; instead the
+      # resources server scores the deliverables already cached under
+      # persist_deliverables_dir/task_<task_id>/repeat_<rollout_index>/ via
+      # /verify. Requires persist_deliverables_dir to point at an existing
+      # cached deliverable set. Default false (normal execute-then-judge run).
+      judge_only: false
+
       # Resources server reference (scores deliverables via /verify).
       resources_server:
         type: resources_servers

--- a/responses_api_agents/stirrup_agent/tests/test_app.py
+++ b/responses_api_agents/stirrup_agent/tests/test_app.py
@@ -13,16 +13,20 @@
 # limitations under the License.
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from stirrup.core.models import AssistantMessage, TokenUsage, ToolCall
 
 from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
+from nemo_gym.openai_utils import (
+    NeMoGymResponseCreateParamsNonStreaming,
+)
 from nemo_gym.server_utils import ServerClient
 from responses_api_agents.stirrup_agent.app import (
     StirrupAgentWrapper,
     StirrupAgentWrapperConfig,
+    StirrupRunRequest,
     _load_task_registry,
     get_task_strategy,
 )
@@ -32,6 +36,20 @@ from responses_api_agents.stirrup_agent.task_strategy import TaskStrategy
 
 
 STIRRUP_AGENT_DIR = Path(__file__).resolve().parent.parent
+
+
+def _make_config(*, judge_only: bool = False, persist_deliverables_dir=None) -> StirrupAgentWrapperConfig:
+    return StirrupAgentWrapperConfig(
+        host="0.0.0.0",
+        port=8080,
+        entrypoint="",
+        name="stirrup_agent",
+        task="gdpval",
+        model_server=ModelServerRef(type="responses_api_models", name="policy_model"),
+        resources_server=ResourcesServerRef(type="resources_servers", name="gdpval_resources_server"),
+        judge_only=judge_only,
+        persist_deliverables_dir=persist_deliverables_dir,
+    )
 
 
 class TestTaskRegistry:
@@ -90,6 +108,82 @@ class TestApp:
         assert output_items[1].type == "function_call_output"
         assert output_items[1].call_id == "call_1"
         assert output_items[1].output == "ok"
+
+
+class TestJudgeOnlyMode:
+    def test_judge_only_requires_persist_dir(self) -> None:
+        """judge_only without a persist dir has no cached deliverables to score."""
+        config = _make_config(judge_only=True, persist_deliverables_dir=None)
+        with pytest.raises(ValueError, match="judge_only=True requires persist_deliverables_dir"):
+            StirrupAgentWrapper(config=config, server_client=MagicMock(spec=ServerClient))
+
+    @pytest.mark.asyncio
+    async def test_run_judge_only_scores_cached_deliverables(self, tmp_path) -> None:
+        """When cached deliverables exist, run() must NOT execute the agent and
+        must POST /verify with the cached deliverables_dir."""
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "answer.txt").write_text("cached deliverable")
+
+        config = _make_config(judge_only=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        params = NeMoGymResponseCreateParamsNonStreaming(
+            input="ignored",
+            metadata={"task_id": "task-1", "prompt": "do the thing", "_ng_rollout_index": "0"},
+        )
+        body = StirrupRunRequest(responses_create_params=params, task_id="task-1", prompt="do the thing")
+        request = MagicMock()
+        request.cookies = {}
+
+        responses_mock = AsyncMock()
+        with patch.object(StirrupAgentWrapper, "responses", responses_mock), patch(
+            "responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()
+        ), patch(
+            "responses_api_agents.stirrup_agent.app.get_response_json",
+            AsyncMock(return_value={"reward": 0.9, "judge_response": "ok"}),
+        ):
+            result = await wrapper.run(request, body)
+
+        # The agent task must never run in judge-only mode.
+        responses_mock.assert_not_awaited()
+
+        verify_calls = [c for c in server_client.post.await_args_list if c.kwargs.get("url_path") == "/verify"]
+        assert len(verify_calls) == 1
+        verify_json = verify_calls[0].kwargs["json"]
+        assert verify_json["deliverables_dir"].endswith(str(Path("task_task-1") / "repeat_0"))
+        assert result == {"reward": 0.9, "judge_response": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_run_judge_only_missing_deliverables_is_skipped(self, tmp_path) -> None:
+        """A task with no cached deliverable dir is reported skipped and never
+        reaches /verify."""
+        config = _make_config(judge_only=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        params = NeMoGymResponseCreateParamsNonStreaming(
+            input="ignored",
+            metadata={"task_id": "missing-task", "prompt": "do the thing", "_ng_rollout_index": "0"},
+        )
+        body = StirrupRunRequest(responses_create_params=params, task_id="missing-task", prompt="do the thing")
+        request = MagicMock()
+        request.cookies = {}
+
+        responses_mock = AsyncMock()
+        with patch.object(StirrupAgentWrapper, "responses", responses_mock), patch(
+            "responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()
+        ):
+            result = await wrapper.run(request, body)
+
+        responses_mock.assert_not_awaited()
+        verify_calls = [c for c in server_client.post.await_args_list if c.kwargs.get("url_path") == "/verify"]
+        assert verify_calls == []
+        assert result["skipped"] is True
+        assert result["reward"] == 0.0
 
 
 class TestExampleDataset:

--- a/responses_api_agents/stirrup_agent/tests/test_app.py
+++ b/responses_api_agents/stirrup_agent/tests/test_app.py
@@ -139,11 +139,13 @@ class TestJudgeOnlyMode:
         request.cookies = {}
 
         responses_mock = AsyncMock()
-        with patch.object(StirrupAgentWrapper, "responses", responses_mock), patch(
-            "responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()
-        ), patch(
-            "responses_api_agents.stirrup_agent.app.get_response_json",
-            AsyncMock(return_value={"reward": 0.9, "judge_response": "ok"}),
+        with (
+            patch.object(StirrupAgentWrapper, "responses", responses_mock),
+            patch("responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()),
+            patch(
+                "responses_api_agents.stirrup_agent.app.get_response_json",
+                AsyncMock(return_value={"reward": 0.9, "judge_response": "ok"}),
+            ),
         ):
             result = await wrapper.run(request, body)
 
@@ -174,8 +176,9 @@ class TestJudgeOnlyMode:
         request.cookies = {}
 
         responses_mock = AsyncMock()
-        with patch.object(StirrupAgentWrapper, "responses", responses_mock), patch(
-            "responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()
+        with (
+            patch.object(StirrupAgentWrapper, "responses", responses_mock),
+            patch("responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()),
         ):
             result = await wrapper.run(request, body)
 


### PR DESCRIPTION
Allows for running judgements on preexisting task deliverable files with needing to re-execute the task.

Benefits:

1. If judging on some tasks fail, we can re-run judgments without also re-doing all the benchmark tasks
2. This allows us to add new reference models and update ELO scores for existing check points without needing to re-run tasks for models we've already evaluated in the past.