### PR TITLE
feat(gdpval): resume multi-stage ELO from cache

### DIFF
--- a/resources_servers/gdpval/multistage_orchestrator.py
+++ b/resources_servers/gdpval/multistage_orchestrator.py
@@ -854,47 +854,34 @@ Stages: {orjson.dumps(stage_summaries, option=orjson.OPT_INDENT_2).decode()}"""
 
 def _prepare_resume(
     rollout_collection_config, output_fpath: Path, journal_fpath: Path, fingerprint: str
-) -> Optional[StageResume]:  # pragma: no cover
-    """Decide resume vs fresh; on fresh, clear stale rollouts, sidecar, journal.
+) -> StageResume:
+    """Build the file-backed :class:`StageResume` for the run.
 
-    Resumes only when ``resume_from_cache`` is requested, both the rollouts file
-    and the journal exist, and the journal's fingerprint matches the current run.
-    Any other case logs exactly why and starts fresh.
+    Always returns a writing StageResume so even a fresh run persists the journal
+    and rows incrementally, giving a later resume state to read. Prior state is
+    reused only when ``resume_from_cache`` is set and both the rollouts file and a
+    fingerprint-matching journal exist; every other case clears stale files and
+    starts fresh (with the reason logged).
     """
     import sys
 
-    def _clear() -> None:
+    resume_requested = bool(getattr(rollout_collection_config, "resume_from_cache", False))
+    if not resume_requested:
+        reason = "resume_from_cache not set"
+    elif not output_fpath.exists() or not journal_fpath.exists():
+        reason = f"no prior cache (rollouts exist={output_fpath.exists()}, journal exists={journal_fpath.exists()})"
+    elif read_journal(journal_fpath)[2] != fingerprint:
+        reason = f"journal STALE (fingerprint {read_journal(journal_fpath)[2]} != {fingerprint})"
+    else:
+        reason = None
+
+    if reason is not None:
+        print(f"[multistage-elo] starting fresh: {reason}", file=sys.stderr, flush=True)
         output_fpath.unlink(missing_ok=True)
         _failures_path_for(output_fpath).unlink(missing_ok=True)
         journal_fpath.unlink(missing_ok=True)
-
-    resume_requested = bool(getattr(rollout_collection_config, "resume_from_cache", False))
-    if not resume_requested:
-        _clear()
-        return None
-
-    if not output_fpath.exists() or not journal_fpath.exists():
-        print(
-            f"[multistage-elo] resume_from_cache requested but starting fresh: "
-            f"rollouts exist={output_fpath.exists()}, journal exists={journal_fpath.exists()}",
-            file=sys.stderr,
-            flush=True,
-        )
-        _clear()
-        return None
-
-    _, _, journal_fingerprint = read_journal(journal_fpath)
-    if journal_fingerprint != fingerprint:
-        print(
-            f"[multistage-elo] resume_from_cache requested but journal is STALE "
-            f"(fingerprint {journal_fingerprint} != {fingerprint}); ignoring cache and starting fresh",
-            file=sys.stderr,
-            flush=True,
-        )
-        _clear()
-        return None
-
-    print("[multistage-elo] resuming multi-stage run from cache (fingerprint match)", file=sys.stderr, flush=True)
+    else:
+        print("[multistage-elo] resuming multi-stage run from cache (fingerprint match)", file=sys.stderr, flush=True)
     return build_file_resume(output_fpath, journal_fpath, fingerprint)
 
 

--- a/resources_servers/gdpval/multistage_orchestrator.py
+++ b/resources_servers/gdpval/multistage_orchestrator.py
@@ -49,6 +49,7 @@ orchestration is unit-testable without any servers.
 
 from __future__ import annotations
 
+import hashlib
 import random
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -58,6 +59,13 @@ from typing import AbstractSet, Any, Awaitable, Callable, Dict, List, Mapping, O
 import orjson
 
 from nemo_gym.global_config import AGENT_REF_KEY_NAME, ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
