### PR TITLE
ci: fail notify job when Slack webhook returns an error

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -225,4 +225,4 @@ jobs:
             ]
           }'
 
-          curl -X POST -H "Content-type: application/json" --data "$MESSAGE" "$SLACK_WEBHOOK"
+          curl -f -X POST -H "Content-type: application/json" --data "$MESSAGE" "$SLACK_WEBHOOK"


### PR DESCRIPTION
## Summary
- Adds `-f` flag to `curl` in the `notify-failure` job so the step fails (non-zero exit) when Slack returns an HTTP error (e.g. `no_service` for a revoked webhook), instead of silently succeeding with a useless 10-byte error body.

## Test plan
- [x] Update `SLACK_TEAM_CHANNEL_WEBHOOK` secret to a valid webhook and verify the step succeeds with `ok` response

🤖 Generated with [Claude Code](https://claude.com/claude-code)