### PR TITLE
docs: use name/flavor selectors instead of internal config paths in data/collate examples

### DIFF
--- a/benchmarks/ioi/README.md
+++ b/benchmarks/ioi/README.md
@@ -47,7 +47,7 @@ elsewhere. Cluster/SLURM users can co-launch the sandbox via Skills'
 ## Running
 
 ```bash
-gym dataset collate --config benchmarks/ioi/config.yaml \
+gym dataset collate --benchmark ioi \
   --output-dir benchmarks/ioi/data \
   --mode benchmark_preparation
 

--- a/benchmarks/labbench2_vlm/README.md
+++ b/benchmarks/labbench2_vlm/README.md
@@ -85,7 +85,7 @@ After changing `example.jsonl`, regenerate its static validation metrics:
 .venv/bin/gym dataset collate \
   --resources-server labbench2_vlm \
   --config resources_servers/labbench2_vlm/configs/judge_model_openai.yaml \
-  --config responses_api_models/openai_model/configs/openai_model.yaml \
+  --model-type openai_model \
   --mode example_validation \
   --output-dir /tmp/labbench2_vlm_example_validation \
   +overwrite_metrics_conflicts=true

--- a/fern/versions/latest/pages/data/index.mdx
+++ b/fern/versions/latest/pages/data/index.mdx
@@ -76,7 +76,7 @@ Run this command from the repository root:
 
 ```bash
 gym dataset collate \
-    --config responses_api_models/vllm_model/configs/vllm_model_for_training.yaml \
+    --model-type vllm_model/vllm_model_for_training \
     --resources-server example_multi_step \
     --output-dir data/test \
     --mode example_validation
@@ -167,7 +167,7 @@ To prepare training data with auto-download:
 
 ```bash
 gym dataset collate \
-    --config responses_api_models/vllm_model/configs/vllm_model_for_training.yaml \
+    --model-type vllm_model/vllm_model_for_training \
     --resources-server workplace_assistant \
     --output-dir data/workplace_assistant \
     --mode train_preparation \

--- a/fern/versions/latest/pages/data/prepare-validate.mdx
+++ b/fern/versions/latest/pages/data/prepare-validate.mdx
@@ -32,7 +32,7 @@ From the repository root:
 ```bash
 gym dataset collate \
     --resources-server example_multi_step \
-    --config responses_api_models/openai_model/configs/openai_model.yaml \
+    --model-type openai_model \
     --output-dir data/test \
     --mode example_validation
 ```
@@ -217,7 +217,7 @@ Run data preparation:
 ```bash
 gym dataset collate \
     --config custom_data.yaml \
-    --config responses_api_models/vllm_model/configs/vllm_model.yaml \
+    --model-type vllm_model \
     --mode train_preparation \
     --output-dir data
 ```
@@ -238,7 +238,7 @@ This validates your data and adds the `agent_ref` field to each row, routing sam
 ```bash
 gym dataset collate \
     --resources-server example_multi_step \
-    --config responses_api_models/vllm_model/configs/vllm_model.yaml \
+    --model-type vllm_model \
     --output-dir data/example_multi_step \
     --mode example_validation
 ```
@@ -248,7 +248,7 @@ gym dataset collate \
 ```bash
 gym dataset collate \
     --resources-server workplace_assistant \
-    --config responses_api_models/vllm_model/configs/vllm_model.yaml \
+    --model-type vllm_model \
     --output-dir data/workplace_assistant \
     --mode train_preparation \
     --download

--- a/fern/versions/latest/pages/environment-tutorials/mcp-resources-server.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/mcp-resources-server.mdx
@@ -209,7 +209,7 @@ anthropic_api_key: sk-ant-...
 Then start the servers:
 
 ```bash
-gym env start --config resources_servers/example_mcp_weather/configs/example_mcp_weather.yaml
+gym env start --resources-server example_mcp_weather
 ```
 
 Then collect rollouts against the `example` dataset and reward-profile as in the [quickstart](/get-started/quickstart). A correct rollout shows Claude Code calling `mcp__example_mcp_weather__get_weather` and a `reward` of `1.0`.

