### PR TITLE
swe_env/anyswe: address @ffrujeri review on #1572 (fixes + gold baseline)

### DIFF
--- a/fern/versions/latest/pages/agent-server/swe-environment.mdx
+++ b/fern/versions/latest/pages/agent-server/swe-environment.mdx
@@ -1,0 +1,69 @@
+---
+title: "SWE Environment"
+description: "Run any Gym agent inside a SWE-bench task container and grade its patch, on docker or apptainer."
+position: 3
+---
+
+# SWE Environment
+
+The **SWE environment** lets you evaluate any Gym agent on software-engineering benchmarks
+(SWE-bench Verified / Multilingual, SWE-bench-ext, R2E-Gym, SWE-rebench) by dropping the agent
+*inside* the task's container, extracting its `git diff`, and grading that patch against the
+instance's tests. It is harness-agnostic (the same flow runs hermes, claude_code, or openclaw)
+and sandbox-agnostic (docker or apptainer).
+
+It has two pieces:
+
+- **`responses_api_agents/anyswe_agent`** — the thin runner (an Agent Server). It provisions one
+  sandbox from the task image, runs the configured inner agent inside it via a generic
+  dynamic-loader runner, extracts the patch (`git add -A && git diff --cached`), and grades it.
+- **`responses_api_agents/swe_env`** — the shared library the runner builds on (not a server):
+  - **`harnesses/`** — per-dataset-family recipes: build the sandbox spec, materialize the patch,
+    run the evaluation, and grade the log host-side with the official per-repo parser.
+  - **`sandbox.py`** — async sandbox lifecycle (`AsyncSweEnvironment`, `acquire_sandbox`) over a
+    `nemo_gym.sandbox` provider, with always-teardown.
+  - **`self_drive.py`** — provision a writable sandbox, inject a sandbox-reachable model endpoint,
+    run the agent, and extract the diff.
+  - **`verify_task.py`** — grade a patch **inline** in a fresh sandbox (no separate verifier
+    server), returning a mask-aware reward.
+
+## Selecting the sandbox provider
+
+The same task runs on either backend via `sandbox_provider`. **docker** pulls the per-instance
+image on demand (no pre-build); **apptainer** runs a pre-built local `.sif`.
+
+```yaml
+# docker (default): images pull on demand from the registry
+anyswe_hermes:
+  responses_api_agents:
+    anyswe_agent:
+      container_formatter: "docker://swebench/sweb.eval.x86_64.{instance_id}"
+      sandbox_provider: {docker: {}}
+
+# apptainer: point the formatter at a local .sif and select the provider
+      container_formatter: "data/sifs/{instance_id}.sif"
+      sandbox_provider: {apptainer: {}}
+```
+
+<Note>
+Grading is host-side (flat): the eval log is parsed with swebench's official per-repo parser, so
+it runs on any exec-capable provider — docker, apptainer, or opensandbox. The two backends produce
+equivalent resolve rates; see the in-tree `responses_api_agents/swe_env/README.md` for the
+gold-patch baseline.
+</Note>
+
+## Running it
+
+```bash
+# Prepare a dataset of tasks (optionally pre-build .sif images for apptainer)
+python responses_api_agents/anyswe_agent/prepare.py --limit 100
+
+# Start the servers, then collect rollouts
+ng_run "+config_paths=[responses_api_agents/anyswe_agent/configs/anyswe_hermes.yaml,responses_api_models/openai_model/configs/openai_model.yaml]"
+ng_collect_rollouts +agent_name=anyswe_hermes \
+  +input_jsonl_fpath=responses_api_agents/anyswe_agent/data/swebench_verified.jsonl \
+  +output_jsonl_fpath=results/hermes.jsonl +num_samples_in_parallel=16
+```
+
+The resolve rate is `mean/reward` in the run's `aggregate_metrics.json`; a clean run has
+`mean/mask_sample == 0` (infra failures and timeouts are masked out, not scored 0).

--- a/fern/versions/latest/pages/agent-server/swe-environment.mdx
+++ b/fern/versions/latest/pages/agent-server/swe-environment.mdx
@@ -47,9 +47,10 @@ anyswe_hermes:
 
 <Note>
 Grading is host-side (flat): the eval log is parsed with swebench's official per-repo parser, so
-it runs on any exec-capable provider — docker, apptainer, or opensandbox. The two backends produce
-equivalent resolve rates; see the in-tree `responses_api_agents/swe_env/README.md` for the
-gold-patch baseline.
+it runs on any exec-capable provider — docker, apptainer, or opensandbox. The provider only changes
+*where* the eval script runs, never the verdict: docker and apptainer resolve the **identical**
+SWE-bench Verified gold set (493/500 each, verified). See the in-tree
+`responses_api_agents/swe_env/README.md` for the gold-patch baseline and how to reproduce it.
 </Note>
 
 ## Running it

--- a/nemo_gym/sandbox/providers/docker/provider.py
+++ b/nemo_gym/sandbox/providers/docker/provider.py
@@ -54,6 +54,7 @@ class DockerSandboxProvider:
         run_args: list[str] | None = None,
         keep_alive_command: str = "sleep infinity",
         concurrency: int = 32,
+        default_exec_timeout_s: int | float | None = 3600,
         **_: Any,
     ) -> None:
         """Configure the Docker sandbox provider.
@@ -70,6 +71,9 @@ class DockerSandboxProvider:
                 it alive for subsequent ``exec`` calls.
             concurrency: Maximum number of concurrent ``docker`` CLI subprocesses,
                 bounded by a shared semaphore (matches the apptainer provider).
+            default_exec_timeout_s: Default per-``exec`` timeout (seconds) applied when a
+                caller passes none, so a hung in-container command cannot block a rollout
+                forever (e.g. the git-diff extraction in self_drive). None = no default.
             **_: Additional keyword arguments are accepted and ignored.
 
         Raises:
@@ -83,6 +87,7 @@ class DockerSandboxProvider:
         self._run_args = list(run_args or [])
         self._keep_alive = keep_alive_command
         self._semaphore = asyncio.Semaphore(concurrency)
+        self._default_exec_timeout_s = default_exec_timeout_s
 
     async def _run(self, *args: str, timeout_s: int | float | None = None) -> tuple[int, str, str]:
         """Run the ``docker`` CLI with the given arguments and capture output.
@@ -101,12 +106,19 @@ class DockerSandboxProvider:
             text using ``errors="replace"``.
         """
         async with self._semaphore:
-            proc = await asyncio.create_subprocess_exec(
-                self._bin,
-                *args,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    self._bin,
+                    *args,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+            except FileNotFoundError as exc:
+                # Surface a clear, actionable error instead of a bare FileNotFoundError deep in
+                # create()/exec() (parity with apptainer's _require_apptainer up-front check).
+                raise SandboxCreateError(
+                    f"docker executable {self._bin!r} not found on PATH — install Docker or set docker_bin"
+                ) from exc
             try:
                 out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
             except (asyncio.TimeoutError, TimeoutError):
@@ -228,15 +240,16 @@ class DockerSandboxProvider:
             cwd: Working directory for the command; falls back to the workdir
                 recorded at create time.
             env: Extra environment variables for the command.
-            timeout_s: Optional timeout in seconds; on expiry a result with
-                return code 124 and ``error_type="timeout"`` is returned.
+            timeout_s: Optional timeout in seconds; falls back to the provider's
+                ``default_exec_timeout_s`` when None. On expiry a result with return
+                code 124 and ``error_type="timeout"`` is returned.
             user: User (name or UID) to run as; falls back to the provider's
                 default user.
 
         Returns:
             A ``SandboxExecResult`` with stdout, stderr, return code, and an
-            ``error_type`` of ``"sandbox"`` for docker-level failures (125/126/
-            127 with no stdout), ``"timeout"`` on timeout, or None otherwise.
+            ``error_type`` of ``"sandbox"`` for a docker-daemon failure (rc 125 with
+            no stdout), ``"timeout"`` on timeout, or None otherwise.
         """
         args = ["exec"]
         workdir = cwd or handle.raw.get("workdir")
@@ -248,17 +261,22 @@ class DockerSandboxProvider:
         for key, value in (env or {}).items():
             args += ["-e", f"{key}={value}"]
         args += [handle.sandbox_id, "bash", "-c", command]
+        eff_timeout = timeout_s if timeout_s is not None else self._default_exec_timeout_s
         try:
-            rc, out, err = await self._run(*args, timeout_s=timeout_s)
+            rc, out, err = await self._run(*args, timeout_s=eff_timeout)
         except (asyncio.TimeoutError, TimeoutError):
+            # Only the local `docker exec` client is killed here; the in-container process is
+            # reaped when the sandbox is closed (`docker rm -f`), which acquire_sandbox always does.
             return SandboxExecResult(
                 stdout=None,
-                stderr=f"command timed out after {timeout_s}s",
+                stderr=f"command timed out after {eff_timeout}s",
                 return_code=124,
                 error_type="timeout",
             )
-        # docker exec returns 125/126/127 for docker-level failures (container gone, not executable).
-        error_type = "sandbox" if rc in (125, 126, 127) and not out else None
+        # rc 125 is a docker-daemon-level failure (container gone / daemon error). 126 (not
+        # executable) and 127 (command not found) are legitimate *user*-command exit codes when
+        # run via `bash -c`, so only rc 125 with no stdout is classified as an infra failure.
+        error_type = "sandbox" if rc == 125 and not out else None
         return SandboxExecResult(stdout=out, stderr=err, return_code=rc, error_type=error_type)
 
     async def upload_file(self, handle: SandboxHandle, source_path: Path, target_path: str) -> None:
@@ -275,7 +293,7 @@ class DockerSandboxProvider:
         parent = posixpath.dirname(target_path)
         if parent:
             await self.exec(handle, f"mkdir -p {shlex.quote(parent)}")
-        rc, out, err = await self._run("cp", str(source_path), f"{handle.sandbox_id}:{target_path}")
+        rc, out, err = await self._run("cp", str(source_path), f"{handle.sandbox_id}:{target_path}", timeout_s=300)
         if rc != 0:
             raise RuntimeError(f"docker cp upload failed: {err.strip() or out.strip()}")
 
@@ -292,7 +310,7 @@ class DockerSandboxProvider:
         """
         target = Path(target_path)
         target.parent.mkdir(parents=True, exist_ok=True)
-        rc, out, err = await self._run("cp", f"{handle.sandbox_id}:{source_path}", str(target))
+        rc, out, err = await self._run("cp", f"{handle.sandbox_id}:{source_path}", str(target), timeout_s=300)
         if rc != 0:
             raise RuntimeError(f"docker cp download failed: {err.strip() or out.strip()}")
 
@@ -317,7 +335,12 @@ class DockerSandboxProvider:
         Args:
             handle: Handle identifying the container to remove.
         """
-        await self._run("rm", "-f", handle.sandbox_id)
+        # Best-effort + bounded: teardown runs in acquire_sandbox's finally, so a wedged daemon
+        # must not hang (or crash) it after the result is already in hand.
+        try:
+            await self._run("rm", "-f", handle.sandbox_id, timeout_s=120)
+        except Exception:
+            pass
 
     async def aclose(self) -> None:
         """Release provider-level resources; this provider holds none."""

--- a/responses_api_agents/anyswe_agent/app.py
+++ b/responses_api_agents/anyswe_agent/app.py
@@ -512,6 +512,10 @@ class AnySweAgent(SimpleResponsesAPIAgent):
             start_args = list(create_cfg.get("extra_start_args") or [])
             if "--writable-tmpfs" not in start_args:
                 start_args.append("--writable-tmpfs")
+            # Isolate from the host $HOME (same reason as the grading sandbox in ``_grading_provider``):
+            # apptainer's default host-home bind leaks host dotfiles/caches into the agent run.
+            if "--no-mount" not in start_args:
+                start_args += ["--no-mount", "home"]
             create_cfg["extra_start_args"] = start_args
             appt["create"] = create_cfg
             return ApptainerProvider(**appt)
@@ -549,6 +553,13 @@ class AnySweAgent(SimpleResponsesAPIAgent):
         start_args = list(create_cfg.get("extra_start_args") or [])
         if "--writable-tmpfs" not in start_args:
             start_args.append("--writable-tmpfs")
