### PR TITLE
docs: use the unified gym CLI and name/flavor selectors across docs

### DIFF
--- a/benchmarks/critpt/README.md
+++ b/benchmarks/critpt/README.md
@@ -30,7 +30,7 @@ in any committed file.
 `CritPt-Benchmark/CritPt` is a public HuggingFace dataset (no auth required).
 
 ```bash
-ng_prepare_benchmark "+config_paths=[benchmarks/critpt/config.yaml]"
+gym eval prepare --benchmark critpt
 ```
 
 This invokes `benchmarks/critpt/prepare.py` (declared as `prepare_script` in `config.yaml`),
@@ -40,20 +40,20 @@ which downloads the dataset and writes the full 70-problem flat-field JSONL to
 ## Run servers
 
 ```bash
-ng_run "+config_paths=[benchmarks/critpt/config.yaml,responses_api_models/vllm_model/configs/vllm_model.yaml]"
+gym env start --benchmark critpt --model-type vllm_model
 ```
 
-While `ng_run` is up, the CritPt resources server exposes a `GET /status` endpoint
+While `gym env start` is up, the CritPt resources server exposes a `GET /status` endpoint
 that reports live batch-fill progress (e.g. `{"pending_batches":[47],"batch_size":70}`).
 
 ## Collect rollouts
 
-With `ng_run` already up, point `ng_collect_rollouts` at the flat-field JSONL and pass the
+With `gym env start` already up, point `gym eval run --no-serve` at the flat-field JSONL and pass the
 Turn 1 prompt config so the framework materializes `responses_create_params.input` at
 rollout time.
 
 ```bash
-ng_collect_rollouts \
+gym eval run --no-serve \
     +agent_name=critpt_benchmark_agent \
     +input_jsonl_fpath=benchmarks/critpt/data/critpt_benchmark.jsonl \
     +output_jsonl_fpath=results/critpt_rollouts.jsonl \
@@ -72,7 +72,7 @@ Runs prepare + servers + rollout collection and tears the servers down afterward
 config_paths="responses_api_models/vllm_model/configs/vllm_model.yaml,\
 benchmarks/critpt/config.yaml"
 
-ng_e2e_collect_rollouts \
+gym eval run \
     "+config_paths=[${config_paths}]" \
     ++output_jsonl_fpath=results/benchmarks/critpt.jsonl \
     ++overwrite_metrics_conflicts=true \

--- a/benchmarks/frontierscience_research/README.md
+++ b/benchmarks/frontierscience_research/README.md
@@ -53,15 +53,15 @@ Claude Opus 4.5 and 19.4% for OpenAI GPT-5.1 on the Research track.
 
 ```bash
 # Prepare benchmark data
-ng_prepare_benchmark "+config_paths=[benchmarks/frontierscience_research/config.yaml]"
+gym eval prepare --benchmark frontierscience_research
 
 # Running servers
 config_paths="responses_api_models/vllm_model/configs/vllm_model.yaml,\
 benchmarks/frontierscience_research/config.yaml"
-ng_run "+config_paths=[$config_paths]"
+gym env start "+config_paths=[$config_paths]"
 
 # Collect rollouts
-ng_collect_rollouts \
+gym eval run --no-serve \
     +agent_name=frontierscience_research_frontierscience_judge_simple_agent \
     +input_jsonl_fpath=benchmarks/frontierscience_research/data/frontierscience_research_benchmark.jsonl \
     +prompt_config=benchmarks/prompts/generic/default.yaml \

--- a/benchmarks/gdpval/config.yaml
+++ b/benchmarks/gdpval/config.yaml
@@ -1,9 +1,9 @@
 # GDPVal benchmark — Stirrup agent + GDPVal resources server.
 #
 # Run:
-#   ng_prepare_benchmark "+config_paths=[benchmarks/gdpval/config.yaml]"
-#   ng_e2e_collect_rollouts \
-#     "+config_paths=[responses_api_models/vllm_model/configs/vllm_model.yaml,benchmarks/gdpval/config.yaml]" \
+#   gym eval prepare --benchmark gdpval
+#   gym eval run \
+#     --model-type vllm_model --benchmark gdpval \
 #     ++split=benchmark \
 #     ++output_jsonl_fpath=results/gdpval.jsonl
 #

--- a/benchmarks/mrcr/config.yaml
+++ b/benchmarks/mrcr/config.yaml
@@ -24,5 +24,5 @@ mrcr_benchmark_simple_agent:
         # NOTE: for `type: benchmark` datasets, `num_repeats` here is a
         # placeholder — it only triggers row duplication for
         # `type: train`/`validation`. To actually get N rollouts per task,
-        # pass `+num_repeats=N` on the `ng_collect_rollouts` CLI.
+        # pass `+num_repeats=N` on the `gym eval run --no-serve` CLI.
         num_repeats: 4

--- a/benchmarks/mrcr/config_n3_128k.yaml
+++ b/benchmarks/mrcr/config_n3_128k.yaml
@@ -24,5 +24,5 @@ mrcr_n3_128k_benchmark_simple_agent:
         # NOTE: for `type: benchmark` datasets, `num_repeats` here is a
         # placeholder — it only triggers row duplication for
         # `type: train`/`validation`. To actually get N rollouts per task,
