### PR TITLE
[codex] feat(sandbox): integrate Apptainer provider stack

### DIFF
--- a/nemo_gym/sandbox/__init__.py
+++ b/nemo_gym/sandbox/__init__.py
@@ -15,7 +15,11 @@
 """Public sandbox API for NeMo Gym."""
 
 from nemo_gym.sandbox.api import AsyncSandbox, Sandbox
-from nemo_gym.sandbox.config import resolve_provider_config, resolve_provider_metadata
+from nemo_gym.sandbox.config import (
+    resolve_provider_config,
+    resolve_provider_default_options,
+    resolve_provider_metadata,
+)
 from nemo_gym.sandbox.providers import (
     ExecResult,
     SandboxCreateError,
@@ -51,6 +55,7 @@ __all__ = [
     "list_providers",
     "register_provider",
     "resolve_provider_config",
+    "resolve_provider_default_options",
     "resolve_provider_metadata",
     "rewrite_image",
 ]

--- a/nemo_gym/sandbox/config.py
+++ b/nemo_gym/sandbox/config.py
@@ -29,14 +29,16 @@ block lives in its own provider config file, so swapping providers is swapping a
 An inline single-key mapping (``{provider_name: {...}}``) is also accepted for
 keeping everything in one file.
 
-A block may also carry a reserved ``default_metadata`` key. Its entries are merged
-into the sandbox's ``SandboxSpec.metadata`` as defaults (the agent's own
-``sandbox_spec.metadata`` overrides them), so provider-identifying tags live with
-the provider rather than the agent config::
+A block may also carry reserved ``default_metadata`` and
+``default_provider_options`` keys. Their top-level entries are shallow-merged
+into the sandbox's ``SandboxSpec.metadata`` and ``SandboxSpec.provider_options``
+respectively (the agent's own ``sandbox_spec`` entries override them), so
+provider-owned defaults live with the provider rather than the agent config::
 
     sandbox:
       opensandbox: { connection: { ... } }
       default_metadata: { sandbox-api: opensandbox-sdk }
+      default_provider_options: { platform: { os: linux, arch: amd64 } }
 """
 
 from collections.abc import Mapping
@@ -45,7 +47,13 @@ from typing import Any
 
 # Reserved keys inside a sandbox block that are not the provider config.
 SANDBOX_BLOCK_DEFAULT_METADATA_KEY = "default_metadata"
-SANDBOX_BLOCK_RESERVED_KEYS = frozenset({SANDBOX_BLOCK_DEFAULT_METADATA_KEY})
+SANDBOX_BLOCK_DEFAULT_PROVIDER_OPTIONS_KEY = "default_provider_options"
+SANDBOX_BLOCK_RESERVED_KEYS = frozenset(
+    {
+        SANDBOX_BLOCK_DEFAULT_METADATA_KEY,
+        SANDBOX_BLOCK_DEFAULT_PROVIDER_OPTIONS_KEY,
+    }
+)
 
 
 def _to_plain_dict(value: Any) -> Any:
@@ -124,8 +132,9 @@ def resolve_provider_config(
     Returns:
         A plain ``{provider_name: provider_kwargs}`` dict suitable for
         :func:`nemo_gym.sandbox.create_provider`. Reserved keys such as
-        ``default_metadata`` are excluded; read them with
-        :func:`resolve_provider_metadata`.
+        ``default_metadata`` and ``default_provider_options`` are excluded; read
+        them with :func:`resolve_provider_metadata` and
+        :func:`resolve_provider_default_options`.
 
     Raises:
         TypeError: If ``sandbox_provider`` is neither a string nor a mapping.
@@ -166,3 +175,29 @@ def resolve_provider_metadata(
             f"Sandbox '{SANDBOX_BLOCK_DEFAULT_METADATA_KEY}' from {source} must be a mapping, got: {metadata!r}"
         )
     return dict(metadata)
+
+
+def resolve_provider_default_options(
+    sandbox_provider: str | Mapping[str, Any],
+    named_configs: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a sandbox block's ``default_provider_options``.
+
+    These provider-owned defaults are shallow-merged by top-level key into
+    ``SandboxSpec.provider_options``; explicit options from the agent's
+    ``sandbox_spec`` take precedence. Returns an empty dict when the block has no
+    ``default_provider_options`` key. See :func:`resolve_provider_config` for
+    argument semantics.
+    """
+    block, source = _resolve_block(sandbox_provider, named_configs)
+    if not isinstance(block, Mapping):
+        raise ValueError(f"Sandbox provider config from {source} must be a mapping, got: {block!r}")
+
+    options = block.get(SANDBOX_BLOCK_DEFAULT_PROVIDER_OPTIONS_KEY)
+    if options is None:
+        return {}
+    if not isinstance(options, Mapping):
+        raise ValueError(
+            f"Sandbox '{SANDBOX_BLOCK_DEFAULT_PROVIDER_OPTIONS_KEY}' from {source} must be a mapping, got: {options!r}"
+        )
+    return dict(options)

--- a/nemo_gym/sandbox/providers/apptainer/README.md
+++ b/nemo_gym/sandbox/providers/apptainer/README.md
@@ -72,29 +72,61 @@ async def run():
 
 ## Selecting and configuring the provider
 
-The provider config is a single-key mapping: `{"apptainer": {<kwargs>}}`. The kwargs are
-grouped into three optional sections, each of which accepts a plain mapping (e.g. from
-Hydra YAML) or the corresponding dataclass:
+For Hydra-composed agents, use the bundled named provider config:
+
+```bash
+AGENT=responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+MODEL=responses_api_models/vllm_model/configs/vllm_model.yaml
+PROVIDER=nemo_gym/sandbox/providers/apptainer/configs/apptainer.yaml
+ng_run "+config_paths=[$AGENT,$PROVIDER,$MODEL]"
+```
+
+The config binds the conventional name `sandbox`, which the agent selects with
+`sandbox_provider: sandbox`. It can therefore replace the OpenSandbox config by changing
+only the provider path. `default_metadata` is merged into each `SandboxSpec.metadata`,
+with the agent's explicit metadata taking precedence:
 
 ```yaml
-# Provider config (the value passed as the sandbox provider)
-apptainer:
-  exec:
-    fakeroot_for_root: true
-    default_binds: ["/tmp"]
-    extra_exec_args: ["--writable-tmpfs"]
-    default_timeout_s: 180
-    concurrency: 32
-  create:
-    mount_point: /sandbox
-    start_timeout_s: 600
-    extra_start_args: []
-    apply_resource_limits: true
-  probe:
-    command: printf apptainer-sandbox-ready
-    expected_stdout: apptainer-sandbox-ready
-    deadline_s: 120
+sandbox:
+  default_metadata:
+    sandbox-api: apptainer-cli
+  apptainer:
+    exec:
+      fakeroot_for_root: false  # instance start establishes fakeroot below
+      default_binds: []
+      extra_exec_args: ["--cleanenv"]
+      default_timeout_s: 180
+      concurrency: 32
+    create:
+      mount_point: /sandbox
+      start_timeout_s: 1200
+      extra_start_args: ["--containall", "--cleanenv", "--fakeroot", "--writable-tmpfs"]
+      apply_resource_limits: false
+    probe:
+      command: printf apptainer-sandbox-ready
+      expected_stdout: apptainer-sandbox-ready
+      timeout_s: 30
+      deadline_s: 120
+      stable_count: 1
+      stable_delay_s: 0.0
 ```
+
+The value under `apptainer` is the provider constructor config. Its three optional
+sections accept either a plain mapping (for example, from Hydra YAML) or the corresponding
+dataclass. Direct Python callers pass the resolved single-key mapping
+`{"apptainer": {<kwargs>}}` to `Sandbox` or `AsyncSandbox`, as shown above.
+
+The bundled config uses `--containall` and `--cleanenv` to suppress Apptainer's standard
+host home/tmp binds and ordinary host environment inheritance. It also starts with
+fakeroot and an ephemeral writable overlay so Mini SWE commands can run as root and
+persistent edits can modify an otherwise read-only SIF image. These flags must be applied
+by `instance start`; adding them only to `exec instance://...` cannot change an existing
+instance's mount/user namespace. The profile therefore disables CPU/memory cgroup flags,
+which Apptainer cannot combine with fakeroot in this provider. A host must support
+fakeroot and writable-tmpfs overlays; adjust `create.extra_start_args` for writable
+sandbox images or hosts without those features. Apptainer's `sessiondir max size`
+controls writable-tmpfs capacity; `SandboxSpec.disk_gib` does not resize it, so raise the
+host limit for Mini SWE workloads.
 
 ### `create` — `ApptainerCreateConfig`
 
@@ -114,9 +146,9 @@ Settings for running commands (`apptainer exec`) and global provider behavior.
 | Field | Default | Meaning |
 |---|---|---|
 | `default_timeout_s` | `180` | Default per-command timeout when the caller doesn't pass one (`None` = no timeout). |
-| `fakeroot_for_root` | `true` | When running as root, add `--fakeroot` (map the host user to root inside the container). |
+| `fakeroot_for_root` | `true` | When `user` is root, request `--fakeroot` on exec. The instance must also have been started with `--fakeroot`; the bundled config does this. |
 | `default_binds` | `[]` | Extra `--bind host:container` mounts added at instance start. |
-| `extra_exec_args` | `[]` | Extra raw flags appended to every `apptainer exec` (e.g. `--no-home`, `--writable-tmpfs`, `--contain`). |
+| `extra_exec_args` | `[]` | Extra raw flags appended to every `apptainer exec` (e.g. `--cleanenv` or `--no-eval`). Mount/user namespace flags belong in `create.extra_start_args`. |
 | `concurrency` | `32` | Upper bound on concurrent `apptainer` subprocesses (shared semaphore). |
 
 ### `probe` — `ApptainerProbeConfig`
@@ -145,8 +177,18 @@ The spec is provider-neutral; the Apptainer provider uses these fields:
 | `workdir` | Default working directory for `exec` (applied as `--pwd`). |
 | `files` | Seed files written into the sandbox at `start()` (handled by the sandbox API via `upload`). |
 | `resources` | Mapped to cgroup flags (see below). |
-| `provider_options` | `binds`: a `"src:dst[:opts]"` string or list of them — extra per-sandbox `--bind` mounts added at instance start (on top of the staging mount and `exec.default_binds`). |
+| `provider_options` | Validated by `ApptainerProviderOptions`; currently supports only `binds` (see below). |
 | `ttl_s` | **Not supported** — ignored with a warning. Tear down via `stop()`/`close()` instead. |
+
+### Per-sandbox provider options — `ApptainerProviderOptions`
+
+`SandboxSpec.provider_options` is parsed into a frozen dataclass before any instance
+resources are allocated. The only supported option is `binds`: either one
+`"src:dst[:opts]"` string or a list/tuple of strings. These per-sandbox mounts are added
+at instance start after the staging mount and `exec.default_binds`.
+
+Unknown keys, a non-mapping `provider_options` value, and non-string bind entries raise a
+clear validation error instead of being silently ignored.
 
 ## How it works
 
@@ -256,8 +298,13 @@ failed" rather than "the command exited 125".
   per relevant create). Manage lifetime with `stop()` / `close()`.
 - **Numeric uids.** The `su`-based user switch expects a *username*; a bare numeric uid
   may not resolve. Prefer named users.
