### PR TITLE
feat: accept opaque string envelopes for routed_experts

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -102,8 +102,11 @@ from nemo_gym.server_utils import (
 # Training-specific
 ########################################
 
-# Per-token routed expert indices with shape [tokens, num_moe_layers, topk].
-RoutedExperts: TypeAlias = List[List[List[int]]]
+# Per-token routed expert indices with shape [tokens, num_moe_layers, topk], either as
+# nested int lists or as an opaque string envelope produced by the training framework
+# (e.g. NeMo-RL's "nrlre1:<dtype>:<SxLxK>:<base64>"). Gym never inspects the value; the
+# string form keeps multi-MB payloads cheap to validate and re-serialize at every hop.
+RoutedExperts: TypeAlias = Union[str, List[List[List[int]]]]
 
 
 class TokenIDLogProbMixin(BaseModel):

--- a/responses_api_agents/harbor_agent/custom_agents/llms/nemo_gym_llm.py
+++ b/responses_api_agents/harbor_agent/custom_agents/llms/nemo_gym_llm.py
@@ -34,7 +34,7 @@ from tenacity import (
 from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
 
 
-_RoutedExperts = list[list[list[int]]]
+_RoutedExperts = list[list[list[int]]] | str
 _RolloutDetailsKey = tuple[tuple[int, ...], tuple[int, ...], tuple[float, ...] | None]
 
 
@@ -352,7 +352,7 @@ class NemoGymLLM(BaseLLM):
         routed_experts = message.get("routed_experts") if isinstance(message, dict) else None
         if routed_experts is None:
             routed_experts = response.get("routed_experts")
-        if not isinstance(routed_experts, list):
+        if not isinstance(routed_experts, (list, str)):
             return None
         return cast(_RoutedExperts, routed_experts)
 

--- a/responses_api_agents/harbor_agent/custom_agents/llms/test_nemo_gym_llm.py
+++ b/responses_api_agents/harbor_agent/custom_agents/llms/test_nemo_gym_llm.py
@@ -117,6 +117,31 @@ async def test_extracts_nemo_proxy_shape():
     assert llm.pop_routed_experts_for_rollout_details([11, 12], [13, 14], [-0.3, -0.4]) is None
 
 
+@pytest.mark.asyncio
+async def test_extracts_routed_experts_string_envelope():
+    """Routes may arrive as one opaque string envelope (e.g. NeMo-RL's
+    "nrlre1:<dtype>:<SxLxK>:<base64>"); it must be extracted and stored, not dropped."""
+    llm = _make_llm(collect_rollout_details=True)
+    routed_experts = "nrlre1:int16:2x1x2:AAABAAIAAwA="
+    response, _ = await _call(
+        llm,
+        _mock_response(
+            content="proxy output",
+            extra_message={
+                "prompt_token_ids": [11, 12],
+                "generation_token_ids": ["token_id:13", "token_id:14"],
+                "generation_log_probs": [-0.3, -0.4],
+                "routed_experts": routed_experts,
+            },
+        ),
+        prompt="hello",
+    )
+
+    assert response.prompt_token_ids == [11, 12]
+    assert llm.pop_routed_experts_for_rollout_details([11, 12], [13, 14], [-0.3, -0.4]) == routed_experts
+    assert llm.pop_routed_experts_for_rollout_details([11, 12], [13, 14], [-0.3, -0.4]) is None
+
+
 def test_duplicate_rollout_details_keys_do_not_guess_routed_experts():
     """Duplicate token/logprob keys are ambiguous, so they fail closed instead of guessing."""
     llm = _make_llm(collect_rollout_details=True)

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -3799,6 +3799,41 @@ class TestTopLogprobsHandling:
         message = response.json()["choices"][0]["message"]
         assert message["routed_experts"] == routed_experts
 
+    def test_capture_path_preserves_routed_experts_string_envelope(self) -> None:
+        """Training frameworks may ship routes as one opaque string (e.g. NeMo-RL's
+        "nrlre1:<dtype>:<SxLxK>:<base64>"); it must pass through unmodified."""
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+        routed_experts = "nrlre1:int16:3x1x2:AAABAAIAAwAEAAUA"
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs={
+                    "content": [
+                        {"token": "token_id:123", "logprob": -0.1, "bytes": None, "top_logprobs": []},
+                    ]
+                },
+                message_extra={"routed_experts": routed_experts},
+            )
+
+        async def mock_create_tokenize(**kwargs):
+            return {"tokens": [10, 20]}
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock(side_effect=mock_create_tokenize)
+        model._clients = [mock_client]
+
+        client = TestClient(app)
+        response = client.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        message = response.json()["choices"][0]["message"]
+        assert message["routed_experts"] == routed_experts
+
     def test_capture_path_raises_when_logprobs_missing(self) -> None:
         """If capture is on but vLLM returns no logprobs, fail loudly with an actionable
         error instead of an opaque TypeError or silently empty training data."""

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -27,6 +27,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseMcpApprovalRequest,
     NeMoGymResponseMcpCall,
     NeMoGymResponseMcpListTools,
+    TokenIDLogProbMixin,
 )
 
 
@@ -123,3 +124,26 @@ class TestNeMoGymResponseHostedMcpItems:
         assert issubclass(NeMoGymResponseMcpCall, McpCall)
         assert issubclass(NeMoGymResponseMcpListTools, McpListTools)
         assert issubclass(NeMoGymResponseMcpApprovalRequest, McpApprovalRequest)
+
+
+class TestRoutedExpertsWireFormats:
+    _BASE = {
+        "prompt_token_ids": [1, 2],
+        "generation_token_ids": [3],
+        "generation_log_probs": [-0.1],
+    }
+
+    def test_accepts_nested_int_lists(self) -> None:
+        mixin = TokenIDLogProbMixin.model_validate({**self._BASE, "routed_experts": [[[0, 1]], [[2, 3]]]})
+        assert mixin.routed_experts == [[[0, 1]], [[2, 3]]]
+
+    def test_accepts_opaque_string_envelope(self) -> None:
+        # Training frameworks may ship routes as a single opaque string (e.g. NeMo-RL's
+        # "nrlre1:<dtype>:<SxLxK>:<base64>") so multi-MB payloads validate in O(1).
+        envelope = "nrlre1:int16:2x1x2:AAABAAIAAwA="
+        mixin = TokenIDLogProbMixin.model_validate({**self._BASE, "routed_experts": envelope})
+        assert mixin.routed_experts == envelope
+
+    def test_rejects_non_list_non_string(self) -> None:
+        with pytest.raises(ValidationError):
+            TokenIDLogProbMixin.model_validate({**self._BASE, "routed_experts": 42})


### PR DESCRIPTION
Training frameworks attach per-token routed-expert indices ([tokens, num_moe_layers, topk]) to chat responses for MoE router replay. As nested JSON int lists these are multi-MB payloads that every gym hop re-parses, re-validates, and re-serializes at ~1s of single-threaded CPU each, throttling rollout throughput.

Widen RoutedExperts to Union[str, List[List[List[int]]]] so a single opaque envelope string (e.g. NeMo-RL's nrlre1:<dtype>:<SxLxK>:<base64>) passes through validation in O(1). Gym never inspects the value; the one non-passthrough site (harbor nemo_gym_llm _extract_routed_experts isinstance-list guard, which would silently drop a string) is widened to match. Nested-list payloads remain fully supported.
