### PR TITLE
docs: add BLADE definition and rename Skills to Benchmark Analysis

### DIFF
--- a/fern/versions/latest/pages/evaluation-tutorials/blade-analysis-skill.mdx
+++ b/fern/versions/latest/pages/evaluation-tutorials/blade-analysis-skill.mdx
@@ -4,11 +4,13 @@ description: "Build and validate a BLADE-style benchmark analysis package from N
 position: 3
 ---
 
-The BLADE analysis skill turns NeMo Gym rollout artifacts into evidence-backed benchmark reports, model comparisons, and benchmark-improvement recommendations. Use it after rollout collection when you need to explain why a score changed, which tasks failed, and what intervention should come next.
+BLADE (**B**enchmark **L**evel **A**nalysis and **D**iagnostics **E**ngine) is NeMo Gym's built-in benchmark analysis skill. It turns raw rollout artifacts into evidence-backed benchmark reports and answers the question: **why did the score change?**
+
+Given two or more scored runs, BLADE identifies which tasks failed and what the dominant failure modes are. It also maps the most likely intervention — harness work, training, verifier repair, prompt change — to close the gap. It works with any benchmark that produces NeMo Gym rollout JSONL.
 
 <Info>
 
-BLADE analysis is a post-run workflow. It does not run the benchmark or replace the verifier. It reads rollout artifacts, aggregate metrics, reward profiles, configs, and report files.
+BLADE is a post-run analysis workflow. It does not run the benchmark or replace the verifier. It reads rollout artifacts, aggregate metrics, reward profiles, configs, and report files produced by `gym eval run`.
 
 </Info>
 
@@ -205,8 +207,8 @@ Before marking the benchmark BLADE-ready:
 
 <Cards>
 
-<Card title="Skills" href="/evaluation/skills">
-Review how skills fit into the evaluation workflow.
+<Card title="Benchmark Analysis" href="/evaluation/skills">
+Review how benchmark analysis skills fit into the evaluation workflow.
 </Card>
 
 <Card title="Evaluate EvalPlus" href="/evaluation-tutorials/evalplus">

--- a/fern/versions/latest/pages/evaluation/skills.mdx
+++ b/fern/versions/latest/pages/evaluation/skills.mdx
@@ -1,19 +1,22 @@
 ---
-title: "Skills"
-description: "Use analysis skills to interpret evaluation artifacts and diagnose benchmark changes."
+title: "Benchmark Analysis"
+description: "Use BLADE and other analysis skills to interpret evaluation artifacts, diagnose benchmark changes, and understand why scores change."
 position: 5
 ---
 
-Skills are reusable analysis instructions that help agents interpret evaluation artifacts consistently. 
-They are used to enhance an agent's capability with a pre-defined, explainable structure.
+Benchmark analysis skills are reusable instructions that help agents interpret evaluation artifacts consistently. After collecting rollouts, an analysis skill turns raw artifacts into structured reports — explaining what changed, which tasks failed, and what intervention is most likely to improve the next run.
 
-NeMo Gym supports skills in two different ways: 
-- Skills evaluation: comparison of an agent's performance with multiple different skills set up.
-- Using skills in model evaluation: the [skills](https://github.com/NVIDIA-NeMo/Gym/tree/main/.codex/skills) folder in Gym contains the skills that can be added to Gym runs.
+NeMo Gym supports skills in two ways:
+- **Skills evaluation**: Compare agent performance across different skill sets by varying `skills.path` between runs.
+- **Using skills in model evaluation**: The [skills](https://github.com/NVIDIA-NeMo/Gym/tree/main/.codex/skills) folder in Gym contains built-in skills that can be added to any Gym run.
 
-## Skill Example: BLADE Analysis
+## BLADE Analysis
 
-The [BLADE analysis](https://github.com/NVIDIA-NeMo/Gym/tree/main/.codex/skills/nemo-gym-blade-analysis) skill is designed to turn NeMo Gym rollout artifacts into BLADE-style benchmark reports, model comparisons, and benchmark-improvement recommendations. Its workflow starts from rollout JSONL, aggregate metrics, reward profiles, configs, model names, repeat counts, and sampling settings. It then computes pass@1/pass@k, separates always-pass, sometimes-pass, never-pass, and missing rows, reads trajectories in order, assigns root-cause labels, and maps findings to concrete interventions.
+BLADE (**B**enchmark **L**evel **A**nalysis and **D**iagnostics **E**ngine) is NeMo Gym's built-in benchmark analysis skill. It is a post-run workflow — it does not run the benchmark or replace the verifier. Instead, it reads rollout artifacts produced by `gym eval run` and answers the question: **why did the score change?**
+
+Use BLADE when you need to go beyond a headline score. It shows which tasks failed, what the dominant failure modes are, and the intervention most likely to close the gap — harness work, training, verifier repair, or prompt change.
+
+The [BLADE analysis](https://github.com/NVIDIA-NeMo/Gym/tree/main/.codex/skills/nemo-gym-blade-analysis) skill turns NeMo Gym rollout artifacts into evidence-backed benchmark reports, model comparisons, and benchmark-improvement recommendations. Its workflow starts from rollout JSONL, aggregate metrics, reward profiles, configs, model names, repeat counts, and sampling settings. It computes pass@1/pass@k, separates always-pass, sometimes-pass, never-pass, and missing rows, reads trajectories in order, assigns root-cause labels, and maps findings to concrete interventions.
 
 BLADE-ready benchmark packages use three deliverables:
 


### PR DESCRIPTION
Closes #1743

## Changes

- Renames `evaluation/skills.mdx` title from **"Skills"** to **"Benchmark Analysis"** — the nav tab is now self-explanatory without prior BLADE knowledge
- Adds BLADE acronym expansion (**B**enchmark **L**evel **A**nalysis and **D**iagnostics **E**ngine) to both the Skills page and the BLADE tutorial so readers are grounded before workflow content
- Updates the back-link card in `blade-analysis-skill.mdx` to match the new page title
- Capitalizes list items after bold labels (NVIDIA style guide)
- Splits sentences exceeding the 30-word style guide target

> This supersedes #1755, which was blocked by DCO (force-push not permitted on that branch to rewrite commit history).