### PR TITLE
feat(vllm-model): consume native Dynamo token data

### DIFF
--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -233,6 +233,11 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
 class VLLMModel(SimpleResponsesAPIModel):
     config: VLLMModelConfig
 
+    _DYNAMO_ENGINE_DATA_FIELD_MAPPING: ClassVar[Dict[str, str]] = {
+        "prompt_token_ids": "prompt_token_ids",
+        "completion_token_ids": "generation_token_ids",
+        "completion_logprobs": "generation_log_probs",
+    }
     _TOKENIZE_CHAT_FIELDS: ClassVar[tuple[str, ...]] = (
         "model",
         "messages",
@@ -601,6 +606,8 @@ class VLLMModel(SimpleResponsesAPIModel):
                 # No user message found — create one with just the audio blocks.
                 body_dict.setdefault("messages", []).append({"role": "user", "content": list(audio_blocks)})
 
+        if self.config.return_token_id_information and self._requests_dynamo_engine_data(body_dict):
+            self._derive_required_prefix_token_ids(body_dict)
         self._apply_sampling_overrides(body_dict)
         self._validate_single_choice_token_request(body_dict)
         return body_dict
@@ -747,25 +754,38 @@ class VLLMModel(SimpleResponsesAPIModel):
 
             # Token metadata uses this source order:
             # 1. A complete bundle on the assistant message.
-            # 2. Prompt IDs at the response top level and generation IDs on the choice.
-            # 3. Generation data from choice logprobs and prompt IDs from `/tokenize`.
+            # 2. A complete bundle in Dynamo engine data.
+            # 3. Prompt IDs at the response top level and generation IDs on the choice.
+            # 4. Generation data from choice logprobs and prompt IDs from `/tokenize`.
             #
             # An earlier source supplies the normalized bundle.
             # Later inline sources are still checked when present.
             # A partially present source is invalid.
             # Duplicate token IDs must agree.
             message_bundle = self._extract_message_token_bundle(message_dict)
-            response_token_ids = self._extract_vllm_response_token_ids(chat_completion_dict, choice_dict)
+            dynamo_bundle = self._extract_dynamo_engine_data(chat_completion_dict)
 
-            if message_bundle is not None:
+            if message_bundle is not None and dynamo_bundle is not None:
+                if any(message_bundle[field] != dynamo_bundle[field] for field in REQUIRED_TOKEN_METADATA_FIELDS):
+                    raise RuntimeError("Message-level token metadata disagrees with Dynamo engine data.")
+
+            native_bundle = message_bundle if message_bundle is not None else dynamo_bundle
+            if native_bundle is None and self._requests_dynamo_engine_data(body_dict):
+                raise RuntimeError("Request asked for `nvext.engine_data` but the response did not include it.")
+            response_token_ids = self._extract_vllm_response_token_ids(
+                chat_completion_dict,
+                choice_dict,
+                ignore_partial=native_bundle is not None,
+            )
+            if native_bundle is not None:
                 if response_token_ids is not None:
                     response_prompt_token_ids, response_generation_token_ids = response_token_ids
                     if (
-                        message_bundle["prompt_token_ids"] != response_prompt_token_ids
-                        or message_bundle["generation_token_ids"] != response_generation_token_ids
+                        native_bundle["prompt_token_ids"] != response_prompt_token_ids
+                        or native_bundle["generation_token_ids"] != response_generation_token_ids
                     ):
-                        raise RuntimeError("Message-level token metadata disagrees with vLLM response token IDs.")
-                message_dict.update(message_bundle)
+                        raise RuntimeError("Native token metadata disagrees with vLLM response token IDs.")
+                message_dict.update(native_bundle)
             else:
                 logprob_token_ids, generation_log_probs = self._extract_choice_logprobs(choice_dict)
                 if response_token_ids is not None:
@@ -798,53 +818,78 @@ class VLLMModel(SimpleResponsesAPIModel):
                     )
                 )
 
-                # The adapter consumed this compatibility payload.
-                choice_dict.pop("logprobs", None)
-
-            # Top-level and choice-level token-ID fields are transport details.
+            # These fields only transport the token bundle to Gym.
+            choice_dict.pop("logprobs", None)
             chat_completion_dict.pop("prompt_token_ids", None)
             choice_dict.pop("token_ids", None)
+            nvext = chat_completion_dict.get("nvext")
+            if isinstance(nvext, dict):
+                nvext.pop("engine_data", None)
+                if not nvext:
+                    chat_completion_dict.pop("nvext", None)
             choice_dict["message"] = NeMoGymChatCompletionMessageForTraining.model_validate(message_dict)
 
         return NeMoGymChatCompletion.model_validate(chat_completion_dict)
 
     @staticmethod
     def _require_token_id_list(value: Any, field_name: str) -> List[Any]:
-        """Check the container without scanning or copying token IDs."""
+        """Validate a JSON token-ID list without copying it."""
         if not isinstance(value, list):
             raise RuntimeError(f"`{field_name}` must be a list of integer token IDs.")
+        for index, token_id in enumerate(value):
+            if not isinstance(token_id, int) or isinstance(token_id, bool):
+                raise RuntimeError(f"`{field_name}[{index}]` must be an integer token ID.")
         return value
 
     @staticmethod
     def _require_log_prob_list(value: Any, field_name: str) -> List[Any]:
-        """Check the container without scanning or copying log probabilities."""
+        """Validate a JSON log-probability list without copying it."""
         if not isinstance(value, list):
             raise RuntimeError(f"`{field_name}` must be a list of numeric log probabilities.")
+        for index, log_prob in enumerate(value):
+            if not isinstance(log_prob, (int, float)) or isinstance(log_prob, bool):
+                raise RuntimeError(f"`{field_name}[{index}]` must be a numeric log probability.")
         return value
 
     @classmethod
