### PR TITLE
feat(scicode): per-rollout subtask_accuracy + across-run std of both headline metrics

### DIFF
--- a/resources_servers/scicode/app.py
+++ b/resources_servers/scicode/app.py
@@ -72,6 +72,10 @@ class ScicodeVerifyResponse(BaseVerifyResponse):
     num_steps_passed: int = 0
     num_steps_total: int = 0
     problem_accuracy: bool = False
+    # Per-rollout sub-step pass fraction. As a numeric verify-response field it
+    # gets the full generic statistics (mean/std/min/max/median) from the
+    # RewardProfiler, which the aggregate-only pooled scalar cannot provide.
+    subtask_accuracy: float = 0.0
 
 
 class ScicodeResourcesServer(SimpleResourcesServer):
@@ -138,6 +142,7 @@ class ScicodeResourcesServer(SimpleResourcesServer):
             num_steps_passed=num_passed,
             num_steps_total=len(scored),
             problem_accuracy=all_passed,
+            subtask_accuracy=num_passed / len(scored),
         )
 
 

--- a/resources_servers/scicode/tests/test_app.py
+++ b/resources_servers/scicode/tests/test_app.py
@@ -164,6 +164,7 @@ class TestApp:
         assert result.step_results == [True, True]
         assert result.num_steps_passed == 2
         assert result.problem_accuracy is True
+        assert result.subtask_accuracy == 1.0
         assert result.problem_id == "1"  # preserved into the rollout output
 
     @pytest.mark.asyncio
@@ -173,6 +174,7 @@ class TestApp:
         assert result.reward == 0.0
         assert result.num_steps_passed == 0
         assert result.problem_accuracy is False
+        assert result.subtask_accuracy == 0.0
 
     @pytest.mark.asyncio
     async def test_verify_out_of_context_step_fails(self):
@@ -182,3 +184,4 @@ class TestApp:
         assert result.step_results == [True, False]
         assert result.num_steps_passed == 1
         assert result.reward == 0.0
+        assert result.subtask_accuracy == 0.5  # per-rollout sub-step pass fraction

--- a/responses_api_agents/scicode_agent/app.py
+++ b/responses_api_agents/scicode_agent/app.py
@@ -28,7 +28,6 @@ Templated on responses_api_agents/proof_refinement_agent (the multi-turn run() s
 """
 
 import logging
-import math
 import statistics
 from typing import Any, Dict, List
 
@@ -129,7 +128,6 @@ def _across_run_stats(tasks: List[List[Dict[str, Any]]]) -> Dict[str, Any]:
             continue
         std_dev = 0.0 if all(v == runs[0] for v in runs) else statistics.stdev(runs)
         metrics[f"{key}/std_dev_across_runs"] = std_dev
-        metrics[f"{key}/std_err_across_runs"] = std_dev / math.sqrt(len(runs))
     return metrics
 
 

--- a/responses_api_agents/scicode_agent/app.py
+++ b/responses_api_agents/scicode_agent/app.py
@@ -28,6 +28,8 @@ Templated on responses_api_agents/proof_refinement_agent (the multi-turn run() s
 """
 
 import logging
+import math
+import statistics
 from typing import Any, Dict, List
 
 from fastapi import Request, Response
@@ -47,6 +49,7 @@ from nemo_gym.base_responses_api_agent import (
     SimpleResponsesAPIAgent,
 )
 from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
+from nemo_gym.global_config import ROLLOUT_INDEX_KEY_NAME
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponse,
@@ -90,6 +93,44 @@ def _empty_response() -> dict:
         tool_choice="auto",
         tools=[],
     ).model_dump()
