### PR TITLE
fix: restore support for num_repeats=null for backward compatibility

### DIFF
--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -27,7 +27,7 @@ from typing import Any, Dict, Iterator, List, Literal, Optional, Tuple, Union
 
 import orjson
 from omegaconf import OmegaConf
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from tqdm.asyncio import tqdm
 from wandb import Table
 
@@ -204,6 +204,13 @@ class RolloutCollectionConfig(SharedRolloutCollectionConfig):
         default=None,
         description="Run-level skills config (skills.path). Makes a directory of Agent Skills standard skills available to the agent at rollout time and stamps each result with a skills_ref. Applied to a skill-agnostic dataset; not a dataset-row field.",
     )
+
+    @field_validator("num_repeats", mode="before")
+    @classmethod
+    def _coerce_null_num_repeats(cls, v):
+        # default to 1 if num_repeats is None
+        # for backwards compatibility
+        return 1 if v is None else v
 
     @model_validator(mode="after")
     def _validate_num_repeats(self) -> "RolloutCollectionConfig":

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -482,6 +482,16 @@ class TestRolloutCollection:
                 num_repeats={"alpha": bad_value},
             )
 
+    def test_num_repeats_null_coerces_to_one(self, tmp_path: Path) -> None:
+        # `--num-repeats null` (None) restores the pre-#1356 default of 1.
+        config = RolloutCollectionConfig(
+            agent_name="my_agent",
+            input_jsonl_fpath=str(tmp_path / "in.jsonl"),
+            output_jsonl_fpath=str(tmp_path / "out.jsonl"),
+            num_repeats=None,
+        )
+        assert config.num_repeats == 1
+
     def test_preprocess_rows_num_repeats_dict_unknown_agent_warns(self, tmp_path: Path) -> None:
         """An agent listed in the dict that never appears in input rows warns (likely typo)."""
         fpath = tmp_path / "input.jsonl"


### PR DESCRIPTION
PR #1356 removed the support for `num_repeats=None`. This PR restores it for backward compatibility.