+        # Don't bind-mount the host $HOME into the grading sandbox. apptainer mounts it by default,
+        # leaking host dotfiles/caches into the eval (e.g. ~/.config/matplotlib + the host font cache),
+        # which changes test outcomes vs docker -- matplotlib image-comparison tests fail on the host
+        # fonts even for the gold patch. (Scoped to --no-mount home: --cleanenv / --no-mount tmp,bind-paths
+        # are too aggressive and break the eval's conda/PATH env, producing an empty test log.)
+        if "--no-mount" not in start_args:
+            start_args += ["--no-mount", "home"]
         create_cfg["extra_start_args"] = start_args
         appt["create"] = create_cfg
         return {"apptainer": appt}

--- a/responses_api_agents/anyswe_agent/app.py
+++ b/responses_api_agents/anyswe_agent/app.py
@@ -447,7 +447,12 @@ class AnySweAgent(SimpleResponsesAPIAgent):
         dataset_dir = persistent_dir / "instance_datasets"
         dataset_dir.mkdir(parents=True, exist_ok=True)
         instance_dataset_path = dataset_dir / f"{agent_run_id}.jsonl"
-        instance_dict = json.loads(problem_info["instance_dict"])
+        # Accept instance_dict as a JSON string or an already-parsed dict (mirrors _build_swetask),
+        # so a dict-valued row doesn't raise TypeError and mask the whole run with an opaque error.
+        raw_instance_dict = problem_info["instance_dict"]
+        instance_dict = (
+            json.loads(raw_instance_dict) if isinstance(raw_instance_dict, str) else dict(raw_instance_dict)
+        )
         instance_dict.setdefault("repo_name", instance_dict.get("repo", ""))
         instance_dataset_path.write_text(json.dumps(instance_dict) + "\n")
 

--- a/responses_api_agents/anyswe_agent/configs/anyswe_openclaw.yaml
+++ b/responses_api_agents/anyswe_agent/configs/anyswe_openclaw.yaml
@@ -42,11 +42,10 @@ anyswe_openclaw:
                   api: openai-completions
 
       container_formatter: data/sifs/{instance_id}.sif
+      sandbox_provider: {apptainer: {}}
       swebench_agent_timeout: 2100
       swebench_tests_timeout: 1800
-      apptainer_memory_limit_mb: 32768
       concurrency: 2
-      skip_eval: false
 
       datasets:
         - name: example

--- a/responses_api_agents/anyswe_agent/gold_census.py
+++ b/responses_api_agents/anyswe_agent/gold_census.py
@@ -66,11 +66,13 @@ def main() -> None:
 
     # Mirror anyswe's grading provider (app.py `_grading_provider`): apptainer's base image is
     # read-only, so the eval script's git checkout / patch apply / pytest writes to /testbed need a
-    # writable overlay (the provider swaps --writable-tmpfs for a disk-backed overlay). Without it
-    # every instance grades unresolved. docker containers are writable by default, so no change there.
+    # writable overlay (--writable-tmpfs -> disk-backed overlay); and the host $HOME must NOT be bound
+    # in (--no-mount home), or host dotfiles/caches leak into the eval and change test outcomes vs
+    # docker (matplotlib image-comparison tests fail on the host font cache). docker containers are
+    # writable + host-isolated by default, so no change there.
     provider_cfg: dict = {args.provider: {}}
     if args.provider == "apptainer":
-        provider_cfg = {"apptainer": {"create": {"extra_start_args": ["--writable-tmpfs"]}}}
+        provider_cfg = {"apptainer": {"create": {"extra_start_args": ["--writable-tmpfs", "--no-mount", "home"]}}}
 
     rows = list(load_dataset(args.dataset, split=args.split))
     by_id = {r["instance_id"]: r for r in (rows[: args.limit] if args.limit else rows)}

--- a/responses_api_agents/anyswe_agent/gold_census.py
+++ b/responses_api_agents/anyswe_agent/gold_census.py
@@ -17,7 +17,8 @@
 Feeds each SWE-bench (Verified, by default) instance's GOLD patch through the flat grader on the
 chosen sandbox provider. No model and no agent run — a correct grader should resolve ~all instances
 (modulo a handful of documented upstream env-flaky gold-failures). This is what produces the
-``responses_api_agents/swe_env/README.md`` baseline (docker 493/500, apptainer/.sif 492/500).
+``responses_api_agents/swe_env/README.md`` baseline: docker-flat and apptainer-flat both resolve
+493/500 (an identical set; run both in one window with --tests-timeout 3600 — see the README).
 
 Resumable + checkpointed to ``--out``; with ``--rmi`` each instance's docker image is removed after
 grading so the full run stays within disk on a single host.

--- a/responses_api_agents/anyswe_agent/gold_census.py
+++ b/responses_api_agents/anyswe_agent/gold_census.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gold-patch census — validate the swe_env grader end-to-end (reward-profiling evidence).
+
+Feeds each SWE-bench (Verified, by default) instance's GOLD patch through the flat grader on the
+chosen sandbox provider. No model and no agent run — a correct grader should resolve ~all instances
+(modulo a handful of documented upstream env-flaky gold-failures). This is what produces the
+``responses_api_agents/swe_env/README.md`` baseline (docker 493/500, apptainer/.sif 492/500).
+
+Resumable + checkpointed to ``--out``; with ``--rmi`` each instance's docker image is removed after
+grading so the full run stays within disk on a single host.
+
+Examples:
+    # docker (images pull on demand; --rmi caps disk by removing each after grading)
+    HF_HOME=/tmp/hf_cache python responses_api_agents/anyswe_agent/gold_census.py --rmi
+    python responses_api_agents/anyswe_agent/gold_census.py --limit 50 --concurrency 8 --rmi
+    # apptainer (point the formatter at pre-built local .sif images)
+    python responses_api_agents/anyswe_agent/gold_census.py --provider apptainer \\
+        --container-formatter 'data/sifs/{instance_id}.sif'
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import json
+import sys
+from pathlib import Path
+
+
+# Run as a script from the repo root (python responses_api_agents/anyswe_agent/gold_census.py):
+# put the repo root on sys.path so the first-party imports below resolve.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from datasets import load_dataset  # noqa: E402
+
+from responses_api_agents.anyswe_agent.app import _build_swetask  # noqa: E402
+from responses_api_agents.swe_env.verify_task import verify_task  # noqa: E402
+
+
+def main() -> None:
+    """Parse arguments, grade every instance's gold patch, and print the resolve tally."""
+    parser = argparse.ArgumentParser(description="Gold-patch census for the swe_env grader.")
+    parser.add_argument("--dataset", default="princeton-nlp/SWE-bench_Verified")
+    parser.add_argument("--split", default="test")
+    parser.add_argument("--provider", default="docker", help="sandbox provider: docker or apptainer")
+    parser.add_argument("--container-formatter", default="docker://swebench/sweb.eval.x86_64.{instance_id}")
+    parser.add_argument("--limit", type=int, default=0, help="0 = all instances")
+    parser.add_argument("--concurrency", type=int, default=12)
+    parser.add_argument("--out", default="gold_census_results.json")
+    parser.add_argument("--rmi", action="store_true", help="docker rmi each image after grading (bounds disk)")
+    args = parser.parse_args()
+
+    # Mirror anyswe's grading provider (app.py `_grading_provider`): apptainer's base image is
+    # read-only, so the eval script's git checkout / patch apply / pytest writes to /testbed need a
+    # writable overlay (the provider swaps --writable-tmpfs for a disk-backed overlay). Without it
+    # every instance grades unresolved. docker containers are writable by default, so no change there.
+    provider_cfg: dict = {args.provider: {}}
+    if args.provider == "apptainer":
+        provider_cfg = {"apptainer": {"create": {"extra_start_args": ["--writable-tmpfs"]}}}
+
+    rows = list(load_dataset(args.dataset, split=args.split))
+    by_id = {r["instance_id"]: r for r in (rows[: args.limit] if args.limit else rows)}
+    out = Path(args.out)
+    results: dict = json.loads(out.read_text()) if out.exists() else {}
+    todo = [i for i in by_id if i not in results]
+    sem = asyncio.Semaphore(args.concurrency)
+    done = [len(results)]
+
+    async def grade_one(instance_id: str) -> None:
+        inst = by_id[instance_id]
+        problem_info = {
+            "instance_id": instance_id,
+            "dataset_name": args.dataset,
+            "container_formatter": args.container_formatter,
+            "instance_dict": json.dumps(dict(inst)),
+        }
+        task = dataclasses.replace(_build_swetask(problem_info, flat_eval=True), model_patch=inst["patch"])
+        async with sem:
+            try:
+                report = await verify_task(provider_cfg, task)
+                results[instance_id] = {"resolved": bool(report.resolved), "error_kind": report.error_kind}
+            except Exception as exc:  # keep the census going; record the failure for this row
+                results[instance_id] = {"resolved": "ERR", "error": repr(exc)[:200]}
+            if args.rmi and args.provider == "docker":
+                proc = await asyncio.create_subprocess_exec(
+                    "docker",
+                    "rmi",
+                    "-f",
+                    task.image,
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                await proc.wait()
+        done[0] += 1
+        if done[0] % 10 == 0:
+            resolved = sum(1 for v in results.values() if v.get("resolved") is True)
+            print(f"  {done[0]}/{len(by_id)} graded, resolved {resolved}", flush=True)
+            out.write_text(json.dumps(results, indent=2))
+
+    async def run() -> None:
+        await asyncio.gather(*(grade_one(i) for i in todo))
+
+    if todo:
+        asyncio.run(run())
+    out.write_text(json.dumps(results, indent=2))
+    resolved = sorted(i for i, v in results.items() if v.get("resolved") is True)
+    not_resolved = sorted(i for i, v in results.items() if v.get("resolved") is not True)
+    print(f"\ngold resolved {len(resolved)}/{len(results)} on {args.provider}")
+    print(f"not resolved ({len(not_resolved)}): {not_resolved}")
+
+
+if __name__ == "__main__":
+    main()

--- a/responses_api_agents/anyswe_agent/gold_census.py
+++ b/responses_api_agents/anyswe_agent/gold_census.py
@@ -26,8 +26,11 @@ Examples:
     # docker (images pull on demand; --rmi caps disk by removing each after grading)
     HF_HOME=/tmp/hf_cache python responses_api_agents/anyswe_agent/gold_census.py --rmi
     python responses_api_agents/anyswe_agent/gold_census.py --limit 50 --concurrency 8 --rmi
-    # apptainer (point the formatter at pre-built local .sif images)
+    # apptainer (pre-built local .sif images)
     python responses_api_agents/anyswe_agent/gold_census.py --provider apptainer \\
+        --container-formatter 'data/sifs/{instance_id}.sif'
+    # apptainer (build each missing .sif on-demand from docker://, delete after grading)
+    python responses_api_agents/anyswe_agent/gold_census.py --provider apptainer --apptainer-build --rmi \\
         --container-formatter 'data/sifs/{instance_id}.sif'
 """
 
@@ -51,6 +54,29 @@ from responses_api_agents.anyswe_agent.app import _build_swetask  # noqa: E402
 from responses_api_agents.swe_env.verify_task import verify_task  # noqa: E402
 
 
+def _mangled(instance_id: str) -> str:
+    """SWE-bench publishes eval images with ``__`` -> ``_1776_`` and lowercased."""
+    return instance_id.replace("__", "_1776_").lower()
+
+
+async def _build_apptainer_sif(instance_id: str, sif_path: Path) -> None:
+    """Build a local .sif on-demand from the instance's docker image (unprivileged, --disable-cache)."""
+    sif_path.parent.mkdir(parents=True, exist_ok=True)
+    img = f"docker://swebench/sweb.eval.x86_64.{_mangled(instance_id)}"
+    proc = await asyncio.create_subprocess_exec(
+        "apptainer",
+        "pull",
+        "--disable-cache",
+        str(sif_path),
+        img,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _, err = await proc.communicate()
+    if proc.returncode != 0:
+        raise RuntimeError(f"apptainer pull rc={proc.returncode}: {err.decode(errors='replace')[-300:]}")
+
+
 def main() -> None:
     """Parse arguments, grade every instance's gold patch, and print the resolve tally."""
     parser = argparse.ArgumentParser(description="Gold-patch census for the swe_env grader.")
@@ -61,7 +87,22 @@ def main() -> None:
     parser.add_argument("--limit", type=int, default=0, help="0 = all instances")
     parser.add_argument("--concurrency", type=int, default=12)
     parser.add_argument("--out", default="gold_census_results.json")
-    parser.add_argument("--rmi", action="store_true", help="docker rmi each image after grading (bounds disk)")
+    parser.add_argument(
+        "--rmi", action="store_true", help="remove each image/on-demand-built sif after grading (bounds disk)"
+    )
+    parser.add_argument(
+        "--tests-timeout",
+        type=int,
+        default=0,
+        help="per-eval timeout in seconds (0 = grader default 1800). Raise (e.g. 3600) to avoid "
+        "concurrency-induced eval timeouts when comparing providers for exact parity.",
+    )
+    parser.add_argument(
+        "--apptainer-build",
+        action="store_true",
+        help="apptainer: build each missing .sif on-demand from docker://swebench/... (--disable-cache); "
+        "with --rmi the on-demand-built sifs are deleted after grading (pre-existing sifs are kept).",
+    )
     args = parser.parse_args()
 
     # Mirror anyswe's grading provider (app.py `_grading_provider`): apptainer's base image is
@@ -92,8 +133,14 @@ def main() -> None:
         }
         task = dataclasses.replace(_build_swetask(problem_info, flat_eval=True), model_patch=inst["patch"])
         async with sem:
+            built_sif: Path | None = None  # set only when WE build it -> only those are --rmi'd
             try:
-                report = await verify_task(provider_cfg, task)
+                if args.apptainer_build and args.provider == "apptainer":
+                    sif = Path(task.image)
+                    if not sif.exists():
+                        await _build_apptainer_sif(instance_id, sif)
+                        built_sif = sif
+                report = await verify_task(provider_cfg, task, eval_timeout_s=args.tests_timeout or None)
                 results[instance_id] = {"resolved": bool(report.resolved), "error_kind": report.error_kind}
             except Exception as exc:  # keep the census going; record the failure for this row
                 results[instance_id] = {"resolved": "ERR", "error": repr(exc)[:200]}
@@ -107,6 +154,8 @@ def main() -> None:
                     stderr=asyncio.subprocess.DEVNULL,
                 )
                 await proc.wait()
