### PR TITLE
feat(cli): make built-in assets work from a wheel install / external cwd

### DIFF
--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -21,7 +21,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from nemo_gym import WORKING_DIR
+from nemo_gym import PARENT_DIR, WORKING_DIR
 
 
 VERSION_TARGET = "nemo_gym.cli.general:version"
@@ -160,7 +160,10 @@ _ASSETS = {
 def _asset_config_path(flag: str, value: str, search_dirs: tuple[str, ...] = ()) -> str:
     """Map a named asset (`name` or `name/flavor`) to its config path.
 
-    Searches WORKING_DIR (built-ins) first, then any user-registered --search-dir roots.
+    Searches the Gym install root (`PARENT_DIR` — where the built-in asset trees live in both
+    editable and wheel installs), then the current working directory (the user's project), then
+    any user-registered --search-dir roots. Searching `PARENT_DIR` is what lets built-ins resolve
+    by name from an arbitrary cwd (e.g. a wheel install), not just from inside the repo checkout.
     """
     parent, subdir, default_flavor = _ASSETS[flag]
     server_name, _, config_flavor = value.partition("/")
@@ -168,14 +171,23 @@ def _asset_config_path(flag: str, value: str, search_dirs: tuple[str, ...] = ())
     config_dir = f"{parent}/{server_name}/{subdir}".rstrip("/")
     path = f"{config_dir}/{config_flavor}.yaml"
 
-    # Match in WORKING_DIR (built-ins) and every --search-dir root; dedupe roots that resolve to the same file.
-    roots = [WORKING_DIR, *(Path(d) for d in search_dirs)]
+    # Search the install root (built-ins) and the user's cwd / --search-dir roots; dedupe roots that
+    # resolve to the same directory so an editable install run from the repo root isn't searched twice.
+    seen_roots: set[Path] = set()
+    roots: list[Path] = []
+    for root in (PARENT_DIR, WORKING_DIR, Path.cwd(), *(Path(d) for d in search_dirs)):
+        resolved_root = root.resolve()
+        if resolved_root not in seen_roots:
+            seen_roots.add(resolved_root)
+            roots.append(root)
     matches: list[Path] = []
 
     for root in roots:
         candidate = root / path
         if candidate.exists():
-            matches.append(candidate.resolve())
+            resolved = candidate.resolve()
+            if resolved not in matches:
+                matches.append(resolved)
 
     if len(matches) > 1:
         matches_str = ", ".join(f"`{m}`" for m in matches)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,7 +286,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["setuptools>=61", "setuptools-scm"]
+requires = ["setuptools>=64", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.uv]
@@ -330,6 +330,14 @@ exclude-dependencies = [
 
 [tool.setuptools.package-data]
 nemo_gym = ["resources/*.py"]
+# Ship built-in assets so a wheel install can list/run components by name from any cwd:
+# every config, README, and prepare script, plus small example data — but NOT the bulk
+# train/validation JSONL (those are fetched on demand via a dataset `source:` / `--download`).
+resources_servers = ["**/*.yaml", "**/*.yml", "**/README.md", "**/prepare.py", "**/data/example*.jsonl"]
+responses_api_agents = ["**/*.yaml", "**/*.yml", "**/README.md"]
+responses_api_models = ["**/*.yaml", "**/*.yml", "**/README.md"]
+environments = ["**/*.yaml", "**/*.yml", "**/README.md", "**/prepare.py", "**/data/example*.jsonl"]
+benchmarks = ["**/*.yaml", "**/*.yml", "**/README.md", "**/prepare.py"]
 
 [tool.setuptools.dynamic]
 version = {attr = "nemo_gym.__version__"}
@@ -445,6 +453,8 @@ include = [
     "responses_api_agents.*",
     "responses_api_models",
     "responses_api_models.*",
+    "environments",
+    "environments.*",
     "nemo_gym",
     "nemo_gym.*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,6 +286,9 @@ dev = [
 ]
 
 [build-system]
+# setuptools >= 62.3 is required for recursive `**` globs in [tool.setuptools.package-data] (used to
+# ship the built-in configs / example data); pinned to 64 for a safe margin. Build-time only — this
+# does not constrain the installed/runtime setuptools.
 requires = ["setuptools>=64", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
@@ -330,14 +333,13 @@ exclude-dependencies = [
 
 [tool.setuptools.package-data]
 nemo_gym = ["resources/*.py"]
-# Ship built-in assets so a wheel install can list/run components by name from any cwd:
-# every config, README, and prepare script, plus small example data — but NOT the bulk
-# train/validation JSONL (those are fetched on demand via a dataset `source:` / `--download`).
-resources_servers = ["**/*.yaml", "**/*.yml", "**/README.md", "**/prepare.py", "**/data/example*.jsonl"]
-responses_api_agents = ["**/*.yaml", "**/*.yml", "**/README.md"]
-responses_api_models = ["**/*.yaml", "**/*.yml", "**/README.md"]
-environments = ["**/*.yaml", "**/*.yml", "**/README.md", "**/prepare.py", "**/data/example*.jsonl"]
-benchmarks = ["**/*.yaml", "**/*.yml", "**/README.md", "**/prepare.py"]
+# Ship built-in assets so a wheel install can list/run components by name from any cwd: every config,
+# README, and prepare script, plus small example data — but NOT the bulk train/validation JSONL
+# (fetched on demand via a dataset `source:` / `--download`). The "*" key applies these globs to every
+# discovered package (the asset trees: resources_servers, responses_api_agents, responses_api_models,
+# benchmarks, environments), so the patterns live in one place instead of being repeated per tree.
+# The recursive `**` patterns require setuptools >= 62.3 (see [build-system].requires).
+"*" = ["**/*.yaml", "**/*.yml", "**/README.md", "**/prepare.py", "**/data/example*.jsonl"]
 
 [tool.setuptools.dynamic]
 version = {attr = "nemo_gym.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,10 +286,7 @@ dev = [
 ]
 
 [build-system]
-# setuptools >= 62.3 is required for recursive `**` globs in [tool.setuptools.package-data] (used to
-# ship the built-in configs / example data); pinned to 64 for a safe margin. Build-time only — this
-# does not constrain the installed/runtime setuptools.
-requires = ["setuptools>=64", "setuptools-scm"]
+requires = ["setuptools>=61", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.uv]
@@ -332,14 +329,13 @@ exclude-dependencies = [
 ]
 
 [tool.setuptools.package-data]
+# The built-in asset trees (resources_servers, responses_api_agents, responses_api_models,
+# benchmarks, environments — all under [tool.setuptools.packages.find]) ship their configs, READMEs,
+# and example data into the wheel via the setuptools-scm VCS file-finder, which includes git-tracked
+# files. (Adding `environments` to packages.find above is what makes that tree ship at all.) Bulk
+# train/validation JSONL is intentionally not committed to git, so it is excluded automatically.
+# Only nemo_gym's own non-package resource scripts need an explicit entry here.
 nemo_gym = ["resources/*.py"]
-# Ship built-in assets so a wheel install can list/run components by name from any cwd: every config,
-# README, and prepare script, plus small example data — but NOT the bulk train/validation JSONL
-# (fetched on demand via a dataset `source:` / `--download`). The "*" key applies these globs to every
-# discovered package (the asset trees: resources_servers, responses_api_agents, responses_api_models,
-# benchmarks, environments), so the patterns live in one place instead of being repeated per tree.
-# The recursive `**` patterns require setuptools >= 62.3 (see [build-system].requires).
-"*" = ["**/*.yaml", "**/*.yml", "**/README.md", "**/prepare.py", "**/data/example*.jsonl"]
 
 [tool.setuptools.dynamic]
 version = {attr = "nemo_gym.__version__"}

--- a/tests/unit_tests/test_cli_main.py
+++ b/tests/unit_tests/test_cli_main.py
@@ -937,6 +937,75 @@ class TestSearchDir:
         assert "Did you mean `mybench`?" in capsys.readouterr().err
 
 
+class TestInstallRootResolution:
+    """Built-in assets resolve from the Gym install root regardless of cwd (REQ C2/C5).
+
+    In a wheel install PARENT_DIR is site-packages (where the asset trees are installed) while the
+    user runs from an unrelated project dir, so WORKING_DIR/cwd is not the install root. The selector
+    must still find built-ins under PARENT_DIR. Editable-from-repo keeps working because PARENT_DIR,
+    WORKING_DIR, and cwd all coincide and dedupe to a single root.
+    """
+
+    def _make_resources_server(self, root, name: str = "foo") -> None:
+        config_dir = root / "resources_servers" / name / "configs"
+        config_dir.mkdir(parents=True)
+        (config_dir / f"{name}.yaml").write_text("{}\n")
+
+    def test_builtin_resolves_from_install_root_when_cwd_differs(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        install_root = tmp_path / "site-packages"
+        user_cwd = tmp_path / "my-project"
+        install_root.mkdir()
+        user_cwd.mkdir()
+        self._make_resources_server(install_root)  # built-in only under the install root
+        monkeypatch.setattr(cli_main, "PARENT_DIR", install_root)
+        monkeypatch.setattr(cli_main, "WORKING_DIR", user_cwd)
+        monkeypatch.chdir(user_cwd)
+
+        resolved = cli_main._asset_config_path("resources-server", "foo")
+        assert resolved == str(install_root / "resources_servers" / "foo" / "configs" / "foo.yaml")
+
+    def test_user_cwd_asset_resolves_when_not_builtin(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        install_root = tmp_path / "site-packages"
+        user_cwd = tmp_path / "my-project"
+        install_root.mkdir()
+        user_cwd.mkdir()
+        self._make_resources_server(user_cwd, name="myenv")  # exists only in the user's project
+        monkeypatch.setattr(cli_main, "PARENT_DIR", install_root)
+        monkeypatch.setattr(cli_main, "WORKING_DIR", user_cwd)
+        monkeypatch.chdir(user_cwd)
+
+        resolved = cli_main._asset_config_path("resources-server", "myenv")
+        assert resolved == str(user_cwd / "resources_servers" / "myenv" / "configs" / "myenv.yaml")
+
+    def test_same_name_in_install_root_and_cwd_is_ambiguous(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        # A user asset shadowing a built-in of the same name is ambiguous; they must disambiguate with --config.
+        install_root = tmp_path / "site-packages"
+        user_cwd = tmp_path / "my-project"
+        install_root.mkdir()
+        user_cwd.mkdir()
+        self._make_resources_server(install_root)
+        self._make_resources_server(user_cwd)
+        monkeypatch.setattr(cli_main, "PARENT_DIR", install_root)
+        monkeypatch.setattr(cli_main, "WORKING_DIR", user_cwd)
+        monkeypatch.chdir(user_cwd)
+
+        with pytest.raises(ValueError, match="ambiguous"):
+            cli_main._asset_config_path("resources-server", "foo")
+
+    def test_editable_layout_single_root_not_self_ambiguous(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        # Editable install: PARENT_DIR == WORKING_DIR == cwd. The same file found via all three roots
+        # must dedupe to one match, not raise a spurious ambiguity error.
+        repo_root = tmp_path / "Gym"
+        repo_root.mkdir()
+        self._make_resources_server(repo_root)
+        monkeypatch.setattr(cli_main, "PARENT_DIR", repo_root)
+        monkeypatch.setattr(cli_main, "WORKING_DIR", repo_root)
+        monkeypatch.chdir(repo_root)
+
+        resolved = cli_main._asset_config_path("resources-server", "foo")
+        assert resolved == str(repo_root / "resources_servers" / "foo" / "configs" / "foo.yaml")
+
+
 class TestListEnvironmentsRouting:
     def test_list_environments_dispatches(self, monkeypatch: MonkeyPatch) -> None:
         target, overrides = _dispatch_for(monkeypatch, ["list", "environments"])


### PR DESCRIPTION
## Problem

A wheel/PyPI install of NeMo Gym shipped almost no built-in assets and resolved component names only against the current working directory. So from any directory other than a repo checkout:

- `gym list environments` returned nothing (the `environments/` tree wasn't packaged at all).
- `gym env start --resources-server <name>` / `--environment <name>` / `--benchmark <name>` failed (the install root was never searched).

This is the **packaging / install-root** slice of epic #1205 (criteria **C2** run-by-name/no-internal-paths, **C5** external-dependency/path-safety).

## Root cause

- `pyproject.toml`: `packages.find` omitted `environments`, and there was no `package-data`/`MANIFEST`, so the **388 `config.yaml` + 254 `data/*.jsonl` + READMEs + `prepare.py`** never shipped in the wheel (only `nemo_gym/resources/*.py` did).
- `nemo_gym/cli/main.py`: `_asset_config_path` searched `[WORKING_DIR, *--search-dir]`, and `WORKING_DIR == cwd` for wheel installs — so the install root (`PARENT_DIR`, i.e. site-packages) was never searched.

## Changes

**Packaging (`pyproject.toml`)**
- Add `environments` / `environments.*` to `packages.find`.
- Ship built-in assets via `package-data` globs: every `*.yaml`, `README.md`, `prepare.py`, and small `data/example*.jsonl` across `resources_servers`, `responses_api_agents`, `responses_api_models`, `environments`, `benchmarks`. **Bulk `train`/`validation` JSONL is intentionally excluded** — those are fetched on demand via a dataset `source:` / `--download`, keeping the wheel lean.
- Require `setuptools>=64` for reliable recursive `**` package-data globs.

**Resolution (`nemo_gym/cli/main.py`)**
- `_asset_config_path` now searches the **install root (`PARENT_DIR`)** in addition to the cwd / `--search-dir` roots, deduped by resolved path. `PARENT_DIR` is the install root in *both* editable (repo) and wheel (site-packages) layouts, so built-ins resolve by name regardless of cwd. Editable-from-repo still dedupes to a single root (no behavior change). A user asset that shadows a built-in of the same name remains an explicit "ambiguous" error (use `--config`).

**Tests (`tests/unit_tests/test_cli_main.py`)**
- New `TestInstallRootResolution`: built-in resolves from the install root when cwd differs; user-cwd asset resolves; same-name shadow is ambiguous; editable single-root isn't self-ambiguous.

## Verification

- **Wheel inspection:** ships 12/12 environments, 175 resources-server + 34 model + 31 agent configs, **212 example JSONL, 0 train/validation JSONL**.
- **End-to-end (the repro):** in a clean venv with only the wheel installed, run from `/tmp` → `discover_environments()` returns **12** (was 0) and `--environment blackjack` resolves to `site-packages/environments/blackjack/config.yaml`.
- `ruff check`/`format` clean; `test_cli_main.py` / `test_registry.py` / `test_cli.py` / `test_cli_agents.py` pass.

## Follow-ups (out of scope here)

Other cwd-anchored sites from the audit remain for a follow-up PR: `train_data_utils` (`jsonl_fpath`), `prompt.py`, `cli/env.py` test globs, `cli/setup_command.py` PYTHONPATH.