-- **`--fakeroot` on exec.** Whether `--fakeroot` works on `exec` into an instance that
-  was started *without* fakeroot varies by Apptainer version and host configuration.
+- **Fakeroot is fixed at instance start.** `exec instance://...` cannot retrofit a user
+  namespace onto a non-fakeroot instance; put `--fakeroot` in
+  `create.extra_start_args` when commands must run as root.
+- **Apptainer launcher variables remain significant.** `APPTAINER_BIND`,
+  `APPTAINER_BINDPATH`, `APPTAINER_MOUNT`, `APPTAINERENV_*`, and legacy Singularity
+  aliases can inject mounts or environment values before container-side `--cleanenv`
+  applies. Sanitize these in the worker/launcher environment when running untrusted code.
 - **Resource enforcement.** CPU/memory cgroup flags require cgroups v2 delegation.
   Disable them with `create.apply_resource_limits: false`.
 - **Runtime-failure detection is heuristic.** It keys off stderr markers, so a user
@@ -265,7 +312,8 @@ failed" rather than "the command exited 125".
 
 ## Development
 
-Source: [`provider.py`](./provider.py). The provider implements the
+Source: [`provider.py`](./provider.py); the bundled named config is
+[`configs/apptainer.yaml`](./configs/apptainer.yaml). The provider implements the
 `SandboxProvider` protocol from [`../base.py`](../base.py) structurally (no subclassing)
 and is registered under the name `apptainer` in [`../registry.py`](../registry.py).
 

