### PR TITLE
feat: unify judge failures in Gym benchmarks

### DIFF
--- a/nemo_gym/judge.py
+++ b/nemo_gym/judge.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared LLM-as-judge failure abstraction.
+
+A failed judge call (auth, rate limit, timeout, endpoint/HTTP error, empty
+response) is a distinct outcome, not a wrong answer. Judge-based resources
+servers record failures with the same field names and semantics via:
+
+- ``JudgeFailureMixin`` — the two standard verify-response fields.
+- ``run_judge`` — await a judge call, recording any error verbatim instead of
+  raising or silently defaulting to a low score.
+- ``judge_failure_metrics`` — failure count + a judge-success-only reward, for a
+  benchmark's ``compute_metrics``.
+"""
+
+from typing import Any, Awaitable, Optional
+
+from pydantic import BaseModel
+
+
+class JudgeFailureMixin(BaseModel):
+    """Standard judge-failure fields to mix into a verify-response model.
+
+    ``judge_failed`` is a bool, so it auto-aggregates to ``mean/judge_failed``
+    (the per-job and per-task failure rate). ``judge_failure_reason`` is the raw
+    error text, carried per-sample into the rollout (dropped from aggregates).
+    """
+
+    judge_failed: bool = False
+    judge_failure_reason: Optional[str] = None
+
+
+async def run_judge(coro: Awaitable[Any]) -> tuple[Optional[Any], Optional[str]]:
+    """Await a judge call. Return ``(result, None)`` on success or
+    ``(None, raw_error_text)`` on any failure. Never raises.
+
+    The error is recorded verbatim — no provider-specific classification.
+    """
+    try:
+        return await coro, None
+    except Exception as e:
+        return None, f"{type(e).__name__}: {e}"
+
+
+def judge_failure_metrics(tasks: list[list[dict]]) -> dict:
+    """Judge-failure metrics from verify responses grouped by task.
+
+    ``mean/reward`` (failures counted as 0.0) and ``mean/judge_failed`` (the
+    rate) are emitted automatically by the aggregator. This adds the absolute
+    failure count and the judge-success-only mean reward (failures excluded from
+    the denominator; ``None`` when every sample failed).
+    """
+    rows = [r for task in tasks for r in task]
+    if not rows:
+        return {}
+    scored = [r for r in rows if not r.get("judge_failed")]
+    return {
+        "judge_failures": len(rows) - len(scored),
+        "reward[judge_ok_only]": (sum(r.get("reward", 0.0) for r in scored) / len(scored)) if scored else None,
+    }

--- a/resources_servers/aalcr/app.py
+++ b/resources_servers/aalcr/app.py
@@ -22,6 +22,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import NeMoGymResponse, NeMoGymResponseCreateParamsNonStreaming
 from nemo_gym.server_utils import get_response_json
 
@@ -43,7 +44,7 @@ class AALCRVerifyRequest(BaseVerifyRequest):
     input_tokens_band: str
 
 
-class AALCRVerifyResponse(AALCRVerifyRequest, BaseVerifyResponse):
+class AALCRVerifyResponse(JudgeFailureMixin, AALCRVerifyRequest, BaseVerifyResponse):
     invalid_model_response: bool
     invalid_judge_response: Optional[bool] = None
     judge_responses_create_params: Optional[NeMoGymResponseCreateParamsNonStreaming] = None
@@ -57,6 +58,24 @@ class AALCRVerifyResponse(AALCRVerifyRequest, BaseVerifyResponse):
 
 class AalcrResourcesServer(SimpleResourcesServer):
     config: AalcrResourcesServerConfig
+
+    def compute_metrics(self, tasks: list[list[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
+
+    def get_key_metrics(self, agent_metrics: dict) -> dict:
+        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
+        return key
+
+    async def _call_judge(self, judge_responses_create_params: dict) -> NeMoGymResponse:
+        http_response = await self.server_client.post(
+            server_name=self.config.judge_model_server.name,
+            url_path="/v1/responses",
+            json=judge_responses_create_params,
+        )
+        return NeMoGymResponse.model_validate(await get_response_json(http_response))
 
     async def verify(self, body: AALCRVerifyRequest) -> AALCRVerifyResponse:
         match body.input_tokens_band:
@@ -93,14 +112,24 @@ Reply only with CORRECT or INCORRECT."""
         judge_responses_create_params = dict(input=[{"role": "user", "content": judge_prompt}])
         judge_responses_create_params |= self.config.judge_responses_create_params_overrides
 
-        http_response = await self.server_client.post(
-            server_name=self.config.judge_model_server.name,
-            url_path="/v1/responses",
-            json=judge_responses_create_params,
-        )
-        judge_response = NeMoGymResponse.model_validate(await get_response_json(http_response))
+        # A failed judge call (auth, rate limit, timeout, HTTP error, empty response) is a
+        # distinct outcome, not a wrong answer: record it instead of silently scoring 0.
+        judge_response, judge_failure = await run_judge(self._call_judge(judge_responses_create_params))
+        judge_response_text = judge_response.output_text.strip() if judge_response is not None else ""
+        if judge_failure is not None or not judge_response_text:
+            reward = 0.0
+            return AALCRVerifyResponse(
+                **body.model_dump(),
+                reward=reward,
+                invalid_model_response=False,
+                invalid_judge_response=True,
+                judge_responses_create_params=judge_responses_create_params,
+                judge_response=judge_response,
+                judge_failed=True,
+                judge_failure_reason=judge_failure or "empty judge response",
+                **{input_tokens_band_key: reward},
+            )
 
-        judge_response_text = judge_response.output_text.strip()
         if judge_response_text == "CORRECT":
             invalid_judge_response = False
             reward = 1.0

--- a/resources_servers/aalcr/tests/test_app.py
+++ b/resources_servers/aalcr/tests/test_app.py
@@ -12,23 +12,80 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
+from pytest import approx
+
+from nemo_gym.openai_utils import (
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseOutputMessage,
+    NeMoGymResponseOutputText,
+)
 from nemo_gym.server_utils import ServerClient
-from resources_servers.aalcr.app import AalcrResourcesServer, AalcrResourcesServerConfig
+from resources_servers.aalcr.app import AalcrResourcesServer, AalcrResourcesServerConfig, AALCRVerifyRequest
+
+
+def _config() -> AalcrResourcesServerConfig:
+    return AalcrResourcesServerConfig(
+        host="0.0.0.0",
+        port=8080,
+        entrypoint="",
+        name="",
+        judge_model_server={
+            "type": "responses_api_models",
+            "name": "abcd",
+        },
+        judge_responses_create_params_overrides=dict(),
+    )
+
+
+def _model_response(text: str) -> NeMoGymResponse:
+    return NeMoGymResponse(
+        id="resp",
+        created_at=0.0,
+        model="test_model",
+        object="response",
+        output=[
+            NeMoGymResponseOutputMessage(
+                id="msg_id",
+                content=[NeMoGymResponseOutputText(annotations=[], text=text, type="output_text")],
+                role="assistant",
+                status="completed",
+                type="message",
+            )
+        ],
+        parallel_tool_calls=False,
+        tool_choice="none",
+        tools=[],
+    )
 
 
 class TestApp:
     def test_sanity(self) -> None:
-        config = AalcrResourcesServerConfig(
-            host="0.0.0.0",
-            port=8080,
-            entrypoint="",
-            name="",
-            judge_model_server={
-                "type": "responses_api_models",
-                "name": "abcd",
-            },
-            judge_responses_create_params_overrides=dict(),
+        AalcrResourcesServer(config=_config(), server_client=MagicMock(spec=ServerClient))
+
+    async def test_verify_judge_failure(self) -> None:
+        """A failed judge call is recorded as a distinct outcome, not a wrong answer."""
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        server = AalcrResourcesServer(config=_config(), server_client=server_client)
+
+        req = AALCRVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=_model_response("candidate answer"),
+            document_category="c",
+            document_set_id="s",
+            question_id=1,
+            question="q",
+            answer="a",
+            data_source_filenames="f",
+            data_source_urls="u",
+            input_tokens=1000,
+            input_tokens_band="<80k",
         )
-        AalcrResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+        res = await server.verify(req)
+
+        assert res.reward == approx(0.0)
+        assert res.judge_failed is True
+        assert "judge timeout" in res.judge_failure_reason

--- a/resources_servers/abstention/app.py
+++ b/resources_servers/abstention/app.py
@@ -44,6 +44,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -274,7 +275,7 @@ class AbstentionVerifyRequest(AbstentionRunRequest, BaseVerifyRequest):
     pass
 
 
-class AbstentionVerifyResponse(BaseVerifyResponse):
+class AbstentionVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     model_config = ConfigDict(extra="allow")
 
     extracted_answer: Optional[str] = None
@@ -299,6 +300,31 @@ class AbstentionServer(SimpleResourcesServer):
         app = super().setup_webserver()
         return app
 