-        # pass `+num_repeats=N` on the `ng_collect_rollouts` CLI.
+        # pass `+num_repeats=N` on the `gym eval run --no-serve` CLI.
         num_repeats: 1

--- a/benchmarks/mrcr/config_n3_1m.yaml
+++ b/benchmarks/mrcr/config_n3_1m.yaml
@@ -24,5 +24,5 @@ mrcr_n3_1m_benchmark_simple_agent:
         # NOTE: for `type: benchmark` datasets, `num_repeats` here is a
         # placeholder — it only triggers row duplication for
         # `type: train`/`validation`. To actually get N rollouts per task,
-        # pass `+num_repeats=N` on the `ng_collect_rollouts` CLI.
+        # pass `+num_repeats=N` on the `gym eval run --no-serve` CLI.
         num_repeats: 1

--- a/benchmarks/scicode/README.md
+++ b/benchmarks/scicode/README.md
@@ -47,7 +47,7 @@ If the file is missing, the resources server fails fast with a clear error rathe
 ## Prepare benchmark data
 
 ```bash
-ng_prepare_benchmark "+config_paths=[benchmarks/scicode/config.yaml]"
+gym eval prepare --benchmark scicode
 ```
 
 Downloads `SciCode1/SciCode` and writes `benchmarks/scicode/data/scicode_benchmark.jsonl`
@@ -66,7 +66,7 @@ some test cases, removed in scipy 1.14) while still providing Python 3.12 wheels
 ```bash
 config_paths="responses_api_models/vllm_model/configs/vllm_model.yaml,\
 benchmarks/scicode/config.yaml"
-ng_run "+config_paths=[$config_paths]"
+gym env start "+config_paths=[$config_paths]"
 ```
 
 Requires `policy_base_url` / `policy_api_key` / `policy_model_name` in `env.yaml` (or passed as CLI
@@ -77,7 +77,7 @@ overrides).
 With the servers up, run the full benchmark:
 
 ```bash
-ng_collect_rollouts \
+gym eval run --no-serve \
     +agent_name=scicode_benchmark_agent \
     +input_jsonl_fpath=benchmarks/scicode/data/scicode_benchmark.jsonl \
     +output_jsonl_fpath=results/scicode_rollouts.jsonl \
@@ -98,7 +98,7 @@ full-benchmark run that produces the headline `subtask_accuracy`. Requires `test
 config_paths="responses_api_models/vllm_model/configs/vllm_model.yaml,\
 benchmarks/scicode/config.yaml"
 
-ng_e2e_collect_rollouts \
+gym eval run \
     "+config_paths=[${config_paths}]" \
     ++split=benchmark \
     ++output_jsonl_fpath=results/benchmarks/scicode.jsonl \

--- a/fern/versions/latest/pages/build-verifiers/multi-reward-verification.mdx
+++ b/fern/versions/latest/pages/build-verifiers/multi-reward-verification.mdx
@@ -35,7 +35,7 @@ A multi-reward verifier is a normal resources server with one change to what `ve
 Skip if you already have one. Otherwise generate the app, config, and test layout:
 
 ```bash
-ng_init_resources_server +entrypoint=resources_servers/my_server
+gym env init +entrypoint=resources_servers/my_server
 ```
 
 ### 2. Subclass `BaseVerifyResponse` to add `reward_components`
@@ -154,9 +154,9 @@ Collect rollouts as with any other environment:
 ```bash
 config_paths="responses_api_models/openai_model/configs/openai_model.yaml,\
 resources_servers/example_tool_call_multireward/configs/example_tool_call_multireward.yaml"
-ng_run "+config_paths=[$config_paths]"
+gym env start "+config_paths=[$config_paths]"
 
-ng_collect_rollouts +agent_name=example_tool_call_multireward_simple_agent \
+gym eval run --no-serve +agent_name=example_tool_call_multireward_simple_agent \
     +input_jsonl_fpath=resources_servers/example_tool_call_multireward/data/example.jsonl \
     +output_jsonl_fpath=resources_servers/example_tool_call_multireward/data/example_rollouts.jsonl \
     +limit=null +num_repeats=null +num_samples_in_parallel=null

--- a/fern/versions/latest/pages/model-server/azure-openai.mdx
+++ b/fern/versions/latest/pages/model-server/azure-openai.mdx
@@ -59,14 +59,14 @@ model_config="responses_api_models/azure_openai_model/configs/azure_openai_model
 Pass your Azure API version on the command line:
 
 ```bash
-ng_run "+config_paths=[${environment_config},${model_config}]" \
+gym env start "+config_paths=[${environment_config},${model_config}]" \
     +policy_model.responses_api_models.azure_openai_model.default_query.api-version=2024-10-21
 ```
 
 ### 3. Evaluate your agent
 
 ```bash
-ng_collect_rollouts +agent_name=mcqa_simple_agent \
+gym eval run --no-serve +agent_name=mcqa_simple_agent \
     +input_jsonl_fpath=resources_servers/mcqa/data/example.jsonl \
     +output_jsonl_fpath=results/mcqa_rollouts.jsonl
 ```

