### PR TITLE
docs(fern): fix Agent Skills duplicate heading and page order

### DIFF
--- a/fern/versions/latest/pages/agent-server/agent-skills.mdx
+++ b/fern/versions/latest/pages/agent-server/agent-skills.mdx
@@ -1,10 +1,8 @@
 ---
 title: "Agent Skills"
 description: "Evaluate agent skills as a run-level variable, decoupled from the dataset"
-position: 2
+position: 3
 ---
-
-# Agent Skills
 
 Skills are reusable units of operational knowledge an agent can load at runtime, following the open [Agent Skills standard](https://agentskills.io/specification) used by Claude Code and Codex CLI. A skill is a **directory** containing a `SKILL.md` file (YAML frontmatter + markdown body) plus optional supporting files.
 


### PR DESCRIPTION
## Summary
- The **Agent Skills** page rendered its title twice: once from the frontmatter `title:` (which Fern renders as the page heading) and again as an in-body `# Agent Skills` H1. Removed the duplicate H1.
- Reordered the page to sort **after Integrate Existing Agents**. Both pages were previously at `position: 2`; Agent Skills is now `position: 3`.

## Resulting order (Configure Agents section)
1. Configure Agents (index)
2. Integrate Existing Agents
3. Agent Skills

## Test plan
- [ ] Docs preview: Agent Skills page shows a single "Agent Skills" heading and appears after Integrate Existing Agents in the sidebar.