### PR TITLE
fix: allow Claude Code unlimited turns

### DIFF
--- a/responses_api_agents/anyterminal_agent/configs/anyterminal_claude_code.yaml
+++ b/responses_api_agents/anyterminal_agent/configs/anyterminal_claude_code.yaml
@@ -14,6 +14,8 @@ anyterminal_claude_code:
         anthropic_api_key: ${anthropic_api_key}
         anthropic_base_url: https://inference-api.nvidia.com
         timeout: 12500 # Max task timeout in Terminal Bench is 12000 seconds
+        max_turns: null # Unlimited turns
+
       # Path to pre-built Apptainer SIF files produced by prepare.py --sif-dir.
       # If omitted, Apptainer will pull docker:// images at runtime (requires internet).
       tb_sif_dir: null

--- a/responses_api_agents/claude_code_agent/README.md
+++ b/responses_api_agents/claude_code_agent/README.md
@@ -119,7 +119,7 @@ claude_code_agent:
 - `model`: model name. Full names like `Qwen/Qwen3-4B-Instruct-2507` are kept as-is for local endpoints; the provider prefix is stripped only when `anthropic_base_url` is not set
 - `anthropic_api_key`: Anthropic API key, or any non-empty string for local endpoints
 - `anthropic_base_url`: if set, used as `ANTHROPIC_BASE_URL`. Leave null for the real Anthropic API
-- `max_turns`: passed to `--max-turns`
+- `max_turns`: passed to `--max-turns`. Set to `null` to omit the flag entirely (unlimited turns)
 - `timeout`: per-request wall-clock seconds
 - `system_prompt`: appended to Claude Code's built-in system prompt via `--append-system-prompt`. The data's system message (if any) is also appended after this.
 - `allowed_tools`: passed to `--allowedTools` (e.g. `"Bash,Read"`)

--- a/responses_api_agents/claude_code_agent/app.py
+++ b/responses_api_agents/claude_code_agent/app.py
@@ -31,11 +31,7 @@ from fastapi import Request
 from pydantic import ConfigDict, PrivateAttr
 
 from nemo_gym.base_resources_server import NEMO_GYM_MCP_METADATA_KEY, BaseRunRequest, BaseVerifyResponse
-from nemo_gym.base_responses_api_agent import (
-    BaseResponsesAPIAgentConfig,
-    Body,
-    SimpleResponsesAPIAgent,
-)
+from nemo_gym.base_responses_api_agent import BaseResponsesAPIAgentConfig, Body, SimpleResponsesAPIAgent
 from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
 from nemo_gym.global_config import SKILLS_REF_KEY_NAME, get_first_server_config_dict
 from nemo_gym.openai_utils import (
@@ -223,7 +219,7 @@ class ClaudeCodeAgentConfig(BaseResponsesAPIAgentConfig):
     model: str = "claude-sonnet-4-6"
     anthropic_api_key: str = ""  # pragma: allowlist secret
     anthropic_base_url: Optional[str] = None
-    max_turns: int = 30
+    max_turns: Optional[int] = 30  # None -> unlimited turns
     timeout: int = 300
     system_prompt: Optional[str] = None
     allowed_tools: Optional[str] = None
@@ -349,7 +345,7 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
             )
         if self.config.bare and not skills_active:
             cmd.append("--bare")
-        cmd += ["--max-turns", str(self.config.max_turns), "--model", model]
+        cmd += ["--model", model]
         effective_mcp_config = mcp_config if mcp_config is not None else self.config.mcp_config
         if effective_mcp_config:
             cmd += ["--mcp-config", effective_mcp_config]
@@ -363,6 +359,8 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
             cmd += ["--thinking", self.config.thinking]
         if self.config.max_thinking_tokens is not None:
             cmd += ["--max-thinking-tokens", str(self.config.max_thinking_tokens)]
+        if self.config.max_turns is not None:
+            cmd += ["--max-turns", str(self.config.max_turns)]
         cmd += ["--", instruction]
         return cmd
 


### PR DESCRIPTION
# Allow unlimited turns for Claude Code agent

## Problem

Claude Code's native default is **unlimited turns**, but the current harness implementation always passed `--max-turns` (hardcoded `30`, non-optional `int`), so there was no way to run unlimited.

This blocks fair comparison. Evaluators like [Harbor](https://github.com/harbor-framework/harbor) run SWE-bench / Terminal-Bench with Claude in unlimited-turns mode. Capping turns changes the harness state and skews our results when comparing scores.

## Changes

- `max_turns` is now `Optional[int]`; setting it to `null` omits the `--max-turns` flag → Claude's native unlimited default.
- `_build_command` only appends `--max-turns` when it's not `None` (previously would have passed the literal string `"None"`).
- `anyterminal_claude_code.yaml`: set `max_turns: null` for Terminal-Bench.
- README: documented that `null` means unlimited.

## Note on the default

IMO the default should be `None` (matches Claude's real behavior), but I left it at `30` to avoid changing existing setups. Happy to flip it if reviewers agree.
