### PR TITLE
feat: [GDPval-AA v2 Updates 4 / n] - Re-Run Failed Tasks and Judgements Only

### DIFF
--- a/benchmarks/gdpval/README.md
+++ b/benchmarks/gdpval/README.md
@@ -171,6 +171,20 @@ express the full run explicitly as a one-stage multi-stage run:
 | `seed` | *(none)* | Seed for reproducible task sampling and reference selection. |
 | `reuse_cached_deliverables` | `true` | Judge a task's cached deliverable in later stages instead of re-running the policy. |
 
+### Resuming an interrupted multi-stage run
+
+Set `RERUN_INCOMPLETE=true` (with the same `PERSIST_DELIVERABLES_DIR` as the
+original run) to resume a staged run that was cut short. A task whose deliverable
+already **finished** on disk (marked by `finish_params.json`) skips the policy
+rollout and is judged from cache; a task that never finished is re-rolled. On top
+of that, `rerun_incomplete` reuses **cached judgements**: the verify cache is keyed
+by each stage's reference subset, so a resumed stage that reselects the same
+references returns its cached judgement instead of re-judging. Use the same
+`multistage.seed` so the stage task sampling — and therefore the reference subsets —
+are reproducible across the resumed run. See
+[Task Re-run Mode](../../responses_api_agents/stirrup_agent/README.md#task-re-run-mode)
+for the full semantics.
+
 ## Aggregate metrics
 
 After `gym eval run` returns, the resources server's

--- a/benchmarks/gdpval/config.yaml
+++ b/benchmarks/gdpval/config.yaml
@@ -73,6 +73,13 @@ gdpval_stirrup_agent:
       # deliverables already cached in persist_deliverables_dir via /verify.
       # Mutually exclusive with execute_only.
       judge_only: ${oc.env:JUDGE_ONLY,false}
+      # Task re-run mode. When true, tasks whose cached deliverable under
+      # persist_deliverables_dir is already valid skip the rollout (re-scored
+      # from cache in full mode, returned as-is in execute_only); tasks without
+      # a valid cached deliverable are rolled out again. Combine with `--resume`
+      # to re-run only the tasks that did not finish with a valid output.
+      # Requires persist_deliverables_dir; mutually exclusive with judge_only.
+      rerun_incomplete: ${oc.env:RERUN_INCOMPLETE,false}
       resources_server:
         type: resources_servers
         name: gdpval_resources_server

--- a/benchmarks/gdpval/config.yaml
+++ b/benchmarks/gdpval/config.yaml
@@ -85,12 +85,17 @@ gdpval_stirrup_agent:
       # deliverables already cached in persist_deliverables_dir via /verify.
       # Mutually exclusive with execute_only.
       judge_only: ${oc.env:JUDGE_ONLY,false}
-      # Task re-run mode. When true, tasks whose cached deliverable under
-      # persist_deliverables_dir is already valid skip the rollout (re-scored
-      # from cache in full mode, returned as-is in execute_only); tasks without
-      # a valid cached deliverable are rolled out again. Combine with `--resume`
-      # to re-run only the tasks that did not finish with a valid output.
-      # Requires persist_deliverables_dir; mutually exclusive with judge_only.
+      # Task re-run mode. When true, tasks that already FINISHED (a
+      # finish_params.json marker is cached under persist_deliverables_dir) skip
+      # the rollout (already-judged tasks return their cached /verify result,
+      # un-judged finished tasks are scored once; in execute_only the cached
+      # payload is returned as-is); tasks that never finished are rolled out
+      # again. Combine with `--resume` to re-run only the tasks that did not
+      # finish. Under multi-stage ELO (multistage.enabled=true) it additionally
+      # reuses cached judgements, keyed by each stage's reference subset, so a
+      # resumed run skips re-judging (task, references) pairs it already scored.
+      # Requires persist_deliverables_dir; composes with execute_only, judge_only,
+      # and multistage.
       rerun_incomplete: ${oc.env:RERUN_INCOMPLETE,false}
       resources_server:
         type: resources_servers

--- a/responses_api_agents/stirrup_agent/README.md
+++ b/responses_api_agents/stirrup_agent/README.md
@@ -312,6 +312,18 @@ with no cached deliverables to judge is still reported `skipped`, as in plain
 judge-only mode.) Use this to finish judging a deliverable set without
 re-judging the tasks that were already scored.
 
+**Combined with multi-stage ELO** (`++multistage.enabled=true`), `rerun_incomplete`
+resumes an interrupted staged run. Deliverable reuse-vs-rerun already works there
+(a finished task skips the rollout; an unfinished one is re-rolled), so the extra
+thing `rerun_incomplete` adds is **cached judgements**. Because each stage scores
+the *same* deliverable against a *different* reference subset, a judgement is only
+valid for the exact references it scored — so the verify cache is **keyed by the
+reference subset** (`repeat_<n>_verify_response_<refset-hash>.json`). A resumed
+stage that reselects the same references returns its cached judgement (no re-judge);
+a stage that scores a new subset judges once and caches that separately. Run with
+the same `multistage.seed` so the stage plans — and therefore the reference subsets
+— line up across the resumed run.
+
 Requirements / notes:
 
 - `persist_deliverables_dir` must be set (and absolute) — it is the cache the

