### PR TITLE
feat(observability): capture agent-side tool and invocation evidence

### DIFF
--- a/nemo_gym/agent_execution_capture.py
+++ b/nemo_gym/agent_execution_capture.py
@@ -1,0 +1,349 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Agent-side execution evidence associated with model-call capture."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Iterator, Literal, Mapping, Optional, Sequence
+from uuid import uuid4
+
+import orjson
+from pydantic import BaseModel, Field, model_validator
+
+from nemo_gym.base_responses_api_model import _validate_rollout_id, maybe_rollout_id_from_run_body
+from nemo_gym.config_types import ModelServerRef
+
+
+logger = logging.getLogger(__name__)
+
+InvocationStatus = Literal["requested", "started", "completed", "failed", "cancelled", "unknown"]
+ToolMeasurementScope = Literal["caller_round_trip", "stream_observation_interval"]
+ToolSpanStatus = Literal["returned", "raised"]
+
+
+class AgentInvocationRecord(BaseModel):
+    """One explicitly observed agent invocation."""
+
+    id: str
+    parent_id: Optional[str] = None
+    source: str
+    status: InvocationStatus = "started"
+    spawn_response_id: Optional[str] = None
+
+
+class ToolSpanRecord(BaseModel):
+    """One observed tool-call interval."""
+
+    id: str
+    agent_invocation_id: str
+    model_ref: Optional[ModelServerRef] = None
+    model_response_id: Optional[str] = None
+    tool_call_id: str
+    measurement_scope: ToolMeasurementScope
+    clock_id: str
+    started_ns: int
+    ended_ns: int
+    started_at: float
+    completed_at: float
+    duration_ms: float
+    status: ToolSpanStatus
+    reported_error: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def validate_interval(self) -> "ToolSpanRecord":
+        if self.ended_ns < self.started_ns:
+            raise ValueError("ended_ns must not precede started_ns")
+        return self
+
+
+class ModelCallLink(BaseModel):
+    """Attribution from an invocation to a captured model response."""
+
+    agent_invocation_id: str
+    model_ref: ModelServerRef
+    response_id: str
+
+
+class AgentExecutionCapture(BaseModel):
+    """Raw agent execution evidence for one rollout."""
+
+    rollout_id: str
+    agent_server: str
+    agent_invocations: list[AgentInvocationRecord]
+    tool_spans: list[ToolSpanRecord] = Field(default_factory=list)
+    model_call_links: list[ModelCallLink] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_references(self) -> "AgentExecutionCapture":
+        _validate_rollout_id(self.rollout_id)
+        invocation_by_id = {invocation.id: invocation for invocation in self.agent_invocations}
+        if len(invocation_by_id) != len(self.agent_invocations):
+            raise ValueError("agent invocation ids must be unique")
+        if not invocation_by_id or not any(invocation.parent_id is None for invocation in self.agent_invocations):
+            raise ValueError("agent invocations must contain at least one root")
+
+        for invocation in self.agent_invocations:
+            if invocation.parent_id is not None and invocation.parent_id not in invocation_by_id:
+                raise ValueError(f"unknown parent agent invocation: {invocation.parent_id}")
+            seen = {invocation.id}
+            parent_id = invocation.parent_id
+            while parent_id is not None:
+                if parent_id in seen:
+                    raise ValueError("agent invocation parent links must not contain a cycle")
+                seen.add(parent_id)
+                parent_id = invocation_by_id[parent_id].parent_id
+
+        if len({span.id for span in self.tool_spans}) != len(self.tool_spans):
+            raise ValueError("tool span ids must be unique")
+        for span in self.tool_spans:
+            if span.agent_invocation_id not in invocation_by_id:
+                raise ValueError(f"tool span references unknown agent invocation: {span.agent_invocation_id}")
+        model_call_owners: dict[tuple[str, str, str], str] = {}
+        for link in self.model_call_links:
+            if link.agent_invocation_id not in invocation_by_id:
+                raise ValueError(f"model-call link references unknown agent invocation: {link.agent_invocation_id}")
+            identity = (link.model_ref.type, link.model_ref.name, link.response_id)
+            existing_owner = model_call_owners.setdefault(identity, link.agent_invocation_id)
+            if existing_owner != link.agent_invocation_id:
+                raise ValueError("one model response cannot belong to multiple agent invocations")
+        return self
+
+
+class AgentExecutionRecorder:
+    """Thread-safe in-memory evidence recorder owned by one Agent Server."""
+
+    ROOT_INVOCATION_ID = "root"
+
+    def __init__(
+        self,
+        rollout_id: str,
+        agent_server: str,
+        *,
+        clock: Callable[[], int] = time.monotonic_ns,
+        wall_clock: Callable[[], float] = time.time,
+        clock_id: Optional[str] = None,
+    ) -> None:
+        self.rollout_id = _validate_rollout_id(rollout_id)
+        self.agent_server = agent_server
+        self._clock = clock
+        self._wall_clock = wall_clock
+        self.clock_id = clock_id or f"{agent_server}:{os.getpid()}:{uuid4().hex}:monotonic"
+        self._lock = threading.Lock()
+        self._next_span_index = 0
+        self._agent_invocations = [
+            AgentInvocationRecord(id=self.ROOT_INVOCATION_ID, source=agent_server, status="started")
+        ]
+        self._tool_spans: list[ToolSpanRecord] = []
+        self._model_call_links: list[ModelCallLink] = []
+        self._warnings: list[str] = []
+
+    def add_agent_invocation(
+        self,
+        invocation_id: str,
+        *,
+        source: str,
+        parent_id: Optional[str] = ROOT_INVOCATION_ID,
+        status: InvocationStatus = "requested",
+        spawn_response_id: Optional[str] = None,
+    ) -> None:
+        invocation = AgentInvocationRecord(
+            id=invocation_id,
+            parent_id=parent_id,
+            source=source,
+            status=status,
+            spawn_response_id=spawn_response_id,
+        )
+        with self._lock:
+            if any(existing.id == invocation_id for existing in self._agent_invocations):
+                raise ValueError(f"duplicate agent invocation id: {invocation_id}")
+            self._agent_invocations.append(invocation)
+
+    def set_invocation_status(self, invocation_id: str, status: InvocationStatus) -> None:
+        with self._lock:
+            for invocation in self._agent_invocations:
+                if invocation.id == invocation_id:
+                    if invocation.status in {"completed", "failed", "cancelled"}:
+                        return
+                    invocation.status = status
+                    return
+        raise ValueError(f"unknown agent invocation id: {invocation_id}")
+
+    def record_tool_span(
+        self,
+        *,
+        tool_call_id: str,
+        measurement_scope: ToolMeasurementScope,
+        started_ns: int,
+        ended_ns: int,
+        started_at: float,
+        completed_at: float,
+        status: ToolSpanStatus,
+        reported_error: Optional[bool] = None,
+        agent_invocation_id: str = ROOT_INVOCATION_ID,
+        model_ref: Optional[ModelServerRef] = None,
+        model_response_id: Optional[str] = None,
+    ) -> ToolSpanRecord:
+        with self._lock:
+            span = ToolSpanRecord(
+                id=f"tool-{self._next_span_index}",
+                agent_invocation_id=agent_invocation_id,
+                model_ref=model_ref,
+                model_response_id=model_response_id,
+                tool_call_id=tool_call_id,
+                measurement_scope=measurement_scope,
+                clock_id=self.clock_id,
+                started_ns=started_ns,
+                ended_ns=ended_ns,
+                started_at=started_at,
+                completed_at=completed_at,
+                duration_ms=(ended_ns - started_ns) / 1_000_000,
+                status=status,
+                reported_error=reported_error,
+            )
+            self._next_span_index += 1
+            self._tool_spans.append(span)
+            return span
+
+    @contextmanager
+    def tool_span(
+        self,
+        *,
+        tool_call_id: str,
+        measurement_scope: ToolMeasurementScope,
+        agent_invocation_id: str = ROOT_INVOCATION_ID,
+        model_ref: Optional[ModelServerRef] = None,
+        model_response_id: Optional[str] = None,
+    ) -> Iterator[None]:
+        try:
+            started_ns = self._clock()
+            started_at = self._wall_clock()
+        except Exception:
+            self.add_warning("tool_span_recording_failed")
+            logger.warning("Agent execution span recording failed.", exc_info=True)
+            yield
+            return
+        status: ToolSpanStatus = "returned"
+        try:
+            yield
+        except BaseException:
+            status = "raised"
+            raise
+        finally:
+            try:
+                ended_ns = self._clock()
+                self.record_tool_span(
+                    tool_call_id=tool_call_id,
+                    measurement_scope=measurement_scope,
+                    started_ns=started_ns,
+                    ended_ns=ended_ns,
+                    started_at=started_at,
+                    completed_at=self._wall_clock(),
+                    status=status,
+                    agent_invocation_id=agent_invocation_id,
+                    model_ref=model_ref,
+                    model_response_id=model_response_id,
+                )
+            except Exception:
+                self.add_warning("tool_span_recording_failed")
+                logger.warning("Agent execution span recording failed.", exc_info=True)
+
+    def add_model_call_link(
+        self,
+        *,
+        response_id: str,
+        model_ref: ModelServerRef,
+        agent_invocation_id: str = ROOT_INVOCATION_ID,
+    ) -> None:
+        with self._lock:
+            self._model_call_links.append(
+                ModelCallLink(
+                    agent_invocation_id=agent_invocation_id,
+                    model_ref=model_ref,
+                    response_id=response_id,
+                )
+            )
+
+    def add_warning(self, warning: str) -> None:
+        with self._lock:
+            if warning not in self._warnings:
+                self._warnings.append(warning)
+
+    def capture(self) -> AgentExecutionCapture:
+        with self._lock:
+            return AgentExecutionCapture(
+                rollout_id=self.rollout_id,
+                agent_server=self.agent_server,
+                agent_invocations=list(self._agent_invocations),
+                tool_spans=list(self._tool_spans),
+                model_call_links=list(self._model_call_links),
+                warnings=list(self._warnings),
+            )
+
+
+class AgentExecutionCaptureStore:
+    """One atomic agent-owned capture file per rollout."""
+
+    def __init__(self, root: str | Path, *, create: bool = True) -> None:
+        self._root = Path(root)
+        if create:
+            self._root.mkdir(parents=True, exist_ok=True)
+
+    def path_for(self, rollout_id: str) -> Path:
+        return self._root / f"{_validate_rollout_id(rollout_id)}.agent-capture.json"
+
+    def write(self, capture: AgentExecutionCapture) -> None:
+        path = self.path_for(capture.rollout_id)
+        payload = orjson.dumps(capture.model_dump(), option=orjson.OPT_APPEND_NEWLINE)
+        temporary_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+        try:
+            temporary_path.write_bytes(payload)
+            os.replace(temporary_path, path)
+        except BaseException:
+            temporary_path.unlink(missing_ok=True)
+            raise
+
+    def read(self, rollout_id: str) -> Optional[AgentExecutionCapture]:
+        try:
+            payload = self.path_for(rollout_id).read_bytes()
+        except FileNotFoundError:
+            return None
+        return AgentExecutionCapture.model_validate_json(payload)
+
+    def clear(self, rollout_id: str) -> None:
+        self.path_for(rollout_id).unlink(missing_ok=True)
+
+
+def clear_agent_execution_captures_for_rollouts(
+    records: Sequence[BaseModel | Mapping[str, Any]], capture_dirs: list[Path]
+) -> None:
+    for directory in capture_dirs:
+        store = AgentExecutionCaptureStore(directory, create=False)
+        for record in records:
+            rollout_id = maybe_rollout_id_from_run_body(record)
+            if rollout_id:
+                store.clear(rollout_id)
+
+
+def merge_agent_execution_capture_into_record(record: dict[str, Any], capture_dirs: list[Path]) -> dict[str, Any]:
+    """Attach raw agent evidence without changing the agent response or reward."""
+    rollout_id = maybe_rollout_id_from_run_body(record)
+    if rollout_id is None:
+        return record
+    for directory in capture_dirs:
+        try:
+            capture = AgentExecutionCaptureStore(directory, create=False).read(rollout_id)
+        except Exception:
+            logger.warning("Unable to read agent execution capture for rollout %s.", rollout_id, exc_info=True)
+            continue
+        if capture is not None:
+            record["ng_agent_execution_capture"] = capture.model_dump()
+            break
+    return record