+
+
+def _across_run_stats(tasks: List[List[Dict[str, Any]]]) -> Dict[str, Any]:
+    """Across-run (repeat-to-repeat) variability of the two headline metrics.
+
+    Run i is "take repeat i of every problem" (repeats aligned by their rollout
+    index, run count = minimum repeat count so the matrix stays rectangular).
+    Per run, problem accuracy is the mean of problem_accuracy over problems and
+    subtask accuracy is the sub-step-weighted pool — the same definitions as
+    the headline mean/problem_accuracy and subtask_accuracy, so the std-dev
+    over the per-run values (sample std, ddof=1) is the run-to-run variability
+    of exactly those metrics. Single-repeat collections emit nothing.
+    """
+    max_k = min((len(t) for t in tasks if t), default=0)
+    if max_k < 2:
+        return {}
+
+    rows = [sorted(t, key=lambda r: r.get(ROLLOUT_INDEX_KEY_NAME, 0))[:max_k] for t in tasks if len(t) >= max_k]
+
+    problem_runs: List[float] = []
+    subtask_runs: List[float] = []
+    for i in range(max_k):
+        acc = [float(r[i]["problem_accuracy"]) for r in rows if r[i].get("problem_accuracy") is not None]
+        if acc:
+            problem_runs.append(sum(acc) / len(acc))
+        passed = sum(r[i].get("num_steps_passed", 0) for r in rows)
+        total = sum(r[i].get("num_steps_total", 0) for r in rows)
+        if total:
+            subtask_runs.append(passed / total)
+
+    metrics: Dict[str, Any] = {}
+    for key, runs in (("mean/problem_accuracy", problem_runs), ("subtask_accuracy", subtask_runs)):
+        if len(runs) < 2:
+            continue
+        std_dev = 0.0 if all(v == runs[0] for v in runs) else statistics.stdev(runs)
+        metrics[f"{key}/std_dev_across_runs"] = std_dev
+        metrics[f"{key}/std_err_across_runs"] = std_dev / math.sqrt(len(runs))
+    return metrics
 
 
 class ScicodeAgent(SimpleResponsesAPIAgent):
@@ -193,13 +234,16 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
         """Headline SciCode metric: sub-step-weighted accuracy = total passed / total over all rollouts."""
         passed = sum(r.get("num_steps_passed", 0) for task in tasks for r in task)
         total = sum(r.get("num_steps_total", 0) for task in tasks for r in task)
-        return {"subtask_accuracy": passed / total if total else 0.0}
+        metrics = {"subtask_accuracy": passed / total if total else 0.0}
+        metrics.update(_across_run_stats(tasks))
+        return metrics
 
     def get_key_metrics(self, agent_metrics: Dict[str, Any]) -> Dict[str, Any]:
-        key = {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
-        if "subtask_accuracy" in agent_metrics:
-            key["subtask_accuracy"] = agent_metrics["subtask_accuracy"]
-        return key
+        return {
+            k: v
+            for k, v in agent_metrics.items()
+            if k.startswith("mean/") or k.startswith("subtask_accuracy")
+        }
 
 
 if __name__ == "__main__":

--- a/responses_api_agents/scicode_agent/app.py
+++ b/responses_api_agents/scicode_agent/app.py
@@ -239,11 +239,7 @@ class ScicodeAgent(SimpleResponsesAPIAgent):
         return metrics
 
     def get_key_metrics(self, agent_metrics: Dict[str, Any]) -> Dict[str, Any]:
-        return {
-            k: v
-            for k, v in agent_metrics.items()
-            if k.startswith("mean/") or k.startswith("subtask_accuracy")
-        }
+        return {k: v for k, v in agent_metrics.items() if k.startswith("mean/") or k.startswith("subtask_accuracy")}
 
 
 if __name__ == "__main__":

--- a/responses_api_agents/scicode_agent/tests/test_app.py
+++ b/responses_api_agents/scicode_agent/tests/test_app.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import math
 import statistics
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -297,13 +296,8 @@ class TestAcrossRunStats:
         problem_runs = [1 / 2, 1 / 2, 0.0]  # run means of problem_accuracy
         subtask_runs = [5 / 6, 5 / 6, 3 / 6]  # per-run pooled sub-step fractions
         assert m["mean/problem_accuracy/std_dev_across_runs"] == pytest.approx(statistics.stdev(problem_runs))
-        assert m["mean/problem_accuracy/std_err_across_runs"] == pytest.approx(
-            statistics.stdev(problem_runs) / math.sqrt(3)
-        )
         assert m["subtask_accuracy/std_dev_across_runs"] == pytest.approx(statistics.stdev(subtask_runs))
-        assert m["subtask_accuracy/std_err_across_runs"] == pytest.approx(
-            statistics.stdev(subtask_runs) / math.sqrt(3)
-        )
+        assert not any(k.endswith("std_err_across_runs") for k in m)
 
     def test_single_repeat_emits_only_pooled_metric(self):
         tasks = [[_repeat(0, 1, 2)], [_repeat(0, 3, 4)]]

--- a/responses_api_agents/scicode_agent/tests/test_app.py
+++ b/responses_api_agents/scicode_agent/tests/test_app.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import math
+import statistics
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -264,3 +266,84 @@ class TestApp:
         assert key["subtask_accuracy"] == 0.414
         assert key["mean/reward"] == 0.1875
         assert "max/reward" not in key  # only mean/* + subtask_accuracy are headline
+
+
+# ---------------------------------------------------------------------------
+# Across-run variability (_across_run_stats via compute_metrics)
+# ---------------------------------------------------------------------------
+
+
+def _repeat(idx, passed, total):
+    return {
+        "_ng_rollout_index": idx,
+        "num_steps_passed": passed,
+        "num_steps_total": total,
+        "problem_accuracy": passed == total,
+    }
+
+
+class TestAcrossRunStats:
+    def test_three_runs_hand_computed(self):
+        # Two problems x three repeats. Per-run problem accuracy is the mean of
+        # problem_accuracy over problems; per-run subtask accuracy is the
+        # sub-step-weighted pool - the same definitions as the headline metrics.
+        tasks = [
+            [_repeat(0, 2, 2), _repeat(1, 1, 2), _repeat(2, 0, 2)],
+            [_repeat(0, 3, 4), _repeat(1, 4, 4), _repeat(2, 3, 4)],
+        ]
+        m = _agent().compute_metrics(tasks)
+        # Pooled headline is unchanged: (2+1+0+3+4+3) / (3*2 + 3*4) = 13/18.
+        assert m["subtask_accuracy"] == pytest.approx(13 / 18)
+        problem_runs = [1 / 2, 1 / 2, 0.0]  # run means of problem_accuracy
+        subtask_runs = [5 / 6, 5 / 6, 3 / 6]  # per-run pooled sub-step fractions
+        assert m["mean/problem_accuracy/std_dev_across_runs"] == pytest.approx(statistics.stdev(problem_runs))
+        assert m["mean/problem_accuracy/std_err_across_runs"] == pytest.approx(
+            statistics.stdev(problem_runs) / math.sqrt(3)
+        )
+        assert m["subtask_accuracy/std_dev_across_runs"] == pytest.approx(statistics.stdev(subtask_runs))
+        assert m["subtask_accuracy/std_err_across_runs"] == pytest.approx(
+            statistics.stdev(subtask_runs) / math.sqrt(3)
+        )
+
+    def test_single_repeat_emits_only_pooled_metric(self):
+        tasks = [[_repeat(0, 1, 2)], [_repeat(0, 3, 4)]]
+        assert _agent().compute_metrics(tasks) == {"subtask_accuracy": 4 / 6}
+
+    def test_rollout_index_alignment_not_arrival_order(self):
+        ordered = [
+            [_repeat(0, 2, 2), _repeat(1, 0, 2)],
+            [_repeat(0, 4, 4), _repeat(1, 1, 4)],
+        ]
+        shuffled = [list(reversed(task)) for task in ordered]
+        assert _agent().compute_metrics(shuffled) == _agent().compute_metrics(ordered)
+
+    def test_uneven_repeat_counts_use_min_k(self):
+        tasks = [
+            [_repeat(0, 2, 2), _repeat(1, 0, 2), _repeat(2, 1, 2)],
+            [_repeat(0, 4, 4), _repeat(1, 0, 4)],
+        ]
+        m = _agent().compute_metrics(tasks)
+        # k = 2: subtask runs (2+4)/6 = 1.0 and (0+0)/6 = 0.0.
+        assert m["subtask_accuracy/std_dev_across_runs"] == pytest.approx(statistics.stdev([1.0, 0.0]))
+
+    def test_identical_runs_zero_std(self):
+        tasks = [
+            [_repeat(0, 1, 2), _repeat(1, 1, 2)],
+            [_repeat(0, 4, 4), _repeat(1, 4, 4)],
+        ]
+        m = _agent().compute_metrics(tasks)
+        assert m["mean/problem_accuracy/std_dev_across_runs"] == 0.0
+        assert m["subtask_accuracy/std_dev_across_runs"] == 0.0
+
+    def test_get_key_metrics_includes_across_run_stats(self):
+        agent_metrics = {
+            "mean/problem_accuracy": 0.19,
+            "mean/problem_accuracy/std_dev_across_runs": 0.02,
+            "subtask_accuracy": 0.41,
+            "subtask_accuracy/std_dev_across_runs": 0.015,
+            "std/reward": 0.4,
+        }
+        key = _agent().get_key_metrics(agent_metrics)
+        assert "mean/problem_accuracy/std_dev_across_runs" in key
+        assert "subtask_accuracy/std_dev_across_runs" in key
+        assert "std/reward" not in key


### PR DESCRIPTION
## What

Two related fixes to SciCode's aggregate metrics:

1. **`subtask_accuracy` gets real statistics.** Today it is only a pooled scalar injected at aggregate time by the agent's `compute_metrics` — it is never a per-rollout field, so the generic `RewardProfiler` computes no statistics for it at all (no `mean/`, `std/`, `min/`, `max/`), unlike `reward`/`problem_accuracy`. `ScicodeVerifyResponse` now carries a per-rollout `subtask_accuracy` (that rollout's sub-step pass fraction), so the profiler describes it like any other numeric field.

