### PR TITLE
feat(observability): agent-side url_path/base-URL helpers + wire remaining url_path-style agents

### DIFF
--- a/fern/versions/latest/pages/model-server/model-call-capture.mdx
+++ b/fern/versions/latest/pages/model-server/model-call-capture.mdx
@@ -42,6 +42,16 @@ the rollout prefix before routing.
 
 Correlation is caller-supplied. An unprefixed call is forwarded normally but is not captured.
 
+Agents built on `SimpleResponsesAPIAgent` can use these helpers: `url_path_for_run(url_path, body)`
+prefixes a downstream call from the run request's task/rollout indices (only when
+`observability_enabled` is true — otherwise URLs stay unprefixed), and
+`url_path_for_request(url_path, request)` carries an inbound prefixed self-call through to the
+model call. The prefixed self-call route (`/ng-rollout/{rollout_id}/v1/responses`) is registered on
+every agent by default. SDK-based harnesses that configure a client once use
+`base_url_for_run(base_url, body)`, the base-URL counterpart with the same gating; harnesses that
+must thread the id through layers use `rollout_id_from_run(body)` +
+`resolve_model_base_url(name, rollout_id)` instead.
+
 The model servers and `rollout_collection` read the same path from the global config. If
 `gym env start` and `gym eval run --no-serve` are separate invocations, pass the same top-level
 capture settings to both. For separate pods or nodes, that absolute path must refer to a volume

--- a/nemo_gym/base_responses_api_agent.py
+++ b/nemo_gym/base_responses_api_agent.py
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import abstractmethod
+from collections.abc import Mapping
 from typing import Any, Optional
 
-from fastapi import Body, FastAPI
+from fastapi import Body, FastAPI, Request
 
 from nemo_gym.base_resources_server import (
     AggregateMetrics,
@@ -24,7 +25,8 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
 )
 from nemo_gym.base_responses_api_model import maybe_rollout_id_from_run_body
