### PR TITLE
design: Prototype for Agent Modules.

### DIFF
--- a/benchmarks/agent_modules_tutorial/config.yaml
+++ b/benchmarks/agent_modules_tutorial/config.yaml
@@ -39,11 +39,13 @@ agent_modules_tutorial_simple_agent:
       modules:
         - type: working_memory
           name: answer_format_prompt
-          path: benchmarks/prompts/eval/aai/mcq-4choices.yaml
+          config:
+            path: benchmarks/prompts/eval/aai/mcq-4choices.yaml
         - type: skill_library
           name: tutorial_skills
-          injection_mode: context
-          adaptation:
-            enabled: true
-            target_skill: cot_enhanced
-            reward_threshold: 1.0
+          config:
+            injection_mode: context
+            adaptation:
+              enabled: true
+              target_skill: cot_enhanced
+              reward_threshold: 1.0

--- a/benchmarks/agent_modules_tutorial/config.yaml
+++ b/benchmarks/agent_modules_tutorial/config.yaml
@@ -1,4 +1,4 @@
-# Agent modules tutorial — MCQA + simple_agent with prompt and skill_library modules.
+# Agent modules tutorial — MCQA + simple_agent with working_memory and skill_library modules.
 #
 # Start (from repo root, after configuring env.yaml — see tutorial doc):
 #
@@ -37,7 +37,7 @@ agent_modules_tutorial_simple_agent:
         type: responses_api_models
         name: policy_model
       modules:
-        - type: prompt
+        - type: working_memory
           name: answer_format_prompt
           path: benchmarks/prompts/eval/aai/mcq-4choices.yaml
         - type: skill_library

--- a/benchmarks/agent_modules_tutorial/config.yaml
+++ b/benchmarks/agent_modules_tutorial/config.yaml
@@ -1,0 +1,49 @@
+# Agent modules tutorial — MCQA + simple_agent with prompt and skill_library modules.
+#
+# Start (from repo root, after configuring env.yaml — see tutorial doc):
+#
+#   gym env start \
+#     --config benchmarks/agent_modules_tutorial/config.yaml \
+#     --resources-server agent_modules_tutorial_mcqa \
+#     --model-type openai_model
+#
+# Evaluate:
+#
+#   cp -r benchmarks/skills/variant_a /tmp/agent_modules_skills_variant_a
+#   gym eval run --no-serve \
+#     +agent_name=agent_modules_tutorial_simple_agent \
+#     +input_jsonl_fpath=benchmarks/agent_modules_tutorial/data/tiny.jsonl \
+#     +output_jsonl_fpath=results/agent_modules_tutorial_rollouts.jsonl \
+#     +skills.path=/tmp/agent_modules_skills_variant_a \
+#     +limit=2 +num_repeats=1
+
+config_paths:
+  - resources_servers/mcqa/configs/mcqa.yaml
+
+agent_modules_tutorial_mcqa:
+  _inherit_from: mcqa
+  resources_servers:
+    mcqa:
+      grading_mode: lenient_answer_colon_md
+
+agent_modules_tutorial_simple_agent:
+  responses_api_agents:
+    simple_agent:
+      entrypoint: app.py
+      resources_server:
+        type: resources_servers
+        name: agent_modules_tutorial_mcqa
+      model_server:
+        type: responses_api_models
+        name: policy_model
+      modules:
+        - type: prompt
+          name: answer_format_prompt
+          path: benchmarks/prompts/eval/aai/mcq-4choices.yaml
+        - type: skill_library
+          name: tutorial_skills
+          injection_mode: context
+          adaptation:
+            enabled: true
+            target_skill: cot_enhanced
+            reward_threshold: 1.0

--- a/benchmarks/skills/variant_a/baseline/SKILL.md
+++ b/benchmarks/skills/variant_a/baseline/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: baseline
+description: Answer directly without extra scaffolding.
+---
+# Baseline
+
+Answer the question using the format required by the system prompt.

--- a/benchmarks/skills/variant_a/cot_enhanced/SKILL.md
+++ b/benchmarks/skills/variant_a/cot_enhanced/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: cot_enhanced
+description: Think step by step before answering multiple-choice questions.
+---
+# Chain-of-thought for MCQ
+
+When solving a multiple-choice question:
+
+1. Restate the question in your own words.
+2. Eliminate clearly wrong options with brief justification.
+3. Compare the remaining options.
+4. State your final answer using the required format from the system prompt.

