### PR TITLE
docs: fix 11 documentation and tutorial issues (DOC/LINK/TUT)

### DIFF
--- a/environments/workplace_assistant/README.md
+++ b/environments/workplace_assistant/README.md
@@ -27,7 +27,7 @@ gym eval run --no-serve \
 
 ## Generating Additional Training Data
 
-To generate your own training JSONL for this environment using NeMo Data Designer, see the [synthetic data generation example](notebooks/synthetic-data-generation/).
+To generate your own training JSONL for this environment using NeMo Data Designer, see the [synthetic data generation example](../../resources_servers/workplace_assistant/).
 
 # Licensing information
 Code: Apache 2.0

--- a/environments/workplace_assistant/README.md
+++ b/environments/workplace_assistant/README.md
@@ -27,7 +27,7 @@ gym eval run --no-serve \
 
 ## Generating Additional Training Data
 
-To generate your own training JSONL for this environment using NeMo Data Designer, see the [synthetic data generation example](../../resources_servers/workplace_assistant/).
+To generate your own training JSONL for this environment using NeMo Data Designer, see the [synthetic data generation example](../../resources_servers/workplace_assistant/notebooks/synthetic-data-generation/).
 
 # Licensing information
 Code: Apache 2.0

--- a/fern/versions/latest/pages/build-verifiers/index.mdx
+++ b/fern/versions/latest/pages/build-verifiers/index.mdx
@@ -17,7 +17,7 @@ New to the concepts? Start with [Environments](/about/concepts/environments) and
 You build a resources server by subclassing one of two base classes. At runtime it runs as a web server that the agent drives over HTTP:
 
 - **`SimpleResourcesServer`** — the agent calls `/seed_session` at the start to initialize per-task state (optional) and `/verify` at the end to score the rollout. Tools are exposed as additional endpoints or over MCP.
-- **`GymnasiumServer`** — scores incrementally via `/step` (with `/reset` at the start) instead of a single `/verify`, for environments that need per-turn observations and rewards.
+- **`GymnasiumServer`** — scores incrementally via `/step` (with `/reset` at the start) instead of a single `/verify`, for environments that need per-turn observations and rewards. `GymnasiumServer` is provided by the bundled `resources_servers/gymnasium/` package, not the core `nemo_gym` library — import it with `from resources_servers.gymnasium import GymnasiumServer`.
 
 <Cards>
 

--- a/fern/versions/latest/pages/contribute/agent-skills.mdx
+++ b/fern/versions/latest/pages/contribute/agent-skills.mdx
@@ -26,7 +26,7 @@ Assistants discover skills automatically when they are pointed at a local Gym ch
 | Skill | What it covers |
 |---|---|
 | [`add-benchmark`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.claude/skills/add-benchmark) | End-to-end workflow for adding a new benchmark or training environment |
-| [`nemo-gym-reward-profiling`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.claude/skills/nemo-gym-reward-profiling) | `ng_run`, `ng_collect_rollouts`, and `ng_reward_profile` baselining |
+| [`nemo-gym-reward-profiling`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.claude/skills/nemo-gym-reward-profiling) | `gym env start`, `gym eval run`, and `gym eval profile` baselining |
 | [`nemo-gym-debugging`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.claude/skills/nemo-gym-debugging) | Diagnosing failed rollouts, partial JSONL, verifier errors, and infra issues |
 | [`nemo-gym-docs`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.claude/skills/nemo-gym-docs) | Adding, moving, and removing pages on the Fern docs site |
 | [`nemo-gym-blade-analysis`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.claude/skills/nemo-gym-blade-analysis) | BLADE-style benchmark reports from rollout evidence |

--- a/fern/versions/latest/pages/evaluation-tutorials/evalplus.mdx
+++ b/fern/versions/latest/pages/evaluation-tutorials/evalplus.mdx
@@ -49,7 +49,7 @@ gym env start \
     --model-type vllm_model \
     --model-url "https://integrate.api.nvidia.com/v1" \
     --model-api-key "${NVIDIA_API_KEY}" \