-from nemo_gym.global_config import get_first_server_config_dict
+from nemo_gym.config_types import ROLLOUT_PATH_PREFIX
+from nemo_gym.global_config import OBSERVABILITY_ENABLED_KEY_NAME, get_first_server_config_dict
 from nemo_gym.openai_utils import (
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
@@ -35,6 +37,7 @@ from nemo_gym.server_utils import (
     BaseServer,
     SimpleServer,
     apply_rollout_prefix,
+    rollout_path_prefix,
 )
 
 
@@ -55,14 +58,62 @@ class SimpleResponsesAPIAgent(BaseResponsesAPIAgent, AggregateMetricsMixin, Simp
         self.setup_session_middleware(app)
 
         app.post("/v1/responses")(self.responses)
+        # Prefixed twin of /v1/responses: a self-call made with url_path_for_run() lands here, and
+        # responses() recovers the rollout id from the path (see url_path_for_request) to correlate
+        # its model calls. Same handler, so unprefixed calls are unaffected.
+        app.post(f"/{ROLLOUT_PATH_PREFIX}/{{rollout_id}}/v1/responses")(self.responses)
         app.post("/run")(self.run)
         app.post("/aggregate_metrics")(self.aggregate_metrics)
 
         return app
 
+    def _model_call_capture_enabled(self) -> bool:
+        # Fail closed: an agent whose client carries no usable global config runs uncorrelated
+        # rather than erroring on every model call.
+        global_config = getattr(self.server_client, "global_config_dict", None)
+        if not isinstance(global_config, Mapping):
+            return False
+        return bool(global_config.get(OBSERVABILITY_ENABLED_KEY_NAME, False))
+
     def rollout_id_from_run(self, body: Any) -> Optional[str]:
-        """Per-rollout capture id for a run request, or None when unavailable."""
+        """Per-rollout capture id for a run-request (its task/rollout indices).
+
+        None when model-call capture (observability) is disabled or the body carries no indices,
+        so callers apply no correlation prefix in either case.
+        """
+        if not self._model_call_capture_enabled():
+            return None
         return maybe_rollout_id_from_run_body(body)
+
+    def url_path_for_run(self, url_path: str, body: Any) -> str:
+        """A downstream url_path with the per-rollout capture-correlation prefix applied.
+
+        Returns ``/ng-rollout/<id><url_path>`` when observability is enabled and the run body
+        carries task/rollout indices; otherwise ``url_path`` unchanged. Use for calls made while
+        handling ``/run`` — both direct model-server calls and self-calls to ``/v1/responses``
+        (the prefixed self-call route carries the id into ``responses()``).
+        """
+        return f"{rollout_path_prefix(self.rollout_id_from_run(body))}{url_path}"
+
+    def base_url_for_run(self, base_url: str, body: Any) -> str:
+        """A model-server base URL with the per-rollout capture-correlation prefix applied.
+
+        ``base_url_for_run`` is the base-URL counterpart of ``url_path_for_run`` for SDK-style
+        harnesses that configure a client once instead of prefixing each call: same gating, applied
+        to a server root URL (append the API-version suffix afterwards).
+        """
+        return apply_rollout_prefix(base_url, self.rollout_id_from_run(body))
+
+    def url_path_for_request(self, url_path: str, request: Optional[Request]) -> str:
+        """Carry an inbound ``/ng-rollout/<id>`` self-call prefix onto a downstream url_path.
+
+        Agents whose model calls happen inside ``responses()`` receive the correlation id as the
+        ``rollout_id`` path parameter of the prefixed self-call route; this re-applies it to the
+        outgoing model call. Unprefixed requests pass through unchanged.
+        """
+        path_params = getattr(request, "path_params", None)
+        rollout_id = path_params.get("rollout_id") if isinstance(path_params, Mapping) else None
+        return f"{rollout_path_prefix(rollout_id)}{url_path}"
 
     def resolve_model_base_url(self, model_server_name: str, rollout_id: Optional[str] = None) -> str:
         """Resolve a model-server URL with an optional rollout prefix."""

--- a/responses_api_agents/aviary_agent/app.py
+++ b/responses_api_agents/aviary_agent/app.py
@@ -165,9 +165,11 @@ class AviaryAgent(SimpleResponsesAPIAgent):
 
                 # Sample action from model
                 try:
+                    # responses() receives the full run request (run() delegates in-process), so the
+                    # correlation id comes straight from the request body rather than a path prefix.
                     raw_model_response = await self.server_client.post(
                         server_name=self.config.model_server.name,
-                        url_path="/v1/responses",
+                        url_path=self.url_path_for_run("/v1/responses", req),
                         json=agent_state,
                         cookies=model_server_cookies,
                     )

--- a/responses_api_agents/browsecomp_agent/app.py
+++ b/responses_api_agents/browsecomp_agent/app.py
@@ -347,7 +347,7 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
                     log_event("model_call_begin", retry=retry_idx)
                     model_response = await self.server_client.post(
                         server_name=self.config.model_server.name,
-                        url_path="/v1/responses",
+                        url_path=self.url_path_for_request("/v1/responses", request),
                         json=new_body,
                         cookies=model_server_cookies,
                     )
@@ -670,7 +670,7 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
 
         response = await self.server_client.post(
             server_name=self.config.name,
-            url_path="/v1/responses",
+            url_path=self.url_path_for_run("/v1/responses", body),
             json=body.responses_create_params,
             cookies=cookies,
         )

--- a/responses_api_agents/critpt_agent/app.py
+++ b/responses_api_agents/critpt_agent/app.py
@@ -70,7 +70,7 @@ class CritPtAgent(SimpleResponsesAPIAgent):
     ) -> NeMoGymResponse:
         model_response = await self.server_client.post(
             server_name=self.config.model_server.name,
-            url_path="/v1/responses",
+            url_path=self.url_path_for_request("/v1/responses", request),
             json=body,
             cookies=request.cookies,
         )
@@ -91,10 +91,12 @@ class CritPtAgent(SimpleResponsesAPIAgent):
         await raise_for_status(seed_response)
         cookies = seed_response.cookies
 
+        self_responses_url_path = self.url_path_for_run("/v1/responses", body)
+
         # Turn 1: solve the problem
         turn1_response = await self.server_client.post(
             server_name=self.config.name,
-            url_path="/v1/responses",
+            url_path=self_responses_url_path,
             json=body.responses_create_params,
             cookies=cookies,
         )
@@ -115,7 +117,7 @@ class CritPtAgent(SimpleResponsesAPIAgent):
 
         turn2_response = await self.server_client.post(
             server_name=self.config.name,
-            url_path="/v1/responses",
+            url_path=self_responses_url_path,
             json=turn2_params,
             cookies=cookies,
         )

--- a/responses_api_agents/cvdp_agent/app.py
+++ b/responses_api_agents/cvdp_agent/app.py
@@ -85,7 +85,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
 
             model_response = await self.server_client.post(
                 server_name=self.config.model_server.name,
-                url_path="/v1/responses",
+                url_path=self.url_path_for_request("/v1/responses", request),
                 json=new_body,
                 cookies=model_server_cookies,
             )
@@ -181,7 +181,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
             try:
                 response = await self.server_client.post(
                     server_name=self.config.name,
-                    url_path="/v1/responses",
+                    url_path=self.url_path_for_run("/v1/responses", body),
                     json=body.responses_create_params,
                     cookies=cookies,
                 )

--- a/responses_api_agents/gymnasium_agent/app.py
+++ b/responses_api_agents/gymnasium_agent/app.py
@@ -30,7 +30,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
 )
