### PR TITLE
Filter malformed simple-agent tool calls from history

### DIFF
--- a/resources_servers/equivalence_llm_judge/configs/equivalence_llm_judge.yaml
+++ b/resources_servers/equivalence_llm_judge/configs/equivalence_llm_judge.yaml
@@ -70,6 +70,7 @@ equivalence_llm_judge_simple_agent:
       model_server:
         type: responses_api_models
         name: policy_model
+      skip_invalid_tool_calls: false
       datasets:
       - name: example
         type: example

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -47,6 +47,7 @@ class SimpleAgentConfig(BaseResponsesAPIAgentConfig):
     resources_server: ResourcesServerRef
     model_server: ModelServerRef
     max_steps: int = None
+    stop_on_invalid_tool_call: bool = False
 
 
 class SimpleAgentRunRequest(BaseRunRequest):
@@ -115,7 +116,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         while True:
             step += 1
             new_body = body.model_copy(update={"input": body.input + new_outputs})
-            allowed_tool_names = self._tool_names(body)
+            allowed_tool_names = self._tool_names(body) if self.config.stop_on_invalid_tool_call else set()
 
             model_response = await self.server_client.post(
                 server_name=self.config.model_server.name,
@@ -163,24 +164,36 @@ class SimpleAgent(SimpleResponsesAPIAgent):
 
             parsed_fn_calls = []
             invalid_tool_call_message = None
+            if not self.config.stop_on_invalid_tool_call:
+                new_outputs.extend(output)
+
             for output_function_call in all_fn_calls:
                 try:
                     parsed_arguments = json.loads(output_function_call.arguments)
                 except (json.JSONDecodeError, TypeError) as e:
+                    if not self.config.stop_on_invalid_tool_call:
+                        tool_response = NeMoGymFunctionCallOutput(
+                            type="function_call_output",
+                            call_id=output_function_call.call_id,
+                            output=json.dumps({"error": f"Invalid tool call arguments: {e!r}"}),
+                        )
+                        new_outputs.append(tool_response)
+                        continue
+
                     invalid_tool_call_message = self._invalid_tool_call_message(
                         call_id=output_function_call.call_id,
                         error=f"Invalid tool call arguments: {e!r}",
                     )
                     break
 
-                if not isinstance(parsed_arguments, dict):
+                if self.config.stop_on_invalid_tool_call and not isinstance(parsed_arguments, dict):
                     invalid_tool_call_message = self._invalid_tool_call_message(
                         call_id=output_function_call.call_id,
                         error=f"Invalid tool call arguments: expected object, got {type(parsed_arguments).__name__}",
                     )
                     break
 
-                if output_function_call.name not in allowed_tool_names:
+                if self.config.stop_on_invalid_tool_call and output_function_call.name not in allowed_tool_names:
                     invalid_tool_call_message = self._invalid_tool_call_message(
                         call_id=output_function_call.call_id,
                         error=f"Invalid tool call name: {output_function_call.name!r}",
@@ -194,7 +207,8 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 new_outputs.append(invalid_tool_call_message)
                 break
 
-            new_outputs.extend(output)
+            if self.config.stop_on_invalid_tool_call:
+                new_outputs.extend(output)
 
             for output_function_call, parsed_arguments in parsed_fn_calls:
                 api_response = await self.server_client.post(

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -38,6 +38,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCall,
     NeMoGymResponseOutputMessage,
+    NeMoGymResponseOutputText,
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
 
@@ -63,6 +64,37 @@ class SimpleAgentVerifyResponse(BaseVerifyResponse):
 class SimpleAgent(SimpleResponsesAPIAgent):
     config: SimpleAgentConfig
 
+    @staticmethod
+    def _tool_names(body: NeMoGymResponseCreateParamsNonStreaming) -> set[str]:
+        tool_names = set()
+        for tool in body.tools:
+            if isinstance(tool, dict):
+                name = tool.get("name") or tool.get("function", {}).get("name")
+            else:
+                name = getattr(tool, "name", None)
+                if name is None:
+                    function = getattr(tool, "function", None)
+                    name = getattr(function, "name", None)
+            if name:
+                tool_names.add(name)
+        return tool_names
+
+    @staticmethod
+    def _invalid_tool_call_message(call_id: str, error: str) -> NeMoGymResponseOutputMessage:
+        return NeMoGymResponseOutputMessage(
+            id=f"msg_invalid_tool_call_{call_id}",
+            content=[
+                NeMoGymResponseOutputText(
+                    annotations=[],
+                    text=json.dumps({"error": error}),
+                    type="output_text",
+                )
+            ],
+            role="assistant",
+            status="completed",
+            type="message",
+        )
+
     async def responses(
         self,
         request: Request,
@@ -83,6 +115,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         while True:
             step += 1
             new_body = body.model_copy(update={"input": body.input + new_outputs})
+            allowed_tool_names = self._tool_names(body)
 
             model_response = await self.server_client.post(
                 server_name=self.config.model_server.name,
@@ -102,7 +135,6 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 ) from e
 
             output = model_response.output
-            new_outputs.extend(output)
 
             if not usage:
                 usage = model_response.usage
@@ -118,6 +150,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 usage.output_tokens_details.reasoning_tokens = 0
 
             if model_response.incomplete_details:
+                new_outputs.extend(output)
                 break
 
             all_fn_calls: List[NeMoGymResponseFunctionToolCall] = [o for o in output if o.type == "function_call"]
@@ -125,26 +158,45 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 o for o in output if o.type == "message" and o.role == "assistant"
             ]
             if not all_fn_calls and all_output_messages:
+                new_outputs.extend(output)
                 break
 
+            parsed_fn_calls = []
+            invalid_tool_call_message = None
             for output_function_call in all_fn_calls:
                 try:
                     parsed_arguments = json.loads(output_function_call.arguments)
                 except (json.JSONDecodeError, TypeError) as e:
-                    # Model produced malformed tool-call arguments. Surface the
-                    # error back as a tool response so the rollout can continue
-                    # (or terminate with a low reward) instead of crashing the
-                    # whole batch on json.loads.
-                    tool_response = NeMoGymFunctionCallOutput(
-                        type="function_call_output",
+                    invalid_tool_call_message = self._invalid_tool_call_message(
                         call_id=output_function_call.call_id,
-                        # Use repr(e) so the exception type name is always
-                        # included even when str(e) would be empty.
-                        output=json.dumps({"error": f"Invalid tool call arguments: {e!r}"}),
+                        error=f"Invalid tool call arguments: {e!r}",
                     )
-                    new_outputs.append(tool_response)
-                    continue
+                    break
 
+                if not isinstance(parsed_arguments, dict):
+                    invalid_tool_call_message = self._invalid_tool_call_message(
+                        call_id=output_function_call.call_id,
+                        error=f"Invalid tool call arguments: expected object, got {type(parsed_arguments).__name__}",
+                    )
+                    break
+
+                if output_function_call.name not in allowed_tool_names:
+                    invalid_tool_call_message = self._invalid_tool_call_message(
+                        call_id=output_function_call.call_id,
+                        error=f"Invalid tool call name: {output_function_call.name!r}",
+                    )
+                    break
+
+                parsed_fn_calls.append((output_function_call, parsed_arguments))
+
+            if invalid_tool_call_message:
+                new_outputs.extend(o for o in output if o.type != "function_call")
+                new_outputs.append(invalid_tool_call_message)
+                break
+
+            new_outputs.extend(output)
+
+            for output_function_call, parsed_arguments in parsed_fn_calls:
                 api_response = await self.server_client.post(
                     server_name=self.config.resources_server.name,
                     url_path=f"/{output_function_call.name}",

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -38,7 +38,6 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCall,
     NeMoGymResponseOutputMessage,
-    NeMoGymResponseOutputText,
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
 
@@ -47,7 +46,7 @@ class SimpleAgentConfig(BaseResponsesAPIAgentConfig):
     resources_server: ResourcesServerRef
     model_server: ModelServerRef
     max_steps: int = None
-    stop_on_invalid_tool_call: bool = False
+    skip_invalid_tool_calls: bool = False
 
 
 class SimpleAgentRunRequest(BaseRunRequest):
@@ -80,22 +79,6 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 tool_names.add(name)
         return tool_names
 
-    @staticmethod
-    def _invalid_tool_call_message(call_id: str, error: str) -> NeMoGymResponseOutputMessage:
-        return NeMoGymResponseOutputMessage(
-            id=f"msg_invalid_tool_call_{call_id}",
-            content=[
-                NeMoGymResponseOutputText(
-                    annotations=[],
-                    text=json.dumps({"error": error}),
-                    type="output_text",
-                )
-            ],
-            role="assistant",
-            status="completed",
-            type="message",
-        )
-
     async def responses(
         self,
         request: Request,
@@ -116,7 +99,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         while True:
             step += 1
             new_body = body.model_copy(update={"input": body.input + new_outputs})
-            allowed_tool_names = self._tool_names(body) if self.config.stop_on_invalid_tool_call else set()
+            allowed_tool_names = self._tool_names(body) if self.config.skip_invalid_tool_calls else set()
 
             model_response = await self.server_client.post(
                 server_name=self.config.model_server.name,
@@ -163,52 +146,41 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 break
 
             parsed_fn_calls = []
-            invalid_tool_call_message = None
-            if not self.config.stop_on_invalid_tool_call:
+            if not self.config.skip_invalid_tool_calls:
                 new_outputs.extend(output)
 
             for output_function_call in all_fn_calls:
                 try:
                     parsed_arguments = json.loads(output_function_call.arguments)
                 except (json.JSONDecodeError, TypeError) as e:
-                    if not self.config.stop_on_invalid_tool_call:
-                        tool_response = NeMoGymFunctionCallOutput(
-                            type="function_call_output",
-                            call_id=output_function_call.call_id,
-                            output=json.dumps({"error": f"Invalid tool call arguments: {e!r}"}),
-                        )
-                        new_outputs.append(tool_response)
+                    if self.config.skip_invalid_tool_calls:
                         continue
 
-                    invalid_tool_call_message = self._invalid_tool_call_message(
+                    tool_response = NeMoGymFunctionCallOutput(
+                        type="function_call_output",
                         call_id=output_function_call.call_id,
-                        error=f"Invalid tool call arguments: {e!r}",
+                        output=json.dumps({"error": f"Invalid tool call arguments: {e!r}"}),
                     )
-                    break
+                    new_outputs.append(tool_response)
+                    continue
 
-                if self.config.stop_on_invalid_tool_call and not isinstance(parsed_arguments, dict):
-                    invalid_tool_call_message = self._invalid_tool_call_message(
-                        call_id=output_function_call.call_id,
-                        error=f"Invalid tool call arguments: expected object, got {type(parsed_arguments).__name__}",
-                    )
-                    break
+                if self.config.skip_invalid_tool_calls:
+                    if not isinstance(parsed_arguments, dict):
+                        continue
 
-                if self.config.stop_on_invalid_tool_call and output_function_call.name not in allowed_tool_names:
-                    invalid_tool_call_message = self._invalid_tool_call_message(
-                        call_id=output_function_call.call_id,
-                        error=f"Invalid tool call name: {output_function_call.name!r}",
-                    )
-                    break
+                    if output_function_call.name not in allowed_tool_names:
+                        continue
 
                 parsed_fn_calls.append((output_function_call, parsed_arguments))
 
-            if invalid_tool_call_message:
-                new_outputs.extend(o for o in output if o.type != "function_call")
-                new_outputs.append(invalid_tool_call_message)
-                break
-
-            if self.config.stop_on_invalid_tool_call:
-                new_outputs.extend(output)
+            if self.config.skip_invalid_tool_calls:
+                valid_call_ids = {output_function_call.call_id for output_function_call, _ in parsed_fn_calls}
+                filtered_output = [
+                    o for o in output if o.type != "function_call" or o.call_id in valid_call_ids
+                ]
+                new_outputs.extend(filtered_output)
+                if not parsed_fn_calls and not filtered_output:
+                    break
 
             for output_function_call, parsed_arguments in parsed_fn_calls:
                 api_response = await self.server_client.post(

--- a/responses_api_agents/simple_agent/configs/simple_agent.yaml
+++ b/responses_api_agents/simple_agent/configs/simple_agent.yaml
@@ -8,3 +8,4 @@ simple_agent:
       model_server:
         type: responses_api_models
         name: policy_model
+      skip_invalid_tool_calls: false

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -20,7 +20,9 @@ from pytest import MonkeyPatch
 
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
+    NeMoGymFunctionCallOutput,
     NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseFunctionToolCall,
     NeMoGymResponseReasoningItem,
     NeMoGymSummary,
 )
@@ -162,6 +164,103 @@ class TestApp:
         }
         assert expected_responses_dict == actual_responses_dict
 
+    async def test_responses_continues_on_malformed_tool_call_arguments_by_default(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """The invalid-tool-call history guard is opt-in for compatibility."""
+        config = SimpleAgentConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            model_server=ModelServerRef(
+                type="responses_api_models",
+                name="my server name",
+            ),
+            resources_server=ResourcesServerRef(
+                type="resources_servers",
+                name="my resources server",
+            ),
+        )
+        server = SimpleAgent(config=config, server_client=MagicMock(spec=ServerClient))
+        app = server.setup_webserver()
+        client = TestClient(app)
+
+        mock_response_bad_tool_call = {
+            "id": "resp_bad_tool_call",
+            "created_at": 1753983920.0,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [
+                {
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "my_tool",
+                    "arguments": "{not json",
+                    "type": "function_call",
+                    "status": "completed",
+                }
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+        mock_response_chat_data = {
+            "id": "resp_final",
+            "created_at": 1753983921.0,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [
+                {
+                    "id": "msg_final",
+                    "content": [
+                        {
+                            "annotations": [],
+                            "text": "Done.",
+                            "type": "output_text",
+                        }
+                    ],
+                    "role": "assistant",
+                    "status": "completed",
+                    "type": "message",
+                }
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+
+        dotjson_mock = AsyncMock()
+        dotjson_mock.read.side_effect = [
+            json.dumps(mock_response_bad_tool_call),
+            json.dumps(mock_response_chat_data),
+        ]
+        dotjson_mock.cookies = MagicMock()
+        server.server_client.post.return_value = dotjson_mock
+
+        res = client.post("/v1/responses", json={"input": [{"role": "user", "content": "hello"}]})
+        assert res.status_code == 200
+
+        post_call_kwargs = [c.kwargs for c in server.server_client.post.call_args_list]
+        server_names_called = [kw["server_name"] for kw in post_call_kwargs]
+        assert server_names_called == ["my server name", "my server name"]
+
+        second_call_input = post_call_kwargs[1]["json"].input
+        assert any(
+            isinstance(item, NeMoGymResponseFunctionToolCall) and item.call_id == "call_1"
+            for item in second_call_input
+        )
+        error_outputs = [
+            item
+            for item in second_call_input
+            if isinstance(item, NeMoGymFunctionCallOutput) and item.call_id == "call_1"
+        ]
+        assert len(error_outputs) == 1
+        error_payload = json.loads(error_outputs[0].output)
+        assert "error" in error_payload
+        assert "Invalid tool call arguments" in error_payload["error"]
+        assert "JSONDecodeError" in error_payload["error"]
+
     async def test_responses_stops_on_malformed_tool_call_arguments(self, monkeypatch: MonkeyPatch) -> None:
         """Malformed JSON in a tool-call's arguments must not crash the rollout.
 
@@ -174,6 +273,7 @@ class TestApp:
             port=8080,
             entrypoint="",
             name="",
+            stop_on_invalid_tool_call=True,
             model_server=ModelServerRef(
                 type="responses_api_models",
                 name="my server name",
@@ -238,6 +338,7 @@ class TestApp:
             port=8080,
             entrypoint="",
             name="",
+            stop_on_invalid_tool_call=True,
             model_server=ModelServerRef(
                 type="responses_api_models",
                 name="my server name",
@@ -314,6 +415,7 @@ class TestApp:
             port=8080,
             entrypoint="",
             name="",
+            stop_on_invalid_tool_call=True,
             model_server=ModelServerRef(
                 type="responses_api_models",
                 name="my server name",

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -20,9 +20,7 @@ from pytest import MonkeyPatch
 
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
-    NeMoGymFunctionCallOutput,
     NeMoGymResponseCreateParamsNonStreaming,
-    NeMoGymResponseFunctionToolCall,
     NeMoGymResponseReasoningItem,
     NeMoGymSummary,
 )
@@ -164,12 +162,12 @@ class TestApp:
         }
         assert expected_responses_dict == actual_responses_dict
 
-    async def test_responses_continues_on_malformed_tool_call_arguments(self, monkeypatch: MonkeyPatch) -> None:
+    async def test_responses_stops_on_malformed_tool_call_arguments(self, monkeypatch: MonkeyPatch) -> None:
         """Malformed JSON in a tool-call's arguments must not crash the rollout.
 
-        The agent should surface the parse error back to the model as a
-        function_call_output and let the loop continue (ultimately terminating
-        on a normal assistant message).
+        The agent must not send malformed function_call items back in the next
+        model-call history, since chat templates may reject them. Instead it
+        should terminate the response with an assistant-visible error message.
         """
         config = SimpleAgentConfig(
             host="0.0.0.0",
@@ -210,24 +208,62 @@ class TestApp:
             "tools": [],
         }
 
-        mock_response_chat_data = {
-            "id": "resp_final",
-            "created_at": 1753983921.0,
+        dotjson_mock = AsyncMock()
+        dotjson_mock.read.return_value = json.dumps(mock_response_bad_tool_call)
+        dotjson_mock.cookies = MagicMock()
+        server.server_client.post.return_value = dotjson_mock
+
+        res = client.post("/v1/responses", json={"input": [{"role": "user", "content": "hello"}]})
+        assert res.status_code == 200
+
+        # The resources server must not be called for a malformed tool call —
+        # only the first model call should hit server_client.post.
+        post_call_kwargs = [c.kwargs for c in server.server_client.post.call_args_list]
+        server_names_called = [kw["server_name"] for kw in post_call_kwargs]
+        assert server_names_called == ["my server name"]
+
+        actual_output = res.json()["output"]
+        assert len(actual_output) == 1
+        assert actual_output[0]["type"] == "message"
+        error_payload = json.loads(actual_output[0]["content"][0]["text"])
+        assert "error" in error_payload
+        assert "Invalid tool call arguments" in error_payload["error"]
+        # The exception type must be visible to the model — repr(e) on a
+        # JSONDecodeError starts with the class name.
+        assert "JSONDecodeError" in error_payload["error"]
+
+    async def test_responses_stops_on_non_object_tool_call_arguments(self, monkeypatch: MonkeyPatch) -> None:
+        config = SimpleAgentConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            model_server=ModelServerRef(
+                type="responses_api_models",
+                name="my server name",
+            ),
+            resources_server=ResourcesServerRef(
+                type="resources_servers",
+                name="my resources server",
+            ),
+        )
+        server = SimpleAgent(config=config, server_client=MagicMock(spec=ServerClient))
+        app = server.setup_webserver()
+        client = TestClient(app)
+
+        mock_response_bad_tool_call = {
+            "id": "resp_bad_tool_call",
+            "created_at": 1753983920.0,
             "model": "dummy_model",
             "object": "response",
             "output": [
                 {
-                    "id": "msg_final",
-                    "content": [
-                        {
-                            "annotations": [],
-                            "text": "Sorry, I'll stop calling that tool.",
-                            "type": "output_text",
-                        }
-                    ],
-                    "role": "assistant",
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "my_tool",
+                    "arguments": '"not an object"',
+                    "type": "function_call",
                     "status": "completed",
-                    "type": "message",
                 }
             ],
             "parallel_tool_calls": True,
@@ -236,41 +272,117 @@ class TestApp:
         }
 
         dotjson_mock = AsyncMock()
-        dotjson_mock.read.side_effect = [
-            json.dumps(mock_response_bad_tool_call),
-            json.dumps(mock_response_chat_data),
-        ]
+        dotjson_mock.read.return_value = json.dumps(mock_response_bad_tool_call)
         dotjson_mock.cookies = MagicMock()
         server.server_client.post.return_value = dotjson_mock
 
-        res = client.post("/v1/responses", json={"input": [{"role": "user", "content": "hello"}]})
+        res = client.post(
+            "/v1/responses",
+            json={
+                "input": [{"role": "user", "content": "hello"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "my_tool",
+                        "description": "Test tool.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"query": {"type": "string"}},
+                            "required": ["query"],
+                            "additionalProperties": False,
+                        },
+                        "strict": True,
+                    }
+                ],
+            },
+        )
         assert res.status_code == 200
 
-        # The resources server must not be called for a malformed tool call —
-        # only the two model calls should hit server_client.post.
         post_call_kwargs = [c.kwargs for c in server.server_client.post.call_args_list]
         server_names_called = [kw["server_name"] for kw in post_call_kwargs]
-        assert server_names_called == ["my server name", "my server name"]
+        assert server_names_called == ["my server name"]
 
-        # The second model call's input must include the original function_call
-        # plus a function_call_output describing the parse error.
-        second_call_input = post_call_kwargs[1]["json"].input
-        assert any(
-            isinstance(item, NeMoGymResponseFunctionToolCall) and item.call_id == "call_1"
-            for item in second_call_input
+        actual_output = res.json()["output"]
+        assert len(actual_output) == 1
+        assert actual_output[0]["type"] == "message"
+        error_payload = json.loads(actual_output[0]["content"][0]["text"])
+        assert error_payload == {"error": "Invalid tool call arguments: expected object, got str"}
+
+    async def test_responses_stops_on_unknown_tool_name(self, monkeypatch: MonkeyPatch) -> None:
+        config = SimpleAgentConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            model_server=ModelServerRef(
+                type="responses_api_models",
+                name="my server name",
+            ),
+            resources_server=ResourcesServerRef(
+                type="resources_servers",
+                name="my resources server",
+            ),
         )
-        error_outputs = [
-            item
-            for item in second_call_input
-            if isinstance(item, NeMoGymFunctionCallOutput) and item.call_id == "call_1"
-        ]
-        assert len(error_outputs) == 1
-        error_payload = json.loads(error_outputs[0].output)
-        assert "error" in error_payload
-        assert "Invalid tool call arguments" in error_payload["error"]
-        # The exception type must be visible to the model — repr(e) on a
-        # JSONDecodeError starts with the class name.
-        assert "JSONDecodeError" in error_payload["error"]
+        server = SimpleAgent(config=config, server_client=MagicMock(spec=ServerClient))
+        app = server.setup_webserver()
+        client = TestClient(app)
+
+        mock_response_bad_tool_name = {
+            "id": "resp_bad_tool_name",
+            "created_at": 1753983920.0,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [
+                {
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "web_search]",
+                    "arguments": '{"query": "foo"}',
+                    "type": "function_call",
+                    "status": "completed",
+                }
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+
+        dotjson_mock = AsyncMock()
+        dotjson_mock.read.return_value = json.dumps(mock_response_bad_tool_name)
+        dotjson_mock.cookies = MagicMock()
+        server.server_client.post.return_value = dotjson_mock
+
+        res = client.post(
+            "/v1/responses",
+            json={
+                "input": [{"role": "user", "content": "hello"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "web_search",
+                        "description": "Search.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"query": {"type": "string"}},
+                            "required": ["query"],
+                            "additionalProperties": False,
+                        },
+                        "strict": True,
+                    }
+                ],
+            },
+        )
+        assert res.status_code == 200
+
+        post_call_kwargs = [c.kwargs for c in server.server_client.post.call_args_list]
+        server_names_called = [kw["server_name"] for kw in post_call_kwargs]
+        assert server_names_called == ["my server name"]
+
+        actual_output = res.json()["output"]
+        assert len(actual_output) == 1
+        assert actual_output[0]["type"] == "message"
+        error_payload = json.loads(actual_output[0]["content"][0]["text"])
+        assert error_payload == {"error": "Invalid tool call name: 'web_search]'"}
 
     async def test_responses_continues_on_reasoning_only(self, monkeypatch: MonkeyPatch) -> None:
         config = SimpleAgentConfig(

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -261,19 +261,19 @@ class TestApp:
         assert "Invalid tool call arguments" in error_payload["error"]
         assert "JSONDecodeError" in error_payload["error"]
 
-    async def test_responses_stops_on_malformed_tool_call_arguments(self, monkeypatch: MonkeyPatch) -> None:
+    async def test_responses_skips_malformed_tool_call_arguments(self, monkeypatch: MonkeyPatch) -> None:
         """Malformed JSON in a tool-call's arguments must not crash the rollout.
 
-        The agent must not send malformed function_call items back in the next
-        model-call history, since chat templates may reject them. Instead it
-        should terminate the response with an assistant-visible error message.
+        When enabled, the agent must not send malformed function_call items
+        back in the next model-call history, since chat templates may reject
+        them. It should keep valid/non-call outputs and continue.
         """
         config = SimpleAgentConfig(
             host="0.0.0.0",
             port=8080,
             entrypoint="",
             name="",
-            stop_on_invalid_tool_call=True,
+            skip_invalid_tool_calls=True,
             model_server=ModelServerRef(
                 type="responses_api_models",
                 name="my server name",
@@ -293,6 +293,12 @@ class TestApp:
             "model": "dummy_model",
             "object": "response",
             "output": [
+                {
+                    "id": "rs_1",
+                    "summary": [{"text": "thinking", "type": "summary_text"}],
+                    "type": "reasoning",
+                    "status": "completed",
+                },
                 {
                     "id": "fc_1",
                     "call_id": "call_1",
@@ -307,9 +313,36 @@ class TestApp:
             "tool_choice": "auto",
             "tools": [],
         }
+        mock_response_chat_data = {
+            "id": "resp_final",
+            "created_at": 1753983921.0,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [
+                {
+                    "id": "msg_final",
+                    "content": [
+                        {
+                            "annotations": [],
+                            "text": "Done.",
+                            "type": "output_text",
+                        }
+                    ],
+                    "role": "assistant",
+                    "status": "completed",
+                    "type": "message",
+                }
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
 
         dotjson_mock = AsyncMock()
-        dotjson_mock.read.return_value = json.dumps(mock_response_bad_tool_call)
+        dotjson_mock.read.side_effect = [
+            json.dumps(mock_response_bad_tool_call),
+            json.dumps(mock_response_chat_data),
+        ]
         dotjson_mock.cookies = MagicMock()
         server.server_client.post.return_value = dotjson_mock
 
@@ -317,28 +350,25 @@ class TestApp:
         assert res.status_code == 200
 
         # The resources server must not be called for a malformed tool call —
-        # only the first model call should hit server_client.post.
+        # only model calls should hit server_client.post.
         post_call_kwargs = [c.kwargs for c in server.server_client.post.call_args_list]
         server_names_called = [kw["server_name"] for kw in post_call_kwargs]
-        assert server_names_called == ["my server name"]
+        assert server_names_called == ["my server name", "my server name"]
+
+        second_call_input = post_call_kwargs[1]["json"].input
+        assert not any(isinstance(item, NeMoGymResponseFunctionToolCall) for item in second_call_input)
+        assert not any(isinstance(item, NeMoGymFunctionCallOutput) for item in second_call_input)
 
         actual_output = res.json()["output"]
-        assert len(actual_output) == 1
-        assert actual_output[0]["type"] == "message"
-        error_payload = json.loads(actual_output[0]["content"][0]["text"])
-        assert "error" in error_payload
-        assert "Invalid tool call arguments" in error_payload["error"]
-        # The exception type must be visible to the model — repr(e) on a
-        # JSONDecodeError starts with the class name.
-        assert "JSONDecodeError" in error_payload["error"]
+        assert [item["type"] for item in actual_output] == ["reasoning", "message"]
 
-    async def test_responses_stops_on_non_object_tool_call_arguments(self, monkeypatch: MonkeyPatch) -> None:
+    async def test_responses_skips_non_object_tool_call_arguments(self, monkeypatch: MonkeyPatch) -> None:
         config = SimpleAgentConfig(
             host="0.0.0.0",
             port=8080,
             entrypoint="",
             name="",
-            stop_on_invalid_tool_call=True,
+            skip_invalid_tool_calls=True,
             model_server=ModelServerRef(
                 type="responses_api_models",
                 name="my server name",
@@ -359,6 +389,12 @@ class TestApp:
             "object": "response",
             "output": [
                 {
+                    "id": "rs_1",
+                    "summary": [{"text": "thinking", "type": "summary_text"}],
+                    "type": "reasoning",
+                    "status": "completed",
+                },
+                {
                     "id": "fc_1",
                     "call_id": "call_1",
                     "name": "my_tool",
@@ -371,9 +407,36 @@ class TestApp:
             "tool_choice": "auto",
             "tools": [],
         }
+        mock_response_chat_data = {
+            "id": "resp_final",
+            "created_at": 1753983921.0,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [
+                {
+                    "id": "msg_final",
+                    "content": [
+                        {
+                            "annotations": [],
+                            "text": "Done.",
+                            "type": "output_text",
+                        }
+                    ],
+                    "role": "assistant",
+                    "status": "completed",
+                    "type": "message",
+                }
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
 
         dotjson_mock = AsyncMock()
-        dotjson_mock.read.return_value = json.dumps(mock_response_bad_tool_call)
+        dotjson_mock.read.side_effect = [
+            json.dumps(mock_response_bad_tool_call),
+            json.dumps(mock_response_chat_data),
+        ]
         dotjson_mock.cookies = MagicMock()
         server.server_client.post.return_value = dotjson_mock
 
@@ -401,21 +464,22 @@ class TestApp:
 
         post_call_kwargs = [c.kwargs for c in server.server_client.post.call_args_list]
         server_names_called = [kw["server_name"] for kw in post_call_kwargs]
-        assert server_names_called == ["my server name"]
+        assert server_names_called == ["my server name", "my server name"]
+
+        second_call_input = post_call_kwargs[1]["json"].input
+        assert not any(isinstance(item, NeMoGymResponseFunctionToolCall) for item in second_call_input)
+        assert not any(isinstance(item, NeMoGymFunctionCallOutput) for item in second_call_input)
 
         actual_output = res.json()["output"]
-        assert len(actual_output) == 1
-        assert actual_output[0]["type"] == "message"
-        error_payload = json.loads(actual_output[0]["content"][0]["text"])
-        assert error_payload == {"error": "Invalid tool call arguments: expected object, got str"}
+        assert [item["type"] for item in actual_output] == ["reasoning", "message"]
 
-    async def test_responses_stops_on_unknown_tool_name(self, monkeypatch: MonkeyPatch) -> None:
+    async def test_responses_skips_unknown_tool_name(self, monkeypatch: MonkeyPatch) -> None:
         config = SimpleAgentConfig(
             host="0.0.0.0",
             port=8080,
             entrypoint="",
             name="",
-            stop_on_invalid_tool_call=True,
+            skip_invalid_tool_calls=True,
             model_server=ModelServerRef(
                 type="responses_api_models",
                 name="my server name",
@@ -436,6 +500,12 @@ class TestApp:
             "object": "response",
             "output": [
                 {
+                    "id": "rs_1",
+                    "summary": [{"text": "thinking", "type": "summary_text"}],
+                    "type": "reasoning",
+                    "status": "completed",
+                },
+                {
                     "id": "fc_1",
                     "call_id": "call_1",
                     "name": "web_search]",
@@ -448,9 +518,36 @@ class TestApp:
             "tool_choice": "auto",
             "tools": [],
         }
+        mock_response_chat_data = {
+            "id": "resp_final",
+            "created_at": 1753983921.0,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [
+                {
+                    "id": "msg_final",
+                    "content": [
+                        {
+                            "annotations": [],
+                            "text": "Done.",
+                            "type": "output_text",
+                        }
+                    ],
+                    "role": "assistant",
+                    "status": "completed",
+                    "type": "message",
+                }
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
 
         dotjson_mock = AsyncMock()
-        dotjson_mock.read.return_value = json.dumps(mock_response_bad_tool_name)
+        dotjson_mock.read.side_effect = [
+            json.dumps(mock_response_bad_tool_name),
+            json.dumps(mock_response_chat_data),
+        ]
         dotjson_mock.cookies = MagicMock()
         server.server_client.post.return_value = dotjson_mock
 
@@ -478,13 +575,148 @@ class TestApp:
 
         post_call_kwargs = [c.kwargs for c in server.server_client.post.call_args_list]
         server_names_called = [kw["server_name"] for kw in post_call_kwargs]
-        assert server_names_called == ["my server name"]
+        assert server_names_called == ["my server name", "my server name"]
+
+        second_call_input = post_call_kwargs[1]["json"].input
+        assert not any(isinstance(item, NeMoGymResponseFunctionToolCall) for item in second_call_input)
+        assert not any(isinstance(item, NeMoGymFunctionCallOutput) for item in second_call_input)
 
         actual_output = res.json()["output"]
-        assert len(actual_output) == 1
-        assert actual_output[0]["type"] == "message"
-        error_payload = json.loads(actual_output[0]["content"][0]["text"])
-        assert error_payload == {"error": "Invalid tool call name: 'web_search]'"}
+        assert [item["type"] for item in actual_output] == ["reasoning", "message"]
+
+    async def test_responses_skips_invalid_tool_call_and_runs_valid_tool_call(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        config = SimpleAgentConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            skip_invalid_tool_calls=True,
+            model_server=ModelServerRef(
+                type="responses_api_models",
+                name="my server name",
+            ),
+            resources_server=ResourcesServerRef(
+                type="resources_servers",
+                name="my resources server",
+            ),
+        )
+        server = SimpleAgent(config=config, server_client=MagicMock(spec=ServerClient))
+        app = server.setup_webserver()
+        client = TestClient(app)
+
+        mock_response_tool_calls = {
+            "id": "resp_tool_calls",
+            "created_at": 1753983920.0,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [
+                {
+                    "id": "fc_good",
+                    "call_id": "call_good",
+                    "name": "my_tool",
+                    "arguments": '{"query": "foo"}',
+                    "type": "function_call",
+                    "status": "completed",
+                },
+                {
+                    "id": "fc_bad",
+                    "call_id": "call_bad",
+                    "name": "web_search]",
+                    "arguments": '{"query": "bar"}',
+                    "type": "function_call",
+                    "status": "completed",
+                },
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+        mock_response_chat_data = {
+            "id": "resp_final",
+            "created_at": 1753983921.0,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [
+                {
+                    "id": "msg_final",
+                    "content": [
+                        {
+                            "annotations": [],
+                            "text": "Done.",
+                            "type": "output_text",
+                        }
+                    ],
+                    "role": "assistant",
+                    "status": "completed",
+                    "type": "message",
+                }
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+
+        first_model_response = AsyncMock()
+        first_model_response.read.return_value = json.dumps(mock_response_tool_calls)
+        first_model_response.cookies = MagicMock()
+        tool_response = MagicMock()
+        tool_response.cookies = MagicMock()
+        tool_response.content.read = AsyncMock(return_value=b'{"result": "ok"}')
+        second_model_response = AsyncMock()
+        second_model_response.read.return_value = json.dumps(mock_response_chat_data)
+        second_model_response.cookies = MagicMock()
+        server.server_client.post.side_effect = [first_model_response, tool_response, second_model_response]
+
+        res = client.post(
+            "/v1/responses",
+            json={
+                "input": [{"role": "user", "content": "hello"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "my_tool",
+                        "description": "Test tool.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"query": {"type": "string"}},
+                            "required": ["query"],
+                            "additionalProperties": False,
+                        },
+                        "strict": True,
+                    }
+                ],
+            },
+        )
+        assert res.status_code == 200
+
+        post_call_kwargs = [c.kwargs for c in server.server_client.post.call_args_list]
+        server_names_called = [kw["server_name"] for kw in post_call_kwargs]
+        assert server_names_called == ["my server name", "my resources server", "my server name"]
+        assert post_call_kwargs[1]["url_path"] == "/my_tool"
+        assert post_call_kwargs[1]["json"] == {"query": "foo"}
+
+        second_call_input = post_call_kwargs[2]["json"].input
+        assert any(
+            isinstance(item, NeMoGymResponseFunctionToolCall) and item.call_id == "call_good"
+            for item in second_call_input
+        )
+        assert not any(
+            isinstance(item, NeMoGymResponseFunctionToolCall) and item.call_id == "call_bad"
+            for item in second_call_input
+        )
+        assert any(
+            isinstance(item, NeMoGymFunctionCallOutput) and item.call_id == "call_good"
+            for item in second_call_input
+        )
+        assert not any(
+            isinstance(item, NeMoGymFunctionCallOutput) and item.call_id == "call_bad"
+            for item in second_call_input
+        )
+
+        actual_output = res.json()["output"]
+        assert [item.get("call_id") for item in actual_output if item["type"] == "function_call"] == ["call_good"]
 
     async def test_responses_continues_on_reasoning_only(self, monkeypatch: MonkeyPatch) -> None:
         config = SimpleAgentConfig(

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -140,7 +140,12 @@ class TestGlobalConfig:
         agent_config = global_config_dict["hle_equivalence_llm_judge_simple_agent"]["responses_api_agents"][
             "simple_agent"
         ]
+        raw_equivalence_config = OmegaConf.load("resources_servers/equivalence_llm_judge/configs/equivalence_llm_judge.yaml")
+        base_agent_config = raw_equivalence_config["equivalence_llm_judge_simple_agent"]["responses_api_agents"][
+            "simple_agent"
+        ]
         assert agent_config["skip_invalid_tool_calls"] is True
+        assert base_agent_config["skip_invalid_tool_calls"] is False
         assert agent_config["resources_server"]["name"] == "ns_tools"
 
     def test_get_global_config_dict_global_exists(self, monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -88,6 +88,61 @@ class TestGlobalConfig:
         global_config_dict = get_global_config_dict()
         assert self._default_global_config_dict_values == global_config_dict
 
+    def test_simple_agent_skip_invalid_tool_calls_override_survives_inheritance(self) -> None:
+        config = OmegaConf.create(
+            {
+                "config_paths": [
+                    "responses_api_models/vllm_model/configs/vllm_model.yaml",
+                    "resources_servers/labbench2_vlm/configs/judge_model_openai.yaml",
+                    "resources_servers/ns_tools/configs/ns_tools.yaml",
+                    "benchmarks/hle/config.yaml",
+                ],
+                "policy_base_url": "http://localhost:3825",
+                "policy_api_key": "dummy",
+                "policy_model_name": "openai/gpt-oss-20b",
+                "judge_base_url": "http://judge.local/v1",
+                "judge_api_key": "dummy",
+                "judge_model_name": "judge",
+                "hle_equivalence_llm_judge_simple_agent": {
+                    "responses_api_agents": {
+                        "simple_agent": {
+                            "resources_server": {"name": "ns_tools"},
+                            "skip_invalid_tool_calls": True,
+                        }
+                    }
+                },
+                "ns_tools": {
+                    "resources_servers": {
+                        "ns_tools": {
+                            "default_verifier": "hle",
+                            "entrypoint": "app_cleanup.py",
+                            "verifiers": {
+                                "hle": {
+                                    "type": "resources_servers",
+                                    "name": "hle_equivalence_llm_judge_resources_server",
+                                }
+                            },
+                        }
+                    }
+                },
+                "error_on_almost_servers": False,
+            }
+        )
+
+        global_config_dict = GlobalConfigDictParser().parse(
+            GlobalConfigDictParserConfig(
+                initial_global_config_dict=config,
+                skip_load_from_cli=True,
+                skip_load_from_dotenv=True,
+            )
+        )
+
+        agent_config = global_config_dict["hle_equivalence_llm_judge_simple_agent"]["responses_api_agents"][
+            "simple_agent"
+        ]
+        assert agent_config["skip_invalid_tool_calls"] is True
+        assert agent_config["resources_server"]["name"] == "ns_tools"
+
     def test_get_global_config_dict_global_exists(self, monkeypatch: MonkeyPatch) -> None:
         # Clear any lingering env vars.
         monkeypatch.delenv(NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME, raising=False)


### PR DESCRIPTION
Adds an optional simple-agent guard to skip malformed tool calls before passing history into the next model turn. This is intended to avoid vLLM/chat-template crashes when malformed tool-call output is fed back into HLE-with-tools runs.