--- a/nemo_gym/sandbox/providers/apptainer/configs/apptainer.yaml
+++ b/nemo_gym/sandbox/providers/apptainer/configs/apptainer.yaml
@@ -1,0 +1,43 @@
+# Apptainer sandbox provider config.
+#
+# `sandbox` is the instance name an agent references via `sandbox_provider:
+# sandbox`; the child key `apptainer` selects the provider class and its value
+# is passed to the provider constructor.
+#
+# Every shipped provider config binds the same name `sandbox`, so swapping
+# providers is swapping this config path in `+config_paths` (no agent edit):
+#
+#   AGENT=responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+#   MODEL=responses_api_models/vllm_model/configs/vllm_model.yaml
+#   ng_run "+config_paths=[$AGENT, nemo_gym/sandbox/providers/apptainer/configs/apptainer.yaml, $MODEL]"
+#
+# To run multiple sandboxes at once, give each block a distinct instance name
+# (e.g. `apptainer_foo`, `apptainer_baz`) and reference each by name.
+#
+# `default_metadata` (optional) is merged into every sandbox's spec metadata
+# (SandboxSpec.metadata); an agent's own sandbox_spec.metadata overrides it.
+sandbox:
+  default_metadata:
+    sandbox-api: apptainer-cli
+  apptainer:
+    exec:
+      default_timeout_s: 180
+      # The instance itself starts with --fakeroot below; repeating it while
+      # joining instance:// is ignored by Apptainer.
+      fakeroot_for_root: false
+      default_binds: []
+      extra_exec_args: ["--cleanenv"]
+      concurrency: 32
+    create:
+      mount_point: /sandbox
+      start_timeout_s: 1200
+      extra_start_args: ["--containall", "--cleanenv", "--fakeroot", "--writable-tmpfs"]
+      # This provider skips CPU/memory cgroup flags when starting with --fakeroot.
+      apply_resource_limits: false
+    probe:
+      command: printf apptainer-sandbox-ready
+      expected_stdout: apptainer-sandbox-ready
+      timeout_s: 30
+      deadline_s: 120
+      stable_count: 1
+      stable_delay_s: 0.0

