### PR TITLE
Fix the cache path for sec.gov URLs 

### DIFF
--- a/resources_servers/finance_sec_search/app.py
+++ b/resources_servers/finance_sec_search/app.py
@@ -758,34 +758,38 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
     # ========================================================================
 
     def _parse_sec_url(self, url: str) -> Optional[Dict[str, str]]:
-        """Parse SEC URL to extract CIK and accession number."""
-        # URL format: https://www.sec.gov/Archives/edgar/data/{CIK}/{ACCESSION_NODASH}/{filename}
-        pattern = r"sec\.gov/Archives/edgar/data/(\d+)/(\d+)/"
+        """Parse SEC URL to extract CIK, accession number, and document filename."""
+        # URL format: https://www.sec.gov/Archives/edgar/data/{CIK}/{ACCESSION_NODASH}/{document}
+        pattern = r"sec\.gov/Archives/edgar/data/(\d+)/(\d+)/([^?#]*)"
         match = re.search(pattern, url)
         if match:
             cik = match.group(1).zfill(10)
             acc_nodash = match.group(2)
+            document = match.group(3).strip("/")
             # Convert to formatted accession: 0001234567-12-123456
             if len(acc_nodash) == 18:
                 accession = f"{acc_nodash[:10]}-{acc_nodash[10:12]}-{acc_nodash[12:]}"
             else:
                 accession = acc_nodash
-            return {"cik": cik, "accession_number": accession}
+            return {"cik": cik, "accession_number": accession, "document": document}
         return None
 
     def _url_to_filing_path(self, url: str) -> Optional[Path]:
         """Convert a SEC EDGAR URL to its local cache file path.
 
+        Keyed by (CIK, accession, document): distinct documents under one accession
+        (e.g. edgar_search sub-documents/exhibits) map to distinct cache files.
         Returns None if the URL doesn't match the expected SEC format.
         """
         parts = self._parse_sec_url(url)
         if not parts:
             return None
-        cik, accession_number = parts["cik"], parts["accession_number"]
-        cik_padded = str(cik).zfill(10)
-        acc_nodash = accession_number.replace("-", "")
-        # TODO: this path assumes the URL is for the primary filing document only, which is true because of how sec_filing_search is constructed
-        return self._filings_dir / cik_padded / f"{acc_nodash}.txt"
+        cik_padded = str(parts["cik"]).zfill(10)
+        acc_nodash = parts["accession_number"].replace("-", "")
+        # Flatten the document path into one safe filename; fall back to "index"
+        # when the URL stops at the accession directory (no document component).
+        safe_doc = re.sub(r"[^A-Za-z0-9._-]", "_", parts.get("document", "")) or "index"
+        return self._filings_dir / cik_padded / acc_nodash / f"{safe_doc}.txt"
 
     # ========================================================================
     # sec_filing_search Endpoint

--- a/resources_servers/finance_sec_search/tests/test_app.py
+++ b/resources_servers/finance_sec_search/tests/test_app.py
@@ -749,12 +749,31 @@ class TestDownloadAndParseFiling:
         assert "iXBRL Header" in result
 
     def test_url_to_filing_path(self, server) -> None:
-        """Test URL-to-filepath conversion for SEC URLs."""
+        """Test URL-to-filepath conversion for SEC URLs (keyed by document)."""
         url = "https://www.sec.gov/Archives/edgar/data/320193/000032019325000008/aapl-20250104.htm"
         path = server._url_to_filing_path(url)
         assert path is not None
-        assert path.name == "000032019325000008.txt"
+        # Path is filings/{CIK}/{accession}/{document}.txt
+        assert path.name == "aapl-20250104.htm.txt"
+        assert path.parent.name == "000032019325000008"
         assert "0000320193" in str(path.parent)
+
+    def test_url_to_filing_path_documents_do_not_collide(self, server) -> None:
+        """Two documents under the same accession map to distinct cache files."""
+        base = "https://www.sec.gov/Archives/edgar/data/320193/000032019325000008"
+        p_primary = server._url_to_filing_path(f"{base}/aapl-20241228.htm")
+        p_exhibit = server._url_to_filing_path(f"{base}/exhibit99-1.htm")
+        assert p_primary is not None and p_exhibit is not None
+        assert p_primary != p_exhibit
+        # ...but they still share the same accession directory.
+        assert p_primary.parent == p_exhibit.parent
+
+    def test_url_to_filing_path_no_document(self, server) -> None:
+        """A URL ending at the accession directory falls back to an index filename."""
+        url = "https://www.sec.gov/Archives/edgar/data/320193/000032019325000008/"
+        path = server._url_to_filing_path(url)
+        assert path is not None
+        assert path.name == "index.txt"
 
     def test_url_to_filing_path_invalid(self, server) -> None:
         """Invalid URLs return None."""


### PR DESCRIPTION
Fix the cache path for URLs so that we use the full doc name and not just accession number