### PR TITLE
feat: structured skill improvement loop (v0)

### DIFF
--- a/fern/versions/latest/pages/evaluation/improve-skills.mdx
+++ b/fern/versions/latest/pages/evaluation/improve-skills.mdx
@@ -1,0 +1,144 @@
+---
+title: "Improve Skills"
+description: "Iterate on agent skills with a structured measure → improve → keep/revert loop built on gym eval run."
+position: 6
+---
+
+Once you can [evaluate a skill variant](/agent-server/agent-skills) and [diagnose the results](/evaluation/diagnose-results), the next need is to *improve* skills over several rounds — edit, re-measure, and keep what helps — without hand-orchestrating each round or losing track of what you tried.
+
+`gym eval improve-*` adds that loop on top of the existing evaluation machinery. It does not run rollouts itself or edit your skills; it snapshots skill directories, records the aggregate metrics from `gym eval run`, shows before/after deltas, and lets you keep or revert a round.
+
+<Info>
+Skills are a run-level variable, not a dataset field. See [Agent Skills](/agent-server/agent-skills) for how `skills.path` and the content-hashed `skills_ref` work — the improve loop keys rounds on that same `skills_ref.hash`.
+</Info>
+
+## The loop
+
+1. **Measure a baseline** with `gym eval run` and note its `*_aggregate_metrics.json`.
+2. **Init** a workspace that snapshots the baseline skills and metrics.
+3. **Edit** skills in your own editor (or with a coding agent).
+4. **Round** — snapshot the edited skills as a candidate.
+5. **Run** the same eval against the round's staged skills.
+6. **Record** the round's metrics and see before/after.
+7. **Analyze** the round's artifacts with [BLADE](/evaluation/diagnose-results) when a change is unexpected.
+8. **Keep or revert** based on the result, then repeat from step 3.
+
+## Commands
+
+### Initialize a workspace
+
+Start from a measured baseline (the `*_aggregate_metrics.json` produced by `gym eval run`):
+
+```bash
+gym eval improve-init \
+  --workspace .gym/improve/my-skills \
+  --skills .claude/skills \
+  --baseline-metrics results/baseline_aggregate_metrics.json \
+  --eval-command-hint "gym eval run --no-serve --agent my_agent --input data/tasks.jsonl --output results/rollouts.jsonl"
+```
+
+This creates the workspace, copies the current skills tree as the accepted baseline, and records its content hash. `--eval-command-hint` is optional; when set, `improve-round` echoes it back with the round's `+skills.path` appended.
+
+### Start a round
+
+After editing your skills, snapshot them as a candidate:
+
+```bash
+gym eval improve-round --workspace .gym/improve/my-skills
+```
+
+This prints the `+skills.path=<workspace>/rounds/0001/candidate_skills` override to use for the round's eval, so the snapshot — not your still-mutating working copy — is what gets evaluated.
+
+### Run the eval
+
+Collect rollouts against the round snapshot with your normal command:
+
+```bash
+gym eval run --no-serve \
+  --agent my_agent \
+  --input data/tasks.jsonl \
+  --output results/round0001_rollouts.jsonl \
+  +skills.path=.gym/improve/my-skills/rounds/0001/candidate_skills
+```
+
+### Record and compare
+
+Ingest the round's aggregate metrics and print a before/after table against the accepted baseline:
+
+```bash
+gym eval improve-record \
+  --workspace .gym/improve/my-skills \
+  --aggregate-metrics results/round0001_rollouts_aggregate_metrics.json
+```
+
+Cost lives in the rollout output as token usage; run [`gym eval profile`](/reference/cli-commands#eval-profile) on the round's rollouts for per-task pass rates and token summaries.
+
+### Keep or revert
+
+Accept a round (updates the accepted baseline and, by default, copies the skills back to your live `skills.path`):
+
+```bash
+gym eval improve-keep --workspace .gym/improve/my-skills --round 0001
+```
+
+Restore the accepted snapshot to your live skills directory if a round regressed:
+
+```bash
+gym eval improve-revert --workspace .gym/improve/my-skills
+```
+
+Both commands refuse to overwrite a live skills directory that changed since the round unless you pass `--force`, so an in-progress edit is never clobbered silently.
+
+### Review history
+
+```bash
+gym eval improve-history --workspace .gym/improve/my-skills
+```
+
+Lists each round, its status (`pending`, `kept`, `reverted`, `superseded`), skill hash, and the primary-metric delta. Add `--json` for machine-readable output.
+
+## Workspace layout
+
+```
+.gym/improve/my-skills/
+├── improve.yaml              # frozen workspace config
+├── accepted/
+│   ├── skills/               # last kept skill tree
+│   ├── skills_ref.json
+│   └── aggregate_metrics.json
+├── rounds/
+│   └── 0001/
+│       ├── manifest.json     # status, skills_ref, comparison
+│       ├── candidate_skills/
+│       ├── aggregate_metrics.json
+│       └── comparison.json
+└── history.jsonl             # append-only event log
+```
+
+Round identity is the `skills_ref.hash` content digest, so reverting to a prior skill state re-pools with its earlier evaluation automatically.
+
+## Scope
+
+The loop is deliberately thin and reuses existing evaluation primitives — it adds no new metrics, verifier, or rollout collector.
+
+- It does **not** run `gym eval run` for you (servers, models, and benchmark configs vary); it prints the command and ingests the result.
+- It does **not** edit skills — you use your own editor or a coding agent.
+- Latency is not a first-class metric until agents emit timing fields; accuracy and token cost come from existing artifacts.
+
+Automated optimizer backends (e.g. GEPA, ACE) can later drive the same loop through the `rollout_collection_driver` seam without changing this workflow.
+
+<Cards>
+
+<Card title="Agent Skills" href="/agent-server/agent-skills">
+How <code>skills.path</code> and <code>skills_ref</code> work.
+</Card>
+
+<Card title="Diagnose Results" href="/evaluation/diagnose-results">
+Use BLADE to explain why a round's score changed.
+</Card>
+
+<Card title="Aggregate Metrics" href="/evaluation/aggregate-metrics">
+The scorecard the before/after comparison reads from.
+</Card>
+
+</Cards>

--- a/nemo_gym/cli/eval.py
+++ b/nemo_gym/cli/eval.py
@@ -459,3 +459,53 @@ Reward profile completion: {completion_summary["completed_rollout_rows"]}/{compl
 Input rows: {completion_summary["total_input_rows"]} total; {completion_summary["complete_input_rows"]} complete; {completion_summary["partial_input_rows"]} partial; {completion_summary["missing_input_rows"]} without rollouts dropped from output.
 Reward profiling outputs: {reward_profiling_fpath}
 Agent-level metrics: {agent_level_metrics_fpath}""")
+
+
+@exit_cleanly_on_config_error
+def improve_init() -> None:
+    from nemo_gym.skill_improvement import ImproveInitConfig, init_workspace
+
+    config = ImproveInitConfig.model_validate(get_global_config_dict())
+    init_workspace(config)
+
+
+@exit_cleanly_on_config_error
+def improve_round() -> None:
+    from nemo_gym.skill_improvement import ImproveRoundConfig, start_round
+
+    config = ImproveRoundConfig.model_validate(get_global_config_dict())
+    start_round(config)
+
+
+@exit_cleanly_on_config_error
+def improve_record() -> None:
+    from nemo_gym.skill_improvement import ImproveRecordConfig, record_round
+
+    config = ImproveRecordConfig.model_validate(get_global_config_dict())
+    record_round(config)
+
+
+@exit_cleanly_on_config_error
+def improve_keep() -> None:
+    from nemo_gym.skill_improvement import ImproveKeepConfig, keep_round
+
+    config = ImproveKeepConfig.model_validate(get_global_config_dict())
+    keep_round(config)
+
+
+@exit_cleanly_on_config_error
+def improve_revert() -> None:
+    from nemo_gym.skill_improvement import ImproveRevertConfig, revert_live_skills
+
+    config = ImproveRevertConfig.model_validate(get_global_config_dict())
+    revert_live_skills(config)
+
+
+@exit_cleanly_on_config_error
+def improve_history() -> None:
+    from nemo_gym.global_config import JSON_OUTPUT_KEY_NAME
+    from nemo_gym.skill_improvement import ImproveHistoryConfig, list_history
+
+    global_config_dict = get_global_config_dict()
+    config = ImproveHistoryConfig.model_validate(global_config_dict)
+    list_history(config, json_output=bool(global_config_dict.get(JSON_OUTPUT_KEY_NAME, False)))

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -536,6 +536,83 @@ COMMANDS = {
             _value_flag("rollouts", "rollouts_jsonl_fpath", "Rollouts JSONL produced by collection."),
         ),
     ),
+    "eval improve-init": Command(
+        target="nemo_gym.cli.eval:improve_init",
+        summary="Initialize a skill-improvement workspace from a baseline eval.",
+        flags=(
+            _value_flag("workspace", "workspace", "Directory for the improvement session."),
+            _value_flag("skills", "skills", "Live skills directory (Agent Skills layout)."),
+            _value_flag(
+                "baseline-metrics",
+                "baseline_metrics",
+                "Baseline *_aggregate_metrics.json from gym eval run.",
+            ),
+            _value_flag("name", "name", "Workspace name (default: skill-improvement)."),
+            _value_flag("baseline-skills", "baseline_skills", "Baseline skills tree; defaults to --skills."),
+            _value_flag(
+                "eval-command-hint",
+                "eval_command_hint",
+                "Template gym eval run command printed by improve-round.",
+            ),
+            _value_flag("primary-metric", "primary_metric", "Headline metric key (default: mean/reward)."),
+        ),
+    ),
+    "eval improve-round": Command(
+        target="nemo_gym.cli.eval:improve_round",
+        summary="Start a new round: snapshot live skills and print eval command.",
+        flags=(
+            _value_flag("workspace", "workspace", "Improvement workspace directory."),
+            _value_flag("notes", "notes", "Optional note stored on the round manifest."),
+        ),
+    ),
+    "eval improve-record": Command(
+        target="nemo_gym.cli.eval:improve_record",
+        summary="Record round eval results and compare to accepted baseline.",
+        flags=(
+            _value_flag("workspace", "workspace", "Improvement workspace directory."),
+            _value_flag(
+                "aggregate-metrics",
+                "aggregate_metrics",
+                "Aggregate metrics JSON for this round.",
+            ),
+            _value_flag("round", "round_id", "Round id; default: latest pending round."),
+            _value_flag("rollouts", "rollouts", "Rollouts JSONL for this round."),
+            _value_flag("materialized-inputs", "materialized_inputs", "Materialized inputs JSONL."),
+        ),
+    ),
+    "eval improve-keep": Command(
+        target="nemo_gym.cli.eval:improve_keep",
+        summary="Accept a round and update the accepted skills baseline.",
+        flags=(
+            _value_flag("workspace", "workspace", "Improvement workspace directory."),
+            _value_flag("round", "round_id", "Round id to keep (e.g. 0003)."),
+            Flag(
+                register=lambda p: p.add_argument(
+                    "--no-copy-live",
+                    action="store_true",
+                    help="Do not copy accepted skills back to the live skills.path directory.",
+                ),
+                translate_to_hydra=lambda args: ["+copy_live=false"] if args.no_copy_live else [],
+            ),
+            _bool_flag("force", "force", "Overwrite live skills even if they changed since the round."),
+        ),
+    ),
+    "eval improve-revert": Command(
+        target="nemo_gym.cli.eval:improve_revert",
+        summary="Restore accepted skills snapshot to the live skills directory.",
+        flags=(
+            _value_flag("workspace", "workspace", "Improvement workspace directory."),
+            _bool_flag("force", "force", "Overwrite live skills even if they differ from accepted."),
+        ),
+    ),
+    "eval improve-history": Command(
+        target="nemo_gym.cli.eval:improve_history",
+        summary="List improvement rounds and metric deltas.",
+        flags=(
+            _value_flag("workspace", "workspace", "Improvement workspace directory."),
+            JSON,
+        ),
+    ),
     "dev test": Command(target="nemo_gym.cli.dev:dev_test", summary="Run NeMo Gym's unit tests."),
 }
 

--- a/nemo_gym/skill_improvement.py
+++ b/nemo_gym/skill_improvement.py
@@ -1,0 +1,585 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Workspace orchestration for iterative agent skill improvement (#1495).
+
+v0 is manual / coding-agent-in-the-loop: snapshot skills, run eval externally,
+record aggregate metrics, keep or revert. See the "Improve Skills" evaluation
+docs page (``fern/versions/latest/pages/evaluation/improve-skills.mdx``).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import orjson
+import rich
+from pydantic import BaseModel, Field
+
+from nemo_gym.config_types import BaseNeMoGymCLIConfig, ConfigError
+from nemo_gym.skills import SkillsRef, hash_skill_dir, load_skill_directory
+
+
+class RoundStatus(str, Enum):
+    PENDING = "pending"
+    KEPT = "kept"
+    REVERTED = "reverted"
+    SUPERSEDED = "superseded"
+
+
+class MetricComparison(BaseModel):
+    name: str
+    baseline: Optional[float]
+    candidate: Optional[float]
+    delta: Optional[float]
+
+
+class RoundComparison(BaseModel):
+    baseline_round_id: Optional[str] = None
+    baseline_skills_hash: Optional[str] = None
+    candidate_skills_hash: str
+    metrics: List[MetricComparison] = Field(default_factory=list)
+
+
+class RoundManifest(BaseModel):
+    round_id: str
+    status: RoundStatus = RoundStatus.PENDING
+    created_at: str
+    skills_ref: SkillsRef
+    aggregate_metrics_fpath: Optional[str] = None
+    rollouts_jsonl_fpath: Optional[str] = None
+    materialized_inputs_jsonl_fpath: Optional[str] = None
+    comparison: Optional[RoundComparison] = None
+    notes: Optional[str] = None
+
+
+class ImproveWorkspaceConfig(BaseModel):
+    """Persisted workspace metadata (``improve.yaml``)."""
+
+    name: str
+    skills_path: str
+    eval_command_hint: Optional[str] = None
+    primary_metric: str = Field(
+        default="mean/reward",
+        description="Headline metric from aggregate key_metrics used for keep/revert summaries.",
+    )
+
+
+class ImproveInitConfig(BaseNeMoGymCLIConfig):
+    """
+    Initialize a skill-improvement workspace from a measured baseline.
+
+    Examples:
+
+    ```bash
+    gym eval improve-init \\
+        --workspace .gym/improve/my-skills \\
+        --skills .claude/skills \\
+        --baseline-metrics results/baseline_aggregate_metrics.json
+    ```
+    """
+
+    workspace: str = Field(description="Directory to create for this improvement session.")
+    skills: str = Field(description="Live skills directory (Agent Skills layout).")
+    name: str = Field(default="skill-improvement", description="Human-readable workspace name.")
+    baseline_metrics: str = Field(description="Path to baseline *_aggregate_metrics.json from gym eval run.")
+    baseline_skills: Optional[str] = Field(
+        default=None,
+        description="Optional skills tree for the baseline; defaults to --skills at init time.",
+    )
+    eval_command_hint: Optional[str] = Field(
+        default=None,
+        description="Optional template command printed by improve-round (e.g. your gym eval run invocation).",
+    )
+    primary_metric: str = Field(default="mean/reward", description="Metric key for before/after summaries.")
+
+
+class ImproveRoundConfig(BaseNeMoGymCLIConfig):
+    """
+    Start a new improve round: snapshot the current live skills directory.
+
+    Examples:
+
+    ```bash
+    gym eval improve-round --workspace .gym/improve/my-skills
+    ```
+    """
+
+    workspace: str = Field(description="Improvement workspace directory.")
+    notes: Optional[str] = Field(default=None, description="Optional note stored on the round manifest.")
+
+
+class ImproveRecordConfig(BaseNeMoGymCLIConfig):
+    """
+    Record eval results for the latest (or specified) round and compare to accepted baseline.
+
+    Examples:
+
+    ```bash
+    gym eval improve-record \\
+        --workspace .gym/improve/my-skills \\
+        --aggregate-metrics results/round3_aggregate_metrics.json \\
+        --rollouts results/round3_rollouts.jsonl
+    ```
+    """
+
+    workspace: str
+    aggregate_metrics: str
+    round_id: Optional[str] = Field(default=None, description="Round to record; default: latest pending round.")
+    rollouts: Optional[str] = None
+    materialized_inputs: Optional[str] = None
+
+
+class ImproveKeepConfig(BaseNeMoGymCLIConfig):
+    """
+    Accept a round: update accepted baseline and optionally copy skills back to the live directory.
+
+    Examples:
+
+    ```bash
+    gym eval improve-keep --workspace .gym/improve/my-skills --round 0003
+    gym eval improve-keep --workspace .gym/improve/my-skills --round 0003 --no-copy-live
+    ```
+    """
+
+    workspace: str
+    round_id: str = Field(description="Round id to keep (e.g. 0003).")
+    copy_live: bool = Field(
+        default=True,
+        description="Copy accepted skills back to the live skills.path directory.",
+    )
+    force: bool = Field(default=False, description="Overwrite live skills even if they changed since the round.")
+
+
+class ImproveRevertConfig(BaseNeMoGymCLIConfig):
+    """
+    Restore the accepted skills snapshot to the live skills directory.
+
+    Examples:
+
+    ```bash
+    gym eval improve-revert --workspace .gym/improve/my-skills
+    ```
+    """
+
+    workspace: str
+    force: bool = Field(default=False, description="Overwrite live skills even if they differ from expected.")
+
+
+class ImproveHistoryConfig(BaseNeMoGymCLIConfig):
+    """List rounds and decisions for a workspace."""
+
+    workspace: str
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _workspace_paths(workspace: Path) -> Dict[str, Path]:
+    return {
+        "root": workspace,
+        "config": workspace / "improve.yaml",
+        "accepted": workspace / "accepted",
+        "accepted_skills": workspace / "accepted" / "skills",
+        "accepted_skills_ref": workspace / "accepted" / "skills_ref.json",
+        "accepted_metrics": workspace / "accepted" / "aggregate_metrics.json",
+        "rounds": workspace / "rounds",
+        "history": workspace / "history.jsonl",
+    }
+
+
+def _copy_skills_tree(src: Path, dest: Path) -> None:
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(src, dest)
+
+
+def _load_workspace_config(workspace: Path) -> ImproveWorkspaceConfig:
+    paths = _workspace_paths(workspace)
+    if not paths["config"].exists():
+        raise ConfigError(f"Workspace not initialized: {workspace} (missing improve.yaml)")
+    return ImproveWorkspaceConfig.model_validate(json.loads(paths["config"].read_text()))
+
+
+def _append_history(workspace: Path, event: str, payload: Dict[str, Any]) -> None:
+    paths = _workspace_paths(workspace)
+    paths["history"].parent.mkdir(parents=True, exist_ok=True)
+    record = {"ts": _utc_now(), "event": event, **payload}
+    with paths["history"].open("ab") as f:
+        f.write(orjson.dumps(record) + b"\n")
+
+
+def _next_round_id(workspace: Path) -> str:
+    rounds_dir = _workspace_paths(workspace)["rounds"]
+    rounds_dir.mkdir(parents=True, exist_ok=True)
+    existing = sorted(p.name for p in rounds_dir.iterdir() if p.is_dir() and p.name.isdigit())
+    if not existing:
+        return "0001"
+    return f"{int(existing[-1]) + 1:04d}"
+
+
+def _round_dir(workspace: Path, round_id: str) -> Path:
+    return _workspace_paths(workspace)["rounds"] / round_id
+
+
+def _load_round_manifest(workspace: Path, round_id: str) -> RoundManifest:
+    manifest_path = _round_dir(workspace, round_id) / "manifest.json"
+    if not manifest_path.exists():
+        raise ConfigError(f"Round {round_id} not found in {workspace}")
+    return RoundManifest.model_validate(json.loads(manifest_path.read_text()))
+
+
+def _save_round_manifest(workspace: Path, manifest: RoundManifest) -> None:
+    round_path = _round_dir(workspace, manifest.round_id)
+    round_path.mkdir(parents=True, exist_ok=True)
+    (round_path / "manifest.json").write_bytes(orjson.dumps(manifest.model_dump(), option=orjson.OPT_INDENT_2))
+
+
+def load_aggregate_metrics_key_metrics(aggregate_metrics_fpath: Path) -> Dict[str, float]:
+    """Extract merged key_metrics across agents from an aggregate metrics file."""
+    if not aggregate_metrics_fpath.exists():
+        raise ConfigError(f"Aggregate metrics file not found: {aggregate_metrics_fpath}")
+
+    data = json.loads(aggregate_metrics_fpath.read_text())
+    if not isinstance(data, list):
+        raise ConfigError(f"Expected aggregate metrics JSON array in {aggregate_metrics_fpath}")
+
+    merged: Dict[str, float] = {}
+    for entry in data:
+        key_metrics = entry.get("key_metrics") or {}
+        for k, v in key_metrics.items():
+            if isinstance(v, (int, float)) and not isinstance(v, bool):
+                merged[k] = float(v)
+    return merged
+
+
+def compare_key_metrics(
+    baseline: Dict[str, float],
+    candidate: Dict[str, float],
+    *,
+    metric_names: Optional[List[str]] = None,
+) -> List[MetricComparison]:
+    names = metric_names or sorted(set(baseline) | set(candidate))
+    comparisons: List[MetricComparison] = []
+    for name in names:
+        b = baseline.get(name)
+        c = candidate.get(name)
+        delta = (c - b) if b is not None and c is not None else None
+        comparisons.append(MetricComparison(name=name, baseline=b, candidate=c, delta=delta))
+    return comparisons
+
+
+def init_workspace(config: ImproveInitConfig) -> Path:
+    workspace = Path(config.workspace)
+    if workspace.exists() and any(workspace.iterdir()):
+        raise ConfigError(f"Workspace {workspace} already exists and is not empty.")
+
+    paths = _workspace_paths(workspace)
+    workspace.mkdir(parents=True, exist_ok=True)
+    paths["rounds"].mkdir(parents=True, exist_ok=True)
+
+    baseline_skills_src = Path(config.baseline_skills or config.skills)
+    if not baseline_skills_src.is_dir():
+        raise ConfigError(f"Baseline skills directory not found: {baseline_skills_src}")
+
+    baseline_metrics_src = Path(config.baseline_metrics)
+    if not baseline_metrics_src.exists():
+        raise ConfigError(f"Baseline aggregate metrics not found: {baseline_metrics_src}")
+
+    ws_config = ImproveWorkspaceConfig(
+        name=config.name,
+        skills_path=config.skills,
+        eval_command_hint=config.eval_command_hint,
+        primary_metric=config.primary_metric,
+    )
+    paths["config"].write_bytes(orjson.dumps(ws_config.model_dump(), option=orjson.OPT_INDENT_2))
+
+    _copy_skills_tree(baseline_skills_src, paths["accepted_skills"])
+    shutil.copy2(baseline_metrics_src, paths["accepted_metrics"])
+
+    skills_ref = load_skill_directory(str(paths["accepted_skills"]))
+    paths["accepted_skills_ref"].write_bytes(orjson.dumps(skills_ref.model_dump(), option=orjson.OPT_INDENT_2))
+
+    _append_history(
+        workspace,
+        "init",
+        {
+            "skills_path": config.skills,
+            "baseline_metrics": str(baseline_metrics_src),
+            "accepted_skills_hash": skills_ref.hash,
+        },
+    )
+
+    rich.print(f"[green]Initialized improve workspace at {workspace}[/green]")
+    rich.print(f"Accepted baseline skills hash: {skills_ref.hash}")
+    return workspace
+
+
+def start_round(config: ImproveRoundConfig) -> Tuple[str, SkillsRef]:
+    workspace = Path(config.workspace)
+    ws_config = _load_workspace_config(workspace)
+    live_skills = Path(ws_config.skills_path)
+    if not live_skills.is_dir():
+        raise ConfigError(f"Live skills directory not found: {live_skills}")
+
+    round_id = _next_round_id(workspace)
+    round_path = _round_dir(workspace, round_id)
+    candidate_skills = round_path / "candidate_skills"
+    _copy_skills_tree(live_skills, candidate_skills)
+
+    skills_ref = load_skill_directory(str(candidate_skills))
+    manifest = RoundManifest(
+        round_id=round_id,
+        status=RoundStatus.PENDING,
+        created_at=_utc_now(),
+        skills_ref=skills_ref,
+        notes=config.notes,
+    )
+    _save_round_manifest(workspace, manifest)
+    _append_history(workspace, "round_start", {"round_id": round_id, "skills_hash": skills_ref.hash})
+
+    rich.print(f"[green]Started round {round_id}[/green] (skills hash={skills_ref.hash})")
+    skills_path_override = f"+skills.path={candidate_skills}"
+    if ws_config.eval_command_hint:
+        rich.print("\nSuggested eval command:")
+        rich.print(f"  {ws_config.eval_command_hint} {skills_path_override}")
+    else:
+        rich.print("\nRun eval with skills staged for this round, e.g.:")
+        rich.print(
+            f"  gym eval run --no-serve ... --output results/round{round_id}_rollouts.jsonl {skills_path_override}"
+        )
+    rich.print(f"\nThen record results:\n  gym eval improve-record --workspace {workspace} --aggregate-metrics <path>")
+
+    return round_id, skills_ref
+
+
+def record_round(config: ImproveRecordConfig) -> RoundManifest:
+    workspace = Path(config.workspace)
+    ws_config = _load_workspace_config(workspace)
+
+    round_id = config.round_id
+    if round_id is None:
+        rounds_dir = _workspace_paths(workspace)["rounds"]
+        pending = []
+        for p in sorted(rounds_dir.iterdir()):
+            if not p.is_dir():
+                continue
+            manifest = _load_round_manifest(workspace, p.name)
+            if manifest.status == RoundStatus.PENDING:
+                pending.append(manifest.round_id)
+        if not pending:
+            raise ConfigError("No pending round to record. Run gym eval improve-round first.")
+        round_id = pending[-1]
+
+    manifest = _load_round_manifest(workspace, round_id)
+    if manifest.status != RoundStatus.PENDING:
+        raise ConfigError(f"Round {round_id} is {manifest.status.value}, expected pending.")
+
+    agg_src = Path(config.aggregate_metrics)
+    round_path = _round_dir(workspace, round_id)
+    agg_dest = round_path / "aggregate_metrics.json"
+    shutil.copy2(agg_src, agg_dest)
+
+    if config.rollouts:
+        shutil.copy2(config.rollouts, round_path / "rollouts.jsonl")
+        manifest.rollouts_jsonl_fpath = str(round_path / "rollouts.jsonl")
+    if config.materialized_inputs:
+        shutil.copy2(config.materialized_inputs, round_path / "materialized_inputs.jsonl")
+        manifest.materialized_inputs_jsonl_fpath = str(round_path / "materialized_inputs.jsonl")
+
+    manifest.aggregate_metrics_fpath = str(agg_dest)
+
+    accepted_metrics = load_aggregate_metrics_key_metrics(_workspace_paths(workspace)["accepted_metrics"])
+    candidate_metrics = load_aggregate_metrics_key_metrics(agg_dest)
+
+    accepted_ref_path = _workspace_paths(workspace)["accepted_skills_ref"]
+    accepted_hash = None
+    if accepted_ref_path.exists():
+        accepted_hash = json.loads(accepted_ref_path.read_text()).get("hash")
+
+    comparison = RoundComparison(
+        baseline_skills_hash=accepted_hash,
+        candidate_skills_hash=manifest.skills_ref.hash,
+        metrics=compare_key_metrics(accepted_metrics, candidate_metrics),
+    )
+    manifest.comparison = comparison
+    _save_round_manifest(workspace, manifest)
+    (round_path / "comparison.json").write_bytes(orjson.dumps(comparison.model_dump(), option=orjson.OPT_INDENT_2))
+
+    _append_history(
+        workspace,
+        "round_record",
+        {"round_id": round_id, "skills_hash": manifest.skills_ref.hash, "aggregate_metrics": str(agg_dest)},
+    )
+
+    _print_comparison_table(comparison, primary_metric=ws_config.primary_metric)
+    rich.print(f"\nKeep:  gym eval improve-keep --workspace {workspace} --round {round_id}")
+    rich.print(f"Revert live skills: gym eval improve-revert --workspace {workspace}")
+
+    return manifest
+
+
+def keep_round(config: ImproveKeepConfig) -> None:
+    workspace = Path(config.workspace)
+    ws_config = _load_workspace_config(workspace)
+    manifest = _load_round_manifest(workspace, config.round_id)
+
+    if manifest.status != RoundStatus.PENDING:
+        raise ConfigError(f"Round {config.round_id} is {manifest.status.value}, expected pending.")
+    if not manifest.aggregate_metrics_fpath:
+        raise ConfigError(f"Round {config.round_id} has no recorded metrics. Run improve-record first.")
+
+    round_path = _round_dir(workspace, config.round_id)
+    paths = _workspace_paths(workspace)
+
+    for other in sorted(paths["rounds"].iterdir()):
+        if not other.is_dir() or other.name == config.round_id:
+            continue
+        other_manifest = _load_round_manifest(workspace, other.name)
+        if other_manifest.status == RoundStatus.KEPT:
+            other_manifest.status = RoundStatus.SUPERSEDED
+            _save_round_manifest(workspace, other_manifest)
+
+    _copy_skills_tree(round_path / "candidate_skills", paths["accepted_skills"])
+    shutil.copy2(Path(manifest.aggregate_metrics_fpath), paths["accepted_metrics"])
+    paths["accepted_skills_ref"].write_bytes(
+        orjson.dumps(manifest.skills_ref.model_dump(), option=orjson.OPT_INDENT_2)
+    )
+
+    manifest.status = RoundStatus.KEPT
+    _save_round_manifest(workspace, manifest)
+
+    if config.copy_live:
+        live = Path(ws_config.skills_path)
+        expected_hash = manifest.skills_ref.hash
+        if live.is_dir():
+            live_hash = hash_skill_dir(live)
+            if live_hash != expected_hash and not config.force:
+                raise ConfigError(
+                    f"Live skills at {live} (hash={live_hash}) differ from round {config.round_id} "
+                    f"(hash={expected_hash}). Re-run with --force to overwrite."
+                )
+        _copy_skills_tree(paths["accepted_skills"], live)
+
+    _append_history(workspace, "round_keep", {"round_id": config.round_id, "skills_hash": manifest.skills_ref.hash})
+    rich.print(f"[green]Kept round {config.round_id}[/green] (accepted hash={manifest.skills_ref.hash})")
+
+
+def revert_live_skills(config: ImproveRevertConfig) -> None:
+    workspace = Path(config.workspace)
+    ws_config = _load_workspace_config(workspace)
+    paths = _workspace_paths(workspace)
+
+    if not paths["accepted_skills"].is_dir():
+        raise ConfigError(f"No accepted skills snapshot in {workspace}")
+
+    accepted_ref = SkillsRef.model_validate(json.loads(paths["accepted_skills_ref"].read_text()))
+    live = Path(ws_config.skills_path)
+
+    if live.is_dir() and not config.force:
+        live_hash = hash_skill_dir(live)
+        if live_hash != accepted_ref.hash:
+            rich.print(f"[yellow]Live skills hash {live_hash} differs from accepted {accepted_ref.hash}.[/yellow]")
+            raise ConfigError("Refusing to revert without --force.")
+
+    live.parent.mkdir(parents=True, exist_ok=True)
+    _copy_skills_tree(paths["accepted_skills"], live)
+    _append_history(workspace, "revert_live", {"skills_hash": accepted_ref.hash})
+    rich.print(f"[green]Restored live skills from accepted baseline[/green] (hash={accepted_ref.hash})")
+
+
+def list_history(config: ImproveHistoryConfig, *, json_output: bool = False) -> List[RoundManifest]:
+    workspace = Path(config.workspace)
+    _load_workspace_config(workspace)
+    rounds_dir = _workspace_paths(workspace)["rounds"]
+
+    manifests: List[RoundManifest] = []
+    if rounds_dir.exists():
+        for p in sorted(rounds_dir.iterdir()):
+            if p.is_dir() and (p / "manifest.json").exists():
+                manifests.append(_load_round_manifest(workspace, p.name))
+
+    if json_output:
+        print(json.dumps([m.model_dump() for m in manifests], indent=2))
+        return manifests
+
+    if not manifests:
+        rich.print("[yellow]No rounds yet.[/yellow]")
+        return manifests
+
+    from rich.table import Table
+
+    ws_config = _load_workspace_config(workspace)
+    table = Table(title=f"Improve rounds — {workspace}")
+    table.add_column("Round")
+    table.add_column("Status")
+    table.add_column("Skills hash")
+    table.add_column(ws_config.primary_metric)
+    table.add_column("Recorded")
+
+    for m in manifests:
+        primary_val = ""
+        if m.comparison:
+            for mc in m.comparison.metrics:
+                if mc.name == ws_config.primary_metric:
+                    parts = []
+                    if mc.baseline is not None:
+                        parts.append(f"{mc.baseline:.4g}")
+                    if mc.candidate is not None:
+                        parts.append(f"→ {mc.candidate:.4g}")
+                    if mc.delta is not None:
+                        sign = "+" if mc.delta >= 0 else ""
+                        parts.append(f"({sign}{mc.delta:.4g})")
+                    primary_val = " ".join(parts)
+                    break
+        table.add_row(
+            m.round_id,
+            m.status.value,
+            m.skills_ref.hash,
+            primary_val,
+            "yes" if m.aggregate_metrics_fpath else "no",
+        )
+
+    rich.print(table)
+    return manifests
+
+
+def _print_comparison_table(comparison: RoundComparison, *, primary_metric: str) -> None:
+    from rich.table import Table
+
+    table = Table(title="Before / after (accepted baseline → this round)")
+    table.add_column("Metric")
+    table.add_column("Baseline")
+    table.add_column("Candidate")
+    table.add_column("Delta")
+
+    for mc in comparison.metrics:
+        style = None
+        if mc.name == primary_metric and mc.delta is not None:
+            style = "green" if mc.delta > 0 else "red" if mc.delta < 0 else None
+        table.add_row(
+            mc.name,
+            f"{mc.baseline:.6g}" if mc.baseline is not None else "—",
+            f"{mc.candidate:.6g}" if mc.candidate is not None else "—",
+            f"{mc.delta:+.6g}" if mc.delta is not None else "—",
+            style=style,
+        )
+
+    rich.print(table)

--- a/tests/unit_tests/test_skill_improvement.py
+++ b/tests/unit_tests/test_skill_improvement.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from nemo_gym.config_types import ConfigError
+from nemo_gym.skill_improvement import (
+    ImproveHistoryConfig,
+    ImproveInitConfig,
+    ImproveKeepConfig,
+    ImproveRecordConfig,
+    ImproveRevertConfig,
+    ImproveRoundConfig,
+    RoundStatus,
+    compare_key_metrics,
+    init_workspace,
+    keep_round,
+    list_history,
+    load_aggregate_metrics_key_metrics,
+    record_round,
+    revert_live_skills,
+    start_round,
+)
+
+
+def _write_skill(skills_dir: Path, name: str, body: str = "# Body\n") -> None:
+    skill_dir = skills_dir / name
+    if skill_dir.exists():
+        shutil.rmtree(skill_dir)
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\ndescription: Test skill.\n---\n{body}")
+
+
+def _write_aggregate_metrics(path: Path, mean_reward: float) -> None:
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "agent_ref": {"name": "my_agent"},
+                    "agent_metrics": {"mean/reward": mean_reward},
+                    "key_metrics": {"mean/reward": mean_reward},
+                    "group_level_metrics": [],
+                }
+            ]
+        )
+    )
+
+
+class TestMetricHelpers:
+    def test_load_and_compare_key_metrics(self, tmp_path: Path) -> None:
+        baseline = tmp_path / "baseline_aggregate_metrics.json"
+        _write_aggregate_metrics(baseline, 0.5)
+        loaded = load_aggregate_metrics_key_metrics(baseline)
+        assert loaded["mean/reward"] == pytest.approx(0.5)
+
+        comparisons = compare_key_metrics({"mean/reward": 0.5}, {"mean/reward": 0.75})
+        assert comparisons[0].delta == pytest.approx(0.25)
+
+
+class TestImproveWorkspace:
+    def test_init_round_record_keep_revert(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "ws"
+        live_skills = tmp_path / "live_skills"
+        _write_skill(live_skills, "baseline_skill")
+
+        baseline_metrics = tmp_path / "baseline_metrics.json"
+        _write_aggregate_metrics(baseline_metrics, 0.4)
+
+        init_workspace(
+            ImproveInitConfig(
+                workspace=str(workspace),
+                skills=str(live_skills),
+                baseline_metrics=str(baseline_metrics),
+            )
+        )
+
+        assert (workspace / "improve.yaml").exists()
+        assert (workspace / "accepted" / "skills" / "baseline_skill" / "SKILL.md").exists()
+
+        # Edit live skills for round 1
+        _write_skill(live_skills, "baseline_skill", body="# Improved body\n")
+        round_id, skills_ref = start_round(ImproveRoundConfig(workspace=str(workspace)))
+        assert round_id == "0001"
+
+        round_metrics = tmp_path / "round_metrics.json"
+        _write_aggregate_metrics(round_metrics, 0.8)
+        manifest = record_round(
+            ImproveRecordConfig(
+                workspace=str(workspace),
+                aggregate_metrics=str(round_metrics),
+            )
+        )
+        assert manifest.comparison is not None
+        assert manifest.comparison.metrics[0].delta == pytest.approx(0.4)
+
+        keep_round(
+            ImproveKeepConfig(
+                workspace=str(workspace),
+                round_id=round_id,
+                copy_live=True,
+            )
+        )
+        kept = json.loads((workspace / "rounds" / round_id / "manifest.json").read_text())
+        assert kept["status"] == RoundStatus.KEPT.value
+
+        # Mutate live skills, then revert
+        _write_skill(live_skills, "baseline_skill", body="# Bad edit\n")
+        revert_live_skills(ImproveRevertConfig(workspace=str(workspace), force=True))
+        reverted_body = (live_skills / "baseline_skill" / "SKILL.md").read_text()
+        assert "Improved body" in reverted_body
+
+    def test_keep_refuses_dirty_live_skills_without_force(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "ws"
+        live_skills = tmp_path / "live_skills"
+        _write_skill(live_skills, "s")
+
+        baseline_metrics = tmp_path / "baseline_metrics.json"
+        _write_aggregate_metrics(baseline_metrics, 0.1)
+
+        init_workspace(
+            ImproveInitConfig(
+                workspace=str(workspace),
+                skills=str(live_skills),
+                baseline_metrics=str(baseline_metrics),
+            )
+        )
+
+        round_id, _ = start_round(ImproveRoundConfig(workspace=str(workspace)))
+        round_metrics = tmp_path / "round_metrics.json"
+        _write_aggregate_metrics(round_metrics, 0.2)
+        record_round(ImproveRecordConfig(workspace=str(workspace), aggregate_metrics=str(round_metrics)))
+
+        _write_skill(live_skills, "s", body="# changed after round\n")
+        with pytest.raises(ConfigError, match="differ from round"):
+            keep_round(ImproveKeepConfig(workspace=str(workspace), round_id=round_id, copy_live=True))
+
+    def test_history_lists_rounds(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "ws"
+        live_skills = tmp_path / "live_skills"
+        _write_skill(live_skills, "s")
+        baseline_metrics = tmp_path / "baseline_metrics.json"
+        _write_aggregate_metrics(baseline_metrics, 0.1)
+
+        init_workspace(
+            ImproveInitConfig(
+                workspace=str(workspace),
+                skills=str(live_skills),
+                baseline_metrics=str(baseline_metrics),
+            )
+        )
+        start_round(ImproveRoundConfig(workspace=str(workspace)))
+
+        rounds = list_history(ImproveHistoryConfig(workspace=str(workspace)))
+        assert len(rounds) == 1
+        assert rounds[0].round_id == "0001"
+
+    def test_init_rejects_nonempty_workspace(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        (workspace / "existing.txt").write_text("x")
+
+        live_skills = tmp_path / "live_skills"
+        _write_skill(live_skills, "s")
+        baseline_metrics = tmp_path / "baseline_metrics.json"
+        _write_aggregate_metrics(baseline_metrics, 0.1)
+
+        with pytest.raises(ConfigError, match="not empty"):
+            init_workspace(
+                ImproveInitConfig(
+                    workspace=str(workspace),
+                    skills=str(live_skills),
+                    baseline_metrics=str(baseline_metrics),
+                )
+            )


### PR DESCRIPTION
## Summary
- Adds v0 manual improve loop: `gym eval improve-init|round|record|keep|revert|history`
- Reuses #1256 substrate (`skills.path`, `skills_ref.hash`, aggregate `key_metrics`)
- Adds the "Improve Skills" fern docs page under Evaluate (epic #1494)
Supersedes #1931 (same changes, commit amended with DCO `Signed-off-by`).
## Test plan
- [x] `uv run pytest tests/unit_tests/test_skill_improvement.py`
- [ ] Manual: init from a real baseline eval, run one round, record, keep
Part of NVIDIA-NeMo/Gym#1495 (v0 manual loop; optimizer backend deferred)