--- a/nemo_gym/sandbox/providers/apptainer/provider.py
+++ b/nemo_gym/sandbox/providers/apptainer/provider.py
@@ -68,7 +68,7 @@ def _require_apptainer() -> str:
     if path is None:
         raise RuntimeError(
             "The 'apptainer' binary is required for the apptainer sandbox provider. "
-            "Install Apptainer before using env.sandbox.provider.name=apptainer."
+            "Install Apptainer before selecting the 'apptainer' sandbox provider."
         )
     return path
 
@@ -137,6 +137,40 @@ class ApptainerProbeConfig:
             raise ValueError("probe.stable_count must be >= 1")
         if self.stable_delay_s < 0:
             raise ValueError("probe.stable_delay_s must be >= 0")
+
+
+@dataclass(frozen=True)
+class ApptainerProviderOptions:
+    """Recognized per-sandbox create options read from ``SandboxSpec.provider_options``."""
+
+    binds: tuple[str, ...] = ()
+
+    @classmethod
+    def from_mapping(cls, options: Mapping[str, Any] | None) -> "ApptainerProviderOptions":
+        if options is None:
+            return cls()
+        if not isinstance(options, Mapping):
+            raise TypeError("Apptainer provider_options must be a mapping")
+
+        allowed = set(cls.__dataclass_fields__)
+        unknown = set(options) - allowed
+        if unknown:
+            raise ValueError(
+                f"Unknown Apptainer provider option(s): {', '.join(sorted(unknown))}. "
+                f"Supported: {', '.join(sorted(allowed))}"
+            )
+
+        binds = options.get("binds")
+        if binds is None:
+            normalized_binds: tuple[str, ...] = ()
+        elif isinstance(binds, str):
+            normalized_binds = (binds,)
+        elif isinstance(binds, (list, tuple)) and all(isinstance(bind, str) for bind in binds):
+            normalized_binds = tuple(binds)
+        else:
+            raise TypeError("Apptainer provider option 'binds' must be a string or list/tuple of strings")
+
+        return cls(binds=normalized_binds)
 
 
 @dataclass
@@ -218,22 +252,6 @@ def _is_runtime_failure(stderr: str) -> bool:
 def _is_missing_instance(stderr: str) -> bool:
     low = stderr.lower()
     return any(marker in low for marker in APPTAINER_MISSING_INSTANCE_MARKERS)
-
-
-def _coerce_binds(value: Any) -> list[str]:
-    """Normalize ``spec.provider_options['binds']`` into a list of bind strings.
-
-    Accepts a single ``"src:dst[:opts]"`` string or a list of them. These are
-    extra per-sandbox bind mounts, added on top of the staging mount and the
-    provider-level ``exec.default_binds``.
-    """
-    if value is None:
-        return []
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, (list, tuple)):
-        return [str(v) for v in value]
-    raise ApptainerCreateError(f"provider_options['binds'] must be a string or list, got {type(value).__name__}")
 
 
 class ApptainerProvider:
@@ -346,7 +364,7 @@ class ApptainerProvider:
            mount_point = self._create_config.mount_point, generate a unique
            name = INSTANCE_NAME_PREFIX + uuid4().hex.
         4. Build argv: [binary, "instance", "start", <--bind staging:mount_point>,
-           <config default_binds>, <spec.provider_options["binds"]>, <--env ...>,
+           <config default_binds>, <provider_options.binds>, <--env ...>,
            _resource_flags(spec.resources), <extra_start_args>, image, name].
         5. await self._run(argv, timeout_s=self._create_config.start_timeout_s);
            on non-zero return, clean up the staging dir and raise
@@ -367,7 +385,7 @@ class ApptainerProvider:
         image = _resolve_image(spec.image)
 
         # Extra per-sandbox bind mounts (validated before we allocate anything).
-        extra_binds = _coerce_binds(spec.provider_options.get("binds"))
+        options = ApptainerProviderOptions.from_mapping(spec.provider_options)
 
         # host staging dir (bind-mounted in), mount point, unique name.
         mount_point = self._create_config.mount_point
@@ -381,7 +399,7 @@ class ApptainerProvider:
         argv += ["--bind", f"{staging_dir}:{mount_point}"]
         for bind in self._exec_config.default_binds:
             argv += ["--bind", bind]
-        for bind in extra_binds:
+        for bind in options.binds:
             argv += ["--bind", bind]
         for key, value in spec.env.items():
             argv += ["--env", f"{key}={value}"]

--- a/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
+++ b/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
@@ -14,11 +14,15 @@
 # To run multiple sandboxes at once, give each block a distinct instance name
 # (e.g. `opensandbox_foo`, `opensandbox_baz`) and reference each by name.
 #
-# `default_metadata` (optional) is merged into every sandbox's spec metadata
-# (SandboxSpec.metadata); an agent's own sandbox_spec.metadata overrides it.
+# `default_metadata` and `default_provider_options` (optional) are shallow-
+# merged by top-level key into every SandboxSpec; agent values override them.
 sandbox:
   default_metadata:
     sandbox-api: opensandbox-sdk
