### PR TITLE
feat: extend `gym list` and `gym search` commands

### DIFF
--- a/nemo_gym/benchmarks.py
+++ b/nemo_gym/benchmarks.py
@@ -39,7 +39,7 @@ BENCHMARKS_DIR = PARENT_DIR / BENCHMARKS_SUBDIR
 
 
 class BenchmarkConfig(BaseModel):
-    name: str
+    name: str  # this is a dataset name, not the config name (they are usually the same)
     path: Path
     agent_name: str
     num_repeats: int
@@ -101,29 +101,16 @@ class BenchmarkConfig(BaseModel):
         )
 
 
-def _load_benchmarks_from_config_paths(config_paths: List[Path]) -> Dict[str, BenchmarkConfig]:
-    benchmarks_dict = dict()
-    for config_path in config_paths:
-        config_path = Path(config_path)
+def _benchmark_config_name(rel_config_path: Path) -> str:
+    """The name of the benchmark config, given its path relative to ``benchmarks/``, sans ``.yaml``.
 
-        try:
-            # Listing has no runtime context, so tolerate unset runtime-only values.
-            maybe_bc = BenchmarkConfig.from_config_path(config_path, strict=False)
-        except Exception as e:
-            # Still unresolvable (e.g. a multi-benchmark suite) — skip with a warning rather than fail the
-            # whole listing, so it isn't silently invisible.
-            print(
-                f"Warning: skipping benchmark config '{config_path}': could not resolve it "
-                f"({type(e).__name__}: {str(e).splitlines()[0]}).",
-                file=sys.stderr,
-            )
-            continue
-        if not maybe_bc:
-            continue
-
-        benchmarks_dict[maybe_bc.name] = maybe_bc
-
-    return benchmarks_dict
+    This is the identity we key benchmarks by, so a listed benchmark is always a valid ``--benchmark`` argument.
+    """
+    rel = rel_config_path.with_suffix("")
+    parts = rel.parts
+    if len(parts) == 2 and parts[1] == "config":
+        return parts[0]
+    return rel.as_posix()
 
 
 def _is_benchmark_config(config_path: Path) -> bool:
@@ -161,7 +148,26 @@ def _benchmark_config_paths(benchmarks_dir: Path) -> List[Path]:
 
 def _discover_benchmarks_in_dir(benchmarks_dir: Path) -> Dict[str, BenchmarkConfig]:
     """Map benchmark name -> :class:`BenchmarkConfig` for every benchmark config under one dir."""
-    return _load_benchmarks_from_config_paths(_benchmark_config_paths(benchmarks_dir))
+    benchmarks_dict = dict()
+    for config_path in _benchmark_config_paths(benchmarks_dir):
+        try:
+            # Listing has no runtime context, so tolerate unset runtime-only values.
+            maybe_bc = BenchmarkConfig.from_config_path(config_path, strict=False)
+        except Exception as e:
+            # Still unresolvable (e.g. a multi-benchmark suite) — skip with a warning rather than fail the
+            # whole listing, so it isn't silently invisible.
+            print(
+                f"Warning: skipping benchmark config '{config_path}': could not resolve it "
+                f"({type(e).__name__}: {str(e).splitlines()[0]}).",
+                file=sys.stderr,
+            )
+            continue
+        if not maybe_bc:
+            continue
+
+        benchmarks_dict[_benchmark_config_name(config_path.relative_to(benchmarks_dir))] = maybe_bc
+
+    return benchmarks_dict
 
 
 def discover_benchmarks() -> Dict[str, BenchmarkConfig]:

--- a/nemo_gym/cli/agents.py
+++ b/nemo_gym/cli/agents.py
@@ -14,14 +14,14 @@
 # limitations under the License.
 import json
 
-import rich
 from rich.table import Table
 
 from nemo_gym.agent_registry import discover_agents
-from nemo_gym.cli.utils import print_rich_table
+from nemo_gym.cli.utils import fuzzy_matches, print_no_matches, print_rich_table
 from nemo_gym.config_types import BaseNeMoGymCLIConfig
 from nemo_gym.global_config import (
     JSON_OUTPUT_KEY_NAME,
+    QUERY_KEY_NAME,
     GlobalConfigDictParserConfig,
     get_global_config_dict,
 )
