### PR TITLE
test(sandbox): hard-import tenacity so a missing sandbox extra fails loudly

### DIFF
--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -23,15 +23,18 @@ from typing import Any
 
 import pytest
 
+# tenacity ships in the `sandbox` optional-dependency extra and is genuinely exercised by
+# these tests. Import it at module load (instead of importorskip) so a CI env that forgets
+# `--extra sandbox` fails loudly here rather than silently skipping these tests and quietly
+# dropping coverage below the fail_under threshold. The `sandbox` marker selects/deselects
+# them; it is not a substitute for the dependency actually being installed.
+import tenacity  # noqa: F401
+
 from nemo_gym.sandbox.providers.base import SandboxResources, SandboxSpec, SandboxStatus
+from nemo_gym.sandbox.providers.opensandbox import provider as opensandbox_provider
 
 
 pytestmark = pytest.mark.sandbox
-
-
-pytest.importorskip("tenacity", reason="tenacity optional sandbox dependency is not installed")
-
-from nemo_gym.sandbox.providers.opensandbox import provider as opensandbox_provider
 
 
 @dataclass(frozen=True)

--- a/tests/unit_tests/test_sandbox.py
+++ b/tests/unit_tests/test_sandbox.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import asyncio
-import importlib.util
 import threading
 from datetime import timedelta
 from pathlib import Path
@@ -21,6 +20,13 @@ from typing import Any
 from uuid import uuid4
 
 import pytest
