### PR TITLE
fix: cap fastapi<0.137 to prevent prometheus-fastapi-instrumentator crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,9 @@ dependencies = [
     # FastAPI: Used for server infrastructure
     # Updated Thu Mar 26, 2026 with fastapi==0.135.2
     # License: MIT https://github.com/fastapi/fastapi/blob/25a3697cedc6e7dfb84e93c8ff965801486f00f4/LICENSE
-    "fastapi",
+    # fastapi>=0.137 breaks prometheus-fastapi-instrumentator via _IncludedRouter.path;
+    # cap until instrumentator handles it: github.com/trallnag/prometheus-fastapi-instrumentator/issues/370
+    "fastapi<0.137",
 
     # MCP Python SDK: Used by Gym-owned Streamable HTTP MCP resources servers.
     # Updated Tue Jun 23, 2026 with mcp>=1.27,<2

--- a/uv.lock
+++ b/uv.lock
@@ -1509,7 +1509,7 @@ requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "datasets" },
     { name = "devtools" },
-    { name = "fastapi" },
+    { name = "fastapi", specifier = "<0.137" },
     { name = "fonttools", specifier = ">=4.60.2" },
     { name = "gitpython", specifier = ">=3.1.50" },
     { name = "gprof2dot" },


### PR DESCRIPTION
## Summary

- `fastapi>=0.137` introduced `_IncludedRouter` — a `BaseRoute` subclass with no `.path` attribute — which breaks `prometheus-fastapi-instrumentator`'s route iteration at server startup, causing `AttributeError: '_IncludedRouter' object has no attribute 'path'` and crashing vLLM serve.
- Caps `fastapi<0.137` in Gym's `dependencies` so uv cannot resolve to the breaking version.
- Same fix as [vllm#45594](https://github.com/vllm-project/vllm/pull/45594). Lift the cap once [prometheus-fastapi-instrumentator#370](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370) is resolved.

## Test plan

- [ ] CI green (Super recipe tests validate the fix end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)