+    def compute_metrics(self, tasks: List[List[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
+
+    def get_key_metrics(self, agent_metrics: dict) -> dict:
+        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
+        return key
+
+    async def _call_judge(self, judge_prompt: str) -> str:
+        msgs: List[NeMoGymEasyInputMessage] = [
+            NeMoGymEasyInputMessage(role="user", content=judge_prompt),
+        ]
+        request_params = self.config.judge_responses_create_params.model_copy(deep=True)
+        request_params.input = msgs
+
+        response_obj = await self.server_client.post(
+            server_name=self.config.judge_model_server.name,
+            url_path="/v1/responses",
+            json=request_params,
+        )
+        judge_response = NeMoGymResponse.model_validate(await response_obj.json())
+        return extract_text_from_response(judge_response)
+
     async def verify(self, body: AbstentionVerifyRequest) -> AbstentionVerifyResponse:
         policy_output = extract_text_from_response(body.response)
 
@@ -321,19 +347,21 @@ class AbstentionServer(SimpleResourcesServer):
                 predicted_answer=extracted,
             )
 
-            msgs: List[NeMoGymEasyInputMessage] = [
-                NeMoGymEasyInputMessage(role="user", content=judge_prompt),
-            ]
-            request_params = self.config.judge_responses_create_params.model_copy(deep=True)
-            request_params.input = msgs
+            judge_text, judge_failure = await run_judge(self._call_judge(judge_prompt))
 
-            response_obj = await self.server_client.post(
-                server_name=self.config.judge_model_server.name,
-                url_path="/v1/responses",
-                json=request_params,
-            )
-            judge_response = NeMoGymResponse.model_validate(await response_obj.json())
-            judge_text = extract_text_from_response(judge_response)
+            # A failed or empty judge call is a distinct outcome, not a wrong answer:
+            # reward stays 0.0 but judge_failed flags it out of the accuracy denominator.
+            if judge_failure is not None or not judge_text:
+                return AbstentionVerifyResponse(
+                    **body.model_dump(),
+                    reward=0.0,
+                    extracted_answer=extracted,
+                    ground_truth=ground_truth,
+                    verdict=None,
+                    judge_output=judge_text or "",
+                    judge_failed=True,
+                    judge_failure_reason=judge_failure or "empty judge response",
+                )
 
             grade = parse_judge_grade(judge_text)
             if grade == "A":

--- a/resources_servers/abstention/tests/test_app.py
+++ b/resources_servers/abstention/tests/test_app.py
@@ -367,6 +367,24 @@ class TestAbstentionServer:
         assert "omniscience_index" in dump
         assert result.ground_truth == "Test answer"
 
+    async def test_verify_judge_failure_recorded(self, config: AbstentionConfig) -> None:
+        server_mock = MagicMock(spec=ServerClient)
+        server = AbstentionServer(config=config, server_client=server_mock)
+        server_mock.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+
+        model_response = self._make_model_response("The answer is \\boxed{No}")
+        request = AbstentionVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=model_response,
+            question="Were Scott Derrickson and Ed Wood of the same nationality?",
+            answer="Yes",
+        )
+
+        result = await server.verify(request)
+        assert result.reward == approx(0.0)
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason
+
     async def test_verify_no_boxed_uses_full_text(self, config: AbstentionConfig) -> None:
         server_mock = MagicMock(spec=ServerClient)
         server = AbstentionServer(config=config, server_client=server_mock)

--- a/resources_servers/arena_judge/app.py
+++ b/resources_servers/arena_judge/app.py
@@ -56,6 +56,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
     NeMoGymChatCompletionCreateParamsNonStreaming,
@@ -155,7 +156,7 @@ class ArenaJudgeVerifyRequest(ArenaJudgeRunRequest, BaseVerifyRequest):
     pass
 
 
-class ArenaJudgeVerifyResponse(BaseVerifyResponse):
+class ArenaJudgeVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     """Verify response carries raw judge outputs + parsed verdicts.
 
     The raw text fields (``judgement_gen_base`` / ``judgement_base_gen``)
@@ -219,15 +220,23 @@ class ArenaJudgeServer(SimpleResourcesServer):
 
         # Two judge calls in parallel — A=candidate/B=baseline (gen-base)
         # and swapped (base-gen).
-        (gen_base_text, gen_base_verdict), (base_gen_text, base_gen_verdict) = await asyncio.gather(
-            self._judge_once(category, question, candidate_answer, baseline_answer),
-            self._judge_once(category, question, baseline_answer, candidate_answer),
+        (gen_base_text, gen_base_verdict, gen_base_fail), (base_gen_text, base_gen_verdict, base_gen_fail) = (
+            await asyncio.gather(
+                self._judge_once(category, question, candidate_answer, baseline_answer),
+                self._judge_once(category, question, baseline_answer, candidate_answer),
+            )
         )
+
+        # A failed judge CALL (auth, rate limit, timeout, HTTP error) is a
+        # distinct outcome, not a wrong answer — flag it via the standard
+        # judge_failed field with reward 0.0. Parser-level invalid verdicts
+        # (no parseable label) keep the existing invalid_* flags.
+        judge_failure = gen_base_fail or base_gen_fail
 
         # Per-rollout binary reward from the gen-base direction.
         # Candidate wins (reward=1.0) if it strictly beats the baseline in
         # the gen-base call; ties and losses both score 0.
-        reward = 1.0 if gen_base_verdict in ("A>>B", "A>B") else 0.0
+        reward = 0.0 if judge_failure is not None else (1.0 if gen_base_verdict in ("A>>B", "A>B") else 0.0)
 
         # ``body.model_dump()`` already carries ``category`` (declared
         # field). Drop it before spreading so the RESOLVED category
@@ -244,6 +253,8 @@ class ArenaJudgeServer(SimpleResourcesServer):
             category=category,
             invalid_gen_base=gen_base_verdict is None,
             invalid_base_gen=base_gen_verdict is None,
+            judge_failed=judge_failure is not None,
+            judge_failure_reason=judge_failure,
         )
 
     # ------------------------------------------------------------------
@@ -252,11 +263,13 @@ class ArenaJudgeServer(SimpleResourcesServer):
 
     async def _judge_once(
         self, category: str, question: str, answer_1: str, answer_2: str
-    ) -> tuple[str, Optional[str]]:
+    ) -> tuple[str, Optional[str], Optional[str]]:
         """Run a single judge call via /v1/chat/completions.
 
-        Returns (raw_text, parsed_verdict). Network or parse failures
-        return ("", None), treated as "invalid score" by the aggregate.
+        Returns (raw_text, parsed_verdict, failure_reason). A failed judge
+        CALL yields ("", None, "ErrType: msg") — recorded as judge_failed,
+        not a wrong answer. A successful call with no parseable label yields
+        (text, None, None), the existing "invalid verdict" outcome.
         """
         prompt = self._prompts[category]
         fill = {"question": question, "answer_1": answer_1, "answer_2": answer_2}
@@ -269,20 +282,22 @@ class ArenaJudgeServer(SimpleResourcesServer):
         request_params = self.config.judge_chat_completions_create_params.model_copy(deep=True)
         request_params.messages = messages
 
-        try:
+        async def _call() -> NeMoGymChatCompletion:
             response_obj = await self.server_client.post(
                 server_name=self.config.judge_model_server.name,
                 url_path="/v1/chat/completions",
                 json=request_params,
             )
-            judge_response = NeMoGymChatCompletion.model_validate(await get_response_json(response_obj))
-        except Exception:
-            logger.exception("Judge call failed for category=%s; treating as invalid verdict.", category)
-            return "", None
+            return NeMoGymChatCompletion.model_validate(await get_response_json(response_obj))
+
+        judge_response, failure = await run_judge(_call())
+        if failure is not None:
+            logger.warning("Judge call failed for category=%s; recording judge failure: %s", category, failure)
+            return "", None, failure
 
         text = self._extract_chat_completion_text(judge_response)
         verdict = self._parse_verdict(text)
-        return text, verdict
+        return text, verdict, None
 
     # ------------------------------------------------------------------
     # Verdict / response helpers
@@ -379,6 +394,7 @@ class ArenaJudgeServer(SimpleResourcesServer):
         # Arena-Elo (MLE + 100-round bootstrap 95% CI) — the headline
         # metric for arena-hard-v2. Overall + per-category.
         metrics.update(self._compute_arena_elo_metrics(tasks))
+        metrics.update(judge_failure_metrics(tasks))
         return metrics
 
     def get_key_metrics(self, agent_metrics: Dict[str, Any]) -> Dict[str, Any]:
@@ -392,6 +408,10 @@ class ArenaJudgeServer(SimpleResourcesServer):
                 key[name] = agent_metrics[name]
         key.update(highest_k_metrics(agent_metrics, "pass@1[avg-of-{k}]"))
         key.update(highest_k_metrics(agent_metrics, "pass@{k}", exclude_names=["no_answer"]))
+        # Judge-failure signal: count, rate, and the judge-success-only reward.
+        for name in ("judge_failures", "mean/judge_failed", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
         return key
 
     # ------------------------------------------------------------------

--- a/resources_servers/arena_judge/app.py
+++ b/resources_servers/arena_judge/app.py
@@ -220,11 +220,12 @@ class ArenaJudgeServer(SimpleResourcesServer):
 
         # Two judge calls in parallel — A=candidate/B=baseline (gen-base)
         # and swapped (base-gen).
-        (gen_base_text, gen_base_verdict, gen_base_fail), (base_gen_text, base_gen_verdict, base_gen_fail) = (
-            await asyncio.gather(
-                self._judge_once(category, question, candidate_answer, baseline_answer),
-                self._judge_once(category, question, baseline_answer, candidate_answer),
-            )
+        (
+            (gen_base_text, gen_base_verdict, gen_base_fail),
+            (base_gen_text, base_gen_verdict, base_gen_fail),
+        ) = await asyncio.gather(
+            self._judge_once(category, question, candidate_answer, baseline_answer),
+            self._judge_once(category, question, baseline_answer, candidate_answer),
         )
 
         # A failed judge CALL (auth, rate limit, timeout, HTTP error) is a

--- a/resources_servers/arena_judge/tests/test_app.py
+++ b/resources_servers/arena_judge/tests/test_app.py
@@ -320,6 +320,10 @@ class TestArenaJudgeServer:
         assert result.reward == approx(0.0)
         assert result.invalid_gen_base is True
         assert result.invalid_base_gen is True
+        # A failed judge CALL is recorded as a distinct outcome via the
+        # standard judge-failure fields, not silently scored as a loss.
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason
 
     @pytest.mark.asyncio
     async def test_unknown_category_falls_back_to_default(self, config: ArenaJudgeConfig) -> None:

--- a/resources_servers/browsecomp_advanced_harness/app.py
+++ b/resources_servers/browsecomp_advanced_harness/app.py
@@ -41,6 +41,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics
 from nemo_gym.openai_utils import (
     RATE_LIMIT_ERROR_CODES,
     RETRY_ERROR_CODES,
@@ -198,7 +199,7 @@ class TavilySearchMetrics(BaseModel):
     async_tavily_calls: List[TavilySearchSingleAsyncTavilyMetrics] = Field(default_factory=list)
 
 
-class TavilySearchVerifyResponse(TavilySearchVerifyRequest, JudgeEvaluation):
+class TavilySearchVerifyResponse(JudgeFailureMixin, TavilySearchVerifyRequest, JudgeEvaluation):
     num_tool_calls: int
     reset_count: int = 0
     metrics: TavilySearchMetrics
@@ -1111,15 +1112,27 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
         results_string = "\n\n".join(blocks)
         return BrowseResponse(results_string=results_string)
 
+    def compute_metrics(self, tasks: list[list[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
+
+    def get_key_metrics(self, agent_metrics: dict) -> dict:
+        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
+        return key
+
     async def verify(self, request: Request, body: TavilySearchVerifyRequest) -> TavilySearchVerifyResponse:
         question = body.question
         ground_truth = body.ground_truth
         last_assistant_response = _last_assistant_text(body.response)
 
         if self.config.use_judge:
-            judge_evaluation = await self._verify_answer_with_judge(question, ground_truth, last_assistant_response)
+            judge_evaluation, judge_failure = await self._verify_answer_with_judge(
+                question, ground_truth, last_assistant_response
+            )
         else:
-            judge_evaluation = self._verify_answer_with_regex(ground_truth, last_assistant_response)
+            judge_evaluation, judge_failure = self._verify_answer_with_regex(ground_truth, last_assistant_response), None
 
         # num_tool_calls now comes from the agent loop (counts ALL tool calls,
         # including those made before context resets). Fall back to the old
@@ -1133,6 +1146,8 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
             num_tool_calls=agent_num_tool_calls,
             reset_count=getattr(body.response, "reset_count", 0) or 0,
             metrics=self._session_id_to_metrics[request.session[SESSION_ID_KEY]],
+            judge_failed=judge_failure is not None,
+            judge_failure_reason=judge_failure,
         )
 
         # terminal mode: clean up this session's disk workspace
@@ -1180,7 +1195,9 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
                     exclude_domains.append(prop["value"])
         return exclude_domains
 
-    async def _verify_answer_with_judge(self, question: str, ground_truth: str, response: str) -> JudgeEvaluation:
+    async def _verify_answer_with_judge(
+        self, question: str, ground_truth: str, response: str
+    ) -> tuple[JudgeEvaluation, Optional[str]]:
         response = re.sub(r"<think>.*?</think>", "", response, flags=re.DOTALL).strip()
 
         judge_prompt = self.JUDGE_PROMPT_TEMPLATE.format(
@@ -1194,6 +1211,7 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
         ]
 
         judge_response = None
+        last_error: Optional[str] = None
         for attempt in range(self.JUDGE_MAX_ATTEMPTS):
             judge_call_start = time()
             try:
@@ -1220,19 +1238,24 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
                         f"[judge_call attempt={attempt + 1} status=success duration_s={time() - judge_call_start:.2f} is_correct={is_correct}]",
                         flush=True,
                     )
-                    return JudgeEvaluation(
-                        judge_response_create_params=judge_create_params,
-                        reasoning=text,
-                        extracted_final_answer=extracted,
-                        reward=1.0 if is_correct else 0.0,
-                        judge_response=judge_response,
+                    return (
+                        JudgeEvaluation(
+                            judge_response_create_params=judge_create_params,
+                            reasoning=text,
+                            extracted_final_answer=extracted,
+                            reward=1.0 if is_correct else 0.0,
+                            judge_response=judge_response,
+                        ),
+                        None,
                     )
                 print(
                     f"[judge_call attempt={attempt + 1} status=parse_error duration_s={time() - judge_call_start:.2f} raw_output={text[:200]!r}]",
                     flush=True,
                 )
+                last_error = f"unparseable judge verdict: {text[:200]!r}"
 
             except Exception as e:
+                last_error = f"{type(e).__name__}: {e}"
                 sleep_s = min(2**attempt, 30)
                 print(
                     f"[judge_call attempt={attempt + 1} status=error duration_s={time() - judge_call_start:.2f} error_type={type(e).__name__} error={str(e)[:200]} backoff_s={sleep_s}]",
@@ -1244,12 +1267,18 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
             f"[judge_exhausted max_attempts={self.JUDGE_MAX_ATTEMPTS} had_response={judge_response is not None}]",
             flush=True,
         )
-        return JudgeEvaluation(
-            judge_response_create_params=judge_create_params,
-            reasoning="",
-            extracted_final_answer="",
-            reward=0.0,
-            judge_response=judge_response,
+        # Exhausting every attempt (repeated call errors or unparseable verdicts) means the judge
+        # never produced a usable score: a distinct outcome, not a wrong answer.
+        judge_failure = last_error or f"judge exhausted after {self.JUDGE_MAX_ATTEMPTS} attempts"
+        return (
+            JudgeEvaluation(
+                judge_response_create_params=judge_create_params,
+                reasoning="",
+                extracted_final_answer="",
+                reward=0.0,
+                judge_response=judge_response,
+            ),
+            judge_failure,
         )
 
     def _verify_answer_with_regex(self, ground_truth: str, response: str) -> JudgeEvaluation:

--- a/resources_servers/browsecomp_advanced_harness/app.py
+++ b/resources_servers/browsecomp_advanced_harness/app.py
@@ -1132,7 +1132,10 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
                 question, ground_truth, last_assistant_response
             )
         else:
-            judge_evaluation, judge_failure = self._verify_answer_with_regex(ground_truth, last_assistant_response), None
+            judge_evaluation, judge_failure = (
+                self._verify_answer_with_regex(ground_truth, last_assistant_response),
+                None,
+            )
 
         # num_tool_calls now comes from the agent loop (counts ALL tool calls,
         # including those made before context resets). Fall back to the old

--- a/resources_servers/browsecomp_advanced_harness/tests/test_app.py
+++ b/resources_servers/browsecomp_advanced_harness/tests/test_app.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import os
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from pytest import approx, fixture
 
@@ -248,6 +248,26 @@ class TestApp:
 
         assert res.reward == approx(1.0)
         assert res.extracted_final_answer == "Paris"
+
+    async def test_verify_judge_failure(self, config: TavilySearchResourcesServerConfig) -> None:
+        """A failed judge call is recorded as a distinct outcome, not a wrong answer."""
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        server = TavilySearchResourcesServer(config=config, server_client=server_client)
+        server.JUDGE_MAX_ATTEMPTS = 1
+
+        req = TavilySearchVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=self._create_model_response("The capital of France is Paris."),
+            ground_truth="Paris",
+            question="What is the capital of France?",
+        )
+        with patch("resources_servers.browsecomp_advanced_harness.app.sleep", new=AsyncMock()):
+            res = await server.verify(self._create_dummy_request(), req)
+
+        assert res.reward == approx(0.0)
+        assert res.judge_failed is True
+        assert "judge timeout" in res.judge_failure_reason
 
     async def test_verify_incorrect_answer(self, config: TavilySearchResourcesServerConfig) -> None:
         server_client = MagicMock(spec=ServerClient)

--- a/resources_servers/equivalence_llm_judge/app.py
+++ b/resources_servers/equivalence_llm_judge/app.py
@@ -37,6 +37,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -136,7 +137,7 @@ class JudgeEvaluation(BaseModel):
     verdict_label: Optional[str] = None
 
 
-class LLMJudgeVerifyResponse(BaseVerifyResponse):
+class LLMJudgeVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     expected_answer: str
     judge_evaluations: list[JudgeEvaluation]
 
@@ -400,6 +401,32 @@ class LLMJudgeResourcesServer(SimpleResourcesServer):
         return self._make_response(body, expected, reward, [first_eval, second_eval])
 
     async def verify(self, body: LLMJudgeVerifyRequest) -> LLMJudgeVerifyResponse:
+        # A judge call that errors (auth, rate limit, timeout, endpoint error) is
+        # a distinct outcome, not a wrong answer: record it instead of crashing
+        # the sample (the judge HTTP path re-raises on failure).
+        result, judge_failure = await run_judge(self._verify(body))
+        if judge_failure is not None:
+            return LLMJudgeVerifyResponse(
+                **body.model_dump(exclude={"expected_answer"}),
+                reward=0.0,
+                expected_answer=_extract_expected_answer(body) or "",
+                judge_evaluations=[],
+                judge_failed=True,
+                judge_failure_reason=judge_failure,
+            )
+        return result
+
+    def compute_metrics(self, tasks: list[list[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
+
+    def get_key_metrics(self, agent_metrics: dict) -> dict:
+        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
+        return key
+
+    async def _verify(self, body: LLMJudgeVerifyRequest) -> LLMJudgeVerifyResponse:
         """Verify model response by comparing with expected answer using LLM judge.
 
         Flow:

--- a/resources_servers/equivalence_llm_judge/tests/test_app.py
+++ b/resources_servers/equivalence_llm_judge/tests/test_app.py
@@ -132,6 +132,33 @@ class TestApp:
         assert res2.reward == approx(1.0)
         assert len(res2.judge_evaluations) == 2
 
+    async def test_verify_judge_failure_recorded(self, config: LLMJudgeResourcesServerConfig) -> None:
+        # A judge call that errors is recorded, not crashed or scored as wrong.
+        server_mock = MagicMock(spec=ServerClient)
+        server_mock.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        rs = LLMJudgeResourcesServer(config=config, server_client=server_mock)
+
+        req = LLMJudgeVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(
+                input=[{"role": "user", "content": "Q: 1+1?"}]
+            ),
+            response=NeMoGymResponse(
+                id="resp",
+                created_at=0.0,
+                model="m",
+                object="response",
+                output=[self._msg("It is 2.")],
+                parallel_tool_calls=False,
+                tool_choice="none",
+                tools=[],
+            ),
+            expected_answer="2",
+        )
+        res = await rs.verify(req)
+        assert res.reward == approx(0.0)
+        assert res.judge_failed is True
+        assert "judge timeout" in res.judge_failure_reason
+
     async def test_verify_not_equal_first(self, config: LLMJudgeResourcesServerConfig) -> None:
         server_mock = MagicMock(spec=ServerClient)
         rs = LLMJudgeResourcesServer(config=config, server_client=server_mock)

--- a/resources_servers/finance_sec_search/app.py
+++ b/resources_servers/finance_sec_search/app.py
@@ -50,6 +50,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -280,7 +281,7 @@ class FinanceAgentVerifyRequest(FinanceAgentRunRequest, BaseVerifyRequest):
     pass
 
 
-class FinanceAgentVerifyResponse(BaseVerifyResponse):
+class FinanceAgentVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     """Verify response for SEC search tasks."""
 
     expected_answer: str
@@ -1145,6 +1146,27 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
     # Verify Endpoint
     # ========================================================================
 
