### PR TITLE
fix(omniscience): preserve answers without reasoning tags

### DIFF
--- a/resources_servers/omniscience/app.py
+++ b/resources_servers/omniscience/app.py
@@ -247,11 +247,14 @@ class OmniscienceServer(SimpleResourcesServer):
 
     async def verify(self, body: OmniscienceVerifyRequest) -> OmniscienceVerifyResponse:
         # Match Skills' parse_reasoning=True behavior:
-        # 1. If </think> present: strip reasoning, keep answer after </think> (done by _strip_thinking_traces)
-        # 2. If </think> absent: empty string (model never finished reasoning)
+        # 1. <think>...</think> pair present: strip reasoning, keep answer after </think>
+        # 2. <think> opened but never closed: response was truncated mid-reasoning → empty
+        # 3. No <think> tags: preserve the plain answer
         raw_text = extract_text_from_response(body.response, strip_thinking=False)
         generation = extract_text_from_response(body.response)  # strips thinking traces
-        if "</think>" not in raw_text and "</thinking>" not in raw_text:
+        opened_think = ("<think>" in raw_text) or ("<thinking>" in raw_text)
+        closed_think = ("</think>" in raw_text) or ("</thinking>" in raw_text)
+        if opened_think and not closed_think:
             generation = ""
 
         question = body.question or ""

--- a/resources_servers/omniscience/tests/test_app.py
+++ b/resources_servers/omniscience/tests/test_app.py
@@ -390,8 +390,29 @@ class TestOmniscienceServer:
         assert "What is the capital of France?" in judge_input
         assert "Paris" in judge_input
 
-    async def test_verify_no_think_tag_produces_empty(self, config: OmniscienceConfig) -> None:
-        """When model output has no </think>, generation should be empty (matching parse_reasoning=True)."""
+    async def test_verify_no_think_tag_preserves_plain_answer(self, config: OmniscienceConfig) -> None:
+        """Plain answers from non-reasoning models should be judged as-is."""
+        server_mock = MagicMock(spec=ServerClient)
+        server = OmniscienceServer(config=config, server_client=server_mock)
+
+        response_mock = AsyncMock()
+        response_mock.json = AsyncMock(return_value=self._make_judge_response("A"))
+        server_mock.post = AsyncMock(return_value=response_mock)
+
+        model_response = self._make_model_response("Paris")
+        request = OmniscienceVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
+            response=model_response,
+            question="What is the capital of France?",
+            expected_answer="Paris",
+        )
+
+        result = await server.verify(request)
+        assert result.extracted_answer == "Paris"
+        assert result.verdict == "correct"
+
+    async def test_verify_unclosed_think_tag_produces_empty(self, config: OmniscienceConfig) -> None:
+        """An unclosed reasoning block indicates a response truncated before its answer."""
         server_mock = MagicMock(spec=ServerClient)
         server = OmniscienceServer(config=config, server_client=server_mock)
 
@@ -399,8 +420,7 @@ class TestOmniscienceServer:
         response_mock.json = AsyncMock(return_value=self._make_judge_response("D"))
         server_mock.post = AsyncMock(return_value=response_mock)
 
-        # Model output without </think> — reasoning that never finished
-        model_response = self._make_model_response("Let me think about this... I'm not sure about the answer")
+        model_response = self._make_model_response("<think>Let me think about this...")
         request = OmniscienceVerifyRequest(
             responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]),
             response=model_response,


### PR DESCRIPTION
## Motivation

Omniscience explicitly instructs the policy to answer with only the final answer and no explanation. Non-reasoning models therefore commonly return plain text without `<think>` tags.

The verifier currently treats every response without a closing `</think>` tag as unfinished reasoning and replaces it with an empty string. Consequently, valid plain answers are sent to the judge as empty responses and incorrectly scored as `not_attempted`.

For example, a policy response such as:

> ASC 606-10-25-14

was recorded as:

> `extracted_answer: ""`  
> `verdict: not_attempted`

This particularly affects the non-reasoning behavior explicitly requested by the benchmark.

## Change

The verifier now distinguishes between:

- **No reasoning tags:** preserve and score the plain answer.
- **Complete `<think>...</think>` block:** strip the reasoning and score the final answer.
- **Opened but unclosed reasoning block:** treat the response as truncated and score an empty answer.

This maintains protection against generations truncated during reasoning while preserving valid responses from non-reasoning models.

## Test plan

- Added coverage confirming that plain answers without reasoning tags are preserved and judged.
- Added coverage confirming that unclosed reasoning blocks still produce an empty answer.
- Ran the complete Omniscience unit-test file: **34 passed**.
- Ran scoped pre-commit checks: **passed**.