+from nemo_gym.rollout_collection import (
+    NG_FAILURE_CLASS_KEY,
+    NG_NO_PERSIST_KEY,
+    NG_TERMINAL_KEY,
+    _failures_path_for,
+    _get_max_rollout_attempts,
+)
 from resources_servers.gdpval.multistage_elo import (
     PerReferenceTotals,
     StageSpec,
@@ -73,6 +81,62 @@ from resources_servers.gdpval.multistage_elo import (
 # return ``(row, result)`` pairs (result == the agent's /run response, i.e. the
 # GDPVal verify response). Injected so tests can avoid real servers.
 RolloutRunner = Callable[[List[Dict[str, Any]]], Awaitable[List[Tuple[Dict[str, Any], Dict[str, Any]]]]]
+
+
+@dataclass
+class StageResume:
+    """Resume seam injected into :func:`run_multistage_stages`.
+
+    ``plans`` holds each stage's recorded references/tasks; ``outcomes`` presence
+    means the stage completed. ``rows_by_stage`` holds persisted success rows
+    (feed pooling + aggregate); ``gated_keys`` holds per-stage
+    ``(task_index, rollout_index)`` not to re-dispatch (success, terminal, or
+    max-attempt). ``on_plan``/``on_outcome``/``on_rows`` persist newly produced
+    state (``on_rows`` routes success/failure/kill_shaped like ``run_from_config``).
+    """
+
+    plans: Mapping[int, dict]
+    outcomes: Mapping[int, dict]
+    rows_by_stage: Mapping[int, List[Dict[str, Any]]]
+    gated_keys: Mapping[int, AbstractSet[Tuple[Any, Any]]]
+    on_plan: Callable[[int, dict], None]
+    on_outcome: Callable[[int, dict], None]
+    on_rows: Callable[[int, List[Dict[str, Any]]], None]
+
+
+def _is_success_row(row: Mapping[str, Any]) -> bool:
+    """A row is a success iff it carries neither a failure class nor no-persist."""
+    return row.get(NG_FAILURE_CLASS_KEY) is None and not row.get(NG_NO_PERSIST_KEY)
+
+
+def compute_fingerprint(
+    ms_config: MultiStageRunConfig,
+    reference_elos: Mapping[str, float],
+    distribution: Mapping[str, Mapping[str, object]],
+) -> str:
+    """Stable hash of everything that affects stage planning.
+
+    A mismatch between the current run's fingerprint and a journal's marks the
+    journal stale: the plans/outcomes it records were produced under a different
+    configuration or task distribution and cannot be safely replayed.
+    """
+    payload = {
+        "stages": [(s.num_tasks, s.num_models, s.seed) for s in ms_config.stages],
+        "seed": ms_config.seed,
+        "nested_tasks": ms_config.nested_tasks,
+        "reuse_cached_deliverables": ms_config.reuse_cached_deliverables,
+        "column": list(ms_config.column),
+        "reference_elos": {k: reference_elos[k] for k in sorted(reference_elos)},
+        "distribution": {
+            grp: {
+                "task_ids": sorted((distribution[grp] or {}).get("task_ids", []) or []),
+                "percentage": (distribution[grp] or {}).get("percentage"),
+            }
+            for grp in sorted(distribution)
+        },
+    }
+    encoded = orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)
+    return hashlib.sha256(encoded).hexdigest()
 
 
 # ---------------------------------------------------------------------------
@@ -275,6 +339,7 @@ async def run_multistage_stages(
     *,
     rng: Optional[random.Random] = None,
     on_event: Optional[Callable[[str, dict], None]] = None,
+    resume: Optional[StageResume] = None,
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Run every stage and return ``(all_result_rows, stage_summaries)``.
 
@@ -284,6 +349,13 @@ async def run_multistage_stages(
     fit the stage ELO (threaded into the next stage's selection). ``all_result_rows``
     is the concatenation of every stage's tagged results (ready to write as the
     standard rollouts file); ``stage_summaries`` is one dict per stage for logging.
+
+    When ``resume`` is provided the loop reuses persisted state: complete stages
+    are not re-dispatched (their cached rows are re-fitted for ELO threading),
+    interrupted stages re-dispatch only the ``(task, rollout)`` rows without a
+    persisted success, and recorded plans are replayed so selection is identical
+    even when ``multistage.seed`` is ``None``. ``resume=None`` is byte-for-byte
+    the pre-resume behavior.
     """
     base_rng = rng or (random.Random(ms_config.seed) if ms_config.seed is not None else random.Random())
     rows_by_task = index_rows_by_task(materialized_rows)
@@ -309,8 +381,23 @@ async def run_multistage_stages(
     # Later stages reuse these instead of re-running the policy.
     produced: set[Tuple[str, int]] = set()
     for index, stage in enumerate(ms_config.stages):
-        reference_ids = select_references(reference_elos, eval_elo, stage.num_models)
-        task_ids = stage_task_sets[index]
+        if resume is not None and index in resume.outcomes:
+            eval_elo = _resume_complete_stage(
+                index,
+                total_stages,
+                resume,
+                reference_elos,
+                produced,
+                all_results,
+                stage_summaries,
+                _emit,
+            )
+            continue
+
+        reference_ids, task_ids, replayed = _plan_stage(
+            index, stage, reference_elos, eval_elo, stage_task_sets, resume
+        )
+
         stage_rows = build_stage_rows(
             rows_by_task,
             task_ids,
@@ -318,6 +405,13 @@ async def run_multistage_stages(
             index,
             produced=produced if ms_config.reuse_cached_deliverables else None,
         )
+
+        cached_rows = resume.rows_by_stage.get(index, []) if resume is not None else []
+        # Gated == not re-dispatched: successes on disk plus terminal / max-attempt
+        # failures from the sidecar (mirrors ``_load_from_cache``, stage-keyed).
+        gated_keys = set(resume.gated_keys.get(index, set())) if resume is not None else set()
+        pending_rows = [r for r in stage_rows if (r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME]) not in gated_keys]
+
         num_reused = sum(1 for r in stage_rows if r.get("reuse_cached_deliverable"))
         _emit(
             "stage_start",
@@ -327,11 +421,18 @@ async def run_multistage_stages(
             num_tasks=len(task_ids),
             num_rollouts=len(stage_rows),
             num_reused=num_reused,
+            num_cached=len(cached_rows),
             prior_elo=eval_elo,
+            replayed=replayed,
         )
 
-        pairs = await run_rollouts(stage_rows)
-        tagged = tag_results(pairs, index)
+        pairs = await run_rollouts(pending_rows)
+        new_tagged = tag_results(pairs, index)
+        if resume is not None:
+            resume.on_rows(index, new_tagged)
+        # Only successful rows feed pooling / aggregate.
+        new_successes = [r for r in new_tagged if _is_success_row(r)]
+        tagged = list(cached_rows) + new_successes
         all_results.extend(tagged)
 
         # Record this stage's deliverables so later stages can reuse them.
@@ -344,6 +445,10 @@ async def run_multistage_stages(
         stage_elo, normalized, num_references = fit_stage_elo(per_reference, reference_elos)
         if stage_elo is not None:
             eval_elo = stage_elo
+
+        # Completion marker only; eval_elo is re-fit from rows on resume.
+        if resume is not None:
+            resume.on_outcome(index, {"stage_index": index, "status": "complete"})
 
         _emit(
             "stage_end",
@@ -369,20 +474,283 @@ async def run_multistage_stages(
     return all_results, stage_summaries
 
 
+def _plan_stage(
+    index: int,
+    stage: StageSpec,
+    reference_elos: Mapping[str, float],
+    eval_elo: Optional[float],
+    stage_task_sets: Sequence[Sequence[str]],
+    resume: Optional[StageResume],
+) -> Tuple[List[str], List[str], bool]:
+    """Return ``(reference_ids, task_ids, replayed)`` for a stage.
+
+    ``replayed`` is True when the recorded plan was returned from
+    ``resume.plans[index]`` (deterministic replay, even with ``seed=None``), False
+    when a fresh plan was computed via ``select_references`` and persisted via
+    ``resume.on_plan``.
+    """
+    if resume is not None and index in resume.plans:
+        recorded = resume.plans[index]
+        return list(recorded["reference_ids"]), list(recorded["task_ids"]), True
+
+    reference_ids = select_references(reference_elos, eval_elo, stage.num_models)
+    task_ids = list(stage_task_sets[index])
+    if resume is not None:
+        resume.on_plan(
+            index,
+            {
+                "stage_index": index,
+                "status": "planned",
+                "reference_ids": list(reference_ids),
+                "task_ids": list(task_ids),
+                "seed": stage.seed,
+                "prior_eval_elo": eval_elo,
+            },
+        )
+    return list(reference_ids), task_ids, False
+
+
+def _resume_complete_stage(
+    index: int,
+    total_stages: int,
+    resume: StageResume,
+    reference_elos: Mapping[str, float],
+    produced: set[Tuple[str, int]],
+    all_results: List[Dict[str, Any]],
+    stage_summaries: List[Dict[str, Any]],
+    emit: Callable[..., None],
+) -> Optional[float]:
+    """Reuse a completed stage's cached rows without dispatch; return threaded ELO.
+
+    ELO is re-fit from the cached tagged rows (authoritative single source of
+    truth) rather than trusting the recorded ``eval_elo`` field, so the value
+    threaded to later stages is always consistent with the persisted rows.
+    """
+    cached_rows = list(resume.rows_by_stage.get(index, []))
+    plan = resume.plans.get(index, {})
+    reference_ids = list(plan.get("reference_ids", []))
+    task_ids = list(plan.get("task_ids", []))
+
+    for row in cached_rows:
+        tid = row_task_id(row)
+        if tid is not None:
+            produced.add((tid, int(row.get(ROLLOUT_INDEX_KEY_NAME, 0) or 0)))
+
+    all_results.extend(cached_rows)
+    per_reference: PerReferenceTotals = pool_per_reference(cached_rows)
+    stage_elo, normalized, num_references = fit_stage_elo(per_reference, reference_elos)
+
+    emit(
+        "stage_cached",
+        index=index,
+        total_stages=total_stages,
+        eval_elo=stage_elo,
+        normalized_elo=normalized,
+        num_references=num_references,
+        num_rollouts=len(cached_rows),
+    )
+    stage_summaries.append(
+        {
+            "stage_index": index,
+            "num_tasks": len(task_ids),
+            "num_rollouts": len(cached_rows),
+            "num_reused": 0,
+            "reference_ids": reference_ids,
+            "eval_elo": stage_elo,
+            "normalized_elo": normalized,
+            "num_references": num_references,
+            "cached": True,
+        }
+    )
+    return stage_elo
+
+
 def write_rollouts(all_results: Sequence[Mapping[str, Any]], output_fpath: str | Path) -> Path:
-    """Write the merged stage results to the standard rollouts JSONL, sorted."""
+    """Write the merged stage results to the standard rollouts JSONL, sorted.
+
+    Dedupes by ``(stage_index, task_index, rollout_index)`` (last write wins), so
+    concatenating incrementally-persisted stage rows with in-memory ones stays
+    idempotent across resume.
+    """
     output_fpath = Path(output_fpath)
     output_fpath.parent.mkdir(parents=True, exist_ok=True)
-    # A (task, rollout) recurs once per stage, so stage_index is part of the row
-    # identity and the primary sort key.
+    # stage_index is part of row identity (a (task, rollout) recurs per stage).
+    deduped: Dict[Tuple[Any, Any, Any], Mapping[str, Any]] = {}
+    for row in all_results:
+        key = (row.get("stage_index", 0), row.get(TASK_INDEX_KEY_NAME, 0), row.get(ROLLOUT_INDEX_KEY_NAME, 0))
+        deduped[key] = row
     ordered = sorted(
-        all_results,
+        deduped.values(),
         key=lambda r: (r.get("stage_index", 0), r.get(TASK_INDEX_KEY_NAME, 0), r.get(ROLLOUT_INDEX_KEY_NAME, 0)),
     )
     with output_fpath.open("wb") as handle:
         for row in ordered:
             handle.write(orjson.dumps(row) + b"\n")
     return output_fpath
+
+
+# ---------------------------------------------------------------------------
+# Stage journal + file-backed resume seam
+# ---------------------------------------------------------------------------
+
+
+def journal_path_for(output_fpath: str | Path) -> Path:
+    """``<output_stem>_multistage_state.jsonl`` sibling of the rollouts file."""
+    output_fpath = Path(output_fpath)
+    return output_fpath.with_name(f"{output_fpath.stem}_multistage_state.jsonl")
+
+
+def read_journal(journal_fpath: str | Path) -> Tuple[Dict[int, dict], Dict[int, dict], Optional[str]]:
+    """Read the append-only journal; latest record per ``stage_index`` wins.
+
+    Returns ``(plans, outcomes, fingerprint)``. ``fingerprint`` is taken from the
+    last record carrying one (all records share it within a run).
+    """
+    plans: Dict[int, dict] = {}
+    outcomes: Dict[int, dict] = {}
+    fingerprint: Optional[str] = None
+    path = Path(journal_fpath)
+    if not path.exists():
+        return plans, outcomes, fingerprint
+    with path.open("rb") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            record = orjson.loads(line)
+            fingerprint = record.get("fingerprint", fingerprint)
+            index = record.get("stage_index")
+            if index is None:
+                continue
+            if record.get("status") == "planned":
+                plans[int(index)] = record
+            elif record.get("status") == "complete":
+                outcomes[int(index)] = record
+    return plans, outcomes, fingerprint
+
+
+def load_persisted_rows(output_fpath: str | Path) -> Dict[int, List[Dict[str, Any]]]:
+    """Group the main-jsonl success rows by ``stage_index``.
+
+    The main jsonl holds successes only; these feed pooling / aggregate. Within a
+    stage, the last row for a ``(task_index, rollout_index)`` key wins.
+    """
+    path = Path(output_fpath)
+    by_stage: Dict[int, Dict[Tuple[Any, Any], Dict[str, Any]]] = {}
+    if not path.exists():
+        return {}
+    with path.open("rb") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            row = orjson.loads(line)
+            if not _is_success_row(row):
+                continue
+            index = int(row.get("stage_index", 0) or 0)
+            key = (row.get(TASK_INDEX_KEY_NAME), row.get(ROLLOUT_INDEX_KEY_NAME))
+            by_stage.setdefault(index, {})[key] = row
+    return {index: list(rows.values()) for index, rows in by_stage.items()}
+
+
+def load_gated_keys(
+    output_fpath: str | Path, rows_by_stage: Mapping[int, List[Dict[str, Any]]]
+) -> Dict[int, set[Tuple[Any, Any]]]:
+    """Per-stage ``(task_index, rollout_index)`` keys that must not be re-dispatched.
+
+    Mirrors ``_load_from_cache`` with the stage dimension added: a stage-row is
+    gated if it is a success (main jsonl), a terminal sidecar failure
+    (``_ng_failure_terminal``), or has hit ``_get_max_rollout_attempts`` attempts
+    in the sidecar. Everything else is re-dispatched.
+    """
+    gated: Dict[int, set[Tuple[Any, Any]]] = {
+        index: {(r.get(TASK_INDEX_KEY_NAME), r.get(ROLLOUT_INDEX_KEY_NAME)) for r in rows}
+        for index, rows in rows_by_stage.items()
+    }
+
+    failures_fpath = _failures_path_for(Path(output_fpath))
+    if not failures_fpath.exists():
+        return gated
+
+    max_attempts = _get_max_rollout_attempts()
+    attempts: Dict[Tuple[int, Any, Any], int] = {}
+    terminal: set[Tuple[int, Any, Any]] = set()
+    with failures_fpath.open("rb") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            fr = orjson.loads(line)
+            if TASK_INDEX_KEY_NAME not in fr or ROLLOUT_INDEX_KEY_NAME not in fr:
+                continue
+            key = (int(fr.get("stage_index", 0) or 0), fr[TASK_INDEX_KEY_NAME], fr[ROLLOUT_INDEX_KEY_NAME])
+            attempts[key] = attempts.get(key, 0) + 1
+            if fr.get(NG_TERMINAL_KEY):
+                terminal.add(key)
+
+    for key in attempts:
+        stage_index, task_index, rollout_index = key
+        if key in terminal or attempts[key] >= max_attempts:
+            gated.setdefault(stage_index, set()).add((task_index, rollout_index))
+    return gated
+
+
+def append_journal_record(journal_fpath: str | Path, record: Mapping[str, Any], fingerprint: str) -> None:
+    """Append a single journal record stamped with the run fingerprint."""
+    path = Path(journal_fpath)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    out = dict(record)
+    out["fingerprint"] = fingerprint
+    with path.open("ab") as handle:
+        handle.write(orjson.dumps(out) + b"\n")
+
+
+def route_stage_rows(output_fpath: str | Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    """Route freshly dispatched tagged rows the way ``run_from_config`` does.
+
+    Success -> main rollouts jsonl; non-kill failure (``_ng_failure_class`` set)
+    -> failures sidecar (one row per attempt, still carrying ``stage_index``);
+    kill_shaped (``_ng_no_persist``) -> written nowhere.
+    """
+    if not rows:
+        return
+    output_fpath = Path(output_fpath)
+    output_fpath.parent.mkdir(parents=True, exist_ok=True)
+    failures_fpath = _failures_path_for(output_fpath)
+    with output_fpath.open("ab") as main_handle, failures_fpath.open("ab") as fail_handle:
+        for row in rows:
+            if row.get(NG_NO_PERSIST_KEY):
+                continue
+            if row.get(NG_FAILURE_CLASS_KEY) is not None:
+                fail_handle.write(orjson.dumps(row) + b"\n")
+            else:
+                main_handle.write(orjson.dumps(row) + b"\n")
+
+
+def build_file_resume(output_fpath: str | Path, journal_fpath: str | Path, fingerprint: str) -> StageResume:
+    """Build a file-backed :class:`StageResume` from the journal + rollout files."""
+    plans, outcomes, _ = read_journal(journal_fpath)
+    rows_by_stage = load_persisted_rows(output_fpath)
+    gated_keys = load_gated_keys(output_fpath, rows_by_stage)
+
+    def on_plan(index: int, plan: dict) -> None:
+        append_journal_record(journal_fpath, plan, fingerprint)
+
+    def on_outcome(index: int, outcome: dict) -> None:
+        append_journal_record(journal_fpath, outcome, fingerprint)
+
+    def on_rows(index: int, rows: List[Dict[str, Any]]) -> None:
+        route_stage_rows(output_fpath, rows)
+
+    return StageResume(
+        plans=plans,
+        outcomes=outcomes,
+        rows_by_stage=rows_by_stage,
+        gated_keys=gated_keys,
+        on_plan=on_plan,
+        on_outcome=on_outcome,
+        on_rows=on_rows,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -456,6 +824,11 @@ async def run_e2e_multistage(
             results.append((row, result))
         return results
 
+    output_fpath = Path(rollout_collection_config.output_jsonl_fpath)
+    journal_fpath = journal_path_for(output_fpath)
+    fingerprint = compute_fingerprint(ms_config, reference_elos, distribution)
+    resume = _prepare_resume(rollout_collection_config, output_fpath, journal_fpath, fingerprint)
+
     all_results, stage_summaries = await run_multistage_stages(
         ms_config,
         reference_elos,
@@ -463,9 +836,9 @@ async def run_e2e_multistage(
         materialized_rows,
         run_rollouts,
         on_event=_log_event,
+        resume=resume,
     )
 
-    output_fpath = Path(rollout_collection_config.output_jsonl_fpath)
     write_rollouts(all_results, output_fpath)
 
     print("[multistage-elo] computing stage-aware aggregate metrics")
@@ -477,6 +850,52 @@ Aggregate metrics: {aggregate_metrics_fpath}
 Stages: {orjson.dumps(stage_summaries, option=orjson.OPT_INDENT_2).decode()}"""
     )
     return aggregate_metrics_fpath
+
+
+def _prepare_resume(
+    rollout_collection_config, output_fpath: Path, journal_fpath: Path, fingerprint: str
+) -> Optional[StageResume]:  # pragma: no cover
+    """Decide resume vs fresh; on fresh, clear stale rollouts, sidecar, journal.
+
+    Resumes only when ``resume_from_cache`` is requested, both the rollouts file
+    and the journal exist, and the journal's fingerprint matches the current run.
+    Any other case logs exactly why and starts fresh.
+    """
+    import sys
+
+    def _clear() -> None:
+        output_fpath.unlink(missing_ok=True)
+        _failures_path_for(output_fpath).unlink(missing_ok=True)
+        journal_fpath.unlink(missing_ok=True)
+
+    resume_requested = bool(getattr(rollout_collection_config, "resume_from_cache", False))
+    if not resume_requested:
+        _clear()
+        return None
+
+    if not output_fpath.exists() or not journal_fpath.exists():
+        print(
+            f"[multistage-elo] resume_from_cache requested but starting fresh: "
+            f"rollouts exist={output_fpath.exists()}, journal exists={journal_fpath.exists()}",
+            file=sys.stderr,
+            flush=True,
+        )
+        _clear()
+        return None
+
+    _, _, journal_fingerprint = read_journal(journal_fpath)
+    if journal_fingerprint != fingerprint:
+        print(
+            f"[multistage-elo] resume_from_cache requested but journal is STALE "
+            f"(fingerprint {journal_fingerprint} != {fingerprint}); ignoring cache and starting fresh",
+            file=sys.stderr,
+            flush=True,
+        )
+        _clear()
+        return None
+
+    print("[multistage-elo] resuming multi-stage run from cache (fingerprint match)", file=sys.stderr, flush=True)
+    return build_file_resume(output_fpath, journal_fpath, fingerprint)
 
 
 def _log_event(name: str, data: dict) -> None:  # pragma: no cover
@@ -494,8 +913,9 @@ def _log_event(name: str, data: dict) -> None:  # pragma: no cover
         prior_str = f"{prior:.1f}" if isinstance(prior, (int, float)) else "n/a"
         num_reused = data.get("num_reused", 0)
         reused_str = f", {num_reused} reused from cache" if num_reused else ""
+        plan_str = "replayed from journal" if data.get("replayed") else "planned fresh"
         print(
-            f"[multistage-elo] stage {data['index'] + 1}/{data['total_stages']}: "
+            f"[multistage-elo] stage {data['index'] + 1}/{data['total_stages']} ({plan_str}): "
             f"{data['num_tasks']} task(s) ({data['num_rollouts']} rollout(s){reused_str}) vs "
             f"{len(data['reference_ids'])} ref(s) {data['reference_ids']} (prior ELO: {prior_str})",
             file=sys.stderr,
@@ -507,6 +927,15 @@ def _log_event(name: str, data: dict) -> None:  # pragma: no cover
         print(
             f"[multistage-elo] stage {data['index'] + 1}/{data['total_stages']} done: "
             f"eval ELO = {elo_str} (fit over {data.get('num_references')} ref(s))",
+            file=sys.stderr,
+            flush=True,
+        )
+    elif name == "stage_cached":
+        elo = data.get("eval_elo")
+        elo_str = f"{elo:.1f}" if isinstance(elo, (int, float)) else "unset (no games)"
+        print(
+            f"[multistage-elo] stage {data['index'] + 1}/{data['total_stages']} reused from cache: "
+            f"eval ELO = {elo_str} ({data.get('num_rollouts')} cached rollout(s))",
             file=sys.stderr,
             flush=True,
         )

--- a/resources_servers/gdpval/tests/test_multistage_orchestrator.py
+++ b/resources_servers/gdpval/tests/test_multistage_orchestrator.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, List, Tuple
 
 import pytest
@@ -31,6 +32,7 @@ from nemo_gym.rollout_collection import (
 from resources_servers.gdpval.multistage_orchestrator import (
     MultiStageRunConfig,
     StageResume,
+    _prepare_resume,
     build_file_resume,
     build_stage_rows,
     compute_fingerprint,
@@ -851,3 +853,75 @@ class TestFailureRouting:
         assert summaries[0]["eval_elo"] == ref_summaries[0]["eval_elo"]
         assert summaries[1]["reference_ids"] == ref_summaries[1]["reference_ids"]
         assert summaries[1]["eval_elo"] == ref_summaries[1]["eval_elo"]
+
+
+class TestPrepareResume:
+    """The integration wiring: a fresh run must persist so a later resume can read."""
+
+    def _cfg(self, resume_from_cache: bool) -> SimpleNamespace:
+        return SimpleNamespace(resume_from_cache=resume_from_cache)
+
+    def test_fresh_returns_writing_resume_with_empty_state(self, tmp_path: Path) -> None:
+        out = tmp_path / "rollouts.jsonl"
+        journal = journal_path_for(out)
+        fp = compute_fingerprint(_two_stage_cfg(), REF_ELOS, _distribution(["t0"]))
+        resume = _prepare_resume(self._cfg(True), out, journal, fp)
+        assert isinstance(resume, StageResume)
+        assert resume.plans == {} and resume.outcomes == {} and resume.rows_by_stage == {}
+        resume.on_plan(0, {"stage_index": 0, "status": "planned", "reference_ids": ["a"], "task_ids": ["t0"]})
+        assert journal.exists()
+        plans, _, got_fp = read_journal(journal)
+        assert 0 in plans and got_fp == fp
+
+    def test_resume_disabled_clears_existing_and_empties_state(self, tmp_path: Path) -> None:
+        out = tmp_path / "rollouts.jsonl"
+        journal = journal_path_for(out)
+        out.write_text('{"x": 1}\n')
+        journal.write_text('{"stage_index": 0, "status": "complete"}\n')
+        fp = compute_fingerprint(_two_stage_cfg(), REF_ELOS, _distribution(["t0"]))
+        resume = _prepare_resume(self._cfg(False), out, journal, fp)
+        assert isinstance(resume, StageResume)
+        assert not out.exists() and not journal.exists()
+        assert resume.outcomes == {}
+
+    def test_stale_fingerprint_clears_and_starts_fresh(self, tmp_path: Path) -> None:
+        out = tmp_path / "rollouts.jsonl"
+        journal = journal_path_for(out)
+        dist = _distribution(["t0"])
+        out.write_text('{"stage_index": 0}\n')
+        from resources_servers.gdpval.multistage_orchestrator import append_journal_record
+
+        append_journal_record(journal, {"stage_index": 0, "status": "complete"}, "STALEFP")
+        fp = compute_fingerprint(_two_stage_cfg(), REF_ELOS, dist)
+        resume = _prepare_resume(self._cfg(True), out, journal, fp)
+        assert not out.exists() and not journal.exists()
+        assert resume.outcomes == {}
+
+    async def test_fresh_run_persists_journal_then_resume_reuses_all(self, tmp_path: Path) -> None:
+        # Regression: a fresh run through _prepare_resume must write the journal +
+        # rows, so a second _prepare_resume resumes without re-dispatching anything.
+        task_ids = [f"t{i}" for i in range(10)]
+        rows = _materialized_rows(task_ids)
+        dist = _distribution(task_ids)
+        run = _fake_run_rollouts_factory()
+        out = tmp_path / "rollouts.jsonl"
+        journal = journal_path_for(out)
+        fp = compute_fingerprint(_two_stage_cfg(), REF_ELOS, dist)
+        cfg = self._cfg(True)
+
+        r1 = _prepare_resume(cfg, out, journal, fp)
+        _, base = await run_multistage_stages(_two_stage_cfg(), REF_ELOS, dist, rows, run, resume=r1)
+        assert journal.exists() and out.exists()
+        plans, outcomes, _ = read_journal(journal)
+        assert set(plans) == {0, 1} and set(outcomes) == {0, 1}
+
+        r2 = _prepare_resume(cfg, out, journal, fp)
+        assert set(r2.outcomes) == {0, 1}
+
+        async def no_dispatch(rows_in: List[Dict[str, Any]]):
+            raise AssertionError(f"resume re-dispatched {len(rows_in)} rows; expected full cache reuse")
+
+        _, again = await run_multistage_stages(_two_stage_cfg(), REF_ELOS, dist, rows, no_dispatch, resume=r2)
+        assert all(s["cached"] for s in again)
+        assert [s["reference_ids"] for s in again] == [s["reference_ids"] for s in base]
+        assert [s["eval_elo"] for s in again] == [s["eval_elo"] for s in base]

--- a/resources_servers/gdpval/tests/test_multistage_orchestrator.py
+++ b/resources_servers/gdpval/tests/test_multistage_orchestrator.py
@@ -22,12 +22,26 @@ from typing import Any, Dict, List, Tuple
 import pytest
 
 from nemo_gym.global_config import AGENT_REF_KEY_NAME, ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
+from nemo_gym.rollout_collection import (
+    NG_FAILURE_CLASS_KEY,
+    NG_NO_PERSIST_KEY,
+    NG_TERMINAL_KEY,
+    _failures_path_for,
+)
 from resources_servers.gdpval.multistage_orchestrator import (
     MultiStageRunConfig,
+    StageResume,
+    build_file_resume,
     build_stage_rows,
+    compute_fingerprint,
     find_gdpval_reference_elos,
     index_rows_by_task,
+    journal_path_for,
+    load_gated_keys,
+    load_persisted_rows,
     parse_multistage_config,
+    read_journal,
+    route_stage_rows,
     row_task_id,
     run_multistage_stages,
     tag_results,
@@ -332,3 +346,508 @@ class TestWriteRollouts:
         out = write_rollouts(results, tmp_path / "rollouts.jsonl")
         lines = [json.loads(line) for line in out.read_text().splitlines()]
         assert [line["task_id"] for line in lines] == ["t0", "t1"]
+
+    def test_dedupes_by_stage_task_rollout(self, tmp_path: Path) -> None:
+        results = [
+            {"stage_index": 0, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "old"},
+            {"stage_index": 0, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "new"},
+            {"stage_index": 1, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "other"},
+        ]
+        out = write_rollouts(results, tmp_path / "rollouts.jsonl")
+        lines = [json.loads(line) for line in out.read_text().splitlines()]
+        # Dedup keeps the last write per (stage, task, rollout); stage 1 is distinct.
+        assert [line["task_id"] for line in lines] == ["new", "other"]
+
+
+# ---------------------------------------------------------------------------
+# Resume seam (pure, in-memory)
+# ---------------------------------------------------------------------------
+
+
+class RecordingResume(StageResume):
+    """In-memory StageResume that records callback invocations.
+
+    ``gated_keys`` defaults to the successes in ``rows_by_stage``; pass it
+    explicitly to model terminal / max-attempt gating from the sidecar.
+    """
+
+    def __init__(self, plans=None, outcomes=None, rows_by_stage=None, gated_keys=None) -> None:
+        self.planned: List[Tuple[int, dict]] = []
+        self.completed: List[Tuple[int, dict]] = []
+        self.appended: Dict[int, List[Dict[str, Any]]] = {}
+        rows_by_stage = dict(rows_by_stage or {})
+        if gated_keys is None:
+            gated_keys = {
+                i: {(r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME]) for r in rows}
+                for i, rows in rows_by_stage.items()
+            }
+        super().__init__(
+            plans=dict(plans or {}),
+            outcomes=dict(outcomes or {}),
+            rows_by_stage=rows_by_stage,
+            gated_keys=dict(gated_keys),
+            on_plan=lambda i, p: self.planned.append((i, p)),
+            on_outcome=lambda i, o: self.completed.append((i, o)),
+            on_rows=lambda i, r: self.appended.setdefault(i, []).extend(r),
+        )
+
+
+def _two_stage_cfg(seed=0, nested=False) -> MultiStageRunConfig:
+    return MultiStageRunConfig(
+        enabled=True,
+        stages=parse_multistage_config({"enabled": True, "stages": ["3", "5:2"]}).stages,
+        seed=seed,
+        nested_tasks=nested,
+    )
+
+
+class TestResumeSeam:
+    async def test_resume_none_is_backward_compatible(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        rows = _materialized_rows(task_ids)
+        cfg = _two_stage_cfg()
+        run = _fake_run_rollouts_factory()
+        base = await run_multistage_stages(cfg, REF_ELOS, _distribution(task_ids), rows, run)
+        again = await run_multistage_stages(cfg, REF_ELOS, _distribution(task_ids), rows, run, resume=None)
+        # Byte-for-byte identical result rows and summaries.
+        assert base[0] == again[0]
+        assert base[1] == again[1]
+
+    async def test_complete_stage_skips_dispatch_and_threads_elo(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        rows = _materialized_rows(task_ids)
+        cfg = _two_stage_cfg()
+
+        # First pass with no resume produces stage-0 tagged rows we can cache.
+        full_run = _fake_run_rollouts_factory()
+        all_results, base_summaries = await run_multistage_stages(
+            cfg, REF_ELOS, _distribution(task_ids), rows, full_run
+        )
+        stage0_rows = [r for r in all_results if r["stage_index"] == 0]
+        stage0_plan = {
+            "stage_index": 0,
+            "reference_ids": base_summaries[0]["reference_ids"],
+            "task_ids": [f"t{i}" for i in range(3)],
+        }
+        resume = RecordingResume(
+            plans={0: stage0_plan},
+            outcomes={0: {"stage_index": 0, "status": "complete", "eval_elo": base_summaries[0]["eval_elo"]}},
+            rows_by_stage={0: stage0_rows},
+        )
+
+        dispatched: List[int] = []
+
+        async def counting_run(rows_in: List[Dict[str, Any]]):
+            dispatched.append(len(rows_in))
+            return await full_run(rows_in)
+
+        _, summaries = await run_multistage_stages(
+            cfg, REF_ELOS, _distribution(task_ids), rows, counting_run, resume=resume
+        )
+
+        # Stage 0 was not dispatched; only stage 1 ran.
+        assert len(dispatched) == 1
+        # Stage 0 ELO was re-fit from cached rows and threaded into stage 1's
+        # reference selection (same as the original full run).
+        assert summaries[0]["cached"] is True
+        assert summaries[1]["reference_ids"] == base_summaries[1]["reference_ids"]
+
+    async def test_interrupted_stage_redispatches_only_missing(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        rows = _materialized_rows(task_ids)
+        cfg = _two_stage_cfg()
+        full_run = _fake_run_rollouts_factory()
+
+        all_results, base_summaries = await run_multistage_stages(
+            cfg, REF_ELOS, _distribution(task_ids), rows, full_run
+        )
+        # Cache all but one of stage 0's successful rows: the missing one must be
+        # re-dispatched; the rest must not.
+        stage0_rows = [r for r in all_results if r["stage_index"] == 0]
+        stage0_task_ids = list(dict.fromkeys(r["task_id"] for r in stage0_rows))
+        cached_stage0 = stage0_rows[:-1]
+        missing_key = (stage0_rows[-1][TASK_INDEX_KEY_NAME], stage0_rows[-1][ROLLOUT_INDEX_KEY_NAME])
+
+        resume = RecordingResume(
+            plans={
+                0: {
+                    "stage_index": 0,
+                    "reference_ids": base_summaries[0]["reference_ids"],
+                    "task_ids": stage0_task_ids,
+                }
+            },
+            rows_by_stage={0: cached_stage0},
+        )
+
+        dispatched_keys: List[Tuple[int, int]] = []
+
+        async def capturing_run(rows_in: List[Dict[str, Any]]):
+            for r in rows_in:
+                if r["stage_index"] == 0:
+                    dispatched_keys.append((r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME]))
+            return await full_run(rows_in)
+
+        _, summaries = await run_multistage_stages(
+            cfg, REF_ELOS, _distribution(task_ids), rows, capturing_run, resume=resume
+        )
+
+        assert dispatched_keys == [missing_key]
+        # Only the newly dispatched row is passed to on_rows.
+        assert len(resume.appended[0]) == 1
+        # Final stage-0 result count equals the full run (cached + re-dispatched).
+        assert summaries[0]["num_rollouts"] == base_summaries[0]["num_rollouts"]
+
+    async def test_plan_replay_is_deterministic_without_seed(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        rows = _materialized_rows(task_ids)
+        cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["3", "5:2"]}).stages,
+            seed=None,
+        )
+        # A recorded plan pins task_ids/reference_ids regardless of the seedless RNG.
+        pinned_tasks = ["t9", "t8", "t7"]
+        resume = RecordingResume(plans={0: {"stage_index": 0, "reference_ids": ["a", "b"], "task_ids": pinned_tasks}})
+        seen_tasks: List[str] = []
+        base = _fake_run_rollouts_factory()
+
+        async def recording_run(rows_in: List[Dict[str, Any]]):
+            for r in rows_in:
+                if r["stage_index"] == 0:
+                    seen_tasks.append(r["task_id"])
+            return await base(rows_in)
+
+        _, summaries = await run_multistage_stages(
+            cfg, REF_ELOS, _distribution(task_ids), rows, recording_run, resume=resume
+        )
+        assert set(seen_tasks) == set(pinned_tasks)
+        assert summaries[0]["reference_ids"] == ["a", "b"]
+        # No new plan was recorded for the replayed stage.
+        assert all(i != 0 for i, _ in resume.planned)
+
+    async def test_failure_rows_are_redispatched(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        rows = _materialized_rows(task_ids)
+        cfg = _two_stage_cfg()
+        full_run = _fake_run_rollouts_factory()
+
+        all_results, base_summaries = await run_multistage_stages(
+            cfg, REF_ELOS, _distribution(task_ids), rows, full_run
+        )
+        stage0_rows = [r for r in all_results if r["stage_index"] == 0]
+        stage0_task_ids = list(dict.fromkeys(r["task_id"] for r in stage0_rows))
+        # Mark one cached row as a failure: load_persisted_rows drops it, so it is
+        # not in rows_by_stage and must be re-dispatched.
+        good = stage0_rows[:-1]
+        failed = dict(stage0_rows[-1])
+        failed[NG_FAILURE_CLASS_KEY] = "some_error"
+        failed_key = (failed[TASK_INDEX_KEY_NAME], failed[ROLLOUT_INDEX_KEY_NAME])
+
+        # Simulate what build_file_resume does: successes only.
+        resume = RecordingResume(
+            plans={
+                0: {
+                    "stage_index": 0,
+                    "reference_ids": base_summaries[0]["reference_ids"],
+                    "task_ids": stage0_task_ids,
+                }
+            },
+            rows_by_stage={0: good},
+        )
+        dispatched_keys: List[Tuple[int, int]] = []
+
+        async def capturing_run(rows_in: List[Dict[str, Any]]):
+            for r in rows_in:
+                if r["stage_index"] == 0:
+                    dispatched_keys.append((r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME]))
+            return await full_run(rows_in)
+
+        await run_multistage_stages(cfg, REF_ELOS, _distribution(task_ids), rows, capturing_run, resume=resume)
+        assert dispatched_keys == [failed_key]
+
+
+class TestFingerprint:
+    def test_stable_and_config_sensitive(self) -> None:
+        dist = _distribution(["t0", "t1", "t2"])
+        cfg = _two_stage_cfg()
+        fp1 = compute_fingerprint(cfg, REF_ELOS, dist)
+        fp2 = compute_fingerprint(cfg, REF_ELOS, dist)
+        assert fp1 == fp2
+
+        other_dist = _distribution(["t0", "t1", "t9"])
+        assert compute_fingerprint(cfg, REF_ELOS, other_dist) != fp1
+
+        other_elos = dict(REF_ELOS, a=999.0)
+        assert compute_fingerprint(cfg, other_elos, dist) != fp1
+
+        cfg2 = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["4", "5:2"]}).stages,
+            seed=0,
+        )
+        assert compute_fingerprint(cfg2, REF_ELOS, dist) != fp1
+
+    def test_percentage_change_invalidates(self) -> None:
+        # Same task-id sets but different group weights ⇒ seeded sampling draws
+        # different tasks, so the fingerprint must differ.
+        cfg = _two_stage_cfg()
+        dist_a = {
+            "g0": {"percentage": 0.5, "task_ids": ["t0", "t1"]},
+            "g1": {"percentage": 0.5, "task_ids": ["t2", "t3"]},
+        }
+        dist_b = {
+            "g0": {"percentage": 0.9, "task_ids": ["t0", "t1"]},
+            "g1": {"percentage": 0.1, "task_ids": ["t2", "t3"]},
+        }
+        assert compute_fingerprint(cfg, REF_ELOS, dist_a) != compute_fingerprint(cfg, REF_ELOS, dist_b)
+
+
+class TestJournalIO:
+    def test_journal_round_trip_latest_wins(self, tmp_path: Path) -> None:
+        from resources_servers.gdpval.multistage_orchestrator import append_journal_record
+
+        journal = journal_path_for(tmp_path / "rollouts.jsonl")
+        assert journal.name == "rollouts_multistage_state.jsonl"
+        # Plan carries references/tasks; completion is just a marker (eval_elo is
+        # re-fit from rows on resume, so it is not stored).
+        append_journal_record(journal, {"stage_index": 0, "status": "planned", "reference_ids": ["a"]}, "FP")
+        append_journal_record(journal, {"stage_index": 0, "status": "complete"}, "FP")
+        append_journal_record(journal, {"stage_index": 1, "status": "planned", "reference_ids": ["b", "c"]}, "FP")
+
+        plans, outcomes, fingerprint = read_journal(journal)
+        assert fingerprint == "FP"
+        assert plans[0]["reference_ids"] == ["a"]
+        assert plans[1]["reference_ids"] == ["b", "c"]
+        assert outcomes[0] == {"stage_index": 0, "status": "complete", "fingerprint": "FP"}
+        assert "eval_elo" not in outcomes[0]
+        assert 1 not in outcomes
+
+    def test_read_journal_missing_file(self, tmp_path: Path) -> None:
+        plans, outcomes, fp = read_journal(tmp_path / "nope.jsonl")
+        assert plans == {} and outcomes == {} and fp is None
+
+    def test_load_persisted_rows_groups_by_stage(self, tmp_path: Path) -> None:
+        out = tmp_path / "rollouts.jsonl"
+        results = [
+            {"stage_index": 0, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "t0"},
+            # Defensive: a legacy failure row in the main jsonl is still dropped.
+            {
+                "stage_index": 0,
+                TASK_INDEX_KEY_NAME: 1,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                "task_id": "t1",
+                NG_FAILURE_CLASS_KEY: "boom",
+            },
+            {"stage_index": 1, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "t0"},
+        ]
+        with out.open("wb") as handle:
+            for r in results:
+                handle.write(json.dumps(r).encode() + b"\n")
+        by_stage = load_persisted_rows(out)
+        assert len(by_stage[0]) == 1  # legacy failure dropped
+        assert by_stage[0][0]["task_id"] == "t0"
+        assert len(by_stage[1]) == 1
+
+    def test_build_file_resume_persists_via_callbacks(self, tmp_path: Path) -> None:
+        out = tmp_path / "rollouts.jsonl"
+        journal = journal_path_for(out)
+        # Seed one persisted success row + one journal plan.
+        with out.open("wb") as handle:
+            handle.write(
+                json.dumps(
+                    {"stage_index": 0, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "t0"}
+                ).encode()
+                + b"\n"
+            )
+        with journal.open("wb") as handle:
+            handle.write(
+                json.dumps(
+                    {"stage_index": 0, "status": "planned", "reference_ids": ["a"], "fingerprint": "FP"}
+                ).encode()
+                + b"\n"
+            )
+
+        resume = build_file_resume(out, journal, "FP")
+        assert 0 in resume.plans
+        assert len(resume.rows_by_stage[0]) == 1
+
+        resume.on_plan(1, {"stage_index": 1, "status": "planned", "reference_ids": ["b"]})
+        resume.on_rows(1, [{"stage_index": 1, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "t0"}])
+        resume.on_outcome(1, {"stage_index": 1, "status": "complete"})
+
+        plans, outcomes, fp = read_journal(journal)
+        assert fp == "FP"
+        assert 1 in plans and 1 in outcomes
+        assert len(load_persisted_rows(out)[1]) == 1
+
+
+class TestFailureRouting:
+    def test_route_stage_rows_splits_by_outcome(self, tmp_path: Path) -> None:
+        out = tmp_path / "rollouts.jsonl"
+        rows = [
+            {"stage_index": 0, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "t0"},
+            {
+                "stage_index": 0,
+                TASK_INDEX_KEY_NAME: 1,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                "task_id": "t1",
+                NG_FAILURE_CLASS_KEY: "boom",
+            },
+            {
+                "stage_index": 0,
+                TASK_INDEX_KEY_NAME: 2,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                "task_id": "t2",
+                NG_NO_PERSIST_KEY: True,
+            },
+        ]
+        route_stage_rows(out, rows)
+
+        main = [json.loads(line) for line in out.read_text().splitlines()]
+        sidecar = [json.loads(line) for line in _failures_path_for(out).read_text().splitlines()]
+        # Success -> main; failure -> sidecar (with stage_index); kill_shaped -> nowhere.
+        assert [r["task_id"] for r in main] == ["t0"]
+        assert [r["task_id"] for r in sidecar] == ["t1"]
+        assert sidecar[0]["stage_index"] == 0
+
+    def test_load_gated_keys_terminal_and_max_attempts(self, tmp_path: Path) -> None:
+        out = tmp_path / "rollouts.jsonl"
+        # One success in main jsonl (stage 0, task 0).
+        with out.open("wb") as handle:
+            handle.write(
+                json.dumps(
+                    {"stage_index": 0, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "t0"}
+                ).encode()
+                + b"\n"
+            )
+        # Sidecar: task 1 terminal (never retried), task 2 hit 3 attempts (gated),
+        # task 3 has 1 attempt (still re-dispatchable).
+        sidecar = _failures_path_for(out)
+        entries = [
+            {
+                "stage_index": 0,
+                TASK_INDEX_KEY_NAME: 1,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                NG_FAILURE_CLASS_KEY: "x",
+                NG_TERMINAL_KEY: True,
+            },
+            {"stage_index": 0, TASK_INDEX_KEY_NAME: 2, ROLLOUT_INDEX_KEY_NAME: 0, NG_FAILURE_CLASS_KEY: "x"},
+            {"stage_index": 0, TASK_INDEX_KEY_NAME: 2, ROLLOUT_INDEX_KEY_NAME: 0, NG_FAILURE_CLASS_KEY: "x"},
+            {"stage_index": 0, TASK_INDEX_KEY_NAME: 2, ROLLOUT_INDEX_KEY_NAME: 0, NG_FAILURE_CLASS_KEY: "x"},
+            {"stage_index": 0, TASK_INDEX_KEY_NAME: 3, ROLLOUT_INDEX_KEY_NAME: 0, NG_FAILURE_CLASS_KEY: "x"},
+        ]
+        with sidecar.open("wb") as handle:
+            for e in entries:
+                handle.write(json.dumps(e).encode() + b"\n")
+
+        rows_by_stage = load_persisted_rows(out)
+        gated = load_gated_keys(out, rows_by_stage)
+        # Success + terminal + max-attempts are gated; the single-attempt one is not.
+        assert (0, 0) in gated[0]
+        assert (1, 0) in gated[0]
+        assert (2, 0) in gated[0]
+        assert (3, 0) not in gated[0]
+
+    async def test_failure_row_redispatched_but_terminal_not(self) -> None:
+        # A failed (non-terminal, below max) row is re-dispatched; a terminal one is not.
+        task_ids = [f"t{i}" for i in range(10)]
+        rows = _materialized_rows(task_ids)
+        cfg = _two_stage_cfg()
+        full_run = _fake_run_rollouts_factory()
+
+        all_results, base_summaries = await run_multistage_stages(
+            cfg, REF_ELOS, _distribution(task_ids), rows, full_run
+        )
+        stage0_rows = [r for r in all_results if r["stage_index"] == 0]
+        stage0_task_ids = list(dict.fromkeys(r["task_id"] for r in stage0_rows))
+        # Cache all but the last two stage-0 successes.
+        good = stage0_rows[:-2]
+        failing_key = (stage0_rows[-1][TASK_INDEX_KEY_NAME], stage0_rows[-1][ROLLOUT_INDEX_KEY_NAME])
+        terminal_key = (stage0_rows[-2][TASK_INDEX_KEY_NAME], stage0_rows[-2][ROLLOUT_INDEX_KEY_NAME])
+
+        # gated_keys marks the terminal one only; the failing one is NOT gated.
+        good_keys = {(r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME]) for r in good}
+        resume = RecordingResume(
+            plans={
+                0: {"stage_index": 0, "reference_ids": base_summaries[0]["reference_ids"], "task_ids": stage0_task_ids}
+            },
+            rows_by_stage={0: good},
+            gated_keys={0: good_keys | {terminal_key}},
+        )
+
+        dispatched_keys: List[Tuple[int, int]] = []
+
+        async def capturing_run(rows_in: List[Dict[str, Any]]):
+            for r in rows_in:
+                if r["stage_index"] == 0:
+                    dispatched_keys.append((r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME]))
+            return await full_run(rows_in)
+
+        await run_multistage_stages(cfg, REF_ELOS, _distribution(task_ids), rows, capturing_run, resume=resume)
+        assert dispatched_keys == [failing_key]
+        assert terminal_key not in dispatched_keys
+
+    async def test_only_successes_reach_all_results(self) -> None:
+        # A run whose fake runner emits one failure + one kill-shaped row per stage:
+        # neither reaches all_results / pooling; only successes do.
+        task_ids = [f"t{i}" for i in range(10)]
+        rows = _materialized_rows(task_ids)
+        cfg = _two_stage_cfg()
+
+        async def mixed_run(rows_in: List[Dict[str, Any]]):
+            pairs: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+            for i, row in enumerate(rows_in):
+                result = {"task_id": row["task_id"], "per_reference": {}, "reward": 1.0}
+                if i % 3 == 1:
+                    result[NG_FAILURE_CLASS_KEY] = "boom"
+                elif i % 3 == 2:
+                    result[NG_NO_PERSIST_KEY] = True
+                pairs.append((row, result))
+            return pairs
+
+        all_results, _ = await run_multistage_stages(cfg, REF_ELOS, _distribution(task_ids), rows, mixed_run)
+        assert all(NG_FAILURE_CLASS_KEY not in r for r in all_results)
+        assert all(not r.get(NG_NO_PERSIST_KEY) for r in all_results)
+
+    async def test_file_backed_resume_end_to_end(self, tmp_path: Path) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        rows = _materialized_rows(task_ids)
+        dist = _distribution(task_ids)
+        run = _fake_run_rollouts_factory()
+
+        # Reference: uninterrupted 2-stage run.
+        _, ref_summaries = await run_multistage_stages(_two_stage_cfg(), REF_ELOS, dist, rows, run)
+
+        out = tmp_path / "rollouts.jsonl"
+        journal = journal_path_for(out)
+        fp = compute_fingerprint(_two_stage_cfg(), REF_ELOS, dist)
+
+        # Simulate a crash after stage 0: run only stage 0 through a file-backed
+        # resume so its plan + rows + outcome are persisted to real files.
+        stage0_cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["3"]}).stages,
+            seed=0,
+        )
+        await run_multistage_stages(stage0_cfg, REF_ELOS, dist, rows, run, resume=build_file_resume(out, journal, fp))
+
+        # Resume the full 2-stage run from the persisted files.
+        dispatched_stages: List[int] = []
+
+        async def capturing_run(rows_in: List[Dict[str, Any]]):
+            for r in rows_in:
+                dispatched_stages.append(r["stage_index"])
+            return await run(rows_in)
+
+        _, summaries = await run_multistage_stages(
+            _two_stage_cfg(), REF_ELOS, dist, rows, capturing_run, resume=build_file_resume(out, journal, fp)
+        )
+
+        # Stage 0 reused from cache (never dispatched); only stage 1 ran.
+        assert 0 not in dispatched_stages
+        assert set(dispatched_stages) == {1}
+        assert summaries[0]["cached"] is True
+        # Threaded ELO + downstream selection match the uninterrupted run.
+        assert summaries[0]["eval_elo"] == ref_summaries[0]["eval_elo"]
+        assert summaries[1]["reference_ids"] == ref_summaries[1]["reference_ids"]
+        assert summaries[1]["eval_elo"] == ref_summaries[1]["eval_elo"]