-    --model "nvidia/nemotron-3-ultra-550b-a55b" \
+    --model "nvidia/nemotron-3-ultra-550b-a55b"
 ```
 
 This starts:

--- a/fern/versions/latest/pages/get-started/installation.mdx
+++ b/fern/versions/latest/pages/get-started/installation.mdx
@@ -24,7 +24,7 @@ uv venv --python 3.12 && source .venv/bin/activate
 uv pip install nemo-gym
 ```
 
-The package includes built-in environments and CLI commands. Config and data paths resolve against the package install location automatically. To pin a release: `python3.12 -m pip install nemo-gym==0.3.1`.
+The package includes built-in environments and CLI commands. Config and data paths resolve against the package install location automatically. To pin a release: `python3.12 -m pip install nemo-gym==0.4.0`.
 
 </Tab>
 <Tab title="Git">
@@ -55,7 +55,7 @@ gym --version
 You should see output like:
 
 ```text
-NeMo Gym v0.3.0
+NeMo Gym v0.4.0
 Python 3.12.x
 Installation: /path/to/Gym
 ```

--- a/fern/versions/latest/pages/get-started/quickstart.mdx
+++ b/fern/versions/latest/pages/get-started/quickstart.mdx
@@ -93,19 +93,19 @@ gym list benchmarks
 ```
 
 ```text
-Available benchmarks in NeMo Gym
-┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
-┃ Benchmark name   ┃ Agent name                        ┃ Num repeats ┃
-┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
-│ aalcr            │ aalcr_benchmark_simple_agent      │ 16          │
-│ aime25           │ aime25_math_with_judge_simple_ag… │ 32          │
-│ browsecomp       │ browsecomp_tavily_search_simple_… │ 1           │
-│ gpqa             │ gpqa_mcqa_simple_agent            │ 8           │
-│ ifbench          │ ifbench_benchmark_simple_agent    │ 5           │
-| ...              | ...                               | ...         |
-│ tau2             │ tau2_benchmark_agent              │ 8           │
-│ xstest           │ xstest_benchmark_simple_agent     │ 4           │
-└──────────────────┴───────────────────────────────────┴─────────────┘
+Available benchmarks in NeMo Gym (76)
+┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
+┃ Benchmark name   ┃ Domain             ┃ Agent name                        ┃ Num repeats ┃
+┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
+│ aime24           │ math               │ aime24_math_with_judge_simple_ag… │ 32          │
+│ aime25           │ math               │ aime25_math_with_judge_simple_ag… │ 32          │
+│ browsecomp       │ agentic            │ browsecomp_tavily_search_simple_… │ 1           │
+│ gpqa             │ knowledge          │ gpqa_mcqa_simple_agent            │ 8           │
+│ ifbench          │ instruction        │ ifbench_benchmark_simple_agent    │ 5           │
+| ...              | ...                | ...                               | ...         |
+│ tau2             │ agentic            │ tau2_benchmark_agent              │ 8           │
+│ xstest           │ safety             │ xstest_benchmark_simple_agent     │ 4           │
+└──────────────────┴────────────────────┴───────────────────────────────────┴─────────────┘
 ```
 
 This lists benchmarks with pre-configured agents. For the full set of environments (including training environments), see the [Available Environments](https://github.com/NVIDIA-NeMo/Gym#-available-environments) table.

--- a/fern/versions/latest/pages/get-started/quickstart.mdx
+++ b/fern/versions/latest/pages/get-started/quickstart.mdx
@@ -99,11 +99,11 @@ Available benchmarks in NeMo Gym (76)
 ┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
 │ aime24           │ math               │ aime24_math_with_judge_simple_ag… │ 32          │
 │ aime25           │ math               │ aime25_math_with_judge_simple_ag… │ 32          │
-│ browsecomp       │ agentic            │ browsecomp_tavily_search_simple_… │ 1           │
+│ browsecomp       │ agent              │ browsecomp_tavily_search_simple_… │ 1           │
 │ gpqa             │ knowledge          │ gpqa_mcqa_simple_agent            │ 8           │
-│ ifbench          │ instruction        │ ifbench_benchmark_simple_agent    │ 5           │
+│ ifbench          │ instruction_fol…   │ ifbench_benchmark_simple_agent    │ 5           │
 | ...              | ...                | ...                               | ...         |
-│ tau2             │ agentic            │ tau2_benchmark_agent              │ 8           │
+│ tau2             │ agent              │ tau2_benchmark_agent              │ 8           │
 │ xstest           │ safety             │ xstest_benchmark_simple_agent     │ 4           │
 └──────────────────┴────────────────────┴───────────────────────────────────┴─────────────┘
 ```

