### PR TITLE
fix(cli): don't let one unresolvable benchmark config break `gym list`

### DIFF
--- a/nemo_gym/cli/eval.py
+++ b/nemo_gym/cli/eval.py
@@ -17,6 +17,7 @@ import asyncio
 import difflib
 import importlib
 import json
+import logging
 from copy import deepcopy
 from glob import glob
 from multiprocessing import Pool
@@ -25,6 +26,7 @@ from typing import Any, Dict, List, Tuple
 
 import rich
 from omegaconf import DictConfig, OmegaConf, open_dict
+from omegaconf.errors import OmegaConfBaseException
 from pydantic import Field
 from rich.table import Table
 from tqdm.auto import tqdm
@@ -56,6 +58,9 @@ from nemo_gym.rollout_collection import (
 from nemo_gym.train_data_utils import TrainDataProcessor
 
 
+LOG = logging.getLogger(__name__)
+
+
 def _fuzzy_matches(query: str, *fields: str) -> bool:
     """Whether `query` fuzzily matches any of `fields`: a substring or a close difflib match (token-aware)."""
     needle = query.lower()
@@ -84,21 +89,30 @@ def _benchmark_domain(bench: BenchmarkConfig) -> str:
         initial_config_dict = OmegaConf.merge(
             initial_config_dict, GlobalConfigDictParserConfig.NO_MODEL_GLOBAL_CONFIG_DICT
         )
-    resolved = GlobalConfigDictParser().parse_no_environment(initial_global_config_dict=initial_config_dict)
+    # Resolving a benchmark's config for the domain column is best-effort: a benchmark whose
+    # config interpolates a key the user hasn't set (e.g. an API key) should still be listable,
+    # just without a resolved domain, rather than raising and breaking `gym list` / `gym search`
+    # for every other benchmark. Interpolations may resolve lazily on access, so the whole scan
+    # is guarded, not just the parse call.
+    try:
+        resolved = GlobalConfigDictParser().parse_no_environment(initial_global_config_dict=initial_config_dict)
 
-    for instance_name in resolved:
-        instance = resolved[instance_name]
-        if not isinstance(instance, (dict, DictConfig)):
-            continue
-
-        for group_key in ("resources_servers", "responses_api_agents", "responses_api_models"):
-            servers = instance.get(group_key)
-            if not servers:
+        for instance_name in resolved:
+            instance = resolved[instance_name]
+            if not isinstance(instance, (dict, DictConfig)):
                 continue
-            for server_config in servers.values():
-                found_domain = (server_config or {}).get("domain")
-                if found_domain:
-                    return str(found_domain)
+
+            for group_key in ("resources_servers", "responses_api_agents", "responses_api_models"):
+                servers = instance.get(group_key)
+                if not servers:
+                    continue
+                for server_config in servers.values():
+                    found_domain = (server_config or {}).get("domain")
+                    if found_domain:
+                        return str(found_domain)
+    except (OmegaConfBaseException, ConfigError) as exc:
+        LOG.warning("Could not resolve domain for benchmark %s: %s", bench.path, exc)
+        return ""
 
     return ""
 

--- a/tests/unit_tests/test_benchmarks.py
+++ b/tests/unit_tests/test_benchmarks.py
@@ -109,6 +109,23 @@ class TestBenchmarkDomain:
 
         assert _benchmark_domain(bench) == "agent"
 
+    def test_survives_unresolvable_interpolation(self, tmp_path: Path) -> None:
+        # A benchmark whose config interpolates a key the user hasn't set (e.g. an API key) must
+        # not break listing: _benchmark_domain returns "" instead of raising, so one such benchmark
+        # can't crash `gym list` / `gym search` for every other benchmark (see #1899).
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            """my_instance:
+  resources_servers:
+    my_server:
+      domain: ${undefined_api_key}
+"""
+        )
+        bench = MagicMock()
+        bench.path = config_path
+
+        assert _benchmark_domain(bench) == ""
+
 
 class TestSearchBenchmarks:
     # Map each benchmark name to the `domain` its config would resolve to.


### PR DESCRIPTION
## What & why

`list_benchmarks()` (the `gym list` / `gym search` entry point) calls `_benchmark_domain()` for **every** benchmark to resolve its config and read the `domain` field. If **any single** benchmark's config interpolates a key the user hasn't configured (e.g. an API key), resolving it raises `InterpolationKeyError`, which aborts the whole command — so no benchmarks are listed for anyone who hasn't set that unrelated key.

This guards the resolution + domain scan in `_benchmark_domain` so an unresolvable config yields an empty domain (and a warning) instead of crashing listing for every other benchmark.

This addresses the robustness half of #1899. The config-naming / discoverability half (benchmarks that don't use `config.yaml`, tracked in #1317) is intentionally out of scope here.

## Change

- `nemo_gym/cli/eval.py`: wrap the parse + server scan in `_benchmark_domain` in a `try/except (OmegaConfBaseException, ConfigError)`, returning `""` and logging a warning. Interpolations can resolve lazily on attribute access, so the scan (not just the parse call) is inside the guard.
- `tests/unit_tests/test_benchmarks.py`: `test_survives_unresolvable_interpolation` — a config whose `domain` interpolates an unset key now returns `""` instead of raising.

## Validation

- New test added under `TestBenchmarkDomain`, matching the existing style.
- Verified the failure mode in isolation: accessing `${undefined_key}` raises `InterpolationKeyError` (a subclass of `OmegaConfBaseException`), and the added guard catches it and returns `""`.
- `ruff check` passes on the changed files.

Note: I couldn't run the full `pytest` locally (needs `uv sync` of the whole package), so the end-to-end test run will happen in CI.
