### PR TITLE
Longmt thread safe

### DIFF
--- a/benchmarks/longmt_pg19/prepare.py
+++ b/benchmarks/longmt_pg19/prepare.py
@@ -10,22 +10,16 @@ grouped or filtered by context length.
 Books are truncated from the end so the model always sees the beginning of the
 book without skipping content.
 
-Also pre-fetches the SEGALE judge models (LASER2, ersatz, wmt22-cometkiwi-da)
-into their cache directories so the resource server can run with
-HF_HUB_OFFLINE=1 from the first verify() call.
-
 Usage:
     python prepare.py
     python prepare.py --target_languages de_DE fr_FR ja_JP
     python prepare.py --lengths 8 32 65
-    python prepare.py --no_prefetch
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import os
 from pathlib import Path
 
 from datasets import load_dataset
@@ -144,48 +138,9 @@ def _truncate_end(text: str, max_tokens: int) -> str:
     return enc.decode(tokens[:max_tokens])
 
 
-def _prefetch_judge_models() -> None:
-    """Pre-fetch LASER2, ersatz, and wmt22-cometkiwi-da into their cache dirs."""
-    laser_home = os.environ.get("LASER_HOME")
-    try:
-        from laser_encoders import LaserEncoderPipeline
-
-        print(f"Pre-fetching LASER2 (LASER_HOME={laser_home})...")
-        LaserEncoderPipeline(laser="laser2", model_dir=laser_home)
-        print("LASER2 cached")
-    except ImportError:
-        print("laser-encoders not installed; skipping LASER2 prefetch")
-    except Exception as exc:
-        print(f"LASER2 prefetch failed (will retry at server start): {exc}")
-
-    try:
-        import ersatz
-
-        print("Pre-fetching ersatz default-multilingual model...")
-        ersatz.split(model="default-multilingual", text=".")
-        print("ersatz cached")
-    except ImportError:
-        print("ersatz not installed; skipping prefetch")
-    except Exception as exc:
-        print(f"ersatz prefetch failed: {exc}")
-
-    try:
-        from comet import download_model, load_from_checkpoint
-
-        print("Pre-fetching Unbabel/wmt22-cometkiwi-da...")
-        ckpt = download_model("Unbabel/wmt22-cometkiwi-da")
-        load_from_checkpoint(ckpt)
-        print("wmt22-cometkiwi-da cached")
-    except ImportError:
-        print("unbabel-comet not installed; skipping COMETKiwi prefetch")
-    except Exception as exc:
-        print(f"COMETKiwi prefetch failed: {exc}")
-
-
 def prepare(
     target_languages: list[str] | None = None,
     lengths: list[int] | None = None,
-    prefetch: bool = True,
 ) -> Path:
     """Download emozilla/pg19 test split and write pg19_benchmark.jsonl.
 
@@ -238,9 +193,6 @@ def prepare(
         f"to {output_fpath}"
     )
 
-    if prefetch:
-        _prefetch_judge_models()
-
     return output_fpath
 
 
@@ -260,10 +212,7 @@ if __name__ == "__main__":
         metavar="N",
         help=f"Truncation lengths in tiktoken tokens (default: {DEFAULT_LENGTHS})",
     )
-    parser.add_argument(
-        "--no_prefetch", action="store_true", help="Skip judge model prefetch (useful on machines without GPU)"
-    )
     args = parser.parse_args()
 
     langs = ALL_LANGUAGES if args.all_languages else args.target_languages
-    prepare(target_languages=langs, lengths=args.lengths, prefetch=not args.no_prefetch)
+    prepare(target_languages=langs, lengths=args.lengths)

--- a/benchmarks/longmt_wmt24pp/prepare.py
+++ b/benchmarks/longmt_wmt24pp/prepare.py
@@ -10,21 +10,15 @@ source_sentences and reference_sentences lists for downstream analysis.
 wmt24pp documents are short (typically < 300 sentences, < 2K tokens) so no
 truncation is needed.
 
-Also pre-fetches the SEGALE judge models (LASER2, ersatz, wmt22-cometkiwi-da)
-into their cache directories so the resource server can run with
-HF_HUB_OFFLINE=1 from the first verify() call.
-
 Usage:
     python prepare.py
     python prepare.py --target_languages de_DE fr_FR ja_JP
-    python prepare.py --no_prefetch
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import os
 from collections import OrderedDict
 from pathlib import Path
 
@@ -116,47 +110,8 @@ def _lang_name(lang_code: str) -> str:
         return _FALLBACK.get(lang_code, lang_code)
 
 
-def _prefetch_judge_models() -> None:
-    """Pre-fetch LASER2, ersatz, and wmt22-cometkiwi-da into their cache dirs."""
-    laser_home = os.environ.get("LASER_HOME")
-    try:
-        from laser_encoders import LaserEncoderPipeline
-
-        print(f"Pre-fetching LASER2 (LASER_HOME={laser_home})...")
-        LaserEncoderPipeline(laser="laser2", model_dir=laser_home)
-        print("LASER2 cached")
-    except ImportError:
-        print("laser-encoders not installed; skipping LASER2 prefetch")
-    except Exception as exc:
-        print(f"LASER2 prefetch failed (will retry at server start): {exc}")
-
-    try:
-        import ersatz
-
-        print("Pre-fetching ersatz default-multilingual model...")
-        ersatz.split(model="default-multilingual", text=".")
-        print("ersatz cached")
-    except ImportError:
-        print("ersatz not installed; skipping prefetch")
-    except Exception as exc:
-        print(f"ersatz prefetch failed: {exc}")
-
-    try:
-        from comet import download_model, load_from_checkpoint
-
-        print("Pre-fetching Unbabel/wmt22-cometkiwi-da...")
-        ckpt = download_model("Unbabel/wmt22-cometkiwi-da")
-        load_from_checkpoint(ckpt)
-        print("wmt22-cometkiwi-da cached")
-    except ImportError:
-        print("unbabel-comet not installed; skipping COMETKiwi prefetch")
-    except Exception as exc:
-        print(f"COMETKiwi prefetch failed: {exc}")
-
-
 def prepare(
     target_languages: list[str] | None = None,
-    prefetch: bool = True,
 ) -> Path:
     """Download google/wmt24pp and write wmt24pp_benchmark.jsonl.
 
