### PR TITLE
fix(scicode): run sub-steps in the resources server process, not a Ray worker

### DIFF
--- a/resources_servers/scicode/app.py
+++ b/resources_servers/scicode/app.py
@@ -19,16 +19,16 @@ Runs the agent's accumulated per-sub-step Python solutions against each sub-step
 (targets loaded from test_data.h5) and returns a binary reward: 1.0 iff every sub-step passes.
 Per-sub-step counts are also returned so sub-step accuracy can be computed downstream.
 
-Designed to execute each sub-step via a Ray subprocess worker (instead of a Docker sandbox).
+Each sub-step is executed in a subprocess in this server's own process (instead of a
+Docker sandbox), so the subprocess inherits this server's interpreter and dependencies.
 """
 
 import asyncio
 from pathlib import Path
 from typing import Dict, List, Optional
 
-import ray
 from pydantic import ConfigDict
-from scicode_integration.runner import build_test_program, run_substep_remote, sanitize_test
+from scicode_integration.runner import build_test_program, run_substep, sanitize_test
 
 from nemo_gym import PARENT_DIR
 from nemo_gym.base_resources_server import (
@@ -124,8 +124,7 @@ class ScicodeResourcesServer(SimpleResourcesServer):
             sanitized = [sanitize_test(tc) for tc in sub_step["test_cases"]]
             program = build_test_program(code, h5_path, sub_step["step_number"], sanitized)
             async with self._semaphore:
-                future = run_substep_remote.remote(program, self.config.timeout_secs)
-                result = await loop.run_in_executor(None, ray.get, future)
+                result = await loop.run_in_executor(None, run_substep, program, self.config.timeout_secs)
             return bool(result["passed"])
 
         step_results = list(await asyncio.gather(*[_run_substep(i) for i in scored]))

--- a/resources_servers/scicode/scicode_integration/runner.py
+++ b/resources_servers/scicode/scicode_integration/runner.py
@@ -29,8 +29,6 @@ import re
 import subprocess
 import sys
 
-import ray
-
 
 # Helper functions ported verbatim from nemo-skills scicode_utils.eval_prefix. H5PY_FILE and the
 # h5py/scipy imports are emitted by build_test_program so the test-data path can be parameterized.
@@ -216,8 +214,6 @@ def build_test_program(full_generation: str, h5_path: str, step_number: str, san
     return program
 
 
-# Kept as a plain function (then wrapped with ray.remote below) so the executor logic can be
-# unit-tested directly without launching Ray.
 def run_substep(program: str, timeout_secs: float) -> dict:
     """Run one sub-step program in a subprocess. Exit code 0 == all assertions passed."""
     try:
@@ -226,6 +222,3 @@ def run_substep(program: str, timeout_secs: float) -> dict:
         return {"passed": False, "error": "timeout"}
     passed = proc.returncode == 0
     return {"passed": passed, "error": "" if passed else proc.stderr.decode("utf-8", errors="replace")[-_STDERR_TAIL:]}
-
-
-run_substep_remote = ray.remote(run_substep)

--- a/resources_servers/scicode/tests/test_app.py
+++ b/resources_servers/scicode/tests/test_app.py
@@ -69,16 +69,9 @@ def _request(solutions, n_steps=2):
 
 
 @contextmanager
-def _mock_ray(passed: bool):
-    """Stub the Ray worker so verify() runs without launching Ray or reading test_data.h5."""
-
-    class _Future:
-        pass
-
-    with (
-        patch.object(app.run_substep_remote, "remote", lambda *a, **k: _Future()),
-        patch.object(app.ray, "get", lambda f: {"passed": passed, "error": ""}),
-    ):
+def _mock_substep(passed: bool):
+    """Stub sub-step execution so verify() runs without executing code or reading test_data.h5."""
+    with patch.object(app, "run_substep", lambda *a, **k: {"passed": passed, "error": ""}):
         yield
 
 
@@ -137,7 +130,7 @@ class TestApp:
     @pytest.mark.asyncio
     async def test_verify_excludes_steps_absent_from_solutions(self):
         # Step 1.2 has no solution entry (prefilled) -> excluded from the denominator entirely.
-        with tempfile.NamedTemporaryFile(suffix=".h5") as h5, _mock_ray(passed=True):
+        with tempfile.NamedTemporaryFile(suffix=".h5") as h5, _mock_substep(passed=True):
             result = await _server(h5.name).verify(_request(solutions={"1.1": "a"}, n_steps=2))
         assert result.num_steps_total == 1
         assert result.num_steps_passed == 1
@@ -165,7 +158,7 @@ class TestApp:
 
     @pytest.mark.asyncio
     async def test_verify_all_pass(self):
-        with tempfile.NamedTemporaryFile(suffix=".h5") as h5, _mock_ray(passed=True):
+        with tempfile.NamedTemporaryFile(suffix=".h5") as h5, _mock_substep(passed=True):
             result = await _server(h5.name).verify(_request(solutions={"1.1": "a", "1.2": "b"}))
         assert result.reward == 1.0
         assert result.step_results == [True, True]
@@ -175,7 +168,7 @@ class TestApp:
 
     @pytest.mark.asyncio
     async def test_verify_all_fail(self):
-        with tempfile.NamedTemporaryFile(suffix=".h5") as h5, _mock_ray(passed=False):
+        with tempfile.NamedTemporaryFile(suffix=".h5") as h5, _mock_substep(passed=False):
             result = await _server(h5.name).verify(_request(solutions={"1.1": "a", "1.2": "b"}))
         assert result.reward == 0.0
         assert result.num_steps_passed == 0
@@ -184,7 +177,7 @@ class TestApp:
     @pytest.mark.asyncio
     async def test_verify_out_of_context_step_fails(self):
         # First sub-step runs (mocked pass); second is the out-of-context sentinel -> fails unrun.
-        with tempfile.NamedTemporaryFile(suffix=".h5") as h5, _mock_ray(passed=True):
+        with tempfile.NamedTemporaryFile(suffix=".h5") as h5, _mock_substep(passed=True):
             result = await _server(h5.name).verify(_request(solutions={"1.1": "a", "1.2": "_ran_out_of_context_"}))
         assert result.step_results == [True, False]
         assert result.num_steps_passed == 1


### PR DESCRIPTION
## Problem

SciCode's `verify()` dispatches each sub-step to a `ray.remote` worker that runs `subprocess.run([sys.executable, "-c", program])`. The worker's `sys.executable` is whatever Python the Ray cluster runs — which is not guaranteed to be the SciCode resources server's venv, the only one with SciCode's scientific deps (`h5py`, `scipy`, `numpy`, `sympy`, `matplotlib`).

In a split deployment — vLLM + the Ray head in one container, the resources server joining that cluster via `ray_head_node_address=auto` — the sub-step lands on a worker whose interpreter lacks those deps, so every generated program dies at `import h5py` and `mean/reward` is stuck at **0** even though the model's answers are fine.

## Fix

Execute the sub-step **in the resources server's own process** via the thread-pool executor instead of shipping it to a Ray worker:

```python
result = await loop.run_in_executor(None, run_substep, program, self.config.timeout_secs)
```

The resources server process already runs the SciCode venv, so `run_substep`'s `subprocess.run([sys.executable, ...])` now uses the interpreter that has the deps. Concurrency is unchanged — still bounded by the existing `num_processes` semaphore, and `subprocess.run` releases the GIL. The now-unused `run_substep_remote`/`import ray` are removed and the `verify()` tests retarget `run_substep`.

## Validation

Ran the full SciCode benchmark end-to-end on a split (vLLM + separate resources) deployment. Before this change every sub-step failed at `import h5py` and reward was 0; after, sub-steps execute in the resources-server venv and `subtask_accuracy` lands in line with the NeMo-Skills SciCode reference. Unit tests updated and passing.

## Alternative considered

Keeping the Ray task but pinning its interpreter (or a `runtime_env`) to the resources-server venv also works, but relies on that venv path being valid on every Ray worker (fragile across nodes/containers). Running in-process removes the ambient-interpreter assumption entirely; SciCode sub-steps are short, timeout-bounded subprocesses, so single-node execution is sufficient.
