### PR TITLE
fix(ns_tools): clean up tool state after verification

### DIFF
--- a/resources_servers/ns_tools/README.md
+++ b/resources_servers/ns_tools/README.md
@@ -3,8 +3,6 @@ This is a resources server for executing NeMo Skills tools (e.g., stateful Pytho
 
 It integrates with the NeMo Skills ToolManager to dynamically load and execute tools, maintaining stateful sessions across multiple tool calls within a rollout.
 
-Tool state lasts until `/verify` completes. Verification ends the rollout and cleans its request-scoped tool state even when the delegated verifier fails. A later rollout starts with fresh tool state.
-
 # Example usage
 
 ## Running servers

--- a/resources_servers/ns_tools/README.md
+++ b/resources_servers/ns_tools/README.md
@@ -3,6 +3,8 @@ This is a resources server for executing NeMo Skills tools (e.g., stateful Pytho
 
 It integrates with the NeMo Skills ToolManager to dynamically load and execute tools, maintaining stateful sessions across multiple tool calls within a rollout.
 
+Tool state lasts until `/verify` completes. Verification ends the rollout and cleans its request-scoped tool state even when the delegated verifier fails. A later rollout starts with fresh tool state.
+
 # Example usage
 
 ## Running servers

--- a/resources_servers/ns_tools/app.py
+++ b/resources_servers/ns_tools/app.py
@@ -411,46 +411,52 @@ class NSToolsResourcesServer(SimpleResourcesServer):
 
         Always aggregates and returns tool execution timing metrics for this session.
         Detailed per-call and summary logging is controlled by verbose_tool_logging.
+        Verification ends the rollout and cleans its request-scoped tool state, even on failure.
         """
         session_id = request.session.get(SESSION_ID_KEY) if request else None
-        metrics = self._aggregate_timing_metrics(session_id)
-        if self.config.verbose_tool_logging:
-            logger.info(
-                f"Session {session_id[:8] if session_id else 'unknown'}... metrics: "
-                f"{metrics['num_tool_calls']} tool calls, total={metrics['total_tool_execution_time_seconds']:.3f}s, "
-                f"avg={metrics['avg_tool_call_time_seconds']:.3f}s, "
-                f"internal_timeouts={metrics['tool_timeout_count']}, request_timeouts={metrics['tool_request_timeout_count']}"
+        try:
+            metrics = self._aggregate_timing_metrics(session_id)
+            if self.config.verbose_tool_logging:
+                logger.info(
+                    f"Session {session_id[:8] if session_id else 'unknown'}... metrics: "
+                    f"{metrics['num_tool_calls']} tool calls, "
+                    f"total={metrics['total_tool_execution_time_seconds']:.3f}s, "
+                    f"avg={metrics['avg_tool_call_time_seconds']:.3f}s, "
+                    f"internal_timeouts={metrics['tool_timeout_count']}, "
+                    f"request_timeouts={metrics['tool_request_timeout_count']}"
+                )
+
+            verifier_type = body.verifier_type or self.config.default_verifier
+
+            if verifier_type not in self.config.verifiers:
+                raise ValueError(
+                    f"Unknown verifier: {verifier_type}. Configure it in 'verifiers' or check 'default_verifier'."
+                )
+
+            verifier_ref = self.config.verifiers[verifier_type]
+            response = await self.server_client.post(
+                server_name=verifier_ref.name,
+                url_path="/verify",
+                json=body.model_dump(),
             )
 
-        # Select verifier
-        verifier_type = body.verifier_type or self.config.default_verifier
+            result = await response.json()
 
-        if verifier_type not in self.config.verifiers:
-            raise ValueError(
-                f"Unknown verifier: {verifier_type}. Configure it in 'verifiers' or check 'default_verifier'."
+            if "reward" not in result:
+                raise ValueError(f"Verifier did not return 'reward' field. Response: {result}")
+
+            return NSToolsVerifyResponse(
+                **body.model_dump(),
+                reward=result["reward"],
+                delegated_response=result,
+                **metrics,
             )
-
-        verifier_ref = self.config.verifiers[verifier_type]
-
-        # Delegate to the verifier
-        response = await self.server_client.post(
-            server_name=verifier_ref.name,
-            url_path="/verify",
-            json=body.model_dump(),
-        )
-
-        result = await response.json()
-
-        # Hard fail if no reward in response
-        if "reward" not in result:
-            raise ValueError(f"Verifier did not return 'reward' field. Response: {result}")
-
-        return NSToolsVerifyResponse(
-            **body.model_dump(),
-            reward=result["reward"],
-            delegated_response=result,
-            **metrics,
-        )
+        finally:
+            if self.tool_manager is not None and session_id:
+                try:
+                    await self.tool_manager.cleanup_request(session_id)
+                except Exception:
+                    logger.exception("Failed to clean up tool state for session %s", session_id)
 
     # --------------------------------------------------------
     # Cleanup

--- a/resources_servers/ns_tools/app.py
+++ b/resources_servers/ns_tools/app.py
@@ -411,7 +411,6 @@ class NSToolsResourcesServer(SimpleResourcesServer):
 
         Always aggregates and returns tool execution timing metrics for this session.
         Detailed per-call and summary logging is controlled by verbose_tool_logging.
-        Verification ends the rollout and cleans its request-scoped tool state, even on failure.
         """
         session_id = request.session.get(SESSION_ID_KEY) if request else None
         try:
@@ -419,13 +418,12 @@ class NSToolsResourcesServer(SimpleResourcesServer):
             if self.config.verbose_tool_logging:
                 logger.info(
                     f"Session {session_id[:8] if session_id else 'unknown'}... metrics: "
-                    f"{metrics['num_tool_calls']} tool calls, "
-                    f"total={metrics['total_tool_execution_time_seconds']:.3f}s, "
+                    f"{metrics['num_tool_calls']} tool calls, total={metrics['total_tool_execution_time_seconds']:.3f}s, "
                     f"avg={metrics['avg_tool_call_time_seconds']:.3f}s, "
-                    f"internal_timeouts={metrics['tool_timeout_count']}, "
-                    f"request_timeouts={metrics['tool_request_timeout_count']}"
+                    f"internal_timeouts={metrics['tool_timeout_count']}, request_timeouts={metrics['tool_request_timeout_count']}"
                 )
 
+            # Select verifier
             verifier_type = body.verifier_type or self.config.default_verifier
 
             if verifier_type not in self.config.verifiers:
@@ -434,6 +432,8 @@ class NSToolsResourcesServer(SimpleResourcesServer):
                 )
 
             verifier_ref = self.config.verifiers[verifier_type]
+
+            # Delegate to the verifier
             response = await self.server_client.post(
                 server_name=verifier_ref.name,
                 url_path="/verify",
@@ -442,6 +442,7 @@ class NSToolsResourcesServer(SimpleResourcesServer):
 
             result = await response.json()
 
+            # Hard fail if no reward in response
             if "reward" not in result:
                 raise ValueError(f"Verifier did not return 'reward' field. Response: {result}")
 
@@ -453,10 +454,7 @@ class NSToolsResourcesServer(SimpleResourcesServer):
             )
         finally:
             if self.tool_manager is not None and session_id:
-                try:
-                    await self.tool_manager.cleanup_request(session_id)
-                except Exception:
-                    logger.exception("Failed to clean up tool state for session %s", session_id)
+                await self.tool_manager.cleanup_request(session_id)
 
     # --------------------------------------------------------
     # Cleanup

--- a/resources_servers/ns_tools/requirements.txt
+++ b/resources_servers/ns_tools/requirements.txt
@@ -1,3 +1,3 @@
 -e nemo-gym[dev] @ ../../
-## NeMo-Skills tools subpackage as of April 8, 2026
-nemo-skills-tools @ git+https://github.com/NVIDIA-NeMo/Skills.git@0596dd20cf9ce338a9a4f1e0010fd67ceb1bb4e6#subdirectory=tools
+## NeMo-Skills tools subpackage as of June 12, 2026
+nemo-skills-tools @ git+https://github.com/NVIDIA-NeMo/Skills.git@da85a881d972e6fec847b90cf553a0bf9bf10638#subdirectory=tools

--- a/resources_servers/ns_tools/tests/test_app.py
+++ b/resources_servers/ns_tools/tests/test_app.py
@@ -23,11 +23,12 @@ from app import (
     NSToolsVerifyRequest,
 )
 from fastapi import FastAPI
+from nemo_skills.mcp.tool_manager import ToolManager
 
 from nemo_gym.base_resources_server import SimpleResourcesServer
 from nemo_gym.config_types import ResourcesServerRef
 from nemo_gym.openai_utils import NeMoGymResponse
-from nemo_gym.server_utils import ServerClient
+from nemo_gym.server_utils import SESSION_ID_KEY, ServerClient
 
 
 class TestApp:
@@ -271,6 +272,128 @@ class TestApp:
         assert "expected_answer" in json_data
         assert "responses_create_params" in json_data
         assert "response" in json_data
+
+
+class TestPerRolloutToolCleanup:
+    def _make_server(self) -> NSToolsResourcesServer:
+        config = NSToolsConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="ns_tools",
+            verifiers={
+                "math_with_judge": ResourcesServerRef(type="resources_servers", name="math_with_judge"),
+            },
+            default_verifier="math_with_judge",
+        )
+        server = NSToolsResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+        server.tool_manager = MagicMock(spec_set=ToolManager)
+        return server
+
+    def _make_verify_request(self) -> NSToolsVerifyRequest:
+        response = NeMoGymResponse(
+            id="resp_test",
+            created_at=0.0,
+            model="dummy",
+            object="response",
+            output=[],
+            parallel_tool_calls=True,
+            tool_choice="auto",
+            tools=[],
+        )
+        return NSToolsVerifyRequest(
+            responses_create_params={"input": [{"role": "user", "content": "test"}]},
+            response=response,
+        )
+
+    def _make_session_request(self, session_id: str | None) -> MagicMock:
+        request = MagicMock()
+        request.session = {SESSION_ID_KEY: session_id} if session_id else {}
+        return request
+
+    def _set_verifier_reward(self, server: NSToolsResourcesServer, reward: float) -> None:
+        response = AsyncMock()
+        response.json = AsyncMock(return_value={"reward": reward})
+        server.server_client.post = AsyncMock(return_value=response)
+
+    async def test_verify_cleans_up_rollout_tool_state(self) -> None:
+        server = self._make_server()
+        self._set_verifier_reward(server, 1.0)
+
+        result = await server.verify(
+            self._make_session_request("rollout-123"),
+            self._make_verify_request(),
+        )
+
+        assert result.reward == 1.0
+        server.tool_manager.cleanup_request.assert_awaited_once_with("rollout-123")
+
+    async def test_verify_cleans_up_when_verifier_fails(self) -> None:
+        server = self._make_server()
+        server.server_client.post = AsyncMock(side_effect=RuntimeError("verifier failed"))
+
+        with pytest.raises(RuntimeError, match="verifier failed"):
+            await server.verify(
+                self._make_session_request("rollout-123"),
+                self._make_verify_request(),
+            )
+
+        server.tool_manager.cleanup_request.assert_awaited_once_with("rollout-123")
+
+    async def test_verify_cleans_up_when_verifier_omits_reward(self) -> None:
+        server = self._make_server()
+        response = AsyncMock()
+        response.json = AsyncMock(return_value={})
+        server.server_client.post = AsyncMock(return_value=response)
+
+        with pytest.raises(ValueError, match="Verifier did not return 'reward'"):
+            await server.verify(
+                self._make_session_request("rollout-123"),
+                self._make_verify_request(),
+            )
+
+        server.tool_manager.cleanup_request.assert_awaited_once_with("rollout-123")
+
+    async def test_verify_without_session_skips_cleanup(self) -> None:
+        server = self._make_server()
+        self._set_verifier_reward(server, 1.0)
+
+        result = await server.verify(
+            self._make_session_request(None),
+            self._make_verify_request(),
+        )
+
+        assert result.reward == 1.0
+        server.tool_manager.cleanup_request.assert_not_awaited()
+
+    async def test_verify_without_tool_manager_succeeds(self) -> None:
+        server = self._make_server()
+        self._set_verifier_reward(server, 1.0)
+        server.tool_manager = None
+
+        result = await server.verify(
+            self._make_session_request("rollout-123"),
+            self._make_verify_request(),
+        )
+
+        assert result.reward == 1.0
+
+    async def test_cleanup_failure_does_not_mask_verification_result(self) -> None:
+        server = self._make_server()
+        self._set_verifier_reward(server, 1.0)
+        server.tool_manager.cleanup_request.side_effect = RuntimeError("cleanup failed")
+
+        with patch("app.logger") as mock_logger:
+            result = await server.verify(
+                self._make_session_request("rollout-123"),
+                self._make_verify_request(),
+            )
+
+        assert result.reward == 1.0
+        mock_logger.exception.assert_called_once_with(
+            "Failed to clean up tool state for session %s",
+            "rollout-123",
+        )
 
 
 class TestPythonToolShutdownReap:

