### PR TITLE
fix(vllm_model): drop orphan tool_choice/parallel_tool_calls when no …

### DIFF
--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -228,6 +228,19 @@ class VLLMModel(SimpleResponsesAPIModel):
 
         body_dict["model"] = self.config.model
 
+        # Normalize tool params when the request carries no tools. vLLM's OpenAI
+        # ChatCompletion validator rejects a request that sets `tool_choice` to
+        # anything other than "none" without any `tools`
+        # ("When using `tool_choice`, `tools` must be set."). No-tool agents
+        # (e.g. an LLM-as-judge) still send the OpenAI-default `tool_choice="auto"`
+        # / `parallel_tool_calls=True`, which would 500 the model server. Drop the
+        # orphaned tool params (an explicit "none" is left untouched) so such
+        # requests validate cleanly.
+        if not body_dict.get("tools"):
+            if body_dict.get("tool_choice") not in (None, "none"):
+                body_dict.pop("tool_choice", None)
+            body_dict.pop("parallel_tool_calls", None)
+
         chat_template_kwargs = {}
         if self.config.chat_template_kwargs:
             chat_template_kwargs = deepcopy(self.config.chat_template_kwargs)

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -3821,3 +3821,53 @@ class TestTopLogprobsHandling:
             )
         # The tokenize endpoint must not be reached once the contract check fails.
         mock_client.create_tokenize.assert_not_called()
+
+
+class TestToolChoiceNormalization:
+    """`_preprocess_chat_completion_create_params` must not forward a
+    tool_choice other than "none" when the request has no tools.
+
+    vLLM's OpenAI ChatCompletion validator raises
+    ``Value error, When using `tool_choice`, `tools` must be set.`` in that case,
+    which returns HTTP 500 and (in NeMo-RL) tears down the whole rollout/training
+    run. No-tool agents such as an LLM-as-judge still send the OpenAI-default
+    ``tool_choice="auto"`` / ``parallel_tool_calls=True``, so the model server
+    must strip them.
+    """
+
+    def test_auto_tool_choice_without_tools_is_dropped(self) -> None:
+        model = _make_minimal_audio_model()
+        body = {
+            "model": "dummy-model",
+            "messages": [{"role": "user", "content": "Which document is correct?"}],
+            "tool_choice": "auto",
+            "parallel_tool_calls": True,
+        }
+        result = model._preprocess_chat_completion_create_params(MagicMock(), body)
+        assert "tool_choice" not in result
+        assert "parallel_tool_calls" not in result
+
+    def test_explicit_none_tool_choice_is_preserved(self) -> None:
+        model = _make_minimal_audio_model()
+        body = {
+            "model": "dummy-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": "none",
+        }
+        result = model._preprocess_chat_completion_create_params(MagicMock(), body)
+        assert result["tool_choice"] == "none"
+
+    def test_tool_choice_with_tools_is_untouched(self) -> None:
+        model = _make_minimal_audio_model()
+        tools = [{"type": "function", "function": {"name": "noop", "parameters": {}}}]
+        body = {
+            "model": "dummy-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": "auto",
+            "parallel_tool_calls": True,
+            "tools": tools,
+        }
+        result = model._preprocess_chat_completion_create_params(MagicMock(), body)
+        assert result["tool_choice"] == "auto"
+        assert result["parallel_tool_calls"] is True
+        assert result["tools"] == tools


### PR DESCRIPTION
# PR title

fix(vllm_model): drop orphan tool_choice/parallel_tool_calls when a request has no tools

---

# PR description

## Problem

A no-tool agent (e.g. an LLM-as-judge) that sends the OpenAI-default `tool_choice="auto"` (or any value other than `"none"`) with **no `tools`** trips vLLM's OpenAI ChatCompletion request validator:

```
Value error, When using `tool_choice`, `tools` must be set.
```

The `vllm_model` server returns HTTP 500. Under NeMo-RL this 500 propagates up the judge `simple_agent` → gym `/run` → `NemoGym.run_rollouts` → `AsyncTrajectoryCollector`, which kills the driver and tears down the whole cluster — surfacing downstream as unrelated NCCL / `TCPStore ... Connection reset by peer` errors that make it look like a distributed-comm hang.

This is a **data-shape** issue: any dataset row whose `responses_create_params` explicitly sets `tool_choice` to a non-`"none"` value while carrying no/empty `tools`. In one training blend this was ~5% of rows. The default does **not** leak (both `ServerClient` and the responses→chat converter serialize with `model_dump(exclude_unset=True)`), so only rows that explicitly set `tool_choice` are affected; rows with tools, without `tool_choice`, or with `tool_choice="none"` are unaffected.

## Fix

Normalize the outbound request in `VLLMModel._preprocess_chat_completion_create_params` (the last mutation before `client.create_chat_completion`, so it covers both the `/chat/completions` and `/responses`→chat paths): when the request has no tools, drop a non-`"none"` `tool_choice` and `parallel_tool_calls`.

```python
if not body_dict.get("tools"):
    if body_dict.get("tool_choice") not in (None, "none"):
        body_dict.pop("tool_choice", None)
    body_dict.pop("parallel_tool_calls", None)
```

- An explicit `tool_choice="none"` is preserved (vLLM treats it as a no-op).
- Tool-using requests are untouched.
- Matches vLLM/OpenAI Chat Completions semantics.

## Tests

`tests/test_app.py::TestToolChoiceNormalization` — drops `auto`+no-tools, preserves explicit `none`, leaves tool-using requests intact. All pass.

## Verification

Reproduced against the real vLLM 0.20.0 `ChatCompletionRequest` validator: the exact crashing payload → the value error; after the fix → validates. The patched `_preprocess` was also exercised directly on the crashing payload with the same result (unpatched control still rejected, confirming the fix is load-bearing).