-    def _validate_token_bundle(cls, bundle: Dict[str, Any], source: str) -> Dict[str, Any]:
+    def _validate_token_bundle(
+        cls,
+        bundle: Dict[str, Any],
+        source: str,
+        source_field_names: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        source_field_names = source_field_names or {}
         present_fields = TOKEN_METADATA_FIELDS.intersection(bundle)
         missing_fields = REQUIRED_TOKEN_METADATA_FIELDS.difference(present_fields)
         if missing_fields:
-            missing = ", ".join(sorted(missing_fields))
+            missing = ", ".join(sorted(source_field_names.get(field, field) for field in missing_fields))
             raise RuntimeError(f"{source} returned partial token metadata; missing: {missing}.")
 
+        def source_field(field: str) -> str:
+            return f"{source}.{source_field_names.get(field, field)}"
+
         normalized = {
-            "prompt_token_ids": cls._require_token_id_list(bundle["prompt_token_ids"], f"{source}.prompt_token_ids"),
+            "prompt_token_ids": cls._require_token_id_list(
+                bundle["prompt_token_ids"], source_field("prompt_token_ids")
+            ),
             "generation_token_ids": cls._require_token_id_list(
-                bundle["generation_token_ids"], f"{source}.generation_token_ids"
+                bundle["generation_token_ids"], source_field("generation_token_ids")
             ),
             "generation_log_probs": cls._require_log_prob_list(
-                bundle["generation_log_probs"], f"{source}.generation_log_probs"
+                bundle["generation_log_probs"], source_field("generation_log_probs")
             ),
         }
         if "routed_experts" in bundle:
             normalized["routed_experts"] = bundle["routed_experts"]
 
         if len(normalized["generation_token_ids"]) != len(normalized["generation_log_probs"]):
+            mismatched_fields = (
+                f"{source_field_names['generation_token_ids']} and {source_field_names['generation_log_probs']}"
+                if source_field_names
+                else "generation token IDs and log probabilities"
+            )
             raise RuntimeError(
-                f"{source} returned mismatched generation token IDs and log probabilities: "
+                f"{source} returned mismatched {mismatched_fields}: "
                 f"{len(normalized['generation_token_ids'])} token IDs and "
                 f"{len(normalized['generation_log_probs'])} log probabilities."
             )
@@ -863,10 +908,36 @@ class VLLMModel(SimpleResponsesAPIModel):
         )
 
     @classmethod
