### PR TITLE
ci: shard full server suite

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -24,6 +24,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  # Number of parallel shards for the full server suite. Keep in sync with the matrix below.
+  NUM_SHARDS: "8"
+  # Pin uv: 0.11.20 has a resolver regression that silently drops pinned deps from
+  # `uv pip install -r requirements.txt` (e.g. matplotlib/scipy/Pillow), breaking
+  # per-server test venvs. 0.11.19 is the latest known-good version.
+  UV_INSTALL_URL: "https://astral.sh/uv/0.11.19/install.sh"
+
 jobs:
   full-test-suite:
     name: Full Test Suite
@@ -44,12 +52,11 @@ jobs:
 
       - name: Setup for test
         run: |
+          export UV_CACHE_DIR="$HOME/.cache/uv"
+          echo "UV_CACHE_DIR=$UV_CACHE_DIR" >> "$GITHUB_ENV"
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends git curl ca-certificates
-          # Pin uv: 0.11.20 has a resolver regression that silently drops pinned deps from
-          # `uv pip install -r requirements.txt` (e.g. matplotlib/scipy/Pillow), breaking
-          # per-server test venvs. 0.11.19 is the latest known-good version.
-          curl -LsSf https://astral.sh/uv/0.11.19/install.sh | sh
+          curl -LsSf "$UV_INSTALL_URL" | sh
           uv venv --python 3.12
           source .venv/bin/activate
           uv sync --extra dev --extra sandbox
@@ -59,7 +66,62 @@ jobs:
           source .venv/bin/activate
           PYTEST_ADDOPTS='-m "not sandbox" --cov-report= --cov-fail-under=0' ng_dev_test
           pytest --cov=. --cov-append --cov-report=term-missing --durations=10 -m sandbox
-          ng_test_all +fail_on_total_and_test_mismatch=true +delete_venvs_after_each_test=true
+
+  server-suite:
+    name: Server suite (shard ${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: 'recursive'
+
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+
+      - name: Setup for test
+        run: |
+          export UV_CACHE_DIR="$HOME/.cache/uv"
+          echo "UV_CACHE_DIR=$UV_CACHE_DIR" >> "$GITHUB_ENV"
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends git curl ca-certificates
+          curl -LsSf "$UV_INSTALL_URL" | sh
+          uv venv --python 3.12
+          source .venv/bin/activate
+          uv sync --extra dev
+
+      - name: Server tests (shard ${{ matrix.shard }}/${{ env.NUM_SHARDS }})
+        run: |
+          source .venv/bin/activate
+          ng_test_all \
+            +fail_on_total_and_test_mismatch=true \
+            +delete_venvs_after_each_test=true \
+            +num_shards=${{ env.NUM_SHARDS }} \
+            +shard_index=${{ matrix.shard }}
+
+  server-suite-result:
+    name: Server suite
+    runs-on: ubuntu-latest
+    needs: [server-suite]
+    if: always()
+    steps:
+      - name: Aggregate shard results
+        run: |
+          if [[ "${{ needs.server-suite.result }}" == "success" ]]; then
+            echo "All server-suite shards passed."
+            exit 0
+          fi
+          echo "One or more server-suite shards failed (result: ${{ needs.server-suite.result }})."
+          exit 1
 
   test-wheel-install:
     name: Test Wheel Use
@@ -82,10 +144,9 @@ jobs:
 
       - name: Setup
         run: |
-          # Pin uv: 0.11.20 has a resolver regression that silently drops pinned deps from
-          # `uv pip install -r requirements.txt` (e.g. matplotlib/scipy/Pillow), breaking
-          # per-server test venvs. 0.11.19 is the latest known-good version.
-          curl -LsSf https://astral.sh/uv/0.11.19/install.sh | sh
+          export UV_CACHE_DIR="$HOME/.cache/uv"
+          echo "UV_CACHE_DIR=$UV_CACHE_DIR" >> "$GITHUB_ENV"
+          curl -LsSf "$UV_INSTALL_URL" | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Build wheel and serve as local PyPI index
@@ -201,9 +262,9 @@ jobs:
   notify-failure:
     name: Notify test failure
     runs-on: ubuntu-latest
-    needs: [full-test-suite, test-wheel-install]
+    needs: [full-test-suite, server-suite-result, test-wheel-install]
     environment: main
-    if: ${{ always() && (needs.full-test-suite.result == 'failure' || needs.test-wheel-install.result == 'failure') }}
+    if: ${{ always() && (needs.full-test-suite.result == 'failure' || needs.server-suite-result.result == 'failure' || needs.test-wheel-install.result == 'failure') }}
     steps:
       - name: Send Slack notification
         env:

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -112,7 +112,7 @@ jobs:
     name: Server suite
     runs-on: ubuntu-latest
     needs: [server-suite]
-    if: always()
+    if: always() && !cancelled()
     steps:
       - name: Aggregate shard results
         run: |

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -264,7 +264,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [full-test-suite, server-suite-result, test-wheel-install]
     environment: main
-    if: ${{ always() && (needs.full-test-suite.result == 'failure' || needs.server-suite-result.result == 'failure' || needs.test-wheel-install.result == 'failure') }}
+    if: ${{ always() && !cancelled() && (needs.full-test-suite.result == 'failure' || needs.server-suite-result.result == 'failure' || needs.test-wheel-install.result == 'failure') }}
     steps:
       - name: Send Slack notification
         env:


### PR DESCRIPTION
## Summary
- split the main-branch full server suite into 8 ng_test_all shards
- keep core pytest coverage commands in the Full Test Suite job
- add a Server suite aggregate job and include it in failure notification wiring
- align uv runtime cache with the Actions cache path

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/full-test-suite.yml"); puts "yaml ok"'
- git diff --check -- .github/workflows/full-test-suite.yml

Test run
https://github.com/NVIDIA-NeMo/Gym/actions/runs/28474026537
https://github.com/NVIDIA-NeMo/Gym/actions/runs/28474433450

## Notes
- actionlint is not installed locally, so GitHub Actions-specific linting was not run.