### PR TITLE
fix(ci): allow SLA tracker to label pull requests

### DIFF
--- a/.github/workflows/pr-sla-tracker.yml
+++ b/.github/workflows/pr-sla-tracker.yml
@@ -22,7 +22,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: pr-sla-tracker

--- a/tests/unit_tests/test_pr_sla_tracker.py
+++ b/tests/unit_tests/test_pr_sla_tracker.py
@@ -395,7 +395,7 @@ def test_workflow_runs_hourly_on_weekdays_with_minimal_permissions() -> None:
     assert workflow["permissions"] == {
         "contents": "read",
         "issues": "write",
-        "pull-requests": "read",
+        "pull-requests": "write",
     }
     assert workflow["jobs"]["refresh"]["timeout-minutes"] == "10"
 


### PR DESCRIPTION
## Summary

- Grant the PR SLA tracker pull-requests: write.
- Update the workflow permission regression test.

## Root cause

The first tracker run received 403 Resource not accessible by integration while adding an SLA label to PR #1788. The workflow granted only pull-requests: read, so it exited before creating or updating the tracker issue.

## Impact

The workflow can now reconcile SLA labels on pull requests and continue to create or update [Tracker] Pull request handoff SLA.

## Validation

- .venv/bin/pytest -q tests/unit_tests/test_pr_sla_tracker.py
- 24 passed

Failed run: https://github.com/NVIDIA-NeMo/Gym/actions/runs/29570272742/job/87852135838