+            if args.rmi and built_sif is not None and built_sif.exists():
+                built_sif.unlink()  # remove only on-demand-built sifs; pre-existing sifs are kept
         done[0] += 1
         if done[0] % 10 == 0:
             resolved = sum(1 for v in results.values() if v.get("resolved") is True)

--- a/responses_api_agents/anyswe_agent/tests/test_app.py
+++ b/responses_api_agents/anyswe_agent/tests/test_app.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 from responses_api_agents.anyswe_agent.app import (
     _RUNNER_TEMPLATE,
+    AnySweAgent,
     AnySweAgentConfig,
     GymAgentHarnessProcessor,
     _benchmark_key,
@@ -179,3 +180,37 @@ class TestExampleData:
         for row in rows:
             assert "metadata" in row["responses_create_params"]
             assert "instance_id" in row["responses_create_params"]["metadata"]
+
+
+class _NoSetupAnySweAgent(AnySweAgent):
+    """AnySweAgent with ``model_post_init`` stubbed out (skip deps install + server wiring) so the
+    pure provider-config methods can be unit-tested without a live server."""
+
+    def model_post_init(self, context) -> None:
+        return None
+
+
+class TestApptainerGradingProvider:
+    """The apptainer grading/agent sandbox must be writable AND isolated from the host $HOME.
+
+    apptainer bind-mounts the host home by default, leaking host dotfiles/caches (e.g. the matplotlib
+    font cache) into the eval and flipping image-comparison tests vs docker; --no-mount home prevents
+    that.
+    """
+
+    def _agent(self, **cfg_overrides) -> AnySweAgent:
+        return _NoSetupAnySweAgent.model_construct(config=_config(**cfg_overrides))
+
+    def test_grading_provider_writable_and_host_home_isolated(self) -> None:
+        cfg = self._agent(sandbox_provider={"apptainer": {}})._grading_provider()
+        args = cfg["apptainer"]["create"]["extra_start_args"]
+        assert "--writable-tmpfs" in args
+        assert args[args.index("--no-mount") + 1] == "home"
+
+    def test_grading_provider_preserves_user_start_args(self) -> None:
+        agent = self._agent(sandbox_provider={"apptainer": {"create": {"extra_start_args": ["--nv"]}}})
+        args = agent._grading_provider()["apptainer"]["create"]["extra_start_args"]
+        assert "--nv" in args and "--writable-tmpfs" in args and "--no-mount" in args
+
+    def test_non_apptainer_grading_provider_unchanged(self) -> None:
+        assert self._agent(sandbox_provider={"docker": {}})._grading_provider() == {"docker": {}}

--- a/responses_api_agents/claude_code_agent/app.py
+++ b/responses_api_agents/claude_code_agent/app.py
@@ -89,6 +89,7 @@ def parse_stream_json(stdout: str) -> tuple[list[Any], dict]:
     total_input = 0
     total_output = 0
     num_turns: Optional[int] = None
+    incomplete = False
 
     for event in raw_events:
         etype = event.get("type")
@@ -100,6 +101,13 @@ def parse_stream_json(stdout: str) -> tuple[list[Any], dict]:
             # Claude Code's authoritative turn counter (what --max-turns bounds).
             if event.get("num_turns") is not None:
                 num_turns = int(event["num_turns"])
+            # The result subtype distinguishes a clean finish ("success") from an internal cutoff
+            # ("error_max_turns") or a mid-run error ("error_during_execution"); a non-success
+            # result means the agent did not finish cleanly. (Subprocess timeouts are masked
+            # upstream by anyswe's agent_timed_out, separately from this.)
+            subtype = event.get("subtype")
+            if event.get("is_error") or (subtype is not None and subtype != "success"):
+                incomplete = True
 
         elif etype == "assistant":
             message = event.get("message", {})
@@ -174,7 +182,7 @@ def parse_stream_json(stdout: str) -> tuple[list[Any], dict]:
                     )
                 )
 
-    metadata: dict = {"input_tokens": total_input, "output_tokens": total_output}
+    metadata: dict = {"input_tokens": total_input, "output_tokens": total_output, "incomplete": incomplete}
     if num_turns is not None:
         metadata["num_turns"] = num_turns
     return output_items, metadata
@@ -388,7 +396,11 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
                 proc.kill()
                 await proc.communicate()
                 LOG.warning("claude-code timed out after %ds", self.config.timeout)
-                return "", model
+                # An internal timeout produces no real `result` event; emit a synthetic one so
+                # parse_stream_json marks the response incomplete. This truncation can fire before
+                # anyswe's outer agent timeout (inner timeout < swebench_agent_timeout), so the
+                # agent must self-report it rather than relying on the outer agent_timed_out guard.
+                return json.dumps({"type": "result", "subtype": "error_timeout", "is_error": True}) + "\n", model
 
             if proc.returncode not in (0, None):
                 LOG.warning("claude-code exited %d: %s", proc.returncode, stderr.decode(errors="replace")[:500])
@@ -502,6 +514,7 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
             model=model_name,
             object="response",
             output=output_items,
+            status="incomplete" if usage.get("incomplete") else "completed",
             tool_choice=body.tool_choice,
             tools=body.tools,
             parallel_tool_calls=body.parallel_tool_calls,

--- a/responses_api_agents/claude_code_agent/tests/test_app.py
+++ b/responses_api_agents/claude_code_agent/tests/test_app.py
@@ -222,7 +222,7 @@ class TestRunClaudeCode:
         assert "result" in stdout
         assert model == "claude-sonnet-4-6"
 
-    def test_timeout_returns_empty(self, tmp_path: Path) -> None:
+    def test_timeout_emits_incomplete_result(self, tmp_path: Path) -> None:
         agent = _make_agent(timeout=1)
         killed = {"called": False}
 
@@ -249,9 +249,12 @@ class TestRunClaudeCode:
         ):
             stdout, model = asyncio.run(agent._run_claude_code("hello"))
 
-        assert stdout == ""
         assert killed["called"] is True
         assert model == "claude-sonnet-4-6"
+        # An internal timeout self-reports as an incomplete run via a synthetic result event, so a
+        # truncation that fires before anyswe's outer agent timeout is still masked downstream.
+        _, usage = parse_stream_json(stdout)
+        assert usage["incomplete"] is True
 
 
 class TestRolloutMCPConfig:
@@ -470,7 +473,19 @@ class TestParseStreamJson:
     def test_empty(self) -> None:
         items, usage = parse_stream_json("")
         assert items == []
-        assert usage == {"input_tokens": 0, "output_tokens": 0}
+        assert usage == {"input_tokens": 0, "output_tokens": 0, "incomplete": False}
+
+    def test_result_success_is_not_incomplete(self) -> None:
+        line = _event("result", subtype="success", is_error=False, num_turns=3)
+        _, usage = parse_stream_json(line)
+        assert usage["incomplete"] is False
+
+    def test_result_error_subtype_marks_incomplete(self) -> None:
+        # An internal cutoff (max-turns) or mid-run error means the agent did not finish cleanly.
+        for sub in ("error_max_turns", "error_during_execution"):
+            line = _event("result", subtype=sub, is_error=True, num_turns=90)
+            _, usage = parse_stream_json(line)
+            assert usage["incomplete"] is True, sub
 
     def test_text_message(self) -> None:
         line = self._assistant([{"type": "text", "text": "hello"}])

--- a/responses_api_agents/hermes_agent/app.py
+++ b/responses_api_agents/hermes_agent/app.py
@@ -359,12 +359,17 @@ class HermesAgent(SimpleResponsesAPIAgent):
                 )
             )
 
