### PR TITLE
Add output_regex parser path to litmus_agent

### DIFF
--- a/resources_servers/litmus_agent/app.py
+++ b/resources_servers/litmus_agent/app.py
@@ -23,9 +23,10 @@ this server keeps only that path and drops everything RDKit-specific.
 What it does
 ------------
 1. Extracts the model's final answer text from the rollout trajectory.
-2. Pulls a value out of that text using the requested ``answer_format`` regex
-   (the ``fmt_XX`` family) -- the same wrapper-syntax extraction the chemistry
-   server used, which was already domain-independent.
+2. Pulls a value out of that text using the row's ``output_regex`` when present,
+   otherwise the requested ``answer_format`` regex (the ``fmt_XX`` family) -- the
+   same wrapper-syntax extraction the chemistry server used, which was already
+   domain-independent.
 3. Scores it against ``expected_answer`` using a small ``answer_type`` taxonomy
    that selects the comparison rule.
 
@@ -302,6 +303,10 @@ class LitmusAgentRunRequest(BaseRunRequest):
     # Selects how the answer is parsed. Optional so legacy rows carrying only
     # ``property_type`` still resolve via _PROPERTY_TYPE_TO_ANSWER_TYPE.
     answer_type: Optional[str] = None
+    # Preferred parser: a regex string carried directly on the row (exactly one
+    # capture group). When present it wins over ``answer_format``; see
+    # extract_predicted_value for the full resolution order.
+    output_regex: Optional[str] = None
     answer_format: Optional[str] = None
     use_box_format: bool = False
     # Per-row reward-rule override: {"rule": <name>, **params}. When absent, the
@@ -376,11 +381,13 @@ def resolve_answer_type(answer_type: Optional[str], extra: Dict[str, Any]) -> st
     return mapped
 
 
-def _raw_capture(text: str, answer_format: str) -> Optional[str]:
-    """Return the last match of the answer-format regex, or None."""
-    pattern = _ANSWER_FORMAT_REGEXES.get(answer_format)
-    if pattern is None:
-        raise ValueError(f"Unsupported answer_format={answer_format!r}")
+def _capture_with_pattern(text: str, pattern: re.Pattern[str]) -> Optional[str]:
+    """Return the last match of a compiled answer regex, or None.
+
+    Only the last match is considered, so a self-correcting response ("...3,
+    actually 5") scores on its final answer. Multi-group patterns collapse to
+    their first non-empty group.
+    """
     matches = pattern.findall(text)
     if not matches:
         return None
@@ -388,6 +395,29 @@ def _raw_capture(text: str, answer_format: str) -> Optional[str]:
     if isinstance(match, tuple):
         match = next((group for group in match if group), "")
     return match.strip()
+
+
+def _raw_capture(text: str, answer_format: str) -> Optional[str]:
+    """Return the last match of the named ``fmt_XX`` regex, or None."""
+    pattern = _ANSWER_FORMAT_REGEXES.get(answer_format)
+    if pattern is None:
+        raise ValueError(f"Unsupported answer_format={answer_format!r}")
+    return _capture_with_pattern(text, pattern)
+
+
+def _compile_output_regex(output_regex: str) -> re.Pattern[str]:
+    """Compile a per-row ``output_regex``, requiring exactly one capture group.
+
+    Fails loudly on an invalid pattern or a group count other than one so bad
+    dataset regexes surface at scoring time instead of silently mis-extracting.
+    """
+    try:
+        pattern = re.compile(output_regex, re.S)
+    except re.error as exc:
+        raise ValueError(f"Invalid output_regex={output_regex!r}: {exc}") from exc
+    if pattern.groups != 1:
+        raise ValueError(f"output_regex={output_regex!r} must have exactly one capture group, got {pattern.groups}")
+    return pattern
 
 
 def _parse_bool(inner: str) -> Optional[float]:
@@ -423,21 +453,36 @@ def extract_predicted_value(
     response: str,
     answer_type: str,
     *,
+    output_regex: Optional[str] = None,
     answer_format: Optional[str] = None,
     use_box_format: bool = False,
 ) -> Optional[Union[float, str]]:
     """Extract the model's predicted value from its response text.
 
-    Locates the answer with the ``answer_format`` regex (legacy rows fall back
-    to boxed/double-paren via ``use_box_format``), then coerces it: numeric
-    types parse to float, ``string`` returns the raw captured text. Returns None
-    when nothing can be extracted.
+    Locates the answer, then coerces it by ``answer_type``: numeric types parse
+    to float, ``bool`` to 1.0/0.0, ``string`` returns the raw captured text.
+
+    The answer is located by the first available of, in order:
+
+    1. ``output_regex`` (preferred): a regex carried directly on the row. Must
+       compile and have exactly one capture group, else ``ValueError``.
+    2. ``answer_format``: look up a regex by ``fmt_XX`` name in the registry
+       kept for rows exported without an ``output_regex``. Unknown names raise
+       ``ValueError`` so bad data fails loudly.
+    3. ``use_box_format``: very-legacy fallback -- boxed when true, double
+       parentheses when false.
+
+    Returns None when nothing can be extracted.
     """
     if not isinstance(response, str):
         return None
     text = response.strip()
-    fmt = answer_format or ("fmt_07" if use_box_format else "fmt_00")
-    raw = _raw_capture(text, fmt)
+
+    if output_regex is not None:
+        raw = _capture_with_pattern(text, _compile_output_regex(output_regex))
+    else:
+        fmt = answer_format or ("fmt_07" if use_box_format else "fmt_00")
+        raw = _raw_capture(text, fmt)
     if raw is None:
         return None
     if answer_type == STRING:
@@ -719,6 +764,7 @@ class LitmusAgentResourcesServer(SimpleResourcesServer):
         predicted = extract_predicted_value(
             text,
             answer_type,
+            output_regex=body.output_regex,
             answer_format=body.answer_format,
             use_box_format=body.use_box_format,
         )

--- a/resources_servers/litmus_agent/tests/test_app.py
+++ b/resources_servers/litmus_agent/tests/test_app.py
@@ -180,6 +180,44 @@ class TestExtractPredictedValue:
     def test_all_formats_registered(self):
         assert set(_ANSWER_FORMAT_REGEXES) == {f"fmt_{i:02d}" for i in range(31)}
 
+    def test_output_regex_extracts_value(self):
+        assert (
+            extract_predicted_value("Correct Answer: [3]", FLOAT, output_regex=r"Correct Answer:\s*\[(.+?)\]") == 3.0
+        )
+
+    def test_output_regex_preferred_over_answer_format(self):
+        # answer_format would pick the boxed 7; output_regex targets the label.
+        text = r"\boxed{7}. Final Answer = 42"
+        assert (
+            extract_predicted_value(text, FLOAT, output_regex=r"Final Answer\s*=\s*(.+)", answer_format="fmt_07")
+            == 42.0
+        )
+
+    def test_output_regex_recovers_dropped_wrapper(self):
+        # A lenient row regex (optional bracket) scores an answer that the strict
+        # fmt_06 regex would miss when the model drops the '[]' wrapper.
+        text = "Correct Answer: 2"
+        assert extract_predicted_value(text, FLOAT, answer_format="fmt_06") is None
+        lenient = r"Correct Answer:\s*\**\[?\s*([-+]?\d*\.?\d+)"
+        assert extract_predicted_value(text, FLOAT, output_regex=lenient) == 2.0
+
+    def test_output_regex_last_match_wins(self):
+        assert extract_predicted_value("val: 3 then val: 5", FLOAT, output_regex=r"val:\s*(\d+)") == 5.0
+
+    def test_output_regex_string_returns_raw(self):
+        assert extract_predicted_value("SMILES: CCO", STRING, output_regex=r"SMILES:\s*(.+)") == "CCO"
+
+    def test_output_regex_no_match_returns_none(self):
+        assert extract_predicted_value("no answer here", FLOAT, output_regex=r"Answer:\s*(\d+)") is None
+
+    def test_output_regex_invalid_raises(self):
+        with pytest.raises(ValueError, match="Invalid output_regex"):
+            extract_predicted_value("x", FLOAT, output_regex=r"(unclosed")
+
+    def test_output_regex_wrong_group_count_raises(self):
+        with pytest.raises(ValueError, match="exactly one capture group"):
+            extract_predicted_value("x", FLOAT, output_regex=r"(a)(b)")
+
 
 # ---------------------------------------------------------------------------
 # compute_reward