### PR DESCRIPTION
## Summary
Make `resume_from_cache` work for multi-stage GDPval/stirrup ELO runs. Previously the multistage driver bypassed the standard rollout-collection resume: a rerun re-planned and re-executed every stage, a crash lost in-progress results, and with `multistage.seed` unset the adaptive task/reference sampling diverged on rerun.

## What changed
- **Fingerprinted stage journal** (`<stem>_multistage_state.jsonl`): per-stage `planned` record (chosen references, task ids, seed, prior ELO) written *before dispatch* + a `complete` marker at stage end. A config fingerprint invalidates stale caches.
- **Stage-keyed instance of the core success/failure-sidecar contract**: successes → main jsonl, non-kill failures → attempt-capped `_failures.jsonl`, kill-shaped → nowhere. Failures never contaminate the main jsonl or ELO.
- **Resume-aware `run_multistage_stages`** (pure, injectable `StageResume` seam): completed stages reuse cached judging results and re-fit ELO from rows; an interrupted stage replays its recorded references (deterministic even when `seed` is `None`) and re-dispatches only not-yet-done `(stage, task, rollout)` rows. Per-task reuse within a partially-done stage is served by the stirrup agent's reference-subset-keyed `/verify` cache (`rerun_incomplete`).
- Fixes a fresh-run persistence gap: `_prepare_resume` now always returns a writing `StageResume`, so a fresh run persists the journal + rows (previously nothing was written on the first run, making resume impossible).

## Test plan
- **Unit:** 63 tests pass in `resources_servers/gdpval/tests/` — incl. fresh→resume cycle, interrupted-stage partial re-dispatch, plan replay with `seed=None`, failure routing (attempt cap / terminal), and fingerprint invalidation.
- **End-to-end on HSG** (nano-3.5, gdpval multistage comparison, stages `[5, 5×num_models:2]`):
  1. Launched a run; let stage 1 complete and stage 2 begin (4/5 stage-2 deliverables produced).
  2. Interrupted the job mid–stage 2 (`nel kill`).
  3. Ran `nel resume` → run completed to **SUCCESS**.
  4. Verified from the run logs that resume worked as intended:
     - `resuming multi-stage run from cache (fingerprint match)`
     - `stage 1/2 reused from cache: eval ELO = 720.0 (5 cached rollout(s))` — stage 1 not re-run
     - `stage 2/2 (replayed from journal): 5 task(s) vs 2 ref(s) ['gemma4_26b','gptoss_120b']` — references replayed from the journal (with `seed=null`, only possible via persistence)
     - stage 2 reused the 4 pre-interrupt deliverables + computed the 1 remaining; final rollouts = 5 stage-0 + 5 stage-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)