### PR TITLE
refactor: use framework BaseVerifyResponse in example_session_state_mgmt

### DIFF
--- a/resources_servers/example_session_state_mgmt/app.py
+++ b/resources_servers/example_session_state_mgmt/app.py
@@ -48,10 +48,6 @@ class StatefulCounterVerifyRequest(BaseVerifyRequest):
     expected_count: int
 
 
-class BaseVerifyResponse(BaseVerifyRequest):
-    reward: float
-
-
 class StatefulCounterSeedSessionRequest(BaseSeedSessionRequest):
     initial_count: int
 


### PR DESCRIPTION
The `example_session_state_mgmt` resources server imported `BaseVerifyResponse` from `nemo_gym.base_resources_server` and then redefined a local class of the same name with an identical body, silently shadowing the framework type.

Because this is an `example_` server that users copy-paste as a template, the redundant redefinition taught a confusing anti-pattern (unused import + shadowed framework type).

This PR removes the local class so the server uses the imported framework `BaseVerifyResponse` directly