### PR TITLE
feat(resources): add shared MultiRewardVerifyResponse contract

### DIFF
--- a/fern/versions/latest/pages/api-reference/index.mdx
+++ b/fern/versions/latest/pages/api-reference/index.mdx
@@ -11,7 +11,7 @@ This reference is built from docstrings in the [source code](https://github.com/
 
 | Module | Description |
 |--------|-------------|
-| `nemo_gym.base_resources_server` | Base classes for building resources servers (`SimpleResourcesServer`, `BaseVerifyRequest`, `BaseVerifyResponse`) |
+| `nemo_gym.base_resources_server` | Base classes for building resources servers (`SimpleResourcesServer`, `BaseVerifyRequest`, `BaseVerifyResponse`, `MultiRewardVerifyResponse`) |
 | `nemo_gym.base_responses_api_agent` | Base classes for building agent servers (`SimpleResponsesAPIAgent`) |
 | `nemo_gym.base_responses_api_model` | Base classes for building model servers (`SimpleResponsesAPIModel`) |
 | `nemo_gym.config_types` | Pydantic configuration models for servers, datasets, and CLI |

--- a/fern/versions/latest/pages/build-verifiers/multi-reward-verification.mdx
+++ b/fern/versions/latest/pages/build-verifiers/multi-reward-verification.mdx
@@ -38,13 +38,16 @@ Skip if you already have one. Otherwise generate the app, config, and test layou
 ng_init_resources_server +entrypoint=resources_servers/my_server
 ```
 
-### 2. Subclass `BaseVerifyResponse` to add `reward_components`
+### 2. Subclass `MultiRewardVerifyResponse`
 
-This is the multi-reward contract: a `{objective_name: score}` dict. Defining it on a subclass (rather than on `BaseVerifyResponse`) keeps every other environment's verify response unchanged.
+This is the shared multi-reward contract: a `{objective_name: score}` dict that already lives on `MultiRewardVerifyResponse`. Keeping it on a dedicated subclass, rather than on `BaseVerifyResponse`, keeps every other environment's verify response unchanged.
 
 ```python
-class MultiRewardResponse(BaseVerifyResponse):
-    reward_components: Dict[str, float] | None = None
+from nemo_gym.base_resources_server import MultiRewardVerifyResponse
+
+
+class MultiRewardResponse(MultiRewardVerifyResponse):
+    pass
 ```
 
 ### 3. Set the scalar `reward`
@@ -113,11 +116,10 @@ The `self._…` helpers (extracting calls, parsing arguments, checking required 
 
 ### 3. Return all three forms
 
-The example's response class adds the `reward_components` dict and the three top-level component fields. The scalar `reward` is already declared on `BaseVerifyResponse`, so it isn't redeclared here — `verify()` computes its value (the sum) in the return below.
+The example's response class inherits the shared `reward_components` dict and adds the three top-level component fields used for aggregate metrics. The scalar `reward` is already declared on `BaseVerifyResponse`, so it isn't redeclared here — `verify()` computes its value (the sum) in the return below.
 
 ```python
-class ToolCallMultiRewardVerifyResponse(BaseVerifyResponse):
-    reward_components: Dict[str, float] | None = None
+class ToolCallMultiRewardVerifyResponse(MultiRewardVerifyResponse):
     correctness: float = 0.0
     schema_valid: float = 0.0
     format: float = 0.0

--- a/nemo_gym/base_resources_server.py
+++ b/nemo_gym/base_resources_server.py
@@ -92,6 +92,10 @@ class BaseVerifyResponse(BaseVerifyRequest):
     reward: float
 
 
+class MultiRewardVerifyResponse(BaseVerifyResponse):
+    reward_components: dict[str, float] | None = None
+
+
 class BaseSeedSessionRequest(BaseModel):
     pass
 

--- a/resources_servers/example_tool_call_multireward/README.md
+++ b/resources_servers/example_tool_call_multireward/README.md
@@ -8,13 +8,14 @@ objective independently) and for **multi-objective RL** such as GDPO
 Each rollout asks the model to call `get_weather` for a city. The verifier scores the
 rollout on three independent `{0, 1}` components:
 
