### PR TITLE
docs: reorder nav and rename Configure Agents and Prepare Data

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -113,7 +113,7 @@ redirects:
   - source: "/nemo/gym/latest/about/concepts/architecture"
     destination: "/nemo/gym/main/infrastructure/engineering-notes/system-design"
   - source: "/nemo/gym/latest/about/concepts/task-verification"
-    destination: "/nemo/gym/main/resources-server"
+    destination: "/nemo/gym/main/build-verifiers/resources-server"
   - source: "/nemo/gym/latest/about/concepts/configuration"
     destination: "/nemo/gym/main/reference/configuration"
   - source: "/nemo/gym/latest/about/concepts/training-approaches"
@@ -206,6 +206,11 @@ redirects:
     destination: "/nemo/gym/main/build-verifiers/verification-patterns"
   - source: "/nemo/gym/main/environment-tutorials/verification-patterns/llm-as-judge"
     destination: "/nemo/gym/main/build-verifiers/verification-patterns/llm-as-judge"
+  # Resources Server moved from top-level into Build Verifiers
+  - source: "/nemo/gym/main/resources-server"
+    destination: "/nemo/gym/main/build-verifiers/resources-server"
+  - source: "/nemo/gym/main/resources-server/example-resources-servers"
+    destination: "/nemo/gym/main/build-verifiers/example-resources-servers"
   # Version alias: latest → main (the `Latest` slug was retired; trunk lives at `main`)
   # Intentionally last so .html stripping and specific reorg rules win first.
   - source: "/nemo/gym/latest"

--- a/fern/versions/latest/pages/agent-server/index.mdx
+++ b/fern/versions/latest/pages/agent-server/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Agent Server"
+title: "Configure Agents"
 description: ""
 position: 1
 ---

--- a/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
+++ b/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
@@ -18,7 +18,7 @@ Existing agents may come with predefined tools, allowing you to leverage them di
 Review the Agent server lifecycle and orchestration role.
 </Card>
 
-<Card title="Resources Server" href="/resources-server">
+<Card title="Resources Server" href="/build-verifiers/resources-server">
 Understand where shared tool implementations and verification logic belong.
 </Card>
 

--- a/fern/versions/latest/pages/build-verifiers/example-resources-servers.mdx
+++ b/fern/versions/latest/pages/build-verifiers/example-resources-servers.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Example Resources Servers"
 description: "Concrete Resources Servers and the task, action, and verification patterns they demonstrate."
-position: 2
+position: 3
 ---
 
 Resources Servers can model anything from a stateful workplace simulation to an isolated code execution sandbox. These examples show the shape of real server implementations and how task setup, tool actions, and verification fit together.

--- a/fern/versions/latest/pages/build-verifiers/index.mdx
+++ b/fern/versions/latest/pages/build-verifiers/index.mdx
@@ -12,7 +12,7 @@ A verifier is the `/verify` endpoint in a NeMo Gym resources server. It receives
 Choose the right verification approach for your task — equivalence match, execution-based checking, LLM-as-Judge, or reward model.
 </Card>
 
-<Card title="Resources Server" href="/resources-server">
+<Card title="Resources Server" href="/build-verifiers/resources-server">
 Understand the full resources server structure that hosts your verifier alongside tools and session state.
 </Card>
 

--- a/fern/versions/latest/pages/build-verifiers/resources-server/index.mdx
+++ b/fern/versions/latest/pages/build-verifiers/resources-server/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Resources Server"
 description: "Understand how Resources Servers define environment tools, state, and verification logic."
-position: 1
+position: 2
 ---
 The Resources server is the "world" the agent interacts with. It defines the task, the tools and actions available to the agent, and the verification logic that evaluates performance and returns reward signals for training.
 

--- a/fern/versions/latest/pages/build-verifiers/verification-patterns/index.mdx
+++ b/fern/versions/latest/pages/build-verifiers/verification-patterns/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Verification Patterns"
 description: "Patterns for evaluating agent behavior and computing scores."
-position: 2
+position: 4
 ---
 
 Verification is how an environment evaluates agent behavior and computes a score. Every environment implements some form of verification — the pattern you choose depends on your task.

--- a/fern/versions/latest/pages/build-verifiers/verification-patterns/llm-as-judge.mdx
+++ b/fern/versions/latest/pages/build-verifiers/verification-patterns/llm-as-judge.mdx
@@ -362,6 +362,6 @@ Done looks like:
 
 ## Related Topics
 
