### PR TITLE
docs(housekeeping): Add PR SLA tracker

### DIFF
--- a/.github/workflows/pr-sla-tracker.yml
+++ b/.github/workflows/pr-sla-tracker.yml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Pull Request SLA Tracker
+
+on:
+  schedule:
+    - cron: "17 * * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: pr-sla-tracker
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Refresh SLA labels and dashboard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/pr_sla_tracker.py --repo "${{ github.repository }}"

--- a/scripts/pr_sla_tracker.py
+++ b/scripts/pr_sla_tracker.py
@@ -1,0 +1,578 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Track pull requests that exceed the team's review handoff SLA."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Literal, TextIO
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+SLA_BUSINESS_DAYS = 1
+REVIEWER_LABEL = "sla:review-overdue"
+AUTHOR_LABEL = "sla:author-overdue"
+TRIAGE_LABEL = "sla:triage-overdue"
+EXCLUDED_LABELS = frozenset({"stale", "paused", "do-not-track"})
+NEW_BREACH_BUSINESS_SECONDS = 24 * 60 * 60
+DASHBOARD_MARKER = "<!-- pr-sla-tracker -->"
+DASHBOARD_TITLE = "[Tracker] Pull request handoff SLA"
+GRAPHQL_QUERY = """
+query PullRequestSlaTracker($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(states: OPEN, first: 50, after: $cursor, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        title
+        url
+        isDraft
+        headRefName
+        createdAt
+        author { __typename login }
+        labels(first: 100) { nodes { name } }
+        reviewRequests(first: 100) {
+          nodes {
+            requestedReviewer {
+              __typename
+              ... on User { login }
+              ... on Mannequin { login }
+              ... on Team { slug organization { login } }
+            }
+          }
+        }
+        reviews(last: 100) { nodes { state submittedAt } }
+        timelineItems(last: 100, itemTypes: [READY_FOR_REVIEW_EVENT, REVIEW_REQUESTED_EVENT]) {
+          nodes {
+            __typename
+            ... on ReadyForReviewEvent { createdAt }
+            ... on ReviewRequestedEvent {
+              createdAt
+              requestedReviewer {
+                __typename
+                ... on User { login }
+                ... on Mannequin { login }
+                ... on Team { slug organization { login } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@dataclass(frozen=True)
+class Breach:
+    """An overdue author, reviewer, or review-assignment handoff."""
+
+    number: int
+    title: str
+    url: str
+    owner: Literal["author", "reviewer", "triage"]
+    people: tuple[str, ...]
+    since: datetime
+    deadline: datetime
+    reason: str
+
+
+class GitHubClient:
+    """Small GitHub REST/GraphQL client using only the Python standard library."""
+
+    def __init__(
+        self,
+        repository: str,
+        token: str,
+        *,
+        api_url: str = "https://api.github.com",
+        opener=urlopen,
+    ) -> None:
+        self.repository = repository
+        self.api_url = api_url.rstrip("/")
+        self.token = token
+        self.opener = opener
+
+    def graphql(self, query: str, variables: dict) -> dict:
+        payload = self._request("POST", "/graphql", {"query": query, "variables": variables})
+        if payload.get("errors"):
+            raise RuntimeError(f"GitHub GraphQL error: {payload['errors']}")
+        return payload["data"]
+
+    def ensure_label(self, name: str, color: str, description: str) -> None:
+        path = f"/repos/{self.repository}/labels/{quote(name, safe='')}"
+        if self._request("GET", path, allow_not_found=True) is None:
+            self._request(
+                "POST",
+                f"/repos/{self.repository}/labels",
+                {"name": name, "color": color, "description": description},
+            )
+
+    def add_label(self, number: int, name: str) -> None:
+        self._request("POST", f"/repos/{self.repository}/issues/{number}/labels", {"labels": [name]})
+
+    def remove_label(self, number: int, name: str) -> None:
+        path = f"/repos/{self.repository}/issues/{number}/labels/{quote(name, safe='')}"
+        self._request("DELETE", path, allow_not_found=True)
+
+    def find_dashboard_issue(self) -> dict | None:
+        page = 1
+        while True:
+            issues = self._request(
+                "GET",
+                f"/repos/{self.repository}/issues?state=all&per_page=100&page={page}",
+            )
+            for issue in issues:
+                if "pull_request" not in issue and DASHBOARD_MARKER in (issue.get("body") or ""):
+                    return issue
+            if len(issues) < 100:
+                return None
+            page += 1
+
+    def create_dashboard_issue(self, body: str) -> None:
+        self._request(
+            "POST",
+            f"/repos/{self.repository}/issues",
+            {"title": DASHBOARD_TITLE, "body": body},
+        )
+
+    def update_dashboard_issue(self, number: int, body: str, *, reopen: bool) -> None:
+        payload = {"body": body}
+        if reopen:
+            payload["state"] = "open"
+        self._request("PATCH", f"/repos/{self.repository}/issues/{number}", payload)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: dict | None = None,
+        *,
+        allow_not_found: bool = False,
+    ):
+        data = json.dumps(payload).encode() if payload is not None else None
+        request = Request(
+            f"{self.api_url}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "nemo-gym-pr-sla-tracker",
+            },
+        )
+        try:
+            with self.opener(request) as response:
+                body = response.read()
+        except HTTPError as error:
+            if allow_not_found and error.code == 404:
+                return None
+            detail = error.read().decode(errors="replace")
+            raise RuntimeError(f"GitHub API {method} {path} failed ({error.code}): {detail}") from error
+        return json.loads(body) if body else None
+
+
+def business_day_deadline(start: datetime, business_days: int = SLA_BUSINESS_DAYS) -> datetime:
+    """Return the same wall-clock time after ``business_days``, skipping weekends."""
+    if start.tzinfo is None:
+        raise ValueError("start must be timezone-aware")
+    if business_days < 0:
+        raise ValueError("business_days must not be negative")
+
+    deadline = start
+    remaining = business_days
+    while remaining:
+        deadline += timedelta(days=1)
+        if deadline.weekday() < 5:
+            remaining -= 1
+    return deadline
+
+
+def classify_pull_request(pull_request: dict, now: datetime) -> Breach | None:
+    """Return the current SLA breach for a normalized pull-request snapshot."""
+    if pull_request["is_draft"]:
+        return None
+
+    author = pull_request["author"] or "ghost"
+    excluded_by_label = EXCLUDED_LABELS.intersection(label.casefold() for label in pull_request["labels"])
+    if (
+        pull_request.get("author_is_bot", False)
+        or author.endswith("[bot]")
+        or pull_request["head_ref"].startswith("release-please--")
+        or excluded_by_label
+    ):
+        return None
+
+    requested_reviewers = pull_request["requested_reviewers"]
+    if requested_reviewers:
+        request_times = pull_request["review_request_times"]
+        fallback = pull_request["ready_at"] or pull_request["created_at"]
+        overdue = []
+        for reviewer in requested_reviewers:
+            since = request_times.get(reviewer, fallback)
+            deadline = business_day_deadline(since)
+            if now > deadline:
+                overdue.append((reviewer, since, deadline))
+
+        if not overdue:
+            return None
+
+        people = tuple(sorted(reviewer for reviewer, _, _ in overdue))
+        since = min(item[1] for item in overdue)
+        deadline = min(item[2] for item in overdue)
+        return _breach(pull_request, "reviewer", people, since, deadline, "review requested")
+
+    latest_review = pull_request["latest_review"]
+    if latest_review is None:
+        since = pull_request["ready_at"] or pull_request["created_at"]
+        deadline = business_day_deadline(since)
+        if now <= deadline:
+            return None
+        return _breach(pull_request, "triage", (), since, deadline, "reviewer not assigned")
+    elif latest_review["state"] == "CHANGES_REQUESTED":
+        since = latest_review["submitted_at"]
+        reason = "changes requested"
+    else:
+        return None
+
+    deadline = business_day_deadline(since)
+    if now <= deadline:
+        return None
+    return _breach(pull_request, "author", (author,), since, deadline, reason)
+
+
+def normalize_pull_request(node: dict) -> dict:
+    """Convert a GitHub GraphQL pull-request node into the tracker model."""
+    timeline = node["timelineItems"]["nodes"]
+    ready_times = [
+        _parse_timestamp(event["createdAt"]) for event in timeline if event["__typename"] == "ReadyForReviewEvent"
+    ]
+    request_times: dict[str, datetime] = {}
+    for event in timeline:
+        if event["__typename"] != "ReviewRequestedEvent":
+            continue
+        reviewer = _reviewer_name(event["requestedReviewer"])
+        if reviewer:
+            event_time = _parse_timestamp(event["createdAt"])
+            request_times[reviewer] = max(request_times.get(reviewer, event_time), event_time)
+
+    reviewers = sorted(
+        reviewer
+        for request in node["reviewRequests"]["nodes"]
+        if (reviewer := _reviewer_name(request["requestedReviewer"]))
+    )
+    reviews = [review for review in node["reviews"]["nodes"] if review.get("submittedAt")]
+    latest_review = max(reviews, key=lambda review: review["submittedAt"], default=None)
+
+    return {
+        "number": node["number"],
+        "title": node["title"],
+        "url": node["url"],
+        "author": (node.get("author") or {}).get("login"),
+        "author_is_bot": (node.get("author") or {}).get("__typename") == "Bot",
+        "is_draft": node["isDraft"],
+        "head_ref": node["headRefName"],
+        "created_at": _parse_timestamp(node["createdAt"]),
+        "ready_at": max(ready_times, default=None),
+        "requested_reviewers": tuple(reviewers),
+        "review_request_times": request_times,
+        "latest_review": (
+            {
+                "state": latest_review["state"],
+                "submitted_at": _parse_timestamp(latest_review["submittedAt"]),
+            }
+            if latest_review
+            else None
+        ),
+        "labels": {label["name"] for label in node["labels"]["nodes"]},
+    }
+
+
+def fetch_pull_requests(client: GitHubClient, repository: str) -> list[dict]:
+    """Fetch and normalize all open pull requests, following GraphQL pagination."""
+    try:
+        owner, name = repository.split("/", maxsplit=1)
+    except ValueError as error:
+        raise ValueError("repository must use OWNER/NAME format") from error
+
+    pull_requests = []
+    cursor = None
+    while True:
+        data = client.graphql(GRAPHQL_QUERY, {"owner": owner, "name": name, "cursor": cursor})
+        connection = data["repository"]["pullRequests"]
+        pull_requests.extend(normalize_pull_request(node) for node in connection["nodes"])
+        if not connection["pageInfo"]["hasNextPage"]:
+            return pull_requests
+        cursor = connection["pageInfo"]["endCursor"]
+
+
+def sync_sla_labels(client, pull_requests: list[dict], breaches_by_number: dict[int, Breach]) -> None:
+    """Add and remove only the SLA labels owned by this tracker."""
+    client.ensure_label(REVIEWER_LABEL, "B60205", "Review response is over the one-business-day SLA")
+    client.ensure_label(AUTHOR_LABEL, "D93F0B", "Author response is over the one-business-day SLA")
+    client.ensure_label(TRIAGE_LABEL, "FBCA04", "Review assignment is over the one-business-day SLA")
+
+    for pull_request in pull_requests:
+        breach = breaches_by_number.get(pull_request["number"])
+        desired = None
+        if breach:
+            desired = {
+                "reviewer": REVIEWER_LABEL,
+                "author": AUTHOR_LABEL,
+                "triage": TRIAGE_LABEL,
+            }[breach.owner]
+
+        current = pull_request["labels"]
+        for label in (REVIEWER_LABEL, AUTHOR_LABEL, TRIAGE_LABEL):
+            if label == desired and label not in current:
+                client.add_label(pull_request["number"], label)
+            elif label != desired and label in current:
+                client.remove_label(pull_request["number"], label)
+
+
+def upsert_dashboard(client, body: str) -> None:
+    """Create the dashboard issue once, then keep the same issue current."""
+    issue = client.find_dashboard_issue()
+    if issue is None:
+        client.create_dashboard_issue(body)
+        return
+    client.update_dashboard_issue(issue["number"], body, reopen=issue["state"] == "closed")
+
+
+def _breach(
+    pull_request: dict,
+    owner: Literal["author", "reviewer", "triage"],
+    people: tuple[str, ...],
+    since: datetime,
+    deadline: datetime,
+    reason: str,
+) -> Breach:
+    return Breach(
+        number=pull_request["number"],
+        title=pull_request["title"],
+        url=pull_request["url"],
+        owner=owner,
+        people=people,
+        since=since,
+        deadline=deadline,
+        reason=reason,
+    )
+
+
+def render_dashboard(breaches: list[Breach], generated_at: datetime) -> str:
+    """Render the stable GitHub issue body used as the daily dashboard."""
+    lines = [
+        DASHBOARD_MARKER,
+        "# Pull request handoff SLA tracker",
+        "",
+        "Review during the daily stand-up alongside the architecture/RFC decision tracker.",
+        "",
+        "The SLA is one business day per handoff; weekends are excluded and public holidays are not modeled.",
+        "Drafts, bots, and PRs labeled `stale`, `paused`, or `do-not-track` are excluded.",
+        f"Last refreshed: {generated_at.isoformat(timespec='minutes')}",
+        "",
+    ]
+
+    if not breaches:
+        lines.append("No pull requests have breached the one-business-day handoff SLA.")
+        return "\n".join(lines) + "\n"
+
+    newly_breached = [
+        breach
+        for breach in breaches
+        if _business_seconds_between(breach.deadline, generated_at) <= NEW_BREACH_BUSINESS_SECONDS
+    ]
+    backlog = [breach for breach in breaches if breach not in newly_breached]
+
+    lines.extend([f"## Newly breached ({len(newly_breached)})", ""])
+    if newly_breached:
+        _append_owner_sections(lines, newly_breached, generated_at)
+    else:
+        lines.extend(["No new breaches in the last business day.", ""])
+
+    if backlog:
+        lines.extend(
+            [
+                "<details>",
+                f"<summary><strong>Older breach backlog ({len(backlog)})</strong></summary>",
+                "",
+            ]
+        )
+        _append_owner_sections(lines, backlog, generated_at)
+        lines.extend(["</details>", ""])
+    return "\n".join(lines) + "\n"
+
+
+def _append_owner_sections(lines: list[str], breaches: list[Breach], generated_at: datetime) -> None:
+    sections = (
+        ("reviewer", "Waiting on reviewers"),
+        ("author", "Waiting on authors"),
+        ("triage", "Needs review assignment"),
+    )
+    for owner, title in sections:
+        owned_breaches = [breach for breach in breaches if breach.owner == owner]
+        if owned_breaches:
+            _append_section(lines, title, owned_breaches, generated_at)
+
+
+def _append_section(lines: list[str], title: str, breaches: list[Breach], generated_at: datetime) -> None:
+    lines.extend(
+        [
+            f"### {title} ({len(breaches)})",
+            "",
+            "| PR | Waiting on | Reason | Handoff | SLA deadline | Overdue |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for breach in sorted(breaches, key=lambda item: (item.deadline, item.number)):
+        people = "Maintainers" if breach.owner == "triage" else ", ".join(_mention(person) for person in breach.people)
+        title_text = _escape_table_cell(breach.title)
+        lines.append(
+            f"| [#{breach.number} — {title_text}]({breach.url}) | {people} | {breach.reason} | "
+            f"{_format_timestamp(breach.since)} | {_format_timestamp(breach.deadline)} | "
+            f"{_format_overdue(breach.deadline, generated_at)} |"
+        )
+    lines.append("")
+
+
+def _mention(person: str) -> str:
+    if "/" in person:
+        organization, team = person.split("/", maxsplit=1)
+        return f"[@{person}](https://github.com/orgs/{organization}/teams/{team})"
+    return f"[@{person}](https://github.com/{person})"
+
+
+def _escape_table_cell(value: str) -> str:
+    return " ".join(value.splitlines()).replace("|", "\\|")
+
+
+def _format_timestamp(value: datetime) -> str:
+    return value.strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _format_overdue(deadline: datetime, now: datetime) -> str:
+    total_seconds = max(0, int(_business_seconds_between(deadline, now)))
+    days, remainder = divmod(total_seconds, 24 * 60 * 60)
+    hours = remainder // (60 * 60)
+    if days:
+        return f"{days}d {hours}h"
+    return f"{hours}h"
+
+
+def _business_seconds_between(start: datetime, end: datetime) -> float:
+    if end <= start:
+        return 0
+
+    total = 0.0
+    cursor = start
+    while cursor.date() < end.date():
+        next_day = cursor.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+        if cursor.weekday() < 5:
+            total += (next_day - cursor).total_seconds()
+        cursor = next_day
+    if cursor.weekday() < 5:
+        total += (end - cursor).total_seconds()
+    return total
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _reviewer_name(reviewer: dict | None) -> str | None:
+    if not reviewer:
+        return None
+    if reviewer["__typename"] == "Team":
+        return f"{reviewer['organization']['login']}/{reviewer['slug']}"
+    return reviewer.get("login")
+
+
+def run(
+    repository: str,
+    token: str,
+    *,
+    now: datetime | None = None,
+    output: TextIO = sys.stdout,
+    dry_run: bool = False,
+    preview_path: Path | None = None,
+    client: GitHubClient | None = None,
+) -> int:
+    """Refresh labels and the dashboard for one repository."""
+    generated_at = now or datetime.now(UTC)
+    client = client or GitHubClient(repository, token)
+    pull_requests = fetch_pull_requests(client, repository)
+    breaches = [
+        breach
+        for pull_request in pull_requests
+        if (breach := classify_pull_request(pull_request, generated_at)) is not None
+    ]
+    breaches_by_number = {breach.number: breach for breach in breaches}
+    dashboard = render_dashboard(breaches, generated_at)
+    if dry_run:
+        if preview_path is None:
+            raise ValueError("preview_path is required for a dry run")
+        preview_path.write_text(dashboard, encoding="utf-8")
+        print(f"Preview written to {preview_path}. No GitHub changes made.", file=output)
+        return 0
+
+    sync_sla_labels(client, pull_requests, breaches_by_number)
+    upsert_dashboard(client, dashboard)
+
+    reviewer_count = sum(breach.owner == "reviewer" for breach in breaches)
+    author_count = sum(breach.owner == "author" for breach in breaches)
+    triage_count = sum(breach.owner == "triage" for breach in breaches)
+    print(
+        f"Tracked {len(pull_requests)} open pull requests: "
+        f"{reviewer_count} reviewer breach(es), {author_count} author breach(es), "
+        f"{triage_count} review-assignment breach(es).",
+        file=output,
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo", default=os.environ.get("GITHUB_REPOSITORY"), help="GitHub repository in OWNER/NAME form"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="write a local preview without changing GitHub")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("tracker-preview.md"),
+        help="dry-run Markdown output path (default: tracker-preview.md)",
+    )
+    args = parser.parse_args(argv)
+    if not args.repo:
+        parser.error("--repo or GITHUB_REPOSITORY is required")
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        parser.error("GH_TOKEN or GITHUB_TOKEN is required")
+    return run(args.repo, token, dry_run=args.dry_run, preview_path=args.output)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit_tests/test_pr_sla_tracker.py
+++ b/tests/unit_tests/test_pr_sla_tracker.py
@@ -1,0 +1,481 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import UTC, datetime
+from importlib import import_module
+from io import StringIO
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def _tracker():
+    return import_module("scripts.pr_sla_tracker")
+
+
+def _at(value: str) -> datetime:
+    return datetime.fromisoformat(value).replace(tzinfo=UTC)
+
+
+def _pull_request(**overrides):
+    pull_request = {
+        "number": 42,
+        "title": "Make rollouts observable",
+        "url": "https://github.com/NVIDIA-NeMo/Gym/pull/42",
+        "author": "octocat",
+        "author_is_bot": False,
+        "is_draft": False,
+        "head_ref": "feature/observability",
+        "created_at": _at("2026-07-10T15:00:00"),
+        "ready_at": _at("2026-07-10T15:00:00"),
+        "requested_reviewers": (),
+        "review_request_times": {},
+        "latest_review": None,
+        "labels": set(),
+    }
+    pull_request.update(overrides)
+    return pull_request
+
+
+def test_business_day_deadline_skips_a_weekend() -> None:
+    tracker = _tracker()
+
+    deadline = tracker.business_day_deadline(_at("2026-07-10T15:00:00"))
+
+    assert deadline == _at("2026-07-13T15:00:00")
+
+
+def test_review_request_breaches_after_one_business_day() -> None:
+    tracker = _tracker()
+    pull_request = _pull_request(
+        requested_reviewers=("reviewer-a",),
+        review_request_times={"reviewer-a": _at("2026-07-10T15:00:00")},
+    )
+
+    assert tracker.classify_pull_request(pull_request, _at("2026-07-13T14:59:59")) is None
+
+    breach = tracker.classify_pull_request(pull_request, _at("2026-07-13T15:00:01"))
+
+    assert breach.owner == "reviewer"
+    assert breach.people == ("reviewer-a",)
+    assert breach.since == _at("2026-07-10T15:00:00")
+    assert breach.deadline == _at("2026-07-13T15:00:00")
+    assert breach.reason == "review requested"
+
+
+def test_only_overdue_reviewers_are_named() -> None:
+    tracker = _tracker()
+    pull_request = _pull_request(
+        requested_reviewers=("reviewer-a", "reviewer-b"),
+        review_request_times={
+            "reviewer-a": _at("2026-07-10T15:00:00"),
+            "reviewer-b": _at("2026-07-13T14:00:00"),
+        },
+    )
+
+    breach = tracker.classify_pull_request(pull_request, _at("2026-07-13T16:00:00"))
+
+    assert breach.people == ("reviewer-a",)
+
+
+def test_changes_requested_breaches_against_author() -> None:
+    tracker = _tracker()
+    pull_request = _pull_request(
+        latest_review={"state": "CHANGES_REQUESTED", "submitted_at": _at("2026-07-13T09:00:00")},
+    )
+
+    breach = tracker.classify_pull_request(pull_request, _at("2026-07-14T09:00:01"))
+
+    assert breach.owner == "author"
+    assert breach.people == ("octocat",)
+    assert breach.since == _at("2026-07-13T09:00:00")
+    assert breach.reason == "changes requested"
+
+
+def test_ready_pull_request_without_a_reviewer_needs_maintainer_triage() -> None:
+    tracker = _tracker()
+    pull_request = _pull_request()
+
+    breach = tracker.classify_pull_request(pull_request, _at("2026-07-13T15:00:01"))
+
+    assert breach.owner == "triage"
+    assert breach.people == ()
+    assert breach.reason == "reviewer not assigned"
+
+
+@pytest.mark.parametrize("state", ["APPROVED", "COMMENTED", "DISMISSED"])
+def test_non_actionable_review_state_is_not_tracked(state: str) -> None:
+    tracker = _tracker()
+    pull_request = _pull_request(
+        latest_review={"state": state, "submitted_at": _at("2026-07-10T15:00:00")},
+    )
+
+    assert tracker.classify_pull_request(pull_request, _at("2026-07-14T15:00:00")) is None
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"is_draft": True},
+        {"author": "dependabot[bot]"},
+        {"author_is_bot": True},
+        {"head_ref": "release-please--branches--main"},
+        {"labels": {"stale"}},
+        {"labels": {"PAUSED"}},
+        {"labels": {"do-not-track"}},
+    ],
+)
+def test_non_actionable_pull_request_is_excluded(overrides: dict) -> None:
+    tracker = _tracker()
+    pull_request = _pull_request(**overrides)
+
+    assert tracker.classify_pull_request(pull_request, _at("2026-07-14T15:00:00")) is None
+
+
+def test_dashboard_groups_reviewer_and_author_breaches() -> None:
+    tracker = _tracker()
+    generated_at = _at("2026-07-14T16:00:00")
+    reviewer_breach = tracker.classify_pull_request(
+        _pull_request(
+            title="Reviewer | handoff",
+            requested_reviewers=("reviewer-a",),
+            review_request_times={"reviewer-a": _at("2026-07-13T15:00:00")},
+        ),
+        generated_at,
+    )
+    author_breach = tracker.classify_pull_request(
+        _pull_request(
+            number=43,
+            title="Author handoff",
+            url="https://github.com/NVIDIA-NeMo/Gym/pull/43",
+            latest_review={"state": "CHANGES_REQUESTED", "submitted_at": _at("2026-07-10T10:00:00")},
+        ),
+        generated_at,
+    )
+    triage_breach = tracker.classify_pull_request(
+        _pull_request(
+            number=44,
+            title="Review assignment needed",
+            url="https://github.com/NVIDIA-NeMo/Gym/pull/44",
+            ready_at=_at("2026-07-13T12:00:00"),
+        ),
+        generated_at,
+    )
+
+    dashboard = tracker.render_dashboard([reviewer_breach, author_breach, triage_breach], generated_at)
+
+    assert "<!-- pr-sla-tracker -->" in dashboard
+    assert "## Newly breached (2)" in dashboard
+    assert "### Waiting on reviewers (1)" in dashboard
+    assert "### Needs review assignment (1)" in dashboard
+    assert "<summary><strong>Older breach backlog (1)</strong></summary>" in dashboard
+    assert "### Waiting on authors (1)" in dashboard
+    assert "Reviewer \\| handoff" in dashboard
+    assert "[@reviewer-a](https://github.com/reviewer-a)" in dashboard
+    assert "Maintainers" in dashboard
+    assert "Review during the daily stand-up" in dashboard
+
+
+def test_dashboard_has_an_explicit_all_clear_state() -> None:
+    tracker = _tracker()
+
+    dashboard = tracker.render_dashboard([], _at("2026-07-14T16:00:00"))
+
+    assert "No pull requests have breached the one-business-day handoff SLA." in dashboard
+
+
+def test_graphql_pull_request_is_normalized_to_latest_handoffs() -> None:
+    tracker = _tracker()
+    node = {
+        "number": 42,
+        "title": "Make rollouts observable",
+        "url": "https://github.com/NVIDIA-NeMo/Gym/pull/42",
+        "isDraft": False,
+        "headRefName": "feature/observability",
+        "createdAt": "2026-07-10T10:00:00Z",
+        "author": {"__typename": "User", "login": "octocat"},
+        "labels": {"nodes": [{"name": "bug"}]},
+        "reviewRequests": {
+            "nodes": [
+                {"requestedReviewer": {"__typename": "User", "login": "reviewer-a"}},
+                {
+                    "requestedReviewer": {
+                        "__typename": "Team",
+                        "slug": "automation",
+                        "organization": {"login": "nvidia-nemo"},
+                    }
+                },
+            ]
+        },
+        "reviews": {
+            "nodes": [
+                {"state": "COMMENTED", "submittedAt": "2026-07-10T12:00:00Z"},
+                {"state": "CHANGES_REQUESTED", "submittedAt": "2026-07-10T13:00:00Z"},
+            ]
+        },
+        "timelineItems": {
+            "nodes": [
+                {"__typename": "ReadyForReviewEvent", "createdAt": "2026-07-10T11:00:00Z"},
+                {
+                    "__typename": "ReviewRequestedEvent",
+                    "createdAt": "2026-07-10T11:30:00Z",
+                    "requestedReviewer": {"__typename": "User", "login": "reviewer-a"},
+                },
+                {
+                    "__typename": "ReviewRequestedEvent",
+                    "createdAt": "2026-07-10T14:00:00Z",
+                    "requestedReviewer": {"__typename": "User", "login": "reviewer-a"},
+                },
+            ]
+        },
+    }
+
+    pull_request = tracker.normalize_pull_request(node)
+
+    assert pull_request["author"] == "octocat"
+    assert pull_request["author_is_bot"] is False
+    assert pull_request["ready_at"] == _at("2026-07-10T11:00:00")
+    assert pull_request["requested_reviewers"] == ("nvidia-nemo/automation", "reviewer-a")
+    assert pull_request["review_request_times"]["reviewer-a"] == _at("2026-07-10T14:00:00")
+    assert pull_request["latest_review"] == {
+        "state": "CHANGES_REQUESTED",
+        "submitted_at": _at("2026-07-10T13:00:00"),
+    }
+    assert pull_request["labels"] == {"bug"}
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.added: list[tuple[int, str]] = []
+        self.removed: list[tuple[int, str]] = []
+        self.ensured: list[str] = []
+        self.dashboard_issue = None
+        self.created_body = None
+        self.updated = None
+
+    def ensure_label(self, name: str, _color: str, _description: str) -> None:
+        self.ensured.append(name)
+
+    def add_label(self, number: int, name: str) -> None:
+        self.added.append((number, name))
+
+    def remove_label(self, number: int, name: str) -> None:
+        self.removed.append((number, name))
+
+    def find_dashboard_issue(self):
+        return self.dashboard_issue
+
+    def create_dashboard_issue(self, body: str) -> None:
+        self.created_body = body
+
+    def update_dashboard_issue(self, number: int, body: str, *, reopen: bool) -> None:
+        self.updated = (number, body, reopen)
+
+
+def test_sla_labels_are_reconciled_without_touching_unrelated_labels() -> None:
+    tracker = _tracker()
+    client = _FakeClient()
+    reviewer_pr = _pull_request(labels={"bug", tracker.AUTHOR_LABEL})
+    author_pr = _pull_request(number=43, labels=set())
+    clear_pr = _pull_request(number=44, labels={tracker.REVIEWER_LABEL})
+    triage_pr = _pull_request(number=45, labels=set())
+    reviewer_breach = tracker.classify_pull_request(
+        _pull_request(
+            requested_reviewers=("reviewer-a",),
+            review_request_times={"reviewer-a": _at("2026-07-10T15:00:00")},
+        ),
+        _at("2026-07-14T16:00:00"),
+    )
+    author_breach = tracker.classify_pull_request(
+        _pull_request(
+            number=43,
+            latest_review={"state": "CHANGES_REQUESTED", "submitted_at": _at("2026-07-10T10:00:00")},
+        ),
+        _at("2026-07-14T16:00:00"),
+    )
+    triage_breach = tracker.classify_pull_request(triage_pr, _at("2026-07-14T16:00:00"))
+
+    tracker.sync_sla_labels(
+        client,
+        [reviewer_pr, author_pr, clear_pr, triage_pr],
+        {42: reviewer_breach, 43: author_breach, 45: triage_breach},
+    )
+
+    assert set(client.ensured) == {tracker.REVIEWER_LABEL, tracker.AUTHOR_LABEL, tracker.TRIAGE_LABEL}
+    assert client.added == [
+        (42, tracker.REVIEWER_LABEL),
+        (43, tracker.AUTHOR_LABEL),
+        (45, tracker.TRIAGE_LABEL),
+    ]
+    assert client.removed == [(42, tracker.AUTHOR_LABEL), (44, tracker.REVIEWER_LABEL)]
+
+
+def test_dashboard_issue_is_created_once_then_reopened_and_updated() -> None:
+    tracker = _tracker()
+    client = _FakeClient()
+
+    tracker.upsert_dashboard(client, "first body")
+
+    assert client.created_body == "first body"
+
+    client.dashboard_issue = {"number": 123, "state": "closed"}
+    tracker.upsert_dashboard(client, "second body")
+
+    assert client.updated == (123, "second body", True)
+
+
+def test_open_pull_requests_are_fetched_across_graphql_pages() -> None:
+    tracker = _tracker()
+    node = {
+        "number": 42,
+        "title": "Make rollouts observable",
+        "url": "https://github.com/NVIDIA-NeMo/Gym/pull/42",
+        "isDraft": False,
+        "headRefName": "feature/observability",
+        "createdAt": "2026-07-10T10:00:00Z",
+        "author": {"login": "octocat"},
+        "labels": {"nodes": []},
+        "reviewRequests": {"nodes": []},
+        "reviews": {"nodes": []},
+        "timelineItems": {"nodes": []},
+    }
+
+    class FakeGraphQLClient:
+        def __init__(self) -> None:
+            self.cursors = []
+
+        def graphql(self, _query: str, variables: dict):
+            self.cursors.append(variables["cursor"])
+            if variables["cursor"] is None:
+                return {
+                    "repository": {
+                        "pullRequests": {
+                            "nodes": [node],
+                            "pageInfo": {"hasNextPage": True, "endCursor": "page-2"},
+                        }
+                    }
+                }
+            return {
+                "repository": {
+                    "pullRequests": {
+                        "nodes": [{**node, "number": 43}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+
+    client = FakeGraphQLClient()
+
+    pull_requests = tracker.fetch_pull_requests(client, "NVIDIA-NeMo/Gym")
+
+    assert [pull_request["number"] for pull_request in pull_requests] == [42, 43]
+    assert client.cursors == [None, "page-2"]
+
+
+def test_workflow_runs_hourly_on_weekdays_with_minimal_permissions() -> None:
+    workflow_path = Path(__file__).parents[2] / ".github/workflows/pr-sla-tracker.yml"
+
+    assert workflow_path.exists()
+    workflow = yaml.load(workflow_path.read_text(), Loader=yaml.BaseLoader)
+
+    assert workflow["on"]["schedule"] == [{"cron": "17 * * * 1-5"}]
+    assert "workflow_dispatch" in workflow["on"]
+    assert workflow["permissions"] == {
+        "contents": "read",
+        "issues": "write",
+        "pull-requests": "read",
+    }
+    assert workflow["jobs"]["refresh"]["timeout-minutes"] == "10"
+
+
+def test_dry_run_writes_live_dashboard_without_github_mutations(tmp_path: Path) -> None:
+    tracker = _tracker()
+    node = {
+        "number": 42,
+        "title": "Make rollouts observable",
+        "url": "https://github.com/NVIDIA-NeMo/Gym/pull/42",
+        "isDraft": False,
+        "headRefName": "feature/observability",
+        "createdAt": "2026-07-10T10:00:00Z",
+        "author": {"login": "octocat"},
+        "labels": {"nodes": []},
+        "reviewRequests": {"nodes": []},
+        "reviews": {"nodes": []},
+        "timelineItems": {"nodes": []},
+    }
+
+    class ReadOnlyClient:
+        def graphql(self, _query: str, _variables: dict):
+            return {
+                "repository": {
+                    "pullRequests": {
+                        "nodes": [node, {**node, "number": 43, "title": "Draft should stay hidden", "isDraft": True}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+
+        def __getattr__(self, name: str):
+            raise AssertionError(f"dry-run attempted GitHub mutation: {name}")
+
+    preview_path = tmp_path / "tracker-preview.md"
+    output = StringIO()
+
+    result = tracker.run(
+        "NVIDIA-NeMo/Gym",
+        "unused-token",
+        now=_at("2026-07-15T09:00:00"),
+        output=output,
+        dry_run=True,
+        preview_path=preview_path,
+        client=ReadOnlyClient(),
+    )
+
+    assert result == 0
+    preview = preview_path.read_text()
+    assert "### Needs review assignment (1)" in preview
+    assert "Draft should stay hidden" not in preview
+    assert "No GitHub changes made" in output.getvalue()
+
+
+def test_cli_accepts_dry_run_and_output_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    tracker = _tracker()
+    preview_path = tmp_path / "live-preview.md"
+    received = {}
+
+    def fake_run(repository: str, token: str, **kwargs) -> int:
+        received.update(repository=repository, token=token, **kwargs)
+        return 0
+
+    monkeypatch.setenv("GH_TOKEN", "test-token")
+    monkeypatch.setattr(tracker, "run", fake_run)
+
+    result = tracker.main(
+        [
+            "--repo",
+            "NVIDIA-NeMo/Gym",
+            "--dry-run",
+            "--output",
+            str(preview_path),
+        ]
+    )
+
+    assert result == 0
+    assert received == {
+        "repository": "NVIDIA-NeMo/Gym",
+        "token": "test-token",
+        "dry_run": True,
+        "preview_path": preview_path,
+    }


### PR DESCRIPTION
The tracker will appear as a regular open GitHub Issue in NVIDIA-NeMo/Gym, titled:
[Tracker] Pull request handoff SLA

The workflow will:
Create that issue on its first run and continually update the same issue.
Add the relevant SLA labels directly to breached PRs.
Run hourly at minute 17, Monday–Friday.
Also be manually runnable under Actions → Pull Request SLA Tracker.

Attached an example run
[gym-pr-sla-preview.md](https://github.com/user-attachments/files/30042552/gym-pr-sla-preview.md)