--- a/fern/versions/latest/pages/model-server/inference-providers.mdx
+++ b/fern/versions/latest/pages/model-server/inference-providers.mdx
@@ -80,13 +80,13 @@ For unlisted providers, use the generic config: `responses_api_models/inference_
 ### 2. Start servers
 
 ```bash
-ng_run "+config_paths=[${environment_config},${model_config}]"
+gym env start "+config_paths=[${environment_config},${model_config}]"
 ```
 
 ### 3. Evaluate your agent
 
 ```bash
-ng_collect_rollouts +agent_name=mcqa_simple_agent \
+gym eval run --no-serve +agent_name=mcqa_simple_agent \
     +input_jsonl_fpath=resources_servers/mcqa/data/example.jsonl \
     +output_jsonl_fpath=results/mcqa_rollouts.jsonl
 ```

--- a/fern/versions/latest/pages/model-server/local-vllm-proxy.mdx
+++ b/fern/versions/latest/pages/model-server/local-vllm-proxy.mdx
@@ -45,7 +45,7 @@ Run it alongside the backing LocalVLLMModel by chaining both configs in `config_
 ```bash
 config_paths="responses_api_models/local_vllm_model/configs/openai/gpt-oss-20b-reasoning-high.yaml,\
 responses_api_models/local_vllm_model_proxy/configs/local_vllm_model_proxy.yaml"
-ng_run "+config_paths=[${config_paths}]" \
+gym env start "+config_paths=[${config_paths}]" \
     ++policy_model_proxy.responses_api_models.local_vllm_model_proxy.model_server.name=gpt-oss-20b-reasoning-high
 ```
 

--- a/fern/versions/latest/pages/model-server/local-vllm.mdx
+++ b/fern/versions/latest/pages/model-server/local-vllm.mdx
@@ -17,20 +17,20 @@ If you want to connect NeMo Gym to a vLLM server you start and manage yourself, 
 
 ## Use LocalVLLMModel
 
-Unlike VLLMModel, LocalVLLMModel does not require a separate vLLM install or a manual model download. vLLM is a transitive dependency of `responses_api_models/local_vllm_model`, and model weights are fetched from the Hugging Face Hub on first run (using `HF_TOKEN` from your environment if present). A single `ng_run` brings up both vLLM and NeMo Gym.
+Unlike VLLMModel, LocalVLLMModel does not require a separate vLLM install or a manual model download. vLLM is a transitive dependency of `responses_api_models/local_vllm_model`, and model weights are fetched from the Hugging Face Hub on first run (using `HF_TOKEN` from your environment if present). A single `gym env start` brings up both vLLM and NeMo Gym.
 
 Several model configs ship with the server under `responses_api_models/local_vllm_model/configs/` — see the `Qwen/`, `openai/`, and `nvidia/` subdirectories for ready-to-use examples. To launch a single-node 8-GPU run with `Qwen3-30B-A3B-Instruct-2507`:
 
 ```bash
 config_paths="resources_servers/example_single_tool_call/configs/example_single_tool_call.yaml,\
 responses_api_models/local_vllm_model/configs/Qwen/Qwen3-30B-A3B-Instruct-2507.yaml"
-ng_run "+config_paths=[${config_paths}]"
+gym env start "+config_paths=[${config_paths}]"
 ```
 
 Override the parallelism dimensions on the command line to match your node:
 
 ```bash
-ng_run "+config_paths=[${config_paths}]" \
+gym env start "+config_paths=[${config_paths}]" \
     ++Qwen3-30B-A3B-Instruct-2507.responses_api_models.local_vllm_model.vllm_serve_kwargs.tensor_parallel_size=4 \
     ++Qwen3-30B-A3B-Instruct-2507.responses_api_models.local_vllm_model.vllm_serve_kwargs.data_parallel_size=2
 ```
@@ -117,14 +117,14 @@ LocalVLLMModel uses Ray to place vLLM workers across nodes. The `VLLM_RAY_DP_PAC
 
 ```bash
 config_paths="responses_api_models/local_vllm_model/configs/openai/gpt-oss-20b-reasoning-high.yaml"
-ng_run "+config_paths=[${config_paths}]"
+gym env start "+config_paths=[${config_paths}]"
 ```
 
 **1 node, 1 instance (DP=2, TP=4).** Split one node into two data-parallel replicas:
 
 ```bash
 config_paths="responses_api_models/local_vllm_model/configs/openai/gpt-oss-20b-reasoning-high.yaml"
-ng_run "+config_paths=[${config_paths}]" \
+gym env start "+config_paths=[${config_paths}]" \
     ++gpt-oss-20b-reasoning-high.responses_api_models.local_vllm_model.vllm_serve_kwargs.data_parallel_size=2 \
     ++gpt-oss-20b-reasoning-high.responses_api_models.local_vllm_model.vllm_serve_kwargs.tensor_parallel_size=4
 ```
@@ -134,7 +134,7 @@ ng_run "+config_paths=[${config_paths}]" \
 ```bash
 config_paths="responses_api_models/local_vllm_model/configs/openai/gpt-oss-20b-reasoning-high.yaml,\
 responses_api_models/local_vllm_model/configs/openai/gpt-oss-120b-reasoning-high.yaml"
