### PR TITLE
[rollout-observability][4/7] Add Hermes rollout observations

### DIFF
--- a/fern/versions/latest/pages/reference/trajectory-capabilities.mdx
+++ b/fern/versions/latest/pages/reference/trajectory-capabilities.mdx
@@ -52,7 +52,7 @@ For C1, C2, and C4, `V` evaluates the correlated Gym Model Server path; direct-p
 | `finance_agent` | X | O | X | X | X | X | X |
 | `gymnasium_agent` | V | V | X | V | X | X | X |
 | `harbor_agent` | X | X | X | X | X | X | X |
-| `hermes_agent` | V | V | X | V | X | X | X |
+| `hermes_agent` | V | V | X | V | V | V | V |
 | `kilocode_agent` | V | V | X | V | X | X | X |
 | `labbench2_vlm_agent` | V | V | O | O | O | X | V |
 | `langgraph_agent` | X | X | X | X | X | X | X |

--- a/responses_api_agents/hermes_agent/app.py
+++ b/responses_api_agents/hermes_agent/app.py
@@ -20,6 +20,7 @@ import shutil
 import sys
 import tempfile
 from asyncio import Semaphore
+from collections.abc import Mapping
 from time import time
 from typing import Any, Callable, Optional
 from uuid import uuid4
@@ -51,8 +52,6 @@ from nemo_gym.rollout_observability import (
     AgentEpisode,
     AgentObservationBundle,
     ObservationGap,
-    pop_response_observations,
-    response_with_observations,
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
 from responses_api_agents.hermes_agent.observability import HermesAgentObserver
@@ -108,6 +107,7 @@ def _trajectory_to_output_items(messages, n_input):
 
 
 LOG = logging.getLogger(__name__)
+_INTERNAL_OBSERVATIONS_KEY = "_ng_agent_observations"
 
 
 # if ray close sys.stderr mid-request, write to the original fd
@@ -424,17 +424,20 @@ class HermesAgent(SimpleResponsesAPIAgent):
         request: Request,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
-        rollout_id = request.path_params.get("rollout_id") if request is not None else None
-        if rollout_id is None:
+        path_params = getattr(request, "path_params", None)
+        rollout_id = path_params.get("rollout_id") if isinstance(path_params, Mapping) else None
+        if not isinstance(rollout_id, str):
             return await self._create_response(body)
-        return response_with_observations(await self.responses_with_observations(request, body, rollout_id=rollout_id))
+        episode = await self._create_episode(body, rollout_id=rollout_id)
+        return episode.response.model_copy(
+            update={_INTERNAL_OBSERVATIONS_KEY: episode.observations.model_dump(mode="json")}
+        )
 
-    async def responses_with_observations(
+    async def _create_episode(
         self,
-        request: Optional[Request],
         body: NeMoGymResponseCreateParamsNonStreaming,
         *,
-        rollout_id: Optional[str] = None,
+        rollout_id: str,
     ) -> AgentEpisode:
         observations: Optional[AgentObservationBundle] = None
 
@@ -452,7 +455,20 @@ class HermesAgent(SimpleResponsesAPIAgent):
                 source="hermes",
                 gaps=[ObservationGap(code="observation_capture_failed")],
             )
-        observations.gaps.append(ObservationGap(code="no_sandbox_runtime"))
+        observations.gaps.append(
+            ObservationGap(
+                code=(
+                    "no_sandbox_runtime"
+                    if self.config.terminal_backend == "local"
+                    else "sandbox_observation_unavailable"
+                ),
+                detail=(
+                    None
+                    if self.config.terminal_backend == "local"
+                    else f"terminal_backend={self.config.terminal_backend}"
+                ),
+            )
+        )
         return AgentEpisode(response=response, observations=observations)
 
     async def run(self, request: Request, body: HermesAgentRunRequest) -> HermesAgentVerifyResponse:
@@ -478,14 +494,17 @@ class HermesAgent(SimpleResponsesAPIAgent):
             await raise_for_status(agent_resp)
             cookies = agent_resp.cookies
             agent_resp_json = await get_response_json(agent_resp)
-            observations = pop_response_observations(agent_resp_json)
+            raw_observations = (
+                agent_resp_json.pop(_INTERNAL_OBSERVATIONS_KEY, None) if rollout_id is not None else None
+            )
+            observations = (
+                AgentObservationBundle.model_validate(raw_observations) if isinstance(raw_observations, dict) else None
+            )
 
             verify_resp = await self.server_client.post(
                 server_name=self.config.resources_server.name,
                 url_path="/verify",
-                json=body.model_dump()
-                | {"response": agent_resp_json}
-                | ({"rollout_id": rollout_id} if rollout_id is not None else {}),
+                json=body.model_dump() | {"response": agent_resp_json},
                 cookies=cookies,
             )
             await raise_for_status(verify_resp)

--- a/responses_api_agents/hermes_agent/app.py
+++ b/responses_api_agents/hermes_agent/app.py
@@ -21,12 +21,12 @@ import sys
 import tempfile
 from asyncio import Semaphore
 from time import time
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 from uuid import uuid4
 
 import model_tools  # noqa: F401  # fail-fast if hermes-agent isn't installed  # pyright: ignore[reportMissingImports]
 from fastapi import Request
-from pydantic import ConfigDict
+from pydantic import ConfigDict, Field
 
 from nemo_gym.base_resources_server import BaseRunRequest, BaseVerifyResponse
 from nemo_gym.base_responses_api_agent import (
@@ -47,7 +47,15 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseOutputTokensDetails,
     NeMoGymResponseUsage,
 )
+from nemo_gym.rollout_observability import (
+    AgentEpisode,
+    AgentObservationBundle,
+    ObservationGap,
+    pop_response_observations,
+    response_with_observations,
+)
 from nemo_gym.server_utils import get_response_json, raise_for_status
+from responses_api_agents.hermes_agent.observability import HermesAgentObserver
 
 
 def _trajectory_to_output_items(messages, n_input):
@@ -176,6 +184,10 @@ class HermesAgentVerifyResponse(BaseVerifyResponse):
     model_config = ConfigDict(extra="allow")
     turns_used: int = 0
     finished_naturally: bool = False
+    ng_agent_observations: AgentObservationBundle | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+    )
 
 
 class HermesAgent(SimpleResponsesAPIAgent):
@@ -255,10 +267,12 @@ class HermesAgent(SimpleResponsesAPIAgent):
     def _model_name(self) -> str:
         return self.config.model or str(self.config.model_server.name)
 
-    async def responses(
+    async def _create_response(
         self,
-        request: Request,
-        body: NeMoGymResponseCreateParamsNonStreaming = Body(),
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        rollout_id: Optional[str] = None,
+        observation_collector: Optional[Callable[[AgentObservationBundle], None]] = None,
     ) -> NeMoGymResponse:
         from run_agent import AIAgent  # from hermes-agent on path  # pyright: ignore[reportMissingImports]
 
@@ -269,8 +283,6 @@ class HermesAgent(SimpleResponsesAPIAgent):
         user_message, history, input_system = _split_input_to_user_and_history(body.input)
         system_message = self.config.system_prompt or input_system
 
-        # A prefixed self-call carries the rollout id into the model-server base URL.
-        rollout_id = request.path_params.get("rollout_id") if request is not None else None
         base_url = self.resolve_model_base_url(self.config.model_server.name, rollout_id)
         model_name = self._model_name()
 
@@ -300,6 +312,12 @@ class HermesAgent(SimpleResponsesAPIAgent):
             return kw
 
         agent._build_api_kwargs = _patched_build_api_kwargs
+        observer = None
+        if observation_collector is not None:
+            try:
+                observer = HermesAgentObserver(model_ref=self.config.model_server).instrument(agent)
+            except Exception:
+                LOG.exception("failed to initialize Hermes observability")
 
         # Interrupt the agent cleanly on SIGTERM so run_conversation returns with partial messages
         # instead of being killed mid-turn (which would leave response.json unwritten). A single
@@ -307,6 +325,8 @@ class HermesAgent(SimpleResponsesAPIAgent):
         self._ensure_sigterm_handler()
         self.active_agents.add(agent)
 
+        result = None
+        agent_error: Optional[BaseException] = None
         try:
             result = await asyncio.to_thread(
                 agent.run_conversation,
@@ -314,8 +334,31 @@ class HermesAgent(SimpleResponsesAPIAgent):
                 system_message,
                 history,
             )
+        except BaseException as exc:
+            agent_error = exc
+            raise
         finally:
             self.active_agents.discard(agent)
+            if observation_collector is not None:
+                try:
+                    observations = (
+                        observer.finish(result, error=agent_error)
+                        if observer is not None
+                        else AgentObservationBundle(
+                            source="hermes",
+                            gaps=[ObservationGap(code="observation_capture_failed")],
+                        )
+                    )
+                except Exception:
+                    LOG.exception("failed to finish Hermes observability")
+                    observations = AgentObservationBundle(
+                        source="hermes",
+                        gaps=[ObservationGap(code="observation_capture_failed")],
+                    )
+                try:
+                    observation_collector(observations)
+                except Exception:
+                    LOG.exception("failed to return Hermes observations")
 
         messages = result.get("messages") or []
         # aiagent omits system from returned messages
@@ -376,6 +419,41 @@ class HermesAgent(SimpleResponsesAPIAgent):
             ),
         )
 