+
+# tenacity ships in the `sandbox` optional-dependency extra and is genuinely exercised by the
+# opensandbox tests below. Import it at module load (instead of importorskip / a skipif marker)
+# so a CI env that forgets `--extra sandbox` fails loudly here rather than silently skipping
+# these tests and quietly dropping coverage below the fail_under threshold. The `sandbox` marker
+# selects/deselects them; it is not a substitute for the dependency actually being installed.
+import tenacity  # noqa: F401
 
 import nemo_gym.sandbox.providers.registry as provider_registry
 from nemo_gym.sandbox import (
@@ -45,21 +51,7 @@ from responses_api_agents.mini_swe_agent_2.sandbox_environment import MiniSWESan
 pytestmark = pytest.mark.sandbox
 
 
-def _has_module(module_name: str) -> bool:
-    try:
-        return importlib.util.find_spec(module_name) is not None
-    except ModuleNotFoundError:
-        return False
-
-
-requires_tenacity = pytest.mark.skipif(
-    not _has_module("tenacity"),
-    reason="tenacity optional sandbox dependency is not installed",
-)
-
-
 def _require_opensandbox_provider() -> tuple[Any, Any, Any, str, str]:
-    pytest.importorskip("tenacity", reason="tenacity optional sandbox dependency is not installed")
     from nemo_gym.sandbox.providers.opensandbox import provider as opensandbox_provider_module
     from nemo_gym.sandbox.providers.opensandbox.provider import (
         IMAGE_PULL_POLICY_ANNOTATION_EXTENSION_KEY,
@@ -561,7 +553,6 @@ def test_sync_sandbox_facade_rejects_async_context() -> None:
         raise AssertionError("expected sync Sandbox to reject async context")
 
 
-@requires_tenacity
 def test_opensandbox_sdk_create_receives_default_image_pull_policy(monkeypatch) -> None:
     asyncio.run(_assert_opensandbox_sdk_create_receives_default_image_pull_policy(monkeypatch))
 
@@ -615,7 +606,6 @@ async def _assert_opensandbox_sdk_create_receives_default_image_pull_policy(monk
     assert extensions[IMAGE_PULL_POLICY_ANNOTATION_EXTENSION_KEY] == "IfNotPresent"
 
 
-@requires_tenacity
 def test_opensandbox_connect_after_create_uses_connection_config(monkeypatch) -> None:
     asyncio.run(_assert_opensandbox_connect_after_create_uses_connection_config(monkeypatch))
 
@@ -665,7 +655,6 @@ async def _assert_opensandbox_connect_after_create_uses_connection_config(monkey
     }
 
 
-@requires_tenacity
 def test_opensandbox_create_probe_can_require_stable_successes(monkeypatch) -> None:
     asyncio.run(_assert_opensandbox_create_probe_can_require_stable_successes(monkeypatch))
 
@@ -714,7 +703,6 @@ async def _assert_opensandbox_create_probe_can_require_stable_successes(monkeypa
     assert all(call["user"] == "root" for call in calls)
 
 
-@requires_tenacity
 def test_opensandbox_create_probe_polls_same_sandbox_after_transient_errors(monkeypatch) -> None:
     asyncio.run(_assert_opensandbox_create_probe_polls_same_sandbox_after_transient_errors(monkeypatch))
 
@@ -787,7 +775,6 @@ def test_opensandbox_starting_pod_endpoint_errors_are_retryable() -> None:
     assert opensandbox_provider_module._is_retryable_create_error(error) is True
 
 
-@requires_tenacity
 def test_opensandbox_exec_retries_retryable_sdk_failures(monkeypatch) -> None:
     asyncio.run(_assert_opensandbox_exec_retries_retryable_sdk_failures(monkeypatch))
 
@@ -852,7 +839,6 @@ async def _assert_opensandbox_exec_retries_retryable_sdk_failures(monkeypatch) -
     assert raw.commands.calls == 3
 
 
-@requires_tenacity
 def test_opensandbox_command_retries_default_to_disabled(monkeypatch) -> None:
     asyncio.run(_assert_opensandbox_command_retries_default_to_disabled(monkeypatch))
 
@@ -904,7 +890,6 @@ async def _assert_opensandbox_command_retries_default_to_disabled(monkeypatch) -
     assert raw.commands.calls == 1
 
 
-@requires_tenacity
 def test_opensandbox_close_timeout_does_not_fail_after_stop() -> None:
     asyncio.run(_assert_opensandbox_close_timeout_does_not_fail_after_stop())
 
@@ -934,7 +919,6 @@ async def _assert_opensandbox_close_timeout_does_not_fail_after_stop() -> None:
     assert raw.killed is True
 
 
-@requires_tenacity
 def test_opensandbox_close_propagates_stop_failure() -> None:
     asyncio.run(_assert_opensandbox_close_propagates_stop_failure())
 


### PR DESCRIPTION
## Summary

Follow-up hardening on top of the merged sandbox-test split (#1778).

#1778 fixed the red coverage by installing `--extra sandbox` in CI and routing the sandbox tests behind a `sandbox` pytest marker. It kept the `importorskip("tenacity")` / `skipif` guards, though — so if any workflow ever drops `--extra sandbox`, the sandbox tests would **silently skip again** and quietly drop coverage, reproducing the exact failure mode that turned the suite red on `main` (a confusing "coverage too low" symptom rather than an obvious cause).

This replaces those guards with a module-level `import tenacity`, so a CI env missing the extra **fails loudly at collection** with a clear `ModuleNotFoundError: tenacity` instead of silently skipping.

## Changes

- `test_sandbox.py` / `test_opensandbox_provider.py`: `importorskip` / `skipif` → module-level `import tenacity`.
- Remove the now-dead `_has_module`, `requires_tenacity`, the eight `@requires_tenacity` decorators, and the unused `importlib.util` import.
- **Preserves** `pytestmark = pytest.mark.sandbox` from #1778 — the split is untouched.

## Verification

Local run with `--extra sandbox`, mirroring the merged CI split:

- Core `-m "not sandbox"` pass: **681 passed, 95 deselected** — the hard-import sandbox modules are collected and deselected cleanly (no collection errors), confirming the hardening coexists with the split.
- Sandbox `-m sandbox` pass: **95 passed**.
- `opensandbox/provider.py` **99%**, **total 97.28%** → `Required test coverage of 96.0% reached`.
- `ruff check` / `ruff format --check` clean.

## Tradeoff

A core-only test run now requires the `sandbox` extra to be installed (collection imports these modules). CI always installs `--extra sandbox` before both the core and sandbox passes, so this is a no-op there; the only effect is that a local "core tests without the extra" run fails fast instead of skipping — which is the intended hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