+  default_provider_options:
+    platform:
+      os: linux
+      arch: amd64
   opensandbox:
     connection:
       domain: ${oc.env:OPENSANDBOX_DOMAIN,opensandbox-server.opensandbox-system.svc.cluster.local}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,8 +327,8 @@ exclude-dependencies = [
 # and example data into the wheel via the setuptools-scm VCS file-finder, which includes git-tracked
 # files. (Adding `environments` to packages.find above is what makes that tree ship at all.) Bulk
 # train/validation JSONL is intentionally not committed to git, so it is excluded automatically.
-# Only nemo_gym's own non-package resource scripts need an explicit entry here.
-nemo_gym = ["resources/*.py"]
+# Only nemo_gym's own non-package resource scripts and sandbox provider configs need an explicit entry here.
+nemo_gym = ["resources/*.py", "sandbox/providers/*/configs/*.yaml"]
 
 [tool.setuptools.dynamic]
 version = {attr = "nemo_gym.__version__"}

--- a/responses_api_agents/mini_swe_agent_2/README.md
+++ b/responses_api_agents/mini_swe_agent_2/README.md
@@ -162,10 +162,6 @@ mini_swe_agent_2:
           cpu: 2
           memory_mib: 8192
           disk_gib: 20
-        provider_options:
-          platform:
-            os: linux
-            arch: amd64
         metadata:
           benchmark: swebench-verified
           harness: mini-swe-agent
@@ -197,6 +193,10 @@ Path - `nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml`
 sandbox:                      # name referenced by the agent's sandbox_provider
   default_metadata:           # optional: merged into sandbox spec metadata (see below)
     sandbox-api: opensandbox-sdk
+  default_provider_options:   # optional: merged into sandbox provider_options
+    platform:
+      os: linux
+      arch: amd64
   opensandbox:                # provider registry key -> provider class
     connection:
       domain: ${oc.env:OPENSANDBOX_DOMAIN,opensandbox-server.opensandbox-system.svc.cluster.local}
@@ -229,11 +229,23 @@ To use a different provider, add a config file under
 `sandbox` block (the name the agent references) with that provider's registry key,
 then point `+config_paths` at it instead — no agent edit required.
 
+Apptainer ships such a config at
+`nemo_gym/sandbox/providers/apptainer/configs/apptainer.yaml`. Select it by replacing
+the OpenSandbox provider path in `+config_paths`; the host must have the `apptainer`
+binary installed. See the [Apptainer provider README](../../nemo_gym/sandbox/providers/apptainer/README.md)
+for its runtime requirements and configuration knobs.
+
 An optional `default_metadata` key holds provider-contributed defaults that are
 merged into each sandbox's spec metadata (`SandboxSpec.metadata`); the agent's own
 `sandbox_spec.metadata` overrides them on conflict. This keeps provider-identifying
 tags (e.g. `sandbox-api: opensandbox-sdk`) with the provider rather than in the
 agent config.
+
+Likewise, optional `default_provider_options` are shallow-merged by top-level key into
+`SandboxSpec.provider_options`, with explicit agent options winning. Nested mappings are
+replaced rather than deep-merged. This keeps provider-specific defaults such as
+OpenSandbox's Linux/AMD64 platform in the provider file while the agent config remains
+portable to Apptainer.
 
 To ship a custom provider class from a separate package, register it under the
 `nemo_gym.sandbox_providers` entry point group so it is available on install:
@@ -408,8 +420,10 @@ environment:
       connection: ...
   spec:
     resources: ...
-    provider_options:
-      platform: ...
+    provider_options:          # contributed by the selected OpenSandbox config
+      platform:
+        os: linux
+        arch: amd64
     metadata: ...
 ```
 

--- a/responses_api_agents/mini_swe_agent_2/app.py
+++ b/responses_api_agents/mini_swe_agent_2/app.py
@@ -47,7 +47,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
 )
 from nemo_gym.reward_profile import compute_pass_majority_metrics, highest_k_metrics
-from nemo_gym.sandbox import resolve_provider_config, resolve_provider_metadata
+from nemo_gym.sandbox import resolve_provider_config, resolve_provider_default_options, resolve_provider_metadata
 from nemo_gym.server_utils import (
     ServerClient,
     get_first_server_config_dict,
@@ -751,6 +751,9 @@ class MiniSWEAgent(SimpleResponsesAPIAgent):
             if self.config.sandbox_provider is None:
                 raise ValueError("mini_swe_agent_2 requires sandbox_provider")
             resolved_sandbox_provider = resolve_provider_config(self.config.sandbox_provider, global_config_dict)
+            provider_default_options = resolve_provider_default_options(
+                self.config.sandbox_provider, global_config_dict
+            )
             provider_default_metadata = resolve_provider_metadata(self.config.sandbox_provider, global_config_dict)
             config.setdefault("environment", {}).update(self.config.sandbox_environment_kwargs or {})
             config["environment"]["provider"] = _sandbox_provider_for_config_dump(resolved_sandbox_provider)
@@ -762,6 +765,12 @@ class MiniSWEAgent(SimpleResponsesAPIAgent):
             if provider_default_metadata:
                 # Provider defaults first; the agent's own spec metadata wins on conflict.
                 instance_spec["metadata"] = {**provider_default_metadata, **(instance_spec.get("metadata") or {})}
+            if provider_default_options:
+                # Provider defaults first; the agent's own provider_options win on conflict.
+                instance_spec["provider_options"] = {
+                    **provider_default_options,
+                    **(instance_spec.get("provider_options") or {}),
+                }
             config["environment"]["spec"] = instance_spec
             should_write_config = True
 

--- a/responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+++ b/responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
@@ -5,7 +5,8 @@
 #
 #   AGENT=responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
 #   MODEL=responses_api_models/vllm_model/configs/vllm_model.yaml
-#   ng_run "+config_paths=[$AGENT, nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml, $MODEL]"
+#   PROVIDER=nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
+#   ng_run "+config_paths=[$AGENT, $PROVIDER, $MODEL]"
 mini_swe_agent_2:
   responses_api_agents:
     mini_swe_agent_2:
@@ -19,7 +20,7 @@ mini_swe_agent_2:
       concurrency: 64
       env: sandbox
       # Name of the sandbox to use; include a provider config that defines a
-      # `sandbox` block (e.g. nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml).
+      # `sandbox` block (e.g. a config under nemo_gym/sandbox/providers/).
       sandbox_provider: sandbox
       sandbox_spec:
         ttl_s: 18000
@@ -28,10 +29,6 @@ mini_swe_agent_2:
           cpu: 2
           memory_mib: 8192
           disk_gib: 20
-        provider_options:
-          platform:
-            os: linux
-            arch: amd64
         metadata:
           benchmark: swebench-verified
           harness: mini-swe-agent

--- a/responses_api_agents/mini_swe_agent_2/tests/test_app.py
+++ b/responses_api_agents/mini_swe_agent_2/tests/test_app.py
@@ -784,6 +784,12 @@ class TestApp:
         monkeypatch.chdir(tmp_path)
         config = create_test_config()
         config.sandbox_provider = "sandbox"
+        config.sandbox_spec = {
+            "provider_options": {
+                "platform": {"os": "linux", "arch": "arm64"},
+                "extensions": {"trace": "enabled"},
+            }
+        }
         mock_server_client = MagicMock(spec=ServerClient)
         server = MiniSWEAgent(config=config, server_client=mock_server_client)
 
@@ -792,6 +798,10 @@ class TestApp:
             "policy_model_name": "test_model",
             "sandbox": {
                 "default_metadata": {"sandbox-api": "opensandbox-sdk"},
+                "default_provider_options": {
+                    "platform": {"os": "linux", "arch": "amd64"},
+                    "skip_health_check": True,
+                },
                 "opensandbox": {
                     "connection": {
                         "domain": "sandbox.example",
@@ -817,6 +827,65 @@ class TestApp:
         assert "api_key" not in provider["connection"]
         # Provider default_metadata flows into the sandbox spec metadata.
         assert generated_config["environment"]["spec"]["metadata"]["sandbox-api"] == "opensandbox-sdk"
+        # Provider defaults fill missing values; explicit agent options win on conflict.
+        assert generated_config["environment"]["spec"]["provider_options"] == {
+            "platform": {"os": "linux", "arch": "arm64"},
+            "skip_health_check": True,
+            "extensions": {"trace": "enabled"},
+        }
+
+    @patch("responses_api_agents.mini_swe_agent_2.app.ServerClient.load_from_global_config")
+    @patch("responses_api_agents.mini_swe_agent_2.app.get_first_server_config_dict")
+    @patch("responses_api_agents.mini_swe_agent_2.app.get_config_path")
+    @patch("responses_api_agents.mini_swe_agent_2.app.runner_ray_remote")
+    @patch("asyncio.to_thread")
+    async def test_run_resolves_bundled_apptainer_provider_reference(
+        self,
+        mock_to_thread,
+        mock_runner_ray_remote,
+        mock_get_config_path,
+        mock_get_first_server_config_dict,
+        mock_load_from_global_config,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        config = create_test_config()
+        config.sandbox_provider = "sandbox"
+        mock_server_client = MagicMock(spec=ServerClient)
+        server = MiniSWEAgent(config=config, server_client=mock_server_client)
+
+        provider_config_path = (
+            Path(__file__).parents[3]
+            / "nemo_gym"
+            / "sandbox"
+            / "providers"
+            / "apptainer"
+            / "configs"
+            / "apptainer.yaml"
+        )
+        bundled_provider_config = yaml.safe_load(provider_config_path.read_text())
+        mock_server_client_instance = MagicMock()
+        mock_server_client_instance.global_config_dict = {
+            "policy_model_name": "test_model",
+            **bundled_provider_config,
+        }
+        mock_load_from_global_config.return_value = mock_server_client_instance
+        mock_get_first_server_config_dict.return_value = {"host": "0.0.0.0", "port": 8080}
+        setup_config_path_mock(mock_get_config_path)
+        setup_run_mini_swe_mock(mock_to_thread, mock_runner_ray_remote)
+
+        await server.run(create_run_request())
+
+        mock_runner_ray_remote.options.assert_not_called()
+        call_args = mock_runner_ray_remote.remote.call_args
+        params = call_args.args[1]
+        generated_config = yaml.safe_load(Path(params["config"]).read_text())
+        assert generated_config["environment"]["provider"] == {
+            "apptainer": bundled_provider_config["sandbox"]["apptainer"]
+        }
+        assert generated_config["environment"]["spec"]["metadata"]["sandbox-api"] == "apptainer-cli"
+        assert "provider_options" not in generated_config["environment"]["spec"]
 
     @patch("responses_api_agents.mini_swe_agent_2.app.ServerClient.load_from_global_config")
     @patch("responses_api_agents.mini_swe_agent_2.app.get_first_server_config_dict")

--- a/tests/unit_tests/test_apptainer_provider.py
+++ b/tests/unit_tests/test_apptainer_provider.py
@@ -135,6 +135,66 @@ def test_config_validation() -> None:
     assert apptainer_provider.ApptainerProbeConfig(command=None, timeout_s=0).command is None
 
 
+def test_provider_options_from_mapping() -> None:
+    options_cls = apptainer_provider.ApptainerProviderOptions
+
+    assert options_cls.from_mapping(None) == options_cls()
+    assert options_cls.from_mapping({"binds": "/host:/container"}).binds == ("/host:/container",)
+    assert options_cls.from_mapping({"binds": ["/a:/a", "/b:/b:ro"]}).binds == (
+        "/a:/a",
+        "/b:/b:ro",
+    )
+    assert options_cls.from_mapping({"binds": ("/a:/a", "/b:/b:ro")}).binds == (
+        "/a:/a",
+        "/b:/b:ro",
+    )
+    assert options_cls.from_mapping({"binds": None}).binds == ()
+
+    with pytest.raises(ValueError, match="Unknown Apptainer provider option"):
+        options_cls.from_mapping({"bogus": True})
+    with pytest.raises(TypeError, match="provider_options must be a mapping"):
+        options_cls.from_mapping(["not", "a", "mapping"])
+    with pytest.raises(TypeError, match="'binds' must be a string or list/tuple of strings"):
+        options_cls.from_mapping({"binds": 123})
+    with pytest.raises(TypeError, match="'binds' must be a string or list/tuple of strings"):
+        options_cls.from_mapping({"binds": ["/host:/container", 123]})
+
+
+def test_bundled_provider_config(fake_binary: str) -> None:
+    from omegaconf import OmegaConf
+
+    from nemo_gym.sandbox import (
+        resolve_provider_config,
+        resolve_provider_default_options,
+        resolve_provider_metadata,
+    )
+
+    config_path = Path(apptainer_provider.__file__).parent / "configs" / "apptainer.yaml"
+    agent_config_path = (
+        Path(__file__).parents[2] / "responses_api_agents" / "mini_swe_agent_2" / "configs" / "mini_swe_agent_2.yaml"
+    )
+    config = OmegaConf.merge(OmegaConf.load(config_path), OmegaConf.load(agent_config_path))
+    agent_config = config.mini_swe_agent_2.responses_api_agents.mini_swe_agent_2
+
+    assert agent_config.sandbox_provider == "sandbox"
+    assert "provider_options" not in agent_config.sandbox_spec
+    resolved = resolve_provider_config(agent_config.sandbox_provider, config)
+    assert resolve_provider_metadata(agent_config.sandbox_provider, config) == {"sandbox-api": "apptainer-cli"}
+    assert resolve_provider_default_options(agent_config.sandbox_provider, config) == {}
+
+    provider = apptainer_provider.ApptainerProvider(**resolved["apptainer"])
+    assert provider._exec_config == apptainer_provider.ApptainerExecConfig(
+        fakeroot_for_root=False,
+        extra_exec_args=["--cleanenv"],
+    )
+    assert provider._create_config == apptainer_provider.ApptainerCreateConfig(
+        start_timeout_s=1200,
+        extra_start_args=["--containall", "--cleanenv", "--fakeroot", "--writable-tmpfs"],
+        apply_resource_limits=False,
+    )
+    assert provider._probe == apptainer_provider.ApptainerProbeConfig(deadline_s=120)
+
+
 def test_resource_flags() -> None:
     flags = apptainer_provider._resource_flags(
         SandboxResources(cpu=2, memory_mib=1024, gpu=1, disk_gib=50, gpu_type="h100")
@@ -312,8 +372,22 @@ async def test_create_extra_binds_accepts_single_string(
 
 async def test_create_extra_binds_invalid_type_raises(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
     provider, _rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
-    with pytest.raises(apptainer_provider.ApptainerCreateError, match="must be a string or list"):
+    with pytest.raises(TypeError, match="must be a string or list/tuple of strings"):
         await provider.create(SandboxSpec(image="docker://img", provider_options={"binds": 123}))
+
+
+async def test_create_rejects_unknown_options_before_allocating(
+    fake_binary: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider, rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+
+    def unexpected_mkdtemp(*_args: Any, **_kwargs: Any) -> str:
+        raise AssertionError("mkdtemp must not run for invalid provider options")
+
+    monkeypatch.setattr(apptainer_provider.tempfile, "mkdtemp", unexpected_mkdtemp)
+    with pytest.raises(ValueError, match="Unknown Apptainer provider option"):
+        await provider.create(SandboxSpec(image="docker://img", provider_options={"platform": {}}))
+    assert rec.calls == []
 
 
 async def test_create_requires_image(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit_tests/test_sandbox.py
+++ b/tests/unit_tests/test_sandbox.py
@@ -38,6 +38,7 @@ from nemo_gym.sandbox import (
     list_providers,
     register_provider,
     resolve_provider_config,
+    resolve_provider_default_options,
     resolve_provider_metadata,
 )
 from nemo_gym.sandbox.api import _AsyncLoopRunner
@@ -512,25 +513,39 @@ def test_resolve_provider_config_errors() -> None:
         resolve_provider_config("sandbox_main", {"sandbox_main": {}})
 
 
-def test_resolve_provider_metadata() -> None:
+def test_resolve_provider_defaults() -> None:
     block = {
         "opensandbox": {"connection": {"domain": "sandbox.example"}},
         "default_metadata": {"sandbox-api": "opensandbox-sdk"},
+        "default_provider_options": {"platform": {"os": "linux", "arch": "amd64"}},
     }
 
     # default_metadata is excluded from the provider config and read separately.
     assert resolve_provider_config(block) == {"opensandbox": {"connection": {"domain": "sandbox.example"}}}
     assert resolve_provider_metadata(block) == {"sandbox-api": "opensandbox-sdk"}
+    assert resolve_provider_default_options(block) == {
+        "platform": {"os": "linux", "arch": "amd64"},
+    }
 
     # A named reference works the same way.
     global_config = {"sandbox": block}
     assert resolve_provider_metadata("sandbox", global_config) == {"sandbox-api": "opensandbox-sdk"}
+    assert resolve_provider_default_options("sandbox", global_config) == {
+        "platform": {"os": "linux", "arch": "amd64"},
+    }
 
-    # No default_metadata key -> empty dict.
+    # No provider-owned defaults -> empty dicts.
     assert resolve_provider_metadata({"opensandbox": {}}) == {}
+    assert resolve_provider_default_options({"opensandbox": {}}) == {}
 
     with pytest.raises(ValueError, match="must be a mapping"):
         resolve_provider_metadata({"opensandbox": {}, "default_metadata": "not-a-mapping"})
+    # Preserve the stack's existing behavior for an empty falsy value.
+    assert resolve_provider_metadata({"opensandbox": {}, "default_metadata": []}) == {}
+
+    for invalid in ("not-a-mapping", []):
+        with pytest.raises(ValueError, match="must be a mapping"):
+            resolve_provider_default_options({"opensandbox": {}, "default_provider_options": invalid})
 
 
 def test_async_sandbox_transfer_fallback_and_unknown_status(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add a canonical named Apptainer `sandbox` config with provider-owned metadata and Mini SWE-ready instance settings
- validate Apptainer `SandboxSpec.provider_options` through a frozen `ApptainerProviderOptions` dataclass
- keep Mini SWE provider-neutral by moving OpenSandbox's Linux/AMD64 option into shallow-merged provider defaults
- package both provider YAML configs in wheels and document Apptainer runtime/isolation constraints

## Why

The provider stack ending at #1713 added named configs, provider defaults, and typed options for OpenSandbox, while the Apptainer provider from #1694 still relied on inline config and silently ignored unknown options. That also made the documented path-only provider swap fail because the Mini SWE config carried an OpenSandbox-only `platform` option.

## Impact

Users can select Apptainer by swapping the provider path in `+config_paths`. Explicit agent provider options still override provider defaults by top-level key. Invalid Apptainer option names and types now fail before a staging directory or subprocess is created.

## Validation

- `uv run pytest tests/unit_tests/test_apptainer_provider.py tests/unit_tests/test_sandbox.py tests/unit_tests/test_opensandbox_provider.py responses_api_agents/mini_swe_agent_2/tests/test_app.py responses_api_agents/mini_swe_agent_2/tests/test_sandbox_environment.py -q` — 125 passed
- scoped `ruff check` and `ruff format --check`
- scoped `pre-commit run --files ...`
- wheel build verified both Apptainer and OpenSandbox provider YAMLs are included

A live Linux Apptainer smoke test was not available on this macOS checkout; provider subprocess behavior remains covered by the existing hermetic test suite.

Refs #1713
Refs #1694
