### PR TITLE
feat(cli): add --model-type selector to gym dataset collate

### DIFF
--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -396,6 +396,7 @@ COMMANDS = {
         flags=(
             CONFIG,
             RESOURCES_SERVER_CONFIG,
+            MODEL_TYPE,
             SEARCH_DIR,
             _value_flag("mode", "mode", "Data preparation mode.", choices=("train_preparation", "example_validation")),
             _value_flag("output-dir", "output_dirpath", "Output directory for the prepared data."),

--- a/tests/unit_tests/test_cli_main.py
+++ b/tests/unit_tests/test_cli_main.py
@@ -780,6 +780,30 @@ class TestAssetSelectors:
             "+output_dirpath=data/example_multi_step",
         }
 
+    def test_collate_model_type_selector(self, monkeypatch: MonkeyPatch) -> None:
+        # `dataset collate` accepts --model-type so model-dependent data workflows (e.g. train_preparation that
+        # generates with a model) can select the model by name instead of an internal config path.
+        target, overrides = _dispatch_for(
+            monkeypatch,
+            [
+                "dataset",
+                "collate",
+                "--resources-server",
+                "format_verification/freeform_formatting",
+                "--model-type",
+                "vllm_model",
+                "--mode",
+                "train_preparation",
+            ],
+        )
+        assert target == "nemo_gym.cli.dataset:prepare_data"
+        paths, others = _split_overrides(overrides)
+        assert paths == {
+            str(WORKING_DIR / "resources_servers/format_verification/configs/freeform_formatting.yaml"),
+            str(WORKING_DIR / "responses_api_models/vllm_model/configs/vllm_model.yaml"),
+        }
+        assert others == {"+mode=train_preparation"}
+
     def test_resource_server_flavor_syntax(self, monkeypatch: MonkeyPatch) -> None:
         # `<server>/<flavor>` picks a named config inside the server's configs/ dir; math_with_judge ships several
         # flavoured configs (see reference/faq.mdx, which pairs a math_with_judge dataset flavour for profiling).


### PR DESCRIPTION
## What

`gym dataset collate` already accepts `--resources-server` but not `--model-type`. Model-dependent data workflows therefore had to pass the model as an internal config path:

```bash
gym dataset collate \
    --config responses_api_models/vllm_model/configs/vllm_model_for_training.yaml \
    --resources-server format_verification/freeform_formatting \
    --mode train_preparation --download
```

This adds the existing `MODEL_TYPE` selector to the `dataset collate` flags so the model can be selected by name, matching `env start` / `eval run`:

```bash
gym dataset collate \
    --resources-server format_verification/freeform_formatting \
    --model-type vllm_model \
    --mode train_preparation --download
```

## Why

Several `collate` workflows (`train_preparation` that generates with a model, `example_validation` with a judge) require a model server, which today forces an internal `+config_paths=[...]` path. Run-by-name parity here is part of the configuration-friction effort (#1205).

## Changes

- `nemo_gym/cli/main.py`: add `MODEL_TYPE` to the `dataset collate` command flags (one line; the selector already exists and is shared with `env start` / `eval run`).
- `tests/unit_tests/test_cli_main.py`: add `test_collate_model_type_selector` asserting `--resources-server` + `--model-type` coalesce into the resolved config paths.

## Testing

- `pytest tests/unit_tests/test_cli_main.py` — 120 passed.
- `gym dataset collate --help` now lists `--model-type NAME`.