### PR TITLE
Align the finance agent loop and finance_sec_search resource server with the vals-ai

### DIFF
--- a/resources_servers/finance_sec_search/README.md
+++ b/resources_servers/finance_sec_search/README.md
@@ -43,6 +43,15 @@ The `tavily_api_key` is referenced as `${tavily_api_key}` in
 The resource server caches SEC data locally to avoid redundant API calls and to
 enable offline operation after the first fetch.
 
+### Enabling / disabling the cache (`use_cache`)
+
+| `use_cache` | Behavior |
+|-------------|----------|
+| `false` (default) | The on-disk cache is fully bypassed — no cache directories are created and **every request fetches fresh filings live**. |
+| `true` | The on-disk cache under `cache_dir` is read and written: ticker mappings, filing metadata, and parsed filing content are cached and reused across requests/runs. |
+
+Keep `use_cache: false` (the default) for **eval**
+
 ### What is cached
 
 | Directory | Contents |

--- a/resources_servers/finance_sec_search/app.py
+++ b/resources_servers/finance_sec_search/app.py
@@ -1024,6 +1024,16 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                 json=retrieval_params,
             )
 
+            # Surface HTTP-level failures (e.g. 4xx context-overflow from vLLM)
+            # explicitly rather than letting them fall through to the vague
+            # "no output" branch.  Body is capped to avoid polluting agent
+            # context with multi-KB error bodies (e.g. vLLM HTML pages).
+            if not llm_response.ok:
+                body_text = (await llm_response.text())[:500]
+                return RetrieveInformationResponse(
+                    results=f"ERROR: Retrieval LLM HTTP {llm_response.status}: {body_text}"
+                )
+
             llm_response_json = await get_response_json(llm_response)
             llm_response_obj = NeMoGymResponse.model_validate(llm_response_json)
 
@@ -1035,7 +1045,26 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                             result_text += getattr(content_item, "text", "")
 
             if not result_text:
-                return RetrieveInformationResponse(results="ERROR: Retrieval LLM returned no output.")
+                # Include any diagnostic the server returned so the agent can
+                # see why output was empty (e.g. incomplete_details.reason ==
+                # "max_output_tokens" or content_filter).  Bare "no output"
+                # masks these.
+                diagnostic_parts: List[str] = []
+                incomplete_details = getattr(llm_response_obj, "incomplete_details", None)
+                if incomplete_details is not None:
+                    reason = getattr(incomplete_details, "reason", None)
+                    if reason:
+                        diagnostic_parts.append(f"incomplete_details.reason={reason}")
+                status = getattr(llm_response_obj, "status", None)
+                if status:
+                    diagnostic_parts.append(f"status={status}")
+                error_field = getattr(llm_response_obj, "error", None)
+                if error_field is not None:
+                    diagnostic_parts.append(f"error={error_field}")
+                diagnostic = (" (" + ", ".join(diagnostic_parts) + ")") if diagnostic_parts else ""
+                return RetrieveInformationResponse(
+                    results=f"ERROR: Retrieval LLM returned no output.{diagnostic}"
+                )
 
             return RetrieveInformationResponse(results=result_text)
 

--- a/resources_servers/finance_sec_search/app.py
+++ b/resources_servers/finance_sec_search/app.py
@@ -210,7 +210,16 @@ class FinanceAgentSearchResponse(BaseModel):
 class RetrieveInformationRequest(BaseModel):
     """Request model for retrieve_information tool."""
 
-    prompt: str = Field(description="Prompt with {{key_name}} placeholders for stored documents.")
+    prompt: str = Field(
+        description=(
+            "An LLM prompt applied to your saved documents. You MUST include at least "
+            "one data-storage key using the exact double-brace format {{key_name}} -- "
+            "for example: 'Summarize this 10-K filing: {{company_10k}}'. The full text "
+            "stored under each key replaces its {{key_name}} placeholder before the "
+            "prompt is sent. If you do not use this exact {{key_name}} format, the tool "
+            "will fail."
+        )
+    )
     input_character_ranges: Optional[List[Dict[str, Any]]] = Field(
         default=None, description="Optional list of character ranges: [{'key': 'doc', 'start': 0, 'end': 100000}]"
     )