-- `correctness`  — a predicted call matches the expected name and arguments.
-- `schema_valid` — the call's arguments parse as a JSON object containing every required
+- `correctness`: a predicted call matches the expected name and arguments.
+- `schema_valid`: the call's arguments parse as a JSON object containing every required
   parameter of the tool.
-- `format`       — exactly one tool call was emitted, with no extra assistant text.
+- `format`: exactly one tool call was emitted, with no extra assistant text.
 
 Each component is surfaced both as a top-level numeric field on the verify response and
-inside the `reward_components` field, alongside the summed scalar `reward`.
+inside the shared `MultiRewardVerifyResponse.reward_components` field, alongside the
+summed scalar `reward`.
 
 - **Evaluation**: because the components are top-level numeric fields, NeMo Gym's
   aggregate-metrics step reports an independent pass rate for each one. This shows *how*
@@ -23,17 +24,17 @@ inside the `reward_components` field, alongside the summed scalar `reward`.
 - **Multi-objective RL**: a GDPO-style algorithm reads the per-objective scores from
   `reward_components` and normalizes each component independently, rather than collapsing
   them into one number. A GRPO baseline instead reads the summed `reward` and therefore
-  cannot distinguish rollouts with the same total but different composition — the advantage
-  collapse GDPO is designed to fix. How `reward_components` reaches the trainer depends on
-  the training framework's NeMo Gym integration.
+  cannot distinguish rollouts with the same total but different composition, so it
+  collapses the advantage GDPO is designed to separate. How `reward_components` reaches
+  the trainer depends on the training framework's NeMo Gym integration.
 
 The example data can be found in `example_tool_call_multireward/data/example.jsonl` and is
 regenerated with `python resources_servers/example_tool_call_multireward/create_examples.py`.
 
 ## Tutorial
 
