### PR TITLE
fixing longmt_eval bug introduced by #03d9d9b

### DIFF
--- a/resources_servers/longmt_eval/requirements.txt
+++ b/resources_servers/longmt_eval/requirements.txt
@@ -1,23 +1,19 @@
 -e nemo-gym[dev] @ ../../
 # SEGALE: forked from bc19b2b with numpy==1.23.5 → >=1.23.5 to resolve
-# the pandas==2.2.3 conflict (pandas requires numpy>=1.26.0).
-segale @ git+https://github.com/kajalj22/SEGALE.git@a7c9a1a9a327e181d82ef01cc6aae96d6840862a
+# the pandas==2.2.3 conflict (pandas requires numpy>=1.26.0) and also vecalign 2.0.0
+segale @ git+https://github.com/jeffwillette/SEGALE.git@ab5e0d722e03f1b97846b7ed057ab7558218b035
 # Bumped torch 2.5.0 → 2.12.0 on Sun Jun 22, 2026 for CVE remediation.
 # torchmetrics imports pkg_resources which setuptools 81 removed; pin <81.
 setuptools>=70,<81
 torch==2.12.0
 torchvision==0.27.0
-# Cython lets pyximport JIT-compile vecalign/dp_core.pyx for Python 3.12.
-# The bundled .so in the SEGALE repo is cpython-310 only; pyximport writes
-# a cpython-312 .so into the installed package dir on first import and caches
-# it there for all subsequent workers.
-Cython>=3.0
+
 # SEGALE judge models
 # Forked from facebookresearch/LASER: fairseq removed from install_requires,
 # fairseq imports wrapped in try/except so the module loads without fairseq
 # (which conflicts with nemo-gym's omegaconf>=2.1 requirement).
 laser-encoders @ git+https://github.com/jeffwillette/LASER.git@14ba8c31efe48c351333ff0159fe2d25a6aaee37
-ersatz @ git+https://github.com/jeffwillette/ersatz.git@c31d420837326b2654354df3eb006e3e3d073057
+ersatz @ git+https://github.com/jeffwillette/ersatz.git@d21f40499be09668d7f9ecb19468be1acf1b17be
 unbabel-comet>=2.2
 # Utilities
 scipy

--- a/resources_servers/longmt_eval/tests/test_app.py
+++ b/resources_servers/longmt_eval/tests/test_app.py
@@ -469,3 +469,98 @@ class TestBuildSegaleActorClass:
 
         with pytest.raises(RuntimeError, match="not found"):
             _build_segale_actor_class()
+
+
+class TestErsatzWeightsOnlyLoad:
+    """The ersatz judge checkpoint pickles an ``argparse.Namespace`` ('args'), which
+    torch>=2.6's ``weights_only=True`` default rejects. The pinned ersatz fork
+    (>= d21f404) allowlists Namespace via ``torch.serialization.add_safe_globals`` so the
+    judge loads WITHOUT a ``TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD`` global override.
+
+    These guard that contract with a tiny synthetic checkpoint — no multi-GB model
+    download. If the pin regresses to an ersatz without the allowlist (or someone drops
+    the ``add_safe_globals`` call), ``load_model`` raises ``UnpicklingError`` and these fail.
+    """
+
+    def _write_namespace_checkpoint(self, tmp_path: Path):
+        import argparse
+
+        import torch
+
+        # Mirror the real checkpoint shape: a pickled argparse.Namespace under 'args'
+        # (the part weights_only=True refuses), plus opaque tokenizer bytes and a
+        # here-empty 'weights' state dict. Real weights are irrelevant to the load gate.
+        ckpt = {
+            "args": argparse.Namespace(vocab_size=8, transformer_nlayers=1, foo="bar"),
+            "tokenizer": b"<sentencepiece-bytes>",
+            "weights": {},
+        }
+        path = tmp_path / "ersatz_ckpt.pt"
+        torch.save(ckpt, str(path))
+        return path
+
+    def _stub_model_construction(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Exercise only load_model's torch.load path; stub the heavy tokenizer/model build.
+        import ersatz.split as split
+
+        class _FakeModel:
+            def load_state_dict(self, *_a, **_k):
+                pass
+
+            def eval(self):
+                return self
+
+        monkeypatch.setattr(split, "SentencePiece", lambda **_k: object())
+        monkeypatch.setattr(split, "ErsatzTransformer", lambda *_a, **_k: _FakeModel())
+
+    def test_loads_namespace_checkpoint_without_env_override(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        pytest.importorskip("ersatz.split")
+        import ersatz.split as split
+        import torch
+
+        # Ensure we're testing the real torch default, not the global escape hatch.
+        monkeypatch.delenv("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", raising=False)
+        self._stub_model_construction(monkeypatch)
+        ckpt = self._write_namespace_checkpoint(tmp_path)
+
+        # add_safe_globals is process-global and sticky, so clear it first (restoring
+        # after) to force load_model to perform the registration itself — otherwise a
+        # regression that dropped the call could pass on residue from another test.
+        ser = torch.serialization
+        prior = list(ser.get_safe_globals()) if hasattr(ser, "get_safe_globals") else None
+        if prior is not None:
+            ser.clear_safe_globals()
+        try:
+            # Must NOT raise UnpicklingError under torch>=2.6 weights_only=True default.
+            model = split.load_model(str(ckpt))
+            assert model is not None
+        finally:
+            if prior is not None:
+                ser.clear_safe_globals()
+                if prior:
+                    ser.add_safe_globals(prior)
+
+    def test_does_not_disable_weights_only(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """The fix must be add_safe_globals + the safe default, NOT weights_only=False."""
+        pytest.importorskip("ersatz.split")
+        import ersatz.split as split
+        import torch
+
+        monkeypatch.delenv("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", raising=False)
+        self._stub_model_construction(monkeypatch)
+        ckpt = self._write_namespace_checkpoint(tmp_path)
+
+        captured: dict = {}
+        real_load = torch.load
+
+        def _spy_load(*args, **kwargs):
+            captured["weights_only"] = kwargs.get("weights_only")
+            return real_load(*args, **kwargs)
+
+        monkeypatch.setattr(torch, "load", _spy_load)
+        split.load_model(str(ckpt))
+        # weights_only=False would defeat the protection wholesale; the allowlist keeps
+        # the default (True on torch>=2.6). Absent kwarg (None) is also acceptable.
+        assert captured.get("weights_only") is not False


### PR DESCRIPTION
torch version bump caused model loading errors
vecalign 2.0.0 was also released which changed dependency structure