### PR TITLE
fix(vllm_model): handle explicit null metadata in preprocessing

### DIFF
--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -301,6 +301,9 @@ class VLLMModel(SimpleResponsesAPIModel):
             chat_template_kwargs = deepcopy(self.config.chat_template_kwargs)
 
         metadata = body_dict.get("metadata", dict())
+        if metadata is None:
+            metadata = {}
+            body_dict["metadata"] = metadata
 
         # Merge global config chat_template_kwargs with per-request overrides in metadata (e.g. per-sample reasoning on/off)
         metadata_chat_template_kwargs_str = metadata.get("chat_template_kwargs", "{}")

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -3306,6 +3306,30 @@ class TestVLLMConverter:
         assert captured_kwargs["min_tokens"] == 20
         assert captured_kwargs["new_param"] == "value"
 
+    def test_metadata_none_normalizes_to_empty_dict(self) -> None:
+        config = VLLMModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            base_url="http://api.openai.com/v1",
+            api_key="dummy_key",  # pragma: allowlist secret
+            model="dummy-model",
+            entrypoint="",
+            name="",
+            return_token_id_information=False,
+            uses_reasoning_parser=False,
+        )
+        model = VLLMModel(config=config, server_client=MagicMock(spec=ServerClient))
+
+        body = {
+            "model": "dummy-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "metadata": None,
+        }
+        result = model._preprocess_chat_completion_create_params(MagicMock(), body)
+
+        assert result["messages"][0]["content"] == "hello"
+        assert result["metadata"] == {}
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Audio sidechannel splice (metadata.audio_data → user-message content block)


### PR DESCRIPTION
`responses_api_models/vllm_model` can still crash on a valid request that explicitly sends `"metadata": null`, because preprocessing expects a dict and dereferences `.get()` on a `None` value. This PR keeps `metadata=None` on the same code path as omitted metadata by normalizing it to `{}` before any metadata lookups.

This PR fixes that with a narrow adapter-only change:

- Normalize only explicit `metadata=None` in `_preprocess_chat_completion_create_params()`
- Keep absent metadata absent and leave present non-null metadata payloads untouched
- Add a focused regression test that calls `_preprocess_chat_completion_create_params()` directly with `metadata: None` and asserts it returns with `metadata == {}`
- Keep the existing metadata override tests unchanged as non-regression coverage

No request schema changes, no other model adapters, and no dependency updates.

Closes #1096

## Checklist
- [ ] Targeted tests pass: `uv run pytest responses_api_models/vllm_model/tests/test_app.py -k "metadata_none or metadata_chat_template_kwargs_override or metadata_extra_body_override" -x`
- [ ] Touched-file hooks pass: `uv run pre-commit run --files responses_api_models/vllm_model/app.py responses_api_models/vllm_model/tests/test_app.py`
- [ ] Touched-file lint passes: `uv run ruff check responses_api_models/vllm_model/app.py responses_api_models/vllm_model/tests/test_app.py`
- [ ] Touched-file format check passes: `uv run ruff format --check responses_api_models/vllm_model/app.py responses_api_models/vllm_model/tests/test_app.py`
- [x] No request schema changes, other model adapter changes, or dependency changes
- [x] DCO sign-off on all commits

Not run locally; upstream CI is the source of truth for the full matrix.