--- a/fern/versions/latest/pages/training-tutorials/offline-training-w-rollouts.mdx
+++ b/fern/versions/latest/pages/training-tutorials/offline-training-w-rollouts.mdx
@@ -108,8 +108,8 @@ def filter_rollouts(input_file: str, output_file: str, filters: Dict):
             # Apply filters
             if (rollout.get('reward', 0) >= filters.get('min_reward', 0.5) and
                 rollout.get('success', False) and
-                len(rollout.get('output', [])) >= filters.get('min_turns', 2) and
-                len(rollout.get('output', [])) <= filters.get('max_turns', 20)):
+                len(rollout.get('response', {}).get('output', [])) >= filters.get('min_turns', 2) and
+                len(rollout.get('response', {}).get('output', [])) <= filters.get('max_turns', 20)):
                 
                 out.write(line)
                 kept += 1
@@ -173,7 +173,7 @@ def process_sft_data(filtered_rollout_file: str, output_file: str):
         for line in f:
             rollout = json.loads(line)
             sft_example = {
-                "messages": rollout['output'],
+                "messages": rollout['response']['output'],
                 "reward": rollout['reward'],
                 "task_type": rollout.get('metadata', {}).get('task_type', 'general')
             }
@@ -219,8 +219,8 @@ def create_dpo_pairs(filtered_rollout_file: str, output_file: str):
             if quality_diff >= 0.1:  # Minimum difference threshold
                 pairs.append({
                     "prompt": chosen['responses_create_params']['input'],
-                    "chosen": chosen['output'],
-                    "rejected": rejected['output'],
+                    "chosen": chosen['response']['output'],
+                    "rejected": rejected['response']['output'],
                     "quality_difference": quality_diff
                 })
     

--- a/fern/versions/v0.2.1/pages/training-tutorials/nemo-rl-grpo/about-workplace-assistant.mdx
+++ b/fern/versions/v0.2.1/pages/training-tutorials/nemo-rl-grpo/about-workplace-assistant.mdx
@@ -25,7 +25,7 @@ Workplace Assistant is a ****multi-step** agentic **tool-use** **training enviro
 
 ## Prerequisites
 
