### PR TITLE
feat(opensandbox): add automatic job attribution (team/user/workload) to sandbox metadata

### DIFF
--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
@@ -139,6 +139,28 @@ Unknown provider option keys raise `ValueError`; values with the wrong type rais
 
 The provider also normalizes metadata values for backend labels by replacing unsupported characters and truncating values to the provider limit.
 
+## Job Attribution
+
+Every sandbox's metadata automatically includes `team`, `user`, and `workload` keys so cluster
+operators can attribute running sandboxes (OpenSandbox stores metadata as Kubernetes labels on
+the sandbox and supports filtering the list API by metadata, e.g. `team=my-team`).
+
+Each field resolves in order: the provider's `attribution` config, then `NEMO_GYM_TEAM` /
+`NEMO_GYM_USER` / `NEMO_GYM_WORKLOAD` environment variables, then Slurm job environment
+variables (`SLURM_JOB_ACCOUNT` / `SLURM_JOB_USER` / `SLURM_JOB_NAME`), then the OS login name
+for `user`. Fields that cannot be resolved are omitted. Explicit `sandbox_spec.metadata` and
+`default_metadata` keys always take precedence over attribution keys.
+
+```yaml
+sandbox:
+  opensandbox:
+    attribution:
+      enabled: true      # set false to disable automatic attribution
+      # team: my-team    # override auto-detection
+      # user: my-user
+      # workload: my-benchmark
+```
+
 ## Lifecycle
 
 The provider creates one OpenSandbox sandbox per Gym sandbox:

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
@@ -141,9 +141,15 @@ The provider also normalizes metadata values for backend labels by replacing uns
 
 ## Job Attribution
 
-Every sandbox's metadata automatically includes `team`, `user`, and `workload` keys so cluster
-operators can attribute running sandboxes (OpenSandbox stores metadata as Kubernetes labels on
-the sandbox and supports filtering the list API by metadata, e.g. `team=my-team`).
+Every sandbox's metadata automatically includes `nemo-gym.nvidia.com/team`,
+`nemo-gym.nvidia.com/user`, and `nemo-gym.nvidia.com/workload` keys. OpenSandbox propagates
+sandbox metadata as Kubernetes labels on the sandbox resources, so running sandboxes are
+attributable both through the OpenSandbox list API metadata filter and directly at the
+cluster level:
+
+```bash
+kubectl get pods -l nemo-gym.nvidia.com/team=my-team
+```
 
 Each field resolves in order: the provider's `attribution` config, then `NEMO_GYM_TEAM` /
 `NEMO_GYM_USER` / `NEMO_GYM_WORKLOAD` environment variables, then Slurm job environment
@@ -155,8 +161,9 @@ for `user`. Fields that cannot be resolved are omitted. Explicit `sandbox_spec.m
 sandbox:
   opensandbox:
     attribution:
-      enabled: true      # set false to disable automatic attribution
-      # team: my-team    # override auto-detection
+      enabled: true                       # set false to disable automatic attribution
+      key_prefix: nemo-gym.nvidia.com/    # label-key namespace; "" for bare team/user/workload keys
+      # team: my-team                     # override auto-detection
       # user: my-user
       # workload: my-benchmark
 ```

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
@@ -141,11 +141,11 @@ The provider also normalizes metadata values for backend labels by replacing uns
 
 ## Job Attribution
 
-Every sandbox's metadata automatically includes `nemo-gym.nvidia.com/team`,
-`nemo-gym.nvidia.com/user`, and `nemo-gym.nvidia.com/workload` keys. OpenSandbox propagates
-sandbox metadata as Kubernetes labels on the sandbox resources, so running sandboxes are
-attributable both through the OpenSandbox list API metadata filter and directly at the
-cluster level:
+The provider merges `nemo-gym.nvidia.com/team`, `nemo-gym.nvidia.com/user`,
+`nemo-gym.nvidia.com/workload`, and `nemo-gym.nvidia.com/run` keys into each sandbox's
+metadata when they can be resolved. OpenSandbox propagates sandbox metadata as Kubernetes
+labels on the sandbox resources, so running sandboxes are attributable both through the
+OpenSandbox list API metadata filter and directly at the cluster level:
 
 ```bash
 kubectl get pods -l nemo-gym.nvidia.com/team=my-team
@@ -153,19 +153,51 @@ kubectl get pods -l nemo-gym.nvidia.com/team=my-team
 
 Each field resolves in order: the provider's `attribution` config, then `NEMO_GYM_TEAM` /
 `NEMO_GYM_USER` / `NEMO_GYM_WORKLOAD` environment variables, then Slurm job environment
-variables (`SLURM_JOB_ACCOUNT` / `SLURM_JOB_USER` / `SLURM_JOB_NAME`), then the OS login name
-for `user`. Fields that cannot be resolved are omitted. Explicit `sandbox_spec.metadata` and
-`default_metadata` keys always take precedence over attribution keys.
+variables (`SLURM_JOB_ACCOUNT` / `SLURM_JOB_USER` / `SLURM_JOB_NAME`). `user` additionally
+falls back to the OS login name (`root` is ignored — containers run as root by default, so
+it would attribute the image, not a person), and `workload` to `NEMO_GYM_CONFIG_PATH`, the
+server instance name the gym CLI sets on every server process it spawns. Fields that cannot
+be resolved are omitted. Explicit `sandbox_spec.metadata` and `default_metadata` keys always
+take precedence over attribution keys.
+
+`run` identifies one launch of the creating process: `NEMO_GYM_RUN_ID` if set, else an id
+generated per process. The resolved attribution is logged once at the first sandbox create —
+note the `run` value from the logs to list or clean up exactly that run's sandboxes (for
+example after killing a run partway through), which `team` / `user` / `workload` cannot do
+when the same user launches the same workload twice:
+
+```bash
+kubectl delete batchsandboxes -l nemo-gym.nvidia.com/run=<run-id>
+```
 
 ```yaml
 sandbox:
   opensandbox:
     attribution:
       enabled: true                       # set false to disable automatic attribution
-      key_prefix: nemo-gym.nvidia.com/    # label-key namespace; "" for bare team/user/workload keys
+      key_prefix: nemo-gym.nvidia.com/    # label-key namespace; "" for bare team/user/workload/run keys
       # team: my-team                     # override auto-detection
       # user: my-user
       # workload: my-benchmark