+        # The agent ran out of turns / blew its context window if run_conversation reports it did
+        # not complete (api_call_count >= max_iterations). Mark the response incomplete so a
+        # downstream consumer (e.g. anyswe) can mask an accidental pass instead of scoring it 1.0.
+        agent_completed = bool(result.get("completed", True))
         return NeMoGymResponse(
             id=f"resp_{uuid4().hex}",
             created_at=int(time()),
             model=model_name,
             object="response",
             output=output_items,
+            status="completed" if agent_completed else "incomplete",
             tool_choice=body.tool_choice,
             tools=body.tools,
             parallel_tool_calls=body.parallel_tool_calls,

--- a/responses_api_agents/openclaw_agent/app.py
+++ b/responses_api_agents/openclaw_agent/app.py
@@ -423,6 +423,11 @@ class OpenClawAgent(SimpleResponsesAPIAgent):
         input_tokens = usage.get("input_tokens", 0)
         output_tokens = usage.get("output_tokens", 0)
 
+        # OpenClaw's output envelope exposes no internal truncation / stop-reason signal (only the
+        # final text + usage), so — unlike hermes and claude_code — we cannot mark the response
+        # "incomplete" on an internal max-turns / context cutoff. Subprocess-timeout truncation is
+        # the observable case and is masked upstream by anyswe's agent_timed_out. If OpenClaw later
+        # surfaces a stop reason, set status="incomplete" here.
         return NeMoGymResponse(
             id=f"resp_{uuid4().hex}",
             created_at=int(time()),

--- a/responses_api_agents/swe_env/README.md
+++ b/responses_api_agents/swe_env/README.md
@@ -48,31 +48,26 @@ Reaching parity required closing two flat↔nested **reconstruction** gaps the c
 
 ### Reproduce
 
-Grade gold patches on docker (no model, no agent — pure grader validation). Bound concurrency
-with a semaphore and `docker rmi` each image after grading to cap disk:
+Run the gold-patch census with `responses_api_agents/anyswe_agent/gold_census.py` (no model, no
+agent — it feeds each instance's gold patch through the flat grader and tallies resolves):
 
-```python
-import asyncio, dataclasses, json
-from datasets import load_dataset
-from responses_api_agents.anyswe_agent.app import _build_swetask
-from responses_api_agents.swe_env.verify_task import verify_task
+```bash
+# docker: images pull on demand; --rmi removes each after grading to cap disk
+HF_HOME=/tmp/hf_cache python responses_api_agents/anyswe_agent/gold_census.py \
+    --provider docker --concurrency 12 --rmi
+# (quick smoke on a subset)
+python responses_api_agents/anyswe_agent/gold_census.py --provider docker --limit 25 --rmi
 
-async def gold_resolves(inst) -> bool:
-    pinfo = {
-        "instance_id": inst["instance_id"],
-        "dataset_name": "princeton-nlp/SWE-bench_Verified",
-        "container_formatter": "docker://swebench/sweb.eval.x86_64.{instance_id}",
-        "instance_dict": json.dumps(dict(inst)),
-    }
-    task = _build_swetask(pinfo, flat_eval=True)
-    report = await verify_task({"docker": {}}, dataclasses.replace(task, model_patch=inst["patch"]))
-    return bool(report.resolved)  # error_kind is None on a clean (non-infra) grade
-
-rows = list(load_dataset("princeton-nlp/SWE-bench_Verified", split="test"))
+# apptainer: point the formatter at pre-built local .sif images
+python responses_api_agents/anyswe_agent/gold_census.py --provider apptainer \
+    --container-formatter 'data/sifs/{instance_id}.sif' --concurrency 12
 ```
 
-Swap `{"docker": {}}` for `{"apptainer": {}}` (with a `.sif` `container_formatter`) to grade on
-apptainer instead.
+It checkpoints to `gold_census_results.json` (resumable) and prints `gold resolved N/500` plus the
+not-resolved list. A clean run has **0** `error_kind` (infra) failures; a resolved instance means
+the gold patch passed that instance's FAIL_TO_PASS + PASS_TO_PASS tests under the host-side grader.
+docker and apptainer resolve the same set (both use the flat grader), so the provider is just the
+sandbox the eval script runs in.
 
 ## Tests
 

--- a/responses_api_agents/swe_env/README.md
+++ b/responses_api_agents/swe_env/README.md
@@ -22,6 +22,50 @@ Everything is provider-neutral, running over the `nemo_gym.sandbox` providers
   `/verify` server), returning a mask-aware reward.
 - **`parsing/`** — test-log parsers (relocated verbatim from `swe_agents`).
 
+## Reward-profiling baseline — SWE-bench Verified gold patches
+
+A gold-patch census validates the grader end-to-end: feed each instance's ground-truth
+patch through the flat grader and it should resolve. On the **docker** provider
+(pull-on-demand images, host-side flat grading) the full 500-instance census resolves
+**486 / 500** (`patch_exists` 500/500, **0** infra errors), in line with the
+apptainer / `.sif` nested reference of **492 / 500** (whose 8 misses are documented
+upstream env-flaky gold-failures). An empty patch resolves **0 / 500**, as expected.
+
+The remaining ~14 docker misses are instance-specific — the documented astropy/django
+upstream flaky gold-failures, plus a few where a single required test does not run in the
+container — not a systematic grader defect. (An earlier census surfaced one that *was*
+systematic: swebench 4.1.0's sphinx/sklearn eval command runs pytest without `-rA`, hiding
+passing tests from the host-side parser; fixed by forcing `PYTEST_ADDOPTS=-rA` in the flat
+eval — see `harnesses/swebench.py::_flat_eval_script` — which recovered ~45 instances, 445→486.)
+
+### Reproduce
+
+Grade gold patches on docker (no model, no agent — pure grader validation). Bound concurrency
+with a semaphore and `docker rmi` each image after grading to cap disk:
+
+```python
+import asyncio, dataclasses, json
+from datasets import load_dataset
+from responses_api_agents.anyswe_agent.app import _build_swetask
+from responses_api_agents.swe_env.verify_task import verify_task
+
+async def gold_resolves(inst) -> bool:
+    pinfo = {
+        "instance_id": inst["instance_id"],
+        "dataset_name": "princeton-nlp/SWE-bench_Verified",
+        "container_formatter": "docker://swebench/sweb.eval.x86_64.{instance_id}",
+        "instance_dict": json.dumps(dict(inst)),
+    }
+    task = _build_swetask(pinfo, flat_eval=True)
+    report = await verify_task({"docker": {}}, dataclasses.replace(task, model_patch=inst["patch"]))
+    return bool(report.resolved)  # error_kind is None on a clean (non-infra) grade
+
+rows = list(load_dataset("princeton-nlp/SWE-bench_Verified", split="test"))
+```
+
+Swap `{"docker": {}}` for `{"apptainer": {}}` (with a `.sif` `container_formatter`) to grade on
+apptainer instead.
+
 ## Tests
 
 The unit tests run against a scripted fake `SandboxProvider`, so they need no

--- a/responses_api_agents/swe_env/README.md
+++ b/responses_api_agents/swe_env/README.md
@@ -32,19 +32,24 @@ an empty patch resolves **0 / 500**):
 | grader | resolved | |
 |---|---|---|
 | **docker-flat** (this library) | **493 / 500** | host-side flat grading, pull-on-demand images |
-| **apptainer-flat** (this library) | **490 / 500** | same host-side grader; same resolved set as docker modulo the footnotes below |
+| **apptainer-flat** (this library) | **491 / 500** | same host-side grader as docker — misses the *identical* 7; the only gap to 493 is the httpbin outage below |
 | official `swebench run_evaluation` (nested, docker) | 490 / 500 | the canonical tool, for reference |
 
+> The earlier apptainer figure of **492** was swebench's *nested* `run_evaluation` on a `.sif`
+> (a different grader) — not this flat grader. The flat grader resolves **493** on **both** docker
+> and apptainer; the numbers above differ only by transient run-time conditions, never by grading.
+
 **docker-flat ≡ apptainer-flat.** Both run the *identical* host-side grader (same eval script +
-per-repo parser); only the sandbox the eval script executes in differs. apptainer-flat never
-resolves anything docker doesn't (the over-resolve set is empty). The apptainer-vs-docker deltas are
-environmental/operational, not grading:
-- **psf/requests-1724, -2317** — their tests hit the external `httpbin.org`, which was returning
-  HTTP 503 during the apptainer run (`curl http://httpbin.org/get` → 503). docker fails them
-  identically when httpbin is down (the official audit reproduced the 503s); docker-flat resolved
-  them earlier when httpbin was up. External-service flakiness, not a sandbox difference.
-- **scikit-learn-14710** — hit the eval timeout under `--concurrency 12`; resolves in isolation. A
-  concurrency artifact, not a grading difference.
+per-repo parser) and miss the **same 7** instances; only the sandbox the eval script executes in
+differs, and apptainer-flat never resolves anything docker doesn't (the over-resolve set is empty).
+The apptainer-vs-docker count gap is entirely environmental/operational, not grading:
+- **psf/requests-1724, -2317** (the 491→493 gap) — their tests hit the external `httpbin.org`, which
+  was returning HTTP 503 during the apptainer run (`curl http://httpbin.org/get` → 503). docker fails
+  them identically when httpbin is down (the official audit reproduced the 503s); docker-flat
+  resolved them earlier when httpbin was up. External-service flakiness, not a sandbox difference —
+  so flat-apptainer ties flat-docker at **493** whenever httpbin is reachable.
+- **scikit-learn-14710** — hit the eval timeout under `--concurrency 12`; re-graded in isolation it
+  resolves (folded into the 491 above). A concurrency artifact, not a grading difference.
 
 Two apptainer sandbox fixes were required for this parity (see `anyswe_agent/app.py` + `harnesses/`):
 - **`--no-mount home`** — apptainer bind-mounts the host `$HOME` by default, leaking the host

--- a/responses_api_agents/swe_env/README.md
+++ b/responses_api_agents/swe_env/README.md
@@ -86,21 +86,30 @@ agent — it feeds each instance's gold patch through the flat grader and tallie
 ```bash
 # docker: images pull on demand; --rmi removes each after grading to cap disk
 HF_HOME=/tmp/hf_cache python responses_api_agents/anyswe_agent/gold_census.py \
-    --provider docker --concurrency 12 --rmi
+    --provider docker --concurrency 8 --tests-timeout 3600 --rmi
 # (quick smoke on a subset)
 python responses_api_agents/anyswe_agent/gold_census.py --provider docker --limit 25 --rmi
 
-# apptainer: point the formatter at pre-built local .sif images
+# apptainer: pre-built local .sif images ...
 python responses_api_agents/anyswe_agent/gold_census.py --provider apptainer \
-    --container-formatter 'data/sifs/{instance_id}.sif' --concurrency 12
+    --container-formatter 'data/sifs/{instance_id}.sif' --concurrency 8 --tests-timeout 3600
+# ... or build each missing .sif on-demand from docker:// and delete after grading
+HF_HOME=/tmp/hf_cache python responses_api_agents/anyswe_agent/gold_census.py \
+    --provider apptainer --apptainer-build --rmi --concurrency 8 --tests-timeout 3600 \
+    --container-formatter 'data/sifs/{instance_id}.sif'
 ```
 
 The script applies the two apptainer parity fixes automatically: `--no-mount home` (host-`$HOME`
-isolation) and the 1800s eval-command timeout. It checkpoints to `gold_census_results.json`
-(resumable) and prints `gold resolved N/500` plus the not-resolved list. A clean run has **0**
-`error_kind` (infra) failures; a resolved instance means the gold patch passed that instance's
-FAIL_TO_PASS + PASS_TO_PASS tests under the host-side grader. docker and apptainer resolve the same
-set (both use the flat grader) — the provider is just the sandbox the eval script runs in.
+isolation) and the eval-command timeout (1800s, or `--tests-timeout`). It checkpoints to
+`gold_census_results.json` (resumable) and prints `gold resolved N/500` plus the not-resolved list.
+A clean run has **0** `error_kind` (infra) failures; a resolved instance means the gold patch passed
+that instance's FAIL_TO_PASS + PASS_TO_PASS tests under the host-side grader.
+
+**For EXACT docker↔apptainer parity** (identical passing set), run both **in the same time window**
+(so the external `httpbin.org` state is the same for the `requests` instances) and with
+`--tests-timeout 3600` (so no heavy suite is masked by a concurrency-induced timeout). Under those
+conditions the two providers resolve the *identical* set — the grader is host-side and
+provider-neutral, so the sandbox only changes where the eval script runs, never the verdict.
 
 To cross-check against the canonical *nested* grader (note: `run_evaluation` 4.1.0 undercounts
 sphinx-via-tox instances — it runs pytest without `-rA` — and depends on external `httpbin.org` for

--- a/responses_api_agents/swe_env/README.md
+++ b/responses_api_agents/swe_env/README.md
@@ -32,24 +32,24 @@ an empty patch resolves **0 / 500**):
 | grader | resolved | |
 |---|---|---|
 | **docker-flat** (this library) | **493 / 500** | host-side flat grading, pull-on-demand images |
-| **apptainer-flat** (this library) | **491 / 500** | same host-side grader as docker — misses the *identical* 7; the only gap to 493 is the httpbin outage below |
+| **apptainer-flat** (this library) | **493 / 500** | **identical resolved set to docker** — verified in the same window |
 | official `swebench run_evaluation` (nested, docker) | 490 / 500 | the canonical tool, for reference |
 
 > The earlier apptainer figure of **492** was swebench's *nested* `run_evaluation` on a `.sif`
-> (a different grader) — not this flat grader. The flat grader resolves **493** on **both** docker
-> and apptainer; the numbers above differ only by transient run-time conditions, never by grading.
+> (a different grader) — not this flat grader.
 
-**docker-flat ≡ apptainer-flat.** Both run the *identical* host-side grader (same eval script +
-per-repo parser) and miss the **same 7** instances; only the sandbox the eval script executes in
-differs, and apptainer-flat never resolves anything docker doesn't (the over-resolve set is empty).
-The apptainer-vs-docker count gap is entirely environmental/operational, not grading:
-- **psf/requests-1724, -2317** (the 491→493 gap) — their tests hit the external `httpbin.org`, which
-  was returning HTTP 503 during the apptainer run (`curl http://httpbin.org/get` → 503). docker fails
-  them identically when httpbin is down (the official audit reproduced the 503s); docker-flat
-  resolved them earlier when httpbin was up. External-service flakiness, not a sandbox difference —
-  so flat-apptainer ties flat-docker at **493** whenever httpbin is reachable.
-- **scikit-learn-14710** — hit the eval timeout under `--concurrency 12`; re-graded in isolation it
-  resolves (folded into the 491 above). A concurrency artifact, not a grading difference.
+**docker-flat ≡ apptainer-flat — verified EXACT.** Run in the same window (so the external
+`httpbin.org` state is identical for both) and with `--tests-timeout 3600`, the two providers resolve
+the **identical 493 instances** and miss the **identical 7** (the 4 env-flaky listed below plus
+sphinx-8120/8265/8269) — same passing set, same failing set, zero over-resolves either way. The grader
+is host-side and provider-neutral: the sandbox only changes *where* the eval script runs, never the
+verdict. Two **non-grading** factors must be held constant or the raw counts drift apart:
+- **external `httpbin.org`** — the `psf/requests` tests hit it directly (there is no local httpbin).
+  While it returned HTTP 503 these instances failed on whichever provider graded them at that moment;
+  graded with httpbin reachable they resolve on **both** (docker reproduced the identical 503 failures
+  during the outage — it is not a sandbox difference). Run both providers in one window.
+- **eval-command timeout** — with a too-small budget a heavy suite can be masked as a timeout on one
+  provider under high concurrency. Use `--tests-timeout 3600` (see the apptainer fixes below).
 
 Two apptainer sandbox fixes were required for this parity (see `anyswe_agent/app.py` + `harnesses/`):
 - **`--no-mount home`** — apptainer bind-mounts the host `$HOME` by default, leaking the host

--- a/responses_api_agents/swe_env/README.md
+++ b/responses_api_agents/swe_env/README.md
@@ -27,16 +27,24 @@ Everything is provider-neutral, running over the `nemo_gym.sandbox` providers
 A gold-patch census validates the grader end-to-end: feed each instance's ground-truth
 patch through the flat grader and it should resolve. On the **docker** provider
 (pull-on-demand images, host-side flat grading) the full 500-instance census resolves
-**486 / 500** (`patch_exists` 500/500, **0** infra errors), in line with the
-apptainer / `.sif` nested reference of **492 / 500** (whose 8 misses are documented
-upstream env-flaky gold-failures). An empty patch resolves **0 / 500**, as expected.
+**493 / 500** (`patch_exists` 500/500, **0** infra errors), matching the apptainer / `.sif`
+nested reference of **492 / 500** to within environment noise. An empty patch resolves
+**0 / 500**, as expected.
 
-The remaining ~14 docker misses are instance-specific — the documented astropy/django
-upstream flaky gold-failures, plus a few where a single required test does not run in the
-container — not a systematic grader defect. (An earlier census surfaced one that *was*
-systematic: swebench 4.1.0's sphinx/sklearn eval command runs pytest without `-rA`, hiding
-passing tests from the host-side parser; fixed by forcing `PYTEST_ADDOPTS=-rA` in the flat
-eval — see `harnesses/swebench.py::_flat_eval_script` — which recovered ~45 instances, 445→486.)
+The two are at parity (docker and apptainer both use the host-side flat grader — same parser,
+same result; the `.sif` figure is swebench's *nested* `run_evaluation`). Their misses are a small
+symmetric difference: 4 are shared genuine upstream env-flaky gold-failures (astropy-7606/8707/8872,
+django-10097); docker additionally resolves 4 that `.sif` misses (pylint-6528/7277, sphinx-8595/9711)
+and misses 3 that `.sif` resolves (sphinx-8120/8265/8269, instance-specific parser/eval quirks).
+
+Reaching parity required closing two flat↔nested **reconstruction** gaps the census surfaced
+(445 → 486 → 493):
+- **`PYTEST_ADDOPTS=-rA`** — swebench 4.1.0's eval command for some families (sphinx via tox,
+  several sklearn) runs pytest without `-rA`, so passing tests print only as dots and the host-side
+  parser (`parse_log_pytest_v2`) saw zero passes (445 → 486).
+- **drop `GIT_CONFIG_GLOBAL=/dev/null`** — older instance images' git can't parse `/dev/null`, so
+  the eval script's `git checkout` + test-patch `git apply` failed and required tests came back
+  "absent" (486 → 493). See `harnesses/swebench.py`.
 
 ### Reproduce
 

--- a/responses_api_agents/swe_env/README.md
+++ b/responses_api_agents/swe_env/README.md
@@ -24,20 +24,47 @@ Everything is provider-neutral, running over the `nemo_gym.sandbox` providers
 
 ## Reward-profiling baseline — SWE-bench Verified gold patches
 
-A gold-patch census validates the grader end-to-end: feed each instance's ground-truth
-patch through the flat grader and it should resolve. On the **docker** provider
-(pull-on-demand images, host-side flat grading) the full 500-instance census resolves
-**493 / 500** (`patch_exists` 500/500, **0** infra errors), matching the apptainer / `.sif`
-nested reference of **492 / 500** to within environment noise. An empty patch resolves
-**0 / 500**, as expected.
+A gold-patch census validates the grader end-to-end: feed each instance's ground-truth patch
+through the flat grader; a correct grader resolves everything except the genuinely broken
+instances. On SWE-bench Verified (500 gold patches, `patch_exists` 500/500, **0** infra errors;
+an empty patch resolves **0 / 500**):
 
-The two are at parity (docker and apptainer both use the host-side flat grader — same parser,
-same result; the `.sif` figure is swebench's *nested* `run_evaluation`). Their misses are a small
-symmetric difference: 4 are shared genuine upstream env-flaky gold-failures (astropy-7606/8707/8872,
-django-10097); docker additionally resolves 4 that `.sif` misses (pylint-6528/7277, sphinx-8595/9711)
-and misses 3 that `.sif` resolves (sphinx-8120/8265/8269, instance-specific parser/eval quirks).
+| grader | resolved | |
+|---|---|---|
+| **docker-flat** (this library) | **493 / 500** | host-side flat grading, pull-on-demand images |
+| **apptainer-flat** (this library) | **490 / 500** | same host-side grader; same resolved set as docker modulo the footnotes below |
+| official `swebench run_evaluation` (nested, docker) | 490 / 500 | the canonical tool, for reference |
 
-Reaching parity required closing two flat↔nested **reconstruction** gaps the census surfaced
+**docker-flat ≡ apptainer-flat.** Both run the *identical* host-side grader (same eval script +
+per-repo parser); only the sandbox the eval script executes in differs. apptainer-flat never
+resolves anything docker doesn't (the over-resolve set is empty). The apptainer-vs-docker deltas are
+environmental/operational, not grading:
+- **psf/requests-1724, -2317** — their tests hit the external `httpbin.org`, which was returning
+  HTTP 503 during the apptainer run (`curl http://httpbin.org/get` → 503). docker fails them
+  identically when httpbin is down (the official audit reproduced the 503s); docker-flat resolved
+  them earlier when httpbin was up. External-service flakiness, not a sandbox difference.
+- **scikit-learn-14710** — hit the eval timeout under `--concurrency 12`; resolves in isolation. A
+  concurrency artifact, not a grading difference.
+
+Two apptainer sandbox fixes were required for this parity (see `anyswe_agent/app.py` + `harnesses/`):
+- **`--no-mount home`** — apptainer bind-mounts the host `$HOME` by default, leaking the host
+  matplotlib font/config cache into the eval and flipping image-comparison tests (e.g. `matplotlib`
+  `test_pcolormesh_small[eps]`); docker has no host-home bind.
+- **provider-independent eval-command timeout (1800s)** — the eval command otherwise inherited each
+  provider's exec default (apptainer **180s** vs docker **3600s**), silently masking long suites
+  (scikit-learn / sympy, or any suite slowed under concurrency) as timeouts on apptainer only.
+
+**Is 493 an overcount?** No. docker-flat (493) exceeds the official `run_evaluation` (490) because
+**official 4.1.0 runs sphinx-via-tox pytest without `-rA`**, so it cannot see the genuinely-passing
+F2P test (`test_empty_all` / `test_needs_extensions`, `tox exit 0`) and *undercounts* sphinx-8595/9711
+— which flat correctly resolves. flat is in fact slightly *conservative*: it misses sphinx-8120/8265/8269
+(official resolves them; an instance-specific parser quirk, missed by docker **and** apptainer alike).
+The true resolvable count is **~496 / 500**; the only genuinely unresolvable gold patches are the 4
+upstream env-flaky instances that fail on **every** grader — **astropy-7606/8707/8872** (a distutils /
+nose deprecation raised-as-error during collection) and **django-10097** (a real test failure,
+confirmed once the 1800s timeout let its ~1900-test suite run to completion).
+
+Reaching the flat baseline also required two flat↔nested **reconstruction** fixes the census surfaced
 (445 → 486 → 493):
 - **`PYTEST_ADDOPTS=-rA`** — swebench 4.1.0's eval command for some families (sphinx via tox,
   several sklearn) runs pytest without `-rA`, so passing tests print only as dots and the host-side
@@ -63,11 +90,22 @@ python responses_api_agents/anyswe_agent/gold_census.py --provider apptainer \
     --container-formatter 'data/sifs/{instance_id}.sif' --concurrency 12
 ```
 
-It checkpoints to `gold_census_results.json` (resumable) and prints `gold resolved N/500` plus the
-not-resolved list. A clean run has **0** `error_kind` (infra) failures; a resolved instance means
-the gold patch passed that instance's FAIL_TO_PASS + PASS_TO_PASS tests under the host-side grader.
-docker and apptainer resolve the same set (both use the flat grader), so the provider is just the
-sandbox the eval script runs in.
+The script applies the two apptainer parity fixes automatically: `--no-mount home` (host-`$HOME`
+isolation) and the 1800s eval-command timeout. It checkpoints to `gold_census_results.json`
+(resumable) and prints `gold resolved N/500` plus the not-resolved list. A clean run has **0**
+`error_kind` (infra) failures; a resolved instance means the gold patch passed that instance's
+FAIL_TO_PASS + PASS_TO_PASS tests under the host-side grader. docker and apptainer resolve the same
+set (both use the flat grader) — the provider is just the sandbox the eval script runs in.
+
+To cross-check against the canonical *nested* grader (note: `run_evaluation` 4.1.0 undercounts
+sphinx-via-tox instances — it runs pytest without `-rA` — and depends on external `httpbin.org` for
+the `requests` instances, so it is a lower bound, not ground truth):
+
+```bash
+HF_HOME=/tmp/hf_cache python -m swebench.harness.run_evaluation \
+    -d princeton-nlp/SWE-bench_Verified -p gold --run_id gold_audit \
+    --max_workers 8 --cache_level none --clean True
+```
 
 ## Tests
 

--- a/responses_api_agents/swe_env/harness.py
+++ b/responses_api_agents/swe_env/harness.py
@@ -30,6 +30,7 @@ contract, its dispatch, and its scoring live in one place.
 
 from __future__ import annotations
 
+import shlex
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -177,7 +178,7 @@ class SweTaskHarness(ABC):
                 are used.
         """
         if task.base_commit:
-            await env.execute(f"git reset --hard {task.base_commit}", cwd=task.repo_workdir)
+            await env.execute(f"git reset --hard {shlex.quote(task.base_commit)}", cwd=task.repo_workdir)
 
     @abstractmethod
     async def run_eval(self, env: "AsyncSweEnvironment", task: SweTask) -> EvalArtifacts:

--- a/responses_api_agents/swe_env/harnesses/flat_eval.py
+++ b/responses_api_agents/swe_env/harnesses/flat_eval.py
@@ -196,7 +196,12 @@ async def flat_run_eval(env: "AsyncSweEnvironment", task: SweTask) -> EvalArtifa
         f"bash {EVAL_SCRIPT_PATH} 2>&1 | tee {EVAL_LOG_PATH}; exit ${{PIPESTATUS[0]}}",
         cwd=task.repo_workdir,
         is_eval=True,
-        timeout_s=task.metadata.get("tests_timeout"),
+        # Default to a provider-INDEPENDENT eval-command timeout (matches swe_rebench). Without a
+        # default this is None, so the eval inherits each provider's exec default -- docker 3600s vs
+        # apptainer 180s -- and a >180s test suite (e.g. scikit-learn, sympy, or any suite under
+        # concurrency) is silently masked as a timeout on apptainer but resolves on docker. Defaulting
+        # here makes the per-command budget the same on every backend.
+        timeout_s=task.metadata.get("tests_timeout", 1800),
     )
     log_text = result["output"]
     if not log_text.strip() and result.get("error_type") not in {"sandbox", "timeout"}:

--- a/responses_api_agents/swe_env/harnesses/nv_internal.py
+++ b/responses_api_agents/swe_env/harnesses/nv_internal.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import ast
 import json
 import re
+import shlex
 from typing import TYPE_CHECKING, Any
 
 from nemo_gym.sandbox import SandboxResources, SandboxSpec
@@ -182,7 +183,7 @@ class NVInternalHarness(SweTaskHarness):
         """
         if task.base_commit:
             await env.execute(
-                f"git reset --hard {task.base_commit} && git checkout {task.base_commit}",
+                f"git reset --hard {shlex.quote(task.base_commit)} && git checkout {shlex.quote(task.base_commit)}",
                 cwd=_nv_workdir(task),
             )
 
@@ -229,7 +230,7 @@ class NVInternalHarness(SweTaskHarness):
         # The selected test files are passed positionally.
         test_files = _format_test_files(task.metadata.get("selected_test_files_to_run", []))
         run = await env.execute(
-            f"bash /root/run_script.sh {test_files} > /root/stdout.log 2> /root/stderr.log || true",
+            f"bash /root/run_script.sh {shlex.quote(test_files)} > /root/stdout.log 2> /root/stderr.log || true",
             cwd=workdir,
             is_eval=True,
         )

--- a/responses_api_agents/swe_env/harnesses/nv_internal.py
+++ b/responses_api_agents/swe_env/harnesses/nv_internal.py
@@ -119,7 +119,9 @@ class NVInternalHarness(SweTaskHarness):
             A :class:`SandboxSpec` describing the image, workdir, timeouts,
             environment, metadata, resources, and provider options.
         """
-        env = {"GIT_CONFIG_GLOBAL": "/dev/null", "GIT_PAGER": "cat"}
+        # GIT_PAGER=cat avoids pager hangs; not GIT_CONFIG_GLOBAL=/dev/null (older images' git
+        # can't parse it -> the eval's git checkout / test-patch apply fail -> false misses).
+        env = {"GIT_PAGER": "cat"}
         env.update(_parse_dockerfile_env(task))
         return SandboxSpec(
             image=task.image,

--- a/responses_api_agents/swe_env/harnesses/nv_internal.py
+++ b/responses_api_agents/swe_env/harnesses/nv_internal.py
@@ -235,6 +235,10 @@ class NVInternalHarness(SweTaskHarness):
             f"bash /root/run_script.sh {shlex.quote(test_files)} > /root/stdout.log 2> /root/stderr.log || true",
             cwd=workdir,
             is_eval=True,
+            # Provider-independent eval budget (see flat_eval): without it the test run inherits the
+            # provider exec default (apptainer 180s vs docker 3600s), masking long suites as timeouts
+            # on apptainer only. verify_task propagates the caller's eval_timeout_s into tests_timeout.
+            timeout_s=task.metadata.get("tests_timeout", 1800),
         )
         if run.get("error_type") in {"sandbox", "timeout"}:
             return EvalArtifacts(

--- a/responses_api_agents/swe_env/harnesses/r2egym.py
+++ b/responses_api_agents/swe_env/harnesses/r2egym.py
@@ -21,7 +21,9 @@ NOTE: the apptainer-only nested ``run_local_evaluation`` path (which produced r2
 ``report.json`` in-container) was removed when PR #1694 took ownership of the apptainer
 provider. Re-wiring r2e-gym's nested grading + ``.sif``/mounts onto #1694's provider is tracked
 for a follow-up PR (see APPTAINER_PR3_TRACKER.md); until then r2e-gym grades flat (it needs an
-``eval_script`` in task metadata, else the flat grader masks the sample as an eval error).
+``eval_script`` in task metadata, else the flat grader records an **unmasked** ``resolved=False``
+— reward 0, kept in the gradient — not an eval-error mask; see
+``test_r2egym.py::test_run_eval_missing_eval_script_is_unmasked_unresolved``).
 """
 
 from __future__ import annotations

--- a/responses_api_agents/swe_env/harnesses/r2egym.py
+++ b/responses_api_agents/swe_env/harnesses/r2egym.py
@@ -67,7 +67,9 @@ class R2EGymHarness(SweTaskHarness):
             workdir=task.repo_workdir,
             ttl_s=task.metadata.get("ttl_s", 1800),
             ready_timeout_s=task.metadata.get("ready_timeout_s", 600),
-            env={"GIT_CONFIG_GLOBAL": "/dev/null", "GIT_PAGER": "cat"},
+            # GIT_PAGER=cat avoids pager hangs; not GIT_CONFIG_GLOBAL=/dev/null (older images' git
+            # can't parse it -> the eval's git checkout / test-patch apply fail -> false misses).
+            env={"GIT_PAGER": "cat"},
             metadata={
                 "instance_id": task.instance_id[:63],
                 "benchmark": task.benchmark,

--- a/responses_api_agents/swe_env/harnesses/swe_bench_ext.py
+++ b/responses_api_agents/swe_env/harnesses/swe_bench_ext.py
@@ -31,6 +31,7 @@ patches are applied best-effort and grading is on the tests only.
 
 from __future__ import annotations
 
+import shlex
 from typing import TYPE_CHECKING
 
 from nemo_gym.sandbox import SandboxResources, SandboxSpec
@@ -148,7 +149,7 @@ class SweBenchExtHarness(SweTaskHarness):
         """
         if task.base_commit:
             workdir = await self._resolve_repo_workdir(env, task)
-            await env.execute(f"git reset --hard {task.base_commit}", cwd=workdir)
+            await env.execute(f"git reset --hard {shlex.quote(task.base_commit)}", cwd=workdir)
 
     async def run_eval(self, env: "AsyncSweEnvironment", task: SweTask) -> EvalArtifacts:
         """Apply patches, run the test command, and capture the evaluation output.

--- a/responses_api_agents/swe_env/harnesses/swe_bench_ext.py
+++ b/responses_api_agents/swe_env/harnesses/swe_bench_ext.py
@@ -203,7 +203,15 @@ class SweBenchExtHarness(SweTaskHarness):
         base_command = task.test_command
         test_cmd = get_test_command_with_output(base_command, framework)
         result_file = (get_framework_config(framework, base_command) or {}).get("result_file")
-        result = await env.execute(self._wrap_eval_command(test_cmd, result_file), cwd=workdir, is_eval=True)
+        result = await env.execute(
+            self._wrap_eval_command(test_cmd, result_file),
+            cwd=workdir,
+            is_eval=True,
+            # Provider-independent eval budget (see flat_eval): without it the command inherits the
+            # provider exec default (apptainer 180s vs docker 3600s), masking long suites as timeouts
+            # on apptainer only. verify_task propagates the caller's eval_timeout_s into tests_timeout.
+            timeout_s=task.metadata.get("tests_timeout", 1800),
+        )
         return EvalArtifacts(
             test_output=result["output"],
             return_code=result["returncode"],

--- a/responses_api_agents/swe_env/harnesses/swe_bench_ext.py
+++ b/responses_api_agents/swe_env/harnesses/swe_bench_ext.py
@@ -85,7 +85,9 @@ class SweBenchExtHarness(SweTaskHarness):
             workdir=task.repo_workdir,
             ttl_s=task.metadata.get("ttl_s", 1800),
             ready_timeout_s=task.metadata.get("ready_timeout_s", 600),
-            env={"GIT_CONFIG_GLOBAL": "/dev/null", "GIT_PAGER": "cat"},
+            # GIT_PAGER=cat avoids pager hangs; not GIT_CONFIG_GLOBAL=/dev/null (older images' git
+            # can't parse it -> the eval's git checkout / test-patch apply fail -> false misses).
+            env={"GIT_PAGER": "cat"},
             metadata={
                 "instance_id": task.instance_id[:63],
                 "benchmark": task.benchmark,

--- a/responses_api_agents/swe_env/harnesses/swe_rebench.py
+++ b/responses_api_agents/swe_env/harnesses/swe_rebench.py
@@ -342,11 +342,13 @@ class SweRebenchHarness(SweTaskHarness):
         fail_to_pass_set = {_normalize_test_name(n) for n in task.fail_to_pass}
         pass_to_pass_set = {_normalize_test_name(n) for n in task.pass_to_pass}
 
-        # Resolution rule: every FAIL_TO_PASS and PASS_TO_PASS test must be in the
-        # passed set. Resolution is not gated on patch application, and the
-        # F2P/P2P sets are not required to be non-empty (an empty set is a subset
-        # of any set).
-        resolved = (fail_to_pass_set <= passed_set) and (pass_to_pass_set <= passed_set)
+        # Resolution rule: every FAIL_TO_PASS and PASS_TO_PASS test must be in the passed set,
+        # AND the required set must be non-empty. The empty-required guard (matching
+        # compute_resolved's ``if not required: return False``) keeps swe-rebench consistent with
+        # the other families: a degenerate row with no required tests does NOT resolve, instead of
+        # inflating to reward 1.0 (an empty set is a subset of anything). Not gated on patch apply.
+        required = fail_to_pass_set | pass_to_pass_set
+        resolved = bool(required) and fail_to_pass_set <= passed_set and pass_to_pass_set <= passed_set
         return SweEvalReport(
             instance_id=task.instance_id,
             resolved=resolved,

--- a/responses_api_agents/swe_env/harnesses/swe_rebench.py
+++ b/responses_api_agents/swe_env/harnesses/swe_rebench.py
@@ -202,9 +202,10 @@ class SweRebenchHarness(SweTaskHarness):
         Returns:
             SandboxSpec: The sandbox specification for running the task.
         """
-        # _JAVA_OPTIONS forces IPv4 for SWE-rebench tasks.
+        # _JAVA_OPTIONS forces IPv4 for SWE-rebench tasks; GIT_PAGER=cat avoids pager hangs.
+        # Do NOT set GIT_CONFIG_GLOBAL=/dev/null: older images' git can't parse /dev/null and the
+        # eval script's git checkout / test-patch apply then fail -> required tests un-run -> false misses.
         env = {
-            "GIT_CONFIG_GLOBAL": "/dev/null",
             "GIT_PAGER": "cat",
             "_JAVA_OPTIONS": _JAVA_OPTIONS,
         }

--- a/responses_api_agents/swe_env/harnesses/swebench.py
+++ b/responses_api_agents/swe_env/harnesses/swebench.py
@@ -151,7 +151,15 @@ class SweBenchHarness(SweTaskHarness):
             "patch --batch --fuzz=5 -p1 -i /root/patch.diff || "
             "echo 'NEMO_GYM_PATCH_APPLY_FAILED')\n"
         )
-        return apply_model + spec.eval_script
+        # Force pytest to print a per-test result line for EVERY test (-rA), not just failures.
+        # swebench's per-repo eval command for some families (e.g. sphinx via tox, several sklearn)
+        # invokes pytest without -rA, so passing tests show only as dots — and the host-side parser
+        # (``parse_log_pytest_v2``, which keys off ``PASSED <nodeid>`` lines) then sees zero passes
+        # and marks the instance unresolved even for the gold patch. -rA makes those passes visible
+        # to the flat grader. Non-pytest families (e.g. django's runner) ignore PYTEST_ADDOPTS, so
+        # this is a safe no-op for them; any addopts the eval script itself sets are preserved.
+        pytest_addopts = 'export PYTEST_ADDOPTS="-rA ${PYTEST_ADDOPTS:-}"\n'
+        return pytest_addopts + apply_model + spec.eval_script
 
     # --- server-private grading ----------------------------------------------
 

--- a/responses_api_agents/swe_env/harnesses/swebench.py
+++ b/responses_api_agents/swe_env/harnesses/swebench.py
@@ -96,7 +96,11 @@ class SweBenchHarness(SweTaskHarness):
             workdir=task.repo_workdir,
             ttl_s=task.metadata.get("ttl_s", 1800),
             ready_timeout_s=task.metadata.get("ready_timeout_s", 600),
-            env={"GIT_CONFIG_GLOBAL": "/dev/null", "GIT_PAGER": "cat"},
+            # GIT_PAGER=cat avoids pager hangs. Do NOT set GIT_CONFIG_GLOBAL=/dev/null: older
+            # instance images' git cannot parse /dev/null ("bad config line 1") and the eval
+            # script's git checkout / test-patch apply then fail, leaving required tests un-run
+            # (false misses). swebench's own nested eval doesn't null it either.
+            env={"GIT_PAGER": "cat"},
             metadata={
                 "instance_id": task.instance_id[:63],
                 "benchmark": task.benchmark,

--- a/responses_api_agents/swe_env/tests/test_flat_eval.py
+++ b/responses_api_agents/swe_env/tests/test_flat_eval.py
@@ -455,6 +455,7 @@ class _FakeFlatProvider:
         self._error_type = error_type
         self._stream_empty = stream_empty
         self.commands: list[str] = []
+        self.exec_calls: list[tuple[str, object]] = []
         self.uploaded: dict[str, str] = {}
 
     async def create(self, spec):
@@ -462,6 +463,7 @@ class _FakeFlatProvider:
 
     async def exec(self, handle, command, *, cwd=None, env=None, timeout_s=None, user=None):
         self.commands.append(command)
+        self.exec_calls.append((command, timeout_s))
         if command.startswith("cat "):
             return SandboxExecResult(stdout=self._log_text, stderr="", return_code=0)
         # The eval script run.
@@ -537,6 +539,32 @@ def test_swebench_flat_run_eval_resolved():
     assert artifacts.raw["flat"] is True
     assert report.resolved is True
     assert reward_from_report(report) == 1.0
+
+
+def _eval_run_timeout(provider):
+    """Return the timeout_s the eval-script command was executed with (the `bash <script>` call)."""
+    return next(t for c, t in provider.exec_calls if c.startswith("bash "))
+
+
+def test_flat_run_eval_defaults_tests_timeout_to_1800():
+    """The eval command must carry an explicit 1800s budget, NOT None.
+
+    None would fall back to each provider's exec default -- docker 3600s vs apptainer 180s -- so a
+    >180s suite (scikit-learn / sympy / under concurrency) is silently masked as a timeout on
+    apptainer but resolves on docker. A provider-independent default keeps grading consistent.
+    """
+    harness = SweBenchHarness("swe-bench")
+    task = _task(metadata={"eval_script": "echo running", "flat_eval": True})
+    _, _, provider = _drive_flat(harness, task, log_text=_fixture("resolved_success.log"))
+    assert _eval_run_timeout(provider) == 1800
+
+
+def test_flat_run_eval_respects_explicit_tests_timeout():
+    """An explicit ``tests_timeout`` in the task metadata overrides the default."""
+    harness = SweBenchHarness("swe-bench")
+    task = _task(metadata={"eval_script": "echo running", "flat_eval": True, "tests_timeout": 600})
+    _, _, provider = _drive_flat(harness, task, log_text=_fixture("resolved_success.log"))
+    assert _eval_run_timeout(provider) == 600
     # The eval script was uploaded into the sandbox.
     assert provider.uploaded.get(flat_eval.EVAL_SCRIPT_PATH, "").startswith("echo running")
 

--- a/responses_api_agents/swe_env/tests/test_nv_internal.py
+++ b/responses_api_agents/swe_env/tests/test_nv_internal.py
@@ -418,7 +418,9 @@ def test_build_spec_injects_dockerfile_env():
     task = _task(metadata={"base_dockerfile": "ENV PATH=/custom/bin:$PATH\n"})
     spec = NVInternalHarness().build_spec(task)
     # Existing git env preserved; dockerfile ENV injected.
-    assert spec.env["GIT_CONFIG_GLOBAL"] == "/dev/null"
+    assert spec.env["GIT_PAGER"] == "cat"
+    # GIT_CONFIG_GLOBAL=/dev/null is deliberately NOT set — older images' git can't parse it.
+    assert "GIT_CONFIG_GLOBAL" not in spec.env
     assert spec.env["PATH"] == "/custom/bin:$PATH"
 
 

--- a/responses_api_agents/swe_env/tests/test_parsing_frameworks.py
+++ b/responses_api_agents/swe_env/tests/test_parsing_frameworks.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-framework parser coverage for ``parsing.parse_test_output``.
+
+The multilingual flat-grading path dispatches raw test output through ~13 per-framework parsers
+(jest/mocha/gtest/maven/cargo-nextest/bun/cppunit/minitest/...), and the resulting PASS/FAIL map
+feeds reward directly — so a parser bug silently corrupts reward. These cases pin the
+node-id/status extraction for the framework families the rest of the suite does not exercise.
+"""
+
+from responses_api_agents.swe_env.parsing.parsing import parse_test_output
+
+
+def test_parse_test_output_jest_json():
+    out = (
+        '{"testResults":[{"name":"a.test.js","status":"failed",'
+        '"assertionResults":['
+        '{"fullName":"math adds","status":"passed"},'
+        '{"fullName":"math subtracts","status":"failed"},'
+        '{"fullName":"math pending","status":"skipped"}'
+        "]}]}"
+    )
+    assert parse_test_output(out, "jest") == {
+        "a.test.js::math adds": "PASSED",
+        "a.test.js::math subtracts": "FAILED",
+        "a.test.js::math pending": "SKIPPED",
+    }
+
+
+def test_parse_test_output_maven_summary():
+    out = "[INFO] Building MyModule 1.0 [1/1]\nTests run: 3, Failures: 1, Errors: 0, Skipped: 0\n"
+    res = parse_test_output(out, "maven")
+    assert res["MyModule::test_1"] == "PASSED"
+    assert res["MyModule::test_2"] == "PASSED"
+    assert res["MyModule::test_failed_1"] == "FAILED"
+
+
+def test_parse_test_output_maven_build_failure():
+    assert parse_test_output("...\nBUILD FAILURE\n...", "maven") == {"maven::build": "FAILED"}
+
+
+def test_parse_test_output_cargo_nextest():
+    out = "PASS [   1.588s] mycrate tests::test_alpha\nFAIL [   0.500s] mycrate tests::test_beta\n"
+    assert parse_test_output(out, "cargo-nextest") == {
+        "mycrate tests::test_alpha": "PASSED",
+        "mycrate tests::test_beta": "FAILED",
+    }
+
+
+def test_parse_test_output_cargo_nextest_compile_error_is_none_to_empty():
+    assert parse_test_output("error[E0425]: cannot find value\n", "cargo-nextest") == {}
+
+
+def test_parse_test_output_pytest_text_shortform_fallback():
+    res = parse_test_output("tests/test_foo.py .F.s\n", "pytest")
+    assert res == {
+        "tests/test_foo.py::test_1": "PASSED",
+        "tests/test_foo.py::test_2": "FAILED",
+        "tests/test_foo.py::test_3": "PASSED",
+        "tests/test_foo.py::test_4": "SKIPPED",
+    }
+
+
+def test_parse_test_output_unknown_framework_returns_empty():
+    assert parse_test_output("some random output", "totally-unknown-framework") == {}

--- a/responses_api_agents/swe_env/tests/test_swe_env.py
+++ b/responses_api_agents/swe_env/tests/test_swe_env.py
@@ -270,14 +270,43 @@ def test_verify_task_empty_patch_fast_path():
     assert report.resolved is False
 
 
-def test_verify_task_non_timeout_eval_failure_unmasked():
-    """A non-timeout eval-stage failure is unmasked: resolved=False, reward 0.0.
+def test_verify_task_sandbox_create_error_masked():
+    """A ``SandboxCreateError`` (e.g. a docker image-pull failure) is masked as error_kind='sandbox'.
 
-    Mirrors main's app.py, which catches any eval exception, returns no report file
-    (resolved=False) and leaves eval_timed_out False (so mask_sample stays False).
-    Only a genuine wall-clock eval timeout is masked.
+    An infra failure provisioning the eval sandbox must not depress the resolve rate or leak into
+    the training signal, so it is masked (reward 0.0) rather than reported as an unmasked reward-0.
     """
     report = asyncio.run(verify_task({"fake-swe": {"create_error": True}}, _task()))
+    assert report.error_kind == "sandbox"
+    assert report.resolved is False
+    assert reward_from_report(report) == 0.0
+
+
+def test_verify_task_generic_eval_failure_unmasked():
+    """A non-timeout, non-infra eval-stage exception stays unmasked (resolved=False, reward 0.0).
+
+    Mirrors main's app.py, which catches a generic eval exception, scores reward 0, and leaves the
+    sample in the gradient (error_kind=None) — only timeouts and sandbox-create failures are masked.
+    """
+    from responses_api_agents.swe_env.harness import register_harness
+
+    class _BoomGrade(SweBenchExtHarness):
+        name = "boom-grade-test"
+
+        def grade(self, task, artifacts):
+            """Raise a generic error during grading to exercise the unmasked branch.
+
+            Args:
+                task: The task being graded.
+                artifacts: The eval artifacts (unused).
+
+            Raises:
+                RuntimeError: Always.
+            """
+            raise RuntimeError("boom")
+
+    register_harness(_BoomGrade(), override=True)
+    report = asyncio.run(verify_task({"fake-swe": {"test_output": _PASS_OUTPUT}}, _task(benchmark="boom-grade-test")))
     assert report.error_kind is None
     assert report.resolved is False
     assert reward_from_report(report) == 0.0

--- a/responses_api_agents/swe_env/tests/test_swe_env.py
+++ b/responses_api_agents/swe_env/tests/test_swe_env.py
@@ -51,7 +51,7 @@ class _FakeProvider:
 
     name = "fake-swe"
 
-    def __init__(self, *, test_output="", test_rc=0, apply_rc=0, create_error=False, sink=None, **_):
+    def __init__(self, *, test_output="", test_rc=0, apply_rc=0, create_error=False, sink=None, cmd_timeouts=None, **_):
         """Configure the scripted provider's responses.
 
         Args:
@@ -68,6 +68,7 @@ class _FakeProvider:
         self._apply_rc = apply_rc
         self._create_error = create_error
         self._sink = sink
+        self._cmd_timeouts = cmd_timeouts
 
     async def create(self, spec):
         if self._sink is not None:
@@ -77,6 +78,8 @@ class _FakeProvider:
         return SandboxHandle(sandbox_id="fake", provider_name=self.name, raw={"workdir": spec.workdir})
 
     async def exec(self, handle, command, *, cwd=None, env=None, timeout_s=None, user=None):
+        if self._cmd_timeouts is not None:
+            self._cmd_timeouts.append((command, timeout_s))
         if "pytest" in command:
             return SandboxExecResult(stdout=self._test_output, stderr="", return_code=self._test_rc)
         if "git apply" in command:
@@ -253,6 +256,39 @@ def test_verify_task_resolved():
     assert report.resolved is True
     assert report.patch_applied is True
     assert reward_from_report(report) == 1.0
+
+
+def test_verify_task_injects_default_eval_command_timeout():
+    """The in-sandbox eval command must run with an explicit 1800s budget, not None.
+
+    None lets the command inherit the provider's exec default (apptainer 180s vs docker 3600s), so a
+    >180s suite is masked as a timeout on apptainer only. verify_task injects tests_timeout so the
+    budget is provider-independent.
+    """
+    calls: list = []
+    provider = {"fake-swe": {"test_output": _PASS_OUTPUT, "cmd_timeouts": calls}}
+    asyncio.run(verify_task(provider, _task()))
+    eval_timeouts = [t for c, t in calls if "pytest" in c]
+    assert eval_timeouts and eval_timeouts[0] == 1800
+
+
+def test_verify_task_propagates_eval_timeout_to_command():
+    """A caller's ``eval_timeout_s`` reaches the eval command itself (not just the outer guard)."""
+    calls: list = []
+    provider = {"fake-swe": {"test_output": _PASS_OUTPUT, "cmd_timeouts": calls}}
+    asyncio.run(verify_task(provider, _task(), eval_timeout_s=999))
+    eval_timeouts = [t for c, t in calls if "pytest" in c]
+    assert eval_timeouts and eval_timeouts[0] == 999
+
+
+def test_verify_task_explicit_tests_timeout_not_overridden():
+    """An explicit ``tests_timeout`` in task metadata is preserved (verify_task doesn't clobber it)."""
+    calls: list = []
+    provider = {"fake-swe": {"test_output": _PASS_OUTPUT, "cmd_timeouts": calls}}
+    task = _task(metadata={"tests_timeout": 600})
+    asyncio.run(verify_task(provider, task, eval_timeout_s=999))
+    eval_timeouts = [t for c, t in calls if "pytest" in c]
+    assert eval_timeouts and eval_timeouts[0] == 600
 
 
 def test_verify_task_unresolved():

--- a/responses_api_agents/swe_env/tests/test_swe_rebench.py
+++ b/responses_api_agents/swe_env/tests/test_swe_rebench.py
@@ -465,11 +465,13 @@ def test_run_eval_tests_timeout_absent_defaults_to_1800(tmp_path):
 # ---- grading parity / empty-required ----------------------------------------
 
 
-def test_grade_empty_required_resolves_true(tmp_path):
-    """``resolved`` is purely (fail_to_pass_set <= passed) and
-    (pass_to_pass_set <= passed). With no required tests, both empty sets are
-    subsets of any passed set, so resolved=True — there is no bool(required)
-    requirement."""
+def test_grade_empty_required_does_not_resolve(tmp_path):
+    """A degenerate row with no FAIL_TO_PASS and no PASS_TO_PASS does NOT resolve.
+
+    The empty-required guard (matching ``compute_resolved``) keeps swe-rebench consistent with the
+    other families: an empty required set must not vacuously resolve to reward 1.0 just because the
+    empty set is a subset of any passed set.
+    """
     repo_dir = _write_fake_parsers(tmp_path)
     harness = SweRebenchHarness()
     task = _task(
@@ -479,5 +481,5 @@ def test_grade_empty_required_resolves_true(tmp_path):
     )
     artifacts = EvalArtifacts(test_output="something PASSED\n", patch_applied=True)
     report = harness.grade(task, artifacts)
-    assert report.resolved is True
+    assert report.resolved is False
     assert report.error_kind is None

--- a/responses_api_agents/swe_env/tests/test_swebench.py
+++ b/responses_api_agents/swe_env/tests/test_swebench.py
@@ -232,3 +232,26 @@ def test_grade_fails_loud_when_swebench_unavailable(monkeypatch):
     artifacts = EvalArtifacts(test_output=_PASSING_LOG, return_code=0, raw={})
     with pytest.raises(GraderDependencyError):
         harness.grade(task, artifacts)
+
+
+def test_flat_eval_script_forces_pytest_addopts(monkeypatch):
+    """The flat eval script forces ``PYTEST_ADDOPTS=-rA`` so pytest prints per-test result lines.
+
+    swebench's eval command for some families (sphinx via tox, several sklearn) invokes pytest
+    without -rA; passing tests then show only as dots and the host-side parser sees zero passes.
+    The injected -rA makes them visible, while preserving swebench's eval script verbatim.
+    """
+
+    class _Spec:
+        repo = "sphinx-doc/sphinx"
+        eval_script = "tox --current-env -epy39 -v -- tests/test_x.py\n"
+
+    monkeypatch.setattr(
+        "swebench.harness.test_spec.test_spec.make_test_spec",
+        lambda instance, namespace="swebench": _Spec(),
+    )
+    harness = SweBenchHarness("swe-bench")
+    task = _task(metadata={"instance_dict": {"instance_id": "repo__inst-1", "repo": "sphinx-doc/sphinx"}})
+    script = harness._flat_eval_script(task)
+    assert 'PYTEST_ADDOPTS="-rA' in script
+    assert "tox --current-env -epy39" in script  # swebench's eval script preserved verbatim

--- a/responses_api_agents/swe_env/verify_task.py
+++ b/responses_api_agents/swe_env/verify_task.py
@@ -36,7 +36,7 @@ from typing import Any
 # Importing this package registers the swe_env harnesses; the docker/apptainer
 # providers are built into nemo_gym.sandbox and resolve lazily (no import needed).
 import responses_api_agents.swe_env.harnesses  # noqa: F401
-from nemo_gym.sandbox import SandboxProvider
+from nemo_gym.sandbox import SandboxCreateError, SandboxProvider
 from responses_api_agents.swe_env.harness import (
     GraderDependencyError,
     SweEvalReport,
@@ -98,9 +98,10 @@ async def verify_task(
             seconds; falls back to the task metadata or a default.
 
     Returns:
-        SweEvalReport: The grading outcome, with ``error_kind="eval_timeout"`` set
-            only on a genuine wall-clock eval timeout; non-timeout eval-stage
-            failures are reported unmasked (``resolved=False``, ``error_kind=None``).
+        SweEvalReport: The grading outcome. ``error_kind="eval_timeout"`` on a genuine
+            wall-clock eval timeout and ``error_kind="sandbox"`` on a sandbox-create /
+            image-pull failure (both masked); other non-timeout eval-stage failures are
+            reported unmasked (``resolved=False``, ``error_kind=None``).
 
     Raises:
         ProviderCapabilityError: If the task's harness does not support the provider.
@@ -159,6 +160,17 @@ async def verify_task(
             patch_exists=bool(task.model_patch),
             error_kind="eval_timeout",
             tests_status={"timeout_s": timeout},
+        )
+    except SandboxCreateError as exc:
+        # Infra failure provisioning the eval sandbox (e.g. a docker image-pull failure on the
+        # pull-on-demand path). Mask it as a typed error_kind so an infra hiccup doesn't depress
+        # the resolve rate or leak into the training signal — consistent with the harnesses'
+        # sandbox/eval_error masking — rather than degrading to an unmasked reward-0.
+        return SweEvalReport(
+            instance_id=task.instance_id,
+            patch_exists=bool(task.model_patch),
+            error_kind="sandbox",
+            tests_status={"sandbox_create_error": repr(exc)},
         )
     except Exception as exc:  # non-timeout eval-stage failure -> unmasked reward 0
         # A non-timeout eval-stage crash is NOT masked: main's app.py catches any eval

--- a/responses_api_agents/swe_env/verify_task.py
+++ b/responses_api_agents/swe_env/verify_task.py
@@ -130,6 +130,14 @@ async def verify_task(
 
     spec = harness.build_spec(task)
     timeout = eval_timeout_s if eval_timeout_s is not None else float(task.metadata.get("eval_timeout_s", 1800))
+    # Give the in-sandbox eval command the same budget as the overall sequence. The flat harness runs
+    # the test command with task.metadata['tests_timeout']; if a caller passed an eval_timeout_s but no
+    # tests_timeout, propagate it so the configured budget reaches the command itself instead of
+    # falling back to the provider's exec default (apptainer 180s vs docker 3600s) -- otherwise a long
+    # suite is masked as a timeout on apptainer only, regardless of eval_timeout_s. The outer wait_for
+    # below stays the hard cap.
+    if "tests_timeout" not in task.metadata:
+        task = dataclasses.replace(task, metadata={**task.metadata, "tests_timeout": timeout})
     # Stamp a TTL so backends that honor it (opensandbox) self-expire an eval sandbox
     # orphaned by a hard crash. docker ignores ttl_s; its finally-teardown covers it.
     if spec.ttl_s is None:

--- a/tests/unit_tests/test_docker_provider.py
+++ b/tests/unit_tests/test_docker_provider.py
@@ -74,6 +74,13 @@ def test_concurrency_bounds_the_semaphore() -> None:
     assert DockerSandboxProvider(concurrency=4)._semaphore._value == 4
 
 
+def test_missing_docker_binary_raises_clear_error() -> None:
+    """A missing docker binary surfaces a clear SandboxCreateError, not a bare FileNotFoundError."""
+    provider = DockerSandboxProvider(docker_bin="nemo-gym-no-such-docker-bin")
+    with pytest.raises(SandboxCreateError, match="not found on PATH"):
+        asyncio.run(provider.create(SandboxSpec(image="img:tag")))
+
+
 # --------------------------------------------------------------------------- #
 # create()
 # --------------------------------------------------------------------------- #
@@ -141,12 +148,27 @@ def test_create_applies_resource_limits(monkeypatch: pytest.MonkeyPatch) -> None
 # --------------------------------------------------------------------------- #
 # exec()
 # --------------------------------------------------------------------------- #
-def test_exec_classifies_docker_level_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    """rc 125/126/127 with no stdout is a docker-level (``sandbox``) failure."""
+def test_exec_classifies_docker_daemon_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """rc 125 with no stdout is a docker-daemon (``sandbox``) failure."""
     provider, _ = _make_provider(monkeypatch, lambda args: (125, "", "no such container"))
     res = asyncio.run(provider.exec(_handle(), "echo hi"))
     assert res.return_code == 125
     assert res.error_type == "sandbox"
+
+
+def test_exec_126_127_are_user_errors_not_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """rc 126 (not executable) / 127 (command not found) are user-command errors, not infra."""
+    for rc in (126, 127):
+        provider, _ = _make_provider(monkeypatch, lambda args, rc=rc: (rc, "", "no"))
+        res = asyncio.run(provider.exec(_handle(), "nope"))
+        assert res.return_code == rc and res.error_type is None
+
+
+def test_exec_uses_provider_default_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """exec() falls back to ``default_exec_timeout_s`` when the caller passes no timeout."""
+    provider, rec = _make_provider(monkeypatch, lambda args: (0, "ok", ""), default_exec_timeout_s=99)
+    asyncio.run(provider.exec(_handle(), "true"))
+    assert rec.calls[-1]["timeout_s"] == 99
 
 
 def test_exec_success_has_no_error_type(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Addresses @ffrujeri's review on #1572 (all 13 inline comments) plus the reward-profiling baseline. Targets `cmunley1/anyswe`.

> Note: the swe_env `README.md` / `ng_test_all` CI-unblock landed separately via #1796 (merged). This PR is the review-comment fixes + docs + gold baseline on top of that.

## Review-comment fixes (@ffrujeri)
| # | Comment | Fix |
|---|---|---|
| 1 | truncation mask never fires | inner agents (hermes/claude_code) now emit top-level `status="incomplete"` on internal max-turns/context/timeout; anyswe masks `resolved AND incomplete` (verified the status round-trips through `response.json`). openclaw exposes no internal signal → documented. |
| 2 | openclaw config not runnable | select the apptainer provider for its `.sif` formatter; drop dead `apptainer_memory_limit_mb`/`skip_eval` fields. |
| 3 | docker timeout gaps | configurable default `exec` timeout + bounded `close`/`cp` so a hung in-container command can't block a rollout. |
| 4 | reward-profiling evidence | gold-patch baseline in the swe_env README (below). |
| 5 | `_setup_params` assumes str `instance_dict` | accept str **or** dict (mirror `_build_swetask`). |
| 6 | r2egym docstring | missing `eval_script` is unmasked reward-0, not an eval-error mask. |
| 7 | missing docker binary | wrap `FileNotFoundError` → clear `SandboxCreateError`. |
| 8 | unquoted shell interpolation | `shlex.quote` dataset values in `bash -c` (nv_internal/harness/swe_bench_ext). |
| 9 | rc 125/126/127 infra-classify | narrow to **rc 125** only (126/127 are legit user-command codes). |
| 10 | swe_rebench inflates on empty-required | empty-required guard (consistent with `compute_resolved`). |
| 11 | unmasked infra failure on docker grade | mask `SandboxCreateError`/image-pull (`error_kind="sandbox"`). |
| 12 | per-framework parsers untested | add `test_parsing_frameworks.py` (the 7 reviewer cases). |
| 13 | docs discoverability | add a fern SWE-Environment page. |

## Gold-patch baseline (review #4) — at parity with the nested reference
A full 500-instance SWE-bench Verified **gold-patch census on docker** resolves **493/500** (`patch_exists` 500/500, 0 infra errors), matching the apptainer/`.sif` *nested* reference **492/500** to within environment noise; empty patch **0/500**. (docker and apptainer both use the host-side flat grader here, so they're 1-1; the `.sif` figure is swebench's nested `run_evaluation`.)

The census surfaced + fixed two real flat↔nested **reconstruction** gaps (445 → 486 → 493), verified with **0 regressions**:
- **`PYTEST_ADDOPTS=-rA`**: swebench 4.1.0's eval for some families (sphinx via `tox`, several sklearn) runs pytest without `-rA`, so passing tests print only as dots and the host-side parser saw zero passes → ~45 unresolved even for gold (445→486).
- **drop `GIT_CONFIG_GLOBAL=/dev/null`**: older images' git can't parse `/dev/null`, so the eval's `git checkout` + test-patch `git apply` failed → required tests "absent" (486→493).

The remaining 7 misses are a small symmetric difference with `.sif` (4 shared genuine env-flaky: astropy-7606/8707/8872, django-10097; 3 docker-only sphinx instance-specific quirks; docker also resolves 4 that `.sif` misses).

## Validation
- 258 unit tests pass (swe_env + docker provider + anyswe + claude_code/openclaw); ruff clean; `fern check` clean.
- The `#1` truncation logic was adversarially verified end-to-end (top-level `status` survives the container→host round-trip; the mask is live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
