### PR TITLE
fix(uv): stop exclude-dependencies from stripping packages server venvs need

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,14 +298,14 @@ required-version = ">=0.9.30"
 constraint-dependencies = [
     "grpcio>=1.81.0rc1",
 ]
+# NOTE: server venvs install nemo-gym editably and inherit this list, so anything
+# here is also silently dropped from them (uv >=0.11.24). Don't add a package any
+# server needs. Context: https://github.com/NVIDIA-NeMo/Gym/pull/1835
 exclude-dependencies = [
     # Exclude unwanted dependencies from mlflow
     "alembic",
     "blinker",
-    "cffi",
-    "contourpy",
     "cryptography",
-    "cycler",
     "flask",
     "flask-cors",
     "graphene",
@@ -313,15 +313,9 @@ exclude-dependencies = [
     "graphql-relay",
     "gunicorn",
     "huey",
-    "joblib",
-    "kiwisolver",
-    "matplotlib",
-    "pillow",
     "prettytable",
-    "scikit-learn",
     "skops",
     "sqlalchemy",
-    "threadpoolctl",
     "wcwidth",
     "werkzeug",
     "waitress",

--- a/responses_api_agents/stirrup_agent/requirements.txt
+++ b/responses_api_agents/stirrup_agent/requirements.txt
@@ -18,7 +18,8 @@ trafilatura>=1.12
 httpx>=0.27
 # moviepy (transitive from stirrup) imports PIL at module load; Pillow must
 # be installed in the same venv or the whole stirrup import chain breaks.
-Pillow==12.2.0
+# moviepy caps pillow<12, so we can't use the repo-wide 12.2.0 floor here.
+Pillow>=10.4.0,<12
 # PDF/Office generation libraries the agent prompt advertises; the model
 # tries to import these inside the sandbox, so they must be installed in
 # the agent venv (which the code sandbox inherits).


### PR DESCRIPTION
> Stacked on #1832 (which drops `scipy` from the same list). Base branch is #1832's; it will retarget to `main` once #1832 merges.

## Summary

`[tool.uv].exclude-dependencies` in the repo-root `pyproject.toml` — added to slim full `mlflow`'s heavy transitive deps out of the **main** env (#727) — also leaks into **every per-server venv** and silently strips packages those servers explicitly depend on. The first visible casualty: **GDPVal `stirrup_agent` crashes at startup** with `ModuleNotFoundError: No module named 'PIL'`, failing 100% of rollouts. The leak is broad — ~12 servers are affected.

## Packages dropped from `exclude-dependencies`

Full set removed (this PR + base #1832):

| Package | Removed by | Needed by (examples) |
|---|---|---|
| `pillow` | this PR | stirrup_agent, aviary, ether0, grl_sokoban, reasoning_gym, vlm_eval_kit (+ moviepy/weasyprint/torchvision/imageio) |
| `matplotlib` | this PR | ether0, reasoning_gym, scicode, vlm_eval_kit (+ seaborn) |
| `scipy` | **#1832** | arena_judge, ether0, grl_sokoban, longmt_eval, math_with_code, newton_bench, scicode, wmt_translation (+ sklearn/scikit-image) |
| `scikit-learn` | this PR | arena_judge, ether0, vlm_eval_kit |
| `joblib` | this PR | arena_judge, longmt_eval (+ sklearn, nltk) |
| `threadpoolctl` | this PR | arena_judge, ether0 (+ sklearn) |
| `contourpy` | this PR | ether0 (+ matplotlib) |
| `cycler` | this PR | ether0, reasoning_gym (+ matplotlib) |
| `kiwisolver` | this PR | ether0, reasoning_gym (+ matplotlib) |
| `cffi` | this PR | weasyprint (via stirrup_agent) |

Remaining excludes are genuine mlflow-UI/server deps no environment needs: `alembic, blinker, cryptography, flask, flask-cors, graphene, graphql-core, graphql-relay, gunicorn, huey, prettytable, skops, sqlalchemy, wcwidth, werkzeug, waitress`.

Plus: `responses_api_agents/stirrup_agent/requirements.txt` relaxes `Pillow==12.2.0` → `>=10.4.0,<12`, because moviepy caps `pillow<12` so the repo-wide 12.2.0 floor can't apply there (resolves to 11.3.0).

## Root cause

Every `responses_api_agents/*` and `resources_servers/*` requirements file installs nemo-gym editably (`-e nemo-gym[dev] @ ../../`). When `gym env start` runs `uv pip install -r requirements.txt` from a server directory, uv walks up, discovers the repo-root `[tool.uv]`, and applies `exclude-dependencies` to **that server's whole resolution** — not just the main env.

**The regression trigger is a silent uv version bump** (Dockerfile installs uv via `curl astral.sh/uv/install.sh`, always latest):

| Image | uv | `exclude-dependencies` behavior | stirrup venv |
|---|---|---|---|
| `…b44e814f` (Apr) | 0.11.8 | excludes **transitive** only → direct `Pillow` pin honored | pillow 12.2.0 ✅ |
| `…aad609d5` (Jun) | 0.11.24 | excludes **direct requirements too** | pillow **dropped** ❌ |

Under uv ≥0.11.24 the install **succeeds with exit 0** and just omits the excluded packages — no conflict, no warning. The `requirements.txt` pin is powerless.

### Evidence (verified in the `aad609d5` image)

- `…/stirrup_agent/.venv` → `import PIL` → `ModuleNotFoundError`; venv has 396 pkgs incl. `moviepy 2.2.1` + `stirrup 0.1.11` but **no pillow**.
- Running the exact gym install command in-image: `uv pip install -r requirements.txt` → **exit 0**, pillow absent. Every pillow spec → dropped.
- `reasoning_gym` dry-run: resolves 150 pkgs, `numpy`/`pandas` present, but directly-requested `matplotlib`/`pillow`/`cycler`/`kiwisolver` dropped.

## Affected sub-venvs

Build their venv from the repo checkout (deployment/CI image **and** any dev running `gym env start` from a clone with uv ≥0.11.x). Pure wheel installs are unaffected (`[tool.uv]` isn't in wheel metadata).

### Direct (server's own requirements lists an excluded package)

| Sub-venv | Dropped (direct) |
|---|---|
| `responses_api_agents/stirrup_agent` | pillow |
| `resources_servers/arena_judge` | scipy, joblib, threadpoolctl, scikit-learn |
| `resources_servers/aviary` | pillow |
| `resources_servers/ether0` | matplotlib, pillow, contourpy, cycler, kiwisolver, scikit-learn, scipy, joblib, threadpoolctl |
| `resources_servers/grl_sokoban` | scipy, pillow |
| `resources_servers/longmt_eval` | scipy, joblib |
| `resources_servers/math_with_code` | scipy |
| `resources_servers/newton_bench` | scipy |
| `resources_servers/reasoning_gym` | matplotlib, pillow, cycler, kiwisolver |
| `resources_servers/scicode` | scipy, matplotlib |
| `resources_servers/vlm_eval_kit` | matplotlib, pillow, scikit-learn |
| `resources_servers/wmt_translation` | scipy |

### Transitive (server requests a puller of an excluded dep)

| Sub-venv | Puller → dropped dep |
|---|---|
| `responses_api_agents/stirrup_agent` | seaborn→matplotlib+scipy, weasyprint→pillow+cffi, reportlab→pillow |
| `resources_servers/grl_sokoban` | imageio→pillow |
| `resources_servers/longmt_eval` | torchvision→pillow |
| `resources_servers/wmt_translation` | torchvision→pillow |
| `resources_servers/vlm_eval_kit` | torchvision→pillow, scikit-image→scipy+pillow+imageio, imageio→pillow, nltk→joblib |
| `resources_servers/cvdp` | nltk→joblib |
| `resources_servers/ifbench` | nltk→joblib |

## Validation (in `aad609d5` image, with this exact edit applied)

`stirrup_agent`, `reasoning_gym`, `arena_judge` all resolve **exit 0**; full stirrup install → `import PIL, moviepy, stirrup, seaborn, matplotlib, weasyprint` all succeed (PIL 11.3.0). Servers pinning `pillow==12.2.0` (e.g. reasoning_gym) still resolve to 12.2.0 — their libs don't cap pillow.

## Tradeoff / follow-up

- stirrup_agent gets pillow **11.3.0** (not the #1370 12.2.0 CVE floor) because moviepy caps `<12`. If a pillow CVE needs ≥12, stirrup needs a moviepy bump that lifts the cap.
- Un-excluding these re-admits full `mlflow`'s heavy transitive deps into the **main** env, growing the image. The cleaner long-term fix is to drop the full `mlflow` dep and keep only `mlflow-skinny` (which doesn't pull these) — but the code currently imports non-skinny `mlflow`, so that needs its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
