### PR TITLE
fix: update version pin, add 'all' extra, surface auth errors (quickstart)

### DIFF
--- a/fern/versions/latest/pages/get-started/installation.mdx
+++ b/fern/versions/latest/pages/get-started/installation.mdx
@@ -24,7 +24,7 @@ uv venv --python 3.12 && source .venv/bin/activate
 uv pip install nemo-gym
 ```
 
-The package includes built-in environments and CLI commands. Config and data paths resolve against the package install location automatically. To pin a release: `python3.12 -m pip install nemo-gym==0.3.1`.
+The package includes built-in environments and CLI commands. Config and data paths resolve against the package install location automatically. To pin a release: `python3.12 -m pip install nemo-gym==0.4.0`.
 
 </Tab>
 <Tab title="Git">
@@ -55,7 +55,7 @@ gym --version
 You should see output like:
 
 ```text
-NeMo Gym v0.3.0
+NeMo Gym v0.4.0
 Python 3.12.x
 Installation: /path/to/Gym
 ```

--- a/fern/versions/latest/pages/get-started/quickstart.mdx
+++ b/fern/versions/latest/pages/get-started/quickstart.mdx
@@ -80,6 +80,10 @@ Rollouts: results/mcqa_rollouts.jsonl
 Aggregate metrics: results/mcqa_rollouts_aggregate_metrics.json
 ```
 
+<Warning>
+If `gym eval run` fails with a `500 Internal Server Error` on the `/run` endpoint, the most common cause is an invalid or missing API key. Verify that `policy_api_key` and `policy_base_url` in your `env.yaml` are correct.
+</Warning>
+
 For per-task pass rates, see `gym eval profile` in the [CLI Reference](/reference/cli-commands).
 
 ## Explore

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -518,6 +518,14 @@ class SimpleServer(BaseServer):
                     "Please use `nemo_gym.server_utils.raise_for_status` for HTTP exceptions!"
                 )
 
+                if e.status in (401, 403):
+                    auth_hint = (
+                        f"Authentication failed (HTTP {e.status}) calling an inner server. "
+                        "Check that policy_api_key and policy_base_url in env.yaml are correct and that the key is valid."
+                    )
+                    print(f"🔑 {auth_hint}")
+                    return JSONResponse(content=auth_hint, status_code=500)
+
                 response_content = f"Hit an exception in {self.get_session_middleware_key()} calling an inner server: {e.response_content}"
                 if _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG:
                     print(response_content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,10 @@ docs = [
 ]
 
 [project.optional-dependencies]
+all = [
+    "nemo-gym[dev,sandbox]",
+]
+
 sandbox = [
     # Tenacity: Retry helpers used by sandbox providers.
     # Updated: Sat May 09, 2026 with tenacity==9.1.4


### PR DESCRIPTION
## Summary

Fixes four getting-started issues reported in the quickstart/installation flow:

| Issue ID | File | Fix |
|---|---|---|
| INSTALL-7be9bae7 | `installation.mdx` | Update `gym --version` sample output and PyPI pin from `v0.3.0`/`0.3.1` → `v0.4.0` |
| INSTALL-7d5b37c1 | `pyproject.toml` | Add `all = ["nemo-gym[dev,sandbox]"]` extra so `uv pip install -e .[all]` works as expected |
| QS-f80cc295 | `nemo_gym/server_utils.py` | Detect 401/403 from upstream model endpoints in exception middleware; print actionable auth hint instead of opaque 500 |
| QS-f80cc295 | `quickstart.mdx` | Add `<Warning>` troubleshooting callout after `gym eval run` output block pointing to `policy_api_key` / `policy_base_url` |

## Details

**INSTALL-7be9bae7** — The `gym --version` sample and the PyPI pin example were both pointing to `v0.3.0`/`0.3.1`. Updated to `v0.4.0` to match the current release.

**INSTALL-7d5b37c1** — `pyproject.toml` only defined `sandbox` and `dev` extras. Running `uv pip install -e .[all]` silently resolved to base deps because the `all` extra didn't exist. Added `all = ["nemo-gym[dev,sandbox]"]` so the common install incantation works.

**QS-f80cc295 (code)** — An invalid `policy_api_key` causes the OpenAI client to receive a 401, which propagates through the model server's exception middleware as a generic 500. The middleware now checks `e.status in (401, 403)` and returns a clear message: `"Authentication failed (HTTP 401) calling an inner server. Check that policy_api_key and policy_base_url in env.yaml are correct and that the key is valid."` It also prints this to the console with a 🔑 prefix for easy scanning in server logs.

**QS-f80cc295 (doc)** — Added a `<Warning>` block in quickstart.mdx directly after the `gym eval run` expected output, so users hitting a 500 immediately see the most likely cause.

## Test plan

- [ ] Verify `uv pip install -e .[all]` now installs both `sandbox` and `dev` dependencies
- [ ] Verify server logs show `🔑 Authentication failed…` when an invalid API key is configured
- [ ] Verify quickstart `<Warning>` block renders correctly in Fern preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)