### PR TITLE
Soft-fail Gym run errors

### DIFF
--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -64,6 +64,13 @@ class SharedRolloutCollectionConfig(BaseNeMoGymCLIConfig):
         default=True,
         description="Upload the rollouts to W&B. Sometimes this should be off because the rollouts are massive. Default: True",
     )
+    soft_fail_run_errors: bool = Field(
+        default=False,
+        description=(
+            "When an agent /run request raises or returns a non-2xx response, persist a reward=0 rollout row "
+            "instead of aborting the whole collection job."
+        ),
+    )
 
 
 class E2ERolloutCollectionConfig(SharedRolloutCollectionConfig):
@@ -141,6 +148,39 @@ def _rollout_request_debug_summary(row: Dict[str, Any]) -> Dict[str, Any]:
         "agent_name": agent_ref.get("name") if isinstance(agent_ref, dict) else None,
     }
     return {k: v for k, v in summary.items() if v is not None}
+
+
+def _make_soft_failed_run_result(row: Dict[str, Any], exc: BaseException, status: Optional[int]) -> Dict[str, Any]:
+    result = {
+        k: deepcopy(v)
+        for k, v in row.items()
+        if k not in (TASK_INDEX_KEY_NAME, ROLLOUT_INDEX_KEY_NAME, AGENT_REF_KEY_NAME)
+    }
+
+    error_message = str(exc) or repr(exc)
+    result.update(
+        {
+            "reward": 0.0,
+            "_ng_soft_failed": True,
+            "_ng_soft_failure_stage": "agent_run",
+            "_ng_soft_failure_type": type(exc).__name__,
+            "_ng_soft_failure_message": error_message,
+            "response": {
+                "output": [],
+                "usage": None,
+                "error": {
+                    "type": type(exc).__name__,
+                    "message": error_message,
+                    "http_status": status,
+                },
+            },
+        }
+    )
+
+    if status is not None:
+        result["_ng_soft_failure_http_status"] = status
+
+    return result
 
 
 class RolloutCollectionHelper(BaseModel):
@@ -302,7 +342,11 @@ class RolloutCollectionHelper(BaseModel):
         pcts_to_print = [20, 40, 60, 80, 90, 95, 98, 99, 100]
         counts_left = Counter(r[AGENT_REF_KEY_NAME]["name"] for r in input_rows)
         results_file = output_fpath.open("ab")
-        for future in self.run_examples(input_rows, semaphore=semaphore):
+        for future in self.run_examples(
+            input_rows,
+            semaphore=semaphore,
+            soft_fail_run_errors=config.soft_fail_run_errors,
+        ):
             row, result = await future
 
             result[TASK_INDEX_KEY_NAME] = row[TASK_INDEX_KEY_NAME]
@@ -446,6 +490,7 @@ Aggregate metrics: {aggregate_metrics_fpath}""")
         examples: List[Dict],
         head_server_config: Optional[BaseServerConfig] = None,
         semaphore: Optional[Semaphore] = None,
+        soft_fail_run_errors: bool = False,
     ) -> Iterator[Future]:  # pragma: no cover
         """
         We provide this function as a lower level interface for running rollout collection.
@@ -455,10 +500,12 @@ Aggregate metrics: {aggregate_metrics_fpath}""")
 
         async def _post_subroutine(row: Dict) -> Tuple[Dict, Dict]:
             async with semaphore:
-                res = await server_client.post(server_name=row["agent_ref"]["name"], url_path="/run", json=row)
+                res = None
                 try:
+                    res = await server_client.post(server_name=row["agent_ref"]["name"], url_path="/run", json=row)
                     await raise_for_status(res)
-                except Exception:
+                    return row, await get_response_json(res)
+                except Exception as e:
                     if is_global_aiohttp_client_request_debug_enabled():
                         print(
                             "[rollout_collection] /run failed "
@@ -466,8 +513,16 @@ Aggregate metrics: {aggregate_metrics_fpath}""")
                             f"row={json.dumps(_rollout_request_debug_summary(row), sort_keys=True)}",
                             flush=True,
                         )
+                    if soft_fail_run_errors:
+                        status = getattr(res, "status", None)
+                        print(
+                            "[rollout_collection] soft-failing /run "
+                            f"status={status} "
+                            f"row={json.dumps(_rollout_request_debug_summary(row), sort_keys=True)}",
+                            flush=True,
+                        )
+                        return row, _make_soft_failed_run_result(row, e, status)
                     raise