--- a/nemo_gym/base_responses_api_agent.py
+++ b/nemo_gym/base_responses_api_agent.py
@@ -12,19 +12,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
+import logging
+import threading
 from abc import abstractmethod
 from collections.abc import Mapping
+from functools import wraps
 from typing import Any, Optional
 
 from fastapi import Body, FastAPI, Request
 
+from nemo_gym.agent_execution_capture import AgentExecutionCaptureStore, AgentExecutionRecorder
 from nemo_gym.base_resources_server import (
     AggregateMetrics,
     AggregateMetricsRequest,
     BaseRunRequest,
     BaseVerifyResponse,
 )
-from nemo_gym.base_responses_api_model import maybe_rollout_id_from_run_body
+from nemo_gym.base_responses_api_model import ModelCallCaptureConfig, maybe_rollout_id_from_run_body
 from nemo_gym.config_types import ROLLOUT_PATH_PREFIX
 from nemo_gym.global_config import OBSERVABILITY_ENABLED_KEY_NAME, get_first_server_config_dict
 from nemo_gym.openai_utils import (
@@ -39,6 +44,9 @@ from nemo_gym.server_utils import (
     apply_rollout_prefix,
     rollout_path_prefix,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class BaseResponsesAPIAgentConfig(BaseRunServerInstanceConfig):
@@ -62,10 +70,134 @@ class SimpleResponsesAPIAgent(BaseResponsesAPIAgent, AggregateMetricsMixin, Simp
         # responses() recovers the rollout id from the path (see url_path_for_request) to correlate
         # its model calls. Same handler, so unprefixed calls are unaffected.
         app.post(f"/{ROLLOUT_PATH_PREFIX}/{{rollout_id}}/v1/responses")(self.responses)
-        app.post("/run")(self.run)
+        run_handler = self.run
+        if self.captures_agent_execution():
+            run_handler = self._run_with_agent_execution_capture(run_handler)
+        app.post("/run")(run_handler)
         app.post("/aggregate_metrics")(self.aggregate_metrics)
 
         return app
+
+    def captures_agent_execution(self) -> bool:
+        """Whether this Agent Server emits agent-side execution evidence."""
+        return False
+
+    def agent_execution_capture_requires_single_worker(self) -> bool:
+        """Whether capture crosses a process-local self-call boundary."""
+        return False
+
+    def _agent_execution_state(self) -> tuple[threading.Lock, dict[str, AgentExecutionRecorder]]:
+        lock = getattr(self, "_agent_execution_lock", None)
+        recorders = getattr(self, "_agent_execution_recorders", None)
+        if lock is None or recorders is None:
+            lock = threading.Lock()
+            recorders = {}
+            self._agent_execution_lock = lock
+            self._agent_execution_recorders = recorders
+        return lock, recorders
+
+    def _agent_execution_store(self) -> Optional[AgentExecutionCaptureStore]:
+        if "_agent_execution_store_instance" in self.__dict__:
+            return self.__dict__["_agent_execution_store_instance"]
+        global_config = getattr(self.server_client, "global_config_dict", None)
+        if not isinstance(global_config, Mapping):
+            return None
+        try:
+            config = ModelCallCaptureConfig.model_validate(global_config)
+            store = (
+                AgentExecutionCaptureStore(config.model_call_capture_dir)
+                if config.observability_enabled and config.model_call_capture_dir is not None
+                else None
+            )
+        except (OSError, ValueError):
+            logger.warning("Could not initialize agent execution capture; disabling it.", exc_info=True)
+            store = None
+        self._agent_execution_store_instance = store
+        return store
+
+    def _start_agent_execution_capture(self, body: Any) -> Optional[AgentExecutionRecorder]:
+        rollout_id = self.rollout_id_from_run(body)
+        if rollout_id is None or self._agent_execution_store() is None:
+            return None
+        if self.agent_execution_capture_requires_single_worker() and (self.config.num_workers or 1) > 1:
+            logger.warning(
+                "Agent execution capture is disabled for %s with num_workers=%s because its self-call may land "
+                "in another process.",
+                self.config.name,
+                self.config.num_workers,
+            )
+            return None
+
+        recorder = AgentExecutionRecorder(rollout_id, self.config.name)
+        lock, recorders = self._agent_execution_state()
+        with lock:
+            if rollout_id in recorders:
+                logger.warning(
+                    "Agent execution capture already active for rollout %s; skipping duplicate.", rollout_id
+                )
+                return None
+            recorders[rollout_id] = recorder
+        return recorder
+
+    async def _finish_agent_execution_capture(self, recorder: Optional[AgentExecutionRecorder]) -> None:
+        if recorder is None:
+            return
+        try:
+            store = self._agent_execution_store()
+            if store is not None:
+                write_task = asyncio.create_task(asyncio.to_thread(store.write, recorder.capture()))
+                try:
+                    await asyncio.shield(write_task)
+                except asyncio.CancelledError:
+                    await asyncio.gather(write_task, return_exceptions=True)
+                    raise
+        except Exception:
+            logger.warning("Agent execution capture finalization failed.", exc_info=True)
+        finally:
+            lock, recorders = self._agent_execution_state()
+            with lock:
+                if recorders.get(recorder.rollout_id) is recorder:
+                    del recorders[recorder.rollout_id]
+
+    def _run_with_agent_execution_capture(self, run_handler):
+        @wraps(run_handler)
+        async def wrapped(*args, **kwargs):
+            recorder = self._start_agent_execution_capture(kwargs.get("body"))
+            try:
+                result = await run_handler(*args, **kwargs)
+            except asyncio.CancelledError:
+                if recorder is not None:
+                    recorder.set_invocation_status(recorder.ROOT_INVOCATION_ID, "cancelled")
+                raise
+            except BaseException:
+                if recorder is not None:
+                    recorder.set_invocation_status(recorder.ROOT_INVOCATION_ID, "failed")
+                raise
+            else:
+                if recorder is not None:
+                    recorder.set_invocation_status(recorder.ROOT_INVOCATION_ID, "completed")
+                return result
+            finally:
+                await self._finish_agent_execution_capture(recorder)
+
+        return wrapped
+
+    def agent_execution_recorder_for_request(self, request: Optional[Request]) -> Optional[AgentExecutionRecorder]:
+        path_params = getattr(request, "path_params", None)
+        rollout_id = path_params.get("rollout_id") if isinstance(path_params, Mapping) else None
+        if rollout_id is None:
+            return None
+        lock, recorders = self._agent_execution_state()
+        with lock:
+            return recorders.get(rollout_id)
+
+    def agent_execution_recorder_for_run(self, body: Any) -> Optional[AgentExecutionRecorder]:
+        rollout_id = self.rollout_id_from_run(body)
+        if rollout_id is None:
+            return None
+        lock, recorders = self._agent_execution_state()
+        with lock:
+            return recorders.get(rollout_id)
 
     def _model_call_capture_enabled(self) -> bool:
         # Fail closed: an agent whose client carries no usable global config runs uncorrelated

--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -397,6 +397,7 @@ class ModelCallRecord(BaseModel):
     model_ref: Optional[ModelServerRef] = None
     dialect: Optional[str] = None
     status_code: Optional[int] = None
+    response_id: Optional[str] = None
 
     # Wall-clock bounds around the downstream ASGI invocation, as UTC Unix timestamps. These are
     # for external trace correlation; durations use the monotonic latency fields below.
@@ -445,6 +446,7 @@ def build_model_call_record(exchange: dict[str, Any], *, call_index: int) -> Mod
         model_ref=exchange.get("model_ref"),
         dialect=exchange.get("dialect"),
         status_code=exchange.get("status_code"),
+        response_id=response.get("id"),
         started_at=exchange.get("started_at"),
         completed_at=exchange.get("completed_at"),
         request=exchange.get("request"),
@@ -663,11 +665,13 @@ def _reconstruct_chat_sse(events: list[dict[str, Any]]) -> Optional[dict[str, An
     reasoning_parts: list[str] = []
     tool_calls: dict[int, dict[str, Any]] = {}
     usage: Optional[dict[str, Any]] = None
+    response_id: Optional[str] = None
     model: Optional[str] = None
     role = "assistant"
     finish_reason: Optional[str] = None
     saw_choice = False
     for chunk in events:
+        response_id = chunk.get("id") or response_id
         model = chunk.get("model") or model
         if chunk.get("usage"):
             usage = chunk["usage"]
@@ -707,6 +711,8 @@ def _reconstruct_chat_sse(events: list[dict[str, Any]]) -> Optional[dict[str, An
         "model": model,
         "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
     }
+    if response_id is not None:
+        result["id"] = response_id
     if usage:
         result["usage"] = usage
     return result

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -32,6 +32,10 @@ from tqdm.asyncio import tqdm
 from wandb import Table
 
 from nemo_gym import PARENT_DIR
+from nemo_gym.agent_execution_capture import (
+    clear_agent_execution_captures_for_rollouts,
+    merge_agent_execution_capture_into_record,
+)
 from nemo_gym.base_resources_server import AggregateMetrics, AggregateMetricsRequest
 from nemo_gym.base_responses_api_model import (
     clear_model_call_captures_for_rollouts,
@@ -525,8 +529,9 @@ class RolloutCollectionHelper(BaseModel):
         # Clear only rows about to be dispatched, after resume has assigned retry suffixes. This also
         # removes a kill-shaped attempt's partial capture when its rollout-attempt id is reused.
         if capture_dirs:
-            print("Clearing existing model-call captures for rollouts being dispatched")
+            print("Clearing existing observability captures for rollouts being dispatched")
             clear_model_call_captures_for_rollouts(input_rows, capture_dirs)
+            clear_agent_execution_captures_for_rollouts(input_rows, capture_dirs)
 
         pcts_to_print = [20, 40, 60, 80, 90, 95, 98, 99, 100]
         counts_left = Counter(r[AGENT_REF_KEY_NAME]["name"] for r in input_rows)
@@ -547,6 +552,7 @@ class RolloutCollectionHelper(BaseModel):
             # when capture is off). Never alters the harness output/reward already in `result`.
             if capture_dirs:
                 merge_model_call_capture_into_record(result, capture_dirs)
+                merge_agent_execution_capture_into_record(result, capture_dirs)
 
             no_persist = bool(result.get(NG_NO_PERSIST_KEY))
             failure_class = result.get(NG_FAILURE_CLASS_KEY)

--- a/responses_api_agents/claude_code_agent/app.py
+++ b/responses_api_agents/claude_code_agent/app.py
@@ -23,13 +23,14 @@ import subprocess
 import tempfile
 from asyncio import Semaphore
 from pathlib import Path
-from time import time
-from typing import Any, Optional
+from time import monotonic_ns, time
+from typing import Any, Callable, Optional
 from uuid import uuid4
 
 from fastapi import Request
 from pydantic import ConfigDict, PrivateAttr
 
+from nemo_gym.agent_execution_capture import AgentExecutionRecorder
 from nemo_gym.base_resources_server import NEMO_GYM_MCP_METADATA_KEY, BaseRunRequest, BaseVerifyResponse
 from nemo_gym.base_responses_api_agent import BaseResponsesAPIAgentConfig, Body, SimpleResponsesAPIAgent
 from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
@@ -52,6 +53,119 @@ from responses_api_agents.claude_code_agent.setup_claude_code import ensure_clau
 
 
 LOG = logging.getLogger(__name__)
+
+
+class _ClaudeStreamObserver:
+    """Translate Claude Code stream events into agent execution evidence."""
+
+    def __init__(
+        self,
+        recorder: AgentExecutionRecorder,
+        *,
+        model_ref: Optional[ModelServerRef],
+        clock: Callable[[], int] = monotonic_ns,
+        wall_clock: Callable[[], float] = time,
+    ) -> None:
+        self.recorder = recorder
+        self.model_ref = model_ref
+        self.clock = clock
+        self.wall_clock = wall_clock
+        self.pending_tools: dict[str, tuple[int, float, str, Optional[str]]] = {}
+        self.invocation_ids = {recorder.ROOT_INVOCATION_ID}
+        self.model_call_owners: dict[str, str] = {}
+
+    def observe(self, event: dict[str, Any]) -> None:
+        invocation_id = event.get("parent_tool_use_id") or self.recorder.ROOT_INVOCATION_ID
+        if invocation_id not in self.invocation_ids:
+            self.recorder.add_warning("claude_unknown_parent_tool_use_id")
+            return
+        if invocation_id != self.recorder.ROOT_INVOCATION_ID:
+            self.recorder.set_invocation_status(invocation_id, "started")
+
+        message = event.get("message")
+        content = message.get("content") if isinstance(message, dict) else None
+        if not isinstance(content, list):
+            return
+
+        if event.get("type") == "assistant":
+            raw_response_id = message.get("id")
+            response_id = raw_response_id if isinstance(raw_response_id, str) else None
+            if response_id is None and self.model_ref is not None:
+                self.recorder.add_warning("claude_model_response_missing_id")
+            if self.model_ref is not None and response_id is not None:
+                owner = self.model_call_owners.get(response_id)
+                if owner is None:
+                    self.model_call_owners[response_id] = invocation_id
+                    self.recorder.add_model_call_link(
+                        response_id=response_id,
+                        model_ref=self.model_ref,
+                        agent_invocation_id=invocation_id,
+                    )
+                elif owner != invocation_id:
+                    self.recorder.add_warning("claude_model_response_has_multiple_owners")
+
+            for block in content:
+                if not isinstance(block, dict) or block.get("type") != "tool_use":
+                    continue
+                tool_call_id = block.get("id")
+                if not isinstance(tool_call_id, str):
+                    self.recorder.add_warning("claude_tool_use_missing_id")
+                    continue
+                if tool_call_id in self.pending_tools:
+                    self.recorder.add_warning("claude_duplicate_tool_use_id")
+                    continue
+                self.pending_tools[tool_call_id] = (self.clock(), self.wall_clock(), invocation_id, response_id)
+
+                if block.get("name") in {"Agent", "Task"}:
+                    tool_input = block.get("input")
+                    source = tool_input.get("subagent_type") if isinstance(tool_input, dict) else None
+                    if tool_call_id in self.invocation_ids:
+                        self.recorder.add_warning("claude_duplicate_agent_invocation")
+                    else:
+                        self.recorder.add_agent_invocation(
+                            tool_call_id,
+                            source=str(source or block["name"]),
+                            parent_id=invocation_id,
+                            status="requested",
+                            spawn_response_id=response_id,
+                        )
+                        self.invocation_ids.add(tool_call_id)
+
+        elif event.get("type") == "user":
+            for block in content:
+                if not isinstance(block, dict) or block.get("type") != "tool_result":
+                    continue
+                tool_call_id = block.get("tool_use_id")
+                if not isinstance(tool_call_id, str):
+                    self.recorder.add_warning("claude_tool_result_missing_id")
+                    continue
+                pending = self.pending_tools.pop(tool_call_id, None)
+                if pending is None:
+                    self.recorder.add_warning("claude_tool_result_without_start")
+                    continue
+                started_ns, started_at, owner_id, response_id = pending
+                self.recorder.record_tool_span(
+                    tool_call_id=tool_call_id,
+                    measurement_scope="stream_observation_interval",
+                    started_ns=started_ns,
+                    ended_ns=self.clock(),
+                    started_at=started_at,
+                    completed_at=self.wall_clock(),
+                    status="returned",
+                    reported_error=bool(block.get("is_error")),
+                    agent_invocation_id=owner_id,
+                    model_ref=self.model_ref,
+                    model_response_id=response_id,
+                )
+                if tool_call_id in self.invocation_ids:
+                    self.recorder.set_invocation_status(
+                        tool_call_id,
+                        "failed" if block.get("is_error") else "completed",
+                    )
+
+    def finish(self) -> None:
+        if self.pending_tools:
+            self.recorder.add_warning("claude_tool_result_missing")
 
 
 def _extract_text(content: list[Any]) -> str:
@@ -251,6 +365,9 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
     _static_mcp_config: Optional[dict[str, Any]] = PrivateAttr(default=None)
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
+    def captures_agent_execution(self) -> bool:
+        return True
+
     def model_post_init(self, __context: Any) -> None:
         self.sem = Semaphore(self.config.concurrency)
         ensure_claude_code(self.config.claude_code_version)
@@ -381,6 +498,7 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
         mcp_config: Optional[str] = None,
         skills_path: Optional[str] = None,
         rollout_id: Optional[str] = None,
+        execution_recorder: Optional[AgentExecutionRecorder] = None,
     ) -> tuple[str, str]:
         """Run claude -p --output-format=stream-json and return (stdout, model_name).
 
@@ -426,15 +544,86 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
             )
-            try:
-                stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=self.config.timeout)
-            except asyncio.TimeoutError:
-                proc.kill()
-                await proc.communicate()
-                LOG.warning("claude-code timed out after %ds", self.config.timeout)
-                return "", model
+            if execution_recorder is None:
+                try:
+                    stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=self.config.timeout)
+                except asyncio.TimeoutError:
+                    proc.kill()
+                    await proc.communicate()
+                    LOG.warning("claude-code timed out after %ds", self.config.timeout)
+                    return "", model
+            else:
+                observer = _ClaudeStreamObserver(
+                    execution_recorder,
+                    model_ref=self.config.model_server,
+                )
+
+                def observe_line(line: bytes) -> None:
+                    if not line.strip():
+                        return
+                    try:
+                        event = json.loads(line)
+                        if isinstance(event, dict):
+                            observer.observe(event)
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        execution_recorder.add_warning("claude_stream_event_invalid")
+                    except Exception:
+                        execution_recorder.add_warning("claude_stream_observation_failed")
+                        LOG.warning("Could not observe Claude Code stream event.", exc_info=True)
+
+                async def read_stdout() -> bytes:
+                    chunks: list[bytes] = []
+                    pending = bytearray()
+                    while chunk := await proc.stdout.read(64 * 1024):
+                        chunks.append(chunk)
+                        pending.extend(chunk)
+                        while (newline := pending.find(b"\n")) >= 0:
+                            observe_line(bytes(pending[:newline]))
+                            del pending[: newline + 1]
+                    if pending:
+                        observe_line(bytes(pending))
+                    return b"".join(chunks)
+
+                stdout_task = asyncio.create_task(read_stdout())
+                stderr_task = asyncio.create_task(proc.stderr.read())
+                timed_out = False
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=self.config.timeout)
+                except asyncio.TimeoutError:
+                    timed_out = True
+                    execution_recorder.add_warning("claude_code_timeout")
+                finally:
+                    if proc.returncode is None:
+                        try:
+                            proc.kill()
+                        except ProcessLookupError:
+                            pass
+                    try:
+                        await asyncio.wait_for(proc.wait(), timeout=5)
+                    except asyncio.TimeoutError:
+                        execution_recorder.add_warning("claude_code_kill_timeout")
+                    try:
+                        output = await asyncio.wait_for(
+                            asyncio.gather(stdout_task, stderr_task, return_exceptions=True), timeout=5
+                        )
+                    except asyncio.TimeoutError:
+                        execution_recorder.add_warning("claude_stream_drain_timeout")
+                        stdout_task.cancel()
+                        stderr_task.cancel()
+                        await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
+                        output = [b"", b""]
+                    stdout = output[0] if isinstance(output[0], bytes) else b""
+                    stderr = output[1] if isinstance(output[1], bytes) else b""
+                    if any(isinstance(item, BaseException) for item in output):
+                        execution_recorder.add_warning("claude_stream_read_failed")
+                    observer.finish()
+                if timed_out:
+                    LOG.warning("claude-code timed out after %ds", self.config.timeout)
+                    return "", model
 
             if proc.returncode not in (0, None):
+                if execution_recorder is not None:
+                    execution_recorder.add_warning("claude_code_nonzero_exit")
                 LOG.warning("claude-code exited %d: %s", proc.returncode, stderr.decode(errors="replace")[:500])
 
             LOG.debug("claude-code stdout (%d chars): %s", len(stdout), stdout[:2000].decode(errors="replace"))
@@ -509,6 +698,7 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
         mcp_config: Optional[str] = None,
         skills_path: Optional[str] = None,
         rollout_id: Optional[str] = None,
+        execution_recorder: Optional[AgentExecutionRecorder] = None,
     ) -> NeMoGymResponse:
         body = body.model_copy(deep=True)
         if isinstance(body.input, str):
@@ -524,6 +714,7 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
             mcp_config=mcp_config,
             skills_path=skills_path,
             rollout_id=rollout_id,
+            execution_recorder=execution_recorder,
         )
         output_items, usage = parse_stream_json(stdout)
 
@@ -590,6 +781,7 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
             # in-process, so no metadata side-channel is needed (unlike the schema-forbidden HTTP path).
             skills_path = ((body.model_extra or {}).get(SKILLS_REF_KEY_NAME) or {}).get("path")
             rollout_id = self.rollout_id_from_run(body)
+            execution_recorder = self.agent_execution_recorder_for_run(body)
 
             with tempfile.TemporaryDirectory(prefix="nemo_gym_claude_mcp_") as mcp_config_dir:
                 mcp_config = self._write_rollout_mcp_config(seed_resp_json, Path(mcp_config_dir))
@@ -598,6 +790,7 @@ class ClaudeCodeAgent(SimpleResponsesAPIAgent):
                     mcp_config=mcp_config,
                     skills_path=skills_path,
                     rollout_id=rollout_id,
+                    execution_recorder=execution_recorder,
                 )
                 agent_resp_json = agent_resp.model_dump(mode="json")
 

--- a/responses_api_agents/claude_code_agent/tests/test_app.py
+++ b/responses_api_agents/claude_code_agent/tests/test_app.py
@@ -23,6 +23,7 @@ import pytest
 import yaml
 from fastapi import Request
 
+from nemo_gym.agent_execution_capture import AgentExecutionRecorder
 from nemo_gym.global_config import SKILLS_REF_KEY_NAME
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
@@ -38,6 +39,7 @@ from responses_api_agents.claude_code_agent.app import (
     ClaudeCodeAgentRunRequest,
     ModelServerRef,
     ResourcesServerRef,
+    _ClaudeStreamObserver,
     _extract_instruction,
     parse_stream_json,
 )
@@ -73,6 +75,32 @@ def _event(type_: str, **kwargs) -> str:
     return json.dumps({"type": type_, **kwargs})
 
 
+def _assistant_tool_event(
+    response_id: str,
+    tool_call_id: str,
+    name: str,
+    *,
+    parent_id: str | None = None,
+    tool_input: dict | None = None,
+) -> dict:
+    return {
+        "type": "assistant",
+        "message": {
+            "id": response_id,
+            "content": [{"type": "tool_use", "id": tool_call_id, "name": name, "input": tool_input or {}}],
+        },
+        "parent_tool_use_id": parent_id,
+    }
+
+
+def _tool_result_event(tool_call_id: str, *, parent_id: str | None = None, is_error: bool = False) -> dict:
+    return {
+        "type": "user",
+        "message": {"content": [{"type": "tool_result", "tool_use_id": tool_call_id, "is_error": is_error}]},
+        "parent_tool_use_id": parent_id,
+    }
+
+
 class FakeAioHTTPResponse:
     ok = True
 
@@ -82,6 +110,30 @@ class FakeAioHTTPResponse:
 
     async def read(self) -> bytes:
         return json.dumps(self.payload).encode()
+
+
+class FakeStreamProc:
+    def __init__(self, stdout: bytes, *, wait_for_kill: bool = False) -> None:
+        self.returncode = None if wait_for_kill else 0
+        self.wait_for_kill = wait_for_kill
+        self.killed = asyncio.Event()
+        self.stdout = asyncio.StreamReader()
+        self.stdout.feed_data(stdout)
+        self.stderr = asyncio.StreamReader()
+        if not wait_for_kill:
+            self.stdout.feed_eof()
+            self.stderr.feed_eof()
+
+    async def wait(self) -> int:
+        if self.wait_for_kill:
+            await self.killed.wait()
+        return self.returncode if self.returncode is not None else 0
+
+    def kill(self) -> None:
+        self.returncode = -9
+        self.stdout.feed_eof()
+        self.stderr.feed_eof()
+        self.killed.set()
 
 
 class TestSanity:
@@ -312,6 +364,30 @@ class TestRunForwardsSkillsPath:
 
 
 class TestRunClaudeCode:
+    def _run_captured(
+        self,
+        tmp_path: Path,
+        agent: ClaudeCodeAgent,
+        recorder: AgentExecutionRecorder,
+        stdout: bytes,
+        *,
+        wait_for_kill: bool = False,
+    ) -> tuple[str, FakeStreamProc]:
+        processes = []
+
+        async def fake_exec(*cmd, **kwargs):
+            process = FakeStreamProc(stdout, wait_for_kill=wait_for_kill)
+            processes.append(process)
+            return process
+
+        with (
+            patch("responses_api_agents.claude_code_agent.app.Path.home", return_value=tmp_path),
+            patch.object(agent, "_resolve_base_url", return_value="http://model-server:9000"),
+            patch("responses_api_agents.claude_code_agent.app.asyncio.create_subprocess_exec", fake_exec),
+        ):
+            result, _ = asyncio.run(agent._run_claude_code("hello", execution_recorder=recorder))
+        return result, processes[0]
+
     def test_wires_command_env_and_cleans_up(self, tmp_path: Path) -> None:
         agent = _make_agent(mcp_config="/path/to/mcp.json")
         captured: dict = {}
@@ -376,6 +452,83 @@ class TestRunClaudeCode:
         assert captured["skill_staged"] is True
         # skills present => --bare must be dropped even though config.bare is True
         assert "--bare" not in captured["cmd"]
+
+    def test_execution_recorder_observes_stream_while_process_runs(self, tmp_path: Path) -> None:
+        agent = _make_agent(model_server=ModelServerRef(type="responses_api_models", name="policy"))
+        recorder = AgentExecutionRecorder("0-0", "claude_code_agent")
+        lines = [
+            _event(
+                "assistant",
+                message={
+                    "id": "msg-1",
+                    "content": [{"type": "tool_use", "id": "tool-1", "name": "Bash", "input": {}}],
+                },
+                parent_tool_use_id=None,
+            ),
+            _event(
+                "user",
+                message={"content": [{"type": "tool_result", "tool_use_id": "tool-1"}]},
+                parent_tool_use_id=None,
+            ),
+        ]
+
+        stdout, _ = self._run_captured(tmp_path, agent, recorder, ("\n".join(lines) + "\n").encode())
+
+        assert stdout == "\n".join(lines) + "\n"
+        capture = recorder.capture()
+        assert capture.model_call_links[0].response_id == "msg-1"
+        assert capture.tool_spans[0].tool_call_id == "tool-1"
+
+    def test_execution_recorder_accepts_stream_event_larger_than_reader_limit(self, tmp_path: Path) -> None:
+        agent = _make_agent(model_server=ModelServerRef(type="responses_api_models", name="policy"))
+        recorder = AgentExecutionRecorder("0-0", "claude_code_agent")
+        line = _event(
+            "assistant",
+            message={"id": "msg-large", "content": [{"type": "text", "text": "x" * (70 * 1024)}]},
+            parent_tool_use_id=None,
+        )
+
+        stdout, _ = self._run_captured(tmp_path, agent, recorder, f"{line}\n".encode())
+
+        assert stdout == f"{line}\n"
+        assert recorder.capture().model_call_links[0].response_id == "msg-large"
+
+    def test_execution_recorder_timeout_kills_process(self, tmp_path: Path) -> None:
+        agent = _make_agent(timeout=0)
+        recorder = AgentExecutionRecorder("0-0", "claude_code_agent")
+        stdout, process = self._run_captured(tmp_path, agent, recorder, b"", wait_for_kill=True)
+
+        assert stdout == ""
+        assert process.killed.is_set()
+        assert recorder.capture().warnings == ["claude_code_timeout"]
+
+    def test_execution_recorder_cancellation_kills_and_drains_process(self, tmp_path: Path) -> None:
+        agent = _make_agent()
+        recorder = AgentExecutionRecorder("0-0", "claude_code_agent")
+        process = None
+        process_created = asyncio.Event()
+
+        async def fake_exec(*cmd, **kwargs):
+            nonlocal process
+            process = FakeStreamProc(b"", wait_for_kill=True)
+            process_created.set()
+            return process
+
+        async def run_and_cancel() -> None:
+            task = asyncio.create_task(agent._run_claude_code("hello", execution_recorder=recorder))
+            await process_created.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        with (
+            patch("responses_api_agents.claude_code_agent.app.Path.home", return_value=tmp_path),
+            patch("responses_api_agents.claude_code_agent.app.asyncio.create_subprocess_exec", fake_exec),
+        ):
+            asyncio.run(run_and_cancel())
+
+        assert process is not None
+        assert process.killed.is_set()
 
     def test_bad_skills_path_does_not_leak_config_dir(self, tmp_path: Path) -> None:
         # stage_skills raises for a missing skills dir; the partially-created config dir must
@@ -645,6 +798,77 @@ class TestRolloutCorrelation:
         # so a prefix would 404 every /v1/messages call.
         anthropic = _make_agent(anthropic_base_url="https://api.anthropic.com")
         assert anthropic._resolve_call_base_url("t3-r1") == "https://api.anthropic.com"
+
+
+class TestClaudeStreamObserver:
+    def _recorder(
+        self, clock, *, model_server: str | None = "policy"
+    ) -> tuple[AgentExecutionRecorder, _ClaudeStreamObserver]:
+        recorder = AgentExecutionRecorder("0-0", "claude_code_agent")
+        model_ref = ModelServerRef(type="responses_api_models", name=model_server) if model_server else None
+        observer = _ClaudeStreamObserver(recorder, model_ref=model_ref, clock=clock, wall_clock=lambda: 1.0)
+        return recorder, observer
+
+    def test_parallel_tool_events_keep_individual_overlapping_intervals(self) -> None:
+        recorder, observer = self._recorder(iter([10, 20, 50, 80]).__next__)
+        observer.observe(_assistant_tool_event("msg-1", "a", "Bash"))
+        observer.observe(_assistant_tool_event("msg-1", "b", "Read"))
+        observer.observe(_tool_result_event("a"))
+        observer.observe(_tool_result_event("b", is_error=True))
+
+        spans = {span.tool_call_id: span for span in recorder.capture().tool_spans}
+        assert (spans["a"].started_ns, spans["a"].ended_ns, spans["a"].status) == (10, 50, "returned")
+        assert (spans["b"].started_ns, spans["b"].ended_ns, spans["b"].status) == (20, 80, "returned")
+        assert spans["a"].reported_error is False
+        assert spans["b"].reported_error is True
+        assert spans["b"].started_ns < spans["a"].ended_ns
+        assert recorder.capture().model_call_links[0].response_id == "msg-1"
+
+    def test_nested_agent_events_form_tree_and_attribute_model_calls(self) -> None:
+        recorder, observer = self._recorder(iter([10, 20, 30, 40, 50, 60]).__next__)
+        events = [
+            _assistant_tool_event("msg-root", "child", "Agent", tool_input={"subagent_type": "Explore"}),
+            _assistant_tool_event("msg-child", "grandchild", "Task", parent_id="child"),
+            _assistant_tool_event("msg-grandchild", "bash", "Bash", parent_id="grandchild"),
+            _tool_result_event("bash", parent_id="grandchild"),
+            _tool_result_event("grandchild", parent_id="child"),
+            _tool_result_event("child"),
+        ]
+        for event in events:
+            observer.observe(event)
+        observer.finish()
+
+        capture = recorder.capture()
+        assert [(item.id, item.parent_id, item.source) for item in capture.agent_invocations] == [
+            ("root", None, "claude_code_agent"),
+            ("child", "root", "Explore"),
+            ("grandchild", "child", "Task"),
+        ]
+        assert [(link.agent_invocation_id, link.response_id) for link in capture.model_call_links] == [
+            ("root", "msg-root"),
+            ("child", "msg-child"),
+            ("grandchild", "msg-grandchild"),
+        ]
+        assert [item.status for item in capture.agent_invocations] == ["started", "completed", "completed"]
+
+    def test_agent_request_without_child_events_retains_attempted_invocation(self) -> None:
+        recorder, observer = self._recorder(iter([10, 20]).__next__)
+        observer.observe(_assistant_tool_event("msg-root", "child", "Agent"))
+
+        child = recorder.capture().agent_invocations[1]
+        assert (child.id, child.parent_id, child.status, child.spawn_response_id) == (
+            "child",
+            "root",
+            "requested",
+            "msg-root",
+        )
+
+    def test_external_model_response_id_is_not_emitted_as_capture_link(self) -> None:
+        recorder, observer = self._recorder(iter([10, 20]).__next__, model_server=None)
+        observer.observe(_assistant_tool_event("msg-external", "tool", "Bash"))
+        observer.observe(_tool_result_event("tool"))
+
+        assert recorder.capture().model_call_links == []
 
 
 class TestExtractInstruction:

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+from contextlib import nullcontext
 from typing import List
 
 from fastapi import Request, Response
@@ -63,6 +64,12 @@ class SimpleAgentVerifyResponse(BaseVerifyResponse):
 class SimpleAgent(SimpleResponsesAPIAgent):
     config: SimpleAgentConfig
 
+    def captures_agent_execution(self) -> bool:
+        return True
+
+    def agent_execution_capture_requires_single_worker(self) -> bool:
+        return True
+
     async def responses(
         self,
         request: Request,
@@ -79,6 +86,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         step = 0
         model_server_cookies = None  # update the cookies on every model response
         resources_server_cookies = request.cookies  # update the cookies on every resources server response
+        execution_recorder = self.agent_execution_recorder_for_request(request)
 
         while True:
             step += 1
@@ -100,6 +108,11 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 raise RuntimeError(
                     f"Received an invalid response from model server: {json.dumps(model_response_json)}"
                 ) from e
+            if execution_recorder is not None:
+                execution_recorder.add_model_call_link(
+                    response_id=model_response.id,
+                    model_ref=self.config.model_server,
+                )
 
             output = model_response.output
             new_outputs.extend(output)
@@ -145,19 +158,31 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                     new_outputs.append(tool_response)
                     continue
 
-                api_response = await self.server_client.post(
-                    server_name=self.config.resources_server.name,
-                    url_path=f"/{output_function_call.name}",
-                    json=parsed_arguments,
-                    cookies=resources_server_cookies,
+                tool_span = (
+                    execution_recorder.tool_span(
+                        tool_call_id=output_function_call.call_id,
+                        measurement_scope="caller_round_trip",
+                        model_ref=self.config.model_server,
+                        model_response_id=model_response.id,
+                    )
+                    if execution_recorder is not None
+                    else nullcontext()
                 )
-                # We don't raise for status here since it's a valid return for the API to error e.g. if the model outputs an invalid call or something.
-                resources_server_cookies = api_response.cookies
+                with tool_span:
+                    api_response = await self.server_client.post(
+                        server_name=self.config.resources_server.name,
+                        url_path=f"/{output_function_call.name}",
+                        json=parsed_arguments,
+                        cookies=resources_server_cookies,
+                    )
+                    # We don't raise for status here since it's a valid return for the API to error e.g. if the model outputs an invalid call or something.
+                    resources_server_cookies = api_response.cookies
+                    tool_output = (await api_response.content.read()).decode()
 
                 tool_response = NeMoGymFunctionCallOutput(
                     type="function_call_output",
                     call_id=output_function_call.call_id,
-                    output=(await api_response.content.read()).decode(),
+                    output=tool_output,
                 )
                 new_outputs.append(tool_response)
 

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, call
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 
+from nemo_gym.agent_execution_capture import AgentExecutionRecorder
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymFunctionCallOutput,
@@ -271,6 +272,75 @@ class TestApp:
         # The exception type must be visible to the model — repr(e) on a
         # JSONDecodeError starts with the class name.
         assert "JSONDecodeError" in error_payload["error"]
+
+    async def test_responses_records_individual_tool_timing(self) -> None:
+        config = SimpleAgentConfig(
+            host="",
+            port=0,
+            entrypoint="",
+            name="test_agent",
+            model_server=ModelServerRef(type="responses_api_models", name="test_model"),
+            resources_server=ResourcesServerRef(type="resources_servers", name="test_resources"),
+        )
+        server = SimpleAgent(config=config, server_client=MagicMock(spec=ServerClient))
+        clock = iter([100, 250])
+        recorder = AgentExecutionRecorder(
+            "0.0",
+            config.name,
+            clock=lambda: next(clock),
+            wall_clock=iter([1.0, 1.5]).__next__,
+            clock_id="test-clock",
+        )
+        lock, recorders = server._agent_execution_state()
+        with lock:
+            recorders[recorder.rollout_id] = recorder
+
+        def response(response_id: str, output: list[dict]) -> dict:
+            return {
+                "id": response_id,
+                "created_at": 0.0,
+                "model": "test_model",
+                "object": "response",
+                "output": output,
+                "parallel_tool_calls": False,
+                "tool_choice": "auto",
+                "tools": [],
+            }
+
+        tool_model_response = response(
+            "resp_tool",
+            [{"id": "fc_1", "call_id": "call_1", "name": "lookup", "arguments": "{}", "type": "function_call"}],
+        )
+        final_model_response = response(
+            "resp_final",
+            [{"id": "msg_1", "content": [], "role": "assistant", "status": "completed", "type": "message"}],
+        )
+        first_model_http = MagicMock(
+            ok=True, cookies={}, read=AsyncMock(return_value=json.dumps(tool_model_response).encode())
+        )
+        tool_http = MagicMock(ok=True, cookies={}, content=MagicMock(read=AsyncMock(return_value=b"result")))
+        final_model_http = MagicMock(
+            ok=True, cookies={}, read=AsyncMock(return_value=json.dumps(final_model_response).encode())
+        )
+        server.server_client.post = AsyncMock(side_effect=[first_model_http, tool_http, final_model_http])
+
+        request = MagicMock(cookies={}, path_params={"rollout_id": recorder.rollout_id})
+        response = MagicMock()
+        await server.responses(
+            request,
+            response,
+            NeMoGymResponseCreateParamsNonStreaming(input=[{"role": "user", "content": "hello"}]),
+        )
+
+        capture = recorder.capture()
+        span = capture.tool_spans[0]
+        assert (span.tool_call_id, span.measurement_scope) == ("call_1", "caller_round_trip")
+        assert (span.started_ns, span.ended_ns, span.status, span.clock_id) == (100, 250, "returned", "test-clock")
+        assert (span.model_ref, span.model_response_id) == (config.model_server, "resp_tool")
+        assert [(link.model_ref, link.response_id) for link in capture.model_call_links] == [
+            (config.model_server, "resp_tool"),
+            (config.model_server, "resp_final"),
+        ]
 
     async def test_responses_continues_on_reasoning_only(self, monkeypatch: MonkeyPatch) -> None:
         config = SimpleAgentConfig(

--- a/tests/unit_tests/test_agent_execution_capture.py
+++ b/tests/unit_tests/test_agent_execution_capture.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import Body
+from fastapi.testclient import TestClient
+from pydantic import ConfigDict, ValidationError
+
+from nemo_gym.agent_execution_capture import (
+    AgentExecutionCapture,
+    AgentExecutionCaptureStore,
+    AgentExecutionRecorder,
+    AgentInvocationRecord,
+    ModelCallLink,
+    clear_agent_execution_captures_for_rollouts,
+    merge_agent_execution_capture_into_record,
+)
+from nemo_gym.base_resources_server import BaseRunRequest
+from nemo_gym.base_responses_api_agent import BaseResponsesAPIAgentConfig, SimpleResponsesAPIAgent
+from nemo_gym.config_types import ModelServerRef
+from nemo_gym.server_utils import ServerClient
+
+
+MODEL_REF = ModelServerRef(type="responses_api_models", name="policy")
+
+
+def test_recorder_captures_tool_span_and_model_link() -> None:
+    ticks = iter([10, 40])
+    wall_times = iter([1.0, 1.5])
+    recorder = AgentExecutionRecorder(
+        "2-3",
+        "simple_agent",
+        clock=lambda: next(ticks),
+        wall_clock=lambda: next(wall_times),
+    )
+
+    recorder.add_model_call_link(response_id="response-1", model_ref=MODEL_REF)
+    with recorder.tool_span(
+        tool_call_id="call-1",
+        measurement_scope="caller_round_trip",
+        model_ref=MODEL_REF,
+        model_response_id="response-1",
+    ):
+        pass
+
+    capture = recorder.capture()
+    assert capture.model_call_links == [
+        ModelCallLink(agent_invocation_id="root", model_ref=MODEL_REF, response_id="response-1")
+    ]
+    span = capture.tool_spans[0]
+    assert (span.tool_call_id, span.agent_invocation_id, span.model_response_id) == ("call-1", "root", "response-1")
+    assert (span.started_ns, span.ended_ns, span.duration_ms, span.status) == (10, 40, 0.00003, "returned")
+    assert (span.started_at, span.completed_at, span.clock_id) == (1.0, 1.5, recorder.clock_id)
+
+
+def test_tool_span_preserves_original_error_when_recording_fails() -> None:
+    reads = 0
+
+    def clock() -> int:
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            return 100
+        raise RuntimeError("clock failed")
+
+    recorder = AgentExecutionRecorder("0-0", "agent", clock=clock, wall_clock=lambda: 1.0)
+    with pytest.raises(ValueError, match="tool failed"):
+        with recorder.tool_span(tool_call_id="call", measurement_scope="caller_round_trip"):
+            raise ValueError("tool failed")
+
+    assert recorder.capture().tool_spans == []
+    assert recorder.capture().warnings == ["tool_span_recording_failed"]
+
+
+def test_capture_accepts_forest_and_rejects_invalid_parent_graph() -> None:
+    forest = AgentExecutionCapture(
+        rollout_id="0-0",
+        agent_server="agent",
+        agent_invocations=[
+            AgentInvocationRecord(id="root-a", source="agent"),
+            AgentInvocationRecord(id="root-b", source="agent"),
+        ],
+    )
+    assert len(forest.agent_invocations) == 2
+
+    with pytest.raises(ValidationError, match="cycle"):
+        AgentExecutionCapture(
+            rollout_id="0-0",
+            agent_server="agent",
+            agent_invocations=[
+                AgentInvocationRecord(id="root", source="agent"),
+                AgentInvocationRecord(id="a", parent_id="b", source="agent"),
+                AgentInvocationRecord(id="b", parent_id="a", source="agent"),
+            ],
+        )
+
+    with pytest.raises(ValidationError, match="multiple agent invocations"):
+        AgentExecutionCapture(
+            rollout_id="0-0",
+            agent_server="agent",
+            agent_invocations=[
+                AgentInvocationRecord(id="root", source="agent"),
+                AgentInvocationRecord(id="child", parent_id="root", source="agent"),
+            ],
+            model_call_links=[
+                ModelCallLink(agent_invocation_id="root", model_ref=MODEL_REF, response_id="response-1"),
+                ModelCallLink(agent_invocation_id="child", model_ref=MODEL_REF, response_id="response-1"),
+            ],
+        )
+
+
+def test_store_merge_and_clear(tmp_path: Path) -> None:
+    recorder = AgentExecutionRecorder("1-2", "agent")
+    recorder.add_model_call_link(response_id="r0", model_ref=MODEL_REF)
+    store = AgentExecutionCaptureStore(tmp_path)
+    store.write(recorder.capture())
+
+    record = {"_ng_task_index": 1, "_ng_rollout_index": 2, "reward": 1.0}
+    merge_agent_execution_capture_into_record(record, [tmp_path])
+    assert record["ng_agent_execution_capture"]["model_call_links"][0]["response_id"] == "r0"
+
+    clear_agent_execution_captures_for_rollouts([record], [tmp_path])
+    assert store.read("1-2") is None
+
+
+class _RunRequest(BaseRunRequest):
+    model_config = ConfigDict(extra="allow")
+
+
+def _capture_agent(tmp_path: Path, *, enabled: bool = True, run_raises: bool = False):
+    class _Agent(SimpleResponsesAPIAgent):
+        def captures_agent_execution(self) -> bool:
+            return True
+
+        async def responses(self, body=Body()):
+            raise NotImplementedError
+
+        async def run(self, body: _RunRequest = Body()):
+            assert (self.agent_execution_recorder_for_run(body) is not None) is enabled
+            if run_raises:
+                raise RuntimeError("run failed")
+            return {"ok": True}
+
+    server_client = MagicMock(spec=ServerClient)
+    server_client.global_config_dict = {
+        "observability_enabled": enabled,
+        "model_call_capture_dir": str(tmp_path),
+    }
+    config = BaseResponsesAPIAgentConfig(host="", port=0, entrypoint="", name="agent")
+    return _Agent(config=config, server_client=server_client)
+
+
+@pytest.mark.parametrize("run_raises", [False, True])
+def test_run_route_flushes_capture_without_replacing_result_or_error(tmp_path: Path, run_raises: bool) -> None:
+    agent = _capture_agent(tmp_path, run_raises=run_raises)
+    request = {
+        "responses_create_params": {"input": []},
+        "_ng_task_index": 3,
+        "_ng_rollout_index": 4,
+    }
+
+    if run_raises:
+        with pytest.raises(RuntimeError, match="run failed"):
+            TestClient(agent.setup_webserver()).post("/run", json=request)
+    else:
+        response = TestClient(agent.setup_webserver()).post("/run", json=request)
+        assert response.json() == {"ok": True}
+
+    capture = AgentExecutionCaptureStore(tmp_path).read("3-4")
+    assert capture is not None
+    assert capture.agent_invocations[0].status == ("failed" if run_raises else "completed")
+
+
+def test_capture_disabled_creates_no_recorder_or_file(tmp_path: Path) -> None:
+    agent = _capture_agent(tmp_path, enabled=False)
+    response = TestClient(agent.setup_webserver()).post(
+        "/run",
+        json={
+            "responses_create_params": {"input": []},
+            "_ng_task_index": 3,
+            "_ng_rollout_index": 4,
+        },
+    )
+
+    assert response.status_code == 200
+    assert not tmp_path.exists() or not list(tmp_path.iterdir())
+
+
+@pytest.mark.asyncio
+async def test_cancelled_finalization_waits_for_capture_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    agent = _capture_agent(tmp_path)
+    recorder = AgentExecutionRecorder("3-4", "agent")
+    lock, recorders = agent._agent_execution_state()
+    with lock:
+        recorders[recorder.rollout_id] = recorder
+
+    write_started = threading.Event()
+    release_write = threading.Event()
+    original_write = AgentExecutionCaptureStore.write
+
+    def delayed_write(store, capture) -> None:
+        write_started.set()
+        release_write.wait()
+        original_write(store, capture)
+
+    monkeypatch.setattr(AgentExecutionCaptureStore, "write", delayed_write)
+    task = asyncio.create_task(agent._finish_agent_execution_capture(recorder))
+    await asyncio.to_thread(write_started.wait)
+    task.cancel()
+    await asyncio.sleep(0)
+    try:
+        assert not task.done()
+    finally:
+        release_write.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert AgentExecutionCaptureStore(tmp_path).read("3-4") is not None
+    with lock:
+        assert "3-4" not in recorders

--- a/tests/unit_tests/test_base_responses_api_model.py
+++ b/tests/unit_tests/test_base_responses_api_model.py
@@ -135,6 +135,7 @@ def test_build_model_call_record_from_exchange():
         "latency_ms": 18.4,
         "request": {"input": "hi"},
         "response": {
+            "id": "response-3",
             "model": "m",
             "usage": {
                 "input_tokens": 10,
@@ -154,6 +155,7 @@ def test_build_model_call_record_from_exchange():
     assert rec.model_call_id == "call-1"
     assert rec.call_index == 3
     assert rec.model_ref is not None and rec.model_ref.name == "srv"
+    assert rec.response_id == "response-3"
     assert rec.dialect == "responses"
     assert rec.started_at == 100.0 and rec.completed_at == 100.02
     assert (rec.tokens_in, rec.tokens_out, rec.tokens_total, rec.tokens_reasoning) == (10, 5, 15, 3)
@@ -167,6 +169,7 @@ def test_build_model_call_record_from_exchange():
         "model_ref",
         "dialect",
         "status_code",
+        "response_id",
         "started_at",
         "completed_at",
         "tokens_in",
@@ -856,7 +859,11 @@ def test_reconstruct_chat_sse():
     from nemo_gym.base_responses_api_model import _reconstruct_streamed_response
 
     chunks = [
-        {"model": "m", "choices": [{"index": 0, "delta": {"role": "assistant", "content": "Hel"}}]},
+        {
+            "id": "chatcmpl-1",
+            "model": "m",
+            "choices": [{"index": 0, "delta": {"role": "assistant", "content": "Hel"}}],
+        },
         {"choices": [{"index": 0, "delta": {"content": "lo", "reasoning": "hmm"}}]},  # vLLM `reasoning` alias
         {
             "choices": [
@@ -884,6 +891,7 @@ def test_reconstruct_chat_sse():
     msg = resp["choices"][0]["message"]
     assert msg["content"] == "Hello" and msg["reasoning_content"] == "hmm"
     assert msg["tool_calls"][0]["function"] == {"name": "f", "arguments": '{"a":1}'}
+    assert resp["id"] == "chatcmpl-1"
     assert resp["usage"]["total_tokens"] == 8
 
 
@@ -949,7 +957,7 @@ def _capture_exchange(dialect, model_server, usage, response):
         "status_code": 200,
         "error_category": None,
         "request": {"input": "hi"},
-        "response": {"model": "m", "usage": usage, **response},
+        "response": {"id": f"response-{model_server}", "model": "m", "usage": usage, **response},
     }
 
 
@@ -977,6 +985,7 @@ def test_merge_capture_attaches_metrics_without_raw_payloads(tmp_path):
     attached_call = capture["calls"][0]
     assert attached_call["model_call_id"] == "call-A"
     assert attached_call["model_ref"] == {"type": "responses_api_models", "name": "A"}
+    assert attached_call["response_id"] == "response-A"
     assert attached_call["started_at"] == 100.0 and attached_call["completed_at"] == 100.01
     assert attached_call["tokens_in"] == 3
     assert "request" not in attached_call and "response" not in attached_call

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -664,6 +664,7 @@ class TestRolloutCollection:
     async def test_run_from_config_replaces_stale_capture_before_dispatch(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, resume_from_cache: bool
     ) -> None:
+        from nemo_gym.agent_execution_capture import AgentExecutionCaptureStore, AgentExecutionRecorder
         from nemo_gym.base_responses_api_model import CaptureStore
 
         capture_dir = tmp_path / "captures"
@@ -690,17 +691,21 @@ class TestRolloutCollection:
             input_fpath.write_bytes(orjson.dumps(source_row) + b"\n")
 
         store = CaptureStore(capture_dir)
+        agent_store = AgentExecutionCaptureStore(capture_dir)
         store.record("0-0", {"model_call_id": "stale", "dialect": "responses", "request": {}, "response": {}})
+        agent_store.write(AgentExecutionRecorder("0-0", "stale-agent").capture())
 
         class Helper(RolloutCollectionHelper):
             def run_examples(self, examples, *args, **kwargs):
                 [example] = examples
                 assert example[TASK_INDEX_KEY_NAME] == 0 and example[ROLLOUT_INDEX_KEY_NAME] == 0
                 assert store.read("0-0") == []
+                assert agent_store.read("0-0") is None
                 store.record(
                     "0-0",
                     {"model_call_id": "fresh", "dialect": "responses", "request": {}, "response": {}},
                 )
+                agent_store.write(AgentExecutionRecorder("0-0", "fresh-agent").capture())
                 future = Future()
                 future.set_result((example, {"response": {"usage": {}}}))
                 return [future]
@@ -709,6 +714,7 @@ class TestRolloutCollection:
 
         assert [exchange["model_call_id"] for exchange in store.read("0-0")] == ["fresh"]
         assert [call["model_call_id"] for call in results[0]["ng_model_call_capture"]["calls"]] == ["fresh"]
+        assert results[0]["ng_agent_execution_capture"]["agent_server"] == "fresh-agent"
 
     async def test_run_from_config_sorted(self, tmp_path: Path, empty_global_config: MagicMock) -> None:
         input_jsonl_fpath = tmp_path / "input.jsonl"


### PR DESCRIPTION
## Scope

[#1715](https://github.com/NVIDIA-NeMo/Gym/pull/1715) captures rollout-correlated model calls. This PR adds the agent-side evidence needed to describe which agent invocation owned those calls and how long agent-observed tool calls took.

The collector attaches this evidence as `ng_agent_execution_capture`, beside `ng_model_call_capture`. It does not define a canonical trajectory or ATIF representation, and it does not change `NeMoGymResponse`, rewards, token IDs, log probabilities, or the training path.

## Evidence

Each attachment contains:

- `agent_invocations`: invocation ID, parent ID, source, lifecycle status, and the model response that requested a child;
- `tool_spans`: owning invocation, tool-call ID, model-call attribution when available, monotonic and wall-clock bounds, duration, boundary status, and reported tool errors;
- `model_call_links`: `(model_ref, response_id)` keys that join an invocation to #1715 model-call records;
- `warnings`: machine-readable capture gaps.

`ModelCallRecord` gains `response_id`. Streamed Chat Completions reconstruction retains the upstream response ID so the same join works for streamed calls.

## Producers

| Producer | Invocation evidence | Tool timing |
|---|---|---|
| Simple Agent | Root invocation and model-response attribution | Caller round trip for each dispatched Gym tool call |
| Claude Code | Parent-linked `Agent` / `Task` invocations using emitted `parent_tool_use_id`, plus model-response attribution from emitted message IDs | Interval between emitted `tool_use` and `tool_result` events; parallel calls retain independent, overlapping intervals |

Claude Code timing is an event-stream observation interval, not an internal executor measurement. Simple Agent capture uses a process-local self-call association and is therefore disabled when that agent is configured with multiple workers. Other agents are unchanged and emit no agent-execution attachment.

## Capture lifecycle

This PR reuses the #1715 configuration:

```yaml
observability_enabled: true
model_call_capture_dir: /absolute/shared/path/model-calls
```

For an instrumented `/run` request with a rollout ID, the Agent Server records evidence in memory and atomically publishes one agent-owned capture file. Rollout collection clears stale files before dispatch and attaches the completed capture without altering the agent response or reward. Final writes are awaited off the event loop; cancellation waits for an in-flight write, and Claude subprocess cleanup remains bounded.

The current persistence invariant is one active `/run` owner per rollout ID. Cross-process duplicate ownership requires a lease or multi-fragment assembly design and is outside this PR.

## Deliberate limits

- This is raw evidence, not a materialized conversation tree.
- No ATIF projection or training representation is introduced.
- Black-box lineage and timing are limited to events the harness emits.
- Tool outputs, compaction events, CPU usage, and sandbox/container metrics are not added here.

## Validation

- 175 focused tests across the capture model, Agent Server lifecycle, model-call joins, rollout collection, Simple Agent, and Claude Code;
- nested and attempted subagents, duplicate model ownership, overlapping tool intervals, tool error reporting, events larger than 64 KiB, timeout/cancellation cleanup, and cancellation-safe persistence;
- Ruff formatting and lint checks.