+    def _extract_dynamo_engine_data(cls, chat_completion_dict: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        nvext = chat_completion_dict.get("nvext")
+        if nvext is None:
+            return None
+        if not isinstance(nvext, dict):
+            raise RuntimeError("`nvext` must be an object when present.")
+        if "engine_data" not in nvext:
+            return None
+
+        engine_data = nvext["engine_data"]
+        if not isinstance(engine_data, dict):
+            raise RuntimeError("`nvext.engine_data` must be an object when present.")
+
+        bundle = {
+            destination: engine_data[source]
+            for source, destination in cls._DYNAMO_ENGINE_DATA_FIELD_MAPPING.items()
+            if source in engine_data
+        }
+        source_field_names = {
+            destination: source for source, destination in cls._DYNAMO_ENGINE_DATA_FIELD_MAPPING.items()
+        }
+        return cls._validate_token_bundle(bundle, "nvext.engine_data", source_field_names)
+
+    @classmethod
     def _extract_vllm_response_token_ids(
         cls,
         chat_completion_dict: Dict[str, Any],
         choice_dict: Dict[str, Any],
+        *,
+        ignore_partial: bool = False,
     ) -> Optional[tuple[List[Any], List[Any]]]:
         prompt_value = chat_completion_dict.get("prompt_token_ids")
         generation_value = choice_dict.get("token_ids")
@@ -874,6 +945,8 @@ class VLLMModel(SimpleResponsesAPIModel):
         generation_present = generation_value is not None
 
         if prompt_present != generation_present:
+            if ignore_partial:
+                return None
             missing = "choice.token_ids" if prompt_present else "prompt_token_ids"
             raise RuntimeError(f"vLLM response returned partial token metadata; missing: {missing}.")
         if not prompt_present:
@@ -920,6 +993,31 @@ class VLLMModel(SimpleResponsesAPIModel):
     def _get_tokenize_chat_body(cls, body_dict: Dict[str, Any]) -> Dict[str, Any]:
         """Keep every known prompt-affecting field aligned with generation."""
         return {field: body_dict[field] for field in cls._TOKENIZE_CHAT_FIELDS if field in body_dict}
+
+    @staticmethod
+    def _requests_dynamo_engine_data(body_dict: Dict[str, Any]) -> bool:
+        nvext = body_dict.get("nvext")
+        if not isinstance(nvext, dict):
+            return False
+        extra_fields = nvext.get("extra_fields")
+        return isinstance(extra_fields, list) and "engine_data" in extra_fields
+
+    @classmethod
+    def _derive_required_prefix_token_ids(cls, body_dict: Dict[str, Any]) -> None:
+        if body_dict.get("required_prefix_token_ids") is not None:
+            return
+
+        for message in reversed(body_dict.get("messages", [])):
+            if not isinstance(message, dict) or message.get("role") != "assistant":
+                continue
+            token_bundle = cls._extract_message_token_bundle(message)
+            if token_bundle is None:
+                continue
+            body_dict["required_prefix_token_ids"] = [
+                *token_bundle["prompt_token_ids"],
+                *token_bundle["generation_token_ids"],
+            ]
+            return
 
     def _validate_single_choice_token_request(self, body_dict: Dict[str, Any]) -> None:
         if self.config.return_token_id_information and body_dict.get("n") not in (None, 1):

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -285,6 +285,11 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
 class VLLMModel(SimpleResponsesAPIModel):
     config: VLLMModelConfig
 
+    _DYNAMO_ENGINE_DATA_FIELD_MAPPING: ClassVar[Dict[str, str]] = {
+        "prompt_token_ids": "prompt_token_ids",
+        "completion_token_ids": "generation_token_ids",
+        "completion_logprobs": "generation_log_probs",
+    }
     _TOKENIZE_CHAT_FIELDS: ClassVar[tuple[str, ...]] = (
         "model",
         "messages",
@@ -697,6 +702,8 @@ class VLLMModel(SimpleResponsesAPIModel):
                 # No user message found — create one with just the audio blocks.
                 body_dict.setdefault("messages", []).append({"role": "user", "content": list(audio_blocks)})
 
+        if self.config.return_token_id_information and self._requests_dynamo_engine_data(body_dict):
+            self._derive_required_prefix_token_ids(body_dict)
         self._apply_sampling_overrides(body_dict)
         self._validate_single_choice_token_request(body_dict)
         if self._external_capture_enabled:
@@ -978,25 +985,38 @@ class VLLMModel(SimpleResponsesAPIModel):
 
             # Token metadata uses this source order:
             # 1. A complete bundle on the assistant message.
-            # 2. Prompt IDs at the response top level and generation IDs on the choice.
-            # 3. Generation data from choice logprobs and prompt IDs from `/tokenize`.
+            # 2. A complete bundle in Dynamo engine data.
+            # 3. Prompt IDs at the response top level and generation IDs on the choice.
+            # 4. Generation data from choice logprobs and prompt IDs from `/tokenize`.
             #
             # An earlier source supplies the normalized bundle.
             # Later inline sources are still checked when present.
             # A partially present source is invalid.
             # Duplicate token IDs must agree.
             message_bundle = self._extract_message_token_bundle(message_dict)
-            response_token_ids = self._extract_vllm_response_token_ids(chat_completion_dict, choice_dict)
+            dynamo_bundle = self._extract_dynamo_engine_data(chat_completion_dict)
 
-            if message_bundle is not None:
+            if message_bundle is not None and dynamo_bundle is not None:
+                if any(message_bundle[field] != dynamo_bundle[field] for field in REQUIRED_TOKEN_METADATA_FIELDS):
+                    raise RuntimeError("Message-level token metadata disagrees with Dynamo engine data.")
+
+            native_bundle = message_bundle if message_bundle is not None else dynamo_bundle
+            if native_bundle is None and self._requests_dynamo_engine_data(body_dict):
+                raise RuntimeError("Request asked for `nvext.engine_data` but the response did not include it.")
+            response_token_ids = self._extract_vllm_response_token_ids(
+                chat_completion_dict,
+                choice_dict,
+                ignore_partial=native_bundle is not None,
+            )
+            if native_bundle is not None:
                 if response_token_ids is not None:
                     response_prompt_token_ids, response_generation_token_ids = response_token_ids
                     if (
-                        message_bundle["prompt_token_ids"] != response_prompt_token_ids
-                        or message_bundle["generation_token_ids"] != response_generation_token_ids
+                        native_bundle["prompt_token_ids"] != response_prompt_token_ids
+                        or native_bundle["generation_token_ids"] != response_generation_token_ids
                     ):
-                        raise RuntimeError("Message-level token metadata disagrees with vLLM response token IDs.")
-                message_dict.update(message_bundle)
+                        raise RuntimeError("Native token metadata disagrees with vLLM response token IDs.")
+                message_dict.update(native_bundle)
             else:
                 logprob_token_ids, generation_log_probs = self._extract_choice_logprobs(choice_dict)
                 if response_token_ids is not None:
@@ -1029,12 +1049,15 @@ class VLLMModel(SimpleResponsesAPIModel):
                     )
                 )
 
-                # The adapter consumed this compatibility payload.
-                choice_dict.pop("logprobs", None)
-
-            # Top-level and choice-level token-ID fields are transport details.
+            # These fields only transport the token bundle to Gym.
+            choice_dict.pop("logprobs", None)
             chat_completion_dict.pop("prompt_token_ids", None)
             choice_dict.pop("token_ids", None)
+            nvext = chat_completion_dict.get("nvext")
+            if isinstance(nvext, dict):
+                nvext.pop("engine_data", None)
+                if not nvext:
+                    chat_completion_dict.pop("nvext", None)
             choice_dict["message"] = NeMoGymChatCompletionMessageForTraining.model_validate(message_dict)
 
         return NeMoGymChatCompletion.model_validate(chat_completion_dict)
@@ -1177,41 +1200,63 @@ class VLLMModel(SimpleResponsesAPIModel):
 
     @staticmethod
     def _require_token_id_list(value: Any, field_name: str) -> List[Any]:
-        """Check the container without scanning or copying token IDs."""
+        """Validate a JSON token-ID list without copying it."""
         if not isinstance(value, list):
             raise RuntimeError(f"`{field_name}` must be a list of integer token IDs.")
+        for index, token_id in enumerate(value):
+            if not isinstance(token_id, int) or isinstance(token_id, bool):
+                raise RuntimeError(f"`{field_name}[{index}]` must be an integer token ID.")
         return value
 
     @staticmethod
     def _require_log_prob_list(value: Any, field_name: str) -> List[Any]:
-        """Check the container without scanning or copying log probabilities."""
+        """Validate a JSON log-probability list without copying it."""
         if not isinstance(value, list):
             raise RuntimeError(f"`{field_name}` must be a list of numeric log probabilities.")
+        for index, log_prob in enumerate(value):
+            if not isinstance(log_prob, (int, float)) or isinstance(log_prob, bool):
+                raise RuntimeError(f"`{field_name}[{index}]` must be a numeric log probability.")
         return value
 
     @classmethod
