### PR TITLE
feat: add stable public API surface to nemo_gym package

### DIFF
--- a/fern/versions/latest/pages/contribute/environments/new-environment.mdx
+++ b/fern/versions/latest/pages/contribute/environments/new-environment.mdx
@@ -226,10 +226,10 @@ Avoid spawning additional threads or processes unless necessary. A single Gym in
 
 ### NeMo Gym OpenAI Client
 
-We recommend using the NeMo Gym OpenAI client from `nemo_gym.openai_utils`:
+We recommend using the NeMo Gym OpenAI client. Import it and the core types from the top-level `nemo_gym` package:
 
 ```python
-from nemo_gym.openai_utils import (
+from nemo_gym import (
     NeMoGymAsyncOpenAI,
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
@@ -240,11 +240,11 @@ The NeMo Gym client is optimized for scale and provides consistent behavior. Ext
 
 ### Pydantic Models
 
-Consider using Pydantic models for request and response validation by extending base classes from `nemo_gym.base_resources_server`:
+Consider using Pydantic models for request and response validation by extending base classes imported from the top-level `nemo_gym` package:
 
 ```python
 from pydantic import BaseModel
-from nemo_gym.base_resources_server import BaseVerifyRequest, BaseVerifyResponse
+from nemo_gym import BaseVerifyRequest, BaseVerifyResponse
 
 class MyVerifyRequest(BaseVerifyRequest):
     expected_result: str

--- a/nemo_gym/__init__.py
+++ b/nemo_gym/__init__.py
@@ -161,3 +161,81 @@ from nemo_gym.package_info import (
     __shortversion__,
     __version__,
 )
+
+
+# Public API surface for downstream environment, agent, and model authors.
+#
+# Symbols are resolved lazily via PEP 562.
+# Importing ``nemo_gym`` does not eagerly pull in FastAPI, pydantic, OpenAI, or the server stack.
+# Keep this surface focused on common extension points and boundary types.
+# Specialized implementation types remain available from their defining modules.
+#
+# Maps each public name to its defining submodule. Existing deep import paths continue to work.
+_LAZY_EXPORTS: dict[str, str] = {
+    # Resources server extension points and contracts
+    "BaseResourcesServerConfig": "base_resources_server",
+    "SimpleResourcesServer": "base_resources_server",
+    "BaseRunRequest": "base_resources_server",
+    "BaseVerifyRequest": "base_resources_server",
+    "BaseVerifyResponse": "base_resources_server",
+    "BaseMultiRewardVerifyResponse": "base_resources_server",
+    "BaseSeedSessionRequest": "base_resources_server",
+    "BaseSeedSessionResponse": "base_resources_server",
+    "ReverifyMode": "base_resources_server",
+    # Agent and model extension points
+    "BaseResponsesAPIAgentConfig": "base_responses_api_agent",
+    "SimpleResponsesAPIAgent": "base_responses_api_agent",
+    "BaseResponsesAPIModelConfig": "base_responses_api_model",
+    "SimpleResponsesAPIModel": "base_responses_api_model",
+    # Common server-client utilities
+    "ServerClient": "server_utils",
+    "raise_for_status": "server_utils",
+    "get_response_json": "server_utils",
+    "SESSION_ID_KEY": "server_utils",
+    # Author-facing config and metrics types
+    "BaseServerConfig": "config_types",
+    "BaseRunServerInstanceConfig": "config_types",
+    "Domain": "config_types",
+    "AggregateMetrics": "config_types",
+    "AggregateMetricsRequest": "config_types",
+    "ModelServerRef": "config_types",
+    # High-level OpenAI-compatible client and API boundary types
+    "NeMoGymAsyncOpenAI": "openai_utils",
+    "NeMoGymResponse": "openai_utils",
+    "NeMoGymResponseCreateParamsNonStreaming": "openai_utils",
+    "NeMoGymChatCompletion": "openai_utils",
+    "NeMoGymChatCompletionCreateParamsNonStreaming": "openai_utils",
+}
+
+# Eagerly-defined names (path constants + package metadata) that live directly in this module.
+_EAGER_PUBLIC: tuple[str, ...] = (
+    "ROOT_DIR",
+    "PARENT_DIR",
+    "WORKING_DIR",
+    "CACHE_DIR",
+    "RESULTS_DIR",
+    "__version__",
+    "__package_name__",
+)
+
+__all__ = sorted({*_EAGER_PUBLIC, *_LAZY_EXPORTS})
+
+
+def __getattr__(name: str):
+    # PEP 562 calls module-level __getattr__ only for names that are absent from the module globals.
+    # Eager symbols and resolved lazy symbols never reach this function.
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    import importlib
+
+    module = importlib.import_module(f"{__name__}.{module_name}")
+    value = getattr(module, name)
+    # Cache on the package so subsequent lookups skip __getattr__ entirely.
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted({*globals(), *_LAZY_EXPORTS})

