### PR TITLE
Add dsv4 and gemma4 config in MRCR

### DIFF
--- a/benchmarks/mrcr/config.yaml
+++ b/benchmarks/mrcr/config.yaml
@@ -25,4 +25,4 @@ mrcr_benchmark_simple_agent:
         # placeholder — it only triggers row duplication for
         # `type: train`/`validation`. To actually get N rollouts per task,
         # pass `--num-repeats N` on the `gym eval run --no-serve` CLI.
-        num_repeats: 4
+        num_repeats: 1

--- a/benchmarks/mrcr/config_dsv4_1m.yaml
+++ b/benchmarks/mrcr/config_dsv4_1m.yaml
@@ -1,0 +1,34 @@
+# MRCR — DeepSeek-V4 1M-context variant.
+# Same data + grading as `config.yaml`, but `prepare_dsv4_1m.py` counts tokens
+# with the DeepSeek-V4 tokenizer and drops samples whose tokenized conversation
+# exceeds 1048576 tokens. Serves both DeepSeek-V4-Flash and DeepSeek-V4-Pro
+# (identical tokenizer).
+config_paths:
+  - resources_servers/mrcr/configs/mrcr.yaml
+
+mrcr_dsv4_1m_benchmark_resources_server:
+  _inherit_from: mrcr_resources_server
+
+mrcr_dsv4_1m_benchmark_simple_agent:
+  _inherit_from: mrcr_simple_agent
+  responses_api_agents:
+    simple_agent:
+      resources_server:
+        name: mrcr_dsv4_1m_benchmark_resources_server
+      datasets:
+      - name: mrcr_dsv4_1m
+        type: benchmark
+        jsonl_fpath: benchmarks/mrcr/data/mrcr_dsv4_1m_benchmark.jsonl
+        prompt_config: null
+        prepare_script: benchmarks/mrcr/prepare_dsv4_1m.py
+        num_repeats: 1
+
+# We need chat_template.jinja for deepseek-v4 to enable thinking.
+# https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/discussions/146
+policy_model:
+  responses_api_models:
+    vllm_model:
+      extra_body:
+        reasoning_effort: max
+        thinking:
+          type: enabled

--- a/benchmarks/mrcr/config_gemma4_128k.yaml
+++ b/benchmarks/mrcr/config_gemma4_128k.yaml
@@ -1,0 +1,31 @@
+# MRCR — Gemma-4-31B-it 128K-context variant.
+# Same data + grading as `config.yaml`, but `prepare_gemma4_128k.py` counts tokens with the
+# google/gemma-4-31B-it HF tokenizer and drops samples whose tokenized conversation exceeds
+# 131072 tokens (the model's 128K context window).
+#
+# Prepare:  gym eval prepare --benchmark mrcr/config_gemma4_128k
+config_paths:
+  - resources_servers/mrcr/configs/mrcr.yaml
+
+mrcr_gemma4_128k_benchmark_resources_server:
+  _inherit_from: mrcr_resources_server
+
+mrcr_gemma4_128k_benchmark_simple_agent:
+  _inherit_from: mrcr_simple_agent
+  responses_api_agents:
+    simple_agent:
+      resources_server:
+        name: mrcr_gemma4_128k_benchmark_resources_server
+      datasets:
+      - name: mrcr_gemma4_128k
+        type: benchmark
+        jsonl_fpath: benchmarks/mrcr/data/mrcr_gemma4_128k_benchmark.jsonl
+        prompt_config: null
+        prepare_script: benchmarks/mrcr/prepare_gemma4_128k.py
+        num_repeats: 1
+
+policy_model:
+  responses_api_models:
+    vllm_model:
+      chat_template_kwargs:
+        enable_thinking: true

--- a/benchmarks/mrcr/prepare.py
+++ b/benchmarks/mrcr/prepare.py
@@ -43,7 +43,7 @@ directly::
 import argparse
 import json
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, Optional, Sequence
 
 import tiktoken
 from datasets import load_dataset
@@ -56,6 +56,7 @@ DEFAULT_OUTPUT_FPATH = DATA_DIR / "mrcr_benchmark.jsonl"
 
 DEFAULT_TOKENIZER_NAME = "o200k_base"
 DEFAULT_MAX_CONTEXT_TOKENS: Optional[int] = None  # no filter by default
+DEFAULT_N_NEEDLES: tuple[int, ...] = (2, 4, 8)  # keep all needle-count buckets by default
 
 
 def _build_token_counter(tokenizer_name: str) -> Callable[[str], int]:
@@ -87,17 +88,24 @@ def prepare(
     tokenizer_name: str = DEFAULT_TOKENIZER_NAME,
     max_context_tokens: Optional[int] = DEFAULT_MAX_CONTEXT_TOKENS,
     output_fpath: Path = DEFAULT_OUTPUT_FPATH,
+    n_needles: Optional[Sequence[int]] = DEFAULT_N_NEEDLES,
 ) -> Path:
     output_fpath = Path(output_fpath)
     output_fpath.parent.mkdir(parents=True, exist_ok=True)
 
     dataset = load_dataset("openai/mrcr", split="train")
     count_one = _build_token_counter(tokenizer_name)
+    needle_set = set(n_needles) if n_needles is not None else None
 
     kept = 0
     skipped_tokens = 0
+    skipped_needles = 0
     with output_fpath.open("w", encoding="utf-8") as fout:
         for entry in tqdm(dataset, desc="Preparing MRCR"):
+            # Drop off-needle samples first (cheap) before the expensive tokenization.
+            if needle_set is not None and entry["n_needles"] not in needle_set:
+                skipped_needles += 1
+                continue
             messages = json.loads(entry["prompt"])
             n_tokens = _count_message_tokens(messages, count_one)
             if max_context_tokens is not None and n_tokens > max_context_tokens:
@@ -115,9 +123,11 @@ def prepare(
             kept += 1
 
     cap_str = "none" if max_context_tokens is None else str(max_context_tokens)
+    needle_str = "all" if needle_set is None else ",".join(map(str, sorted(needle_set)))
     print(
         f"Wrote {kept} samples to {output_fpath} "
-        f"(tokenizer={tokenizer_name}, cap={cap_str}; dropped {skipped_tokens} over cap)"
+        f"(tokenizer={tokenizer_name}, cap={cap_str}, n_needles={needle_str}; "
+        f"dropped {skipped_tokens} over cap, {skipped_needles} off-needle)"
     )
     return output_fpath
 
@@ -150,10 +160,26 @@ def _parse_args() -> argparse.Namespace:
         default=DEFAULT_OUTPUT_FPATH,
         help=f"Output JSONL path. Default: {DEFAULT_OUTPUT_FPATH}",
     )
+    parser.add_argument(
+        "--n_needles",
+        type=int,
+        nargs="+",
+        default=list(DEFAULT_N_NEEDLES),
+        help=(
+            "Which n_needles buckets to keep (MRCR ships 2, 4, 8). "
+            "e.g. '--n_needles 8' for the 8-needle subset only. "
+            f"Default: {' '.join(map(str, DEFAULT_N_NEEDLES))} (all)."
+        ),
+    )
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = _parse_args()
     cap = args.max_context_tokens if (args.max_context_tokens is None or args.max_context_tokens >= 0) else None
-    prepare(tokenizer_name=args.tokenizer_name, max_context_tokens=cap, output_fpath=args.output_fpath)
+    prepare(
+        tokenizer_name=args.tokenizer_name,
+        max_context_tokens=cap,
+        output_fpath=args.output_fpath,
+        n_needles=args.n_needles,
+    )

--- a/benchmarks/mrcr/prepare_dsv4_1m.py
+++ b/benchmarks/mrcr/prepare_dsv4_1m.py
@@ -37,7 +37,9 @@ TOKENIZER_NAME = "deepseek-ai/DeepSeek-V4-Pro"
 MAX_CONTEXT_TOKENS = 1048576
 OUTPUT_FPATH = Path(__file__).parent / "data" / "mrcr_dsv4_1m_benchmark.jsonl"
 # Which n_needles buckets to keep (MRCR ships 2, 4, 8). Default 8-needle only; override e.g. MRCR_N_NEEDLES=2,4,8.
-N_NEEDLES = tuple(int(x) for x in os.environ["MRCR_N_NEEDLES"].split(",")) if os.environ.get("MRCR_N_NEEDLES") else (8,)
+N_NEEDLES = (
+    tuple(int(x) for x in os.environ["MRCR_N_NEEDLES"].split(",")) if os.environ.get("MRCR_N_NEEDLES") else (8,)
+)
 
 
 def prepare() -> Path:

--- a/benchmarks/mrcr/prepare_dsv4_1m.py
+++ b/benchmarks/mrcr/prepare_dsv4_1m.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MRCR variant: DeepSeek-V4 tokenizer with a 1M token cap.
+
+Same data + grading as ``prepare.py``, but counts ``n_tokens`` with the
+DeepSeek-V4 tokenizer and drops samples whose tokenized conversation exceeds
+1048576 tokens (DeepSeek-V4's 1M context window). DeepSeek-V4-Flash and
+DeepSeek-V4-Pro ship the identical tokenizer (vocab 129280), so this single
+dataset serves both models.
+
+The tokenizer is read from a local model dir (fast tokenizer.json, no gated HF
+download). Override the path with the ``DSV4_TOKENIZER`` env var if needed.
+
+Paired with ``config_dsv4_1m.yaml``.
+"""
+
+import os
+from pathlib import Path
+
+from benchmarks.mrcr.prepare import prepare as _prepare
+
+
+# Either DeepSeek-V4 model dir works — their tokenizers are identical.
+TOKENIZER_NAME = "deepseek-ai/DeepSeek-V4-Pro"
+MAX_CONTEXT_TOKENS = 1048576
+OUTPUT_FPATH = Path(__file__).parent / "data" / "mrcr_dsv4_1m_benchmark.jsonl"
+# Which n_needles buckets to keep (MRCR ships 2, 4, 8). Default 8-needle only; override e.g. MRCR_N_NEEDLES=2,4,8.
+N_NEEDLES = tuple(int(x) for x in os.environ["MRCR_N_NEEDLES"].split(",")) if os.environ.get("MRCR_N_NEEDLES") else (8,)
+
+
+def prepare() -> Path:
+    return _prepare(
+        tokenizer_name=TOKENIZER_NAME,
+        max_context_tokens=MAX_CONTEXT_TOKENS,
+        output_fpath=OUTPUT_FPATH,
+        n_needles=N_NEEDLES,
+    )
+
+
+if __name__ == "__main__":
+    prepare()

--- a/benchmarks/mrcr/prepare_gemma4_128k.py
+++ b/benchmarks/mrcr/prepare_gemma4_128k.py
@@ -12,29 +12,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""MRCR variant: Nemotron-3-Super tokenizer with a 1M token cap.
+"""MRCR variant: Gemma-4-31B-it tokenizer with a 128K token cap.
 
-Same data + grading as ``prepare.py``, but counts ``n_tokens`` with
-the ``nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16`` HuggingFace
-tokenizer and drops samples whose tokenized conversation exceeds
-1048576 tokens (Nemotron-3-Super's native 1M context window).
+Same data + grading as ``prepare.py``, but counts ``n_tokens`` with the
+``google/gemma-4-31B-it`` HuggingFace tokenizer and drops samples whose
+tokenized conversation exceeds 131072 tokens (the model's 128K context window).
 
-Paired with ``config_n3_1m.yaml``. Requires HF auth for the gated
-NVIDIA repo (``HF_TOKEN`` env or ``huggingface-cli login``).
+Paired with ``config_gemma4_128k.yaml``. Requires HF auth / license acceptance
+for the gated Google repo (``HF_TOKEN`` env or ``huggingface-cli login``).
 """
 
-from pathlib import Path
-
 import os
+from pathlib import Path
 
 from benchmarks.mrcr.prepare import prepare as _prepare
 
 
-TOKENIZER_NAME = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"  # pragma: allowlist secret
-MAX_CONTEXT_TOKENS = 1048576
-OUTPUT_FPATH = Path(__file__).parent / "data" / "mrcr_n3_1m_benchmark.jsonl"
-# Which n_needles buckets to keep (MRCR ships 2, 4, 8). Default all; override e.g. MRCR_N_NEEDLES=8.
-N_NEEDLES = tuple(int(x) for x in os.environ["MRCR_N_NEEDLES"].split(",")) if os.environ.get("MRCR_N_NEEDLES") else (2, 4, 8)
+TOKENIZER_NAME = os.environ.get("GEMMA4_TOKENIZER", "google/gemma-4-31B-it")
+MAX_CONTEXT_TOKENS = 131072
+OUTPUT_FPATH = Path(__file__).parent / "data" / "mrcr_gemma4_128k_benchmark.jsonl"
+# Which n_needles buckets to keep (MRCR ships 2, 4, 8). Default 8-needle only; override e.g. MRCR_N_NEEDLES=2,4,8.
+N_NEEDLES = tuple(int(x) for x in os.environ["MRCR_N_NEEDLES"].split(",")) if os.environ.get("MRCR_N_NEEDLES") else (8,)
 
 
 def prepare() -> Path:

--- a/benchmarks/mrcr/prepare_gemma4_128k.py
+++ b/benchmarks/mrcr/prepare_gemma4_128k.py
@@ -32,7 +32,9 @@ TOKENIZER_NAME = os.environ.get("GEMMA4_TOKENIZER", "google/gemma-4-31B-it")
 MAX_CONTEXT_TOKENS = 131072
 OUTPUT_FPATH = Path(__file__).parent / "data" / "mrcr_gemma4_128k_benchmark.jsonl"
 # Which n_needles buckets to keep (MRCR ships 2, 4, 8). Default 8-needle only; override e.g. MRCR_N_NEEDLES=2,4,8.
-N_NEEDLES = tuple(int(x) for x in os.environ["MRCR_N_NEEDLES"].split(",")) if os.environ.get("MRCR_N_NEEDLES") else (8,)
+N_NEEDLES = (
+    tuple(int(x) for x in os.environ["MRCR_N_NEEDLES"].split(",")) if os.environ.get("MRCR_N_NEEDLES") else (8,)
+)
 
 
 def prepare() -> Path:

--- a/benchmarks/mrcr/prepare_n3_128k.py
+++ b/benchmarks/mrcr/prepare_n3_128k.py
@@ -25,12 +25,16 @@ NVIDIA repo (``HF_TOKEN`` env or ``huggingface-cli login``).
 
 from pathlib import Path
 
+import os
+
 from benchmarks.mrcr.prepare import prepare as _prepare
 
 
 TOKENIZER_NAME = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"  # pragma: allowlist secret
 MAX_CONTEXT_TOKENS = 131072
 OUTPUT_FPATH = Path(__file__).parent / "data" / "mrcr_n3_128k_benchmark.jsonl"
+# Which n_needles buckets to keep (MRCR ships 2, 4, 8). Default all; override e.g. MRCR_N_NEEDLES=8.
+N_NEEDLES = tuple(int(x) for x in os.environ["MRCR_N_NEEDLES"].split(",")) if os.environ.get("MRCR_N_NEEDLES") else (2, 4, 8)
 
 
 def prepare() -> Path:
@@ -38,6 +42,7 @@ def prepare() -> Path:
         tokenizer_name=TOKENIZER_NAME,
         max_context_tokens=MAX_CONTEXT_TOKENS,
         output_fpath=OUTPUT_FPATH,
+        n_needles=N_NEEDLES,
     )
 
 

--- a/benchmarks/mrcr/prepare_n3_128k.py
+++ b/benchmarks/mrcr/prepare_n3_128k.py
@@ -23,9 +23,8 @@ Paired with ``config_n3_128k.yaml``. Requires HF auth for the gated
 NVIDIA repo (``HF_TOKEN`` env or ``huggingface-cli login``).
 """
 
-from pathlib import Path
-
 import os
+from pathlib import Path
 
 from benchmarks.mrcr.prepare import prepare as _prepare
 
@@ -34,7 +33,9 @@ TOKENIZER_NAME = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"  # pragma: allo
 MAX_CONTEXT_TOKENS = 131072
 OUTPUT_FPATH = Path(__file__).parent / "data" / "mrcr_n3_128k_benchmark.jsonl"
 # Which n_needles buckets to keep (MRCR ships 2, 4, 8). Default all; override e.g. MRCR_N_NEEDLES=8.
-N_NEEDLES = tuple(int(x) for x in os.environ["MRCR_N_NEEDLES"].split(",")) if os.environ.get("MRCR_N_NEEDLES") else (2, 4, 8)
+N_NEEDLES = (
+    tuple(int(x) for x in os.environ["MRCR_N_NEEDLES"].split(",")) if os.environ.get("MRCR_N_NEEDLES") else (2, 4, 8)
+)
 
 
 def prepare() -> Path:

--- a/benchmarks/mrcr/prepare_n3_1m.py
+++ b/benchmarks/mrcr/prepare_n3_1m.py
@@ -23,9 +23,8 @@ Paired with ``config_n3_1m.yaml``. Requires HF auth for the gated
 NVIDIA repo (``HF_TOKEN`` env or ``huggingface-cli login``).
 """
 
-from pathlib import Path
-
 import os
+from pathlib import Path
 
 from benchmarks.mrcr.prepare import prepare as _prepare
 
@@ -34,7 +33,9 @@ TOKENIZER_NAME = "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"  # pragma: allo
 MAX_CONTEXT_TOKENS = 1048576
 OUTPUT_FPATH = Path(__file__).parent / "data" / "mrcr_n3_1m_benchmark.jsonl"
 # Which n_needles buckets to keep (MRCR ships 2, 4, 8). Default all; override e.g. MRCR_N_NEEDLES=8.
-N_NEEDLES = tuple(int(x) for x in os.environ["MRCR_N_NEEDLES"].split(",")) if os.environ.get("MRCR_N_NEEDLES") else (2, 4, 8)
+N_NEEDLES = (
+    tuple(int(x) for x in os.environ["MRCR_N_NEEDLES"].split(",")) if os.environ.get("MRCR_N_NEEDLES") else (2, 4, 8)
+)
 
 
 def prepare() -> Path:


### PR DESCRIPTION
Add dsv4 and gemma4 config to help evaluator team to reproduce published numbers.

- deepseek-ai/DeepSeek-V4-Flash
  - Setup
    - 8 needles 
    - 1,048,576 tokens (1M)
    - reasoning effort: max
  - Scores
    - report: [78.7](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash)
    - gym: 76.3
- google/gemma-4-31B-it
  - Setup
    - 8 needles
    - 131,072 tokens (128K)
  - Scores
    - report: [66.4](https://huggingface.co/google/gemma-4-31B-it)
    - gym: 64.3
 - nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
   - Setup
     - 2,4,8 needles 
     - 1,048,576 tokens (1M)
   - Scores
     - gym: 8.26