-    def _validate_token_bundle(cls, bundle: Dict[str, Any], source: str) -> Dict[str, Any]:
+    def _validate_token_bundle(
+        cls,
+        bundle: Dict[str, Any],
+        source: str,
+        source_field_names: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        source_field_names = source_field_names or {}
         present_fields = TOKEN_METADATA_FIELDS.intersection(bundle)
         missing_fields = REQUIRED_TOKEN_METADATA_FIELDS.difference(present_fields)
         if missing_fields:
-            missing = ", ".join(sorted(missing_fields))
+            missing = ", ".join(sorted(source_field_names.get(field, field) for field in missing_fields))
             raise RuntimeError(f"{source} returned partial token metadata; missing: {missing}.")
 
+        def source_field(field: str) -> str:
+            return f"{source}.{source_field_names.get(field, field)}"
+
         normalized = {
-            "prompt_token_ids": cls._require_token_id_list(bundle["prompt_token_ids"], f"{source}.prompt_token_ids"),
+            "prompt_token_ids": cls._require_token_id_list(
+                bundle["prompt_token_ids"], source_field("prompt_token_ids")
+            ),
             "generation_token_ids": cls._require_token_id_list(
-                bundle["generation_token_ids"], f"{source}.generation_token_ids"
+                bundle["generation_token_ids"], source_field("generation_token_ids")
             ),
             "generation_log_probs": cls._require_log_prob_list(
-                bundle["generation_log_probs"], f"{source}.generation_log_probs"
+                bundle["generation_log_probs"], source_field("generation_log_probs")
             ),
         }
         if "routed_experts" in bundle:
             normalized["routed_experts"] = bundle["routed_experts"]
 
         if len(normalized["generation_token_ids"]) != len(normalized["generation_log_probs"]):
+            mismatched_fields = (
+                f"{source_field_names['generation_token_ids']} and {source_field_names['generation_log_probs']}"
+                if source_field_names
+                else "generation token IDs and log probabilities"
+            )
             raise RuntimeError(
-                f"{source} returned mismatched generation token IDs and log probabilities: "
+                f"{source} returned mismatched {mismatched_fields}: "
                 f"{len(normalized['generation_token_ids'])} token IDs and "
                 f"{len(normalized['generation_log_probs'])} log probabilities."
             )
@@ -1230,10 +1275,36 @@ class VLLMModel(SimpleResponsesAPIModel):
         )
 
     @classmethod
+    def _extract_dynamo_engine_data(cls, chat_completion_dict: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        nvext = chat_completion_dict.get("nvext")
+        if nvext is None:
+            return None
+        if not isinstance(nvext, dict):
+            raise RuntimeError("`nvext` must be an object when present.")
+        if "engine_data" not in nvext:
+            return None
+
+        engine_data = nvext["engine_data"]
+        if not isinstance(engine_data, dict):
+            raise RuntimeError("`nvext.engine_data` must be an object when present.")
+
+        bundle = {
+            destination: engine_data[source]
+            for source, destination in cls._DYNAMO_ENGINE_DATA_FIELD_MAPPING.items()
+            if source in engine_data
+        }
+        source_field_names = {
+            destination: source for source, destination in cls._DYNAMO_ENGINE_DATA_FIELD_MAPPING.items()
+        }
+        return cls._validate_token_bundle(bundle, "nvext.engine_data", source_field_names)
+
+    @classmethod
     def _extract_vllm_response_token_ids(
         cls,
         chat_completion_dict: Dict[str, Any],
         choice_dict: Dict[str, Any],
+        *,
+        ignore_partial: bool = False,
     ) -> Optional[tuple[List[Any], List[Any]]]:
         prompt_value = chat_completion_dict.get("prompt_token_ids")
         generation_value = choice_dict.get("token_ids")
@@ -1241,6 +1312,8 @@ class VLLMModel(SimpleResponsesAPIModel):
         generation_present = generation_value is not None
 
         if prompt_present != generation_present:
+            if ignore_partial:
+                return None
             missing = "choice.token_ids" if prompt_present else "prompt_token_ids"
             raise RuntimeError(f"vLLM response returned partial token metadata; missing: {missing}.")
         if not prompt_present:
@@ -1287,6 +1360,31 @@ class VLLMModel(SimpleResponsesAPIModel):
     def _get_tokenize_chat_body(cls, body_dict: Dict[str, Any]) -> Dict[str, Any]:
         """Keep every known prompt-affecting field aligned with generation."""
         return {field: body_dict[field] for field in cls._TOKENIZE_CHAT_FIELDS if field in body_dict}
+
+    @staticmethod
+    def _requests_dynamo_engine_data(body_dict: Dict[str, Any]) -> bool:
+        nvext = body_dict.get("nvext")
+        if not isinstance(nvext, dict):
+            return False
+        extra_fields = nvext.get("extra_fields")
+        return isinstance(extra_fields, list) and "engine_data" in extra_fields
+
+    @classmethod
+    def _derive_required_prefix_token_ids(cls, body_dict: Dict[str, Any]) -> None:
+        if body_dict.get("required_prefix_token_ids") is not None:
+            return
+
+        for message in reversed(body_dict.get("messages", [])):
+            if not isinstance(message, dict) or message.get("role") != "assistant":
+                continue
+            token_bundle = cls._extract_message_token_bundle(message)
+            if token_bundle is None:
+                continue
+            body_dict["required_prefix_token_ids"] = [
+                *token_bundle["prompt_token_ids"],
+                *token_bundle["generation_token_ids"],
+            ]
+            return
 
     def _validate_single_choice_token_request(self, body_dict: Dict[str, Any]) -> None:
         context = current_capture_context()

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+from copy import deepcopy
 from typing import Any, Union
 from unittest.mock import AsyncMock, MagicMock
 
@@ -4639,6 +4640,103 @@ class TestTopLogprobsHandling:
                 },
             )
 