--- a/resources_servers/ns_tools/tests/test_app.py
+++ b/resources_servers/ns_tools/tests/test_app.py
@@ -99,6 +99,9 @@ class TestApp:
             default_verifier="math_with_judge",
         )
         server = NSToolsResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+        server.tool_manager = MagicMock(spec_set=ToolManager)
+        request = MagicMock()
+        request.session = {SESSION_ID_KEY: "rollout-123"}
 
         # Mock the server_client.post to return a successful verification
         mock_response = AsyncMock()
@@ -143,7 +146,7 @@ class TestApp:
             expected_answer="4",
         )
 
-        result = await server.verify(None, verify_request)
+        result = await server.verify(request, verify_request)
 
         assert result.reward == 1.0
         assert result.delegated_response is not None
@@ -154,6 +157,32 @@ class TestApp:
         call_args = server.server_client.post.call_args
         assert call_args.kwargs["server_name"] == "math_with_judge"
         assert call_args.kwargs["url_path"] == "/verify"
+        server.tool_manager.cleanup_request.assert_awaited_once_with("rollout-123")
+
+    async def test_verify_cleans_up_when_verifier_fails(self) -> None:
+        verifiers = {
+            "math_with_judge": ResourcesServerRef(type="resources_servers", name="math_with_judge"),
+        }
+        config = NSToolsConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="ns_tools",
+            verifiers=verifiers,
+            default_verifier="math_with_judge",
+        )
+        server = NSToolsResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+        server.tool_manager = MagicMock(spec_set=ToolManager)
+        server.server_client.post = AsyncMock(side_effect=RuntimeError("verifier failed"))
+        request = MagicMock()
+        request.session = {SESSION_ID_KEY: "rollout-123"}
+        verify_request = MagicMock(spec=NSToolsVerifyRequest)
+        verify_request.verifier_type = None
+
+        with pytest.raises(RuntimeError, match="verifier failed"):
+            await server.verify(request, verify_request)
+
+        server.tool_manager.cleanup_request.assert_awaited_once_with("rollout-123")
 
     async def test_verify_uses_default_verifier(self) -> None:
         """Test that default verifier is used when verifier_type not specified."""