--- a/responses_api_agents/stirrup_agent/README.md
+++ b/responses_api_agents/stirrup_agent/README.md
@@ -13,6 +13,9 @@ healthcare, and engineering.
 - [Quick Start](#quick-start)
 - [Configuration](#configuration)
 - [Advanced Features](#advanced-features)
+  - [Task-Only Execution Mode](#task-only-execution-mode)
+  - [Judge-Only Mode](#judge-only-mode)
+  - [Task Re-run Mode](#task-re-run-mode)
   - [Apptainer Sandboxing](#apptainer-sandboxing)
   - [Pairwise ELO Judging](#pairwise-elo-judging)
   - [Tavily Web Search](#tavily-web-search)
@@ -123,7 +126,9 @@ The agent reads its Hydra config at `configs/stirrup_gdpval.yaml`. Notable keys:
 | `resources_server` | required | Reference to the GDPVal resources server (which scores the deliverable via `/verify`). |
 | `gdpval_container_path` | `null` | Path to an Apptainer `.sif` (see below). |
 | `persist_deliverables_dir` | `null` | If set, each task's artifacts land in `<dir>/task_<task_id>/`. The resources server reads this dir to score the deliverable. |
-| `judge_only` | `false` | If true, skip task execution and score the deliverables already cached under `persist_deliverables_dir` (see [Judge-Only Mode](#judge-only-mode)). |
+| `execute_only` | `false` | If true, run tasks and cache deliverables but **skip judging** — no `reward` / `judge_response` (see [Task-Only Execution Mode](#task-only-execution-mode)). Mutually exclusive with `judge_only`. |
+| `judge_only` | `false` | If true, skip task execution and score the deliverables already cached under `persist_deliverables_dir` (see [Judge-Only Mode](#judge-only-mode)). Mutually exclusive with `execute_only`. |
+| `rerun_incomplete` | `false` | If true, skip the rollout for tasks that already **finished** (a finish marker is cached) and only re-run the ones that didn't (see [Task Re-run Mode](#task-re-run-mode)). Composes with `execute_only` and `judge_only`. |
 | `model_id` | `null` | HF model id or local path used to load a tokenizer for dynamic output sizing. |
 | `completion_token_buffer` | `1000` | Safety margin (in tokens) reserved when sizing `max_completion_tokens` per call. |
 
@@ -159,6 +164,53 @@ sporadic HTTP 400 responses at the vLLM proxy.
 
 ## Advanced Features
 
+NeMo Gym splits a GDPVal evaluation into two halves — *executing* the task
+(running the agent to produce deliverables) and *judging* it (scoring those
+deliverables with the rubric LLM). By default a run does both back to back, but
+each half can run on its own: [Task-Only Execution Mode](#task-only-execution-mode)
+(`execute_only`) runs and caches deliverables without judging, and
+[Judge-Only Mode](#judge-only-mode) (`judge_only`) scores cached deliverables
+without re-running the agent. [Task Re-run Mode](#task-re-run-mode)
+(`rerun_incomplete`) then lets you resume any of these flows, redoing only the
+work that didn't finish.
+
+### Task-Only Execution Mode
+
+Sometimes you want to *run* the tasks and keep their deliverables without judging
+them — e.g. to build a reference set for later pairwise comparison, to defer
+scoring to a separate pass, or to inspect raw model outputs. Set `execute_only:
+true` (or export `EXECUTE_ONLY=true` with the benchmark config) to do exactly
+that:
+
+- Each task runs through the Stirrup agent and its deliverables are cached to
+  `persist_deliverables_dir/task_<task_id>/repeat_<n>/` (the same layout used by
+  comparison mode's `reference_deliverables_dir`).
+- The judge `/verify` call is **skipped entirely** — no judgement is made or
+  sent, and no LLM-judge tokens are spent.
+- Each rollout row carries the `response`, the `deliverables_dir`, and
+  `execute_only: true`, but **no `reward`** and **no `judge_response`**.
+- `aggregate_metrics` returns baseline (reward-free) stats instead of proxying
+  to the judge server.
+
+`execute_only: true` is mutually exclusive with `judge_only`, and **requires**
+`persist_deliverables_dir` to be set to an absolute path — without it nothing is
+saved and the mode is rejected at startup.
+
+```bash
+EXECUTE_ONLY=true \
+PERSIST_DELIVERABLES_DIR=/abs/path/to/output/gdpval/my-model \
+HF_TOKEN=... \
+gym eval run \
+  --model-type vllm_model \
+  --benchmark gdpval \
+  --split benchmark \
+  --output results/gdpval_execute_only.jsonl
+```
+
+The cached deliverables can later be scored with a separate rubric or
+comparison run by pointing the resources server at the same directory — see
+[Judge-Only Mode](#judge-only-mode).
+
 ### Judge-Only Mode
 
 `judge_only` re-scores a set of deliverables that an earlier run already
@@ -184,6 +236,9 @@ Requirements / notes:
   the deliverables to score. The agent raises at startup otherwise.
 - Run judge-only over the same benchmark / `num_repeats` that produced the
   cache so the `task_<id>/repeat_<n>` directories line up.
+- To **resume an interrupted judging pass** (re-judge only the tasks that were
+  not scored yet, skipping the ones already judged), combine `judge_only` with
+  `rerun_incomplete` — see [Task Re-run Mode](#task-re-run-mode).
 
 Enable it via the config key or the `JUDGE_ONLY` env var honored by
 `benchmarks/gdpval/config.yaml`:
@@ -197,6 +252,102 @@ or as a Hydra override:
 
 ```bash
 ++gdpval_stirrup_agent.responses_api_agents.stirrup_agent.judge_only=true
+```
+
+### Task Re-run Mode
+
+`rerun_incomplete` re-runs **only** the tasks that did not finish, without
+paying the (expensive) rollout cost on tasks that already did. It composes with
+all three execution flows: the full rollout+judge run, [task-only
+execution](#task-only-execution-mode) (`execute_only`), and
+[judge-only](#judge-only-mode) (`judge_only`). What "re-run" means depends on
+which flow it is layered on:
+
+| Layered on… | Finished task (finish marker cached) | Unfinished task |
+|-------------|--------------------------------------|-----------------|
+| full rollout+judge | skip rollout; return cached `/verify` if present, else judge once and cache it | roll out again, then judge |
+| `+ execute_only` | skip rollout; return cached deliverable payload as-is (never judged) | roll out again |
+| `+ judge_only` | return cached `/verify` if present, else judge the cached deliverables once and cache it (no rollout in either case) | reported `skipped` (no deliverables to judge) |
+
+The per-task cache at
+`persist_deliverables_dir/task_<task_id>/repeat_<rollout_index>/` is the source
+of truth for "did this task finish". A task counts as **finished** once it has
+persisted the finish marker `finish_params.json`. That file is written only
+*after* the Stirrup session runs to completion, so its presence definitively
+means the agent loop reached the end. A finished task is **not** re-run even
+when it produced **no deliverable files**: that means the model was simply
+unable to make a deliverable (a finished, typically low-scoring outcome), not
+that the run was cut short. Deliverable files (and the `history.*` /
+`metadata.json` artifacts), when present, are still used to score the task and
+collect run metadata — they just aren't what decides whether the task finished.
+
+For each task:
+
+- **Already finished** (a finish marker is cached) → the Stirrup rollout is
+  **skipped**. In `execute_only` mode the cached payload is returned as-is. In
+  the full mode, a task that was **already judged** returns its cached `/verify`
+  result directly (no rollout *and* no judge call); a finished task that was
+  never successfully judged is scored via `/verify` once (whether or not it has
+  deliverables), and that judgement is cached for next time. The judgement is
+  stored as a sibling file (`task_<id>/repeat_<n>_verify_response.json`), never
+  inside the deliverables directory, so it cannot leak into the judge's input.
+- **Never finished** (no finish marker — killed, OOM, or crashed before
+  persisting) → the task is rolled out again. If the fresh rollout *still* does
+  not persist a finish marker, the result is routed as a retryable `incomplete`
+  failure to the failures sidecar (`<output>_failures.jsonl`) instead of the
+  main rollouts JSONL, so it is not mistaken for a success.
+
+Combine it with `--resume` (`resume_from_cache`) to re-dispatch *only* the
+unfinished tasks across runs: successes stay gated out of the main JSONL while
+`incomplete` sidecar rows are retried up to `NEMO_GYM_MAX_ROLLOUT_ATTEMPTS`
+(default 3). To give tasks that already exhausted that budget another shot on a
+re-run, raise the cap (e.g. `NEMO_GYM_MAX_ROLLOUT_ATTEMPTS=6`) — tasks are gated
+only once their recorded attempt count reaches the cap, so a higher value
+re-dispatches them.
+
+**Combined with `judge_only`**, `rerun_incomplete` resumes an interrupted
+judging pass: a task that already has a cached `/verify` result is returned
+as-is, and only tasks whose judgement was never cached are (re-)scored. (A task
+with no cached deliverables to judge is still reported `skipped`, as in plain
+judge-only mode.) Use this to finish judging a deliverable set without
+re-judging the tasks that were already scored.
+
+Requirements / notes:
+
+- `persist_deliverables_dir` must be set (and absolute) — it is the cache the
+  finish-marker / cached-judgement checks read. The agent raises at startup
+  otherwise.
+- Point at the same `persist_deliverables_dir` the original run used so the
+  `task_<id>/repeat_<n>` directories line up.
+
+```bash
+# Re-run only the GDPVal tasks that didn't finish, then judge them.
+RERUN_INCOMPLETE=true \
+PERSIST_DELIVERABLES_DIR=/abs/path/to/output/gdpval/my-model \
+HF_TOKEN=... JUDGE_API_KEY=... \
+gym eval run \
+  --model-type vllm_model \
+  --benchmark gdpval \
+  --split benchmark \
+  --resume \
+  --output results/gdpval.jsonl
+```
+
+To instead **finish an interrupted judging pass** — re-judge only the tasks
+that were never scored, without re-running any rollout or re-judging the ones
+already cached — layer `rerun_incomplete` on top of `judge_only`:
+
+```bash
+# Judge only the GDPVal deliverables that don't yet have a cached judgement.
+RERUN_INCOMPLETE=true JUDGE_ONLY=true \
+PERSIST_DELIVERABLES_DIR=/abs/path/to/output/gdpval/my-model \
+JUDGE_API_KEY=... \
+gym eval run \
+  --model-type vllm_model \
+  --benchmark gdpval \
+  --split benchmark \
+  --resume \
+  --output results/gdpval.jsonl
 ```
 
 ### Apptainer Sandboxing
@@ -245,41 +396,6 @@ for the full recipe.
 To give the agent web access (some GDPVal tasks benefit from fresh facts), set
 `TAVILY_API_KEY` in the environment. The agent automatically exposes `web_search` and
 `web_fetch` tools backed by the [Tavily Search API](https://tavily.com).
-
-### Task-Only Execution Mode
-
-Sometimes you want to *run* the tasks and keep their deliverables without judging
-them — e.g. to build a reference set for later pairwise comparison, to defer
-scoring to a separate pass, or to inspect raw model outputs. Set `execute_only:
-true` (or export `EXECUTE_ONLY=true` with the benchmark config) to do exactly
-that:
-
-- Each task runs through the Stirrup agent and its deliverables are cached to
-  `persist_deliverables_dir/task_<task_id>/repeat_<n>/` (the same layout used by
-  comparison mode's `reference_deliverables_dir`).
-- The judge `/verify` call is **skipped entirely** — no judgement is made or
-  sent, and no LLM-judge tokens are spent.
-- Each rollout row carries the `response`, the `deliverables_dir`, and
-  `execute_only: true`, but **no `reward`** and **no `judge_response`**.
-- `aggregate_metrics` returns baseline (reward-free) stats instead of proxying
-  to the judge server.
-
-`execute_only: true` **requires** `persist_deliverables_dir` to be set to an
-absolute path — without it nothing is saved and the mode is rejected at startup.
-
-```bash
-EXECUTE_ONLY=true \
-PERSIST_DELIVERABLES_DIR=/abs/path/to/output/gdpval/my-model \
-HF_TOKEN=... \
-gym eval run \
-  --model-type vllm_model \
-  --benchmark gdpval \
-  --split benchmark \
-  --output results/gdpval_execute_only.jsonl
-```
-
-The cached deliverables can later be scored with a separate rubric or
-comparison run by pointing the resources server at the same directory.
 
 ## Extending to New Tasks
 

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -131,6 +131,49 @@ _USER_CODE_PATH_SUBSTRINGS = (
     "/stirrup/",
 )
 
+# Bookkeeping artifact ``_run_stirrup_agent`` persists into the task directory
+# *immediately after* a Stirrup session runs to completion (see the
+# ``persist_deliverables_dir`` block). Its presence is the signal that the
+# rollout finished: the persist block only runs once ``session.run()`` has
+# returned, so a task dir containing this file definitively reached the end of
+# its agent loop — whether or not it managed to produce a deliverable.
+_FINISH_MARKER_FILE = "finish_params.json"
+
+
+def _task_finished(deliverables_dir: Optional[str]) -> bool:
+    """Return True if the task's rollout ran to completion.
+
+    Finishing is signaled solely by ``finish_params.json``, the bookkeeping
+    artifact ``_run_stirrup_agent`` persists right after a Stirrup session
+    completes. A finished task is NOT re-run even when it produced no deliverable
+    files: the model simply could not make a deliverable, which is a legitimate
+    (typically low-scoring) outcome rather than an unfinished run. Only a task
+    that never persisted ``finish_params.json`` — killed by Slurm/OOM, or crashed
+    before the persist block ran — is treated as incomplete and re-dispatched by
+    ``rerun_incomplete``.
+    """
+    if not deliverables_dir:
+        return False
+    root = Path(deliverables_dir)
+    if not root.is_dir():
+        return False
+    return (root / _FINISH_MARKER_FILE).is_file()
+
+
+def _verify_cache_path(deliverables_dir: Optional[str]) -> Optional[Path]:
+    """Path of the cached ``/verify`` result for a task+repeat.
+
+    Stored as a *sibling* of the deliverables directory (e.g. next to
+    ``repeat_0/``, not inside it) so it is never picked up by the resources
+    server, which reads every file *inside* ``deliverables_dir`` as deliverable
+    content. ``rerun_incomplete`` uses this so an already-judged task can return
+    its cached judgement instead of being re-judged.
+    """
+    if not deliverables_dir:
+        return None
+    d = Path(deliverables_dir)
+    return d.parent / f"{d.name}_verify_response.json"
+
 
 def _has_user_code_frame(exc: BaseException) -> bool:
     """Return True iff *exc* (or any cause/context in its chain) has a
@@ -764,6 +807,26 @@ class StirrupAgentWrapperConfig(BaseResponsesAPIAgentConfig):
         "deliverable set produced by an earlier run without paying the rollout cost again. "
         "Mutually exclusive with execute_only.",
     )
+    rerun_incomplete: bool = Field(
+        default=False,
+        description="Task re-run mode. When True, the per-task cache under "
+        "persist_deliverables_dir/task_<task_id>/repeat_<rollout_index>/ is the source of truth "
+        "for whether a task already FINISHED. A task counts as finished once it has persisted the "
+        "finish marker finish_params.json, which only happens after "
+        "its Stirrup session ran to completion — even if the model produced no deliverable files "
+        "(that is a finished, legitimately low-scoring outcome, not an unfinished run). For each "
+        "task: if it already finished, the (expensive) Stirrup rollout is SKIPPED — in the full "
+        "rollout+judge mode an already-judged task returns its cached /verify result and an "
+        "un-judged one is scored once, while in execute_only mode the cached payload is returned "
+        "as-is. If the task never finished (no finish marker), it is rolled out again; should the "
+        "fresh rollout still not persist a finish marker, the result is routed as a retryable "
+        "'incomplete' failure (sidecar, not the main rollouts jsonl) so a subsequent "
+        "resume_from_cache run re-dispatches only those tasks. This lets you re-run just the tasks "
+        "that did not finish without redoing rollouts on every task. Combined with judge_only, it "
+        "instead re-judges only the tasks whose judgement was not cached previously (tasks with a "
+        "cached /verify result are returned as-is). Requires persist_deliverables_dir; works with "
+        "the full rollout+judge mode, execute_only, and judge_only.",
+    )
     model_id: Optional[str] = Field(
         default=None,
         description="HuggingFace model ID (or local checkpoint path) used to load a tokenizer "
@@ -892,6 +955,39 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
             print(
                 "Stirrup agent running in judge_only mode: tasks will NOT be executed; the resources "
                 f"server will score cached deliverables under {self.config.persist_deliverables_dir!r}.",
+                flush=True,
+            )
+        # rerun_incomplete drives off the per-task cache, so it needs a populated
+        # persist_deliverables_dir to read from.
+        if self.config.rerun_incomplete and not self.config.persist_deliverables_dir:
+            raise ValueError(
+                "rerun_incomplete=True requires persist_deliverables_dir to be set — the per-task "
+                "finish marker / cached judgement there is the source of truth for what still needs "
+                "running."
+            )
+        if self.config.rerun_incomplete and self.config.judge_only:
+            print(
+                "Stirrup agent running in rerun_incomplete + judge_only mode: tasks that already have "
+                f"a cached judge result under {self.config.persist_deliverables_dir!r} are returned "
+                "as-is; only tasks whose judgement was not cached are (re-)scored via /verify.",
+                flush=True,
+            )
+        elif self.config.rerun_incomplete and self.config.execute_only:
+            print(
+                "Stirrup agent running in rerun_incomplete + execute_only (task-only) mode: for each "
+                f"task that already finished (a finish marker is cached under "
+                f"{self.config.persist_deliverables_dir!r}) the agent will skip the rollout and return "
+                "its cached deliverables without judging; tasks that never finished are rolled out "
+                "again.",
+                flush=True,
+            )
+        elif self.config.rerun_incomplete:
+            print(
+                "Stirrup agent running in rerun_incomplete mode: for each task that already finished "
+                f"(a finish marker is cached under {self.config.persist_deliverables_dir!r}) the agent "
+                "skips the rollout and, if a cached judge result already exists, returns it as-is; "
+                "only finished tasks without a cached judgement are scored via the judge (/verify). "
+                "Tasks that never finished are rolled out again and then judged.",
                 flush=True,
             )
         print(f"Stirrup agent initialized with task={self.config.task!r}", flush=True)
@@ -1099,6 +1195,52 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                         skipped=True,
                         error_class="skipped",
                     )
+                # rerun_incomplete + judge_only: skip tasks already judged. If a
+                # cached /verify result exists, return it directly instead of
+                # re-running the judge; otherwise fall through to /verify (which
+                # caches the fresh judgement so the next pass skips it).
+                if self.config.rerun_incomplete:
+                    cached_verify = self._read_cached_verify(deliverables_dir)
+                    if cached_verify is not None:
+                        task_info = self.task_strategy.extract_task_info(existing_metadata)
+                        instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
+                        print(
+                            f"[stirrup-judge_only-cached-judgement] {instance_hint}: returning cached "
+                            f"/verify result; skipping judge.",
+                            flush=True,
+                        )
+                        return cached_verify
+                response_clean = self._build_judge_only_response(existing_metadata, fixed_params.model)
+                response_metadata = {}
+            elif self.config.rerun_incomplete and _task_finished(deliverables_dir):
+                # Task re-run mode: this task already ran to completion (a finish
+                # marker is cached), so skip the (expensive) Stirrup rollout and
+                # reuse what is on disk — even if the model produced no deliverable
+                # files (that is a finished, legitimately low-scoring outcome, not
+                # an unfinished run). In execute_only mode the cached payload is
+                # returned as-is below. In the full rollout+judge mode, if the task
+                # was already judged (a cached /verify result exists), return that
+                # judgement directly so it is NOT re-judged; otherwise score the
+                # cached deliverable via /verify once (using the same placeholder
+                # response path judge_only uses, since no fresh model output
+                # exists) and cache the result for next time.
+                task_info = self.task_strategy.extract_task_info(existing_metadata)
+                instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
+                if not self.config.execute_only:
+                    cached_verify = self._read_cached_verify(deliverables_dir)
+                    if cached_verify is not None:
+                        print(
+                            f"[stirrup-rerun_incomplete-cached-judgement] {instance_hint}: returning cached "
+                            f"/verify result; skipping rollout and judge.",
+                            flush=True,
+                        )
+                        return cached_verify
+                print(
+                    f"[stirrup-rerun_incomplete-reuse] {instance_hint}: task already finished at "
+                    f"{deliverables_dir}; skipping rollout"
+                    f"{'' if self.config.execute_only else ' (will judge cached deliverable)'}.",
+                    flush=True,
+                )
                 response_clean = self._build_judge_only_response(existing_metadata, fixed_params.model)
                 response_metadata = {}
             else:
@@ -1124,6 +1266,35 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
 
                 response_clean = response.model_copy(update={"metadata": None})
                 response_metadata = response.metadata or {}
+
+                # Task re-run mode: if the fresh rollout returned but never
+                # persisted a finish marker (e.g. the persist block was
+                # interrupted), the task did not actually finish. Route the result
+                # as a retryable 'incomplete' failure (written to the failures
+                # sidecar, not the main rollouts jsonl) so a subsequent
+                # resume_from_cache run re-dispatches just this task. A rollout
+                # that finished but produced no deliverable is NOT incomplete — it
+                # finished, so it falls through to the normal verify/success path.
+                # Only applies when the cache location is determinable
+                # (deliverables_dir set); without it we cannot tell and fall back
+                # to the normal success path.
+                if (
+                    self.config.rerun_incomplete
+                    and deliverables_dir is not None
+                    and not _task_finished(deliverables_dir)
+                ):
+                    task_info = self.task_strategy.extract_task_info(existing_metadata)
+                    instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
+                    reason = f"rerun_incomplete: rollout did not persist a finish marker at {deliverables_dir}"
+                    print(f"[stirrup-incomplete] {instance_hint}: {reason}", flush=True)
+                    return self._build_failed_run_payload(
+                        body_dict=body_dict,
+                        fixed_params=fixed_params,
+                        task_info=task_info,
+                        reason=reason,
+                        skipped=False,
+                        error_class="incomplete",
+                    )
 
             # Task-only execution mode: the deliverables are already cached to
             # ``deliverables_dir`` by ``responses()``. Skip the /verify judge
@@ -1154,7 +1325,13 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     cookies=cookies,
                 )
                 await raise_for_status(verify_response)
-                return await get_response_json(verify_response)
+                verify_result = await get_response_json(verify_response)
+                # Task re-run mode: cache the judgement next to the deliverables
+                # so a subsequent rerun_incomplete pass returns it instead of
+                # re-judging this task.
+                if self.config.rerun_incomplete:
+                    self._write_cached_verify(deliverables_dir, verify_result)
+                return verify_result
             except Exception as exc:
                 task_info = self.task_strategy.extract_task_info(existing_metadata)
                 failure_class = _classify_verify_failure(exc)
@@ -1171,6 +1348,43 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     skipped=False,
                     error_class=failure_class,
                 )
+
+    def _read_cached_verify(self, deliverables_dir: Optional[str]) -> Optional[Dict[str, Any]]:
+        """Return the cached ``/verify`` result for *deliverables_dir*, or None.
+
+        Used by ``rerun_incomplete`` to skip re-judging a task that was already
+        judged. Returns None on a missing or unreadable cache (the task is then
+        judged afresh).
+        """
+        cache_path = _verify_cache_path(deliverables_dir)
+        if cache_path is None or not cache_path.is_file():
+            return None
+        try:
+            import json as _json
+
+            with cache_path.open("r", encoding="utf-8") as f:
+                return _json.load(f)
+        except Exception as exc:
+            print(f"[stirrup] warning: could not read cached verify result {cache_path}: {exc}", flush=True)
+            return None
+
+    def _write_cached_verify(self, deliverables_dir: Optional[str], verify_result: Dict[str, Any]) -> None:
+        """Persist *verify_result* next to *deliverables_dir* (best-effort).
+
+        Stored as a sibling file so it is never read by the resources server as
+        deliverable content. Failures are logged but never abort the run.
+        """
+        cache_path = _verify_cache_path(deliverables_dir)
+        if cache_path is None:
+            return
+        try:
+            import json as _json
+
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            with cache_path.open("w", encoding="utf-8") as f:
+                _json.dump(verify_result, f)
+        except Exception as exc:
+            print(f"[stirrup] warning: could not write cached verify result {cache_path}: {exc}", flush=True)
 
     def _build_judge_only_response(
         self,
@@ -1231,8 +1445,9 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
           resume's set-difference on the main jsonl re-dispatches the task.
         - ``_ng_failure_terminal=True`` for ``timeout_exceeded`` / ``skipped``:
           one sidecar entry, never retried.
-        - Otherwise (``legitimate``, ``transient``): sidecar entry per attempt;
-          retried up to ``NEMO_GYM_MAX_ROLLOUT_ATTEMPTS`` on chain resume.
+        - Otherwise (``legitimate``, ``transient``, ``incomplete``): sidecar
+          entry per attempt; retried up to ``NEMO_GYM_MAX_ROLLOUT_ATTEMPTS`` on
+          chain resume.
         """
         if error_class == "timeout_exceeded":
             suffix = "timeout"
@@ -1240,6 +1455,11 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         elif error_class == "kill_shaped":
             suffix = "killed"
             status_word = "Killed"
+        elif error_class == "incomplete":
+            # rerun_incomplete produced no valid deliverable. Not terminal: a
+            # resume_from_cache run re-dispatches it (capped by max_attempts).
+            suffix = "incomplete"
+            status_word = "Incomplete"
         elif skipped or error_class == "skipped":
             suffix = "skipped"
             status_word = "Skipped"
@@ -1285,8 +1505,9 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
             elif error_class in ("timeout_exceeded", "skipped"):
                 # Sidecar entry written once; chain-hop 2 will not retry.
                 payload[NG_TERMINAL_KEY] = True
-            # 'legitimate' / 'transient': sidecar entry per attempt; retried
-            # by chain-hop up to NEMO_GYM_MAX_ROLLOUT_ATTEMPTS (default 3).
+            # 'legitimate' / 'transient' / 'incomplete': sidecar entry per
+            # attempt; retried by chain-hop / resume up to
+            # NEMO_GYM_MAX_ROLLOUT_ATTEMPTS (default 3).
         return payload
 
     async def aggregate_metrics(self, body: AggregateMetricsRequest = Body()) -> AggregateMetrics:

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -22,6 +22,7 @@ construction, scoring, response building) is delegated to a
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import os
 import shutil
 import sys
@@ -29,7 +30,7 @@ import tempfile
 import time
 from asyncio import Semaphore
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import ray
 from fastapi import Request
@@ -160,7 +161,27 @@ def _task_finished(deliverables_dir: Optional[str]) -> bool:
     return (root / _FINISH_MARKER_FILE).is_file()
 
 
-def _verify_cache_path(deliverables_dir: Optional[str]) -> Optional[Path]:
+def _reference_set_key(reference_ids: Optional[Sequence[str]]) -> Optional[str]:
+    """Stable short key identifying a judgement's reference set, or None.
+
+    A GDPVal judgement is only valid for the exact reference subset it scored
+    against, and multi-stage ELO judges the *same* deliverable against a
+    *different* subset each stage. So a cached judgement must be keyed by that
+    subset. Returns a short hex digest of the sorted, de-duplicated
+    ``reference_ids`` (order-independent), or ``None`` when no references are in
+    play (rubric mode, or comparison mode where every request scores against the
+    same fixed set — a single unkeyed cache slot is correct there).
+    """
+    if not reference_ids:
+        return None
+    normalized = ",".join(sorted({str(r) for r in reference_ids}))
+    return hashlib.sha1(normalized.encode()).hexdigest()[:12]
+
+
+def _verify_cache_path(
+    deliverables_dir: Optional[str],
+    reference_ids: Optional[Sequence[str]] = None,
+) -> Optional[Path]:
     """Path of the cached ``/verify`` result for a task+repeat.
 
     Stored as a *sibling* of the deliverables directory (e.g. next to
@@ -168,11 +189,19 @@ def _verify_cache_path(deliverables_dir: Optional[str]) -> Optional[Path]:
     server, which reads every file *inside* ``deliverables_dir`` as deliverable
     content. ``rerun_incomplete`` uses this so an already-judged task can return
     its cached judgement instead of being re-judged.
+
+    When ``reference_ids`` identify a specific reference subset (multi-stage ELO),
+    the filename is keyed by that subset so each stage's judgement is cached (and
+    reused) independently — a resumed stage that reselects the same references
+    hits the cache, a different subset re-judges. Without references the single
+    ``_verify_response.json`` slot is used (rubric / fixed-reference comparison).
     """
     if not deliverables_dir:
         return None
     d = Path(deliverables_dir)
-    return d.parent / f"{d.name}_verify_response.json"
+    key = _reference_set_key(reference_ids)
+    suffix = f"_verify_response_{key}.json" if key else "_verify_response.json"
+    return d.parent / f"{d.name}{suffix}"
 
 
 def _has_user_code_frame(exc: BaseException) -> bool:
@@ -1182,6 +1211,11 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 and Path(deliverables_dir).is_dir()
                 and any(Path(deliverables_dir).iterdir())
             )
+            # The reference subset this request is judged against (multi-stage ELO
+            # tags each row with the stage's references; empty for rubric / fixed-
+            # reference comparison). A cached judgement is only valid for the exact
+            # subset it scored, so it keys the rerun_incomplete verify cache.
+            reference_ids = body_dict.get("reference_ids") or None
 
             if self.config.judge_only:
                 # Judge-only mode: do NOT run the agent. Score the pre-existing
@@ -1206,11 +1240,12 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                         error_class="skipped",
                     )
                 # rerun_incomplete + judge_only: skip tasks already judged. If a
-                # cached /verify result exists, return it directly instead of
-                # re-running the judge; otherwise fall through to /verify (which
-                # caches the fresh judgement so the next pass skips it).
+                # cached /verify result exists (for this reference subset), return
+                # it directly instead of re-running the judge; otherwise fall
+                # through to /verify (which caches the fresh judgement so the next
+                # pass skips it).
                 if self.config.rerun_incomplete:
-                    cached_verify = self._read_cached_verify(deliverables_dir)
+                    cached_verify = self._read_cached_verify(deliverables_dir, reference_ids)
                     if cached_verify is not None:
                         task_info = self.task_strategy.extract_task_info(existing_metadata)
                         instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
@@ -1229,15 +1264,22 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 # files (that is a finished, legitimately low-scoring outcome, not
                 # an unfinished run). In execute_only mode the cached payload is
                 # returned as-is below. In the full rollout+judge mode, if the task
-                # was already judged (a cached /verify result exists), return that
-                # judgement directly so it is NOT re-judged; otherwise score the
-                # cached deliverable via /verify once (using the same placeholder
-                # response path judge_only uses, since no fresh model output
-                # exists) and cache the result for next time.
+                # was already judged (a cached /verify result exists for this
+                # reference subset), return that judgement directly so it is NOT
+                # re-judged; otherwise score the cached deliverable via /verify once
+                # (using the same placeholder response path judge_only uses, since
+                # no fresh model output exists) and cache the result for next time.
+                #
+                # This also covers multi-stage ELO reuse rows
+                # (reuse_cached_deliverable=True): the cache is keyed by the
+                # request's reference subset, so each stage reuses only a judgement
+                # produced against the SAME references and otherwise re-judges — a
+                # resumed staged run skips only the (task, references) pairs it
+                # already scored.
                 task_info = self.task_strategy.extract_task_info(existing_metadata)
                 instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
                 if not self.config.execute_only:
-                    cached_verify = self._read_cached_verify(deliverables_dir)
+                    cached_verify = self._read_cached_verify(deliverables_dir, reference_ids)
                     if cached_verify is not None:
                         print(
                             f"[stirrup-rerun_incomplete-cached-judgement] {instance_hint}: returning cached "
@@ -1347,11 +1389,13 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 )
                 await raise_for_status(verify_response)
                 verify_result = await get_response_json(verify_response)
-                # Task re-run mode: cache the judgement next to the deliverables
-                # so a subsequent rerun_incomplete pass returns it instead of
-                # re-judging this task.
+                # Task re-run mode: cache the judgement next to the deliverables so
+                # a subsequent rerun_incomplete pass returns it instead of re-judging
+                # this task. The cache is keyed by the reference subset scored, so a
+                # multi-stage ELO run caches each stage's judgement independently
+                # and only replays it for a request against the same references.
                 if self.config.rerun_incomplete:
-                    self._write_cached_verify(deliverables_dir, verify_result)
+                    self._write_cached_verify(deliverables_dir, verify_result, reference_ids)
                 return verify_result
             except Exception as exc:
                 task_info = self.task_strategy.extract_task_info(existing_metadata)
@@ -1370,14 +1414,18 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     error_class=failure_class,
                 )
 
-    def _read_cached_verify(self, deliverables_dir: Optional[str]) -> Optional[Dict[str, Any]]:
+    def _read_cached_verify(
+        self, deliverables_dir: Optional[str], reference_ids: Optional[Sequence[str]] = None
+    ) -> Optional[Dict[str, Any]]:
         """Return the cached ``/verify`` result for *deliverables_dir*, or None.
 
         Used by ``rerun_incomplete`` to skip re-judging a task that was already
-        judged. Returns None on a missing or unreadable cache (the task is then
-        judged afresh).
+        judged. ``reference_ids`` scope the lookup to the judgement produced
+        against that reference subset (multi-stage ELO); omit it for rubric /
+        fixed-reference runs. Returns None on a missing or unreadable cache (the
+        task is then judged afresh).
         """
-        cache_path = _verify_cache_path(deliverables_dir)
+        cache_path = _verify_cache_path(deliverables_dir, reference_ids)
         if cache_path is None or not cache_path.is_file():
             return None
         try:
@@ -1389,13 +1437,20 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
             print(f"[stirrup] warning: could not read cached verify result {cache_path}: {exc}", flush=True)
             return None
 
-    def _write_cached_verify(self, deliverables_dir: Optional[str], verify_result: Dict[str, Any]) -> None:
+    def _write_cached_verify(
+        self,
+        deliverables_dir: Optional[str],
+        verify_result: Dict[str, Any],
+        reference_ids: Optional[Sequence[str]] = None,
+    ) -> None:
         """Persist *verify_result* next to *deliverables_dir* (best-effort).
 
         Stored as a sibling file so it is never read by the resources server as
-        deliverable content. Failures are logged but never abort the run.
+        deliverable content. ``reference_ids`` key the cache to the reference
+        subset scored (multi-stage ELO), so each stage's judgement is cached
+        independently. Failures are logged but never abort the run.
         """
-        cache_path = _verify_cache_path(deliverables_dir)
+        cache_path = _verify_cache_path(deliverables_dir, reference_ids)
         if cache_path is None:
             return
         try:

--- a/responses_api_agents/stirrup_agent/configs/stirrup_gdpval.yaml
+++ b/responses_api_agents/stirrup_agent/configs/stirrup_gdpval.yaml
@@ -47,6 +47,17 @@ stirrup_agent:
       # Mutually exclusive with execute_only.
       judge_only: false
 
+      # Task re-run mode: when true, the per-task deliverable cache is the source
+      # of truth for whether a task already finished with a valid output. Tasks
+      # with a valid cached deliverable skip the (expensive) rollout (re-scored
+      # from cache in full mode, returned as-is in execute_only); tasks without
+      # one are rolled out again, and a fresh rollout that still yields nothing
+      # valid is routed as a retryable 'incomplete' failure so a `--resume` run
+      # re-dispatches just those tasks. Requires persist_deliverables_dir; works
+      # with both full rollout+judge and execute_only; mutually exclusive with
+      # judge_only.
+      rerun_incomplete: false
+
       # Resources server reference (scores deliverables via /verify).
       resources_server:
         type: resources_servers

--- a/responses_api_agents/stirrup_agent/tests/test_app.py
+++ b/responses_api_agents/stirrup_agent/tests/test_app.py
@@ -27,10 +27,15 @@ from nemo_gym.openai_utils import (
 )
 from nemo_gym.server_utils import ServerClient
 from responses_api_agents.stirrup_agent.app import (
+    NG_FAILURE_CLASS_KEY,
+    NG_NO_PERSIST_KEY,
+    NG_TERMINAL_KEY,
     StirrupAgentWrapper,
     StirrupAgentWrapperConfig,
     StirrupRunRequest,
     _load_task_registry,
+    _task_finished,
+    _verify_cache_path,
     get_task_strategy,
 )
 from responses_api_agents.stirrup_agent.nemo_agent import NeMoUserMessage
@@ -42,7 +47,11 @@ STIRRUP_AGENT_DIR = Path(__file__).resolve().parent.parent
 
 
 def _make_config(
-    *, execute_only: bool = False, judge_only: bool = False, persist_deliverables_dir=None
+    *,
+    execute_only: bool = False,
+    judge_only: bool = False,
+    rerun_incomplete: bool = False,
+    persist_deliverables_dir=None,
 ) -> StirrupAgentWrapperConfig:
     return StirrupAgentWrapperConfig(
         host="0.0.0.0",
@@ -54,7 +63,31 @@ def _make_config(
         resources_server=ResourcesServerRef(type="resources_servers", name="gdpval_resources_server"),
         execute_only=execute_only,
         judge_only=judge_only,
+        rerun_incomplete=rerun_incomplete,
         persist_deliverables_dir=persist_deliverables_dir,
+    )
+
+
+def _fake_response(response_id: str = "gdpval-task-1") -> NeMoGymResponse:
+    """A minimal completed NeMoGymResponse for patching ``responses()``."""
+    return NeMoGymResponse(
+        id=response_id,
+        created_at=0,
+        model="policy",
+        object="response",
+        output=[
+            NeMoGymResponseOutputMessage(
+                id="msg-1",
+                content=[NeMoGymResponseOutputText(type="output_text", text="done", annotations=[])],
+                role="assistant",
+                status="completed",
+                type="message",
+            )
+        ],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+        metadata={"elapsed_seconds": "5.0"},
     )
 
 
@@ -256,6 +289,365 @@ class TestJudgeOnlyMode:
         assert verify_calls == []
         assert result["skipped"] is True
         assert result["reward"] == 0.0
+
+
+class TestTaskFinished:
+    def test_none_dir_is_unfinished(self) -> None:
+        assert _task_finished(None) is False
+
+    def test_missing_dir_is_unfinished(self, tmp_path) -> None:
+        assert _task_finished(str(tmp_path / "does-not-exist")) is False
+
+    def test_empty_dir_is_unfinished(self, tmp_path) -> None:
+        assert _task_finished(str(tmp_path)) is False
+
+    def test_finish_params_alone_counts_as_finished(self, tmp_path) -> None:
+        """A finish marker means the rollout completed even with NO deliverable —
+        the model just couldn't make one, so the task is finished, not re-run."""
+        (tmp_path / "finish_params.json").write_text("{}")
+        assert _task_finished(str(tmp_path)) is True
+
+    def test_history_file_alone_is_unfinished(self, tmp_path) -> None:
+        """Only finish_params.json marks completion; history/metadata files alone
+        (e.g. partial persist, or a crash mid-persist) do not."""
+        (tmp_path / "history.json").write_text("[]")
+        (tmp_path / "history.pkl").write_bytes(b"")
+        assert _task_finished(str(tmp_path)) is False
+
+    def test_metadata_file_alone_is_unfinished(self, tmp_path) -> None:
+        (tmp_path / "metadata.json").write_text("{}")
+        assert _task_finished(str(tmp_path)) is False
+
+    def test_finished_with_deliverable_is_finished(self, tmp_path) -> None:
+        (tmp_path / "finish_params.json").write_text("{}")
+        (tmp_path / "report.docx").write_text("the deliverable")
+        assert _task_finished(str(tmp_path)) is True
+
+    def test_deliverable_without_finish_marker_is_unfinished(self, tmp_path) -> None:
+        """Deliverable files but no finish marker (e.g. persist interrupted) means
+        the rollout did not actually finish."""
+        (tmp_path / "report.docx").write_text("the deliverable")
+        assert _task_finished(str(tmp_path)) is False
+
+
+class TestRerunIncompleteMode:
+    def test_rerun_incomplete_requires_persist_dir(self) -> None:
+        config = _make_config(rerun_incomplete=True, persist_deliverables_dir=None)
+        with pytest.raises(ValueError, match="rerun_incomplete=True requires persist_deliverables_dir"):
+            StirrupAgentWrapper(config=config, server_client=MagicMock(spec=ServerClient))
+
+    def test_rerun_incomplete_and_judge_only_is_allowed(self, tmp_path) -> None:
+        """rerun_incomplete + judge_only is a valid combination (resume judging)."""
+        config = _make_config(rerun_incomplete=True, judge_only=True, persist_deliverables_dir=str(tmp_path))
+        StirrupAgentWrapper(config=config, server_client=MagicMock(spec=ServerClient))
+
+    def _make_body(self, task_id: str = "task-1") -> StirrupRunRequest:
+        params = NeMoGymResponseCreateParamsNonStreaming(
+            input="ignored",
+            metadata={"task_id": task_id, "prompt": "do the thing", "_ng_rollout_index": "0"},
+        )
+        return StirrupRunRequest(responses_create_params=params, task_id=task_id, prompt="do the thing")
+
+    @pytest.mark.asyncio
+    async def test_full_mode_finished_task_skips_rollout_and_verifies(self, tmp_path) -> None:
+        """A finished task (finish marker cached) must NOT run the agent and must
+        re-score the cached deliverable via /verify."""
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "finish_params.json").write_text("{}")
+        (deliverables_root / "report.docx").write_text("cached deliverable")
+
+        config = _make_config(rerun_incomplete=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        request = MagicMock()
+        request.cookies = {}
+
+        responses_mock = AsyncMock()
+        with (
+            patch.object(StirrupAgentWrapper, "responses", responses_mock),
+            patch("responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()),
+            patch(
+                "responses_api_agents.stirrup_agent.app.get_response_json",
+                AsyncMock(return_value={"reward": 0.7, "judge_response": "ok"}),
+            ),
+        ):
+            result = await wrapper.run(request, self._make_body())
+
+        responses_mock.assert_not_awaited()
+        verify_calls = [c for c in server_client.post.await_args_list if c.kwargs.get("url_path") == "/verify"]
+        assert len(verify_calls) == 1
+        assert verify_calls[0].kwargs["json"]["deliverables_dir"].endswith(str(Path("task_task-1") / "repeat_0"))
+        assert result == {"reward": 0.7, "judge_response": "ok"}
+
+        # The judgement must be cached as a sibling file (NOT inside the
+        # deliverables dir, so it can't leak into the judge's input).
+        cache_path = _verify_cache_path(str(deliverables_root))
+        assert cache_path == tmp_path / "task_task-1" / "repeat_0_verify_response.json"
+        assert json.loads(cache_path.read_text()) == {"reward": 0.7, "judge_response": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_full_mode_already_judged_returns_cached_judgement(self, tmp_path) -> None:
+        """A finished task AND a cached /verify result must return that judgement
+        directly — no rollout and no /verify call."""
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "finish_params.json").write_text("{}")
+        (deliverables_root / "report.docx").write_text("cached deliverable")
+        cache_path = _verify_cache_path(str(deliverables_root))
+        cache_path.write_text(json.dumps({"reward": 0.55, "judge_response": "prior"}))
+
+        config = _make_config(rerun_incomplete=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        request = MagicMock()
+        request.cookies = {}
+
+        responses_mock = AsyncMock()
+        with patch.object(StirrupAgentWrapper, "responses", responses_mock):
+            result = await wrapper.run(request, self._make_body())
+
+        responses_mock.assert_not_awaited()
+        verify_calls = [c for c in server_client.post.await_args_list if c.kwargs.get("url_path") == "/verify"]
+        assert verify_calls == []
+        assert result == {"reward": 0.55, "judge_response": "prior"}
+
+    @pytest.mark.asyncio
+    async def test_full_mode_no_finish_marker_routes_incomplete(self, tmp_path) -> None:
+        """When the fresh rollout persists no finish marker, run() returns a
+        retryable 'incomplete' failure routed to the sidecar (not terminal, not
+        no-persist) and never reaches /verify."""
+        config = _make_config(rerun_incomplete=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(side_effect=RuntimeError("no server in unit test"))
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        request = MagicMock()
+        request.cookies = {}
+
+        # responses() returns but writes nothing to disk (no finish marker persisted).
+        with patch.object(StirrupAgentWrapper, "responses", AsyncMock(return_value=_fake_response())):
+            result = await wrapper.run(request, self._make_body())
+
+        for call in server_client.post.await_args_list:
+            assert call.kwargs.get("url_path") == "/seed_session"
+        assert result[NG_FAILURE_CLASS_KEY] == "incomplete"
+        assert result["error_class"] == "incomplete"
+        assert result["reward"] == 0.0
+        assert result["skipped"] is False
+        assert NG_TERMINAL_KEY not in result
+        assert NG_NO_PERSIST_KEY not in result
+
+    @pytest.mark.asyncio
+    async def test_full_mode_fresh_finished_rollout_verifies(self, tmp_path) -> None:
+        """When the fresh rollout finishes (persists a finish marker), the normal
+        /verify path runs (no 'incomplete' routing)."""
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+
+        config = _make_config(rerun_incomplete=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        request = MagicMock()
+        request.cookies = {}
+
+        async def _responses_side_effect(*_args, **_kwargs):
+            # Mimic the Ray worker persisting a finish marker + deliverable.
+            deliverables_root.mkdir(parents=True, exist_ok=True)
+            (deliverables_root / "finish_params.json").write_text("{}")
+            (deliverables_root / "report.docx").write_text("fresh deliverable")
+            return _fake_response()
+
+        with (
+            patch.object(StirrupAgentWrapper, "responses", AsyncMock(side_effect=_responses_side_effect)),
+            patch("responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()),
+            patch(
+                "responses_api_agents.stirrup_agent.app.get_response_json",
+                AsyncMock(return_value={"reward": 0.4}),
+            ),
+        ):
+            result = await wrapper.run(request, self._make_body())
+
+        verify_calls = [c for c in server_client.post.await_args_list if c.kwargs.get("url_path") == "/verify"]
+        assert len(verify_calls) == 1
+        assert result == {"reward": 0.4}
+
+    @pytest.mark.asyncio
+    async def test_full_mode_finished_without_deliverable_is_judged_not_rerun(self, tmp_path) -> None:
+        """The model finished but made no deliverable: the task is NOT re-run; the
+        fresh rollout's result is judged via /verify like any finished task."""
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+
+        config = _make_config(rerun_incomplete=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        request = MagicMock()
+        request.cookies = {}
+
+        async def _responses_side_effect(*_args, **_kwargs):
+            # Finished (finish marker persisted) but produced NO deliverable file.
+            deliverables_root.mkdir(parents=True, exist_ok=True)
+            (deliverables_root / "finish_params.json").write_text('{"reason": "could not produce file"}')
+            (deliverables_root / "history.json").write_text("[]")
+            return _fake_response()
+
+        with (
+            patch.object(StirrupAgentWrapper, "responses", AsyncMock(side_effect=_responses_side_effect)),
+            patch("responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()),
+            patch(
+                "responses_api_agents.stirrup_agent.app.get_response_json",
+                AsyncMock(return_value={"reward": 0.0, "judge_response": "no deliverable"}),
+            ),
+        ):
+            result = await wrapper.run(request, self._make_body())
+
+        # Not routed as 'incomplete' — it finished, so it is judged normally.
+        assert NG_FAILURE_CLASS_KEY not in result
+        verify_calls = [c for c in server_client.post.await_args_list if c.kwargs.get("url_path") == "/verify"]
+        assert len(verify_calls) == 1
+        assert result == {"reward": 0.0, "judge_response": "no deliverable"}
+
+    @pytest.mark.asyncio
+    async def test_full_mode_finished_without_deliverable_cache_reused(self, tmp_path) -> None:
+        """A previously finished task with only a finish marker (no deliverable)
+        skips the rollout and is judged from cache — it is not re-run."""
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "finish_params.json").write_text('{"reason": "abandoned"}')
+
+        config = _make_config(rerun_incomplete=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        request = MagicMock()
+        request.cookies = {}
+
+        responses_mock = AsyncMock()
+        with (
+            patch.object(StirrupAgentWrapper, "responses", responses_mock),
+            patch("responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()),
+            patch(
+                "responses_api_agents.stirrup_agent.app.get_response_json",
+                AsyncMock(return_value={"reward": 0.0}),
+            ),
+        ):
+            result = await wrapper.run(request, self._make_body())
+
+        responses_mock.assert_not_awaited()
+        verify_calls = [c for c in server_client.post.await_args_list if c.kwargs.get("url_path") == "/verify"]
+        assert len(verify_calls) == 1
+        assert result == {"reward": 0.0}
+
+    @pytest.mark.asyncio
+    async def test_execute_only_finished_skips_rollout(self, tmp_path) -> None:
+        """rerun_incomplete + execute_only: a finished task (finish marker cached)
+        returns the payload without running the agent or judging."""
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "finish_params.json").write_text("{}")
+        (deliverables_root / "report.docx").write_text("cached deliverable")
+
+        config = _make_config(rerun_incomplete=True, execute_only=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(side_effect=RuntimeError("no server in unit test"))
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        request = MagicMock()
+        request.cookies = {}
+
+        responses_mock = AsyncMock()
+        with patch.object(StirrupAgentWrapper, "responses", responses_mock):
+            result = await wrapper.run(request, self._make_body())
+
+        responses_mock.assert_not_awaited()
+        for call in server_client.post.await_args_list:
+            assert call.kwargs.get("url_path") == "/seed_session"
+        assert result["execute_only"] is True
+        assert "reward" not in result
+        assert result["deliverables_dir"].endswith(str(Path("task_task-1") / "repeat_0"))
+
+    @pytest.mark.asyncio
+    async def test_execute_only_no_finish_marker_routes_incomplete(self, tmp_path) -> None:
+        """rerun_incomplete + execute_only: a fresh rollout that persists no finish
+        marker is routed as 'incomplete' rather than a success payload."""
+        config = _make_config(rerun_incomplete=True, execute_only=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(side_effect=RuntimeError("no server in unit test"))
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        request = MagicMock()
+        request.cookies = {}
+
+        with patch.object(StirrupAgentWrapper, "responses", AsyncMock(return_value=_fake_response())):
+            result = await wrapper.run(request, self._make_body())
+
+        assert result.get("execute_only") is not True
+        assert result[NG_FAILURE_CLASS_KEY] == "incomplete"
+        assert result["reward"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_judge_only_already_judged_returns_cached_judgement(self, tmp_path) -> None:
+        """rerun_incomplete + judge_only: a task whose judgement is already cached
+        is returned as-is — the judge is NOT re-run."""
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "report.docx").write_text("cached deliverable")
+        _verify_cache_path(str(deliverables_root)).write_text(json.dumps({"reward": 0.8, "judge_response": "prior"}))
+
+        config = _make_config(rerun_incomplete=True, judge_only=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        request = MagicMock()
+        request.cookies = {}
+
+        with patch.object(StirrupAgentWrapper, "responses", AsyncMock()):
+            result = await wrapper.run(request, self._make_body())
+
+        verify_calls = [c for c in server_client.post.await_args_list if c.kwargs.get("url_path") == "/verify"]
+        assert verify_calls == []
+        assert result == {"reward": 0.8, "judge_response": "prior"}
+
+    @pytest.mark.asyncio
+    async def test_judge_only_unjudged_task_is_judged_and_cached(self, tmp_path) -> None:
+        """rerun_incomplete + judge_only: a task with deliverables but no cached
+        judgement is scored via /verify, and that judgement is cached."""
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "report.docx").write_text("cached deliverable")
+
+        config = _make_config(rerun_incomplete=True, judge_only=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        request = MagicMock()
+        request.cookies = {}
+
+        with (
+            patch.object(StirrupAgentWrapper, "responses", AsyncMock()),
+            patch("responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()),
+            patch(
+                "responses_api_agents.stirrup_agent.app.get_response_json",
+                AsyncMock(return_value={"reward": 0.3, "judge_response": "fresh"}),
+            ),
+        ):
+            result = await wrapper.run(request, self._make_body())
+
+        verify_calls = [c for c in server_client.post.await_args_list if c.kwargs.get("url_path") == "/verify"]
+        assert len(verify_calls) == 1
+        assert result == {"reward": 0.3, "judge_response": "fresh"}
+        cache_path = _verify_cache_path(str(deliverables_root))
+        assert json.loads(cache_path.read_text()) == {"reward": 0.3, "judge_response": "fresh"}
 
 
 class TestExampleDataset:

--- a/responses_api_agents/stirrup_agent/tests/test_app.py
+++ b/responses_api_agents/stirrup_agent/tests/test_app.py
@@ -754,6 +754,7 @@ class TestReuseCachedDeliverable:
         responses_mock.assert_awaited_once()
         assert result == {"reward": 0.5}
 
+
 class TestReferenceKeyedVerifyCache:
     """rerun_incomplete + multi-stage ELO: the cached judgement is keyed by the
     stage's reference subset, so each stage reuses only a judgement produced

--- a/responses_api_agents/stirrup_agent/tests/test_app.py
+++ b/responses_api_agents/stirrup_agent/tests/test_app.py
@@ -754,6 +754,110 @@ class TestReuseCachedDeliverable:
         responses_mock.assert_awaited_once()
         assert result == {"reward": 0.5}
 
+class TestReferenceKeyedVerifyCache:
+    """rerun_incomplete + multi-stage ELO: the cached judgement is keyed by the
+    stage's reference subset, so each stage reuses only a judgement produced
+    against the SAME references (and re-judges otherwise)."""
+
+    def _body(self, reference_ids):
+        params = NeMoGymResponseCreateParamsNonStreaming(
+            input="ignored",
+            metadata={"task_id": "task-1", "prompt": "do the thing", "_ng_rollout_index": "0"},
+        )
+        return StirrupRunRequest(
+            responses_create_params=params,
+            task_id="task-1",
+            prompt="do the thing",
+            reuse_cached_deliverable=True,
+            reference_ids=list(reference_ids),
+        )
+
+    def test_cache_path_is_reference_set_keyed_and_order_independent(self, tmp_path) -> None:
+        d = str(tmp_path / "task_task-1" / "repeat_0")
+        unkeyed = _verify_cache_path(d)
+        bc = _verify_cache_path(d, ["ref_b", "ref_c"])
+        cb = _verify_cache_path(d, ["ref_c", "ref_b"])
+        bd = _verify_cache_path(d, ["ref_b", "ref_d"])
+        # No references ⇒ the single unkeyed slot.
+        assert unkeyed.name == "repeat_0_verify_response.json"
+        # Reference sets get distinct, order-independent slots.
+        assert bc == cb
+        assert bc != unkeyed
+        assert bc != bd
+
+    @pytest.mark.asyncio
+    async def test_same_reference_set_reuses_cached_judgement(self, tmp_path) -> None:
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "finish_params.json").write_text("{}")
+        (deliverables_root / "report.docx").write_text("cached deliverable")
+        # A judgement for the {b,c} reference set is already cached.
+        cached = {"reward": 0.9, "judge_response": "bc"}
+        _verify_cache_path(str(deliverables_root), ["ref_b", "ref_c"]).write_text(json.dumps(cached))
+
+        config = _make_config(rerun_incomplete=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        request = MagicMock()
+        request.cookies = {}
+
+        responses_mock = AsyncMock()
+        with patch.object(StirrupAgentWrapper, "responses", responses_mock):
+            result = await wrapper.run(request, self._body(["ref_c", "ref_b"]))
+
+        # Same reference set (order-independent) ⇒ cached judgement returned; no
+        # rollout and no /verify call.
+        responses_mock.assert_not_awaited()
+        verify_calls = [c for c in server_client.post.await_args_list if c.kwargs.get("url_path") == "/verify"]
+        assert verify_calls == []
+        assert result == cached
+
+    @pytest.mark.asyncio
+    async def test_different_reference_set_rejudges_and_caches_separately(self, tmp_path) -> None:
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "finish_params.json").write_text("{}")
+        (deliverables_root / "report.docx").write_text("cached deliverable")
+        # Cached judgement is for {b,c}; this request judges against {a,b}.
+        bc_cached = {"reward": 0.9, "judge_response": "bc"}
+        bc_path = _verify_cache_path(str(deliverables_root), ["ref_b", "ref_c"])
+        bc_path.write_text(json.dumps(bc_cached))
+
+        config = _make_config(rerun_incomplete=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+
+        request = MagicMock()
+        request.cookies = {}
+
+        responses_mock = AsyncMock()
+        fresh = {"reward": 0.3, "judge_response": "ab"}
+        with (
+            patch.object(StirrupAgentWrapper, "responses", responses_mock),
+            patch("responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()),
+            patch(
+                "responses_api_agents.stirrup_agent.app.get_response_json",
+                AsyncMock(return_value=fresh),
+            ),
+        ):
+            result = await wrapper.run(request, self._body(["ref_a", "ref_b"]))
+
+        # Different reference set ⇒ policy still skipped (deliverable cached) but
+        # the deliverable is re-judged against {a,b}...
+        responses_mock.assert_not_awaited()
+        verify_calls = [c for c in server_client.post.await_args_list if c.kwargs.get("url_path") == "/verify"]
+        assert len(verify_calls) == 1
+        assert verify_calls[0].kwargs["json"]["reference_ids"] == ["ref_a", "ref_b"]
+        assert result == fresh
+        # ...the {b,c} cache is untouched and the {a,b} judgement is cached separately.
+        assert json.loads(bc_path.read_text()) == bc_cached
+        ab_path = _verify_cache_path(str(deliverables_root), ["ref_a", "ref_b"])
+        assert ab_path != bc_path
+        assert json.loads(ab_path.read_text()) == fresh
+
 
 class TestExampleDataset:
     def test_example_jsonl_is_valid(self) -> None:


### PR DESCRIPTION
## Summary

Adds a **task re-run mode** (`rerun_incomplete`) to the Stirrup agent that resumes an evaluation by re-executing only the tasks that didn't finish, instead of re-rolling every task. Composes with `execute_only`, `judge_only`, and multi-stage ELO.

## Changes

- **`rerun_incomplete` mode** (`responses_api_agents/stirrup_agent/app.py`): a task is treated as *finished* if a `finish_params.json` marker exists under `persist_deliverables_dir`. Finished tasks skip the rollout; tasks that never finished are rolled out again.
- **Cached judgements**: `/verify` results are persisted next to each deliverable so already-judged tasks return their cached result instead of re-judging. Un-judged finished tasks are scored once; in `execute_only` the cached payload is returned as-is.
- **`rerun_incomplete` + `judge_only`**: judges only tasks with no cached judgement, returning cached results for the rest.
- **Multi-stage ELO support**: the verify cache is **keyed by the stage's reference subset** (`repeat_<n>_verify_response_<refset-hash>.json`, order-independent). A resumed stage that reselects the same references reuses its cached judgement; a stage scoring a different subset judges once and caches separately. The agent stays agnostic to the verify payload (no benchmark-specific reconstruction).
- **Config + docs**: `rerun_incomplete` exposed via `RERUN_INCOMPLETE` env in `benchmarks/gdpval/config.yaml` and `stirrup_gdpval.yaml`; READMEs document `execute_only`, `judge_only`, `rerun_incomplete`, and the re-run behavior matrix.
- **Tests**: `_task_finished` (marker-only), and `TestReferenceKeyedVerifyCache` covering cache-path uniqueness/order-independence, same-set reuse, and different-set re-judging.

## Benefits

- **Cheap resumes**: only unfinished tasks are re-rolled and only unjudged tasks are re-judged — big compute/cost savings on interrupted or partial runs.
- **No wasted judge calls**: cached judgements avoid re-running the (often expensive) judge on work already scored.
- **Correct under multi-stage ELO**: reference-set keying guarantees a cached judgement is only reused for the exact references it scored.
- **Composable**: works with `execute_only`, `judge_only`, and multi-stage without new flags beyond `rerun_incomplete`.
- **Low complexity**: additive to the existing flow; the agent remains benchmark-agnostic.