### PR TITLE
PinchBench: rotate Tavily keys across task sandboxes

### DIFF
--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -37,13 +37,14 @@ See README.md for design + findings (skill patch, gateway, parity).
 
 import asyncio
 import glob
+import itertools
 import json
 import shutil
 import tarfile
 import textwrap
 import uuid
 from pathlib import Path
-from typing import Any, Literal, Optional
+from typing import Any, List, Literal, Optional, Union
 
 from fastapi import Request, Response
 from pydantic import ConfigDict
@@ -106,7 +107,9 @@ class PinchBenchAgentConfig(BaseResponsesAPIAgentConfig):
 
     web_search_provider: str = "brave"
     brave_api_key: Optional[str] = None
-    tavily_api_key: Optional[str] = None
+    # Single key, comma-separated keys, or a list; multiple keys rotate across task
+    # sandboxes to spread provider rate limits.
+    tavily_api_key: Optional[Union[str, List[str]]] = None
 
     timeout_multiplier: float = 3.0
     max_concurrent: int = 4
@@ -157,7 +160,14 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
 
     def model_post_init(self, context):
         self._sem = asyncio.Semaphore(self.config.max_concurrent)
+        self._tavily_rr = itertools.count()
         return super().model_post_init(context)
+
+    def _next_tavily_key(self) -> str:
+        raw = self.config.tavily_api_key
+        keys = raw if isinstance(raw, list) else [k.strip() for k in raw.split(",")]
+        keys = [k for k in keys if k]
+        return keys[next(self._tavily_rr) % len(keys)]
 
     async def responses(
         self,
@@ -191,7 +201,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         if self.config.brave_api_key:
             env["BRAVE_API_KEY"] = self.config.brave_api_key
         if self.config.tavily_api_key:
-            env["TAVILY_API_KEY"] = self.config.tavily_api_key
+            env["TAVILY_API_KEY"] = self._next_tavily_key()
         return env
 
     # --- per-task sandbox (Gym Sandbox API; provider-neutral) ---------------

--- a/responses_api_agents/pinchbench/tests/test_app.py
+++ b/responses_api_agents/pinchbench/tests/test_app.py
@@ -343,3 +343,20 @@ def test_classify_task_failure_mapping():
     assert _classify_task_failure(TimeoutError("timed out")) == "timeout_exceeded"
     assert _classify_task_failure(RuntimeError("exec failed")) == "legitimate"
     assert _classify_task_failure(FileNotFoundError("apptainer")) == "legitimate"
+
+
+def test_tavily_single_key_unchanged():
+    agent = make_agent(tavily_api_key="tvly-only")  # pragma: allowlist secret
+    assert [agent._task_env("t")["TAVILY_API_KEY"] for _ in range(3)] == ["tvly-only"] * 3
+
+
+def test_tavily_comma_keys_rotate():
+    agent = make_agent(tavily_api_key="tvly-a, tvly-b,tvly-c")  # pragma: allowlist secret
+    got = [agent._task_env("t")["TAVILY_API_KEY"] for _ in range(6)]
+    assert got == ["tvly-a", "tvly-b", "tvly-c"] * 2
+
+
+def test_tavily_list_keys_rotate():
+    agent = make_agent(tavily_api_key=["tvly-x", "tvly-y"])  # pragma: allowlist secret
+    got = [agent._task_env("t")["TAVILY_API_KEY"] for _ in range(4)]
+    assert got == ["tvly-x", "tvly-y", "tvly-x", "tvly-y"]


### PR DESCRIPTION
A single Tavily key rate-limits under benchmark concurrency — 429/rate-limit signatures appear in 40–50% of task transcripts on full runs, hitting the web-research task families hardest and, for some models, spiraling into retry loops that consume the whole task budget.

`tavily_api_key` now accepts a single key (behavior unchanged), a comma-separated string, or a list; task sandboxes take keys round-robin, spreading the provider quota across tasks. Covered by unit tests for all three forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)