### PR TITLE
fix(tau2): tolerate rollout rows without result in aggregate metrics

### DIFF
--- a/responses_api_agents/tau2/app.py
+++ b/responses_api_agents/tau2/app.py
@@ -250,7 +250,15 @@ class Tau2Agent(SimpleResponsesAPIAgent):
                     subtask = task["task"]["id"].split("]")[0].removeprefix("[")
                     telecom_subtask_rewards[f"telecom/{subtask}/reward"].append(task["reward"])
 
-                termination_reason = task["result"]["termination_reason"]
+                result = task.get("result")
+                if result is None:
+                    reason = "soft_failed" if task.get("_ng_soft_failed") else "missing_result"
+                    termination_reason_count[f"trajectory_termination_reason/{reason}/count"] += 1
+                    termination_reason_domain_count[f"{domain}/trajectory_termination_reason/{reason}/count"] += 1
+                    total_count += 1
+                    continue
+
+                termination_reason = result["termination_reason"]
                 termination_reason_count[f"trajectory_termination_reason/{termination_reason}/count"] += 1
                 termination_reason_domain_count[
                     f"{domain}/trajectory_termination_reason/{termination_reason}/count"
@@ -258,7 +266,7 @@ class Tau2Agent(SimpleResponsesAPIAgent):
 
                 this_task_transfer_to_human_agents = False
                 has_tool_call = False
-                for message in task["result"]["messages"]:
+                for message in result["messages"]:
                     if message["role"] == "tool":
                         # e.g. `Error: Tool 'run_speed_test' not found.`
                         if "Error: Tool" and "not found" in message["content"]:

--- a/responses_api_agents/tau2/tests/test_app.py
+++ b/responses_api_agents/tau2/tests/test_app.py
@@ -183,3 +183,25 @@ class TestApp:
             "messages_with_incomplete_reasoning/pct": 0.0,
         }
         assert expected_key_aggregate_metrics == actual_aggregate_metrics.key_metrics
+
+    async def test_compute_metrics_tolerates_soft_failed_rows(self) -> None:
+        example_rollouts_fpath = Path(__file__).parent.parent / "data" / "example_rollouts.jsonl"
+        with example_rollouts_fpath.open() as f:
+            rollouts = list(map(json.loads, f))
+
+        soft_failed_row = {
+            "config": {"domain": "retail"},
+            "reward": 0.0,
+            "_ng_soft_failed": True,
+            "_ng_soft_failure_stage": "agent_run",
+            "response": {"output": [], "usage": None, "error": {"message": "boom"}},
+        }
+        rollouts.append(soft_failed_row)
+
+        _, server = self._dummy_server()
+        actual_metrics = server.compute_metrics([rollouts])
+
+        assert actual_metrics["trajectory_termination_reason/soft_failed/count"] == 1
+        assert actual_metrics["retail/trajectory_termination_reason/soft_failed/count"] == 1
+        assert actual_metrics["retail/num_samples_total"] == 2
+        assert actual_metrics["retail/reward"] == 0.5


### PR DESCRIPTION
Rows synthesized by the soft-fail path (#2017) carry `reward` and forensic markers but no simulation `result`. tau2's `compute_metrics` indexed `task["result"]` unconditionally, so a single soft-failed row raised `KeyError` and failed `/aggregate_metrics` for the entire run.

This buckets result-less rows under a `soft_failed` (or `missing_result`) termination reason while keeping their reward in the domain means — full denominator, no aborted aggregation.

Stacked on #2017 (base branch set accordingly); retarget to `main` once that merges. Unit test included; existing aggregate test unchanged.