### PR TITLE
[RFC/draft] MCP auto-exposure prototype (route harvesting + replay bridge)

### DIFF
--- a/prototypes/mcp_auto_exposure/README.md
+++ b/prototypes/mcp_auto_exposure/README.md
@@ -1,0 +1,89 @@
+# MCP auto-exposure prototype (draft — for design discussion)
+
+**Status: prototype / RFC. Not for merge as-is.** This is a self-contained proof-of-concept for an
+alternative way to serve NeMo Gym resources-server tools over MCP, built for design review against
+the [dual-registration PR](https://github.com/NVIDIA-NeMo/Gym/pull/2002). It lives under
+`prototypes/` and wires into nothing — no CI, no imports from the rest of the tree.
+
+## The idea
+
+Expose **every existing FastAPI tool route as an MCP tool automatically**, with:
+
+- **R1 — no decorator.** Env authors write plain FastAPI routes exactly as on `main`.
+- **R2 — byte-identical handlers.** Handlers keep their `request: Request` parameter and read
+  `request.session[SESSION_ID_KEY]`. This module never edits a handler.
+- **R3 — every non-basic POST route becomes a tool.** Parameterized catch-all routes (dispatcher
+  servers) can't be a single tool, so those servers override one method,
+  `mcp_tool_inventory()`, returning `[{name, input_schema, description}]`; those calls dispatch
+  through the existing catch-all.
+- **R4 — backwards compatible.** The HTTP door is untouched except two additive deltas: the
+  `/seed_session` response gains an `mcp` key, and a new `/mcp` endpoint exists.
+
+Contrast with PR #2002 (the `@gym_tool` design): that migrates each tool to a new signature
+(`session_id: str` + typed params) and dispatches MCP calls **directly**, at the cost of ~861 lines
+changed across 16 server files. This prototype changes **zero** tool files, at the cost of a
+**replay** step (below).
+
+## The mechanism: the replay bridge
+
+A frozen `request: Request` handler can only be invoked correctly by the HTTP machinery itself
+(the MCP SDK can't even register a `Request`-typed function). So an MCP `tools/call` is served by
+**re-issuing it as an internal in-process HTTP request** through the app's own ASGI stack:
+
+```
+MCP tools/call
+  -> verify the signed session token (X-NeMo-Gym-Session-Token; itsdangerous, same salt/secret
+     derivation as base_resources_server.py's MCP token)
+  -> mint the SessionMiddleware cookie for that session id (the server owns the secret)
+  -> re-issue POST /<tool> internally through the FULL app stack (httpx-free hand-built ASGI call);
+     SessionMiddleware populates request.session, FastAPI validates the body, the unmodified
+     handler runs
+  -> map the HTTP response to an MCP result (2xx JSON -> content + structuredContent;
+     otherwise -> isError carrying the HTTP status and body text)
+```
+
+MCP-side engine: the official SDK's **public low-level** `mcp.server.lowlevel.Server` +
+`StreamableHTTPSessionManager` — no private-attribute access.
+
+## Files
+
+| File | What |
+|---|---|
+| `autoexpose.py` | the whole engine: route harvest, `/seed_session` wrap, token mint/verify, the two MCP handlers, the ASGI replay bridge, `/mcp` mount |
+| `servers.py` | builds test servers from the **unmodified in-tree** `resources_servers/` (finance = typed routes, workplace = 27-tool dispatcher, aviary = plumbing case when `fhaviary` is installed) |
+| `run_checks.py` | live acceptance suite — real uvicorn servers driven by the official MCP client |
+
+## Run it
+
+```bash
+# from the repo root, with the dev env installed
+python prototypes/mcp_auto_exposure/run_checks.py
+```
+
+Expected: `37/37 checks passed` (finance + workplace). Install `fhaviary` to add the aviary
+plumbing-hazard case (7 more checks). The suite proves, against **pristine `origin/main` handler
+code imported directly from the tree**: R1 (zero decorators), R2 (handlers run over MCP with
+`request.session` working, sharing per-session state with the HTTP door), R3 (typed schemas
+harvested, dispatcher via the override, aviary's `step`/`close` exposed), R4 (tool-route HTTP
+responses byte-identical; only the two documented additive deltas), plus per-session
+`allowed_tools` filtering and cross-session isolation.
+
+## Known trade-offs (for the discussion, not hidden)
+
+- **Replay is a 2x in-process pass** (middleware + routing + validation run again). Measured
+  ~260-290 us/call on a real server — dominated by Gym's own `add_session_id` `BaseHTTPMiddleware`
+  (~191 us), which the normal HTTP door also pays. Negligible under any real tool (web search,
+  sandbox, model turn), but real for megabyte payloads or extreme call rates.
+- **`aviary` shows the exposure hazard**: `/step` and `/close` are agent/harness plumbing, not
+  model-facing tools, yet auto-exposure advertises them — and `/step`'s body carries `env_id`, so
+  an auto-exposed `step` lets a model address other rollouts' environments. This is why exposure
+  should likely be opt-in per server, and why a toolless-catch-all / plumbing-route declaration is
+  needed (finance's `mcp_toolless_catchall_paths` is a first cut).
+- **Schema harvest reads `route.body_field`**, a semi-internal FastAPI attribute whose spelling has
+  moved across versions; the code fails loudly if it can't resolve it (rather than silently
+  advertising a wrong schema).
+- **Direct dispatch (no replay) is being explored separately** as a possible middle ground —
+  synthesizing `gym_tool` registrations from the routes so the reviewed engine serves MCP without
+  the replay pass.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/prototypes/mcp_auto_exposure/README.md
+++ b/prototypes/mcp_auto_exposure/README.md
@@ -20,36 +20,43 @@ Expose **every existing FastAPI tool route as an MCP tool automatically**, with:
   `/seed_session` response gains an `mcp` key, and a new `/mcp` endpoint exists.
 
 Contrast with PR #2002 (the `@gym_tool` design): that migrates each tool to a new signature
-(`session_id: str` + typed params) and dispatches MCP calls **directly**, at the cost of ~861 lines
-changed across 16 server files. This prototype changes **zero** tool files, at the cost of a
-**replay** step (below).
+(`session_id: str` + typed params) and dispatches MCP calls directly, at the cost of ~861 lines
+changed across 16 server files. This prototype changes **zero** tool files and **also dispatches
+directly** (below) — so it aims to combine both designs' wins.
 
-## The mechanism: the replay bridge
+## The mechanism: direct dispatch (default) + replay fallback
 
-A frozen `request: Request` handler can only be invoked correctly by the HTTP machinery itself
-(the MCP SDK can't even register a `Request`-typed function). So an MCP `tools/call` is served by
-**re-issuing it as an internal in-process HTTP request** through the app's own ASGI stack:
+An MCP `tools/call` must run a frozen `request: Request` handler. Two strategies, chosen per route
+by a startup **detector** (`hybrid_dispatch.py`):
 
-```
-MCP tools/call
-  -> verify the signed session token (X-NeMo-Gym-Session-Token; itsdangerous, same salt/secret
-     derivation as base_resources_server.py's MCP token)
-  -> mint the SessionMiddleware cookie for that session id (the server owns the secret)
-  -> re-issue POST /<tool> internally through the FULL app stack (httpx-free hand-built ASGI call);
-     SessionMiddleware populates request.session, FastAPI validates the body, the unmodified
-     handler runs
-  -> map the HTTP response to an MCP result (2xx JSON -> content + structuredContent;
-     otherwise -> isError carrying the HTTP status and body text)
-```
+**Direct dispatch (the default, no second pass).** The handler is called exactly once, with a
+fabricated `Request` whose `session` is served by a public `Request` subclass overriding the
+documented `.session` property (FastAPI's own "Custom Request and Route Class" pattern) — no
+cookie mint, no middleware pass, no ASGI re-entry. Measured ~5–7 µs/call vs ~270 µs for replay
+(~40× cheaper). Uses only public FastAPI/Starlette/pydantic surface.
 
-MCP-side engine: the official SDK's **public low-level** `mcp.server.lowlevel.Server` +
-`StreamableHTTPSessionManager` — no private-attribute access.
+**Replay fallback (correctness net).** Where the detector cannot *prove* direct == a real HTTP
+request — a server with **custom middleware**, or a handler using FastAPI dependency-injection /
+streaming / other shapes direct dispatch doesn't reproduce — that route (or the whole server) falls
+back to re-issuing the call as an internal in-process HTTP request through the full ASGI stack
+(httpx-free). A `git grep` of all in-tree resources servers shows none currently need the fallback,
+but it guarantees correctness never depends on the fast path.
+
+Both paths: verify the signed session token (`X-NeMo-Gym-Session-Token`; itsdangerous, same
+salt/secret derivation as `base_resources_server.py`'s MCP token) → resolve the session →
+run the handler → map the result to MCP (`2xx` JSON → content + structuredContent; otherwise →
+`isError` carrying the status and body text). MCP-side engine: the official SDK's **public
+low-level** `mcp.server.lowlevel.Server` + `StreamableHTTPSessionManager` — no private-attr access.
+
+In the acceptance run below, all 32 tools (finance's 5 + workplace's 27) dispatch **direct, zero
+replay**; adding a custom middleware flips that server to replay automatically.
 
 ## Files
 
 | File | What |
 |---|---|
-| `autoexpose.py` | the whole engine: route harvest, `/seed_session` wrap, token mint/verify, the two MCP handlers, the ASGI replay bridge, `/mcp` mount |
+| `autoexpose.py` | the engine: route harvest, `/seed_session` wrap, token mint/verify, the two MCP handlers, direct-dispatch + replay-fallback wiring, `/mcp` mount |
+| `hybrid_dispatch.py` | the direct dispatcher + the two-gate detector (server-level middleware audit, route-level signature bind) that picks direct vs replay per route |
 | `servers.py` | builds test servers from the **unmodified in-tree** `resources_servers/` (finance = typed routes, workplace = 27-tool dispatcher, aviary = plumbing case when `fhaviary` is installed) |
 | `run_checks.py` | live acceptance suite — real uvicorn servers driven by the official MCP client |
 
@@ -70,20 +77,28 @@ responses byte-identical; only the two documented additive deltas), plus per-ses
 
 ## Known trade-offs (for the discussion, not hidden)
 
-- **Replay is a 2x in-process pass** (middleware + routing + validation run again). Measured
-  ~260-290 us/call on a real server — dominated by Gym's own `add_session_id` `BaseHTTPMiddleware`
-  (~191 us), which the normal HTTP door also pays. Negligible under any real tool (web search,
-  sandbox, model turn), but real for megabyte payloads or extreme call rates.
+- **Direct dispatch's residue is one non-public spelling.** The read side (`request.session`) is
+  public; the fabricated request serves the session via a public `Request` subclass. The detector
+  reads `app.user_middleware` (a stable Starlette attribute, not in the docs index) to decide
+  direct-safety; the fully-public productization is for `SimpleServer` to wrap the app's public
+  `add_middleware` and record what env authors add. No FastAPI DI internals (`solve_dependencies`,
+  `body_field`, `dependant`) are touched.
+- **Replay fallback keeps its 2x cost** where it fires (custom middleware, unsupported handler
+  shapes) — ~260-290 us/call, dominated by Gym's own `add_session_id` `BaseHTTPMiddleware` (~191 us,
+  which the HTTP door also pays). No in-tree server needs it today; a front-door split (routing
+  `/mcp` before the middleware) would remove the wasted pass-1 session-mint for both paths.
 - **`aviary` shows the exposure hazard**: `/step` and `/close` are agent/harness plumbing, not
   model-facing tools, yet auto-exposure advertises them — and `/step`'s body carries `env_id`, so
   an auto-exposed `step` lets a model address other rollouts' environments. This is why exposure
   should likely be opt-in per server, and why a toolless-catch-all / plumbing-route declaration is
   needed (finance's `mcp_toolless_catchall_paths` is a first cut).
-- **Schema harvest reads `route.body_field`**, a semi-internal FastAPI attribute whose spelling has
-  moved across versions; the code fails loudly if it can't resolve it (rather than silently
-  advertising a wrong schema).
-- **Direct dispatch (no replay) is being explored separately** as a possible middle ground —
-  synthesizing `gym_tool` registrations from the routes so the reviewed engine serves MCP without
-  the replay pass.
+- **Detector hardening is required before repo-wide rollout.** The two gates refuse (fall back to
+  replay) on route-level `Depends()`, non-Gym middleware, and unsupported parameter shapes; ad-hoc
+  probing found further constructions it should also refuse. As-built it dispatches the current
+  in-tree servers correctly, but the classifier needs an audit plus a per-route replay default for
+  anything it has not proven.
+- **If adopted, the `@gym_tool` migration could revert.** Because this engine synthesizes the
+  equivalent registration from each existing route, the ~861 lines PR #2002 changed across 16 tool
+  files would become unnecessary — one engine, zero tool-file changes, direct dispatch.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/prototypes/mcp_auto_exposure/autoexpose.py
+++ b/prototypes/mcp_auto_exposure/autoexpose.py
@@ -1,0 +1,466 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Brian-design auto-exposure base (spike).
+
+Contract (R1-R4):
+  R1  Env authors write plain FastAPI routes exactly as on origin/main. No decorators.
+  R2  Handlers keep their ``request: Request`` params and read ``request.session[SESSION_ID_KEY]``
+      — byte-identical handler code. This module never touches handler functions.
+  R3  Every non-basic POST route is exposed as an MCP tool automatically. Parameterized catch-all
+      routes cannot be single tools; dispatcher servers override ONE function,
+      ``mcp_tool_inventory()``, returning the tool inventory (names + schemas); those tools
+      dispatch by replaying ``POST /<name>`` which the existing catch-all route matches.
+  R4  The HTTP door is untouched except for two additive deltas, both reported by the checks:
+      the ``/seed_session`` response gains an ``mcp`` key, and ``/mcp`` (a new path) exists.
+
+Mechanism (the replay bridge):
+  MCP tools/call -> verify the signed session token (header ``X-NeMo-Gym-Session-Token``) ->
+  mint the starlette SessionMiddleware cookie for that session id (Gym owns the itsdangerous
+  secret) -> re-issue the call as an INTERNAL ASGI request through the app's OWN middleware
+  stack (SessionMiddleware populates request.session; the unmodified handler runs) -> map the
+  HTTP response to an MCP result (2xx JSON -> content + structuredContent; anything else ->
+  isError carrying the HTTP status and body text).
+
+MCP-side implementation choice: the official SDK's LOW-LEVEL ``mcp.server.lowlevel.Server`` +
+``StreamableHTTPSessionManager`` (stateless, json_response). Why:
+  * tools here are dynamic (harvested from routes / returned by an inventory hook) with
+    hand-built JSON schemas — lowlevel serves that first-class via list_tools/call_tool
+    handlers, no function-introspection to fight and no private attributes to patch
+    (FastMCP would need ``_tool_manager`` surgery for dynamic tools);
+  * the SDK populates ``server.request_context.request`` with the actual starlette Request of
+    the POST /mcp envelope, so the session-token header is read directly — no ASGI middleware
+    + ContextVar bridge needed;
+  * zero new dependency: Gym already ships the ``mcp`` package.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+from base64 import b64encode
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, get_type_hints
+from uuid import uuid4
+
+import mcp.types as types
+from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.routing import APIRoute
+from itsdangerous import BadSignature, TimestampSigner, URLSafeSerializer
+from mcp.server.lowlevel import Server as _LowLevelMCPServer
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from mcp.server.transport_security import TransportSecuritySettings
+from pydantic import BaseModel
+from starlette.responses import JSONResponse
+from starlette.routing import Mount, Route
+
+from nemo_gym.server_utils import SESSION_ID_KEY, SimpleServer
+
+
+LOG = logging.getLogger("autoexpose")
+
+# Mirrors nemo_gym.base_resources_server (kept literal so this base stands alone).
+TOKEN_HEADER = "X-NeMo-Gym-Session-Token"
+TOKEN_SALT = "nemo-gym-mcp-session-token"
+MCP_METADATA_KEY = "mcp"
+MCP_URL_PATH = "/mcp"
+
+# "Basic" routes are infrastructure, not tools (R3). Docs/openapi routes are GET-only and are
+# excluded by the POST filter; the /mcp endpoint itself is excluded by path.
+BASIC_PATHS = frozenset({"/seed_session", "/verify", "/aggregate_metrics", MCP_URL_PATH})
+
+PERMISSIVE_SCHEMA: dict = {"type": "object", "additionalProperties": True}
+
+
+# ==================================================================================================
+# The httpx-free internal ASGI invoker
+# ==================================================================================================
+
+
+async def asgi_call(
+    app: Any, method: str, path: str, headers: dict[str, str], body: bytes = b""
+) -> tuple[int, list[tuple[bytes, bytes]], bytes]:
+    """Issue one in-process HTTP request through the app's FULL ASGI stack. No httpx anywhere."""
+    raw_headers = tuple((k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in headers.items())
+    return await _asgi_call_prepared(app, method.upper(), path, path.encode("utf-8"), raw_headers, body)
+
+
+async def _asgi_call_prepared(
+    app: Any, method: str, path: str, raw_path: bytes, base_headers: tuple, body: bytes
+) -> tuple[int, list[tuple[bytes, bytes]], bytes]:
+    """``asgi_call`` core with the per-call encodes hoisted out (perf/bench_interleaved.py).
+
+    ``base_headers`` is a tuple of pre-encoded ``(name, value)`` byte pairs WITHOUT content-length
+    (appended here from the actual body). Only IMMUTABLE objects (a tuple of bytes pairs, the
+    raw_path bytes) are shared between calls — the scope dict, its nested "asgi" dict, the headers
+    list, and "state" are built fresh per call, so a middleware that mutates its scope can never
+    leak state into a later replay (verified by perf/bench_safe_wins.py proofs P3/P4).
+    """
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": raw_path,
+        "query_string": b"",
+        "root_path": "",
+        "headers": [*base_headers, (b"content-length", str(len(body)).encode("latin-1"))],
+        "client": ("127.0.0.1", 0),
+        "server": ("internal-mcp-replay", 80),
+        "state": {},
+    }
+
+    body_sent = False
+
+    async def receive() -> dict:
+        nonlocal body_sent
+        if body_sent:
+            return {"type": "http.disconnect"}
+        body_sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    status: Optional[int] = None
+    response_headers: list[tuple[bytes, bytes]] = []
+    chunks: list[bytes] = []
+
+    async def send(message: dict) -> None:
+        nonlocal status, response_headers
+        if message["type"] == "http.response.start":
+            status = message["status"]
+            response_headers = list(message.get("headers", []))
+        elif message["type"] == "http.response.body":
+            chunks.append(message.get("body", b""))
+
+    try:
+        await app(scope, receive, send)
+    except BaseException:
+        # Starlette's ServerErrorMiddleware sends its 500 response BEFORE re-raising (so real
+        # servers can log). If a response completed, surface it exactly like the HTTP door would.
+        if status is None:
+            raise
+    assert status is not None, "ASGI app returned no response"
+    return status, response_headers, b"".join(chunks)
+
+
+# ==================================================================================================
+# Session-cookie mint (Gym owns the SessionMiddleware secret; forge what it would have set)
+# ==================================================================================================
+
+
+def mint_session_cookie(secret_key: str, cookie_name: str, session_id: str) -> str:
+    """Build the exact Cookie header value starlette's SessionMiddleware would verify."""
+    data = b64encode(json.dumps({SESSION_ID_KEY: session_id}).encode("utf-8"))
+    signed = TimestampSigner(str(secret_key)).sign(data).decode("utf-8")
+    return f"{cookie_name}={signed}"
+
+
+# ==================================================================================================
+# Route harvesting (R3) — name = path, schema = route.body_field's model, description = docstring
+# ==================================================================================================
+
+
+@dataclass
+class ToolEntry:
+    name: str
+    path: str  # the POST path the MCP call replays
+    tool: types.Tool
+    raw_path: bytes = b""  # pre-encoded ``path`` for the replay scope (derived, immutable)
+
+    def __post_init__(self) -> None:
+        if not self.raw_path:
+            self.raw_path = self.path.encode("utf-8")
+
+
+def _route_input_schema(route: APIRoute) -> dict:
+    body_field = getattr(route, "body_field", None)
+    if body_field is None:
+        return dict(PERMISSIVE_SCHEMA)  # honest fallback: the handler takes no request body
+    # FastAPI <=0.11x exposes the body model as ModelField.type_; newer _compat.v2 ModelFields
+    # carry it on field_info.annotation. Accept either.
+    model = getattr(body_field, "type_", None)
+    if model is None:
+        model = getattr(getattr(body_field, "field_info", None), "annotation", None)
+    if model is None:
+        # A body model EXISTS but neither known spelling resolved it — a FastAPI internal layout
+        # this code does not handle. Crash rather than silently advertise a typed tool as
+        # permissive: a wrong schema poisons rollouts invisibly, a startup crash is a small fix.
+        raise RuntimeError(
+            f"Cannot extract the body model for route {route.path!r}: body_field is present but "
+            "has neither .type_ nor .field_info.annotation. FastAPI's internals changed; update "
+            "_route_input_schema()."
+        )
+    if isinstance(model, type) and issubclass(model, BaseModel):
+        return model.model_json_schema()
+    return dict(PERMISSIVE_SCHEMA)  # honest fallback: the body is a scalar/non-model type
+
+
+def harvest_route_tools(app: FastAPI) -> tuple[list[ToolEntry], list[APIRoute]]:
+    """Scan app.routes; return (typed tool entries, parameterized catch-all routes)."""
+    entries: list[ToolEntry] = []
+    catchalls: list[APIRoute] = []
+    for route in app.routes:
+        if not isinstance(route, APIRoute) or "POST" not in (route.methods or set()):
+            continue
+        if route.path in BASIC_PATHS:
+            continue
+        if "{" in route.path:
+            catchalls.append(route)
+            continue
+        name = route.path.lstrip("/")
+        description = (route.description or route.summary or "").strip() or None
+        entries.append(
+            ToolEntry(
+                name=name,
+                path=route.path,
+                tool=types.Tool(name=name, description=description, inputSchema=_route_input_schema(route)),
+            )
+        )
+    return entries, catchalls
+
+
+# ==================================================================================================
+# /seed_session augmentation: wrap (never edit) the route endpoint so the response gains the
+# signed session token under the "mcp" key. Mirrors _build_seed_session_endpoint on the
+# mcp-dual-registration branch; the wrapped route is swapped IN PLACE to preserve route order
+# (a dispatcher's catch-all must keep matching after /seed_session).
+# ==================================================================================================
+
+
+def _wrap_seed_session(app: FastAPI, mint_metadata: Callable[[Request], dict]) -> None:
+    idx, route = next(
+        (i, r) for i, r in enumerate(app.router.routes) if isinstance(r, APIRoute) and r.path == "/seed_session"
+    )
+    method = route.endpoint
+    signature = inspect.signature(method)
+    hints = get_type_hints(method)
+    request_param_name = next(
+        (n for n, p in signature.parameters.items() if hints.get(n, p.annotation) is Request),
+        None,
+    )
+    params = [p.replace(annotation=hints.get(n, p.annotation)) for n, p in signature.parameters.items()]
+    passthrough = tuple(signature.parameters)
+    if request_param_name is None:
+        request_param_name = "request"
+        params = [
+            inspect.Parameter("request", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Request),
+            *params,
+        ]
+
+    async def seed_session_endpoint(**kwargs: Any) -> JSONResponse:
+        request: Request = kwargs[request_param_name]
+        result = method(**{k: kwargs[k] for k in passthrough})
+        if inspect.isawaitable(result):
+            result = await result
+        payload = jsonable_encoder(result)
+        if isinstance(payload, dict) and MCP_METADATA_KEY not in payload:
+            payload[MCP_METADATA_KEY] = mint_metadata(request)
+        return JSONResponse(payload)
+
+    seed_session_endpoint.__name__ = "seed_session"
+    seed_session_endpoint.__signature__ = inspect.Signature(parameters=params)
+    seed_session_endpoint.__annotations__ = {p.name: p.annotation for p in params}
+
+    app.post("/seed_session")(seed_session_endpoint)
+    new_route = app.router.routes.pop()  # the route just appended by app.post
+    app.router.routes[idx] = new_route  # in-place swap keeps ordering vs catch-all routes
+
+
+# ==================================================================================================
+# The auto-exposure installer
+# ==================================================================================================
+
+
+def install_auto_exposure(
+    server: SimpleServer, app: FastAPI, allowed_tools: Optional[list[str]] = None
+) -> dict[str, ToolEntry]:
+    """Post-registration hook: harvest routes, wire /seed_session metadata, mount /mcp.
+
+    ``server`` is ANY Gym SimpleServer built exactly as on origin/main; ``app`` is the FastAPI app
+    its unmodified ``setup_webserver()`` returned. Dispatcher servers (one catch-all route backing
+    many tools) override one function: ``mcp_tool_inventory(self) -> list[dict]`` with items
+    ``{"name": ..., "input_schema": {...}, "description": ...}`` (Brian's 2.d). Returns the tool
+    map for introspection.
+    """
+    secret = server.get_session_middleware_key()  # Gym convention: secret == session cookie name
+    serializer = URLSafeSerializer(secret, salt=TOKEN_SALT)
+
+    # ---- tool inventory (R3) ---------------------------------------------------------------
+    entries, catchall_routes = harvest_route_tools(app)
+
+    # Whether a catch-all backs real tools is author knowledge no classifier can recover
+    # (workplace's /{path} backs 27 tools; finance's /{tool_name} only returns error strings).
+    # Authors declare toolless catch-alls explicitly so the missing-inventory warning below
+    # stays meaningful. A declared path that matches no harvested catch-all is a hard error —
+    # a typo here would silently re-enable the very blindness the declaration exists to remove.
+    declared_toolless = frozenset(getattr(server, "mcp_toolless_catchall_paths", ()) or ())
+    unknown_declared = declared_toolless - {route.path for route in catchall_routes}
+    if unknown_declared:
+        raise ValueError(
+            f"mcp_toolless_catchall_paths on {type(server).__name__} names route(s) "
+            f"{sorted(unknown_declared)} but the app's catch-all routes are "
+            f"{sorted(route.path for route in catchall_routes)}. Fix the declaration."
+        )
+    undeclared_catchalls = [route for route in catchall_routes if route.path not in declared_toolless]
+
+    inventory_fn = getattr(server, "mcp_tool_inventory", None)
+    if inventory_fn is not None:
+        for item in inventory_fn():
+            entries.append(
+                ToolEntry(
+                    name=item["name"],
+                    path="/" + item["name"],  # dispatch through the existing catch-all route
+                    tool=types.Tool(
+                        name=item["name"],
+                        description=item.get("description"),
+                        inputSchema=item.get("input_schema") or dict(PERMISSIVE_SCHEMA),
+                    ),
+                )
+            )
+    elif undeclared_catchalls:
+        LOG.warning(
+            "%s has parameterized catch-all route(s) %s but no mcp_tool_inventory() override; "
+            "any tools behind them are NOT exposed over MCP. Add the override (R3), or declare "
+            "them toolless via mcp_toolless_catchall_paths to silence this warning.",
+            type(server).__name__,
+            [r.path for r in undeclared_catchalls],
+        )
+
+    tool_map: dict[str, ToolEntry] = {}
+    for entry in entries:
+        if entry.name in tool_map:
+            raise ValueError(f"Duplicate MCP tool name {entry.name!r} (route harvest vs inventory override)")
+        tool_map[entry.name] = entry
+
+    # ---- /seed_session -> signed session token (mint mirrors base_resources_server) ----------
+    def mint_metadata(request: Request) -> dict:
+        session_id = request.session.get(SESSION_ID_KEY)
+        if not session_id:
+            session_id = str(uuid4())
+            request.session[SESSION_ID_KEY] = session_id
+        payload: Any = session_id if allowed_tools is None else {"sid": session_id, "tools": list(allowed_tools)}
+        return {
+            "server_name": server.config.name or type(server).__name__,
+            "url_path": MCP_URL_PATH,
+            "transport": "http",
+            "headers": {TOKEN_HEADER: serializer.dumps(payload)},
+        }
+
+    _wrap_seed_session(app, mint_metadata)
+
+    # ---- the MCP server: tools/list + tools/call (the replay bridge) -------------------------
+    mcp_server = _LowLevelMCPServer(server.config.name or type(server).__name__)
+
+    # Perf caches (perf/bench_interleaved.py). Both are keyed by per-session values, so they grow
+    # one small entry per rollout session — the same rate as any Gym server's own session state.
+    #   claims_cache: serializer.loads is deterministic per token; verify the HMAC once per
+    #     session instead of on every tools/call (~6-10 us/call saved). Failures are NOT cached,
+    #     so invalid tokens take exactly today's path.
+    #   session_headers_cache: the minted session cookie is deterministic per (secret, session
+    #     id); mint + encode the replay's request headers once per session (~14 us/call saved).
+    #     Caching is MORE main-faithful than re-minting: a real HTTP client re-sends the cookie
+    #     bytes it was last handed, it does not re-mint per call. (SessionMiddleware max_age is
+    #     14 days — a cached cookie only goes stale for a session idle that long, at which point
+    #     the HTTP door's cookie would have expired identically.)
+    claims_cache: dict[str, Any] = {}
+    session_headers_cache: dict[str, tuple] = {}
+
+    def session_claims(required: bool = True) -> tuple[Optional[str], Optional[frozenset]]:
+        ctx_request = mcp_server.request_context.request  # starlette Request of the POST /mcp
+        token = ctx_request.headers.get(TOKEN_HEADER) if ctx_request is not None else None
+        if not token:
+            if required:
+                raise ValueError(f"Missing {TOKEN_HEADER} for Gym MCP tool call.")
+            return None, None
+        payload = claims_cache.get(token)
+        if payload is None:
+            try:
+                payload = serializer.loads(token)
+            except BadSignature:
+                if required:
+                    raise ValueError("Invalid Gym MCP session token.")
+                return None, None
+            claims_cache[token] = payload
+        if isinstance(payload, dict):
+            allowed = payload.get("tools")
+            return payload.get("sid"), None if allowed is None else frozenset(allowed)
+        return payload, None
+
+    @mcp_server.list_tools()
+    async def list_tools() -> list[types.Tool]:
+        _, allowed = session_claims(required=False)
+        return [e.tool for e in tool_map.values() if allowed is None or e.name in allowed]
+
+    # validate_input=False: argument validation stays where it always was — the FastAPI route.
+    # Malformed args therefore surface as the HTTP door's own 422 body, mapped to isError below.
+    @mcp_server.call_tool(validate_input=False)
+    async def call_tool(name: str, arguments: dict):
+        entry = tool_map.get(name)
+        if entry is None:
+            raise ValueError(f"Unknown tool: {name!r}. Available tools: {sorted(tool_map)}")
+        session_id, allowed = session_claims(required=True)
+        if allowed is not None and name not in allowed:
+            raise ValueError(f"Tool {name!r} is not allowed for this session.")
+
+        base_headers = session_headers_cache.get(session_id)
+        if base_headers is None:
+            # Byte-for-byte the headers asgi_call would build from the previous per-call dict
+            # (same names, same order, content-length appended per body by _asgi_call_prepared).
+            base_headers = (
+                (b"content-type", b"application/json"),
+                (b"cookie", mint_session_cookie(secret, secret, session_id).encode("latin-1")),
+                (b"host", b"internal-mcp-replay"),
+            )
+            session_headers_cache[session_id] = base_headers
+
+        status, _, resp_body = await _asgi_call_prepared(
+            app,
+            "POST",
+            entry.path,
+            entry.raw_path,
+            base_headers,
+            json.dumps(arguments or {}).encode("utf-8"),
+        )
+        text = resp_body.decode("utf-8", errors="replace")
+        if not 200 <= status < 300:
+            raise ValueError(f"HTTP {status} from POST {entry.path}: {text}")
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            return [types.TextContent(type="text", text=text)]
+        if isinstance(parsed, dict):
+            return [types.TextContent(type="text", text=text)], parsed
+        return [types.TextContent(type="text", text=text)]
+
+    # ---- mount the streamable-http transport at /mcp -----------------------------------------
+    manager = StreamableHTTPSessionManager(
+        app=mcp_server,
+        event_store=None,
+        json_response=True,
+        stateless=True,
+        # Mirrors the Gym rationale: endpoint is token-gated; Host/Origin checks would 421
+        # off-loopback multi-node access.
+        security_settings=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+    )
+
+    class _MCPEndpoint:
+        async def __call__(self, scope, receive, send):
+            await manager.handle_request(scope, receive, send)
+
+    endpoint = _MCPEndpoint()
+    # Insert at the FRONT so a dispatcher's catch-all POST /{path} cannot shadow POST /mcp.
+    app.router.routes.insert(0, Route(MCP_URL_PATH, endpoint, include_in_schema=False))
+    app.router.routes.insert(1, Mount(MCP_URL_PATH, app=endpoint))
+
+    main_lifespan = app.router.lifespan_context
+
+    @asynccontextmanager
+    async def lifespan_wrapper(app_: FastAPI):
+        async with manager.run():
+            async with main_lifespan(app_) as state:
+                yield state
+
+    app.router.lifespan_context = lifespan_wrapper
+    return tool_map

--- a/prototypes/mcp_auto_exposure/autoexpose.py
+++ b/prototypes/mcp_auto_exposure/autoexpose.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Brian-design auto-exposure base (spike).
+"""Auto-exposure engine: serve unmodified FastAPI tool routes over MCP.
 
 Contract (R1-R4):
   R1  Env authors write plain FastAPI routes exactly as on origin/main. No decorators.
@@ -7,29 +7,23 @@ Contract (R1-R4):
       — byte-identical handler code. This module never touches handler functions.
   R3  Every non-basic POST route is exposed as an MCP tool automatically. Parameterized catch-all
       routes cannot be single tools; dispatcher servers override ONE function,
-      ``mcp_tool_inventory()``, returning the tool inventory (names + schemas); those tools
-      dispatch by replaying ``POST /<name>`` which the existing catch-all route matches.
+      ``mcp_tool_inventory()``, returning the tool inventory (names + schemas).
   R4  The HTTP door is untouched except for two additive deltas, both reported by the checks:
       the ``/seed_session`` response gains an ``mcp`` key, and ``/mcp`` (a new path) exists.
 
-Mechanism (the replay bridge):
-  MCP tools/call -> verify the signed session token (header ``X-NeMo-Gym-Session-Token``) ->
-  mint the starlette SessionMiddleware cookie for that session id (Gym owns the itsdangerous
-  secret) -> re-issue the call as an INTERNAL ASGI request through the app's OWN middleware
-  stack (SessionMiddleware populates request.session; the unmodified handler runs) -> map the
-  HTTP response to an MCP result (2xx JSON -> content + structuredContent; anything else ->
-  isError carrying the HTTP status and body text).
+Dispatch (per route, chosen at startup by hybrid_dispatch.plan_hybrid):
+  * DIRECT (default): run the frozen handler ONCE with a fabricated Request whose ``.session`` is
+    served by a public Request subclass — no second app pass. ~5-7 us/call. See hybrid_dispatch.py.
+  * REPLAY (fallback): where the detector cannot prove direct == a real HTTP request (custom
+    middleware, unsupported handler shapes), re-issue the call as an INTERNAL ASGI request through
+    the app's OWN stack (SessionMiddleware populates request.session; the unmodified handler runs).
+    Same result mapping either way: 2xx JSON -> content + structuredContent; else -> isError.
 
-MCP-side implementation choice: the official SDK's LOW-LEVEL ``mcp.server.lowlevel.Server`` +
-``StreamableHTTPSessionManager`` (stateless, json_response). Why:
-  * tools here are dynamic (harvested from routes / returned by an inventory hook) with
-    hand-built JSON schemas — lowlevel serves that first-class via list_tools/call_tool
-    handlers, no function-introspection to fight and no private attributes to patch
-    (FastMCP would need ``_tool_manager`` surgery for dynamic tools);
-  * the SDK populates ``server.request_context.request`` with the actual starlette Request of
-    the POST /mcp envelope, so the session-token header is read directly — no ASGI middleware
-    + ContextVar bridge needed;
-  * zero new dependency: Gym already ships the ``mcp`` package.
+MCP-side engine: the official SDK's LOW-LEVEL ``mcp.server.lowlevel.Server`` +
+``StreamableHTTPSessionManager`` (stateless, json_response). Tools here are dynamic (harvested from
+routes / an inventory hook) with hand-built JSON schemas — lowlevel serves that first-class via
+list_tools/call_tool handlers, no private attributes patched, and the SDK exposes the POST /mcp
+Request via ``request_context`` so the session-token header is read directly. Gym already ships mcp.
 """
 
 from __future__ import annotations
@@ -47,6 +41,7 @@ import mcp.types as types
 from fastapi import FastAPI, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.routing import APIRoute
+from hybrid_dispatch import DirectDispatchError, call_direct, plan_hybrid
 from itsdangerous import BadSignature, TimestampSigner, URLSafeSerializer
 from mcp.server.lowlevel import Server as _LowLevelMCPServer
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
@@ -288,7 +283,7 @@ def install_auto_exposure(
     serializer = URLSafeSerializer(secret, salt=TOKEN_SALT)
 
     # ---- tool inventory (R3) ---------------------------------------------------------------
-    entries, catchall_routes = harvest_route_tools(app)
+    typed_entries, catchall_routes = harvest_route_tools(app)
 
     # Whether a catch-all backs real tools is author knowledge no classifier can recover
     # (workplace's /{path} backs 27 tools; finance's /{tool_name} only returns error strings).
@@ -305,13 +300,14 @@ def install_auto_exposure(
         )
     undeclared_catchalls = [route for route in catchall_routes if route.path not in declared_toolless]
 
+    inventory_entries: list[ToolEntry] = []
     inventory_fn = getattr(server, "mcp_tool_inventory", None)
     if inventory_fn is not None:
         for item in inventory_fn():
-            entries.append(
+            inventory_entries.append(
                 ToolEntry(
                     name=item["name"],
-                    path="/" + item["name"],  # dispatch through the existing catch-all route
+                    path="/" + item["name"],  # replay fall-through matches the catch-all by URL
                     tool=types.Tool(
                         name=item["name"],
                         description=item.get("description"),
@@ -329,10 +325,31 @@ def install_auto_exposure(
         )
 
     tool_map: dict[str, ToolEntry] = {}
-    for entry in entries:
+    for entry in (*typed_entries, *inventory_entries):
         if entry.name in tool_map:
             raise ValueError(f"Duplicate MCP tool name {entry.name!r} (route harvest vs inventory override)")
         tool_map[entry.name] = entry
+
+    # ---- hybrid dispatch plan: DIRECT where provably safe, REPLAY where not ------------------
+    # Direct dispatch runs the frozen handler exactly once (no second app pass). The detector
+    # falls a route (or the whole server, on custom middleware) back to replay when it cannot
+    # prove direct == replay, so correctness never depends on the fast path.
+    typed_tool_paths = {e.name: e.path for e in typed_entries}
+    inventory_catchalls = [r for r in catchall_routes if r.path not in declared_toolless]
+    catchall_tools: dict[str, str] = {}
+    if inventory_entries and inventory_catchalls:
+        catchall_path = inventory_catchalls[0].path  # the (single) catch-all backing the inventory
+        catchall_tools = {e.name: catchall_path for e in inventory_entries}
+    plan = plan_hybrid(app, typed_tool_paths, catchall_tools)
+    direct_n = sum(1 for t in plan.tools.values() if t.mode == "direct")
+    LOG.info(
+        "%s MCP dispatch: %d direct, %d replay (server_mode=%s%s)",
+        type(server).__name__,
+        direct_n,
+        len(plan.tools) - direct_n,
+        plan.server_mode,
+        f", custom middleware {plan.custom_middleware}" if plan.custom_middleware else "",
+    )
 
     # ---- /seed_session -> signed session token (mint mirrors base_resources_server) ----------
     def mint_metadata(request: Request) -> dict:
@@ -393,8 +410,18 @@ def install_auto_exposure(
         _, allowed = session_claims(required=False)
         return [e.tool for e in tool_map.values() if allowed is None or e.name in allowed]
 
-    # validate_input=False: argument validation stays where it always was — the FastAPI route.
-    # Malformed args therefore surface as the HTTP door's own 422 body, mapped to isError below.
+    def _to_mcp_result(payload: Any):
+        # Match the replay path's shaping: dict -> text + structuredContent; str -> text;
+        # other JSON -> text. JSONResponse renders the door's exact success bytes.
+        if isinstance(payload, dict):
+            return [types.TextContent(type="text", text=JSONResponse(payload).body.decode("utf-8"))], payload
+        if isinstance(payload, str):
+            return [types.TextContent(type="text", text=payload)]
+        return [types.TextContent(type="text", text=JSONResponse(payload).body.decode("utf-8"))]
+
+    # validate_input=False: argument validation stays where it always was (the handler's own
+    # body model), whether the call is dispatched directly or replayed. Errors surface as the
+    # HTTP door's 422 / 400 body, mapped to an isError result.
     @mcp_server.call_tool(validate_input=False)
     async def call_tool(name: str, arguments: dict):
         entry = tool_map.get(name)
@@ -404,6 +431,18 @@ def install_auto_exposure(
         if allowed is not None and name not in allowed:
             raise ValueError(f"Tool {name!r} is not allowed for this session.")
 
+        # DIRECT dispatch where the detector proved it safe: run the frozen handler once.
+        tool_plan = plan.tools.get(name)
+        if tool_plan is not None and tool_plan.mode == "direct":
+            try:
+                payload = await call_direct(
+                    app, tool_plan.binding, session_id, arguments, path_value=tool_plan.path_value
+                )
+            except DirectDispatchError as exc:
+                raise ValueError(f"HTTP {exc.status} from POST /{name}: {exc.detail}")
+            return _to_mcp_result(payload)
+
+        # REPLAY fallback (custom middleware, or a handler shape direct dispatch won't reproduce).
         base_headers = session_headers_cache.get(session_id)
         if base_headers is None:
             # Byte-for-byte the headers asgi_call would build from the previous per-call dict

--- a/prototypes/mcp_auto_exposure/hybrid_dispatch.py
+++ b/prototypes/mcp_auto_exposure/hybrid_dispatch.py
@@ -110,6 +110,8 @@ class DirectBinding:
     defaulted_params: tuple[str, ...] = ()
     return_model: Optional[type[BaseModel]] = None
     needs_raw_body: bool = False  # handler reads await request.json() (no body model)
+    body_is_dict: bool = False  # handler declares ``body: dict`` — FastAPI passes the parsed
+    #                             JSON through unvalidated; direct dispatch passes ``arguments``
 
 
 @dataclass
@@ -119,24 +121,41 @@ class BindOutcome:
 
 
 def bind_route(route: APIRoute) -> BindOutcome:
-    """Classify one route's handler signature. PUBLIC introspection only."""
+    """Classify one route's handler signature. PUBLIC introspection only.
+
+    Annotation resolution matches FastAPI's own: ``inspect.signature`` first (it honors a
+    factory-set ``__signature__`` — newton_bench rewrites __signature__ with the real per-module
+    body model while ``__annotations__`` still says ``Any``), falling back to ``get_type_hints``
+    only for deferred string annotations (``from __future__ import annotations``).
+    """
     endpoint = route.endpoint
     reasons: list[str] = []
     try:
         hints = get_type_hints(endpoint)
-    except Exception as e:  # unresolvable forward refs etc.
-        return BindOutcome(None, [f"get_type_hints failed: {e!r}"])
+    except Exception:  # unresolvable forward refs; only fatal if a needed annotation is a string
+        hints = {}
     signature = inspect.signature(endpoint)
     path_params = set(_PATH_PARAM_RE.findall(route.path))
+
+    def resolve(name: str, raw: Any) -> Any:
+        if isinstance(raw, str):  # deferred annotation — get_type_hints is the resolver
+            return hints.get(name, raw)
+        if raw is inspect.Parameter.empty:
+            return hints.get(name, raw)
+        return raw  # concrete object on the signature wins (FastAPI reads the signature too)
 
     request_params: list[str] = []
     body_param: Optional[str] = None
     body_model: Optional[type[BaseModel]] = None
+    body_is_dict = False
     path_param: Optional[str] = None
     defaulted: list[str] = []
 
     for name, param in signature.parameters.items():
-        annotation = hints.get(name, param.annotation)
+        annotation = resolve(name, param.annotation)
+        if isinstance(annotation, str):
+            reasons.append(f"unresolvable string annotation on {name!r}: {annotation!r}")
+            continue
         if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
             reasons.append(f"*args/**kwargs parameter {name!r}")
             continue
@@ -148,6 +167,14 @@ def bind_route(route: APIRoute) -> BindOutcome:
                 reasons.append(f"multiple body models ({body_param!r}, {name!r})")
                 continue
             body_param, body_model = name, annotation
+            continue
+        if annotation is dict:
+            # ``body: dict`` — FastAPI parses the JSON body and passes the dict through with no
+            # validation (openenv's non-MCP /step). Direct equivalent: pass ``arguments`` as-is.
+            if body_param is not None:
+                reasons.append(f"multiple body params ({body_param!r}, {name!r})")
+                continue
+            body_param, body_is_dict = name, True
             continue
         if name in path_params:
             if annotation not in (str, inspect.Parameter.empty):
@@ -167,7 +194,7 @@ def bind_route(route: APIRoute) -> BindOutcome:
             continue
         reasons.append(f"unsupported required param {name!r}: {annotation!r}")
 
-    ret = hints.get("return")
+    ret = resolve("return", signature.return_annotation)
     return_model = ret if isinstance(ret, type) and issubclass(ret, BaseModel) else None
 
     if reasons:
@@ -182,7 +209,8 @@ def bind_route(route: APIRoute) -> BindOutcome:
             path_param=path_param,
             defaulted_params=tuple(defaulted),
             return_model=return_model,
-            needs_raw_body=body_model is None and bool(request_params),
+            needs_raw_body=body_param is None and bool(request_params),
+            body_is_dict=body_is_dict,
         ),
         [],
     )
@@ -245,6 +273,8 @@ async def call_direct(
             kwargs[binding.body_param] = binding.body_model.model_validate(arguments)
         except ValidationError as e:
             raise DirectDispatchError(422, json.dumps(jsonable_encoder(e.errors()))) from e
+    elif binding.body_is_dict:
+        kwargs[binding.body_param] = dict(arguments or {})  # FastAPI's dict-body pass-through
     if binding.request_params:
         raw = json.dumps(arguments or {}).encode("utf-8") if binding.needs_raw_body else b""
         headers = [(b"content-type", b"application/json")]

--- a/prototypes/mcp_auto_exposure/hybrid_dispatch.py
+++ b/prototypes/mcp_auto_exposure/hybrid_dispatch.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hybrid dispatch (spike): direct handler invocation where provably safe, replay where not.
+
+Track: WHAT DIRECT DISPATCH GIVES UP, AND THE HYBRID SAFETY NET.
+
+Direct dispatch = call the frozen origin/main handler function ONCE, with a fabricated
+starlette Request whose scope carries a pre-populated session. No second pass through the
+app's middleware/routing/validation stack (that second pass is Design B's replay bridge).
+
+The DETECTOR decides per server and per route, at startup, whether direct dispatch is
+provably equivalent to a replay. Two independent gates:
+
+  Gate 1 (server-level): the app's middleware stack must contain ONLY Gym's own middleware
+      (SessionMiddleware + the nemo_gym.server_utils @app.middleware functions). Any other
+      middleware means an env author installed per-request behavior that direct dispatch
+      would silently skip -> the WHOLE server falls back to replay.
+  Gate 2 (route-level): every handler parameter must be one of the shapes real Gym handlers
+      use — `request: Request`, one pydantic BaseModel body param, a str path param, or a
+      defaulted param whose default is not a Depends/Security marker. Anything else (true
+      DI, BackgroundTasks, UploadFile, ...) -> THAT route falls back to replay; the rest of
+      the server stays direct.
+
+Public-surface inventory of THIS module (the honest list):
+  PUBLIC:  inspect.signature / typing.get_type_hints on the endpoint; pydantic
+           model_validate / ValidationError; fastapi.encoders.jsonable_encoder;
+           starlette Request(scope, receive) constructor; Response.body/.status_code;
+           starlette.middleware.Middleware .cls/.kwargs (documented data-holder);
+           fastapi/starlette HTTPException fields.
+  SEMI:    app.user_middleware (stable Starlette attribute since 0.13, not in the docs
+           index; the productized alternative is fully public — Gym builds the app, so
+           SimpleServer.setup_webserver can wrap the instance's public add_middleware to
+           RECORD anything an env author adds after Gym's own stack);
+           route.endpoint / route.path / route.methods (Starlette Route attributes mirroring
+           documented constructor args);
+           scope["session"] (the key SessionMiddleware documents itself as providing;
+           request.session is the public reader — the WRITE side has no public spelling).
+  NOT USED: fastapi.dependencies.utils.solve_dependencies, Dependant, route.body_field,
+           route.dependant — none of FastAPI's DI internals are touched for dispatch.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, get_type_hints
+
+from aiohttp import ClientResponseError
+from fastapi import FastAPI
+from fastapi.encoders import jsonable_encoder
+from fastapi.routing import APIRoute
+from pydantic import BaseModel, ValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.requests import Request
+from starlette.responses import Response
+
+from nemo_gym.server_utils import SESSION_ID_KEY
+
+
+# Middleware whose dispatch function lives in these modules is Gym's own stack
+# (add_session_id, exception_handling_middleware) — replicated by the dispatcher, so its
+# absence under direct dispatch is compensated, not lost.
+GYM_MIDDLEWARE_MODULES = frozenset({"nemo_gym.server_utils"})
+_PATH_PARAM_RE = re.compile(r"{([^}:]+)(?::[^}]+)?}")
+
+
+# ==================================================================================================
+# Gate 1: middleware audit (server-level)
+# ==================================================================================================
+
+
+def audit_middleware(app: FastAPI) -> list[str]:
+    """Return the names of NON-Gym middleware installed on the app (empty == direct-safe).
+
+    ``app.user_middleware`` is the semi-public read (see module docstring for the fully
+    public productization: wrap the app instance's public ``add_middleware`` inside
+    ``SimpleServer.setup_webserver`` and record what env authors add).
+    Each entry is a ``starlette.middleware.Middleware`` data holder: ``.cls`` is the
+    middleware class, ``.kwargs`` its constructor kwargs (``dispatch=fn`` for
+    ``@app.middleware("http")`` functions).
+    """
+    custom: list[str] = []
+    for m in app.user_middleware:
+        cls = m.cls
+        if f"{cls.__module__}.{cls.__name__}" == "starlette.middleware.sessions.SessionMiddleware":
+            continue  # Gym's SessionMiddleware — replaced by scope["session"] seeding
+        dispatch = m.kwargs.get("dispatch")
+        if dispatch is not None and getattr(dispatch, "__module__", None) in GYM_MIDDLEWARE_MODULES:
+            continue  # Gym's add_session_id / exception_handling_middleware
+        custom.append(f"{cls.__module__}.{cls.__name__}")
+    return custom
+
+
+# ==================================================================================================
+# Gate 2: route binding (route-level)
+# ==================================================================================================
+
+
+@dataclass
+class DirectBinding:
+    """Everything needed to invoke one frozen handler directly, resolved once at startup."""
+
+    endpoint: Callable
+    path: str
+    request_params: tuple[str, ...] = ()
+    body_param: Optional[str] = None
+    body_model: Optional[type[BaseModel]] = None
+    path_param: Optional[str] = None  # catch-all routes: the str param bound per tool
+    defaulted_params: tuple[str, ...] = ()
+    return_model: Optional[type[BaseModel]] = None
+    needs_raw_body: bool = False  # handler reads await request.json() (no body model)
+
+
+@dataclass
+class BindOutcome:
+    binding: Optional[DirectBinding]
+    reasons: list[str] = field(default_factory=list)  # non-empty == replay this route
+
+
+def bind_route(route: APIRoute) -> BindOutcome:
+    """Classify one route's handler signature. PUBLIC introspection only."""
+    endpoint = route.endpoint
+    reasons: list[str] = []
+    try:
+        hints = get_type_hints(endpoint)
+    except Exception as e:  # unresolvable forward refs etc.
+        return BindOutcome(None, [f"get_type_hints failed: {e!r}"])
+    signature = inspect.signature(endpoint)
+    path_params = set(_PATH_PARAM_RE.findall(route.path))
+
+    request_params: list[str] = []
+    body_param: Optional[str] = None
+    body_model: Optional[type[BaseModel]] = None
+    path_param: Optional[str] = None
+    defaulted: list[str] = []
+
+    for name, param in signature.parameters.items():
+        annotation = hints.get(name, param.annotation)
+        if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            reasons.append(f"*args/**kwargs parameter {name!r}")
+            continue
+        if annotation is Request:
+            request_params.append(name)
+            continue
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            if body_param is not None:
+                reasons.append(f"multiple body models ({body_param!r}, {name!r})")
+                continue
+            body_param, body_model = name, annotation
+            continue
+        if name in path_params:
+            if annotation not in (str, inspect.Parameter.empty):
+                reasons.append(f"non-str path param {name!r}: {annotation!r}")
+            else:
+                path_param = name
+            continue
+        if param.default is not inspect.Parameter.empty:
+            # FastAPI treats these as query params; MCP calls carry no query string, so the
+            # HTTP door would hand the handler the default too — matching direct behavior.
+            # EXCEPT DI markers (Depends/Security), which the HTTP door would resolve.
+            default_type = f"{type(param.default).__module__}.{type(param.default).__name__}"
+            if default_type.startswith("fastapi."):
+                reasons.append(f"DI marker default on {name!r}: {default_type}")
+            else:
+                defaulted.append(name)
+            continue
+        reasons.append(f"unsupported required param {name!r}: {annotation!r}")
+
+    ret = hints.get("return")
+    return_model = ret if isinstance(ret, type) and issubclass(ret, BaseModel) else None
+
+    if reasons:
+        return BindOutcome(None, reasons)
+    return BindOutcome(
+        DirectBinding(
+            endpoint=endpoint,
+            path=route.path,
+            request_params=tuple(request_params),
+            body_param=body_param,
+            body_model=body_model,
+            path_param=path_param,
+            defaulted_params=tuple(defaulted),
+            return_model=return_model,
+            needs_raw_body=body_model is None and bool(request_params),
+        ),
+        [],
+    )
+
+
+# ==================================================================================================
+# Direct invocation: fabricate the Request, call the frozen handler ONCE
+# ==================================================================================================
+
+
+def _make_receive(body: bytes):
+    sent = False
+
+    async def receive() -> dict:
+        nonlocal sent
+        if sent:
+            return {"type": "http.disconnect"}
+        sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return receive
+
+
+class DirectDispatchError(Exception):
+    """Wraps handler-visible failures with the same semantics the replay bridge's isError has."""
+
+    def __init__(self, status: int, detail: str):
+        super().__init__(f"HTTP {status} (direct) from {'POST'}: {detail}")
+        self.status = status
+        self.detail = detail
+
+
+async def call_direct(
+    app: FastAPI,
+    binding: DirectBinding,
+    session_id: str,
+    arguments: dict,
+    path_value: Optional[str] = None,
+    cookie_header: Optional[bytes] = None,
+) -> Any:
+    """Invoke the frozen handler once. Returns the JSON-able response payload.
+
+    Replicates what skipping Gym's own stack would otherwise lose:
+      * SessionMiddleware + add_session_id  -> scope["session"] = {SESSION_ID_KEY: sid}
+        (handlers only ever READ request.session[SESSION_ID_KEY] — grep-verified);
+      * exception_handling_middleware       -> exceptions propagate to the MCP SDK's
+        call_tool wrapper, which already maps ANY Exception to isError(str(e)); we
+        pre-format HTTPException/ValidationError/ClientResponseError so the text carries
+        the same status information the replay bridge's isError text carries;
+      * the session cookie the HTTP door would carry -> pass ``cookie_header`` (the minted,
+        per-session-cached SessionMiddleware cookie) so a handler that forwards
+        ``request.cookies`` downstream (the CLAUDE.md stateful-env pattern; today only
+        AGENT servers do this, no resources server does) sees exactly what replay sees.
+    """
+    kwargs: dict[str, Any] = {}
+    if binding.path_param is not None:
+        kwargs[binding.path_param] = path_value if path_value is not None else ""
+    if binding.body_model is not None:
+        try:
+            kwargs[binding.body_param] = binding.body_model.model_validate(arguments)
+        except ValidationError as e:
+            raise DirectDispatchError(422, json.dumps(jsonable_encoder(e.errors()))) from e
+    if binding.request_params:
+        raw = json.dumps(arguments or {}).encode("utf-8") if binding.needs_raw_body else b""
+        headers = [(b"content-type", b"application/json")]
+        if cookie_header is not None:
+            headers.append((b"cookie", cookie_header))
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": binding.path if path_value is None else "/" + path_value,
+            "query_string": b"",
+            "root_path": "",
+            "headers": headers,
+            "client": ("127.0.0.1", 0),
+            "server": ("internal-mcp-direct", 80),
+            "state": {},
+            "app": app,
+            # SessionMiddleware's documented effect, materialized directly: the session the
+            # cookie round-trip would have produced for this rollout's session id.
+            "session": {SESSION_ID_KEY: session_id},
+        }
+        request = Request(scope, _make_receive(raw))
+        for name in binding.request_params:
+            kwargs[name] = request
+
+    try:
+        result = binding.endpoint(**kwargs)
+        if inspect.isawaitable(result):
+            result = await result
+    except StarletteHTTPException as e:  # fastapi.HTTPException subclasses this
+        raise DirectDispatchError(e.status_code, str(e.detail)) from e
+    except ClientResponseError as e:
+        # Gym's exception_handling_middleware special-case, replicated (its message shape).
+        detail = getattr(e, "response_content", None)
+        raise DirectDispatchError(500, f"Hit an exception calling an inner server: {detail or e}") from e
+
+    if isinstance(result, Response):  # litmus_agent / ns_tools return PlainTextResponse
+        text = bytes(result.body).decode("utf-8", errors="replace")
+        if not 200 <= result.status_code < 300:
+            raise DirectDispatchError(result.status_code, text)
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return text
+    if binding.return_model is not None and not isinstance(result, binding.return_model):
+        # Parity with FastAPI's return-annotation-as-response_model filtering.
+        result = binding.return_model.model_validate(result)
+    return jsonable_encoder(result)
+
+
+# ==================================================================================================
+# The hybrid plan: detector output + one call surface
+# ==================================================================================================
+
+
+@dataclass
+class ToolPlan:
+    name: str
+    mode: str  # "direct" | "replay"
+    path: str
+    binding: Optional[DirectBinding] = None
+    path_value: Optional[str] = None  # catch-all tools: value for the path param
+    reasons: list[str] = field(default_factory=list)
+
+
+@dataclass
+class HybridPlan:
+    server_mode: str  # "direct" | "replay" (Gate 1)
+    custom_middleware: list[str]
+    tools: dict[str, ToolPlan]
+
+    def summary(self) -> dict:
+        return {
+            "server_mode": self.server_mode,
+            "custom_middleware": self.custom_middleware,
+            "tools": {n: {"mode": t.mode, "reasons": t.reasons} for n, t in self.tools.items()},
+        }
+
+
+def plan_hybrid(
+    app: FastAPI,
+    typed_tool_paths: dict[str, str],
+    catchall_tools: Optional[dict[str, str]] = None,  # tool name -> catch-all route path
+) -> HybridPlan:
+    """The DETECTOR. Runs once at startup; every decision is inspectable in .summary()."""
+    custom = audit_middleware(app)
+    server_mode = "replay" if custom else "direct"
+    routes_by_path: dict[str, APIRoute] = {
+        r.path: r for r in app.routes if isinstance(r, APIRoute) and "POST" in (r.methods or set())
+    }
+
+    tools: dict[str, ToolPlan] = {}
+
+    def add(name: str, route_path: str, path_value: Optional[str]) -> None:
+        route = routes_by_path[route_path]
+        if server_mode == "replay":
+            tools[name] = ToolPlan(name, "replay", route_path, reasons=[f"custom middleware: {custom}"])
+            return
+        outcome = bind_route(route)
+        if outcome.binding is None:
+            tools[name] = ToolPlan(name, "replay", route_path, reasons=outcome.reasons)
+        else:
+            tools[name] = ToolPlan(name, "direct", route_path, binding=outcome.binding, path_value=path_value)
+
+    for name, route_path in typed_tool_paths.items():
+        add(name, route_path, None)
+    for name, route_path in (catchall_tools or {}).items():
+        add(name, route_path, name)
+    return HybridPlan(server_mode=server_mode, custom_middleware=custom, tools=tools)
+
+
+async def hybrid_call(
+    app: FastAPI,
+    plan: HybridPlan,
+    replay_fn: Callable,  # async (path: str, session_id: str, arguments: dict) -> payload
+    name: str,
+    session_id: str,
+    arguments: dict,
+) -> Any:
+    tool = plan.tools[name]
+    if tool.mode == "direct":
+        return await call_direct(app, tool.binding, session_id, arguments, path_value=tool.path_value)
+    replay_path = tool.path if tool.path_value is None else "/" + tool.path_value
+    return await replay_fn(replay_path, session_id, arguments)

--- a/prototypes/mcp_auto_exposure/run_checks.py
+++ b/prototypes/mcp_auto_exposure/run_checks.py
@@ -1,0 +1,643 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Acceptance checks a-f for the Brian-design auto-exposure spike.
+
+Runs six live uvicorn servers (exposed + unmodified-main-style pair per test server), drives them
+with the official MCP client (streamable HTTP) and aiohttp for the HTTP door, and prints
+PASS/FAIL per check with captured output.
+
+  a. R2: verbatim main handlers execute over MCP; MCP + HTTP-door calls mutate the SAME
+     per-session state (core invariant).
+  b. R1/R3: tools/list = finance's 5 typed tools (harvested schemas), workplace's 27 (override),
+     aviary step+close. Zero decorators.
+  c. R4: HTTP-door byte-parity vs an unmodified main-style app (happy + error paths).
+  d. Error mapping over MCP (unseeded 400, unknown tool, malformed args, missing/invalid token).
+  e. The aviary hazard: step with a DIFFERENT rollout's env_id over MCP.
+  f. Concurrency sanity: interleaved sessions, no state cross-talk.
+  g. (bonus) allowed_tools claim restricts tools/list and tools/call.
+
+Run:  ../../.venv/bin/python run_checks.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import re
+import sys
+import tempfile
+import threading
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import aiohttp
+import uvicorn
+
+import servers as spike_servers  # sets sys.path for main_snapshot + vendor
+from autoexpose import TOKEN_HEADER, TOKEN_SALT, mint_session_cookie
+from itsdangerous import URLSafeSerializer
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+SPIKE_DIR = Path(__file__).resolve().parent
+OUT = SPIKE_DIR / "out"
+OUT.mkdir(exist_ok=True)
+
+PORTS = {
+    "finance": 18871,
+    "finance_plain": 18872,
+    "workplace": 18873,
+    "workplace_plain": 18874,
+    "aviary": 18875,
+    "aviary_plain": 18876,
+}
+PAGE_PORT = 18899
+PAGE_URL = f"http://127.0.0.1:{PAGE_PORT}/page.html"
+
+RESULTS: list[tuple[str, bool, str]] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    RESULTS.append((name, ok, detail))
+    print(f"[{'PASS' if ok else 'FAIL'}] {name}" + (f"  -- {detail}" if detail else ""))
+
+
+def section(title: str) -> None:
+    print(f"\n{'=' * 100}\n{title}\n{'=' * 100}")
+
+
+# ---------------------------------------------------------------- infrastructure
+
+
+def start_page_server() -> ThreadingHTTPServer:
+    page_dir = Path(tempfile.mkdtemp(prefix="spike_pages_"))
+    (page_dir / "page.html").write_text(
+        "<html><body><p>NVIDIA reported record data center revenue of $30.77B in Q3 FY2025.</p></body></html>"
+    )
+
+    class Quiet(SimpleHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+    httpd = ThreadingHTTPServer(("127.0.0.1", PAGE_PORT), partial(Quiet, directory=str(page_dir)))
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd
+
+
+async def start_uvicorn(app, port: int) -> uvicorn.Server:
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning", lifespan="on")
+    server = uvicorn.Server(config)
+    asyncio.get_event_loop().create_task(server.serve())
+    while not server.started:
+        await asyncio.sleep(0.02)
+    return server
+
+
+def mcp_url(key: str) -> str:
+    return f"http://127.0.0.1:{PORTS[key]}/mcp"
+
+
+async def mcp_list_tools(url: str, token: str | None):
+    headers = {TOKEN_HEADER: token} if token else {}
+    async with streamablehttp_client(url, headers=headers) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            return (await session.list_tools()).tools
+
+
+async def mcp_call(url: str, token: str | None, name: str, args: dict):
+    headers = {TOKEN_HEADER: token} if token else {}
+    async with streamablehttp_client(url, headers=headers) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            return await session.call_tool(name, args)
+
+
+def result_text(result) -> str:
+    return "".join(c.text for c in result.content if getattr(c, "type", None) == "text")
+
+
+async def http_post_json(client: aiohttp.ClientSession, port: int, path: str, payload: dict) -> tuple[int, dict]:
+    async with client.post(f"http://127.0.0.1:{port}{path}", json=payload) as resp:
+        return resp.status, await resp.json()
+
+
+async def raw_post(
+    client: aiohttp.ClientSession, port: int, path: str, body: bytes, cookie: str | None = None
+) -> tuple[int, bytes, list[tuple[bytes, bytes]]]:
+    headers = {"content-type": "application/json"}
+    if cookie:
+        headers["cookie"] = cookie
+    async with client.post(f"http://127.0.0.1:{port}{path}", data=body, headers=headers) as resp:
+        return resp.status, await resp.read(), list(resp.raw_headers)
+
+
+VOLATILE_HEADERS = {b"date", b"set-cookie"}
+
+
+def filter_headers(raw: list[tuple[bytes, bytes]]) -> list[tuple[bytes, bytes]]:
+    return [(k, v) for k, v in raw if k.lower() not in VOLATILE_HEADERS]
+
+
+def parity_compare(label: str, a: tuple, b: tuple, expect_equal: bool = True) -> None:
+    """a = exposed response, b = plain-main response: (status, body, headers)."""
+    same = a[0] == b[0] and a[1] == b[1] and filter_headers(a[2]) == filter_headers(b[2])
+    if expect_equal:
+        check(
+            f"c. byte-parity: {label}",
+            same,
+            f"status {a[0]}=={b[0]}, body {len(a[1])}B" if same else f"exposed={a[:2]!r} plain={b[:2]!r}",
+        )
+    else:
+        return
+
+
+# ---------------------------------------------------------------- checks
+
+
+async def check_b_tools_list(tokens: dict[str, str]) -> None:
+    section("CHECK b (R1/R3): tools/list — harvested typed schemas, dispatcher override, plumbing routes")
+
+    fin_tools = await mcp_list_tools(mcp_url("finance"), tokens["finance"])
+    fin_names = sorted(t.name for t in fin_tools)
+    expected_fin = sorted(
+        ["sec_filing_search", "parse_html_page", "retrieve_information", "submit_final_result", "web_search"]
+    )
+    check("b. finance tools/list == 5 typed routes", fin_names == expected_fin, f"{fin_names}")
+    by_name = {t.name: t for t in fin_tools}
+    php = by_name["parse_html_page"].inputSchema
+    check(
+        "b. finance parse_html_page harvested schema has field names + required",
+        sorted(php.get("properties", {})) == ["key", "url"] and sorted(php.get("required", [])) == ["key", "url"],
+        json.dumps(php)[:200],
+    )
+    sfs = by_name["sec_filing_search"].inputSchema
+    check(
+        "b. finance sec_filing_search schema fields",
+        sorted(sfs.get("properties", {})) == ["end_date", "form_types", "start_date", "ticker"],
+        f"props={sorted(sfs.get('properties', {}))}",
+    )
+    check(
+        "b. finance descriptions from docstrings",
+        (by_name["sec_filing_search"].description or "").startswith("Search for SEC filings by ticker symbol."),
+        repr((by_name["sec_filing_search"].description or "")[:80]),
+    )
+
+    wp_tools = await mcp_list_tools(mcp_url("workplace"), tokens["workplace"])
+    wp_names = sorted(t.name for t in wp_tools)
+    check("b. workplace tools/list has 27 tools (inventory override)", len(wp_names) == 27, f"{len(wp_names)} tools")
+    wp_by_name = {t.name: t for t in wp_tools}
+    send_schema = wp_by_name.get("email_send_email")
+    check(
+        "b. workplace email_send_email schema from get_tools()['schemas']",
+        send_schema is not None
+        and sorted(send_schema.inputSchema.get("properties", {})) == ["body", "recipient", "subject"],
+        json.dumps(send_schema.inputSchema if send_schema else {})[:160],
+    )
+
+    if "aviary" in tokens:
+        av_tools = await mcp_list_tools(mcp_url("aviary"), tokens["aviary"])
+        av_names = sorted(t.name for t in av_tools)
+        check("b. aviary tools/list == [close, step]", av_names == ["close", "step"], f"{av_names}")
+        step_schema = {t.name: t for t in av_tools}["step"].inputSchema
+        check(
+            "b. aviary step schema exposes env_id + action",
+            sorted(step_schema.get("properties", {})) == ["action", "env_id"],
+            f"props={sorted(step_schema.get('properties', {}))}",
+        )
+        print("\naviary step schema:", json.dumps(step_schema)[:400])
+
+    print("\nfinance tools/list:", json.dumps([t.model_dump(exclude_none=True) for t in fin_tools], indent=1)[:1200])
+    print("\nworkplace 27 names:", wp_names)
+
+
+async def check_a_state(fin_server, fin_client: aiohttp.ClientSession, fin_token: str, fin_sid: str) -> None:
+    section("CHECK a (R2): verbatim handlers over MCP; MCP + HTTP door share the SAME per-session state")
+
+    # 1. MCP writes state: parse_html_page stores the page under key 'mcp_doc'.
+    result = await mcp_call(mcp_url("finance"), fin_token, "parse_html_page", {"url": PAGE_URL, "key": "mcp_doc"})
+    text = result_text(result)
+    print("MCP parse_html_page ->", text.strip()[:300])
+    check(
+        "a. MCP call ran the verbatim Request-taking handler (session via minted cookie)",
+        not result.isError and "SUCCESS" in text and "mcp_doc" in text,
+        text.strip()[:120],
+    )
+    check(
+        "a. structuredContent mirrors the HTTP JSON body",
+        isinstance(result.structuredContent, dict) and "results" in result.structuredContent,
+        str(result.structuredContent)[:120],
+    )
+
+    # 2. HTTP door (same session cookie) writes 'http_doc'; its response lists BOTH keys.
+    status, body = await http_post_json(fin_client, PORTS["finance"], "/parse_html_page", {"url": PAGE_URL, "key": "http_doc"})
+    print("HTTP parse_html_page ->", body["results"].strip()[:300])
+    check(
+        "a. HTTP-door call sees the key MCP stored (same storage dict)",
+        status == 200 and "mcp_doc" in body["results"] and "http_doc" in body["results"],
+        body["results"].strip().replace("\n", " | ")[:160],
+    )
+
+    # 3. MCP reads state back: retrieve_information's missing-key error enumerates session keys.
+    result = await mcp_call(mcp_url("finance"), fin_token, "retrieve_information", {"prompt": "{{missing_key}}"})
+    text = result_text(result)
+    print("MCP retrieve_information ->", text.strip()[:300])
+    check(
+        "a. MCP call reads back HTTP-door mutations (available keys list)",
+        "mcp_doc" in text and "http_doc" in text,
+        text.strip()[:160],
+    )
+
+    # 4. Server-side ground truth: one storage dict, keyed by the token's session id.
+    storage = fin_server._data_storage.get(fin_sid, {})
+    check(
+        "a. server _data_storage[token_sid] holds exactly both docs",
+        sorted(storage) == ["http_doc", "mcp_doc"],
+        f"_data_storage[{fin_sid[:8]}...] keys = {sorted(storage)}",
+    )
+
+
+async def check_c_parity(secrets: dict[str, str]) -> None:
+    section("CHECK c (R4): HTTP door byte-parity vs unmodified main-style app")
+
+    connector = aiohttp.TCPConnector()
+    async with aiohttp.ClientSession(connector=connector, cookie_jar=aiohttp.DummyCookieJar()) as client:
+        # Same class name + config name on both instances => same SessionMiddleware secret => the
+        # SAME minted cookie is valid on both, so both sides see identical requests, byte for byte.
+        def cookies(server_key: str, sid: str) -> str:
+            secret = secrets[server_key]
+            return mint_session_cookie(secret, secret, sid)
+
+        # ---------- finance ----------
+        fin_cookie = cookies("finance", "parity-fin-1")
+        seed = b"{}"
+        a = await raw_post(client, PORTS["finance"], "/seed_session", seed, fin_cookie)
+        b = await raw_post(client, PORTS["finance_plain"], "/seed_session", seed, fin_cookie)
+        a_json, b_json = json.loads(a[1]), json.loads(b[1])
+        mcp_meta = a_json.pop("mcp", None)
+        print("seed_session exposed body:", json.dumps(json.loads(a[1].decode()))[:60], "... plus 'mcp':", json.dumps(mcp_meta)[:120])
+        print("seed_session plain body:  ", b[1].decode())
+        check(
+            "c. KNOWN ADDITIVE DELTA: /seed_session gains only the 'mcp' key (rest identical)",
+            mcp_meta is not None and "mcp" not in b_json and a_json == b_json and a[0] == b[0] == 200,
+            f"delta keys: {{'mcp'}}; shared body: {json.dumps(a_json)}",
+        )
+
+        payload = json.dumps({"url": PAGE_URL, "key": "doc"}).encode()
+        a = await raw_post(client, PORTS["finance"], "/parse_html_page", payload, fin_cookie)
+        b = await raw_post(client, PORTS["finance_plain"], "/parse_html_page", payload, fin_cookie)
+        parity_compare("finance parse_html_page happy path (200)", a, b)
+
+        bad = json.dumps({"url": PAGE_URL}).encode()  # missing required 'key' -> 422
+        a = await raw_post(client, PORTS["finance"], "/parse_html_page", bad, fin_cookie)
+        b = await raw_post(client, PORTS["finance_plain"], "/parse_html_page", bad, fin_cookie)
+        print("finance 422 body:", a[1].decode()[:160])
+        parity_compare("finance parse_html_page malformed args (422)", a, b)
+
+        payload = json.dumps({"prompt": "{{nokey}}"}).encode()
+        a = await raw_post(client, PORTS["finance"], "/retrieve_information", payload, fin_cookie)
+        b = await raw_post(client, PORTS["finance_plain"], "/retrieve_information", payload, fin_cookie)
+        parity_compare("finance retrieve_information soft-error (200)", a, b)
+
+        payload = json.dumps({"final_result": "42"}).encode()
+        a = await raw_post(client, PORTS["finance"], "/submit_final_result", payload, fin_cookie)
+        b = await raw_post(client, PORTS["finance_plain"], "/submit_final_result", payload, fin_cookie)
+        parity_compare("finance submit_final_result (200)", a, b)
+
+        payload = json.dumps({"anything": 1}).encode()
+        a = await raw_post(client, PORTS["finance"], "/made_up_tool", payload, fin_cookie)
+        b = await raw_post(client, PORTS["finance_plain"], "/made_up_tool", payload, fin_cookie)
+        parity_compare("finance catch-all unknown tool (200 soft error)", a, b)
+
+        # no-cookie request: both mint fresh sessions, identical bodies
+        payload = json.dumps({"final_result": "no-cookie"}).encode()
+        a = await raw_post(client, PORTS["finance"], "/submit_final_result", payload, None)
+        b = await raw_post(client, PORTS["finance_plain"], "/submit_final_result", payload, None)
+        parity_compare("finance request with NO cookie (fresh session on both)", a, b)
+
+        # ---------- workplace ----------
+        wp_cookie = cookies("workplace", "parity-wp-1")
+        a = await raw_post(client, PORTS["workplace"], "/seed_session", seed, wp_cookie)
+        b = await raw_post(client, PORTS["workplace_plain"], "/seed_session", seed, wp_cookie)
+        a_json, b_json = json.loads(a[1]), json.loads(b[1])
+        a_json.pop("mcp", None)
+        check("c. workplace /seed_session additive-only delta", a_json == b_json and a[0] == b[0] == 200, json.dumps(a_json))
+
+        payload = json.dumps({"recipient": "jane.doe@company.com", "subject": "Parity", "body": "hello"}).encode()
+        a = await raw_post(client, PORTS["workplace"], "/email_send_email", payload, wp_cookie)
+        b = await raw_post(client, PORTS["workplace_plain"], "/email_send_email", payload, wp_cookie)
+        print("workplace happy body:", a[1].decode()[:120])
+        parity_compare("workplace dispatcher email_send_email happy (200)", a, b)
+
+        payload = json.dumps({"recipient": "jane.doe@company.com"}).encode()  # missing args
+        a = await raw_post(client, PORTS["workplace"], "/email_send_email", payload, wp_cookie)
+        b = await raw_post(client, PORTS["workplace_plain"], "/email_send_email", payload, wp_cookie)
+        print("workplace 200-soft-error body:", a[1].decode()[:200])
+        parity_compare("workplace 200-soft-error (bad args)", a, b)
+
+        unseeded = cookies("workplace", "parity-wp-unseeded")
+        payload = json.dumps({"recipient": "x@y.z", "subject": "s", "body": "b"}).encode()
+        a = await raw_post(client, PORTS["workplace"], "/email_send_email", payload, unseeded)
+        b = await raw_post(client, PORTS["workplace_plain"], "/email_send_email", payload, unseeded)
+        print("workplace unseeded 400 body:", a[1].decode())
+        parity_compare("workplace unseeded session (400)", a, b)
+        check("c. workplace unseeded is HTTP 400", a[0] == 400, f"status={a[0]}")
+
+        payload = json.dumps({}).encode()
+        a = await raw_post(client, PORTS["workplace"], "/unknown_tool_name", payload, wp_cookie)
+        b = await raw_post(client, PORTS["workplace_plain"], "/unknown_tool_name", payload, wp_cookie)
+        print("workplace unknown-tool body:", a[1].decode()[:160])
+        parity_compare("workplace unknown tool via catch-all (200 soft error)", a, b)
+
+        # ---------- aviary (only when fhaviary is installed) ----------
+        if "aviary" in PORTS:
+            av_cookie = cookies("aviary", "parity-av-1")
+            seed_payload = json.dumps({"task_idx": 0}).encode()
+            a = await raw_post(client, PORTS["aviary"], "/seed_session", seed_payload, av_cookie)
+            b = await raw_post(client, PORTS["aviary_plain"], "/seed_session", seed_payload, av_cookie)
+            a_json, b_json = json.loads(a[1]), json.loads(b[1])
+            a_json.pop("mcp", None)
+            env_a, env_b = a_json.pop("env_id"), b_json.pop("env_id")
+            check(
+                "c. aviary /seed_session parity modulo env_id uuid (nondeterministic on main too) + 'mcp'",
+                a_json == b_json and a[0] == b[0] == 200,
+                "obs+tools identical; env_id uuids differ by construction",
+            )
+
+            step = lambda env_id: json.dumps(
+                {"env_id": env_id, "action": [{"type": "function_call", "call_id": "c1", "name": "cast_float", "arguments": json.dumps({"x": "3.14"})}]}
+            ).encode()
+            a = await raw_post(client, PORTS["aviary"], "/step", step(env_a), av_cookie)
+            b = await raw_post(client, PORTS["aviary_plain"], "/step", step(env_b), av_cookie)
+            print("aviary step body:", a[1].decode()[:200])
+            parity_compare("aviary /step happy path (200)", a, b)
+
+            payload = json.dumps({"env_id": "no-such-env"}).encode()
+            a = await raw_post(client, PORTS["aviary"], "/close", payload, av_cookie)
+            b = await raw_post(client, PORTS["aviary_plain"], "/close", payload, av_cookie)
+            print("aviary close-unknown body:", a[1].decode())
+            parity_compare("aviary /close unknown env (200, success=false)", a, b)
+
+            a = await raw_post(client, PORTS["aviary"], "/close", json.dumps({"env_id": env_a}).encode(), av_cookie)
+            b = await raw_post(client, PORTS["aviary_plain"], "/close", json.dumps({"env_id": env_b}).encode(), av_cookie)
+            parity_compare("aviary /close happy path (200)", a, b)
+
+        # ---------- openapi surface ----------
+        async with client.get(f"http://127.0.0.1:{PORTS['finance']}/openapi.json") as r:
+            exposed_oapi = await r.json()
+        async with client.get(f"http://127.0.0.1:{PORTS['finance_plain']}/openapi.json") as r:
+            plain_oapi = await r.json()
+        path_delta = set(exposed_oapi["paths"]) ^ set(plain_oapi["paths"])
+        tool_paths_equal = all(
+            exposed_oapi["paths"][p] == plain_oapi["paths"][p]
+            for p in plain_oapi["paths"]
+            if p != "/seed_session"
+        )
+        check(
+            "c. openapi: path set unchanged (/mcp hidden); every tool route's spec byte-identical",
+            path_delta == set() and tool_paths_equal,
+            f"path delta={path_delta}; seed_session response schema differs (documented delta): "
+            f"{exposed_oapi['paths']['/seed_session']['post']['responses']['200']['content'] != plain_oapi['paths']['/seed_session']['post']['responses']['200']['content']}",
+        )
+
+
+async def check_d_errors(tokens: dict[str, str], wp_secret: str) -> None:
+    section("CHECK d: error mapping over MCP — what does the model see?")
+
+    serializer = URLSafeSerializer(wp_secret, salt=TOKEN_SALT)
+
+    # 1. Unseeded session (valid token, but seed_session never ran for this sid) -> handler's 400
+    stale_token = serializer.dumps("never-seeded-sid")
+    result = await mcp_call(mcp_url("workplace"), stale_token, "email_send_email", {"recipient": "a@b.c", "subject": "s", "body": "b"})
+    text = result_text(result)
+    print("unseeded-400 over MCP -> isError:", result.isError, "| text:", text)
+    check(
+        "d. unseeded-session 400 -> isError with status + handler detail",
+        result.isError and "HTTP 400" in text and "Session not initialized" in text,
+        text[:160],
+    )
+
+    # 2. Dispatcher unknown tool over MCP -> clean isError, never reaches the catch-all
+    result = await mcp_call(mcp_url("workplace"), tokens["workplace"], "email_explode", {})
+    text = result_text(result)
+    print("unknown-tool over MCP -> isError:", result.isError, "| text:", text[:200])
+    check("d. unknown tool -> isError 'Unknown tool'", result.isError and "Unknown tool" in text, text[:120])
+
+    # 3. Malformed args -> the HTTP door's own 422 body, verbatim
+    result = await mcp_call(mcp_url("finance"), tokens["finance"], "parse_html_page", {"url": PAGE_URL})
+    text = result_text(result)
+    print("malformed-args over MCP -> isError:", result.isError, "| text:", text[:220])
+    check(
+        "d. malformed args -> isError with FastAPI 422 body",
+        result.isError and "HTTP 422" in text and "Field required" in text,
+        text[:160],
+    )
+
+    # 4. Missing token
+    result = await mcp_call(mcp_url("workplace"), None, "email_send_email", {"recipient": "a@b.c", "subject": "s", "body": "b"})
+    text = result_text(result)
+    print("missing-token over MCP -> isError:", result.isError, "| text:", text)
+    check("d. missing token -> isError", result.isError and TOKEN_HEADER in text, text[:120])
+
+    # 5. Forged/invalid token
+    result = await mcp_call(mcp_url("workplace"), "forged.token.value", "email_send_email", {"recipient": "a@b.c", "subject": "s", "body": "b"})
+    text = result_text(result)
+    print("invalid-token over MCP -> isError:", result.isError, "| text:", text)
+    check("d. invalid token -> isError", result.isError and "Invalid" in text, text[:120])
+
+
+async def check_e_aviary_hazard(av_server) -> None:
+    section("CHECK e: the aviary hazard — MCP step with a DIFFERENT rollout's env_id")
+
+    async with aiohttp.ClientSession(cookie_jar=aiohttp.CookieJar(unsafe=True)) as c1, aiohttp.ClientSession(
+        cookie_jar=aiohttp.CookieJar(unsafe=True)
+    ) as c2:
+        _, seed1 = await http_post_json(c1, PORTS["aviary"], "/seed_session", {"task_idx": 1})
+        _, seed2 = await http_post_json(c2, PORTS["aviary"], "/seed_session", {"task_idx": 2})
+        env1, tok1 = seed1["env_id"], seed1["mcp"]["headers"][TOKEN_HEADER]
+        env2 = seed2["env_id"]
+        print(f"rollout 1: env_id={env1}  |  rollout 2: env_id={env2}")
+
+        reward_before = dict(av_server.env_id_to_total_reward)
+        action = [{"type": "function_call", "call_id": "x1", "name": "print_story", "arguments": json.dumps({"story": "five word story right here"})}]
+        # Session 1's token, session 2's env_id:
+        result = await mcp_call(mcp_url("aviary"), tok1, "step", {"env_id": env2, "action": action})
+        text = result_text(result)
+        print("cross-rollout step -> isError:", result.isError, "| body:", text[:200])
+        reward_after = dict(av_server.env_id_to_total_reward)
+        interfered = not result.isError and reward_after.get(env2, 0.0) > reward_before.get(env2, 0.0)
+        check(
+            "e. HAZARD CONFIRMED: session 1's token can step session 2's env (env registry is env_id-keyed, not session-keyed)",
+            interfered,
+            f"env2 total_reward {reward_before.get(env2, 0.0)} -> {reward_after.get(env2, 0.0)}; "
+            f"identical behavior to the HTTP door on main (env_id is the only key)",
+        )
+
+
+async def check_f_concurrency(wp_server) -> None:
+    section("CHECK f: two interleaved sessions, no state cross-talk (dispatcher, over MCP)")
+
+    async with aiohttp.ClientSession(cookie_jar=aiohttp.CookieJar(unsafe=True)) as cA, aiohttp.ClientSession(
+        cookie_jar=aiohttp.CookieJar(unsafe=True)
+    ) as cB:
+        _, seedA = await http_post_json(cA, PORTS["workplace"], "/seed_session", {})
+        _, seedB = await http_post_json(cB, PORTS["workplace"], "/seed_session", {})
+        tokA = seedA["mcp"]["headers"][TOKEN_HEADER]
+        tokB = seedB["mcp"]["headers"][TOKEN_HEADER]
+
+        url = mcp_url("workplace")
+        sends = []
+        for i in range(6):
+            tok, tag = (tokA, "AAA") if i % 2 == 0 else (tokB, "BBB")
+            sends.append(
+                mcp_call(url, tok, "email_send_email",
+                         {"recipient": "jane.doe@company.com", "subject": f"subject-{tag}-{i}", "body": "x"})
+            )
+        send_results = await asyncio.gather(*sends)
+        check("f. 6 interleaved MCP sends all succeeded", all(not r.isError for r in send_results),
+              "; ".join(result_text(r)[:40] for r in send_results[:2]))
+
+        searchA, searchB = await asyncio.gather(
+            mcp_call(url, tokA, "email_search_emails", {"query": "subject-"}),
+            mcp_call(url, tokB, "email_search_emails", {"query": "subject-"}),
+        )
+        tA, tB = result_text(searchA), result_text(searchB)
+        okA = "subject-AAA" in tA and "subject-BBB" not in tA
+        okB = "subject-BBB" in tB and "subject-AAA" not in tB
+        print("session A sees:", re.findall(r"subject-\w+-\d+", tA))
+        print("session B sees:", re.findall(r"subject-\w+-\d+", tB))
+        check("f. session A sees only A's emails; B only B's (no cross-talk)", okA and okB,
+              f"A={re.findall(r'subject-[A-Z]+', tA)[:4]} B={re.findall(r'subject-[A-Z]+', tB)[:4]}")
+        check(
+            "f. two distinct tool envs live server-side",
+            len(wp_server.session_id_to_tool_env) >= 2,
+            f"{len(wp_server.session_id_to_tool_env)} sessions in session_id_to_tool_env",
+        )
+
+
+async def check_g_allowed_tools(wp_secret: str) -> None:
+    section("CHECK g (bonus): allowed_tools claim inside the signed token")
+
+    serializer = URLSafeSerializer(wp_secret, salt=TOKEN_SALT)
+    async with aiohttp.ClientSession(cookie_jar=aiohttp.CookieJar(unsafe=True)) as c:
+        _, seed = await http_post_json(c, PORTS["workplace"], "/seed_session", {})
+        full_token = seed["mcp"]["headers"][TOKEN_HEADER]
+        sid = serializer.loads(full_token)
+    restricted = serializer.dumps({"sid": sid, "tools": ["email_send_email"]})
+
+    tools = await mcp_list_tools(mcp_url("workplace"), restricted)
+    check("g. restricted token: tools/list shows only the allowed tool", [t.name for t in tools] == ["email_send_email"],
+          f"{[t.name for t in tools]}")
+    result = await mcp_call(mcp_url("workplace"), restricted, "calendar_create_event",
+                            {"event_name": "x", "participant_email": "a@b.c", "event_start": "2026-01-01 10:00:00", "duration": "30"})
+    check("g. restricted token: disallowed call -> isError", result.isError and "not allowed" in result_text(result),
+          result_text(result)[:100])
+    result = await mcp_call(mcp_url("workplace"), restricted, "email_send_email",
+                            {"recipient": "jane.doe@company.com", "subject": "ok", "body": "ok"})
+    check("g. restricted token: allowed call still works", not result.isError, result_text(result)[:80])
+
+
+# ---------------------------------------------------------------- main
+
+
+async def main() -> int:
+    logging.basicConfig(level=logging.WARNING)
+    print("Building servers from BYTE-IDENTICAL origin/main handler code (see proofs/diff_handlers.sh)...")
+
+    fin_server, fin_app = spike_servers.build_finance(expose=True)
+    fin_plain_server, fin_plain_app = spike_servers.build_finance(expose=False)
+    wp_server, wp_app = spike_servers.build_workplace(expose=True)
+    wp_plain_server, wp_plain_app = spike_servers.build_workplace(expose=False)
+
+    app_by_key = [
+        ("finance", fin_app), ("finance_plain", fin_plain_app),
+        ("workplace", wp_app), ("workplace_plain", wp_plain_app),
+    ]
+    av_server = None
+    if spike_servers.AVIARY_AVAILABLE:
+        av_server, av_app = spike_servers.build_aviary(expose=True)
+        av_plain_server, av_plain_app = spike_servers.build_aviary(expose=False)
+        app_by_key += [("aviary", av_app), ("aviary_plain", av_plain_app)]
+    else:
+        for k in ("aviary", "aviary_plain"):
+            PORTS.pop(k, None)
+        print("NOTE: fhaviary not installed — skipping the aviary plumbing-hazard case "
+              "(finance + workplace cover the typed + dispatcher paradigms).")
+
+    start_page_server()
+    servers = []
+    for key, app in app_by_key:
+        servers.append(await start_uvicorn(app, PORTS[key]))
+    print(f"{len(servers)} uvicorn servers up on ports {sorted(PORTS.values())}; page server on {PAGE_PORT}")
+
+    # One seeded session per server, reused throughout (the rollout pattern).
+    secrets = {
+        "finance": fin_server.get_session_middleware_key(),
+        "workplace": wp_server.get_session_middleware_key(),
+    }
+    secret_precondition = (
+        secrets["finance"] == fin_plain_server.get_session_middleware_key()
+        and secrets["workplace"] == wp_plain_server.get_session_middleware_key()
+    )
+    if av_server is not None:
+        secrets["aviary"] = av_server.get_session_middleware_key()
+        secret_precondition = secret_precondition and secrets["aviary"] == av_plain_server.get_session_middleware_key()
+    check(
+        "pre. exposed and plain instances share session secrets (parity precondition)",
+        secret_precondition,
+        str(secrets),
+    )
+
+    fin_client = aiohttp.ClientSession(cookie_jar=aiohttp.CookieJar(unsafe=True))
+    tokens: dict[str, str] = {}
+    _, fin_seed = await http_post_json(fin_client, PORTS["finance"], "/seed_session", {})
+    tokens["finance"] = fin_seed["mcp"]["headers"][TOKEN_HEADER]
+    fin_sid = URLSafeSerializer(secrets["finance"], salt=TOKEN_SALT).loads(tokens["finance"])
+
+    wp_client = aiohttp.ClientSession(cookie_jar=aiohttp.CookieJar(unsafe=True))
+    _, wp_seed = await http_post_json(wp_client, PORTS["workplace"], "/seed_session", {})
+    tokens["workplace"] = wp_seed["mcp"]["headers"][TOKEN_HEADER]
+
+    av_client = None
+    if av_server is not None:
+        av_client = aiohttp.ClientSession(cookie_jar=aiohttp.CookieJar(unsafe=True))
+        _, av_seed = await http_post_json(av_client, PORTS["aviary"], "/seed_session", {"task_idx": 0})
+        tokens["aviary"] = av_seed["mcp"]["headers"][TOKEN_HEADER]
+
+    wp_secret = secrets["workplace"]
+
+    try:
+        await check_b_tools_list(tokens)
+        await check_a_state(fin_server, fin_client, tokens["finance"], fin_sid)
+        await check_c_parity(secrets)
+        await check_d_errors(tokens, wp_secret)
+        if av_server is not None:
+            await check_e_aviary_hazard(av_server)
+        await check_f_concurrency(wp_server)
+        await check_g_allowed_tools(wp_secret)
+    finally:
+        await fin_client.close()
+        await wp_client.close()
+        if av_client is not None:
+            await av_client.close()
+        for srv in (fin_server, fin_plain_server):  # finance's own shared aiohttp session (main behavior)
+            if srv._session is not None and not srv._session.closed:
+                await srv._session.close()
+        for s in servers:
+            s.should_exit = True
+        await asyncio.sleep(0.3)
+
+    section("SUMMARY")
+    passed = sum(1 for _, ok, _ in RESULTS if ok)
+    for name, ok, _ in RESULTS:
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
+    print(f"\n{passed}/{len(RESULTS)} checks passed")
+    (OUT / "summary.json").write_text(json.dumps([{"check": n, "pass": ok, "detail": d} for n, ok, d in RESULTS], indent=1))
+    return 0 if passed == len(RESULTS) else 1
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(KeyboardInterrupt):
+        sys.exit(asyncio.run(main()))

--- a/prototypes/mcp_auto_exposure/servers.py
+++ b/prototypes/mcp_auto_exposure/servers.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prototype test servers, built from UNMODIFIED in-tree resources_servers/ code.
+
+This branch is based on origin/main, so the resources_servers/ handlers are pristine. This module
+imports them directly (no snapshot needed) — which is the whole point: the same unmodified handler
+files are MCP-enabled by install_auto_exposure() with zero edits. It only:
+  * instantiates those unmodified server classes (configs + fixtures, exactly like their tests do),
+  * adds the ONE dispatcher override Brian's design allows (workplace ``mcp_tool_inventory``),
+  * provides trivially concrete aviary plumbing (a DummyEnv dataset — fixture, not handler code)
+    when the optional fhaviary dependency is installed; otherwise the aviary case is skipped.
+
+Zero decorators. Zero handler edits.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import ClassVar
+from unittest.mock import MagicMock
+
+PROTO_DIR = Path(__file__).resolve().parent
+REPO_ROOT = PROTO_DIR.parents[1]  # prototypes/mcp_auto_exposure/ -> repo root
+sys.path.insert(0, str(REPO_ROOT))  # the real, unmodified resources_servers/ + nemo_gym
+sys.path.insert(1, str(PROTO_DIR))  # autoexpose
+
+from fastapi import FastAPI  # noqa: E402
+from pydantic import Field  # noqa: E402
+
+from autoexpose import install_auto_exposure  # noqa: E402
+from nemo_gym.config_types import ModelServerRef  # noqa: E402
+from nemo_gym.server_utils import ServerClient  # noqa: E402
+
+# ---- unmodified in-tree classes (resources_servers/, pristine on this origin/main-based branch) --
+from resources_servers.finance_sec_search.app import (  # noqa: E402
+    FinanceAgentResourcesServer,
+    FinanceAgentResourcesServerConfig,
+)
+from resources_servers.workplace_assistant.app import (  # noqa: E402
+    WorkbenchResourcesServer,
+    WorkbenchResourcesServerConfig,
+)
+from resources_servers.workplace_assistant.utils import get_tools  # noqa: E402
+
+# aviary (the plumbing-exposed case) needs the optional fhaviary package. Import lazily so the
+# finance + workplace demonstrations run without it.
+try:
+    from resources_servers.aviary.app import AviaryResourcesServer  # noqa: E402
+    from resources_servers.aviary.schemas import AviaryResourcesServerConfig  # noqa: E402
+    from aviary.core import DummyEnv, TaskDataset  # noqa: E402
+
+    AVIARY_AVAILABLE = True
+except ImportError:
+    AVIARY_AVAILABLE = False
+
+
+MOCK_TICKERS = {
+    "0": {"ticker": "AAPL", "cik_str": "320193", "title": "APPLE INC."},
+    "1": {"ticker": "NVDA", "cik_str": "1045810", "title": "NVIDIA CORP"},
+}
+
+WORKBENCH_TOOLKITS = [
+    "email",
+    "calendar",
+    "analytics",
+    "project_management",
+    "customer_relationship_manager",
+]
+
+
+# ==================================================================================================
+# (a) finance_sec_search — typed fixed-route case. Zero decorators, zero handler edits; the one
+#     addition is the toolless-catch-all declaration (its /{tool_name} route backs no tools).
+# ==================================================================================================
+
+
+def build_finance(expose: bool = True) -> tuple[FinanceAgentResourcesServer, FastAPI]:
+    cache_dir = tempfile.mkdtemp(prefix="spike_finance_cache_")
+    (Path(cache_dir) / "tickers.json").write_text(json.dumps(MOCK_TICKERS))  # skip SEC.gov download
+    config = FinanceAgentResourcesServerConfig(
+        host="127.0.0.1",
+        port=8080,
+        entrypoint="",
+        name="finance_sec_search_spike",
+        cache_dir=cache_dir,
+        judge_prompt_template="{question} {expected_answer} {generated_answer}",
+        retrieval_system_prompt="You answer questions from stored documents.",
+        # Truthy ref so retrieve_information proceeds to its storage lookup; the storage-error
+        # paths return before any LLM call, so the mock ServerClient is never used.
+        retrieval_model_server=ModelServerRef(type="responses_api_models", name="spike_fake_model"),
+    )
+    server = SpikeFinanceResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+    app = server.setup_webserver()
+    if expose:
+        install_auto_exposure(server, app)
+    return server, app
+
+
+class SpikeFinanceResourcesServer(FinanceAgentResourcesServer):
+    # finance's /{tool_name} catch-all only returns error strings for unknown tool names — it
+    # backs no tools. Declaring that silences the missing-inventory warning (author knowledge
+    # the harvest cannot recover). One attribute, zero handler edits. ClassVar because Gym
+    # servers are pydantic models (a bare attribute would be rejected as an unannotated field).
+    mcp_toolless_catchall_paths: ClassVar[frozenset[str]] = frozenset({"/{tool_name}"})
+
+
+# Same invariant as SpikeWorkbench below: in production the declaration lives on the real class in
+# its own app.py, so the class NAME (which seeds get_session_middleware_key) must not change here.
+SpikeFinanceResourcesServer.__name__ = "FinanceAgentResourcesServer"
+
+
+# ==================================================================================================
+# (b) workplace_assistant — dispatcher case (one catch-all route, 27 tools). Brian's 2.d: the
+#     server overrides ONE function returning the tool inventory; calls route through the
+#     existing catch-all. Handlers untouched.
+# ==================================================================================================
+
+
+class SpikeWorkbenchResourcesServer(WorkbenchResourcesServer):
+    def mcp_tool_inventory(self) -> list[dict]:
+        schemas = get_tools(WORKBENCH_TOOLKITS)["schemas"]
+        return [
+            {"name": s["name"], "input_schema": s["parameters"], "description": s.get("description")} for s in schemas
+        ]
+
+
+# In production Brian's design puts mcp_tool_inventory() directly on WorkbenchResourcesServer in
+# its own app.py — the class NAME (which seeds get_session_middleware_key) would not change. Keep
+# that invariant here so the exposed and plain instances share the same session secret/cookie name.
+SpikeWorkbenchResourcesServer.__name__ = "WorkbenchResourcesServer"
+
+
+def build_workplace(expose: bool = True) -> tuple[WorkbenchResourcesServer, FastAPI]:
+    config = WorkbenchResourcesServerConfig(
+        host="127.0.0.1", port=8080, entrypoint="", name="workplace_assistant_spike"
+    )
+    cls = SpikeWorkbenchResourcesServer if expose else WorkbenchResourcesServer
+    server = cls(config=config, server_client=MagicMock(spec=ServerClient))
+    app = server.setup_webserver()
+    if expose:
+        install_auto_exposure(server, app)
+    return server, app
+
+
+# ==================================================================================================
+# (c) aviary — plumbing-exposed case (/step + /close typed with env_id). The abstract origin/main
+#     server needs a concrete dataset; DummyEnv (from the aviary library itself) keeps the spike
+#     network-free. Handler code untouched.
+# ==================================================================================================
+
+
+if AVIARY_AVAILABLE:
+
+    class DummyTaskDataset(TaskDataset):
+        def get_new_env_by_idx(self, idx: int) -> DummyEnv:
+            # end_immediately=False keeps episodes alive across multiple /step calls.
+            return DummyEnv(task=f"dummy-task-{idx}", end_immediately=False)
+
+        def __len__(self) -> int:
+            return 1000
+
+    class SpikeAviaryResourcesServer(AviaryResourcesServer[DummyEnv, DummyTaskDataset]):
+        dataset: DummyTaskDataset = Field(default_factory=DummyTaskDataset)
+
+    def build_aviary(expose: bool = True):
+        config = AviaryResourcesServerConfig(host="127.0.0.1", port=8080, entrypoint="", name="aviary_spike")
+        server = SpikeAviaryResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+        app = server.setup_webserver()
+        if expose:
+            install_auto_exposure(server, app)
+        return server, app
+
+else:
+
+    def build_aviary(expose: bool = True):
+        raise RuntimeError("aviary case requires the optional fhaviary package (pip install fhaviary)")


### PR DESCRIPTION
> **Draft / RFC — not for merge.** Prototype for design discussion alongside #2002. Lives entirely under `prototypes/` and wires into nothing (no CI, no imports from the rest of the tree).

## What this is

A working proof-of-concept for an **alternative** way to serve resources-server tools over MCP: **auto-expose every existing FastAPI tool route as an MCP tool**, with **zero decorator changes and byte-identical handlers**. It's the counterpoint to #2002's `@gym_tool` design, built so we can compare the two approaches on concrete, runnable code.

| | #2002 (`@gym_tool`) | This prototype (auto-exposure) |
|---|---|---|
| Tool-file changes | ~861 lines across 16 servers (new signatures) | **0** — handlers byte-identical to `main` |
| MCP dispatch | direct call | **replay** (internal in-process HTTP request) |
| Per-call cost | ~0 extra | ~260–290 µs (2× stack pass; see trade-offs) |
| Schema source | explicit (`@gym_tool` / `input_schema`) | harvested from route body models + one dispatcher override |

## The mechanism (replay bridge)

A frozen `request: Request` handler can only be invoked correctly by the HTTP machinery itself. So an MCP `tools/call` is served by re-issuing it as an **internal in-process HTTP request** through the app's own ASGI stack: verify the signed session token → mint the SessionMiddleware cookie for that session id → replay `POST /<tool>` through the full stack (session populated, body validated, unmodified handler runs) → map the HTTP response to an MCP result. MCP-side engine is the official SDK's **public low-level** `Server` — no private attrs.

## Verified

`37/37` live acceptance checks pass against **pristine `origin/main` handler code imported directly from `resources_servers/`** — finance (typed routes) + workplace (27-tool dispatcher via the `mcp_tool_inventory` override). Proves R1 (no decorator), R2 (handlers run over MCP with `request.session` working, sharing state with the HTTP door), R3 (schemas harvested + dispatcher override + plumbing routes), R4 (HTTP door byte-identical bar two additive deltas), plus per-session `allowed_tools` filtering and cross-session isolation.

```bash
python prototypes/mcp_auto_exposure/run_checks.py   # -> 37/37 (install fhaviary for +7 aviary checks)
```

## Trade-offs on the table (documented, not hidden)

- **Replay is a 2× pass** — dominated by Gym's own `add_session_id` `BaseHTTPMiddleware` (~191 µs), which the HTTP door also pays. Negligible under real tools; real for MB payloads / extreme rates.
- **Exposure hazard** — aviary's `/step`/`/close` are harness plumbing, not model tools, yet get auto-exposed; `/step` carries `env_id`, so an exposed `step` could address other rollouts' envs. Argues for opt-in-per-server + a plumbing-route declaration (`mcp_toolless_catchall_paths` is a first cut).
- **`route.body_field`** is a semi-internal FastAPI attribute (fails loudly if unresolvable).
- A **direct-dispatch middle ground** (synthesize `gym_tool`s from routes, no replay) is being explored separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
