### PR TITLE
Harden SWE agent test file parsing

### DIFF
--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import ast
 import asyncio
 import base64
 import glob
@@ -585,6 +586,28 @@ EVAL_HARNESS_COMMIT={eval_harness_commit} \\
 
 
 class NVInternalDatasetProcessor(BaseDatasetHarnessProcessor):
+    @staticmethod
+    def _parse_selected_test_files_to_run(raw_value: Any) -> list[str]:
+        parsed_value = raw_value
+        if isinstance(raw_value, str):
+            try:
+                parsed_value = json.loads(raw_value)
+            except json.JSONDecodeError:
+                try:
+                    parsed_value = ast.literal_eval(raw_value)
+                except (SyntaxError, ValueError) as exc:
+                    raise ValueError(
+                        "selected_test_files_to_run must be a JSON array or Python literal list of strings"
+                    ) from exc
+
+        if isinstance(parsed_value, tuple):
+            parsed_value = list(parsed_value)
+
+        if not isinstance(parsed_value, list) or not all(isinstance(test_file, str) for test_file in parsed_value):
+            raise ValueError("selected_test_files_to_run must decode to a list of strings")
+
+        return parsed_value
+
     def get_run_command(self) -> ExecuteContainerCommandArgs:
         instance_dict = json.loads(self.config.problem_info["instance_dict"])
         base_dockerfile = instance_dict.get("base_dockerfile", "")
@@ -620,11 +643,9 @@ class NVInternalDatasetProcessor(BaseDatasetHarnessProcessor):
             repo_cmd = repo_cmd.split("\n")[-1]
 
         # Get test files
-        test_files_str = instance_dict.get("selected_test_files_to_run", "[]")
-        if isinstance(test_files_str, str):
-            test_files = ",".join(eval(test_files_str))
-        else:
-            test_files = ",".join(test_files_str)
+        test_files = self._parse_selected_test_files_to_run(instance_dict.get("selected_test_files_to_run", "[]"))
+        test_files_arg = ",".join(test_files)
+        test_files_arg = f" {shlex.quote(test_files_arg)}" if test_files_arg else ""
 
         run_script = instance_dict["run_script.sh"]
         parsing_script = instance_dict["parsing_script.py"]
@@ -656,7 +677,7 @@ git apply --ignore-space-change --ignore-whitespace --reject -v /root/patch.diff
 {repo_cmd}
 
 # Run tests
-bash /root/run_script.sh {test_files} > /root/stdout.log 2> /root/stderr.log || true
+bash /root/run_script.sh{test_files_arg} > /root/stdout.log 2> /root/stderr.log || true
 
 # Parse results
 python /root/parsing_script.py /root/stdout.log /root/stderr.log /root/output.json

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -531,6 +531,50 @@ class TestNVInternalDatasetProcessor:
             result = processor.get_run_command()
             assert "test_x.py,test_y.py" in result.command
 
+    def test_get_run_command_python_literal_test_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            processor = self._make_processor(
+                tmpdir,
+                {
+                    "selected_test_files_to_run": "['test_x.py', 'test_y.py']",
+                },
+            )
+            result = processor.get_run_command()
+            assert "test_x.py,test_y.py" in result.command
+
+    def test_get_run_command_quotes_test_files_arg(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            processor = self._make_processor(
+                tmpdir,
+                {
+                    "selected_test_files_to_run": ["test_x.py", "test;touch /tmp/pwned"],
+                },
+            )
+            result = processor.get_run_command()
+            assert "bash /root/run_script.sh 'test_x.py,test;touch /tmp/pwned'" in result.command
+
+    def test_get_run_command_rejects_executable_test_files_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            processor = self._make_processor(
+                tmpdir,
+                {
+                    "selected_test_files_to_run": '__import__("os").system("touch /tmp/pwned")',
+                },
+            )
+            with pytest.raises(ValueError, match="selected_test_files_to_run"):
+                processor.get_run_command()
+
+    def test_get_run_command_rejects_non_string_test_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            processor = self._make_processor(
+                tmpdir,
+                {
+                    "selected_test_files_to_run": '["test_x.py", 1]',
+                },
+            )
+            with pytest.raises(ValueError, match="selected_test_files_to_run"):
+                processor.get_run_command()
+
     def test_get_run_command_no_repo_cmd(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             processor = self._make_processor(


### PR DESCRIPTION
## Summary
- replace `eval()` when decoding `selected_test_files_to_run` with JSON parsing plus a constrained `ast.literal_eval()` compatibility fallback
- preserve support for JSON arrays and Python literal lists/tuples
- validate that the decoded value is a list of strings before building the eval harness command
- shell-quote the joined test-file argument so filenames cannot inject shell commands

## Root cause
The NV-internal SWE harness treated dataset-provided `selected_test_files_to_run` metadata as executable Python. A malformed or malicious dataset row could therefore run arbitrary code in the agent process before test execution began.

## Validation
From `responses_api_agents/swe_agents`:

- `uv run --with-requirements requirements.txt python -m pytest tests/test_app.py::TestNVInternalDatasetProcessor` (15 passed)
- `uv run --extra dev ruff check app.py tests/test_app.py`
- `uv run --extra dev ruff format --check app.py tests/test_app.py`