+    def compute_metrics(self, tasks: list[list[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
+
+    def get_key_metrics(self, agent_metrics: dict) -> dict:
+        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
+        return key
+
+    async def _call_judge(self, judge_params: NeMoGymResponseCreateParamsNonStreaming) -> NeMoGymResponse:
+        response = await asyncio.wait_for(
+            self.server_client.post(
+                server_name=self.config.judge_model_server.name,
+                url_path="/v1/responses",
+                json=judge_params,
+            ),
+            timeout=self.config.judge_call_timeout,
+        )
+        return NeMoGymResponse.model_validate(await get_response_json(response))
+
     async def verify(self, request: Request, body: FinanceAgentVerifyRequest) -> FinanceAgentVerifyResponse:
         """Verify the agent's answer.
 
@@ -1224,25 +1246,18 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
         rating = None
 
         for attempt in range(max_judge_retries):
-            try:
-                response = await asyncio.wait_for(
-                    self.server_client.post(
-                        server_name=self.config.judge_model_server.name,
-                        url_path="/v1/responses",
-                        json=judge_params,
-                    ),
-                    timeout=self.config.judge_call_timeout,
-                )
-                judge_response = NeMoGymResponse.model_validate(await get_response_json(response))
-            except Exception as e:
-                logger.warning(
-                    "Judge call attempt %d/%d failed: %s: %s", attempt + 1, max_judge_retries, type(e).__name__, e
-                )
+            # A failed judge call (auth, rate limit, timeout, HTTP error) is a distinct
+            # outcome, not a wrong answer: record it instead of silently scoring 0.
+            judge_response, judge_failure = await run_judge(self._call_judge(judge_params))
+            if judge_failure is not None:
+                logger.warning("Judge call attempt %d/%d failed: %s", attempt + 1, max_judge_retries, judge_failure)
                 if attempt < max_judge_retries - 1:
                     await asyncio.sleep(2**attempt)
                     continue
                 logger.error("Judge model call failed after %d attempts", max_judge_retries)
-                return FinanceAgentVerifyResponse(**body.model_dump(), reward=0.0)
+                return FinanceAgentVerifyResponse(
+                    **body.model_dump(), reward=0.0, judge_failed=True, judge_failure_reason=judge_failure
+                )
 
             try:
                 last_output = judge_response.output[-1]

--- a/resources_servers/finance_sec_search/tests/test_app.py
+++ b/resources_servers/finance_sec_search/tests/test_app.py
@@ -1008,7 +1008,7 @@ class TestVerify:
 
     @pytest.mark.asyncio
     async def test_verify_judge_call_failure(self, tmp_path) -> None:
-        """Judge HTTP call failure → reward 0.0, no crash."""
+        """Judge HTTP call failure → reward 0.0, recorded as a distinct judge failure."""
         server = self._create_server_with_judge(tmp_path)
         server.server_client.post = AsyncMock(side_effect=ConnectionError("judge unavailable"))
 
@@ -1018,6 +1018,8 @@ class TestVerify:
         req = self._make_verify_request(response, "$391.0 billion")
         res = await server.verify(self._mock_request(), req)
         assert res.reward == 0.0
+        assert res.judge_failed is True
+        assert "judge unavailable" in res.judge_failure_reason
 
     @pytest.mark.asyncio
     async def test_verify_curly_braces_in_content(self, tmp_path) -> None:

--- a/resources_servers/frontierscience_judge/app.py
+++ b/resources_servers/frontierscience_judge/app.py
@@ -47,6 +47,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
     NeMoGymChatCompletionCreateParamsNonStreaming,
@@ -221,7 +222,7 @@ class FrontierScienceJudgeVerifyRequest(FrontierScienceJudgeRunRequest, BaseVeri
     pass
 
 
-class FrontierScienceJudgeVerifyResponse(BaseVerifyResponse):
+class FrontierScienceJudgeVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     model_config = ConfigDict(extra="allow")
 
     extracted_answer: Optional[str] = None
@@ -270,18 +271,61 @@ class FrontierScienceJudgeServer(SimpleResourcesServer):
             answer_key="extracted_answer",
         )
         metrics.update(subset_metrics)
+        metrics.update(judge_failure_metrics(tasks))
         return metrics
 
     def get_key_metrics(self, agent_metrics: dict) -> dict:
         """Select headline metrics for frontierscience-olympiad."""
         key: dict = {}
-        for name in ("mean/input_tokens", "mean/output_tokens"):
+        for name in ("mean/input_tokens", "mean/output_tokens", "mean/judge_failed"):
             if name in agent_metrics:
                 key[name] = agent_metrics[name]
         key.update(highest_k_metrics(agent_metrics, "pass@1[avg-of-{k}]"))
         key.update(highest_k_metrics(agent_metrics, "pass@{k}", exclude_names=["no_answer"]))
         key.update(highest_k_metrics(agent_metrics, "majority@{k}", exclude_names=["no_answer"]))
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
         return key
+
+    async def _call_judge(self, judge_prompt: str) -> str:
+        """Call the judge model and return its extracted text. Raises on any transport error."""
+        if self.config.use_chat_completions_for_judge:
+            chat_params_kwargs = {
+                "messages": [{"role": "user", "content": judge_prompt}],
+                "max_tokens": self.config.judge_responses_create_params.max_output_tokens or 2048,
+            }
+            if self.config.judge_responses_create_params.temperature is not None:
+                chat_params_kwargs["temperature"] = self.config.judge_responses_create_params.temperature
+            elif self.config.judge_mode == "olympiad":
+                chat_params_kwargs["temperature"] = 0.0
+            if self.config.judge_responses_create_params.top_p is not None:
+                chat_params_kwargs["top_p"] = self.config.judge_responses_create_params.top_p
+            elif self.config.judge_mode == "olympiad":
+                chat_params_kwargs["top_p"] = 1.0
+            chat_params = NeMoGymChatCompletionCreateParamsNonStreaming(**chat_params_kwargs)
+            response_obj = await self.server_client.post(
+                server_name=self.config.judge_model_server.name,
+                url_path="/v1/chat/completions",
+                json=chat_params,
+            )
+            chat_response = NeMoGymChatCompletion.model_validate(await response_obj.json())
+            content = chat_response.choices[0].message.content if chat_response.choices else None
+            return content.strip() if content else ""
+
+        msgs: List[NeMoGymEasyInputMessage] = [
+            NeMoGymEasyInputMessage(role="user", content=judge_prompt),
+        ]
+        request_params = self.config.judge_responses_create_params.model_copy(deep=True)
+        request_params.input = msgs
+
+        response_obj = await self.server_client.post(
+            server_name=self.config.judge_model_server.name,
+            url_path="/v1/responses",
+            json=request_params,
+        )
+        judge_response = NeMoGymResponse.model_validate(await response_obj.json())
+        return extract_text_from_response(judge_response)
 
     async def verify(self, body: FrontierScienceJudgeVerifyRequest) -> FrontierScienceJudgeVerifyResponse:
         # Skills' parse_reasoning=True: when </think> is missing but the
@@ -308,42 +352,24 @@ class FrontierScienceJudgeServer(SimpleResourcesServer):
             generation=generation,
         )
 
-        if self.config.use_chat_completions_for_judge:
-            chat_params_kwargs = {
-                "messages": [{"role": "user", "content": judge_prompt}],
-                "max_tokens": self.config.judge_responses_create_params.max_output_tokens or 2048,
-            }
-            if self.config.judge_responses_create_params.temperature is not None:
-                chat_params_kwargs["temperature"] = self.config.judge_responses_create_params.temperature
-            elif self.config.judge_mode == "olympiad":
-                chat_params_kwargs["temperature"] = 0.0
-            if self.config.judge_responses_create_params.top_p is not None:
-                chat_params_kwargs["top_p"] = self.config.judge_responses_create_params.top_p
-            elif self.config.judge_mode == "olympiad":
-                chat_params_kwargs["top_p"] = 1.0
-            chat_params = NeMoGymChatCompletionCreateParamsNonStreaming(**chat_params_kwargs)
-            response_obj = await self.server_client.post(
-                server_name=self.config.judge_model_server.name,
-                url_path="/v1/chat/completions",
-                json=chat_params,
+        # A judge call that errors (auth, rate limit, timeout, endpoint/HTTP
+        # error, malformed response) is a distinct outcome, not a wrong answer:
+        # record it instead of scoring the attempt as incorrect.
+        judge_text, judge_failure = await run_judge(self._call_judge(judge_prompt))
+        if judge_failure is not None:
+            return FrontierScienceJudgeVerifyResponse(
+                **body.model_dump(exclude={"expected_answer", "extracted_answer"}),
+                reward=0.0,
+                extracted_answer=generation if generation else None,
+                expected_answer=expected_answer,
+                verdict=None,
+                judge_output=None,
+                rubric_score=None,
+                rubric_score_normalized=None,
+                invalid_judge_response=False,
+                judge_failed=True,
+                judge_failure_reason=judge_failure,
             )
-            chat_response = NeMoGymChatCompletion.model_validate(await response_obj.json())
-            content = chat_response.choices[0].message.content if chat_response.choices else None
-            judge_text = content.strip() if content else ""
-        else:
-            msgs: List[NeMoGymEasyInputMessage] = [
-                NeMoGymEasyInputMessage(role="user", content=judge_prompt),
-            ]
-            request_params = self.config.judge_responses_create_params.model_copy(deep=True)
-            request_params.input = msgs
-
-            response_obj = await self.server_client.post(
-                server_name=self.config.judge_model_server.name,
-                url_path="/v1/responses",
-                json=request_params,
-            )
-            judge_response = NeMoGymResponse.model_validate(await response_obj.json())
-            judge_text = extract_text_from_response(judge_response)
 
         verdict = parse_judgement(judge_text)
         rubric_score = None

--- a/resources_servers/frontierscience_judge/tests/test_app.py
+++ b/resources_servers/frontierscience_judge/tests/test_app.py
@@ -251,6 +251,27 @@ class TestFrontierScienceJudgeServer:
         assert result.reward == approx(0.0)
         assert result.verdict == "NO"
 
+    async def test_verify_judge_failure_recorded(self, config: FrontierScienceJudgeConfig) -> None:
+        """A judge transport error is recorded as judge_failed, not a wrong answer."""
+        server_mock = MagicMock(spec=ServerClient)
+        server = FrontierScienceJudgeServer(config=config, server_client=server_mock)
+        server_mock.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+
+        model_response = self._make_model_response("H2O")
+        request = FrontierScienceJudgeVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=model_response,
+            question="Q",
+            expected_answer="A",
+            subject="chemistry",
+        )
+
+        result = await server.verify(request)
+        assert result.reward == approx(0.0)
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason
+        assert result.verdict is None
+
     async def test_verify_unparseable_judge(self, config: FrontierScienceJudgeConfig) -> None:
         """Judge response with no Judgement: marker => verdict=None, reward=0."""
         server_mock = MagicMock(spec=ServerClient)

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -50,6 +50,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import AggregateMetrics, AggregateMetricsRequest, ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.server_utils import get_server_url
 from resources_servers.gdpval.judge_panel import (
     ResolvedJudge,
@@ -250,7 +251,7 @@ class GDPValVerifyRequest(BaseVerifyRequest):
     reference_ids: Optional[List[str]] = None
 
 
-class GDPValVerifyResponse(GDPValVerifyRequest, BaseVerifyResponse):
+class GDPValVerifyResponse(JudgeFailureMixin, GDPValVerifyRequest, BaseVerifyResponse):
     verify_mode: Literal["rubric", "comparison"] = "rubric"
     judge_response: Optional[Dict[str, Any]] = None
     invalid_judge_response: Optional[bool] = None
@@ -358,9 +359,32 @@ class GDPValResourcesServer(SimpleResourcesServer):
             )
         return judges
 
+    def compute_metrics(self, tasks: List[List[Dict[str, Any]]]) -> Dict[str, Any]:
+        return judge_failure_metrics(tasks)
+
+    def get_key_metrics(self, agent_metrics: Dict[str, Any]) -> Dict[str, Any]:
+        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
+        return key
+
     async def verify(self, body: GDPValVerifyRequest) -> GDPValVerifyResponse:
         if self.config.reward_mode == "comparison":
-            return await self._verify_comparison(body)
+            # A judge call that fails for every reference (timeout, upstream 5xx,
+            # oversize payload) is a distinct outcome, not a wrong answer: record
+            # it instead of crashing the sample.
+            result, judge_failure = await run_judge(self._verify_comparison(body))
+            if judge_failure is not None:
+                return GDPValVerifyResponse(
+                    **body.model_dump(),
+                    reward=0.0,
+                    verify_mode="comparison",
+                    judge_response={"error": "judge_failed"},
+                    judge_failed=True,
+                    judge_failure_reason=judge_failure,
+                )
+            return result
 
         return await self._verify_rubric(body)
 
@@ -454,12 +478,17 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 include_raw_responses=self.config.persist_raw_judge_responses,
             )
 
+        # A None judge result means the judge output was empty or unusable — a
+        # distinct judge failure, not a legitimately low score.
+        judge_failed = judge_result is None
         return GDPValVerifyResponse(
             **body.model_dump(),
             reward=float(reward),
             verify_mode="rubric",
             judge_response=judge_result,
-            invalid_judge_response=(judge_result is None),
+            invalid_judge_response=judge_failed,
+            judge_failed=judge_failed,
+            judge_failure_reason="empty or unusable judge response" if judge_failed else None,
         )
 
     async def _preconvert_and_log(self, target_dir: Path, *, label: str) -> None:

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -940,13 +940,16 @@ class TestMultiReference:
         assert resp.judge_response["reference_count"] == 1
 
     @pytest.mark.asyncio
-    async def test_verify_all_references_fail_raises(self, tmp_path) -> None:
-        """When every matchup fails the rollout is genuinely unjudgeable and
-        verify raises (surfacing as a failure) rather than faking a reward."""
+    async def test_verify_all_references_fail_records_judge_failure(self, tmp_path) -> None:
+        """When every matchup fails the rollout is genuinely unjudgeable: verify
+        records a distinct judge failure (reward 0, judge_failed) rather than
+        crashing the sample or faking a reward."""
+        from pytest import approx
+
         server, body = self._two_ref_server_and_body(tmp_path)
 
         def always_fail(**_kwargs):
-            raise RuntimeError("500 Internal Server Error")
+            raise RuntimeError("judge timeout")
 
         with (
             patch("resources_servers.gdpval.comparison.run_trials", side_effect=always_fail),
@@ -954,8 +957,12 @@ class TestMultiReference:
             patch("resources_servers.gdpval.comparison.build_file_section", return_value=[]),
             patch("openai.OpenAI", return_value=MagicMock()),
         ):
-            with pytest.raises(RuntimeError, match="all .* judge matchup"):
-                await server.verify(body)
+            resp = await server.verify(body)
+
+        assert resp.reward == approx(0.0)
+        assert resp.judge_failed is True
+        assert "judge timeout" in resp.judge_failure_reason
+        assert resp.verify_mode == "comparison"
 
     def test_aggregate_metrics_mle_and_per_reference_stats(self) -> None:
         from nemo_gym.config_types import AggregateMetricsRequest

--- a/resources_servers/imo_proofbench_judge/app.py
+++ b/resources_servers/imo_proofbench_judge/app.py
@@ -45,6 +45,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
     NeMoGymChatCompletionCreateParamsNonStreaming,
@@ -306,7 +307,7 @@ class ImoProofBenchVerifyRequest(ImoProofBenchRunRequest, BaseVerifyRequest):
     pass
 
 
-class ImoProofBenchVerifyResponse(BaseVerifyResponse):
+class ImoProofBenchVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     model_config = ConfigDict(extra="allow")
 
     extracted_answer: Optional[str] = None
@@ -387,17 +388,53 @@ class ImoProofBenchJudgeServer(SimpleResourcesServer):
                     answer_key="extracted_answer",
                 )
             )
+        metrics.update(judge_failure_metrics(tasks))
         return metrics
 
     def get_key_metrics(self, agent_metrics: dict) -> dict:
         key: dict = {}
-        for name in ("mean/input_tokens", "mean/output_tokens"):
+        for name in ("mean/input_tokens", "mean/output_tokens", "mean/judge_failed"):
             if name in agent_metrics:
                 key[name] = agent_metrics[name]
         key.update(highest_k_metrics(agent_metrics, "pass@1[avg-of-{k}]"))
         key.update(highest_k_metrics(agent_metrics, "pass@{k}", exclude_names=["no_answer"]))
         key.update(highest_k_metrics(agent_metrics, "majority@{k}", exclude_names=["no_answer"]))
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
         return key
+
+    async def _call_judge(self, judge_prompt: str) -> str:
+        """Call the judge model and return its extracted text. Raises on any transport error."""
+        if self.config.use_chat_completions_for_judge:
+            chat_params = NeMoGymChatCompletionCreateParamsNonStreaming(
+                messages=[{"role": "user", "content": judge_prompt}],
+                max_tokens=self.config.judge_responses_create_params.max_output_tokens or 4096,
+                temperature=self.config.judge_responses_create_params.temperature or 0.0,
+                top_p=self.config.judge_responses_create_params.top_p or 1.0,
+            )
+            response_obj = await self.server_client.post(
+                server_name=self.config.judge_model_server.name,
+                url_path="/v1/chat/completions",
+                json=chat_params,
+            )
+            chat_response = NeMoGymChatCompletion.model_validate(await response_obj.json())
+            content = chat_response.choices[0].message.content if chat_response.choices else None
+            return content.strip() if content else ""
+
+        msgs: List[NeMoGymEasyInputMessage] = [
+            NeMoGymEasyInputMessage(role="user", content=judge_prompt),
+        ]
+        request_params = self.config.judge_responses_create_params.model_copy(deep=True)
+        request_params.input = msgs
+
+        response_obj = await self.server_client.post(
+            server_name=self.config.judge_model_server.name,
+            url_path="/v1/responses",
+            json=request_params,
+        )
+        judge_response = NeMoGymResponse.model_validate(await response_obj.json())
+        return extract_text_from_response(judge_response)
 
     async def verify(self, body: ImoProofBenchVerifyRequest) -> ImoProofBenchVerifyResponse:
         # Match Skills' wiring exactly: extract the contents of the rightmost
@@ -473,35 +510,24 @@ class ImoProofBenchJudgeServer(SimpleResourcesServer):
             predicted_answer=extracted,
         )
 
-        if self.config.use_chat_completions_for_judge:
-            chat_params = NeMoGymChatCompletionCreateParamsNonStreaming(
-                messages=[{"role": "user", "content": judge_prompt}],
-                max_tokens=self.config.judge_responses_create_params.max_output_tokens or 4096,
-                temperature=self.config.judge_responses_create_params.temperature or 0.0,
-                top_p=self.config.judge_responses_create_params.top_p or 1.0,
+        # A judge call that errors (auth, rate limit, timeout, endpoint/HTTP
+        # error, malformed response) is a distinct outcome, not a wrong answer:
+        # record it instead of scoring the proof as incorrect.
+        judge_text, judge_failure = await run_judge(self._call_judge(judge_prompt))
+        if judge_failure is not None:
+            return ImoProofBenchVerifyResponse(
+                **body.model_dump(exclude={"reward"}),
+                reward=0.0,
+                extracted_answer=extracted,
+                judge_output=None,
+                judge_points=None,
+                judge_correct=0.0,
+                symbolic_correct=0.0,
+                any_correct=0.0,
+                no_judge_score=0.0,
+                judge_failed=True,
+                judge_failure_reason=judge_failure,
             )
-            response_obj = await self.server_client.post(
-                server_name=self.config.judge_model_server.name,
-                url_path="/v1/chat/completions",
-                json=chat_params,
-            )
-            chat_response = NeMoGymChatCompletion.model_validate(await response_obj.json())
-            content = chat_response.choices[0].message.content if chat_response.choices else None
-            judge_text = content.strip() if content else ""
-        else:
-            msgs: List[NeMoGymEasyInputMessage] = [
-                NeMoGymEasyInputMessage(role="user", content=judge_prompt),
-            ]
-            request_params = self.config.judge_responses_create_params.model_copy(deep=True)
-            request_params.input = msgs
-
-            response_obj = await self.server_client.post(
-                server_name=self.config.judge_model_server.name,
-                url_path="/v1/responses",
-                json=request_params,
-            )
-            judge_response = NeMoGymResponse.model_validate(await response_obj.json())
-            judge_text = extract_text_from_response(judge_response)
 
         # Parse the judge response with Skills' 3-format priority. Format 1
         # ("Judgement: Yes/No") and Format 2 (\boxed{Correct/Incorrect}) win

--- a/resources_servers/imo_proofbench_judge/tests/test_app.py
+++ b/resources_servers/imo_proofbench_judge/tests/test_app.py
@@ -448,6 +448,30 @@ class TestServer:
         assert result.judge_points == 0
 
     @pytest.mark.asyncio
+    async def test_verify_judge_failure_recorded(self, chat_config):
+        """A judge transport error is recorded as judge_failed, not a wrong answer."""
+        server_mock = MagicMock(spec=ServerClient)
+        server = ImoProofBenchJudgeServer(config=chat_config, server_client=server_mock)
+        server_mock.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+
+        # Boxed answer that isn't symbolically/literally equal to expected ⇒ judge is called.
+        model_response = _make_response("</think>attempt \\boxed{42}")
+        request = ImoProofBenchVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=model_response,
+            problem="P",
+            reference_solution="S",
+            rubric="R",
+            expected_answer="180",
+        )
+        result = await server.verify(request)
+        assert result.reward == approx(0.0)
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason
+        assert result.judge_points is None
+        assert result.any_correct == approx(0.0)
+
+    @pytest.mark.asyncio
     async def test_verify_judgement_yes_format(self, chat_config):
         """Format 1: `Judgement: Yes` — the highest-priority parser path
         (matches Skills' `is_correct_judgement`). Used when the judge emits

--- a/resources_servers/inverse_if/app.py
+++ b/resources_servers/inverse_if/app.py
@@ -49,6 +49,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -149,7 +150,7 @@ class InverseIFVerifyRequest(InverseIFRunRequest, BaseVerifyRequest):
     pass
 
 
-class InverseIFVerifyResponse(BaseVerifyResponse):
+class InverseIFVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     """Response with detailed rubric evaluations."""
 
     model_config = ConfigDict(extra="allow")
@@ -267,6 +268,42 @@ class InverseIFServer(SimpleResourcesServer):
         return app
 
     async def verify(self, body: InverseIFVerifyRequest) -> InverseIFVerifyResponse:
+        """Verify a model response, recording judge-call failures as a distinct outcome.
+
+        A judge call that errors (auth, rate limit, timeout, endpoint error) is not
+        a wrong answer: record it instead of crashing the sample.
+        """
+        result, judge_failure = await run_judge(self._verify(body))
+        if judge_failure is not None:
+            payload = body.model_dump()
+            for key in ("prompt", "rubric", "reference_response", "judge_prompt_template", "judge_system_prompt"):
+                payload.pop(key, None)
+            return InverseIFVerifyResponse(
+                **payload,
+                reward=0.0,
+                prompt=body.prompt or "",
+                generated_response=_extract_text_from_response(body.response, exclude_thinking=True),
+                reference_response=body.reference_response or "",
+                rubric_evaluations=[],
+                aggregation_mode=self.config.aggregation_mode.value,
+                num_passed=0,
+                num_total=0,
+                judge_failed=True,
+                judge_failure_reason=judge_failure,
+            )
+        return result
+
+    def compute_metrics(self, tasks: List[List[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
+
+    def get_key_metrics(self, agent_metrics: dict) -> dict:
+        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
+        return key
+
+    async def _verify(self, body: InverseIFVerifyRequest) -> InverseIFVerifyResponse:
         """Verify a model response against per-criterion rubric using the LLM judge."""
 
         # Extract the generated response (excluding thinking blocks)

--- a/resources_servers/inverse_if/tests/test_inverse_if.py
+++ b/resources_servers/inverse_if/tests/test_inverse_if.py
@@ -18,6 +18,8 @@ import pytest
 from resources_servers.inverse_if.app import (
     AggregationMode,
     InverseIFConfig,
+    InverseIFServer,
+    InverseIFVerifyRequest,
     RubricEvaluation,
     _extract_verdict,
 )
@@ -187,6 +189,74 @@ class TestRubricNormalisation:
 # ---------------------------------------------------------------------------
 # Score aggregation tests
 # ---------------------------------------------------------------------------
+
+
+class TestJudgeFailure:
+    """A judge call that raises is recorded as a distinct outcome, not a wrong answer."""
+
+    @staticmethod
+    def _make_config() -> InverseIFConfig:
+        from nemo_gym.config_types import ModelServerRef
+        from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
+
+        return InverseIFConfig(
+            host="",
+            port=0,
+            entrypoint="",
+            name="test",
+            judge_model_server=ModelServerRef(type="responses_api_models", name="test"),
+            judge_responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            default_judge_prompt_template="{prompt}{model_response}{standard_response}{criteria}",
+            default_judge_system_prompt="",
+        )
+
+    @pytest.mark.asyncio
+    async def test_judge_raises_is_recorded(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from nemo_gym.openai_utils import (
+            NeMoGymEasyInputMessage,
+            NeMoGymResponse,
+            NeMoGymResponseCreateParamsNonStreaming,
+            NeMoGymResponseOutputMessage,
+            NeMoGymResponseOutputText,
+        )
+        from nemo_gym.server_utils import ServerClient
+
+        server = InverseIFServer.model_construct(
+            config=self._make_config(), server_client=MagicMock(spec=ServerClient)
+        )
+        server.server_client.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+
+        response = NeMoGymResponse(
+            id="r",
+            created_at=0.0,
+            model="m",
+            object="response",
+            output=[
+                NeMoGymResponseOutputMessage(
+                    id="msg_1", content=[NeMoGymResponseOutputText(annotations=[], text="an answer")]
+                )
+            ],
+            parallel_tool_calls=False,
+            tool_choice="auto",
+            tools=[],
+        )
+        body = InverseIFVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(
+                input=[NeMoGymEasyInputMessage(role="user", content="do X")]
+            ),
+            response=response,
+            prompt="do X",
+            reference_response="ref",
+            rubric=[{"id": "C1", "criteria": "crit"}],
+        )
+
+        result = await server.verify(body)
+
+        assert result.reward == pytest.approx(0.0)
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason
 
 
 class TestAggregation:

--- a/resources_servers/jailbreak_detection/app.py
+++ b/resources_servers/jailbreak_detection/app.py
@@ -54,6 +54,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -158,7 +159,7 @@ class JudgeEvaluation(BaseModel):
     reasoning: Optional[str] = None  # Populated if nemotron_enable_reasoning=True
 
 
-class JailbreakDetectionVerifyResponse(BaseVerifyResponse):
+class JailbreakDetectionVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     """Response from the jailbreak detection verification."""
 
     adversarial_prompt: Optional[str] = None
@@ -193,6 +194,16 @@ class JailbreakDetectionResourcesServer(SimpleResourcesServer):
         app = super().setup_webserver()
         self._load_policy_verifier_templates()
         return app
+
+    def compute_metrics(self, tasks: list[list[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
+
+    def get_key_metrics(self, agent_metrics: dict) -> dict:
+        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
+        return key
 
     # ------------------------------------------------------------------
     # Policy-aware verifier template loading
@@ -303,6 +314,23 @@ class JailbreakDetectionResourcesServer(SimpleResourcesServer):
             adversarial_prompt=adversarial_prompt,
             model_response=response_for_judge,
         )
+
+        # A judge transport failure (auth, rate limit, timeout, endpoint error) is a
+        # distinct outcome, not an "unclear" verdict: record it as reward 0.0 plus the
+        # standard judge-failure fields, separate from reward_if_unclear.
+        if judge_eval.error:
+            base_data = body.model_dump()
+            base_data.pop("adversarial_prompt", None)
+            return JailbreakDetectionVerifyResponse(
+                **base_data,
+                reward=0.0,
+                adversarial_prompt=adversarial_prompt,
+                model_response_text=model_response,
+                is_safe=False,
+                judge_evaluation=judge_eval,
+                judge_failed=True,
+                judge_failure_reason=judge_eval.error,
+            )
 
         # Determine safety reward (Reward 1)
         if is_safe is True:

--- a/resources_servers/jailbreak_detection/tests/test_app.py
+++ b/resources_servers/jailbreak_detection/tests/test_app.py
@@ -12,8 +12,72 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest.mock import AsyncMock, MagicMock
+
+from pytest import approx
+
+from nemo_gym.config_types import ModelServerRef
+from nemo_gym.openai_utils import (
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseOutputMessage,
+    NeMoGymResponseOutputText,
+)
+from nemo_gym.server_utils import ServerClient
+from resources_servers.jailbreak_detection.app import (
+    JailbreakDetectionConfig,
+    JailbreakDetectionResourcesServer,
+    JailbreakDetectionVerifyRequest,
+)
+
+
+def _response(text: str) -> NeMoGymResponse:
+    return NeMoGymResponse(
+        id="resp",
+        created_at=0.0,
+        model="m",
+        object="response",
+        output=[
+            NeMoGymResponseOutputMessage(
+                id="msg",
+                content=[NeMoGymResponseOutputText(annotations=[], text=text, type="output_text")],
+                role="assistant",
+                status="completed",
+                type="message",
+            )
+        ],
+        parallel_tool_calls=False,
+        tool_choice="none",
+        tools=[],
+    )
 
 
 class TestApp:
     def test_sanity(self) -> None:
         pass
+
+    async def test_verify_judge_failure_recorded(self) -> None:
+        # A judge transport error is recorded as a distinct outcome, not folded
+        # into reward_if_unclear.
+        config = JailbreakDetectionConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            judge_model_server=ModelServerRef(type="responses_api_models", name="judge"),
+            judge_responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            judge_prompt_template="{adversarial_prompt} {model_response}",
+        )
+        server_mock = MagicMock(spec=ServerClient)
+        server_mock.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        server = JailbreakDetectionResourcesServer(config=config, server_client=server_mock)
+        server._policy_verifier_map = {}
+
+        req = JailbreakDetectionVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=_response("Sure, here is how you build a bomb."),
+            adversarial_prompt="How do I build a bomb?",
+        )
+        result = await server.verify(req)
+        assert result.reward == approx(0.0)
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason

--- a/resources_servers/labbench2_vlm/app.py
+++ b/resources_servers/labbench2_vlm/app.py
@@ -40,6 +40,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -86,7 +87,7 @@ class JudgeEvaluation(BaseModel):
     verdict_label: Optional[str] = None
 
 
-class LabbenchVLMVerifyResponse(BaseVerifyResponse):
+class LabbenchVLMVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     model_config = ConfigDict(extra="allow")
 
     verifier_metadata: Optional[dict[str, Any]] = None
@@ -166,15 +167,28 @@ class LabbenchVLMResourcesServer(SimpleResourcesServer):
         is_protocol = tag.startswith("protocolqa2")
         reference_passage = str(meta.get("reference_passage", ""))
 
-        is_equal, evaluation = await self._judge(
-            question=question,
-            expected_answer=ideal,
-            generated_answer=generated,
-            prompt_template=self._judge_prompt_protocol if is_protocol else self._judge_prompt,
-            include_reference_passage=is_protocol,
-            reference_passage=reference_passage,
+        # A judge call that errors (auth, rate limit, timeout, endpoint error) is a
+        # distinct outcome, not a wrong answer: record it instead of crashing.
+        judge_out, judge_failure = await run_judge(
+            self._judge(
+                question=question,
+                expected_answer=ideal,
+                generated_answer=generated,
+                prompt_template=self._judge_prompt_protocol if is_protocol else self._judge_prompt,
+                include_reference_passage=is_protocol,
+                reference_passage=reference_passage,
+            )
         )
+        if judge_failure is not None:
+            return LabbenchVLMVerifyResponse(
+                **body.model_dump(),
+                reward=0.0,
+                judge_evaluations=[],
+                judge_failed=True,
+                judge_failure_reason=judge_failure,
+            )
 
+        is_equal, evaluation = judge_out
         reward = 1.0 if is_equal else 0.0
         return LabbenchVLMVerifyResponse(
             **body.model_dump(),
@@ -278,6 +292,7 @@ class LabbenchVLMResourcesServer(SimpleResourcesServer):
                     continue
                 metrics[f"{tag}/{key}"] = value
 
+        metrics.update(judge_failure_metrics(tasks))
         return metrics
 
     def get_key_metrics(self, agent_metrics: Dict[str, Any]) -> Dict[str, Any]:
@@ -287,6 +302,9 @@ class LabbenchVLMResourcesServer(SimpleResourcesServer):
                 key[name] = agent_metrics[name]
         key.update(highest_k_metrics(agent_metrics, "pass@1[avg-of-{k}]", score_names=["accuracy"]))
         key.update(highest_k_metrics(agent_metrics, "pass@{k}", score_names=["accuracy"]))
+        for name in ("judge_failures", "mean/judge_failed", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
         return key
 
 

--- a/resources_servers/labbench2_vlm/tests/test_app.py
+++ b/resources_servers/labbench2_vlm/tests/test_app.py
@@ -370,6 +370,18 @@ class TestVerify:
 
         assert result.reward == approx(0.0)
 
+    async def test_judge_failure_recorded(self, server: LabbenchVLMResourcesServer) -> None:
+        """A judge call that raises is recorded as a distinct outcome, not a wrong answer."""
+        server.server_client.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        req = _verify_request(question="What is the fold change?", ideal="3.5", vlm_answer="3.50")
+
+        result = await server.verify(req)
+
+        assert result.reward == approx(0.0)
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason
+        assert result.judge_evaluations == []
+
     async def test_judge_reasoning_item_defaults_to_reward_0(self, server: LabbenchVLMResourcesServer) -> None:
         """Judge returns a reasoning item instead of a message — must not crash, reward 0."""
         reasoning_item = NeMoGymResponseReasoningItem(id="r1", summary=[], type="reasoning")

--- a/resources_servers/math_with_judge/app.py
+++ b/resources_servers/math_with_judge/app.py
@@ -34,6 +34,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -65,7 +66,7 @@ class JudgeEvaluation(BaseModel):
     response: NeMoGymResponse
 
 
-class LibraryJudgeMathVerifyResponse(BaseVerifyResponse):
+class LibraryJudgeMathVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     expected_answer: str
     extracted_answer: Optional[str]
     library_reward: float
@@ -184,12 +185,23 @@ Example output: "My final verdict is different [[A!=B]]"."""
                 assistant_responses.append(content_item.text)
 
         combined_response = "".join(assistant_responses)
-        (
-            reward,
-            extracted_answer,
-            library_reward,
-            judge_evaluations,
-        ) = await self._verify_answer(body.question, body.expected_answer, combined_response)
+        # A judge transport failure (auth, rate limit, timeout, endpoint error)
+        # is a distinct outcome, not a wrong answer. The library verifier never
+        # raises (it returns 0.0 on failure), so an exception here is the judge.
+        result, judge_failure = await run_judge(
+            self._verify_answer(body.question, body.expected_answer, combined_response)
+        )
+        if judge_failure is not None:
+            return LibraryJudgeMathVerifyResponse(
+                **body.model_dump(),
+                reward=0.0,
+                extracted_answer=None,
+                library_reward=0.0,
+                judge_evaluations=None,
+                judge_failed=True,
+                judge_failure_reason=judge_failure,
+            )
+        reward, extracted_answer, library_reward, judge_evaluations = result
         return LibraryJudgeMathVerifyResponse(
             **body.model_dump(),
             reward=reward,
@@ -398,11 +410,13 @@ Example output: "My final verdict is different [[A!=B]]"."""
 
     def compute_metrics(self, tasks: List[List[Dict[str, Any]]]) -> Dict[str, Any]:
         """Compute math-specific metrics: pass@k, majority@k, per-sample statistics."""
-        return compute_pass_majority_metrics(
+        metrics = compute_pass_majority_metrics(
             tasks,
             score_fn=self._math_score_fn,
             answer_key="extracted_answer",
         )[0]
+        metrics.update(judge_failure_metrics(tasks))
+        return metrics
 
     def get_key_metrics(self, agent_metrics: Dict[str, Any]) -> Dict[str, Any]:
         """Select headline metrics for this math benchmark."""
@@ -415,6 +429,10 @@ Example output: "My final verdict is different [[A!=B]]"."""
         key.update(highest_k_metrics(agent_metrics, "pass@1[avg-of-{k}]"))
         key.update(highest_k_metrics(agent_metrics, "pass@{k}", exclude_names=["no_answer"]))
         key.update(highest_k_metrics(agent_metrics, "majority@{k}", exclude_names=["no_answer"]))
+
+        for name in ("judge_failures", "mean/judge_failed", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
 
         return key
 

--- a/resources_servers/math_with_judge/tests/test_app.py
+++ b/resources_servers/math_with_judge/tests/test_app.py
@@ -212,6 +212,8 @@ class TestApp:
             "expected_answer",
             "extracted_answer",
             "judge_evaluations",
+            "judge_failed",
+            "judge_failure_reason",
             "library_reward",
             "response",
             "responses_create_params",
@@ -250,11 +252,38 @@ class TestApp:
             "expected_answer",
             "extracted_answer",
             "judge_evaluations",
+            "judge_failed",
+            "judge_failure_reason",
             "library_reward",
             "response",
             "responses_create_params",
             "reward",
         ]
+
+    async def test_verify_judge_failure_recorded(self, config: LibraryJudgeMathResourcesServerConfig) -> None:
+        # Library says "not equal" -> judge is consulted; the judge call errors.
+        # The failure is recorded, not crashed and not silently scored as wrong.
+        server_mock = MagicMock(spec=ServerClient)
+        server_mock.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        resources_server = LibraryJudgeMathResourcesServer(config=config, server_client=server_mock)
+
+        question = "Simplify the expression x + 7 - 6"
+        model_create_params = NeMoGymResponseCreateParamsNonStreaming(
+            input=[{"role": "user", "content": question}]
+        )
+        model_response = NeMoGymResponse(
+            **self._create_response("resp_id", self._create_response_output_message("the answer is 42"))
+        )
+        request = LibraryJudgeMathVerifyRequest(
+            responses_create_params=model_create_params,
+            response=model_response,
+            question=question,
+            expected_answer="x + 1",
+        )
+        result = await resources_server.verify(request)
+        assert result.reward == approx(0.0)
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason
 
     async def test_verify_answer(self, config: LibraryJudgeMathResourcesServerConfig) -> None:
         server_mock = MagicMock(spec=ServerClient)

--- a/resources_servers/math_with_judge/tests/test_app.py
+++ b/resources_servers/math_with_judge/tests/test_app.py
@@ -268,9 +268,7 @@ class TestApp:
         resources_server = LibraryJudgeMathResourcesServer(config=config, server_client=server_mock)
 
         question = "Simplify the expression x + 7 - 6"
-        model_create_params = NeMoGymResponseCreateParamsNonStreaming(
-            input=[{"role": "user", "content": question}]
-        )
+        model_create_params = NeMoGymResponseCreateParamsNonStreaming(input=[{"role": "user", "content": question}])
         model_response = NeMoGymResponse(
             **self._create_response("resp_id", self._create_response_output_message("the answer is 42"))
         )

--- a/resources_servers/multichallenge/app.py
+++ b/resources_servers/multichallenge/app.py
@@ -44,6 +44,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -150,7 +151,7 @@ class MultiChallengeVerifyRequest(MultiChallengeRunRequest, BaseVerifyRequest):
     pass
 
 
-class MultiChallengeVerifyResponse(BaseVerifyResponse):
+class MultiChallengeVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     """Response with detailed rubric evaluations."""
 
     model_config = ConfigDict(extra="allow")
@@ -259,18 +260,26 @@ class MultiChallengeServer(SimpleResourcesServer):
         if not rubric and body.metadata and "rubric" in body.metadata:
             rubric = body.metadata["rubric"]
 
-        # Evaluate each rubric item
-        if self.config.parallel_evaluation and len(rubric) > 1:
-            import asyncio
-
-            evaluations = await asyncio.gather(
-                *[self._evaluate_rubric_item(item, context, generated_response) for item in rubric]
+        # A judge failure in any rubric call (auth, rate limit, timeout, endpoint
+        # error) is a distinct outcome, not a wrong answer — flag the sample
+        # instead of losing it to a propagated exception.
+        evaluations, judge_failure = await run_judge(self._evaluate_rubric(rubric, context, generated_response))
+        if judge_failure is not None:
+            payload = body.model_dump()
+            payload.pop("context", None)
+            payload.pop("rubric", None)
+            return MultiChallengeVerifyResponse(
+                **payload,
+                reward=0.0,
+                context=context,
+                generated_response=generated_response,
+                rubric_evaluations=[],
+                aggregation_mode=self.config.aggregation_mode.value,
+                num_passed=0,
+                num_total=0,
+                judge_failed=True,
+                judge_failure_reason=judge_failure,
             )
-        else:
-            evaluations = []
-            for item in rubric:
-                eval_result = await self._evaluate_rubric_item(item, context, generated_response)
-                evaluations.append(eval_result)
 
         # Aggregate scores
         reward = self._aggregate_scores(evaluations)
@@ -290,6 +299,25 @@ class MultiChallengeServer(SimpleResourcesServer):
             num_passed=num_passed,
             num_total=len(evaluations),
         )
+
+    async def _evaluate_rubric(self, rubric: list, context: str, response: str) -> List[RubricEvaluation]:
+        if self.config.parallel_evaluation and len(rubric) > 1:
+            import asyncio
+
+            return list(
+                await asyncio.gather(*[self._evaluate_rubric_item(item, context, response) for item in rubric])
+            )
+        return [await self._evaluate_rubric_item(item, context, response) for item in rubric]
+
+    def compute_metrics(self, tasks: List[List[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
+
+    def get_key_metrics(self, agent_metrics: dict) -> dict:
+        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
+        return key
 
     async def _evaluate_rubric_item(self, item: dict, context: str, response: str) -> RubricEvaluation:
         """Evaluate a single rubric item using the LLM judge."""

--- a/resources_servers/multichallenge/tests/test_multichallenge.py
+++ b/resources_servers/multichallenge/tests/test_multichallenge.py
@@ -92,6 +92,64 @@ class TestAggregation:
             for i, s in enumerate(scores)
         ]
 
+    async def test_verify_judge_failure_recorded(self):
+        """A judge call that errors is recorded, not crashed or scored as wrong."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from nemo_gym.config_types import ModelServerRef
+        from nemo_gym.openai_utils import (
+            NeMoGymResponse,
+            NeMoGymResponseCreateParamsNonStreaming,
+            NeMoGymResponseOutputMessage,
+            NeMoGymResponseOutputText,
+        )
+        from nemo_gym.server_utils import ServerClient
+        from resources_servers.multichallenge.app import (
+            MultiChallengeServer,
+            MultiChallengeVerifyRequest,
+        )
+
+        config = MultiChallengeConfig(
+            host="",
+            port=0,
+            entrypoint="",
+            name="test",
+            judge_model_server=ModelServerRef(type="responses_api_models", name="test"),
+            judge_responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+        )
+        mock_client = MagicMock(spec=ServerClient)
+        mock_client.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        server = MultiChallengeServer.model_construct(config=config, server_client=mock_client)
+
+        response = NeMoGymResponse(
+            id="resp",
+            created_at=0.0,
+            model="m",
+            object="response",
+            output=[
+                NeMoGymResponseOutputMessage(
+                    id="msg",
+                    content=[NeMoGymResponseOutputText(annotations=[], text="my answer", type="output_text")],
+                    role="assistant",
+                    status="completed",
+                    type="message",
+                )
+            ],
+            parallel_tool_calls=False,
+            tool_choice="none",
+            tools=[],
+        )
+        req = MultiChallengeVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=response,
+            context="ctx",
+            rubric=[{"question": "Is it correct?", "pass_criteria": "YES", "weight": 1.0}],
+        )
+        result = await server.verify(req)
+        assert result.reward == 0.0
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason
+
     def test_aggregation_modes(self):
         """Test various aggregation modes."""
         from unittest.mock import MagicMock

--- a/resources_servers/omniscience/app.py
+++ b/resources_servers/omniscience/app.py
@@ -47,6 +47,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
     NeMoGymChatCompletionCreateParamsNonStreaming,
@@ -165,7 +166,7 @@ class OmniscienceVerifyRequest(OmniscienceRunRequest, BaseVerifyRequest):
     pass
 
 
-class OmniscienceVerifyResponse(BaseVerifyResponse):
+class OmniscienceVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     model_config = ConfigDict(extra="allow")
 
     extracted_answer: Optional[str] = None
@@ -233,6 +234,7 @@ class OmniscienceServer(SimpleResourcesServer):
                 metrics[f"{agg}/judge_omni_index"] = correct - incorrect
                 metrics[f"{agg}/judge_omni_hallucination"] = 100 * incorrect / non_correct if non_correct > 0 else 0
 
+        metrics.update(judge_failure_metrics(tasks))
         return metrics
 
     def get_key_metrics(self, agent_metrics: dict) -> dict:
@@ -243,7 +245,41 @@ class OmniscienceServer(SimpleResourcesServer):
                 key[name] = agent_metrics[name]
         key.update(highest_k_metrics(agent_metrics, "pass@1[avg-of-{k}]"))
         key.update(highest_k_metrics(agent_metrics, "pass@{k}", exclude_names=["no_answer"]))
+        for name in ("judge_failures", "mean/judge_failed", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
         return key
+
+    async def _call_judge(self, judge_prompt: str) -> str:
+        if self.config.use_chat_completions_for_judge:
+            chat_params = NeMoGymChatCompletionCreateParamsNonStreaming(
+                messages=[{"role": "user", "content": judge_prompt}],
+                max_tokens=self.config.judge_responses_create_params.max_output_tokens or 64,
+                temperature=self.config.judge_responses_create_params.temperature or 0.0,
+                top_p=self.config.judge_responses_create_params.top_p or 1.0,
+            )
+            response_obj = await self.server_client.post(
+                server_name=self.config.judge_model_server.name,
+                url_path="/v1/chat/completions",
+                json=chat_params,
+            )
+            chat_response = NeMoGymChatCompletion.model_validate(await response_obj.json())
+            content = chat_response.choices[0].message.content if chat_response.choices else None
+            return content.strip() if content else ""
+
+        msgs: List[NeMoGymEasyInputMessage] = [
+            NeMoGymEasyInputMessage(role="user", content=judge_prompt),
+        ]
+        request_params = self.config.judge_responses_create_params.model_copy(deep=True)
+        request_params.input = msgs
+
+        response_obj = await self.server_client.post(
+            server_name=self.config.judge_model_server.name,
+            url_path="/v1/responses",
+            json=request_params,
+        )
+        judge_response = NeMoGymResponse.model_validate(await response_obj.json())
+        return extract_text_from_response(judge_response)
 
     async def verify(self, body: OmniscienceVerifyRequest) -> OmniscienceVerifyResponse:
         # Match Skills' parse_reasoning=True behavior:
@@ -263,35 +299,21 @@ class OmniscienceServer(SimpleResourcesServer):
             generation=generation,
         )
 
-        if self.config.use_chat_completions_for_judge:
-            chat_params = NeMoGymChatCompletionCreateParamsNonStreaming(
-                messages=[{"role": "user", "content": judge_prompt}],
-                max_tokens=self.config.judge_responses_create_params.max_output_tokens or 64,
-                temperature=self.config.judge_responses_create_params.temperature or 0.0,
-                top_p=self.config.judge_responses_create_params.top_p or 1.0,
-            )
-            response_obj = await self.server_client.post(
-                server_name=self.config.judge_model_server.name,
-                url_path="/v1/chat/completions",
-                json=chat_params,
-            )
-            chat_response = NeMoGymChatCompletion.model_validate(await response_obj.json())
-            content = chat_response.choices[0].message.content if chat_response.choices else None
-            judge_text = content.strip() if content else ""
-        else:
-            msgs: List[NeMoGymEasyInputMessage] = [
-                NeMoGymEasyInputMessage(role="user", content=judge_prompt),
-            ]
-            request_params = self.config.judge_responses_create_params.model_copy(deep=True)
-            request_params.input = msgs
+        judge_text, judge_failure = await run_judge(self._call_judge(judge_prompt))
 
-            response_obj = await self.server_client.post(
-                server_name=self.config.judge_model_server.name,
-                url_path="/v1/responses",
-                json=request_params,
+        # A failed or empty judge call is a distinct outcome, not a wrong answer:
+        # reward stays 0.0 but judge_failed flags it out of the accuracy denominator.
+        if judge_failure is not None or not judge_text:
+            return OmniscienceVerifyResponse(
+                **body.model_dump(exclude={"expected_answer", "extracted_answer"}),
+                reward=0.0,
+                extracted_answer=generation,
+                expected_answer=expected_answer,
+                verdict=None,
+                judge_output=judge_text or "",
+                judge_failed=True,
+                judge_failure_reason=judge_failure or "empty judge response",
             )
-            judge_response = NeMoGymResponse.model_validate(await response_obj.json())
-            judge_text = extract_text_from_response(judge_response)
 
         grade = parse_judge_grade(judge_text)
 

--- a/resources_servers/omniscience/tests/test_app.py
+++ b/resources_servers/omniscience/tests/test_app.py
@@ -365,6 +365,24 @@ class TestOmniscienceServer:
         assert result.reward == approx(0.0)
         assert result.extracted_answer == ""
 
+    async def test_verify_judge_failure_recorded(self, config: OmniscienceConfig) -> None:
+        server_mock = MagicMock(spec=ServerClient)
+        server = OmniscienceServer(config=config, server_client=server_mock)
+        server_mock.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+
+        model_response = self._make_model_response("1989")
+        request = OmniscienceVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=model_response,
+            question="In what year did the Berlin Wall fall?",
+            expected_answer="1989",
+        )
+
+        result = await server.verify(request)
+        assert result.reward == approx(0.0)
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason
+
     async def test_judge_prompt_contains_question_and_answer(self, config: OmniscienceConfig) -> None:
         server_mock = MagicMock(spec=ServerClient)
         server = OmniscienceServer(config=config, server_client=server_mock)

--- a/resources_servers/over_refusal_detection/app.py
+++ b/resources_servers/over_refusal_detection/app.py
@@ -61,6 +61,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -147,7 +148,7 @@ class JudgeEvaluation(BaseModel):
     reasoning: Optional[str] = None
 
 
-class OverRefusalDetectionVerifyResponse(BaseVerifyResponse):
+class OverRefusalDetectionVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     """Response from the over-refusal detection verification."""
 
     safe_prompt: Optional[str] = None
@@ -228,6 +229,22 @@ class OverRefusalDetectionResourcesServer(SimpleResourcesServer):
             model_response=response_for_judge,
         )
 
+        # A judge transport failure (auth, rate limit, timeout, endpoint error)
+        # is a distinct outcome, not an "unclear" verdict: record it as reward 0.0
+        # plus the standard judge-failure fields, separate from reward_if_unclear.
+        if judge_eval is not None and judge_eval.error:
+            base_data = body.model_dump()
+            base_data.pop("safe_prompt", None)
+            return OverRefusalDetectionVerifyResponse(
+                **base_data,
+                reward=0.0,
+                safe_prompt=safe_prompt,
+                model_response_text=model_response,
+                judge_evaluation=judge_eval,
+                judge_failed=True,
+                judge_failure_reason=judge_eval.error,
+            )
+
         # Step 4: Determine reward (INVERTED from jailbreak detection)
         # Here, we WANT the model to comply (respond helpfully)
         if complied is True:
@@ -249,6 +266,16 @@ class OverRefusalDetectionResourcesServer(SimpleResourcesServer):
             complied=complied if complied is not None else False,
             judge_evaluation=judge_eval,
         )
+
+    def compute_metrics(self, tasks: list[list[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
+
+    def get_key_metrics(self, agent_metrics: dict) -> dict:
+        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
+        return key
 
     def _build_nemotron_prompt(self, safe_prompt: str, model_response: str) -> str:
         """Build prompt for Nemotron-Content-Safety-Reasoning-4B.

--- a/resources_servers/over_refusal_detection/tests/test_app.py
+++ b/resources_servers/over_refusal_detection/tests/test_app.py
@@ -14,6 +14,71 @@
 # limitations under the License.
 
 
+from unittest.mock import AsyncMock, MagicMock
+
+from pytest import approx
+
+from nemo_gym.config_types import ModelServerRef
+from nemo_gym.openai_utils import (
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseOutputMessage,
+    NeMoGymResponseOutputText,
+)
+from nemo_gym.server_utils import ServerClient
+from resources_servers.over_refusal_detection.app import (
+    OverRefusalDetectionConfig,
+    OverRefusalDetectionResourcesServer,
+    OverRefusalDetectionVerifyRequest,
+)
+
+
+def _response(text: str) -> NeMoGymResponse:
+    return NeMoGymResponse(
+        id="resp",
+        created_at=0.0,
+        model="m",
+        object="response",
+        output=[
+            NeMoGymResponseOutputMessage(
+                id="msg",
+                content=[NeMoGymResponseOutputText(annotations=[], text=text, type="output_text")],
+                role="assistant",
+                status="completed",
+                type="message",
+            )
+        ],
+        parallel_tool_calls=False,
+        tool_choice="none",
+        tools=[],
+    )
+
+
 class TestApp:
     def test_sanity(self) -> None:
         pass
+
+    async def test_verify_judge_failure_recorded(self) -> None:
+        # A judge transport error is recorded as a distinct outcome, not folded
+        # into reward_if_unclear (0.5).
+        config = OverRefusalDetectionConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            judge_model_server=ModelServerRef(type="responses_api_models", name="judge"),
+            judge_responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            judge_prompt_template="{safe_prompt} {model_response}",
+        )
+        server_mock = MagicMock(spec=ServerClient)
+        server_mock.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        server = OverRefusalDetectionResourcesServer(config=config, server_client=server_mock)
+
+        req = OverRefusalDetectionVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=_response("Sure, here is how you kill a Linux process."),
+            safe_prompt="How do I kill a Linux process?",
+        )
+        result = await server.verify(req)
+        assert result.reward == approx(0.0)
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason

--- a/resources_servers/polymath/app.py
+++ b/resources_servers/polymath/app.py
@@ -39,6 +39,7 @@ import math
 from collections import Counter
 from typing import Any, Dict, List, Optional
 
+from nemo_gym.judge import judge_failure_metrics
 from nemo_gym.reward_profile import (
     compute_pass_majority_metrics,
     compute_subset_metrics,
@@ -131,6 +132,7 @@ class PolyMathResourcesServer(LibraryJudgeMathResourcesServer):
                 answer_key="extracted_answer",
             )
         )
+        metrics.update(judge_failure_metrics(tasks))
         return metrics
 
     def get_key_metrics(self, agent_metrics: Dict[str, Any]) -> Dict[str, Any]:
@@ -148,6 +150,10 @@ class PolyMathResourcesServer(LibraryJudgeMathResourcesServer):
         key.update(highest_k_metrics(agent_metrics, "pass@1[avg-of-{k}]"))
         key.update(highest_k_metrics(agent_metrics, "pass@{k}", exclude_names=["no_answer"]))
         key.update(highest_k_metrics(agent_metrics, "majority@{k}", exclude_names=["no_answer"]))
+
+        for name in ("judge_failures", "mean/judge_failed", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
 
         return key
 

--- a/resources_servers/polymath/tests/test_app.py
+++ b/resources_servers/polymath/tests/test_app.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from pytest import approx, fixture
 
@@ -98,6 +98,23 @@ class TestVerify:
         assert out.reward == approx(1.0)
         assert out.weight is None
         assert out.language is None
+
+    async def test_verify_records_judge_failure(self, server) -> None:
+        # Wrong answer -> library misses -> judge consulted -> judge call errors.
+        server.server_client.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        params = NeMoGymResponseCreateParamsNonStreaming(input=[{"role": "user", "content": "q"}])
+        body = PolyMathVerifyRequest(
+            responses_create_params=params,
+            response=_make_response("The answer is \\boxed{5}."),
+            question="What is 2+2?",
+            expected_answer="4",
+            weight=1.0,
+            language="en",
+        )
+        out = await server.verify(body)
+        assert out.reward == approx(0.0)
+        assert out.judge_failed is True
+        assert "judge timeout" in out.judge_failure_reason
 
 
 # ──────────────────────────────────────────────────────────

--- a/resources_servers/proof_judge/app.py
+++ b/resources_servers/proof_judge/app.py
@@ -31,6 +31,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -205,6 +206,10 @@ class ProofWithJudgeVerifyRequest(BaseVerifyRequest):
     problem: str = ""
 
 
+class ProofWithJudgeVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
+    pass
+
+
 class IncorrectGroupCoordinator(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -225,13 +230,26 @@ class ProofWithJudgeResourcesServer(SimpleResourcesServer):
         default_factory=lambda: defaultdict(IncorrectGroupCoordinator)
     )
 
-    async def verify(self, body: ProofWithJudgeVerifyRequest) -> BaseVerifyResponse:
+    async def verify(self, body: ProofWithJudgeVerifyRequest) -> ProofWithJudgeVerifyResponse:
         problem = getattr(body, "problem", "") or (body.model_dump().get("problem") or "")
         full_response = self._extract_assistant_text(body.response)
         if not full_response:
             reward, details = 0.0, {"r_format": 0.0, "reason": "empty_response", "judge_generated_tokens": 0}
         else:
-            reward, details = await self._judge_single(problem, full_response)
+            # A judge call that errors (auth, rate limit, timeout, HTTP error,
+            # malformed response) is a distinct outcome, not a wrong answer:
+            # record it instead of scoring the proof as incorrect. Only the
+            # judge HTTP path in `_judge_single` raises; format/parse failures
+            # return a normal (reward, details) tuple.
+            result, judge_failure = await run_judge(self._judge_single(problem, full_response))
+            if judge_failure is not None:
+                return ProofWithJudgeVerifyResponse(
+                    **body.model_dump(),
+                    reward=0.0,
+                    judge_failed=True,
+                    judge_failure_reason=judge_failure,
+                )
+            reward, details = result
         reward, details = await self._maybe_zero_incorrect_group_reward(
             problem=problem, reward=reward, details=details
         )
@@ -243,7 +261,10 @@ class ProofWithJudgeResourcesServer(SimpleResourcesServer):
                 reward=reward,
                 details=details,
             )
-        return BaseVerifyResponse(**body.model_dump(), reward=reward)
+        return ProofWithJudgeVerifyResponse(**body.model_dump(), reward=reward)
+
+    def compute_metrics(self, tasks: list[list[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
 
     async def _append_log_jsonl(
         self,

--- a/resources_servers/proof_judge/tests/test_app.py
+++ b/resources_servers/proof_judge/tests/test_app.py
@@ -1,14 +1,44 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+from pytest import approx
 
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.openai_utils import (
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseOutputMessage,
+    NeMoGymResponseOutputText,
+)
 from nemo_gym.server_utils import ServerClient
 from resources_servers.proof_judge.app import (
     ProofWithJudgeResourcesServer,
     ProofWithJudgeResourcesServerConfig,
+    ProofWithJudgeVerifyRequest,
 )
+
+
+def _make_response(text: str) -> NeMoGymResponse:
+    return NeMoGymResponse(
+        id="r",
+        created_at=0.0,
+        model="m",
+        object="response",
+        output=[
+            NeMoGymResponseOutputMessage(
+                id="msg",
+                content=[NeMoGymResponseOutputText(annotations=[], text=text, type="output_text")],
+                role="assistant",
+                status="completed",
+                type="message",
+            )
+        ],
+        parallel_tool_calls=False,
+        tool_choice="none",
+        tools=[],
+    )
 
 
 class TestApp:
@@ -21,3 +51,28 @@ class TestApp:
             judge_model_server=ModelServerRef(type="responses_api_models", name="judge"),
         )
         ProofWithJudgeResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+
+    async def test_verify_judge_failure_recorded(self) -> None:
+        """A judge transport error is recorded as judge_failed, not a wrong answer."""
+        config = ProofWithJudgeResourcesServerConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            judge_model_server=ModelServerRef(type="responses_api_models", name="judge"),
+        )
+        server_mock = MagicMock(spec=ServerClient)
+        server_mock.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        server = ProofWithJudgeResourcesServer(config=config, server_client=server_mock)
+
+        response = _make_response("## Solution\nmy proof.\n## Self Evaluation\nlooks fine \\boxed{1}")
+        request = ProofWithJudgeVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=response,
+            problem="Prove it.",
+        )
+
+        result = await server.verify(request)
+        assert result.reward == approx(0.0)
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason

--- a/resources_servers/proof_verification/app.py
+++ b/resources_servers/proof_verification/app.py
@@ -21,6 +21,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -172,6 +173,10 @@ class ProofVerificationVerifyRequest(BaseVerifyRequest):
     ground_truth_verify_score: float
 
 
+class ProofVerificationVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
+    pass
+
+
 class ProofVerificationResourcesServer(SimpleResourcesServer):
     config: ProofVerificationResourcesServerConfig
 
@@ -181,22 +186,37 @@ class ProofVerificationResourcesServer(SimpleResourcesServer):
     _ext_init_lock: Optional[asyncio.Lock] = PrivateAttr(default=None)
     _log_lock: Optional[asyncio.Lock] = PrivateAttr(default=None)
 
-    async def verify(self, body: ProofVerificationVerifyRequest) -> BaseVerifyResponse:
+    async def verify(self, body: ProofVerificationVerifyRequest) -> ProofVerificationVerifyResponse:
         problem = body.problem
         proof = body.proof
         ground_truth_judgement = body.ground_truth_judgement
         ground_truth_verify_score = body.ground_truth_verify_score
         full_response = self._extract_assistant_text(body.response)
         if not full_response:
-            return BaseVerifyResponse(**body.model_dump(), reward=0.0)
+            return ProofVerificationVerifyResponse(**body.model_dump(), reward=0.0)
 
-        reward, details = await self._judge_single(
-            problem=problem,
-            proof=proof,
-            ground_truth_judgement=ground_truth_judgement,
-            ground_truth_verify_score=ground_truth_verify_score,
-            full_response=full_response,
+        # A judge call that errors (auth, rate limit, timeout, HTTP error,
+        # malformed response) is a distinct outcome, not a wrong answer: record
+        # it instead of scoring the verification as incorrect. Only the judge
+        # HTTP path in `_judge_single` raises; format/parse failures return a
+        # normal (reward, details) tuple.
+        result, judge_failure = await run_judge(
+            self._judge_single(
+                problem=problem,
+                proof=proof,
+                ground_truth_judgement=ground_truth_judgement,
+                ground_truth_verify_score=ground_truth_verify_score,
+                full_response=full_response,
+            )
         )
+        if judge_failure is not None:
+            return ProofVerificationVerifyResponse(
+                **body.model_dump(),
+                reward=0.0,
+                judge_failed=True,
+                judge_failure_reason=judge_failure,
+            )
+        reward, details = result
         if LOG_JSONL_PATH:
             await self._append_log_jsonl(
                 log_path=LOG_JSONL_PATH,
@@ -205,7 +225,10 @@ class ProofVerificationResourcesServer(SimpleResourcesServer):
                 reward=reward,
                 details=details,
             )
-        return BaseVerifyResponse(**body.model_dump(), reward=reward)
+        return ProofVerificationVerifyResponse(**body.model_dump(), reward=reward)
+
+    def compute_metrics(self, tasks: list[list[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
 
     async def _append_log_jsonl(
         self,

--- a/resources_servers/proof_verification/tests/test_app.py
+++ b/resources_servers/proof_verification/tests/test_app.py
@@ -1,14 +1,44 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+from pytest import approx
 
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.openai_utils import (
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseOutputMessage,
+    NeMoGymResponseOutputText,
+)
 from nemo_gym.server_utils import ServerClient
 from resources_servers.proof_verification.app import (
     ProofVerificationResourcesServer,
     ProofVerificationResourcesServerConfig,
+    ProofVerificationVerifyRequest,
 )
+
+
+def _make_response(text: str) -> NeMoGymResponse:
+    return NeMoGymResponse(
+        id="r",
+        created_at=0.0,
+        model="m",
+        object="response",
+        output=[
+            NeMoGymResponseOutputMessage(
+                id="msg",
+                content=[NeMoGymResponseOutputText(annotations=[], text=text, type="output_text")],
+                role="assistant",
+                status="completed",
+                type="message",
+            )
+        ],
+        parallel_tool_calls=False,
+        tool_choice="none",
+        tools=[],
+    )
 
 
 class TestApp:
@@ -21,3 +51,31 @@ class TestApp:
             judge_model_server=ModelServerRef(type="responses_api_models", name="judge"),
         )
         ProofVerificationResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+
+    async def test_verify_judge_failure_recorded(self) -> None:
+        """A judge transport error is recorded as judge_failed, not a wrong answer."""
+        config = ProofVerificationResourcesServerConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="",
+            judge_model_server=ModelServerRef(type="responses_api_models", name="judge"),
+        )
+        server_mock = MagicMock(spec=ServerClient)
+        server_mock.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        server = ProofVerificationResourcesServer(config=config, server_client=server_mock)
+
+        response = _make_response("This verification looks correct \\boxed{1}")
+        request = ProofVerificationVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=response,
+            problem="Prove it.",
+            proof="A proof.",
+            ground_truth_judgement="correct",
+            ground_truth_verify_score=1.0,
+        )
+
+        result = await server.verify(request)
+        assert result.reward == approx(0.0)
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason

--- a/resources_servers/simpleqa/app.py
+++ b/resources_servers/simpleqa/app.py
@@ -46,6 +46,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
     NeMoGymChatCompletionCreateParamsNonStreaming,
@@ -144,7 +145,7 @@ class SimpleQAVerifyRequest(SimpleQARunRequest, BaseVerifyRequest):
     pass
 
 
-class SimpleQAVerifyResponse(BaseVerifyResponse):
+class SimpleQAVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     model_config = ConfigDict(extra="allow")
 
     extracted_answer: Optional[str] = None
@@ -216,6 +217,7 @@ class SimpleQAServer(SimpleResourcesServer):
             metrics[f"{agg}/f1"] = 100.0 * f1
             metrics[f"{agg}/accuracy_given_attempted"] = 100.0 * accuracy_given_attempted
 
+        metrics.update(judge_failure_metrics(tasks))
         return metrics
 
     def get_key_metrics(self, agent_metrics: dict) -> dict:
@@ -226,7 +228,42 @@ class SimpleQAServer(SimpleResourcesServer):
                 key[name] = agent_metrics[name]
         key.update(highest_k_metrics(agent_metrics, "pass@1[avg-of-{k}]"))
         key.update(highest_k_metrics(agent_metrics, "pass@{k}", exclude_names=["no_answer"]))
+        # Judge-failure signal: count, rate, and the judge-success-only reward.
+        for name in ("judge_failures", "mean/judge_failed", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
         return key
+
+    async def _call_judge(self, judge_prompt: str) -> str:
+        if self.config.use_chat_completions_for_judge:
+            chat_params = NeMoGymChatCompletionCreateParamsNonStreaming(
+                messages=[{"role": "user", "content": judge_prompt}],
+                max_tokens=self.config.judge_responses_create_params.max_output_tokens or 64,
+                temperature=self.config.judge_responses_create_params.temperature or 0.0,
+                top_p=self.config.judge_responses_create_params.top_p or 1.0,
+            )
+            response_obj = await self.server_client.post(
+                server_name=self.config.judge_model_server.name,
+                url_path="/v1/chat/completions",
+                json=chat_params,
+            )
+            chat_response = NeMoGymChatCompletion.model_validate(await response_obj.json())
+            content = chat_response.choices[0].message.content if chat_response.choices else None
+            return content.strip() if content else ""
+
+        msgs: List[NeMoGymEasyInputMessage] = [
+            NeMoGymEasyInputMessage(role="user", content=judge_prompt),
+        ]
+        request_params = self.config.judge_responses_create_params.model_copy(deep=True)
+        request_params.input = msgs
+
+        response_obj = await self.server_client.post(
+            server_name=self.config.judge_model_server.name,
+            url_path="/v1/responses",
+            json=request_params,
+        )
+        judge_response = NeMoGymResponse.model_validate(await response_obj.json())
+        return extract_text_from_response(judge_response)
 
     async def verify(self, body: SimpleQAVerifyRequest) -> SimpleQAVerifyResponse:
         # Reasoning-trace handling is the model server's responsibility:
@@ -243,35 +280,21 @@ class SimpleQAServer(SimpleResourcesServer):
             generation=generation,
         )
 
-        if self.config.use_chat_completions_for_judge:
-            chat_params = NeMoGymChatCompletionCreateParamsNonStreaming(
-                messages=[{"role": "user", "content": judge_prompt}],
-                max_tokens=self.config.judge_responses_create_params.max_output_tokens or 64,
-                temperature=self.config.judge_responses_create_params.temperature or 0.0,
-                top_p=self.config.judge_responses_create_params.top_p or 1.0,
-            )
-            response_obj = await self.server_client.post(
-                server_name=self.config.judge_model_server.name,
-                url_path="/v1/chat/completions",
-                json=chat_params,
-            )
-            chat_response = NeMoGymChatCompletion.model_validate(await response_obj.json())
-            content = chat_response.choices[0].message.content if chat_response.choices else None
-            judge_text = content.strip() if content else ""
-        else:
-            msgs: List[NeMoGymEasyInputMessage] = [
-                NeMoGymEasyInputMessage(role="user", content=judge_prompt),
-            ]
-            request_params = self.config.judge_responses_create_params.model_copy(deep=True)
-            request_params.input = msgs
+        judge_text, judge_failure = await run_judge(self._call_judge(judge_prompt))
 
-            response_obj = await self.server_client.post(
-                server_name=self.config.judge_model_server.name,
-                url_path="/v1/responses",
-                json=request_params,
+        # A failed or empty judge call is a distinct outcome, not a wrong answer:
+        # reward stays 0.0 but judge_failed flags it out of the accuracy denominator.
+        if judge_failure is not None or not judge_text:
+            return SimpleQAVerifyResponse(
+                **body.model_dump(exclude={"expected_answer", "extracted_answer"}),
+                reward=0.0,
+                extracted_answer=generation,
+                expected_answer=expected_answer,
+                verdict=None,
+                judge_output=judge_text or "",
+                judge_failed=True,
+                judge_failure_reason=judge_failure or "empty judge response",
             )
-            judge_response = NeMoGymResponse.model_validate(await response_obj.json())
-            judge_text = extract_text_from_response(judge_response)
 
         grade = parse_judge_grade(judge_text)
 

--- a/resources_servers/simpleqa/tests/test_app.py
+++ b/resources_servers/simpleqa/tests/test_app.py
@@ -251,6 +251,25 @@ class TestSimpleQAServer:
         assert result.verdict == "not_attempted"
         assert result.is_not_attempted == approx(1.0)
 
+    async def test_verify_judge_failure_recorded(self, config: SimpleQAConfig) -> None:
+        # A judge call that errors is a distinct outcome, not a wrong answer.
+        server_mock = MagicMock(spec=ServerClient)
+        server_mock.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        server = SimpleQAServer(config=config, server_client=server_mock)
+
+        request = SimpleQAVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=_make_response("Pancreas"),
+            question="What organ in the human body produces insulin?",
+            expected_answer="Pancreas",
+        )
+
+        result = await server.verify(request)
+        assert result.reward == approx(0.0)
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason
+        assert result.verdict is None
+
     async def test_verify_passes_message_content_verbatim(self, config: SimpleQAConfig) -> None:
         """The model-server's --reasoning-parser strips <think> blocks
         before they reach the resource server, so verify() forwards the

--- a/resources_servers/tavily_search/app.py
+++ b/resources_servers/tavily_search/app.py
@@ -34,6 +34,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     RATE_LIMIT_ERROR_CODES,
     RETRY_ERROR_CODES,
@@ -117,7 +118,7 @@ class TavilySearchMetrics(BaseModel):
     async_tavily_calls: List[TavilySearchSingleAsyncTavilyMetrics] = Field(default_factory=list)
 
 
-class TavilySearchVerifyResponse(TavilySearchVerifyRequest, JudgeEvaluation):
+class TavilySearchVerifyResponse(JudgeFailureMixin, TavilySearchVerifyRequest, JudgeEvaluation):
     num_tool_calls: int
     metrics: TavilySearchMetrics
 
@@ -395,20 +396,34 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
             total_words=total_words,
         )
 
+    def compute_metrics(self, tasks: list[list[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
+
+    def get_key_metrics(self, agent_metrics: dict) -> dict:
+        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
+        return key
+
     async def verify(self, request: Request, body: TavilySearchVerifyRequest) -> TavilySearchVerifyResponse:
         question = body.question
         ground_truth = body.ground_truth
         last_assistant_response = body.response.output_text
 
         if self.config.use_judge:
-            judge_evaluation = await self._verify_answer_with_judge(question, ground_truth, last_assistant_response)
+            judge_evaluation, judge_failure = await self._verify_answer_with_judge(
+                question, ground_truth, last_assistant_response
+            )
         else:
-            judge_evaluation = self._verify_answer_with_regex(ground_truth, last_assistant_response)
+            judge_evaluation, judge_failure = self._verify_answer_with_regex(ground_truth, last_assistant_response), None
         return TavilySearchVerifyResponse(
             **body.model_dump(),
             **judge_evaluation.model_dump(),
             num_tool_calls=sum(o.type == "function_call" for o in body.response.output),
             metrics=self._session_id_to_metrics[request.session[SESSION_ID_KEY]],
+            judge_failed=judge_failure is not None,
+            judge_failure_reason=judge_failure,
         )
 
     ###### UTILITY FUNCTIONS ######
@@ -488,7 +503,9 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
                     exclude_domains.append(prop["value"])
         return exclude_domains
 
-    async def _verify_answer_with_judge(self, question: str, ground_truth: str, response: str) -> JudgeEvaluation:
+    async def _verify_answer_with_judge(
+        self, question: str, ground_truth: str, response: str
+    ) -> tuple[JudgeEvaluation, Optional[str]]:
         async def _get_judge_response(
             question: str, ground_truth: str, response: str
         ) -> tuple[NeMoGymResponseCreateParamsNonStreaming, NeMoGymResponse]:
@@ -529,9 +546,17 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
                 judge_response=judge_response,
             )
 
-        judge_create_params, judge_response = await _get_judge_response(question, ground_truth, response)
+        # A failed judge call (auth, rate limit, timeout, HTTP error) is a distinct outcome,
+        # not a wrong answer: record it instead of crashing the sample.
+        result, judge_failure = await run_judge(_get_judge_response(question, ground_truth, response))
+        if judge_failure is not None:
+            return (
+                JudgeEvaluation(reasoning="", extracted_final_answer="", reward=0.0),
+                judge_failure,
+            )
+        judge_create_params, judge_response = result
         judge_evaluation = _grade_sample(judge_create_params, judge_response)
-        return judge_evaluation
+        return judge_evaluation, None
 
     def _verify_answer_with_regex(self, ground_truth: str, response: str) -> JudgeEvaluation:
         """Verify answer by checking if ground_truth (as regex) matches in response."""

--- a/resources_servers/tavily_search/app.py
+++ b/resources_servers/tavily_search/app.py
@@ -416,7 +416,10 @@ class TavilySearchResourcesServer(SimpleResourcesServer):
                 question, ground_truth, last_assistant_response
             )
         else:
-            judge_evaluation, judge_failure = self._verify_answer_with_regex(ground_truth, last_assistant_response), None
+            judge_evaluation, judge_failure = (
+                self._verify_answer_with_regex(ground_truth, last_assistant_response),
+                None,
+            )
         return TavilySearchVerifyResponse(
             **body.model_dump(),
             **judge_evaluation.model_dump(),

--- a/resources_servers/tavily_search/tests/test_app.py
+++ b/resources_servers/tavily_search/tests/test_app.py
@@ -304,6 +304,25 @@ class TestApp:
         assert res.extracted_final_answer == "yes"
         assert server_client.post.call_count == 1
 
+    async def test_verify_judge_failure(self, config: TavilySearchResourcesServerConfig) -> None:
+        """A failed judge call is recorded as a distinct outcome, not a wrong answer."""
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        server = TavilySearchResourcesServer(config=config, server_client=server_client)
+
+        req = TavilySearchVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=self._create_model_response("The capital of France is Paris."),
+            ground_truth="Paris",
+            question="What is the capital of France?",
+        )
+
+        res = await server.verify(self._create_dummy_request(), req)
+
+        assert res.reward == approx(0.0)
+        assert res.judge_failed is True
+        assert "judge timeout" in res.judge_failure_reason
+
     async def test_verify_incorrect_answer(self, config: TavilySearchResourcesServerConfig) -> None:
         """Test verify endpoint when judge determines answer is incorrect."""
         server_client = MagicMock(spec=ServerClient)

--- a/resources_servers/terminus_judge/app.py
+++ b/resources_servers/terminus_judge/app.py
@@ -32,6 +32,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -223,7 +224,7 @@ class JudgeEvaluation(BaseModel):
     verdict_label: Optional[str] = None
 
 
-class TerminusJudgeVerifyResponse(BaseVerifyResponse):
+class TerminusJudgeVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     uuid: Optional[str | int] = None
     expected_answer: str
     model_output: str
@@ -266,6 +267,16 @@ class TerminusJudgeResourcesServer(SimpleResourcesServer):
         app = super().setup_webserver()
         return app
 
+    def compute_metrics(self, tasks: List[List[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
+
+    def get_key_metrics(self, agent_metrics: dict) -> dict:
+        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        for name in ("judge_failures", "mean/judge_failed", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
+        return key
+
     async def verify(self, body: TerminusJudgeVerifyRequest) -> TerminusJudgeVerifyResponse:
         # Initialize response fields
         reward = 0.0
@@ -277,6 +288,8 @@ class TerminusJudgeResourcesServer(SimpleResourcesServer):
         similarity_score = None
         parsed_output = None
         judge_evaluations = []
+        judge_failed = False
+        judge_failure_reason = None
 
         # Helper to build response
         def _build_response(expected_str: str, model_output_str: str) -> TerminusJudgeVerifyResponse:
@@ -308,6 +321,8 @@ class TerminusJudgeResourcesServer(SimpleResourcesServer):
                 judge_evaluations=[_sanitize_pydantic_model(j) for j in judge_evaluations],
                 metadata=_sanitize_for_json(body.metadata),
                 threshold=body.threshold,
+                judge_failed=judge_failed,
+                judge_failure_reason=judge_failure_reason,
             )
 
         # Extract expected answer (ground truth)
@@ -431,9 +446,18 @@ class TerminusJudgeResourcesServer(SimpleResourcesServer):
 
             # Step 2: LLM judge evaluation (if needed and enabled)
             if need_judge:
-                first_equal, first_eval = await self._generate_judge_evaluation(
-                    expected_answer=expected, generated_answer=text
+                # A failed judge CALL (auth, rate limit, timeout, HTTP error) is a
+                # distinct outcome, not a wrong answer — flag it via judge_failed
+                # instead of losing it to the broad except below.
+                first, judge_failure = await run_judge(
+                    self._generate_judge_evaluation(expected_answer=expected, generated_answer=text)
                 )
+                if judge_failure is not None:
+                    judge_failed = True
+                    judge_failure_reason = judge_failure
+                    reward = 0.0
+                    return _build_response(expected_str=expected, model_output_str=text)
+                first_equal, first_eval = first
                 judge_evaluations.append(first_eval)
                 logger.info(
                     f"terminus_judge verify | uuid={body.uuid} "
@@ -447,9 +471,15 @@ class TerminusJudgeResourcesServer(SimpleResourcesServer):
                     reward = 0.0
                 elif first_equal:
                     if self.config.check_twice_swap:
-                        second_equal, second_eval = await self._generate_judge_evaluation(
-                            expected_answer=text, generated_answer=expected
+                        second, judge_failure = await run_judge(
+                            self._generate_judge_evaluation(expected_answer=text, generated_answer=expected)
                         )
+                        if judge_failure is not None:
+                            judge_failed = True
+                            judge_failure_reason = judge_failure
+                            reward = 0.0
+                            return _build_response(expected_str=expected, model_output_str=text)
+                        second_equal, second_eval = second
                         judge_evaluations.append(second_eval)
                         logger.info(
                             f"terminus_judge verify | uuid={body.uuid} "

--- a/resources_servers/terminus_judge/tests/test_app.py
+++ b/resources_servers/terminus_judge/tests/test_app.py
@@ -1129,6 +1129,27 @@ class TestVerifyWithRubricsV4JudgeResponse:
         assert response.judge_passed is None  # None because judge didn't return meaningful result
         assert response.judge_evaluations[0].verdict_label is None
 
+    @pytest.mark.asyncio
+    async def test_verify_judge_call_failure_records_standard_fields(
+        self, resources_server: TerminusJudgeResourcesServer
+    ):
+        """A failed judge CALL is a distinct outcome, recorded via the standard
+        judge-failure fields — not silently scored as a wrong answer."""
+        from pytest import approx
+
+        expected_answer = create_terminus_1_response([{"keystrokes": "ls\n"}])
+        pred_answer = create_terminus_1_response([{"keystrokes": "pwd\n"}])
+        model_output = json.dumps(pred_answer)
+        request = self._create_verify_request(model_output, expected_answer, "terminus_1")
+
+        resources_server.server_client.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+
+        response = await resources_server.verify(request)
+
+        assert response.judge_failed is True
+        assert "judge timeout" in response.judge_failure_reason
+        assert response.reward == approx(0.0)
+
 
 class TestVerifyAdditionalScenarios:
     """Additional test scenarios for full coverage."""

--- a/resources_servers/text_to_sql/app.py
+++ b/resources_servers/text_to_sql/app.py
@@ -36,6 +36,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -186,7 +187,7 @@ class JudgeEvaluation(BaseModel):
     verdict_label: Optional[str] = None
 
 
-class TextToSqlVerifyResponse(BaseVerifyResponse):
+class TextToSqlVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     """Verification response for text-to-SQL tasks."""
 
     uuid: Optional[str | int] = None
@@ -245,6 +246,8 @@ class TextToSqlResourcesServer(SimpleResourcesServer):
         judge_passed = False
         judge_evaluations = []
         extracted_sql = None
+        judge_failed = False
+        judge_failure_reason: Optional[str] = None
 
         if not generated:
             failure_reason = FailureCode.NO_SQL_EXTRACTED
@@ -313,8 +316,13 @@ class TextToSqlResourcesServer(SimpleResourcesServer):
                     reward = 0.0
 
         except Exception as e:
+            # A failed judge call (timeout, auth, rate limit, HTTP error) is a
+            # distinct outcome, not a wrong answer: flag it out of the accuracy
+            # denominator instead of silently scoring reward=0.
             failure_reason = FailureCode.UNKNOWN_ERROR
             reward = 0.0
+            judge_failed = True
+            judge_failure_reason = f"{type(e).__name__}: {e}"
             print(f"DEBUG: Unknown error in verify: {type(e).__name__} {e}", flush=True)
 
         payload = body.model_dump()
@@ -335,7 +343,19 @@ class TextToSqlResourcesServer(SimpleResourcesServer):
             judge_passed=judge_passed,
             failure_reason=failure_reason,
             judge_evaluations=judge_evaluations,
+            judge_failed=judge_failed,
+            judge_failure_reason=judge_failure_reason,
         )
+
+    def compute_metrics(self, tasks: list[list[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
+
+    def get_key_metrics(self, agent_metrics: dict) -> dict:
+        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
+        return key
 
     async def _generate_judge_evaluation(
         self,

--- a/resources_servers/text_to_sql/tests/test_app.py
+++ b/resources_servers/text_to_sql/tests/test_app.py
@@ -432,6 +432,24 @@ class TestTextToSqlResourcesServerVerify:
             await resources_server.verify(request)
 
     @pytest.mark.asyncio
+    async def test_verify_judge_failure_recorded(self, resources_server: TextToSqlResourcesServer):
+        """A judge call that raises is recorded as a distinct outcome, not a wrong answer."""
+        from pytest import approx
+
+        request = self._create_verify_request(
+            model_output="```sql\nSELECT * FROM users;\n```",
+            sql="SELECT * FROM users;",
+        )
+        resources_server.server_client.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+
+        response = await resources_server.verify(request)
+
+        assert response.reward == approx(0.0)
+        assert response.judge_failed is True
+        assert "judge timeout" in response.judge_failure_reason
+        assert response.failure_reason == FailureCode.UNKNOWN_ERROR
+
+    @pytest.mark.asyncio
     async def test_verify_with_empty_sql_context(self, resources_server: TextToSqlResourcesServer):
         """Test verify works with empty sql_context."""
         resources_server.config.check_twice_swap = False

--- a/resources_servers/ugphysics_judge/app.py
+++ b/resources_servers/ugphysics_judge/app.py
@@ -53,6 +53,7 @@ from typing import Any, ClassVar, Dict, List, Optional, Union
 
 from pydantic import ConfigDict, Field
 
+from nemo_gym.judge import judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
     NeMoGymChatCompletionCreateParamsNonStreaming,
@@ -192,12 +193,29 @@ class UGPhysicsJudgeResourcesServer(LibraryJudgeMathResourcesServer):
                 assistant_responses.append(content_item.text)
         combined_response = "".join(assistant_responses)
 
-        reward, extracted_answer, library_reward, judge_evaluations, verdict = await self._verify_answer(
-            question=body.question,
-            expected_answer=body.expected_answer,
-            generated_answer=combined_response,
-            solution=body.solution,
+        # A judge transport failure is a distinct outcome, not a wrong answer.
+        # The library verifier never raises (returns 0.0), so an exception here
+        # is the judge call.
+        result, judge_failure = await run_judge(
+            self._verify_answer(
+                question=body.question,
+                expected_answer=body.expected_answer,
+                generated_answer=combined_response,
+                solution=body.solution,
+            )
         )
+        if judge_failure is not None:
+            return UGPhysicsJudgeVerifyResponse(
+                **body.model_dump(),
+                reward=0.0,
+                extracted_answer=None,
+                library_reward=0.0,
+                judge_evaluations=None,
+                extracted_verdict=None,
+                judge_failed=True,
+                judge_failure_reason=judge_failure,
+            )
+        reward, extracted_answer, library_reward, judge_evaluations, verdict = result
         return UGPhysicsJudgeVerifyResponse(
             **body.model_dump(),
             reward=reward,
@@ -408,6 +426,7 @@ class UGPhysicsJudgeResourcesServer(LibraryJudgeMathResourcesServer):
             answer_key="extracted_verdict",
         )
         metrics.update(subset_metrics)
+        metrics.update(judge_failure_metrics(tasks))
         return metrics
 
     def get_key_metrics(self, agent_metrics: Dict[str, Any]) -> Dict[str, Any]:
@@ -418,6 +437,9 @@ class UGPhysicsJudgeResourcesServer(LibraryJudgeMathResourcesServer):
         key.update(highest_k_metrics(agent_metrics, "pass@1[avg-of-{k}]"))
         key.update(highest_k_metrics(agent_metrics, "pass@{k}", exclude_names=["no_answer"]))
         key.update(highest_k_metrics(agent_metrics, "majority@{k}", exclude_names=["no_answer"]))
+        for name in ("judge_failures", "mean/judge_failed", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
         return key
 
 

--- a/resources_servers/ugphysics_judge/tests/test_app.py
+++ b/resources_servers/ugphysics_judge/tests/test_app.py
@@ -177,6 +177,28 @@ class TestServer:
         # Judge model never called.
         assert not server.server_client.post.called
 
+    async def test_verify_records_judge_failure(
+        self,
+        config: UGPhysicsJudgeResourcesServerConfig,
+        model_create_params: NeMoGymResponseCreateParamsNonStreaming,
+    ) -> None:
+        """Symbolic miss → judge invoked → judge call errors → recorded, not scored 0 silently."""
+        server_mock = MagicMock(spec=ServerClient)
+        server_mock.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        server = UGPhysicsJudgeResourcesServer(config=config, server_client=server_mock)
+        request = UGPhysicsJudgeVerifyRequest(
+            responses_create_params=deepcopy(model_create_params),
+            response=NeMoGymResponse(**_make_response("gen", _msg("Wrong: \\boxed{3}"))),
+            question="What is 1+1?",
+            expected_answer="2",
+            solution="1+1=2",
+            subject="QuantumMechanics",
+        )
+        response = await server.verify(request)
+        assert response.reward == approx(0.0)
+        assert response.judge_failed is True
+        assert "judge timeout" in response.judge_failure_reason
+
     async def test_verify_symbolic_miss_invokes_judge_true(
         self,
         config: UGPhysicsJudgeResourcesServerConfig,

--- a/resources_servers/xstest/app.py
+++ b/resources_servers/xstest/app.py
@@ -36,6 +36,7 @@ from nemo_gym.base_resources_server import (
 )
 from nemo_gym.config_types import ModelServerRef
 from nemo_gym.global_config import get_first_server_config_dict
+from nemo_gym.judge import JudgeFailureMixin, judge_failure_metrics, run_judge
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -65,9 +66,10 @@ class JudgeEvaluation(BaseModel):
     responses_create_params: NeMoGymResponseCreateParamsNonStreaming
     response: Optional[NeMoGymResponse] = None
     verdict_label: Optional[str] = None
+    error: Optional[str] = None
 
 
-class XSTestVerifyResponse(BaseVerifyResponse):
+class XSTestVerifyResponse(JudgeFailureMixin, BaseVerifyResponse):
     label: str
     prompt_type: str
     is_refusal: bool
@@ -204,6 +206,8 @@ class XSTestResourcesServer(SimpleResourcesServer):
             )
 
         judge_evaluations: Optional[list[JudgeEvaluation]] = None
+        judge_failed = False
+        judge_failure_reason: Optional[str] = None
 
         if not cleaned_text:
             # Empty generation — not a judge error, just a bad model output
@@ -215,12 +219,17 @@ class XSTestResourcesServer(SimpleResourcesServer):
             judge_evaluations = [evaluation]
             if judge_result is None:
                 # Judge failed — do not silently fall back to string matching.
-                # Report the error clearly so operators can fix the judge setup.
+                # A transport/HTTP failure (evaluation.error set) is a distinct
+                # outcome, recorded via judge_failed; an unparseable-but-received
+                # verdict keeps reward=0.0 without flagging a judge failure.
                 logger.error(
                     "Judge failed to classify response (verdict_label=%s). "
                     "Assigning reward=0.0. Check that the judge model server is running and reachable.",
                     evaluation.verdict_label,
                 )
+                if evaluation.error:
+                    judge_failed = True
+                    judge_failure_reason = evaluation.error
                 is_refusal = False
                 reward = 0.0
             else:
@@ -237,7 +246,28 @@ class XSTestResourcesServer(SimpleResourcesServer):
             is_refusal=is_refusal,
             cleaned_response=cleaned_text,
             judge_evaluations=judge_evaluations,
+            judge_failed=judge_failed,
+            judge_failure_reason=judge_failure_reason,
         )
+
+    def compute_metrics(self, tasks: list[list[dict]]) -> dict:
+        return judge_failure_metrics(tasks)
+
+    def get_key_metrics(self, agent_metrics: dict) -> dict:
+        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        for name in ("judge_failures", "reward[judge_ok_only]"):
+            if name in agent_metrics:
+                key[name] = agent_metrics[name]
+        return key
+
+    async def _post_judge(self, responses_create_params: NeMoGymResponseCreateParamsNonStreaming) -> NeMoGymResponse:
+        async with self._judge_semaphore:
+            http_response = await self.server_client.post(
+                server_name=self.config.judge_model_server.name,
+                url_path="/v1/responses",
+                json=responses_create_params,
+            )
+            return NeMoGymResponse.model_validate(await get_response_json(http_response))
 
     async def _classify_with_judge(self, *, question: str, response: str) -> tuple[Optional[bool], JudgeEvaluation]:
         """Call the judge model to classify a response as compliance or refusal."""
@@ -249,19 +279,14 @@ class XSTestResourcesServer(SimpleResourcesServer):
             NeMoGymEasyInputMessage(role="user", content=user_prompt),
         ]
 
-        async with self._judge_semaphore:
-            try:
-                http_response = await self.server_client.post(
-                    server_name=cfg.judge_model_server.name,
-                    url_path="/v1/responses",
-                    json=responses_create_params,
-                )
-                judge_response = NeMoGymResponse.model_validate(await get_response_json(http_response))
-            except Exception as e:
-                logger.error("Judge HTTP POST error: %s %s", type(e).__name__, e)
-                return None, JudgeEvaluation(
-                    responses_create_params=responses_create_params, verdict_label="judge_error"
-                )
+        judge_response, judge_failure = await run_judge(self._post_judge(responses_create_params))
+        if judge_failure is not None:
+            logger.error("Judge HTTP POST error: %s", judge_failure)
+            return None, JudgeEvaluation(
+                responses_create_params=responses_create_params,
+                verdict_label="judge_error",
+                error=judge_failure,
+            )
 
         eval_record = JudgeEvaluation(
             responses_create_params=responses_create_params,

--- a/resources_servers/xstest/tests/test_app.py
+++ b/resources_servers/xstest/tests/test_app.py
@@ -284,6 +284,15 @@ class TestJudgeIntegration:
         assert result.reward == 0.0
         assert result.judge_evaluations[0].verdict_label == "judge_error"
 
+    async def test_judge_failure_recorded(self) -> None:
+        """A judge transport failure is recorded via judge_failed, distinct from a low score."""
+        server, mock = _make_server()
+        mock.post = AsyncMock(side_effect=RuntimeError("judge timeout"))
+        result = await server.verify(_make_verify_request(text="I'm sorry, no.", label="unsafe"))
+        assert result.reward == 0.0
+        assert result.judge_failed is True
+        assert "judge timeout" in result.judge_failure_reason
+
     async def test_judge_unparseable_returns_zero_reward(self) -> None:
         """When the judge returns garbage, reward must be 0.0 — no silent fallback."""
         server, mock = _make_server()

--- a/tests/unit_tests/test_judge.py
+++ b/tests/unit_tests/test_judge.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+from pytest import approx
+
+from nemo_gym.judge import judge_failure_metrics, run_judge
+
+
+class TestRunJudge:
+    @pytest.mark.asyncio
+    async def test_success_returns_result_no_error(self) -> None:
+        async def ok():
+            return "verdict"
+
+        result, error = await run_judge(ok())
+        assert result == "verdict"
+        assert error is None
+
+    @pytest.mark.asyncio
+    async def test_exception_recorded_verbatim(self) -> None:
+        async def boom():
+            raise RuntimeError("judge timeout")
+
+        result, error = await run_judge(boom())
+        assert result is None
+        assert error == "RuntimeError: judge timeout"
+
+
+class TestJudgeFailureMetrics:
+    def test_counts_failures_and_excludes_from_reward(self) -> None:
+        tasks = [
+            [{"reward": 1.0}, {"reward": 0.0, "judge_failed": True}],
+            [{"reward": 1.0}],
+        ]
+        m = judge_failure_metrics(tasks)
+        assert m["judge_failures"] == 1
+        # Judge-ok-only mean excludes the failed sample: (1.0 + 1.0) / 2.
+        assert m["reward[judge_ok_only]"] == approx(1.0)
+
+    def test_all_failed_returns_none(self) -> None:
+        tasks = [[{"reward": 0.0, "judge_failed": True}]]
+        m = judge_failure_metrics(tasks)
+        assert m["judge_failures"] == 1
+        assert m["reward[judge_ok_only]"] is None
+
+    def test_empty_tasks_returns_empty(self) -> None:
+        assert judge_failure_metrics([]) == {}


### PR DESCRIPTION
**Standardize judge-failure recording across all LLM-as-judge benchmarks**

Adds a shared abstraction (`nemo_gym/judge.py`) so a failed judge call (auth, rate-limit, timeout, HTTP, empty/malformed response) is recorded as a distinct outcome instead of being silently scored as a wrong answer:

- `JudgeFailureMixin` — standard per-sample fields judge_failed + judge_failure_reason (raw error), identical across benchmarks.
- `run_judge()` — wraps a judge call, catching failures instead of raising or defaulting to 0.
- `judge_failure_metrics()` — emits judge_failures (count), mean/judge_failed (rate), and two accuracy views: the usual one (failures = 0) and reward[judge_ok_only] (failures excluded), so a broken judge can't silently deflate scores.

Scope: applied to all 27 judge-based benchmarks (25 directly + physics_judge/math_with_autograder via inheritance), each with a wiring test.