-ng_run "+config_paths=[${config_paths}]" \
+gym env start "+config_paths=[${config_paths}]" \
     ++gpt-oss-20b-reasoning-high.responses_api_models.local_vllm_model.vllm_serve_kwargs.tensor_parallel_size=4 \
     ++gpt-oss-120b-reasoning-high.responses_api_models.local_vllm_model.vllm_serve_kwargs.tensor_parallel_size=4
 ```
@@ -144,7 +144,7 @@ ng_run "+config_paths=[${config_paths}]" \
 ```bash
 config_paths="responses_api_models/local_vllm_model/configs/openai/gpt-oss-20b-reasoning-high.yaml,\
 responses_api_models/local_vllm_model/configs/openai/gpt-oss-120b-reasoning-high.yaml"
-ng_run "+config_paths=[${config_paths}]"
+gym env start "+config_paths=[${config_paths}]"
 ```
 
 ## Inherited features

--- a/fern/versions/latest/pages/model-server/openai.mdx
+++ b/fern/versions/latest/pages/model-server/openai.mdx
@@ -60,13 +60,13 @@ model_config="responses_api_models/openai_model/configs/openai_model.yaml"
 ### 2. Start servers
 
 ```bash
-ng_run "+config_paths=[${environment_config},${model_config}]"
+gym env start "+config_paths=[${environment_config},${model_config}]"
 ```
 
 ### 3. Evaluate your agent
 
 ```bash
-ng_collect_rollouts +agent_name=mcqa_simple_agent \
+gym eval run --no-serve +agent_name=mcqa_simple_agent \
     +input_jsonl_fpath=resources_servers/mcqa/data/example.jsonl \
     +output_jsonl_fpath=results/mcqa_rollouts.jsonl
 ```

--- a/resources_servers/arena_judge/configs/arena_judge.yaml
+++ b/resources_servers/arena_judge/configs/arena_judge.yaml
@@ -4,7 +4,7 @@
 # against any OpenAI-compatible endpoint — swap via ``ARENA_JUDGE_*``
 # overrides (or set the env vars at launch). The ``MISSING`` fallback
 # on the api_key keeps config-load green for judge-unrelated jobs
-# (``ng_prepare_data``, ``ng_dump_config``, ``ng_test``); live
+# (``gym dataset collate``, ``gym env resolve``, ``gym env test``); live
 # ``verify()`` calls will fail loudly if the key is actually unset.
 
 arena_judge_judge_model:

--- a/resources_servers/critpt/README.md
+++ b/resources_servers/critpt/README.md
@@ -41,7 +41,7 @@ batch, so `pass@1` across the 70 problems equals the AA aggregate.
 that doesn't already contain its `problem_id`, opening a new batch if every pending batch
 already has it. With `num_repeats=N` and 70 problems, this produces N independent batches of
 70 unique `problem_id`s — N AA API calls total, each scored as a separate run. Assumes
-uniform `num_repeats` across problems (which `ng_collect_rollouts` enforces).
+uniform `num_repeats` across problems (which `gym eval run --no-serve` enforces).
 
 ## Dataset Format
 
@@ -91,7 +91,7 @@ On HPC: bind is `127.0.0.1` on the compute node — curl from the same host, or
 ## Running servers
 
 ```bash
-ng_run "+config_paths=[benchmarks/critpt/config.yaml,responses_api_models/openai_model/configs/openai_model.yaml]"
+gym env start --benchmark critpt --model-type openai_model
 ```
 
 ## Smoke test (5 example problems)
@@ -106,14 +106,14 @@ has one opt-in config knob:
 Defaults to `None`/unset, so production behavior is unchanged. Set it only for testing purposes:
 
 ```bash
-ng_run "+config_paths=[benchmarks/critpt/config.yaml,responses_api_models/openai_model/configs/openai_model.yaml]" \
+gym env start --benchmark critpt --model-type openai_model \
     '++critpt_benchmark_resources_server.resources_servers.critpt.fire_after=5'
 ```
 
 ## Collecting rollouts
 
 ```bash
-ng_collect_rollouts \
+gym eval run --no-serve \
     +agent_name=critpt_benchmark_agent \
     +input_jsonl_fpath=resources_servers/critpt/data/example.jsonl \
     +output_jsonl_fpath=results/critpt_smoke.jsonl \
@@ -128,7 +128,7 @@ call -> aggregate distributed to the 5 real rollouts.
 ## Tests
 
 ```bash
-ng_test +entrypoint=resources_servers/critpt
+gym env test +entrypoint=resources_servers/critpt
 ```
 
 Covers code extraction edge cases, partial/full/multi-batch buffering, the `/status`

--- a/resources_servers/imo_proofbench_judge/configs/imo_proofbench_judge.yaml
+++ b/resources_servers/imo_proofbench_judge/configs/imo_proofbench_judge.yaml
@@ -47,7 +47,7 @@ imo_proofbench_judge_simple_agent:
 # Default-null judge config keys so OmegaConf can resolve the
 # `${judge_base_url}` / `${judge_api_key}` / `${judge_model_name}`
 # interpolations on the `judge_model` server even when the consumer
