### PR TITLE
docs(fern): rebase Build Verifiers content from PR #1751

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -196,19 +196,26 @@ redirects:
   # to fire on the no-extension form before the slug-only catch-all takes over.
   - source: "/nemo/gym/:path*.html"
     destination: "/nemo/gym/:path*"
-  # LLM-as-Judge moved into verification-patterns subsection
+  # LLM-as-Judge and Verification Patterns moved from Environment Tutorials to Build Verifiers
   - source: "/nemo/gym/environment-tutorials/llm-as-judge-verification"
     destination: "/nemo/gym/main/build-verifiers/verification-patterns/llm-as-judge"
   - source: "/nemo/gym/main/environment-tutorials/llm-as-judge-verification"
     destination: "/nemo/gym/main/build-verifiers/verification-patterns/llm-as-judge"
-  # Verification Patterns moved from Environment Tutorials to Build Verifiers
+  - source: "/nemo/gym/environment-tutorials/verification-patterns"
+    destination: "/nemo/gym/main/build-verifiers/verification-patterns"
   - source: "/nemo/gym/main/environment-tutorials/verification-patterns"
     destination: "/nemo/gym/main/build-verifiers/verification-patterns"
+  - source: "/nemo/gym/environment-tutorials/verification-patterns/llm-as-judge"
+    destination: "/nemo/gym/main/build-verifiers/verification-patterns/llm-as-judge"
   - source: "/nemo/gym/main/environment-tutorials/verification-patterns/llm-as-judge"
     destination: "/nemo/gym/main/build-verifiers/verification-patterns/llm-as-judge"
   # Resources Server moved from top-level into Build Verifiers
+  - source: "/nemo/gym/resources-server"
+    destination: "/nemo/gym/main/build-verifiers/resources-server"
   - source: "/nemo/gym/main/resources-server"
     destination: "/nemo/gym/main/build-verifiers/resources-server"
+  - source: "/nemo/gym/resources-server/example-resources-servers"
+    destination: "/nemo/gym/main/build-verifiers/example-resources-servers"
   - source: "/nemo/gym/main/resources-server/example-resources-servers"
     destination: "/nemo/gym/main/build-verifiers/example-resources-servers"
   # Version alias: latest → main (the `Latest` slug was retired; trunk lives at `main`)

--- a/fern/versions/latest/pages/build-verifiers/index.mdx
+++ b/fern/versions/latest/pages/build-verifiers/index.mdx
@@ -1,15 +1,28 @@
 ---
 title: "Build Verifiers"
-description: "Implement the verification logic that evaluates agent behavior and computes reward signals."
+description: "Build the resources server that scores rollouts — the verifier, state, and verification patterns."
 position: 1
 ---
 
-A verifier is the `/verify` endpoint in a NeMo Gym resources server. It receives the agent's output at the end of a rollout, evaluates it against the task's ground truth, and returns a numeric reward used for training and evaluation.
+A verifier scores an agent's behavior on a task. In NeMo Gym you implement it in a **resources server** — the component that owns the verifier, per-task state, and any environment-specific tools.
+
+<Info>
+
+New to the concepts? Start with [Environments](/about/concepts/environments) and [Architecture](/about/architecture) to see how the resources server, agent server, and model server fit together.
+
+</Info>
+
+## Resources Server Interfaces
+
+You build a resources server by subclassing one of two base classes. At runtime it runs as a web server that the agent drives over HTTP:
+
+- **`SimpleResourcesServer`** — the agent calls `/seed_session` at the start to initialize per-task state (optional) and `/verify` at the end to score the rollout. Tools are exposed as additional endpoints or over MCP.
+- **`GymnasiumServer`** — scores incrementally via `/step` (with `/reset` at the start) instead of a single `/verify`, for environments that need per-turn observations and rewards.
 
 <Cards>
 
 <Card title="Verification Patterns" href="/build-verifiers/verification-patterns">
-Choose the right verification approach for your task — equivalence match, execution-based checking, LLM-as-Judge, or reward model.
+How to score a rollout, from execution and state checks to LLM-as-Judge.
 </Card>
 
 <Card title="Resources Server" href="/build-verifiers/resources-server">

--- a/fern/versions/latest/pages/environment-tutorials/index.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/index.mdx
@@ -53,7 +53,7 @@ Production environment with dynamic routing and state-based verification.
 <Badge intent="success" minimal outlined>advanced</Badge>
 </Card>
 
-<Card title="Verification Patterns" href="/build-verifiers/verification-patterns">
+<Card title="Build Verifiers" href="/build-verifiers">
 How environments compute rewards — equivalence matching, execution-based checking, LLM-as-Judge, and reward models.
 </Card>
 
@@ -67,10 +67,6 @@ Wrap a third-party benchmark or agent framework as a NeMo Gym agent server.
 End-to-end checklist for contributing a new benchmark — data, config, tests, and baselining.
 
 <Badge minimal outlined>contributor</Badge>
-</Card>
-
-<Card title="Aggregate Metrics" href="/evaluation/aggregate-metrics">
-Compute per-task pass rates and roll-up metrics from collected rollouts.
 </Card>
 
 </Cards>

--- a/fern/versions/latest/pages/evaluation/environment-list.mdx
+++ b/fern/versions/latest/pages/evaluation/environment-list.mdx
@@ -102,7 +102,7 @@ NeMo Gym currently includes 90+ environments covering math, coding, reasoning, k
 Use the contribution checklist to add a new benchmark.
 </Card>
 
-<Card title="Verification Patterns" href="/build-verifiers/verification-patterns">
+<Card title="Build Verifiers" href="/build-verifiers">
 Learn how environments verify agent behavior and compute rewards.
 </Card>
 


### PR DESCRIPTION
## Summary

Rebases the new content from #1751 (cwing) onto current `main` after the IA re-org PRs (#1771, #1774, #1777) landed. The nav restructure and file moves are already merged; this PR brings forward what was unique to #1751:

- **Resources Server Interfaces section** added to `build-verifiers/index.mdx` — explains `SimpleResourcesServer` and `GymnasiumServer` base classes with concrete descriptions of their lifecycle (seed/verify vs step/reset).
- **Unversioned redirects** for `/nemo/gym/resources-server` and `/nemo/gym/environment-tutorials/verification-patterns` paths (the merged PRs only had `/main/`-prefixed variants).
- **`environment-tutorials/index.mdx`** — card updated to link to `/build-verifiers` (broader entry point); Aggregate Metrics card removed (belongs under Evaluate).
- **`evaluation/environment-list.mdx`** — Verification Patterns card updated to link to `/build-verifiers`.

Closes #1751.

## Test plan

- [ ] `fern check` passes
- [ ] Docs preview: Build Verifiers landing page shows Resources Server Interfaces section
- [ ] `/resources-server` redirect lands on Build Verifiers
- [ ] `/environment-tutorials/verification-patterns` redirect lands on Build Verifiers > Verification Patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)