### PR TITLE
[7/n] external agent integration: multiple mcp server tool use, single verifier example

### DIFF
--- a/resources_servers/blackbox_echo_tool/app.py
+++ b/resources_servers/blackbox_echo_tool/app.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""blackbox_echo_tool — a tiny MCP tool provider (no task, no grading).
+
+Exists to demonstrate the multi-resources-server pattern: an external harness
+can be given tools from SEVERAL resources servers at once. This server only
+lends a tool (``echo_upper``) over MCP; it never seeds a task or verifies. When
+listed under an agent's ``tool_providers``, it is seeded with ``tool_only=true``
+and its tool is namespaced ``mcp__blackbox_echo_tool__echo_upper`` so it cannot
+clash with the verifier's tools.
+"""
+
+from __future__ import annotations
+
+from fastapi import Request
+from pydantic import ConfigDict
+
+from nemo_gym.base_resources_server import (
+    BaseResourcesServerConfig,
+    BaseSeedSessionRequest,
+    BaseSeedSessionResponse,
+    BaseVerifyRequest,
+    BaseVerifyResponse,
+    MCPResourcesServer,
+    gym_tool,
+)
+from nemo_gym.server_utils import is_nemo_gym_fastapi_entrypoint
+
+
+class BlackboxEchoToolConfig(BaseResourcesServerConfig):
+    pass
+
+
+class EchoSeedRequest(BaseSeedSessionRequest):
+    model_config = ConfigDict(extra="allow")
+
+
+class EchoSeedResponse(BaseSeedSessionResponse):
+    model_config = ConfigDict(extra="allow")
+    mcp: dict = {}
+
+
+class EchoVerifyRequest(BaseVerifyRequest):
+    model_config = ConfigDict(extra="allow")
+    response: dict = {}
+
+
+class EchoVerifyResponse(BaseVerifyResponse):
+    model_config = ConfigDict(extra="allow")
+    response: dict = {}
+
+
+class BlackboxEchoToolResourcesServer(MCPResourcesServer):
+    config: BlackboxEchoToolConfig
+
+    async def seed_session(self, body: EchoSeedRequest, request: Request) -> EchoSeedResponse:
+        # Tool-only: hand back the per-rollout MCP metadata + signed token; no
+        # task is materialized (tool_only=true rides on the request, ignored here).
+        return EchoSeedResponse(mcp=self.build_mcp_session_metadata(request).model_dump())
+
+    @gym_tool
+    def echo_upper(self, text: str) -> str:
+        """Return the given text uppercased."""
+        return (text or "").upper()
+
+    async def verify(self, body: EchoVerifyRequest) -> EchoVerifyResponse:
+        # A tool-only provider is never the verifier; return a no-op if called.
+        return EchoVerifyResponse(**body.model_dump(), reward=0.0, is_resolved=False)
+
+
+if __name__ == "__main__":
+    BlackboxEchoToolResourcesServer.run_webserver()
+elif is_nemo_gym_fastapi_entrypoint(__file__):
+    app = BlackboxEchoToolResourcesServer.run_webserver()  # noqa: F401

--- a/resources_servers/blackbox_echo_tool/requirements.txt
+++ b/resources_servers/blackbox_echo_tool/requirements.txt
@@ -1,0 +1,1 @@
+-e nemo-gym[dev] @ ../../

--- a/responses_api_agents/external_harness/configs/external_harness_multi_mcp_claude_code.yaml
+++ b/responses_api_agents/external_harness/configs/external_harness_multi_mcp_claude_code.yaml
@@ -1,0 +1,71 @@
+# Multi-resources-server MCP demo (design R3 / 3.3): ONE verifier + N tool
+# providers, all lent to a single external harness. Claude Code gets tools from
+# both servers, namespaced (mcp__blackbox_tool_toy__get_passphrase and
+# mcp__blackbox_echo_tool__echo_upper), so they can't clash. The verifier
+# (blackbox_tool_toy) seeds the task and owns /verify; blackbox_echo_tool only
+# lends a tool (seeded tool_only, never grades).
+#
+#   vllm serve <model> --port 8000 --enable-auto-tool-choice --tool-call-parser hermes
+
+
+policy_model:
+  responses_api_models:
+    vllm_model:
+      entrypoint: app.py
+      base_url: ${policy_base_url}
+      api_key: ${policy_api_key}
+      model: ${policy_model_name}
+      uses_reasoning_parser: false
+      return_token_id_information: false
+      observability:
+        enabled: true
+        capture_dir: ng_captures
+        run_id: workstation
+        return_token_ids: false
+
+blackbox_tool_toy:
+  resources_servers:
+    blackbox_tool_toy:
+      entrypoint: app.py
+      domain: coding
+
+blackbox_echo_tool:
+  resources_servers:
+    blackbox_echo_tool:
+      entrypoint: app.py
+      domain: coding
+
+external_harness_agent:
+  responses_api_agents:
+    external_harness:
+      entrypoint: app.py
+      resources_server:          # the verifier: seeds the task + owns /verify
+        type: resources_servers
+        name: blackbox_tool_toy
+      tool_providers:            # tool-only providers (seeded tool_only)
+        - type: resources_servers
+          name: blackbox_echo_tool
+      model_server:
+        type: responses_api_models
+        name: policy_model
+      policy_model_name: ${policy_model_name}
+      settings:
+        harness: claude_code
+        builder: prefix_merging
+        training_mode: false
+        sandbox_provider:
+          docker: {}
+        sandbox_spec:
+          image: node:20-bookworm-slim
+          workdir: /tmp/nemo-gym-harness
+          provider_options:
+            run_args: ["--network", "host"]
+        harness_spec:
+          pinned_version: null
+          max_output_tokens: 4096
+          bare: false
+      datasets:
+        - name: example
+          type: validation
+          license: MIT
+          jsonl_fpath: resources_servers/blackbox_tool_toy/data/example.jsonl


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>