### PR TITLE
feat(pinchbench): report across-run std of mean reward

### DIFF
--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -51,12 +51,12 @@ from fastapi import Request, Response
 from pydantic import ConfigDict
 
 from nemo_gym.base_resources_server import BaseRunRequest, BaseVerifyResponse
-from nemo_gym.global_config import ROLLOUT_INDEX_KEY_NAME
 from nemo_gym.base_responses_api_agent import (
     BaseResponsesAPIAgentConfig,
     Body,
     SimpleResponsesAPIAgent,
 )
+from nemo_gym.global_config import ROLLOUT_INDEX_KEY_NAME
 from nemo_gym.openai_utils import (
     NeMoGymFunctionCallOutput,
     NeMoGymResponse,

--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -38,7 +38,9 @@ See README.md for design + findings (skill patch, gateway, parity).
 import asyncio
 import glob
 import json
+import math
 import shutil
+import statistics
 import tarfile
 import textwrap
 import uuid
@@ -49,6 +51,7 @@ from fastapi import Request, Response
 from pydantic import ConfigDict
 
 from nemo_gym.base_resources_server import BaseRunRequest, BaseVerifyResponse
+from nemo_gym.global_config import ROLLOUT_INDEX_KEY_NAME
 from nemo_gym.base_responses_api_agent import (
     BaseResponsesAPIAgentConfig,
     Body,
@@ -152,12 +155,51 @@ class PinchBenchVerifyResponse(BaseVerifyResponse):
     raw_rollout: dict  # transcript archive location + compact metadata
 
 
+def _reward_std_across_runs(tasks: list[list[dict[str, Any]]]) -> dict[str, Any]:
+    """Across-run variability of the benchmark's mean reward.
+
+    Run i is "take repeat i of every task and average the rewards"; the
+    std-dev over those per-run means measures repeat-to-repeat variability
+    of mean/reward, unlike the pooled per-rollout std/reward. Repeats are
+    aligned by their rollout index, the run count is the minimum rollout
+    count present (keeps the matrix rectangular under partial outputs),
+    and single-repeat collections emit nothing.
+    """
+    max_k = min((len(t) for t in tasks if t), default=0)
+    if max_k < 2:
+        return {}
+
+    matrix: list[list[float]] = []
+    for task_rollouts in tasks:
+        # Stable sort: falls back to arrival order when the index is absent.
+        ordered = sorted(task_rollouts, key=lambda r: r.get(ROLLOUT_INDEX_KEY_NAME, 0))
+        row = [ordered[i].get("reward") for i in range(max_k)]
+        if any(v is None for v in row):
+            continue
+        matrix.append([float(v) for v in row])
+    if not matrix:
+        return {}
+
+    run_means = [sum(row[i] for row in matrix) / len(matrix) for i in range(max_k)]
+    if all(v == run_means[0] for v in run_means):
+        std_dev = 0.0
+    else:
+        std_dev = statistics.stdev(run_means)
+    return {
+        "mean/reward/std_dev_across_runs": std_dev,
+        "mean/reward/std_err_across_runs": std_dev / math.sqrt(max_k),
+    }
+
+
 class PinchBenchAgent(SimpleResponsesAPIAgent):
     config: PinchBenchAgentConfig
 
     def model_post_init(self, context):
         self._sem = asyncio.Semaphore(self.config.max_concurrent)
         return super().model_post_init(context)
+
+    def compute_metrics(self, tasks: list[list[dict[str, Any]]]) -> dict[str, Any]:
+        return _reward_std_across_runs(tasks)
 
     async def responses(
         self,

--- a/responses_api_agents/pinchbench/tests/test_app.py
+++ b/responses_api_agents/pinchbench/tests/test_app.py
@@ -19,6 +19,8 @@ fast and offline.
 """
 
 import json
+import math
+import statistics
 from unittest.mock import MagicMock
 
 import pytest
@@ -32,6 +34,7 @@ from responses_api_agents.pinchbench.app import (
     PinchBenchAgentConfig,
     SandboxKilledError,
     _classify_task_failure,
+    _reward_std_across_runs,
 )
 
 
@@ -343,3 +346,82 @@ def test_classify_task_failure_mapping():
     assert _classify_task_failure(TimeoutError("timed out")) == "timeout_exceeded"
     assert _classify_task_failure(RuntimeError("exec failed")) == "legitimate"
     assert _classify_task_failure(FileNotFoundError("apptainer")) == "legitimate"
+
+
+# ---------------------------------------------------------------------------
+# Across-run reward variability (compute_metrics)
+# ---------------------------------------------------------------------------
+
+
+class TestRewardStdAcrossRuns:
+    def test_two_runs_hand_computed(self):
+        tasks = [
+            [{"reward": 1.0, "_ng_rollout_index": 0}, {"reward": 0.0, "_ng_rollout_index": 1}],
+            [{"reward": 0.5, "_ng_rollout_index": 0}, {"reward": 0.5, "_ng_rollout_index": 1}],
+            [{"reward": 1.0, "_ng_rollout_index": 0}, {"reward": 0.5, "_ng_rollout_index": 1}],
+        ]
+        m = _reward_std_across_runs(tasks)
+        # Run means: (1.0 + 0.5 + 1.0)/3 = 5/6 and (0.0 + 0.5 + 0.5)/3 = 1/3;
+        # sample std-dev (ddof=1) of those two means.
+        expected_std = statistics.stdev([5 / 6, 1 / 3])
+        assert m["mean/reward/std_dev_across_runs"] == pytest.approx(expected_std)
+        assert m["mean/reward/std_err_across_runs"] == pytest.approx(expected_std / math.sqrt(2))
+
+    def test_single_repeat_emits_nothing(self):
+        tasks = [[{"reward": 1.0, "_ng_rollout_index": 0}], [{"reward": 0.0, "_ng_rollout_index": 0}]]
+        assert _reward_std_across_runs(tasks) == {}
+
+    def test_empty_input(self):
+        assert _reward_std_across_runs([]) == {}
+
+    def test_rollout_index_alignment_not_arrival_order(self):
+        ordered = [
+            [{"reward": 1.0, "_ng_rollout_index": 0}, {"reward": 0.0, "_ng_rollout_index": 1}],
+            [{"reward": 0.8, "_ng_rollout_index": 0}, {"reward": 0.2, "_ng_rollout_index": 1}],
+        ]
+        shuffled = [list(reversed(task)) for task in ordered]
+        assert _reward_std_across_runs(shuffled) == _reward_std_across_runs(ordered)
+
+    def test_uneven_rollout_counts_use_min_k(self):
+        tasks = [
+            [{"reward": 1.0, "_ng_rollout_index": i} for i in range(3)],
+            [{"reward": 0.0, "_ng_rollout_index": 0}, {"reward": 1.0, "_ng_rollout_index": 1}],
+        ]
+        m = _reward_std_across_runs(tasks)
+        # k = 2: run means (1.0+0.0)/2 = 0.5 and (1.0+1.0)/2 = 1.0.
+        assert m["mean/reward/std_dev_across_runs"] == pytest.approx(statistics.stdev([0.5, 1.0]))
+
+    def test_missing_reward_drops_task(self):
+        tasks = [
+            [{"reward": 1.0, "_ng_rollout_index": 0}, {"_ng_rollout_index": 1}],
+            [{"reward": 0.5, "_ng_rollout_index": 0}, {"reward": 0.5, "_ng_rollout_index": 1}],
+        ]
+        m = _reward_std_across_runs(tasks)
+        # Only the fully-rewarded task remains -> both run means 0.5 -> zero variance.
+        assert m["mean/reward/std_dev_across_runs"] == 0.0
+
+    def test_identical_runs_zero_std(self):
+        tasks = [
+            [{"reward": 0.7, "_ng_rollout_index": 0}, {"reward": 0.7, "_ng_rollout_index": 1}],
+            [{"reward": 0.3, "_ng_rollout_index": 0}, {"reward": 0.3, "_ng_rollout_index": 1}],
+        ]
+        m = _reward_std_across_runs(tasks)
+        assert m["mean/reward/std_dev_across_runs"] == 0.0
+        assert m["mean/reward/std_err_across_runs"] == 0.0
+
+    def test_agent_compute_metrics_and_key_metrics(self):
+        agent = make_agent()
+        tasks = [
+            [{"reward": 1.0, "_ng_rollout_index": 0}, {"reward": 0.0, "_ng_rollout_index": 1}],
+            [{"reward": 1.0, "_ng_rollout_index": 0}, {"reward": 0.5, "_ng_rollout_index": 1}],
+        ]
+        metrics = agent.compute_metrics(tasks)
+        assert set(metrics) == {
+            "mean/reward/std_dev_across_runs",
+            "mean/reward/std_err_across_runs",
+        }
+        # Default key-metrics selection keeps mean/* entries, so the new
+        # across-run stats surface as headline metrics automatically.
+        key = agent.get_key_metrics({"mean/reward": 0.6, "std/reward": 0.2, **metrics})
+        assert "mean/reward/std_dev_across_runs" in key
+        assert "std/reward" not in key


### PR DESCRIPTION
## What

When a PinchBench collection runs with `num_repeats > 1`, the agent's `compute_metrics` hook now emits:

- `mean/reward/std_dev_across_runs` — sample std-dev (ddof=1) of the per-run mean rewards, where run *i* is "take repeat *i* of every task (aligned by `_ng_rollout_index`) and average"
- `mean/reward/std_err_across_runs` — the above divided by √k

This measures repeat-to-repeat variability of the headline `mean/reward`, which the pooled per-rollout `std/reward` cannot (it mixes in across-sample spread). Single-repeat collections are unaffected — no keys are emitted.

## Why

Benchmark dashboards want an explicit across-run variability artifact next to the main metric (same convention as `compute_pass_majority_metrics`' `pass@1[avg-of-k]/*/std_dev_across_runs` and speed_bench's `spec_*_std_dev_across_runs`). PinchBench's main metric is `mean/reward`, which today has no across-run statistic.

## Details

- Repeats are aligned by `_ng_rollout_index` (stable-sorted; arrival order as fallback), the run count is the minimum rollout count across tasks (rectangular matrix under partial outputs), and tasks with missing rewards are dropped — mirroring `speed_bench._compute_std_metrics`.
- The new keys start with `mean/`, so the default `get_key_metrics` surfaces them as headline metrics automatically.

## Tests

`responses_api_agents/pinchbench/tests/test_app.py` — 8 new tests: hand-computed two-run std + std-err, single-repeat/empty no-op, rollout-index alignment vs arrival order, min-k rectangularization, missing-reward task drop, zero-variance case, and agent-level `compute_metrics`/`get_key_metrics` integration. Full file: 24 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)