### PR TITLE
feat(sandbox): local Docker sandbox provider (#1695)

### DIFF
--- a/fern/versions/latest/pages/infrastructure/sandbox/adding-a-provider.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/adding-a-provider.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Adding a Sandbox Provider"
 description: "Implement and register a sandbox runtime backend for NeMo Gym."
-position: 3
+position: 4
 ---
 
 Add a provider when NeMo Gym needs to create sandboxes through a new runtime backend, such as a container service, HPC isolation layer, or in-house execution platform. The public `AsyncSandbox` and `Sandbox` facades stay the same; the provider owns runtime-specific create, command, file transfer, status, and cleanup behavior.

--- a/fern/versions/latest/pages/infrastructure/sandbox/docker.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/docker.mdx
@@ -1,0 +1,148 @@
+---
+title: "Docker Provider"
+description: "Configure NeMo Gym sandboxes backed by the local Docker daemon."
+position: 3
+---
+
+The `docker` provider runs each sandbox as one long-lived container on the local Docker daemon. It shells out to the `docker` CLI (`docker run`, `docker exec`, `docker cp`, `docker rm`), so it needs a running daemon but no OpenSandbox server, control plane, or Kubernetes. Use it for local development, CI, and single-machine setups where Docker is the available runtime.
+
+## Setup
+
+Install Docker and make sure the `docker` binary is on `PATH` with a running daemon. The provider does not install or start Docker; constructing it raises `RuntimeError` if the binary is missing, and `create()` fails if the daemon is unreachable.
+
+Images can be any reference the daemon can run, such as `ubuntu:22.04`, `python:3.12-slim`, or a registry reference. An Apptainer-style `docker://` prefix is tolerated and stripped. GPU passthrough needs the NVIDIA Container Toolkit; CPU and memory limits need cgroups.
+
+## Provider Config
+
+NeMo Gym ships a Docker provider config at `nemo_gym/sandbox/providers/docker/configs/docker.yaml`. It defines a top-level `sandbox` block that agents reference with `sandbox_provider: sandbox`.
+
+```yaml
+sandbox:
+  default_metadata:
+    sandbox-api: docker-cli
+  docker:
+    create:
+      keepalive_shell: /bin/sh
+      keepalive_cmd: "while :; do sleep 2147483647; done"
+      start_timeout_s: 600
+      use_init: true
+      apply_resource_limits: true
+      # Isolation knobs -- opt in when running untrusted code (see Isolation and Security):
+      # network: none
+      # read_only: true
+      # cap_drop: ["ALL"]
+      # security_opt: ["no-new-privileges"]
+      # pids_limit: 512
+    exec:
+      default_timeout_s: 180
+      concurrency: 32
+      # exec_shell: /bin/bash   # null auto-detects bash, then falls back to sh
+    probe:
+      command: printf docker-sandbox-ready
+      expected_stdout: docker-sandbox-ready
+      timeout_s: 30
+      deadline_s: 60
+      stable_count: 1
+```
+
+Run an agent with the provider config by passing it alongside the agent and model configs:
+
+```bash
+gym env start \
+  --config responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml \
+  --config nemo_gym/sandbox/providers/docker/configs/docker.yaml \
+  --config responses_api_models/vllm_model/configs/vllm_model.yaml
+```
+
+The provider constructor accepts three optional config sections:
+
+| Section | Purpose |
+| --- | --- |
+| `create` | Keep-alive command, `docker run` start timeout, `--init` zombie reaping, isolation flags (network, read-only root, dropped capabilities, security options, pids limit), and CPU/memory limit behavior. |
+| `exec` | Per-command timeout, the shell used for `<shell> -c <command>` (auto-detected when unset), extra `docker exec` flags, and subprocess concurrency. |
+| `probe` | Post-create command probe used to verify command execution before the sandbox is returned. |
+
+## SandboxSpec Provider Options
+
+Set Docker-specific create options under `SandboxSpec.provider_options`, or under `sandbox_spec.provider_options` in an agent config:
+
+```yaml
+sandbox_spec:
+  provider_options:
+    volumes:
+      - /datasets/swebench:/datasets/swebench:ro
+    run_args: ["--shm-size", "1g"]
+```
+
+| Option | Purpose |
+| --- | --- |
+| `volumes` | A `src:dst[:opts]` bind-mount string or list of them, added as `-v` at `docker run`. |
+| `run_args` | Extra raw flags appended to `docker run` for this sandbox. |
+
+## Relevant SandboxSpec Fields
+
+| Field | Docker behavior |
+| --- | --- |
+| `image` | Required. Any image the daemon can run. A `docker://` prefix is stripped. |
+| `env` | Passed as `--env KEY=VALUE` at `docker run` and re-applied on each `exec()`. |
+| `workdir` | `-w` at `docker run` (created if absent) and the default `exec()` working directory. |
+| `files` | Seed files uploaded before the first command. |
+| `resources` | Mapped to CPU, memory, and GPU flags (see Resource Mapping). |
+| `entrypoint` | Overrides the keep-alive: the container runs this as its main process instead. |
+| `provider_options` | `volumes` and `run_args`, applied per-sandbox. |
+| `ttl_s` | Max lifetime: the keep-alive sleeps for `ttl_s` and the container self-removes (`--rm`) on exit. Ignored when a custom `entrypoint` owns the container lifetime. |
+
+## Resource Mapping
+
+`SandboxResources` is translated into Docker CLI flags when `create.apply_resource_limits` is enabled:
+
+| SandboxResources field | Docker flag |
+| --- | --- |
+| `cpu` | `--cpus <value>` |
+| `memory_mib` | `--memory <value>m`, plus a matching `--memory-swap` so the limit is a hard cap rather than doubled through swap. |
+| `gpu` | `--gpus <count>` when nonzero (needs the NVIDIA Container Toolkit). |
+| `disk_gib` | No direct flag; ignored. |
+| `gpu_type` | No direct flag; ignored. |
+
+## Lifecycle
+
+The provider runs one detached container per sandbox:
+
+| Operation | Docker command |
+| --- | --- |
+| Create | `docker run -d --name nemo-gym-<uuid> --label nemo-gym.sandbox=1 --init [flags] --entrypoint <shell> <image> -c <keepalive>` |
+| Exec | `docker exec [-w cwd] [--env ...] [--user ...] <name> <shell> -c <command>` |
+| Status | `docker inspect -f '{{.State.Status}}' <name>` |
+| Close | `docker rm -f <name>` |
+
+Containers are named `nemo-gym-<uuid>`, and the image `ENTRYPOINT` is overridden with a keep-alive command so images that define their own entrypoint (common for SWE benchmark images) stay up across `exec()` calls. State written by one command is visible to later commands in the same sandbox. `--init` inserts a minimal init process so the many short `docker exec` children are reaped instead of accumulating as zombies.
+
+## File Transfer
+
+Uploads and downloads use `docker cp` in both directions, creating the target's parent directory first on upload. Uploaded files are owned by `root`; read them as root or `chown` them for a non-root user. Download any files you need before stopping the sandbox — stopping force-removes the container.
+
+## Isolation and Security
+
+<Warning>
+Docker containers share the host kernel. This is process and namespace isolation, not a virtual machine, and is not a hard boundary for hostile code. For adversarial or untrusted workloads, run Docker on a disposable VM or use a stronger runtime such as gVisor, Kata Containers, or a microVM.
+</Warning>
+
+- Never run with `--privileged` and never mount the Docker socket into the sandbox; either grants host root.
+- Networking is on by default because most tasks need egress (pip, git). Set `network: none` to cut it entirely, or `network: <name>` to attach a locked-down internal network.
+- Harden with `read_only: true`, `cap_drop: ["ALL"]`, `security_opt: ["no-new-privileges"]`, and `pids_limit: <n>` as a fork-bomb guard. Enforce `resources` so one sandbox cannot starve the host.
+- Rootless Docker narrows the blast radius (container root is not host root) and is recommended for shared machines; `docker cp` ownership and some `--user` behaviors differ under it.
+- Every container is labeled `nemo-gym.sandbox=1`. Reap leaks from an unclean shutdown with `docker rm -f $(docker ps -aq --filter label=nemo-gym.sandbox=1)`.
+
+## User and Runtime Notes
+
+The neutral `user` argument to `exec()` maps onto `--user`:
+
+| `user` value | Behavior |
+| --- | --- |
+| `None` | Run as the image's default user. |
+| `"root"` or `0` | Run as `--user 0`. |
+| Other user or uid | Passed through as `--user <value>`. |
+
+By default `exec_shell` is unset, so the provider auto-detects `bash` once the container is ready (conda and SWE-bench setup commands use `source`, which POSIX `sh`/dash lack) and falls back to `sh`. Pin `exec_shell` to `/bin/sh` or `/bin/bash` to skip the per-create probe.
+
+Command failures return `SandboxExecResult` with the command's exit code. A command timeout returns code `125` with `error_type="timeout"`, and a docker runtime failure — daemon down or container gone, detected via stderr markers — returns code `125` with `error_type="sandbox"`. A timed-out command's in-container process is reaped when the sandbox is closed, since `docker rm -f` stops the whole process tree.

--- a/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
@@ -30,6 +30,12 @@ Run sandboxes as local Apptainer instances on a host or HPC node.
 <Badge minimal outlined>provider</Badge> <Badge minimal outlined>apptainer</Badge>
 </Card>
 
+<Card title="Docker Provider" href="/infrastructure/sandbox/docker">
+Run sandboxes as containers on the local Docker daemon for local and CI runs.
+
+<Badge minimal outlined>provider</Badge> <Badge minimal outlined>docker</Badge>
+</Card>
+
 <Card title="Adding a Provider" href="/infrastructure/sandbox/adding-a-provider">
 Implement the `SandboxProvider` protocol and register a new runtime backend.
 

--- a/nemo_gym/sandbox/providers/docker/README.md
+++ b/nemo_gym/sandbox/providers/docker/README.md
@@ -1,0 +1,210 @@
+# Docker Sandbox Provider
+
+A [NeMo Gym](../../../../README.md) sandbox provider backed by the **local Docker daemon**
+via the `docker` CLI. Each sandbox is one long-lived container; the provider shells out to
+`docker run` / `docker exec` / `docker cp` / `docker rm` — **no OpenSandbox server, no
+control plane, no Kubernetes**. It gives real container isolation out-of-the-box for anyone
+with Docker installed.
+
+Use it for local/CI runs and single-machine setups where Docker is the available runtime.
+(For an HPC node without a Docker daemon, use the [`apptainer`](../apptainer/README.md)
+provider; for a managed remote pool, use `opensandbox`.)
+
+> **Provider name:** `docker` (select it via the sandbox config; see below).
+
+## Requirements
+
+- The **`docker` binary** on `PATH` **and a running daemon**. The provider does not install
+  or start Docker; constructing it raises `RuntimeError` if the binary is missing, and
+  `create()` fails if the daemon is unreachable.
+- A container **image** Docker can run (`ubuntu:22.04`, `python:3.12-slim`, a registry ref,
+  …). An apptainer-style `docker://` prefix is tolerated and stripped.
+- For GPUs: the NVIDIA Container Toolkit (`--gpus`). For CPU/memory limits: cgroups.
+
+## Quick start
+
+The provider is used through NeMo Gym's provider-neutral sandbox API
+(`nemo_gym.sandbox.api`); you pick the provider with a single-key mapping and describe the
+sandbox with a `SandboxSpec`.
+
+```python
+from nemo_gym.sandbox.api import Sandbox
+from nemo_gym.sandbox.providers import SandboxSpec
+
+spec = SandboxSpec(
+    image="python:3.12-slim",
+    workdir="/sandbox",
+    env={"GREETING": "hello"},
+    files={"/sandbox/input.txt": "some seed content"},
+    resources={"cpu": 2, "memory_mib": 4096},
+)
+
+with Sandbox({"docker": {}}, spec) as sandbox:
+    sandbox.start()
+    result = sandbox.exec("echo $GREETING && cat /sandbox/input.txt")
+    print(result.return_code, result.stdout)
+    sandbox.upload("./local_script.sh", "/sandbox/script.sh")
+    sandbox.download("/sandbox/result.txt", "./result.txt")
+# leaving the `with` block removes the container
+```
+
+`AsyncSandbox` is the async equivalent (`async with` + `await`). Download anything you want
+to keep **before** the sandbox stops — stopping force-removes the container.
+
+## Selecting and configuring the provider
+
+The provider config is a single-key mapping `{"docker": {<kwargs>}}`, grouped into three
+optional sections (each accepts a plain mapping from Hydra YAML or the dataclass):
+
+```yaml
+docker:
+  create:
+    keepalive_shell: /bin/sh
+    keepalive_cmd: "while :; do sleep 2147483647; done"
+    start_timeout_s: 600
+    use_init: true
+    apply_resource_limits: true
+    network: none          # isolation knobs (see Isolation & security)
+    read_only: true
+    cap_drop: ["ALL"]
+    pids_limit: 512
+  exec:
+    default_timeout_s: 180
+    concurrency: 32
+  probe:
+    command: printf docker-sandbox-ready
+    expected_stdout: docker-sandbox-ready
+    deadline_s: 60
+```
+
+### `create` — `DockerCreateConfig`
+
+| Field | Default | Meaning |
+|---|---|---|
+| `keepalive_shell` | `/bin/sh` | Entrypoint the container is started with (overrides the image ENTRYPOINT). |
+| `keepalive_cmd` | `while :; do sleep …; done` | Long-lived PID 1 command that keeps the container up across `exec` calls. |
+| `start_timeout_s` | `600` | Max seconds for `docker run` (covers an implicit image pull; `None` = no timeout). |
+| `use_init` | `true` | Add `--init` (tini) to reap zombies from many short `docker exec` processes. |
+| `network` | `None` | `None` = default bridge (egress); `"none"` = no network; else a named network. |
+| `read_only` | `false` | Mount the container root filesystem read-only (`--read-only`). |
+| `cap_drop` | `[]` | Linux capabilities to drop (`--cap-drop`), e.g. `["ALL"]`. |
+| `security_opt` | `[]` | `--security-opt` values, e.g. `["no-new-privileges"]` (blocks setuid escalation). |
+| `pids_limit` | `None` | Cap the container's process count (`--pids-limit`). |
+| `extra_run_args` | `[]` | Extra raw flags appended to `docker run`. |
+| `apply_resource_limits` | `true` | Apply CPU/memory flags from `SandboxSpec.resources`. |
+
+### `exec` — `DockerExecConfig`
+
+| Field | Default | Meaning |
+|---|---|---|
+| `default_timeout_s` | `180` | Default per-command timeout when the caller passes none (`None` = no timeout). |
+| `extra_exec_args` | `[]` | Extra raw flags appended to every `docker exec`. |
+| `concurrency` | `32` | Upper bound on concurrent `docker` subprocesses (shared semaphore). |
+| `exec_shell` | `null` (auto) | Shell for `<shell> -c <command>`. `null` **auto-detects `bash`** at create (for conda/SWE-bench `source`, which POSIX `sh`/dash lacks) and falls back to `sh`. Pin to `/bin/sh` or `/bin/bash` to skip the probe. |
+
+### `probe` — `DockerProbeConfig`
+
+Readiness-probe knobs. After `docker run`, `create` runs `command` and checks its output
+before returning, so callers never get a container that can't `exec`. Set `command: null`
+to skip. Same fields as the other providers: `command`, `expected_stdout`, `timeout_s`,
+`deadline_s`, `stable_count`, `stable_delay_s`.
+
+### Relevant `SandboxSpec` fields
+
+| Field | Used for |
+|---|---|
+| `image` | Docker image ref (required). A `docker://` prefix is stripped. |
+| `env` | `--env KEY=VALUE` at `docker run` and re-applied on every `exec`. |
+| `workdir` | `-w` at `docker run` (created if absent) and default `exec` cwd. |
+| `files` | Seed files written in at `start()` (via the sandbox API's `upload`). |
+| `resources` | `cpu`→`--cpus`, `memory_mib`→`--memory` (+`--memory-swap`, hard cap), `gpu`→`--gpus <n>`. `disk_gib`/`gpu_type` ignored. |
+| `entrypoint` | Overrides the keep-alive: the container runs this as its main process instead. |
+| `provider_options` | `volumes` (a `src:dst[:opts]` string or list → `-v` mounts) and `run_args` (extra `docker run` flags), applied per-sandbox. |
+| `ttl_s` | Max lifetime: the keep-alive `sleep`s for `ttl_s` and the container self-removes (`--rm`) on exit. Not enforced with a custom `entrypoint`. |
+
+## How it works
+
+| Step | Docker command |
+|---|---|
+| Create | `docker run -d --name nemo-gym-<uuid> --label nemo-gym.sandbox=1 --init [flags] --entrypoint <sh> <image> -c <keepalive>` |
+| Exec | `docker exec [-w cwd] [--env…] [--user…] <name> <shell> -c <command>` |
+| Upload | `mkdir -p <parent>` (via exec), then `docker cp <src> <name>:<dst>` |
+| Download | `docker cp <name>:<src> <local>` |
+| Status | `docker inspect -f '{{.State.Status}}' <name>` |
+| Close | `docker rm -f <name>` |
+
+- **Keep-alive + `--entrypoint`.** The container is started with `--entrypoint` pointing at
+  the keep-alive so images that define their own `ENTRYPOINT` (common for SWE benchmark
+  images) don't swallow it. Container state persists across `exec` calls — agents rely on it.
+- **`--init`.** A naive PID 1 doesn't reap children; `--init` inserts tini so the many
+  short-lived `docker exec` processes don't accumulate as zombies.
+- **File transfer** uses `docker cp` (arbitrary paths, both directions). Uploaded files are
+  owned by **root** — read them as root, or `chown` them for a non-root user.
+- **`user`** maps to `--user` (`None`→container default, `"root"`/`0`→`--user 0`, else
+  `--user <value>`).
+- **Resources** map to `--cpus`, `--memory <n>m` (+ a matching `--memory-swap` so it's a hard cap,
+  not 2x via swap), and `--gpus <n>`. `disk_gib` / `gpu_type` have no direct flag and are ignored.
+- **Status**: `running`/`paused`→`RUNNING`, `created`/`restarting`→`STARTING`,
+  `exited`/`dead`/`removing`→`STOPPED`, missing container→`STOPPED`, timeout/other→`UNKNOWN`.
+- **Errors**: `exec` never raises for command failure — it returns a `SandboxExecResult` with
+  the real `return_code`; a timeout or a docker-runtime failure (daemon down, container gone —
+  detected via stderr markers) returns `return_code=125` with `error_type` `"timeout"` /
+  `"sandbox"`.
+
+## Isolation & security
+
+**Docker containers share the host kernel — this is process/namespace isolation, not a VM.
+It is not a hard boundary for hostile code.** For adversarial or untrusted workloads, run
+Docker on a disposable VM or use a stronger runtime (gVisor `runsc`, Kata Containers, or a
+microVM). For that reason:
+
+- **Never** run with `--privileged` and don't mount the Docker socket into the sandbox
+  (either would grant host root).
+- **Networking** is on by default (the bridge network) because most tasks need egress
+  (pip/git). For untrusted code set `network: none` to cut it entirely (or attach a locked
+  internal network via `network: <name>`).
+- Harden with `read_only: true`, `cap_drop: ["ALL"]`, `security_opt: ["no-new-privileges"]`, and
+  `pids_limit: <n>` (fork-bomb guard). Enforce `resources` (`--cpus`/`--memory` — a hard cap, swap
+  disabled) so one sandbox can't starve the host.
+- **Rootless Docker** narrows the blast radius (container root ≠ host root) and is recommended
+  for shared machines; `docker cp` ownership and some `--user`/cgroup behaviors differ under it.
+- Every container is labeled `nemo-gym.sandbox=1`; if a run is killed uncleanly, reap leaks with
+  `docker rm -f $(docker ps -aq --filter label=nemo-gym.sandbox=1)`.
+
+## Limitations
+
+- **`ttl_s` is a _max_ lifetime**, not a scheduler: the container self-removes when the keep-alive
+  `sleep` expires. Not enforced with a custom `entrypoint` (that process owns its lifetime).
+- **Distroless / no-shell images** — the default keep-alive and `sh -c` exec need a shell;
+  set `keepalive_shell` / a custom `entrypoint` for images without `/bin/sh`.
+- **`disk_gib` / `gpu_type`** have no direct docker flag and are ignored.
+- **Runtime-failure detection is heuristic** — it keys off stderr markers, so a user command
+  whose own output contains e.g. `Error response from daemon` could be misclassified.
+- **Command timeouts** return a timeout result and leave the sandbox running — it is reused across a
+  rollout's commands, so one command's timeout doesn't tear it down. The command's process is reaped
+  with the container at `close()` (`docker rm -f` stops the whole process tree); resource limits bound
+  it in the meantime.
+
+## Development
+
+Source: [`provider.py`](./provider.py). It implements the `SandboxProvider` protocol from
+[`../base.py`](../base.py) structurally (no subclassing) and is registered under the name
+`docker` in [`../registry.py`](../registry.py).
+
+Unit tests live in
+[`tests/unit_tests/test_docker_provider.py`](../../../../tests/unit_tests/test_docker_provider.py)
+and run as part of the core suite — **no Docker required**:
+
+```bash
+uv venv && uv sync --extra dev
+pytest tests/unit_tests/test_docker_provider.py -q
+```
+
+The suite mocks at the **subprocess boundary**: `_require_docker` is monkeypatched to a fake
+path, and `DockerProvider._run` (the single chokepoint every CLI call goes through) is
+replaced with a recorder that captures `argv` / `timeout_s` and returns canned
+`(return_code, stdout, stderr)`, so tests assert the exact command line built for each
+operation. A few tests exercise the real subprocess plumbing with harmless binaries
+(`echo`, `cat`, `sleep`), each guarded with `@pytest.mark.skipif(shutil.which(...) is None)`;
+real end-to-end tests are additionally guarded on a reachable Docker daemon. Async tests need
+no decorator (`asyncio_mode = "auto"`).

--- a/nemo_gym/sandbox/providers/docker/__init__.py
+++ b/nemo_gym/sandbox/providers/docker/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Docker provider package."""
+
+from nemo_gym.sandbox.providers.docker.provider import (
+    DockerCreateConfig,
+    DockerCreateError,
+    DockerCreateVerificationError,
+    DockerExecConfig,
+    DockerProbeConfig,
+    DockerProvider,
+)
+
+
+__all__ = [
+    "DockerCreateConfig",
+    "DockerCreateError",
+    "DockerCreateVerificationError",
+    "DockerExecConfig",
+    "DockerProbeConfig",
+    "DockerProvider",
+]

--- a/nemo_gym/sandbox/providers/docker/configs/docker.yaml
+++ b/nemo_gym/sandbox/providers/docker/configs/docker.yaml
@@ -1,0 +1,47 @@
+# Docker sandbox provider config.
+#
+# `sandbox` is the instance name an agent references via `sandbox_provider: sandbox`;
+# the child key `docker` selects the provider class and its value is passed to the
+# provider constructor.
+#
+# Every shipped provider config binds the same name `sandbox`, so swapping providers is
+# swapping this config path in `+config_paths` (no agent edit):
+#
+#   AGENT=responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+#   MODEL=responses_api_models/vllm_model/configs/vllm_model.yaml
+#   ng_run "+config_paths=[$AGENT, nemo_gym/sandbox/providers/docker/configs/docker.yaml, $MODEL]"
+#
+# Requires a local Docker daemon (the `docker` CLI on PATH). See ../README.md -- especially
+# the Isolation & security section -- before running untrusted code.
+#
+# `default_metadata` (optional) is merged into every sandbox's spec metadata
+# (SandboxSpec.metadata); an agent's own sandbox_spec.metadata overrides it.
+sandbox:
+  default_metadata:
+    sandbox-api: docker-cli
+  docker:
+    create:
+      # Keep the container alive across exec calls, independent of the image's CMD/ENTRYPOINT.
+      keepalive_shell: /bin/sh
+      keepalive_cmd: "while :; do sleep 2147483647; done"
+      start_timeout_s: 600
+      use_init: true
+      apply_resource_limits: true
+      # Isolation knobs -- opt in when running untrusted code (see README):
+      # network: none          # cut all networking (also breaks pip/git installs)
+      # read_only: true        # read-only root filesystem
+      # cap_drop: ["ALL"]      # drop Linux capabilities
+      # security_opt: ["no-new-privileges"]   # block setuid privilege escalation
+      # pids_limit: 512        # cap process count (fork-bomb guard)
+    exec:
+      default_timeout_s: 180
+      concurrency: 32
+      # exec_shell auto-detects bash (conda/SWE-bench commands use `source`, which sh/dash lacks)
+      # and falls back to sh. Pin it (e.g. /bin/sh or /bin/bash) to skip the per-create probe.
+      # exec_shell: /bin/bash
+    probe:
+      command: printf docker-sandbox-ready
+      expected_stdout: docker-sandbox-ready
+      timeout_s: 30
+      deadline_s: 60
+      stable_count: 1

--- a/nemo_gym/sandbox/providers/docker/provider.py
+++ b/nemo_gym/sandbox/providers/docker/provider.py
@@ -1,0 +1,482 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Docker sandbox provider: one long-lived container per sandbox, driven via the docker CLI."""
+
+import asyncio
+import contextlib
+import logging
+import math
+import os
+import posixpath
+import shlex
+import shutil
+import signal
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from nemo_gym.sandbox.providers.base import (
+    SandboxCreateError,
+    SandboxCreateVerificationError,
+    SandboxExecResult,
+    SandboxHandle,
+    SandboxResources,
+    SandboxSpec,
+    SandboxStatus,
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+CONTAINER_NAME_PREFIX = "nemo-gym-"
+SANDBOX_LABEL = "nemo-gym.sandbox"
+READY_PROBE_COMMAND = "printf docker-sandbox-ready"
+READY_PROBE_EXPECTED = "docker-sandbox-ready"
+SANDBOX_RUNTIME_RETURN_CODE = 125
+DEFAULT_KEEPALIVE_SHELL = "/bin/sh"
+DEFAULT_KEEPALIVE_CMD = "while :; do sleep 2147483647; done"
+DOCKER_RUNTIME_ERROR_MARKERS = (
+    "no such container",
+    "is not running",
+    "is not paused",
+    "cannot connect to the docker daemon",
+    "error response from daemon",
+)
+DOCKER_MISSING_CONTAINER_MARKERS = ("no such container", "no such object")
+
+
+class DockerCreateError(SandboxCreateError):
+    """Raised when Docker cannot create a sandbox."""
+
+
+class DockerCreateVerificationError(SandboxCreateVerificationError):
+    """Raised when a new container fails its readiness probe."""
+
+
+def _require_docker() -> str:
+    path = shutil.which("docker")
+    if path is None:
+        raise RuntimeError(
+            "The 'docker' binary is required for the docker sandbox provider. Install Docker and "
+            "ensure the daemon is running before selecting env.sandbox.provider.name=docker."
+        )
+    return path
+
+
+def _coerce_config(value: Any, config_cls: type[Any]) -> Any:
+    if value is None:
+        return config_cls()
+    if isinstance(value, config_cls):
+        return value
+    if isinstance(value, Mapping):
+        return config_cls(**value)
+    raise TypeError(f"{config_cls.__name__} must be a mapping or {config_cls.__name__} instance")
+
+
+def _coerce_str_list(value: Any, what: str) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple)):
+        return [str(v) for v in value]
+    raise DockerCreateError(f"provider_options[{what!r}] must be a string or list, got {type(value).__name__}")
+
+
+def _redact_argv(argv: list[str]) -> list[str]:
+    """argv copy with ``--env KEY=VALUE`` values masked, so timeouts/logs don't leak secrets."""
+    out: list[str] = []
+    mask_next = False
+    for tok in argv:
+        if mask_next:
+            out.append(f"{tok.split('=', 1)[0]}=***" if "=" in tok else tok)
+        else:
+            out.append(tok)
+        mask_next = tok == "--env"
+    return out
+
+
+@dataclass(frozen=True)
+class DockerCreateConfig:
+    keepalive_shell: str = DEFAULT_KEEPALIVE_SHELL
+    keepalive_cmd: str = DEFAULT_KEEPALIVE_CMD
+    start_timeout_s: float | None = 600
+    use_init: bool = True
+    network: str | None = None  # None: default bridge; "none": no network; else a named network.
+    read_only: bool = False
+    cap_drop: list[str] = field(default_factory=list)
+    security_opt: list[str] = field(default_factory=list)
+    pids_limit: int | None = None
+    extra_run_args: list[str] = field(default_factory=list)
+    apply_resource_limits: bool = True
+
+    def __post_init__(self) -> None:
+        if self.start_timeout_s is not None and self.start_timeout_s <= 0:
+            raise ValueError("create.start_timeout_s must be > 0")
+        if self.pids_limit is not None and self.pids_limit <= 0:
+            raise ValueError("create.pids_limit must be > 0")
+
+
+@dataclass(frozen=True)
+class DockerExecConfig:
+    default_timeout_s: float | None = 180
+    extra_exec_args: list[str] = field(default_factory=list)
+    concurrency: int = 32
+    # `<shell> -c <cmd>`. None auto-detects bash (needed for conda `source`), else falls back to sh.
+    exec_shell: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.default_timeout_s is not None and self.default_timeout_s <= 0:
+            raise ValueError("exec.default_timeout_s must be > 0")
+        if self.concurrency < 1:
+            raise ValueError("exec.concurrency must be >= 1")
+        if self.exec_shell is not None and not self.exec_shell:
+            raise ValueError("exec.exec_shell must be null (auto) or a non-empty shell name/path")
+
+
+@dataclass(frozen=True)
+class DockerProbeConfig:
+    command: str | None = READY_PROBE_COMMAND
+    expected_stdout: str | None = READY_PROBE_EXPECTED
+    timeout_s: int = 30
+    deadline_s: float | None = None
+    stable_count: int = 1
+    stable_delay_s: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.command is not None and self.timeout_s <= 0:
+            raise ValueError("probe.timeout_s must be > 0")
+        if self.deadline_s is not None and self.deadline_s <= 0:
+            raise ValueError("probe.deadline_s must be > 0")
+        if self.stable_count < 1:
+            raise ValueError("probe.stable_count must be >= 1")
+        if self.stable_delay_s < 0:
+            raise ValueError("probe.stable_delay_s must be >= 0")
+
+
+@dataclass
+class _DockerContainer:
+    name: str
+    image: str
+    shell: str = "sh"
+    env: dict[str, str] = field(default_factory=dict)
+
+
+def _normalize_image(image: str) -> str:
+    prefix = "docker://"
+    return image[len(prefix) :] if image.startswith(prefix) else image
+
+
+def _resource_limit_flags(resources: SandboxResources) -> list[str]:
+    flags: list[str] = []
+    if resources.cpu is not None:
+        flags += ["--cpus", str(resources.cpu)]
+    if resources.memory_mib is not None:
+        # --memory-swap == --memory disables swap, so the memory limit is a hard cap (not 2x via swap).
+        flags += ["--memory", f"{resources.memory_mib}m", "--memory-swap", f"{resources.memory_mib}m"]
+    return flags
+
+
+def _resource_passthrough_flags(resources: SandboxResources) -> list[str]:
+    return ["--gpus", str(resources.gpu)] if resources.gpu else []
+
+
+def _to_sandbox_status(state: str | None) -> SandboxStatus:
+    normalized = str(state or "").lower()
+    if normalized in {"running", "paused"}:
+        return SandboxStatus.RUNNING
+    if normalized in {"created", "restarting"}:
+        return SandboxStatus.STARTING
+    if normalized in {"exited", "removing", "dead"}:
+        return SandboxStatus.STOPPED
+    return SandboxStatus.UNKNOWN
+
+
+def _is_runtime_failure(stderr: str) -> bool:
+    low = stderr.lower()
+    return any(marker in low for marker in DOCKER_RUNTIME_ERROR_MARKERS)
+
+
+def _is_missing_container(stderr: str) -> bool:
+    low = stderr.lower()
+    return any(marker in low for marker in DOCKER_MISSING_CONTAINER_MARKERS)
+
+
+class DockerProvider:
+    """Sandbox provider backed by the local Docker CLI / daemon."""
+
+    name = "docker"
+
+    def __init__(
+        self,
+        *,
+        exec: DockerExecConfig | Mapping[str, Any] | None = None,
+        create: DockerCreateConfig | Mapping[str, Any] | None = None,
+        probe: DockerProbeConfig | Mapping[str, Any] | None = None,
+    ) -> None:
+        self._exec_config = _coerce_config(exec, DockerExecConfig)
+        self._create_config = _coerce_config(create, DockerCreateConfig)
+        self._probe = _coerce_config(probe, DockerProbeConfig)
+        self._binary = _require_docker()
+        self._semaphore = asyncio.Semaphore(self._exec_config.concurrency)
+
+    async def _run(
+        self, argv: list[str], *, timeout_s: float | None, stdin: bytes | None = None
+    ) -> tuple[int, str, str]:
+        """Run a docker CLI command as (return_code, stdout, stderr); SIGKILL the group on timeout."""
+        async with self._semaphore:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdin=asyncio.subprocess.PIPE if stdin is not None else None,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
+            )
+            try:
+                stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(input=stdin), timeout=timeout_s)
+            except asyncio.TimeoutError as e:
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                with contextlib.suppress(Exception):
+                    await proc.wait()
+                raise TimeoutError(f"docker command timed out after {timeout_s:g}s: {_redact_argv(argv)}") from e
+
+            return_code = proc.returncode if proc.returncode is not None else SANDBOX_RUNTIME_RETURN_CODE
+            return return_code, stdout_b.decode(errors="replace"), stderr_b.decode(errors="replace")
+
+    async def create(self, spec: SandboxSpec) -> SandboxHandle:
+        """Start a detached keep-alive container (image ENTRYPOINT overridden) and probe readiness.
+
+        ``spec.ttl_s`` bounds the lifetime (the keep-alive sleeps for it and ``--rm`` self-removes on
+        exit). ``spec.provider_options`` may carry ``volumes`` (-> ``-v``) and ``run_args`` (extra run
+        flags). A half-created container is force-removed on any failure.
+        """
+        if spec.image is None:
+            raise DockerCreateError("spec.image is required for the docker provider")
+
+        image = _normalize_image(spec.image)
+        cfg = self._create_config
+        name = CONTAINER_NAME_PREFIX + uuid.uuid4().hex
+        volumes = _coerce_str_list(spec.provider_options.get("volumes"), "volumes")
+        per_sandbox_args = _coerce_str_list(spec.provider_options.get("run_args"), "run_args")
+
+        argv: list[str] = [self._binary, "run", "-d", "--name", name, "--label", f"{SANDBOX_LABEL}=1"]
+        if cfg.use_init:
+            argv.append("--init")
+        if spec.workdir:
+            argv += ["-w", spec.workdir]
+        for key, value in spec.env.items():
+            argv += ["--env", f"{key}={value}"]
+        if cfg.apply_resource_limits:
+            argv += _resource_limit_flags(spec.resources)
+        argv += _resource_passthrough_flags(spec.resources)
+        if cfg.network is not None:
+            argv += ["--network", cfg.network]
+        if cfg.read_only:
+            argv.append("--read-only")
+        for cap in cfg.cap_drop:
+            argv += ["--cap-drop", cap]
+        for opt in cfg.security_opt:
+            argv += ["--security-opt", opt]
+        if cfg.pids_limit is not None:
+            argv += ["--pids-limit", str(cfg.pids_limit)]
+        for vol in volumes:
+            argv += ["-v", vol]
+        argv += list(cfg.extra_run_args) + per_sandbox_args
+        # ttl_s (no custom entrypoint): keep-alive sleeps ttl_s, --rm self-removes when it exits.
+        enforce_ttl = spec.ttl_s is not None and not spec.entrypoint
+        if enforce_ttl:
+            argv.append("--rm")
+        if spec.entrypoint:
+            if spec.ttl_s is not None:
+                LOGGER.warning("ttl_s is not enforced when spec.entrypoint is set; it will be ignored.")
+            argv += ["--entrypoint", spec.entrypoint[0], image, *spec.entrypoint[1:]]
+        else:
+            keepalive_cmd = f"sleep {max(1, math.ceil(spec.ttl_s))}" if enforce_ttl else cfg.keepalive_cmd
+            argv += ["--entrypoint", cfg.keepalive_shell, image, "-c", keepalive_cmd]
+
+        try:
+            code, _out, err = await self._run(argv, timeout_s=cfg.start_timeout_s)
+        except TimeoutError as e:
+            await self._force_remove(name)
+            raise DockerCreateError(f"docker run timed out for image={image!r}: {e}") from e
+        if code != 0:
+            await self._force_remove(name)
+            raise DockerCreateError(f"docker run failed (code={code}) for image={image!r}: {err.strip()}")
+
+        handle = SandboxHandle(
+            sandbox_id=name,
+            provider_name=self.name,
+            raw=_DockerContainer(name=name, image=image, env=dict(spec.env)),
+        )
+        try:
+            await self._verify_created_handle(handle)  # readiness via default sh (printf works there)
+            handle.raw.shell = await self._resolve_shell(name)  # resolve real shell once exec is confirmed live
+        except Exception:
+            await self._cleanup_failed_create_handle(handle)
+            raise
+        return handle
+
+    async def _resolve_shell(self, name: str) -> str:
+        """Configured exec shell, else bash when the image has it (for conda `source`), else sh."""
+        if self._exec_config.exec_shell:
+            return self._exec_config.exec_shell
+        with contextlib.suppress(Exception):
+            code, _out, _err = await self._run(
+                [self._binary, "exec", name, "sh", "-c", "command -v bash"],
+                timeout_s=self._exec_config.default_timeout_s,
+            )
+            if code == 0:
+                return "bash"
+        return "sh"
+
+    async def _force_remove(self, name: str) -> None:
+        with contextlib.suppress(Exception):
+            await self._run([self._binary, "rm", "-f", name], timeout_s=self._exec_config.default_timeout_s)
+
+    async def _cleanup_failed_create_handle(self, handle: SandboxHandle) -> None:
+        await self._force_remove(handle.raw.name)
+
+    async def _verify_created_handle(self, handle: SandboxHandle) -> None:
+        """Poll the readiness probe until it passes ``stable_count`` times or the deadline elapses."""
+        probe = self._probe
+        if probe.command is None:
+            return
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + probe.deadline_s if probe.deadline_s is not None else None
+        consecutive = 0
+        last_detail = "no probe attempt completed"
+        while True:
+            result = await self.exec(handle, probe.command, timeout_s=probe.timeout_s)
+            passed = result.return_code == 0 and (
+                probe.expected_stdout is None or probe.expected_stdout in (result.stdout or "")
+            )
+            if passed:
+                consecutive += 1
+                if consecutive >= probe.stable_count:
+                    return
+            else:
+                consecutive = 0
+                last_detail = f"return_code={result.return_code}, stderr={(result.stderr or '').strip()!r}"
+                if deadline is None:
+                    raise DockerCreateVerificationError(
+                        f"sandbox {handle.sandbox_id!r} failed readiness probe: {last_detail}"
+                    )
+            if deadline is not None and loop.time() >= deadline:
+                raise DockerCreateVerificationError(
+                    f"sandbox {handle.sandbox_id!r} did not pass readiness probe within {probe.deadline_s:g}s: {last_detail}"
+                )
+            if probe.stable_delay_s > 0:
+                await asyncio.sleep(probe.stable_delay_s)
+
+    async def exec(
+        self,
+        handle: SandboxHandle,
+        command: str,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_s: int | float | None = None,
+        user: str | int | None = None,
+        stdin: bytes | None = None,
+    ) -> SandboxExecResult:
+        """Run ``<shell> -c <command>`` via ``docker exec``; never raises for command failure.
+
+        ``user`` maps to ``--user`` (root/0 -> 0). A timeout kills the local docker client only; the
+        in-container process is reaped when the sandbox is closed.
+        """
+        inst = handle.raw
+        flags: list[str] = []
+        if stdin is not None:
+            flags.append("-i")
+        if cwd is not None:
+            flags += ["-w", cwd]
+        merged_env = dict(getattr(inst, "env", {}))
+        if env:
+            merged_env.update(env)
+        for key, value in merged_env.items():
+            flags += ["--env", f"{key}={value}"]
+        if user is not None:
+            flags += ["--user", "0" if user == "root" or user == 0 else str(user)]
+        flags += list(self._exec_config.extra_exec_args)
+
+        argv = [self._binary, "exec", *flags, inst.name, inst.shell, "-c", command]
+        effective_timeout = timeout_s if timeout_s is not None else self._exec_config.default_timeout_s
+        try:
+            code, out, err = await self._run(argv, timeout_s=effective_timeout, stdin=stdin)
+        except TimeoutError as e:
+            return SandboxExecResult(
+                stdout=None, stderr=str(e), return_code=SANDBOX_RUNTIME_RETURN_CODE, error_type="timeout"
+            )
+        if code != 0 and _is_runtime_failure(err):
+            return SandboxExecResult(
+                stdout=out, stderr=err, return_code=SANDBOX_RUNTIME_RETURN_CODE, error_type="sandbox"
+            )
+        return SandboxExecResult(stdout=out, stderr=err, return_code=code, error_type=None)
+
+    async def upload_file(self, handle: SandboxHandle, source_path: Path, target_path: str) -> None:
+        """Upload one host file (creates the parent dir; the file lands owned by root)."""
+        inst = handle.raw
+        parent = posixpath.dirname(target_path)
+        if parent:
+            mk = await self.exec(handle, f"mkdir -p {shlex.quote(parent)}", user="root")
+            if mk.return_code != 0:
+                raise RuntimeError(f"docker upload to {target_path!r} failed (mkdir parent): {mk.stderr}")
+        code, _out, err = await self._run(
+            [self._binary, "cp", str(source_path), f"{inst.name}:{target_path}"],
+            timeout_s=self._exec_config.default_timeout_s,
+        )
+        if code != 0:
+            raise RuntimeError(f"docker cp upload to {target_path!r} failed: {err.strip()}")
+
+    async def download_file(self, handle: SandboxHandle, source_path: str, target_path: Path) -> None:
+        """Download one container file to the host."""
+        inst = handle.raw
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        code, _out, err = await self._run(
+            [self._binary, "cp", f"{inst.name}:{source_path}", str(target_path)],
+            timeout_s=self._exec_config.default_timeout_s,
+        )
+        if code != 0:
+            raise RuntimeError(f"docker cp download from {source_path!r} failed: {err.strip()}")
+
+    async def status(self, handle: SandboxHandle) -> SandboxStatus:
+        """Container status via ``docker inspect`` (missing -> STOPPED; error/timeout -> UNKNOWN)."""
+        inst = handle.raw
+        try:
+            code, out, err = await self._run(
+                [self._binary, "inspect", "-f", "{{.State.Status}}", inst.name],
+                timeout_s=self._exec_config.default_timeout_s,
+            )
+        except TimeoutError:
+            return SandboxStatus.UNKNOWN
+        if code != 0:
+            return SandboxStatus.STOPPED if _is_missing_container(err) else SandboxStatus.UNKNOWN
+        return _to_sandbox_status(out.strip())
+
+    async def close(self, handle: SandboxHandle) -> None:
+        """Force-remove the container (already-gone counts as success)."""
+        inst = handle.raw
+        code, _out, err = await self._run(
+            [self._binary, "rm", "-f", inst.name],
+            timeout_s=self._exec_config.default_timeout_s,
+        )
+        if code != 0 and not _is_missing_container(err):
+            raise RuntimeError(f"docker rm -f failed (code={code}) for {inst.name!r}: {err.strip()}")
+
+    async def aclose(self) -> None:
+        return None