-- [Resources Server](/resources-server) — role of `verify()` and verification overview
+- [Resources Server](/build-verifiers/resources-server) — role of `verify()` and verification overview
 - [Deployment Topology](/infrastructure/deployment-topology) — cluster layout and GPUs
 - [New Environment](/contribute/environments/new-environment) — scaffolding a new resources server

--- a/fern/versions/latest/pages/data/index.mdx
+++ b/fern/versions/latest/pages/data/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Data"
+title: "Prepare Data"
 description: ""
 position: 1
 ---

--- a/fern/versions/latest/pages/model-server/index.mdx
+++ b/fern/versions/latest/pages/model-server/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Configure Model"
+title: "Configure Models"
 description: ""
 position: 1
 ---

--- a/fern/versions/main.yml
+++ b/fern/versions/main.yml
@@ -22,7 +22,7 @@ navigation:
         title: "Configure Agents"
         title-source: frontmatter
       - folder: ./latest/pages/model-server
-        title: "Configure Model"
+        title: "Configure Models"
         title-source: frontmatter
       - folder: ./latest/pages/resources-server
         title: "Resources Server"

--- a/fern/versions/main.yml
+++ b/fern/versions/main.yml
@@ -15,8 +15,11 @@ navigation:
       - folder: ./latest/pages/get-started
         title: "Get Started"
         title-source: frontmatter
+      - folder: ./latest/pages/data
+        title: "Prepare Data"
+        title-source: frontmatter
       - folder: ./latest/pages/agent-server
-        title: "Agent Server"
+        title: "Configure Agents"
         title-source: frontmatter
       - folder: ./latest/pages/model-server
         title: "Configure Model"
@@ -27,20 +30,19 @@ navigation:
       - folder: ./latest/pages/build-verifiers
         title: "Build Verifiers"
         title-source: frontmatter
-      - folder: ./latest/pages/data
-        title: "Data"
-        title-source: frontmatter
-      - folder: ./latest/pages/environment-tutorials
-        title: "Build Environments"
-        title-source: frontmatter
       - folder: ./latest/pages/evaluation
         title: "Evaluation"
         title-source: frontmatter
-      - folder: ./latest/pages/evaluation-tutorials
-        title: "Evaluation Tutorials"
-        title-source: frontmatter
-      - folder: ./latest/pages/training-tutorials
-        title: "Training Tutorials"
+      - section: Tutorials
+        contents:
+          - folder: ./latest/pages/training-tutorials
+            title: "Training Tutorials"
+            title-source: frontmatter
+          - folder: ./latest/pages/evaluation-tutorials
+            title: "Evaluation Tutorials"
+            title-source: frontmatter
+      - folder: ./latest/pages/environment-tutorials
+        title: "Build Environments"
         title-source: frontmatter
       - folder: ./latest/pages/model-recipes
         title: "Model Recipes"

--- a/fern/versions/main.yml
+++ b/fern/versions/main.yml
@@ -24,9 +24,6 @@ navigation:
       - folder: ./latest/pages/model-server
         title: "Configure Models"
         title-source: frontmatter
-      - folder: ./latest/pages/resources-server
-        title: "Resources Server"
-        title-source: frontmatter
       - folder: ./latest/pages/build-verifiers
         title: "Build Verifiers"
         title-source: frontmatter


### PR DESCRIPTION
Closes #1776
Part of #1436

## Changes

**`fern/versions/main.yml`** — reorder + renames + absorb Tutorials grouping:

New order:
```
About → Get Started → Prepare Data → Configure Agents → Configure Model
→ Resources Server → Build Verifiers → Evaluation → Tutorials
→ Build Environments → Model Recipes → Infrastructure → Reference
→ Troubleshooting → Contribute
```

**`agent-server/index.mdx`** — title: "Agent Server" → "Configure Agents"

**`data/index.mdx`** — title: "Data" → "Prepare Data"

## Notes

- This PR absorbs the Tutorials section grouping from #1773/#1775 to avoid a merge conflict — if #1775 merges first, this PR will need a rebase
- "Resources Server" is kept in place (not in the final target IA but retained until Build Verifiers absorbs it)
- Troubleshooting kept at the end pending confirmation of deprecation
- No URL changes; all folder paths unchanged so no redirects needed

`fern check` passes with 0 errors.