### PR TITLE
fix(mini_swe_agent_2): don't install agent deps into root venv (openai pin conflict)

### DIFF
--- a/responses_api_agents/mini_swe_agent_2/README.md
+++ b/responses_api_agents/mini_swe_agent_2/README.md
@@ -327,25 +327,33 @@ tool. The successful smoke kept `tool_choice=auto` and lowered
 
 ### Prerequisites
 
-- A NeMo Gym development environment with this agent's requirements installed.
-  From the repo root:
+- A NeMo Gym development environment. From the repo root:
 
 ```bash
 uv sync --extra dev --extra sandbox
-uv pip install mini-swe-agent==2.1.0 swebench==4.1.0
 ```
 
-  `uv sync --extra dev --extra sandbox` installs `nemo-gym[dev,sandbox]`
-  (including the OpenSandbox SDK) into the root venv, so the manual step only
-  adds this agent's extra runtime dependencies. Do **not** run
+  This installs `nemo-gym[dev,sandbox]` (including the OpenSandbox SDK) into the
+  root venv, which is all `gym env start` needs. `gym env start` builds this
+  agent's own per-server venv from
+  `responses_api_agents/mini_swe_agent_2/requirements.txt` (installing
+  `mini-swe-agent`, `swebench`, and a compatible `openai`), so you do not
+  install those yourself.
+
+  Do **not** install `mini-swe-agent`/`swebench` into the root venv (e.g.
+  `uv pip install mini-swe-agent==2.1.0 swebench==4.1.0`). `mini-swe-agent`
+  allows a newer `openai` than `nemo-gym` pins (`openai<=2.7.2`), so installing
+  it upgrades the root venv's `openai`. `gym env start` then pins every
+  per-server venv to the root venv's `openai` version, which conflicts with
+  `nemo-gym`'s pin and fails to resolve (`... nemo-gym depends on openai<=2.7.2
+  ... you require openai==2.44.0 ... unsatisfiable`). If this happens, reset the
+  root venv with `uv sync --extra dev --extra sandbox`.
+
+  Also do not run
   `uv pip install -r responses_api_agents/mini_swe_agent_2/requirements.txt`
-  from the repo root: that file pins `nemo-gym` via a `../../` editable path
-  that pip/uv resolve relative to the current working directory, so from the
-  repo root it points one level above the repo and fails with
-  `... does not appear to be a Python project`. That requirements file is meant
-  to be installed with the agent directory as the working directory, which is
-  exactly what `gym env start` does automatically when it builds the agent's
-  per-server virtual environment.
+  from the repo root: its `../../` editable path resolves relative to the
+  current working directory, so from the repo root it points above the repo and
+  fails with `... does not appear to be a Python project`.
 
 - Access to an OpenSandbox deployment reachable from the server process.
 - A policy model endpoint compatible with `responses_api_models/vllm_model`.


### PR DESCRIPTION
## Summary

Fixes a QA-blocking `gym env start` failure for `mini_swe_agent_2` introduced by the Quick Start prerequisites.

The Quick Start instructed installing the agent's runtime deps into the **root** venv:
```bash
uv pip install mini-swe-agent==2.1.0 swebench==4.1.0
```
`mini-swe-agent==2.1.0` allows any recent `openai` (`openai!=1.100.*`), so this **upgrades the root venv's `openai` from 2.7.2 → 2.44.0**. `gym env start` then pins every per-server venv to the root venv's `openai` version via `head_server_deps` (`openai=={openai_version}`), which collides with `nemo-gym`'s `openai<=2.7.2` pin in each sub-server venv:

```
nemo-gym==0.4.0rc0 depends on openai<=2.7.2 ... you require openai==2.44.0 ... unsatisfiable
Process `mini_swe_agent_2` finished unexpectedly!
```

## Fix

The root venv only needs `uv sync --extra dev --extra sandbox`. `gym env start` already builds this agent's own per-server venv from its `requirements.txt` (installing `mini-swe-agent`, `swebench`, and a compatible `openai`), so the manual root-venv install is both unnecessary and harmful. This PR drops it and documents why not to add it (plus how to recover: re-run `uv sync`).

## Immediate workaround for anyone hit by this

```bash
uv sync --extra dev --extra sandbox   # resets the root venv's openai back to <=2.7.2
gym env start --config ... --model-type ...   # do NOT install mini-swe-agent/swebench into root
```

## Test plan

- [x] Root venv from `uv sync --extra dev --extra sandbox` alone → `gym env start` builds the `mini_swe_agent_2` + model server venvs successfully (verified previously end-to-end against OpenSandbox + a local vLLM).
- [x] Confirmed `uv pip install mini-swe-agent==2.1.0` upgrades `openai` 2.7.2 → 2.44.0 in the target venv (dry-run resolve), which is what triggers the `head_server_deps` conflict.