--- a/nemo_gym/sandbox/providers/registry.py
+++ b/nemo_gym/sandbox/providers/registry.py
@@ -137,5 +137,12 @@ def _load_apptainer_provider() -> ProviderClass:
     return ApptainerProvider
 
 
+def _load_docker_provider() -> ProviderClass:
+    from nemo_gym.sandbox.providers.docker import DockerProvider
+
+    return DockerProvider
+
+
 _BUILTIN_PROVIDER_LOADERS["apptainer"] = _load_apptainer_provider
+_BUILTIN_PROVIDER_LOADERS["docker"] = _load_docker_provider
 _BUILTIN_PROVIDER_LOADERS["opensandbox"] = _load_opensandbox_provider

--- a/tests/unit_tests/test_docker_provider.py
+++ b/tests/unit_tests/test_docker_provider.py
@@ -1,0 +1,775 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+from nemo_gym.sandbox.providers.base import (
+    SandboxExecResult,
+    SandboxHandle,
+    SandboxResources,
+    SandboxSpec,
+    SandboxStatus,
+)
+from nemo_gym.sandbox.providers.docker import provider as docker_provider
+
+
+pytestmark = pytest.mark.sandbox
+
+
+FAKE_BINARY = "/usr/bin/docker"
+
+
+# --------------------------------------------------------------------------- #
+# Test helpers
+# --------------------------------------------------------------------------- #
+class RunRecorder:
+    """Stand-in for DockerProvider._run that records argv and returns canned output."""
+
+    def __init__(self, responder: Callable[[list[str]], tuple[int, str, str]]) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._responder = responder
+
+    async def __call__(
+        self, argv: list[str], *, timeout_s: float | None, stdin: bytes | None = None
+    ) -> tuple[int, str, str]:
+        self.calls.append({"argv": list(argv), "timeout_s": timeout_s, "stdin": stdin})
+        return self._responder(list(argv))
+
+
+def _contains_seq(haystack: list[str], needle: list[str]) -> bool:
+    return any(haystack[i : i + len(needle)] == needle for i in range(len(haystack) - len(needle) + 1))
+
+
+def _make_handle(
+    *, name: str = "nemo-gym-x", image: str = "img", shell: str = "sh", env: dict[str, str] | None = None
+) -> SandboxHandle:
+    inst = docker_provider._DockerContainer(name=name, image=image, shell=shell, env=env or {})
+    return SandboxHandle(sandbox_id=name, provider_name="docker", raw=inst)
+
+
+@pytest.fixture
+def fake_binary(monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setattr(docker_provider, "_require_docker", lambda: FAKE_BINARY)
+    return FAKE_BINARY
+
+
+def _make_provider(
+    monkeypatch: pytest.MonkeyPatch, responder: Callable[[list[str]], tuple[int, str, str]], **kwargs: Any
+) -> tuple[Any, RunRecorder]:
+    # Pin the exec shell by default so create tests skip the auto-detect probe; pass exec={} to opt in.
+    kwargs.setdefault("exec", {"exec_shell": "sh"})
+    provider = docker_provider.DockerProvider(**kwargs)
+    rec = RunRecorder(responder)
+    monkeypatch.setattr(provider, "_run", rec)
+    return provider, rec
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+def test_require_docker(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(docker_provider.shutil, "which", lambda _name: "/opt/docker")
+    assert docker_provider._require_docker() == "/opt/docker"
+
+    monkeypatch.setattr(docker_provider.shutil, "which", lambda _name: None)
+    with pytest.raises(RuntimeError, match="docker"):
+        docker_provider._require_docker()
+
+
+def test_coerce_config() -> None:
+    coerce = docker_provider._coerce_config
+    cls = docker_provider.DockerExecConfig
+
+    assert coerce(None, cls) == cls()
+    existing = cls(concurrency=4)
+    assert coerce(existing, cls) is existing
+    assert coerce({"concurrency": 7}, cls).concurrency == 7
+    with pytest.raises(TypeError):
+        coerce(123, cls)
+
+
+def test_config_validation() -> None:
+    with pytest.raises(ValueError, match="start_timeout_s"):
+        docker_provider.DockerCreateConfig(start_timeout_s=0)
+    with pytest.raises(ValueError, match="pids_limit"):
+        docker_provider.DockerCreateConfig(pids_limit=0)
+    with pytest.raises(ValueError, match="default_timeout_s"):
+        docker_provider.DockerExecConfig(default_timeout_s=-1)
+    with pytest.raises(ValueError, match="concurrency"):
+        docker_provider.DockerExecConfig(concurrency=0)
+    with pytest.raises(ValueError, match="exec_shell"):
+        docker_provider.DockerExecConfig(exec_shell="")
+    with pytest.raises(ValueError, match="timeout_s"):
+        docker_provider.DockerProbeConfig(timeout_s=0)
+    with pytest.raises(ValueError, match="deadline_s"):
+        docker_provider.DockerProbeConfig(deadline_s=0)
+    with pytest.raises(ValueError, match="stable_count"):
+        docker_provider.DockerProbeConfig(stable_count=0)
+    with pytest.raises(ValueError, match="stable_delay_s"):
+        docker_provider.DockerProbeConfig(stable_delay_s=-1)
+    # command=None disables the timeout_s validation gate.
+    assert docker_provider.DockerProbeConfig(command=None, timeout_s=0).command is None
+
+
+def test_resource_flags() -> None:
+    res = SandboxResources(cpu=2, memory_mib=1024, gpu=1, disk_gib=50, gpu_type="h100")
+    flags = docker_provider._resource_limit_flags(res) + docker_provider._resource_passthrough_flags(res)
+    assert _contains_seq(flags, ["--cpus", "2"])
+    assert _contains_seq(flags, ["--memory", "1024m"])
+    assert _contains_seq(flags, ["--memory-swap", "1024m"])  # hard cap: swap == memory
+    assert _contains_seq(flags, ["--gpus", "1"])
+    # disk_gib and gpu_type have no flag.
+    assert "50" not in flags and "h100" not in flags
+
+    empty = SandboxResources()
+    assert docker_provider._resource_limit_flags(empty) + docker_provider._resource_passthrough_flags(empty) == []
+
+
+def test_normalize_image() -> None:
+    normalize = docker_provider._normalize_image
+    assert normalize("ubuntu:22.04") == "ubuntu:22.04"
+    assert normalize("docker://ubuntu:22.04") == "ubuntu:22.04"
+    assert normalize("ghcr.io/org/img:tag") == "ghcr.io/org/img:tag"
+
+
+def test_to_sandbox_status() -> None:
+    to_status = docker_provider._to_sandbox_status
+    assert to_status("running") is SandboxStatus.RUNNING
+    assert to_status("paused") is SandboxStatus.RUNNING
+    assert to_status("created") is SandboxStatus.STARTING
+    assert to_status("restarting") is SandboxStatus.STARTING
+    assert to_status("exited") is SandboxStatus.STOPPED
+    assert to_status("dead") is SandboxStatus.STOPPED
+    assert to_status("nonsense") is SandboxStatus.UNKNOWN
+    assert to_status(None) is SandboxStatus.UNKNOWN
+
+
+def test_is_runtime_failure() -> None:
+    assert docker_provider._is_runtime_failure("Error response from daemon: No such container: x") is True
+    assert docker_provider._is_runtime_failure("Cannot connect to the Docker daemon") is True
+    assert docker_provider._is_runtime_failure("ls: cannot access") is False
+
+
+def test_is_missing_container() -> None:
+    assert docker_provider._is_missing_container("No such container: x") is True
+    assert docker_provider._is_missing_container("Error: No such object: y") is True
+    assert docker_provider._is_missing_container("permission denied") is False
+
+
+def test_coerce_str_list() -> None:
+    f = docker_provider._coerce_str_list
+    assert f(None, "volumes") == []
+    assert f("/h:/c", "volumes") == ["/h:/c"]
+    assert f(["/h:/c", "/h2:/c2:ro"], "volumes") == ["/h:/c", "/h2:/c2:ro"]
+    with pytest.raises(docker_provider.DockerCreateError, match="run_args"):
+        f(123, "run_args")
+
+
+def test_redact_argv() -> None:
+    argv = [FAKE_BINARY, "run", "--env", "SECRET=abc123", "--name", "x", "--env", "PLAIN", "img"]
+    red = docker_provider._redact_argv(argv)
+    assert "SECRET=abc123" not in red
+    assert "SECRET=***" in red
+    assert "PLAIN" in red  # no '=' -> left untouched
+    assert red[:2] == [FAKE_BINARY, "run"]
+
+
+def test_constructor_requires_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(docker_provider.shutil, "which", lambda _name: None)
+    with pytest.raises(RuntimeError):
+        docker_provider.DockerProvider()
+
+
+# --------------------------------------------------------------------------- #
+# create
+# --------------------------------------------------------------------------- #
+async def test_create_builds_argv_and_runs_probe(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        if "run" in argv:
+            return (0, "cid", "")
+        if "exec" in argv:
+            return (0, docker_provider.READY_PROBE_EXPECTED, "")
+        return (0, "", "")
+
+    provider, rec = _make_provider(monkeypatch, responder)
+    spec = SandboxSpec(
+        image="ubuntu:22.04",
+        workdir="/sandbox",
+        env={"FOO": "bar"},
+        resources={"cpu": 2, "memory_mib": 1024, "gpu": 1},
+    )
+    handle = await provider.create(spec)
+
+    assert handle.provider_name == "docker"
+    assert handle.sandbox_id.startswith(docker_provider.CONTAINER_NAME_PREFIX)
+    assert handle.raw.image == "ubuntu:22.04"
+    assert handle.raw.env == {"FOO": "bar"}
+
+    run_argv = rec.calls[0]["argv"]
+    assert run_argv[:4] == [FAKE_BINARY, "run", "-d", "--name"]
+    assert run_argv[4] == handle.sandbox_id
+    assert run_argv[5:7] == ["--label", f"{docker_provider.SANDBOX_LABEL}=1"]
+    assert "--init" in run_argv
+    assert "--rm" not in run_argv  # no ttl_s -> no self-remove
+    assert _contains_seq(run_argv, ["-w", "/sandbox"])
+    assert _contains_seq(run_argv, ["--env", "FOO=bar"])
+    assert _contains_seq(run_argv, ["--cpus", "2.0"])
+    assert _contains_seq(run_argv, ["--memory", "1024m"])
+    assert _contains_seq(run_argv, ["--gpus", "1"])
+    assert run_argv[-5:] == ["--entrypoint", "/bin/sh", "ubuntu:22.04", "-c", docker_provider.DEFAULT_KEEPALIVE_CMD]
+
+    probe_argv = rec.calls[1]["argv"]
+    assert "exec" in probe_argv
+    assert handle.sandbox_id in probe_argv
+    assert probe_argv[-3:] == ["sh", "-c", docker_provider.READY_PROBE_COMMAND]
+    assert rec.calls[1]["timeout_s"] == 30
+
+
+async def test_create_strips_docker_prefix(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        if "exec" in argv:
+            return (0, docker_provider.READY_PROBE_EXPECTED, "")
+        return (0, "", "")
+
+    provider, rec = _make_provider(monkeypatch, responder)
+    handle = await provider.create(SandboxSpec(image="docker://ubuntu:22.04"))
+    assert handle.raw.image == "ubuntu:22.04"
+    assert rec.calls[0]["argv"][-3] == "ubuntu:22.04"
+
+
+async def test_create_skips_cgroup_resource_limits(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        if "exec" in argv:
+            return (0, docker_provider.READY_PROBE_EXPECTED, "")
+        return (0, "", "")
+
+    provider, rec = _make_provider(monkeypatch, responder, create={"apply_resource_limits": False})
+    await provider.create(SandboxSpec(image="ubuntu:22.04", resources={"cpu": 2, "memory_mib": 1024, "gpu": 1}))
+
+    run_argv = rec.calls[0]["argv"]
+    assert "--cpus" not in run_argv
+    assert "--memory" not in run_argv
+    assert _contains_seq(run_argv, ["--gpus", "1"])  # passthrough is always applied
+
+
+async def test_create_security_flags(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        if "exec" in argv:
+            return (0, docker_provider.READY_PROBE_EXPECTED, "")
+        return (0, "", "")
+
+    provider, rec = _make_provider(
+        monkeypatch,
+        responder,
+        create={
+            "network": "none",
+            "read_only": True,
+            "cap_drop": ["ALL"],
+            "security_opt": ["no-new-privileges"],
+            "pids_limit": 512,
+            "extra_run_args": ["--dns", "1.1.1.1"],
+        },
+    )
+    await provider.create(SandboxSpec(image="ubuntu:22.04"))
+
+    run_argv = rec.calls[0]["argv"]
+    assert _contains_seq(run_argv, ["--network", "none"])
+    assert "--read-only" in run_argv
+    assert _contains_seq(run_argv, ["--cap-drop", "ALL"])
+    assert _contains_seq(run_argv, ["--security-opt", "no-new-privileges"])
+    assert _contains_seq(run_argv, ["--pids-limit", "512"])
+    assert _contains_seq(run_argv, ["--dns", "1.1.1.1"])
+
+
+async def test_create_no_init_when_disabled(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        if "exec" in argv:
+            return (0, docker_provider.READY_PROBE_EXPECTED, "")
+        return (0, "", "")
+
+    provider, rec = _make_provider(monkeypatch, responder, create={"use_init": False})
+    await provider.create(SandboxSpec(image="ubuntu:22.04"))
+    assert "--init" not in rec.calls[0]["argv"]
+
+
+async def test_create_uses_spec_entrypoint(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        if "exec" in argv:
+            return (0, docker_provider.READY_PROBE_EXPECTED, "")
+        return (0, "", "")
+
+    provider, rec = _make_provider(monkeypatch, responder)
+    await provider.create(SandboxSpec(image="ubuntu:22.04", entrypoint=["/bin/bash", "-lc", "serve"]))
+
+    run_argv = rec.calls[0]["argv"]
+    assert run_argv[-5:] == ["--entrypoint", "/bin/bash", "ubuntu:22.04", "-lc", "serve"]
+    assert docker_provider.DEFAULT_KEEPALIVE_CMD not in run_argv
+
+
+async def test_create_requires_image(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+    with pytest.raises(docker_provider.DockerCreateError, match="image is required"):
+        await provider.create(SandboxSpec(image=None))
+
+
+async def test_create_run_failure_cleans_up(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        if "run" in argv:
+            return (1, "", "boom")
+        return (0, "", "")  # force-remove during cleanup
+
+    provider, rec = _make_provider(monkeypatch, responder)
+    with pytest.raises(docker_provider.DockerCreateError, match="failed"):
+        await provider.create(SandboxSpec(image="ubuntu:22.04"))
+    assert any(c["argv"][:3] == [FAKE_BINARY, "rm", "-f"] for c in rec.calls)
+
+
+async def test_create_run_timeout_cleans_up(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        if "run" in argv:
+            raise TimeoutError("slow")
+        return (0, "", "")
+
+    provider, rec = _make_provider(monkeypatch, responder)
+    with pytest.raises(docker_provider.DockerCreateError, match="timed out"):
+        await provider.create(SandboxSpec(image="ubuntu:22.04"))
+    assert any(c["argv"][:3] == [FAKE_BINARY, "rm", "-f"] for c in rec.calls)
+
+
+async def test_create_probe_failure_cleans_up(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        if "run" in argv:
+            return (0, "", "")
+        if "exec" in argv:
+            return (1, "", "probe broke")
+        return (0, "", "")  # force-remove during cleanup
+
+    provider, rec = _make_provider(monkeypatch, responder)
+    with pytest.raises(docker_provider.DockerCreateVerificationError):
+        await provider.create(SandboxSpec(image="ubuntu:22.04"))
+    assert any(c["argv"][:3] == [FAKE_BINARY, "rm", "-f"] for c in rec.calls)
+
+
+async def test_resolve_shell_configured_skips_probe(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, rec = _make_provider(monkeypatch, lambda argv: (0, "", ""), exec={"exec_shell": "/bin/zsh"})
+    assert await provider._resolve_shell("c") == "/bin/zsh"
+    assert rec.calls == []  # configured -> no probe
+
+
+async def test_resolve_shell_autodetects_bash(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        return (0, "/bin/bash", "") if "command -v bash" in argv else (0, "", "")
+
+    provider, _rec = _make_provider(monkeypatch, responder, exec={})
+    assert await provider._resolve_shell("c") == "bash"
+
+
+async def test_resolve_shell_falls_back_to_sh(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (1, "", "not found"), exec={})
+    assert await provider._resolve_shell("c") == "sh"
+
+
+async def test_resolve_shell_suppresses_probe_error(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(argv: list[str]) -> tuple[int, str, str]:
+        raise TimeoutError("slow")
+
+    provider, _rec = _make_provider(monkeypatch, boom, exec={})
+    assert await provider._resolve_shell("c") == "sh"
+
+
+async def test_create_autodetects_bash_shell(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        if "run" in argv:
+            return (0, "cid", "")
+        if "command -v bash" in argv:
+            return (0, "/bin/bash", "")
+        if "exec" in argv:
+            return (0, docker_provider.READY_PROBE_EXPECTED, "")
+        return (0, "", "")
+
+    provider, _rec = _make_provider(monkeypatch, responder, exec={})
+    handle = await provider.create(SandboxSpec(image="ubuntu:22.04"))
+    assert handle.raw.shell == "bash"
+
+
+async def test_create_provider_options_volumes_and_run_args(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        if "exec" in argv:
+            return (0, docker_provider.READY_PROBE_EXPECTED, "")
+        return (0, "", "")
+
+    provider, rec = _make_provider(monkeypatch, responder)
+    await provider.create(
+        SandboxSpec(
+            image="ubuntu:22.04",
+            provider_options={"volumes": ["/h:/c", "/h2:/c2:ro"], "run_args": ["--dns", "8.8.8.8"]},
+        )
+    )
+    run_argv = rec.calls[0]["argv"]
+    assert _contains_seq(run_argv, ["-v", "/h:/c"])
+    assert _contains_seq(run_argv, ["-v", "/h2:/c2:ro"])
+    assert _contains_seq(run_argv, ["--dns", "8.8.8.8"])
+
+
+async def test_create_provider_options_bad_type_raises(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+    with pytest.raises(docker_provider.DockerCreateError, match="volumes"):
+        await provider.create(SandboxSpec(image="ubuntu:22.04", provider_options={"volumes": 123}))
+
+
+async def test_create_ttl_s_bounds_keepalive_and_self_removes(
+    fake_binary: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        return (0, docker_provider.READY_PROBE_EXPECTED, "") if "exec" in argv else (0, "", "")
+
+    provider, rec = _make_provider(monkeypatch, responder)
+    await provider.create(SandboxSpec(image="ubuntu:22.04", ttl_s=90))
+    run_argv = rec.calls[0]["argv"]
+    assert "--rm" in run_argv
+    assert run_argv[-5:] == ["--entrypoint", "/bin/sh", "ubuntu:22.04", "-c", "sleep 90"]
+
+
+async def test_create_ttl_s_ignored_with_entrypoint(
+    fake_binary: str, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        return (0, docker_provider.READY_PROBE_EXPECTED, "") if "exec" in argv else (0, "", "")
+
+    provider, rec = _make_provider(monkeypatch, responder)
+    with caplog.at_level("WARNING"):
+        await provider.create(SandboxSpec(image="ubuntu:22.04", ttl_s=90, entrypoint=["/bin/bash", "-lc", "serve"]))
+    assert "ttl_s is not enforced" in caplog.text
+    run_argv = rec.calls[0]["argv"]
+    assert "--rm" not in run_argv
+    assert run_argv[-5:] == ["--entrypoint", "/bin/bash", "ubuntu:22.04", "-lc", "serve"]
+
+
+# --------------------------------------------------------------------------- #
+# exec
+# --------------------------------------------------------------------------- #
+async def test_exec_normal_with_cwd_and_env(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, rec = _make_provider(monkeypatch, lambda argv: (0, "hello", ""))
+    result = await provider.exec(_make_handle(), "echo hi", cwd="/work", env={"A": "b"})
+
+    assert result.return_code == 0
+    assert result.stdout == "hello"
+    assert result.error_type is None
+
+    argv = rec.calls[0]["argv"]
+    assert argv[:2] == [FAKE_BINARY, "exec"]
+    assert _contains_seq(argv, ["-w", "/work"])
+    assert _contains_seq(argv, ["--env", "A=b"])
+    assert argv[-4:] == ["nemo-gym-x", "sh", "-c", "echo hi"]
+    assert rec.calls[0]["timeout_s"] == 180
+
+
+async def test_exec_reapplies_create_env_and_overrides_call_env(
+    fake_binary: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider, rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+    handle = _make_handle(env={"A": "from-create", "B": "base"})
+
+    await provider.exec(handle, "env", env={"A": "from-call"})
+
+    argv = rec.calls[0]["argv"]
+    assert _contains_seq(argv, ["--env", "A=from-call"])
+    assert _contains_seq(argv, ["--env", "B=base"])
+    assert "A=from-create" not in argv
+
+
+async def test_exec_empty_streams_are_strings(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+    result = await provider.exec(_make_handle(), "true")
+    assert result.return_code == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+async def test_exec_uses_handle_shell(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    # exec runs under the shell resolved at create (bash for conda images that use `source`).
+    provider, rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+    await provider.exec(_make_handle(shell="bash"), "source x && echo hi")
+    assert rec.calls[0]["argv"][-4:] == ["nemo-gym-x", "bash", "-c", "source x && echo hi"]
+
+
+@pytest.mark.parametrize(
+    "user,expect_user_flag",
+    [(None, None), ("root", "0"), (0, "0"), ("alice", "alice"), (1000, "1000")],
+)
+async def test_exec_user_mapping(
+    fake_binary: str, monkeypatch: pytest.MonkeyPatch, user: Any, expect_user_flag: str | None
+) -> None:
+    provider, rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+    await provider.exec(_make_handle(), "whoami", user=user)
+    argv = rec.calls[0]["argv"]
+
+    if expect_user_flag is None:
+        assert "--user" not in argv
+    else:
+        assert _contains_seq(argv, ["--user", expect_user_flag])
+
+
+async def test_exec_passes_stdin(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, rec = _make_provider(monkeypatch, lambda argv: (0, "ok", ""))
+    await provider.exec(_make_handle(), "cat", stdin=b"prompt-bytes")
+    assert rec.calls[0]["stdin"] == b"prompt-bytes"
+    assert "-i" in rec.calls[0]["argv"]
+
+
+async def test_exec_timeout(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        raise TimeoutError("too slow")
+
+    provider, _rec = _make_provider(monkeypatch, responder)
+    result = await provider.exec(_make_handle(), "sleep 99", timeout_s=1)
+
+    assert result.return_code == docker_provider.SANDBOX_RUNTIME_RETURN_CODE
+    assert result.error_type == "timeout"
+    assert result.stdout is None
+
+
+async def test_exec_runtime_failure(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (1, "", "Error: No such container: nemo-gym-x"))
+    result = await provider.exec(_make_handle(), "echo hi")
+
+    assert result.return_code == docker_provider.SANDBOX_RUNTIME_RETURN_CODE
+    assert result.error_type == "sandbox"
+    assert "No such container" in result.stderr
+
+
+async def test_exec_command_failure_is_not_runtime_error(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (2, "", "ls: cannot access"))
+    result = await provider.exec(_make_handle(), "ls /nope")
+    assert result.return_code == 2
+    assert result.error_type is None
+
+
+# --------------------------------------------------------------------------- #
+# upload / download
+# --------------------------------------------------------------------------- #
+async def test_upload_builds_mkdir_and_cp(fake_binary: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    provider, rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+    src = tmp_path / "src.txt"
+    src.write_bytes(b"payload")
+
+    await provider.upload_file(_make_handle(), src, "/etc/app.conf")
+
+    exec_calls = [c for c in rec.calls if "exec" in c["argv"]]
+    cp_calls = [c for c in rec.calls if "cp" in c["argv"]]
+    assert exec_calls and "mkdir -p /etc" in exec_calls[0]["argv"][-1]
+    assert _contains_seq(exec_calls[0]["argv"], ["--user", "0"])  # mkdir runs as root
+    assert cp_calls[0]["argv"] == [FAKE_BINARY, "cp", str(src), "nemo-gym-x:/etc/app.conf"]
+
+
+async def test_upload_no_parent_skips_mkdir(fake_binary: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    provider, rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+    src = tmp_path / "src.txt"
+    src.write_bytes(b"payload")
+
+    await provider.upload_file(_make_handle(), src, "out.txt")  # relative -> no parent dir
+
+    assert not any("exec" in c["argv"] for c in rec.calls)
+    assert rec.calls[0]["argv"] == [FAKE_BINARY, "cp", str(src), "nemo-gym-x:out.txt"]
+
+
+async def test_upload_mkdir_failure_raises(fake_binary: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (1, "", "denied") if "exec" in argv else (0, "", ""))
+    src = tmp_path / "src.txt"
+    src.write_bytes(b"x")
+    with pytest.raises(RuntimeError, match="mkdir parent"):
+        await provider.upload_file(_make_handle(), src, "/etc/app.conf")
+
+
+async def test_upload_cp_failure_raises(fake_binary: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (0, "", "") if "exec" in argv else (1, "", "boom"))
+    src = tmp_path / "src.txt"
+    src.write_bytes(b"x")
+    with pytest.raises(RuntimeError, match="docker cp upload"):
+        await provider.upload_file(_make_handle(), src, "/etc/app.conf")
+
+
+async def test_download_builds_cp(fake_binary: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    provider, rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+    dest = tmp_path / "nested" / "local.txt"
+
+    await provider.download_file(_make_handle(), "/var/log/app.log", dest)
+
+    assert dest.parent.exists()  # local parent created
+    assert rec.calls[0]["argv"] == [FAKE_BINARY, "cp", "nemo-gym-x:/var/log/app.log", str(dest)]
+
+
+async def test_download_cp_failure_raises(fake_binary: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (1, "", "missing"))
+    with pytest.raises(RuntimeError, match="docker cp download"):
+        await provider.download_file(_make_handle(), "/var/log/app.log", tmp_path / "local.txt")
+
+
+# --------------------------------------------------------------------------- #
+# status
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "state,expected",
+    [
+        ("running", SandboxStatus.RUNNING),
+        ("created", SandboxStatus.STARTING),
+        ("exited", SandboxStatus.STOPPED),
+        ("weird", SandboxStatus.UNKNOWN),
+    ],
+)
+async def test_status_maps_state(
+    fake_binary: str, monkeypatch: pytest.MonkeyPatch, state: str, expected: SandboxStatus
+) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (0, f"{state}\n", ""))
+    assert await provider.status(_make_handle()) is expected
+
+
+async def test_status_missing_container_is_stopped(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (1, "", "Error: No such object: nemo-gym-x"))
+    assert await provider.status(_make_handle()) is SandboxStatus.STOPPED
+
+
+async def test_status_other_error_is_unknown(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (1, "", "some daemon hiccup"))
+    assert await provider.status(_make_handle()) is SandboxStatus.UNKNOWN
+
+
+async def test_status_timeout_is_unknown(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        raise TimeoutError("slow")
+
+    provider, _rec = _make_provider(monkeypatch, responder)
+    assert await provider.status(_make_handle()) is SandboxStatus.UNKNOWN
+
+
+# --------------------------------------------------------------------------- #
+# close / aclose
+# --------------------------------------------------------------------------- #
+async def test_close_success(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+    await provider.close(_make_handle())
+    assert rec.calls[0]["argv"] == [FAKE_BINARY, "rm", "-f", "nemo-gym-x"]
+
+
+async def test_close_missing_container_is_success(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (1, "", "No such container: nemo-gym-x"))
+    await provider.close(_make_handle())  # does not raise
+
+
+async def test_close_real_failure_raises(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (1, "", "permission denied"))
+    with pytest.raises(RuntimeError, match="docker rm -f failed"):
+        await provider.close(_make_handle())
+
+
+async def test_close_timeout_raises(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        raise TimeoutError("slow")
+
+    provider, _rec = _make_provider(monkeypatch, responder)
+    with pytest.raises(TimeoutError):
+        await provider.close(_make_handle())
+
+
+async def test_aclose(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+    assert await provider.aclose() is None
+
+
+# --------------------------------------------------------------------------- #
+# readiness probe
+# --------------------------------------------------------------------------- #
+async def test_verify_skipped_when_command_none(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (0, "", ""), probe={"command": None})
+
+    async def boom(*_a: Any, **_k: Any) -> SandboxExecResult:
+        raise AssertionError("exec should not be called when probe is disabled")
+
+    monkeypatch.setattr(provider, "exec", boom)
+    await provider._verify_created_handle(_make_handle())
+
+
+async def test_verify_single_attempt_failure(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))  # probe.deadline_s is None by default
+
+    async def fail(*_a: Any, **_k: Any) -> SandboxExecResult:
+        return SandboxExecResult(stdout="", stderr="nope", return_code=1)
+
+    monkeypatch.setattr(provider, "exec", fail)
+    with pytest.raises(docker_provider.DockerCreateVerificationError, match="failed readiness probe"):
+        await provider._verify_created_handle(_make_handle())
+
+
+async def test_verify_polls_until_stable(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(
+        monkeypatch, lambda argv: (0, "", ""), probe={"deadline_s": 5, "stable_count": 2, "stable_delay_s": 0}
+    )
+    results = iter(
+        [
+            SandboxExecResult(stdout="", stderr="warming up", return_code=1),
+            SandboxExecResult(stdout=docker_provider.READY_PROBE_EXPECTED, stderr="", return_code=0),
+            SandboxExecResult(stdout=docker_provider.READY_PROBE_EXPECTED, stderr="", return_code=0),
+        ]
+    )
+
+    async def fake_exec(*_a: Any, **_k: Any) -> SandboxExecResult:
+        return next(results)
+
+    monkeypatch.setattr(provider, "exec", fake_exec)
+    await provider._verify_created_handle(_make_handle())
+
+
+async def test_verify_deadline_exceeded(fake_binary: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(
+        monkeypatch, lambda argv: (0, "", ""), probe={"deadline_s": 0.01, "stable_delay_s": 0.02}
+    )
+
+    async def always_fail(*_a: Any, **_k: Any) -> SandboxExecResult:
+        return SandboxExecResult(stdout="", stderr="nope", return_code=1)
+
+    monkeypatch.setattr(provider, "exec", always_fail)
+    with pytest.raises(docker_provider.DockerCreateVerificationError, match="within"):
+        await provider._verify_created_handle(_make_handle())
+
+
+# --------------------------------------------------------------------------- #
+# _run against real lightweight binaries (exercises subprocess plumbing)
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(shutil.which("echo") is None, reason="echo not available")
+async def test_run_real_echo(fake_binary: str) -> None:
+    provider = docker_provider.DockerProvider()
+    code, out, err = await provider._run([shutil.which("echo"), "hi"], timeout_s=10)
+    assert code == 0
+    assert out.strip() == "hi"
+    assert err == ""
+
+
+@pytest.mark.skipif(shutil.which("cat") is None, reason="cat not available")
+async def test_run_real_stdin(fake_binary: str) -> None:
+    provider = docker_provider.DockerProvider()
+    code, out, _err = await provider._run([shutil.which("cat")], timeout_s=10, stdin=b"piped")
+    assert code == 0
+    assert out == "piped"
+
+
+@pytest.mark.skipif(shutil.which("sleep") is None, reason="sleep not available")
+async def test_run_real_timeout(fake_binary: str) -> None:
+    provider = docker_provider.DockerProvider()
+    with pytest.raises(TimeoutError):
+        await provider._run([shutil.which("sleep"), "5"], timeout_s=0.1)


### PR DESCRIPTION
## Summary
Adds a built-in **`docker`** sandbox provider that runs each sandbox as a container on the **local Docker daemon** via the `docker` CLI — no OpenSandbox server or control plane required. It gives real container isolation out of the box on any machine with Docker, and plugs in behind the existing provider-neutral `SandboxProvider` protocol, so every agent built on `nemo_gym.sandbox` works with it unchanged. Part of the sandbox-providers epic (#1685).

## Motivation
The existing providers need either a remote control plane (`opensandbox`) or a non-Docker local runtime (`apptainer`, common on HPC). There was no zero-setup path for the most common developer/CI environment — a machine with Docker. This provider closes that gap; provider choice is a one-line config swap.

## Design
Mirrors the `apptainer` provider's shape — a single subprocess chokepoint, a readiness probe, and neutral status/error mapping. **CLI-based, no new Python dependency.**

```mermaid
flowchart LR
  Agent["Any agent"] --> API["nemo_gym.sandbox API"]
  API -- "create / exec / cp / close" --> P["DockerProvider"]
  P -- "docker run/exec/cp/rm" --> D[("local Docker daemon")]
  D --> C["sandbox container"]
```

- **One long-lived container per sandbox** — `docker run -d` + a keep-alive PID; `docker exec` for commands, `docker cp` for files, `docker rm -f` for teardown. State persists across `exec` calls.
- **Config swap** — registers under `docker`; the shipped `docker.yaml` binds the same `sandbox` name every provider config uses, so switching is a single `+config_paths` change (no agent edits).
- **`--entrypoint` override + `--init`** — the keep-alive is injected via `--entrypoint` so images with their own `ENTRYPOINT` (e.g. SWE-bench) don't swallow it; `--init` (tini) reaps short-lived `exec` processes.
- **Auto-detected exec shell** — uses `bash` when the image has it (needed for conda `source`, e.g. SWE-bench), falls back to `sh`; resolved once per sandbox after readiness. Overridable via `exec_shell`.
- **`ttl_s` self-destruct** — when set (no custom entrypoint), the keep-alive sleeps for `ttl_s` and `--rm` removes the container on exit — a safety net for leaked/expired sandboxes.
- **Resource hard caps + isolation knobs** — `--cpus`, `--memory` (+ a matching `--memory-swap`), `--gpus <n>`; opt-in `network` (incl. `none`), `read_only`, `cap_drop`, `pids_limit`, `security_opt` (e.g. `no-new-privileges`); never `--privileged`. Containers are labeled for orphan reaping, and `--env` values are redacted from error messages.
- **Per-sandbox `provider_options`** — `volumes` (→ `-v`) and `run_args`.

## Usage
```bash
ng_run "+config_paths=[$AGENT, nemo_gym/sandbox/providers/docker/configs/docker.yaml, $MODEL]"
```
or directly: `Sandbox({"docker": {}}, spec)`.

## Docs
Documented as a Fern provider page — `fern/versions/latest/pages/infrastructure/sandbox/docker.mdx` — a sibling of the Apptainer/OpenSandbox pages from #1717 with the same shape (setup / config / `provider_options` / resource mapping / lifecycle / isolation), plus a Docker card in the sandbox index. The in-repo `README.md` stays as the developer reference, matching the other providers.

## Validation
- **68 unit tests, 100% coverage** of the provider module — hermetic (mock the CLI boundary) with skip-guarded real-daemon tests.
- Real-daemon smoke: create / exec / seeded files / upload / download / status / close; `ttl_s` self-destruct verified live.
- **SWE-bench Verified (golden):** gold patch applied and graded in-sandbox → reward 1.0.
- **SWE-bench Verified (agent):** a hosted OpenAI-compatible model drove `mini_swe_agent_2` end-to-end through the provider → resolved, reward 1.0.

## Acceptance criteria (#1695)
- [x] Provider implementing `SandboxProvider`, registered in `registry.py`
- [x] YAML config + example, selectable via `sandbox_provider`
- [x] Passing tests, skip-guarded when Docker/daemon is absent
- [x] Docs — Fern provider page (sibling to the #1717 sandbox pages) + repo README, covering setup + isolation/security
- [x] Validated end-to-end on a real runtime (rollouts collected)

## Limitations
- A command timeout returns a timeout result and leaves the reused sandbox running; the command's process is reaped with the container at `close()` (standard `docker rm -f` teardown).
- Shares the host kernel — not an isolation boundary for untrusted code (use a VM/gVisor/Kata).