+    def test_capture_path_derives_prefix_only_for_dynamo_requests(self) -> None:
+        messages = [
+            {"role": "user", "content": "old"},
+            {
+                "role": "assistant",
+                "content": "old answer",
+                "prompt_token_ids": [90],
+                "generation_token_ids": [91],
+                "generation_log_probs": [-0.9],
+            },
+            {"role": "user", "content": "first"},
+            {
+                "role": "assistant",
+                "content": "answer",
+                "prompt_token_ids": [1, 2],
+                "generation_token_ids": [3, 4],
+                "generation_log_probs": [-0.1, -0.2],
+            },
+            {"role": "user", "content": "next"},
+        ]
+
+        standard_model = _make_top_logprobs_model(return_token_id_information=True)
+        result = standard_model._preprocess_chat_completion_create_params(
+            MagicMock(),
+            {"model": "dummy_model", "messages": deepcopy(messages)},
+        )
+        assert "required_prefix_token_ids" not in result
+
+        dynamo_model = _make_top_logprobs_model(
+            return_token_id_information=True,
+            extra_body={"nvext": {"extra_fields": ["engine_data"]}},
+        )
+        result = dynamo_model._preprocess_chat_completion_create_params(
+            MagicMock(),
+            {"model": "dummy_model", "messages": deepcopy(messages)},
+        )
+        assert result["required_prefix_token_ids"] == [1, 2, 3, 4]
+
+        result = dynamo_model._preprocess_chat_completion_create_params(
+            MagicMock(),
+            {
+                "model": "dummy_model",
+                "messages": deepcopy(messages),
+                "required_prefix_token_ids": [99],
+            },
+        )
+        assert result["required_prefix_token_ids"] == [99]
+
+    def test_capture_path_derives_prefix_through_http_request(self) -> None:
+        model = _make_top_logprobs_model(
+            return_token_id_information=True,
+            extra_body={"nvext": {"extra_fields": ["engine_data"]}},
+        )
+        app = model.setup_webserver()
+        captured_kwargs: dict[str, Any] = {}
+
+        async def mock_create_chat_completion(**kwargs):
+            captured_kwargs.update(kwargs)
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                response_extra={
+                    "nvext": {
+                        "engine_data": {
+                            "prompt_token_ids": [1, 2, 3, 4, 5],
+                            "completion_token_ids": [6],
+                            "completion_logprobs": [-0.1],
+                        }
+                    }
+                },
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock()
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={
+                "messages": [
+                    {"role": "user", "content": "first"},
+                    {
+                        "role": "assistant",
+                        "content": "answer",
+                        "prompt_token_ids": [1, 2],
+                        "generation_token_ids": [3, 4],
+                        "generation_log_probs": [-0.2, -0.3],
+                    },
+                    {"role": "user", "content": "next"},
+                ]
+            },
+        )
+
+        assert response.status_code == 200
+        assert captured_kwargs["required_prefix_token_ids"] == [1, 2, 3, 4]
+        assert captured_kwargs["nvext"] == {"extra_fields": ["engine_data"]}
+
     def test_noncapture_path_strips_null_top_logprobs(self) -> None:
         """On the non-capture path a null top_logprobs is dropped (letting vLLM apply its
         default) rather than forwarded as null (which vLLM reads as "no logprobs")."""
@@ -4801,7 +4899,16 @@ class TestTopLogprobsHandling:
                 logprobs=None,
                 message_extra=token_bundle,
                 choice_extra={"token_ids": [123]},
-                response_extra={"prompt_token_ids": [10, 20]},
+                response_extra={
+                    "prompt_token_ids": [10, 20],
+                    "nvext": {
+                        "engine_data": {
+                            "prompt_token_ids": [10, 20],
+                            "completion_token_ids": [123],
+                            "completion_logprobs": [-0.1],
+                        }
+                    },
+                },
             )
 
         mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
@@ -4821,6 +4928,312 @@ class TestTopLogprobsHandling:
         for field, value in token_bundle.items():
             assert message[field] == value
         mock_client.create_tokenize.assert_not_awaited()