--- a/tests/unit_tests/test_public_api.py
+++ b/tests/unit_tests/test_public_api.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Guards the ``nemo_gym`` public API surface.
+
+Environments are expected to import base classes and core types from ``nemo_gym``.
+These tests pin that contract.
+Every advertised name resolves to the same object as its defining module.
+Importing ``nemo_gym`` does not eagerly import the server stack.
+"""
+
+import importlib
+import subprocess
+import sys
+
+import pytest
+
+import nemo_gym
+from nemo_gym import _LAZY_EXPORTS
+
+
+EXPECTED_LAZY_EXPORTS = {
+    "AggregateMetrics",
+    "AggregateMetricsRequest",
+    "BaseMultiRewardVerifyResponse",
+    "BaseResourcesServerConfig",
+    "BaseResponsesAPIAgentConfig",
+    "BaseResponsesAPIModelConfig",
+    "BaseRunRequest",
+    "BaseRunServerInstanceConfig",
+    "BaseSeedSessionRequest",
+    "BaseSeedSessionResponse",
+    "BaseServerConfig",
+    "BaseVerifyRequest",
+    "BaseVerifyResponse",
+    "Domain",
+    "ModelServerRef",
+    "NeMoGymAsyncOpenAI",
+    "NeMoGymChatCompletion",
+    "NeMoGymChatCompletionCreateParamsNonStreaming",
+    "NeMoGymResponse",
+    "NeMoGymResponseCreateParamsNonStreaming",
+    "ReverifyMode",
+    "SESSION_ID_KEY",
+    "ServerClient",
+    "SimpleResourcesServer",
+    "SimpleResponsesAPIAgent",
+    "SimpleResponsesAPIModel",
+    "get_response_json",
+    "raise_for_status",
+}
+
+EXPECTED_EAGER_EXPORTS = {
+    "CACHE_DIR",
+    "PARENT_DIR",
+    "RESULTS_DIR",
+    "ROOT_DIR",
+    "WORKING_DIR",
+    "__package_name__",
+    "__version__",
+}
+
+
+def test_public_api_contract_is_explicit():
+    assert set(_LAZY_EXPORTS) == EXPECTED_LAZY_EXPORTS
+    assert set(nemo_gym.__all__) == EXPECTED_EAGER_EXPORTS | EXPECTED_LAZY_EXPORTS
+
+
+@pytest.mark.parametrize("name", sorted(_LAZY_EXPORTS))
+def test_public_symbol_is_accessible(name: str):
+    assert getattr(nemo_gym, name) is not None
+
+
+@pytest.mark.parametrize("name, module_name", sorted(_LAZY_EXPORTS.items()))
+def test_public_symbol_matches_deep_import(name: str, module_name: str):
+    """The top-level re-export must be the identical object exposed by the internal module.
+
+    This lets downstream code migrate without behavior changes.
+    It preserves ``isinstance`` and subclass checks across both import styles.
+    """
+    module = importlib.import_module(f"nemo_gym.{module_name}")
+    assert getattr(nemo_gym, name) is getattr(module, name)
+
+
+def test_all_is_sorted():
+    assert nemo_gym.__all__ == sorted(nemo_gym.__all__)
+
+
+def test_dir_includes_lazy_exports():
+    listed = dir(nemo_gym)
+    assert set(_LAZY_EXPORTS).issubset(listed)
+
+
+def test_unknown_attribute_raises_attribute_error():
+    with pytest.raises(AttributeError):
+        _ = nemo_gym.DefinitelyNotARealSymbol
+
+
+def test_top_level_import_is_lazy():
+    """Importing ``nemo_gym`` must not eagerly import the heavy submodules.
+
+    Run in a fresh interpreter to avoid modules loaded by other tests.
+    Accessing a symbol should import its backing module on demand.
+    """
+    script = (
+        "import sys\n"
+        "import nemo_gym\n"
+        "assert 'nemo_gym.base_resources_server' not in sys.modules, 'import was not lazy'\n"
+        "assert nemo_gym.SimpleResourcesServer is not None\n"
+        "assert 'nemo_gym.base_resources_server' in sys.modules, 'access did not import module'\n"
+    )
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Downstream environments import common extension points and boundary types from internal modules such as `nemo_gym.base_resources_server`, `nemo_gym.openai_utils`, `nemo_gym.server_utils`, and `nemo_gym.config_types`. Those imports couple user code to Gym's internal module layout.

This PR adds a focused public API at the top-level `nemo_gym` package:

- Resources server configs, request and response contracts, `SimpleResourcesServer`, and `ReverifyMode`.
- Agent and model server configs with their `Simple*` extension classes.
- Common client, configuration, metrics, and model-reference types used by server authors.
- High-level Responses and Chat Completions request-response types plus `NeMoGymAsyncOpenAI`. Specialized OpenAI schema types remain in `nemo_gym.openai_utils`.
- Lazy resolution through `__getattr__` and `__all__`, so importing `nemo_gym` does not eagerly import the server stack.

The environment authoring documentation now uses the top-level API. Existing deep import paths and in-repo Gym imports remain unchanged.