### PR TITLE
release: drop pre-release tag for v0.4.0

### DIFF
--- a/nemo_gym/package_info.py
+++ b/nemo_gym/package_info.py
@@ -17,7 +17,7 @@
 MAJOR = 0
 MINOR = 4
 PATCH = 0
-PRE_RELEASE = "rc0"
+PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)


### PR DESCRIPTION
Drops the `rc0` pre-release suffix on the `r0.4.0` release branch

Pre-requisite before running the release workflow