@@ -303,6 +341,28 @@ class TestVerify:
         assert result.predicted_value == 3.0
         assert result.resolved_answer_type == FLOAT
         assert result.resolved_reward_rule == "isclose"
+
+    async def test_output_regex_row_scores_dropped_wrapper(self):
+        # End-to-end: a lenient output_regex on the row recovers an answer whose
+        # strict fmt_06 wrapper the model dropped ("Correct Answer: 2", no []).
+        server = _make_server()
+        strict = await server.verify(
+            _make_verify_request("Correct Answer: 2", expected_answer="2", answer_type=FLOAT, answer_format="fmt_06")
+        )
+        assert strict.reward == 0.0
+        assert strict.predicted_value is None
+
+        lenient = await server.verify(
+            _make_verify_request(
+                "Correct Answer: 2",
+                expected_answer="2",
+                answer_type=FLOAT,
+                answer_format="fmt_06",
+                output_regex=r"Correct Answer:\s*\**\[?\s*([-+]?\d*\.?\d+)",
+            )
+        )
+        assert lenient.reward == 1.0
+        assert lenient.predicted_value == 2.0
 
     async def test_per_row_match_window(self):
         server = _make_server()


### PR DESCRIPTION
## What

Teach the `litmus_agent` verifier to extract answers using a per-row `output_regex` when present, falling back to the existing `answer_format` (`fmt_XX`) registry otherwise. Resolution order in `extract_predicted_value`:

1. `output_regex` (preferred) — a regex carried directly on the row; must compile and have exactly one capture group, else `ValueError`.
2. `answer_format` — look up a regex by `fmt_XX` name (unchanged).
3. `use_box_format` — very-legacy fallback (unchanged).

`answer_type` coercion (float/bool/string) and the last-match semantics are unchanged. this allows the question row carry its own extraction pattern instead of relying on the verifier's built-in strict table.

## Why

The built-in `_ANSWER_FORMAT_REGEXES` require the literal wrapper (e.g. `fmt_06` needs `Correct Answer: [3]`). Models frequently compute the right number but drop the delimiter (`Correct Answer: 3`), which the strict regex misses → reward 0. In a 20-question paired gpt-oss-120b run (320 rollouts), this discarded correct answers dragged strict accuracy from ~0.47 down to 0.30. Carrying a wrapper-tolerant `output_regex` on the row recovers those with **zero regressions** across all formats measured. Keeping the leniency in the row (not hardcoded in the server) also removes the duplicated regex table as a source of truth.
There is a [matching PR in `limtus-bench`](https://gitlab-master.nvidia.com/clara-discovery/litmus/litmus-lab/-/merge_requests/82) repo 

## Testing

`pytest resources_servers/litmus_agent/tests/test_app.py` — 86 passed. New cases cover: output_regex extraction, preference over `answer_format`, dropped-wrapper recovery, last-match, string coercion, no-match, invalid-regex and wrong-group-count `ValueError`, plus an end-to-end `verify()` test asserting a lenient row regex scores an answer the strict `fmt_06` misses.

## Follow-ups / notes

- litmus-bench will generate the lenient `output_regex` into the parquet (separate change)[; this PR](https://gitlab-master.nvidia.com/clara-discovery/litmus/litmus-lab/-/merge_requests/82) is the verifier side that consumes it.
- Draft: the commit still needs a cryptographic signature (`-S`) to satisfy the DCO+signature gate.