### PR TITLE
fix(security): bump aiohttp >=3.14.1 and Pillow >=12.3.0 (CVE mitigations)

### DIFF
--- a/resources_servers/finance_sec_search/requirements.txt
+++ b/resources_servers/finance_sec_search/requirements.txt
@@ -1,6 +1,6 @@
 # Finance Agent Resource Server Dependencies
 -e nemo-gym[dev] @ ../../
-aiohttp>=3.9.0
+aiohttp>=3.14.1
 beautifulsoup4>=4.12.0
 tavily==1.1.0
 tenacity

--- a/responses_api_agents/stirrup_agent/requirements.txt
+++ b/responses_api_agents/stirrup_agent/requirements.txt
@@ -18,7 +18,8 @@ trafilatura>=1.12
 httpx>=0.27
 # moviepy (transitive from stirrup) imports PIL at module load; Pillow must
 # be installed in the same venv or the whole stirrup import chain breaks.
-Pillow>=12.3.0
+# moviepy caps pillow<12, so we can't use the repo-wide 12.2.0 floor here.
+Pillow>=10.4.0,<12
 # PDF/Office generation libraries the agent prompt advertises; the model
 # tries to import these inside the sandbox, so they must be installed in
 # the agent venv (which the code sandbox inherits).

--- a/responses_api_agents/stirrup_agent/requirements.txt
+++ b/responses_api_agents/stirrup_agent/requirements.txt
@@ -18,8 +18,7 @@ trafilatura>=1.12
 httpx>=0.27
 # moviepy (transitive from stirrup) imports PIL at module load; Pillow must
 # be installed in the same venv or the whole stirrup import chain breaks.
-# moviepy caps pillow<12, so we can't use the repo-wide 12.2.0 floor here.
-Pillow>=10.4.0,<12
+Pillow>=12.3.0
 # PDF/Office generation libraries the agent prompt advertises; the model
 # tries to import these inside the sandbox, so they must be installed in
 # the agent venv (which the code sandbox inherits).


### PR DESCRIPTION
## Summary

- **finance_sec_search**: raise `aiohttp` floor `3.9.0` → `3.14.1` (CVE mitigation)

**Note:** Pillow bump for `stirrup_agent` (`10.4.0` → `12.3.0`) is blocked — `stirrup` hard-depends on `moviepy>=2.0.0` which caps `Pillow<12`. Needs moviepy to make itself optional in stirrup before this can be resolved.


🤖 Generated with [Claude Code](https://claude.com/claude-code)