2. **Across-run (repeat-to-repeat) std for both headline metrics.** With `num_repeats > 1` (the benchmark config default is 3), the agent's `compute_metrics` now emits:
   - `mean/problem_accuracy/std_dev_across_runs` — sample std-dev (ddof=1) over per-run means of `problem_accuracy`
   - `subtask_accuracy/std_dev_across_runs` — sample std-dev over per-run **sub-step-weighted pools**, i.e. the exact micro-average definition of the headline `subtask_accuracy`, computed per run

   Repeats are aligned by `_ng_rollout_index`; the run count is the minimum repeat count across problems (rectangular under partial outputs); single-repeat collections emit nothing extra.

## Why

Benchmark dashboards want an explicit across-run variability artifact next to each declared main metric (same convention as `compute_pass_majority_metrics`' `pass@1[avg-of-k]/*/std_dev_across_runs`). SciCode's declared metrics are `mean/problem_accuracy` and `subtask_accuracy`; neither had an across-run statistic, and `subtask_accuracy` had **no** statistics of any kind — a symptom of the pooled-scalar-only definition this PR fixes.

## Compatibility

- The pooled `subtask_accuracy` value and its definition are unchanged (still sub-step-weighted micro-average, matching nemo-skills parity noted in the benchmark README).
- `get_key_metrics` moves from an exact-key special case to a prefix match so the new `subtask_accuracy/*` stats surface as headline metrics; `mean/*` behavior unchanged.
- Note: the new per-rollout field also yields `mean/subtask_accuracy` (a macro-average over rollouts), which is intentionally distinct from the pooled micro-average `subtask_accuracy`.

## Tests

- `resources_servers/scicode/tests/test_app.py`: verify-path asserts for the new field (all-pass → 1.0, all-fail → 0.0, out-of-context partial → 0.5).
- `responses_api_agents/scicode_agent/tests/test_app.py`: 6 new tests — hand-computed 2-problems×3-repeats case for both metrics, single-repeat no-op, rollout-index alignment vs arrival order, min-k rectangularization, zero-variance case, and key-metrics surfacing.
- Both files: 37 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