+    async def responses(
+        self,
+        request: Request,
+        body: NeMoGymResponseCreateParamsNonStreaming = Body(),
+    ) -> NeMoGymResponse:
+        rollout_id = request.path_params.get("rollout_id") if request is not None else None
+        if rollout_id is None:
+            return await self._create_response(body)
+        return response_with_observations(await self.responses_with_observations(request, body, rollout_id=rollout_id))
+
+    async def responses_with_observations(
+        self,
+        request: Optional[Request],
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        rollout_id: Optional[str] = None,
+    ) -> AgentEpisode:
+        observations: Optional[AgentObservationBundle] = None
+
+        def collect(bundle: AgentObservationBundle) -> None:
+            nonlocal observations
+            observations = bundle
+
+        response = await self._create_response(
+            body,
+            rollout_id=rollout_id,
+            observation_collector=collect,
+        )
+        if observations is None:
+            observations = AgentObservationBundle(
+                source="hermes",
+                gaps=[ObservationGap(code="observation_capture_failed")],
+            )
+        return AgentEpisode(response=response, observations=observations)
+
     async def run(self, request: Request, body: HermesAgentRunRequest) -> HermesAgentVerifyResponse:
         async with self.sem:
             cookies = request.cookies
@@ -389,6 +467,7 @@ class HermesAgent(SimpleResponsesAPIAgent):
             await raise_for_status(seed_resp)
             cookies = seed_resp.cookies
 
+            rollout_id = self.rollout_id_from_run(body)
             agent_resp = await self.server_client.post(
                 server_name=self.config.name,
                 url_path=self.url_path_for_run("/v1/responses", body),
@@ -398,11 +477,14 @@ class HermesAgent(SimpleResponsesAPIAgent):
             await raise_for_status(agent_resp)
             cookies = agent_resp.cookies
             agent_resp_json = await get_response_json(agent_resp)
+            observations = pop_response_observations(agent_resp_json)
 
             verify_resp = await self.server_client.post(
                 server_name=self.config.resources_server.name,
                 url_path="/verify",
-                json=body.model_dump() | {"response": agent_resp_json},
+                json=body.model_dump()
+                | {"response": agent_resp_json}
+                | ({"rollout_id": rollout_id} if rollout_id is not None else {}),
                 cookies=cookies,
             )
             await raise_for_status(verify_resp)
@@ -417,9 +499,10 @@ class HermesAgent(SimpleResponsesAPIAgent):
             last = gym_resp.output[-1] if gym_resp.output else None
             naturally = getattr(last, "type", None) == "message" and getattr(last, "role", None) == "assistant"
 
-            return HermesAgentVerifyResponse.model_validate(
-                verify_json | {"turns_used": turns, "finished_naturally": naturally}
-            )
+            result = verify_json | {"turns_used": turns, "finished_naturally": naturally}
+            if observations is not None:
+                result["ng_agent_observations"] = observations.model_dump(mode="json")
+            return HermesAgentVerifyResponse.model_validate(result)
 
 
 if __name__ == "__main__":

--- a/responses_api_agents/hermes_agent/app.py
+++ b/responses_api_agents/hermes_agent/app.py
@@ -452,6 +452,7 @@ class HermesAgent(SimpleResponsesAPIAgent):
                 source="hermes",
                 gaps=[ObservationGap(code="observation_capture_failed")],
             )
+        observations.gaps.append(ObservationGap(code="no_sandbox_runtime"))
         return AgentEpisode(response=response, observations=observations)
 
     async def run(self, request: Request, body: HermesAgentRunRequest) -> HermesAgentVerifyResponse:

--- a/responses_api_agents/hermes_agent/observability.py
+++ b/responses_api_agents/hermes_agent/observability.py
@@ -1,0 +1,428 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Observability hooks for the pinned Hermes ``AIAgent`` integration."""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Callable, Iterable
+from time import monotonic, time
+from typing import Any
+
+from nemo_gym.config_types import ModelServerRef
+from nemo_gym.openai_utils import (
+    NeMoGymEasyInputMessage,
+    NeMoGymFunctionCallOutput,
+    NeMoGymResponseFunctionToolCall,
+    NeMoGymResponseInputItem,
+    NeMoGymResponseOutputMessage,
+    NeMoGymResponseOutputText,
+)
+from nemo_gym.rollout_observability import (
+    AgentInvocation,
+    AgentObservationBundle,
+    ContextCompactionObservation,
+    ModelCallRef,
+    ObservationGap,
+    ToolCallObservation,
+)
+
+
+_SOURCE = "hermes"
+
+
+def _text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            part.get("text", "") if isinstance(part, dict) else str(getattr(part, "text", "")) for part in content
+        )
+    return "" if content is None else str(content)
+
+
+def normalize_hermes_messages(messages: Iterable[Any], *, id_prefix: str = "hermes") -> list[NeMoGymResponseInputItem]:
+    """Convert a Hermes conversation to ordered Gym Responses items."""
+    output: list[NeMoGymResponseInputItem] = []
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            continue
+        role, content = message.get("role"), _text(message.get("content"))
+        if role in {"system", "user", "developer"}:
+            output.append(NeMoGymEasyInputMessage(role=role, content=content))
+        elif role == "assistant":
+            output.append(
+                NeMoGymResponseOutputMessage(
+                    id=str(message.get("id") or f"{id_prefix}-message-{index}"),
+                    content=[NeMoGymResponseOutputText(text=content, annotations=[])],
+                )
+            )
+            for call in message.get("tool_calls") or []:
+                function = call.get("function") if isinstance(call, dict) else None
+                if not isinstance(function, dict):
+                    continue
+                arguments = function.get("arguments", "")
+                if not isinstance(arguments, str):
+                    try:
+                        arguments = json.dumps(arguments, ensure_ascii=False)
+                    except (TypeError, ValueError):
+                        arguments = "{}"
+                call_id = str(call.get("id") or "")
+                output.append(
+                    NeMoGymResponseFunctionToolCall(
+                        arguments=arguments,
+                        call_id=call_id,
+                        id=call_id or None,
+                        name=str(function.get("name") or ""),
+                        status="completed",
+                    )
+                )
+        elif role == "tool":
+            output.append(
+                NeMoGymFunctionCallOutput(
+                    call_id=str(message.get("tool_call_id") or ""),
+                    output=content,
+                    status="completed",
+                )
+            )
+    return output
+
+
+class _ObservedChildren(list):
+    def __init__(self, values: Iterable[Any], observer: "HermesAgentObserver", parent_id: str):
+        super().__init__(values)
+        self.observer, self.parent_id = observer, parent_id
+
+    def append(self, child: Any) -> None:
+        super().append(child)
+        self.observer._child_added(child, self.parent_id)
+
+
+class HermesAgentObserver:
+    """Instrument one Hermes agent tree without modifying global Hermes state."""
+
+    def __init__(
+        self,
+        *,
+        root_invocation_id: str = "root",
+        model_ref: ModelServerRef | None = None,
+    ) -> None:
+        self._lock = threading.RLock()
+        self._current = threading.local()
+        self._root_id = root_invocation_id
+        self._model_ref = model_ref
+        self._child_index = 0
+        self._agents: set[int] = set()
+        self._tools_by_args: dict[int, tuple[str, str]] = {}
+        self._tools: dict[tuple[str, str], ToolCallObservation] = {}
+        self._started_ticks: dict[tuple[str, str], float] = {}
+        self._invocations = {root_invocation_id: AgentInvocation(invocation_id=root_invocation_id)}
+        self._compactions: list[ContextCompactionObservation] = []
+        self._gaps: list[ObservationGap] = []
+
+    def instrument(self, agent: Any) -> "HermesAgentObserver":
+        self._instrument_safely(agent, self._root_id, wrap_conversation=False)
+        return self
+
+    def finish(
+        self, result: dict[str, Any] | None = None, *, error: BaseException | None = None
+    ) -> AgentObservationBundle:
+        self._record_conversation(self._root_id, result, error)
+        with self._lock:
+            for tool in self._tools.values():
+                if tool.status == "unknown":
+                    tool.status = "incomplete"
+                if tool.timing_source is None:
+                    self._gap(
+                        "tool_execution_boundary_unavailable",
+                        tool.invocation_id,
+                        tool.tool_call_id,
+                    )
+            for invocation in self._invocations.values():
+                if not invocation.model_calls:
+                    self._gap("model_call_ownership_unavailable", invocation.invocation_id)
+            return AgentObservationBundle(
+                source=_SOURCE,
+                records=[
+                    *self._invocations.values(),
+                    *self._tools.values(),
+                    *self._compactions,
+                ],
+                gaps=self._gaps,
+            )
+
+    def _instrument_safely(self, agent: Any, invocation_id: str, *, wrap_conversation: bool) -> None:
+        try:
+            self._instrument(agent, invocation_id, wrap_conversation)
+        except Exception as exc:
+            self._gap("hermes_observer_error", invocation_id, f"instrument: {type(exc).__name__}")
+
+    def _instrument(self, agent: Any, invocation_id: str, wrap_conversation: bool) -> None:
+        with self._lock:
+            agent_id = id(agent)
+            if agent_id in self._agents:
+                return
+            self._agents.add(agent_id)
+
+        self._chain_callback(agent, "tool_start_callback", self._tool_started, invocation_id)
+        self._chain_callback(agent, "tool_complete_callback", self._tool_completed, invocation_id)
+        self._wrap_model_calls(agent, invocation_id)
+        self._wrap_invoke(agent, invocation_id)
+        self._wrap_compaction(agent, invocation_id)
+
+        children = getattr(agent, "_active_children", None)
+        if isinstance(children, list):
+            setattr(agent, "_active_children", _ObservedChildren(children, self, invocation_id))
+        else:
+            self._gap("hermes_hook_unavailable", invocation_id, "_active_children")
+
+        if wrap_conversation:
+            original = getattr(agent, "run_conversation", None)
+            if callable(original):
+
+                def run(*args: Any, **kwargs: Any) -> Any:
+                    try:
+                        child_result = original(*args, **kwargs)
+                    except BaseException as exc:
+                        self._record_conversation(invocation_id, None, exc)
+                        raise
+                    self._record_conversation(invocation_id, child_result, None)
+                    return child_result
+
+                setattr(agent, "run_conversation", run)
+            else:
+                self._gap("hermes_hook_unavailable", invocation_id, "run_conversation")
+
+    def _wrap_model_calls(self, agent: Any, invocation_id: str) -> None:
+        original = getattr(agent, "_interruptible_api_call", None)
+        if not callable(original):
+            self._gap("hermes_hook_unavailable", invocation_id, "_interruptible_api_call")
+            return
+
+        def call(*args: Any, **kwargs: Any) -> Any:
+            try:
+                response = original(*args, **kwargs)
+            except BaseException as exc:
+                self._gap("model_response_id_unavailable", invocation_id, type(exc).__name__)
+                raise
+            response_id = response.get("id") if isinstance(response, dict) else getattr(response, "id", None)
+            if self._model_ref is None or not isinstance(response_id, str) or not response_id:
+                self._gap("model_response_id_unavailable", invocation_id)
+            else:
+                reference = ModelCallRef(model_ref=self._model_ref, response_id=response_id)
+                with self._lock:
+                    invocation = self._invocations[invocation_id]
+                    if reference not in invocation.model_calls:
+                        invocation.model_calls.append(reference)
+            return response
+
+        setattr(agent, "_interruptible_api_call", call)
+
+    def _chain_callback(self, agent: Any, name: str, observer: Callable[..., None], invocation_id: str) -> None:
+        if not hasattr(agent, name):
+            self._gap("hermes_hook_unavailable", invocation_id, name)
+            return
+        previous = getattr(agent, name)
+
+        def callback(*args: Any, **kwargs: Any) -> None:
+            try:
+                observer(invocation_id, *args, **kwargs)
+            except Exception:
+                self._gap("hermes_observer_error", invocation_id, name)
+            if callable(previous):
+                try:
+                    previous(*args, **kwargs)
+                except Exception:
+                    pass  # Hermes callbacks are explicitly non-fatal.
+
+        setattr(agent, name, callback)
+
+    def _wrap_invoke(self, agent: Any, invocation_id: str) -> None:
+        original = getattr(agent, "_invoke_tool", None)
+        if not callable(original):
+            self._gap("hermes_hook_unavailable", invocation_id, "_invoke_tool")
+            return
+
+        def invoke(*args: Any, **kwargs: Any) -> Any:
+            key, previous = None, getattr(self._current, "tool", None)
+            try:
+                name = args[0] if args else kwargs.get("function_name")
+                call_args = args[1] if len(args) > 1 else kwargs.get("function_args")
+                with self._lock:
+                    key = self._tools_by_args.get(id(call_args))
+                if key is not None and key[0] == invocation_id:
+                    self._current.tool = (*key, name)
+                    self._start_execution(key)
+                else:
+                    key = None
+            except Exception:
+                self._gap("hermes_observer_error", invocation_id, "_invoke_tool")
+            failed = False
+            try:
+                return original(*args, **kwargs)
+            except BaseException:
+                failed = True
+                raise
+            finally:
+                if key is not None:
+                    self._end_execution(key, failed=failed)
+                self._current.tool = previous
+
+        setattr(agent, "_invoke_tool", invoke)
+
+    def _wrap_compaction(self, agent: Any, invocation_id: str) -> None:
+        original = getattr(agent, "_compress_context", None)
+        if not callable(original):
+            self._gap("hermes_hook_unavailable", invocation_id, "_compress_context")
+            return
+
+        def compact(*args: Any, **kwargs: Any) -> Any:
+            failed = False
+            try:
+                result = original(*args, **kwargs)
+            except BaseException:
+                failed = True
+                raise
+            finally:
+                before = kwargs.get("approx_tokens")
+                after = getattr(getattr(agent, "context_compressor", None), "last_prompt_tokens", None)
+                try:
+                    with self._lock:
+                        self._compactions.append(
+                            ContextCompactionObservation(
+                                invocation_id=invocation_id,
+                                observed_at=time(),
+                                trigger="context_pressure",
+                                tokens_before=before if type(before) is int else None,
+                                tokens_after=after if type(after) is int else None,
+                                outcome="failed" if failed else "completed",
+                            )
+                        )
+                    self._gap("compaction_model_call_boundary_unavailable", invocation_id)
+                    self._gap("compaction_summary_unavailable", invocation_id)
+                except Exception:
+                    self._gap("hermes_observer_error", invocation_id, "_compress_context")
+            return result
+
+        setattr(agent, "_compress_context", compact)
+
+    def _child_added(self, child: Any, parent_id: str) -> None:
+        try:
+            with self._lock:
+                self._child_index += 1
+                invocation_id = f"{parent_id}.child-{self._child_index}"
+                current = getattr(self._current, "tool", None)
+                call_id = current[1] if current and current[0] == parent_id and current[2] == "delegate_task" else None
+                self._invocations[invocation_id] = AgentInvocation(
+                    invocation_id=invocation_id,
+                    parent_invocation_id=parent_id,
+                    spawned_by_tool_call_id=call_id,
+                )
+                if call_id is None:
+                    self._gap("subagent_spawn_unattributed", invocation_id)
+            self._instrument_safely(child, invocation_id, wrap_conversation=True)
+        except Exception as exc:
+            self._gap("hermes_observer_error", parent_id, f"child: {type(exc).__name__}")
+
+    def _tool_started(self, invocation_id: str, call_id: Any, name: Any, args: Any) -> None:
+        key = (invocation_id, str(call_id or ""))
+        started_at = time()
+        started_tick = monotonic()
+        with self._lock:
+            if key in self._tools:
+                self._gap("duplicate_tool_call", invocation_id, key[1])
+            self._tools[key] = ToolCallObservation(
+                invocation_id=invocation_id,
+                tool_call_id=key[1],
+                tool_name=str(name or "") or None,
+                started_at=started_at,
+                timing_source="harness",
+            )
+            self._started_ticks[key] = started_tick
+            if isinstance(args, dict):
+                self._tools_by_args[id(args)] = key
+        self._current.tool = (*key, str(name or ""))
+
+    def _tool_completed(self, invocation_id: str, call_id: Any, name: Any, args: Any, result: Any) -> None:
+        key = (invocation_id, str(call_id or ""))
+        with self._lock:
+            if key not in self._tools:
+                self._tool_started(invocation_id, call_id, name, args)
+            tool = self._tools[key]
+            failed = self._failed_result(result)
+            if failed:
+                tool.status = "failed"
+            if isinstance(args, dict):
+                self._tools_by_args.pop(id(args), None)
+        current = getattr(self._current, "tool", None)
+        if current and current[:2] == key:
+            self._current.tool = None
+        self._end_execution(key, failed=failed)
+
+    def _start_execution(self, key: tuple[str, str]) -> None:
+        with self._lock:
+            tool = self._tools[key]
+            tool.started_at = time()
+            tool.timing_source = "executor"
+            self._started_ticks[key] = monotonic()
+
+    def _end_execution(self, key: tuple[str, str], *, failed: bool) -> None:
+        try:
+            with self._lock:
+                tool = self._tools[key]
+                if tool.completed_at is None:
+                    tool.completed_at = time()
+                    started_tick = self._started_ticks.pop(key, None)
+                    if started_tick is not None:
+                        tool.duration_ms = max(0.0, (monotonic() - started_tick) * 1000)
+                    tool.status = "failed" if failed else "completed"
+                elif failed:
+                    tool.status = "failed"
+        except Exception:
+            self._gap("hermes_observer_error", key[0], "_invoke_tool")
+
+    def _record_conversation(
+        self,
+        invocation_id: str,
+        result: dict[str, Any] | None,
+        error: BaseException | None,
+    ) -> None:
+        try:
+            messages = result.get("messages") if isinstance(result, dict) else []
+            conversation = normalize_hermes_messages(messages or [], id_prefix=invocation_id)
+            status = "failed" if error or (result and result.get("error")) else "unknown"
+            if isinstance(result, dict) and status != "failed":
+                if result.get("interrupted"):
+                    status = "incomplete"
+                elif result.get("completed") or result.get("final_response"):
+                    status = "completed"
+                elif messages:
+                    status = "incomplete"
+            with self._lock:
+                self._invocations[invocation_id].conversation = conversation
+                self._invocations[invocation_id].status = status
+        except Exception as exc:
+            self._gap("hermes_observer_error", invocation_id, f"conversation: {type(exc).__name__}")
+
+    @staticmethod
+    def _failed_result(result: Any) -> bool:
+        if not isinstance(result, str):
+            return False
+        value = result.lstrip()
+        if value.lower().startswith("error executing tool"):
+            return True
+        try:
+            payload = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return False
+        return isinstance(payload, dict) and (
+            payload.get("status") in {"error", "failed"} or bool(payload.get("error"))
+        )
+
+    def _gap(self, code: str, invocation_id: str | None, detail: str | None = None) -> None:
+        with self._lock:
+            gap = ObservationGap(code=code, invocation_id=invocation_id, detail=detail)
+            if gap not in self._gaps:
+                self._gaps.append(gap)

--- a/responses_api_agents/hermes_agent/observability.py
+++ b/responses_api_agents/hermes_agent/observability.py
@@ -19,6 +19,8 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseInputItem,
     NeMoGymResponseOutputMessage,
     NeMoGymResponseOutputText,
+    NeMoGymResponseReasoningItem,
+    NeMoGymSummary,
 )
 from nemo_gym.rollout_observability import (
     AgentInvocation,
@@ -53,6 +55,14 @@ def normalize_hermes_messages(messages: Iterable[Any], *, id_prefix: str = "herm
         if role in {"system", "user", "developer"}:
             output.append(NeMoGymEasyInputMessage(role=role, content=content))
         elif role == "assistant":
+            reasoning = message.get("reasoning")
+            if isinstance(reasoning, str) and reasoning:
+                output.append(
+                    NeMoGymResponseReasoningItem(
+                        id=f"{id_prefix}-reasoning-{index}",
+                        summary=[NeMoGymSummary(text=reasoning, type="summary_text")],
+                    )
+                )
             output.append(
                 NeMoGymResponseOutputMessage(
                     id=str(message.get("id") or f"{id_prefix}-message-{index}"),
@@ -115,6 +125,7 @@ class HermesAgentObserver:
         self._model_ref = model_ref
         self._child_index = 0
         self._agents: set[int] = set()
+        self._invocation_agents: dict[str, Any] = {}
         self._tools_by_args: dict[int, tuple[str, str]] = {}
         self._tools: dict[tuple[str, str], ToolCallObservation] = {}
         self._started_ticks: dict[tuple[str, str], float] = {}
@@ -127,9 +138,17 @@ class HermesAgentObserver:
         return self
 
     def finish(
-        self, result: dict[str, Any] | None = None, *, error: BaseException | None = None
+        self,
+        result: dict[str, Any] | None = None,
+        *,
+        error: BaseException | None = None,
     ) -> AgentObservationBundle:
-        self._record_conversation(self._root_id, result, error)
+        self._record_conversation(
+            self._root_id,
+            result,
+            error,
+            system_message=self._system_prompt(self._invocation_agents.get(self._root_id)),
+        )
         with self._lock:
             for tool in self._tools.values():
                 if tool.status == "unknown":
@@ -165,6 +184,7 @@ class HermesAgentObserver:
             if agent_id in self._agents:
                 return
             self._agents.add(agent_id)
+            self._invocation_agents[invocation_id] = agent
 
         self._chain_callback(agent, "tool_start_callback", self._tool_started, invocation_id)
         self._chain_callback(agent, "tool_complete_callback", self._tool_completed, invocation_id)
@@ -186,9 +206,19 @@ class HermesAgentObserver:
                     try:
                         child_result = original(*args, **kwargs)
                     except BaseException as exc:
-                        self._record_conversation(invocation_id, None, exc)
+                        self._record_conversation(
+                            invocation_id,
+                            None,
+                            exc,
+                            system_message=self._system_prompt(agent),
+                        )
                         raise
-                    self._record_conversation(invocation_id, child_result, None)
+                    self._record_conversation(
+                        invocation_id,
+                        child_result,
+                        None,
+                        system_message=self._system_prompt(agent),
+                    )
                     return child_result
 
                 setattr(agent, "run_conversation", run)
@@ -287,8 +317,12 @@ class HermesAgentObserver:
                 raise
             finally:
                 before = kwargs.get("approx_tokens")
-                after = getattr(getattr(agent, "context_compressor", None), "last_prompt_tokens", None)
                 try:
+                    after = None
+                    if not failed:
+                        value = getattr(getattr(agent, "context_compressor", None), "last_prompt_tokens", None)
+                        if type(value) is int and value >= 0:
+                            after = value
                     with self._lock:
                         self._compactions.append(
                             ContextCompactionObservation(
@@ -296,12 +330,14 @@ class HermesAgentObserver:
                                 observed_at=time(),
                                 trigger="context_pressure",
                                 tokens_before=before if type(before) is int else None,
-                                tokens_after=after if type(after) is int else None,
+                                tokens_after=after,
                                 outcome="failed" if failed else "completed",
                             )
                         )
                     self._gap("compaction_model_call_boundary_unavailable", invocation_id)
                     self._gap("compaction_summary_unavailable", invocation_id)
+                    if after is None:
+                        self._gap("compaction_tokens_after_unavailable", invocation_id)
                 except Exception:
                     self._gap("hermes_observer_error", invocation_id, "_compress_context")
             return result
@@ -351,7 +387,7 @@ class HermesAgentObserver:
             if key not in self._tools:
                 self._tool_started(invocation_id, call_id, name, args)
             tool = self._tools[key]
-            failed = self._failed_result(result)
+            failed = self._failed_result(name, result)
             if failed:
                 tool.status = "failed"
             if isinstance(args, dict):
@@ -388,15 +424,29 @@ class HermesAgentObserver:
         invocation_id: str,
         result: dict[str, Any] | None,
         error: BaseException | None,
+        *,
+        system_message: Any = None,
     ) -> None:
         try:
             messages = result.get("messages") if isinstance(result, dict) else []
             conversation = normalize_hermes_messages(messages or [], id_prefix=invocation_id)
+            if any(isinstance(message, dict) and message.get("reasoning_details") for message in messages or []):
+                self._gap("reasoning_details_unavailable", invocation_id)
+            if (
+                isinstance(system_message, str)
+                and system_message
+                and not (conversation and getattr(conversation[0], "role", None) == "system")
+            ):
+                conversation.insert(0, NeMoGymEasyInputMessage(role="system", content=system_message))
             status = "failed" if error or (result and result.get("error")) else "unknown"
             if isinstance(result, dict) and status != "failed":
                 if result.get("interrupted"):
                     status = "incomplete"
-                elif result.get("completed") or result.get("final_response"):
+                elif result.get("completed") is True:
+                    status = "completed"
+                elif result.get("completed") is False:
+                    status = "incomplete"
+                elif result.get("final_response"):
                     status = "completed"
                 elif messages:
                     status = "incomplete"
@@ -407,19 +457,29 @@ class HermesAgentObserver:
             self._gap("hermes_observer_error", invocation_id, f"conversation: {type(exc).__name__}")
 
     @staticmethod
-    def _failed_result(result: Any) -> bool:
+    def _system_prompt(agent: Any) -> str | None:
+        if agent is None:
+            return None
+        cached = getattr(agent, "_cached_system_prompt", None)
+        ephemeral = getattr(agent, "ephemeral_system_prompt", None)
+        parts = [value for value in (cached, ephemeral) if isinstance(value, str) and value]
+        return "\n\n".join(parts).strip() or None
+
+    @staticmethod
+    def _failed_result(tool_name: Any, result: Any) -> bool:
         if not isinstance(result, str):
             return False
         value = result.lstrip()
-        if value.lower().startswith("error executing tool"):
-            return True
         try:
             payload = json.loads(value)
         except (json.JSONDecodeError, TypeError):
+            lower = value[:500].lower()
+            return value.startswith("Error") or '"error"' in lower or '"failed"' in lower
+        if not isinstance(payload, dict):
             return False
-        return isinstance(payload, dict) and (
-            payload.get("status") in {"error", "failed"} or bool(payload.get("error"))
-        )
+        if tool_name == "terminal" and payload.get("exit_code") not in (None, 0):
+            return True
+        return payload.get("status") in {"error", "failed"} or bool(payload.get("error"))
 
     def _gap(self, code: str, invocation_id: str | None, detail: str | None = None) -> None:
         with self._lock:

--- a/responses_api_agents/hermes_agent/observability.py
+++ b/responses_api_agents/hermes_agent/observability.py
@@ -153,12 +153,6 @@ class HermesAgentObserver:
             for tool in self._tools.values():
                 if tool.status == "unknown":
                     tool.status = "incomplete"
-                if tool.timing_source is None:
-                    self._gap(
-                        "tool_execution_boundary_unavailable",
-                        tool.invocation_id,
-                        tool.tool_call_id,
-                    )
             for invocation in self._invocations.values():
                 if not invocation.model_calls:
                     self._gap("model_call_ownership_unavailable", invocation.invocation_id)

--- a/responses_api_agents/hermes_agent/tests/test_app.py
+++ b/responses_api_agents/hermes_agent/tests/test_app.py
@@ -356,7 +356,10 @@ class TestObservability:
 
         assert episode.response.output == baseline.output
         assert episode.response.usage == baseline.usage
-        assert [gap.code for gap in episode.observations.gaps] == ["observation_capture_failed"]
+        assert [gap.code for gap in episode.observations.gaps] == [
+            "observation_capture_failed",
+            "no_sandbox_runtime",
+        ]
 
     def test_run_passes_rollout_id_to_verifier(self) -> None:
         server_client = MagicMock(spec=ServerClient)

--- a/responses_api_agents/hermes_agent/tests/test_app.py
+++ b/responses_api_agents/hermes_agent/tests/test_app.py
@@ -304,12 +304,12 @@ class TestRolloutCorrelation:
         assert client.post("/ng-rollout/rid/v1/responses", json={"input": "hi"}).status_code == 200
         assert seen["base_url"] == "http://h:1/ng-rollout/rid/v1"
 
-        asyncio.run(agent.responses(request=None, body=NeMoGymResponseCreateParamsNonStreaming(input="hi")))
+        direct = asyncio.run(agent.responses(request=None, body=NeMoGymResponseCreateParamsNonStreaming(input="hi")))
         assert seen["base_url"] == "http://h:1/v1"
+        assert "_ng_agent_observations" not in direct.model_dump(mode="json")
 
         episode = asyncio.run(
-            agent.responses_with_observations(
-                request=None,
+            agent._create_episode(
                 body=NeMoGymResponseCreateParamsNonStreaming(input="hi"),
                 rollout_id="rid",
             )
@@ -320,7 +320,11 @@ class TestRolloutCorrelation:
 
 
 class TestObservability:
-    def test_observation_failure_does_not_change_response(self, monkeypatch) -> None:
+    @pytest.mark.parametrize(
+        ("terminal_backend", "runtime_gap"),
+        [("local", "no_sandbox_runtime"), ("docker", "sandbox_observation_unavailable")],
+    )
+    def test_observation_failure_does_not_change_response(self, monkeypatch, terminal_backend, runtime_gap) -> None:
         import nemo_gym.base_responses_api_agent as base_agent
         from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
 
@@ -328,7 +332,7 @@ class TestObservability:
         server_client = MagicMock(spec=ServerClient)
         server_client.global_config_dict = {}
         server_client._build_server_base_url = lambda _cfg: "http://h:1"
-        agent = HermesAgent(config=_config(), server_client=server_client)
+        agent = HermesAgent(config=_config(terminal_backend=terminal_backend), server_client=server_client)
         monkeypatch.setattr(agent, "_ensure_sigterm_handler", lambda: None)
 
         class _StubAIAgent:
@@ -352,16 +356,16 @@ class TestObservability:
             raise RuntimeError("observer failed")
 
         monkeypatch.setattr(HermesAgentObserver, "finish", fail_finish)
-        episode = asyncio.run(agent.responses_with_observations(request=None, body=body, rollout_id="rid"))
+        episode = asyncio.run(agent._create_episode(body=body, rollout_id="rid"))
 
         assert episode.response.output == baseline.output
         assert episode.response.usage == baseline.usage
         assert [gap.code for gap in episode.observations.gaps] == [
             "observation_capture_failed",
-            "no_sandbox_runtime",
+            runtime_gap,
         ]
 
-    def test_run_passes_rollout_id_to_verifier(self) -> None:
+    def test_run_returns_observations_without_leaking_internal_attachment(self) -> None:
         server_client = MagicMock(spec=ServerClient)
         server_client.global_config_dict = {"observability_enabled": True}
         agent = HermesAgent(config=_config(), server_client=server_client)
@@ -403,10 +407,14 @@ class TestObservability:
             }
         )
 
-        with patch.object(HermesAgent, "responses_with_observations", observed_response):
-            asyncio.run(agent.run(request, body))
+        with patch.object(HermesAgent, "_create_episode", observed_response):
+            result = asyncio.run(agent.run(request, body))
 
-        assert server_client.post.await_args_list[-1].kwargs["json"]["rollout_id"] == "1-2"
+        assert result.ng_agent_observations is not None
+        assert result.ng_agent_observations.source == "hermes"
+        verify_json = server_client.post.await_args_list[-1].kwargs["json"]
+        assert "_ng_agent_observations" not in verify_json["response"]
+        assert "rollout_id" not in verify_json
 
     def test_observer_failure_does_not_mask_agent_exception(self, monkeypatch) -> None:
         import nemo_gym.base_responses_api_agent as base_agent
@@ -435,8 +443,7 @@ class TestObservability:
 
         with pytest.raises(ValueError, match="agent failed"):
             asyncio.run(
-                agent.responses_with_observations(
-                    request=None,
+                agent._create_episode(
                     body=NeMoGymResponseCreateParamsNonStreaming(input="hi"),
                     rollout_id="rid",
                 )

--- a/responses_api_agents/hermes_agent/tests/test_app.py
+++ b/responses_api_agents/hermes_agent/tests/test_app.py
@@ -13,23 +13,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
-from unittest.mock import MagicMock
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymFunctionCallOutput,
+    NeMoGymResponse,
     NeMoGymResponseFunctionToolCall,
     NeMoGymResponseOutputMessageForTraining,
 )
+from nemo_gym.rollout_observability import AgentEpisode, AgentObservationBundle
 from nemo_gym.server_utils import ServerClient
 from responses_api_agents.hermes_agent.app import (
     HermesAgent,
     HermesAgentConfig,
+    HermesAgentRunRequest,
     ModelServerRef,
     ResourcesServerRef,
     _split_input_to_user_and_history,
     _trajectory_to_output_items,
 )
+from responses_api_agents.hermes_agent.observability import HermesAgentObserver
+
+
+class _FakeResponse:
+    ok = True
+
+    def __init__(self, payload: dict, cookies: dict | None = None) -> None:
+        self.payload = payload
+        self.cookies = cookies or {}
+
+    async def read(self) -> bytes:
+        return json.dumps(self.payload).encode()
 
 
 def _config(**kwargs) -> HermesAgentConfig:
@@ -256,8 +274,6 @@ class TestTrajectoryToOutputItems:
 
 
 class TestRolloutCorrelation:
-    """The prefixed self-call path makes responses() build AIAgent with the same model URL prefix."""
-
     def test_responses_applies_rollout_prefix(self, monkeypatch) -> None:
         from fastapi.testclient import TestClient
 
@@ -290,3 +306,135 @@ class TestRolloutCorrelation:
 
         asyncio.run(agent.responses(request=None, body=NeMoGymResponseCreateParamsNonStreaming(input="hi")))
         assert seen["base_url"] == "http://h:1/v1"
+
+        episode = asyncio.run(
+            agent.responses_with_observations(
+                request=None,
+                body=NeMoGymResponseCreateParamsNonStreaming(input="hi"),
+                rollout_id="rid",
+            )
+        )
+        assert seen["base_url"] == "http://h:1/ng-rollout/rid/v1"
+        assert episode.observations.source == "hermes"
+        assert episode.observations.records[0].invocation_id == "root"
+
+
+class TestObservability:
+    def test_observation_failure_does_not_change_response(self, monkeypatch) -> None:
+        import nemo_gym.base_responses_api_agent as base_agent
+        from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
+
+        monkeypatch.setattr(base_agent, "get_first_server_config_dict", lambda _gc, _name: {"host": "h", "port": 1})
+        server_client = MagicMock(spec=ServerClient)
+        server_client.global_config_dict = {}
+        server_client._build_server_base_url = lambda _cfg: "http://h:1"
+        agent = HermesAgent(config=_config(), server_client=server_client)
+        monkeypatch.setattr(agent, "_ensure_sigterm_handler", lambda: None)
+
+        class _StubAIAgent:
+            def __init__(self, **kwargs) -> None:
+                self._build_api_kwargs = lambda _messages: {}
+
+            def run_conversation(self, *args, **kwargs) -> dict:
+                return {
+                    "completed": True,
+                    "messages": [
+                        {"role": "user", "content": "hi"},
+                        {"role": "assistant", "content": "ok"},
+                    ],
+                }
+
+        monkeypatch.setattr("run_agent.AIAgent", _StubAIAgent)
+        body = NeMoGymResponseCreateParamsNonStreaming(input="hi")
+        baseline = asyncio.run(agent.responses(request=None, body=body))
+
+        def fail_finish(*args, **kwargs):
+            raise RuntimeError("observer failed")
+
+        monkeypatch.setattr(HermesAgentObserver, "finish", fail_finish)
+        episode = asyncio.run(agent.responses_with_observations(request=None, body=body, rollout_id="rid"))
+
+        assert episode.response.output == baseline.output
+        assert episode.response.usage == baseline.usage
+        assert [gap.code for gap in episode.observations.gaps] == ["observation_capture_failed"]
+
+    def test_run_passes_rollout_id_to_verifier(self) -> None:
+        server_client = MagicMock(spec=ServerClient)
+        server_client.global_config_dict = {"observability_enabled": True}
+        agent = HermesAgent(config=_config(), server_client=server_client)
+        response = NeMoGymResponse.model_validate(
+            {
+                "id": "resp-1",
+                "created_at": 1,
+                "model": "model",
+                "object": "response",
+                "output": [],
+                "parallel_tool_calls": True,
+                "tool_choice": "auto",
+                "tools": [],
+            }
+        )
+        observed_response = AsyncMock(
+            return_value=AgentEpisode(
+                response=response,
+                observations=AgentObservationBundle(source="hermes"),
+            )
+        )
+
+        async def post(server_name, url_path, json=None, cookies=None, **kwargs):
+            if url_path == "/seed_session":
+                return _FakeResponse({}, {"session": "1"})
+            if url_path.endswith("/v1/responses"):
+                response = await agent.responses(MagicMock(path_params={"rollout_id": "1-2"}), json)
+                return _FakeResponse(response.model_dump(mode="json"), cookies)
+            return _FakeResponse(json | {"reward": 1.0})
+
+        server_client.post = AsyncMock(side_effect=post)
+        request = MagicMock()
+        request.cookies = {}
+        body = HermesAgentRunRequest.model_validate(
+            {
+                "responses_create_params": {"input": "solve"},
+                "_ng_task_index": 1,
+                "_ng_rollout_index": 2,
+            }
+        )
+
+        with patch.object(HermesAgent, "responses_with_observations", observed_response):
+            asyncio.run(agent.run(request, body))
+
+        assert server_client.post.await_args_list[-1].kwargs["json"]["rollout_id"] == "1-2"
+
+    def test_observer_failure_does_not_mask_agent_exception(self, monkeypatch) -> None:
+        import nemo_gym.base_responses_api_agent as base_agent
+        from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
+
+        monkeypatch.setattr(base_agent, "get_first_server_config_dict", lambda _gc, _name: {"host": "h", "port": 1})
+        server_client = MagicMock(spec=ServerClient)
+        server_client.global_config_dict = {}
+        server_client._build_server_base_url = lambda _cfg: "http://h:1"
+        agent = HermesAgent(config=_config(), server_client=server_client)
+        monkeypatch.setattr(agent, "_ensure_sigterm_handler", lambda: None)
+
+        class _FailingAIAgent:
+            def __init__(self, **kwargs) -> None:
+                self._build_api_kwargs = lambda _messages: {}
+
+            def run_conversation(self, *args, **kwargs) -> dict:
+                raise ValueError("agent failed")
+
+        monkeypatch.setattr("run_agent.AIAgent", _FailingAIAgent)
+        monkeypatch.setattr(
+            HermesAgentObserver,
+            "finish",
+            MagicMock(side_effect=RuntimeError("observer failed")),
+        )
+
+        with pytest.raises(ValueError, match="agent failed"):
+            asyncio.run(
+                agent.responses_with_observations(
+                    request=None,
+                    body=NeMoGymResponseCreateParamsNonStreaming(input="hi"),
+                    rollout_id="rid",
+                )
+            )

--- a/responses_api_agents/hermes_agent/tests/test_observability.py
+++ b/responses_api_agents/hermes_agent/tests/test_observability.py
@@ -1,0 +1,333 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from nemo_gym.config_types import ModelServerRef
+from nemo_gym.rollout_observability import (
+    AgentInvocation,
+    ContextCompactionObservation,
+    ToolCallObservation,
+)
+from responses_api_agents.hermes_agent.observability import (
+    HermesAgentObserver,
+    normalize_hermes_messages,
+)
+
+
+class _FakeAgent:
+    def __init__(self, conversation=None):
+        self.tool_start_callback = None
+        self.tool_complete_callback = None
+        self._active_children = []
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self._conversation = conversation or {"completed": True, "messages": []}
+
+    def _invoke_tool(self, function_name, function_args, effective_task_id):
+        return function_args.get("result", function_name)
+
+    def _interruptible_api_call(self, api_kwargs):
+        return SimpleNamespace(id=api_kwargs.get("response_id", "resp-1"))
+
+    def _compress_context(self, messages, system_message, **kwargs):
+        self.context_compressor.last_prompt_tokens = 7
+        return messages[-1:], system_message
+
+    def run_conversation(self, *args, **kwargs):
+        return self._conversation
+
+
+def _invocation(bundle, invocation_id):
+    return next(
+        item for item in bundle.records if isinstance(item, AgentInvocation) and item.invocation_id == invocation_id
+    )
+
+
+def _tool(bundle, tool_call_id):
+    return next(
+        item for item in bundle.records if isinstance(item, ToolCallObservation) and item.tool_call_id == tool_call_id
+    )
+
+
+def _compactions(bundle):
+    return [item for item in bundle.records if isinstance(item, ContextCompactionObservation)]
+
+
+def test_normalize_hermes_messages_preserves_conversation_order():
+    items = normalize_hermes_messages(
+        [
+            {"role": "user", "content": "inspect"},
+            {
+                "role": "assistant",
+                "content": "working",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "function": {"name": "terminal", "arguments": {"command": "pwd"}},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "content": "/workspace"},
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "done"}],
+            },
+        ],
+        id_prefix="root",
+    )
+
+    assert [item.type for item in items] == [
+        "message",
+        "message",
+        "function_call",
+        "function_call_output",
+        "message",
+    ]
+    assert items[2].arguments == '{"command": "pwd"}'
+    assert items[3].call_id == "call-1"
+    assert items[4].content[0].text == "done"
+
+
+def test_matching_invoke_tool_records_executor_interval():
+    calls = []
+    agent = _FakeAgent()
+    agent.tool_start_callback = lambda *args: calls.append(("start", *args))
+    agent.tool_complete_callback = lambda *args: calls.append(("complete", *args))
+    observer = HermesAgentObserver().instrument(agent)
+    args = {"command": "pwd"}
+
+    agent.tool_start_callback("call-1", "terminal", args)
+    agent._invoke_tool("terminal", args, "task")
+    agent.tool_complete_callback("call-1", "terminal", args, "/workspace")
+    bundle = observer.finish({"completed": True, "messages": []})
+
+    tool = _tool(bundle, "call-1")
+    assert tool.status == "completed"
+    assert tool.started_at is not None
+    assert tool.completed_at >= tool.started_at
+    assert tool.duration_ms >= 0
+    assert tool.timing_source == "executor"
+    assert [call[0] for call in calls] == ["start", "complete"]
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        "Error executing tool: boom",
+        '{"error":"boom"}',
+        '{"status":"error","message":"boom"}',
+    ],
+)
+def test_tool_error_payloads_are_reported_as_failed(result):
+    agent = _FakeAgent()
+    observer = HermesAgentObserver().instrument(agent)
+    args = {"command": "pwd"}
+
+    agent.tool_start_callback("call-1", "terminal", args)
+    agent.tool_complete_callback("call-1", "terminal", args, result)
+
+    assert _tool(observer.finish({"completed": True, "messages": []}), "call-1").status == "failed"
+
+
+def test_callback_only_tool_records_harness_interval():
+    agent = _FakeAgent()
+    observer = HermesAgentObserver().instrument(agent)
+    callback_args = {"command": "pwd"}
+
+    agent.tool_start_callback("call-1", "terminal", callback_args)
+    agent._invoke_tool("terminal", {"command": "pwd"}, "task")
+    agent.tool_complete_callback("call-1", "terminal", callback_args, "/workspace")
+    bundle = observer.finish({"completed": True, "messages": []})
+
+    tool = _tool(bundle, "call-1")
+    assert tool.status == "completed"
+    assert tool.started_at is not None
+    assert tool.completed_at >= tool.started_at
+    assert tool.duration_ms >= 0
+    assert tool.timing_source == "harness"
+
+
+def test_model_response_id_is_joined_to_the_owning_invocation():
+    model_ref = ModelServerRef(type="responses_api_models", name="policy")
+    agent = _FakeAgent()
+    observer = HermesAgentObserver(model_ref=model_ref).instrument(agent)
+
+    response = agent._interruptible_api_call({"response_id": "resp-7"})
+    bundle = observer.finish({"completed": True, "messages": []})
+
+    assert response.id == "resp-7"
+    [reference] = _invocation(bundle, "root").model_calls
+    assert reference.model_ref == model_ref
+    assert reference.response_id == "resp-7"
+    assert "model_call_ownership_unavailable" not in {gap.code for gap in bundle.gaps}
+
+
+def test_concurrent_tool_intervals_end_at_each_worker_not_completion_callback():
+    from run_agent import AIAgent
+
+    agent = _FakeAgent()
+    release = {"fast": threading.Event(), "slow": threading.Event()}
+    entered = {"fast": threading.Event(), "slow": threading.Event()}
+
+    def invoke(function_name, function_args, effective_task_id):
+        entered[function_name].set()
+        assert release[function_name].wait(timeout=2)
+        return function_name
+
+    agent._invoke_tool = invoke
+    agent._interrupt_requested = False
+    agent.quiet_mode = False
+    agent.verbose_logging = False
+    agent.log_prefix_chars = 100
+    agent.tool_progress_callback = None
+    agent._checkpoint_mgr = SimpleNamespace(enabled=False)
+    agent._get_budget_warning = lambda _count: None
+    observer = HermesAgentObserver().instrument(agent)
+    calls = [
+        SimpleNamespace(id=f"{name}-call", function=SimpleNamespace(name=name, arguments="{}"))
+        for name in ("fast", "slow")
+    ]
+    execute = AIAgent._execute_tool_calls_concurrent.__get__(agent, _FakeAgent)
+    execution = threading.Thread(target=execute, args=(SimpleNamespace(tool_calls=calls), [], "task"))
+    execution.start()
+    assert entered["fast"].wait(timeout=2)
+    assert entered["slow"].wait(timeout=2)
+    release["fast"].set()
+    assert not threading.Event().wait(timeout=0.02)
+    release["slow"].set()
+    execution.join(timeout=2)
+    assert not execution.is_alive()
+    bundle = observer.finish({"completed": True, "messages": []})
+
+    fast = _tool(bundle, "fast-call")
+    slow = _tool(bundle, "slow-call")
+    assert fast.completed_at < slow.completed_at
+    assert fast.duration_ms < slow.duration_ms
+
+
+def test_delegate_children_retain_exact_tree_and_full_conversations():
+    root = _FakeAgent()
+    observer = HermesAgentObserver(root_invocation_id="root").instrument(root)
+    delegate_args = {"tasks": [{"goal": "one"}]}
+    root.tool_start_callback("delegate-1", "delegate_task", delegate_args)
+
+    child = _FakeAgent(
+        {
+            "completed": True,
+            "messages": [
+                {"role": "user", "content": "one"},
+                {"role": "assistant", "content": "child answer"},
+            ],
+        }
+    )
+    root._active_children.append(child)
+    child.run_conversation("one")
+    child_delegate_args = {"goal": "nested"}
+    child.tool_start_callback("delegate-2", "delegate_task", child_delegate_args)
+    grandchild = _FakeAgent(
+        {
+            "completed": True,
+            "messages": [{"role": "assistant", "content": "nested answer"}],
+        }
+    )
+    child._active_children.append(grandchild)
+    grandchild.run_conversation("nested")
+    child.tool_complete_callback("delegate-2", "delegate_task", child_delegate_args, "ok")
+    root.tool_complete_callback("delegate-1", "delegate_task", delegate_args, "ok")
+
+    bundle = observer.finish(
+        {
+            "completed": True,
+            "messages": [
+                {"role": "user", "content": "root task"},
+                {"role": "assistant", "content": "root answer"},
+            ],
+        }
+    )
+
+    root_invocation = _invocation(bundle, "root")
+    child_invocation = _invocation(bundle, "root.child-1")
+    grandchild_invocation = _invocation(bundle, "root.child-1.child-2")
+    assert root_invocation.status == "completed"
+    assert child_invocation.parent_invocation_id == "root"
+    assert child_invocation.spawned_by_tool_call_id == "delegate-1"
+    assert [item.type for item in child_invocation.conversation] == ["message", "message"]
+    assert grandchild_invocation.parent_invocation_id == "root.child-1"
+    assert grandchild_invocation.spawned_by_tool_call_id == "delegate-2"
+    assert all(not invocation.model_calls for invocation in bundle.records if isinstance(invocation, AgentInvocation))
+    ownership_gaps = [gap for gap in bundle.gaps if gap.code == "model_call_ownership_unavailable"]
+    assert {gap.invocation_id for gap in ownership_gaps} == {
+        "root",
+        "root.child-1",
+        "root.child-1.child-2",
+    }
+
+
+def test_compaction_is_explicit_and_hook_failures_do_not_break_execution():
+    agent = _FakeAgent()
+    agent.tool_start_callback = MagicMock(side_effect=RuntimeError("callback"))
+    observer = HermesAgentObserver().instrument(agent)
+
+    assert agent._invoke_tool("terminal", {"result": "ok"}, "task") == "ok"
+    compressed, prompt = agent._compress_context([{"role": "user", "content": "x"}], "system", approx_tokens=42)
+    assert compressed == [{"role": "user", "content": "x"}]
+    assert prompt == "system"
+    bundle = observer.finish({"interrupted": True, "messages": [{"role": "user", "content": "x"}]})
+
+    assert _invocation(bundle, "root").status == "incomplete"
+    [compaction] = _compactions(bundle)
+    assert compaction.tokens_before == 42
+    assert compaction.tokens_after == 7
+    assert compaction.outcome == "completed"
+    assert {
+        "compaction_model_call_boundary_unavailable",
+        "compaction_summary_unavailable",
+    } <= {gap.code for gap in bundle.gaps}
+
+
+def test_failed_compaction_is_recorded_without_swallowing_the_error():
+    agent = _FakeAgent()
+    agent._compress_context = MagicMock(side_effect=RuntimeError("compression failed"))
+    observer = HermesAgentObserver().instrument(agent)
+
+    with pytest.raises(RuntimeError, match="compression failed"):
+        agent._compress_context([], "system", approx_tokens=42)
+
+    [compaction] = _compactions(observer.finish({"completed": True, "messages": []}))
+    assert compaction.outcome == "failed"
+
+
+def test_missing_private_hooks_are_reported_without_raising():
+    class MinimalAgent:
+        pass
+
+    observer = HermesAgentObserver().instrument(MinimalAgent())
+    bundle = observer.finish({"completed": True, "messages": []})
+
+    unavailable = {gap.detail for gap in bundle.gaps if gap.code == "hermes_hook_unavailable"}
+    assert unavailable == {
+        "tool_start_callback",
+        "tool_complete_callback",
+        "_interruptible_api_call",
+        "_invoke_tool",
+        "_compress_context",
+        "_active_children",
+    }
+
+
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        ({"completed": True, "messages": []}, "completed"),
+        ({"final_response": "ok", "messages": []}, "completed"),
+        ({"interrupted": True, "messages": []}, "incomplete"),
+        ({"error": "boom", "messages": []}, "failed"),
+    ],
+)
+def test_root_status(result, expected):
+    observer = HermesAgentObserver().instrument(_FakeAgent())
+    assert _invocation(observer.finish(result), "root").status == expected

--- a/responses_api_agents/hermes_agent/tests/test_observability.py
+++ b/responses_api_agents/hermes_agent/tests/test_observability.py
@@ -64,6 +64,7 @@ def test_normalize_hermes_messages_preserves_conversation_order():
             {
                 "role": "assistant",
                 "content": "working",
+                "reasoning": "checking the workspace",
                 "tool_calls": [
                     {
                         "id": "call-1",
@@ -82,14 +83,16 @@ def test_normalize_hermes_messages_preserves_conversation_order():
 
     assert [item.type for item in items] == [
         "message",
+        "reasoning",
         "message",
         "function_call",
         "function_call_output",
         "message",
     ]
-    assert items[2].arguments == '{"command": "pwd"}'
-    assert items[3].call_id == "call-1"
-    assert items[4].content[0].text == "done"
+    assert items[1].summary[0].text == "checking the workspace"
+    assert items[3].arguments == '{"command": "pwd"}'
+    assert items[4].call_id == "call-1"
+    assert items[5].content[0].text == "done"
 
 
 def test_matching_invoke_tool_records_executor_interval():
@@ -118,6 +121,7 @@ def test_matching_invoke_tool_records_executor_interval():
     "result",
     [
         "Error executing tool: boom",
+        "Error: permission denied",
         '{"error":"boom"}',
         '{"status":"error","message":"boom"}',
     ],
@@ -131,6 +135,33 @@ def test_tool_error_payloads_are_reported_as_failed(result):
     agent.tool_complete_callback("call-1", "terminal", args, result)
 
     assert _tool(observer.finish({"completed": True, "messages": []}), "call-1").status == "failed"
+
+
+def test_terminal_nonzero_exit_is_reported_as_failed():
+    agent = _FakeAgent()
+    observer = HermesAgentObserver().instrument(agent)
+    args = {"command": "false"}
+
+    agent.tool_start_callback("call-1", "terminal", args)
+    agent.tool_complete_callback("call-1", "terminal", args, '{"exit_code": 1}')
+
+    assert _tool(observer.finish({"completed": True, "messages": []}), "call-1").status == "failed"
+
+
+def test_terminal_success_with_null_error_is_reported_as_completed():
+    agent = _FakeAgent()
+    observer = HermesAgentObserver().instrument(agent)
+    args = {"command": "true"}
+
+    agent.tool_start_callback("call-1", "terminal", args)
+    agent.tool_complete_callback(
+        "call-1",
+        "terminal",
+        args,
+        '{"output":"","exit_code":0,"error":null}',
+    )
+
+    assert _tool(observer.finish({"completed": True, "messages": []}), "call-1").status == "completed"
 
 
 def test_callback_only_tool_records_harness_interval():
@@ -209,8 +240,9 @@ def test_concurrent_tool_intervals_end_at_each_worker_not_completion_callback():
     assert fast.duration_ms < slow.duration_ms
 
 
-def test_delegate_children_retain_exact_tree_and_full_conversations():
+def test_delegate_child_retains_parent_and_conversation():
     root = _FakeAgent()
+    root._cached_system_prompt = "root system"
     observer = HermesAgentObserver(root_invocation_id="root").instrument(root)
     delegate_args = {"tasks": [{"goal": "one"}]}
     root.tool_start_callback("delegate-1", "delegate_task", delegate_args)
@@ -224,19 +256,10 @@ def test_delegate_children_retain_exact_tree_and_full_conversations():
             ],
         }
     )
+    child._cached_system_prompt = "child system"
+    child.ephemeral_system_prompt = "child ephemeral"
     root._active_children.append(child)
-    child.run_conversation("one")
-    child_delegate_args = {"goal": "nested"}
-    child.tool_start_callback("delegate-2", "delegate_task", child_delegate_args)
-    grandchild = _FakeAgent(
-        {
-            "completed": True,
-            "messages": [{"role": "assistant", "content": "nested answer"}],
-        }
-    )
-    child._active_children.append(grandchild)
-    grandchild.run_conversation("nested")
-    child.tool_complete_callback("delegate-2", "delegate_task", child_delegate_args, "ok")
+    child.run_conversation(user_message="one")
     root.tool_complete_callback("delegate-1", "delegate_task", delegate_args, "ok")
 
     bundle = observer.finish(
@@ -251,25 +274,20 @@ def test_delegate_children_retain_exact_tree_and_full_conversations():
 
     root_invocation = _invocation(bundle, "root")
     child_invocation = _invocation(bundle, "root.child-1")
-    grandchild_invocation = _invocation(bundle, "root.child-1.child-2")
     assert root_invocation.status == "completed"
+    assert root_invocation.conversation[0].role == "system"
+    assert root_invocation.conversation[0].content == "root system"
     assert child_invocation.parent_invocation_id == "root"
     assert child_invocation.spawned_by_tool_call_id == "delegate-1"
-    assert [item.type for item in child_invocation.conversation] == ["message", "message"]
-    assert grandchild_invocation.parent_invocation_id == "root.child-1"
-    assert grandchild_invocation.spawned_by_tool_call_id == "delegate-2"
+    assert [item.type for item in child_invocation.conversation] == ["message", "message", "message"]
+    assert child_invocation.conversation[0].content == "child system\n\nchild ephemeral"
     assert all(not invocation.model_calls for invocation in bundle.records if isinstance(invocation, AgentInvocation))
     ownership_gaps = [gap for gap in bundle.gaps if gap.code == "model_call_ownership_unavailable"]
-    assert {gap.invocation_id for gap in ownership_gaps} == {
-        "root",
-        "root.child-1",
-        "root.child-1.child-2",
-    }
+    assert {gap.invocation_id for gap in ownership_gaps} == {"root", "root.child-1"}
 
 
 def test_compaction_is_explicit_and_hook_failures_do_not_break_execution():
     agent = _FakeAgent()
-    agent.tool_start_callback = MagicMock(side_effect=RuntimeError("callback"))
     observer = HermesAgentObserver().instrument(agent)
 
     assert agent._invoke_tool("terminal", {"result": "ok"}, "task") == "ok"
@@ -287,6 +305,7 @@ def test_compaction_is_explicit_and_hook_failures_do_not_break_execution():
         "compaction_model_call_boundary_unavailable",
         "compaction_summary_unavailable",
     } <= {gap.code for gap in bundle.gaps}
+    assert "compaction_tokens_after_unavailable" not in {gap.code for gap in bundle.gaps}
 
 
 def test_failed_compaction_is_recorded_without_swallowing_the_error():
@@ -297,8 +316,11 @@ def test_failed_compaction_is_recorded_without_swallowing_the_error():
     with pytest.raises(RuntimeError, match="compression failed"):
         agent._compress_context([], "system", approx_tokens=42)
 
-    [compaction] = _compactions(observer.finish({"completed": True, "messages": []}))
+    bundle = observer.finish({"completed": True, "messages": []})
+    [compaction] = _compactions(bundle)
     assert compaction.outcome == "failed"
+    assert compaction.tokens_after is None
+    assert "compaction_tokens_after_unavailable" in {gap.code for gap in bundle.gaps}
 
 
 def test_missing_private_hooks_are_reported_without_raising():
@@ -324,6 +346,7 @@ def test_missing_private_hooks_are_reported_without_raising():
     [
         ({"completed": True, "messages": []}, "completed"),
         ({"final_response": "ok", "messages": []}, "completed"),
+        ({"completed": False, "final_response": "summary", "messages": []}, "incomplete"),
         ({"interrupted": True, "messages": []}, "incomplete"),
         ({"error": "boom", "messages": []}, "failed"),
     ],


### PR DESCRIPTION
## Summary

Add Hermes production of `ng_agent_observations` for correlated rollouts and update the trajectory capability matrix.

Hermes observations use instance-local hooks. Uncorrelated requests retain the existing response path.

## Capability coverage

`V` = supported, `O` = partial or path-dependent, `X` = unavailable. C1, C2, and C4 require correlated Gym Model Server capture.

| Agent | C1 | C2 | C3 | C4 | C5 | C6 | C7 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `hermes_agent` | V | V | X | V | V | V | V |

C3 remains unavailable because Hermes does not emit standardized per-turn records.

## Captured evidence

- root and delegated-agent conversations, including system prompts and plain reasoning
- parent and `delegate_task` spawn relationships when directly observed
- model-call references from response IDs
- model-visible tool outputs, execution status, timestamps, duration, and independent concurrent-call intervals
- context-compaction outcomes and available pre/post token estimates
- invocation outcomes

Existing Hermes callbacks are chained. Observation failures do not mask agent failures.

## Evidence boundaries

- Missing Hermes hooks and unattributed child spawns are reported as explicit gaps.
- Opaque `reasoning_details` are not normalized.
- Compaction summaries and exact adjacent model calls are unavailable; failed compactions do not report a post-compaction token count.
- Local terminal execution reports `no_sandbox_runtime`.
- External terminal backends report `sandbox_observation_unavailable` because Gym does not receive their lifecycle or resource telemetry.

## Compatibility

- observation capture is enabled only for correlated rollouts
- the private self-call attachment is removed before verification
- verifier payloads, rewards, and token-bearing output retain existing semantics
- `ng_agent_observations` is optional and additive

## Validation

- Hermes suite: 44 passed
- compatibility suite: 239 passed
- local E2E: pinned Hermes agent, concurrent tools, model-call correlation, normalized conversation, and trajectory projection
- Ruff, formatting, compile, and diff checks passed

## Related pull requests

This is **4/7** in the rollout-observability series. Producer PRs 4/7 through 7/7 are independently based on `main`.

<!-- stack-links -->

- [1/7 #2114 — Define the rollout observation and correlation contract](https://github.com/NVIDIA-NeMo/Gym/pull/2114)
- [2/7 #2153 — Add Claude Code rollout observations](https://github.com/NVIDIA-NeMo/Gym/pull/2153)
- [3/7 #2115 — Add OpenClaw rollout observations](https://github.com/NVIDIA-NeMo/Gym/pull/2115)
- [4/7 #2117 — Add Hermes rollout observations](https://github.com/NVIDIA-NeMo/Gym/pull/2117)
- [5/7 #2118 — Add Pi rollout observations](https://github.com/NVIDIA-NeMo/Gym/pull/2118)
- [6/7 #2119 — Add OpenCode rollout observations](https://github.com/NVIDIA-NeMo/Gym/pull/2119)
- [7/7 #2120 — Add SWE and OpenHands rollout observations](https://github.com/NVIDIA-NeMo/Gym/pull/2120)