@@ -205,17 +160,11 @@ def prepare(
 
     print(f"Wrote {count} rows to {OUTPUT_FPATH}")
 
-    if prefetch:
-        _prefetch_judge_models()
-
     return OUTPUT_FPATH
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--target_languages", nargs="+", default=None, help="Target language codes (default: all 55)")
-    parser.add_argument(
-        "--no_prefetch", action="store_true", help="Skip judge model prefetch (useful on machines without GPU)"
-    )
     args = parser.parse_args()
-    prepare(target_languages=args.target_languages, prefetch=not args.no_prefetch)
+    prepare(target_languages=args.target_languages)

--- a/resources_servers/longmt_eval/segale_actor.py
+++ b/resources_servers/longmt_eval/segale_actor.py
@@ -142,9 +142,17 @@ def _build_segale_actor_class(actors_per_gpu: int = 1, use_extra_gpu: bool = Fal
         # Ray thinks this node has 0 GPUs; preserve physical CUDA_VISIBLE_DEVICES
         # so the actor can still access its assigned GPU directly.
         env_vars["RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"] = "1"
-    for key in ("HF_HOME", "HF_HUB_OFFLINE", "HF_HUB_CACHE", "LASER_HOME", "ERSATZ", "TRANSFORMERS_CACHE"):
+    # HF_HOME: root HuggingFace cache dir; hub cache derives from it.
+    # HF_HUB_OFFLINE: when 1, blocks all HF Hub network calls.
+    # HF_HUB_CACHE: overrides just the hub model-cache location.
+    # TRANSFORMERS_CACHE: legacy transformers cache dir (deprecated; forwarded for compat).
+    # LASER_HOME: dir for LASER2 weights
+    # ERSATZ: dir for ersatz segmenter weights
+    for key in ("HF_HOME", "HF_HUB_OFFLINE", "HF_HUB_CACHE", "TRANSFORMERS_CACHE"):
         if os.environ.get(key):
             env_vars[key] = os.environ[key]
+    env_vars["LASER_HOME"] = os.environ.get("LASER_HOME", "/opt/Gym/.cache/longmt-laser")
+    env_vars["ERSATZ"] = os.environ.get("ERSATZ", "/opt/Gym/.cache/longmt-ersatz")
 
     gpu_fraction = 1 / actors_per_gpu
     if use_extra_gpu:

--- a/resources_servers/longmt_eval/segale_actor.py
+++ b/resources_servers/longmt_eval/segale_actor.py
@@ -11,10 +11,12 @@ class, then instantiate one actor per GPU on the gym node.
 
 from __future__ import annotations
 
+import gzip
 import logging
 import os
 import shutil
 import sys
+import urllib.request
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -51,6 +53,61 @@ def _mirror_python(cache_env_var: str, default_cache: str) -> Path:
         tmp.rename(mirrored_root)
 
     return mirrored_bin
+
+
+def _download_once(dest: str, produce) -> None:
+    """Produce `dest` (a file or dir) exactly once, race-safe across Ray actors.
+
+    `produce(tmp)` fills a private pid-scoped tmp beside `dest`; we then atomically
+    os.replace() it in (atomic for files and dirs on one filesystem). A competing
+    actor that published first simply wins.
+    """
+    if os.path.exists(dest):
+        return
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    tmp = f"{dest}.{os.getpid()}.tmp"
+    produce(tmp)
+    if os.path.exists(dest):
+        # Lost the race: another actor published first. Discard our just-made copy.
+        shutil.rmtree(tmp) if os.path.isdir(tmp) else os.remove(tmp)
+    else:
+        os.replace(tmp, dest)
+
+
+def _download_to(url: str, tmp: str, gunzip: bool = False) -> None:
+    with urllib.request.urlopen(url) as resp:
+        stream = gzip.GzipFile(fileobj=resp) if gunzip else resp
+        with open(tmp, "wb") as out:
+            shutil.copyfileobj(stream, out)
+
+
+def _download_ersatz_model(model_name: str = "default-multilingual") -> None:
+    """Fetch ersatz weights once; its download_model() writes in-place with no lock."""
+    from ersatz.utils import ERSATZ_DIR, MODELS
+
+    m = MODELS[model_name]
+    _download_once(os.path.join(ERSATZ_DIR, m["destination"]), lambda tmp: _download_to(m["source"], tmp, gunzip=True))
+
+
+def _download_laser_model(model_dir: str) -> None:
+    """Fetch LASER2 weights once; its downloader's cross-fs shutil.move() isn't atomic."""
+    from laser_encoders.download_models import LaserModelDownloader
+
+    base_url = LaserModelDownloader(model_dir).base_url
+    for filename in ("laser2.pt", "laser2.spm", "laser2.cvocab"):
+        url = f"{base_url}/{filename}"
+        _download_once(os.path.join(model_dir, filename), lambda tmp, url=url: _download_to(url, tmp))
+
+
+def _download_comet_model(comet_model: str) -> str:
+    """Fetch a COMET checkpoint once and return its path; its non-HF URL fallback isn't race-safe."""
+    from comet import download_model
+
+    cache_root = os.environ.get("LONGMT_COMET_CACHE", "/opt/Gym/.cache/longmt-comet")
+    dest = os.path.join(cache_root, comet_model.replace("/", "__"))
+    _download_once(dest, lambda tmp: download_model(comet_model, saving_directory=tmp))
+    # Files are present now; resolve the checkpoint path locally, no network.
+    return download_model(comet_model, saving_directory=dest, local_files_only=True)
 
 
 def _build_segale_actor_class(actors_per_gpu: int = 1, use_extra_gpu: bool = False):
@@ -104,7 +161,7 @@ def _build_segale_actor_class(actors_per_gpu: int = 1, use_extra_gpu: bool = Fal
             embed_batch_size: int,
         ):
             import torch
-            from comet import download_model, load_from_checkpoint
+            from comet import load_from_checkpoint
             from ersatz.split import EvalModel as ErsatzModel
             from ersatz.utils import get_model_path
             from laser_encoders import LaserEncoderPipeline
@@ -126,16 +183,18 @@ def _build_segale_actor_class(actors_per_gpu: int = 1, use_extra_gpu: bool = Fal
 
             laser_home = os.environ.get("LASER_HOME")
             LOG.info("SegaleActor[%d]: loading LASER2 from %s", gpu_idx, laser_home)
+            _download_laser_model(laser_home)
             self._laser = LaserEncoderPipeline(laser="laser2", model_dir=laser_home)
 
             LOG.info("SegaleActor[%d]: loading COMETKiwi %s on %s", gpu_idx, comet_model, self._device)
-            ckpt = download_model(comet_model)
+            ckpt = _download_comet_model(comet_model)
             self._comet = load_from_checkpoint(ckpt)
             self._comet.to(self._device).eval()
 
             LOG.info("SegaleActor[%d]: loading ersatz segmenter", gpu_idx)
             from ersatz.candidates import MultilingualPunctuation
 
+            _download_ersatz_model("default-multilingual")
             self._ersatz = ErsatzModel(get_model_path("default-multilingual"))
             self._ersatz.device = torch.device("cpu")
             self._ersatz_candidates = MultilingualPunctuation()

--- a/resources_servers/longmt_eval/tests/test_app.py
+++ b/resources_servers/longmt_eval/tests/test_app.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+import gzip
+import io
+import os
 import sys
+import urllib.request
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -564,3 +568,255 @@ class TestErsatzWeightsOnlyLoad:
         # weights_only=False would defeat the protection wholesale; the allowlist keeps
         # the default (True on torch>=2.6). Absent kwarg (None) is also acceptable.
         assert captured.get("weights_only") is not False
+
+
+class TestDownloadOnce:
+    """Unit tests for _download_once() in segale_actor.py — the generic race-safe
+    publish guard shared by the ersatz/laser/comet fetchers.
+
+    Deliberately free of library or network deps: a fake ``produce`` callback plus
+    real tmp dirs exercises every branch (fast-path, won-race file/dir, lost-race
+    file/dir), so these run everywhere and are the cheapest coverage of the logic
+    most likely to corrupt a shared cache.
+    """
+
+    def test_fast_path_skips_produce_when_present(self, tmp_path: Path) -> None:
+        import segale_actor
+
+        dest = tmp_path / "sub" / "f.bin"
+        dest.parent.mkdir(parents=True)
+        dest.write_bytes(b"cached")
+        called: list[int] = []
+
+        segale_actor._download_once(str(dest), lambda tmp: called.append(1))
+
+        assert called == []
+        assert dest.read_bytes() == b"cached"
+
+    def test_publishes_file_atomically(self, tmp_path: Path) -> None:
+        import segale_actor
+
+        dest = tmp_path / "sub" / "f.bin"  # parent does not exist yet
+        segale_actor._download_once(str(dest), lambda tmp: Path(tmp).write_bytes(b"hello"))
+
+        assert dest.read_bytes() == b"hello"
+        assert not list(dest.parent.glob("*.tmp"))
+
+    def test_publishes_directory_atomically(self, tmp_path: Path) -> None:
+        import segale_actor
+
+        dest = tmp_path / "model"
+
+        def produce(tmp: str) -> None:
+            ck = Path(tmp) / "checkpoints"
+            ck.mkdir(parents=True)
+            (ck / "model.ckpt").write_bytes(b"ckpt")
+
+        segale_actor._download_once(str(dest), produce)
+
+        assert (dest / "checkpoints" / "model.ckpt").read_bytes() == b"ckpt"
+        assert not list(tmp_path.glob("*.tmp"))
+
+    def test_lost_race_file_keeps_winner(self, tmp_path: Path) -> None:
+        import segale_actor
+
+        dest = tmp_path / "race" / "f.bin"
+
+        def produce(tmp: str) -> None:
+            Path(tmp).write_bytes(b"ours")
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"theirs")  # a competitor publishes while we "download"
+
+        segale_actor._download_once(str(dest), produce)
+
+        assert dest.read_bytes() == b"theirs"  # winner kept, our copy discarded
+        assert not list(dest.parent.glob("*.tmp"))
+
+    def test_lost_race_directory_keeps_winner(self, tmp_path: Path) -> None:
+        import segale_actor
+
+        dest = tmp_path / "model"
+
+        def produce(tmp: str) -> None:
+            Path(tmp).mkdir()
+            (Path(tmp) / "x").write_bytes(b"ours")
+            dest.mkdir()
+            (dest / "x").write_bytes(b"theirs")  # competitor publishes the dir first
+
+        segale_actor._download_once(str(dest), produce)
+
+        assert (dest / "x").read_bytes() == b"theirs"  # our tmp dir was rmtree'd
+        assert not list(tmp_path.glob("*.tmp"))
+
+
+class TestDownloadTo:
+    """Unit tests for _download_to() — the single URL->file download body."""
+
+    def test_plain_download(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        import segale_actor
+
+        monkeypatch.setattr(urllib.request, "urlopen", lambda url: io.BytesIO(b"raw-bytes"))
+        out = tmp_path / "out.bin"
+        segale_actor._download_to("http://x/f", str(out))
+
+        assert out.read_bytes() == b"raw-bytes"
+
+    def test_gunzip_download(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        import segale_actor
+
+        raw = b"decompressed-payload"
+        monkeypatch.setattr(urllib.request, "urlopen", lambda url: io.BytesIO(gzip.compress(raw)))
+        out = tmp_path / "out.bin"
+        segale_actor._download_to("http://x/f.gz", str(out), gunzip=True)
+
+        assert out.read_bytes() == raw
+
+
+class TestDownloadErsatzModel:
+    """Unit tests for _download_ersatz_model(): path wiring against the real ersatz
+    registry (ERSATZ_DIR/MODELS) with the network mocked — no multi-GB fetch."""
+
+    def _patch_registry(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, source: str = "http://x/model.gz"
+    ) -> Path:
+        eu = pytest.importorskip("ersatz.utils")
+        monkeypatch.setattr(eu, "ERSATZ_DIR", str(tmp_path / "ersatz_home"))
+        monkeypatch.setattr(
+            eu,
+            "MODELS",
+            {"default-multilingual": {"destination": os.path.join("models", "dm"), "source": source}},
+        )
+        return Path(eu.ERSATZ_DIR) / "models" / "dm"
+
+    def test_downloads_and_gunzips(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        import segale_actor
+
+        dest = self._patch_registry(monkeypatch, tmp_path)
+        raw = b"ersatz-weights"
+        monkeypatch.setattr(urllib.request, "urlopen", lambda url: io.BytesIO(gzip.compress(raw)))
+
+        segale_actor._download_ersatz_model("default-multilingual")
+
+        assert dest.read_bytes() == raw
+        assert not list(dest.parent.glob("*.tmp"))
+
+    def test_idempotent_second_call_skips_download(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        import segale_actor
+
+        dest = self._patch_registry(monkeypatch, tmp_path)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"cached")
+
+        def _boom(url):
+            raise AssertionError("must not download when the checkpoint already exists")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _boom)
+
+        segale_actor._download_ersatz_model("default-multilingual")
+
+        assert dest.read_bytes() == b"cached"
+
+
+class TestDownloadLaserModel:
+    """Unit tests for _download_laser_model(): fetches laser2.{pt,spm,cvocab} via the
+    real LaserModelDownloader.base_url plumbing, with the network mocked."""
+
+    def _patch_downloader(self, monkeypatch: pytest.MonkeyPatch, base_url: str = "http://x/laser") -> None:
+        dl = pytest.importorskip("laser_encoders.download_models")
+
+        class _FakeDownloader:
+            def __init__(self, model_dir):
+                self.base_url = base_url
+
+        monkeypatch.setattr(dl, "LaserModelDownloader", _FakeDownloader)
+
+    def test_downloads_all_three(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        import segale_actor
+
+        self._patch_downloader(monkeypatch)
+        monkeypatch.setattr(
+            urllib.request, "urlopen", lambda url: io.BytesIO(b"data-" + url.rsplit("/", 1)[-1].encode())
+        )
+        model_dir = tmp_path / "laser_home"
+
+        segale_actor._download_laser_model(str(model_dir))
+
+        for fn in ("laser2.pt", "laser2.spm", "laser2.cvocab"):
+            assert (model_dir / fn).read_bytes() == b"data-" + fn.encode()
+        assert not list(model_dir.glob("*.tmp"))
+
+    def test_skips_existing_files(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        import segale_actor
+
+        self._patch_downloader(monkeypatch)
+        model_dir = tmp_path / "laser_home"
+        model_dir.mkdir()
+        (model_dir / "laser2.pt").write_bytes(b"cached-pt")
+
+        fetched: list[str] = []
+
+        def _urlopen(url):
+            fetched.append(url.rsplit("/", 1)[-1])
+            return io.BytesIO(b"new")
+
+        monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+
+        segale_actor._download_laser_model(str(model_dir))
+
+        assert fetched == ["laser2.spm", "laser2.cvocab"]  # laser2.pt skipped via fast-path
+        assert (model_dir / "laser2.pt").read_bytes() == b"cached-pt"
+
+
+class TestDownloadCometModel:
+    """Unit tests for _download_comet_model(): the produce-into-tmp then
+    resolve-from-dest flow, with comet.download_model mocked (no HF/URL fetch)."""
+
+    @staticmethod
+    def _fake_download_model(calls: list):
+        def fake(model, saving_directory=None, local_files_only=False):
+            calls.append((saving_directory, local_files_only))
+            ck = Path(saving_directory) / "checkpoints"
+            ck.mkdir(parents=True, exist_ok=True)
+            p = ck / "model.ckpt"
+            if not p.exists():
+                p.write_bytes(b"ckpt")
+            return str(p)
+
+        return fake
+
+    def test_two_call_flow_and_path(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        import segale_actor
+
+        comet = pytest.importorskip("comet")
+        calls: list = []
+        monkeypatch.setattr(comet, "download_model", self._fake_download_model(calls))
+        monkeypatch.setenv("LONGMT_COMET_CACHE", str(tmp_path / "comet_cache"))
+
+        ckpt = segale_actor._download_comet_model("Unbabel/wmt22-cometkiwi-da")
+
+        dest = tmp_path / "comet_cache" / "Unbabel__wmt22-cometkiwi-da"
+        assert ckpt == str(dest / "checkpoints" / "model.ckpt")
+        assert Path(ckpt).read_bytes() == b"ckpt"
+        # First call produces into a private .tmp dir; second resolves locally from dest.
+        assert len(calls) == 2
+        assert calls[0][0].endswith(".tmp")
+        assert calls[1] == (str(dest), True)
+        assert not list(dest.parent.glob("*.tmp"))
+
+    def test_idempotent_second_call_only_resolves(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        import segale_actor
+
+        comet = pytest.importorskip("comet")
+        monkeypatch.setattr(comet, "download_model", self._fake_download_model([]))
+        monkeypatch.setenv("LONGMT_COMET_CACHE", str(tmp_path / "comet_cache"))
+        segale_actor._download_comet_model("m")  # populate the cache
+
+        calls: list = []
+        monkeypatch.setattr(comet, "download_model", self._fake_download_model(calls))
+
+        ckpt = segale_actor._download_comet_model("m")
+
+        dest = tmp_path / "comet_cache" / "m"
+        # Fast-path skips produce entirely; only the local resolve runs.
+        assert calls == [(str(dest), True)]
+        assert ckpt == str(dest / "checkpoints" / "model.ckpt")


### PR DESCRIPTION
The _prefetch_judge_models() functions in benchmarks/longmt_pg19/prepare.py and benchmarks/longmt_wmt24pp/prepare.py were intended to pre-fetch models (comet, laser2, and ersatz) before agents were fanned out because those agents perform downloads which are not threadsafe. However, the venv that _prefetch_judge_models() is called from does not match that of the agents, causing the pre-fetch to fail and the subsequent downloads to collide. 

The agent venv is already fragile and I did not believe it was a good idea to duplicate those requirements across a second venv, potentially conflicting with existing requirements. 

Instead, I removed the _prefetch_judge_models() functions and added protection around each download within the agent code to prevent collision. 

I also added defaults for two environment variables (LASER_HOME, ERSATZ) in the agent environment only. A missing LASER_HOME in particular caused the code to crash. 