### PR TITLE
docs: consolidate Training and Evaluation Tutorials under a Tutorials tab

### DIFF
--- a/fern/versions/main.yml
+++ b/fern/versions/main.yml
@@ -36,12 +36,14 @@ navigation:
       - folder: ./latest/pages/evaluation
         title: "Evaluation"
         title-source: frontmatter
-      - folder: ./latest/pages/evaluation-tutorials
-        title: "Evaluation Tutorials"
-        title-source: frontmatter
-      - folder: ./latest/pages/training-tutorials
-        title: "Training Tutorials"
-        title-source: frontmatter
+      - section: Tutorials
+        contents:
+          - folder: ./latest/pages/training-tutorials
+            title: "Training Tutorials"
+            title-source: frontmatter
+          - folder: ./latest/pages/evaluation-tutorials
+            title: "Evaluation Tutorials"
+            title-source: frontmatter
       - folder: ./latest/pages/model-recipes
         title: "Model Recipes"
         title-source: frontmatter


### PR DESCRIPTION
Closes #1773
Part of #1436

## Change

One file changed — `fern/versions/main.yml`.

Replaces the two separate top-level nav entries:

```yaml
- folder: ./latest/pages/evaluation-tutorials
  title: "Evaluation Tutorials"
  title-source: frontmatter
- folder: ./latest/pages/training-tutorials
  title: "Training Tutorials"
  title-source: frontmatter
```

With a single grouped section:

```yaml
- section: Tutorials
  contents:
    - folder: ./latest/pages/training-tutorials
      title: "Training Tutorials"
      title-source: frontmatter
    - folder: ./latest/pages/evaluation-tutorials
      title: "Evaluation Tutorials"
      title-source: frontmatter
```

## No URL changes

Folder paths are unchanged, so all existing page URLs, bookmarks, and redirects remain valid. Page groupings within each tutorial section are unaffected.

`fern check` passes with 0 errors.