-# doesn't supply them. `ng_prepare_benchmark` reads the merged config
+# doesn't supply them. `gym eval prepare` reads the merged config
 # but doesn't instantiate the judge — without these defaults, prepare
 # crashes with `InterpolationKeyError` before prepare.py runs. CLI
 # overrides (`+judge_base_url=…`) supersede the null at server launch.

--- a/resources_servers/labbench2_vlm/configs/judge_model_openai.yaml
+++ b/resources_servers/labbench2_vlm/configs/judge_model_openai.yaml
@@ -5,7 +5,7 @@
 # responses_api_models instance named `judge_model`.
 #
 # Env vars are wrapped in `oc.select` so that config parsing succeeds even
-# when env.yaml hasn't been loaded (e.g. during `ng_list_benchmarks`). At
+# when env.yaml hasn't been loaded (e.g. during `gym list benchmarks`). At
 # runtime, set judge_base_url / judge_api_key / judge_model_name in env.yaml
 # (or on the CLI) — the real values will override the unset.* sentinels.
 judge_model:

--- a/resources_servers/ns_tools/configs/ns_tools.yaml
+++ b/resources_servers/ns_tools/configs/ns_tools.yaml
@@ -4,7 +4,7 @@
 # for tool execution (e.g., stateful Python code execution).
 #
 # USAGE:
-#   ng_run "+config_paths=[resources_servers/ns_tools/configs/ns_tools.yaml,\
+#   gym env start "+config_paths=[resources_servers/ns_tools/configs/ns_tools.yaml,\
 #   resources_servers/math_with_judge/configs/math_with_judge.yaml,\
 #   responses_api_models/vllm_model/configs/vllm_model.yaml]"
 

--- a/resources_servers/reasoning_gym/configs/reasoning_gym_claude_code_agent_model_server.yaml
+++ b/resources_servers/reasoning_gym/configs/reasoning_gym_claude_code_agent_model_server.yaml
@@ -5,10 +5,10 @@
 # model server; the CLI appends /v1/messages. Needs NO anthropic_* env vars.
 #
 # Compose with any model server as `policy_model`, e.g. a vLLM OpenAI-compatible endpoint:
-#   ng_run "+config_paths=[\
+#   gym env start "+config_paths=[\
 #     resources_servers/reasoning_gym/configs/reasoning_gym_claude_code_agent_model_server.yaml,\
 #     responses_api_models/vllm_model/configs/vllm_model.yaml]"
-#   ng_collect_rollouts \
+#   gym eval run --no-serve \
 #     +agent_name=reasoning_gym_claude_code_agent_model_server \
 #     +input_jsonl_fpath=resources_servers/reasoning_gym/data/example.jsonl \
 #     +output_jsonl_fpath=claude_code_via_model_server_rollout.jsonl +limit=1

--- a/resources_servers/scicode/README.md
+++ b/resources_servers/scicode/README.md
@@ -66,7 +66,7 @@ rollouts.
 ## Running servers
 
 ```bash
-ng_run "+config_paths=[benchmarks/scicode/config.yaml,responses_api_models/openai_model/configs/openai_model.yaml]"
+gym env start --benchmark scicode --model-type openai_model
 ```
 
 ## Smoke test (5 example problems)
