### PR TITLE
feat: resolve built-in data & prompt files from the install root

### DIFF
--- a/nemo_gym/__init__.py
+++ b/nemo_gym/__init__.py
@@ -38,7 +38,7 @@ RESULTS_DIR = WORKING_DIR / "results"
 sys.path.append(str(PARENT_DIR))
 
 
-def resolve_under_cwd_or_install(path) -> Path:
+def _resolve_under_cwd_or_install(path) -> Path:
     """Resolve a possibly-relative path for *reading* a built-in or user-supplied file.
 
     Absolute paths are returned unchanged. A relative path is tried first under the current working

--- a/nemo_gym/__init__.py
+++ b/nemo_gym/__init__.py
@@ -37,6 +37,31 @@ RESULTS_DIR = WORKING_DIR / "results"
 
 sys.path.append(str(PARENT_DIR))
 
+
+def resolve_under_cwd_or_install(path) -> Path:
+    """Resolve a possibly-relative path for *reading* a built-in or user-supplied file.
+
+    Absolute paths are returned unchanged. A relative path is tried first under the current working
+    directory (the user's project), then under the Gym install root (``PARENT_DIR``) where built-in
+    assets live in both editable and wheel installs. This mirrors ``config_paths`` resolution, so a
+    repo-relative path like ``resources_servers/<env>/data/example.jsonl`` resolves by name from any
+    cwd. If neither exists the cwd candidate is returned so error messages point at the user's cwd.
+
+    Use this for read paths only — never for write targets (e.g. metrics written next to a dataset),
+    which must stay relative to the user's writable cwd rather than the install root.
+    """
+    p = Path(path)
+    if p.is_absolute():
+        return p
+    cwd_candidate = Path.cwd() / p
+    if cwd_candidate.exists():
+        return cwd_candidate
+    install_candidate = PARENT_DIR / p
+    if install_candidate.exists():
+        return install_candidate
+    return cwd_candidate
+
+
 # TODO: Maybe eventually we want an override for OMP_NUM_THREADS ?
 
 # Turn off HF tokenizers paralellism

--- a/nemo_gym/prompt.py
+++ b/nemo_gym/prompt.py
@@ -27,7 +27,7 @@ from typing import Dict, List, Optional
 import yaml
 from pydantic import BaseModel, Field
 
-from nemo_gym import PARENT_DIR
+from nemo_gym import resolve_under_cwd_or_install
 from nemo_gym.config_types import BaseNeMoGymCLIConfig
 
 
@@ -39,19 +39,21 @@ class PromptConfig(BaseModel):
 
 
 def _resolve_path(path: str) -> Path:
-    """Resolve a path relative to the Gym root (PARENT_DIR), consistent with config_paths resolution."""
-    p = Path(path)
-    if not p.is_absolute():
-        p = PARENT_DIR / p
-    return p
+    """Resolve a prompt-config path: cwd first (the user's project), then the Gym install root.
+
+    Consistent with ``config_paths`` resolution. Resolving cwd first lets a user pass a relative
+    ``--prompt-config`` from their own project, while built-in prompt YAMLs still resolve by their
+    repo-relative path from any cwd (e.g. a wheel install).
+    """
+    return resolve_under_cwd_or_install(path)
 
 
 @lru_cache(maxsize=64)
 def load_prompt_config(path: str) -> PromptConfig:
     """Load and validate a YAML prompt config file.
 
-    Relative paths are resolved against the Gym root directory (``PARENT_DIR``),
-    consistent with how ``config_paths`` and other Gym paths are resolved.
+    Relative paths are resolved against the current working directory first, then the Gym install
+    root, consistent with how ``config_paths`` and other Gym paths are resolved.
 
     Returns a ``PromptConfig`` with required ``user`` and optional ``system`` fields.
     Each value is a string template with ``{placeholder}`` syntax.

--- a/nemo_gym/prompt.py
+++ b/nemo_gym/prompt.py
@@ -27,7 +27,7 @@ from typing import Dict, List, Optional
 import yaml
 from pydantic import BaseModel, Field
 
-from nemo_gym import resolve_under_cwd_or_install
+from nemo_gym import _resolve_under_cwd_or_install
 from nemo_gym.config_types import BaseNeMoGymCLIConfig
 
 
@@ -36,16 +36,6 @@ class PromptConfig(BaseModel):
 
     user: str
     system: Optional[str] = None
-
-
-def _resolve_path(path: str) -> Path:
-    """Resolve a prompt-config path: cwd first (the user's project), then the Gym install root.
-
-    Consistent with ``config_paths`` resolution. Resolving cwd first lets a user pass a relative
-    ``--prompt-config`` from their own project, while built-in prompt YAMLs still resolve by their
-    repo-relative path from any cwd (e.g. a wheel install).
-    """
-    return resolve_under_cwd_or_install(path)
 
 
 @lru_cache(maxsize=64)
@@ -59,7 +49,7 @@ def load_prompt_config(path: str) -> PromptConfig:
     Each value is a string template with ``{placeholder}`` syntax.
     Results are cached so the same file is only parsed once.
     """
-    resolved = _resolve_path(path)
+    resolved = _resolve_under_cwd_or_install(path)
     with open(resolved) as f:
         data = yaml.safe_load(f)
     return PromptConfig.model_validate(data)
@@ -127,7 +117,7 @@ def materialize_prompts(input_jsonl: str, prompt_config: str, output_jsonl: str)
         output_jsonl: Path to write materialized JSONL (with responses_create_params.input).
     """
     prompt_cfg = load_prompt_config(prompt_config)
-    resolved_prompt_path = str(_resolve_path(prompt_config))
+    resolved_prompt_path = str(_resolve_under_cwd_or_install(prompt_config))
     output_path = Path(output_jsonl)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/nemo_gym/train_data_utils.py
+++ b/nemo_gym/train_data_utils.py
@@ -25,6 +25,7 @@ from omegaconf import DictConfig
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from tqdm.auto import tqdm
 
+from nemo_gym import resolve_under_cwd_or_install
 from nemo_gym.base_resources_server import BaseRunRequest
 from nemo_gym.config_types import (
     AGENT_REF_KEY,
@@ -424,7 +425,9 @@ class TrainDataProcessor(BaseModel):
         local_datasets_not_found: Dict[str, List[DatasetConfig]] = defaultdict(list)
         for c in server_instance_configs:
             for d in c.datasets:
-                jsonl_fpath = Path(d.jsonl_fpath)
+                # Read check: a built-in dataset path resolves under the install root too, so a
+                # bundled example dataset counts as "found" (no download) from an external cwd.
+                jsonl_fpath = resolve_under_cwd_or_install(d.jsonl_fpath)
                 if jsonl_fpath.exists():
                     local_datasets_found[c.name].append(d)
                 else:
@@ -523,7 +526,7 @@ class TrainDataProcessor(BaseModel):
             )
 
         # Don't load everything into memory at once. Throw things away immediately.
-        with open(dataset_config.jsonl_fpath) as f:
+        with open(resolve_under_cwd_or_install(dataset_config.jsonl_fpath)) as f:
             for line in tqdm(f, desc=f"{dataset_config.jsonl_fpath}"):
                 for _ in range(repeats):
                     yield line

--- a/nemo_gym/train_data_utils.py
+++ b/nemo_gym/train_data_utils.py
@@ -25,7 +25,7 @@ from omegaconf import DictConfig
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from tqdm.auto import tqdm
 
-from nemo_gym import resolve_under_cwd_or_install
+from nemo_gym import _resolve_under_cwd_or_install
 from nemo_gym.base_resources_server import BaseRunRequest
 from nemo_gym.config_types import (
     AGENT_REF_KEY,
@@ -427,7 +427,7 @@ class TrainDataProcessor(BaseModel):
             for d in c.datasets:
                 # Read check: a built-in dataset path resolves under the install root too, so a
                 # bundled example dataset counts as "found" (no download) from an external cwd.
-                jsonl_fpath = resolve_under_cwd_or_install(d.jsonl_fpath)
+                jsonl_fpath = _resolve_under_cwd_or_install(d.jsonl_fpath)
                 if jsonl_fpath.exists():
                     local_datasets_found[c.name].append(d)
                 else:
@@ -526,7 +526,7 @@ class TrainDataProcessor(BaseModel):
             )
 
         # Don't load everything into memory at once. Throw things away immediately.
-        with open(resolve_under_cwd_or_install(dataset_config.jsonl_fpath)) as f:
+        with open(_resolve_under_cwd_or_install(dataset_config.jsonl_fpath)) as f:
             for line in tqdm(f, desc=f"{dataset_config.jsonl_fpath}"):
                 for _ in range(repeats):
                     yield line

--- a/tests/unit_tests/test_prompt.py
+++ b/tests/unit_tests/test_prompt.py
@@ -18,10 +18,9 @@ import json
 import pytest
 import yaml
 
-from nemo_gym import PARENT_DIR, resolve_under_cwd_or_install
+from nemo_gym import PARENT_DIR, _resolve_under_cwd_or_install
 from nemo_gym.prompt import (
     PromptConfig,
-    _resolve_path,
     apply_prompt_to_row,
     fill_prompt,
     load_prompt_config,
@@ -73,38 +72,14 @@ class TestLoadPromptConfig:
         assert result1 is result2
 
 
-class TestResolvePath:
-    def test_absolute_path(self, tmp_path):
-        p = tmp_path / "prompt.yaml"
-        p.write_text("")
-        assert _resolve_path(str(p)) == p
-
-    def test_relative_path_resolves_to_parent_dir(self, tmp_path):
-        # Create a file relative to PARENT_DIR to test resolution
-        test_file = PARENT_DIR / "test_resolve_path_temp.yaml"
-        test_file.write_text("user: '{q}'")
-        try:
-            resolved = _resolve_path("test_resolve_path_temp.yaml")
-            assert resolved.exists()
-        finally:
-            test_file.unlink()
-
-    def test_relative_path_resolves_to_cwd_first(self, tmp_path, monkeypatch):
-        # A user's own relative prompt config (in their cwd) resolves there, not the install root.
-        monkeypatch.chdir(tmp_path)
-        (tmp_path / "my_prompt.yaml").write_text("user: '{q}'")
-        resolved = _resolve_path("my_prompt.yaml")
-        assert resolved == tmp_path / "my_prompt.yaml"
-
-
 class TestResolveUnderCwdOrInstall:
     def test_absolute_returned_unchanged(self, tmp_path):
-        assert resolve_under_cwd_or_install(str(tmp_path / "x.yaml")) == tmp_path / "x.yaml"
+        assert _resolve_under_cwd_or_install(str(tmp_path / "x.yaml")) == tmp_path / "x.yaml"
 
     def test_cwd_preferred_over_install_root(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         (tmp_path / "rel.yaml").write_text("{}")
-        assert resolve_under_cwd_or_install("rel.yaml") == tmp_path / "rel.yaml"
+        assert _resolve_under_cwd_or_install("rel.yaml") == tmp_path / "rel.yaml"
 
     def test_falls_back_to_install_root(self, tmp_path, monkeypatch):
         # cwd lacks the file; a file present under the install root resolves there.
@@ -113,13 +88,13 @@ class TestResolveUnderCwdOrInstall:
         install_file = PARENT_DIR / rel
         install_file.write_text("{}")
         try:
-            assert resolve_under_cwd_or_install(rel) == install_file
+            assert _resolve_under_cwd_or_install(rel) == install_file
         finally:
             install_file.unlink()
 
     def test_missing_returns_cwd_candidate(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
-        assert resolve_under_cwd_or_install("nope.yaml") == tmp_path / "nope.yaml"
+        assert _resolve_under_cwd_or_install("nope.yaml") == tmp_path / "nope.yaml"
 
 
 class TestFillPrompt:

--- a/tests/unit_tests/test_prompt.py
+++ b/tests/unit_tests/test_prompt.py
@@ -18,7 +18,7 @@ import json
 import pytest
 import yaml
 
-from nemo_gym import PARENT_DIR
+from nemo_gym import PARENT_DIR, resolve_under_cwd_or_install
 from nemo_gym.prompt import (
     PromptConfig,
     _resolve_path,
@@ -88,6 +88,38 @@ class TestResolvePath:
             assert resolved.exists()
         finally:
             test_file.unlink()
+
+    def test_relative_path_resolves_to_cwd_first(self, tmp_path, monkeypatch):
+        # A user's own relative prompt config (in their cwd) resolves there, not the install root.
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "my_prompt.yaml").write_text("user: '{q}'")
+        resolved = _resolve_path("my_prompt.yaml")
+        assert resolved == tmp_path / "my_prompt.yaml"
+
+
+class TestResolveUnderCwdOrInstall:
+    def test_absolute_returned_unchanged(self, tmp_path):
+        assert resolve_under_cwd_or_install(str(tmp_path / "x.yaml")) == tmp_path / "x.yaml"
+
+    def test_cwd_preferred_over_install_root(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "rel.yaml").write_text("{}")
+        assert resolve_under_cwd_or_install("rel.yaml") == tmp_path / "rel.yaml"
+
+    def test_falls_back_to_install_root(self, tmp_path, monkeypatch):
+        # cwd lacks the file; a file present under the install root resolves there.
+        monkeypatch.chdir(tmp_path)
+        rel = "test_resolve_install_fallback.yaml"
+        install_file = PARENT_DIR / rel
+        install_file.write_text("{}")
+        try:
+            assert resolve_under_cwd_or_install(rel) == install_file
+        finally:
+            install_file.unlink()
+
+    def test_missing_returns_cwd_candidate(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert resolve_under_cwd_or_install("nope.yaml") == tmp_path / "nope.yaml"
 
 
 class TestFillPrompt:

--- a/tests/unit_tests/test_train_data_utils.py
+++ b/tests/unit_tests/test_train_data_utils.py
@@ -21,7 +21,7 @@ from pytest import MonkeyPatch, raises
 
 import nemo_gym.global_config
 import nemo_gym.train_data_utils
-from nemo_gym import resolve_under_cwd_or_install
+from nemo_gym import _resolve_under_cwd_or_install
 from nemo_gym.config_types import DatasetConfig, ResponsesAPIAgentServerInstanceConfig
 from nemo_gym.global_config import DictConfig, GlobalConfigDictParser
 from nemo_gym.train_data_utils import (
@@ -577,7 +577,7 @@ class TestValidateSamplesAndAggregateMetrics:
                 write_filenames.append(filename)
                 return mock_write_file()
 
-            if Path(filename) == resolve_under_cwd_or_install(
+            if Path(filename) == _resolve_under_cwd_or_install(
                 "resources_servers/example_multi_step/data/example.jsonl"
             ):
                 return original_open(filename, mode)

--- a/tests/unit_tests/test_train_data_utils.py
+++ b/tests/unit_tests/test_train_data_utils.py
@@ -21,6 +21,7 @@ from pytest import MonkeyPatch, raises
 
 import nemo_gym.global_config
 import nemo_gym.train_data_utils
+from nemo_gym import resolve_under_cwd_or_install
 from nemo_gym.config_types import DatasetConfig, ResponsesAPIAgentServerInstanceConfig
 from nemo_gym.global_config import DictConfig, GlobalConfigDictParser
 from nemo_gym.train_data_utils import (
@@ -576,7 +577,9 @@ class TestValidateSamplesAndAggregateMetrics:
                 write_filenames.append(filename)
                 return mock_write_file()
 
-            if filename == "resources_servers/example_multi_step/data/example.jsonl":
+            if Path(filename) == resolve_under_cwd_or_install(
+                "resources_servers/example_multi_step/data/example.jsonl"
+            ):
                 return original_open(filename, mode)
             elif filename == Path("resources_servers/example_multi_step/data/example_metrics.json"):
                 with original_open(filename, mode) as f:


### PR DESCRIPTION
## Problem

Follow-up to #1805. Relative dataset and prompt-config paths were resolved only against the current working directory (dataset reads) or only against the install root (prompt configs). So built-in files referenced by their repo-relative path didn't resolve from an arbitrary cwd, and a user's own relative `--prompt-config` was never found.

Part of epic #1205 (criterion **C5**, external-dependency/path-safety).

## Changes

- **`nemo_gym/__init__.py`** — add `resolve_under_cwd_or_install(path)`: a shared **read-path** resolver. Absolute → unchanged; relative → tried under the cwd (the user's project) first, then the Gym install root (`PARENT_DIR`, where built-ins live in both editable and wheel installs). Mirrors `config_paths` resolution. Documented as read-only — never for write targets.
- **`nemo_gym/prompt.py`** — `_resolve_path` now resolves **cwd-first then install root** (was install-root only). A user can pass a relative `--prompt-config` from their own project, and built-in prompt YAMLs still resolve by repo-relative path from any cwd.
- **`nemo_gym/train_data_utils.py`** — the dataset **existence-check** and **collation read** use the resolver, so a bundled `data/example.jsonl` resolves from an external cwd. The **metrics-write** paths intentionally stay cwd-relative — writing `_metrics.json` into the install root (site-packages) would be wrong.

## Tests

- `TestResolveUnderCwdOrInstall`: absolute returned unchanged; cwd preferred over install root; falls back to install root; missing returns the cwd candidate.
- `test_relative_path_resolves_to_cwd_first` for prompt configs.
- Updated one `train_data_utils` mock that matched the old relative-string `open()` argument.

ruff clean; prompt + train_data_utils + cli_main + registry suites pass (only the 3 pre-existing `TestDidYouMean` argparse failures remain, unrelated).

## Scope / follow-up

Complements #1805 (which packages built-in assets incl. example data into the wheel). The `gym env test`-from-an-external-cwd plumbing (`test_all` globs + `setup_command` PYTHONPATH) is **intentionally deferred** — that path is `# pragma: no cover` and requires reworking the test-execution resolution (`TestConfig` asserts a relative entrypoint; `_test_single` does `cd {dir_path}` relative to cwd), so it rides with the `gym env test`/validate hardening work.