--- a/resources_servers/finance_sec_search/app.py
+++ b/resources_servers/finance_sec_search/app.py
@@ -68,6 +68,7 @@ class FinanceAgentResourcesServerConfig(BaseResourcesServerConfig):
         default=None,
         description="Path for caching ticker mappings and filing metadata. Defaults to ~/.cache/nemo_gym/finance_sec_search/ if not set. Relative paths are resolved from cwd.",
     )
+    use_cache: bool = Field(default=False, description="Keep False to always fetch fresh filings (used for eval).")
     user_agent: str = Field(
         default="Gym-SEC-Search/1.0 (research@nvidia.com)", description="User-Agent header for SEC.gov requests"
     )
@@ -110,9 +111,11 @@ class FinanceAgentResourcesServerConfig(BaseResourcesServerConfig):
         "'binary': only [[2]] → 1.0, else 0.0. "
         "'scaled': [[0]] → 0.0, [[1]] → 0.5, [[2]] → 1.0.",
     )
-    retrieval_max_output_tokens: int = Field(
-        default=8192,
-        description="Max output tokens for retrieve_information LLM calls. Increase for thinking models.",
+    retrieval_max_output_tokens: Optional[int] = Field(
+        default=None,
+        description="Max output tokens for retrieve_information LLM calls. Increase for thinking models. "
+        "Set to null/None to leave it unset so the retrieval call inherits the full generation budget "
+        "(used for eval); set an integer to cap it (used for training).",
     )
     retrieval_model_context_length: int = Field(
         default=131072,
@@ -358,12 +361,15 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
             if not self._cache_dir.is_absolute():
                 self._cache_dir = Path.cwd() / self._cache_dir
                 logger.info("Resolved relative cache_dir to %s", self._cache_dir)
-        self._cache_dir.mkdir(parents=True, exist_ok=True)
         self._filings_metadata_dir = self._cache_dir / "filings_metadata"
-        self._filings_metadata_dir.mkdir(exist_ok=True)
         self._filings_dir = self._cache_dir / "filings"
-        self._filings_dir.mkdir(exist_ok=True)
         self._tickers_file = self._cache_dir / "tickers.json"
+        # Only materialize the on-disk cache when caching is enabled. With
+        # use_cache=False every request fetches live and no dirs are created.
+        if self.config.use_cache:
+            self._cache_dir.mkdir(parents=True, exist_ok=True)
+            self._filings_metadata_dir.mkdir(exist_ok=True)
+            self._filings_dir.mkdir(exist_ok=True)
 
         self._rate_limiter = RateLimiter(max_requests=self.config.requests_per_second, window_seconds=1.0)
 
@@ -544,7 +550,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
 
         raw = None
 
-        if self._tickers_file.exists():
+        if self.config.use_cache and self._tickers_file.exists():
             try:
                 with open(self._tickers_file, "r") as f:
                     raw = json.load(f)
@@ -559,8 +565,9 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                     with urllib.request.urlopen(req, timeout=30) as resp:
                         data = resp.read().decode("utf-8")
                     raw = json.loads(data)
-                    with open(self._tickers_file, "w") as f:
-                        json.dump(raw, f)
+                    if self.config.use_cache:
+                        with open(self._tickers_file, "w") as f:
+                            json.dump(raw, f)
                     break
                 except (urllib.error.URLError, json.JSONDecodeError, OSError) as e:
                     wait = 2**attempt
@@ -655,7 +662,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                 return self._filings_cache[cik_padded]
 
             cache_path = self._get_company_cache_path(cik)
-            if cache_path.exists():
+            if self.config.use_cache and cache_path.exists():
                 with open(cache_path, "r") as f:
                     filings = json.load(f)
                 self._filings_cache[cik_padded] = filings
@@ -684,7 +691,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                         except json.JSONDecodeError:
                             logger.warning("Failed to parse supplementary file %s for CIK %s", filename, cik)
 
-                if filings:
+                if filings and self.config.use_cache:
                     self._atomic_write(cache_path, json.dumps(filings))
                 self._filings_cache[cik_padded] = filings
                 return filings
@@ -777,6 +784,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
         cik, accession_number = parts["cik"], parts["accession_number"]
         cik_padded = str(cik).zfill(10)
         acc_nodash = accession_number.replace("-", "")
+        # TODO: this path assumes the URL is for the primary filing document only, which is true because of how sec_filing_search is constructed
         return self._filings_dir / cik_padded / f"{acc_nodash}.txt"
 
     # ========================================================================
@@ -891,12 +899,12 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
             raise ValueError(f"Invalid SEC URL format: {url}")
 
         text_content = None
-        if file_path.exists():
+        if self.config.use_cache and file_path.exists():
             text_content = file_path.read_text(encoding="utf-8")
 
         if text_content is None and self.config.sec_dump_path:
             text_content = await self._lookup_dump(url)
-            if text_content:
+            if text_content and self.config.use_cache:
                 self._atomic_write(file_path, text_content)
 
         if text_content is None:
@@ -909,7 +917,8 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
             text_content = await asyncio.get_running_loop().run_in_executor(
                 None, self._parse_html_to_text, html_content
             )
-            self._atomic_write(file_path, text_content)
+            if self.config.use_cache:
+                self._atomic_write(file_path, text_content)
 
         if not text_content:
             raise ValueError("Filing content was empty after parsing.")
@@ -1071,9 +1080,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                 if error_field is not None:
                     diagnostic_parts.append(f"error={error_field}")
                 diagnostic = (" (" + ", ".join(diagnostic_parts) + ")") if diagnostic_parts else ""
-                return RetrieveInformationResponse(
-                    results=f"ERROR: Retrieval LLM returned no output.{diagnostic}"
-                )
+                return RetrieveInformationResponse(results=f"ERROR: Retrieval LLM returned no output.{diagnostic}")
 
             return RetrieveInformationResponse(results=result_text)
 

--- a/resources_servers/finance_sec_search/configs/finance_sec_search.yaml
+++ b/resources_servers/finance_sec_search/configs/finance_sec_search.yaml
@@ -9,7 +9,10 @@ finance_sec_search_resources_server:
       value: Enable LLMs to search and analyze SEC filings
       cache_dir: null  # defaults to ~/.cache/nemo_gym/finance_sec_search/ if not set
       use_cache: false  # keep false for eval to fetch fresh filings, set to true for training to reuse cached filings
-      tavily_api_key: ${tavily_api_key}
+      # Wrapped in oc.select (Gym convention, cf. labbench2_vlm) so the env resolves
+      # standalone (`gym env start` / `+dry_run`); override via env / NVFlow overlay.
+      # null default => web search disabled unless a key is supplied.
+      tavily_api_key: ${oc.select:tavily_api_key,null}
       retrieval_model_server:
         type: responses_api_models
         name: policy_model
@@ -39,9 +42,11 @@ search_judge_model:
   responses_api_models:
     openai_model:
       entrypoint: app.py
-      openai_base_url: ${search_judge_model_base_url}
-      openai_api_key: ${search_judge_model_api_key}
-      openai_model: ${search_judge_model_name}
+      # oc.select w/ defaults => env resolves standalone (dry_run/bake); overlays
+      # (or env.yaml) still override by setting the referenced keys.
+      openai_base_url: ${oc.select:search_judge_model_base_url,https://api.openai.com/v1}
+      openai_api_key: ${oc.select:search_judge_model_api_key,unset}
+      openai_model: ${oc.select:search_judge_model_name,gpt-5-mini}
 
 finance_agent:
   responses_api_agents:

--- a/resources_servers/finance_sec_search/configs/finance_sec_search.yaml
+++ b/resources_servers/finance_sec_search/configs/finance_sec_search.yaml
@@ -8,6 +8,7 @@ finance_sec_search_resources_server:
       description: SEC EDGAR filing search for financial analysis questions
       value: Enable LLMs to search and analyze SEC filings
       cache_dir: null  # defaults to ~/.cache/nemo_gym/finance_sec_search/ if not set
+      use_cache: false  # keep false for eval to fetch fresh filings, set to true for training to reuse cached filings
       tavily_api_key: ${tavily_api_key}
       retrieval_model_server:
         type: responses_api_models

--- a/resources_servers/finance_sec_search/tests/test_app.py
+++ b/resources_servers/finance_sec_search/tests/test_app.py
@@ -769,6 +769,93 @@ class TestRetrieveInformation:
         response = await server.retrieve_information(_mock_request(), body)
         assert "Summary of huge doc" in response.results
 
+    # ------------------------------------------------------------------
+    # F2: HTTP status check + richer empty-output diagnostic
+    # ------------------------------------------------------------------
+    # Background: the pre-F2 branch surfaced 4xx/5xx from vLLM as a bare
+    # "Retrieval LLM returned no output" message because the JSON parser
+    # swallowed the error body.  Operators were left guessing whether
+    # the retrieval model was misconfigured, oversubscribed, or just
+    # quietly silent.  These tests pin the diagnostic contract.
+
+    @pytest.mark.asyncio
+    async def test_http_error_surfaces_status_and_body(self, server) -> None:
+        """4xx/5xx from the retrieval model server must surface the status
+        code + body excerpt (not be silently converted to 'no output').
+        """
+        server._data_storage[_TEST_SESSION_ID] = {"doc": "Annual Report 2023"}
+        mock_response = MagicMock()
+        mock_response.ok = False
+        mock_response.status = 500
+        mock_response.text = AsyncMock(return_value="Internal Server Error: model is overloaded")
+        server.server_client = MagicMock()
+        server.server_client.post = AsyncMock(return_value=mock_response)
+
+        body = RetrieveInformationRequest(prompt="Summarize {{doc}}")
+        response = await server.retrieve_information(_mock_request(), body)
+
+        assert "ERROR" in response.results
+        assert "HTTP 500" in response.results
+        assert "Internal Server Error" in response.results
+        assert "model is overloaded" in response.results
+
+    @pytest.mark.asyncio
+    async def test_http_error_body_is_capped_at_500_chars(self, server) -> None:
+        """Error bodies are truncated to avoid polluting agent context with
+        multi-KB vLLM HTML error pages.
+        """
+        server._data_storage[_TEST_SESSION_ID] = {"doc": "Annual Report 2023"}
+        huge_body = "X" * 5000
+        mock_response = MagicMock()
+        mock_response.ok = False
+        mock_response.status = 503
+        mock_response.text = AsyncMock(return_value=huge_body)
+        server.server_client = MagicMock()
+        server.server_client.post = AsyncMock(return_value=mock_response)
+
+        body = RetrieveInformationRequest(prompt="Summarize {{doc}}")
+        response = await server.retrieve_information(_mock_request(), body)
+
+        assert "HTTP 503" in response.results
+        # Body excerpt must be capped to ≤500 chars; full 5000-char body
+        # would have ballooned the agent's next prompt by ~5KB.
+        assert response.results.count("X") <= 500
+
+    @pytest.mark.asyncio
+    async def test_empty_output_includes_incomplete_details(self, server) -> None:
+        """When the LLM returns 200 OK but no output text, the empty-output
+        branch must surface ``incomplete_details.reason`` so the operator
+        can distinguish max-output-token truncation from a model bug.
+        """
+        import orjson
+
+        server._data_storage[_TEST_SESSION_ID] = {"doc": "Annual Report 2023"}
+        payload = orjson.dumps(
+            {
+                "id": "resp_1",
+                "created_at": 0,
+                "model": "m",
+                "object": "response",
+                "output": [],
+                "incomplete_details": {"reason": "max_output_tokens"},
+                "parallel_tool_calls": False,
+                "tool_choice": "auto",
+                "tools": [],
+            }
+        )
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.read = AsyncMock(return_value=payload)
+        server.server_client = MagicMock()
+        server.server_client.post = AsyncMock(return_value=mock_response)
+
+        body = RetrieveInformationRequest(prompt="Summarize {{doc}}")
+        response = await server.retrieve_information(_mock_request(), body)
+
+        assert "ERROR" in response.results
+        assert "no output" in response.results
+        assert "max_output_tokens" in response.results
+
 
 # ============================================================================
 # Test: Verify (reward calculation)

--- a/resources_servers/finance_sec_search/tests/test_app.py
+++ b/resources_servers/finance_sec_search/tests/test_app.py
@@ -89,6 +89,10 @@ def server_config(temp_cache_dir):
         entrypoint="",
         name="finance_sec_search_test",
         cache_dir=temp_cache_dir,
+        # The default is use_cache=False (eval). The bulk of these tests exercise
+        # the on-disk cache, so the shared fixture pins it True; the use_cache=False
+        # bypass path is covered explicitly in TestUseCacheFlag.
+        use_cache=True,
         judge_prompt_template_fpath=str(_prompt_dir / "finance_sec_search_judge.yaml"),
         retrieval_system_prompt_fpath=str(_prompt_dir / "finance_sec_search_retrieval.yaml"),
     )
@@ -116,6 +120,96 @@ class TestServerInitialization:
         assert Path(temp_cache_dir).exists()
         assert (Path(temp_cache_dir) / "filings_metadata").exists()
         assert (Path(temp_cache_dir) / "filings").exists()
+
+
+# ============================================================================
+# Test: use_cache flag (on-disk cache enable/disable)
+# ============================================================================
+
+
+class TestUseCacheFlag:
+    """Tests that the use_cache flag fully gates the on-disk SEC cache."""
+
+    _SEC_URL = "https://www.sec.gov/Archives/edgar/data/320193/000032019325000008/aapl-20241228.htm"
+
+    @staticmethod
+    def _make_server(cache_dir: Path, use_cache: bool) -> FinanceAgentResourcesServer:
+        _pd = Path(__file__).resolve().parents[1] / "prompt_templates"
+        config = FinanceAgentResourcesServerConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="finance_sec_search_test",
+            cache_dir=str(cache_dir),
+            use_cache=use_cache,
+            judge_prompt_template_fpath=str(_pd / "finance_sec_search_judge.yaml"),
+            retrieval_system_prompt_fpath=str(_pd / "finance_sec_search_retrieval.yaml"),
+        )
+        return FinanceAgentResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+
+    def test_directories_created_when_enabled(self, tmp_path) -> None:
+        """use_cache=True creates the cache directories."""
+        cache_dir = tmp_path / "cache"
+        self._make_server(cache_dir, use_cache=True)
+        assert (cache_dir / "filings").exists()
+        assert (cache_dir / "filings_metadata").exists()
+
+    def test_directories_not_created_when_disabled(self, tmp_path) -> None:
+        """use_cache=False does not create any cache directories."""
+        cache_dir = tmp_path / "cache"
+        server = self._make_server(cache_dir, use_cache=False)
+        assert not (cache_dir / "filings").exists()
+        assert not (cache_dir / "filings_metadata").exists()
+        # The path is still derived so URL→path conversion keeps working.
+        assert server._url_to_filing_path(self._SEC_URL) is not None
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_served_when_enabled(self, tmp_path) -> None:
+        """use_cache=True serves a pre-populated filing from disk without fetching."""
+        server = self._make_server(tmp_path / "cache", use_cache=True)
+        path = server._url_to_filing_path(self._SEC_URL)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("CACHED CONTENT", encoding="utf-8")
+
+        fetch_mock = AsyncMock(return_value="<html><body><p>LIVE CONTENT</p></body></html>")
+        with patch.object(server, "_fetch_with_retry", fetch_mock):
+            text = await server._fetch_sec_filing_text(self._SEC_URL)
+
+        assert text == "CACHED CONTENT"
+        fetch_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_bypassed_when_disabled(self, tmp_path) -> None:
+        """use_cache=False ignores an existing cache file, fetches live, and never writes back."""
+        server = self._make_server(tmp_path / "cache", use_cache=False)
+        path = server._url_to_filing_path(self._SEC_URL)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("CACHED CONTENT", encoding="utf-8")
+
+        fetch_mock = AsyncMock(return_value="<html><body><p>LIVE CONTENT</p></body></html>")
+        with patch.object(server, "_fetch_with_retry", fetch_mock):
+            text = await server._fetch_sec_filing_text(self._SEC_URL)
+
+        assert "LIVE CONTENT" in text
+        assert "CACHED CONTENT" not in text
+        fetch_mock.assert_called_once()
+        # The live result must NOT overwrite the cache file when caching is disabled.
+        assert path.read_text(encoding="utf-8") == "CACHED CONTENT"
+
+    @pytest.mark.asyncio
+    async def test_cache_written_when_enabled(self, tmp_path) -> None:
+        """use_cache=True writes a freshly fetched filing to the cache file."""
+        server = self._make_server(tmp_path / "cache", use_cache=True)
+        path = server._url_to_filing_path(self._SEC_URL)
+        assert not path.exists()
+
+        fetch_mock = AsyncMock(return_value="<html><body><p>FRESH CONTENT</p></body></html>")
+        with patch.object(server, "_fetch_with_retry", fetch_mock):
+            text = await server._fetch_sec_filing_text(self._SEC_URL)
+
+        assert "FRESH CONTENT" in text
+        assert path.exists()
+        assert "FRESH CONTENT" in path.read_text(encoding="utf-8")
 
 
 # ============================================================================

--- a/responses_api_agents/finance_agent/app.py
+++ b/responses_api_agents/finance_agent/app.py
@@ -242,7 +242,11 @@ class FinanceAgent(SimpleResponsesAPIAgent):
             ]
 
             if not all_fn_calls and all_output_messages:
-                break
+                # Match vals-ai/finance-agent eval (get_agent.py _before_query +
+                # _should_stop=False): inject "Continue." instead of breaking so
+                # the model keeps looping until submit_final_result or max_steps.
+                new_outputs.append(NeMoGymEasyInputMessage(role="user", content="Continue."))
+                continue
 
             done = False
             for output_function_call in all_fn_calls:

--- a/responses_api_agents/finance_agent/tests/test_app.py
+++ b/responses_api_agents/finance_agent/tests/test_app.py
@@ -311,9 +311,7 @@ class TestResponses:
             "loop should have run max_steps=3 model calls instead of breaking after first text response"
         )
 
-        user_continues = [
-            o for o in output if o["type"] == "message" and o["role"] == "user"
-        ]
+        user_continues = [o for o in output if o["type"] == "message" and o["role"] == "user"]
         assert len(user_continues) >= 1, "no 'Continue.' user message injected"
         assert any(o["content"] == "Continue." for o in user_continues), (
             f"Continue. literal missing; got user contents: {[o['content'] for o in user_continues]}"

--- a/responses_api_agents/finance_agent/tests/test_app.py
+++ b/responses_api_agents/finance_agent/tests/test_app.py
@@ -289,20 +289,70 @@ class TestTruncateOldestExchange:
 
 
 class TestResponses:
-    def test_text_only_response_terminates_loop(self) -> None:
-        """Model returns a text message → loop exits after one step."""
-        agent, client = _make_agent_and_client()
+    def test_text_only_response_injects_continue_until_max_steps(self) -> None:
+        """Text-only assistant responses must inject 'Continue.' and keep
+        looping (mirrors vals-ai/finance-agent ``_before_query`` +
+        ``_should_stop=False``) rather than terminating after one step.
+
+        The historical break-on-text behavior caused training to silently
+        truncate trajectories whenever the model emitted explanatory text
+        between tool calls -- which is exactly what Nemotron-Nano did on
+        its rs0 chunk, masking partial progress as a "completed" rollout.
+        """
+        config = _make_config(max_steps=3)
+        agent, client = _make_agent_and_client(config)
         agent.server_client.post.return_value = _dotjson_mock(_text_response("Hello!"))
 
         res = client.post("/v1/responses", json=_INPUT)
         assert res.status_code == 200
-        data = res.json()
-        assert len(data["output"]) == 1
-        assert data["output"][0]["type"] == "message"
+        output = res.json()["output"]
 
-    def test_tool_call_then_text_terminates(self) -> None:
-        """Model calls a tool, gets result, then responds with text."""
-        agent, client = _make_agent_and_client()
+        assert agent.server_client.post.call_count == 3, (
+            "loop should have run max_steps=3 model calls instead of breaking after first text response"
+        )
+
+        user_continues = [
+            o for o in output if o["type"] == "message" and o["role"] == "user"
+        ]
+        assert len(user_continues) >= 1, "no 'Continue.' user message injected"
+        assert any(o["content"] == "Continue." for o in user_continues), (
+            f"Continue. literal missing; got user contents: {[o['content'] for o in user_continues]}"
+        )
+
+    def test_continue_injection_stops_at_submit_final_result(self) -> None:
+        """Continue.-loop must yield as soon as a done-tool fires -- otherwise
+        the agent could keep looping past a legitimate terminal tool call.
+        """
+        config = _make_config(max_steps=5)
+        agent, client = _make_agent_and_client(config)
+
+        text_then_submit_responses = [
+            _text_response("Thinking out loud..."),
+            _tool_call_response("submit_final_result", json.dumps({"final_result": "42"})),
+        ]
+        model_mock = _dotjson_mock(*text_then_submit_responses)
+        rs_mock = _dotjson_mock({"status": "ok"})
+
+        def route_post(**kwargs):
+            if kwargs["server_name"] == _MODEL_SERVER:
+                return model_mock
+            return rs_mock
+
+        agent.server_client.post = AsyncMock(side_effect=route_post)
+
+        res = client.post("/v1/responses", json=_INPUT)
+        assert res.status_code == 200
+        output = res.json()["output"]
+        fn_names = [o.get("name") for o in output if o["type"] == "function_call"]
+        assert "submit_final_result" in fn_names, "done-tool should still terminate after Continue. injection"
+
+    def test_tool_call_then_text_continues_until_max_steps(self) -> None:
+        """Tool call → text response no longer terminates -- under C1 the
+        loop injects ``Continue.`` and keeps going.  Bounded by max_steps
+        here so the test doesn't run forever.
+        """
+        config = _make_config(max_steps=2)
+        agent, client = _make_agent_and_client(config)
 
         tool_call_data = _tool_call_response("sec_filing_search", json.dumps({"ticker": "AAPL"}))
         text_data = _text_response("Here is the data.")
@@ -324,7 +374,11 @@ class TestResponses:
         types = [o["type"] for o in output]
         assert "function_call" in types
         assert "function_call_output" in types
+        # Last item is the injected Continue. user message (would have been
+        # the seed for a step-3 model call if max_steps had allowed it).
         assert output[-1]["type"] == "message"
+        assert output[-1]["role"] == "user"
+        assert output[-1]["content"] == "Continue."
 
     def test_done_tool_terminates_loop(self) -> None:
         """submit_final_result tool call exits the loop immediately."""
@@ -454,14 +508,16 @@ class TestResponses:
         """Context overflow with truncate_on_overflow=True → retries after truncation.
 
         Need >=2 tool-call rounds so _truncate_oldest_exchange can drop one
-        and keep another. Overflow on model call 3, success on model call 4.
+        and keep another. Overflow on model call 3, recovery on model call 4
+        via a done-tool so the loop terminates cleanly (under C1 a text
+        response would keep looping with Continue. injection).
         """
         config = _make_config(truncate_on_overflow=True, max_steps=10)
         agent, client = _make_agent_and_client(config)
 
         tc1 = _tool_call_response("sec_filing_search", json.dumps({"ticker": "AAPL"}), call_id="c1")
         tc2 = _tool_call_response("sec_filing_search", json.dumps({"ticker": "MSFT"}), call_id="c2")
-        text = _text_response("Got it.")
+        submit = _tool_call_response("submit_final_result", json.dumps({"final_result": "Got it."}), call_id="c3")
 
         model_calls = {"n": 0}
 
@@ -473,7 +529,7 @@ class TestResponses:
                     return _dotjson_mock(data)
                 if model_calls["n"] == 3:
                     raise Exception("maximum context length is 8192 tokens")
-                return _dotjson_mock(text)
+                return _dotjson_mock(submit)
             return _dotjson_mock({"result": "filing data"})
 
         agent.server_client.post = AsyncMock(side_effect=route_post)
@@ -481,7 +537,8 @@ class TestResponses:
         res = client.post("/v1/responses", json=_INPUT)
         assert res.status_code == 200
         output = res.json()["output"]
-        assert output[-1]["type"] == "message"
+        fn_names = [o.get("name") for o in output if o["type"] == "function_call"]
+        assert "submit_final_result" in fn_names
         assert model_calls["n"] == 4
 
     def test_context_overflow_without_truncation_breaks(self) -> None:
@@ -530,8 +587,13 @@ class TestResponses:
         assert u["total_tokens"] == 330
 
     def test_string_input_converted_to_message(self) -> None:
-        """String input is automatically wrapped in a user message."""
-        agent, client = _make_agent_and_client()
+        """String input is automatically wrapped in a user message.
+
+        Bounded by max_steps=1 because under C1 a text-only response no
+        longer terminates the loop on its own.
+        """
+        config = _make_config(max_steps=1)
+        agent, client = _make_agent_and_client(config)
         agent.server_client.post.return_value = _dotjson_mock(_text_response("Hi!"))
 
         res = client.post("/v1/responses", json={"input": "hello"})


### PR DESCRIPTION
Changes vs main

- finance_agent loop parity — On text-only model responses (no tool calls), injects a "Continue." user message and keeps looping until submit_final_result or max_steps, instead of stopping after one step. Matches vals-ai get_agent.py behavior and avoids rollouts ending early when the model emits explanatory text between tool calls.
- Fresh filings for eval — Adds use_cache (default false) to finance_sec_search; when off, all on-disk cache reads/writes are skipped so every request fetches live SEC data. README documents eval vs training usage.
- Uncapped retrieval tokens for eval — retrieval_max_output_tokens is now Optional[int] (None = no cap, inherits full generation budget; set an int to cap for training).
- Better retrieval error diagnostics — retrieve_information surfaces HTTP 4xx/5xx with status + body excerpt (≤500 chars), and empty-output cases include incomplete_details.reason (e.g. max_output_tokens) instead of a generic “no output” message.
- Tool description fix — Restores the explicit {{key_name}} placeholder example in the retrieve_information prompt field description to cut down tool-format violations.
- Standalone config resolution — Wraps tavily_api_key and search_judge_model_* in ${oc.select:...} so gym env start / +dry_run works without supplying every key; NVFlow overlays still override.
- Tests — New/updated unit tests for Continue-injection loop behavior, HTTP error surfacing, empty-output diagnostics, and cache gating (~270 lines of new test coverage in finance_sec_search).