### PR TITLE
[GDPval] Fix local-judge repeat-dir fallback + harden judging/proxy/docs

### DIFF
--- a/benchmarks/gdpval/README.md
+++ b/benchmarks/gdpval/README.md
@@ -320,27 +320,26 @@ Two pieces make this work:
 
 ### Run it
 
-First serve MiniMax-M3 yourself from the container on your GPU node(s) (the
-vendor GB200 command, TP=8 across two nodes):
+First serve MiniMax-M3 yourself on your GPU node(s) using the provided sbatch
+scripts, which pin the **validated single-node topology**. Do NOT serve TP=8
+across nodes: the cross-node MXFP8 all-reduce path on this container produces
+*garbage logits that still start cleanly* (see the header of
+`serve_minimax_multimodal_1node.sh`).
 
 ```bash
-IFACE_NAME=<fabric-nic>; HEAD_IP=<this-node-ip>
-docker run --gpus all --privileged --ipc=host -p 8000:8000 \
-    -v ~/.cache/huggingface:/root/.cache/huggingface \
-    -e GLOO_SOCKET_IFNAME=$IFACE_NAME -e NCCL_SOCKET_IFNAME=$IFACE_NAME \
-    vllm/vllm-openai:minimax-m3 MiniMaxAI/MiniMax-M3 \
-    --block-size 128 -cc.pass_config.fuse_allreduce_rms=False \
-    --tensor-parallel-size 8 --nnodes 2 --node-rank 0 --master-addr $HEAD_IP \
-    --tool-call-parser minimax_m3 --enable-auto-tool_choice \
-    --reasoning-parser minimax_m3
-# On Slurm without Docker, convert with enroot/pyxis and run the same args via
-# `srun --container-image=...`. Verify: curl -s http://$HEAD_IP:8000/v1/models
+# 1 GB200 node (TP=4) — simplest:
+sbatch resources_servers/gdpval/serve_minimax_multimodal_1node.sh
+# or 2 nodes (TP=4 x DP=2) for ~2x judge throughput:
+sbatch resources_servers/gdpval/serve_minimax_multimodal_dp2.sh
+# Verify (from the gym host): curl -s http://<node-ip>:5000/v1/models
 ```
 
-Then point gym at your endpoint:
+Then point gym at the endpoint the script wrote (note port **5000** and the
+served-model name):
 
 ```bash
-export MINIMAX_BASE_URL=http://$HEAD_IP:8000/v1   # your server's /v1 route
+export MINIMAX_BASE_URL=$(. ${OUTPUT_DIR}/server_info/minimax-m3.env; echo "$SERVER_URL")
+export MINIMAX_MODEL=minimax-m3   # must match the server's --served-model-name
 
 gym eval run \
     --model-type vllm_model \

--- a/benchmarks/gdpval/README.md
+++ b/benchmarks/gdpval/README.md
@@ -320,26 +320,25 @@ Two pieces make this work:
 
 ### Run it
 
-First serve MiniMax-M3 yourself on your GPU node(s) using the provided sbatch
-scripts, which pin the **validated single-node topology**. Do NOT serve TP=8
-across nodes: the cross-node MXFP8 all-reduce path on this container produces
-*garbage logits that still start cleanly* (see the header of
-`serve_minimax_multimodal_1node.sh`).
+First serve MiniMax-M3 yourself on your GPU node(s). NVIDIA users should use
+the internal serving workflow, which is maintained separately from Gym. Use a
+**single-node TP=4** instance, or independent single-node TP=4 replicas for
+data-parallel throughput. Do NOT form one TP=8 group across two nodes: the
+cross-node MXFP8 all-reduce path on this container produces *garbage logits
+that still start cleanly*.
 
 ```bash
-# 1 GB200 node (TP=4) — simplest:
-sbatch resources_servers/gdpval/serve_minimax_multimodal_1node.sh
-# or 2 nodes (TP=4 x DP=2) for ~2x judge throughput:
-sbatch resources_servers/gdpval/serve_minimax_multimodal_dp2.sh
-# Verify (from the gym host): curl -s http://<node-ip>:5000/v1/models
+# Verify the self-hosted endpoint from the gym host:
+curl -s http://<judge-host>:5000/v1/models
 ```
 
-Then point gym at the endpoint the script wrote (note port **5000** and the
-served-model name):
+Then point gym at that endpoint (the port and served-model name must match your
+deployment):
 
 ```bash