-                return row, await get_response_json(res)
 
         return tqdm.as_completed(
             map(_post_subroutine, examples),

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -99,6 +99,46 @@ class TestRolloutCollection:
         else:
             assert "[rollout_collection] /run failed" not in captured.out
 
+    async def test_run_examples_soft_fail_run_errors_returns_reward_zero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        row = {
+            AGENT_REF_KEY_NAME: {"name": "my_agent"},
+            TASK_INDEX_KEY_NAME: 7,
+            ROLLOUT_INDEX_KEY_NAME: 0,
+            "responses_create_params": {"input": []},
+            "question": "q",
+            "expected_answer": "a",
+        }
+        response = MagicMock()
+        response.status = 500
+
+        mock_server_client = MagicMock()
+        mock_server_client.post = AsyncMock(return_value=response)
+
+        class MockHelper(RolloutCollectionHelper):
+            def setup_server_client(self, *args, **kwargs):
+                return mock_server_client
+
+        async def fail_raise_for_status(_response):
+            raise RuntimeError("model parser exploded")
+
+        monkeypatch.setattr(nemo_gym.rollout_collection, "raise_for_status", fail_raise_for_status)
+
+        returned_row, result = await next(MockHelper().run_examples([row], soft_fail_run_errors=True))
+
+        assert returned_row == row
+        assert result["reward"] == 0.0
+        assert result["_ng_soft_failed"] is True
+        assert result["_ng_soft_failure_stage"] == "agent_run"
+        assert result["_ng_soft_failure_type"] == "RuntimeError"
+        assert result["_ng_soft_failure_http_status"] == 500
+        assert result["response"]["output"] == []
+        assert result["response"]["error"]["message"] == "model parser exploded"
+        assert result["question"] == "q"
+        assert result["expected_answer"] == "a"
+
     def test_preprocess_rows_with_prompt_config(self, tmp_path: Path) -> None:
         """prompt_config builds responses_create_params.input from template."""
         prompt_path = tmp_path / "prompt.yaml"
@@ -399,6 +439,76 @@ class TestRolloutCollection:
             }
         ]
         assert expected_aggregate_metrics == actual_aggregate_metrics
+
+    async def test_run_from_config_soft_fail_run_errors_persists_reward_zero(self, tmp_path: Path) -> None:
+        input_jsonl_fpath = tmp_path / "input.jsonl"
+        input_jsonl_fpath.write_text(
+            json.dumps(
+                {
+                    "responses_create_params": {"input": []},
+                    "agent_ref": {"name": "my agent name"},
+                    "question": "q",
+                }
+            )
+            + "\n"
+        )
+        output_jsonl_fpath = tmp_path / "output.jsonl"
+
+        config = RolloutCollectionConfig(
+            input_jsonl_fpath=str(input_jsonl_fpath),
+            output_jsonl_fpath=str(output_jsonl_fpath),
+            soft_fail_run_errors=True,
+            upload_rollouts_to_wandb=False,
+        )
+
+        class TestRolloutCollectionHelper(RolloutCollectionHelper):
+            def run_examples(
+                self,
+                examples: list[dict],
+                *args,
+                **kwargs,
+            ):
+                assert kwargs["soft_fail_run_errors"] is True
+                futures = []
+                for example in examples:
+                    future = Future()
+                    future.set_result(
+                        (
+                            example,
+                            {
+                                "reward": 0.0,
+                                "_ng_soft_failed": True,
+                                "_ng_soft_failure_stage": "agent_run",
+                                "response": {"output": [], "usage": None, "error": {"message": "boom"}},
+                            },
+                        )
+                    )
+                    futures.append(future)
+
+                return futures
+
+            async def _call_aggregate_metrics(self, results, rows, output_fpath):
+                stripped = [
+                    {k: v for k, v in r.items() if k not in ("response", "responses_create_params")} for r in results
+                ]
+                agg = compute_aggregate_metrics(stripped)
+                metrics_fpath = output_fpath.with_stem(output_fpath.stem + "_aggregate_metrics").with_suffix(".json")
+                metrics_fpath.write_bytes(
+                    orjson.dumps(
+                        [{"agent_ref": {"name": "my agent name"}, **agg.model_dump()}], option=orjson.OPT_INDENT_2
+                    )
+                )
+                return metrics_fpath
+
+        await TestRolloutCollectionHelper().run_from_config(config)
+
+        written_rows = [json.loads(line) for line in output_jsonl_fpath.read_text().splitlines()]
+        assert len(written_rows) == 1
+        assert written_rows[0]["reward"] == 0.0
+        assert written_rows[0]["_ng_soft_failed"] is True
+
+        aggregate_metrics = json.loads((tmp_path / "output_aggregate_metrics.json").read_text())
+        assert aggregate_metrics[0]["agent_metrics"]["mean/reward"] == 0.0
 
     async def test_run_from_config_sorted(self, tmp_path: Path) -> None:
         input_jsonl_fpath = tmp_path / "input.jsonl"


### PR DESCRIPTION
Adds an optional Gym rollout soft-fail path so selected run errors can be recorded as reward=0 rows instead of aborting the whole evaluation. This mirrors the behavior used in NS for HLE-with-tools/gpt-oss-20b failures.