-from nemo_gym.server_utils import get_response_json, raise_for_status, rollout_path_prefix
+from nemo_gym.server_utils import get_response_json, raise_for_status
 from resources_servers.gymnasium import EnvResetResponse, EnvStepResponse
 
 
@@ -74,8 +74,7 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
 
     async def run(self, request: Request, body: GymnasiumAgentRunRequest) -> GymnasiumRunResponse:
         env_cookies = request.cookies
-        rollout_id = self.rollout_id_from_run(body)
-        model_url_path = f"{rollout_path_prefix(rollout_id)}/v1/responses"
+        model_url_path = self.url_path_for_run("/v1/responses", body)
 
         reset_resp = await self.server_client.post(
             server_name=self.config.resources_server.name,

--- a/responses_api_agents/gymnasium_agent/tests/test_app.py
+++ b/responses_api_agents/gymnasium_agent/tests/test_app.py
@@ -23,7 +23,7 @@ from nemo_gym.server_utils import ServerClient
 from responses_api_agents.gymnasium_agent.app import GymnasiumAgent, GymnasiumAgentConfig, GymnasiumAgentRunRequest
 
 
-def _make_agent(max_steps=10):
+def _make_agent(max_steps=10, observability=True):
     config = GymnasiumAgentConfig(
         host="",
         port=0,
@@ -33,7 +33,9 @@ def _make_agent(max_steps=10):
         model_server=ModelServerRef(type="responses_api_models", name="policy_model"),
         max_steps=max_steps,
     )
-    return GymnasiumAgent(config=config, server_client=MagicMock(spec=ServerClient))
+    server_client = MagicMock(spec=ServerClient)
+    server_client.global_config_dict = {"observability_enabled": observability}
+    return GymnasiumAgent(config=config, server_client=server_client)
 
 
 def _model_response(text: str, input_toks=1, output_toks=1) -> dict:
@@ -158,6 +160,28 @@ class TestRun:
         assert urls.count("/step") == 1
         model_calls = [(u, h) for (u, h) in seen if u == model_path]
         assert model_calls == [(model_path, None)]
+
+    @pytest.mark.asyncio
+    async def test_no_rollout_prefix_when_observability_disabled(self):
+        agent = _make_agent(observability=False)
+        call_log = _wire_mock_client(
+            agent,
+            {
+                "/reset": [{"observation": "go", "info": {}}],
+                "/v1/responses": [_model_response("move A")],
+                "/step": [{"observation": None, "reward": 1.0, "terminated": True, "truncated": False, "info": {}}],
+            },
+        )
+        req = MagicMock()
+        req.cookies = {}
+        body = GymnasiumAgentRunRequest(
+            responses_create_params={"input": [{"role": "user", "content": "play"}]},
+            **{TASK_INDEX_KEY_NAME: 2, ROLLOUT_INDEX_KEY_NAME: 0},
+        )
+        result = await agent.run(req, body)
+        assert result.terminated is True
+        # Task indices are present, but capture is off -> the model call stays unprefixed.
+        assert [u for _s, u, _j in call_log if u.startswith("/v1/")] == ["/v1/responses"]
 
     @pytest.mark.asyncio
     async def test_multi_step_preserves_output_items_in_history(self):

--- a/responses_api_agents/hermes_agent/app.py
+++ b/responses_api_agents/hermes_agent/app.py
@@ -25,7 +25,7 @@ from typing import Any, Optional
 from uuid import uuid4
 
 import model_tools  # noqa: F401  # fail-fast if hermes-agent isn't installed  # pyright: ignore[reportMissingImports]
-from fastapi import FastAPI, Request
+from fastapi import Request
 from pydantic import ConfigDict
 
 from nemo_gym.base_resources_server import BaseRunRequest, BaseVerifyResponse
@@ -47,7 +47,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseOutputTokensDetails,
     NeMoGymResponseUsage,
 )
