### PR TITLE
ci: use PAT for code-freeze branch push

### DIFF
--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -35,13 +35,15 @@ on:
         default: true
 jobs:
   code-freeze:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_code_freeze.yml@v0.86.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_code_freeze.yml@v1.4.2
     with:
       library-name: NeMo-Gym
       python-package: nemo_gym
       release-type: ${{ inputs.release-type }}
       freeze-commit: ${{ inputs.freeze-commit }}
       dry-run: ${{ inputs.dry-run }}
+      use-pat: true
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_ENDPOINT }}
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
+      PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
## Summary

- The `github.token` (Actions bot) doesn't have permission to push to protected `r*` release branches — it gets rejected with `GH006: Protected branch update failed`
- Switch to `use-pat: true` so the workflow uses `secrets.PAT` (already set in repo secrets), which has the necessary bypass permissions
- Bump FW-CI-templates from `v0.86.0` → `v1.4.2` (aligns with Megatron-Bridge, the reference repo that runs this workflow successfully)

## Context

Discovered during the failed run on 2026-06-30: https://github.com/NVIDIA-NeMo/Gym/actions/runs/28482988481/job/84423300655

Megatron-Bridge's equivalent workflow already uses this pattern correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)