@@ -75,7 +75,7 @@ Requires `test_data.h5` staged. Use the benchmark config (so `test_data_fpath` i
 benchmark agent:
 
 ```bash
-ng_collect_rollouts \
+gym eval run --no-serve \
     +agent_name=scicode_benchmark_agent \
     +input_jsonl_fpath=resources_servers/scicode/data/example.jsonl \
     +output_jsonl_fpath=results/scicode_smoke.jsonl \
@@ -86,7 +86,7 @@ ng_collect_rollouts \
 ## Tests
 
 ```bash
-ng_test +entrypoint=resources_servers/scicode
+gym env test +entrypoint=resources_servers/scicode
 ```
 
 Covers test sanitization, the program builder, subprocess pass/fail/timeout, and the `verify()`

--- a/responses_api_agents/anyterminal_agent/README.md
+++ b/responses_api_agents/anyterminal_agent/README.md
@@ -47,20 +47,20 @@ Requires the `harbor` CLI on PATH. Tasks are downloaded automatically and cached
 **2. Start the environment** with Hermes and a model server:
 
 ```bash
-ng_run "+config_paths=[responses_api_agents/anyterminal_agent/configs/anyterminal_hermes.yaml,responses_api_models/vllm_model/configs/vllm_model.yaml]"
+gym env start "+config_paths=[responses_api_agents/anyterminal_agent/configs/anyterminal_hermes.yaml,responses_api_models/vllm_model/configs/vllm_model.yaml]"
 ```
 
 If you pre-built SIFs into a custom directory, override `tb_sif_dir`:
 
 ```bash
-ng_run "+config_paths=[...]" \
+gym env start "+config_paths=[...]" \
   ++anyterminal_hermes.responses_api_agents.anyterminal_agent.tb_sif_dir=/shared/sifs
 ```
 
 **3. Collect rollouts:**
 
 ```bash
-ng_collect_rollouts \
+gym eval run --no-serve \
   +agent_name=anyterminal_hermes \
   +input_jsonl_fpath=responses_api_agents/anyterminal_agent/data/terminal_bench.jsonl \
   +output_jsonl_fpath=results/anyterminal_rollouts.jsonl

--- a/responses_api_agents/claude_code_agent/README.md
+++ b/responses_api_agents/claude_code_agent/README.md
@@ -39,7 +39,7 @@ Every Gym model server now exposes `POST /v1/messages` (a default Messages ↔ R
 `reasoning_gym_claude_code_agent_model_server.yaml` wires the agent's `model_server` ref to `policy_model`. Compose it with any model server (here a vLLM serving `policy_model`):
 
 ```bash
-ng_run "+config_paths=[resources_servers/reasoning_gym/configs/reasoning_gym_claude_code_agent_model_server.yaml,responses_api_models/vllm_model/configs/vllm_model.yaml]"
+gym env start --resources-server reasoning_gym/reasoning_gym_claude_code_agent_model_server --model-type vllm_model
 ```
 
 This path needs only the model server's `policy_base_url`, `policy_api_key`, and `policy_model_name` (in `env.yaml` or as `+` overrides) — no `anthropic_*` vars.
@@ -60,10 +60,10 @@ For the model-server config above, use `+agent_name=reasoning_gym_claude_code_ag
 
 ### Smoke test
 
-Check the `/v1/messages` proxy and the real-CLI seam without a full rollout. Launch a model server, then take its URL from the `ng_run` log (`'url': 'http://127.0.0.1:<port>'`):
+Check the `/v1/messages` proxy and the real-CLI seam without a full rollout. Launch a model server, then take its URL from the `gym env start` log (`'url': 'http://127.0.0.1:<port>'`):
 
 ```bash
-ng_run "+config_paths=[responses_api_models/vllm_model/configs/vllm_model.yaml]" \
+gym env start --model-type vllm_model \
   +policy_base_url=https://integrate.api.nvidia.com/v1 \
   '+policy_api_key=${oc.env:NVIDIA_API_KEY}' +policy_model_name=meta/llama-3.1-8b-instruct
 
@@ -144,7 +144,7 @@ The per-run `CLAUDE_CONFIG_DIR` is created fresh for each request and removed af
 
 ## Skills evaluation
 
-Skills are evaluated as a run-level variable, not a dataset field — the same skill-agnostic dataset is reused across skill variants (mirroring how `prompt_config` works). You point `skills.path` at a directory of [Agent Skills standard](https://agentskills.io/specification) skill directories on `ng_collect_rollouts`, and the agent stages them into each request's `CLAUDE_CONFIG_DIR/skills/` so Claude Code's native discovery picks them up. When skills are present, `--bare` is forced off for that request regardless of the `bare` config.
+Skills are evaluated as a run-level variable, not a dataset field — the same skill-agnostic dataset is reused across skill variants (mirroring how `prompt_config` works). You point `skills.path` at a directory of [Agent Skills standard](https://agentskills.io/specification) skill directories on `gym eval run --no-serve`, and the agent stages them into each request's `CLAUDE_CONFIG_DIR/skills/` so Claude Code's native discovery picks them up. When skills are present, `--bare` is forced off for that request regardless of the `bare` config.
 
 Expected layout (each skill is a directory with a `SKILL.md`):
 
@@ -163,12 +163,12 @@ skills/variant_a/
 Compare two variants over the same dataset by changing only `skills.path`:
 
 ```bash
-ng_collect_rollouts +agent_name=reasoning_gym_claude_code_agent \
+gym eval run --no-serve +agent_name=reasoning_gym_claude_code_agent \
     +input_jsonl_fpath=resources_servers/reasoning_gym/data/example.jsonl \
     +output_jsonl_fpath=rollouts_variant_a.jsonl \
     +skills.path=skills/variant_a/
 
-ng_collect_rollouts +agent_name=reasoning_gym_claude_code_agent \
+gym eval run --no-serve +agent_name=reasoning_gym_claude_code_agent \
     +input_jsonl_fpath=resources_servers/reasoning_gym/data/example.jsonl \
     +output_jsonl_fpath=rollouts_variant_b.jsonl \
     +skills.path=skills/variant_b/

--- a/responses_api_agents/mini_swe_agent_2/README.md
+++ b/responses_api_agents/mini_swe_agent_2/README.md
@@ -46,7 +46,7 @@ evaluation report includes test status.
 
 `MiniSWEAgent.setup_webserver()` also registers `/v1/responses`, but
 `MiniSWEAgent.responses()` is intentionally not implemented in this agent. The
-supported eval path is `/run`, typically via `ng_collect_rollouts`.
+supported eval path is `/run`, typically via `gym eval run --no-serve`.
 
 ## Dataset Information
 
@@ -218,7 +218,7 @@ model server. The values below show a representative SWE-bench eval setup:
 ```bash
 CONFIG_PATHS="responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_opensandbox.yaml,responses_api_models/vllm_model/configs/vllm_model.yaml"
 
-ng_run "+config_paths=[$CONFIG_PATHS]" \
+gym env start "+config_paths=[$CONFIG_PATHS]" \
     +mini_swe_agent_2.responses_api_agents.mini_swe_agent_2.concurrency=64 \
     +mini_swe_agent_2.responses_api_agents.mini_swe_agent_2.step_timeout=600 \
     +mini_swe_agent_2.responses_api_agents.mini_swe_agent_2.eval_timeout=1800 \
@@ -237,7 +237,7 @@ example above uses `vllm_model`, which is the common path for hosted vLLM
 Collect eval rollouts from a SWE-bench-style JSONL file:
 
 ```bash
-ng_collect_rollouts \
+gym eval run --no-serve \
     +agent_name=mini_swe_agent_2 \
     +input_jsonl_fpath=data/mini_swe_verified_smoke8.jsonl \
     +output_jsonl_fpath=results/mini_swe_agent_2_pass8.jsonl \
@@ -247,14 +247,14 @@ ng_collect_rollouts \
     '+responses_create_params={max_output_tokens: 32768, temperature: 0.6, top_p: 0.95, metadata: {chat_template_kwargs: "{\"enable_thinking\": true}"}}'
 ```
 
-`ng_collect_rollouts` also writes
+`gym eval run --no-serve` also writes
 `results/mini_swe_agent_2_pass8_aggregate_metrics.json`
 with per-task eval status, pass@k, resolved task counts, and eval error rates.
-After collecting repeated rollouts, run `ng_reward_profile` on the collected
+After collecting repeated rollouts, run `gym eval profile` on the collected
 output when you want the standalone profiler JSONL as well:
 
 ```bash
-ng_reward_profile \
+gym eval profile \
     +input_jsonl_fpath=data/mini_swe_verified_smoke8.jsonl \
     +materialized_inputs_jsonl_fpath=results/mini_swe_agent_2_pass8_materialized_inputs.jsonl \
     +rollouts_jsonl_fpath=results/mini_swe_agent_2_pass8.jsonl \

--- a/responses_api_agents/openclaw_agent/README.md
+++ b/responses_api_agents/openclaw_agent/README.md
@@ -12,9 +12,9 @@ OpenClaw must be installed (or it is auto-installed on first start).
 Make sure `env.yaml` is also set.
 
 ```bash
-ng_run "+config_paths=[resources_servers/math_with_judge/configs/math_with_judge_openclaw_agent.yaml]"
+gym env start --resources-server math_with_judge/math_with_judge_openclaw_agent
 
-ng_collect_rollouts +agent_name=math_with_judge_openclaw_agent \
+gym eval run --no-serve +agent_name=math_with_judge_openclaw_agent \
   +input_jsonl_fpath=resources_servers/math_with_judge/data/example.jsonl \
   +output_jsonl_fpath=openclaw_rollout.jsonl +limit=3
 ```

--- a/responses_api_agents/opencode_agent/README.md
+++ b/responses_api_agents/opencode_agent/README.md
@@ -14,9 +14,9 @@ OpenCode must be on PATH (auto-installed on first start, or `npm install -g open
 `policy_base_url`, `policy_api_key`, and `policy_model_name` in `env.yaml`.
 
 ```bash
-ng_run "+config_paths=[resources_servers/math_with_judge/configs/math_with_judge_opencode_agent.yaml,responses_api_models/openai_model/configs/openai_model.yaml]"
+gym env start --resources-server math_with_judge/math_with_judge_opencode_agent --model-type openai_model
 
-ng_collect_rollouts +agent_name=math_with_judge_opencode_agent \
+gym eval run --no-serve +agent_name=math_with_judge_opencode_agent \
   +input_jsonl_fpath=responses_api_agents/opencode_agent/data/example.jsonl \
   +output_jsonl_fpath=opencode_rollout.jsonl +limit=5
 ```

--- a/responses_api_agents/pi_agent/README.md
+++ b/responses_api_agents/pi_agent/README.md
@@ -12,9 +12,9 @@ pi must be on PATH (auto-installed on first start, or `npm install -g @earendil-
 Put `policy_base_url`, `policy_api_key`, and `policy_model_name` in `env.yaml`.
 
 ```bash
-ng_run "+config_paths=[resources_servers/math_with_judge/configs/math_with_judge_pi_agent.yaml,responses_api_models/openai_model/configs/openai_model.yaml]"
+gym env start --resources-server math_with_judge/math_with_judge_pi_agent --model-type openai_model
 
-ng_collect_rollouts +agent_name=math_with_judge_pi_agent \
+gym eval run --no-serve +agent_name=math_with_judge_pi_agent \
   +input_jsonl_fpath=responses_api_agents/pi_agent/data/example.jsonl \
   +output_jsonl_fpath=pi_rollout.jsonl +limit=5
 ```

--- a/responses_api_agents/stirrup_agent/README.md
+++ b/responses_api_agents/stirrup_agent/README.md
@@ -191,7 +191,7 @@ Enable it via the config key or the `JUDGE_ONLY` env var honored by
 
 ```bash
 JUDGE_ONLY=true PERSIST_DELIVERABLES_DIR=/abs/path/to/cached/deliverables \
-  ng_e2e_collect_rollouts ...
+  gym eval run ...
 ```
 
 or as a Hydra override:
@@ -272,8 +272,8 @@ absolute path — without it nothing is saved and the mode is rejected at startu
 EXECUTE_ONLY=true \
 PERSIST_DELIVERABLES_DIR=/abs/path/to/output/gdpval/my-model \
 HF_TOKEN=... \
-ng_e2e_collect_rollouts \
-  "+config_paths=[responses_api_models/vllm_model/configs/vllm_model.yaml,benchmarks/gdpval/config.yaml]" \
+gym eval run \
+  --model-type vllm_model --benchmark gdpval \
   ++split=benchmark \
   ++output_jsonl_fpath=results/gdpval_execute_only.jsonl
 ```

--- a/responses_api_agents/stirrup_agent/configs/stirrup_gdpval.yaml
+++ b/responses_api_agents/stirrup_agent/configs/stirrup_gdpval.yaml
@@ -1,7 +1,7 @@
 # Stand-alone stirrup_agent config. The canonical entry point for GDPVal is
 # ``benchmarks/gdpval/config.yaml`` which composes this agent with the GDPVal
-# resources server and supports ``ng_prepare_benchmark`` +
-# ``ng_e2e_collect_rollouts``.
+# resources server and supports ``gym eval prepare`` +
+# ``gym eval run``.
 #
 # To add a new task (e.g. "my_bench"), create a TaskStrategy subclass in
 # responses_api_agents/stirrup_agent/tasks/my_bench.py, register it in

--- a/responses_api_models/inference_provider/README.md
+++ b/responses_api_models/inference_provider/README.md
@@ -30,13 +30,13 @@ policy_model_name: meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo
 Then reference the provider config:
 
 ```bash
-ng_run "+config_paths=[resources_servers/my_benchmark/configs/my_benchmark.yaml,responses_api_models/inference_provider/configs/together.yaml]"
+gym env start --resources-server my_benchmark --model-type inference_provider/together
 ```
 
 Or use the generic config and set the base URL in `env.yaml`:
 
 ```bash
-ng_run "+config_paths=[resources_servers/my_benchmark/configs/my_benchmark.yaml,responses_api_models/inference_provider/configs/inference_provider.yaml]"
+gym env start --resources-server my_benchmark --model-type inference_provider
 ```
 
 ## Configuration

--- a/responses_api_models/vllm_model/README.md
+++ b/responses_api_models/vllm_model/README.md
@@ -5,7 +5,7 @@ VLLMModel connects NeMo Gym to a vLLM server that you start and manage yourself.
 ```bash
 config_paths="resources_servers/example_single_tool_call/configs/example_single_tool_call.yaml,\
 responses_api_models/vllm_model/configs/vllm_model.yaml"
-ng_run "+config_paths=[${config_paths}]" \
+gym env start "+config_paths=[${config_paths}]" \
     ++policy_base_url=http://0.0.0.0:10240/v1 \
     ++policy_model_name=<your-model> \
     ++policy_api_key=dummy_key &> temp.log &


### PR DESCRIPTION
## Summary

Sweeps docs, READMEs, and config-comment examples off the deprecated `ng_*` / `nemo_gym_*` commands and opaque internal `config_paths` onto the unified `gym` CLI and name/flavor selectors. Part of epic #1205 (criteria **C2** run-by-name/no-internal-paths, **C3** composability). Fourth of a 5-PR series (after #1805, #1806, #1807). Docs-only — the legacy commands still work via the deprecation shims; this updates what the docs *teach*.

30 files, 79 lines.

## What changed

- **Legacy commands → `gym` subcommands**, driven by the authoritative `nemo_gym/cli/legacy.py:LEGACY` map: `ng_run`→`gym env start`, `ng_collect_rollouts`→`gym eval run --no-serve`, `ng_e2e_collect_rollouts`→`gym eval run`, `ng_prepare_benchmark`→`gym eval prepare`, `ng_dump_config`→`gym env resolve`, `ng_test`→`gym env test`, etc.
- **Explicit inline `"+config_paths=[...]"` → name/flavor selectors** (`--resources-server` / `--model-type` / `--benchmark`). Example:
  ```
  "+config_paths=[benchmarks/scicode/config.yaml,responses_api_models/openai_model/configs/openai_model.yaml]"
  ```
  becomes `--benchmark scicode --model-type openai_model`. Flavors are preserved (e.g. `--model-type inference_provider/together`, `--resources-server math_with_judge/math_with_judge_pi_agent`).

## How

Scripted, whole-word, authoritative-map conversion with a dry-run + spot-check pass. **Every generated selector was verified to resolve back to its real config** via the CLI's `_asset_config_path`. All changed YAMLs were re-parsed to confirm validity (edits are in `#` comment blocks).

## Intentionally left as-is

- **Migration tables / release-note history** (`reference/cli-commands.mdx`, `about/release-notes.mdx`) — they document the legacy names on purpose.
- **Frozen versioned docs** (`fern/versions/v0.2.1`, `v0.3.0`) and vendored content.
- **Shell-variable `${config_paths}` forms** — converting would require restructuring the bash snippet; the command was still modernized.
- **Agent `config_paths`** — the `--agent` selector lands with the compose-by-name work (PR #5).