### PR TITLE
docs: rename Environment Tutorials to Build Environments

### DIFF
--- a/fern/versions/latest/pages/environment-tutorials/index.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Overview"
+title: "Build Environments"
 subtitle: "Build your own custom environment"
 description: ""
 position: 1
@@ -10,6 +10,10 @@ Learn how to build custom environments for training or evaluation using NeMo Gym
 Looking to use an existing environment rather than build your own? See the [Available Environments](https://github.com/NVIDIA-NeMo/Gym#-available-environments) in the README.
 
 </Tip>
+
+<Note>
+These guides focus on resources server implementation — tools, state management, and verification logic. For verification pattern reference (equivalence match, execution-based checking, LLM-as-Judge, reward models), see [Verification Patterns](/build-verifiers/verification-patterns). For data preparation, see [Prepare Data](/data). For agent harness setup, see [Agent Server](/agent-server). For running and analyzing evaluations, see [Evaluation](/evaluation).
+</Note>
 
 <Accordion title="Key Concepts">
 Before diving in, review these foundational pages:
@@ -47,10 +51,6 @@ Per-episode session state with `SESSION_ID_KEY`.
 Production environment with dynamic routing and state-based verification.
 
 <Badge intent="success" minimal outlined>advanced</Badge>
-</Card>
-
-<Card title="Verification Patterns" href="/environment-tutorials/verification-patterns">
-How environments compute rewards — equivalence matching, execution-based checking, LLM-as-Judge, and reward models.
 </Card>
 
 <Card title="Integrate External Libraries" href="/environment-tutorials/integrate-external-environments">

--- a/fern/versions/main.yml
+++ b/fern/versions/main.yml
@@ -28,7 +28,7 @@ navigation:
         title: "Data"
         title-source: frontmatter
       - folder: ./latest/pages/environment-tutorials
-        title: "Environment Tutorials"
+        title: "Build Environments"
         title-source: frontmatter
       - folder: ./latest/pages/evaluation
         title: "Evaluation"


### PR DESCRIPTION
Closes #1772
Part of #1436

## Changes

- Renames the nav tab in `main.yml` from **"Environment Tutorials"** to **"Build Environments"**
- Updates `environment-tutorials/index.mdx` title frontmatter to match
- Adds a scoping note orienting readers to adjacent sections: Verification Patterns (Build Verifiers), Prepare Data, Agent Server, Evaluation
- Removes the Verification Patterns nav card — that page has moved to Build Verifiers (#1765 / #1771)

## No URL changes

The folder path stays as `environment-tutorials/` so all existing URLs, bookmarks, and redirects remain valid. Only the display name in the nav changes.

## Dependency

The scoping note cross-links to `/build-verifiers/verification-patterns`. This resolves correctly once #1771 is merged; until then the link will redirect via the existing `docs.yml` redirect added in #1771.

`fern check` passes with 0 errors.