### PR TITLE
docs: add Build Verifiers tab and move Verification Patterns

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -198,9 +198,14 @@ redirects:
     destination: "/nemo/gym/:path*"
   # LLM-as-Judge moved into verification-patterns subsection
   - source: "/nemo/gym/environment-tutorials/llm-as-judge-verification"
-    destination: "/nemo/gym/main/environment-tutorials/verification-patterns/llm-as-judge"
+    destination: "/nemo/gym/main/build-verifiers/verification-patterns/llm-as-judge"
   - source: "/nemo/gym/main/environment-tutorials/llm-as-judge-verification"
-    destination: "/nemo/gym/main/environment-tutorials/verification-patterns/llm-as-judge"
+    destination: "/nemo/gym/main/build-verifiers/verification-patterns/llm-as-judge"
+  # Verification Patterns moved from Environment Tutorials to Build Verifiers
+  - source: "/nemo/gym/main/environment-tutorials/verification-patterns"
+    destination: "/nemo/gym/main/build-verifiers/verification-patterns"
+  - source: "/nemo/gym/main/environment-tutorials/verification-patterns/llm-as-judge"
+    destination: "/nemo/gym/main/build-verifiers/verification-patterns/llm-as-judge"
   # Version alias: latest → main (the `Latest` slug was retired; trunk lives at `main`)
   # Intentionally last so .html stripping and specific reorg rules win first.
   - source: "/nemo/gym/latest"

--- a/fern/versions/latest/pages/build-verifiers/index.mdx
+++ b/fern/versions/latest/pages/build-verifiers/index.mdx
@@ -1,0 +1,19 @@
+---
+title: "Build Verifiers"
+description: "Implement the verification logic that evaluates agent behavior and computes reward signals."
+position: 1
+---
+
+A verifier is the `/verify` endpoint in a NeMo Gym resources server. It receives the agent's output at the end of a rollout, evaluates it against the task's ground truth, and returns a numeric reward used for training and evaluation.
+
+<Cards>
+
+<Card title="Verification Patterns" href="/build-verifiers/verification-patterns">
+Choose the right verification approach for your task — equivalence match, execution-based checking, LLM-as-Judge, or reward model.
+</Card>
+
+<Card title="Resources Server" href="/resources-server">
+Understand the full resources server structure that hosts your verifier alongside tools and session state.
+</Card>
+
+</Cards>

--- a/fern/versions/latest/pages/build-verifiers/verification-patterns/index.mdx
+++ b/fern/versions/latest/pages/build-verifiers/verification-patterns/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verification Patterns"
 description: "Patterns for evaluating agent behavior and computing scores."
-position: 8
+position: 2
 ---
 
 Verification is how an environment evaluates agent behavior and computes a score. Every environment implements some form of verification — the pattern you choose depends on your task.
@@ -20,7 +20,7 @@ Execute the agent's actions, such as tool calls or generated code, and verify th
 <Badge minimal outlined>coming soon</Badge>
 </Card>
 
-<Card title="LLM-as-Judge" href="/environment-tutorials/verification-patterns/llm-as-judge">
+<Card title="LLM-as-Judge" href="/build-verifiers/verification-patterns/llm-as-judge">
 Prompt an LLM to evaluate the agent's output against rubrics, instructions, or reference answers.
 </Card>
 

--- a/fern/versions/latest/pages/build-verifiers/verification-patterns/llm-as-judge.mdx
+++ b/fern/versions/latest/pages/build-verifiers/verification-patterns/llm-as-judge.mdx
@@ -16,7 +16,7 @@ The walkthrough uses [`over_refusal_detection`](https://github.com/NVIDIA-NeMo/G
 - Call the judge from `verify()` and parse strict verdict labels.
 - Handle failures without crashing verification.
 
-<NavButton href="/environment-tutorials/verification-patterns" label="Back to Verification Patterns" direction="back" />
+<NavButton href="/build-verifiers/verification-patterns" label="Back to Verification Patterns" direction="back" />
 
 ---
 

--- a/fern/versions/latest/pages/environment-tutorials/index.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/index.mdx
@@ -49,7 +49,7 @@ Production environment with dynamic routing and state-based verification.
 <Badge intent="success" minimal outlined>advanced</Badge>
 </Card>
 
-<Card title="Verification Patterns" href="/environment-tutorials/verification-patterns">
+<Card title="Verification Patterns" href="/build-verifiers/verification-patterns">
 How environments compute rewards — equivalence matching, execution-based checking, LLM-as-Judge, and reward models.
 </Card>
 

--- a/fern/versions/latest/pages/evaluation/environment-list.mdx
+++ b/fern/versions/latest/pages/evaluation/environment-list.mdx
@@ -102,7 +102,7 @@ NeMo Gym currently includes 90+ environments covering math, coding, reasoning, k
 Use the contribution checklist to add a new benchmark.
 </Card>
 
-<Card title="Verification Patterns" href="/environment-tutorials/verification-patterns">
+<Card title="Verification Patterns" href="/build-verifiers/verification-patterns">
 Learn how environments verify agent behavior and compute rewards.
 </Card>
 

--- a/fern/versions/latest/pages/resources-server/index.mdx
+++ b/fern/versions/latest/pages/resources-server/index.mdx
@@ -41,7 +41,7 @@ Tools are exposed as HTTP endpoints that the Agent server calls during a rollout
 
 Every Resources server implements a `verify()` function that evaluates the result of a rollout and returns a reward signal for training.
 
-For semantic or rubric-based scoring, `verify()` can call a **second language model** (LLM-as-Judge). For configuration, deployment, and implementation patterns, refer to [LLM-as-Judge](/environment-tutorials/verification-patterns/llm-as-judge).
+For semantic or rubric-based scoring, `verify()` can call a **second language model** (LLM-as-Judge). For configuration, deployment, and implementation patterns, refer to [LLM-as-Judge](/build-verifiers/verification-patterns/llm-as-judge).
 
 ## Examples
 

--- a/fern/versions/main.yml
+++ b/fern/versions/main.yml
@@ -24,6 +24,9 @@ navigation:
       - folder: ./latest/pages/resources-server
         title: "Resources Server"
         title-source: frontmatter
+      - folder: ./latest/pages/build-verifiers
+        title: "Build Verifiers"
+        title-source: frontmatter
       - folder: ./latest/pages/data
         title: "Data"
         title-source: frontmatter


### PR DESCRIPTION
Closes #1765
Part of #1436

## Changes

- Adds a new **Build Verifiers** top-level section (`fern/versions/latest/pages/build-verifiers/`) with a minimal index page as the entry point
- Moves `verification-patterns/` from `environment-tutorials/` into `build-verifiers/` via `git mv`
- Registers Build Verifiers in `main.yml` nav after Resources Server (per the v0.4.0 IA order in #1436)
- Adds redirects in `docs.yml` for both old paths:
  - `/environment-tutorials/verification-patterns` → `/build-verifiers/verification-patterns`
  - `/environment-tutorials/verification-patterns/llm-as-judge` → `/build-verifiers/verification-patterns/llm-as-judge`
- Updates also the two pre-existing `llm-as-judge-verification` legacy redirects to point to the new path
- Fixes incoming links in:
  - `environment-tutorials/index.mdx`
  - `resources-server/index.mdx`
  - `evaluation/environment-list.mdx`
- Updates the NavButton back-link and card href inside the moved pages

`fern check` passes with 0 errors.