-export MINIMAX_BASE_URL=$(. ${OUTPUT_DIR}/server_info/minimax-m3.env; echo "$SERVER_URL")
-export MINIMAX_MODEL=minimax-m3   # must match the server's --served-model-name
+export MINIMAX_BASE_URL=http://<judge-host>:5000/v1
+export MINIMAX_MODEL=minimax-m3
+export MINIMAX_API_KEY=unused
 
 gym eval run \
     --model-type vllm_model \

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -359,9 +359,37 @@ class NeMoGymChatCompletionContentPartImageParam(ChatCompletionContentPartImageP
     pass
 
 
+class _NeMoGymVideoURL(TypedDict, total=False):
+    url: Required[str]
+
+
+class NeMoGymChatCompletionContentPartVideoParam(TypedDict, total=False):
+    # vLLM-standard ``video_url`` content part (not in the OpenAI SDK). Self-hosted
+    # VLM judges (e.g. MiniMax-M3) read video through this type; the proxy forwards
+    # it unchanged so it reaches the model's video tower. Without it in the union
+    # the proxy schema rejected video parts with a 422 and the matchup was silently
+    # dropped.
+    type: Required[Literal["video_url"]]
+    video_url: Required[_NeMoGymVideoURL]
+
+
+class _NeMoGymInputAudio(TypedDict, total=False):
+    data: Required[str]
+    format: Required[str]
+
+
+class NeMoGymChatCompletionContentPartInputAudioParam(TypedDict, total=False):
+    # OpenAI/vLLM ``input_audio`` content part (raw base64 + a format token) for
+    # self-hosted judges that read audio.
+    type: Required[Literal["input_audio"]]
+    input_audio: Required[_NeMoGymInputAudio]
+
+
 NeMoGymChatCompletionContentPartParam = Union[
     NeMoGymChatCompletionContentPartTextParam,
     NeMoGymChatCompletionContentPartImageParam,
+    NeMoGymChatCompletionContentPartVideoParam,
+    NeMoGymChatCompletionContentPartInputAudioParam,
 ]
 
 

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -715,6 +715,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
         total_wins = 0
         total_losses = 0
         total_ties = 0
+        total_invalid = 0
         # Per-reference-model vote tallies + a flat list of every (ref × repeat)
         # matchup for back-compat with the single-reference judge_response shape.
         per_reference: Dict[str, Dict[str, Any]] = {}
@@ -788,15 +789,19 @@ class GDPValResourcesServer(SimpleResourcesServer):
                     ref_wins += result["win_count_b"]
                     ref_losses += result["win_count_a"]
                     ref_ties += result["tie_count"]
+                    total_invalid += result.get("invalid_count", 0)
                     ref_judged_repeats += 1
                     # Fold per-judge counts into eval-perspective panel totals
                     # (B=eval, A=ref) so the per-member balance is auditable.
                     for jname, jc in (result.get("per_judge") or {}).items():
-                        agg = per_judge_totals.setdefault(jname, {"wins": 0, "losses": 0, "ties": 0, "trials": 0})
+                        agg = per_judge_totals.setdefault(
+                            jname, {"wins": 0, "losses": 0, "ties": 0, "trials": 0, "invalid_count": 0}
+                        )
                         agg["wins"] += jc.get("win_count_b", 0)
                         agg["losses"] += jc.get("win_count_a", 0)
                         agg["ties"] += jc.get("tie_count", 0)
                         agg["trials"] += jc.get("trials", 0)
+                        agg["invalid_count"] += jc.get("invalid_count", 0)
                     per_ref_results.append({"ref_id": ref_id, "ref_repeat": ref_dir.name, **result})
 
                 # Only record references that produced at least one valid matchup;
@@ -843,6 +848,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 "total_losses": total_losses,
                 "total_ties": total_ties,
                 "total_judged": total_judged,
+                "total_invalid": total_invalid,
                 "reference_count": len(per_reference),
                 # Back-compat: total matchups across all references × repeats.
                 "ref_repeat_count": len(per_ref_results),

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -538,23 +538,23 @@ _BOXED_RE = re.compile(r"BOXED\[(A|B|TIE)\]")
 _BOXED_TO_RESPONSE = {"A": A_WIN_RESPONSE, "B": B_WIN_RESPONSE, "TIE": TIE_RESPONSE}
 
 
-def parse_judgement(response_text: str) -> str:
+def parse_judgement(response_text: str) -> Optional[str]:
     """Extract the judge's verdict (``BOXED[A|B|TIE]``) from its response.
 
     Uses the **last** boxed token so a verbose/reasoning judge that writes e.g.
     ``"not BOXED[A]; the answer is BOXED[B]"`` is scored on its conclusion rather
     than the first token mentioned (the old first-substring match scored A here).
-    When no boxed verdict is present the response is mis-formatted; we log it and
-    fall back to a TIE so the failure is visible rather than silently pulling the
-    win rate toward 0.5.
+    When no boxed verdict is present the response is mis-formatted; return
+    ``None`` so the caller can exclude it from the ELO calculation. Treating an
+    invalid response as a tie would award the eval model half a win.
     """
     matches = _BOXED_RE.findall(response_text or "")
     if not matches:
         LOGGER.warning(
-            "judge response has no BOXED[A|B|TIE] verdict; scoring as TIE. head=%r",
+            "judge response has no BOXED[A|B|TIE] verdict; dropping vote. head=%r",
             (response_text or "")[:200],
         )
-        return TIE_RESPONSE
+        return None
     return _BOXED_TO_RESPONSE[matches[-1]]
 
 
@@ -628,11 +628,16 @@ def run_trials(
     historical single-judge loop. Pass *rng* (a seeded ``random.Random``) for
     reproducible judge selection.
 
+    Invalid responses without a boxed verdict are excluded rather than scored
+    as ties. If every response is invalid, the matchup fails so its caller can
+    retry or drop it explicitly.
+
     Returns a dict with ``winner``, ``win_count_a``, ``win_count_b``,
-    ``tie_count``, ``task_count``, ``per_judge`` (per-member a/b/tie/trial
-    counts keyed by judge name), and ``trial_judges`` (the judge name that graded
-    each trial, ordered by trial index — always present so the grader of every
-    match is documented).
+    ``tie_count``, ``task_count`` (valid votes only), ``invalid_count``,
+    ``per_judge`` (per-member a/b/tie/valid/invalid counts keyed by judge name),
+    and ``trial_judges`` (the judge name that graded each attempted trial,
+    ordered by trial index — always present so the grader of every match is
+    documented).
 
     When ``return_raw_responses`` is True, the dict also carries
     ``raw_responses`` (per-trial judge completion strings, same ordering as
@@ -645,6 +650,7 @@ def run_trials(
     win_count_a = 0
     win_count_b = 0
     tie_count = 0
+    invalid_count = 0
     raw_responses: list[str] = []
     trial_judges: list[str] = []
     per_judge: dict[str, dict] = {}
@@ -668,15 +674,27 @@ def run_trials(
         if return_raw_responses:
             raw_responses.append(response_text)
         judgement = parse_judgement(response_text)
-        win_count_a, win_count_b, tie_count = tally_result(judgement, swapped, win_count_a, win_count_b, tie_count)
 
         # Per-judge tally (same A=submission_a / B=submission_b convention as the
         # global counts) so the panel's per-member balance is auditable.
-        jc = per_judge.setdefault(judge.name, {"win_count_a": 0, "win_count_b": 0, "tie_count": 0, "trials": 0})
+        jc = per_judge.setdefault(
+            judge.name,
+            {"win_count_a": 0, "win_count_b": 0, "tie_count": 0, "trials": 0, "invalid_count": 0},
+        )
+        if judgement is None:
+            invalid_count += 1
+            jc["invalid_count"] += 1
+            continue
+
+        win_count_a, win_count_b, tie_count = tally_result(judgement, swapped, win_count_a, win_count_b, tie_count)
         jc["win_count_a"], jc["win_count_b"], jc["tie_count"] = tally_result(
             judgement, swapped, jc["win_count_a"], jc["win_count_b"], jc["tie_count"]
         )
         jc["trials"] += 1
+
+    valid_count = win_count_a + win_count_b + tie_count
+    if valid_count == 0:
+        raise ValueError(f"All {num_trials} pairwise judge responses were invalid")
 
     if win_count_a > win_count_b:
         winner = A_WIN_RESPONSE
@@ -690,7 +708,8 @@ def run_trials(
         "win_count_a": win_count_a,
         "win_count_b": win_count_b,
         "tie_count": tie_count,
-        "task_count": num_trials,
+        "task_count": valid_count,
+        "invalid_count": invalid_count,
         "per_judge": per_judge,
         # Always recorded (just judge names, ordered by trial) so every match's
         # per-trial grader is documented even when raw responses aren't kept.

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -21,9 +21,11 @@ between the eval model and a reference model's deliverables) and
 from __future__ import annotations
 
 import base64
+import logging
 import math
 import os
 import random
+import re
 import shutil
 import tempfile
 import time
@@ -35,6 +37,9 @@ from typing import Any, Optional
 from openai import APITimeoutError
 
 from resources_servers.gdpval.judge_panel import merge_create_kwargs, sample_judge
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 JUDGE_PROMPT = (
@@ -71,12 +76,15 @@ REQUEST_MAX_ATTEMPTS = 5
 REQUEST_INITIAL_BACKOFF_SECONDS = 5.0
 REQUEST_BACKOFF_MULTIPLIER = 2.0
 REQUEST_MAX_BACKOFF_SECONDS = 60.0
-# Per-request OpenAI client timeout. Multimodal payloads through a flaky
-# proxy have historically taken hours when this defaulted to 600 s × 5
-# retries (50 min/trial × 4 trials = 200 min/verify worst case). 120 s here,
-# combined with non-retryable ``APITimeoutError`` below, bounds wall-clock
-# damage to ~8 min/verify when the upstream is genuinely down.
-JUDGE_REQUEST_TIMEOUT_SECONDS = 120.0
+# Per-request OpenAI client timeout. A local multimodal VLM judge must prefill
+# the whole payload (dozens of rasterized pages + extracted text per side)
+# before the first token, which for image-dense deliverables can exceed the
+# 120 s originally tuned for a flaky frontier proxy -- silently dropping
+# slow-but-healthy local judgements and biasing the ELO fit. Default 300 s;
+# override with ``GDPVAL_JUDGE_REQUEST_TIMEOUT_SECONDS``. Kept non-retryable
+# (below) so a genuinely dead upstream still bounds wall-clock rather than
+# retrying N x timeout.
+JUDGE_REQUEST_TIMEOUT_SECONDS = float(os.environ.get("GDPVAL_JUDGE_REQUEST_TIMEOUT_SECONDS", "300"))
 # Per-file size cap on multimodal content blocks. Above this the file is
 # replaced with a one-line text marker so the judge still knows what was
 # claimed without us pushing 100s of MB of base64 through the proxy.
@@ -296,6 +304,16 @@ def get_file_image_text_blocks(
             pdf_bytes: bytes | None = Path(full_path).read_bytes()
         elif file_type == "DOC":
             pdf_bytes = _convert_to_pdf(full_path)
+            if pdf_bytes is None:
+                # No sibling .pdf render exists, so this Office deliverable's content
+                # is invisible to an image-only judge (only the filename is shown).
+                # Warn so an incomplete-preconvert reference cache surfaces instead of
+                # silently scoring empty -- run preconvert on the cache to include it.
+                LOGGER.warning(
+                    "office file %r has no sibling .pdf render; its content is invisible "
+                    "to this judge -- preconvert the deliverables cache to include it",
+                    file_name,
+                )
         else:
             pdf_bytes = None
 
@@ -344,7 +362,7 @@ def build_file_section(
     clean_up_list: list[Path] | None = None,
     *,
     media_mode: str = "native_pdf",
-    render_dpi: int = 150,
+    render_dpi: int = 144,
     max_pages: int = 50,
     include_text: bool = True,
     audio_capable: bool = False,
@@ -515,15 +533,29 @@ def send_judge_request(
 # ---------------------------------------------------------------------------
 
 
+_BOXED_RE = re.compile(r"BOXED\[(A|B|TIE)\]")
+
+_BOXED_TO_RESPONSE = {"A": A_WIN_RESPONSE, "B": B_WIN_RESPONSE, "TIE": TIE_RESPONSE}
+
+
 def parse_judgement(response_text: str) -> str:
-    """Extract ``BOXED[A]``, ``BOXED[B]``, or ``BOXED[TIE]`` from judge response."""
-    if A_WIN_RESPONSE in response_text:
-        return A_WIN_RESPONSE
-    if B_WIN_RESPONSE in response_text:
-        return B_WIN_RESPONSE
-    if TIE_RESPONSE in response_text:
+    """Extract the judge's verdict (``BOXED[A|B|TIE]``) from its response.
+
+    Uses the **last** boxed token so a verbose/reasoning judge that writes e.g.
+    ``"not BOXED[A]; the answer is BOXED[B]"`` is scored on its conclusion rather
+    than the first token mentioned (the old first-substring match scored A here).
+    When no boxed verdict is present the response is mis-formatted; we log it and
+    fall back to a TIE so the failure is visible rather than silently pulling the
+    win rate toward 0.5.
+    """
+    matches = _BOXED_RE.findall(response_text or "")
+    if not matches:
+        LOGGER.warning(
+            "judge response has no BOXED[A|B|TIE] verdict; scoring as TIE. head=%r",
+            (response_text or "")[:200],
+        )
         return TIE_RESPONSE
-    return TIE_RESPONSE
+    return _BOXED_TO_RESPONSE[matches[-1]]
 
 
 def tally_result(

--- a/resources_servers/gdpval/configs/gdpval_minimax_selfhosted_judge.yaml
+++ b/resources_servers/gdpval/configs/gdpval_minimax_selfhosted_judge.yaml
@@ -21,26 +21,18 @@
 #   gdpval_minimax_local_judge.yaml + the standalone local_vllm_model config, but
 #   it does NOT currently start on GB200.)
 #
-# STEP 1 — serve MiniMax-M3 yourself from the vendor container (on your GPU
-# node(s)):
-#   IFACE_NAME=<fabric-nic>   # e.g. the NIC ib/eth used for multi-node NCCL
-#   HEAD_IP=<this-node-ip>
-#   docker run --gpus all --privileged --ipc=host -p 8000:8000 \
-#     -v ~/.cache/huggingface:/root/.cache/huggingface \
-#     -e GLOO_SOCKET_IFNAME=$IFACE_NAME -e NCCL_SOCKET_IFNAME=$IFACE_NAME \
-#     vllm/vllm-openai:minimax-m3 MiniMaxAI/MiniMax-M3 \
-#     --block-size 128 -cc.pass_config.fuse_allreduce_rms=False \
-#     --tensor-parallel-size 8 --nnodes 2 --node-rank 0 --master-addr $HEAD_IP \
-#     --tool-call-parser minimax_m3 --enable-auto-tool_choice \
-#     --reasoning-parser minimax_m3
-#   (On Slurm without Docker, convert the image with enroot/pyxis and run the
-#   same args via `srun --container-image=...`. Confirm it is up:
-#   `curl -s http://$HEAD_IP:8000/v1/models`.)
+# STEP 1 — serve MiniMax-M3 yourself from the vendor container. NVIDIA users
+# should use the internal serving workflow maintained separately from Gym. Use
+# one single-node TP=4 instance, or independent single-node TP=4 replicas for
+# data-parallel throughput. Do NOT form one TP=8 group across two nodes: the
+# cross-node MXFP8 all-reduce path can produce garbage logits despite a clean
+# startup. Confirm the endpoint from the gym host:
+#   curl -s http://<judge-host>:5000/v1/models
 #
 # STEP 2 — run GDPVal with gym pointing at your endpoint. Chain this overlay
 # AFTER the benchmark config and export the endpoint:
 #
-#   export MINIMAX_BASE_URL=http://$HEAD_IP:8000/v1   # your server's /v1 route
+#   export MINIMAX_BASE_URL=http://<judge-host>:5000/v1
 #   gym eval run --benchmark gdpval --model-type vllm_model \
 #     --config resources_servers/gdpval/configs/gdpval_minimax_selfhosted_judge.yaml \
 #     --split benchmark --output results/gdpval_minimax_judge.jsonl

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -600,9 +600,22 @@ class TestApp:
                 "win_count_b": 2,
                 "tie_count": 0,
                 "task_count": 2,
+                "invalid_count": 1,
                 "per_judge": {
-                    "gpt-5.5": {"win_count_a": 0, "win_count_b": 1, "tie_count": 0, "trials": 1},
-                    "gemini-3.1-pro": {"win_count_a": 0, "win_count_b": 1, "tie_count": 0, "trials": 1},
+                    "gpt-5.5": {
+                        "win_count_a": 0,
+                        "win_count_b": 1,
+                        "tie_count": 0,
+                        "trials": 1,
+                        "invalid_count": 1,
+                    },
+                    "gemini-3.1-pro": {
+                        "win_count_a": 0,
+                        "win_count_b": 1,
+                        "tie_count": 0,
+                        "trials": 1,
+                        "invalid_count": 0,
+                    },
                 },
                 "trial_judges": ["gpt-5.5", "gemini-3.1-pro"],
             }
@@ -624,8 +637,15 @@ class TestApp:
         # Panel summary + pooled per-judge tally (over 2 ref repeats).
         assert [m["name"] for m in resp.judge_response["judge_panel"]] == ["gpt-5.5", "gemini-3.1-pro"]
         per_judge = resp.judge_response["per_judge"]
-        assert per_judge["gpt-5.5"] == {"wins": 2, "losses": 0, "ties": 0, "trials": 2}
-        assert per_judge["gemini-3.1-pro"] == {"wins": 2, "losses": 0, "ties": 0, "trials": 2}
+        assert per_judge["gpt-5.5"] == {"wins": 2, "losses": 0, "ties": 0, "trials": 2, "invalid_count": 2}
+        assert per_judge["gemini-3.1-pro"] == {
+            "wins": 2,
+            "losses": 0,
+            "ties": 0,
+            "trials": 2,
+            "invalid_count": 0,
+        }
+        assert resp.judge_response["total_invalid"] == 2
         assert resp.total_wins == 4
         assert resp.reward == 1.0
         assert resp.judge_response["av_routed"] is False

--- a/resources_servers/gdpval/tests/test_judge_panel.py
+++ b/resources_servers/gdpval/tests/test_judge_panel.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from resources_servers.gdpval.comparison import Judge, run_trials
+from resources_servers.gdpval.comparison import B_WIN_RESPONSE, TIE_RESPONSE, Judge, parse_judgement, run_trials
 from resources_servers.gdpval.judge_panel import (
     ResolvedJudge,
     dir_contains_audio_video,
@@ -211,6 +211,27 @@ def _judge_returning(name: str, verdict: str) -> Judge:
     return Judge(name=name, client=client, model=f"model-{name}")
 
 
+def _judge_returning_sequence(name: str, verdicts: list[str]) -> Judge:
+    """A Judge whose sync OpenAI client returns each response in order."""
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        MagicMock(choices=[MagicMock(message=MagicMock(content=verdict))]) for verdict in verdicts
+    ]
+    return Judge(name=name, client=client, model=f"model-{name}")
+
+
+class TestParseJudgement:
+    def test_last_boxed_verdict_wins(self) -> None:
+        assert parse_judgement("not BOXED[A]; final answer BOXED[B]") == B_WIN_RESPONSE
+
+    @pytest.mark.parametrize("response", ["", "A wins", "BOXED[C]"])
+    def test_missing_valid_verdict_is_invalid(self, response: str) -> None:
+        assert parse_judgement(response) is None
+
+    def test_explicit_tie_is_valid(self) -> None:
+        assert parse_judgement("Final answer: BOXED[TIE]") == TIE_RESPONSE
+
+
 class TestRunTrialsPanel:
     def test_requires_non_empty_panel(self) -> None:
         with pytest.raises(ValueError):
@@ -249,3 +270,36 @@ class TestRunTrialsPanel:
         assert result["trial_judges"] == ["solo"] * 4
         assert result["per_judge"]["solo"]["trials"] == 4
         assert result["tie_count"] == 4
+
+    def test_invalid_response_is_excluded_from_counts(self) -> None:
+        panel = [_judge_returning_sequence("solo", ["BOXED[B]", "malformed", "BOXED[B]"])]
+        result = run_trials(
+            judges=panel,
+            task_prompt="p",
+            refs=[],
+            submission_a=[],
+            submission_b=[],
+            num_trials=3,
+            return_raw_responses=True,
+        )
+
+        assert result["winner"] == B_WIN_RESPONSE
+        assert result["win_count_b"] == 2
+        assert result["tie_count"] == 0
+        assert result["task_count"] == 2
+        assert result["invalid_count"] == 1
+        assert result["per_judge"]["solo"]["trials"] == 2
+        assert result["per_judge"]["solo"]["invalid_count"] == 1
+        assert len(result["raw_responses"]) == 3
+
+    def test_all_invalid_responses_fail_matchup(self) -> None:
+        panel = [_judge_returning("solo", "malformed")]
+        with pytest.raises(ValueError, match="All 2 pairwise judge responses were invalid"):
+            run_trials(
+                judges=panel,
+                task_prompt="p",
+                refs=[],
+                submission_a=[],
+                submission_b=[],
+                num_trials=2,
+            )


### PR DESCRIPTION
Follow-up fixes for #2046, found while independently reproducing the MiniMax-M3 local-judge calibration end-to-end (Gemma-4-26B reproduced at ELO **725.9** vs the reported 731.5). Targets this branch so it can be merged into #2046.

## Fixes

**CI-green:**
- **Repeat-dir fallback (fixes the 3 failing `stirrup_agent` tests):** `run()` computed `deliverables_dir` and then stripped the `repeat_0` suffix whenever that dir did not yet exist — which is the normal fresh / execute-only / rerun case, since the Ray worker persists it *after* this point. Now it falls back to the flat legacy layout only when such a dir actually exists. Also fixes that block's broken indentation + trailing whitespace (the two Lint failures).
- `verified: false` added to the 4 new configs (text-insert, to preserve their header comments — the `add_verified_flag` hook otherwise re-serializes and strips them).

**Correctness / robustness (surfaced during the reproduction):**
- **Judge timeout** 120 → 300 s + `GDPVAL_JUDGE_REQUEST_TIMEOUT_SECONDS` override — a local VLM's multimodal prefill legitimately exceeds 120 s on image-dense deliverables; ~1% of matchups were silently dropped as non-retryable `APITimeoutError`, biasing the fit.
- **`parse_judgement`** now takes the *last* `BOXED[...]` token (so a verbose/reasoning judge that writes "not BOXED[A]… the answer is BOXED[B]" scores B, not A) and logs unparseable output instead of silently returning TIE.
- **Video/audio through the proxy:** extended the `openai_model` content-part union with `video_url` + `input_audio`, so a self-hosted judge's video/audio parts are no longer rejected by the proxy schema with a 422 and silently dropped.
- **Warn** when an Office deliverable has no sibling PDF render (its content is otherwise invisible to an image-only judge) — surfaces incomplete-preconvert reference caches instead of scoring empty.
- **README:** replaced the cross-node `--tensor-parallel-size 8 --nnodes 2` serve command (which the serve scripts themselves warn produces garbage logits on GB200) with the provided sbatch scripts; fixed the `--enable-auto-tool_choice` typo and the 8000 → 5000 port.
- `render_dpi` default aligned 150 → 144 (matches the config).

## Verification
- `parse_judgement`: 6 cases including the "last-wins" ambiguity case.
- proxy union: Pydantic validates text / image / video / audio parts.
- repeat-dir fix traced against all 3 failing test scenarios (local run blocked only by the private `stirrup` dep; CI confirms).
- `ruff check` clean; no trailing whitespace.

Recommend rebasing #2046 on `main` (currently 53 commits behind) alongside these.
