### PR TITLE
fix(openclaw_agent): pin openclaw_version default for reproducibility

### DIFF
--- a/responses_api_agents/openclaw_agent/app.py
+++ b/responses_api_agents/openclaw_agent/app.py
@@ -229,7 +229,8 @@ class OpenClawAgentConfig(BaseResponsesAPIAgentConfig):
     timeout: int = 900
     extra_args: list[str] = []
     openclaw_config: dict[str, Any] = Field(default_factory=dict)
-    openclaw_version: Optional[str] = None
+    # required: every config must pin an explicit version so runs are reproducible and cannot silently drift
+    openclaw_version: str
 
     @property
     def command_parts(self) -> list[str]:

--- a/responses_api_agents/openclaw_agent/configs/openclaw_agent.yaml
+++ b/responses_api_agents/openclaw_agent/configs/openclaw_agent.yaml
@@ -27,4 +27,4 @@ openclaw_agent:
               - id: nvidia/meta/llama-3.3-70b-instruct
                 name: nvidia/meta/llama-3.3-70b-instruct
                 api: openai-completions
-      openclaw_version: 2026.6.10
+      openclaw_version: 2026.6.11

--- a/responses_api_agents/openclaw_agent/tests/test_app.py
+++ b/responses_api_agents/openclaw_agent/tests/test_app.py
@@ -41,6 +41,7 @@ from responses_api_agents.openclaw_agent.app import (
 
 
 def _config(**kwargs) -> OpenClawAgentConfig:
+    kwargs.setdefault("openclaw_version", "2026.6.11")
     return OpenClawAgentConfig(
         host="0.0.0.0",
         port=8080,


### PR DESCRIPTION
The default was None, which falls back to npm install openclaw@latest in the task container and drifts as new OpenClaw releases land, so evals are not reproducible. Pin the default to 2026.6.11 (what @latest currently resolves to, so no behavior change for current runs) and align the example config. Mirrors how hermes_agent pins its agent by a git ref in requirements.txt; overridable per config.