-For a walkthrough of the multi-reward pattern — including how the components are surfaced
-for both evaluation and multi-objective RL — see the [Multi-Reward Verification](https://docs.nvidia.com/nemo/gym/main/build-verifiers/multi-reward-verification) docs.
+For a walkthrough of the multi-reward pattern, including how the components are surfaced
+for both evaluation and multi-objective RL, see the [Multi-Reward Verification](https://docs.nvidia.com/nemo/gym/main/build-verifiers/multi-reward-verification) docs.
 
 # Licensing information
 Code: Apache 2.0

--- a/resources_servers/example_tool_call_multireward/app.py
+++ b/resources_servers/example_tool_call_multireward/app.py
@@ -43,7 +43,7 @@ from pydantic import Field
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
     BaseVerifyRequest,
-    BaseVerifyResponse,
+    MultiRewardVerifyResponse,
     SimpleResourcesServer,
 )
 
@@ -58,13 +58,12 @@ class ToolCallMultiRewardVerifyRequest(BaseVerifyRequest):
     expected_call: Dict[str, Any] = Field(default_factory=dict)
 
 
-class ToolCallMultiRewardVerifyResponse(BaseVerifyResponse):
+class ToolCallMultiRewardVerifyResponse(MultiRewardVerifyResponse):
     # Per-component scores are also surfaced as top-level fields so the aggregate
     # metrics endpoint profiles each one in addition to the combined reward.
     # Decoupled per-component rewards (name -> score). How these reach a trainer
-    # depends on the training framework's NeMo Gym integration. Defined here (not on
-    # BaseVerifyResponse) so other environments' verify responses are unchanged.
-    reward_components: Dict[str, float] | None = None
+    # depends on the training framework's NeMo Gym integration. The shared
+    # MultiRewardVerifyResponse contract keeps other environments unchanged.
     correctness: float = 0.0
     schema_valid: float = 0.0
     format: float = 0.0

--- a/resources_servers/example_tool_call_multireward/tests/test_app.py
+++ b/resources_servers/example_tool_call_multireward/tests/test_app.py
@@ -21,6 +21,7 @@ from app import (
     ToolCallMultiRewardVerifyRequest,
 )
 
+from nemo_gym.base_resources_server import MultiRewardVerifyResponse
 from nemo_gym.openai_utils import NeMoGymResponse
 from nemo_gym.server_utils import ServerClient
 
@@ -96,6 +97,14 @@ class TestApp:
         result = await _server().verify(
             _request([_function_call("get_weather", json.dumps({"city": "San Francisco"}))])
         )
+        assert result.reward_components == {"correctness": 1.0, "schema_valid": 1.0, "format": 1.0}
+        assert result.reward == 3.0
+
+    async def test_verify_uses_shared_multi_reward_contract(self) -> None:
+        result = await _server().verify(
+            _request([_function_call("get_weather", json.dumps({"city": "San Francisco"}))])
+        )
+        assert isinstance(result, MultiRewardVerifyResponse)
         assert result.reward_components == {"correctness": 1.0, "schema_valid": 1.0, "format": 1.0}
         assert result.reward == 3.0
 


### PR DESCRIPTION
## Summary

Add a shared `MultiRewardVerifyResponse` contract in `nemo_gym` so multi-reward verifiers can expose `reward_components` through an importable shared type instead of an example-local subclass, and update the checked-in multi-reward docs to teach that shared contract.

Closes #1664

Follow-up to #1525, which introduced the example-local `reward_components` shape and the GDPO motivation that this shared contract now formalizes.

## Background

The example tool-call multi-reward server already documents `reward_components` as the contract GDPO-style consumers should read, but current `origin/main` defines that field only on `resources_servers/example_tool_call_multireward/app.py`'s local response subclass. That leaves new multi-reward environments without a shared `nemo_gym` type to inherit.

## Changes

- Add `MultiRewardVerifyResponse(BaseVerifyResponse)` in `nemo_gym.base_resources_server` with optional `reward_components`.
- Update the example tool-call multi-reward response to inherit from the shared class while keeping its server-specific `correctness`, `schema_valid`, `format`, and `predicted_calls` fields.
- Add focused regression coverage that proves the example verifier now returns an instance of the shared contract and preserves the existing component payload.
- Update the example README, the latest multi-reward tutorial, and the latest API reference entry where they need to name the shared contract.

## Scope

- `BaseVerifyResponse` remains scalar-only for existing single-reward verifiers.
- Trainer-side integration, NeMo-RL or VeRL wiring, version-pinned docs backfills, and new dependencies stay out of scope.
- Reward math and top-level per-component example fields remain unchanged.

## Before / After

- Before: `reward_components` exists only on `ToolCallMultiRewardVerifyResponse` inside `resources_servers/example_tool_call_multireward/app.py`.
- After: `reward_components` lives on shared `MultiRewardVerifyResponse`, the example response inherits that contract instead of defining it locally, and the latest tutorial/API reference now point users at the shared type.

## Validation

- [ ] `ng_test +entrypoint=resources_servers/example_tool_call_multireward` (Not run locally.)
- [ ] `pre-commit run --files nemo_gym/base_resources_server.py resources_servers/example_tool_call_multireward/app.py resources_servers/example_tool_call_multireward/tests/test_app.py resources_servers/example_tool_call_multireward/README.md` (Not run locally.)
- [x] `ruff check --config pyproject.toml nemo_gym/base_resources_server.py resources_servers/example_tool_call_multireward/app.py resources_servers/example_tool_call_multireward/tests/test_app.py`
- [x] `ruff format --config pyproject.toml --check nemo_gym/base_resources_server.py resources_servers/example_tool_call_multireward/app.py resources_servers/example_tool_call_multireward/tests/test_app.py`
- [x] `npm run check` in `fern/`
- [ ] Broader CI matrix, covered by pull_request workflows and not run locally

## Notes

The latest docs now teach the shared contract directly. The version-pinned `fern/versions/v0.3.0` API reference was left unchanged.