@@ -272,128 +301,6 @@ class TestApp:
         assert "expected_answer" in json_data
         assert "responses_create_params" in json_data
         assert "response" in json_data
-
-
-class TestPerRolloutToolCleanup:
-    def _make_server(self) -> NSToolsResourcesServer:
-        config = NSToolsConfig(
-            host="0.0.0.0",
-            port=8080,
-            entrypoint="",
-            name="ns_tools",
-            verifiers={
-                "math_with_judge": ResourcesServerRef(type="resources_servers", name="math_with_judge"),
-            },
-            default_verifier="math_with_judge",
-        )
-        server = NSToolsResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
-        server.tool_manager = MagicMock(spec_set=ToolManager)
-        return server
-
-    def _make_verify_request(self) -> NSToolsVerifyRequest:
-        response = NeMoGymResponse(
-            id="resp_test",
-            created_at=0.0,
-            model="dummy",
-            object="response",
-            output=[],
-            parallel_tool_calls=True,
-            tool_choice="auto",
-            tools=[],
-        )
-        return NSToolsVerifyRequest(
-            responses_create_params={"input": [{"role": "user", "content": "test"}]},
-            response=response,
-        )
-
-    def _make_session_request(self, session_id: str | None) -> MagicMock:
-        request = MagicMock()
-        request.session = {SESSION_ID_KEY: session_id} if session_id else {}
-        return request
-
-    def _set_verifier_reward(self, server: NSToolsResourcesServer, reward: float) -> None:
-        response = AsyncMock()
-        response.json = AsyncMock(return_value={"reward": reward})
-        server.server_client.post = AsyncMock(return_value=response)
-
-    async def test_verify_cleans_up_rollout_tool_state(self) -> None:
-        server = self._make_server()
-        self._set_verifier_reward(server, 1.0)
-
-        result = await server.verify(
-            self._make_session_request("rollout-123"),
-            self._make_verify_request(),
-        )
-
-        assert result.reward == 1.0
-        server.tool_manager.cleanup_request.assert_awaited_once_with("rollout-123")
-
-    async def test_verify_cleans_up_when_verifier_fails(self) -> None:
-        server = self._make_server()
-        server.server_client.post = AsyncMock(side_effect=RuntimeError("verifier failed"))
-
-        with pytest.raises(RuntimeError, match="verifier failed"):
-            await server.verify(
-                self._make_session_request("rollout-123"),
-                self._make_verify_request(),
-            )
-
-        server.tool_manager.cleanup_request.assert_awaited_once_with("rollout-123")
-
-    async def test_verify_cleans_up_when_verifier_omits_reward(self) -> None:
-        server = self._make_server()
-        response = AsyncMock()
-        response.json = AsyncMock(return_value={})
-        server.server_client.post = AsyncMock(return_value=response)
-
-        with pytest.raises(ValueError, match="Verifier did not return 'reward'"):
-            await server.verify(
-                self._make_session_request("rollout-123"),
-                self._make_verify_request(),
-            )
-
-        server.tool_manager.cleanup_request.assert_awaited_once_with("rollout-123")
-
-    async def test_verify_without_session_skips_cleanup(self) -> None:
-        server = self._make_server()
-        self._set_verifier_reward(server, 1.0)
-
-        result = await server.verify(
-            self._make_session_request(None),
-            self._make_verify_request(),
-        )
-
-        assert result.reward == 1.0
-        server.tool_manager.cleanup_request.assert_not_awaited()
-
-    async def test_verify_without_tool_manager_succeeds(self) -> None:
-        server = self._make_server()
-        self._set_verifier_reward(server, 1.0)
-        server.tool_manager = None
-
-        result = await server.verify(
-            self._make_session_request("rollout-123"),
-            self._make_verify_request(),
-        )
-
-        assert result.reward == 1.0
-
-    async def test_cleanup_failure_does_not_mask_verification_result(self) -> None:
-        server = self._make_server()
-        self._set_verifier_reward(server, 1.0)
-        server.tool_manager.cleanup_request.side_effect = RuntimeError("cleanup failed")
-
-        with patch("app.logger") as mock_logger:
-            result = await server.verify(
-                self._make_session_request("rollout-123"),
-                self._make_verify_request(),
-            )
-
-        assert result.reward == 1.0
-        mock_logger.exception.assert_called_once_with(
-            "Failed to clean up tool state for session %s",
-            "rollout-123",
-        )
 
 
 class TestPythonToolShutdownReap:


### PR DESCRIPTION
## Summary

- Await `ToolManager.cleanup_request(session_id)` in `NSToolsResourcesServer.verify()` so request-scoped tool state is released after each verified rollout, including verifier failures.
- Pin `nemo-skills-tools` to the HLE-tested `da85a881` revision that provides the cleanup hook for `DirectPythonTool` and `DirectTavilyV3Tool`.

## Why

The server used Gym session IDs for stateful tool calls but never released request-scoped state after verification. Downstream integrations therefore had to replace the stock server with a cleanup-only subclass.

## Test plan

- [x] `RAY_TMPDIR=/tmp gym env test --resources-server ns_tools` (20 passed)
- [x] Scoped pre-commit hooks for all changed files

## Scope

- Rollouts that stop before `/verify` still rely on whole-server shutdown cleanup; a generic abort endpoint is out of scope.