+
+    def test_capture_path_accepts_dynamo_engine_data_without_logprobs(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                response_extra={
+                    "nvext": {
+                        "engine_data": {
+                            "prompt_token_ids": [10, 20],
+                            "completion_token_ids": [123, 456],
+                            "completion_logprobs": [-0.1, -0.2],
+                        },
+                        "timing": {"request_duration_ms": 12},
+                    }
+                },
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock(
+            side_effect=AssertionError("create_tokenize must not be called for Dynamo engine data")
+        )
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        message = data["choices"][0]["message"]
+        assert message["prompt_token_ids"] == [10, 20]
+        assert message["generation_token_ids"] == [123, 456]
+        assert message["generation_log_probs"] == [-0.1, -0.2]
+        assert data["nvext"] == {"timing": {"request_duration_ms": 12}}
+        mock_client.create_tokenize.assert_not_awaited()
+
+    def test_capture_path_uses_dynamo_logprobs_and_strips_transport_data(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+        choice_logprobs = {
+            "content": [
+                {"token": "token_id:123", "logprob": -9.1, "bytes": None, "top_logprobs": []},
+            ]
+        }
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=choice_logprobs,
+                response_extra={
+                    "nvext": {
+                        "engine_data": {
+                            "prompt_token_ids": [10, 20],
+                            "completion_token_ids": [123],
+                            "completion_logprobs": [-0.1],
+                        }
+                    }
+                },
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock()
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["choices"][0]["message"]["generation_log_probs"] == [-0.1]
+        assert data["choices"][0]["logprobs"] is None
+        assert "nvext" not in data
+        mock_client.create_tokenize.assert_not_awaited()
+
+    @mark.parametrize(
+        ("engine_data", "error"),
+        [
+            (
+                {"prompt_token_ids": [10], "completion_logprobs": [-0.1]},
+                "missing: completion_token_ids",
+            ),
+            ([], "must be an object"),
+            (
+                {
+                    "prompt_token_ids": [10, 20],
+                    "completion_token_ids": [123, 456],
+                    "completion_logprobs": [-0.1],
+                },
+                "mismatched completion_token_ids and completion_logprobs",
+            ),
+            (
+                {
+                    "prompt_token_ids": [10, 20],
+                    "completion_token_ids": [123],
+                    "completion_logprobs": [{"logprob": -0.1}],
+                },
+                r"completion_logprobs\[0\].*numeric",
+            ),
+        ],
+    )
+    def test_capture_path_rejects_malformed_dynamo_engine_data(self, engine_data: Any, error: str) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                response_extra={"nvext": {"engine_data": engine_data}},
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock(side_effect=AssertionError("malformed native data must not fall back"))
+        model._clients = [mock_client]
+
+        with raises(RuntimeError, match=error):
+            TestClient(app).post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+        mock_client.create_tokenize.assert_not_awaited()
+
+    def test_capture_path_rejects_non_object_nvext(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                response_extra={"nvext": []},
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        model._clients = [mock_client]
+
+        with raises(RuntimeError, match="nvext.*must be an object"):
+            TestClient(app).post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+
+    def test_capture_path_nvext_without_engine_data_uses_tokenize_fallback(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs={
+                    "content": [
+                        {"token": "token_id:123", "logprob": -0.1, "bytes": None, "top_logprobs": []},
+                    ]
+                },
+                response_extra={"nvext": {"timing": {"request_duration_ms": 12}}},
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock(return_value={"tokens": [10, 20]})
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["nvext"] == {"timing": {"request_duration_ms": 12}}
+        mock_client.create_tokenize.assert_awaited_once()
+
+    def test_capture_path_requires_requested_dynamo_engine_data(self) -> None:
+        model = _make_top_logprobs_model(
+            return_token_id_information=True,
+            extra_body={"nvext": {"extra_fields": ["engine_data"]}},
+        )
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs={
+                    "content": [
+                        {"token": "token_id:123", "logprob": -0.1, "bytes": None, "top_logprobs": []},
+                    ]
+                },
+                response_extra={"nvext": {"timing": {"request_duration_ms": 12}}},
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock(
+            side_effect=AssertionError("missing requested engine data must not fall back")
+        )
+        model._clients = [mock_client]
+
+        with raises(RuntimeError, match="asked for `nvext.engine_data` but the response did not include it"):
+            TestClient(app).post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+        mock_client.create_tokenize.assert_not_awaited()
+
+    def test_complete_dynamo_bundle_ignores_partial_vllm_token_ids(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                response_extra={
+                    "prompt_token_ids": [10, 20],
+                    "nvext": {
+                        "engine_data": {
+                            "prompt_token_ids": [10, 20],
+                            "completion_token_ids": [123],
+                            "completion_logprobs": [-0.1],
+                        }
+                    },
+                },
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock()
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["choices"][0]["message"]["generation_token_ids"] == [123]
+        mock_client.create_tokenize.assert_not_awaited()
+
+    def test_capture_path_rejects_disagreeing_dynamo_and_message_ids(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                message_extra={
+                    "prompt_token_ids": [10, 20],
+                    "generation_token_ids": [123],
+                    "generation_log_probs": [-0.1],
+                },
+                response_extra={
+                    "nvext": {
+                        "engine_data": {
+                            "prompt_token_ids": [10, 20],
+                            "completion_token_ids": [999],
+                            "completion_logprobs": [-0.1],
+                        }
+                    }
+                },
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        model._clients = [mock_client]
+
+        with raises(RuntimeError, match="disagrees with Dynamo engine data"):
+            TestClient(app).post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+
+    def test_capture_path_rejects_disagreeing_dynamo_and_message_logprobs(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                message_extra={
+                    "prompt_token_ids": [10, 20],
+                    "generation_token_ids": [123],
+                    "generation_log_probs": [-9.1],
+                },
+                response_extra={
+                    "nvext": {
+                        "engine_data": {
+                            "prompt_token_ids": [10, 20],
+                            "completion_token_ids": [123],
+                            "completion_logprobs": [-0.1],
+                        }
+                    }
+                },
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        model._clients = [mock_client]
+
+        with raises(RuntimeError, match="disagrees with Dynamo engine data"):
+            TestClient(app).post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
 
     def test_capture_path_rejects_disagreeing_duplicate_ids(self) -> None:
         model = _make_top_logprobs_model(return_token_id_information=True)

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -15,6 +15,7 @@
 import asyncio
 import json
 import logging
+from copy import deepcopy
 from typing import Any, Union
 from unittest.mock import AsyncMock, MagicMock
 
@@ -4692,6 +4693,103 @@ class TestTopLogprobsHandling:
                 },
             )
 
+    def test_capture_path_derives_prefix_only_for_dynamo_requests(self) -> None:
+        messages = [
+            {"role": "user", "content": "old"},
+            {
+                "role": "assistant",
+                "content": "old answer",
+                "prompt_token_ids": [90],
+                "generation_token_ids": [91],
+                "generation_log_probs": [-0.9],
+            },
+            {"role": "user", "content": "first"},
+            {
+                "role": "assistant",
+                "content": "answer",
+                "prompt_token_ids": [1, 2],
+                "generation_token_ids": [3, 4],
+                "generation_log_probs": [-0.1, -0.2],
+            },
+            {"role": "user", "content": "next"},
+        ]
+
+        standard_model = _make_top_logprobs_model(return_token_id_information=True)
+        result = standard_model._preprocess_chat_completion_create_params(
+            MagicMock(),
+            {"model": "dummy_model", "messages": deepcopy(messages)},
+        )
+        assert "required_prefix_token_ids" not in result
+
+        dynamo_model = _make_top_logprobs_model(
+            return_token_id_information=True,
+            extra_body={"nvext": {"extra_fields": ["engine_data"]}},
+        )
+        result = dynamo_model._preprocess_chat_completion_create_params(
+            MagicMock(),
+            {"model": "dummy_model", "messages": deepcopy(messages)},
+        )
+        assert result["required_prefix_token_ids"] == [1, 2, 3, 4]
+
+        result = dynamo_model._preprocess_chat_completion_create_params(
+            MagicMock(),
+            {
+                "model": "dummy_model",
+                "messages": deepcopy(messages),
+                "required_prefix_token_ids": [99],
+            },
+        )
+        assert result["required_prefix_token_ids"] == [99]
+
+    def test_capture_path_derives_prefix_through_http_request(self) -> None:
+        model = _make_top_logprobs_model(
+            return_token_id_information=True,
+            extra_body={"nvext": {"extra_fields": ["engine_data"]}},
+        )
+        app = model.setup_webserver()
+        captured_kwargs: dict[str, Any] = {}
+
+        async def mock_create_chat_completion(**kwargs):
+            captured_kwargs.update(kwargs)
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                response_extra={
+                    "nvext": {
+                        "engine_data": {
+                            "prompt_token_ids": [1, 2, 3, 4, 5],
+                            "completion_token_ids": [6],
+                            "completion_logprobs": [-0.1],
+                        }
+                    }
+                },
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock()
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={
+                "messages": [
+                    {"role": "user", "content": "first"},
+                    {
+                        "role": "assistant",
+                        "content": "answer",
+                        "prompt_token_ids": [1, 2],
+                        "generation_token_ids": [3, 4],
+                        "generation_log_probs": [-0.2, -0.3],
+                    },
+                    {"role": "user", "content": "next"},
+                ]
+            },
+        )
+
+        assert response.status_code == 200
+        assert captured_kwargs["required_prefix_token_ids"] == [1, 2, 3, 4]
+        assert captured_kwargs["nvext"] == {"extra_fields": ["engine_data"]}
+
     def test_noncapture_path_strips_null_top_logprobs(self) -> None:
         """On the non-capture path a null top_logprobs is dropped (letting vLLM apply its
         default) rather than forwarded as null (which vLLM reads as "no logprobs")."""
@@ -4854,7 +4952,16 @@ class TestTopLogprobsHandling:
                 logprobs=None,
                 message_extra=token_bundle,
                 choice_extra={"token_ids": [123]},
-                response_extra={"prompt_token_ids": [10, 20]},
+                response_extra={
+                    "prompt_token_ids": [10, 20],
+                    "nvext": {
+                        "engine_data": {
+                            "prompt_token_ids": [10, 20],
+                            "completion_token_ids": [123],
+                            "completion_logprobs": [-0.1],
+                        }
+                    },
+                },
             )
 
         mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
@@ -4874,6 +4981,312 @@ class TestTopLogprobsHandling:
         for field, value in token_bundle.items():
             assert message[field] == value
         mock_client.create_tokenize.assert_not_awaited()
+
+    def test_capture_path_accepts_dynamo_engine_data_without_logprobs(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                response_extra={
+                    "nvext": {
+                        "engine_data": {
+                            "prompt_token_ids": [10, 20],
+                            "completion_token_ids": [123, 456],
+                            "completion_logprobs": [-0.1, -0.2],
+                        },
+                        "timing": {"request_duration_ms": 12},
+                    }
+                },
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock(
+            side_effect=AssertionError("create_tokenize must not be called for Dynamo engine data")
+        )
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        message = data["choices"][0]["message"]
+        assert message["prompt_token_ids"] == [10, 20]
+        assert message["generation_token_ids"] == [123, 456]
+        assert message["generation_log_probs"] == [-0.1, -0.2]
+        assert data["nvext"] == {"timing": {"request_duration_ms": 12}}
+        mock_client.create_tokenize.assert_not_awaited()
+
+    def test_capture_path_uses_dynamo_logprobs_and_strips_transport_data(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+        choice_logprobs = {
+            "content": [
+                {"token": "token_id:123", "logprob": -9.1, "bytes": None, "top_logprobs": []},
+            ]
+        }
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=choice_logprobs,
+                response_extra={
+                    "nvext": {
+                        "engine_data": {
+                            "prompt_token_ids": [10, 20],
+                            "completion_token_ids": [123],
+                            "completion_logprobs": [-0.1],
+                        }
+                    }
+                },
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock()
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["choices"][0]["message"]["generation_log_probs"] == [-0.1]
+        assert data["choices"][0]["logprobs"] is None
+        assert "nvext" not in data
+        mock_client.create_tokenize.assert_not_awaited()
+
+    @mark.parametrize(
+        ("engine_data", "error"),
+        [
+            (
+                {"prompt_token_ids": [10], "completion_logprobs": [-0.1]},
+                "missing: completion_token_ids",
+            ),
+            ([], "must be an object"),
+            (
+                {
+                    "prompt_token_ids": [10, 20],
+                    "completion_token_ids": [123, 456],
+                    "completion_logprobs": [-0.1],
+                },
+                "mismatched completion_token_ids and completion_logprobs",
+            ),
+            (
+                {
+                    "prompt_token_ids": [10, 20],
+                    "completion_token_ids": [123],
+                    "completion_logprobs": [{"logprob": -0.1}],
+                },
+                r"completion_logprobs\[0\].*numeric",
+            ),
+        ],
+    )
+    def test_capture_path_rejects_malformed_dynamo_engine_data(self, engine_data: Any, error: str) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                response_extra={"nvext": {"engine_data": engine_data}},
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock(side_effect=AssertionError("malformed native data must not fall back"))
+        model._clients = [mock_client]
+
+        with raises(RuntimeError, match=error):
+            TestClient(app).post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+        mock_client.create_tokenize.assert_not_awaited()
+
+    def test_capture_path_rejects_non_object_nvext(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                response_extra={"nvext": []},
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        model._clients = [mock_client]
+
+        with raises(RuntimeError, match="nvext.*must be an object"):
+            TestClient(app).post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+
+    def test_capture_path_nvext_without_engine_data_uses_tokenize_fallback(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs={
+                    "content": [
+                        {"token": "token_id:123", "logprob": -0.1, "bytes": None, "top_logprobs": []},
+                    ]
+                },
+                response_extra={"nvext": {"timing": {"request_duration_ms": 12}}},
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock(return_value={"tokens": [10, 20]})
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["nvext"] == {"timing": {"request_duration_ms": 12}}
+        mock_client.create_tokenize.assert_awaited_once()
+
+    def test_capture_path_requires_requested_dynamo_engine_data(self) -> None:
+        model = _make_top_logprobs_model(
+            return_token_id_information=True,
+            extra_body={"nvext": {"extra_fields": ["engine_data"]}},
+        )
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs={
+                    "content": [
+                        {"token": "token_id:123", "logprob": -0.1, "bytes": None, "top_logprobs": []},
+                    ]
+                },
+                response_extra={"nvext": {"timing": {"request_duration_ms": 12}}},
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock(
+            side_effect=AssertionError("missing requested engine data must not fall back")
+        )
+        model._clients = [mock_client]
+
+        with raises(RuntimeError, match="asked for `nvext.engine_data` but the response did not include it"):
+            TestClient(app).post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+        mock_client.create_tokenize.assert_not_awaited()
+
+    def test_complete_dynamo_bundle_ignores_partial_vllm_token_ids(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                response_extra={
+                    "prompt_token_ids": [10, 20],
+                    "nvext": {
+                        "engine_data": {
+                            "prompt_token_ids": [10, 20],
+                            "completion_token_ids": [123],
+                            "completion_logprobs": [-0.1],
+                        }
+                    },
+                },
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock()
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["choices"][0]["message"]["generation_token_ids"] == [123]
+        mock_client.create_tokenize.assert_not_awaited()
+
+    def test_capture_path_rejects_disagreeing_dynamo_and_message_ids(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                message_extra={
+                    "prompt_token_ids": [10, 20],
+                    "generation_token_ids": [123],
+                    "generation_log_probs": [-0.1],
+                },
+                response_extra={
+                    "nvext": {
+                        "engine_data": {
+                            "prompt_token_ids": [10, 20],
+                            "completion_token_ids": [999],
+                            "completion_logprobs": [-0.1],
+                        }
+                    }
+                },
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        model._clients = [mock_client]
+
+        with raises(RuntimeError, match="disagrees with Dynamo engine data"):
+            TestClient(app).post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+
+    def test_capture_path_rejects_disagreeing_dynamo_and_message_logprobs(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs=None,
+                message_extra={
+                    "prompt_token_ids": [10, 20],
+                    "generation_token_ids": [123],
+                    "generation_log_probs": [-9.1],
+                },
+                response_extra={
+                    "nvext": {
+                        "engine_data": {
+                            "prompt_token_ids": [10, 20],
+                            "completion_token_ids": [123],
+                            "completion_logprobs": [-0.1],
+                        }
+                    }
+                },
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        model._clients = [mock_client]
+
+        with raises(RuntimeError, match="disagrees with Dynamo engine data"):
+            TestClient(app).post(
+                "/v1/chat/completions",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
 
     def test_capture_path_rejects_disagreeing_duplicate_ids(self) -> None:
         model = _make_top_logprobs_model(return_token_id_information=True)


### PR DESCRIPTION
## Summary

Move native Dynamo response-token handling into NeMo-Gym's shared vLLM token-selection path.

- Read `prompt_token_ids`, `completion_token_ids`, and `completion_logprobs` from `nvext.engine_data`.
- Normalize them to Gym's existing `prompt_token_ids`, `generation_token_ids`, and `generation_log_probs` bundle.
- Select token data in this order: assistant-message metadata, Dynamo engine data, standard vLLM token IDs, then `choice.logprobs` plus `/tokenize`.
- Derive `required_prefix_token_ids` from the latest tokenized assistant message unless the caller supplied a non-null list.
- Reject partial or malformed native data and duplicate token IDs that disagree.
- Preserve response fields, including `choice.logprobs` and message extensions such as `routed_experts`.

## Motivation

NeMo-Gym needs the model's original token IDs and log probabilities for training. Dynamo already returns these values in `nvext.engine_data`. Consuming that native bundle in Gym removes duplicate response conversion from NeMo-RL and avoids an unsupported `/tokenize` fallback.

Gym owns response interpretation. The NeMo-RL wrapper continues to render exact prompt tokens, splice the prior prefix, send `nvext.token_data`, and request `engine_data`.

## Compatibility

- Existing NeMo-RL wrappers that copy matching token metadata onto the assistant message remain supported.
- Native Dynamo data does not require `choice.logprobs` and remains authoritative if that optional field differs.
- Standard vLLM token IDs and the existing `/tokenize` fallback remain unchanged when native data is absent.
- No public schema or configuration flag is added.

## Validation

- `uv run --extra dev pytest responses_api_models/vllm_model/tests/test_app.py` (`132 passed`)
- `uv run --extra dev pre-commit run --files responses_api_models/vllm_model/app.py responses_api_models/vllm_model/tests/test_app.py`

The final managed Dynamo smoke will run from NeMo-RL after this PR merges and NeMo-RL pins the exact containing Gym `main` commit.

## Related

- Token-selection framework: #1558
- NeMo-RL cleanup: to follow after this PR merges