+      # run: my-run-id
+```
+
+### Attribution in Kubernetes deployments
+
+When the gym servers themselves run in Kubernetes (for example a driver pod launching an
+eval), none of the automatic sources resolve: there are no Slurm variables, and the
+container's OS login is typically `root`, which is ignored. Set the `NEMO_GYM_*` variables
+on the pod spec — either directly or via the downward API from labels the pod already
+carries:
+
+```yaml
+env:
+  - name: NEMO_GYM_TEAM
+    value: my-team
+  - name: NEMO_GYM_USER
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.labels['owner']
 ```
 
 ## Lifecycle

--- a/nemo_gym/sandbox/attribution.py
+++ b/nemo_gym/sandbox/attribution.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Automatic job attribution (team / user / workload) for sandbox metadata.
+
+Sandbox providers merge these keys into every sandbox's metadata so cluster
+operators can attribute running sandboxes to the team, user, and workload that
+created them (on OpenSandbox, metadata becomes queryable Kubernetes labels on
+the sandbox). Each field resolves from explicit configuration first, then
+``NEMO_GYM_*`` environment variables, then Slurm job environment variables,
+then (for ``user`` only) the OS login name. Fields that cannot be resolved are
+omitted rather than guessed.
+"""
+
+import getpass
+import logging
+import os
+from collections.abc import Mapping
+
+
+LOGGER = logging.getLogger(__name__)
+
+TEAM_KEY = "team"
+USER_KEY = "user"
+WORKLOAD_KEY = "workload"
+
+TEAM_ENV_VARS = ("NEMO_GYM_TEAM", "SLURM_JOB_ACCOUNT")
+USER_ENV_VARS = ("NEMO_GYM_USER", "SLURM_JOB_USER")
+WORKLOAD_ENV_VARS = ("NEMO_GYM_WORKLOAD", "SLURM_JOB_NAME")
+
+
+def _first_env(environ: Mapping[str, str], names: tuple[str, ...]) -> str | None:
+    for name in names:
+        value = (environ.get(name) or "").strip()
+        if value:
+            return value
+    return None
+
+
+def _detect_user(environ: Mapping[str, str]) -> str | None:
+    value = _first_env(environ, USER_ENV_VARS)
+    if value:
+        return value
+    try:
+        return getpass.getuser().strip() or None
+    except Exception:
+        # getpass raises on hosts with neither login env vars nor a passwd entry for the uid.
+        return None
+
+
+def resolve_attribution(
+    *,
+    team: str | None = None,
+    user: str | None = None,
+    workload: str | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Resolve ``team`` / ``user`` / ``workload`` attribution metadata.
+
+    Args:
+        team: Explicit team; falls back to ``NEMO_GYM_TEAM``, then ``SLURM_JOB_ACCOUNT``.
+        user: Explicit user; falls back to ``NEMO_GYM_USER``, then ``SLURM_JOB_USER``,
+            then the OS login name.
+        workload: Explicit workload; falls back to ``NEMO_GYM_WORKLOAD``, then
+            ``SLURM_JOB_NAME``.
+        environ: Environment mapping override, for testing. Defaults to ``os.environ``.
+
+    Returns:
+        A dict with only the resolved keys among ``team``, ``user``, and ``workload``.
+        Values are returned raw; providers apply their own metadata sanitization.
+    """
+    environ = os.environ if environ is None else environ
+    resolved: dict[str, str] = {}
+    team = team or _first_env(environ, TEAM_ENV_VARS)
+    if team:
+        resolved[TEAM_KEY] = str(team)
+    user = user or _detect_user(environ)
+    if user:
+        resolved[USER_KEY] = str(user)
+    workload = workload or _first_env(environ, WORKLOAD_ENV_VARS)
+    if workload:
+        resolved[WORKLOAD_KEY] = str(workload)
+    return resolved

--- a/nemo_gym/sandbox/attribution.py
+++ b/nemo_gym/sandbox/attribution.py
@@ -12,20 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Automatic job attribution (team / user / workload) for sandbox metadata.
+"""Automatic job attribution (team / user / workload / run) for sandbox metadata.
 
 Sandbox providers merge these keys into every sandbox's metadata so cluster
 operators can attribute running sandboxes to the team, user, and workload that
 created them (on OpenSandbox, metadata becomes queryable Kubernetes labels on
 the sandbox). Each field resolves from explicit configuration first, then
 ``NEMO_GYM_*`` environment variables, then Slurm job environment variables,
-then (for ``user`` only) the OS login name. Fields that cannot be resolved are
-omitted rather than guessed.
+then (for ``user`` only) the OS login name and (for ``workload``) the server
+instance's config path. Fields that cannot be resolved are omitted rather than
+guessed.
+
+``run`` identifies one launch of the creating process so a run's sandboxes can
+be listed or garbage-collected exactly, even when the same user runs the same
+workload twice. It resolves from explicit configuration, then ``NEMO_GYM_RUN_ID``,
+then a per-process generated id.
 """
 
 import getpass
 import logging
 import os
+import uuid
 from collections.abc import Mapping
 
 
@@ -34,10 +41,23 @@ LOGGER = logging.getLogger(__name__)
 TEAM_KEY = "team"
 USER_KEY = "user"
 WORKLOAD_KEY = "workload"
+RUN_KEY = "run"
 
 TEAM_ENV_VARS = ("NEMO_GYM_TEAM", "SLURM_JOB_ACCOUNT")
 USER_ENV_VARS = ("NEMO_GYM_USER", "SLURM_JOB_USER")
-WORKLOAD_ENV_VARS = ("NEMO_GYM_WORKLOAD", "SLURM_JOB_NAME")
+# NEMO_GYM_CONFIG_PATH is set by the gym CLI on every server process it spawns
+# (see nemo_gym.global_config.NEMO_GYM_CONFIG_PATH_ENV_VAR_NAME, not imported
+# here to keep this module dependency-free) and names the server instance,
+# which is the best automatic description of the workload.
+WORKLOAD_ENV_VARS = ("NEMO_GYM_WORKLOAD", "SLURM_JOB_NAME", "NEMO_GYM_CONFIG_PATH")
+RUN_ENV_VARS = ("NEMO_GYM_RUN_ID",)
+
+# Container images default to running as root, so a "root" login attributes the
+# image, not a person. Treat it as unresolved instead of emitting a false identity.
+IGNORED_LOGIN_NAMES = frozenset({"root"})
+
+_process_run_id: str | None = None
+_logged_attribution = False
 
 
 def _first_env(environ: Mapping[str, str], names: tuple[str, ...]) -> str | None:
@@ -53,10 +73,13 @@ def _detect_user(environ: Mapping[str, str]) -> str | None:
     if value:
         return value
     try:
-        return getpass.getuser().strip() or None
+        login = getpass.getuser().strip()
     except Exception:
         # getpass raises on hosts with neither login env vars nor a passwd entry for the uid.
         return None
+    if not login or login.lower() in IGNORED_LOGIN_NAMES:
+        return None
+    return login
 
 
 def resolve_attribution(
@@ -71,9 +94,11 @@ def resolve_attribution(
     Args:
         team: Explicit team; falls back to ``NEMO_GYM_TEAM``, then ``SLURM_JOB_ACCOUNT``.
         user: Explicit user; falls back to ``NEMO_GYM_USER``, then ``SLURM_JOB_USER``,
-            then the OS login name.
+            then the OS login name (``root`` is ignored — containers run as root by
+            default, so it attributes the image, not a person).
         workload: Explicit workload; falls back to ``NEMO_GYM_WORKLOAD``, then
-            ``SLURM_JOB_NAME``.
+            ``SLURM_JOB_NAME``, then ``NEMO_GYM_CONFIG_PATH`` (the server instance
+            name the gym CLI sets on every server process it spawns).
         environ: Environment mapping override, for testing. Defaults to ``os.environ``.
 
     Returns:
@@ -92,3 +117,34 @@ def resolve_attribution(
     if workload:
         resolved[WORKLOAD_KEY] = str(workload)
     return resolved
+
+
+def resolve_run_id(run: str | None = None, environ: Mapping[str, str] | None = None) -> str:
+    """Resolve the ``run`` attribution id: explicit value, then ``NEMO_GYM_RUN_ID``,
+    then an id generated once per process.
+
+    Unlike :func:`resolve_attribution` fields, ``run`` is always resolvable. It scopes
+    sandboxes to one launch of the creating process, so an interrupted run's sandboxes
+    can be listed and cleaned up exactly (``team`` / ``user`` / ``workload`` cannot
+    distinguish two runs of the same workload by the same user).
+    """
+    global _process_run_id
+    resolved = (run or "").strip() or _first_env(os.environ if environ is None else environ, RUN_ENV_VARS)
+    if resolved:
+        return resolved
+    if _process_run_id is None:
+        _process_run_id = uuid.uuid4().hex[:12]
+    return _process_run_id
+
+
+def log_attribution_once(metadata: Mapping[str, str]) -> None:
+    """Log the resolved attribution metadata once per process.
+
+    The generated ``run`` id only exists in this process, so surfacing it in the logs
+    is what lets operators later filter or garbage-collect this run's sandboxes.
+    """
+    global _logged_attribution
+    if _logged_attribution or not metadata:
+        return
+    _logged_attribution = True
+    LOGGER.info("Sandbox attribution metadata: %s", dict(metadata))

--- a/nemo_gym/sandbox/providers/opensandbox/__init__.py
+++ b/nemo_gym/sandbox/providers/opensandbox/__init__.py
@@ -15,6 +15,7 @@
 """OpenSandbox provider package."""
 
 from nemo_gym.sandbox.providers.opensandbox.provider import (
+    OpenSandboxAttributionConfig,
     OpenSandboxConnectionConfig,
     OpenSandboxCreateConfig,
     OpenSandboxCreateError,
@@ -27,6 +28,7 @@ from nemo_gym.sandbox.providers.opensandbox.provider import (
 
 
 __all__ = [
+    "OpenSandboxAttributionConfig",
     "OpenSandboxConnectionConfig",
     "OpenSandboxCreateConfig",
     "OpenSandboxCreateError",

--- a/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
+++ b/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
@@ -44,15 +44,18 @@ sandbox:
       retry_max_delay_s: 45.0
       command_retries: 0
       close_timeout_s: 30
-    # Job attribution merged into every sandbox's metadata (Kubernetes labels on the
-    # sandbox), so cluster operators can attribute sandboxes to a team/user/workload
-    # (e.g. filter the OpenSandbox list API by `team=...`). Unset fields auto-detect
+    # Job attribution merged into every sandbox's metadata. OpenSandbox propagates
+    # metadata as Kubernetes labels on the sandbox resources, so sandboxes are
+    # attributable both via the OpenSandbox list API and at the cluster level, e.g.
+    # `kubectl get pods -l nemo-gym.nvidia.com/team=my-team`. Unset fields auto-detect
     # from NEMO_GYM_TEAM / NEMO_GYM_USER / NEMO_GYM_WORKLOAD, then Slurm job env vars
     # (SLURM_JOB_ACCOUNT / SLURM_JOB_USER / SLURM_JOB_NAME), then the OS login name
     # for `user`; unresolvable fields are omitted. Explicit sandbox_spec.metadata and
     # default_metadata keys always win over attribution keys.
     attribution:
       enabled: true
+      # Kubernetes prefixed-key namespace for the injected label keys; "" for bare keys.
+      key_prefix: nemo-gym.nvidia.com/
       # team: my-team
       # user: my-user
       # workload: my-benchmark

--- a/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
+++ b/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
@@ -49,9 +49,13 @@ sandbox:
     # attributable both via the OpenSandbox list API and at the cluster level, e.g.
     # `kubectl get pods -l nemo-gym.nvidia.com/team=my-team`. Unset fields auto-detect
     # from NEMO_GYM_TEAM / NEMO_GYM_USER / NEMO_GYM_WORKLOAD, then Slurm job env vars
-    # (SLURM_JOB_ACCOUNT / SLURM_JOB_USER / SLURM_JOB_NAME), then the OS login name
-    # for `user`; unresolvable fields are omitted. Explicit sandbox_spec.metadata and
-    # default_metadata keys always win over attribution keys.
+    # (SLURM_JOB_ACCOUNT / SLURM_JOB_USER / SLURM_JOB_NAME), then the OS login name for
+    # `user` ("root" is ignored) and the gym CLI's NEMO_GYM_CONFIG_PATH server instance
+    # name for `workload`; unresolvable fields are omitted. `run` scopes sandboxes to one
+    # launch of the creating process (NEMO_GYM_RUN_ID, else generated per process and
+    # logged) so an interrupted run's sandboxes can be listed and cleaned up exactly.
+    # Explicit sandbox_spec.metadata and default_metadata keys always win over
+    # attribution keys.
     attribution:
       enabled: true
       # Kubernetes prefixed-key namespace for the injected label keys; "" for bare keys.
@@ -59,3 +63,4 @@ sandbox:
       # team: my-team
       # user: my-user
       # workload: my-benchmark
+      # run: my-run-id

--- a/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
+++ b/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
@@ -44,3 +44,15 @@ sandbox:
       retry_max_delay_s: 45.0
       command_retries: 0
       close_timeout_s: 30
+    # Job attribution merged into every sandbox's metadata (Kubernetes labels on the
+    # sandbox), so cluster operators can attribute sandboxes to a team/user/workload
+    # (e.g. filter the OpenSandbox list API by `team=...`). Unset fields auto-detect
+    # from NEMO_GYM_TEAM / NEMO_GYM_USER / NEMO_GYM_WORKLOAD, then Slurm job env vars
+    # (SLURM_JOB_ACCOUNT / SLURM_JOB_USER / SLURM_JOB_NAME), then the OS login name
+    # for `user`; unresolvable fields are omitted. Explicit sandbox_spec.metadata and
+    # default_metadata keys always win over attribution keys.
+    attribution:
+      enabled: true
+      # team: my-team
+      # user: my-user
+      # workload: my-benchmark

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -24,7 +24,7 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
-from nemo_gym.sandbox.attribution import resolve_attribution
+from nemo_gym.sandbox.attribution import RUN_KEY, log_attribution_once, resolve_attribution, resolve_run_id
 from nemo_gym.sandbox.providers.base import (
     SandboxCreateError,
     SandboxCreateVerificationError,
@@ -91,8 +91,10 @@ RETRYABLE_ERROR_MARKERS = (
     "timeout",
 )
 METADATA_VALUE_RE = re.compile(r"[^A-Za-z0-9_.-]+")
-# Kubernetes prefixed-key namespace for auto-injected attribution labels (team/user/workload).
+# Kubernetes prefixed-key namespace for auto-injected attribution labels (team/user/workload/run).
 DEFAULT_ATTRIBUTION_KEY_PREFIX = "nemo-gym.nvidia.com/"
+# Kubernetes label-key prefixes must be DNS-1123 subdomains (max 253 chars).
+ATTRIBUTION_KEY_PREFIX_RE = re.compile(r"(?=.{1,253}$)[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*")
 DEFAULT_IMAGE_PULL_POLICY = "IfNotPresent"
 IMAGE_PULL_POLICY_EXTENSION_KEY = "imagePullPolicy"
 IMAGE_PULL_POLICY_ANNOTATION_EXTENSION_KEY = "opensandbox.extensions.image-pull-policy"
@@ -363,25 +365,36 @@ class OpenSandboxAttributionConfig:
     attribution is queryable both through the OpenSandbox list API and at the cluster level
     (e.g. ``kubectl get pods -l nemo-gym.nvidia.com/team=my-team``). ``key_prefix`` namespaces
     the label keys (Kubernetes prefixed-key convention); set it to ``""`` for bare
-    ``team`` / ``user`` / ``workload`` keys.
+    ``team`` / ``user`` / ``workload`` / ``run`` keys.
 
     Unset fields are auto-detected: ``NEMO_GYM_TEAM`` / ``NEMO_GYM_USER`` / ``NEMO_GYM_WORKLOAD``
     environment variables first, then Slurm job env vars (``SLURM_JOB_ACCOUNT`` /
-    ``SLURM_JOB_USER`` / ``SLURM_JOB_NAME``), then the OS login name for ``user``. Fields that
-    cannot be resolved are omitted. Explicit ``SandboxSpec.metadata`` keys always take
-    precedence over attribution keys.
+    ``SLURM_JOB_USER`` / ``SLURM_JOB_NAME``), then the OS login name for ``user`` (``root`` is
+    ignored) and the gym CLI's ``NEMO_GYM_CONFIG_PATH`` server instance name for ``workload``.
+    Fields that cannot be resolved are omitted. ``run`` scopes sandboxes to one launch of the
+    creating process (``NEMO_GYM_RUN_ID``, else generated per process and logged) so a run's
+    sandboxes can be listed and cleaned up exactly. Explicit ``SandboxSpec.metadata`` keys
+    always take precedence over attribution keys.
     """
 
     enabled: bool = True
     team: str | None = None
     user: str | None = None
     workload: str | None = None
+    run: str | None = None
     key_prefix: str = DEFAULT_ATTRIBUTION_KEY_PREFIX
 
     def __post_init__(self) -> None:
         normalized = self.key_prefix.strip()
         if normalized and not normalized.endswith("/"):
             normalized += "/"
+        if normalized and not ATTRIBUTION_KEY_PREFIX_RE.fullmatch(normalized[:-1]):
+            # Invalid prefixes would otherwise fail server-side at sandbox create with an
+            # opaque error; values are sanitized by the provider but keys pass through.
+            raise ValueError(
+                f"attribution key_prefix {self.key_prefix!r} must be a lowercase DNS subdomain "
+                "(Kubernetes label-key prefix), e.g. 'nemo-gym.nvidia.com/', or '' for bare keys"
+            )
         object.__setattr__(self, "key_prefix", normalized)
 
 
@@ -885,14 +898,17 @@ class OpenSandboxProvider:
             user=self._attribution.user,
             workload=self._attribution.workload,
         )
+        resolved[RUN_KEY] = resolve_run_id(self._attribution.run)
         prefix = self._attribution.key_prefix
-        return {f"{prefix}{key}": value for key, value in resolved.items()}
+        metadata = {f"{prefix}{key}": value for key, value in resolved.items()}
+        log_attribution_once(metadata)
+        return metadata
 
     async def create(self, spec: SandboxSpec) -> SandboxHandle:
         """Create one sandbox through the configured OpenSandbox path.
 
-        Job attribution keys (``team`` / ``user`` / ``workload``) are merged into the spec's
-        metadata (explicit spec keys win) so every sandbox is attributable via its labels.
+        Job attribution keys (``team`` / ``user`` / ``workload`` / ``run``) are merged into the
+        spec's metadata (explicit spec keys win) so every sandbox is attributable via its labels.
         """
         spec = replace(spec, metadata={**self._attribution_metadata(), **spec.metadata})
         return await self._create_with_retries(_normalize_spec(spec))

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -91,6 +91,8 @@ RETRYABLE_ERROR_MARKERS = (
     "timeout",
 )
 METADATA_VALUE_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+# Kubernetes prefixed-key namespace for auto-injected attribution labels (team/user/workload).
+DEFAULT_ATTRIBUTION_KEY_PREFIX = "nemo-gym.nvidia.com/"
 DEFAULT_IMAGE_PULL_POLICY = "IfNotPresent"
 IMAGE_PULL_POLICY_EXTENSION_KEY = "imagePullPolicy"
 IMAGE_PULL_POLICY_ANNOTATION_EXTENSION_KEY = "opensandbox.extensions.image-pull-policy"
@@ -357,6 +359,12 @@ class OpenSandboxConnectionConfig:
 class OpenSandboxAttributionConfig:
     """Job attribution merged into every sandbox's metadata (Kubernetes labels on the sandbox).
 
+    OpenSandbox propagates sandbox metadata as Kubernetes labels on the sandbox resources, so
+    attribution is queryable both through the OpenSandbox list API and at the cluster level
+    (e.g. ``kubectl get pods -l nemo-gym.nvidia.com/team=my-team``). ``key_prefix`` namespaces
+    the label keys (Kubernetes prefixed-key convention); set it to ``""`` for bare
+    ``team`` / ``user`` / ``workload`` keys.
+
     Unset fields are auto-detected: ``NEMO_GYM_TEAM`` / ``NEMO_GYM_USER`` / ``NEMO_GYM_WORKLOAD``
     environment variables first, then Slurm job env vars (``SLURM_JOB_ACCOUNT`` /
     ``SLURM_JOB_USER`` / ``SLURM_JOB_NAME``), then the OS login name for ``user``. Fields that
@@ -368,6 +376,13 @@ class OpenSandboxAttributionConfig:
     team: str | None = None
     user: str | None = None
     workload: str | None = None
+    key_prefix: str = DEFAULT_ATTRIBUTION_KEY_PREFIX
+
+    def __post_init__(self) -> None:
+        normalized = self.key_prefix.strip()
+        if normalized and not normalized.endswith("/"):
+            normalized += "/"
+        object.__setattr__(self, "key_prefix", normalized)
 
 
 @dataclass(frozen=True)
@@ -865,11 +880,13 @@ class OpenSandboxProvider:
     def _attribution_metadata(self) -> dict[str, str]:
         if not self._attribution.enabled:
             return {}
-        return resolve_attribution(
+        resolved = resolve_attribution(
             team=self._attribution.team,
             user=self._attribution.user,
             workload=self._attribution.workload,
         )
+        prefix = self._attribution.key_prefix
+        return {f"{prefix}{key}": value for key, value in resolved.items()}
 
     async def create(self, spec: SandboxSpec) -> SandboxHandle:
         """Create one sandbox through the configured OpenSandbox path.

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -24,6 +24,7 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
+from nemo_gym.sandbox.attribution import resolve_attribution
 from nemo_gym.sandbox.providers.base import (
     SandboxCreateError,
     SandboxCreateVerificationError,
@@ -353,6 +354,23 @@ class OpenSandboxConnectionConfig:
 
 
 @dataclass(frozen=True)
+class OpenSandboxAttributionConfig:
+    """Job attribution merged into every sandbox's metadata (Kubernetes labels on the sandbox).
+
+    Unset fields are auto-detected: ``NEMO_GYM_TEAM`` / ``NEMO_GYM_USER`` / ``NEMO_GYM_WORKLOAD``
+    environment variables first, then Slurm job env vars (``SLURM_JOB_ACCOUNT`` /
+    ``SLURM_JOB_USER`` / ``SLURM_JOB_NAME``), then the OS login name for ``user``. Fields that
+    cannot be resolved are omitted. Explicit ``SandboxSpec.metadata`` keys always take
+    precedence over attribution keys.
+    """
+
+    enabled: bool = True
+    team: str | None = None
+    user: str | None = None
+    workload: str | None = None
+
+
+@dataclass(frozen=True)
 class OpenSandboxCreateConfig:
     """OpenSandbox create/reconnect retry settings."""
 
@@ -499,11 +517,13 @@ class OpenSandboxProvider:
         create: OpenSandboxCreateConfig | Mapping[str, Any] | None = None,
         probe: OpenSandboxProbeConfig | Mapping[str, Any] | None = None,
         operations: OpenSandboxOperationConfig | Mapping[str, Any] | None = None,
+        attribution: OpenSandboxAttributionConfig | Mapping[str, Any] | None = None,
     ) -> None:
         self._connection = _coerce_config(connection, OpenSandboxConnectionConfig)
         self._create = _coerce_config(create, OpenSandboxCreateConfig)
         self._probe = _coerce_config(probe, OpenSandboxProbeConfig)
         self._operations = _coerce_config(operations, OpenSandboxOperationConfig)
+        self._attribution = _coerce_config(attribution, OpenSandboxAttributionConfig)
 
     def _resolve_extensions(self, extensions: Mapping[str, str]) -> dict[str, str]:
         """Add the configured default image pull policy to SDK create extensions."""
@@ -842,8 +862,22 @@ class OpenSandboxProvider:
 
         raise OpenSandboxCreateError("OpenSandbox create retry loop did not run")
 
+    def _attribution_metadata(self) -> dict[str, str]:
+        if not self._attribution.enabled:
+            return {}
+        return resolve_attribution(
+            team=self._attribution.team,
+            user=self._attribution.user,
+            workload=self._attribution.workload,
+        )
+
     async def create(self, spec: SandboxSpec) -> SandboxHandle:
-        """Create one sandbox through the configured OpenSandbox path."""
+        """Create one sandbox through the configured OpenSandbox path.
+
+        Job attribution keys (``team`` / ``user`` / ``workload``) are merged into the spec's
+        metadata (explicit spec keys win) so every sandbox is attributable via its labels.
+        """
+        spec = replace(spec, metadata={**self._attribution_metadata(), **spec.metadata})
         return await self._create_with_retries(_normalize_spec(spec))
 
     async def status(self, handle: SandboxHandle) -> SandboxStatus:

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -759,3 +759,78 @@ async def test_retry_loop_empty_iterator_guards(monkeypatch: pytest.MonkeyPatch)
 
 async def _return_value(value: Any) -> Any:
     return value
+
+
+ATTRIBUTION_ENV_VARS = (
+    "NEMO_GYM_TEAM",
+    "NEMO_GYM_USER",
+    "NEMO_GYM_WORKLOAD",
+    "SLURM_JOB_ACCOUNT",
+    "SLURM_JOB_USER",
+    "SLURM_JOB_NAME",
+)
+
+
+@pytest.fixture
+def clean_attribution_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ATTRIBUTION_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+async def test_create_injects_attribution_metadata(
+    fake_opensandbox_sdk: None,
+    clean_attribution_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NEMO_GYM_TEAM", "nemo rl")  # sanitized to a valid label value below
+    monkeypatch.setenv("NEMO_GYM_USER", "alice")
+    monkeypatch.setenv("NEMO_GYM_WORKLOAD", "swe-gym")
+    provider = opensandbox_provider.OpenSandboxProvider(
+        connection={"request_timeout_s": 10},
+        probe={"command": None},
+    )
+
+    await provider.create(SandboxSpec(image="image:tag", metadata={"purpose": "test"}))
+
+    assert FakeSandbox.created_kwargs["metadata"] == {
+        "team": "nemo_rl",
+        "user": "alice",
+        "workload": "swe-gym",
+        "purpose": "test",
+    }
+
+
+async def test_create_spec_metadata_and_config_win_over_attribution_detection(
+    fake_opensandbox_sdk: None,
+    clean_attribution_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NEMO_GYM_TEAM", "env-team")
+    provider = opensandbox_provider.OpenSandboxProvider(
+        connection={"request_timeout_s": 10},
+        probe={"command": None},
+        attribution={"team": "cfg-team", "user": "cfg-user", "workload": "cfg-workload"},
+    )
+
+    await provider.create(SandboxSpec(image="image:tag", metadata={"team": "explicit-team"}))
+
+    assert FakeSandbox.created_kwargs["metadata"] == {
+        "team": "explicit-team",
+        "user": "cfg-user",
+        "workload": "cfg-workload",
+    }
+
+
+async def test_create_attribution_disabled(
+    fake_opensandbox_sdk: None,
+    clean_attribution_env: None,
+) -> None:
+    provider = opensandbox_provider.OpenSandboxProvider(
+        connection={"request_timeout_s": 10},
+        probe={"command": None},
+        attribution={"enabled": False, "team": "cfg-team"},
+    )
+
+    await provider.create(SandboxSpec(image="image:tag"))
+
+    assert FakeSandbox.created_kwargs["metadata"] == {}

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -793,9 +793,9 @@ async def test_create_injects_attribution_metadata(
     await provider.create(SandboxSpec(image="image:tag", metadata={"purpose": "test"}))
 
     assert FakeSandbox.created_kwargs["metadata"] == {
-        "team": "nemo_rl",
-        "user": "alice",
-        "workload": "swe-gym",
+        "nemo-gym.nvidia.com/team": "nemo_rl",
+        "nemo-gym.nvidia.com/user": "alice",
+        "nemo-gym.nvidia.com/workload": "swe-gym",
         "purpose": "test",
     }
 
@@ -812,12 +812,12 @@ async def test_create_spec_metadata_and_config_win_over_attribution_detection(
         attribution={"team": "cfg-team", "user": "cfg-user", "workload": "cfg-workload"},
     )
 
-    await provider.create(SandboxSpec(image="image:tag", metadata={"team": "explicit-team"}))
+    await provider.create(SandboxSpec(image="image:tag", metadata={"nemo-gym.nvidia.com/team": "explicit-team"}))
 
     assert FakeSandbox.created_kwargs["metadata"] == {
-        "team": "explicit-team",
-        "user": "cfg-user",
-        "workload": "cfg-workload",
+        "nemo-gym.nvidia.com/team": "explicit-team",
+        "nemo-gym.nvidia.com/user": "cfg-user",
+        "nemo-gym.nvidia.com/workload": "cfg-workload",
     }
 
 
@@ -834,3 +834,30 @@ async def test_create_attribution_disabled(
     await provider.create(SandboxSpec(image="image:tag"))
 
     assert FakeSandbox.created_kwargs["metadata"] == {}
+
+
+@pytest.mark.parametrize(
+    ("key_prefix", "expected_key"),
+    [
+        ("", "team"),
+        ("acme.example.com/", "acme.example.com/team"),
+        ("acme.example.com", "acme.example.com/team"),  # trailing slash is normalized in
+        ("  ", "team"),
+    ],
+)
+async def test_create_attribution_key_prefix(
+    fake_opensandbox_sdk: None,
+    clean_attribution_env: None,
+    key_prefix: str,
+    expected_key: str,
+) -> None:
+    provider = opensandbox_provider.OpenSandboxProvider(
+        connection={"request_timeout_s": 10},
+        probe={"command": None},
+        attribution={"team": "cfg-team", "key_prefix": key_prefix},
+    )
+
+    await provider.create(SandboxSpec(image="image:tag"))
+
+    metadata = FakeSandbox.created_kwargs["metadata"]
+    assert metadata[expected_key] == "cfg-team"

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -765,6 +765,8 @@ ATTRIBUTION_ENV_VARS = (
     "NEMO_GYM_TEAM",
     "NEMO_GYM_USER",
     "NEMO_GYM_WORKLOAD",
+    "NEMO_GYM_RUN_ID",
+    "NEMO_GYM_CONFIG_PATH",
     "SLURM_JOB_ACCOUNT",
     "SLURM_JOB_USER",
     "SLURM_JOB_NAME",
@@ -782,9 +784,10 @@ async def test_create_injects_attribution_metadata(
     clean_attribution_env: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("NEMO_GYM_TEAM", "nemo rl")  # sanitized to a valid label value below
+    monkeypatch.setenv("NEMO_GYM_TEAM", "gym team")  # sanitized to a valid label value below
     monkeypatch.setenv("NEMO_GYM_USER", "alice")
     monkeypatch.setenv("NEMO_GYM_WORKLOAD", "swe-gym")
+    monkeypatch.setenv("NEMO_GYM_RUN_ID", "run-123")
     provider = opensandbox_provider.OpenSandboxProvider(
         connection={"request_timeout_s": 10},
         probe={"command": None},
@@ -793,9 +796,10 @@ async def test_create_injects_attribution_metadata(
     await provider.create(SandboxSpec(image="image:tag", metadata={"purpose": "test"}))
 
     assert FakeSandbox.created_kwargs["metadata"] == {
-        "nemo-gym.nvidia.com/team": "nemo_rl",
+        "nemo-gym.nvidia.com/team": "gym_team",
         "nemo-gym.nvidia.com/user": "alice",
         "nemo-gym.nvidia.com/workload": "swe-gym",
+        "nemo-gym.nvidia.com/run": "run-123",
         "purpose": "test",
     }
 
@@ -809,7 +813,7 @@ async def test_create_spec_metadata_and_config_win_over_attribution_detection(
     provider = opensandbox_provider.OpenSandboxProvider(
         connection={"request_timeout_s": 10},
         probe={"command": None},
-        attribution={"team": "cfg-team", "user": "cfg-user", "workload": "cfg-workload"},
+        attribution={"team": "cfg-team", "user": "cfg-user", "workload": "cfg-workload", "run": "cfg-run"},
     )
 
     await provider.create(SandboxSpec(image="image:tag", metadata={"nemo-gym.nvidia.com/team": "explicit-team"}))
@@ -818,6 +822,7 @@ async def test_create_spec_metadata_and_config_win_over_attribution_detection(
         "nemo-gym.nvidia.com/team": "explicit-team",
         "nemo-gym.nvidia.com/user": "cfg-user",
         "nemo-gym.nvidia.com/workload": "cfg-workload",
+        "nemo-gym.nvidia.com/run": "cfg-run",
     }
 
 
@@ -861,3 +866,23 @@ async def test_create_attribution_key_prefix(
 
     metadata = FakeSandbox.created_kwargs["metadata"]
     assert metadata[expected_key] == "cfg-team"
+
+
+async def test_create_attribution_run_id_generated(
+    fake_opensandbox_sdk: None,
+    clean_attribution_env: None,
+) -> None:
+    provider = opensandbox_provider.OpenSandboxProvider(
+        connection={"request_timeout_s": 10},
+        probe={"command": None},
+    )
+
+    await provider.create(SandboxSpec(image="image:tag"))
+
+    assert FakeSandbox.created_kwargs["metadata"]["nemo-gym.nvidia.com/run"]  # generated per process
+
+
+@pytest.mark.parametrize("key_prefix", ["Not_A_Valid_Prefix/", "-bad.example.com/", "bad..example.com/"])
+def test_attribution_invalid_key_prefix_raises(key_prefix: str) -> None:
+    with pytest.raises(ValueError, match="key_prefix"):
+        opensandbox_provider.OpenSandboxAttributionConfig(key_prefix=key_prefix)

--- a/tests/unit_tests/test_sandbox_attribution.py
+++ b/tests/unit_tests/test_sandbox_attribution.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemo_gym.sandbox import attribution
+from nemo_gym.sandbox.attribution import resolve_attribution
+
+
+pytestmark = pytest.mark.sandbox
+
+
+def test_explicit_values_win_over_env() -> None:
+    resolved = resolve_attribution(
+        team="cfg-team",
+        user="cfg-user",
+        workload="cfg-workload",
+        environ={"NEMO_GYM_TEAM": "env-team", "NEMO_GYM_USER": "env-user", "NEMO_GYM_WORKLOAD": "env-workload"},
+    )
+    assert resolved == {"team": "cfg-team", "user": "cfg-user", "workload": "cfg-workload"}
+
+
+def test_nemo_gym_env_beats_slurm_env() -> None:
+    environ = {
+        "NEMO_GYM_TEAM": "gym-team",
+        "SLURM_JOB_ACCOUNT": "slurm-account",
+        "NEMO_GYM_USER": "gym-user",
+        "SLURM_JOB_USER": "slurm-user",
+        "NEMO_GYM_WORKLOAD": "gym-workload",
+        "SLURM_JOB_NAME": "slurm-job",
+    }
+    assert resolve_attribution(environ=environ) == {
+        "team": "gym-team",
+        "user": "gym-user",
+        "workload": "gym-workload",
+    }
+
+
+def test_slurm_env_fallback() -> None:
+    environ = {"SLURM_JOB_ACCOUNT": "account", "SLURM_JOB_USER": "slurm-user", "SLURM_JOB_NAME": "job-name"}
+    assert resolve_attribution(environ=environ) == {
+        "team": "account",
+        "user": "slurm-user",
+        "workload": "job-name",
+    }
+
+
+def test_user_falls_back_to_login_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(attribution.getpass, "getuser", lambda: "login-user")
+    assert resolve_attribution(environ={}) == {"user": "login-user"}
+
+
+def test_unresolvable_fields_are_omitted(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_no_user() -> str:
+        raise OSError("no passwd entry for uid")
+
+    monkeypatch.setattr(attribution.getpass, "getuser", raise_no_user)
+    assert resolve_attribution(environ={}) == {}
+
+
+def test_blank_env_and_login_values_are_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(attribution.getpass, "getuser", lambda: "  ")
+    environ = {"NEMO_GYM_TEAM": "   ", "SLURM_JOB_ACCOUNT": "", "SLURM_JOB_NAME": "job"}
+    assert resolve_attribution(environ=environ) == {"workload": "job"}
+
+
+def test_environ_defaults_to_os_environ(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEMO_GYM_TEAM", "process-env-team")
+    assert resolve_attribution()["team"] == "process-env-team"

--- a/tests/unit_tests/test_sandbox_attribution.py
+++ b/tests/unit_tests/test_sandbox_attribution.py
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 import pytest
 
 from nemo_gym.sandbox import attribution
-from nemo_gym.sandbox.attribution import resolve_attribution
+from nemo_gym.sandbox.attribution import log_attribution_once, resolve_attribution, resolve_run_id
 
 
 pytestmark = pytest.mark.sandbox
@@ -57,9 +59,30 @@ def test_slurm_env_fallback() -> None:
     }
 
 
+def test_workload_falls_back_to_gym_config_path() -> None:
+    resolved = resolve_attribution(environ={"NEMO_GYM_CONFIG_PATH": "my_agent_server"})
+    assert resolved["workload"] == "my_agent_server"
+
+
+def test_slurm_job_name_beats_gym_config_path() -> None:
+    environ = {"SLURM_JOB_NAME": "job-name", "NEMO_GYM_CONFIG_PATH": "my_agent_server"}
+    assert resolve_attribution(environ=environ)["workload"] == "job-name"
+
+
 def test_user_falls_back_to_login_name(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(attribution.getpass, "getuser", lambda: "login-user")
     assert resolve_attribution(environ={}) == {"user": "login-user"}
+
+
+def test_root_login_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Containers default to root; "root" attributes the image, not a person.
+    monkeypatch.setattr(attribution.getpass, "getuser", lambda: "root")
+    assert resolve_attribution(environ={}) == {}
+
+
+def test_root_env_user_is_kept(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Only the OS-login fallback filters root; an explicit env value is deliberate.
+    assert resolve_attribution(environ={"NEMO_GYM_USER": "root"}) == {"user": "root"}
 
 
 def test_unresolvable_fields_are_omitted(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -79,3 +102,31 @@ def test_blank_env_and_login_values_are_ignored(monkeypatch: pytest.MonkeyPatch)
 def test_environ_defaults_to_os_environ(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("NEMO_GYM_TEAM", "process-env-team")
     assert resolve_attribution()["team"] == "process-env-team"
+
+
+def test_run_id_explicit_wins_over_env() -> None:
+    assert resolve_run_id("explicit-run", environ={"NEMO_GYM_RUN_ID": "env-run"}) == "explicit-run"
+
+
+def test_run_id_env_fallback() -> None:
+    assert resolve_run_id(environ={"NEMO_GYM_RUN_ID": "env-run"}) == "env-run"
+
+
+def test_run_id_generated_once_per_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(attribution, "_process_run_id", None)
+    first = resolve_run_id(environ={})
+    assert first
+    assert resolve_run_id(environ={}) == first
+
+
+def test_log_attribution_once_logs_only_once(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(attribution, "_logged_attribution", False)
+    with caplog.at_level(logging.INFO, logger=attribution.LOGGER.name):
+        log_attribution_once({})  # empty metadata is not worth a log line
+        log_attribution_once({"nemo-gym.nvidia.com/run": "run-1"})
+        log_attribution_once({"nemo-gym.nvidia.com/run": "run-1"})
+    matching = [record for record in caplog.records if "Sandbox attribution metadata" in record.getMessage()]
+    assert len(matching) == 1
+    assert "run-1" in matching[0].getMessage()


### PR DESCRIPTION
## Summary

Fixes RL-1013 ([Linear issue](https://linear.app/nvidia/issue/RL-1013/add-job-attribution-teamuserworkload-to-opensandbox)). Every sandbox created through the OpenSandbox provider now automatically carries `nemo-gym.nvidia.com/team` / `nemo-gym.nvidia.com/user` / `nemo-gym.nvidia.com/workload` / `nemo-gym.nvidia.com/run` keys in its metadata. OpenSandbox propagates sandbox metadata as **Kubernetes labels** on the sandbox resources (BatchSandbox CR + pod), so sandboxes are attributable both through the OpenSandbox list API and directly at the cluster level:

```bash
kubectl get pods -l nemo-gym.nvidia.com/team=my-team
```

## Why metadata (SDK research)

From the `opensandbox` SDK (0.1.9) source, there are exactly three candidate carriers for attribution:

| Carrier | Verdict |
|---|---|
| `Sandbox.create(metadata=...)` | ✅ **Chosen.** Becomes Kubernetes labels on the sandbox (server enforces K8s label rules: values ≤63 chars, `opensandbox.io/` prefix reserved for the platform itself), is queryable via `SandboxManager.list_sandbox_infos(SandboxFilter(metadata={...}))`, and is patchable post-create (`PATCH /v1/sandboxes/{id}/metadata`). |
| `extensions` | ❌ Opaque provider pass-through, not queryable, immutable post-create. |
| `ConnectionConfig.headers` / `user_agent` / `api_key` | ❌ Per-request HTTP headers only; not stored on the sandbox. |

K8s **annotations** are not settable through the SDK/API at all — labels are the only k8s-level channel it propagates. Keys use the Kubernetes prefixed-key convention (`nemo-gym.nvidia.com/`) for namespacing and provenance, matching the existing `<project>.nvidia.com/` label-key convention used by run-level sandbox tooling; the prefix is configurable (`key_prefix: ""` restores bare `team`/`user`/`workload` keys).

The provider already sanitizes metadata values to K8s label rules (`_metadata_value`: charset replacement + 63-char truncation) and pipes `spec.metadata` into `Sandbox.create`, so this change only adds the automatic injection.

## Design

- **`nemo_gym/sandbox/attribution.py`** (shared, provider-agnostic so docker/openshell/ecs can adopt it later): `resolve_attribution()` resolves each field in order — explicit config → `NEMO_GYM_TEAM` / `NEMO_GYM_USER` / `NEMO_GYM_WORKLOAD` env vars → Slurm job env vars (`SLURM_JOB_ACCOUNT` / `SLURM_JOB_USER` / `SLURM_JOB_NAME`) → OS login name (`user` only; `root` is ignored since containers default to it) → the gym CLI's `NEMO_GYM_CONFIG_PATH` server instance name (`workload` only). Unresolvable fields are **omitted, never guessed**. A `run` key (`NEMO_GYM_RUN_ID`, else generated once per process and logged at first create) scopes sandboxes to one launch so an interrupted run's sandboxes can be listed and garbage-collected exactly.
- **`OpenSandboxProvider`**: new `attribution` config group (`enabled: true` by default; `team`/`user`/`workload` overrides; `key_prefix` for the label-key namespace). `create()` merges attribution **under** the spec's metadata, so explicit `sandbox_spec.metadata` / `default_metadata` keys always win; values then flow through the existing K8s-label sanitization.
- Documented in `configs/opensandbox.yaml` and `fern/.../sandbox/opensandbox.mdx` (new *Job Attribution* section).

## Testing

- `tests/unit_tests/test_sandbox_attribution.py`: resolution precedence (config > NEMO_GYM_* > Slurm > login name), blank-value handling, omission when unresolvable, `os.environ` default.
- `tests/unit_tests/test_opensandbox_provider.py`: attribution lands in the SDK `create` call's `metadata` with prefixed keys (and sanitization applied, e.g. `nemo rl` → `nemo_rl`), explicit spec metadata beats attribution, config overrides beat env detection, `enabled: false` disables injection, and `key_prefix` variants (bare, custom, trailing-slash normalization).
- Full unit suite: 1152 passed; the 6 failures are pre-existing terminal-formatting assertions that fail identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