--- a/fern/versions/latest/pages/reference/faq.mdx
+++ b/fern/versions/latest/pages/reference/faq.mdx
@@ -218,7 +218,7 @@ For every PR that contributes data, we require common dataset statistics and san
 ```bash
 gym dataset collate \
     --resources-server example_multi_step \
-    --config responses_api_models/openai_model/configs/openai_model.yaml \
+    --model-type openai_model \
     --output-dir data/example_multi_step \
     --mode example_validation
 ```
@@ -227,7 +227,7 @@ To download missing datasets automatically, add --download. By default, datasets
 ```bash
 gym dataset collate \
     --resources-server example_multi_step \
-    --config responses_api_models/openai_model/configs/openai_model.yaml \
+    --model-type openai_model \
     --output-dir data/example_multi_step \
     --mode train_preparation \
     --download
@@ -238,7 +238,7 @@ For NVIDIA internal users, you can download from GitLab instead:
 ```bash
 gym dataset collate \
     --resources-server example_multi_step \
-    --config responses_api_models/openai_model/configs/openai_model.yaml \
+    --model-type openai_model \
     --output-dir data/example_multi_step \
     --mode train_preparation \
     --download \
@@ -273,7 +273,7 @@ The `gym dataset collate` command has 2 modes, one for actual train and validati
 ```bash
 gym dataset collate \
     --resources-server example_multi_step \
-    --config responses_api_models/openai_model/configs/openai_model.yaml \
+    --model-type openai_model \
     --output-dir data/example_multi_step \
     --mode example_validation
 ```

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/setup.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/setup.mdx
@@ -227,7 +227,7 @@ Prepare the data:
 
 ```bash
 gym dataset collate \
-    --config responses_api_models/vllm_model/configs/vllm_model_for_training.yaml \
+    --model-type vllm_model/vllm_model_for_training \
     --resources-server workplace_assistant \
     --output-dir data/workplace_assistant \
     --mode train_preparation \

--- a/fern/versions/latest/pages/training-tutorials/verl.mdx
+++ b/fern/versions/latest/pages/training-tutorials/verl.mdx
@@ -38,7 +38,7 @@ source .venv/bin/activate
 
 gym dataset collate \
     --resources-server workplace_assistant \
-    --config responses_api_models/vllm_model/configs/vllm_model_for_training.yaml \
+    --model-type vllm_model/vllm_model_for_training \
     --output-dir data/workplace_assistant \
     --mode train_preparation \
     --download \

--- a/resources_servers/example_mcp_weather/README.md
+++ b/resources_servers/example_mcp_weather/README.md
@@ -14,7 +14,7 @@ Put your key in a repo-root `env.yaml` (the config interpolates `${anthropic_api
 
 ```bash
 # env.yaml:  anthropic_api_key: sk-ant-...
-gym env start --config resources_servers/example_mcp_weather/configs/example_mcp_weather.yaml
+gym env start --resources-server example_mcp_weather
 ```
 
 Then collect rollouts against `data/example.jsonl` and reward-profile as in the

--- a/resources_servers/format_verification/README.md
+++ b/resources_servers/format_verification/README.md
@@ -63,7 +63,7 @@ gym eval run --no-serve \
 ### Freeform Formatting
 ```bash
 gym dataset collate \
-    --config responses_api_models/vllm_model/configs/vllm_model_for_training.yaml \
+    --model-type vllm_model/vllm_model_for_training \
     --resources-server format_verification/freeform_formatting \
     --output-dir data/format_verification_freeform/ \
     --mode train_preparation \
@@ -73,7 +73,7 @@ gym dataset collate \
 ### Citation Format
 ```bash
 gym dataset collate \
-    --config responses_api_models/vllm_model/configs/vllm_model_for_training.yaml \
+    --model-type vllm_model/vllm_model_for_training \
     --resources-server format_verification/citation_format \
     --output-dir data/format_verification_citation/ \
     --mode train_preparation \

--- a/resources_servers/math_with_judge/README.md
+++ b/resources_servers/math_with_judge/README.md
@@ -39,7 +39,7 @@ gym eval run --no-serve \
 ```bash
 gym dataset collate \
     --config resources_servers/math_with_judge/configs/dapo17k_trajectory_collection.yaml \
-    --config responses_api_models/openai_model/configs/openai_model.yaml \
+    --model-type openai_model \
     --output-dir data/dapo17k_trajectory_collection \
     --mode train_preparation \
     --download

--- a/resources_servers/ns_tools/README.md
+++ b/resources_servers/ns_tools/README.md
@@ -80,7 +80,7 @@ To validate the example data and regenerate metrics:
 ```bash
 gym dataset collate \
     --resources-server ns_tools \
-    --config responses_api_models/openai_model/configs/openai_model.yaml \
+    --model-type openai_model \
     --output-dir data/ns_tools \
     --mode example_validation
 ```

--- a/resources_servers/openenv/README.md
+++ b/resources_servers/openenv/README.md
@@ -185,7 +185,7 @@ Then start servers and collect rollouts:
 # Terminal 1: Start servers
 source .venv/bin/activate
 gym env start \
-    --config resources_servers/openenv/configs/openenv_<name>.yaml \
+    --resources-server openenv/openenv_<name> \
     --model-type openai_model
 
 # Terminal 2: Collect rollouts (after servers are ready)

--- a/resources_servers/structured_outputs/README.md
+++ b/resources_servers/structured_outputs/README.md
@@ -99,7 +99,7 @@ python resources_servers/structured_outputs/misc/breakdown_rollouts_metrics.py \
 You can prepare the data for training with:
 ```bash
 gym dataset collate \
-    --config responses_api_models/openai_model/configs/openai_model.yaml \
+    --model-type openai_model \
     --resources-server structured_outputs/structured_outputs_json \
     --output-dir data/structured_outputs \
     --mode train_preparation \
@@ -110,7 +110,7 @@ gym dataset collate \
 ```bash
 # prepare
 gym dataset collate \
-    --config responses_api_models/vllm_model/configs/vllm_model_for_training.yaml \
+    --model-type vllm_model/vllm_model_for_training \
     --resources-server structured_outputs/structured_outputs_json_yaml_xml_v1 \
     --output-dir data/structured_outputs/ \
     --mode train_preparation \
@@ -120,7 +120,7 @@ gym dataset collate \
 ### Version 3 [260409] (JSON, YAML, XML, TOML, CSV)
 ```bash
 gym dataset collate \
-    --config responses_api_models/vllm_model/configs/vllm_model_for_training.yaml \
+    --model-type vllm_model/vllm_model_for_training \
     --resources-server structured_outputs/structured_outputs_v3 \
     --output-dir data/structured_outputs_v3/ \
     --mode train_preparation \
@@ -141,7 +141,7 @@ The uploaded GitLab dataset is:
 Prepare the v4 training data with:
 ```bash
 gym dataset collate \
-    --config responses_api_models/vllm_model/configs/vllm_model_for_training.yaml \
+    --model-type vllm_model/vllm_model_for_training \
     --resources-server structured_outputs/structured_outputs_v4 \
     --output-dir data/structured_outputs_v4_tool_call/ \
     --mode train_preparation \


### PR DESCRIPTION
## What

Converts data-prep and server-start examples that pass built-in components via internal `--config <parent>/<name>/configs/<flavor>.yaml` paths to the equivalent **name selectors** (`--model-type`, `--resources-server`, `--benchmark`), matching `env start` / `eval run`. 25 conversions across 14 files.

## Stacked on #1834

The `gym dataset collate --model-type ...` examples rely on the `--model-type` selector added to `collate` in #1834, so this is **based on that branch and should merge after it** (retarget base to `main` once #1834 lands).

## Scope / left as-is (intentional)

- **Agent configs** (`--config responses_api_agents/...`) — no `--agent` selector on `main` yet (ships with #1673).
- **Multi-config compositions** where two configs share one selector type (`nemotron_3_ultra` endpoint+suite; `labbench2_vlm` server+judge overlay) — secondary config stays `--config`.
- **A judge overlay under `benchmarks/ugphysics/`** — `--benchmark` would resolve it but read misleadingly.
- **Pre-existing broken references** (`nano_v3_single_node.yaml`, `config_short.yaml`, `dapo17k_trajectory_collection.yaml` no longer exist) — left untouched; need a separate content fix.
- **Reference/troubleshooting pages** that deliberately document `--config`; files already in the open #1808.

## Verification

Every introduced selector was resolved through `nemo_gym.cli.main._asset_config_path` and confirmed to map to an existing config file. Part of the configuration-friction work (#1205).
