### PR TITLE
fix(server_utils): use unpredictable per-process secret for session signing

### DIFF
--- a/nemo_gym/mcp_auto_exposure.py
+++ b/nemo_gym/mcp_auto_exposure.py
@@ -757,7 +757,7 @@ def install_auto_exposure(server: Any, app: FastAPI) -> dict[str, MCPTool]:
             "on the same server. Remove the hand-rolled /mcp mount and rely on expose_tools_over_mcp."
         )
 
-    secret = server.get_session_middleware_key()
+    secret = server.get_session_secret_key()
     serializer = URLSafeSerializer(secret, salt=_MCP_TOKEN_SALT)
     tools = harvest_tools(app, server)
 

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -16,6 +16,7 @@ import asyncio
 import atexit
 import json
 import resource
+import secrets
 import socket
 import sys
 import time
@@ -528,9 +529,29 @@ class SimpleServer(BaseServer):
         pass
 
     def get_session_middleware_key(self) -> str:
-        # This method is here to override in case we want to ever use an actual session middleware secret key.
-        # e.g. for an actual product.
+        # This value is used as the session-cookie name, in error messages,
+        # and as a profiling-directory identifier. It is intentionally stable
+        # and human-readable. It MUST NOT be used as a cryptographic signing
+        # key — both components (class name + config name) are public, so any
+        # client can reconstruct it and forge session cookies. For the signing
+        # secret, use get_session_secret_key() instead.
         return f"{self.__class__.__name__}___{self.config.name}"
+
+    def get_session_secret_key(self) -> str:
+        # Per-process random signing secret for SessionMiddleware and MCP
+        # session tokens. The previous default reused get_session_middleware_key()
+        # (a predictable string of public class/config names) as the signing
+        # secret, which let any client forge session cookies and MCP tokens
+        # offline — breaking rollout isolation (a resources server holds
+        # session_state for all concurrent rollouts keyed by session_id) and
+        # defeating the per-rollout MCP tool allow-list.
+        # Override this to provide a deployment-wide stable secret (needed for
+        # multi-process deployments where all workers must agree on the key).
+        cached = getattr(self, "_session_secret_key", None)
+        if cached is None:
+            cached = secrets.token_hex(32)
+            self._session_secret_key = cached
+        return cached
 
     def setup_session_middleware(self, app: FastAPI) -> None:
         if getattr(app.state, "nemo_gym_session_middleware_installed", False):
@@ -552,7 +573,10 @@ class SimpleServer(BaseServer):
             return response
 
         session_middleware_key = self.get_session_middleware_key()
-        app.add_middleware(SessionMiddleware, secret_key=session_middleware_key, session_cookie=session_middleware_key)
+        session_secret_key = self.get_session_secret_key()
+        app.add_middleware(
+            SessionMiddleware, secret_key=session_secret_key, session_cookie=session_middleware_key
+        )
 
     def setup_exception_middleware(self, app: FastAPI) -> None:  # pragma: no cover
         @app.middleware("http")


### PR DESCRIPTION
## Summary

`get_session_middleware_key()` returned a deterministic string built from two public components — the Python class name and the benchmark's config name:

```python
def get_session_middleware_key(self) -> str:
    return f"{self.__class__.__name__}___{self.config.name}"
```

Both are knowable by any client: the class name appears in source and in error responses (`server_utils.py:567`); the config name is the public benchmark server name. This string was reused as the signing secret for **both**:

1. **Starlette `SessionMiddleware`** (`server_utils.py:555`, `secret_key=session_middleware_key`) — signs session cookies via `itsdangerous`.
2. **MCP auto-exposure `URLSafeSerializer`** (`mcp_auto_exposure.py:760-761`, `secret = server.get_session_middleware_key()`) — signs per-rollout MCP session tokens.

Knowing the secret, any client can forge session cookies and MCP tokens offline.

The code's own comment acknowledged this was a placeholder:

> *"This method is here to override in case we want to ever use an actual session middleware secret key. e.g. for an actual product."*

…but no benchmark in the repo overrides it, so the default ships with every example environment.

## Impact

A resources server is a **single process holding `session_state` for all concurrent rollouts** (`base_resources_server.py`), keyed by `session_id`. A forged cookie carrying another rollout's `session_id` lets one rollout read or clobber another's env state. A forged MCP token with `"tools": None` defeats the per-rollout tool allow-list (`mcp_allowed_tools_for_session` at `base_resources_server.py:132`). This breaks rollout isolation even on localhost — the threat isn't a remote attacker, it's one rollout's agent accessing another rollout's state within the same benchmark run.

**Honest scope:** this does not grant remote code execution or network-level access. The integrity failure is within-process: cross-rollout `session_state` access and MCP tool-allow-list bypass. That's still a real trust-boundary failure in a multi-tenant RL eval framework.

## Reproduction

```python
from itsdangerous import URLSafeTimedSerializer, URLSafeSerializer

# Attacker reconstructs the predictable secret from public information
secret = "SimpleResourcesServer___blackjack"  # class name + config name

# Forge a session cookie for any session_id
serializer = URLSafeTimedSerializer(secret, salt="cookie-session")
forged_cookie = serializer.dumps({"session_id": "victim-rollout-session-id"})
# → accepted by the server as session_id="victim-rollout-session-id"

# Forge an MCP token that defeats the tool allow-list
mcp_serializer = URLSafeSerializer(secret, salt="mcp_session_token")
forged_token = mcp_serializer.dumps({"sid": "victim-rollout-session-id", "tools": None})
# → tools=None defeats mcp_allowed_tools_for_session narrowing
```

Verified locally: both forgeries succeed with the pre-fix secret and fail with a random per-process secret.

## The fix

Split the concerns. `get_session_middleware_key()` continues to return the stable, human-readable identifier (used as the cookie name, in error messages, and as a profiling-dir name — all non-security contexts). A new `get_session_secret_key()` returns a **cached per-process random secret** (`secrets.token_hex(32)`) used only as the signing key for `SessionMiddleware` and the MCP token serializer:

```python
def get_session_secret_key(self) -> str:
    cached = getattr(self, "_session_secret_key", None)
    if cached is None:
        cached = secrets.token_hex(32)
        self._session_secret_key = cached
    return cached
```

The caching is important: `get_session_secret_key()` is called from both `setup_session_middleware` and `install_auto_exposure`, and they must agree on the same secret. For multi-process deployments where all workers must share the key, override `get_session_secret_key()` to return a deployment-wide stable value (read from an env var or secret store).

## Verification

- **PoC**: the pre-fix forgery (above) succeeds; with the fix, the per-process secret is unpredictable so the same forgery fails signature verification.
- **Caching verified**: the same instance returns the same secret across calls (so SessionMiddleware and MCP agree); different instances get different secrets.
- **`ruff check` passes** (line-length 119, full rule set).
- Both changed files pass AST/syntax validation.
- **Tests**: I could not run `tests/unit_tests/test_server_utils.py` and `tests/unit_tests/test_mcp_auto_exposure.py` locally due to missing optional deps in my environment (`omegaconf`, `ray`); CI will run them. The change is additive (new method + two call-site swaps) and does not alter any existing method's signature or return type.

## Checklist

- [x] Predictable signing secret replaced with cached per-process random secret
- [x] Session cookie forgery defeated
- [x] MCP token forgery defeated
- [x] `get_session_middleware_key()` unchanged (still used for cookie name, error messages, profiling dir)
- [x] Override hook documented for multi-process deployments
- [x] `ruff check` passes
- [x] No new dependencies
- [x] Honest scope: within-process integrity (cross-rollout state + tool allow-list), not RCE
