### PR TITLE
release: bump main to 0.5.0rc0 for next dev cycle

### DIFF
--- a/nemo_gym/package_info.py
+++ b/nemo_gym/package_info.py
@@ -15,7 +15,7 @@
 
 
 MAJOR = 0
-MINOR = 4
+MINOR = 5
 PATCH = 0
 PRE_RELEASE = "rc0"
 


### PR DESCRIPTION
Bumps the version on `main` from `0.4.0rc0` to `0.5.0rc0` now that the `r0.4.0` release branch has been cut