@@ -29,8 +29,9 @@ from nemo_gym.global_config import (
 
 def list_agents() -> None:
     """List discovered agent harnesses and how each composes: freely wireable into a separate environment
-    (Pattern A) vs. self-contained harnesses that run with their own config (Pattern B). ``--search-dir``
-    adds extra roots to scan on top of the cwd and built-ins.
+    (Pattern A) vs. self-contained harnesses that run with their own config (Pattern B). Optionally filtered
+    by a `query` (the `gym search agents` entry point). ``--search-dir`` adds extra roots on top of the cwd
+    and built-ins.
     """
     global_config_dict = get_global_config_dict(
         global_config_dict_parser_config=GlobalConfigDictParserConfig(
@@ -40,6 +41,11 @@ def list_agents() -> None:
     BaseNeMoGymCLIConfig.model_validate(global_config_dict)
 
     agents = discover_agents()
+
+    # `gym search agents <query>` reuses this command, narrowing to fuzzy matches on name + variant names.
+    query = global_config_dict.get(QUERY_KEY_NAME)
+    if query:
+        agents = {name: entry for name, entry in agents.items() if fuzzy_matches(query, name, *entry.variants)}
 
     if global_config_dict.get(JSON_OUTPUT_KEY_NAME, False):
         payload = [
@@ -56,10 +62,10 @@ def list_agents() -> None:
         return
 
     if not agents:
-        rich.print("No agents found.")
+        print_no_matches("agents", query)
         return
 
-    table = Table(title="NeMo Gym agents")
+    table = Table(title=f"Agents matching '{query}'" if query else "NeMo Gym agents")
     table.add_column("agent", style="bold")
     table.add_column("composition")
     table.add_column("variants")

--- a/nemo_gym/cli/agents.py
+++ b/nemo_gym/cli/agents.py
@@ -42,10 +42,15 @@ def list_agents() -> None:
 
     agents = discover_agents()
 
-    # `gym search agents <query>` reuses this command, narrowing to fuzzy matches on name + variant names.
+    # `gym search agents <query>` reuses this command, narrowing to fuzzy matches on
+    # name + description + variant names.
     query = global_config_dict.get(QUERY_KEY_NAME)
     if query:
-        agents = {name: entry for name, entry in agents.items() if fuzzy_matches(query, name, *entry.variants)}
+        agents = {
+            name: entry
+            for name, entry in agents.items()
+            if fuzzy_matches(query, name, entry.description or "", *entry.variants)
+        }
 
     if global_config_dict.get(JSON_OUTPUT_KEY_NAME, False):
         payload = [

--- a/nemo_gym/cli/env.py
+++ b/nemo_gym/cli/env.py
@@ -940,11 +940,14 @@ def list_environments() -> None:
 
     environments = discover_environments()
 
-    # `gym search environments <query>` reuses this command, narrowing to fuzzy matches on name + domain.
+    # `gym search environments <query>` reuses this command, narrowing to fuzzy matches on
+    # name + domain + description.
     query = global_config_dict.get(QUERY_KEY_NAME)
     if query:
         environments = {
-            name: env for name, env in environments.items() if fuzzy_matches(query, name, env.domain or "")
+            name: env
+            for name, env in environments.items()
+            if fuzzy_matches(query, name, env.domain or "", env.description or "")
         }
 
     if global_config_dict.get(JSON_OUTPUT_KEY_NAME, False):

--- a/nemo_gym/cli/env.py
+++ b/nemo_gym/cli/env.py
@@ -38,7 +38,7 @@ from tqdm.auto import tqdm
 
 from nemo_gym import PARENT_DIR, ROOT_DIR, _resolve_under_cwd_or_install, component_search_roots
 from nemo_gym.cli.setup_command import run_command, setup_env_command
-from nemo_gym.cli.utils import exit_cleanly_on_config_error, print_rich_table
+from nemo_gym.cli.utils import exit_cleanly_on_config_error, fuzzy_matches, print_no_matches, print_rich_table
 from nemo_gym.config_types import BaseNeMoGymCLIConfig
 from nemo_gym.global_config import (
     DRY_RUN_KEY_NAME,
@@ -46,6 +46,7 @@ from nemo_gym.global_config import (
     NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME,
     NEMO_GYM_CONFIG_PATH_ENV_VAR_NAME,
     NEMO_GYM_RESERVED_TOP_LEVEL_KEYS,
+    QUERY_KEY_NAME,
     GlobalConfigDictParser,
     GlobalConfigDictParserConfig,
     get_global_config_dict,
@@ -919,9 +920,8 @@ def validate():
 
 
 def list_environments() -> None:
-    """List the environments available under environments/, by short name.
-
-    ``--search-dir`` adds extra roots to scan on top of the cwd and built-ins.
+    """List the environments available under environments/, optionally filtered by a `query` (the
+    `gym search environments` entry point). ``--search-dir`` adds extra roots on top of the cwd and built-ins.
 
     Examples:
 
@@ -940,6 +940,13 @@ def list_environments() -> None:
 
     environments = discover_environments()
 
+    # `gym search environments <query>` reuses this command, narrowing to fuzzy matches on name + domain.
+    query = global_config_dict.get(QUERY_KEY_NAME)
+    if query:
+        environments = {
+            name: env for name, env in environments.items() if fuzzy_matches(query, name, env.domain or "")
+        }
+
     if global_config_dict.get(JSON_OUTPUT_KEY_NAME, False):
         print(
             json.dumps(
@@ -952,10 +959,15 @@ def list_environments() -> None:
         return
 
     if not environments:
-        rich.print("[yellow]No environments found.[/yellow]")
+        print_no_matches("environments", query)
         return
 
-    table = Table(title=f"Available environments in NeMo Gym ({len(environments)})")
+    title = (
+        f"Environments matching '{query}' ({len(environments)})"
+        if query
+        else f"Available environments in NeMo Gym ({len(environments)})"
+    )
+    table = Table(title=title)
     table.add_column("Name")
     table.add_column("Domain")
     table.add_column("Description")

--- a/nemo_gym/cli/eval.py
+++ b/nemo_gym/cli/eval.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import asyncio
-import difflib
 import importlib
 import json
 from copy import deepcopy
@@ -22,19 +21,17 @@ from multiprocessing import Pool
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-import rich
 from omegaconf import DictConfig, OmegaConf, open_dict
 from pydantic import Field
 from rich.table import Table
 from tqdm.auto import tqdm
 
 from nemo_gym.benchmarks import (
-    BENCHMARKS_DIR,
     BenchmarkConfig,
     discover_benchmarks,
 )
 from nemo_gym.cli.env import RunHelper
-from nemo_gym.cli.utils import exit_cleanly_on_config_error, print_rich_table
+from nemo_gym.cli.utils import exit_cleanly_on_config_error, fuzzy_matches, print_no_matches, print_rich_table
 from nemo_gym.config_types import BaseNeMoGymCLIConfig, BenchmarkDatasetConfig, ConfigError, ConfigPathNotFoundError
 from nemo_gym.discovery import read_config_metadata
 from nemo_gym.global_config import (
@@ -56,21 +53,6 @@ from nemo_gym.rollout_collection import (
     loads_jsonl_line,
 )
 from nemo_gym.train_data_utils import TrainDataProcessor
-
-
-def _fuzzy_matches(query: str, *fields: str) -> bool:
-    """Whether `query` fuzzily matches any of `fields`: a substring or a close difflib match (token-aware)."""
-    needle = query.lower()
-    for field in fields:
-        if not field:
-            continue
-        haystack = field.lower()
-        if needle in haystack:
-            return True
-        tokens = haystack.replace("_", " ").replace("-", " ").split()
-        if difflib.get_close_matches(needle, [haystack, *tokens], n=1, cutoff=0.70):
-            return True
-    return False
 
 
 def list_benchmarks() -> None:
@@ -98,7 +80,7 @@ def list_benchmarks() -> None:
     query = global_config_dict.get(QUERY_KEY_NAME)
     if query:
         benchmarks = {
-            name: bench for name, bench in benchmarks.items() if _fuzzy_matches(query, name, metadata[name][0] or "")
+            name: bench for name, bench in benchmarks.items() if fuzzy_matches(query, name, metadata[name][0] or "")
         }
 
     if global_config_dict.get(JSON_OUTPUT_KEY_NAME, False):
@@ -116,11 +98,7 @@ def list_benchmarks() -> None:
         return
 
     if not benchmarks:
-        if query:
-            rich.print(f"[yellow]No benchmarks match '{query}'.[/yellow]")
-            return
-        rich.print("[yellow]No benchmarks found.[/yellow]")
-        rich.print(f"Expected benchmarks directory: {BENCHMARKS_DIR}")
+        print_no_matches("benchmarks", query)
         return
 
     title = (

--- a/nemo_gym/cli/eval.py
+++ b/nemo_gym/cli/eval.py
@@ -76,11 +76,13 @@ def list_benchmarks() -> None:
     metadata = {name: read_config_metadata(bench.path) for name, bench in benchmarks.items()}
 
     # `gym search <query>` reuses this command, narrowing the listing to fuzzy matches
-    # across the benchmark name and domain.
+    # across the benchmark cofnig name, its dataset name, and domain.
     query = global_config_dict.get(QUERY_KEY_NAME)
     if query:
         benchmarks = {
-            name: bench for name, bench in benchmarks.items() if fuzzy_matches(query, name, metadata[name][0] or "")
+            name: bench
+            for name, bench in benchmarks.items()
+            if fuzzy_matches(query, name, bench.name, metadata[name][0] or "")
         }
 
     if global_config_dict.get(JSON_OUTPUT_KEY_NAME, False):

--- a/nemo_gym/cli/eval.py
+++ b/nemo_gym/cli/eval.py
@@ -43,16 +43,11 @@ from nemo_gym.global_config import (
     get_first_server_config_dict,
     get_global_config_dict,
 )
-from nemo_gym.reward_profile import RewardProfileConfig, RewardProfiler
-from nemo_gym.rollout_collection import (
-    E2ERolloutCollectionConfig,
-    RolloutAggregationConfig,
-    RolloutAggregationHelper,
-    RolloutCollectionConfig,
-    RolloutCollectionHelper,
-    loads_jsonl_line,
-)
-from nemo_gym.train_data_utils import TrainDataProcessor
+
+
+# NOTE: `reward_profile`, `rollout_collection`, and `train_data_utils` are imported lazily inside the run/aggregate/
+# profile commands below: they pull in heavy deps (wandb, mlflow, anthropic) that the fast `list`/`search`
+# commands in this module must not pay for on every invocation.
 
 
 def list_benchmarks() -> None:
@@ -286,6 +281,13 @@ def prepare_benchmark() -> None:
 
 @exit_cleanly_on_config_error
 def e2e_rollout_collection():  # pragma: no cover
+    from nemo_gym.rollout_collection import (
+        E2ERolloutCollectionConfig,
+        RolloutCollectionConfig,
+        RolloutCollectionHelper,
+    )
+    from nemo_gym.train_data_utils import TrainDataProcessor
+
     global_config_dict = get_global_config_dict()
 
     # Ensure we have the right config first thing
@@ -364,6 +366,8 @@ def e2e_rollout_collection():  # pragma: no cover
 
 @exit_cleanly_on_config_error
 def collect_rollouts():  # pragma: no cover
+    from nemo_gym.rollout_collection import RolloutCollectionConfig, RolloutCollectionHelper
+
     config = RolloutCollectionConfig.model_validate(get_global_config_dict())
     rch = RolloutCollectionHelper()
 
@@ -372,6 +376,8 @@ def collect_rollouts():  # pragma: no cover
 
 @exit_cleanly_on_config_error
 def aggregate_rollouts():  # pragma: no cover
+    from nemo_gym.rollout_collection import RolloutAggregationConfig, RolloutAggregationHelper
+
     config = RolloutAggregationConfig.model_validate(get_global_config_dict())
     rah = RolloutAggregationHelper()
 
@@ -380,6 +386,9 @@ def aggregate_rollouts():  # pragma: no cover
 
 @exit_cleanly_on_config_error
 def reward_profile():  # pragma: no cover
+    from nemo_gym.reward_profile import RewardProfileConfig, RewardProfiler
+    from nemo_gym.rollout_collection import loads_jsonl_line
+
     config = RewardProfileConfig.model_validate(get_global_config_dict())
 
     if not Path(config.materialized_inputs_jsonl_fpath).exists():

--- a/nemo_gym/cli/eval.py
+++ b/nemo_gym/cli/eval.py
@@ -76,13 +76,13 @@ def list_benchmarks() -> None:
     metadata = {name: read_config_metadata(bench.path) for name, bench in benchmarks.items()}
 
     # `gym search <query>` reuses this command, narrowing the listing to fuzzy matches
-    # across the benchmark cofnig name, its dataset name, and domain.
+    # across the benchmark config name, its dataset name, domain, and description.
     query = global_config_dict.get(QUERY_KEY_NAME)
     if query:
         benchmarks = {
             name: bench
             for name, bench in benchmarks.items()
-            if fuzzy_matches(query, name, bench.name, metadata[name][0] or "")
+            if fuzzy_matches(query, name, bench.name, metadata[name][0] or "", metadata[name][1] or "")
         }
 
     if global_config_dict.get(JSON_OUTPUT_KEY_NAME, False):

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -13,29 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
-import difflib
 import importlib
 import logging
 import os
 import re
 import sys
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from nemo_gym import NEMO_GYM_EXTRA_ROOTS_ENV_VAR_NAME, _augment_sys_path, component_search_roots
+from nemo_gym.cli.utils import did_you_mean
 
 
 logger = logging.getLogger(__name__)
 
 VERSION_TARGET = "nemo_gym.cli.general:version"
-
-
-def _did_you_mean(value: str, candidates: Iterable[str]) -> str:
-    """A ` Did you mean \\`X\\`?` fragment for the closest candidate to `value`, or `""` if none is close enough."""
-    matches = difflib.get_close_matches(value, list(candidates), n=1)
-    return f" Did you mean `{matches[0]}`?" if matches else ""
 
 
 class _GymArgumentParser(argparse.ArgumentParser):
@@ -52,7 +46,7 @@ class _GymArgumentParser(argparse.ArgumentParser):
             choices = re.findall(r"'([^']+)'", match.group(2))
             if not choices:
                 choices = [choice.strip() for choice in match.group(2).split(",")]
-            message += _did_you_mean(typo, choices)
+            message += did_you_mean(typo, choices)
         super().error(message)
 
 
@@ -243,7 +237,7 @@ def _asset_config_path(flag: str, value: str) -> str:
         ]
 
     raise ValueError(
-        f"`--{flag} {value}` was specified which implies config `{path}`, which does not exist.{_did_you_mean(typo, candidates)} "
+        f"`--{flag} {value}` was specified which implies config `{path}`, which does not exist.{did_you_mean(typo, candidates)} "
         f"See available {flag} configs in {available}."
     )
 
@@ -693,7 +687,7 @@ def main() -> None:
     if unknown_flags:
         error_parser = getattr(args, "_parser", parser)
         known_options = [opt for action in error_parser._actions for opt in action.option_strings]
-        hints = "".join(_did_you_mean(flag.split("=", 1)[0], known_options) for flag in unknown_flags)
+        hints = "".join(did_you_mean(flag.split("=", 1)[0], known_options) for flag in unknown_flags)
         error_parser.error(f"unrecognized arguments: {' '.join(unknown_flags)}{hints}")
 
     # set NEMO_GYM_EXTRA_ROOTS from --search-dir for the duration of the command

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -297,7 +297,7 @@ def _dataset_download(args: argparse.Namespace, overrides: list[str]) -> None:
 
 # One-line help for each command group, shown in `gym --help`.
 GROUPS = {
-    "list": "List available components (benchmarks, agents, environments).",
+    "list": "List available components (benchmarks, environments, agents, models).",
     "dataset": "Manage datasets.",
     "env": "Develop and run environments.",
     "eval": "Run evaluations.",
@@ -320,6 +320,11 @@ COMMANDS = {
     "list agents": Command(
         target="nemo_gym.cli.agents:list_agents",
         summary="List agent harnesses and how each composes (Pattern A vs self-contained B).",
+        flags=(JSON, SEARCH_DIR),
+    ),
+    "list models": Command(
+        target="nemo_gym.cli.models:list_models",
+        summary="List model servers by the value to pass to --model-type.",
         flags=(JSON, SEARCH_DIR),
     ),
     "search": Command(

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -157,6 +157,7 @@ _SEARCHABLE_TYPES = {
     "environments": "nemo_gym.cli.env:list_environments",
     "agents": "nemo_gym.cli.agents:list_agents",
     "models": "nemo_gym.cli.models:list_models",
+    "resources-servers": "nemo_gym.cli.resources_servers:list_resources_servers",
 }
 
 SEARCH_TERMS = Flag(
@@ -320,7 +321,7 @@ def _dataset_download(args: argparse.Namespace, overrides: list[str]) -> None:
 
 # One-line help for each command group, shown in `gym --help`.
 GROUPS = {
-    "list": "List available components (benchmarks, environments, agents, models).",
+    "list": "List available components (benchmarks, environments, agents, models, resources-servers).",
     "dataset": "Manage datasets.",
     "env": "Develop and run environments.",
     "eval": "Run evaluations.",
@@ -348,6 +349,11 @@ COMMANDS = {
     "list models": Command(
         target="nemo_gym.cli.models:list_models",
         summary="List model servers by the value to pass to --model-type.",
+        flags=(JSON, SEARCH_DIR),
+    ),
+    "list resources-servers": Command(
+        target="nemo_gym.cli.resources_servers:list_resources_servers",
+        summary="List resources servers (selectable with --resources-server) by name.",
         flags=(JSON, SEARCH_DIR),
     ),
     "search": Command(

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -219,25 +219,47 @@ def _asset_config_path(flag: str, value: str) -> str:
     if matches:
         return str(matches[0])
 
-    # No match: suggest the closest real name across all roots (a config flavor when the server exists, else a
-    # server name) and report the full paths that were searched.
-    available = ", ".join(set(f"`{(root / config_dir).resolve()}`" for root in roots if (root / config_dir).is_dir()))
-    typo = config_flavor
-    candidates = [p.stem for root in roots for p in (root / config_dir).glob("*.yaml")]
+    # No match: build a "did you mean?" hint and the roots searched
+    if flag == "benchmark":
+        # Benchmarks need special handling because some use non-standard config paths (arbitrary nesting), so
+        # the generic one-level flavor/sibling search below can't see them.
+        # Enumerate their real config names (the same values `gym list benchmarks` prints) instead.
+        from nemo_gym.benchmarks import _benchmark_config_name, _benchmark_config_paths
 
-    if len(candidates) == 0:
-        available = ", ".join(set(f"`{(root / parent).resolve()}`" for root in roots if (root / parent).is_dir()))
-        typo = server_name
-        candidates = [
-            child.name
+        config_names = {
+            _benchmark_config_name(p.relative_to(root / parent))
             for root in roots
-            if (root / parent).is_dir()
-            for child in (root / parent).iterdir()
-            if child.is_dir()
-        ]
+            for p in _benchmark_config_paths(root / parent)
+        }
+        # A bare directory that only groups benchmarks (e.g. `livecodebench`) is not itself selectable, so point
+        # at the config names under it; otherwise fall back to a fuzzy match across every token.
+        under_dir = sorted(config_name for config_name in config_names if config_name.startswith(f"{value}/"))
+        hint = f" Did you mean `{min(under_dir, key=len)}`?" if under_dir else did_you_mean(value, config_names)
+        available = ", ".join(sorted(f"`{(root / parent).resolve()}`" for root in roots if (root / parent).is_dir()))
+    else:
+        # Suggest the closest real name across all roots: a config flavor when the server exists, else a server
+        # name, reporting the full paths that were searched in each case.
+        available = ", ".join(
+            set(f"`{(root / config_dir).resolve()}`" for root in roots if (root / config_dir).is_dir())
+        )
+        typo = config_flavor
+        candidates = [p.stem for root in roots for p in (root / config_dir).glob("*.yaml")]
+
+        if len(candidates) == 0:
+            available = ", ".join(set(f"`{(root / parent).resolve()}`" for root in roots if (root / parent).is_dir()))
+            typo = server_name
+            candidates = [
+                child.name
+                for root in roots
+                if (root / parent).is_dir()
+                for child in (root / parent).iterdir()
+                if child.is_dir()
+            ]
+
+        hint = did_you_mean(typo, candidates)
 
     raise ValueError(
-        f"`--{flag} {value}` was specified which implies config `{path}`, which does not exist.{did_you_mean(typo, candidates)} "
+        f"`--{flag} {value}` was specified which implies config `{path}`, which does not exist.{hint} "
         f"See available {flag} configs in {available}."
     )
 

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -164,7 +164,7 @@ SEARCH_TERMS = Flag(
         ),
         p.add_argument("query", metavar="QUERY", help="Substring to match against component names."),
     ),
-    translate_to_hydra=lambda args: [f"+query={args.query}"] if getattr(args, "query", None) else [],
+    translate_to_hydra=lambda args: [f'+query="{args.query}"'] if getattr(args, "query", None) else [],
 )
 
 

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -162,7 +162,11 @@ SEARCH_TERMS = Flag(
             choices=list(_SEARCHABLE_TYPES),
             help="Component type to search (default: benchmarks).",
         ),
-        p.add_argument("query", metavar="QUERY", help="Substring to match against component names."),
+        p.add_argument(
+            "query",
+            metavar="QUERY",
+            help="Text matched (substring or fuzzy) against a component's name, description, and key metadata.",
+        ),
     ),
     translate_to_hydra=lambda args: [f'+query="{args.query}"'] if getattr(args, "query", None) else [],
 )

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -149,11 +149,34 @@ RESOURCES_SERVER = Flag(
 # global_config_dict.get(JSON_OUTPUT_KEY_NAME) (see general.py, eval.py, env.py).
 JSON = _bool_flag("json", "json", "Output as machine-readable JSON.")
 
-# Positional search query for `gym search`; surfaced to the listing command as the `query` config key.
-QUERY = Flag(
-    register=lambda p: p.add_argument("query", metavar="QUERY", help="Substring to match against component names."),
+# `gym search [<type>] <query>`: an optional component type plus the query. The query is surfaced to the
+# chosen listing command as the reserved `query` config key; the type only picks which command to run
+# (see `_search`). A lone positional is the query, defaulting to benchmarks — backward compatible.
+_SEARCHABLE_TYPES = {
+    "benchmarks": "nemo_gym.cli.eval:list_benchmarks",
+    "environments": "nemo_gym.cli.env:list_environments",
+    "agents": "nemo_gym.cli.agents:list_agents",
+    "models": "nemo_gym.cli.models:list_models",
+}
+
+SEARCH_TERMS = Flag(
+    register=lambda p: (
+        p.add_argument(
+            "component_type",
+            nargs="?",
+            choices=list(_SEARCHABLE_TYPES),
+            help="Component type to search (default: benchmarks).",
+        ),
+        p.add_argument("query", metavar="QUERY", help="Substring to match against component names."),
+    ),
     translate_to_hydra=lambda args: [f"+query={args.query}"] if getattr(args, "query", None) else [],
 )
+
+
+def _search(args: argparse.Namespace, overrides: list[str]) -> None:
+    """`gym search [<type>] <query>`: dispatch to the chosen type's listing command (default benchmarks),
+    which filters itself to the `query` config key already in `overrides`."""
+    dispatch(_SEARCHABLE_TYPES[getattr(args, "component_type", None) or "benchmarks"], overrides)
 
 
 # Asset selector flag -> (parent dir, configs subdir, default config flavor). All accept `name` or `name/flavor`,
@@ -328,9 +351,9 @@ COMMANDS = {
         flags=(JSON, SEARCH_DIR),
     ),
     "search": Command(
-        target="nemo_gym.cli.eval:list_benchmarks",
-        summary="Search available components (currently benchmarks) by name; like `list` filtered to a query.",
-        flags=(QUERY, JSON, SEARCH_DIR),
+        target=_search,
+        summary="Search a component type (default benchmarks) by name; like `list` filtered to a query.",
+        flags=(SEARCH_TERMS, JSON, SEARCH_DIR),
     ),
     "dataset upload": Command(
         target=_dataset_upload,

--- a/nemo_gym/cli/models.py
+++ b/nemo_gym/cli/models.py
@@ -14,13 +14,13 @@
 # limitations under the License.
 import json
 
-import rich
 from rich.table import Table
 
-from nemo_gym.cli.utils import print_rich_table
+from nemo_gym.cli.utils import fuzzy_matches, print_no_matches, print_rich_table
 from nemo_gym.config_types import BaseNeMoGymCLIConfig
 from nemo_gym.global_config import (
     JSON_OUTPUT_KEY_NAME,
+    QUERY_KEY_NAME,
     GlobalConfigDictParserConfig,
     get_global_config_dict,
 )
@@ -29,8 +29,9 @@ from nemo_gym.model_registry import discover_models
 
 def list_models() -> None:
     """List model servers, one row per ``--model-type`` value: ``Model`` is the token to pass (``<name>``
-    for the default flavor, ``<name>/<flavor>`` for the rest); ``Model group`` is its model. ``--search-dir``
-    adds extra roots on top of the cwd and built-ins.
+    for the default flavor, ``<name>/<flavor>`` for the rest); ``Model group`` is its model. Optionally
+    filtered by a `query` (the `gym search models` entry point). ``--search-dir`` adds extra roots on top of
+    the cwd and built-ins.
     """
     global_config_dict = get_global_config_dict(
         global_config_dict_parser_config=GlobalConfigDictParserConfig(
@@ -48,15 +49,20 @@ def list_models() -> None:
         for model_type in entry.model_types
     ]
 
+    # `gym search models <query>` reuses this command, narrowing to rows matching the token or its model.
+    query = global_config_dict.get(QUERY_KEY_NAME)
+    if query:
+        rows = [row for row in rows if fuzzy_matches(query, row["model"], row["model_group"])]
+
     if global_config_dict.get(JSON_OUTPUT_KEY_NAME, False):
         print(json.dumps(rows))
         return
 
     if not rows:
-        rich.print("No models found.")
+        print_no_matches("models", query)
         return
 
-    table = Table(title="NeMo Gym models")
+    table = Table(title=f"Models matching '{query}'" if query else "NeMo Gym models")
     table.add_column("Model", style="bold")
     table.add_column("Model group")
     for row in rows:

--- a/nemo_gym/cli/models.py
+++ b/nemo_gym/cli/models.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+import rich
+from rich.table import Table
+
+from nemo_gym.cli.utils import print_rich_table
+from nemo_gym.config_types import BaseNeMoGymCLIConfig
+from nemo_gym.global_config import (
+    JSON_OUTPUT_KEY_NAME,
+    GlobalConfigDictParserConfig,
+    get_global_config_dict,
+)
+from nemo_gym.model_registry import discover_models
+
+
+def list_models() -> None:
+    """List model servers, one row per ``--model-type`` value: ``Model`` is the token to pass (``<name>``
+    for the default flavor, ``<name>/<flavor>`` for the rest); ``Model group`` is its model. ``--search-dir``
+    adds extra roots on top of the cwd and built-ins.
+    """
+    global_config_dict = get_global_config_dict(
+        global_config_dict_parser_config=GlobalConfigDictParserConfig(
+            initial_global_config_dict=GlobalConfigDictParserConfig.NO_MODEL_GLOBAL_CONFIG_DICT,
+        )
+    )
+    BaseNeMoGymCLIConfig.model_validate(global_config_dict)
+
+    models = discover_models()
+
+    # One row per passable `--model-type` value: `model` is the token, `model_group` its model.
+    rows = [
+        {"model": model_type, "model_group": name}
+        for name, entry in models.items()
+        for model_type in entry.model_types
+    ]
+
+    if global_config_dict.get(JSON_OUTPUT_KEY_NAME, False):
+        print(json.dumps(rows))
+        return
+
+    if not rows:
+        rich.print("No models found.")
+        return
+
+    table = Table(title="NeMo Gym models")
+    table.add_column("Model", style="bold")
+    table.add_column("Model group")
+    for row in rows:
+        table.add_row(row["model"], row["model_group"])
+    print_rich_table(table)

--- a/nemo_gym/cli/models.py
+++ b/nemo_gym/cli/models.py
@@ -43,11 +43,7 @@ def list_models() -> None:
     models = discover_models()
 
     # One row per passable `--model-type` value: `model` is the token, `model_group` its model.
-    rows = [
-        {"model": model_type, "model_group": name}
-        for name, entry in models.items()
-        for model_type in entry.model_types
-    ]
+    rows = [{"model": entry.name, "model_group": entry.model_group} for entry in models.values()]
 
     # `gym search models <query>` reuses this command, narrowing to rows matching the token or its model.
     query = global_config_dict.get(QUERY_KEY_NAME)

--- a/nemo_gym/cli/resources_servers.py
+++ b/nemo_gym/cli/resources_servers.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+from rich.table import Table
+
+from nemo_gym.cli.utils import fuzzy_matches, print_no_matches, print_rich_table
+from nemo_gym.config_types import BaseNeMoGymCLIConfig
+from nemo_gym.global_config import (
+    JSON_OUTPUT_KEY_NAME,
+    QUERY_KEY_NAME,
+    GlobalConfigDictParserConfig,
+    get_global_config_dict,
+)
+from nemo_gym.resources_server_registry import discover_resources_servers
+
+
+def list_resources_servers() -> None:
+    """List the resources servers selectable with ``--resources-server``, by short name. Optionally filtered
+    by a `query` (the `gym search resources-servers` entry point). ``--search-dir`` adds extra roots on top
+    of the cwd and built-ins.
+    """
+    global_config_dict = get_global_config_dict(
+        global_config_dict_parser_config=GlobalConfigDictParserConfig(
+            initial_global_config_dict=GlobalConfigDictParserConfig.NO_MODEL_GLOBAL_CONFIG_DICT,
+        )
+    )
+    BaseNeMoGymCLIConfig.model_validate(global_config_dict)
+
+    servers = discover_resources_servers()
+
+    # `gym search resources-servers <query>` reuses this command, narrowing to fuzzy matches on name + domain.
+    query = global_config_dict.get(QUERY_KEY_NAME)
+    if query:
+        servers = {name: s for name, s in servers.items() if fuzzy_matches(query, name, s.domain or "")}
+
+    if global_config_dict.get(JSON_OUTPUT_KEY_NAME, False):
+        print(
+            json.dumps(
+                [{"name": name, "domain": s.domain, "description": s.description} for name, s in servers.items()]
+            )
+        )
+        return
+
+    if not servers:
+        print_no_matches("resources servers", query)
+        return
+
+    title = (
+        f"Resources servers matching '{query}' ({len(servers)})"
+        if query
+        else f"Available resources servers in NeMo Gym ({len(servers)})"
+    )
+    table = Table(title=title)
+    table.add_column("Name")
+    table.add_column("Domain")
+    table.add_column("Description")
+    for name, server in servers.items():
+        table.add_row(name, server.domain or "", server.description or "")
+    print_rich_table(table)

--- a/nemo_gym/cli/resources_servers.py
+++ b/nemo_gym/cli/resources_servers.py
@@ -41,10 +41,13 @@ def list_resources_servers() -> None:
 
     servers = discover_resources_servers()
 
-    # `gym search resources-servers <query>` reuses this command, narrowing to fuzzy matches on name + domain.
+    # `gym search resources-servers <query>` reuses this command, narrowing to fuzzy matches on
+    # name + domain + description.
     query = global_config_dict.get(QUERY_KEY_NAME)
     if query:
-        servers = {name: s for name, s in servers.items() if fuzzy_matches(query, name, s.domain or "")}
+        servers = {
+            name: s for name, s in servers.items() if fuzzy_matches(query, name, s.domain or "", s.description or "")
+        }
 
     if global_config_dict.get(JSON_OUTPUT_KEY_NAME, False):
         print(

--- a/nemo_gym/cli/utils.py
+++ b/nemo_gym/cli/utils.py
@@ -13,7 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import difflib
-from typing import Optional
+from typing import Iterable, Optional
+
+
+def did_you_mean(value: str, candidates: Iterable[str]) -> str:
+    """A ` Did you mean \\`X\\`?` fragment for the closest candidate to `value`, or `""` if none is close enough."""
+    matches = difflib.get_close_matches(value, list(candidates), n=1)
+    return f" Did you mean `{matches[0]}`?" if matches else ""
 
 
 def print_no_matches(component_type: str, query: Optional[str]) -> None:

--- a/nemo_gym/cli/utils.py
+++ b/nemo_gym/cli/utils.py
@@ -12,6 +12,40 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import difflib
+from typing import Optional
+
+
+def print_no_matches(component_type: str, query: Optional[str]) -> None:
+    """Print the standard 'nothing to show' message for a `gym list`/`gym search` command.
+
+    ``component_type`` is the plural noun (``benchmarks``, ``environments``, ...). Keeps the message
+    and styling identical across every listing.
+    """
+    import rich
+
+    if query:
+        rich.print(f"[yellow]No {component_type} match '{query}'.[/yellow]")
+    else:
+        rich.print(f"[yellow]No {component_type} found.[/yellow]")
+
+
+def fuzzy_matches(query: str, *fields: str) -> bool:
+    """Whether `query` fuzzily matches any of `fields`: a substring or a close difflib match (token-aware).
+
+    The shared matcher behind `gym search <type> <query>` across every component type.
+    """
+    needle = query.lower()
+    for field in fields:
+        if not field:
+            continue
+        haystack = field.lower()
+        if needle in haystack:
+            return True
+        tokens = haystack.replace("_", " ").replace("-", " ").split()
+        if difflib.get_close_matches(needle, [haystack, *tokens], n=1, cutoff=0.70):
+            return True
+    return False
 
 
 def print_rich_table(table) -> None:

--- a/nemo_gym/model_registry.py
+++ b/nemo_gym/model_registry.py
@@ -21,7 +21,7 @@ directory tree only; never loads a config.
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict
 
 from nemo_gym import PARENT_DIR
 from nemo_gym.discovery import discover_components
@@ -34,30 +34,18 @@ MODEL_CONFIGS_SUBDIR = "configs"
 
 @dataclass(frozen=True)
 class ModelEntry:
-    """A discovered model server: its name, where it lives, and its config flavors."""
+    """A discovered model server: its name, group, and config file."""
 
     name: str
-    path: Path
-    config_paths: Tuple[Path, ...]  # flavor config files, sorted (a model always ships at least one)
-
-    @property
-    def variants(self) -> Dict[str, Path]:
-        """Map flavor name (config filename stem) -> config path."""
-        return {path.stem: path for path in self.config_paths}
-
-    @property
-    def model_types(self) -> List[str]:
-        """The tokens accepted by ``--model-type``: ``<name>`` for the flavor named after the model (the
-        default the selector resolves), ``<name>/<flavor>`` for the rest."""
-        return [self.name if stem == self.name else f"{self.name}/{stem}" for stem in sorted(self.variants)]
+    model_group: str
+    config_path: Path
 
 
 def _discover_models_in_dir(models_dir: Path) -> Dict[str, ModelEntry]:
-    """Map model name -> :class:`ModelEntry` for every model dir under one ``responses_api_models/`` dir.
+    """Map model name -> :class:`ModelEntry` for every config flavor under one ``responses_api_models/`` dir.
 
-    The name is the directory name. A directory is a model iff it ships at least one ``configs/*.yaml`` —
-    the config a user passes to ``--model-type`` (a config-less dir has nothing to select, so it isn't
-    listed). Returns an empty dict if the directory is missing.
+    One entry per ``configs/<flavor>.yaml``: ``<dir>`` for the flavor named after the model, ``<dir>/<flavor>``
+    for the rest. A config-less dir contributes nothing. Returns an empty dict if the directory is missing.
     """
     models: Dict[str, ModelEntry] = {}
     if not models_dir.is_dir():
@@ -67,10 +55,10 @@ def _discover_models_in_dir(models_dir: Path) -> Dict[str, ModelEntry]:
         if not child.is_dir():
             continue
         configs_dir = child / MODEL_CONFIGS_SUBDIR
-        config_files = tuple(sorted(configs_dir.glob("*.yaml"))) if configs_dir.is_dir() else ()
-        if not config_files:
-            continue
-        models[child.name] = ModelEntry(name=child.name, path=child, config_paths=config_files)
+        config_files = sorted(configs_dir.glob("*.yaml")) if configs_dir.is_dir() else []
+        for config in config_files:
+            name = child.name if config.stem == child.name else f"{child.name}/{config.stem}"
+            models[name] = ModelEntry(name=name, model_group=child.name, config_path=config)
 
     return models
 

--- a/nemo_gym/model_registry.py
+++ b/nemo_gym/model_registry.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Registry of model servers under ``responses_api_models/<name>/``.
+
+Maps each model dir to the config flavors it ships (``configs/<flavor>.yaml``), so they can be
+enumerated by the token passed to ``--model-type`` (see :attr:`ModelEntry.model_types`). Reads the
+directory tree only; never loads a config.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from nemo_gym import PARENT_DIR
+from nemo_gym.discovery import discover_components
+
+
+MODELS_SUBDIR = "responses_api_models"
+MODELS_DIR = PARENT_DIR / MODELS_SUBDIR
+MODEL_CONFIGS_SUBDIR = "configs"
+
+
+@dataclass(frozen=True)
+class ModelEntry:
+    """A discovered model server: its name, where it lives, and its config flavors."""
+
+    name: str
+    path: Path
+    config_paths: Tuple[Path, ...]  # flavor config files, sorted (a model always ships at least one)
+
+    @property
+    def variants(self) -> Dict[str, Path]:
+        """Map flavor name (config filename stem) -> config path."""
+        return {path.stem: path for path in self.config_paths}
+
+    @property
+    def model_types(self) -> List[str]:
+        """The tokens accepted by ``--model-type``: ``<name>`` for the flavor named after the model (the
+        default the selector resolves), ``<name>/<flavor>`` for the rest."""
+        return [self.name if stem == self.name else f"{self.name}/{stem}" for stem in sorted(self.variants)]
+
+
+def _discover_models_in_dir(models_dir: Path) -> Dict[str, ModelEntry]:
+    """Map model name -> :class:`ModelEntry` for every model dir under one ``responses_api_models/`` dir.
+
+    The name is the directory name. A directory is a model iff it ships at least one ``configs/*.yaml`` —
+    the config a user passes to ``--model-type`` (a config-less dir has nothing to select, so it isn't
+    listed). Returns an empty dict if the directory is missing.
+    """
+    models: Dict[str, ModelEntry] = {}
+    if not models_dir.is_dir():
+        return models
+
+    for child in sorted(models_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        configs_dir = child / MODEL_CONFIGS_SUBDIR
+        config_files = tuple(sorted(configs_dir.glob("*.yaml"))) if configs_dir.is_dir() else ()
+        if not config_files:
+            continue
+        models[child.name] = ModelEntry(name=child.name, path=child, config_paths=config_files)
+
+    return models
+
+
+def discover_models() -> Dict[str, ModelEntry]:
+    """Map model name -> :class:`ModelEntry` for every discoverable model server.
+
+    Scans the ``responses_api_models/`` subdir of every :func:`~nemo_gym.discovery.component_search_roots`
+    root (``NEMO_GYM_EXTRA_ROOTS`` + cwd + built-ins), merged so user models shadow same-named built-ins.
+    """
+    return discover_components(MODELS_SUBDIR, _discover_models_in_dir)

--- a/nemo_gym/resources_server_registry.py
+++ b/nemo_gym/resources_server_registry.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Registry of resources servers under ``resources_servers/<name>/``.
+
+A resources server (verifier + per-task state) is one *component* of an environment, selected by name
+with ``--resources-server``. This module maps each server dir to its ``(domain, description)`` — read
+the same way ``gym list environments``/``benchmarks`` read theirs (via
+:func:`~nemo_gym.discovery.read_config_metadata`) — so they can be enumerated by name.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+from nemo_gym import PARENT_DIR
+from nemo_gym.discovery import discover_components, read_config_metadata
+
+
+RESOURCES_SERVERS_SUBDIR = "resources_servers"
+RESOURCES_SERVERS_DIR = PARENT_DIR / RESOURCES_SERVERS_SUBDIR
+RESOURCES_SERVER_CONFIGS_SUBDIR = "configs"
+
+
+@dataclass(frozen=True)
+class ResourcesServerEntry:
+    """A discovered resources server: its name, where it lives, and lightweight metadata."""
+
+    name: str
+    config_path: Path  # the config metadata was read from (the default `<name>` flavor, else the first)
+    path: Path
+    description: Optional[str] = None
+    domain: Optional[str] = None
+
+
+def _discover_resources_servers_in_dir(resources_servers_dir: Path) -> Dict[str, ResourcesServerEntry]:
+    """Map resources-server name -> :class:`ResourcesServerEntry` for every server dir under one dir.
+
+    The name is the directory name. A directory is a resources server iff it ships at least one
+    ``configs/*.yaml`` (the config selected by ``--resources-server``). Metadata is read from the default
+    ``<name>.yaml`` flavor when present, else the first config. Returns an empty dict if the dir is missing.
+    """
+    servers: Dict[str, ResourcesServerEntry] = {}
+    if not resources_servers_dir.is_dir():
+        return servers
+
+    for child in sorted(resources_servers_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        configs_dir = child / RESOURCES_SERVER_CONFIGS_SUBDIR
+        config_files = sorted(configs_dir.glob("*.yaml")) if configs_dir.is_dir() else []
+        if not config_files:
+            continue
+        metadata_config = next((c for c in config_files if c.stem == child.name), config_files[0])
+        domain, description = read_config_metadata(metadata_config)
+        servers[child.name] = ResourcesServerEntry(
+            name=child.name,
+            config_path=metadata_config,
+            path=child,
+            description=description,
+            domain=domain,
+        )
+
+    return servers
+
+
+def discover_resources_servers() -> Dict[str, ResourcesServerEntry]:
+    """Map resources-server name -> :class:`ResourcesServerEntry` for every discoverable server.
+
+    Scans the ``resources_servers/`` subdir of every :func:`~nemo_gym.discovery.component_search_roots`
+    root (``NEMO_GYM_EXTRA_ROOTS`` + cwd + built-ins), merged so user servers shadow same-named built-ins.
+    """
+    return discover_components(RESOURCES_SERVERS_SUBDIR, _discover_resources_servers_in_dir)

--- a/nemo_gym/resources_server_registry.py
+++ b/nemo_gym/resources_server_registry.py
@@ -15,7 +15,7 @@
 """Registry of resources servers under ``resources_servers/<name>/``.
 
 A resources server (verifier + per-task state) is one *component* of an environment, selected by name
-with ``--resources-server``. This module maps each server dir to its ``(domain, description)`` — read
+with ``--resources-server``. This module maps each config flavor to its ``(domain, description)`` — read
 the same way ``gym list environments``/``benchmarks`` read theirs (via
 :func:`~nemo_gym.discovery.read_config_metadata`) — so they can be enumerated by name.
 """
@@ -23,6 +23,8 @@ the same way ``gym list environments``/``benchmarks`` read theirs (via
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional
+
+from omegaconf import OmegaConf
 
 from nemo_gym import PARENT_DIR
 from nemo_gym.discovery import discover_components, read_config_metadata
@@ -38,18 +40,31 @@ class ResourcesServerEntry:
     """A discovered resources server: its name, where it lives, and lightweight metadata."""
 
     name: str
-    config_path: Path  # the config metadata was read from (the default `<name>` flavor, else the first)
+    config_path: Path
     path: Path
     description: Optional[str] = None
     domain: Optional[str] = None
 
 
-def _discover_resources_servers_in_dir(resources_servers_dir: Path) -> Dict[str, ResourcesServerEntry]:
-    """Map resources-server name -> :class:`ResourcesServerEntry` for every server dir under one dir.
+def _config_defines_resources_server(config_path: Path) -> bool:
+    """True if a config declares a ``resources_servers`` block (vs a helper like a judge model). Never raises."""
+    try:
+        raw = OmegaConf.to_container(OmegaConf.load(config_path), resolve=False, throw_on_missing=False)
+    except Exception:
+        return False
+    if not isinstance(raw, dict):
+        return False
+    return any(
+        isinstance(instance, dict) and isinstance(instance.get("resources_servers"), dict) for instance in raw.values()
+    )
 
-    The name is the directory name. A directory is a resources server iff it ships at least one
-    ``configs/*.yaml`` (the config selected by ``--resources-server``). Metadata is read from the default
-    ``<name>.yaml`` flavor when present, else the first config. Returns an empty dict if the dir is missing.
+
+def _discover_resources_servers_in_dir(resources_servers_dir: Path) -> Dict[str, ResourcesServerEntry]:
+    """Map resources-server name -> :class:`ResourcesServerEntry` for every flavor under one dir.
+
+    One entry per config flavor that declares a `resources_servers` block: `<dir>` for the default config
+    (`<dir>.yaml`) and `<dir>/<flavor>` for the rest (`<flavor>.yaml`).
+    Helper configs (no `resources_servers` block) are skipped. Empty dict if the dir is missing.
     """
     servers: Dict[str, ResourcesServerEntry] = {}
     if not resources_servers_dir.is_dir():
@@ -62,15 +77,18 @@ def _discover_resources_servers_in_dir(resources_servers_dir: Path) -> Dict[str,
         config_files = sorted(configs_dir.glob("*.yaml")) if configs_dir.is_dir() else []
         if not config_files:
             continue
-        metadata_config = next((c for c in config_files if c.stem == child.name), config_files[0])
-        domain, description = read_config_metadata(metadata_config)
-        servers[child.name] = ResourcesServerEntry(
-            name=child.name,
-            config_path=metadata_config,
-            path=child,
-            description=description,
-            domain=domain,
-        )
+        for config in config_files:
+            if not _config_defines_resources_server(config):
+                continue
+            name = child.name if config.stem == child.name else f"{child.name}/{config.stem}"
+            domain, description = read_config_metadata(config)
+            servers[name] = ResourcesServerEntry(
+                name=name,
+                config_path=config,
+                path=child,
+                description=description,
+                domain=domain,
+            )
 
     return servers
 

--- a/tests/unit_tests/test_benchmarks.py
+++ b/tests/unit_tests/test_benchmarks.py
@@ -121,11 +121,15 @@ class TestListBenchmarks:
         assert json.loads(capsys.readouterr().out) == []
 
 
-class TestLoadBenchmarksFromConfigPaths:
-    def test_skips_configs_that_fail_to_resolve_with_warning(self, capsys) -> None:
+class TestDiscoverBenchmarksInDir:
+    def test_skips_configs_that_fail_to_resolve_with_warning(self, tmp_path: Path, capsys) -> None:
         # A candidate that still can't be resolved even with tolerance (e.g. a multi-benchmark suite) must
         # be skipped with a warning — not crash the whole listing, and not vanish silently.
-        from nemo_gym.benchmarks import BenchmarkConfig, _load_benchmarks_from_config_paths
+        from nemo_gym.benchmarks import BenchmarkConfig, _discover_benchmarks_in_dir
+
+        for name in ("bad", "good"):
+            (tmp_path / name).mkdir()
+            (tmp_path / name / "config.yaml").write_text("x:\n  datasets:\n  - type: benchmark\n")
 
         good = MagicMock()
         good.name = "good_bench"
@@ -133,33 +137,62 @@ class TestLoadBenchmarksFromConfigPaths:
         # Listing must resolve tolerantly (it scans files with no runtime context), so it opts out of strict.
         def fake_from_config_path(path, *, strict=True):
             assert strict is False
-            if Path(path).name == "bad.yaml":
+            if Path(path).parent.name == "bad":
                 raise RuntimeError("cannot resolve without runtime values")
             return good
 
         with patch.object(BenchmarkConfig, "from_config_path", side_effect=fake_from_config_path):
-            result = _load_benchmarks_from_config_paths([Path("bad.yaml"), Path("good.yaml")])
+            result = _discover_benchmarks_in_dir(tmp_path)
 
-        assert set(result) == {"good_bench"}
+        # The surviving benchmark is keyed by its config name (path under the dir, sans `.yaml`), not `dataset.name`.
+        assert set(result) == {"good"}
         err = capsys.readouterr().err
-        assert "Warning" in err and "bad.yaml" in err
+        assert "Warning" in err and "bad" in err
 
     def test_every_repo_benchmark_appears_in_listing(self, capsys) -> None:
         # Every config that declares a `type: benchmark` dataset must surface as its own listing entry —
         # no silent drop from a name collision (the name-keyed dict is last-writer-wins) or a resolve
         # failure. Mirrors the content-based discovery in `list_benchmarks`.
-        from nemo_gym.benchmarks import BENCHMARKS_DIR, _benchmark_config_paths, _load_benchmarks_from_config_paths
+        from nemo_gym.benchmarks import BENCHMARKS_DIR, _benchmark_config_paths, _discover_benchmarks_in_dir
 
         config_paths = _benchmark_config_paths(BENCHMARKS_DIR)
         assert config_paths, "no benchmark configs discovered under BENCHMARKS_DIR"
 
-        benchmarks = _load_benchmarks_from_config_paths(config_paths)
+        benchmarks = _discover_benchmarks_in_dir(BENCHMARKS_DIR)
 
         assert len(benchmarks) == len(config_paths), (
             f"{len(config_paths)} benchmark config(s) discovered but only {len(benchmarks)} appear in the "
-            f"listing — a duplicate dataset name or resolve failure is hiding at least one.\n"
+            f"listing — a duplicate name or resolve failure is hiding at least one.\n"
             f"stderr:\n{capsys.readouterr().err}"
         )
+
+
+class TestBenchmarkConfigName:
+    @pytest.mark.parametrize(
+        "rel, expected",
+        [
+            ("aime24/config.yaml", "aime24"),  # `<name>/config.yaml` shortens to `<name>`
+            ("tau2/configs/tau2.yaml", "tau2/configs/tau2"),  # a flavor keeps its full relative path
+            ("livecodebench/v5_2408_2502/config.yaml", "livecodebench/v5_2408_2502/config"),  # nested: no shorten
+        ],
+    )
+    def test_name_matches_the_benchmark_selector(self, rel: str, expected: str) -> None:
+        from nemo_gym.benchmarks import _benchmark_config_name
+
+        assert _benchmark_config_name(Path(rel)) == expected
+
+    def test_every_listed_token_round_trips_through_the_benchmark_selector(self) -> None:
+        # The point of keying by token: every value `gym list benchmarks` prints must resolve back to its own
+        # config via `--benchmark`, using the same `_asset_config_path` mapping the CLI uses. This covers the
+        # benchmarks whose `dataset.name` diverges from their on-disk path (e.g. tau2, livecodebench).
+        from nemo_gym.benchmarks import discover_benchmarks
+        from nemo_gym.cli.main import _asset_config_path
+
+        benchmarks = discover_benchmarks()
+        assert benchmarks, "no benchmarks discovered"
+        for token, bench in benchmarks.items():
+            resolved = Path(_asset_config_path("benchmark", token))
+            assert resolved.resolve() == bench.path.resolve(), f"token {token!r} does not select its own config"
 
 
 class TestBenchmarkConfigStrictParsing:
@@ -190,6 +223,7 @@ class TestSearchBenchmarks:
 
     def _bench(self, key: str):
         bench = MagicMock(agent_name="my_agent", num_repeats=1)
+        bench.name = key  # `dataset.name`; also fuzzy-matched by `gym search`
         bench.path = key  # the patched read_config_metadata keys off the path to find the domain
         return bench
 

--- a/tests/unit_tests/test_benchmarks.py
+++ b/tests/unit_tests/test_benchmarks.py
@@ -19,7 +19,7 @@ import pytest
 from omegaconf import OmegaConf
 from yaml import safe_load
 
-from nemo_gym.cli.eval import _fuzzy_matches, list_benchmarks, prepare_benchmark
+from nemo_gym.cli.eval import list_benchmarks, prepare_benchmark
 
 
 def _mock_global_config(config: dict = None):
@@ -181,24 +181,6 @@ class TestBenchmarkConfigStrictParsing:
         assert tolerated is None
 
 
-class TestFuzzyMatches:
-    def test_substring_matches(self) -> None:
-        assert _fuzzy_matches("math", "math_with_judge")
-
-    def test_token_typo_matches(self) -> None:
-        # `aimee` is a near-miss for the `aime` token in `aime24`.
-        assert _fuzzy_matches("aimee", "aime24")
-
-    def test_matches_against_agent_field(self) -> None:
-        assert _fuzzy_matches("judge", "aime24", "math_with_judge_agent")
-
-    def test_skips_empty_fields(self) -> None:
-        assert not _fuzzy_matches("math", "", None)
-
-    def test_no_match(self) -> None:
-        assert not _fuzzy_matches("zzznomatch", "aime24", "math_with_judge")
-
-
 class TestSearchBenchmarks:
     # Map each benchmark name to the `domain` its config would resolve to.
     DOMAINS = {
@@ -279,7 +261,6 @@ class TestPrepareBenchmark:
                     {"config_paths": [str(config_path)], **safe_load(config_path.read_text())}
                 ),
             ),
-            patch("nemo_gym.cli.eval.BENCHMARKS_DIR", bench_dir.parent),
             patch("nemo_gym.cli.eval.importlib.import_module", return_value=mock_module),
         ):
             prepare_benchmark()
@@ -296,7 +277,6 @@ class TestPrepareBenchmark:
                     {"config_paths": [str(config_path)], **safe_load(config_path.read_text())}
                 ),
             ),
-            patch("nemo_gym.cli.eval.BENCHMARKS_DIR", bench_dir.parent),
         ):
             with pytest.raises(SystemExit) as exc_info:
                 prepare_benchmark()
@@ -316,7 +296,6 @@ class TestPrepareBenchmark:
                     {"config_paths": [str(config_path)], **safe_load(config_path.read_text())}
                 ),
             ),
-            patch("nemo_gym.cli.eval.BENCHMARKS_DIR", bench_dir.parent),
             patch("nemo_gym.cli.eval.importlib.import_module", return_value=mock_module),
         ):
             with pytest.raises(SystemExit) as exc_info:
@@ -369,7 +348,6 @@ class TestPrepareBenchmark:
                     {"config_paths": [str(config_path)], **safe_load(config_path.read_text())}
                 ),
             ),
-            patch("nemo_gym.cli.eval.BENCHMARKS_DIR", bench_dir.parent),
             patch("nemo_gym.cli.eval.importlib.import_module", return_value=mock_module),
         ):
             prepare_benchmark()
@@ -394,7 +372,6 @@ class TestPrepareBenchmark:
                     }
                 ),
             ),
-            patch("nemo_gym.cli.eval.BENCHMARKS_DIR", bench_dir.parent),
             patch("nemo_gym.cli.eval.importlib.import_module", return_value=mock_module),
         ):
             prepare_benchmark()

--- a/tests/unit_tests/test_benchmarks.py
+++ b/tests/unit_tests/test_benchmarks.py
@@ -220,6 +220,11 @@ class TestSearchBenchmarks:
         "aime24": "math",
         "gpqa_diamond": "science",
     }
+    # Descriptions carry text found in neither the name nor the domain, so a match proves description is searched.
+    DESCRIPTIONS = {
+        "aime24": "Competition problems from the AIME.",
+        "gpqa_diamond": "Graduate-level questions written by PhD experts.",
+    }
 
     def _bench(self, key: str):
         bench = MagicMock(agent_name="my_agent", num_repeats=1)
@@ -234,7 +239,10 @@ class TestSearchBenchmarks:
         with (
             patch("nemo_gym.cli.eval.get_global_config_dict", return_value=_mock_global_config({"query": query})),
             patch("nemo_gym.cli.eval.discover_benchmarks", return_value=benchmarks),
-            patch("nemo_gym.cli.eval.read_config_metadata", side_effect=lambda path: (self.DOMAINS[path], None)),
+            patch(
+                "nemo_gym.cli.eval.read_config_metadata",
+                side_effect=lambda path: (self.DOMAINS[path], self.DESCRIPTIONS[path]),
+            ),
         ):
             list_benchmarks()
         return capsys.readouterr().out
@@ -250,9 +258,15 @@ class TestSearchBenchmarks:
         assert "gpqa_diamond" in out
         assert "aime24" not in out
 
+    def test_query_matches_description(self, capsys) -> None:
+        # "PhD" only appears in gpqa's description, not its name/domain.
+        out = self._run("PhD", self._benchmarks(), capsys)
+        assert "gpqa_diamond" in out
+        assert "aime24" not in out
+
     def test_query_does_not_match_resource_server(self, capsys) -> None:
         # "judge" appears only in a resources server name, which is no longer searched:
-        # matching is restricted to the benchmark name and domain.
+        # matching is restricted to the benchmark name, domain, and description.
         assert "No benchmarks match 'judge'" in self._run("judge", self._benchmarks(), capsys)
 
     def test_query_no_match_message(self, capsys) -> None:

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -425,7 +425,8 @@ class TestListEnvironments:
         ]
 
     def test_query_filters_environments(self, monkeypatch: MonkeyPatch, capsys) -> None:
-        # `gym search environments <query>` reuses this command via the `query` config key (matches name + domain).
+        # `gym search environments <query>` reuses this command via the `query` config key
+        # (matches name + domain + description).
         beta = EnvironmentEntry(
             name="beta",
             config_path=Path("environments/beta/config.yaml"),
@@ -446,3 +447,25 @@ class TestListEnvironments:
         assert "Environments matching 'alpha'" in out
         assert "agent" in out  # alpha's domain -> its row was rendered
         assert "beta" not in out and "math" not in out  # beta and its domain filtered out
+
+    def test_query_matches_description(self, monkeypatch: MonkeyPatch, capsys) -> None:
+        # "Robotics" only appears in gamma's description, not its name or domain.
+        gamma = EnvironmentEntry(
+            name="gamma",
+            config_path=Path("environments/gamma/config.yaml"),
+            path=Path("environments/gamma"),
+            description="Robotics manipulation tasks",
+            domain="control",
+        )
+        monkeypatch.setattr(
+            nemo_gym.cli.env, "get_global_config_dict", lambda **k: OmegaConf.create({"query": "Robotics"})
+        )
+        monkeypatch.setattr(
+            nemo_gym.cli.env, "discover_environments", lambda *a, **k: {"alpha": self._ALPHA, "gamma": gamma}
+        )
+
+        list_environments()
+
+        out = capsys.readouterr().out
+        assert "gamma" in out
+        assert "alpha" not in out

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -423,3 +423,26 @@ class TestListEnvironments:
         assert json.loads(capsys.readouterr().out) == [
             {"name": "alpha", "domain": "agent", "description": "Alpha env"}
         ]
+
+    def test_query_filters_environments(self, monkeypatch: MonkeyPatch, capsys) -> None:
+        # `gym search environments <query>` reuses this command via the `query` config key (matches name + domain).
+        beta = EnvironmentEntry(
+            name="beta",
+            config_path=Path("environments/beta/config.yaml"),
+            path=Path("environments/beta"),
+            description="Beta env",
+            domain="math",
+        )
+        monkeypatch.setattr(
+            nemo_gym.cli.env, "get_global_config_dict", lambda **k: OmegaConf.create({"query": "alpha"})
+        )
+        monkeypatch.setattr(
+            nemo_gym.cli.env, "discover_environments", lambda *a, **k: {"alpha": self._ALPHA, "beta": beta}
+        )
+
+        list_environments()
+
+        out = capsys.readouterr().out
+        assert "Environments matching 'alpha'" in out
+        assert "agent" in out  # alpha's domain -> its row was rendered
+        assert "beta" not in out and "math" not in out  # beta and its domain filtered out

--- a/tests/unit_tests/test_cli_agents.py
+++ b/tests/unit_tests/test_cli_agents.py
@@ -75,3 +75,14 @@ class TestListAgents:
         assert by_name["simple_agent"]["pattern"] == "A (composable)"
         assert by_name["swe_agents"]["self_contained"] is True
         assert by_name["swe_agents"]["variants"] == ["swebench_openhands"]
+
+    def test_query_filters_agents(self, capsys) -> None:
+        # `gym search agents <query>` reuses this command via the `query` config key (name + variant names).
+        with (
+            patch("nemo_gym.cli.agents.get_global_config_dict", return_value=_mock_global_config({"query": "swe"})),
+            patch("nemo_gym.cli.agents.discover_agents", return_value=_AGENTS),
+        ):
+            list_agents()
+        out = capsys.readouterr().out
+        assert "swe_agents" in out and "Agents matching" in out
+        assert "simple_agent" not in out

--- a/tests/unit_tests/test_cli_agents.py
+++ b/tests/unit_tests/test_cli_agents.py
@@ -40,7 +40,12 @@ def _entry(name: str, self_contained: bool, variants=(), description=None) -> Ag
 
 _AGENTS = {
     "simple_agent": _entry("simple_agent", self_contained=False, variants=("simple_agent",)),
-    "swe_agents": _entry("swe_agents", self_contained=True, variants=("swebench_openhands",), description="SWE tasks"),
+    "swe_agents": _entry(
+        "swe_agents",
+        self_contained=True,
+        variants=("swebench_openhands",),
+        description="Agent for software engineering tasks",
+    ),
 }
 
 
@@ -77,9 +82,23 @@ class TestListAgents:
         assert by_name["swe_agents"]["variants"] == ["swebench_openhands"]
 
     def test_query_filters_agents(self, capsys) -> None:
-        # `gym search agents <query>` reuses this command via the `query` config key (name + variant names).
+        # `gym search agents <query>` reuses this command via the `query` config key (name + description + variants).
         with (
             patch("nemo_gym.cli.agents.get_global_config_dict", return_value=_mock_global_config({"query": "swe"})),
+            patch("nemo_gym.cli.agents.discover_agents", return_value=_AGENTS),
+        ):
+            list_agents()
+        out = capsys.readouterr().out
+        assert "swe_agents" in out and "Agents matching" in out
+        assert "simple_agent" not in out
+
+    def test_query_matches_description(self, capsys) -> None:
+        # "engineering" only appears in swe_agents' description, not its name or variants.
+        with (
+            patch(
+                "nemo_gym.cli.agents.get_global_config_dict",
+                return_value=_mock_global_config({"query": "engineering"}),
+            ),
             patch("nemo_gym.cli.agents.discover_agents", return_value=_AGENTS),
         ):
             list_agents()

--- a/tests/unit_tests/test_cli_main.py
+++ b/tests/unit_tests/test_cli_main.py
@@ -18,6 +18,7 @@ import sys
 import types
 
 import pytest
+from hydra.core.override_parser.overrides_parser import OverridesParser
 from pytest import MonkeyPatch
 
 import nemo_gym.cli.main as cli_main
@@ -674,7 +675,7 @@ class TestSearch:
         # `gym search <query>` (no type) reuses the benchmarks listing — backward compatible.
         target, overrides = _dispatch_for(monkeypatch, ["search", "math"])
         assert target == "nemo_gym.cli.eval:list_benchmarks"
-        assert overrides == ["+query=math"]
+        assert overrides == ['+query="math"']
 
     @pytest.mark.parametrize(
         "component_type, expected_target",
@@ -690,11 +691,21 @@ class TestSearch:
         # `gym search <type> <query>` runs that type's listing, filtered by the query.
         target, overrides = _dispatch_for(monkeypatch, ["search", component_type, "swe"])
         assert target == expected_target
-        assert overrides == ["+query=swe"]
+        assert overrides == ['+query="swe"']
 
     def test_search_json(self, monkeypatch: MonkeyPatch) -> None:
         _, overrides = _dispatch_for(monkeypatch, ["search", "math", "--json"])
-        assert set(overrides) == {"+query=math", "+json=true"}
+        assert set(overrides) == {'+query="math"', "+json=true"}
+
+    @pytest.mark.parametrize("query", ["(A)", "a b", "[x]", "A|B"])
+    def test_search_query_with_special_chars_is_hydra_safe(self, monkeypatch: MonkeyPatch, query) -> None:
+        # The query is quoted so Hydra's override grammar accepts characters that are otherwise syntax,
+        # e.g. `gym search agents "(A)"` used to raise an override parse error. The quoted override must
+        # both be valid Hydra and round-trip back to the original query string.
+        _, overrides = _dispatch_for(monkeypatch, ["search", "agents", query])
+        assert overrides == [f'+query="{query}"']
+        parsed = OverridesParser.create().parse_overrides(overrides)[0]
+        assert parsed.value() == query
 
     def test_version_json_dispatches_with_override(self, monkeypatch: MonkeyPatch) -> None:
         # `gym --version --json` is the top-level path; it still forwards +json=true to the version command.

--- a/tests/unit_tests/test_cli_main.py
+++ b/tests/unit_tests/test_cli_main.py
@@ -654,6 +654,7 @@ class TestJsonFlag:
         [
             (["list", "benchmarks", "--json"], "nemo_gym.cli.eval:list_benchmarks"),
             (["list", "agents", "--json"], "nemo_gym.cli.agents:list_agents"),
+            (["list", "models", "--json"], "nemo_gym.cli.models:list_models"),
             (["env", "status", "--json"], "nemo_gym.cli.env:status"),
         ],
     )

--- a/tests/unit_tests/test_cli_main.py
+++ b/tests/unit_tests/test_cli_main.py
@@ -964,10 +964,14 @@ class TestDidYouMean:
     """difflib-backed "did you mean?" hints for mistyped commands, flags, and component names (proposal UX 4)."""
 
     def test_helper_suggests_close_match(self) -> None:
-        assert cli_main._did_you_mean("evl", ["list", "eval", "env"]) == " Did you mean `eval`?"
+        from nemo_gym.cli.utils import did_you_mean
+
+        assert did_you_mean("evl", ["list", "eval", "env"]) == " Did you mean `eval`?"
 
     def test_helper_silent_when_nothing_close(self) -> None:
-        assert cli_main._did_you_mean("zzzzzz", ["list", "eval", "env"]) == ""
+        from nemo_gym.cli.utils import did_you_mean
+
+        assert did_you_mean("zzzzzz", ["list", "eval", "env"]) == ""
 
     def _run_expecting_exit(self, monkeypatch: MonkeyPatch, capsys, argv: list[str]) -> str:
         monkeypatch.setattr(cli_main, "dispatch", lambda target, overrides: None)

--- a/tests/unit_tests/test_cli_main.py
+++ b/tests/unit_tests/test_cli_main.py
@@ -1009,6 +1009,19 @@ class TestDidYouMean:
         )
         assert "Did you mean `dapo17k`?" in err
 
+    def test_benchmark_group_dir_suggests_a_nested_token(self, monkeypatch: MonkeyPatch, capsys) -> None:
+        # `livecodebench` is a directory that only groups benchmarks (its configs are nested), so it is not
+        # itself a valid `--benchmark` value. The hint must point at a real nested token, not circle back to
+        # the bare directory name.
+        err = self._run_expecting_exit(monkeypatch, capsys, ["eval", "run", "--benchmark", "livecodebench"])
+        assert "Did you mean `livecodebench/" in err
+        assert "Did you mean `livecodebench`?" not in err
+
+    def test_benchmark_group_dir_with_flavor_configs_subdir(self, monkeypatch: MonkeyPatch, capsys) -> None:
+        # tau2 keeps its benchmarks under `configs/`; the hint should surface one of those tokens.
+        err = self._run_expecting_exit(monkeypatch, capsys, ["eval", "prepare", "--benchmark", "tau2"])
+        assert "Did you mean `tau2/configs/" in err
+
 
 class TestSearchDir:
     """--search-dir registers extra roots that the name->config selectors also search (REQ 5)."""
@@ -1016,7 +1029,9 @@ class TestSearchDir:
     def _make_user_benchmark(self, tmp_path, name: str = "mybench") -> None:
         bench_dir = tmp_path / "benchmarks" / name
         bench_dir.mkdir(parents=True)
-        (bench_dir / "config.yaml").write_text("{}\n")
+        # A `type: benchmark` dataset so the config is discoverable as a real benchmark (the "did you mean"
+        # suggestions enumerate real benchmark tokens); resolution itself only needs the file to exist.
+        (bench_dir / "config.yaml").write_text("x:\n  datasets:\n  - type: benchmark\n")
 
     def test_resolves_component_from_user_dir(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
         self._make_user_benchmark(tmp_path)

--- a/tests/unit_tests/test_cli_main.py
+++ b/tests/unit_tests/test_cli_main.py
@@ -683,6 +683,7 @@ class TestSearch:
             ("environments", "nemo_gym.cli.env:list_environments"),
             ("agents", "nemo_gym.cli.agents:list_agents"),
             ("models", "nemo_gym.cli.models:list_models"),
+            ("resources-servers", "nemo_gym.cli.resources_servers:list_resources_servers"),
         ],
     )
     def test_search_type_routes_to_that_listing(self, monkeypatch, component_type, expected_target) -> None:

--- a/tests/unit_tests/test_cli_main.py
+++ b/tests/unit_tests/test_cli_main.py
@@ -670,11 +670,26 @@ class TestJsonFlag:
 
 
 class TestSearch:
-    def test_search_routes_to_list_with_query(self, monkeypatch: MonkeyPatch) -> None:
-        # `gym search <query>` reuses the benchmarks listing, passing the query as the `query` config key.
+    def test_search_query_only_defaults_to_benchmarks(self, monkeypatch: MonkeyPatch) -> None:
+        # `gym search <query>` (no type) reuses the benchmarks listing — backward compatible.
         target, overrides = _dispatch_for(monkeypatch, ["search", "math"])
         assert target == "nemo_gym.cli.eval:list_benchmarks"
         assert overrides == ["+query=math"]
+
+    @pytest.mark.parametrize(
+        "component_type, expected_target",
+        [
+            ("benchmarks", "nemo_gym.cli.eval:list_benchmarks"),
+            ("environments", "nemo_gym.cli.env:list_environments"),
+            ("agents", "nemo_gym.cli.agents:list_agents"),
+            ("models", "nemo_gym.cli.models:list_models"),
+        ],
+    )
+    def test_search_type_routes_to_that_listing(self, monkeypatch, component_type, expected_target) -> None:
+        # `gym search <type> <query>` runs that type's listing, filtered by the query.
+        target, overrides = _dispatch_for(monkeypatch, ["search", component_type, "swe"])
+        assert target == expected_target
+        assert overrides == ["+query=swe"]
 
     def test_search_json(self, monkeypatch: MonkeyPatch) -> None:
         _, overrides = _dispatch_for(monkeypatch, ["search", "math", "--json"])

--- a/tests/unit_tests/test_cli_models.py
+++ b/tests/unit_tests/test_cli_models.py
@@ -26,15 +26,15 @@ def _mock_global_config(config: dict = None):
     return OmegaConf.create(config or {})
 
 
-def _entry(name: str, flavors=()) -> ModelEntry:
-    path = Path("responses_api_models") / name
-    config_paths = tuple(path / "configs" / f"{f}.yaml" for f in flavors)
-    return ModelEntry(name=name, path=path, config_paths=config_paths)
+def _entry(name: str, group: str) -> ModelEntry:
+    config_path = Path("responses_api_models") / group / "configs" / f"{name.split('/')[-1]}.yaml"
+    return ModelEntry(name=name, model_group=group, config_path=config_path)
 
 
 _MODELS = {
-    "my_model": _entry("my_model", flavors=("my_model", "some_other_flavor")),
-    "another_model": _entry("another_model", flavors=("another_model",)),
+    "my_model": _entry("my_model", "my_model"),
+    "my_model/some_other_flavor": _entry("my_model/some_other_flavor", "my_model"),
+    "another_model": _entry("another_model", "another_model"),
 }
 
 
@@ -47,7 +47,7 @@ class TestListModels:
             list_models()
         out = capsys.readouterr().out
 
-        variants = [token for entry in _MODELS.values() for token in entry.model_types]
+        variants = list(_MODELS)
         assert len(variants) == 3
         # one data row per variant (data rows use the light "│"; the header uses the heavy "┃")
         assert sum(1 for line in out.splitlines() if "│" in line) == 3

--- a/tests/unit_tests/test_cli_models.py
+++ b/tests/unit_tests/test_cli_models.py
@@ -62,6 +62,20 @@ class TestListModels:
             list_models()
         assert "No models found" in capsys.readouterr().out
 
+    def test_query_filters_rows(self, capsys) -> None:
+        # `gym search models <query>` reuses this command via the `query` config key (token + model group).
+        with (
+            patch(
+                "nemo_gym.cli.models.get_global_config_dict",
+                return_value=_mock_global_config({"query": "some_other_flavor"}),
+            ),
+            patch("nemo_gym.cli.models.discover_models", return_value=_MODELS),
+        ):
+            list_models()
+        out = capsys.readouterr().out
+        assert "my_model/some_other_flavor" in out and "Models matching" in out
+        assert "another_model" not in out
+
     def test_json_output_is_per_variant_rows(self, capsys) -> None:
         with (
             patch("nemo_gym.cli.models.get_global_config_dict", return_value=_mock_global_config({"json": True})),

--- a/tests/unit_tests/test_cli_models.py
+++ b/tests/unit_tests/test_cli_models.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from omegaconf import OmegaConf
+
+from nemo_gym.cli.models import list_models
+from nemo_gym.model_registry import ModelEntry
+
+
+def _mock_global_config(config: dict = None):
+    return OmegaConf.create(config or {})
+
+
+def _entry(name: str, flavors=()) -> ModelEntry:
+    path = Path("responses_api_models") / name
+    config_paths = tuple(path / "configs" / f"{f}.yaml" for f in flavors)
+    return ModelEntry(name=name, path=path, config_paths=config_paths)
+
+
+_MODELS = {
+    "my_model": _entry("my_model", flavors=("my_model", "some_other_flavor")),
+    "another_model": _entry("another_model", flavors=("another_model",)),
+}
+
+
+class TestListModels:
+    def test_lists_per_variant_rows(self, capsys) -> None:
+        with (
+            patch("nemo_gym.cli.models.get_global_config_dict", return_value=_mock_global_config()),
+            patch("nemo_gym.cli.models.discover_models", return_value=_MODELS),
+        ):
+            list_models()
+        out = capsys.readouterr().out
+
+        variants = [token for entry in _MODELS.values() for token in entry.model_types]
+        assert len(variants) == 3
+        # one data row per variant (data rows use the light "│"; the header uses the heavy "┃")
+        assert sum(1 for line in out.splitlines() if "│" in line) == 3
+        for variant in variants:
+            assert variant in out
+
+    def test_no_models(self, capsys) -> None:
+        with (
+            patch("nemo_gym.cli.models.get_global_config_dict", return_value=_mock_global_config()),
+            patch("nemo_gym.cli.models.discover_models", return_value={}),
+        ):
+            list_models()
+        assert "No models found" in capsys.readouterr().out
+
+    def test_json_output_is_per_variant_rows(self, capsys) -> None:
+        with (
+            patch("nemo_gym.cli.models.get_global_config_dict", return_value=_mock_global_config({"json": True})),
+            patch("nemo_gym.cli.models.discover_models", return_value=_MODELS),
+        ):
+            list_models()
+        payload = json.loads(capsys.readouterr().out)
+        expected = [
+            {"model": "my_model", "model_group": "my_model"},
+            {"model": "my_model/some_other_flavor", "model_group": "my_model"},
+            {"model": "another_model", "model_group": "another_model"},
+        ]
+        assert len(payload) == len(expected)
+        for row in expected:
+            assert row in payload

--- a/tests/unit_tests/test_cli_resources_servers.py
+++ b/tests/unit_tests/test_cli_resources_servers.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from omegaconf import OmegaConf
+
+from nemo_gym.cli.resources_servers import list_resources_servers
+from nemo_gym.resources_server_registry import ResourcesServerEntry
+
+
+def _mock_global_config(config: dict = None):
+    return OmegaConf.create(config or {})
+
+
+def _entry(name: str, domain: str, description: str) -> ResourcesServerEntry:
+    path = Path("resources_servers") / name
+    return ResourcesServerEntry(
+        name=name, config_path=path / "configs" / f"{name}.yaml", path=path, description=description, domain=domain
+    )
+
+
+_SERVERS = {
+    "mcqa": _entry("mcqa", "knowledge", "Multi-choice QA"),
+    "aviary": _entry("aviary", "math", "Math tasks"),
+}
+
+
+class TestListResourcesServers:
+    def test_lists_servers(self, capsys) -> None:
+        with (
+            patch("nemo_gym.cli.resources_servers.get_global_config_dict", return_value=_mock_global_config()),
+            patch("nemo_gym.cli.resources_servers.discover_resources_servers", return_value=_SERVERS),
+        ):
+            list_resources_servers()
+        out = capsys.readouterr().out
+        assert "mcqa" in out and "knowledge" in out and "aviary" in out
+
+    def test_no_servers(self, capsys) -> None:
+        with (
+            patch("nemo_gym.cli.resources_servers.get_global_config_dict", return_value=_mock_global_config()),
+            patch("nemo_gym.cli.resources_servers.discover_resources_servers", return_value={}),
+        ):
+            list_resources_servers()
+        assert "No resources servers found" in capsys.readouterr().out
+
+    def test_json_output(self, capsys) -> None:
+        with (
+            patch(
+                "nemo_gym.cli.resources_servers.get_global_config_dict",
+                return_value=_mock_global_config({"json": True}),
+            ),
+            patch("nemo_gym.cli.resources_servers.discover_resources_servers", return_value=_SERVERS),
+        ):
+            list_resources_servers()
+        payload = json.loads(capsys.readouterr().out)
+        expected = [
+            {"name": "mcqa", "domain": "knowledge", "description": "Multi-choice QA"},
+            {"name": "aviary", "domain": "math", "description": "Math tasks"},
+        ]
+        assert len(payload) == len(expected)
+        for row in expected:
+            assert row in payload
+
+    def test_query_filters_servers(self, capsys) -> None:
+        # `gym search resources-servers <query>` reuses this command via the `query` config key (name + domain).
+        with (
+            patch(
+                "nemo_gym.cli.resources_servers.get_global_config_dict",
+                return_value=_mock_global_config({"query": "math"}),
+            ),
+            patch("nemo_gym.cli.resources_servers.discover_resources_servers", return_value=_SERVERS),
+        ):
+            list_resources_servers()
+        out = capsys.readouterr().out
+        assert "aviary" in out and "Resources servers matching" in out
+        assert "mcqa" not in out and "knowledge" not in out

--- a/tests/unit_tests/test_cli_resources_servers.py
+++ b/tests/unit_tests/test_cli_resources_servers.py
@@ -76,7 +76,8 @@ class TestListResourcesServers:
             assert row in payload
 
     def test_query_filters_servers(self, capsys) -> None:
-        # `gym search resources-servers <query>` reuses this command via the `query` config key (name + domain).
+        # `gym search resources-servers <query>` reuses this command via the `query` config key
+        # (name + domain + description).
         with (
             patch(
                 "nemo_gym.cli.resources_servers.get_global_config_dict",
@@ -88,3 +89,17 @@ class TestListResourcesServers:
         out = capsys.readouterr().out
         assert "aviary" in out and "Resources servers matching" in out
         assert "mcqa" not in out and "knowledge" not in out
+
+    def test_query_matches_description(self, capsys) -> None:
+        # "multichoice" only appears in mcqa's description ("Multi-choice QA"), not its name or domain.
+        with (
+            patch(
+                "nemo_gym.cli.resources_servers.get_global_config_dict",
+                return_value=_mock_global_config({"query": "multichoice"}),
+            ),
+            patch("nemo_gym.cli.resources_servers.discover_resources_servers", return_value=_SERVERS),
+        ):
+            list_resources_servers()
+        out = capsys.readouterr().out
+        assert "mcqa" in out and "Resources servers matching" in out
+        assert "aviary" not in out

--- a/tests/unit_tests/test_cli_utils.py
+++ b/tests/unit_tests/test_cli_utils.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 from rich.console import Console
 from rich.table import Table
 
-from nemo_gym.cli.utils import print_rich_table
+from nemo_gym.cli.utils import fuzzy_matches, print_rich_table
 
 
 # A cell value wider than Rich's 80-col non-TTY default, so a truncated render would ellipsize it.
@@ -59,3 +59,21 @@ class TestPrintRichTable:
         out = capsys.readouterr().out
         assert _LONG_NAME in out
         assert "…" not in out
+
+
+class TestFuzzyMatches:
+    def test_substring_matches(self) -> None:
+        assert fuzzy_matches("math", "math_with_judge")
+
+    def test_token_typo_matches(self) -> None:
+        # `aimee` is a near-miss for the `aime` token in `aime24`.
+        assert fuzzy_matches("aimee", "aime24")
+
+    def test_matches_any_field(self) -> None:
+        assert fuzzy_matches("judge", "aime24", "math_with_judge_agent")
+
+    def test_skips_empty_fields(self) -> None:
+        assert not fuzzy_matches("math", "", None)
+
+    def test_no_match(self) -> None:
+        assert not fuzzy_matches("zzznomatch", "aime24", "math_with_judge")

--- a/tests/unit_tests/test_model_registry.py
+++ b/tests/unit_tests/test_model_registry.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 from pathlib import Path
 
+from nemo_gym.discovery import merge_by_name
 from nemo_gym.model_registry import _discover_models_in_dir
 
 
@@ -31,23 +32,32 @@ def _make_model(models_dir: Path, name: str, *, app: bool = True, flavors=()) ->
 
 
 class TestDiscoverModels:
-    def test_discovers_by_directory_name(self, tmp_path: Path) -> None:
+    def test_keys_by_model_name(self, tmp_path: Path) -> None:
+        # One entry per --model-type name: `<dir>` for the flavor named after the model, `<dir>/<flavor>`
+        # for the rest.
         _make_model(tmp_path, "my_model", flavors=("my_model", "some_other_flavor"))
         _make_model(tmp_path, "another_model", flavors=("another_model",))
 
         models = _discover_models_in_dir(tmp_path)
 
-        assert set(models) == {"my_model", "another_model"}
-        assert list(models["my_model"].variants) == ["my_model", "some_other_flavor"]
+        assert set(models) == {"my_model", "my_model/some_other_flavor", "another_model"}
+        assert models["my_model/some_other_flavor"].model_group == "my_model"
+        assert models["my_model"].config_path == tmp_path / "my_model" / "configs" / "my_model.yaml"
 
-    def test_model_types_are_the_model_type_tokens(self, tmp_path: Path) -> None:
-        # The flavor named after the model is the default (bare `<name>`); others are `<name>/<flavor>`.
-        _make_model(tmp_path, "my_model", flavors=("my_model", "some_other_flavor"))
+    def test_user_flavor_shadows_only_its_name_not_the_whole_group(self, tmp_path: Path) -> None:
+        # A user's `vllm_model` flavor shadows only the `vllm_model` name; the built-in
+        # `vllm_model/vllm_model_for_training` flavor stays discoverable.
+        user = tmp_path / "user"
+        builtin = tmp_path / "builtin"
+        _make_model(user, "vllm_model", flavors=("vllm_model",))
+        _make_model(builtin, "vllm_model", flavors=("vllm_model", "vllm_model_for_training"))
 
-        assert _discover_models_in_dir(tmp_path)["my_model"].model_types == [
-            "my_model",
-            "my_model/some_other_flavor",
-        ]
+        merged = merge_by_name([_discover_models_in_dir(user), _discover_models_in_dir(builtin)])
+
+        assert set(merged) == {"vllm_model", "vllm_model/vllm_model_for_training"}
+        assert merged["vllm_model"].config_path == user / "vllm_model" / "configs" / "vllm_model.yaml"  # user wins
+        survivor = merged["vllm_model/vllm_model_for_training"]  # built-in flavor survives
+        assert survivor.config_path == builtin / "vllm_model" / "configs" / "vllm_model_for_training.yaml"
 
     def test_dirs_without_a_config_are_skipped(self, tmp_path: Path) -> None:
         # Only a dir that ships a config (something to pass to --model-type) is a model: a stray .egg-info,

--- a/tests/unit_tests/test_model_registry.py
+++ b/tests/unit_tests/test_model_registry.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+
+from nemo_gym.model_registry import _discover_models_in_dir
+
+
+def _make_model(models_dir: Path, name: str, *, app: bool = True, flavors=()) -> Path:
+    model_dir = models_dir / name
+    model_dir.mkdir(parents=True)
+    if app:
+        (model_dir / "app.py").write_text("# app\n")
+    if flavors:
+        configs_dir = model_dir / "configs"
+        configs_dir.mkdir()
+        for flavor in flavors:
+            (configs_dir / f"{flavor}.yaml").write_text("{}\n")
+    return model_dir
+
+
+class TestDiscoverModels:
+    def test_discovers_by_directory_name(self, tmp_path: Path) -> None:
+        _make_model(tmp_path, "my_model", flavors=("my_model", "some_other_flavor"))
+        _make_model(tmp_path, "another_model", flavors=("another_model",))
+
+        models = _discover_models_in_dir(tmp_path)
+
+        assert set(models) == {"my_model", "another_model"}
+        assert list(models["my_model"].variants) == ["my_model", "some_other_flavor"]
+
+    def test_model_types_are_the_model_type_tokens(self, tmp_path: Path) -> None:
+        # The flavor named after the model is the default (bare `<name>`); others are `<name>/<flavor>`.
+        _make_model(tmp_path, "my_model", flavors=("my_model", "some_other_flavor"))
+
+        assert _discover_models_in_dir(tmp_path)["my_model"].model_types == [
+            "my_model",
+            "my_model/some_other_flavor",
+        ]
+
+    def test_dirs_without_a_config_are_skipped(self, tmp_path: Path) -> None:
+        # Only a dir that ships a config (something to pass to --model-type) is a model: a stray .egg-info,
+        # or a dir with just an app.py and no configs, has nothing selectable and is not listed.
+        (tmp_path / "my_model.egg-info").mkdir()
+        _make_model(tmp_path, "app_only_model", app=True, flavors=())
+        _make_model(tmp_path, "another_model", flavors=("another_model",))
+
+        assert set(_discover_models_in_dir(tmp_path)) == {"another_model"}
+
+    def test_missing_directory_yields_no_models(self, tmp_path: Path) -> None:
+        assert _discover_models_in_dir(tmp_path / "nope") == {}

--- a/tests/unit_tests/test_resources_server_registry.py
+++ b/tests/unit_tests/test_resources_server_registry.py
@@ -39,22 +39,24 @@ class TestDiscoverResourcesServers:
             flavors={"my_server": ("knowledge", "The default"), "some_other_flavor": ("other", "A flavor")},
         )
 
-        entry = _discover_resources_servers_in_dir(tmp_path)["my_server"]
+        servers = _discover_resources_servers_in_dir(tmp_path)
 
+        assert set(servers) == {"my_server", "my_server/some_other_flavor"}  # one token per flavor
+        entry = servers["my_server"]
         assert entry.domain == "knowledge"
         assert entry.description == "The default"
         assert entry.config_path.name == "my_server.yaml"
 
-    def test_reads_first_flavor_when_no_default(self, tmp_path: Path) -> None:
-        # No `<name>.yaml`, so metadata is read from the first config alphabetically.
+    def test_flavor_tokens_when_no_default(self, tmp_path: Path) -> None:
+        # No `<name>.yaml`, so each flavor is its own `<name>/<flavor>` token (no collapsing to one entry).
         _make_resources_server(
             tmp_path, "my_server", flavors={"beta": ("science", "Beta"), "alpha": ("math", "Alpha")}
         )
 
-        entry = _discover_resources_servers_in_dir(tmp_path)["my_server"]
+        servers = _discover_resources_servers_in_dir(tmp_path)
 
-        assert entry.config_path.name == "alpha.yaml"
-        assert entry.domain == "math"
+        assert set(servers) == {"my_server/alpha", "my_server/beta"}
+        assert servers["my_server/alpha"].domain == "math"
 
     def test_dirs_without_a_config_are_skipped(self, tmp_path: Path) -> None:
         # A dir with no config (e.g. a stray .egg-info) is not a resources server.
@@ -62,6 +64,15 @@ class TestDiscoverResourcesServers:
         _make_resources_server(tmp_path, "real_server", flavors={"real_server": ("other", "Real")})
 
         assert set(_discover_resources_servers_in_dir(tmp_path)) == {"real_server"}
+
+    def test_helper_configs_are_skipped(self, tmp_path: Path) -> None:
+        # A config with no `resources_servers` block (e.g. a judge model helper) is not a flavor.
+        _make_resources_server(tmp_path, "my_server", flavors={"my_server": ("knowledge", "Default")})
+        (tmp_path / "my_server" / "configs" / "judge_model.yaml").write_text(
+            "judge_model:\n  responses_api_models:\n    m:\n      x: 1\n"
+        )
+
+        assert set(_discover_resources_servers_in_dir(tmp_path)) == {"my_server"}
 
     def test_missing_directory_yields_no_servers(self, tmp_path: Path) -> None:
         assert _discover_resources_servers_in_dir(tmp_path / "nope") == {}

--- a/tests/unit_tests/test_resources_server_registry.py
+++ b/tests/unit_tests/test_resources_server_registry.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+
+from nemo_gym.resources_server_registry import _discover_resources_servers_in_dir
+
+
+def _make_resources_server(rs_dir: Path, name: str, *, flavors: dict) -> Path:
+    """`flavors` maps config stem -> (domain, description). At least one config makes a resources server."""
+    server_dir = rs_dir / name
+    configs_dir = server_dir / "configs"
+    configs_dir.mkdir(parents=True)
+    for stem, (domain, description) in flavors.items():
+        (configs_dir / f"{stem}.yaml").write_text(
+            f"{name}:\n  resources_servers:\n    {name}:\n"
+            f"      entrypoint: app.py\n      domain: {domain}\n      description: {description}\n"
+        )
+    return server_dir
+
+
+class TestDiscoverResourcesServers:
+    def test_reads_metadata_from_default_flavor(self, tmp_path: Path) -> None:
+        # Metadata comes from the `<name>.yaml` flavor (the one `--resources-server <name>` resolves to).
+        _make_resources_server(
+            tmp_path,
+            "my_server",
+            flavors={"my_server": ("knowledge", "The default"), "some_other_flavor": ("other", "A flavor")},
+        )
+
+        entry = _discover_resources_servers_in_dir(tmp_path)["my_server"]
+
+        assert entry.domain == "knowledge"
+        assert entry.description == "The default"
+        assert entry.config_path.name == "my_server.yaml"
+
+    def test_reads_first_flavor_when_no_default(self, tmp_path: Path) -> None:
+        # No `<name>.yaml`, so metadata is read from the first config alphabetically.
+        _make_resources_server(
+            tmp_path, "my_server", flavors={"beta": ("science", "Beta"), "alpha": ("math", "Alpha")}
+        )
+
+        entry = _discover_resources_servers_in_dir(tmp_path)["my_server"]
+
+        assert entry.config_path.name == "alpha.yaml"
+        assert entry.domain == "math"
+
+    def test_dirs_without_a_config_are_skipped(self, tmp_path: Path) -> None:
+        # A dir with no config (e.g. a stray .egg-info) is not a resources server.
+        (tmp_path / "my_server.egg-info").mkdir()
+        _make_resources_server(tmp_path, "real_server", flavors={"real_server": ("other", "Real")})
+
+        assert set(_discover_resources_servers_in_dir(tmp_path)) == {"real_server"}
+
+    def test_missing_directory_yields_no_servers(self, tmp_path: Path) -> None:
+        assert _discover_resources_servers_in_dir(tmp_path / "nope") == {}


### PR DESCRIPTION
Extends CLI commands for discovery:

```
gym list models
gym list resources-servers

gym search environments
gym search agents
gym search models
gym search resources-servers
```

Part of NVIDIA-NeMo/Gym#1582