-- Read the [tutorial overview](#training-nemo-rl-grpo-index) to understand the training goals
+- Read the [tutorial overview](/v0.2/training-tutorials/nemo-rl-grpo) to understand the training goals
 
 ---
 

--- a/resources_servers/proof_judge/README.md
+++ b/resources_servers/proof_judge/README.md
@@ -51,7 +51,7 @@ By default the converter reads the `problem` field and routes examples to the
 - The verifier can run through Gym's `/v1/responses` path or through external
   OpenAI-compatible judge servers exposed with `JUDGE_SERVER_ARGS`.
 - `alpha` and `beta` in
-  [proof_judge.yaml](/Users/smahdavi/Desktop/ls/Gym/resources_servers/proof_judge/configs/proof_judge.yaml)
+  [proof_judge.yaml](configs/proof_judge.yaml)
   control the weight of verifier reward versus self-evaluation consistency.
 
 ## Licensing Information

--- a/responses_api_agents/stirrup_agent/README.md
+++ b/responses_api_agents/stirrup_agent/README.md
@@ -11,7 +11,6 @@ healthcare, and engineering.
 - [Dataset](#dataset)
 - [Prerequisites](#prerequisites)
 - [Quick Start](#quick-start)
-- [Full GDPVal Evaluation](#full-gdpval-evaluation)
 - [Configuration](#configuration)
 - [Advanced Features](#advanced-features)
   - [Apptainer Sandboxing](#apptainer-sandboxing)


### PR DESCRIPTION
Supersedes #1836 (closed due to merge conflict with #1791 and #1826).

Fixes 11 tracked issues across documentation and tutorials. DOC-23e863df is dropped — the `example-resources-servers.mdx` file it targeted was removed by #1791, which also added the needed redirects for `/resources-server`.

## P1 Issues

| ID | File | Fix |
|---|---|---|
| DOC-525c894a | `build-verifiers/index.mdx:17` | `GymnasiumServer` incorrectly implied to be importable from `nemo_gym` core. Added note: lives in `resources_servers/gymnasium/` and must be imported with `from resources_servers.gymnasium import GymnasiumServer` |
| LINK-f3437a67 | `resources_servers/proof_judge/README.md:54` | Hard-coded local filesystem path `/Users/<redacted>/Desktop/ls/Gym/...` replaced with relative link `configs/proof_judge.yaml` |
| TUT-0e5ca040 | `get-started/quickstart.mdx:95` | `gym list benchmarks` sample output was 3-column and stale. Updated to 4-column format (Domain column added) with current count of 76. Domain values verified against `Domain` enum in `nemo_gym/config_types.py` |
| TUT-2ef29637 | `training-tutorials/offline-training-w-rollouts.mdx:111` | `rollout['output']` and `rollout.get('output', [])` do not exist — model output lives at `rollout['response']['output']`. Fixed in all three places: filter, SFT, and DPO snippets |
| TUT-85a2f46b | `evaluation-tutorials/evalplus.mdx:52` | Dangling trailing backslash on last argument of `gym env start` block causes shell to hang. Removed |

## P2 Issues

| ID | File | Fix |
|---|---|---|
| DOC-9f8467fd | `contribute/agent-skills.mdx:29` | `nemo-gym-reward-profiling` skill description listed deprecated `ng_run`, `ng_collect_rollouts`, `ng_reward_profile`. Updated to `gym env start`, `gym eval run`, `gym eval profile` (verified against SKILL.md) |
| DOC-ebccd396 | `get-started/installation.mdx:27` | Version pin `nemo-gym==0.3.1` references a phantom release. Updated to `nemo-gym==0.4.0` |
| TUT-bbc10555 | `get-started/installation.mdx:58` | `gym --version` sample showed `NeMo Gym v0.3.0`. Updated to `v0.4.0` |
| LINK-58668ec0 | `environments/workplace_assistant/README.md:30` | Broken link `notebooks/synthetic-data-generation/` (relative to wrong directory). Repointed to `../../resources_servers/workplace_assistant/notebooks/synthetic-data-generation/` where the notebook actually lives |
| LINK-c38be399 | `responses_api_agents/stirrup_agent/README.md:14` | Stale TOC entry `[Full GDPVal Evaluation](#full-gdpval-evaluation)` has no matching heading. Removed |
| LINK-e8de6b7e | `fern/versions/v0.2.1/.../about-workplace-assistant.mdx:28` | Bare same-page anchor `#training-nemo-rl-grpo-index` has no matching target. Changed to cross-page link `/v0.2/training-tutorials/nemo-rl-grpo` |

## Dropped

| ID | Reason |
|---|---|
| DOC-23e863df | `example-resources-servers.mdx` was deleted by #1791, which also added proper `/resources-server` redirects to docs.yml |

## Test plan

- [ ] Fern preview auto-generated — verify the Fern page changes render correctly
- [ ] `fern check` passes in CI
- [ ] `proof_judge/configs/proof_judge.yaml` exists at relative path (confirmed)
- [ ] `resources_servers/workplace_assistant/notebooks/synthetic-data-generation/` exists (confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)