--- a/fern/versions/latest/pages/agent-server/agent-skills.mdx
+++ b/fern/versions/latest/pages/agent-server/agent-skills.mdx
@@ -6,7 +6,15 @@ position: 3
 
 Skills are reusable units of operational knowledge an agent can load at runtime, following the open [Agent Skills standard](https://agentskills.io/specification) used by Claude Code and Codex CLI. A skill is a **directory** containing a `SKILL.md` file (YAML frontmatter + markdown body) plus optional supporting files.
 
-NeMo Gym treats skills as an **environment-level variable you can sweep**, the same way it treats prompts. You point a run at a directory of skills, the agent loads them with its own native mechanism, and each rollout result is tagged so you can compare variants. NeMo Gym does not interpret or activate skills — it sets up the skill environment and measures the outcome.
+NeMo Gym treats skills as a **run-level variable you can sweep**, the same way it treats `prompt_config`. You pass `+skills.path=…` on `gym eval run` — not in dataset rows — reuse the same task JSONL across skill variants, and compare runs using the content-hashed `skills_ref` on each result.
+
+<Note>
+
+**Run-level, not Environment.** In Gym terminology, the **Environment** is the resources server (`seed_session`, tools, `verify`, reward). Skills are not owned by the Environment. `RolloutCollectionHelper` resolves `skills.path`, stamps `skills_ref` on each row, and the Agent makes skills available during `/run` (native discovery, staging, or a `skill_library` module).
+
+</Note>
+
+For agents with native skill runtimes (Claude Code, Codex), Gym core does not parse or activate skills — it records provenance and the agent stages the directory. For agents without discovery (`simple_agent`), a `skill_library` module with `injection_mode: context` can inject `SKILL.md` bodies into the system message. See [Agent Modules Walkthrough](/evaluation-tutorials/agent-modules-walkthrough).
 
 ## Skills are a run-level knob, not a dataset field
 

--- a/fern/versions/latest/pages/evaluation-tutorials/agent-modules-walkthrough.mdx
+++ b/fern/versions/latest/pages/evaluation-tutorials/agent-modules-walkthrough.mdx
@@ -1,0 +1,199 @@
+---
+title: "Agent Modules Walkthrough"
+description: "Run prompt and skill_library Agent modules on simple_agent with MCQA — inspect prepare, observe, and provenance fields."
+position: 4
+---
+
+This walkthrough runs the **Agent modules** reference implementation end-to-end: a `prompt` module injects the answer format, a `skill_library` module injects skill content into the system message, and optional **adaptation** appends lessons to skills after failed rollouts.
+
+Use it to see the `prepare` → harness → `verify` → `observe` flow before scaling to GEPA, ACE, or full benchmarks.
+
+<Info>
+
+This tutorial uses `simple_agent`, which has no native skill discovery. Skills are injected via `injection_mode: context`. Claude Code agents use `injection_mode: none` and `stage_skills` instead — see [Agent Skills](/agent-server/agent-skills).
+
+</Info>
+
+## What This Tutorial Runs
+
+| Component | Value |
+| --- | --- |
+| Resources server | `agent_modules_tutorial_mcqa` (inherits [mcqa](/environment-tutorials/mcp-resources-server)) |
+| Agent | `agent_modules_tutorial_simple_agent` |
+| Config | `benchmarks/agent_modules_tutorial/config.yaml` |
+| Dataset | `benchmarks/agent_modules_tutorial/data/tiny.jsonl` (2 MCQ tasks, no pre-baked prompts) |
+| Skills | `benchmarks/skills/variant_a/` (`cot_enhanced`, `baseline`) |
+| Prompt module | `benchmarks/prompts/eval/aai/mcq-4choices.yaml` |
+| Pass score | `reward: 1.0` when the model answer matches `expected_answer` |
+
+## Flow (what happens per rollout)
+
+```mermaid
+sequenceDiagram
+    participant CLI as gym eval run
+    participant P as Rollout collector
+    participant A as simple_agent /run
+    participant M as Agent modules
+    participant H as /v1/responses
+    participant E as mcqa verify
+
+    CLI->>P: tiny.jsonl + skills.path
+    P->>P: stamp skills_ref on each row
+    P->>A: POST /run
+    A->>E: seed_session
+    A->>M: prepare (prompt + skills → system/user messages)
+    A->>H: ReAct tool loop (no tools on these tasks)
+    H-->>A: model response
+    A->>E: verify → reward
+    A->>M: observe (adapt skill if reward < 1.0)
+    A-->>P: reward + agent_artifact_refs + agent_update_events
+```
+
+## Prerequisites
+
+1. Complete [Installation](/get-started/installation).
+2. Configure a model endpoint in `env.yaml` at the repo root (same as [Quickstart](/get-started/quickstart)):
+
+```yaml
+policy_base_url: https://api.openai.com/v1
+policy_api_key: <your-api-key>
+policy_model_name: gpt-4.1-2025-04-14
+```
+
+Or use another supported backend from [Configure Model](/model-server).
+
+## Step 1 — Copy skills to a writable directory
+
+Adaptation **mutates** `SKILL.md` in place when a rollout fails. Copy the sample skills so the repo stays clean:
+
+```bash
+cp -r benchmarks/skills/variant_a /tmp/agent_modules_skills_variant_a
+```
+
+To compare skill variants later without adaptation, copy `variant_b` or edit skills under `/tmp/…` only.
+
+## Step 2 — Start servers
+
+From the repository root:
+
+```bash
+source .venv/bin/activate
+
+gym env start \
+  --config benchmarks/agent_modules_tutorial/config.yaml \
+  --resources-server agent_modules_tutorial_mcqa \
+  --model-type openai_model
+```
+
+You should see three instances, including `agent_modules_tutorial_simple_agent` and `policy_model`.
+
+Leave this terminal running.
+
+## Step 3 — Collect rollouts
+
+In a second terminal:
+
+```bash
+source .venv/bin/activate
+mkdir -p results
+
+gym eval run --no-serve \
+  +agent_name=agent_modules_tutorial_simple_agent \
+  +input_jsonl_fpath=benchmarks/agent_modules_tutorial/data/tiny.jsonl \
+  +output_jsonl_fpath=results/agent_modules_tutorial_rollouts.jsonl \
+  +skills.path=/tmp/agent_modules_skills_variant_a \
+  +limit=2 \
+  +num_repeats=1
+```
+
+The run stamps `skills_ref` on each row (Processor) and applies Agent modules inside `/run` (Agent).
+
+## Step 4 — Inspect outputs
+
+**Aggregate metrics** (terminal summary):
+
+```text
+Key metrics for agent_modules_tutorial_simple_agent:
+{
+    "mean/reward": ...
+}
+```
+
+**Single rollout row** — provenance and adaptation:
+
+```bash
+head -1 results/agent_modules_tutorial_rollouts.jsonl | python -m json.tool
+```
+
+Look for these fields:
+
+| Field | Meaning |
+| --- | --- |
+| `reward` | Environment verifier score (`1.0` = correct MCQ answer) |
+| `skills_ref` | Run-level skills directory + content hash (Processor stamp) |
+| `agent_artifact_refs` | Active module artifacts (`prompt` hash, `skill_library` hash) |
+| `agent_update_events` | Skill adaptations after failed rollouts (`before_hash` → `after_hash`) |
+
+Example `agent_artifact_refs` entry:
+
+```json
+{
+  "type": "skill_library",
+  "name": "tutorial_skills",
+  "hash": "a1b2c3d4e5f6",
+  "path": "/tmp/agent_modules_skills_variant_a",
+  "metadata": {
+    "injection_mode": "context",
+    "adaptation_enabled": true,
+    "skills": [{"name": "baseline", "description": "..."}, {"name": "cot_enhanced", "description": "..."}]
+  }
+}
+```
+
+If any rollout had `reward < 1.0`, check whether adaptation ran:
+
+```bash
+grep -o '"agent_update_events":\[[^]]*\]' results/agent_modules_tutorial_rollouts.jsonl | head -1
+cat /tmp/agent_modules_skills_variant_a/cot_enhanced/SKILL.md
+```
+
+A `## Lesson` section at the bottom of `cot_enhanced/SKILL.md` means `observe` appended an adaptation stub.
+
+## Step 5 — Compare skill variants (optional)
+
+Re-run with the same tasks but a different skills directory (no code changes):
+
+```bash
+cp -r benchmarks/skills/variant_a /tmp/agent_modules_skills_variant_b
+# Edit /tmp/agent_modules_skills_variant_b/cot_enhanced/SKILL.md if you like
+
+gym eval run --no-serve \
+  +agent_name=agent_modules_tutorial_simple_agent \
+  +input_jsonl_fpath=benchmarks/agent_modules_tutorial/data/tiny.jsonl \
+  +output_jsonl_fpath=results/agent_modules_tutorial_variant_b.jsonl \
+  +skills.path=/tmp/agent_modules_skills_variant_b \
+  +limit=2 \
+  +num_repeats=1
+```
+
+Compare `skills_ref.hash` or `agent_artifact_refs[].hash` between files — different skill bytes produce different hashes even at the same path pattern ([#1256](https://github.com/NVIDIA-NeMo/Gym/issues/1256)).
+
+## Step 6 — Prompt-only baseline (optional)
+
+To see modules in isolation, temporarily disable skills on the command line by omitting `+skills.path` and removing the `skill_library` block from `benchmarks/agent_modules_tutorial/config.yaml`, then restart servers. The `prompt` module alone still materializes `responses_create_params.input` from each row's `problem` field.
+
+## Files to read in the repo
+
+| Path | Role |
+| --- | --- |
+| `nemo_gym/agent_modules.py` | `AgentModule`, `prepare` / `observe`, `artifact_refs` |
+| `responses_api_agents/simple_agent/app.py` | `/run` wiring |
+| `nemo_gym/skills.py` | `format_skills_for_context`, `apply_skill_adaptation` |
+| `benchmarks/agent_modules_tutorial/config.yaml` | Tutorial server + module config |
+| [Agent Modules research note](/researchnotes/agent-modules) | Design rationale |
+
+## Next steps
+
+- Scale up: [GPQA](/evaluation/environment-list) with the same module pattern on a full benchmark config.
+- Native skills: [Claude Code agent](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/claude_code_agent) + `injection_mode: none`.
+- Optimizers: replace rule-based `adaptation` with GEPA (prompt) or ACE (playbook) drivers — see [Agent Modules research note](/researchnotes/agent-modules).

--- a/fern/versions/latest/pages/evaluation-tutorials/agent-modules-walkthrough.mdx
+++ b/fern/versions/latest/pages/evaluation-tutorials/agent-modules-walkthrough.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Agent Modules Walkthrough"
-description: "Run prompt and skill_library Agent modules on simple_agent with MCQA — inspect prepare, observe, and provenance fields."
+description: "Run working_memory and skill Agent modules on simple_agent with MCQA — inspect activate, adapt, and provenance fields."
 position: 4
 ---
 
-This walkthrough runs the **Agent modules** reference implementation end-to-end: a `prompt` module injects the answer format, a `skill_library` module injects skill content into the system message, and optional **adaptation** appends lessons to skills after failed rollouts.
+This walkthrough runs the **Agent modules** reference implementation end-to-end: a `working_memory` module injects the answer format, a `skill_library` module injects skill content into the system message, and optional **adaptation** appends lessons to skills after failed rollouts.
 
-Use it to see the `prepare` → harness → `verify` → `observe` flow before scaling to GEPA, ACE, or full benchmarks.
+Use it to see the `activate` → harness → `verify` → `adapt` flow before scaling to GEPA, ACE, or full benchmarks.
 
 <Info>
 
@@ -41,12 +41,12 @@ sequenceDiagram
     P->>P: stamp skills_ref on each row
     P->>A: POST /run
     A->>E: seed_session
-    A->>M: prepare (prompt + skills → system/user messages)
+    A->>M: activate (working_memory + skill_library → system/user messages)
     A->>H: ReAct tool loop (no tools on these tasks)
     H-->>A: model response
     A->>E: verify → reward
-    A->>M: observe (adapt skill if reward < 1.0)
-    A-->>P: reward + agent_artifact_refs + agent_update_events
+    A->>M: adapt (update skill if reward < 1.0)
+    A-->>P: reward + agent_module_refs + agent_update_events
 ```
 
 ## Prerequisites
@@ -106,7 +106,7 @@ gym eval run --no-serve \
   +num_repeats=1
 ```
 
-The run stamps `skills_ref` on each row (Processor) and applies Agent modules inside `/run` (Agent).
+The run stamps `skills_ref` on each row during rollout collection and applies Agent modules inside `/run`.
 
 ## Step 4 — Inspect outputs
 
@@ -130,23 +130,18 @@ Look for these fields:
 | Field | Meaning |
 | --- | --- |
 | `reward` | Environment verifier score (`1.0` = correct MCQ answer) |
-| `skills_ref` | Run-level skills directory + content hash (Processor stamp) |
-| `agent_artifact_refs` | Active module artifacts (`prompt` hash, `skill_library` hash) |
+| `skills_ref` | Run-level skills directory + content hash stamped by rollout collection |
+| `agent_module_refs` | Active module refs (`working_memory` hash, `skill_library` hash) |
 | `agent_update_events` | Skill adaptations after failed rollouts (`before_hash` → `after_hash`) |
 
-Example `agent_artifact_refs` entry:
+Example `agent_module_refs` entry:
 
 ```json
 {
   "type": "skill_library",
   "name": "tutorial_skills",
   "hash": "a1b2c3d4e5f6",
-  "path": "/tmp/agent_modules_skills_variant_a",
-  "metadata": {
-    "injection_mode": "context",
-    "adaptation_enabled": true,
-    "skills": [{"name": "baseline", "description": "..."}, {"name": "cot_enhanced", "description": "..."}]
-  }
+  "path": "/tmp/agent_modules_skills_variant_a"
 }
 ```
 
@@ -157,7 +152,7 @@ grep -o '"agent_update_events":\[[^]]*\]' results/agent_modules_tutorial_rollout
 cat /tmp/agent_modules_skills_variant_a/cot_enhanced/SKILL.md
 ```
 
-A `## Lesson` section at the bottom of `cot_enhanced/SKILL.md` means `observe` appended an adaptation stub.
+A `## Lesson` section at the bottom of `cot_enhanced/SKILL.md` means `adapt` appended an adaptation stub.
 
 ## Step 5 — Compare skill variants (optional)
 
@@ -176,17 +171,17 @@ gym eval run --no-serve \
   +num_repeats=1
 ```
 
-Compare `skills_ref.hash` or `agent_artifact_refs[].hash` between files — different skill bytes produce different hashes even at the same path pattern ([#1256](https://github.com/NVIDIA-NeMo/Gym/issues/1256)).
+Compare `skills_ref.hash` or `agent_module_refs[].hash` between files — different skill bytes produce different hashes even at the same path pattern ([#1256](https://github.com/NVIDIA-NeMo/Gym/issues/1256)).
 
 ## Step 6 — Prompt-only baseline (optional)
 
-To see modules in isolation, temporarily disable skills on the command line by omitting `+skills.path` and removing the `skill_library` block from `benchmarks/agent_modules_tutorial/config.yaml`, then restart servers. The `prompt` module alone still materializes `responses_create_params.input` from each row's `problem` field.
+To see modules in isolation, temporarily disable skills on the command line by omitting `+skills.path` and removing the `skill_library` block from `benchmarks/agent_modules_tutorial/config.yaml`, then restart servers. The `working_memory` module alone still materializes `responses_create_params.input` from each row's `problem` field.
 
 ## Files to read in the repo
 
 | Path | Role |
 | --- | --- |
-| `nemo_gym/agent_modules.py` | `AgentModule`, `prepare` / `observe`, `artifact_refs` |
+| `nemo_gym/agent_modules.py` | `AgentModule`, `activate` / `adapt`, `module_refs` |
 | `responses_api_agents/simple_agent/app.py` | `/run` wiring |
 | `nemo_gym/skills.py` | `format_skills_for_context`, `apply_skill_adaptation` |
 | `benchmarks/agent_modules_tutorial/config.yaml` | Tutorial server + module config |
@@ -196,4 +191,4 @@ To see modules in isolation, temporarily disable skills on the command line by o
 
 - Scale up: [GPQA](/evaluation/environment-list) with the same module pattern on a full benchmark config.
 - Native skills: [Claude Code agent](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/claude_code_agent) + `injection_mode: none`.
-- Optimizers: replace rule-based `adaptation` with GEPA (prompt) or ACE (playbook) drivers — see [Agent Modules research note](/researchnotes/agent-modules).
+- Optimizers: replace rule-based `adaptation` with GEPA (working memory) or ACE (skill/playbook) drivers — see [Agent Modules research note](/researchnotes/agent-modules).

--- a/fern/versions/latest/pages/evaluation-tutorials/index.mdx
+++ b/fern/versions/latest/pages/evaluation-tutorials/index.mdx
@@ -13,7 +13,7 @@ Run the EvalPlus coding benchmark and inspect rollout and aggregate metric outpu
 </Card>
 
 <Card title="Agent Modules Walkthrough" href="/evaluation-tutorials/agent-modules-walkthrough">
-Run prompt and skill_library modules on simple_agent + MCQA; inspect provenance and adaptation fields.
+Run working_memory and skill modules on simple_agent + MCQA; inspect provenance and adaptation fields.
 </Card>
 
 <Card title="Environment List" href="/evaluation/environment-list">

--- a/fern/versions/latest/pages/evaluation-tutorials/index.mdx
+++ b/fern/versions/latest/pages/evaluation-tutorials/index.mdx
@@ -12,6 +12,10 @@ Here are the hands-on walkthroughs for running benchmarks, collecting rollouts, 
 Run the EvalPlus coding benchmark and inspect rollout and aggregate metric outputs.
 </Card>
 
+<Card title="Agent Modules Walkthrough" href="/evaluation-tutorials/agent-modules-walkthrough">
+Run prompt and skill_library modules on simple_agent + MCQA; inspect provenance and adaptation fields.
+</Card>
+
 <Card title="Environment List" href="/evaluation/environment-list">
 Browse the built-in benchmark and training environments.
 </Card>

--- a/fern/versions/latest/pages/infrastructure/engineering-notes/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/engineering-notes/index.mdx
@@ -31,4 +31,10 @@ Why NeMo Gym uses aiohttp instead of httpx for async HTTP.
 <Badge minimal outlined>server-infra</Badge> <Badge minimal outlined>performance</Badge>
 </Card>
 
+<Card title="Research Notes" href="/researchnotes">
+Architecture research: Agent–Environment boundary, Agent modules, and related design rationale.
+
+<Badge minimal outlined>research</Badge> <Badge minimal outlined>architecture</Badge>
+</Card>
+
 </Cards>

--- a/fern/versions/latest/pages/researchnotes/agent-environment-boundary.mdx
+++ b/fern/versions/latest/pages/researchnotes/agent-environment-boundary.mdx
@@ -1,0 +1,66 @@
+---
+title: "The Agent–Environment Boundary"
+description: ""
+---
+*Research note, 2026-07-03. On the agent–environment boundary in agentic RL: competing views in the literature, systems that embody each, and trade-offs for NeMo Gym.*
+
+## The question
+
+An LLM agent system is a composite: a **model** (token distribution), a **harness** (orchestration — prompts, tool parsing, compaction, retries, subagents), and a **world** (repo, browser, OS, user). RL needs an agent–environment boundary to define the policy, actions, and transition dynamics — but the composite admits more than one cut:
+
+- **Policy-level:** agent = model; actions = tokens; harness + world = environment
+- **System-level:** agent = harness + model; actions = tool calls; world = environment
+
+Both cuts claim the RL formalism. The disagreement is real and largely unstated in systems papers.
+
+## Three views
+
+### 1. The gradient boundary (policy-level): agent = model
+
+Everything downstream of token emission — tool parsing, compaction, subagent spawning, retries — is transition dynamics `p(s'|s,a)`.
+
+**Sutton & Barto (§3.1):** anything that cannot be changed *arbitrarily* by the agent is outside it. The model sets sampled tokens; it only *influences* what the harness does with them.
+
+**Examples:** OpenAI Gym / MuJoCo; [Polar](https://arxiv.org/abs/2605.24220) / [ProRL-Agent-Server](https://github.com/NVIDIA-NeMo/ProRL-Agent-Server) (gradient boundary at the model API); SkyRL, PRIME-RL (harness reimplemented inside the framework's env).
+
+**Why systems pick this:** universality (every agent has a model API); signal fidelity (token IDs + logprobs only at inference server); train/deploy parity when proxying the production harness.
+
+### 2. The agent boundary (system-level): agent = harness + model
+
+The environment begins at the world.
+
+**Positions:** Russell & Norvig — agent = architecture + program; options / hierarchical RL — harness is an option machine; Silver's agent-state argument — context construction `S_t^a = f(H_t)` is part of the agent; AlphaZero — agent = network + search; Anthropic [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents); embodied AI — harness partially constitutes cognition.
+
+### 3. The hierarchical boundary (both at once)
+
+[ArCHer](https://arxiv.org/abs/2402.19446), [SWEET-RL](https://arxiv.org/abs/2503.15478), and [Agent Lightning](https://arxiv.org/abs/2508.03680) use a **two-level MDP**: outer turn-level MDP at the agent boundary with inner token-level MDP per turn. Sutton & Barto: *"the agent–environment boundary can be located at different places for different purposes."*
+
+## Terminology discipline
+
+| Term | Meaning | In an LLM agent system |
+| ---- | ------- | ---------------------- |
+| **Policy** | Distribution being differentiated | The model |
+| **Agent** | System that acts | Harness + model |
+| **Environment** | Observations and reward | World (+ harness *relative to the policy*) |
+
+"Training the agent" usually means training the **policy**. Papers that treat the harness as environment mean *relative to the policy*. NeMo Gym docs should adopt this discipline.
+
+## Trade-offs (summary)
+
+| | Proxied gradient (Polar) | Framework-owned gradient | Agent boundary |
+| - | - | - | - |
+| Integration cost | ~Zero (proxy base URL) | Reimplement harness | Instrument agent code |
+| Learnable surface | Token policy only | Token policy only | Harness decisions optimizable |
+| Failure mode | Dialect-fitting; reward at wrong granularity | Train/deploy harness drift | Credit-assignment complexity |
+
+## Implications for NeMo Gym
+
+1. **Name the boundary** each environment implements: policy API vs tool interface vs whole-program MDP.
+2. **Gradient boundary is instrumentation**, not ontology — requires token IDs + logprobs from a cooperative inference server.
+3. **Hierarchical view is the likely end-state** for teams that own harness and model — [Agent Modules](/researchnotes/agent-modules) recover optimizable harness surface (prompts, playbooks, skills) while token training stays on the inner boundary.
+4. **Watch dialect-fitting** — large RL gains on a foreign harness may be learning the action protocol, not capability.
+
+## Related reading
+
+- [Agent Modules](/researchnotes/agent-modules) — first-class harness artifacts and `prepare`/`observe` lifecycle
+- [System Design](/infrastructure/engineering-notes/system-design) — Processor / Agent / Environment roles in Gym

--- a/fern/versions/latest/pages/researchnotes/agent-modules.mdx
+++ b/fern/versions/latest/pages/researchnotes/agent-modules.mdx
@@ -6,13 +6,13 @@ description: ""
 
 ## The question
 
-NeMo Gym already has behavior-shaping knobs — `prompt_config` on `gym eval run`, `skills.path` with `skills_ref` provenance ([#1256](https://github.com/NVIDIA-NeMo/Gym/issues/1256)), per-agent harness logic in `app.py`, and optimizer drivers (GEPA/DSPy, ACE/TALES) that treat `/run` as a black box. These pieces work, but they do not share one boundary:
+NeMo Gym already has behavior-shaping knobs — `prompt_config` on `gym eval run`, `skills.path` with `skills_ref` provenance ([#1256](https://github.com/NVIDIA-NeMo/Gym/issues/1256)), per-agent harness logic in `app.py`, and optimizer drivers (GEPA/DSPy, ACE/TALES) that treat `/run` as a black box. These concrete mechanisms implement broader cognitive capabilities such as working memory, skill libraries, long-term memory, planning, reasoning, and control, but they do not share one boundary:
 
 - **Where** does prompt injection happen — run-level preprocessing or Agent `activate`?
 - **How** do optimizers know which module version was active?
 - **What** is trainable policy vs optimizable module vs Environment reward?
 
-This note proposes **`AgentModule`s**: typed pieces on the **Agent boundary** with a `activate` / `adapt` / `module_refs` lifecycle. Each module has a cognitive capability **`type`** discriminator (`working_memory`, `skill_library`, `planning`, …). More types may be added over time.
+This note proposes **`AgentModule`s**: typed pieces on the **Agent boundary** with an `activate` / `adapt` / `module_refs` lifecycle. Each module has a cognitive capability **`type`** discriminator (`working_memory`, `skill_library`, `planning`, …). More types may be added over time.
 
 ## Module types (first cut)
 
@@ -193,7 +193,7 @@ Existing run-level prompt preprocessing remains supported during migration. Agen
 ## What this does not solve yet
 
 - Standardized per-step **trajectory** objects ([#1867](https://github.com/NVIDIA-NeMo/Gym/issues/1867))
-- `playbook`, `memory`, `guardrails`, `model_roles` module types
+- `long_term_memory`, `guardrails`, `planning`, and `reasoning` module types
 - Moving seed/verify or `/run` responsibilities out of Agent servers
 - GEPA/ACE drivers consuming `adapt` events in-process
 

--- a/fern/versions/latest/pages/researchnotes/agent-modules.mdx
+++ b/fern/versions/latest/pages/researchnotes/agent-modules.mdx
@@ -1,0 +1,189 @@
+---
+title: "Agent Modules"
+description: ""
+---
+*Research note, 2026-07-08. First-class Agent modules in NeMo Gym: what they are, where they sit relative to the [Agent–Environment boundary](/researchnotes/agent-environment-boundary), and a minimal reference implementation on `simple_agent`.*
+
+## The question
+
+NeMo Gym already has behavior-shaping knobs — `prompt_config` on `gym eval run`, `skills.path` with `skills_ref` provenance ([#1256](https://github.com/NVIDIA-NeMo/Gym/issues/1256)), per-agent harness logic in `app.py`, and optimizer drivers (GEPA/DSPy, ACE/TALES) that treat `/run` as a black box. These pieces work, but they do not share one boundary:
+
+- **Where** does prompt injection happen — Processor preprocess or Agent `prepare`?
+- **How** do optimizers know which artifact version was active?
+- **What** is trainable policy vs optimizable harness artifact vs Environment reward?
+
+This note proposes **Agent modules**: typed, provenance-stamped components on the **Agent boundary** with a small `prepare` / `observe` / `artifact_refs` lifecycle.
+
+## Terminology discipline
+
+Follow the same three-way split as [The Agent–Environment Boundary](/researchnotes/agent-environment-boundary):
+
+| Term | Meaning | Agent modules |
+| ---- | ------- | ------------- |
+| **Policy** | Parameterized token distribution being differentiated | Model server weights — *not* a module |
+| **Agent** | Architecture + program (harness + model + modules) | Modules shape harness behavior |
+| **Environment** | Pushes back with observations and reward | Resources server `seed_session` / `verify` |
+
+"Training the agent" in RL papers usually means training the **policy**. Optimizing a prompt, playbook, or skill library is **Agent module optimization** — same trajectories, different learnable surface.
+
+NeMo Gym implements a **hierarchical** decomposition in practice:
+
+```text
+Processor     — rollout scheduling, dataset iteration, persistence
+Agent         — harness loop (/v1/responses) + Agent modules (prepare/observe)
+Environment   — tools, session state, verify, reward
+Model server  — policy (and optional auxiliary roles)
+```
+
+Under the **gradient boundary** (Polar-style), the harness is environment relative to the policy; modules are still Agent-owned configuration that the harness reads at runtime. Under the **agent boundary**, modules are unambiguously part of the Agent.
+
+## Reference implementation
+
+The POC lives in `nemo_gym/agent_modules.py` and is wired into `responses_api_agents/simple_agent/app.py`.
+
+### Core types
+
+```python
+class AgentModule:
+    async def prepare(self, ctx: AgentContext) -> AgentContext: ...
+    async def observe(self, event: TrajectoryEvent) -> list[AgentUpdateEvent]: ...
+    def artifact_refs(self) -> list[AgentArtifactRef]: ...
+```
+
+- **`prepare`** — runs before the policy loop; mutates `responses_create_params` (prompt injection, future: memory, tool policy).
+- **`observe`** — runs after `verify`; modules may emit `AgentUpdateEvent`s for optimizers (GEPA, ACE curator).
+- **`artifact_refs`** — content hashes stamped on rollout results as `agent_artifact_refs`.
+
+### Module types (phase 1)
+
+| Type | Wraps | `prepare` behavior | `observe` behavior | Provenance |
+| ---- | ----- | ------------------ | ------------------ | ---------- |
+| `prompt` | `nemo_gym.prompt` | Build or prepend `responses_create_params.input` | — | SHA-256 prefix of prompt YAML |
+| `skill_library` | `nemo_gym.skills` | `injection_mode: context` injects `SKILL.md` bodies into system message; `none` is provenance-only | `adaptation.enabled`: append lesson to target skill on failed rollouts | `skills_ref` content hash |
+
+#### Skill library: injection modes
+
+| `injection_mode` | Use when |
+| ---------------- | -------- |
+| `none` | Native skill runtimes (Claude Code stages via `stage_skills`) |
+| `context` | Agents without discovery (`simple_agent`) — Gym injects formatted skill bodies |
+
+#### Skill adaptation (optimizer scaffold)
+
+When `adaptation.enabled` is true and terminal `reward < reward_threshold`, the module appends a lesson section to `target_skill`'s `SKILL.md` **in place**. The directory hash changes, so `agent_artifact_refs` and `skills_ref` distinguish variants — the same contract as skill evaluation ([#1256](https://github.com/NVIDIA-NeMo/Gym/issues/1256)). Optimizers (ACE, EvoSkill, GEPA-over-skills) can replace this rule-based append with richer `observe` logic.
+
+Sample skills: `benchmarks/skills/variant_a/`. **Runnable tutorial:** [Agent Modules Walkthrough](/evaluation-tutorials/agent-modules-walkthrough).
+
+### `simple_agent` rollout flow
+
+```mermaid
+sequenceDiagram
+    participant P as Processor
+    participant A as simple_agent /run
+    participant M as Agent modules
+    participant H as /v1/responses harness
+    participant E as Environment
+
+    P->>A: run(row)
+    A->>E: seed_session(row)
+    A->>M: prepare(row, responses_create_params)
+    M-->>A: updated params + artifact_refs
+    A->>H: ReAct tool loop
+    H-->>A: NeMoGymResponse
+    A->>E: verify(row + response)
+    E-->>A: reward
+    A->>M: observe(trajectory_event)
+  A-->>P: verify response + agent_artifact_refs
+```
+
+`/v1/responses` remains the **ReAct harness** (model ↔ tools until stop). `/run` is Processor orchestration plus module `prepare`/`observe`.
+
+### Agent config example (prompt + skills + adaptation)
+
+```yaml
+simple_agent_with_skills_module:
+  responses_api_agents:
+    simple_agent:
+      entrypoint: app.py
+      resources_server:
+        type: resources_servers
+        name: my_resources_server
+      model_server:
+        type: responses_api_models
+        name: policy_model
+      modules:
+        - type: prompt
+          name: answer_format_prompt
+          path: benchmarks/prompts/eval/aai/mcq-4choices.yaml
+        - type: skill_library
+          name: baseline_skills
+          injection_mode: context
+          adaptation:
+            enabled: true
+            target_skill: cot_enhanced
+            reward_threshold: 1.0
+```
+
+Pair with run-level `+skills.path=benchmarks/skills/variant_a` so Processor stamps `skills_ref` on each row.
+
+See `responses_api_agents/simple_agent/configs/simple_agent_with_skills_module.yaml`.
+
+### Rollout result fields
+
+When modules are configured, `/run` responses may include:
+
+```json
+{
+  "reward": 1.0,
+  "response": { "...": "..." },
+  "agent_artifact_refs": [
+    {
+      "type": "prompt",
+      "name": "answer_format_prompt",
+      "hash": "a1b2c3d4e5f6",
+      "path": "benchmarks/prompts/eval/aai/mcq-4choices.yaml"
+    }
+  ],
+  "agent_update_events": []
+}
+```
+
+`skills_ref` on the row remains the backwards-compatible stamp; `skill_library` modules mirror it into `agent_artifact_refs`.
+
+## Mapping external abstractions
+
+Agent modules are Gym's slot for patterns documented elsewhere:
+
+| External primitive | Gym module type | Notes |
+| ------------------ | --------------- | ----- |
+| DSPy **Predictor** instruction | `prompt` | GEPA mutates predictor-scoped prompts |
+| Claude / OpenAI **Skills** | `skill_library` | Gym stages + provenance; runtime loads |
+| ACE **playbook** bullets | `playbook` (planned) | Delta updates via `observe` |
+| Letta **core memory** blocks | `memory` (planned) | In-context vs archival tiers |
+| OpenAI **guardrails** | `guardrails` (planned) | Distinct from Environment `verify` |
+| LangGraph **checkpointer** | Processor session / future `state` | Thread-scoped vs cross-thread store |
+
+Full framework survey: GitHub issue draft `issues/agent-modules-first-class-citizens.md`.
+
+## Migration from Processor knobs
+
+| Today | Target |
+| ----- | ------ |
+| `prompt_config` on `gym eval run` | `prompt` module on Agent config **or** Processor alias that expands to module + ref |
+| `skills.path` + row `skills_ref` | `skill_library` module + same `skills_ref` stamp |
+| Optimizer calls `/run` black-box | Optimizer reads `agent_artifact_refs` + `AgentUpdateEvent`s |
+
+Processor preprocess of prompts remains supported during migration. Agent-declared modules run at `prepare` inside `/run` and are the long-term source of truth for provenance.
+
+## What this does not solve yet
+
+- Standardized per-step **trajectory** objects ([#1867](https://github.com/NVIDIA-NeMo/Gym/issues/1867))
+- `playbook`, `memory`, `guardrails`, `model_roles` module types
+- Processor `run_one` refactor (modules today hook `simple_agent.run` only)
+- GEPA/ACE drivers consuming `observe` events in-process
+
+## Related reading
+
+- [The Agent–Environment Boundary](/researchnotes/agent-environment-boundary) — gradient vs agent vs hierarchical RL boundaries
+- [System Design](/infrastructure/engineering-notes/system-design) — Processor / Agent / Environment startup and rollout collection
+- [Agent Skills](/agent-server/agent-skills) — `skills.path` run knob and `skills_ref` provenance

--- a/fern/versions/latest/pages/researchnotes/agent-modules.mdx
+++ b/fern/versions/latest/pages/researchnotes/agent-modules.mdx
@@ -127,14 +127,16 @@ simple_agent_with_skills_module:
       modules:
         - type: working_memory
           name: answer_format_prompt
-          path: benchmarks/prompts/eval/aai/mcq-4choices.yaml
+          config:
+            path: benchmarks/prompts/eval/aai/mcq-4choices.yaml
         - type: skill_library
           name: baseline_skills
-          injection_mode: context
-          adaptation:
-            enabled: true
-            target_skill: cot_enhanced
-            reward_threshold: 1.0
+          config:
+            injection_mode: context
+            adaptation:
+              enabled: true
+              target_skill: cot_enhanced
+              reward_threshold: 1.0
 ```
 
 Pair with run-level `+skills.path=benchmarks/skills/variant_a` so rollout collection stamps `skills_ref` on each row.

--- a/fern/versions/latest/pages/researchnotes/agent-modules.mdx
+++ b/fern/versions/latest/pages/researchnotes/agent-modules.mdx
@@ -2,40 +2,53 @@
 title: "Agent Modules"
 description: ""
 ---
-*Research note, 2026-07-08. First-class Agent modules in NeMo Gym: what they are, where they sit relative to the [Agent–Environment boundary](/researchnotes/agent-environment-boundary), and a minimal reference implementation on `simple_agent`.*
+*Research note, 2026-07-08. **Agent modules** in NeMo Gym: typed `AgentModule`s with provenance via `AgentModuleRef`. Reference implementation on `simple_agent`. See [Agent–Environment boundary](/researchnotes/agent-environment-boundary).*
 
 ## The question
 
 NeMo Gym already has behavior-shaping knobs — `prompt_config` on `gym eval run`, `skills.path` with `skills_ref` provenance ([#1256](https://github.com/NVIDIA-NeMo/Gym/issues/1256)), per-agent harness logic in `app.py`, and optimizer drivers (GEPA/DSPy, ACE/TALES) that treat `/run` as a black box. These pieces work, but they do not share one boundary:
 
-- **Where** does prompt injection happen — Processor preprocess or Agent `prepare`?
-- **How** do optimizers know which artifact version was active?
-- **What** is trainable policy vs optimizable harness artifact vs Environment reward?
+- **Where** does prompt injection happen — run-level preprocessing or Agent `activate`?
+- **How** do optimizers know which module version was active?
+- **What** is trainable policy vs optimizable module vs Environment reward?
 
-This note proposes **Agent modules**: typed, provenance-stamped components on the **Agent boundary** with a small `prepare` / `observe` / `artifact_refs` lifecycle.
+This note proposes **`AgentModule`s**: typed pieces on the **Agent boundary** with a `activate` / `adapt` / `module_refs` lifecycle. Each module has a cognitive capability **`type`** discriminator (`working_memory`, `skill_library`, `planning`, …). More types may be added over time.
+
+## Module types (first cut)
+
+| `type` | Role |
+| ------ | ---- |
+| `working_memory` | Active context for the current rollout (prompt-backed instructions, scratchpad, compacted context) |
+| `skill_library` | Skill packages / reusable operational procedures ([#1256](https://github.com/NVIDIA-NeMo/Gym/issues/1256)) |
+| `long_term_memory` | Playbooks, persistent recall, archival stores, summaries |
+| `planning` | Plan templates, decomposition, workflows |
+| `reasoning` | Deliberation strategies, reflection / critique loops |
+| `control` | Guardrails, tool policies, budgets, permissions |
+
+**Run-level vs Environment:** `skills.path` and `prompt_config` are **run-level** knobs handled by rollout collection. Gym **Environment** = resources server (`verify`, reward) only.
 
 ## Terminology discipline
 
 Follow the same three-way split as [The Agent–Environment Boundary](/researchnotes/agent-environment-boundary):
 
-| Term | Meaning | Agent modules |
-| ---- | ------- | ------------- |
-| **Policy** | Parameterized token distribution being differentiated | Model server weights — *not* a module |
-| **Agent** | Architecture + program (harness + model + modules) | Modules shape harness behavior |
-| **Environment** | Pushes back with observations and reward | Resources server `seed_session` / `verify` |
+| Term | Meaning | Examples |
+| ---- | ------- | ---------- |
+| **Policy** | Parameterized token distribution | Model server weights |
+| **Agent** | Harness + model + modules | Modules shape behavior around the policy |
+| **Environment** | Observations and reward | Resources server `seed_session` / `verify` |
 
-"Training the agent" in RL papers usually means training the **policy**. Optimizing a prompt, playbook, or skill library is **Agent module optimization** — same trajectories, different learnable surface.
+Optimizing a prompt, playbook, or skill library is **module optimization** — same trajectories, different learnable surface than weight training.
 
-NeMo Gym implements a **hierarchical** decomposition in practice:
+NeMo Gym implements a practical decomposition:
 
 ```text
-Processor     — rollout scheduling, dataset iteration, persistence
-Agent         — harness loop (/v1/responses) + Agent modules (prepare/observe)
+Rollout collection — dataset iteration, repeats, persistence
+Agent         — harness loop (/v1/responses) + Agent modules
 Environment   — tools, session state, verify, reward
 Model server  — policy (and optional auxiliary roles)
 ```
 
-Under the **gradient boundary** (Polar-style), the harness is environment relative to the policy; modules are still Agent-owned configuration that the harness reads at runtime. Under the **agent boundary**, modules are unambiguously part of the Agent.
+Modules are Agent-owned configuration that the harness reads at runtime during `/run`.
 
 ## Reference implementation
 
@@ -45,21 +58,21 @@ The POC lives in `nemo_gym/agent_modules.py` and is wired into `responses_api_ag
 
 ```python
 class AgentModule:
-    async def prepare(self, ctx: AgentContext) -> AgentContext: ...
-    async def observe(self, event: TrajectoryEvent) -> list[AgentUpdateEvent]: ...
-    def artifact_refs(self) -> list[AgentArtifactRef]: ...
+    async def activate(self, ctx: AgentContext) -> AgentContext: ...
+    async def adapt(self, event: TrajectoryEvent) -> list[AgentUpdateEvent]: ...
+    def module_refs(self) -> list[AgentModuleRef]: ...
 ```
 
-- **`prepare`** — runs before the policy loop; mutates `responses_create_params` (prompt injection, future: memory, tool policy).
-- **`observe`** — runs after `verify`; modules may emit `AgentUpdateEvent`s for optimizers (GEPA, ACE curator).
-- **`artifact_refs`** — content hashes stamped on rollout results as `agent_artifact_refs`.
+- **`activate`** — runs before the policy loop; mutates `responses_create_params` (prompt injection, future: memory, tool policy).
+- **`adapt`** — runs after `verify`; modules may emit `AgentUpdateEvent`s for optimizers (GEPA, ACE curator).
+- **`module_refs`** — content hashes stamped on rollout results as `agent_module_refs`.
 
 ### Module types (phase 1)
 
-| Type | Wraps | `prepare` behavior | `observe` behavior | Provenance |
-| ---- | ----- | ------------------ | ------------------ | ---------- |
-| `prompt` | `nemo_gym.prompt` | Build or prepend `responses_create_params.input` | — | SHA-256 prefix of prompt YAML |
-| `skill_library` | `nemo_gym.skills` | `injection_mode: context` injects `SKILL.md` bodies into system message; `none` is provenance-only | `adaptation.enabled`: append lesson to target skill on failed rollouts | `skills_ref` content hash |
+| Type | `activate` | `adapt` | Provenance |
+| ---- | --------- | --------- | ---------- |
+| `working_memory` | Build/prepend prompt-backed `input` | — | prompt YAML hash |
+| `skill_library` | context inject or stage skills | optional adaptation | `skills_ref` hash |
 
 #### Skill library: injection modes
 
@@ -70,7 +83,7 @@ class AgentModule:
 
 #### Skill adaptation (optimizer scaffold)
 
-When `adaptation.enabled` is true and terminal `reward < reward_threshold`, the module appends a lesson section to `target_skill`'s `SKILL.md` **in place**. The directory hash changes, so `agent_artifact_refs` and `skills_ref` distinguish variants — the same contract as skill evaluation ([#1256](https://github.com/NVIDIA-NeMo/Gym/issues/1256)). Optimizers (ACE, EvoSkill, GEPA-over-skills) can replace this rule-based append with richer `observe` logic.
+When `adaptation.enabled` is true and terminal `reward < reward_threshold`, the module appends a lesson section to `target_skill`'s `SKILL.md` **in place**. The directory hash changes, so `agent_module_refs` and `skills_ref` distinguish variants — the same contract as skill evaluation ([#1256](https://github.com/NVIDIA-NeMo/Gym/issues/1256)). Optimizers (ACE, EvoSkill, GEPA-over-skills) can replace this rule-based append with richer `adapt` logic.
 
 Sample skills: `benchmarks/skills/variant_a/`. **Runnable tutorial:** [Agent Modules Walkthrough](/evaluation-tutorials/agent-modules-walkthrough).
 
@@ -78,7 +91,7 @@ Sample skills: `benchmarks/skills/variant_a/`. **Runnable tutorial:** [Agent Mod
 
 ```mermaid
 sequenceDiagram
-    participant P as Processor
+    participant P as Rollout collection
     participant A as simple_agent /run
     participant M as Agent modules
     participant H as /v1/responses harness
@@ -86,17 +99,17 @@ sequenceDiagram
 
     P->>A: run(row)
     A->>E: seed_session(row)
-    A->>M: prepare(row, responses_create_params)
-    M-->>A: updated params + artifact_refs
+    A->>M: activate(row, responses_create_params)
+    M-->>A: updated params + module_refs
     A->>H: ReAct tool loop
     H-->>A: NeMoGymResponse
     A->>E: verify(row + response)
     E-->>A: reward
-    A->>M: observe(trajectory_event)
-  A-->>P: verify response + agent_artifact_refs
+    A->>M: adapt(trajectory_event)
+  A-->>P: verify response + agent_module_refs
 ```
 
-`/v1/responses` remains the **ReAct harness** (model ↔ tools until stop). `/run` is Processor orchestration plus module `prepare`/`observe`.
+`/v1/responses` remains the **ReAct harness** (model ↔ tools until stop). `/run` remains the Agent-server rollout endpoint and now includes module `activate`/`adapt` hooks.
 
 ### Agent config example (prompt + skills + adaptation)
 
@@ -112,7 +125,7 @@ simple_agent_with_skills_module:
         type: responses_api_models
         name: policy_model
       modules:
-        - type: prompt
+        - type: working_memory
           name: answer_format_prompt
           path: benchmarks/prompts/eval/aai/mcq-4choices.yaml
         - type: skill_library
@@ -124,7 +137,7 @@ simple_agent_with_skills_module:
             reward_threshold: 1.0
 ```
 
-Pair with run-level `+skills.path=benchmarks/skills/variant_a` so Processor stamps `skills_ref` on each row.
+Pair with run-level `+skills.path=benchmarks/skills/variant_a` so rollout collection stamps `skills_ref` on each row.
 
 See `responses_api_agents/simple_agent/configs/simple_agent_with_skills_module.yaml`.
 
@@ -136,9 +149,9 @@ When modules are configured, `/run` responses may include:
 {
   "reward": 1.0,
   "response": { "...": "..." },
-  "agent_artifact_refs": [
+  "agent_module_refs": [
     {
-      "type": "prompt",
+      "type": "working_memory",
       "name": "answer_format_prompt",
       "hash": "a1b2c3d4e5f6",
       "path": "benchmarks/prompts/eval/aai/mcq-4choices.yaml"
@@ -148,7 +161,7 @@ When modules are configured, `/run` responses may include:
 }
 ```
 
-`skills_ref` on the row remains the backwards-compatible stamp; `skill_library` modules mirror it into `agent_artifact_refs`.
+`skills_ref` on the row remains the backwards-compatible stamp; `skill_library` modules mirror it into `agent_module_refs`.
 
 ## Mapping external abstractions
 
@@ -156,34 +169,34 @@ Agent modules are Gym's slot for patterns documented elsewhere:
 
 | External primitive | Gym module type | Notes |
 | ------------------ | --------------- | ----- |
-| DSPy **Predictor** instruction | `prompt` | GEPA mutates predictor-scoped prompts |
+| DSPy **Predictor** instruction | `working_memory` | GEPA mutates prompt-backed active context |
 | Claude / OpenAI **Skills** | `skill_library` | Gym stages + provenance; runtime loads |
-| ACE **playbook** bullets | `playbook` (planned) | Delta updates via `observe` |
-| Letta **core memory** blocks | `memory` (planned) | In-context vs archival tiers |
-| OpenAI **guardrails** | `guardrails` (planned) | Distinct from Environment `verify` |
-| LangGraph **checkpointer** | Processor session / future `state` | Thread-scoped vs cross-thread store |
+| ACE **playbook** bullets | `long_term_memory` | Delta updates via `adapt` |
+| Letta **core memory** blocks | `working_memory` / `long_term_memory` | In-context vs archival tiers |
+| OpenAI **guardrails** | `control` | Distinct from Environment `verify` |
+| LangGraph **checkpointer** | Agent harness state / future `long_term_memory` | Thread-scoped vs cross-thread store |
 
 Full framework survey: GitHub issue draft `issues/agent-modules-first-class-citizens.md`.
 
-## Migration from Processor knobs
+## Migration from run-level knobs
 
 | Today | Target |
 | ----- | ------ |
-| `prompt_config` on `gym eval run` | `prompt` module on Agent config **or** Processor alias that expands to module + ref |
+| `prompt_config` on `gym eval run` | `working_memory` module on Agent config **or** rollout config alias that expands to module + ref |
 | `skills.path` + row `skills_ref` | `skill_library` module + same `skills_ref` stamp |
-| Optimizer calls `/run` black-box | Optimizer reads `agent_artifact_refs` + `AgentUpdateEvent`s |
+| Optimizer calls `/run` black-box | Optimizer reads `agent_module_refs` + `AgentUpdateEvent`s |
 
-Processor preprocess of prompts remains supported during migration. Agent-declared modules run at `prepare` inside `/run` and are the long-term source of truth for provenance.
+Existing run-level prompt preprocessing remains supported during migration. Agent-declared modules run at `activate` inside `/run` and are the long-term source of truth for provenance.
 
 ## What this does not solve yet
 
 - Standardized per-step **trajectory** objects ([#1867](https://github.com/NVIDIA-NeMo/Gym/issues/1867))
 - `playbook`, `memory`, `guardrails`, `model_roles` module types
-- Processor `run_one` refactor (modules today hook `simple_agent.run` only)
-- GEPA/ACE drivers consuming `observe` events in-process
+- Moving seed/verify or `/run` responsibilities out of Agent servers
+- GEPA/ACE drivers consuming `adapt` events in-process
 
 ## Related reading
 
-- [The Agent–Environment Boundary](/researchnotes/agent-environment-boundary) — gradient vs agent vs hierarchical RL boundaries
-- [System Design](/infrastructure/engineering-notes/system-design) — Processor / Agent / Environment startup and rollout collection
+- [The Agent–Environment Boundary](/researchnotes/agent-environment-boundary) — where the agent ends and the environment begins
+- [System Design](/infrastructure/engineering-notes/system-design) — Agent / Environment startup and rollout collection
 - [Agent Skills](/agent-server/agent-skills) — `skills.path` run knob and `skills_ref` provenance

--- a/fern/versions/latest/pages/researchnotes/index.mdx
+++ b/fern/versions/latest/pages/researchnotes/index.mdx
@@ -8,7 +8,7 @@ Design and research notes that inform NeMo Gym architecture. These documents sta
 <Cards>
 
 <Card title="Agent Modules" href="/researchnotes/agent-modules">
-First-class behavior-shaping artifacts on the Agent boundary: prompts, skills, playbooks, and the prepare/observe lifecycle.
+First-class behavior-shaping artifacts on the Agent boundary: prompts, skills, playbooks, and the prepare/adapt lifecycle.
 
 <Badge minimal outlined>agent-modules</Badge> <Badge minimal outlined>architecture</Badge>
 </Card>

--- a/fern/versions/latest/pages/researchnotes/index.mdx
+++ b/fern/versions/latest/pages/researchnotes/index.mdx
@@ -1,0 +1,22 @@
+---
+title: "Research Notes"
+description: ""
+position: 5
+---
+Design and research notes that inform NeMo Gym architecture. These documents state trade-offs and vocabulary discipline; they are not API reference.
+
+<Cards>
+
+<Card title="Agent Modules" href="/researchnotes/agent-modules">
+First-class behavior-shaping artifacts on the Agent boundary: prompts, skills, playbooks, and the prepare/observe lifecycle.
+
+<Badge minimal outlined>agent-modules</Badge> <Badge minimal outlined>architecture</Badge>
+</Card>
+
+<Card title="The Agent–Environment Boundary" href="/researchnotes/agent-environment-boundary">
+Where does the agent end and the environment begin? Gradient vs system vs hierarchical RL cuts.
+
+<Badge minimal outlined>agentic-rl</Badge> <Badge minimal outlined>terminology</Badge>
+</Card>
+
+</Cards>

--- a/fern/versions/main.yml
+++ b/fern/versions/main.yml
@@ -47,6 +47,9 @@ navigation:
       - folder: ./latest/pages/infrastructure
         title: "Infrastructure"
         title-source: frontmatter
+      - folder: ./latest/pages/researchnotes
+        title: "Research Notes"
+        title-source: frontmatter
       - folder: ./latest/pages/reference
         title: "Reference"
         title-source: frontmatter

--- a/nemo_gym/agent_modules.py
+++ b/nemo_gym/agent_modules.py
@@ -12,12 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""First-class Agent modules: behavior-shaping artifacts with provenance and observe hooks.
+"""Agent modules: behavior-shaping components on the Agent boundary.
 
-Agent modules sit on the Agent boundary (see research note ``agent-modules``). They shape
-what the policy model sees and record which artifact versions were active during a rollout.
-Processor-level knobs like ``prompt_config`` and ``skills.path`` are migrating toward this
-interface; modules declared on an Agent config are applied at ``prepare`` time inside ``/run``.
+Each module has a cognitive capability ``type`` discriminator (``working_memory``,
+``skill_library``, ``planning``, …) and a shared lifecycle — ``activate``, ``adapt``,
+``module_refs``. See research note ``agent-modules`` and
+``issues/agent-modules-first-class-citizens.md``.
+
+Run-level knobs (``prompt_config``, ``skills.path``) are migrating toward modules
+declared on Agent config and activated inside ``/run``.
 """
 
 from __future__ import annotations
@@ -46,7 +49,7 @@ from nemo_gym.skills import (
 _HASH_PREFIX_LEN = 12
 
 # Stamped on rollout results alongside legacy ``skills_ref``.
-AGENT_ARTIFACT_REFS_KEY = "agent_artifact_refs"
+AGENT_MODULE_REFS_KEY = "agent_module_refs"
 AGENT_UPDATE_EVENTS_KEY = "agent_update_events"
 
 TrajectoryEventKind = Literal[
@@ -59,19 +62,18 @@ TrajectoryEventKind = Literal[
 ]
 
 
-class AgentArtifactRef(BaseModel):
-    """Provenance stamp for an optimizable Agent artifact active during a rollout."""
+class AgentModuleRef(BaseModel):
+    """Provenance stamp for an active Agent module during a rollout."""
 
     type: str
     name: str
     hash: str
     path: Optional[str] = None
     uri: Optional[str] = None
-    metadata: dict = Field(default_factory=dict)
 
 
 class AgentUpdateEvent(BaseModel):
-    """Structured before/after transition emitted by a module ``observe`` hook."""
+    """Structured before/after transition emitted by a module ``adapt`` hook."""
 
     module_type: str
     module_name: str
@@ -82,7 +84,7 @@ class AgentUpdateEvent(BaseModel):
 
 
 class TrajectoryEvent(BaseModel):
-    """Minimal trajectory signal for module ``observe`` hooks (full contract: issue #1867)."""
+    """Minimal trajectory signal for module ``adapt`` hooks (full contract: issue #1867)."""
 
     kind: TrajectoryEventKind
     reward: Optional[float] = None
@@ -93,11 +95,11 @@ class TrajectoryEvent(BaseModel):
 
 
 class AgentContext(BaseModel):
-    """Mutable per-rollout context passed through the module ``prepare`` chain."""
+    """Mutable per-rollout context passed through the module ``activate`` chain."""
 
     row: dict
     responses_create_params: NeMoGymResponseCreateParamsNonStreaming
-    artifact_refs: List[AgentArtifactRef] = Field(default_factory=list)
+    module_refs: List[AgentModuleRef] = Field(default_factory=list)
 
 
 def _hash_bytes(data: bytes) -> str:
@@ -116,13 +118,13 @@ class AgentModule(ABC):
         self.module_type = module_type
 
     @abstractmethod
-    def artifact_refs(self) -> List[AgentArtifactRef]:
+    def module_refs(self) -> List[AgentModuleRef]:
         pass
 
-    async def prepare(self, ctx: AgentContext) -> AgentContext:
+    async def activate(self, ctx: AgentContext) -> AgentContext:
         return ctx
 
-    async def observe(self, event: TrajectoryEvent) -> List[AgentUpdateEvent]:
+    async def adapt(self, event: TrajectoryEvent) -> List[AgentUpdateEvent]:
         return []
 
 
@@ -136,24 +138,23 @@ class PromptAgentModule(AgentModule):
     """
 
     def __init__(self, name: str, path: str) -> None:
-        super().__init__(name=name, module_type="prompt")
+        super().__init__(name=name, module_type="working_memory")
         self.path = path
         self._resolved_path = _resolve_under_cwd_or_install(path)
         self._prompt_config = load_prompt_config(path)
         self._content_hash = hash_file(self._resolved_path)
 
-    def artifact_refs(self) -> List[AgentArtifactRef]:
+    def module_refs(self) -> List[AgentModuleRef]:
         return [
-            AgentArtifactRef(
-                type="prompt",
+            AgentModuleRef(
+                type="working_memory",
                 name=self.name,
                 hash=self._content_hash,
                 path=self.path,
-                metadata={"predictor_id": self.name},
             )
         ]
 
-    async def prepare(self, ctx: AgentContext) -> AgentContext:
+    async def activate(self, ctx: AgentContext) -> AgentContext:
         rcp = ctx.responses_create_params.model_copy(deep=True)
         messages = fill_prompt(self._prompt_config, ctx.row)
         easy_messages = [NeMoGymEasyInputMessage.model_validate(m) for m in messages]
@@ -189,8 +190,8 @@ class PromptAgentModule(AgentModule):
 
 
 class PromptModuleConfig(BaseModel):
-    type: Literal["prompt"] = "prompt"
-    name: str = "prompt"
+    type: Literal["working_memory"] = "working_memory"
+    name: str = "working_memory"
     path: str
 
 
@@ -199,7 +200,7 @@ class SkillAdaptationConfig(BaseModel):
 
     When ``enabled``, failed rollouts (reward below ``reward_threshold``) append a lesson
     section to ``target_skill``'s ``SKILL.md``. The content hash changes so ``skills_ref`` and
-    ``agent_artifact_refs`` distinguish variants (issue #1256).
+    ``agent_module_refs`` distinguish variants (issue #1256).
     """
 
     enabled: bool = False
@@ -216,7 +217,7 @@ class SkillAdaptationConfig(BaseModel):
 
 class SkillLibraryModuleConfig(BaseModel):
     type: Literal["skill_library"] = "skill_library"
-    name: str = "skills"
+    name: str = "skill_library"
     path: Optional[str] = None
     injection_mode: Literal["none", "context"] = Field(
         default="none",
@@ -232,12 +233,12 @@ class SkillLibraryAgentModule(AgentModule):
     """Agent Skills library: provenance, optional context injection, optional adaptation.
 
       - **Provenance:** ``skills_ref`` from the rollout row or module ``path``; stamped in
-        ``artifact_refs``.
-      - **Context injection:** for agents without native discovery, ``prepare`` appends formatted
+        ``module_refs``.
+      - **Context injection:** for agents without native discovery, ``activate`` appends formatted
         ``SKILL.md`` bodies to the system message.
-      - **Adaptation:** on failed rollouts, ``observe`` can append a lesson to ``target_skill`` in
+      - **Adaptation:** on failed rollouts, ``adapt`` can append a lesson to ``target_skill`` in
         place (hash changes; optimizers like ACE/EvoSkill can replace this with richer logic).
-    - **Staging:** when ``staging_dir`` is set on the config, ``prepare`` copies skills there for
+    - **Staging:** when ``staging_dir`` is set on the config, ``activate`` copies skills there for
         native runtimes (Claude Code pattern).
     """
 
@@ -276,25 +277,20 @@ class SkillLibraryAgentModule(AgentModule):
         if self.path is None:
             self.path = skills_ref.path
 
-    def artifact_refs(self) -> List[AgentArtifactRef]:
+    def module_refs(self) -> List[AgentModuleRef]:
         skills_ref = self._resolve_skills_ref()
         if skills_ref is None:
             return []
         return [
-            AgentArtifactRef(
+            AgentModuleRef(
                 type="skill_library",
                 name=self.name,
                 hash=skills_ref.hash,
                 path=skills_ref.path,
-                metadata={
-                    "skills": [s.model_dump() for s in skills_ref.skills],
-                    "injection_mode": self.injection_mode,
-                    "adaptation_enabled": bool(self.adaptation and self.adaptation.enabled),
-                },
             )
         ]
 
-    async def prepare(self, ctx: AgentContext) -> AgentContext:
+    async def activate(self, ctx: AgentContext) -> AgentContext:
         skills_path = self.skills_path
         if skills_path is None:
             return ctx
@@ -322,7 +318,7 @@ class SkillLibraryAgentModule(AgentModule):
         ctx.responses_create_params = rcp
         return ctx
 
-    async def observe(self, event: TrajectoryEvent) -> List[AgentUpdateEvent]:
+    async def adapt(self, event: TrajectoryEvent) -> List[AgentUpdateEvent]:
         if event.kind != "terminated" or not self.adaptation or not self.adaptation.enabled:
             return []
         if event.reward is None or event.reward >= self.adaptation.reward_threshold:
@@ -368,7 +364,7 @@ def build_agent_modules(configs: Optional[Sequence[AgentModuleConfig]]) -> List[
         return []
     modules: List[AgentModule] = []
     for cfg in configs:
-        if cfg.type == "prompt":
+        if cfg.type == "working_memory":
             modules.append(PromptAgentModule(name=cfg.name, path=cfg.path))
         elif cfg.type == "skill_library":
             modules.append(
@@ -392,7 +388,7 @@ def bind_row_skills_ref(modules: Sequence[AgentModule], row: dict) -> None:
             module.bind_skills_ref(skills_ref)
 
 
-async def prepare_agent_context(
+async def activate_agent_context(
     modules: Sequence[AgentModule],
     row: dict,
     responses_create_params: NeMoGymResponseCreateParamsNonStreaming,
@@ -400,23 +396,23 @@ async def prepare_agent_context(
     bind_row_skills_ref(modules, row)
     ctx = AgentContext(row=row, responses_create_params=responses_create_params)
     for module in modules:
-        ctx = await module.prepare(ctx)
-    ctx.artifact_refs = collect_artifact_refs(modules)
+        ctx = await module.activate(ctx)
+    ctx.module_refs = collect_module_refs(modules)
     return ctx
 
 
-async def observe_agent_modules(
+async def adapt_agent_modules(
     modules: Sequence[AgentModule],
     event: TrajectoryEvent,
 ) -> List[AgentUpdateEvent]:
     updates: List[AgentUpdateEvent] = []
     for module in modules:
-        updates.extend(await module.observe(event))
+        updates.extend(await module.adapt(event))
     return updates
 
 
-def collect_artifact_refs(modules: Sequence[AgentModule]) -> List[AgentArtifactRef]:
-    refs: List[AgentArtifactRef] = []
+def collect_module_refs(modules: Sequence[AgentModule]) -> List[AgentModuleRef]:
+    refs: List[AgentModuleRef] = []
     for module in modules:
-        refs.extend(module.artifact_refs())
+        refs.extend(module.module_refs())
     return refs

--- a/nemo_gym/agent_modules.py
+++ b/nemo_gym/agent_modules.py
@@ -189,10 +189,14 @@ class PromptAgentModule(AgentModule):
         return result
 
 
+class WorkingMemoryModuleSettings(BaseModel):
+    path: str
+
+
 class PromptModuleConfig(BaseModel):
     type: Literal["working_memory"] = "working_memory"
     name: str = "working_memory"
-    path: str
+    config: WorkingMemoryModuleSettings
 
 
 class SkillAdaptationConfig(BaseModel):
@@ -215,9 +219,7 @@ class SkillAdaptationConfig(BaseModel):
     )
 
 
-class SkillLibraryModuleConfig(BaseModel):
-    type: Literal["skill_library"] = "skill_library"
-    name: str = "skill_library"
+class SkillLibraryModuleSettings(BaseModel):
     path: Optional[str] = None
     injection_mode: Literal["none", "context"] = Field(
         default="none",
@@ -227,6 +229,12 @@ class SkillLibraryModuleConfig(BaseModel):
         ),
     )
     adaptation: Optional[SkillAdaptationConfig] = None
+
+
+class SkillLibraryModuleConfig(BaseModel):
+    type: Literal["skill_library"] = "skill_library"
+    name: str = "skill_library"
+    config: SkillLibraryModuleSettings = Field(default_factory=SkillLibraryModuleSettings)
 
 
 class SkillLibraryAgentModule(AgentModule):
@@ -365,14 +373,14 @@ def build_agent_modules(configs: Optional[Sequence[AgentModuleConfig]]) -> List[
     modules: List[AgentModule] = []
     for cfg in configs:
         if cfg.type == "working_memory":
-            modules.append(PromptAgentModule(name=cfg.name, path=cfg.path))
+            modules.append(PromptAgentModule(name=cfg.name, path=cfg.config.path))
         elif cfg.type == "skill_library":
             modules.append(
                 SkillLibraryAgentModule(
                     name=cfg.name,
-                    path=cfg.path,
-                    injection_mode=cfg.injection_mode,
-                    adaptation=cfg.adaptation,
+                    path=cfg.config.path,
+                    injection_mode=cfg.config.injection_mode,
+                    adaptation=cfg.config.adaptation,
                 )
             )
     return modules

--- a/nemo_gym/agent_modules.py
+++ b/nemo_gym/agent_modules.py
@@ -1,0 +1,422 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""First-class Agent modules: behavior-shaping artifacts with provenance and observe hooks.
+
+Agent modules sit on the Agent boundary (see research note ``agent-modules``). They shape
+what the policy model sees and record which artifact versions were active during a rollout.
+Processor-level knobs like ``prompt_config`` and ``skills.path`` are migrating toward this
+interface; modules declared on an Agent config are applied at ``prepare`` time inside ``/run``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Annotated, List, Literal, Optional, Sequence, Union
+
+from pydantic import BaseModel, Field
+
+from nemo_gym import _resolve_under_cwd_or_install
+from nemo_gym.global_config import SKILLS_REF_KEY_NAME
+from nemo_gym.openai_utils import NeMoGymEasyInputMessage, NeMoGymResponse, NeMoGymResponseCreateParamsNonStreaming
+from nemo_gym.prompt import fill_prompt, load_prompt_config
+from nemo_gym.skills import (
+    SkillsRef,
+    apply_skill_adaptation,
+    format_skills_for_context,
+    load_skill_bodies,
+    load_skill_directory,
+    stage_skills,
+)
+
+
+_HASH_PREFIX_LEN = 12
+
+# Stamped on rollout results alongside legacy ``skills_ref``.
+AGENT_ARTIFACT_REFS_KEY = "agent_artifact_refs"
+AGENT_UPDATE_EVENTS_KEY = "agent_update_events"
+
+TrajectoryEventKind = Literal[
+    "model_call",
+    "tool_call",
+    "tool_result",
+    "verify",
+    "terminated",
+    "truncated",
+]
+
+
+class AgentArtifactRef(BaseModel):
+    """Provenance stamp for an optimizable Agent artifact active during a rollout."""
+
+    type: str
+    name: str
+    hash: str
+    path: Optional[str] = None
+    uri: Optional[str] = None
+    metadata: dict = Field(default_factory=dict)
+
+
+class AgentUpdateEvent(BaseModel):
+    """Structured before/after transition emitted by a module ``observe`` hook."""
+
+    module_type: str
+    module_name: str
+    update_type: Literal["replace", "append", "prune", "reweight", "checkpoint"] = "replace"
+    before_hash: Optional[str] = None
+    after_hash: Optional[str] = None
+    reason: Optional[str] = None
+
+
+class TrajectoryEvent(BaseModel):
+    """Minimal trajectory signal for module ``observe`` hooks (full contract: issue #1867)."""
+
+    kind: TrajectoryEventKind
+    reward: Optional[float] = None
+    response: Optional[NeMoGymResponse] = None
+    row: dict = Field(default_factory=dict)
+    task_index: Optional[int] = None
+    rollout_index: Optional[int] = None
+
+
+class AgentContext(BaseModel):
+    """Mutable per-rollout context passed through the module ``prepare`` chain."""
+
+    row: dict
+    responses_create_params: NeMoGymResponseCreateParamsNonStreaming
+    artifact_refs: List[AgentArtifactRef] = Field(default_factory=list)
+
+
+def _hash_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()[:_HASH_PREFIX_LEN]
+
+
+def hash_file(path: Path) -> str:
+    return _hash_bytes(path.read_bytes())
+
+
+class AgentModule(ABC):
+    """Behavior-shaping component on the Agent boundary."""
+
+    def __init__(self, name: str, module_type: str) -> None:
+        self.name = name
+        self.module_type = module_type
+
+    @abstractmethod
+    def artifact_refs(self) -> List[AgentArtifactRef]:
+        pass
+
+    async def prepare(self, ctx: AgentContext) -> AgentContext:
+        return ctx
+
+    async def observe(self, event: TrajectoryEvent) -> List[AgentUpdateEvent]:
+        return []
+
+
+class PromptAgentModule(AgentModule):
+    """Inject a YAML prompt template into ``responses_create_params.input``.
+
+    Wraps ``nemo_gym.prompt`` with content-hash provenance. When ``input`` is empty, builds
+    messages from the template and row fields. When ``input`` is already set (e.g. Processor
+    applied ``prompt_config``), only prepends a ``system`` message if the template defines one
+    and the conversation does not already start with ``system``.
+    """
+
+    def __init__(self, name: str, path: str) -> None:
+        super().__init__(name=name, module_type="prompt")
+        self.path = path
+        self._resolved_path = _resolve_under_cwd_or_install(path)
+        self._prompt_config = load_prompt_config(path)
+        self._content_hash = hash_file(self._resolved_path)
+
+    def artifact_refs(self) -> List[AgentArtifactRef]:
+        return [
+            AgentArtifactRef(
+                type="prompt",
+                name=self.name,
+                hash=self._content_hash,
+                path=self.path,
+                metadata={"predictor_id": self.name},
+            )
+        ]
+
+    async def prepare(self, ctx: AgentContext) -> AgentContext:
+        rcp = ctx.responses_create_params.model_copy(deep=True)
+        messages = fill_prompt(self._prompt_config, ctx.row)
+        easy_messages = [NeMoGymEasyInputMessage.model_validate(m) for m in messages]
+
+        existing_input = rcp.input
+        if existing_input is None or existing_input == "" or existing_input == []:
+            rcp.input = easy_messages
+        elif self._prompt_config.system is not None:
+            normalized = self._coerce_input_list(existing_input)
+            if not normalized or normalized[0].role != "system":
+                rcp.input = [easy_messages[0]] + normalized
+            else:
+                rcp.input = normalized
+        else:
+            rcp.input = self._coerce_input_list(existing_input)
+
+        ctx.responses_create_params = rcp
+        return ctx
+
+    @staticmethod
+    def _coerce_input_list(
+        existing_input: Union[str, List[NeMoGymEasyInputMessage], List[dict]],
+    ) -> List[NeMoGymEasyInputMessage]:
+        if isinstance(existing_input, str):
+            return [NeMoGymEasyInputMessage(role="user", content=existing_input)]
+        result: List[NeMoGymEasyInputMessage] = []
+        for item in existing_input:
+            if isinstance(item, NeMoGymEasyInputMessage):
+                result.append(item)
+            else:
+                result.append(NeMoGymEasyInputMessage.model_validate(item))
+        return result
+
+
+class PromptModuleConfig(BaseModel):
+    type: Literal["prompt"] = "prompt"
+    name: str = "prompt"
+    path: str
+
+
+class SkillAdaptationConfig(BaseModel):
+    """In-place skill mutation after rollouts (optimizer scaffold).
+
+    When ``enabled``, failed rollouts (reward below ``reward_threshold``) append a lesson
+    section to ``target_skill``'s ``SKILL.md``. The content hash changes so ``skills_ref`` and
+    ``agent_artifact_refs`` distinguish variants (issue #1256).
+    """
+
+    enabled: bool = False
+    target_skill: str = Field(description="Frontmatter ``name`` of the skill to adapt.")
+    reward_threshold: float = Field(
+        default=1.0,
+        description="Adapt when terminal reward is strictly below this value.",
+    )
+    lesson_template: str = (
+        "\n\n## Lesson (task={task_index}, rollout={rollout_index}, reward={reward})\n"
+        "Previous attempt did not succeed. Re-read the task and apply the skill more carefully."
+    )
+
+
+class SkillLibraryModuleConfig(BaseModel):
+    type: Literal["skill_library"] = "skill_library"
+    name: str = "skills"
+    path: Optional[str] = None
+    injection_mode: Literal["none", "context"] = Field(
+        default="none",
+        description=(
+            "``none``: provenance only (native runtimes stage via ``stage_skills``). "
+            "``context``: inject ``SKILL.md`` bodies into the system message (for ``simple_agent``)."
+        ),
+    )
+    adaptation: Optional[SkillAdaptationConfig] = None
+
+
+class SkillLibraryAgentModule(AgentModule):
+    """Agent Skills library: provenance, optional context injection, optional adaptation.
+
+      - **Provenance:** ``skills_ref`` from the rollout row or module ``path``; stamped in
+        ``artifact_refs``.
+      - **Context injection:** for agents without native discovery, ``prepare`` appends formatted
+        ``SKILL.md`` bodies to the system message.
+      - **Adaptation:** on failed rollouts, ``observe`` can append a lesson to ``target_skill`` in
+        place (hash changes; optimizers like ACE/EvoSkill can replace this with richer logic).
+    - **Staging:** when ``staging_dir`` is set on the config, ``prepare`` copies skills there for
+        native runtimes (Claude Code pattern).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        path: Optional[str] = None,
+        injection_mode: Literal["none", "context"] = "none",
+        adaptation: Optional[SkillAdaptationConfig] = None,
+        staging_dir: Optional[str] = None,
+    ) -> None:
+        super().__init__(name=name, module_type="skill_library")
+        self.path = path
+        self.injection_mode = injection_mode
+        self.adaptation = adaptation
+        self.staging_dir = staging_dir
+        self._skills_ref: Optional[SkillsRef] = None
+        self._before_adapt_hash: Optional[str] = None
+
+    @property
+    def skills_path(self) -> Optional[str]:
+        ref = self._resolve_skills_ref()
+        return ref.path if ref else self.path
+
+    def _resolve_skills_ref(self) -> Optional[SkillsRef]:
+        if self._skills_ref is not None:
+            return self._skills_ref
+        if self.path is None:
+            return None
+        self._skills_ref = load_skill_directory(self.path)
+        return self._skills_ref
+
+    def bind_skills_ref(self, skills_ref: SkillsRef) -> None:
+        """Prefer the run-level ``skills_ref`` stamped by rollout collection when present."""
+        self._skills_ref = skills_ref
+        if self.path is None:
+            self.path = skills_ref.path
+
+    def artifact_refs(self) -> List[AgentArtifactRef]:
+        skills_ref = self._resolve_skills_ref()
+        if skills_ref is None:
+            return []
+        return [
+            AgentArtifactRef(
+                type="skill_library",
+                name=self.name,
+                hash=skills_ref.hash,
+                path=skills_ref.path,
+                metadata={
+                    "skills": [s.model_dump() for s in skills_ref.skills],
+                    "injection_mode": self.injection_mode,
+                    "adaptation_enabled": bool(self.adaptation and self.adaptation.enabled),
+                },
+            )
+        ]
+
+    async def prepare(self, ctx: AgentContext) -> AgentContext:
+        skills_path = self.skills_path
+        if skills_path is None:
+            return ctx
+
+        if self.staging_dir is not None:
+            dest = Path(self.staging_dir)
+            if dest.exists():
+                raise ValueError(f"staging_dir already exists: {dest}")
+            stage_skills(skills_path, dest)
+
+        if self.injection_mode != "context":
+            return ctx
+
+        bodies = load_skill_bodies(skills_path)
+        skills_block = format_skills_for_context(bodies)
+        rcp = ctx.responses_create_params.model_copy(deep=True)
+        existing_input = rcp.input
+        normalized = PromptAgentModule._coerce_input_list(existing_input if existing_input not in (None, "") else [])
+        system_msg = NeMoGymEasyInputMessage(role="system", content=skills_block)
+        if normalized and normalized[0].role == "system":
+            merged = f"{normalized[0].content.rstrip()}\n\n{skills_block}"
+            rcp.input = [NeMoGymEasyInputMessage(role="system", content=merged)] + normalized[1:]
+        else:
+            rcp.input = [system_msg] + normalized
+        ctx.responses_create_params = rcp
+        return ctx
+
+    async def observe(self, event: TrajectoryEvent) -> List[AgentUpdateEvent]:
+        if event.kind != "terminated" or not self.adaptation or not self.adaptation.enabled:
+            return []
+        if event.reward is None or event.reward >= self.adaptation.reward_threshold:
+            return []
+
+        skills_path = self.skills_path
+        if skills_path is None:
+            return []
+
+        before_ref = self._resolve_skills_ref()
+        if before_ref is None:
+            return []
+
+        self._before_adapt_hash = before_ref.hash
+        lesson = self.adaptation.lesson_template.format(
+            reward=event.reward,
+            task_index=event.task_index,
+            rollout_index=event.rollout_index,
+        )
+        after_ref = apply_skill_adaptation(skills_path, self.adaptation.target_skill, lesson)
+        self._skills_ref = after_ref
+
+        return [
+            AgentUpdateEvent(
+                module_type=self.module_type,
+                module_name=self.name,
+                update_type="append",
+                before_hash=self._before_adapt_hash,
+                after_hash=after_ref.hash,
+                reason=f"reward {event.reward} < {self.adaptation.reward_threshold}",
+            )
+        ]
+
+
+AgentModuleConfig = Annotated[
+    Union[PromptModuleConfig, SkillLibraryModuleConfig],
+    Field(discriminator="type"),
+]
+
+
+def build_agent_modules(configs: Optional[Sequence[AgentModuleConfig]]) -> List[AgentModule]:
+    if not configs:
+        return []
+    modules: List[AgentModule] = []
+    for cfg in configs:
+        if cfg.type == "prompt":
+            modules.append(PromptAgentModule(name=cfg.name, path=cfg.path))
+        elif cfg.type == "skill_library":
+            modules.append(
+                SkillLibraryAgentModule(
+                    name=cfg.name,
+                    path=cfg.path,
+                    injection_mode=cfg.injection_mode,
+                    adaptation=cfg.adaptation,
+                )
+            )
+    return modules
+
+
+def bind_row_skills_ref(modules: Sequence[AgentModule], row: dict) -> None:
+    skills_ref_data = row.get(SKILLS_REF_KEY_NAME)
+    if not skills_ref_data:
+        return
+    skills_ref = SkillsRef.model_validate(skills_ref_data)
+    for module in modules:
+        if isinstance(module, SkillLibraryAgentModule):
+            module.bind_skills_ref(skills_ref)
+
+
+async def prepare_agent_context(
+    modules: Sequence[AgentModule],
+    row: dict,
+    responses_create_params: NeMoGymResponseCreateParamsNonStreaming,
+) -> AgentContext:
+    bind_row_skills_ref(modules, row)
+    ctx = AgentContext(row=row, responses_create_params=responses_create_params)
+    for module in modules:
+        ctx = await module.prepare(ctx)
+    ctx.artifact_refs = collect_artifact_refs(modules)
+    return ctx
+
+
+async def observe_agent_modules(
+    modules: Sequence[AgentModule],
+    event: TrajectoryEvent,
+) -> List[AgentUpdateEvent]:
+    updates: List[AgentUpdateEvent] = []
+    for module in modules:
+        updates.extend(await module.observe(event))
+    return updates
+
+
+def collect_artifact_refs(modules: Sequence[AgentModule]) -> List[AgentArtifactRef]:
+    refs: List[AgentArtifactRef] = []
+    for module in modules:
+        refs.extend(module.artifact_refs())
+    return refs

--- a/nemo_gym/skills.py
+++ b/nemo_gym/skills.py
@@ -56,6 +56,16 @@ class SkillMetadata(BaseModel):
     version: Optional[str] = None
 
 
+class SkillBody(BaseModel):
+    """Full skill content: frontmatter metadata plus markdown body after the closing ``---``."""
+
+    name: str
+    description: Optional[str] = None
+    version: Optional[str] = None
+    body: str
+    skill_md_path: Path
+
+
 class SkillsRef(BaseModel):
     """Provenance stamp describing the skills made available for a run.
 
@@ -147,6 +157,113 @@ def parse_skill_md(skill_md_path: Path) -> SkillMetadata:
         description=data.get("description"),
         version=version,
     )
+
+
+def _split_skill_md(skill_md_path: Path) -> tuple[SkillMetadata, str]:
+    """Return frontmatter metadata and markdown body for a ``SKILL.md`` file."""
+    text = skill_md_path.read_text(encoding="utf-8-sig", errors="replace")
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise ValueError(
+            f"Skill file {skill_md_path} is missing YAML frontmatter. "
+            f"It must start with a '---' line followed by 'name:' and 'description:' fields."
+        )
+
+    closing_idx = None
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            closing_idx = idx
+            break
+    if closing_idx is None:
+        raise ValueError(
+            f"Skill file {skill_md_path} has an unterminated YAML frontmatter block (no closing '---' line)."
+        )
+
+    metadata = parse_skill_md(skill_md_path)
+    body = "\n".join(lines[closing_idx + 1 :]).strip()
+    return metadata, body
+
+
+def read_skill_body(skill_md_path: Path) -> SkillBody:
+    """Load one skill's metadata and markdown body."""
+    metadata, body = _split_skill_md(skill_md_path)
+    return SkillBody(
+        name=metadata.name,
+        description=metadata.description,
+        version=metadata.version,
+        body=body,
+        skill_md_path=skill_md_path,
+    )
+
+
+def load_skill_bodies(path: str) -> List[SkillBody]:
+    """Load every skill under ``path`` (directory of skill directories)."""
+    resolved = _resolve_skills_path(path)
+    if not resolved.is_dir():
+        raise ValueError(f"Skills path must be a directory of skill directories: {resolved}")
+
+    bodies: List[SkillBody] = []
+    for skill_dir in sorted(d for d in resolved.iterdir() if d.is_dir()):
+        skill_md = skill_dir / SKILL_MD_FILENAME
+        if skill_md.is_file():
+            bodies.append(read_skill_body(skill_md))
+    if not bodies:
+        raise ValueError(f"Skills path {resolved} contains no readable {SKILL_MD_FILENAME} files.")
+    return bodies
+
+
+def format_skills_for_context(bodies: List[SkillBody]) -> str:
+    """Format skill bodies for injection into a model-visible system message.
+
+      Agents without native skill discovery (e.g. ``simple_agent``) can use this to surface
+      Agent Skills standard content in-context. Native runtimes (Claude Code, Codex) should
+    prefer ``stage_skills`` instead.
+    """
+    sections: List[str] = ["The following agent skills are available. Follow their guidance when relevant.\n"]
+    for skill in bodies:
+        header = f"### Skill: {skill.name}"
+        if skill.description:
+            header += f"\n{skill.description}"
+        body = skill.body.strip() or "(no additional instructions)"
+        sections.append(f"{header}\n\n{body}")
+    return "\n\n".join(sections)
+
+
+def find_skill_md_by_name(skills_root: Path, skill_name: str) -> Path:
+    """Resolve a skill's ``SKILL.md`` path by frontmatter ``name``."""
+    for skill_dir in sorted(d for d in skills_root.iterdir() if d.is_dir()):
+        skill_md = skill_dir / SKILL_MD_FILENAME
+        if not skill_md.is_file():
+            continue
+        if parse_skill_md(skill_md).name == skill_name:
+            return skill_md
+    raise ValueError(f"No skill named {skill_name!r} under {skills_root}.")
+
+
+def append_skill_body_section(skill_md_path: Path, section: str) -> None:
+    """Append markdown to a skill body (preserving YAML frontmatter).
+
+    Used by skill adaptation loops (ACE, EvoSkill, GEPA-over-skills) that mutate skills in place.
+    The directory content hash changes, so subsequent rollouts get a new ``skills_ref``.
+    """
+    metadata, body = _split_skill_md(skill_md_path)
+    frontmatter_lines = skill_md_path.read_text(encoding="utf-8-sig", errors="replace").splitlines()
+    closing_idx = next(i for i in range(1, len(frontmatter_lines)) if frontmatter_lines[i].strip() == "---")
+    prefix = "\n".join(frontmatter_lines[: closing_idx + 1])
+    new_body = body
+    if new_body:
+        new_body = f"{new_body.rstrip()}\n{section.rstrip()}\n"
+    else:
+        new_body = f"{section.rstrip()}\n"
+    skill_md_path.write_text(f"{prefix}\n{new_body}", encoding="utf-8")
+
+
+def apply_skill_adaptation(skills_path: str, skill_name: str, section: str) -> SkillsRef:
+    """Append an adaptation section to one skill and return the updated ``SkillsRef``."""
+    resolved = _resolve_skills_path(skills_path)
+    skill_md = find_skill_md_by_name(resolved, skill_name)
+    append_skill_body_section(skill_md, section)
+    return load_skill_directory(skills_path)
 
 
 def load_skill_directory(path: str) -> SkillsRef:

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -13,11 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-from typing import List
+from typing import List, Optional
 
 from fastapi import Request, Response
-from pydantic import ConfigDict, ValidationError
+from pydantic import ConfigDict, Field, ValidationError
 
+from nemo_gym.agent_modules import (
+    AGENT_ARTIFACT_REFS_KEY,
+    AGENT_UPDATE_EVENTS_KEY,
+    AgentModuleConfig,
+    TrajectoryEvent,
+    build_agent_modules,
+    collect_artifact_refs,
+    observe_agent_modules,
+    prepare_agent_context,
+)
 from nemo_gym.base_resources_server import (
     AggregateMetrics,
     AggregateMetricsRequest,
@@ -46,6 +56,10 @@ class SimpleAgentConfig(BaseResponsesAPIAgentConfig):
     resources_server: ResourcesServerRef
     model_server: ModelServerRef
     max_steps: int = None
+    modules: Optional[List[AgentModuleConfig]] = Field(
+        default=None,
+        description="Agent modules applied at prepare/observe time (prompt, skill_library, …).",
+    )
 
 
 class SimpleAgentRunRequest(BaseRunRequest):
@@ -175,37 +189,61 @@ class SimpleAgent(SimpleResponsesAPIAgent):
 
     async def run(self, request: Request, body: SimpleAgentRunRequest) -> SimpleAgentVerifyResponse:
         cookies = request.cookies
+        row = body.model_dump()
+        modules = build_agent_modules(self.config.modules)
 
         seed_session_response = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/seed_session",
-            json=body.model_dump(),
+            json=row,
             cookies=cookies,
         )
         await raise_for_status(seed_session_response)
         cookies = seed_session_response.cookies
 
+        agent_ctx = await prepare_agent_context(modules, row, body.responses_create_params)
+        responses_create_params = agent_ctx.responses_create_params
+
         response = await self.server_client.post(
             server_name=self.config.name,
             url_path="/v1/responses",
-            json=body.responses_create_params,
+            json=responses_create_params.model_dump(mode="json"),
             cookies=cookies,
         )
         await raise_for_status(response)
         cookies = response.cookies
+        model_response_json = await get_response_json(response)
+        model_response = NeMoGymResponse.model_validate(model_response_json)
 
-        verify_request = SimpleAgentVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(response)}
-        )
+        verify_request = SimpleAgentVerifyRequest.model_validate(row | {"response": model_response_json})
 
         verify_response = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/verify",
-            json=verify_request.model_dump(),
+            json=verify_request.model_dump(mode="json"),
             cookies=cookies,
         )
         await raise_for_status(verify_response)
-        return SimpleAgentVerifyResponse.model_validate(await get_response_json(verify_response))
+        verify_response_json = await get_response_json(verify_response)
+
+        trajectory_event = TrajectoryEvent(
+            kind="terminated",
+            reward=verify_response_json.get("reward"),
+            response=model_response,
+            row=row,
+            task_index=row.get("_ng_task_index"),
+            rollout_index=row.get("_ng_rollout_index"),
+        )
+        update_events = await observe_agent_modules(modules, trajectory_event)
+
+        result = verify_response_json
+        artifact_refs = collect_artifact_refs(modules)
+        if artifact_refs:
+            result[AGENT_ARTIFACT_REFS_KEY] = [ref.model_dump() for ref in artifact_refs]
+        if update_events:
+            result[AGENT_UPDATE_EVENTS_KEY] = [event.model_dump() for event in update_events]
+
+        return SimpleAgentVerifyResponse.model_validate(result)
 
     async def aggregate_metrics(self, body: AggregateMetricsRequest = Body()) -> AggregateMetrics:
         """Proxy aggregate_metrics to the resources server."""

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -19,14 +19,14 @@ from fastapi import Request, Response
 from pydantic import ConfigDict, Field, ValidationError
 
 from nemo_gym.agent_modules import (
-    AGENT_ARTIFACT_REFS_KEY,
+    AGENT_MODULE_REFS_KEY,
     AGENT_UPDATE_EVENTS_KEY,
     AgentModuleConfig,
     TrajectoryEvent,
+    activate_agent_context,
+    adapt_agent_modules,
     build_agent_modules,
-    collect_artifact_refs,
-    observe_agent_modules,
-    prepare_agent_context,
+    collect_module_refs,
 )
 from nemo_gym.base_resources_server import (
     AggregateMetrics,
@@ -58,7 +58,7 @@ class SimpleAgentConfig(BaseResponsesAPIAgentConfig):
     max_steps: int = None
     modules: Optional[List[AgentModuleConfig]] = Field(
         default=None,
-        description="Agent modules applied at prepare/observe time (prompt, skill_library, …).",
+        description="Agent modules activated/adapted during /run (working_memory, skill_library, …).",
     )
 
 
@@ -201,7 +201,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         await raise_for_status(seed_session_response)
         cookies = seed_session_response.cookies
 
-        agent_ctx = await prepare_agent_context(modules, row, body.responses_create_params)
+        agent_ctx = await activate_agent_context(modules, row, body.responses_create_params)
         responses_create_params = agent_ctx.responses_create_params
 
         response = await self.server_client.post(
@@ -234,12 +234,12 @@ class SimpleAgent(SimpleResponsesAPIAgent):
             task_index=row.get("_ng_task_index"),
             rollout_index=row.get("_ng_rollout_index"),
         )
-        update_events = await observe_agent_modules(modules, trajectory_event)
+        update_events = await adapt_agent_modules(modules, trajectory_event)
 
         result = verify_response_json
-        artifact_refs = collect_artifact_refs(modules)
-        if artifact_refs:
-            result[AGENT_ARTIFACT_REFS_KEY] = [ref.model_dump() for ref in artifact_refs]
+        module_refs = collect_module_refs(modules)
+        if module_refs:
+            result[AGENT_MODULE_REFS_KEY] = [ref.model_dump() for ref in module_refs]
         if update_events:
             result[AGENT_UPDATE_EVENTS_KEY] = [event.model_dump() for event in update_events]
 

--- a/responses_api_agents/simple_agent/configs/simple_agent_with_prompt_module.yaml
+++ b/responses_api_agents/simple_agent/configs/simple_agent_with_prompt_module.yaml
@@ -1,0 +1,22 @@
+# Example: simple_agent with an Agent-side prompt module.
+#
+# The prompt module injects instructions at Agent prepare time and stamps
+# agent_artifact_refs on rollout results. Pair with a resources server config
+# that supplies tools and verify logic.
+#
+#   gym env start --config responses_api_agents/simple_agent/configs/simple_agent_with_prompt_module.yaml ...
+#
+simple_agent_with_prompt_module:
+  responses_api_agents:
+    simple_agent:
+      entrypoint: app.py
+      resources_server:
+        type: resources_servers
+        name: ???
+      model_server:
+        type: responses_api_models
+        name: policy_model
+      modules:
+        - type: prompt
+          name: answer_format_prompt
+          path: benchmarks/prompts/eval/aai/mcq-4choices.yaml

--- a/responses_api_agents/simple_agent/configs/simple_agent_with_prompt_module.yaml
+++ b/responses_api_agents/simple_agent/configs/simple_agent_with_prompt_module.yaml
@@ -1,6 +1,6 @@
 # Example: simple_agent with an Agent-side working_memory module.
 #
-# The working_memory module injects instructions at Agent prepare time and stamps
+# The working_memory module injects instructions at Agent activation time and stamps
 # agent_module_refs on rollout results. Pair with a resources server config
 # that supplies tools and verify logic.
 #
@@ -19,4 +19,5 @@ simple_agent_with_prompt_module:
       modules:
         - type: working_memory
           name: answer_format_prompt
-          path: benchmarks/prompts/eval/aai/mcq-4choices.yaml
+          config:
+            path: benchmarks/prompts/eval/aai/mcq-4choices.yaml

--- a/responses_api_agents/simple_agent/configs/simple_agent_with_prompt_module.yaml
+++ b/responses_api_agents/simple_agent/configs/simple_agent_with_prompt_module.yaml
@@ -1,7 +1,7 @@
-# Example: simple_agent with an Agent-side prompt module.
+# Example: simple_agent with an Agent-side working_memory module.
 #
-# The prompt module injects instructions at Agent prepare time and stamps
-# agent_artifact_refs on rollout results. Pair with a resources server config
+# The working_memory module injects instructions at Agent prepare time and stamps
+# agent_module_refs on rollout results. Pair with a resources server config
 # that supplies tools and verify logic.
 #
 #   gym env start --config responses_api_agents/simple_agent/configs/simple_agent_with_prompt_module.yaml ...
@@ -17,6 +17,6 @@ simple_agent_with_prompt_module:
         type: responses_api_models
         name: policy_model
       modules:
-        - type: prompt
+        - type: working_memory
           name: answer_format_prompt
           path: benchmarks/prompts/eval/aai/mcq-4choices.yaml

--- a/responses_api_agents/simple_agent/configs/simple_agent_with_skills_module.yaml
+++ b/responses_api_agents/simple_agent/configs/simple_agent_with_skills_module.yaml
@@ -1,4 +1,4 @@
-# simple_agent with prompt + skill_library modules (context injection + adaptation).
+# simple_agent with working_memory + skill_library modules (context injection + adaptation).
 #
 # Run with skills.path so Processor stamps skills_ref on each row:
 #
@@ -19,7 +19,7 @@ simple_agent_with_skills_module:
         type: responses_api_models
         name: policy_model
       modules:
-        - type: prompt
+        - type: working_memory
           name: answer_format_prompt
           path: benchmarks/prompts/eval/aai/mcq-4choices.yaml
         - type: skill_library

--- a/responses_api_agents/simple_agent/configs/simple_agent_with_skills_module.yaml
+++ b/responses_api_agents/simple_agent/configs/simple_agent_with_skills_module.yaml
@@ -1,6 +1,6 @@
 # simple_agent with working_memory + skill_library modules (context injection + adaptation).
 #
-# Run with skills.path so Processor stamps skills_ref on each row:
+# Run with skills.path so rollout collection stamps skills_ref on each row:
 #
 #   gym eval run --no-serve \
 #     +agent_name=simple_agent_with_skills_module \
@@ -21,11 +21,13 @@ simple_agent_with_skills_module:
       modules:
         - type: working_memory
           name: answer_format_prompt
-          path: benchmarks/prompts/eval/aai/mcq-4choices.yaml
+          config:
+            path: benchmarks/prompts/eval/aai/mcq-4choices.yaml
         - type: skill_library
           name: baseline_skills
-          injection_mode: context
-          adaptation:
-            enabled: true
-            target_skill: cot_enhanced
-            reward_threshold: 1.0
+          config:
+            injection_mode: context
+            adaptation:
+              enabled: true
+              target_skill: cot_enhanced
+              reward_threshold: 1.0

--- a/responses_api_agents/simple_agent/configs/simple_agent_with_skills_module.yaml
+++ b/responses_api_agents/simple_agent/configs/simple_agent_with_skills_module.yaml
@@ -1,0 +1,31 @@
+# simple_agent with prompt + skill_library modules (context injection + adaptation).
+#
+# Run with skills.path so Processor stamps skills_ref on each row:
+#
+#   gym eval run --no-serve \
+#     +agent_name=simple_agent_with_skills_module \
+#     +input_jsonl_fpath=data/tasks.jsonl \
+#     +output_jsonl_fpath=results/rollouts.jsonl \
+#     +skills.path=benchmarks/skills/variant_a
+#
+simple_agent_with_skills_module:
+  responses_api_agents:
+    simple_agent:
+      entrypoint: app.py
+      resources_server:
+        type: resources_servers
+        name: ???
+      model_server:
+        type: responses_api_models
+        name: policy_model
+      modules:
+        - type: prompt
+          name: answer_format_prompt
+          path: benchmarks/prompts/eval/aai/mcq-4choices.yaml
+        - type: skill_library
+          name: baseline_skills
+          injection_mode: context
+          adaptation:
+            enabled: true
+            target_skill: cot_enhanced
+            reward_threshold: 1.0

--- a/tests/unit_tests/test_agent_modules.py
+++ b/tests/unit_tests/test_agent_modules.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import yaml
+
+from nemo_gym.agent_modules import (
+    AgentContext,
+    PromptAgentModule,
+    PromptModuleConfig,
+    SkillAdaptationConfig,
+    SkillLibraryAgentModule,
+    SkillLibraryModuleConfig,
+    TrajectoryEvent,
+    build_agent_modules,
+    observe_agent_modules,
+    prepare_agent_context,
+)
+from nemo_gym.openai_utils import NeMoGymEasyInputMessage, NeMoGymResponseCreateParamsNonStreaming
+from nemo_gym.prompt import load_prompt_config
+from nemo_gym.skills import SKILL_MD_FILENAME, hash_skill_dir, load_skill_directory
+
+
+@pytest.fixture(autouse=True)
+def _clear_prompt_cache():
+    load_prompt_config.cache_clear()
+    yield
+    load_prompt_config.cache_clear()
+
+
+class TestPromptAgentModule:
+    @pytest.mark.asyncio
+    async def test_prepare_builds_input_from_row(self, tmp_path):
+        prompt_path = tmp_path / "prompt.yaml"
+        prompt_path.write_text(yaml.dump({"system": "Be concise.", "user": "Question: {question}"}))
+
+        module = PromptAgentModule(name="test_prompt", path=str(prompt_path))
+        row = {"question": "What is 2+2?"}
+        rcp = NeMoGymResponseCreateParamsNonStreaming(input="")
+        ctx = await module.prepare(AgentContext(row=row, responses_create_params=rcp))
+
+        assert len(ctx.responses_create_params.input) == 2
+        assert ctx.responses_create_params.input[0].role == "system"
+        assert ctx.responses_create_params.input[1].content == "Question: What is 2+2?"
+
+        refs = module.artifact_refs()
+        assert refs[0].type == "prompt"
+        assert refs[0].name == "test_prompt"
+        assert len(refs[0].hash) == 12
+
+    @pytest.mark.asyncio
+    async def test_prepare_prepends_system_when_input_exists(self, tmp_path):
+        prompt_path = tmp_path / "prompt.yaml"
+        prompt_path.write_text(yaml.dump({"system": "Format: A/B/C/D", "user": "{question}"}))
+
+        module = PromptAgentModule(name="fmt", path=str(prompt_path))
+        rcp = NeMoGymResponseCreateParamsNonStreaming(
+            input=[NeMoGymEasyInputMessage(role="user", content="Pick one.")]
+        )
+        ctx = await module.prepare(AgentContext(row={"question": "ignored"}, responses_create_params=rcp))
+
+        assert ctx.responses_create_params.input[0].role == "system"
+        assert ctx.responses_create_params.input[1].content == "Pick one."
+
+    def test_artifact_ref_hash_changes_with_content(self, tmp_path):
+        prompt_path = tmp_path / "prompt.yaml"
+        prompt_path.write_text(yaml.dump({"user": "{q}"}))
+        module_a = PromptAgentModule(name="p", path=str(prompt_path))
+        hash_a = module_a.artifact_refs()[0].hash
+
+        prompt_path.write_text(yaml.dump({"user": "{q} updated"}))
+        load_prompt_config.cache_clear()
+        module_b = PromptAgentModule(name="p", path=str(prompt_path))
+        hash_b = module_b.artifact_refs()[0].hash
+
+        assert hash_a != hash_b
+
+
+class TestSkillLibraryAgentModule:
+    def test_artifact_ref_from_path(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skill_dir = skills_root / "demo"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / SKILL_MD_FILENAME).write_text("---\nname: demo\ndescription: test\n---\n")
+
+        module = SkillLibraryAgentModule(name="baseline", path=str(skills_root))
+        refs = module.artifact_refs()
+        assert refs[0].type == "skill_library"
+        assert refs[0].hash == hash_skill_dir(skills_root)[:12]
+
+    def test_bind_skills_ref_from_row(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skill_dir = skills_root / "demo"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / SKILL_MD_FILENAME).write_text("---\nname: demo\ndescription: test\n---\n")
+
+        skills_ref = load_skill_directory(str(skills_root))
+        module = SkillLibraryAgentModule(name="baseline")
+        module.bind_skills_ref(skills_ref)
+
+        refs = module.artifact_refs()
+        assert refs[0].path == str(skills_root)
+
+    @pytest.mark.asyncio
+    async def test_context_injection_prepends_system_block(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skill_dir = skills_root / "cot"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / SKILL_MD_FILENAME).write_text(
+            "---\nname: cot\ndescription: Think step by step.\n---\n# CoT\nAlways reason first.\n"
+        )
+
+        module = SkillLibraryAgentModule(
+            name="skills",
+            path=str(skills_root),
+            injection_mode="context",
+        )
+        rcp = NeMoGymResponseCreateParamsNonStreaming(input=[NeMoGymEasyInputMessage(role="user", content="Q?")])
+        ctx = await module.prepare(AgentContext(row={}, responses_create_params=rcp))
+
+        assert ctx.responses_create_params.input[0].role == "system"
+        assert "cot" in ctx.responses_create_params.input[0].content.lower()
+        assert "Always reason first" in ctx.responses_create_params.input[0].content
+        assert ctx.responses_create_params.input[1].content == "Q?"
+
+    @pytest.mark.asyncio
+    async def test_adaptation_on_failed_rollout(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skill_dir = skills_root / "cot"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / SKILL_MD_FILENAME
+        skill_md.write_text("---\nname: cot\ndescription: CoT\n---\n# Body\n")
+
+        adaptation = SkillAdaptationConfig(enabled=True, target_skill="cot", reward_threshold=1.0)
+        module = SkillLibraryAgentModule(
+            name="skills",
+            path=str(skills_root),
+            adaptation=adaptation,
+        )
+        before_hash = module.artifact_refs()[0].hash
+
+        event = TrajectoryEvent(kind="terminated", reward=0.0, task_index=1, rollout_index=2)
+        updates = await module.observe(event)
+
+        assert len(updates) == 1
+        assert updates[0].update_type == "append"
+        assert updates[0].before_hash == before_hash
+        assert updates[0].after_hash != before_hash
+        assert "Lesson" in skill_md.read_text()
+        assert module.artifact_refs()[0].hash == updates[0].after_hash
+
+    @pytest.mark.asyncio
+    async def test_adaptation_skipped_on_success(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skill_dir = skills_root / "cot"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / SKILL_MD_FILENAME
+        skill_md.write_text("---\nname: cot\ndescription: CoT\n---\n# Body\n")
+
+        module = SkillLibraryAgentModule(
+            name="skills",
+            path=str(skills_root),
+            adaptation=SkillAdaptationConfig(enabled=True, target_skill="cot"),
+        )
+        updates = await module.observe(TrajectoryEvent(kind="terminated", reward=1.0))
+        assert updates == []
+        assert skill_md.read_text().endswith("# Body\n")
+
+
+class TestBuildAndPrepare:
+    @pytest.mark.asyncio
+    async def test_prepare_agent_context_runs_module_chain(self, tmp_path):
+        prompt_path = tmp_path / "prompt.yaml"
+        prompt_path.write_text(yaml.dump({"user": "Solve {problem}"}))
+
+        modules = build_agent_modules([PromptModuleConfig(path=str(prompt_path))])
+        row = {"problem": "1+1"}
+        rcp = NeMoGymResponseCreateParamsNonStreaming(input="")
+
+        ctx = await prepare_agent_context(modules, row, rcp)
+        assert ctx.responses_create_params.input[0].content == "Solve 1+1"
+        assert len(ctx.artifact_refs) == 1
+        assert ctx.artifact_refs[0].type == "prompt"
+
+    def test_build_skill_library_module_config(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skill_dir = skills_root / "demo"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / SKILL_MD_FILENAME).write_text("---\nname: demo\ndescription: test\n---\n")
+
+        modules = build_agent_modules([SkillLibraryModuleConfig(path=str(skills_root))])
+        assert len(modules) == 1
+        assert isinstance(modules[0], SkillLibraryAgentModule)
+
+
+class TestObserveAgentModules:
+    @pytest.mark.asyncio
+    async def test_default_observe_returns_empty(self, tmp_path):
+        prompt_path = tmp_path / "prompt.yaml"
+        prompt_path.write_text(yaml.dump({"user": "{x}"}))
+        modules = build_agent_modules([PromptModuleConfig(path=str(prompt_path))])
+        event = TrajectoryEvent(kind="terminated", reward=1.0, row={"x": "hi"})
+        updates = await observe_agent_modules(modules, event)
+        assert updates == []

--- a/tests/unit_tests/test_agent_modules.py
+++ b/tests/unit_tests/test_agent_modules.py
@@ -11,7 +11,9 @@ from nemo_gym.agent_modules import (
     SkillAdaptationConfig,
     SkillLibraryAgentModule,
     SkillLibraryModuleConfig,
+    SkillLibraryModuleSettings,
     TrajectoryEvent,
+    WorkingMemoryModuleSettings,
     activate_agent_context,
     adapt_agent_modules,
     build_agent_modules,
@@ -173,7 +175,7 @@ class TestBuildAndActivate:
         prompt_path = tmp_path / "prompt.yaml"
         prompt_path.write_text(yaml.dump({"user": "Solve {problem}"}))
 
-        modules = build_agent_modules([PromptModuleConfig(path=str(prompt_path))])
+        modules = build_agent_modules([PromptModuleConfig(config=WorkingMemoryModuleSettings(path=str(prompt_path)))])
         row = {"problem": "1+1"}
         rcp = NeMoGymResponseCreateParamsNonStreaming(input="")
 
@@ -188,7 +190,9 @@ class TestBuildAndActivate:
         skill_dir.mkdir(parents=True)
         (skill_dir / SKILL_MD_FILENAME).write_text("---\nname: demo\ndescription: test\n---\n")
 
-        modules = build_agent_modules([SkillLibraryModuleConfig(path=str(skills_root))])
+        modules = build_agent_modules(
+            [SkillLibraryModuleConfig(config=SkillLibraryModuleSettings(path=str(skills_root)))]
+        )
         assert len(modules) == 1
         assert isinstance(modules[0], SkillLibraryAgentModule)
 
@@ -198,7 +202,7 @@ class TestAdaptAgentModules:
     async def test_default_adapt_returns_empty(self, tmp_path):
         prompt_path = tmp_path / "prompt.yaml"
         prompt_path.write_text(yaml.dump({"user": "{x}"}))
-        modules = build_agent_modules([PromptModuleConfig(path=str(prompt_path))])
+        modules = build_agent_modules([PromptModuleConfig(config=WorkingMemoryModuleSettings(path=str(prompt_path)))])
         event = TrajectoryEvent(kind="terminated", reward=1.0, row={"x": "hi"})
         updates = await adapt_agent_modules(modules, event)
         assert updates == []

--- a/tests/unit_tests/test_agent_modules.py
+++ b/tests/unit_tests/test_agent_modules.py
@@ -12,9 +12,9 @@ from nemo_gym.agent_modules import (
     SkillLibraryAgentModule,
     SkillLibraryModuleConfig,
     TrajectoryEvent,
+    activate_agent_context,
+    adapt_agent_modules,
     build_agent_modules,
-    observe_agent_modules,
-    prepare_agent_context,
 )
 from nemo_gym.openai_utils import NeMoGymEasyInputMessage, NeMoGymResponseCreateParamsNonStreaming
 from nemo_gym.prompt import load_prompt_config
@@ -30,26 +30,26 @@ def _clear_prompt_cache():
 
 class TestPromptAgentModule:
     @pytest.mark.asyncio
-    async def test_prepare_builds_input_from_row(self, tmp_path):
+    async def test_activate_builds_input_from_row(self, tmp_path):
         prompt_path = tmp_path / "prompt.yaml"
         prompt_path.write_text(yaml.dump({"system": "Be concise.", "user": "Question: {question}"}))
 
         module = PromptAgentModule(name="test_prompt", path=str(prompt_path))
         row = {"question": "What is 2+2?"}
         rcp = NeMoGymResponseCreateParamsNonStreaming(input="")
-        ctx = await module.prepare(AgentContext(row=row, responses_create_params=rcp))
+        ctx = await module.activate(AgentContext(row=row, responses_create_params=rcp))
 
         assert len(ctx.responses_create_params.input) == 2
         assert ctx.responses_create_params.input[0].role == "system"
         assert ctx.responses_create_params.input[1].content == "Question: What is 2+2?"
 
-        refs = module.artifact_refs()
-        assert refs[0].type == "prompt"
+        refs = module.module_refs()
+        assert refs[0].type == "working_memory"
         assert refs[0].name == "test_prompt"
         assert len(refs[0].hash) == 12
 
     @pytest.mark.asyncio
-    async def test_prepare_prepends_system_when_input_exists(self, tmp_path):
+    async def test_activate_prepends_system_when_input_exists(self, tmp_path):
         prompt_path = tmp_path / "prompt.yaml"
         prompt_path.write_text(yaml.dump({"system": "Format: A/B/C/D", "user": "{question}"}))
 
@@ -57,7 +57,7 @@ class TestPromptAgentModule:
         rcp = NeMoGymResponseCreateParamsNonStreaming(
             input=[NeMoGymEasyInputMessage(role="user", content="Pick one.")]
         )
-        ctx = await module.prepare(AgentContext(row={"question": "ignored"}, responses_create_params=rcp))
+        ctx = await module.activate(AgentContext(row={"question": "ignored"}, responses_create_params=rcp))
 
         assert ctx.responses_create_params.input[0].role == "system"
         assert ctx.responses_create_params.input[1].content == "Pick one."
@@ -66,12 +66,12 @@ class TestPromptAgentModule:
         prompt_path = tmp_path / "prompt.yaml"
         prompt_path.write_text(yaml.dump({"user": "{q}"}))
         module_a = PromptAgentModule(name="p", path=str(prompt_path))
-        hash_a = module_a.artifact_refs()[0].hash
+        hash_a = module_a.module_refs()[0].hash
 
         prompt_path.write_text(yaml.dump({"user": "{q} updated"}))
         load_prompt_config.cache_clear()
         module_b = PromptAgentModule(name="p", path=str(prompt_path))
-        hash_b = module_b.artifact_refs()[0].hash
+        hash_b = module_b.module_refs()[0].hash
 
         assert hash_a != hash_b
 
@@ -84,7 +84,7 @@ class TestSkillLibraryAgentModule:
         (skill_dir / SKILL_MD_FILENAME).write_text("---\nname: demo\ndescription: test\n---\n")
 
         module = SkillLibraryAgentModule(name="baseline", path=str(skills_root))
-        refs = module.artifact_refs()
+        refs = module.module_refs()
         assert refs[0].type == "skill_library"
         assert refs[0].hash == hash_skill_dir(skills_root)[:12]
 
@@ -98,7 +98,7 @@ class TestSkillLibraryAgentModule:
         module = SkillLibraryAgentModule(name="baseline")
         module.bind_skills_ref(skills_ref)
 
-        refs = module.artifact_refs()
+        refs = module.module_refs()
         assert refs[0].path == str(skills_root)
 
     @pytest.mark.asyncio
@@ -116,7 +116,7 @@ class TestSkillLibraryAgentModule:
             injection_mode="context",
         )
         rcp = NeMoGymResponseCreateParamsNonStreaming(input=[NeMoGymEasyInputMessage(role="user", content="Q?")])
-        ctx = await module.prepare(AgentContext(row={}, responses_create_params=rcp))
+        ctx = await module.activate(AgentContext(row={}, responses_create_params=rcp))
 
         assert ctx.responses_create_params.input[0].role == "system"
         assert "cot" in ctx.responses_create_params.input[0].content.lower()
@@ -137,17 +137,17 @@ class TestSkillLibraryAgentModule:
             path=str(skills_root),
             adaptation=adaptation,
         )
-        before_hash = module.artifact_refs()[0].hash
+        before_hash = module.module_refs()[0].hash
 
         event = TrajectoryEvent(kind="terminated", reward=0.0, task_index=1, rollout_index=2)
-        updates = await module.observe(event)
+        updates = await module.adapt(event)
 
         assert len(updates) == 1
         assert updates[0].update_type == "append"
         assert updates[0].before_hash == before_hash
         assert updates[0].after_hash != before_hash
         assert "Lesson" in skill_md.read_text()
-        assert module.artifact_refs()[0].hash == updates[0].after_hash
+        assert module.module_refs()[0].hash == updates[0].after_hash
 
     @pytest.mark.asyncio
     async def test_adaptation_skipped_on_success(self, tmp_path):
@@ -162,14 +162,14 @@ class TestSkillLibraryAgentModule:
             path=str(skills_root),
             adaptation=SkillAdaptationConfig(enabled=True, target_skill="cot"),
         )
-        updates = await module.observe(TrajectoryEvent(kind="terminated", reward=1.0))
+        updates = await module.adapt(TrajectoryEvent(kind="terminated", reward=1.0))
         assert updates == []
         assert skill_md.read_text().endswith("# Body\n")
 
 
-class TestBuildAndPrepare:
+class TestBuildAndActivate:
     @pytest.mark.asyncio
-    async def test_prepare_agent_context_runs_module_chain(self, tmp_path):
+    async def test_activate_agent_context_runs_module_chain(self, tmp_path):
         prompt_path = tmp_path / "prompt.yaml"
         prompt_path.write_text(yaml.dump({"user": "Solve {problem}"}))
 
@@ -177,10 +177,10 @@ class TestBuildAndPrepare:
         row = {"problem": "1+1"}
         rcp = NeMoGymResponseCreateParamsNonStreaming(input="")
 
-        ctx = await prepare_agent_context(modules, row, rcp)
+        ctx = await activate_agent_context(modules, row, rcp)
         assert ctx.responses_create_params.input[0].content == "Solve 1+1"
-        assert len(ctx.artifact_refs) == 1
-        assert ctx.artifact_refs[0].type == "prompt"
+        assert len(ctx.module_refs) == 1
+        assert ctx.module_refs[0].type == "working_memory"
 
     def test_build_skill_library_module_config(self, tmp_path):
         skills_root = tmp_path / "skills"
@@ -193,12 +193,12 @@ class TestBuildAndPrepare:
         assert isinstance(modules[0], SkillLibraryAgentModule)
 
 
-class TestObserveAgentModules:
+class TestAdaptAgentModules:
     @pytest.mark.asyncio
-    async def test_default_observe_returns_empty(self, tmp_path):
+    async def test_default_adapt_returns_empty(self, tmp_path):
         prompt_path = tmp_path / "prompt.yaml"
         prompt_path.write_text(yaml.dump({"user": "{x}"}))
         modules = build_agent_modules([PromptModuleConfig(path=str(prompt_path))])
         event = TrajectoryEvent(kind="terminated", reward=1.0, row={"x": "hi"})
-        updates = await observe_agent_modules(modules, event)
+        updates = await adapt_agent_modules(modules, event)
         assert updates == []

--- a/tests/unit_tests/test_skills.py
+++ b/tests/unit_tests/test_skills.py
@@ -18,9 +18,14 @@ import pytest
 from nemo_gym import PARENT_DIR
 from nemo_gym.skills import (
     _resolve_skills_path,
+    append_skill_body_section,
+    apply_skill_adaptation,
+    format_skills_for_context,
     hash_skill_dir,
+    load_skill_bodies,
     load_skill_directory,
     parse_skill_md,
+    read_skill_body,
     stage_skills,
 )
 
@@ -196,3 +201,37 @@ class TestStageSkills:
     def test_missing_source_raises(self, tmp_path):
         with pytest.raises(ValueError, match="is not a directory"):
             stage_skills(str(tmp_path / "nope"), tmp_path / "dest")
+
+
+class TestSkillBodiesAndAdaptation:
+    def test_read_skill_body_and_format_context(self, tmp_path):
+        skill_dir = _write_skill(tmp_path, "cot", description="Think.", body="# CoT\nStep by step.\n")
+        body = read_skill_body(skill_dir / "SKILL.md")
+        assert body.name == "cot"
+        assert "Step by step" in body.body
+
+        text = format_skills_for_context([body])
+        assert "Skill: cot" in text
+        assert "Step by step" in text
+
+    def test_append_skill_body_section_preserves_frontmatter(self, tmp_path):
+        skill_dir = _write_skill(tmp_path, "cot", body="# Body\n")
+        skill_md = skill_dir / "SKILL.md"
+        append_skill_body_section(skill_md, "\n## Lesson\nNew tip.")
+        content = skill_md.read_text()
+        assert content.startswith("---\nname: cot")
+        assert "## Lesson" in content
+        assert "New tip" in content
+
+    def test_apply_skill_adaptation_changes_hash(self, tmp_path):
+        _write_skill(tmp_path, "cot", body="# Body\n")
+        before = load_skill_directory(str(tmp_path))
+        after = apply_skill_adaptation(str(tmp_path), "cot", "\n## Lesson\nTry again.")
+        assert after.hash != before.hash
+        assert "Try again" in (tmp_path / "cot" / "SKILL.md").read_text()
+
+    def test_load_skill_bodies(self, tmp_path):
+        _write_skill(tmp_path, "a")
+        _write_skill(tmp_path, "b")
+        bodies = load_skill_bodies(str(tmp_path))
+        assert {b.name for b in bodies} == {"a", "b"}


### PR DESCRIPTION
Add AgentModule refs for working memory and skill libraries
Introduce typed AgentModule lifecycle hooks for activation, adaptation, and rollout provenance, with simple_agent wiring and docs/tutorial coverage for working_memory and skill_library modules.