-from nemo_gym.server_utils import ROLLOUT_PATH_PREFIX, get_response_json, raise_for_status, rollout_path_prefix
+from nemo_gym.server_utils import get_response_json, raise_for_status
 
 
 def _trajectory_to_output_items(messages, n_input):
@@ -251,11 +251,6 @@ class HermesAgent(SimpleResponsesAPIAgent):
             _f.write(self._build_config())
         os.environ["HERMES_HOME"] = hermes_home
 
-    def setup_webserver(self) -> FastAPI:
-        app = super().setup_webserver()
-        app.post(f"/{ROLLOUT_PATH_PREFIX}/{{rollout_id}}/v1/responses")(self.responses)
-        return app
-
     async def responses(
         self,
         request: Request,
@@ -390,10 +385,9 @@ class HermesAgent(SimpleResponsesAPIAgent):
             await raise_for_status(seed_resp)
             cookies = seed_resp.cookies
 
-            rollout_id = self.rollout_id_from_run(body)
             agent_resp = await self.server_client.post(
                 server_name=self.config.name,
-                url_path=f"{rollout_path_prefix(rollout_id)}/v1/responses",
+                url_path=self.url_path_for_run("/v1/responses", body),
                 json=body.responses_create_params,
                 cookies=cookies,
             )

--- a/responses_api_agents/mini_swe_agent_2/app.py
+++ b/responses_api_agents/mini_swe_agent_2/app.py
@@ -50,7 +50,6 @@ from nemo_gym.reward_profile import compute_pass_majority_metrics, highest_k_met
 from nemo_gym.sandbox import resolve_provider_config, resolve_provider_metadata
 from nemo_gym.server_utils import (
     ServerClient,
-    apply_rollout_prefix,
     get_first_server_config_dict,
 )
 
@@ -716,7 +715,7 @@ class MiniSWEAgent(SimpleResponsesAPIAgent):
             workers = 1
             run_golden = self.config.run_golden
             base_url = f"http://{model_server_config['host']}:{model_server_config['port']}"
-            base_url = f"{apply_rollout_prefix(base_url, self.rollout_id_from_run(body))}/v1"
+            base_url = f"{self.base_url_for_run(base_url, body)}/v1"
             dummy_key = "dummy_key"
             model_name = f"hosted_vllm/{policy_model_name}"
             step_timeout = self.config.step_timeout

--- a/responses_api_agents/mini_swe_agent_2/tests/test_app.py
+++ b/responses_api_agents/mini_swe_agent_2/tests/test_app.py
@@ -714,6 +714,8 @@ class TestApp:
 
         config = create_test_config()
         mock_server_client = MagicMock(spec=ServerClient)
+        # The rollout prefix is only applied when model-call capture is enabled.
+        mock_server_client.global_config_dict = {"observability_enabled": True}
         server = MiniSWEAgent(config=config, server_client=mock_server_client)
 
         setup_server_client_mocks(mock_load_from_global_config, mock_get_first_server_config_dict)

--- a/responses_api_agents/non_executing_simple_agent/app.py
+++ b/responses_api_agents/non_executing_simple_agent/app.py
@@ -71,7 +71,7 @@ class NonExecutingSimpleAgent(SimpleResponsesAPIAgent):
 
         model_response = await self.server_client.post(
             server_name=self.config.model_server.name,
-            url_path="/v1/responses",
+            url_path=self.url_path_for_request("/v1/responses", request),
             json=body,
         )
         await raise_for_status(model_response)
@@ -108,7 +108,7 @@ class NonExecutingSimpleAgent(SimpleResponsesAPIAgent):
 
         response = await self.server_client.post(
             server_name=self.config.name,
-            url_path="/v1/responses",
+            url_path=self.url_path_for_run("/v1/responses", body),
             json=body.responses_create_params,
             cookies=cookies,
         )

--- a/responses_api_agents/proof_refinement_agent/app.py
+++ b/responses_api_agents/proof_refinement_agent/app.py
@@ -117,7 +117,7 @@ class ProofRefinementAgent(SimpleResponsesAPIAgent):
 
         model_response = await self.server_client.post(
             server_name=self.config.model_server.name,
-            url_path="/v1/responses",
+            url_path=self.url_path_for_request("/v1/responses", request),
             json=body,
             cookies=request.cookies,
         )
@@ -167,7 +167,7 @@ class ProofRefinementAgent(SimpleResponsesAPIAgent):
             # 2. Generate proof attempt
             gen_response = await self.server_client.post(
                 server_name=self.config.name,
-                url_path="/v1/responses",
+                url_path=self.url_path_for_run("/v1/responses", body),
                 json=current_input,
                 cookies=cookies,
             )

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -86,7 +86,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
 
             model_response = await self.server_client.post(
                 server_name=self.config.model_server.name,
-                url_path="/v1/responses",
+                url_path=self.url_path_for_request("/v1/responses", request),
                 json=new_body,
                 cookies=model_server_cookies,
             )
@@ -187,7 +187,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
 
         response = await self.server_client.post(
             server_name=self.config.name,
-            url_path="/v1/responses",
+            url_path=self.url_path_for_run("/v1/responses", body),
             json=body.responses_create_params,
             cookies=cookies,
         )

--- a/responses_api_agents/speed_bench_agent/app.py
+++ b/responses_api_agents/speed_bench_agent/app.py
@@ -163,7 +163,7 @@ class SpeedBenchAgent(SimpleResponsesAPIAgent):
             new_body = body.model_copy(update={"input": turn_input})
             model_response = await self.server_client.post(
                 server_name=self.config.model_server.name,
-                url_path="/v1/responses",
+                url_path=self.url_path_for_request("/v1/responses", request),
                 json=new_body,
                 cookies=model_server_cookies,
             )
@@ -235,7 +235,7 @@ class SpeedBenchAgent(SimpleResponsesAPIAgent):
 
         api_response = await self.server_client.post(
             server_name=self.config.name,
-            url_path="/v1/responses",
+            url_path=self.url_path_for_run("/v1/responses", body),
             json=body.responses_create_params,
             cookies=cookies,
         )

--- a/responses_api_agents/tool_simulation_agent/app.py
+++ b/responses_api_agents/tool_simulation_agent/app.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import json
 
-from fastapi import Body
+from fastapi import Body, Request
 from pydantic import ConfigDict, ValidationError
 
 from nemo_gym.base_resources_server import BaseRunRequest, BaseVerifyRequest, BaseVerifyResponse
@@ -44,10 +44,12 @@ class ToolSimulationAgentVerifyResponse(BaseVerifyResponse):
 class ToolSimulationAgent(SimpleResponsesAPIAgent):
     config: ToolSimulationAgentConfig
 
-    async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:
+    async def responses(
+        self, request: Request, body: NeMoGymResponseCreateParamsNonStreaming = Body()
+    ) -> NeMoGymResponse:
         model_response = await self.server_client.post(
             server_name=self.config.model_server.name,
-            url_path="/v1/responses",
+            url_path=self.url_path_for_request("/v1/responses", request),
             json=body,
         )
 
@@ -66,7 +68,7 @@ class ToolSimulationAgent(SimpleResponsesAPIAgent):
         config = self.config
         response = await self.server_client.post(
             server_name=config.name,
-            url_path="/v1/responses",
+            url_path=self.url_path_for_run("/v1/responses", body),
             json=body.responses_create_params,
         )
         await raise_for_status(response)

--- a/tests/unit_tests/test_base_responses_api_model.py
+++ b/tests/unit_tests/test_base_responses_api_model.py
@@ -34,7 +34,7 @@ from nemo_gym.base_responses_api_model import (
     make_capture_store,
     read_model_call_records,
 )
-from nemo_gym.global_config import NEMO_GYM_RESERVED_TOP_LEVEL_KEYS
+from nemo_gym.global_config import NEMO_GYM_RESERVED_TOP_LEVEL_KEYS, ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
     NeMoGymResponse,
@@ -574,6 +574,58 @@ def test_base_agent_resolve_model_base_url(monkeypatch):
 
     assert SimpleResponsesAPIAgent.resolve_model_base_url(agent, "model", "rid") == "http://h:1/ng-rollout/rid/v1"
     assert SimpleResponsesAPIAgent.resolve_model_base_url(agent, "model", None) == "http://h:1/v1"
+
+
+def _make_base_agent(global_config):
+    from nemo_gym.base_responses_api_agent import BaseResponsesAPIAgentConfig
+
+    class _Agent(SimpleResponsesAPIAgent):
+        async def responses(self, body=...):
+            raise NotImplementedError
+
+        async def run(self, body=...):
+            raise NotImplementedError
+
+    server_client = MagicMock(spec=ServerClient)
+    server_client.global_config_dict = global_config
+    config = BaseResponsesAPIAgentConfig(host="", port=0, entrypoint="", name="agent")
+    return _Agent(config=config, server_client=server_client)
+
+
+def test_base_agent_url_path_for_run_gates_on_observability_and_indices():
+    body = {TASK_INDEX_KEY_NAME: 3, ROLLOUT_INDEX_KEY_NAME: 1}
+
+    enabled = _make_base_agent({"observability_enabled": True})
+    assert enabled.rollout_id_from_run(body) == "3-1"
+    assert enabled.url_path_for_run("/v1/responses", body) == "/ng-rollout/3-1/v1/responses"
+    assert enabled.base_url_for_run("http://h:1", body) == "http://h:1/ng-rollout/3-1"
+    assert enabled.url_path_for_run("/v1/responses", {}) == "/v1/responses"
+    assert enabled.base_url_for_run("http://h:1", {}) == "http://h:1"
+
+    disabled = _make_base_agent({"observability_enabled": False})
+    assert disabled.rollout_id_from_run(body) is None
+    assert disabled.url_path_for_run("/v1/responses", body) == "/v1/responses"
+    assert disabled.base_url_for_run("http://h:1", body) == "http://h:1"
+
+    assert _make_base_agent(MagicMock()).url_path_for_run("/v1/responses", body) == "/v1/responses"
+
+
+def test_base_agent_url_path_for_request_propagates_inbound_prefix():
+    agent = _make_base_agent({})
+
+    prefixed = SimpleNamespace(path_params={"rollout_id": "7-0"})
+    assert agent.url_path_for_request("/v1/responses", prefixed) == "/ng-rollout/7-0/v1/responses"
+    assert agent.url_path_for_request("/v1/responses", SimpleNamespace(path_params={})) == "/v1/responses"
+    assert agent.url_path_for_request("/v1/responses", SimpleNamespace()) == "/v1/responses"
+    assert agent.url_path_for_request("/v1/responses", None) == "/v1/responses"
+
+
+def test_base_agent_registers_prefixed_self_call_route():
+    from nemo_gym.server_utils import ROLLOUT_PATH_PREFIX
+
+    routes = {route.path for route in _make_base_agent({}).setup_webserver().routes}
+    assert f"/{ROLLOUT_PATH_PREFIX}/{{rollout_id}}/v1/responses" in routes
+    assert "/v1/responses" in routes
 
 
 def _sse(event_type: str, data: dict) -> bytes:


### PR DESCRIPTION
## Summary

Gives every agent a one-call way to correlate its model calls with a rollout for model-call capture, and wires the remaining url_path-style agent harnesses with it. Also addresses the PR #1715 review ask to collapse `apply_rollout_prefix(base_url, self.rollout_id_from_run(body))` into a single function.

Correlation is now gated on `observability_enabled`: when capture is off, no agent emits `/ng-rollout/<id>` prefixes anywhere — URLs stay clean instead of carrying a prefix the model server strips and ignores.

## New helpers on `SimpleResponsesAPIAgent`

- **`url_path_for_run(url_path, body)`** — returns `/ng-rollout/<id><url_path>` when observability is enabled and the run body carries task/rollout indices; otherwise `url_path` unchanged. Used for downstream calls made while handling `/run` (direct model calls or self-calls to `/v1/responses`).
- **`base_url_for_run(base_url, body)`** — the base-URL counterpart with identical gating, for SDK-style harnesses that configure a client once instead of prefixing each call. This is the one-function collapse requested in the #1715 review.
- **`url_path_for_request(url_path, request)`** — for agents whose model calls happen inside `responses()`: carries an inbound prefixed self-call's rollout id (from the request's path params) onto the outgoing model call.
- **`rollout_id_from_run(body)`** now applies the observability gate itself (fail-closed: no usable global config → uncorrelated, never an error). This is the single gate point, so the base-URL agents already wired on the parent branch (claude_code, anyterminal, mini_swe_agent_2) became gated with no changes to their code. It remains public because some flows need the bare id: claude_code and anyterminal thread it through layers that have no run body, and hermes' `responses()` derives it from path params.
- The prefixed self-call route `/ng-rollout/{rollout_id}/v1/responses` is registered on every agent by the base `setup_webserver()`, so agents no longer hand-register it (hermes' override removed).

## Agents wired

Model calls in these harnesses are now correlated (and therefore captured when observability is on):

- **New:** `simple_agent`, `non_executing_simple_agent`, `tool_simulation_agent` (its `responses()` gained a `Request` parameter), `proof_refinement_agent`, `critpt_agent`, `cvdp_agent`, `speed_bench_agent`, `browsecomp_agent`, and `aviary_agent` (its `responses()` receives the full run request in-process, so it uses `url_path_for_run` directly on the model call).
- **Refactored to the helpers:** `hermes_agent` and `gymnasium_agent` (previously hand-rolled `rollout_path_prefix` f-strings, applied unconditionally — they now gate on observability like everyone else), and `mini_swe_agent_2` (the #1715-flagged line is now `self.base_url_for_run(base_url, body)`).

The wiring pattern for the common shape (model calls inside `responses()`, `run()` self-calls `/v1/responses`): `run()` prefixes the self-call via `url_path_for_run`, the base-registered prefixed route carries the id in, and `responses()` re-applies it to the model call via `url_path_for_request`.

Not wired here (bespoke model plumbing, each needs individual treatment): `harbor_agent`, `finance_agent`, `langgraph_agent`, `tau2`, `scicode_agent`, `stirrup_agent`, `verifiers_agent`, `swe_agents`, `mini_swe_agent`.

## Behavior change

Hermes and gymnasium previously applied the correlation prefix unconditionally. Harmless in practice (the model-server middleware strips it either way), but now the prefix appears only when `observability_enabled: true`, consistent across all harness styles.

## Testing

- New unit tests for the helpers: gate on/off, missing indices, fail-closed on unusable config, inbound-prefix propagation (including non-Starlette request objects), and default prefixed-route registration.
- `gym dev test`: 1178 passed, 97.27% coverage (gate ≥96%); the only 2 failures are the pre-existing `test_opensandbox_provider.py` ones.
- All touched agent suites pass: simple (6), non_executing_simple (4), tool_simulation (2), proof_refinement (2), critpt (15), cvdp (3), aviary (7), gymnasium (8, incl. a new gate-off test), mini_swe_agent_2 (22), claude_code (43), anyterminal (66).
- Pre-existing failures verified unrelated by stashing: browsecomp's 3 `responses()` tests (Hydra parsing in `app.py:197`) and speed_bench's collection error (needs its per-server venv). hermes' suite requires `model_tools` locally; its correlation test exercises the responses-side path, which is behaviorally unchanged.
- Docs: the correlation section of `model-call-capture.mdx` documents the helpers and the gating.