### PR TITLE
feat(token-id-capture): chain a rollout's calls into one response

### DIFF
--- a/nemo_gym/token_id_capture/__init__.py
+++ b/nemo_gym/token_id_capture/__init__.py
@@ -27,7 +27,22 @@ There is no HTTP token reader.
 This leaf package avoids imports from Gym's server stack.
 """
 
+from nemo_gym.token_id_capture.builder import (
+    Chain,
+    assert_prefix_contiguity,
+    per_request,
+    prefix_merging,
+    project_chain_to_output_items,
+    project_main_chain_response,
+    run_builder,
+)
 from nemo_gym.token_id_capture.config import TokenIdCaptureConfig
+from nemo_gym.token_id_capture.consumer import (
+    clear_token_captures_for_rollouts,
+    token_id_capture_dirs_from_config,
+    trajectories_for_rollout,
+    trajectories_from_source,
+)
 from nemo_gym.token_id_capture.protocols import (
     TokenCaptureSnapshot,
     TokenSink,
@@ -55,6 +70,7 @@ from nemo_gym.token_id_capture.store import TokenCaptureStore, make_token_store,
 
 
 __all__ = [
+    "Chain",
     "TokenIdCaptureConfig",
     "TokenEntry",
     "TOKEN_ENTRY_RECORD_SCHEMA_VERSION",
@@ -76,4 +92,14 @@ __all__ = [
     "capture_tokens",
     "commit_entry",
     "current_capture_context",
+    "per_request",
+    "prefix_merging",
+    "project_chain_to_output_items",
+    "project_main_chain_response",
+    "run_builder",
+    "assert_prefix_contiguity",
+    "trajectories_for_rollout",
+    "clear_token_captures_for_rollouts",
+    "trajectories_from_source",
+    "token_id_capture_dirs_from_config",
 ]

--- a/nemo_gym/token_id_capture/builder.py
+++ b/nemo_gym/token_id_capture/builder.py
@@ -1,0 +1,392 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Turn a rollout's captured token records into trainable trajectories.
+
+The builder is a pure function over a list of ``TokenEntry`` records (whatever a
+``TokenSource`` returns). It has two strategies:
+
+  per_request     assumes nothing about how the calls relate; every call becomes
+                  its own training sequence. Always valid.
+  prefix_merging  chains calls by the token-prefix relationship: each call is
+                  parented to the earlier call whose full token sequence (prompt
+                  plus generation) is the longest prefix of this call's prompt.
+                  This rebuilds a multi-turn, append-only rollout into one chain.
+                  A prompt that no longer extends any earlier call starts a new
+                  root (a compacted or rewritten context). Two candidate parents
+                  with identical sequences are ambiguous, so that subtree is
+                  quarantined rather than guessed.
+
+Both are order-independent: they do not depend on arrival order or any sequence
+number. ``prefix_merging`` processes entries by increasing prompt length, which
+is derived from the tokens themselves (a parent's prompt is shorter than its
+child's), so concurrent or out-of-order capture yields the same result.
+
+Loss masks follow provenance: tokens the policy generated are marked 1 (with
+their captured log probabilities), and everything re-fed into a prompt (history,
+tool output, tokens added between calls) is marked 0.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+from nemo_gym.token_id_capture.records import TokenEntry
+
+
+@dataclass
+class ChainLink:
+    entry: TokenEntry
+    interstitial: list[int]  # prompt tokens added since the parent (tool output, new user turn); mask 0
+
+
+@dataclass
+class Chain:
+    chain_id: str
+    links: list[ChainLink] = field(default_factory=list)
+    root_prompt: list[int] = field(default_factory=list)
+
+    def validate(self) -> None:
+        """Every generated token needs its log probability; a trainer cannot use a chain
+        where they disagree, and the mismatch is easier to read here than downstream."""
+        for link in self.links:
+            generated = link.entry.generation_token_ids
+            log_probs = link.entry.generation_log_probs
+            if len(log_probs) != len(generated):
+                raise ValueError(
+                    f"log-prob/token length mismatch on {link.entry.model_call_id}: "
+                    f"{len(log_probs)} vs {len(generated)}"
+                )
+
+
+@dataclass
+class BuildNotes:
+    """What the build kept, dropped and had to guess at.
+
+    Typed rather than a free-form dict because the consumer turns these into the metrics a run is
+    judged by, and a renamed key in an untyped dict reads as a zero on a dashboard instead of an
+    error.
+    """
+
+    builder: str
+    roots: int = 0
+    chains: int = 0
+    generated_tokens_captured: int = 0
+    generated_tokens_delivered: int = 0
+    # Only one chain is delivered per rollout today, so sub-agent branches and everything after a
+    # context compaction are dropped. That is a deliberate limitation and has to stay visible.
+    delivered_fraction: float = 0.0
+    # Calls whose sibling was a retry the harness may or may not have kept. Unresolvable for the
+    # final call of a rollout, because no later call names the survivor.
+    unresolved_retries: list[str] = field(default_factory=list)
+    # Calls the model returned with no generated tokens, kept out of the chain entirely.
+    empty_generation_calls: list[str] = field(default_factory=list)
+
+
+@dataclass
+class BuildOutput:
+    chains: list[Chain]
+    quarantined: list[str] = field(default_factory=list)  # model_call_ids
+    notes: BuildNotes = field(default_factory=lambda: BuildNotes(builder=""))
+
+
+def per_request(entries: list[TokenEntry]) -> BuildOutput:
+    ordered = sorted(entries, key=lambda e: (len(e.prompt_token_ids), e.model_call_id))
+    chains = [
+        Chain(chain_id=f"req-{i}", root_prompt=list(e.prompt_token_ids), links=[ChainLink(entry=e, interstitial=[])])
+        for i, e in enumerate(ordered)
+    ]
+    return BuildOutput(chains=chains, notes=BuildNotes(builder="per_request", chains=len(chains)))
+
+
+def _is_prefix(a: list[int], b: list[int]) -> bool:
+    return len(a) <= len(b) and b[: len(a)] == a
+
+
+@dataclass(eq=False)  # identity-based, so nodes are hashable for set membership
+class _Node:
+    entry: TokenEntry
+    cumulative: list[int]  # prompt + generation for this call
+    parent: "_Node | None" = None
+    children: list["_Node"] = field(default_factory=list)
+    quarantined: bool = False
+
+
+def _infer_parent(prompt: list[int], candidates: list["_Node"]) -> tuple["_Node | None", bool]:
+    """Fallback when no verified parent link is recorded: the earlier call whose
+    cumulative sequence is the longest prefix of this prompt.
+
+    Two candidates with identical cumulative sequences are indistinguishable, so
+    the subtree is quarantined rather than guessed.
+    """
+    matches = [n for n in candidates if _is_prefix(n.cumulative, prompt)]
+    if not matches:
+        return None, False
+    best_len = max(len(n.cumulative) for n in matches)
+    best = [n for n in matches if len(n.cumulative) == best_len]
+    return best[0], len(best) > 1
+
+
+def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
+    # A call that generated nothing (content filter, or the output budget exhausted before the
+    # first token) has no trainable tokens, and its cumulative sequence equals its prompt. Left in,
+    # it matches the prefix test against any call sharing that prompt and becomes its parent, so a
+    # filtered call followed by a retry reads as a two-turn chain. Retry resolution only compares
+    # siblings under a shared parent, so it would never see the pair.
+    empty_generation = [e.model_call_id for e in entries if not e.generation_token_ids]
+    entries = [e for e in entries if e.generation_token_ids]
+    if not entries:
+        return BuildOutput(
+            chains=[], notes=BuildNotes(builder="prefix_merging", empty_generation_calls=empty_generation)
+        )
+
+    # Increasing prompt length is an order derived from the tokens: a parent's
+    # cumulative sequence is a prefix of its child's prompt, so the parent's
+    # prompt is shorter. This makes the pass order-independent.
+    ordered = sorted(entries, key=lambda e: (len(e.prompt_token_ids), e.model_call_id))
+    nodes: list[_Node] = []
+    roots: list[_Node] = []
+    quarantined: list[str] = []
+
+    for entry in ordered:
+        prompt = list(entry.prompt_token_ids)
+        node = _Node(entry=entry, cumulative=prompt + list(entry.generation_token_ids))
+        parent, ambiguous = _infer_parent(prompt, nodes)
+        if parent is not None:
+            node.parent = parent
+            if ambiguous:
+                # Two candidate parents with identical sequences: quarantine rather than guess.
+                node.quarantined = True
+                quarantined.append(entry.model_call_id)
+            parent.children.append(node)
+        else:
+            roots.append(node)
+        nodes.append(node)
+
+    # Resolve retry siblings. A harness (Claude Code) retries on timeout / 5xx / dropped SSE, and the
+    # capture point records a call even if the client never received it, so a retry yields two nodes
+    # with identical prompt ids under the same parent and divergent generations.
+    #
+    # A recorded parent link settles this exactly: a later call names the sibling the harness actually
+    # kept, so the other is provably unused. Without one we fall back to "the sibling a later call
+    # extended wins". Neither can resolve a retry of the last call, because no later call names the
+    # survivor, so that case is flagged as unresolved rather than tie-broken silently, and the
+    # caller masks the rollout instead of training on a generation the client may never have received.
+    unresolved_retries: list[str] = []
+    # Group by parent identity. Roots share the ROOTS key on purpose: a retry of a rollout's first
+    # call produces two roots with the same prompt, and they have to be compared as siblings like
+    # any other pair. An explicit key says so, where id(None) would leave it looking accidental.
+    ROOTS = "roots"
+    siblings_by_parent: dict[object, list[_Node]] = {}
+    for node in nodes:
+        siblings_by_parent.setdefault(ROOTS if node.parent is None else id(node.parent), []).append(node)
+    for group in siblings_by_parent.values():
+        by_prompt: dict[tuple, list[_Node]] = {}
+        for node in group:
+            by_prompt.setdefault(tuple(node.entry.prompt_token_ids), []).append(node)
+        for retry_group in by_prompt.values():
+            if len(retry_group) < 2:
+                continue
+            extended = [n for n in retry_group if n.children]
+            if extended:
+                keep = set(extended)
+            else:
+                keep = {min(retry_group, key=lambda n: n.entry.model_call_id)}
+                unresolved_retries.extend(n.entry.model_call_id for n in retry_group)
+            for node in retry_group:
+                if node not in keep and not node.quarantined:
+                    node.quarantined = True
+                    quarantined.append(node.entry.model_call_id)
+
+    chains: list[Chain] = []
+
+    def walk(node: _Node, path: list[_Node]) -> None:
+        path = path + [node]
+        if not node.children:
+            if any(p.quarantined for p in path):
+                return
+            root = path[0]
+            chain = Chain(chain_id="", root_prompt=list(root.entry.prompt_token_ids))
+            prev_cumulative = list(root.entry.prompt_token_ids)
+            for step, p in enumerate(path):
+                interstitial = [] if step == 0 else list(p.entry.prompt_token_ids[len(prev_cumulative) :])
+                chain.links.append(ChainLink(entry=p.entry, interstitial=interstitial))
+                prev_cumulative = list(p.entry.prompt_token_ids) + list(p.entry.generation_token_ids)
+            chains.append(chain)
+            return
+        for child in node.children:
+            walk(child, path)
+
+    for root in roots:
+        walk(root, [])
+
+    # Only one chain is delivered per rollout, so when a rollout has more than one root, one has
+    # to be chosen. The choice is the root whose call completed first.
+    #
+    # That is dispatch order for a sequential harness. capture_tokens is awaited inside the model
+    # server's response path, so a call's record is durable before its response reaches the
+    # harness, which means the next call has not been made yet. created_at is stamped at that
+    # point. Ordering on the record's own timestamp rather than on file order matters because a
+    # server running num_workers > 1 has several processes appending, and their interleaving is
+    # lock order, not completion order.
+    #
+    # Two known shapes are not handled, both involving a second agent:
+    #
+    # An auxiliary call the harness makes on its own account, such as generating a conversation
+    # title, is short and can complete before the agent's first real turn. It would then be picked
+    # as the root and the agent's own chain relabelled a branch.
+    #
+    # Parallel sub-agents overlap, so completion order stops meaning dispatch order at all, and
+    # nothing in a record says which agent made the call. Ordering cannot recover that. Keeping
+    # sub-agent calls out of the records, by pointing them at a model server that is not the
+    # policy's, can; some harnesses support configuring that.
+    #
+    # Both are follow-up work. Until then the split is visible rather than silent: a rollout that
+    # split reports chains > 1 and a delivered_fraction below 1.
+    def selection_key(c: Chain) -> tuple:
+        # Earliest root first. Ties break on call id so the result is deterministic when two
+        # records share a timestamp, and a chain with no links sorts last rather than raising.
+        if not c.links:
+            return (float("inf"), "")
+        root = c.links[0].entry
+        return (root.created_at, root.model_call_id)
+
+    if chains:
+        main = min(chains, key=selection_key)
+        main.chain_id = "main"
+        branch = 0
+        for c in chains:
+            if c is not main:
+                c.chain_id = f"branch-{branch}"
+                branch += 1
+
+    delivered = sum(len(link.entry.generation_token_ids) for link in main.links) if chains else 0
+    captured = sum(len(e.generation_token_ids) for e in entries)
+    notes = BuildNotes(
+        builder="prefix_merging",
+        roots=len(roots),
+        chains=len(chains),
+        generated_tokens_captured=captured,
+        generated_tokens_delivered=delivered,
+        delivered_fraction=round(delivered / captured, 4) if captured else 0.0,
+        unresolved_retries=unresolved_retries,
+        empty_generation_calls=empty_generation,
+    )
+    return BuildOutput(chains=chains, quarantined=quarantined, notes=notes)
+
+
+_BUILDERS: dict[str, Callable[[list[TokenEntry]], BuildOutput]] = {
+    "per_request": per_request,
+    "prefix_merging": prefix_merging,
+}
+
+
+def run_builder(entries: list[TokenEntry], builder: str = "prefix_merging") -> BuildOutput:
+    """Chain a rollout's records using the named strategy."""
+    if builder not in _BUILDERS:
+        raise ValueError(f"unknown builder {builder!r}; known: {sorted(_BUILDERS)}")
+    return _BUILDERS[builder](entries)
+
+
+# --- Projection to a contiguous, token-bearing response ---
+
+
+def project_chain_to_output_items(chain: Chain) -> list[dict]:
+    """Project the chain into content-bearing Responses output items whose prompts are
+    contiguous. For each call, emit its captured output items (assistant text, tool
+    calls preserved) and set the contiguous prompt on the item that carries the
+    generation, so each generated item's prompt extends the previous one. That is the
+    shape a trainer ingests, with the text intact for anything that scores it. Falls back to a
+    synthesized token-only item only when a call captured no content items."""
+    items: list[dict] = []
+    cumulative = list(chain.root_prompt)
+    for step, link in enumerate(chain.links):
+        cumulative = cumulative + (link.interstitial if step > 0 else [])
+        entry = link.entry
+        content_items = [dict(item) for item in (entry.output_items or [])]
+        index = entry.token_item_index
+        if index is not None and 0 <= index < len(content_items):
+            # The item the arrays were taken off, recorded at capture time.
+            generated = [content_items[index]]
+        else:
+            # Records written before the arrays were de-duplicated still carry them inline.
+            generated = [item for item in content_items if item.get("generation_token_ids") is not None]
+        if not generated and content_items:
+            # No item carried token fields (unexpected); attach to the last so tokens are not lost.
+            generated = content_items[-1:]
+        if content_items:
+            for item in generated:
+                item["prompt_token_ids"] = list(cumulative)
+                item["generation_token_ids"] = list(entry.generation_token_ids)
+                item["generation_log_probs"] = list(entry.generation_log_probs)
+                if entry.routed_experts is not None:
+                    item["routed_experts"] = entry.routed_experts
+            items.extend(content_items)
+        else:
+            item = {
+                "type": "message",
+                "prompt_token_ids": list(cumulative),
+                "generation_token_ids": list(entry.generation_token_ids),
+                "generation_log_probs": list(entry.generation_log_probs),
+            }
+            if entry.routed_experts is not None:
+                item["routed_experts"] = entry.routed_experts
+            items.append(item)
+        cumulative = cumulative + list(entry.generation_token_ids)
+    return items
+
+
+def project_main_chain_response(rollout_id: str, out: BuildOutput, model: str = "") -> dict:
+    """Rebuild the main chain as a Responses object whose output items are contiguous.
+
+    The result is an ordinary Gym-native Responses payload: ``object: "response"``, a list
+    of ``output`` items, and ``usage``. The only thing that distinguishes it from what the
+    model server returned is that the token fields on each generated item now describe an
+    unbroken sequence across the whole rollout, because the items come from several model
+    calls stitched together rather than one.
+    """
+    mains = [c for c in out.chains if c.chain_id == "main"] or out.chains[:1]
+    output = project_chain_to_output_items(mains[0]) if mains else []
+    # Token fields ride only on generated items; a content-only leading item (e.g. assistant
+    # text emitted before a tool call) carries none. Read the usage counts from the items that
+    # actually have token fields so a leading content item does not KeyError or skew the totals.
+    generated = [item for item in output if item.get("generation_token_ids") is not None]
+    n_in = len(generated[0]["prompt_token_ids"]) if generated else 0
+    n_out = sum(len(item["generation_token_ids"]) for item in generated)
+    return {
+        "id": f"proj-{rollout_id}",
+        "model": model,
+        "object": "response",
+        "output": output,
+        "usage": {"input_tokens": n_in, "output_tokens": n_out},
+    }
+
+
+def assert_prefix_contiguity(response: dict) -> None:
+    """Check the invariant the projection promises: each output item's
+    prompt_token_ids must extend the tokens seen so far (prompt plus generation
+    of all prior items). Raises AssertionError otherwise."""
+    seen: list[int] = []
+    for item in response.get("output", []):
+        if not isinstance(item, dict) or item.get("generation_token_ids") is None:
+            continue
+        prompt = item.get("prompt_token_ids") or []
+        if prompt[: len(seen)] != seen:
+            raise AssertionError(
+                "projection is not prefix-contiguous: an output item's prompt_token_ids "
+                "does not extend the tokens seen so far"
+            )
+        seen = list(prompt) + list(item["generation_token_ids"])

--- a/nemo_gym/token_id_capture/builder.py
+++ b/nemo_gym/token_id_capture/builder.py
@@ -115,10 +115,6 @@ def per_request(entries: list[TokenEntry]) -> BuildOutput:
     return BuildOutput(chains=chains, notes=BuildNotes(builder="per_request", chains=len(chains)))
 
 
-def _is_prefix(a: list[int], b: list[int]) -> bool:
-    return len(a) <= len(b) and b[: len(a)] == a
-
-
 @dataclass(eq=False)  # Identity-based equality keeps nodes hashable.
 class _Node:
     entry: TokenEntry
@@ -128,19 +124,45 @@ class _Node:
     quarantined: bool = False
 
 
-def _infer_parent(prompt: list[int], candidates: list["_Node"]) -> tuple["_Node | None", bool]:
+@dataclass
+class _PrefixTrieNode:
+    children: dict[int, "_PrefixTrieNode"] = field(default_factory=dict)
+    candidates: list[_Node] = field(default_factory=list)
+
+
+class _PrefixIndex:
+    """Index cumulative token sequences for linear-time parent lookup."""
+
+    def __init__(self) -> None:
+        self._root = _PrefixTrieNode()
+
+    def add(self, candidate: _Node) -> None:
+        current = self._root
+        for token_id in candidate.cumulative:
+            current = current.children.setdefault(token_id, _PrefixTrieNode())
+        current.candidates.append(candidate)
+
+    def infer_parent(self, prompt: list[int]) -> tuple[_Node | None, bool]:
+        best: list[_Node] = []
+        current = self._root
+        for token_id in prompt:
+            next_node = current.children.get(token_id)
+            if next_node is None:
+                break
+            current = next_node
+            if current.candidates:
+                best = current.candidates
+        return (best[0], len(best) > 1) if best else (None, False)
+
+
+def _infer_parent(prompt: list[int], index: _PrefixIndex) -> tuple["_Node | None", bool]:
     """Infer the parent from the longest cumulative prefix.
 
     This is the fallback when no verified parent link exists.
     Identical cumulative sequences are ambiguous.
     The caller quarantines an ambiguous subtree.
     """
-    matches = [n for n in candidates if _is_prefix(n.cumulative, prompt)]
-    if not matches:
-        return None, False
-    best_len = max(len(n.cumulative) for n in matches)
-    best = [n for n in matches if len(n.cumulative) == best_len]
-    return best[0], len(best) > 1
+    return index.infer_parent(prompt)
 
 
 def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
@@ -164,11 +186,12 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
     nodes: list[_Node] = []
     roots: list[_Node] = []
     quarantined: list[str] = []
+    prefix_index = _PrefixIndex()
 
     for entry in ordered:
         prompt = list(entry.prompt_token_ids)
         node = _Node(entry=entry, cumulative=prompt + list(entry.generation_token_ids))
-        parent, ambiguous = _infer_parent(prompt, nodes)
+        parent, ambiguous = _infer_parent(prompt, prefix_index)
         if parent is not None:
             node.parent = parent
             if ambiguous:
@@ -179,6 +202,7 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
         else:
             roots.append(node)
         nodes.append(node)
+        prefix_index.add(node)
 
     # Resolve retry siblings.
     # A harness can retry after a timeout, server error, or dropped stream.
@@ -219,25 +243,25 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
 
     chains: list[Chain] = []
 
-    def walk(node: _Node, path: list[_Node]) -> None:
-        path = path + [node]
-        if not node.children:
-            if any(p.quarantined for p in path):
-                return
-            root = path[0]
-            chain = Chain(chain_id="", root_prompt=list(root.entry.prompt_token_ids))
-            prev_cumulative = list(root.entry.prompt_token_ids)
-            for step, p in enumerate(path):
-                interstitial = [] if step == 0 else list(p.entry.prompt_token_ids[len(prev_cumulative) :])
-                chain.links.append(ChainLink(entry=p.entry, interstitial=interstitial))
-                prev_cumulative = list(p.entry.prompt_token_ids) + list(p.entry.generation_token_ids)
-            chains.append(chain)
-            return
-        for child in node.children:
-            walk(child, path)
-
-    for root in roots:
-        walk(root, [])
+    # Materialize root-to-leaf chains without recursion.
+    # Agent rollouts can exceed Python's recursion limit.
+    for leaf in (node for node in nodes if not node.children):
+        reverse_path: list[_Node] = []
+        current: _Node | None = leaf
+        while current is not None:
+            reverse_path.append(current)
+            current = current.parent
+        path = list(reversed(reverse_path))
+        if any(node.quarantined for node in path):
+            continue
+        root = path[0]
+        chain = Chain(chain_id="", root_prompt=list(root.entry.prompt_token_ids))
+        prev_cumulative = list(root.entry.prompt_token_ids)
+        for step, node in enumerate(path):
+            interstitial = [] if step == 0 else list(node.entry.prompt_token_ids[len(prev_cumulative) :])
+            chain.links.append(ChainLink(entry=node.entry, interstitial=interstitial))
+            prev_cumulative = list(node.entry.prompt_token_ids) + list(node.entry.generation_token_ids)
+        chains.append(chain)
 
     # Deliver only one chain per rollout.
     # Choose the chain whose root call completed first.

--- a/nemo_gym/token_id_capture/builder.py
+++ b/nemo_gym/token_id_capture/builder.py
@@ -200,7 +200,7 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
         for retry_group in by_prompt.values():
             if len(retry_group) < 2:
                 continue
-            extended = [n for n in retry_group if n.children]
+            extended = [n for n in retry_group if any(not child.quarantined for child in n.children)]
             if extended:
                 keep = set(extended)
             else:
@@ -358,8 +358,14 @@ def project_main_chain_response(rollout_id: str, out: BuildOutput, model: str = 
     unbroken sequence across the whole rollout, because the items come from several model
     calls stitched together rather than one.
     """
+    if not out.chains:
+        raise ValueError("capture produced no safe trainable chain")
+    if out.notes.builder == "per_request" and len(out.chains) != 1:
+        raise ValueError("per_request produced multiple trajectories for a single-response delivery")
     mains = [c for c in out.chains if c.chain_id == "main"] or out.chains[:1]
-    output = project_chain_to_output_items(mains[0]) if mains else []
+    output = project_chain_to_output_items(mains[0])
+    if not any(item.get("generation_token_ids") for item in output):
+        raise ValueError("capture produced no trainable generated tokens")
     # Token fields ride only on generated items; a content-only leading item (e.g. assistant
     # text emitted before a tool call) carries none. Read the usage counts from the items that
     # actually have token fields so a leading content item does not KeyError or skew the totals.

--- a/nemo_gym/token_id_capture/builder.py
+++ b/nemo_gym/token_id_capture/builder.py
@@ -13,30 +13,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Turn a rollout's captured token records into trainable trajectories.
+"""Build trainable trajectories from a frozen token capture.
 
-The builder is a pure function over a list of ``TokenEntry`` records (whatever a
-``TokenSource`` returns). It has two strategies:
+The builder consumes ``TokenEntry`` records from a ``TokenCaptureSnapshot``.
+The snapshot is frozen before the consumer passes its entries to the builder.
 
-  per_request     assumes nothing about how the calls relate; every call becomes
-                  its own training sequence. Always valid.
-  prefix_merging  chains calls by the token-prefix relationship: each call is
-                  parented to the earlier call whose full token sequence (prompt
-                  plus generation) is the longest prefix of this call's prompt.
-                  This rebuilds a multi-turn, append-only rollout into one chain.
-                  A prompt that no longer extends any earlier call starts a new
-                  root (a compacted or rewritten context). Two candidate parents
-                  with identical sequences are ambiguous, so that subtree is
-                  quarantined rather than guessed.
+``per_request`` creates one training sequence per call.
+It does not infer relationships between calls.
+It can return multiple trajectories.
 
-Both are order-independent: they do not depend on arrival order or any sequence
-number. ``prefix_merging`` processes entries by increasing prompt length, which
-is derived from the tokens themselves (a parent's prompt is shorter than its
-child's), so concurrent or out-of-order capture yields the same result.
+``prefix_merging`` chains calls by token-prefix relationships.
+Each call uses the earlier call with the longest matching cumulative sequence as its parent.
+The cumulative sequence contains the prompt and generation.
+This strategy rebuilds an append-only rollout as one chain.
+A rewritten or compacted prompt starts a new root.
+Identical candidate parents are ambiguous.
+The builder quarantines the ambiguous subtree.
 
-Loss masks follow provenance: tokens the policy generated are marked 1 (with
-their captured log probabilities), and everything re-fed into a prompt (history,
-tool output, tokens added between calls) is marked 0.
+Both strategies are independent of capture order.
+``prefix_merging`` processes entries by increasing prompt length.
+This order comes from the tokens.
+A parent's prompt is shorter than its child's prompt.
+
+Loss masks follow token provenance.
+Policy-generated tokens have a mask value of 1 and retain their captured log probabilities.
+Prompt tokens have a mask value of 0.
 """
 
 from __future__ import annotations
@@ -50,7 +51,7 @@ from nemo_gym.token_id_capture.records import TokenEntry
 @dataclass
 class ChainLink:
     entry: TokenEntry
-    interstitial: list[int]  # prompt tokens added since the parent (tool output, new user turn); mask 0
+    interstitial: list[int]  # Prompt tokens added after the parent have a mask value of 0.
 
 
 @dataclass
@@ -60,8 +61,10 @@ class Chain:
     root_prompt: list[int] = field(default_factory=list)
 
     def validate(self) -> None:
-        """Every generated token needs its log probability; a trainer cannot use a chain
-        where they disagree, and the mismatch is easier to read here than downstream."""
+        """Require one log probability for each generated token.
+
+        A trainer cannot use a chain with mismatched token and log-probability counts.
+        """
         for link in self.links:
             generated = link.entry.generation_token_ids
             log_probs = link.entry.generation_log_probs
@@ -74,11 +77,10 @@ class Chain:
 
 @dataclass
 class BuildNotes:
-    """What the build kept, dropped and had to guess at.
+    """Describe what the build kept, dropped, or could not resolve.
 
-    Typed rather than a free-form dict because the consumer turns these into the metrics a run is
-    judged by, and a renamed key in an untyped dict reads as a zero on a dashboard instead of an
-    error.
+    The consumer converts these fields into run metrics.
+    Typed fields prevent renamed keys from appearing as zero values on dashboards.
     """
 
     builder: str
@@ -86,20 +88,21 @@ class BuildNotes:
     chains: int = 0
     generated_tokens_captured: int = 0
     generated_tokens_delivered: int = 0
-    # Only one chain is delivered per rollout today, so sub-agent branches and everything after a
-    # context compaction are dropped. That is a deliberate limitation and has to stay visible.
+    # Only one chain is delivered per rollout.
+    # Sub-agent branches and post-compaction chains are dropped.
+    # The delivered fraction exposes this limitation.
     delivered_fraction: float = 0.0
-    # Calls whose sibling was a retry the harness may or may not have kept. Unresolvable for the
-    # final call of a rollout, because no later call names the survivor.
+    # These calls have a retry sibling that the harness may not have kept.
+    # A final-call retry is unresolved because no later call identifies the survivor.
     unresolved_retries: list[str] = field(default_factory=list)
-    # Calls the model returned with no generated tokens, kept out of the chain entirely.
+    # Calls without generated tokens are excluded from the chain.
     empty_generation_calls: list[str] = field(default_factory=list)
 
 
 @dataclass
 class BuildOutput:
     chains: list[Chain]
-    quarantined: list[str] = field(default_factory=list)  # model_call_ids
+    quarantined: list[str] = field(default_factory=list)  # Model call IDs.
     notes: BuildNotes = field(default_factory=lambda: BuildNotes(builder=""))
 
 
@@ -116,21 +119,21 @@ def _is_prefix(a: list[int], b: list[int]) -> bool:
     return len(a) <= len(b) and b[: len(a)] == a
 
 
-@dataclass(eq=False)  # identity-based, so nodes are hashable for set membership
+@dataclass(eq=False)  # Identity-based equality keeps nodes hashable.
 class _Node:
     entry: TokenEntry
-    cumulative: list[int]  # prompt + generation for this call
+    cumulative: list[int]  # Prompt and generation tokens for this call.
     parent: "_Node | None" = None
     children: list["_Node"] = field(default_factory=list)
     quarantined: bool = False
 
 
 def _infer_parent(prompt: list[int], candidates: list["_Node"]) -> tuple["_Node | None", bool]:
-    """Fallback when no verified parent link is recorded: the earlier call whose
-    cumulative sequence is the longest prefix of this prompt.
+    """Infer the parent from the longest cumulative prefix.
 
-    Two candidates with identical cumulative sequences are indistinguishable, so
-    the subtree is quarantined rather than guessed.
+    This is the fallback when no verified parent link exists.
+    Identical cumulative sequences are ambiguous.
+    The caller quarantines an ambiguous subtree.
     """
     matches = [n for n in candidates if _is_prefix(n.cumulative, prompt)]
     if not matches:
@@ -141,11 +144,11 @@ def _infer_parent(prompt: list[int], candidates: list["_Node"]) -> tuple["_Node 
 
 
 def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
-    # A call that generated nothing (content filter, or the output budget exhausted before the
-    # first token) has no trainable tokens, and its cumulative sequence equals its prompt. Left in,
-    # it matches the prefix test against any call sharing that prompt and becomes its parent, so a
-    # filtered call followed by a retry reads as a two-turn chain. Retry resolution only compares
-    # siblings under a shared parent, so it would never see the pair.
+    # A call without generated tokens has no training signal.
+    # Its cumulative sequence equals its prompt.
+    # Keeping it would make it the parent of another call with the same prompt.
+    # A filtered call and its retry would then look like a two-turn chain.
+    # Retry resolution compares only siblings and would miss that pair.
     empty_generation = [e.model_call_id for e in entries if not e.generation_token_ids]
     entries = [e for e in entries if e.generation_token_ids]
     if not entries:
@@ -153,9 +156,10 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
             chains=[], notes=BuildNotes(builder="prefix_merging", empty_generation_calls=empty_generation)
         )
 
-    # Increasing prompt length is an order derived from the tokens: a parent's
-    # cumulative sequence is a prefix of its child's prompt, so the parent's
-    # prompt is shorter. This makes the pass order-independent.
+    # Increasing prompt length defines an order from the tokens.
+    # A parent's cumulative sequence is a prefix of its child's prompt.
+    # The parent's prompt is therefore shorter.
+    # This makes the pass independent of capture order.
     ordered = sorted(entries, key=lambda e: (len(e.prompt_token_ids), e.model_call_id))
     nodes: list[_Node] = []
     roots: list[_Node] = []
@@ -168,7 +172,7 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
         if parent is not None:
             node.parent = parent
             if ambiguous:
-                # Two candidate parents with identical sequences: quarantine rather than guess.
+                # Quarantine calls with identical candidate parents.
                 node.quarantined = True
                 quarantined.append(entry.model_call_id)
             parent.children.append(node)
@@ -176,19 +180,21 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
             roots.append(node)
         nodes.append(node)
 
-    # Resolve retry siblings. A harness (Claude Code) retries on timeout / 5xx / dropped SSE, and the
-    # capture point records a call even if the client never received it, so a retry yields two nodes
-    # with identical prompt ids under the same parent and divergent generations.
+    # Resolve retry siblings.
+    # A harness can retry after a timeout, server error, or dropped stream.
+    # The capture point can record a call that the client never received.
+    # A retry then creates siblings with identical prompts and different generations.
     #
-    # A recorded parent link settles this exactly: a later call names the sibling the harness actually
-    # kept, so the other is provably unused. Without one we fall back to "the sibling a later call
-    # extended wins". Neither can resolve a retry of the last call, because no later call names the
-    # survivor, so that case is flagged as unresolved rather than tie-broken silently, and the
-    # caller masks the rollout instead of training on a generation the client may never have received.
+    # A recorded parent link identifies the sibling retained by the harness.
+    # Without a link, retain the sibling extended by a later call.
+    # Neither method can resolve a retry of the final call.
+    # Mark that retry as unresolved.
+    # The consumer masks the rollout instead of training on an unconfirmed generation.
     unresolved_retries: list[str] = []
-    # Group by parent identity. Roots share the ROOTS key on purpose: a retry of a rollout's first
-    # call produces two roots with the same prompt, and they have to be compared as siblings like
-    # any other pair. An explicit key says so, where id(None) would leave it looking accidental.
+    # Group calls by parent identity.
+    # All roots share the explicit ROOTS key.
+    # A retry of the first call creates roots with the same prompt.
+    # Treat those roots as siblings.
     ROOTS = "roots"
     siblings_by_parent: dict[object, list[_Node]] = {}
     for node in nodes:
@@ -233,32 +239,32 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
     for root in roots:
         walk(root, [])
 
-    # Only one chain is delivered per rollout, so when a rollout has more than one root, one has
-    # to be chosen. The choice is the root whose call completed first.
+    # Deliver only one chain per rollout.
+    # Choose the chain whose root call completed first.
     #
-    # That is dispatch order for a sequential harness. capture_tokens is awaited inside the model
-    # server's response path, so a call's record is durable before its response reaches the
-    # harness, which means the next call has not been made yet. created_at is stamped at that
-    # point. Ordering on the record's own timestamp rather than on file order matters because a
-    # server running num_workers > 1 has several processes appending, and their interleaving is
-    # lock order, not completion order.
+    # Completion order matches dispatch order for a sequential harness.
+    # The model server awaits token capture before returning the response.
+    # The next call therefore starts after the previous record is durable.
+    # The capture point sets ``created_at``.
+    # Use this timestamp instead of file order.
+    # Multiple server workers append in lock order rather than completion order.
     #
-    # Two known shapes are not handled, both involving a second agent:
+    # Two unsupported shapes involve a second agent.
     #
-    # An auxiliary call the harness makes on its own account, such as generating a conversation
-    # title, is short and can complete before the agent's first real turn. It would then be picked
-    # as the root and the agent's own chain relabelled a branch.
+    # A short auxiliary call can finish before the agent's first task call.
+    # Selection then treats the auxiliary call as the main root.
     #
-    # Parallel sub-agents overlap, so completion order stops meaning dispatch order at all, and
-    # nothing in a record says which agent made the call. Ordering cannot recover that. Keeping
-    # sub-agent calls out of the records, by pointing them at a model server that is not the
-    # policy's, can; some harnesses support configuring that.
+    # Parallel sub-agents make completion order differ from dispatch order.
+    # Records do not identify the calling agent.
+    # Ordering cannot recover that identity.
+    # Some harnesses can route sub-agent calls to a different model server.
     #
-    # Both are follow-up work. Until then the split is visible rather than silent: a rollout that
-    # split reports chains > 1 and a delivered_fraction below 1.
+    # These shapes require future work.
+    # A split rollout reports multiple chains and a delivered fraction below 1.
     def selection_key(c: Chain) -> tuple:
-        # Earliest root first. Ties break on call id so the result is deterministic when two
-        # records share a timestamp, and a chain with no links sorts last rather than raising.
+        # Sort by the earliest root.
+        # Break timestamp ties by call ID.
+        # Sort an empty chain last.
         if not c.links:
             return (float("inf"), "")
         root = c.links[0].entry
@@ -295,7 +301,7 @@ _BUILDERS: dict[str, Callable[[list[TokenEntry]], BuildOutput]] = {
 
 
 def run_builder(entries: list[TokenEntry], builder: str = "prefix_merging") -> BuildOutput:
-    """Chain a rollout's records using the named strategy."""
+    """Chain frozen snapshot entries with the named strategy."""
     if builder not in _BUILDERS:
         raise ValueError(f"unknown builder {builder!r}; known: {sorted(_BUILDERS)}")
     return _BUILDERS[builder](entries)
@@ -305,12 +311,14 @@ def run_builder(entries: list[TokenEntry], builder: str = "prefix_merging") -> B
 
 
 def project_chain_to_output_items(chain: Chain) -> list[dict]:
-    """Project the chain into content-bearing Responses output items whose prompts are
-    contiguous. For each call, emit its captured output items (assistant text, tool
-    calls preserved) and set the contiguous prompt on the item that carries the
-    generation, so each generated item's prompt extends the previous one. That is the
-    shape a trainer ingests, with the text intact for anything that scores it. Falls back to a
-    synthesized token-only item only when a call captured no content items."""
+    """Project a chain into Responses output items with contiguous prompts.
+
+    Preserve captured assistant text and tool calls.
+    Put the contiguous prompt on the item that carries each generation.
+    Each generated item's prompt extends the previous generated item.
+    Preserve text for downstream scoring.
+    Create a token-only item only when a call has no captured content items.
+    """
     items: list[dict] = []
     cumulative = list(chain.root_prompt)
     for step, link in enumerate(chain.links):
@@ -319,13 +327,13 @@ def project_chain_to_output_items(chain: Chain) -> list[dict]:
         content_items = [dict(item) for item in (entry.output_items or [])]
         index = entry.token_item_index
         if index is not None and 0 <= index < len(content_items):
-            # The item the arrays were taken off, recorded at capture time.
+            # Capture records the item that originally carried the token arrays.
             generated = [content_items[index]]
         else:
-            # Records written before the arrays were de-duplicated still carry them inline.
+            # Older records keep token arrays inline.
             generated = [item for item in content_items if item.get("generation_token_ids") is not None]
         if not generated and content_items:
-            # No item carried token fields (unexpected); attach to the last so tokens are not lost.
+            # Attach tokens to the last item when no item carries token fields.
             generated = content_items[-1:]
         if content_items:
             for item in generated:
@@ -352,11 +360,10 @@ def project_chain_to_output_items(chain: Chain) -> list[dict]:
 def project_main_chain_response(rollout_id: str, out: BuildOutput, model: str = "") -> dict:
     """Rebuild the main chain as a Responses object whose output items are contiguous.
 
-    The result is an ordinary Gym-native Responses payload: ``object: "response"``, a list
-    of ``output`` items, and ``usage``. The only thing that distinguishes it from what the
-    model server returned is that the token fields on each generated item now describe an
-    unbroken sequence across the whole rollout, because the items come from several model
-    calls stitched together rather than one.
+    The result is a Gym-native Responses payload.
+    It contains ``object: "response"``, ``output`` items, and ``usage``.
+    Token fields describe one unbroken sequence across the rollout.
+    The sequence combines items from multiple model calls.
     """
     if not out.chains:
         raise ValueError("capture produced no safe trainable chain")
@@ -366,9 +373,10 @@ def project_main_chain_response(rollout_id: str, out: BuildOutput, model: str = 
     output = project_chain_to_output_items(mains[0])
     if not any(item.get("generation_token_ids") for item in output):
         raise ValueError("capture produced no trainable generated tokens")
-    # Token fields ride only on generated items; a content-only leading item (e.g. assistant
-    # text emitted before a tool call) carries none. Read the usage counts from the items that
-    # actually have token fields so a leading content item does not KeyError or skew the totals.
+    # Only generated items carry token fields.
+    # A leading content-only item carries no token fields.
+    # Read usage counts from token-bearing items.
+    # This avoids missing keys and incorrect totals.
     generated = [item for item in output if item.get("generation_token_ids") is not None]
     n_in = len(generated[0]["prompt_token_ids"]) if generated else 0
     n_out = sum(len(item["generation_token_ids"]) for item in generated)
@@ -382,9 +390,11 @@ def project_main_chain_response(rollout_id: str, out: BuildOutput, model: str = 
 
 
 def assert_prefix_contiguity(response: dict) -> None:
-    """Check the invariant the projection promises: each output item's
-    prompt_token_ids must extend the tokens seen so far (prompt plus generation
-    of all prior items). Raises AssertionError otherwise."""
+    """Require each generated item to extend all preceding tokens.
+
+    The preceding tokens include the prompt and all prior generations.
+    Raise ``AssertionError`` when the response is not contiguous.
+    """
     seen: list[int] = []
     for item in response.get("output", []):
         if not isinstance(item, dict) or item.get("generation_token_ids") is None:

--- a/nemo_gym/token_id_capture/consumer.py
+++ b/nemo_gym/token_id_capture/consumer.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The consumer that turns a rollout's captured tokens into trajectories.
+
+This is the single primitive both consumers call after a rollout finishes: Gym's
+rollout collection (co-located, reading the token store's files) and a trainer's
+finalizer, which passes whatever ``TokenSource`` its transport provides.
+The only difference between them is where the ``TokenEntry`` records come from;
+the build and projection are identical.
+
+It is deliberately free of any rollout-record or model-server imports, so it
+does not couple to those layers. The caller supplies the ``rollout_id`` (Gym's
+rollout collection derives it from the record's task/rollout/attempt indices)
+and the metrics that describe what the build kept.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from nemo_gym.token_id_capture.builder import (
+    assert_prefix_contiguity,
+    project_main_chain_response,
+    run_builder,
+)
+from nemo_gym.token_id_capture.protocols import TokenSource
+from nemo_gym.token_id_capture.records import TokenEntry
+from nemo_gym.token_id_capture.store import TokenCaptureStore
+
+
+logger = logging.getLogger(__name__)
+
+
+def token_id_capture_dirs_from_config(global_config_dict) -> list[Path]:
+    """Resolve the token store directory when training-token capture is enabled, else []."""
+    from nemo_gym.token_id_capture.config import TokenIdCaptureConfig
+
+    config = TokenIdCaptureConfig.model_validate(global_config_dict)
+    directory = config.resolved_dir()
+    # A configured sink replaces the file store, so there is no directory to read back from.
+    if not config.enabled or config.token_id_capture.sink is not None:
+        return []
+    return [directory] if directory is not None else []
+
+
+def clear_token_captures_for_rollouts(records: list, token_capture_dirs: list[Path]) -> None:
+    """Remove stale token records for rollouts about to be dispatched.
+
+    Rollout ids are deterministic and ``TokenCaptureStore.append`` opens in "ab"
+    mode, so a rerun that reuses an id would append onto the previous attempt's
+    records and the builder would stitch two attempts into one trajectory. The
+    caller passes only the rows being dispatched, after any retry suffix has been
+    assigned.
+    """
+    if not token_capture_dirs:
+        return
+    from nemo_gym.base_responses_api_model import maybe_rollout_id_from_run_body
+
+    for directory in token_capture_dirs:
+        store = TokenCaptureStore(directory)
+        for record in records:
+            rollout_id = maybe_rollout_id_from_run_body(record)
+            if rollout_id:
+                store.delete(rollout_id)
+
+
+def _assemble(
+    rollout_id: str,
+    entries: list[TokenEntry],
+    builder: str,
+    model: str,
+) -> dict:
+    # A malformed capture must degrade this one rollout, not take down the caller.
+    # Both the contiguity assertion and the flattener raise, and the callers are a
+    # rollout-collection loop and a trainer's step loop, where an escaping exception
+    # kills a whole batch rather than dropping one sample.
+    try:
+        out = run_builder(entries, builder)
+        for chain in out.chains:
+            chain.validate()
+        response = project_main_chain_response(rollout_id, out, model=model)
+        assert_prefix_contiguity(response)
+    except (AssertionError, ValueError, KeyError, IndexError, TypeError) as error:
+        logger.warning(
+            "Could not build a trajectory for rollout %s from %d captured call(s): %s",
+            rollout_id,
+            len(entries),
+            error,
+        )
+        return {
+            "rollout_id": rollout_id,
+            "builder": builder,
+            "rebuilt_response": None,
+            "mask_sample": True,
+            "error": f"{type(error).__name__}: {error}",
+            "metrics": {"n_calls": len(entries)},
+        }
+
+    notes = out.notes
+    # Surface what the build dropped, so a rollout that trained on one of five calls does not look
+    # like one that trained on all five.
+    metrics = {
+        "n_calls": len(entries),
+        "chains": notes.chains,
+        "quarantined_calls": len(out.quarantined),
+        "quarantined_fraction": round(len(out.quarantined) / len(entries), 4) if entries else 0.0,
+        "delivered_fraction": notes.delivered_fraction,
+        "generated_tokens_captured": notes.generated_tokens_captured,
+        "generated_tokens_delivered": notes.generated_tokens_delivered,
+        # Calls the model returned with no generated tokens. They carry no training signal and are
+        # kept out of the chain; a non-zero count usually means the output budget or a content
+        # filter is cutting generations off.
+        "empty_generation_calls": len(notes.empty_generation_calls),
+    }
+    unresolved = notes.unresolved_retries
+    return {
+        "rollout_id": rollout_id,
+        "builder": builder,
+        "rebuilt_response": response,
+        "metrics": metrics,
+        # A retry of the final call leaves two generations with no way to tell which one the client
+        # received. Training on the wrong one is silently off-policy, so the rollout is masked.
+        "mask_sample": bool(unresolved),
+        "unresolved_retries": list(unresolved),
+    }
+
+
+def trajectories_for_rollout(
+    rollout_id: str,
+    token_capture_dirs: list[Path],
+    *,
+    builder: str = "prefix_merging",
+    model: str = "",
+) -> dict | None:
+    """Co-located path: read the rollout's tokens from the store files and build its trajectories.
+
+    come from the verifier result and ride the trajectory; they are not read from the token store.
+    Returns ``None`` when no tokens were captured for the rollout (capture off, or a dialect the
+    engine returned no ids for). Mirrors how evaluation capture is merged into a rollout record.
+    """
+    for directory in token_capture_dirs:
+        store = TokenCaptureStore(directory)
+        entries = store.read_entries(rollout_id)
+        if entries:
+            built = _assemble(rollout_id, entries, builder, model)
+            if store.is_incomplete(rollout_id):
+                # At least one call of this rollout failed to capture. The chain we built may look
+                # perfectly contiguous while being missing a turn, so mask rather than train on it.
+                built["mask_sample"] = True
+                built.setdefault("metrics", {})["capture_incomplete"] = True
+            return built
+    return None
+
+
+async def trajectories_from_source(
+    rollout_id: str,
+    source: TokenSource,
+    *,
+    builder: str = "prefix_merging",
+    model: str = "",
+) -> dict | None:
+    """Read the rollout's records through a ``TokenSource`` and build its trajectories.
+
+    Returns ``None`` when nothing was recorded for it.
+    """
+    entries = await source.tokens_for(rollout_id)
+    if not entries:
+        return None
+    built = _assemble(rollout_id, entries, builder, model)
+    # A rollout that lost a call can stitch into a chain that looks perfectly contiguous while
+    # missing a turn, so this is the only way to tell. A transport that cannot report it says so
+    # by returning False.
+    if source.is_incomplete(rollout_id):
+        built["mask_sample"] = True
+        built.setdefault("metrics", {})["capture_incomplete"] = True
+    return built

--- a/nemo_gym/token_id_capture/consumer.py
+++ b/nemo_gym/token_id_capture/consumer.py
@@ -45,6 +45,17 @@ from nemo_gym.token_id_capture.store import TokenCaptureStore
 logger = logging.getLogger(__name__)
 
 
+def _failed_build(rollout_id: str, builder: str, error: str, *, n_calls: int = 0) -> dict:
+    return {
+        "rollout_id": rollout_id,
+        "builder": builder,
+        "rebuilt_response": None,
+        "mask_sample": True,
+        "error": error,
+        "metrics": {"n_calls": n_calls},
+    }
+
+
 def token_id_capture_dirs_from_config(global_config_dict) -> list[Path]:
     """Resolve the token store directory when training-token capture is enabled, else []."""
     from nemo_gym.token_id_capture.config import TokenIdCaptureConfig
@@ -101,14 +112,12 @@ def _assemble(
             len(entries),
             error,
         )
-        return {
-            "rollout_id": rollout_id,
-            "builder": builder,
-            "rebuilt_response": None,
-            "mask_sample": True,
-            "error": f"{type(error).__name__}: {error}",
-            "metrics": {"n_calls": len(entries)},
-        }
+        return _failed_build(
+            rollout_id,
+            builder,
+            f"{type(error).__name__}: {error}",
+            n_calls=len(entries),
+        )
 
     notes = out.notes
     # Surface what the build dropped, so a rollout that trained on one of five calls does not look
@@ -116,6 +125,7 @@ def _assemble(
     metrics = {
         "n_calls": len(entries),
         "chains": notes.chains,
+        "roots": notes.roots,
         "quarantined_calls": len(out.quarantined),
         "quarantined_fraction": round(len(out.quarantined) / len(entries), 4) if entries else 0.0,
         "delivered_fraction": notes.delivered_fraction,
@@ -134,7 +144,7 @@ def _assemble(
         "metrics": metrics,
         # A retry of the final call leaves two generations with no way to tell which one the client
         # received. Training on the wrong one is silently off-policy, so the rollout is masked.
-        "mask_sample": bool(unresolved),
+        "mask_sample": bool(unresolved) or notes.roots != 1 or notes.chains != 1,
         "unresolved_retries": list(unresolved),
     }
 
@@ -149,20 +159,28 @@ def trajectories_for_rollout(
     """Co-located path: read the rollout's tokens from the store files and build its trajectories.
 
     come from the verifier result and ride the trajectory; they are not read from the token store.
-    Returns ``None`` when no tokens were captured for the rollout (capture off, or a dialect the
-    engine returned no ids for). Mirrors how evaluation capture is merged into a rollout record.
+    Returns ``None`` only when no capture directory is configured. A configured
+    capture with no records is unusable and returns a masked result.
     """
     for directory in token_capture_dirs:
         store = TokenCaptureStore(directory)
-        entries = store.read_entries(rollout_id)
-        if entries:
-            built = _assemble(rollout_id, entries, builder, model)
-            if store.is_incomplete(rollout_id):
-                # At least one call of this rollout failed to capture. The chain we built may look
-                # perfectly contiguous while being missing a turn, so mask rather than train on it.
-                built["mask_sample"] = True
-                built.setdefault("metrics", {})["capture_incomplete"] = True
-            return built
+        try:
+            snapshot = store.seal_now(rollout_id)
+        except Exception as error:
+            logger.warning("Could not seal token capture for rollout %s.", rollout_id, exc_info=True)
+            return _failed_build(rollout_id, builder, f"{type(error).__name__}: {error}")
+        if not snapshot.entries:
+            built = _failed_build(rollout_id, builder, "capture contains no token records")
+        else:
+            built = _assemble(rollout_id, list(snapshot.entries), builder, model)
+        if snapshot.incomplete:
+            built["mask_sample"] = True
+            built.setdefault("metrics", {})["capture_incomplete"] = True
+        built["_capture_snapshot"] = {
+            "seal_id": snapshot.seal_id,
+            "version": snapshot.version,
+        }
+        return built
     return None
 
 
@@ -177,14 +195,20 @@ async def trajectories_from_source(
 
     Returns ``None`` when nothing was recorded for it.
     """
-    entries = await source.tokens_for(rollout_id)
-    if not entries:
-        return None
-    built = _assemble(rollout_id, entries, builder, model)
-    # A rollout that lost a call can stitch into a chain that looks perfectly contiguous while
-    # missing a turn, so this is the only way to tell. A transport that cannot report it says so
-    # by returning False.
-    if source.is_incomplete(rollout_id):
+    try:
+        snapshot = await source.seal(rollout_id)
+    except Exception as error:
+        logger.warning("Could not seal token capture for rollout %s.", rollout_id, exc_info=True)
+        return _failed_build(rollout_id, builder, f"{type(error).__name__}: {error}")
+    if not snapshot.entries:
+        built = _failed_build(rollout_id, builder, "capture contains no token records")
+    else:
+        built = _assemble(rollout_id, list(snapshot.entries), builder, model)
+    if snapshot.incomplete:
         built["mask_sample"] = True
         built.setdefault("metrics", {})["capture_incomplete"] = True
+    built["_capture_snapshot"] = {
+        "seal_id": snapshot.seal_id,
+        "version": snapshot.version,
+    }
     return built

--- a/nemo_gym/token_id_capture/consumer.py
+++ b/nemo_gym/token_id_capture/consumer.py
@@ -13,18 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The consumer that turns a rollout's captured tokens into trajectories.
+"""Turn a rollout's frozen token capture into trajectories.
 
-This is the single primitive both consumers call after a rollout finishes: Gym's
-rollout collection (co-located, reading the token store's files) and a trainer's
-finalizer, which passes whatever ``TokenSource`` its transport provides.
-The only difference between them is where the ``TokenEntry`` records come from;
-the build and projection are identical.
+Gym rollout collection and trainer finalization use this consumer.
+Gym reads a frozen snapshot from the local token store.
+A trainer freezes the ``TokenSource`` provided by its transport.
+Both paths pass snapshot entries through the same build and projection.
+Single-response delivery rejects ``per_request`` because it can return multiple trajectories.
 
-It is deliberately free of any rollout-record or model-server imports, so it
-does not couple to those layers. The caller supplies the ``rollout_id`` (Gym's
-rollout collection derives it from the record's task/rollout/attempt indices)
-and the metrics that describe what the build kept.
+This module does not import rollout-record or model-server modules.
+The caller supplies the ``rollout_id``.
+Gym derives that ID from task, rollout, and attempt indices.
+The result includes metrics that describe the build.
 """
 
 from __future__ import annotations
@@ -57,12 +57,12 @@ def _failed_build(rollout_id: str, builder: str, error: str, *, n_calls: int = 0
 
 
 def token_id_capture_dirs_from_config(global_config_dict) -> list[Path]:
-    """Resolve the token store directory when training-token capture is enabled, else []."""
+    """Return the enabled token store directory or an empty list."""
     from nemo_gym.token_id_capture.config import TokenIdCaptureConfig
 
     config = TokenIdCaptureConfig.model_validate(global_config_dict)
     directory = config.resolved_dir()
-    # A configured sink replaces the file store, so there is no directory to read back from.
+    # A configured sink replaces the readable file store.
     if not config.enabled or config.token_id_capture.sink is not None:
         return []
     return [directory] if directory is not None else []
@@ -71,11 +71,12 @@ def token_id_capture_dirs_from_config(global_config_dict) -> list[Path]:
 def clear_token_captures_for_rollouts(records: list, token_capture_dirs: list[Path]) -> None:
     """Remove stale token records for rollouts about to be dispatched.
 
-    Rollout ids are deterministic and ``TokenCaptureStore.append`` opens in "ab"
-    mode, so a rerun that reuses an id would append onto the previous attempt's
-    records and the builder would stitch two attempts into one trajectory. The
-    caller passes only the rows being dispatched, after any retry suffix has been
-    assigned.
+    Rollout IDs are deterministic.
+    ``TokenCaptureStore.append`` uses append mode.
+    A reused ID would append records to a previous attempt.
+    The builder could then combine two attempts.
+    The caller passes only rows ready for dispatch.
+    Retry suffixes must already be assigned.
     """
     if not token_capture_dirs:
         return
@@ -96,15 +97,16 @@ def _assemble(
     model: str,
 ) -> dict:
     if builder == "per_request":
+        # Single-response delivery cannot represent multiple trajectories.
         return _failed_build(
             rollout_id,
             builder,
             "per_request returns multiple trajectories and is not supported by single-response delivery",
             n_calls=len(entries),
         )
-    # A malformed capture must degrade this one rollout, not take down the caller.
-    # The contiguity assertion and flattener can both raise.
-    # An escaping exception would kill a full rollout or training batch.
+    # Mask a malformed rollout instead of failing the caller.
+    # The contiguity check and projection can raise.
+    # An uncaught exception could fail a full rollout or training batch.
     try:
         out = run_builder(entries, builder)
         for chain in out.chains:
@@ -126,8 +128,8 @@ def _assemble(
         )
 
     notes = out.notes
-    # Surface what the build dropped.
-    # A partial build must not look like a rollout that trained on every call.
+    # Report everything dropped by the build.
+    # A partial build must not appear complete.
     metrics = {
         "n_calls": len(entries),
         "chains": notes.chains,
@@ -137,8 +139,8 @@ def _assemble(
         "delivered_fraction": notes.delivered_fraction,
         "generated_tokens_captured": notes.generated_tokens_captured,
         "generated_tokens_delivered": notes.generated_tokens_delivered,
-        # Calls with no generated tokens carry no training signal.
-        # A non-zero count can indicate an output-budget or content-filter cutoff.
+        # Calls without generated tokens have no training signal.
+        # A nonzero count can indicate an output-budget or content-filter cutoff.
         "empty_generation_calls": len(notes.empty_generation_calls),
     }
     unresolved = notes.unresolved_retries
@@ -147,8 +149,8 @@ def _assemble(
         "builder": builder,
         "rebuilt_response": response,
         "metrics": metrics,
-        # A final-call retry can leave two plausible generations.
-        # Mask the rollout because the client-selected generation is unknown.
+        # A retry of the final call can leave two plausible generations.
+        # Mask the rollout when the client-selected generation is unknown.
         "mask_sample": bool(unresolved) or notes.roots != 1 or notes.chains != 1,
         "unresolved_retries": list(unresolved),
     }
@@ -161,11 +163,11 @@ def trajectories_for_rollout(
     builder: str = "prefix_merging",
     model: str = "",
 ) -> dict | None:
-    """Co-located path: read the rollout's tokens from the store files and build its trajectories.
+    """Build trajectories from a frozen local token-store snapshot.
 
-    come from the verifier result and ride the trajectory; they are not read from the token store.
-    Returns ``None`` only when no capture directory is configured. A configured
-    capture with no records is unusable and returns a masked result.
+    Return ``None`` only when no capture directory is configured.
+    Missing records are unsafe and return a masked result.
+    An incomplete snapshot is unsafe and returns a masked result.
     """
     for directory in token_capture_dirs:
         store = TokenCaptureStore(directory)
@@ -196,9 +198,10 @@ async def trajectories_from_source(
     builder: str = "prefix_merging",
     model: str = "",
 ) -> dict | None:
-    """Read the rollout's records through a ``TokenSource`` and build its trajectories.
+    """Build trajectories from a frozen ``TokenSource`` snapshot.
 
-    Returns ``None`` when nothing was recorded for it.
+    Missing records are unsafe and return a masked result.
+    An incomplete snapshot is unsafe and returns a masked result.
     """
     try:
         snapshot = await source.freeze(rollout_id)

--- a/nemo_gym/token_id_capture/consumer.py
+++ b/nemo_gym/token_id_capture/consumer.py
@@ -29,6 +29,7 @@ The result includes metrics that describe the build.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -211,7 +212,7 @@ async def trajectories_from_source(
     if not snapshot.entries:
         built = _failed_build(rollout_id, builder, "capture contains no token records")
     else:
-        built = _assemble(rollout_id, list(snapshot.entries), builder, model)
+        built = await asyncio.to_thread(_assemble, rollout_id, list(snapshot.entries), builder, model)
     if snapshot.incomplete:
         built["mask_sample"] = True
         built.setdefault("metrics", {})["capture_incomplete"] = True

--- a/nemo_gym/token_id_capture/consumer.py
+++ b/nemo_gym/token_id_capture/consumer.py
@@ -95,10 +95,16 @@ def _assemble(
     builder: str,
     model: str,
 ) -> dict:
+    if builder == "per_request":
+        return _failed_build(
+            rollout_id,
+            builder,
+            "per_request returns multiple trajectories and is not supported by single-response delivery",
+            n_calls=len(entries),
+        )
     # A malformed capture must degrade this one rollout, not take down the caller.
-    # Both the contiguity assertion and the flattener raise, and the callers are a
-    # rollout-collection loop and a trainer's step loop, where an escaping exception
-    # kills a whole batch rather than dropping one sample.
+    # The contiguity assertion and flattener can both raise.
+    # An escaping exception would kill a full rollout or training batch.
     try:
         out = run_builder(entries, builder)
         for chain in out.chains:
@@ -120,8 +126,8 @@ def _assemble(
         )
 
     notes = out.notes
-    # Surface what the build dropped, so a rollout that trained on one of five calls does not look
-    # like one that trained on all five.
+    # Surface what the build dropped.
+    # A partial build must not look like a rollout that trained on every call.
     metrics = {
         "n_calls": len(entries),
         "chains": notes.chains,
@@ -131,9 +137,8 @@ def _assemble(
         "delivered_fraction": notes.delivered_fraction,
         "generated_tokens_captured": notes.generated_tokens_captured,
         "generated_tokens_delivered": notes.generated_tokens_delivered,
-        # Calls the model returned with no generated tokens. They carry no training signal and are
-        # kept out of the chain; a non-zero count usually means the output budget or a content
-        # filter is cutting generations off.
+        # Calls with no generated tokens carry no training signal.
+        # A non-zero count can indicate an output-budget or content-filter cutoff.
         "empty_generation_calls": len(notes.empty_generation_calls),
     }
     unresolved = notes.unresolved_retries
@@ -142,8 +147,8 @@ def _assemble(
         "builder": builder,
         "rebuilt_response": response,
         "metrics": metrics,
-        # A retry of the final call leaves two generations with no way to tell which one the client
-        # received. Training on the wrong one is silently off-policy, so the rollout is masked.
+        # A final-call retry can leave two plausible generations.
+        # Mask the rollout because the client-selected generation is unknown.
         "mask_sample": bool(unresolved) or notes.roots != 1 or notes.chains != 1,
         "unresolved_retries": list(unresolved),
     }
@@ -165,9 +170,9 @@ def trajectories_for_rollout(
     for directory in token_capture_dirs:
         store = TokenCaptureStore(directory)
         try:
-            snapshot = store.seal_now(rollout_id)
+            snapshot = store.freeze_now(rollout_id)
         except Exception as error:
-            logger.warning("Could not seal token capture for rollout %s.", rollout_id, exc_info=True)
+            logger.warning("Could not freeze token capture for rollout %s.", rollout_id, exc_info=True)
             return _failed_build(rollout_id, builder, f"{type(error).__name__}: {error}")
         if not snapshot.entries:
             built = _failed_build(rollout_id, builder, "capture contains no token records")
@@ -177,7 +182,7 @@ def trajectories_for_rollout(
             built["mask_sample"] = True
             built.setdefault("metrics", {})["capture_incomplete"] = True
         built["_capture_snapshot"] = {
-            "seal_id": snapshot.seal_id,
+            "snapshot_id": snapshot.snapshot_id,
             "version": snapshot.version,
         }
         return built
@@ -196,9 +201,9 @@ async def trajectories_from_source(
     Returns ``None`` when nothing was recorded for it.
     """
     try:
-        snapshot = await source.seal(rollout_id)
+        snapshot = await source.freeze(rollout_id)
     except Exception as error:
-        logger.warning("Could not seal token capture for rollout %s.", rollout_id, exc_info=True)
+        logger.warning("Could not freeze token capture for rollout %s.", rollout_id, exc_info=True)
         return _failed_build(rollout_id, builder, f"{type(error).__name__}: {error}")
     if not snapshot.entries:
         built = _failed_build(rollout_id, builder, "capture contains no token records")
@@ -208,7 +213,7 @@ async def trajectories_from_source(
         built["mask_sample"] = True
         built.setdefault("metrics", {})["capture_incomplete"] = True
     built["_capture_snapshot"] = {
-        "seal_id": snapshot.seal_id,
+        "snapshot_id": snapshot.snapshot_id,
         "version": snapshot.version,
     }
     return built

--- a/tests/unit_tests/test_trajectory_builder.py
+++ b/tests/unit_tests/test_trajectory_builder.py
@@ -1,0 +1,456 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Trajectory builder: chaining calls into one contiguous Responses projection."""
+
+import pytest
+
+from nemo_gym.token_id_capture import (
+    assert_prefix_contiguity,
+    per_request,
+    prefix_merging,
+    project_chain_to_output_items,
+    project_main_chain_response,
+    token_id_capture_dirs_from_config,
+    trajectories_for_rollout,
+)
+from nemo_gym.token_id_capture.records import TokenEntry
+from nemo_gym.token_id_capture.store import TokenCaptureStore
+
+
+def _entry(mcid, prompt, gen, lp=None, created_at=0.0):
+    return TokenEntry(
+        rollout_id="t0-r0",
+        model_call_id=mcid,
+        model="m",
+        prompt_token_ids=prompt,
+        generation_token_ids=gen,
+        generation_log_probs=lp if lp is not None else [-0.1] * len(gen),
+        # Stamped when the call completed. Chain selection orders on it.
+        created_at=created_at,
+    )
+
+
+# An append-only 3-call rollout: each call's prompt extends the prior prompt+generation
+# plus interstitial tokens (tool output / new user turn).
+CALL1 = _entry("c1", [1, 2, 3], [10, 11])
+CALL2 = _entry("c2", [1, 2, 3, 10, 11, 4, 5], [12])
+CALL3 = _entry("c3", [1, 2, 3, 10, 11, 4, 5, 12, 6], [13, 14])
+APPEND_ONLY = [CALL1, CALL2, CALL3]
+
+
+def _generated_tokens(response: dict) -> list[int]:
+    """What the policy sampled, read back off the projection."""
+    out: list[int] = []
+    for item in response["output"]:
+        out += item.get("generation_token_ids") or []
+    return sorted(out)
+
+
+def test_prefix_merging_builds_one_contiguous_main_chain():
+    out = prefix_merging(APPEND_ONLY)
+    assert [c.chain_id for c in out.chains] == ["main"]
+
+    response = project_main_chain_response("t0-r0", out, model="m")
+    # Each item's prompt is the running cumulative sequence, so the loss mask a trainer needs
+    # follows from the structure: prompt positions are context, generation positions are sampled.
+    assert [i["prompt_token_ids"] for i in response["output"]] == [
+        [1, 2, 3],
+        [1, 2, 3, 10, 11, 4, 5],
+        [1, 2, 3, 10, 11, 4, 5, 12, 6],
+    ]
+    assert [i["generation_token_ids"] for i in response["output"]] == [[10, 11], [12], [13, 14]]
+    # A log probability for every sampled token.
+    assert [len(i["generation_log_probs"]) for i in response["output"]] == [2, 1, 2]
+
+
+def test_order_independent():
+    import random
+
+    shuffled = list(APPEND_ONLY)
+    random.Random(0).shuffle(shuffled)
+    a = project_main_chain_response("t0-r0", prefix_merging(APPEND_ONLY), model="m")
+    b = project_main_chain_response("t0-r0", prefix_merging(shuffled), model="m")
+    assert a["output"] == b["output"]
+
+
+def test_per_request_marks_the_same_generated_tokens():
+    # Both builders must agree on which tokens the policy sampled.
+    merged = prefix_merging(APPEND_ONLY)
+    per_req = per_request(APPEND_ONLY)
+    assert len(per_req.chains) == 3
+
+    merged_tokens = _generated_tokens(project_main_chain_response("t0-r0", merged, model="m"))
+    per_req_tokens = sorted(
+        tok
+        for chain in per_req.chains
+        for item in project_chain_to_output_items(chain)
+        for tok in (item.get("generation_token_ids") or [])
+    )
+    assert merged_tokens == sorted([10, 11, 12, 13, 14])
+    assert per_req_tokens == sorted([10, 11, 12, 13, 14])
+
+
+def test_projection_is_prefix_contiguous():
+    out = prefix_merging(APPEND_ONLY)
+    response = project_main_chain_response("t0-r0", out, model="m")
+    assert [len(i["prompt_token_ids"]) for i in response["output"]] == [3, 7, 9]
+    assert response["usage"] == {"input_tokens": 3, "output_tokens": 5}
+    assert_prefix_contiguity(response)  # must not raise
+
+
+def test_projection_uses_the_recorded_carrier():
+    """The record holds the arrays once; projection puts the chain-correct values back on
+    the item they came off, leaving the other content items token-free."""
+    entry = _entry("m1", [1, 2, 3], [4, 5])
+    entry.output_items = [
+        {"type": "message", "content": "thinking out loud"},
+        {"type": "function_call", "name": "f", "arguments": "{}"},
+    ]
+    entry.token_item_index = 1
+    projected = project_chain_to_output_items(prefix_merging([entry]).chains[0])
+    assert projected[1]["prompt_token_ids"] == [1, 2, 3]
+    assert projected[1]["generation_token_ids"] == [4, 5]
+    assert "prompt_token_ids" not in projected[0]
+    assert projected[0]["content"] == "thinking out loud"
+
+
+def test_projection_falls_back_for_records_without_a_carrier_index():
+    """Records written before the arrays moved off the items carry them inline and set no
+    index. Scanning for the item that has them projects those identically."""
+    entry = _entry("m1", [1, 2, 3], [4, 5])
+    entry.output_items = [
+        {"type": "message", "content": "thinking out loud"},
+        {"type": "function_call", "name": "f", "arguments": "{}", "generation_token_ids": [4, 5]},
+    ]
+    projected = project_chain_to_output_items(prefix_merging([entry]).chains[0])
+    assert projected[1]["prompt_token_ids"] == [1, 2, 3]
+    assert "prompt_token_ids" not in projected[0]
+
+
+def test_contiguity_assert_catches_a_gap():
+    broken = {
+        "output": [
+            {"type": "message", "prompt_token_ids": [1, 2, 3], "generation_token_ids": [10]},
+            # prompt does not extend [1,2,3,10]:
+            {"type": "message", "prompt_token_ids": [1, 2, 3, 99], "generation_token_ids": [11]},
+        ]
+    }
+    with pytest.raises(AssertionError):
+        assert_prefix_contiguity(broken)
+
+
+def _content_entry(mcid, prompt, gen, text):
+    lp = [-0.1] * len(gen)
+    return TokenEntry(
+        rollout_id="t0-r0",
+        model_call_id=mcid,
+        model="m",
+        prompt_token_ids=prompt,
+        generation_token_ids=gen,
+        generation_log_probs=lp,
+        output_items=[
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": text}],
+                "prompt_token_ids": prompt,
+                "generation_token_ids": gen,
+                "generation_log_probs": lp,
+            }
+        ],
+    )
+
+
+def test_projection_carries_content_and_stays_contiguous():
+    entries = [
+        _content_entry("c1", [1, 2, 3], [10, 11], "first turn"),
+        _content_entry("c2", [1, 2, 3, 10, 11, 4, 5], [12], "second turn"),
+    ]
+    out = prefix_merging(entries)
+    resp = project_main_chain_response("t0-r0", out, model="m")
+    texts = [item["content"][0]["text"] for item in resp["output"]]
+    assert texts == ["first turn", "second turn"]  # content preserved (not token-only)
+    assert [len(i["prompt_token_ids"]) for i in resp["output"]] == [3, 7]
+    assert_prefix_contiguity(resp)  # prompts still contiguous with content attached
+
+
+def test_projection_handles_content_only_leading_item():
+    # A single call whose output is an assistant text message (no token fields) followed by a
+    # tool call that carries the token fields, the real shape when a model narrates before a
+    # tool call. Usage must be read from the token-bearing item, not output[0].
+    entry = TokenEntry(
+        rollout_id="t0-r0",
+        model_call_id="c1",
+        model="m",
+        prompt_token_ids=[1, 2, 3],
+        generation_token_ids=[10, 11],
+        generation_log_probs=[-0.1, -0.1],
+        output_items=[
+            {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "let me check"}]},
+            {"type": "function_call", "name": "grep", "arguments": "{}", "call_id": "x"},
+        ],
+    )
+    out = prefix_merging([entry])
+    resp = project_main_chain_response("t0-r0", out, model="m")
+    assert resp["output"][0]["type"] == "message"  # content-only leading item preserved
+    assert "prompt_token_ids" not in resp["output"][0]
+    assert resp["usage"] == {"input_tokens": 3, "output_tokens": 2}  # counts from the token-bearing item
+    assert_prefix_contiguity(resp)
+
+
+def test_consumer_reads_store_and_builds(tmp_path):
+    # The co-located consumer: write the rollout's tokens, then build from the store files.
+    store = TokenCaptureStore(tmp_path)
+    for e in APPEND_ONLY:
+        store.append(e.model_copy(update={"rollout_id": "t0-r0"}))
+    dirs = token_id_capture_dirs_from_config({"token_id_capture": {"enabled": True, "dir": str(tmp_path)}})
+    assert dirs == [tmp_path]
+    merged = trajectories_for_rollout("t0-r0", dirs, builder="prefix_merging")
+    assert merged is not None
+    assert merged["builder"] == "prefix_merging"
+    # Three calls become three contiguous output items on one Responses payload.
+    output = merged["rebuilt_response"]["output"]
+    assert len(output) == 3
+    assert output[-1]["prompt_token_ids"] + output[-1]["generation_token_ids"] == [
+        1,
+        2,
+        3,
+        10,
+        11,
+        4,
+        5,
+        12,
+        6,
+        13,
+        14,
+    ]
+
+
+def test_consumer_noop_when_disabled_or_absent(tmp_path):
+    assert token_id_capture_dirs_from_config({}) == []
+    assert trajectories_for_rollout("t0-r0", []) is None
+    # Enabled dir but no file for this rollout -> None (graceful no-op).
+    dirs = token_id_capture_dirs_from_config({"token_id_capture": {"enabled": True, "dir": str(tmp_path)}})
+    assert trajectories_for_rollout("missing", dirs) is None
+
+
+def test_ambiguous_parents_are_quarantined():
+    # Two roots with identical prompt+generation, then a call extending that shared
+    # sequence: its parent is ambiguous, so the subtree is quarantined, not guessed.
+    a = _entry("a", [1, 2], [7, 8])
+    b = _entry("b", [1, 2], [7, 8])
+    child = _entry("child", [1, 2, 7, 8, 9], [20])
+    out = prefix_merging([a, b, child])
+    assert "child" in out.quarantined
+    # The quarantined child is excluded from every emitted chain.
+    for chain in out.chains:
+        assert all(link.entry.model_call_id != "child" for link in chain.links)
+
+
+# --- side calls and chain selection -------------------------------------------
+
+
+def test_the_earliest_root_becomes_the_delivered_chain():
+    """The rollout's own first call completes before anything it goes on to do.
+
+    Prompt length cannot decide this: the first real call carries the whole system prompt and
+    tool definitions, so it is among the longest, while an auxiliary call is tiny. Generated
+    length cannot either: an orchestrator that delegates generates less than what it delegates to.
+    """
+    # A short auxiliary call, dispatched after the agent's first turn was already served.
+    side = _entry("side", [9000, 9001], [7, 7, 7], created_at=200.0)
+    real_1 = _entry("real1", list(range(100, 160)), [200, 201, 202, 203], created_at=100.0)
+    real_2 = _entry("real2", list(range(100, 160)) + [200, 201, 202, 203, 500], [300, 301, 302], created_at=150.0)
+
+    out = prefix_merging([side, real_1, real_2])
+    main = next(c for c in out.chains if c.chain_id == "main")
+
+    assert [link.entry.model_call_id for link in main.links] == ["real1", "real2"]
+    assert out.notes.chains == 2
+    # The dropped chain is reported rather than silently discarded.
+    assert out.notes.generated_tokens_captured == 10
+    assert out.notes.generated_tokens_delivered == 7
+    assert out.notes.delivered_fraction == 0.7
+
+
+def test_an_orchestrator_is_delivered_over_the_sub_agent_it_delegates_to():
+    """An orchestrator generates little and delegates the work, so the chain that generated
+    the most is the wrong one to deliver. It starts first, which is what selection uses."""
+    orchestrator = _entry("orch", list(range(100, 160)), [1, 2], created_at=100.0)
+    sub_agent = _entry("sub", [9000, 9001], list(range(500, 560)), created_at=120.0)
+
+    out = prefix_merging([orchestrator, sub_agent])
+    main = next(c for c in out.chains if c.chain_id == "main")
+
+    assert [link.entry.model_call_id for link in main.links] == ["orch"]
+    # Most of the rollout's generation was not delivered, and that is visible rather than silent.
+    assert out.notes.chains == 2
+    assert out.notes.delivered_fraction < 0.1
+
+
+def test_an_auxiliary_call_that_finishes_first_is_selected_and_reported():
+    """A known limitation, pinned so it is not mistaken for correct behaviour.
+
+    A harness that issues an auxiliary call before the agent's first turn, and whose short prompt
+    returns sooner, has that call selected as the root. Selection cannot tell the two apart,
+    because nothing in a record says which agent made the call. The rollout is not silently wrong:
+    it reports more than one chain and a low delivered fraction.
+    """
+    side = _entry("side", [9000, 9001], [7, 7, 7], created_at=90.0)
+    real = _entry("real", list(range(100, 160)), [200, 201, 202, 203], created_at=100.0)
+
+    out = prefix_merging([side, real])
+    main = next(c for c in out.chains if c.chain_id == "main")
+
+    assert [link.entry.model_call_id for link in main.links] == ["side"]
+    assert out.notes.chains == 2
+    assert out.notes.delivered_fraction < 0.5
+
+
+def test_selection_is_deterministic_when_timestamps_tie():
+    """Records written in the same clock tick must not make the delivered chain arbitrary."""
+    a = _entry("aaa", [1, 2], [3], created_at=100.0)
+    b = _entry("bbb", [7, 8], [9], created_at=100.0)
+
+    first = prefix_merging([a, b])
+    second = prefix_merging([b, a])
+
+    def main_id(out):
+        return next(c for c in out.chains if c.chain_id == "main").links[0].entry.model_call_id
+
+    assert main_id(first) == main_id(second) == "aaa"
+
+
+def test_post_compaction_chain_is_reported_as_dropped():
+    """A rewritten context starts a new root. Only one chain is delivered today,
+    so what is left behind has to show up in the metrics."""
+    call_1 = _entry("c1", [1, 2, 3], [4, 5])
+    call_2 = _entry("c2", [1, 2, 3, 4, 5, 6], [7])
+    # Compaction: the prompt no longer extends anything captured.
+    call_3 = _entry("c3", [90, 91], [92, 93, 94, 95])
+
+    out = prefix_merging([call_1, call_2, call_3])
+    assert out.notes.chains == 2
+    assert out.notes.generated_tokens_captured == 7
+    assert out.notes.delivered_fraction < 1.0
+
+
+# --- recorded parent links ----------------------------------------------------
+
+
+def test_malformed_capture_masks_the_rollout_instead_of_raising(tmp_path):
+    """The callers are a rollout-collection loop and a training framework's loop; an
+    escaping exception there kills a whole step's batch rather than dropping one
+    sample."""
+    store = TokenCaptureStore(tmp_path)
+    bad = _entry("c1", [1, 2, 3], [4, 5])
+    bad.generation_log_probs = [-0.1]  # one log prob for two generated tokens
+    store.append(bad)
+
+    built = trajectories_for_rollout("t0-r0", [tmp_path])
+    assert built is not None
+    assert built["mask_sample"] is True
+    assert built["rebuilt_response"] is None
+    assert "ValueError" in built["error"]
+
+
+def test_incomplete_capture_masks_the_rollout(tmp_path):
+    """A rollout that lost a call can still stitch into a clean-looking chain --
+    it is just missing a turn. The marker is what makes that visible."""
+    store = TokenCaptureStore(tmp_path)
+    store.append(_entry("c1", [1, 2, 3], [4, 5]))
+    store.mark_incomplete("t0-r0", "c2")
+
+    built = trajectories_for_rollout("t0-r0", [tmp_path])
+    assert built["mask_sample"] is True
+    assert built["metrics"]["capture_incomplete"] is True
+
+
+def test_clean_rollout_is_not_masked_and_reports_full_delivery(tmp_path):
+    store = TokenCaptureStore(tmp_path)
+    store.append(_entry("c1", [1, 2, 3], [4, 5]))
+    store.append(_entry("c2", [1, 2, 3, 4, 5, 6], [7]))
+
+    built = trajectories_for_rollout("t0-r0", [tmp_path])
+    assert built["mask_sample"] is False
+    assert built["metrics"]["delivered_fraction"] == 1.0
+    assert built["metrics"]["quarantined_calls"] == 0
+
+
+# --- side calls ---------------------------------------------------------------
+
+
+def _sc(mcid, prompt, gen, requested_model=""):
+    entry = _entry(mcid, prompt, gen)
+    entry.requested_model = requested_model
+    return entry
+
+
+def test_a_call_that_generated_nothing_is_not_a_parent():
+    """A filtered call and its retry share a prompt. If the filtered one is treated as a parent the
+    pair reads as a two-turn chain, and retry resolution never compares them because it only looks
+    at siblings under a shared parent."""
+    filtered = _entry("filtered", [1, 2, 3], [])
+    retry = _entry("retry", [1, 2, 3], [9, 9])
+
+    out = prefix_merging([filtered, retry])
+    main = next(c for c in out.chains if c.chain_id == "main")
+
+    assert [link.entry.model_call_id for link in main.links] == ["retry"]
+    assert out.notes.empty_generation_calls == ["filtered"]
+    assert out.notes.delivered_fraction == 1.0
+
+
+def test_a_rollout_of_only_empty_generations_builds_nothing():
+    out = prefix_merging([_entry("a", [1, 2], []), _entry("b", [1, 2, 3], [])])
+    assert out.chains == []
+    assert out.notes.empty_generation_calls == ["a", "b"]
+
+
+def test_the_builder_runs_once_per_rollout(tmp_path, monkeypatch):
+    """The metrics and the trajectories must come from the same chaining pass, and chaining is
+    quadratic in call count when parent links are absent."""
+    import nemo_gym.token_id_capture.consumer as consumer_module
+
+    store = TokenCaptureStore(tmp_path)
+    store.append(_entry("c1", [1, 2, 3], [4, 5]))
+    store.append(_entry("c2", [1, 2, 3, 4, 5, 6], [7]))
+
+    calls = []
+    real_run_builder = consumer_module.run_builder
+
+    def counting_run_builder(entries, builder="prefix_merging"):
+        calls.append(builder)
+        return real_run_builder(entries, builder)
+
+    monkeypatch.setattr(consumer_module, "run_builder", counting_run_builder)
+    built = trajectories_for_rollout("t0-r0", [tmp_path])
+
+    assert calls == ["prefix_merging"]
+    assert built["metrics"]["n_calls"] == 2
+
+
+def test_a_chain_that_breaks_is_split_and_reported():
+    """Two calls whose prompts do not extend each other are separate sequences. Stitching them
+    would hand the trainer positions the policy never generated in that order, so they become
+    separate chains and delivered_fraction reports what was left behind."""
+    first = _entry("a", [1, 2, 3], [4, 5])
+    unrelated = _entry("b", [80, 81], [82])
+
+    out = prefix_merging([first, unrelated])
+
+    assert len(out.chains) > 1
+    assert out.notes.delivered_fraction < 1.0
+    assert_prefix_contiguity(project_main_chain_response("r0", out, model="m"))

--- a/tests/unit_tests/test_trajectory_builder.py
+++ b/tests/unit_tests/test_trajectory_builder.py
@@ -19,6 +19,7 @@ import asyncio
 import pytest
 
 from nemo_gym.token_id_capture import (
+    TokenCaptureSnapshot,
     assert_prefix_contiguity,
     per_request,
     prefix_merging,
@@ -26,6 +27,7 @@ from nemo_gym.token_id_capture import (
     project_main_chain_response,
     token_id_capture_dirs_from_config,
     trajectories_for_rollout,
+    trajectories_from_source,
 )
 from nemo_gym.token_id_capture.records import TokenEntry
 from nemo_gym.token_id_capture.store import TokenCaptureStore
@@ -213,7 +215,7 @@ def test_projection_handles_content_only_leading_item():
 
 
 def test_consumer_reads_store_and_builds(tmp_path):
-    # The co-located consumer: write the rollout's tokens, then build from the store files.
+    # The colocated consumer builds from records written to the local store.
     store = TokenCaptureStore(tmp_path)
     for e in APPEND_ONLY:
         store.append(e.model_copy(update={"rollout_id": "t0-r0"}))
@@ -238,6 +240,119 @@ def test_consumer_reads_store_and_builds(tmp_path):
         13,
         14,
     ]
+
+
+def test_consumer_reads_and_freezes_an_external_source():
+    class Source:
+        async def freeze(self, rollout_id):
+            return TokenCaptureSnapshot(
+                rollout_id=rollout_id,
+                entries=tuple(APPEND_ONLY),
+                incomplete=False,
+                snapshot_id="snapshot-1",
+                version=4,
+            )
+
+        async def drop(self, rollout_id, *, snapshot_id, version):
+            return True
+
+        async def close(self):
+            return None
+
+    built = asyncio.run(trajectories_from_source("t0-r0", Source()))
+
+    assert built["mask_sample"] is False
+    assert built["_capture_snapshot"] == {
+        "snapshot_id": "snapshot-1",
+        "version": 4,
+    }
+
+
+def test_consumer_masks_an_incomplete_external_snapshot():
+    class Source:
+        async def freeze(self, rollout_id):
+            return TokenCaptureSnapshot(
+                rollout_id=rollout_id,
+                entries=(APPEND_ONLY[0],),
+                incomplete=True,
+                snapshot_id="snapshot-2",
+                version=2,
+            )
+
+        async def drop(self, rollout_id, *, snapshot_id, version):
+            return True
+
+        async def close(self):
+            return None
+
+    built = asyncio.run(trajectories_from_source("t0-r0", Source()))
+
+    assert built["mask_sample"] is True
+    assert built["metrics"]["capture_incomplete"] is True
+
+
+def test_consumer_masks_an_empty_external_snapshot():
+    class Source:
+        async def freeze(self, rollout_id):
+            return TokenCaptureSnapshot(
+                rollout_id=rollout_id,
+                entries=(),
+                incomplete=False,
+                snapshot_id="snapshot-empty",
+                version=1,
+            )
+
+        async def drop(self, rollout_id, *, snapshot_id, version):
+            return True
+
+        async def close(self):
+            return None
+
+    built = asyncio.run(trajectories_from_source("t0-r0", Source()))
+
+    assert built["mask_sample"] is True
+    assert built["error"] == "capture contains no token records"
+
+
+def test_consumer_masks_an_external_source_failure():
+    class Source:
+        async def freeze(self, rollout_id):
+            raise RuntimeError("transport unavailable")
+
+        async def drop(self, rollout_id, *, snapshot_id, version):
+            return True
+
+        async def close(self):
+            return None
+
+    built = asyncio.run(trajectories_from_source("t0-r0", Source()))
+
+    assert built["mask_sample"] is True
+    assert "transport unavailable" in built["error"]
+
+
+def test_single_response_consumer_rejects_per_request_builder():
+    class Source:
+        async def freeze(self, rollout_id):
+            return TokenCaptureSnapshot(
+                rollout_id=rollout_id,
+                entries=(APPEND_ONLY[0],),
+                incomplete=False,
+                snapshot_id="snapshot-3",
+                version=1,
+            )
+
+        async def drop(self, rollout_id, *, snapshot_id, version):
+            return True
+
+        async def close(self):
+            return None
+
+    built = asyncio.run(trajectories_from_source("t0-r0", Source(), builder="per_request"))
+
+    assert built["mask_sample"] is True
+    assert built["rebuilt_response"] is None
+    assert "not supported by single-response delivery" in built["error"]
 
 
 def test_consumer_noop_when_disabled_or_absent(tmp_path):

--- a/tests/unit_tests/test_trajectory_builder.py
+++ b/tests/unit_tests/test_trajectory_builder.py
@@ -15,6 +15,7 @@
 """Test trajectory building and contiguous Responses projection."""
 
 import asyncio
+import threading
 
 import pytest
 
@@ -80,6 +81,22 @@ def test_prefix_merging_builds_one_contiguous_main_chain():
     assert [i["generation_token_ids"] for i in response["output"]] == [[10, 11], [12], [13, 14]]
     # Every sampled token has a log probability.
     assert [len(i["generation_log_probs"]) for i in response["output"]] == [2, 1, 2]
+
+
+def test_prefix_merging_handles_a_thousand_turns_without_recursive_traversal():
+    entries = []
+    prompt = [1]
+    for turn in range(1_100):
+        generation = [10_000 + turn]
+        entries.append(_entry(f"call-{turn:04d}", list(prompt), generation))
+        prompt.extend(generation)
+        prompt.append(20_000 + turn)
+
+    out = prefix_merging(entries)
+
+    assert len(out.chains) == 1
+    assert len(out.chains[0].links) == len(entries)
+    assert out.notes.delivered_fraction == 1.0
 
 
 def test_order_independent():
@@ -275,6 +292,46 @@ def test_consumer_reads_and_freezes_an_external_source():
         "snapshot_id": "snapshot-1",
         "version": 4,
     }
+
+
+def test_external_source_offloads_trajectory_assembly(monkeypatch):
+    import nemo_gym.token_id_capture.consumer as consumer_module
+
+    assemble_threads = []
+    original_assemble = consumer_module._assemble
+
+    def recording_assemble(*args, **kwargs):
+        assemble_threads.append(threading.get_ident())
+        return original_assemble(*args, **kwargs)
+
+    monkeypatch.setattr(consumer_module, "_assemble", recording_assemble)
+
+    class Source:
+        async def freeze(self, rollout_id):
+            return TokenCaptureSnapshot(
+                rollout_id=rollout_id,
+                entries=tuple(APPEND_ONLY),
+                incomplete=False,
+                snapshot_id="snapshot-thread",
+                version=1,
+            )
+
+        async def drop(self, rollout_id, *, snapshot_id, version):
+            return True
+
+        async def close(self):
+            return None
+
+    async def consume():
+        event_loop_thread = threading.get_ident()
+        built = await trajectories_from_source("t0-r0", Source())
+        return event_loop_thread, built
+
+    event_loop_thread, built = asyncio.run(consume())
+
+    assert built["mask_sample"] is False
+    assert assemble_threads
+    assert assemble_threads[0] != event_loop_thread
 
 
 def test_consumer_masks_an_incomplete_external_snapshot():

--- a/tests/unit_tests/test_trajectory_builder.py
+++ b/tests/unit_tests/test_trajectory_builder.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Trajectory builder: chaining calls into one contiguous Responses projection."""
 
+import asyncio
+
 import pytest
 
 from nemo_gym.token_id_capture import (
@@ -241,9 +243,11 @@ def test_consumer_reads_store_and_builds(tmp_path):
 def test_consumer_noop_when_disabled_or_absent(tmp_path):
     assert token_id_capture_dirs_from_config({}) == []
     assert trajectories_for_rollout("t0-r0", []) is None
-    # Enabled dir but no file for this rollout -> None (graceful no-op).
+    # Once capture is configured, missing records are unsafe rather than a no-op.
     dirs = token_id_capture_dirs_from_config({"token_id_capture": {"enabled": True, "dir": str(tmp_path)}})
-    assert trajectories_for_rollout("missing", dirs) is None
+    missing = trajectories_for_rollout("missing", dirs)
+    assert missing["mask_sample"] is True
+    assert missing["rebuilt_response"] is None
 
 
 def test_ambiguous_parents_are_quarantined():
@@ -257,6 +261,19 @@ def test_ambiguous_parents_are_quarantined():
     # The quarantined child is excluded from every emitted chain.
     for chain in out.chains:
         assert all(link.entry.model_call_id != "child" for link in chain.links)
+
+
+def test_ambiguous_retry_evidence_cannot_collapse_to_an_empty_success(tmp_path):
+    store = TokenCaptureStore(tmp_path)
+    for entry in (
+        _entry("a", [1, 2], [7, 8]),
+        _entry("b", [1, 2], [7, 8]),
+        _entry("child", [1, 2, 7, 8, 9], [20]),
+    ):
+        store.append(entry)
+    built = trajectories_for_rollout("t0-r0", [tmp_path])
+    assert built["mask_sample"] is True
+    assert built["rebuilt_response"] is None
 
 
 # --- side calls and chain selection -------------------------------------------
@@ -363,7 +380,7 @@ def test_malformed_capture_masks_the_rollout_instead_of_raising(tmp_path):
     assert built is not None
     assert built["mask_sample"] is True
     assert built["rebuilt_response"] is None
-    assert "ValueError" in built["error"]
+    assert "ValidationError" in built["error"]
 
 
 def test_incomplete_capture_masks_the_rollout(tmp_path):
@@ -371,7 +388,7 @@ def test_incomplete_capture_masks_the_rollout(tmp_path):
     it is just missing a turn. The marker is what makes that visible."""
     store = TokenCaptureStore(tmp_path)
     store.append(_entry("c1", [1, 2, 3], [4, 5]))
-    store.mark_incomplete("t0-r0", "c2")
+    asyncio.run(store.mark_incomplete("t0-r0", "c2"))
 
     built = trajectories_for_rollout("t0-r0", [tmp_path])
     assert built["mask_sample"] is True
@@ -417,6 +434,25 @@ def test_a_rollout_of_only_empty_generations_builds_nothing():
     out = prefix_merging([_entry("a", [1, 2], []), _entry("b", [1, 2, 3], [])])
     assert out.chains == []
     assert out.notes.empty_generation_calls == ["a", "b"]
+
+
+def test_a_rollout_of_only_empty_generations_is_masked(tmp_path):
+    store = TokenCaptureStore(tmp_path)
+    store.append(_entry("a", [1, 2], []))
+    store.append(_entry("b", [1, 2, 3], []))
+    built = trajectories_for_rollout("t0-r0", [tmp_path])
+    assert built["mask_sample"] is True
+    assert built["rebuilt_response"] is None
+
+
+def test_multiple_roots_are_masked_instead_of_rewarding_an_auxiliary_chain(tmp_path):
+    store = TokenCaptureStore(tmp_path)
+    store.append(_entry("side", [90], [91], created_at=1.0))
+    store.append(_entry("task", [1, 2], [3], created_at=2.0))
+    built = trajectories_for_rollout("t0-r0", [tmp_path])
+    assert built["mask_sample"] is True
+    assert built["metrics"]["roots"] == 2
+    assert built["metrics"]["chains"] == 2
 
 
 def test_the_builder_runs_once_per_rollout(tmp_path, monkeypatch):

--- a/tests/unit_tests/test_trajectory_builder.py
+++ b/tests/unit_tests/test_trajectory_builder.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Trajectory builder: chaining calls into one contiguous Responses projection."""
+"""Test trajectory building and contiguous Responses projection."""
 
 import asyncio
 
@@ -41,13 +41,15 @@ def _entry(mcid, prompt, gen, lp=None, created_at=0.0):
         prompt_token_ids=prompt,
         generation_token_ids=gen,
         generation_log_probs=lp if lp is not None else [-0.1] * len(gen),
-        # Stamped when the call completed. Chain selection orders on it.
+        # Capture stamps this value when the call completes.
+        # Chain selection uses this value.
         created_at=created_at,
     )
 
 
-# An append-only 3-call rollout: each call's prompt extends the prior prompt+generation
-# plus interstitial tokens (tool output / new user turn).
+# This append-only rollout has three calls.
+# Each prompt extends the previous prompt and generation.
+# Interstitial tokens represent tool output or a new user turn.
 CALL1 = _entry("c1", [1, 2, 3], [10, 11])
 CALL2 = _entry("c2", [1, 2, 3, 10, 11, 4, 5], [12])
 CALL3 = _entry("c3", [1, 2, 3, 10, 11, 4, 5, 12, 6], [13, 14])
@@ -55,7 +57,7 @@ APPEND_ONLY = [CALL1, CALL2, CALL3]
 
 
 def _generated_tokens(response: dict) -> list[int]:
-    """What the policy sampled, read back off the projection."""
+    """Return policy-sampled tokens from the projection."""
     out: list[int] = []
     for item in response["output"]:
         out += item.get("generation_token_ids") or []
@@ -67,15 +69,16 @@ def test_prefix_merging_builds_one_contiguous_main_chain():
     assert [c.chain_id for c in out.chains] == ["main"]
 
     response = project_main_chain_response("t0-r0", out, model="m")
-    # Each item's prompt is the running cumulative sequence, so the loss mask a trainer needs
-    # follows from the structure: prompt positions are context, generation positions are sampled.
+    # Each prompt is the cumulative sequence.
+    # Prompt positions are context.
+    # Generation positions are sampled tokens.
     assert [i["prompt_token_ids"] for i in response["output"]] == [
         [1, 2, 3],
         [1, 2, 3, 10, 11, 4, 5],
         [1, 2, 3, 10, 11, 4, 5, 12, 6],
     ]
     assert [i["generation_token_ids"] for i in response["output"]] == [[10, 11], [12], [13, 14]]
-    # A log probability for every sampled token.
+    # Every sampled token has a log probability.
     assert [len(i["generation_log_probs"]) for i in response["output"]] == [2, 1, 2]
 
 
@@ -90,7 +93,7 @@ def test_order_independent():
 
 
 def test_per_request_marks_the_same_generated_tokens():
-    # Both builders must agree on which tokens the policy sampled.
+    # Both builders identify the same sampled tokens.
     merged = prefix_merging(APPEND_ONLY)
     per_req = per_request(APPEND_ONLY)
     assert len(per_req.chains) == 3
@@ -111,12 +114,14 @@ def test_projection_is_prefix_contiguous():
     response = project_main_chain_response("t0-r0", out, model="m")
     assert [len(i["prompt_token_ids"]) for i in response["output"]] == [3, 7, 9]
     assert response["usage"] == {"input_tokens": 3, "output_tokens": 5}
-    assert_prefix_contiguity(response)  # must not raise
+    assert_prefix_contiguity(response)  # This must not raise.
 
 
 def test_projection_uses_the_recorded_carrier():
-    """The record holds the arrays once; projection puts the chain-correct values back on
-    the item they came off, leaving the other content items token-free."""
+    """Restore token arrays to their recorded carrier item.
+
+    Leave other content items without token fields.
+    """
     entry = _entry("m1", [1, 2, 3], [4, 5])
     entry.output_items = [
         {"type": "message", "content": "thinking out loud"},
@@ -131,8 +136,11 @@ def test_projection_uses_the_recorded_carrier():
 
 
 def test_projection_falls_back_for_records_without_a_carrier_index():
-    """Records written before the arrays moved off the items carry them inline and set no
-    index. Scanning for the item that has them projects those identically."""
+    """Support records that keep token arrays inline.
+
+    Older records do not set a carrier index.
+    Scan those records for the token-bearing item.
+    """
     entry = _entry("m1", [1, 2, 3], [4, 5])
     entry.output_items = [
         {"type": "message", "content": "thinking out loud"},
@@ -147,7 +155,7 @@ def test_contiguity_assert_catches_a_gap():
     broken = {
         "output": [
             {"type": "message", "prompt_token_ids": [1, 2, 3], "generation_token_ids": [10]},
-            # prompt does not extend [1,2,3,10]:
+            # This prompt does not extend [1, 2, 3, 10].
             {"type": "message", "prompt_token_ids": [1, 2, 3, 99], "generation_token_ids": [11]},
         ]
     }
@@ -185,15 +193,16 @@ def test_projection_carries_content_and_stays_contiguous():
     out = prefix_merging(entries)
     resp = project_main_chain_response("t0-r0", out, model="m")
     texts = [item["content"][0]["text"] for item in resp["output"]]
-    assert texts == ["first turn", "second turn"]  # content preserved (not token-only)
+    assert texts == ["first turn", "second turn"]  # Preserve content.
     assert [len(i["prompt_token_ids"]) for i in resp["output"]] == [3, 7]
-    assert_prefix_contiguity(resp)  # prompts still contiguous with content attached
+    assert_prefix_contiguity(resp)  # Content does not break prompt contiguity.
 
 
 def test_projection_handles_content_only_leading_item():
-    # A single call whose output is an assistant text message (no token fields) followed by a
-    # tool call that carries the token fields, the real shape when a model narrates before a
-    # tool call. Usage must be read from the token-bearing item, not output[0].
+    # This call emits assistant text before a tool call.
+    # The assistant text has no token fields.
+    # The tool call carries the token fields.
+    # Usage comes from the token-bearing item.
     entry = TokenEntry(
         rollout_id="t0-r0",
         model_call_id="c1",
@@ -208,14 +217,14 @@ def test_projection_handles_content_only_leading_item():
     )
     out = prefix_merging([entry])
     resp = project_main_chain_response("t0-r0", out, model="m")
-    assert resp["output"][0]["type"] == "message"  # content-only leading item preserved
+    assert resp["output"][0]["type"] == "message"  # Preserve the leading content-only item.
     assert "prompt_token_ids" not in resp["output"][0]
-    assert resp["usage"] == {"input_tokens": 3, "output_tokens": 2}  # counts from the token-bearing item
+    assert resp["usage"] == {"input_tokens": 3, "output_tokens": 2}  # Count the token-bearing item.
     assert_prefix_contiguity(resp)
 
 
 def test_consumer_reads_store_and_builds(tmp_path):
-    # The colocated consumer builds from records written to the local store.
+    # The colocated consumer freezes the local store before building.
     store = TokenCaptureStore(tmp_path)
     for e in APPEND_ONLY:
         store.append(e.model_copy(update={"rollout_id": "t0-r0"}))
@@ -224,7 +233,7 @@ def test_consumer_reads_store_and_builds(tmp_path):
     merged = trajectories_for_rollout("t0-r0", dirs, builder="prefix_merging")
     assert merged is not None
     assert merged["builder"] == "prefix_merging"
-    # Three calls become three contiguous output items on one Responses payload.
+    # Three calls become contiguous items in one Responses payload.
     output = merged["rebuilt_response"]["output"]
     assert len(output) == 3
     assert output[-1]["prompt_token_ids"] + output[-1]["generation_token_ids"] == [
@@ -358,7 +367,7 @@ def test_single_response_consumer_rejects_per_request_builder():
 def test_consumer_noop_when_disabled_or_absent(tmp_path):
     assert token_id_capture_dirs_from_config({}) == []
     assert trajectories_for_rollout("t0-r0", []) is None
-    # Once capture is configured, missing records are unsafe rather than a no-op.
+    # Missing records are unsafe after capture is configured.
     dirs = token_id_capture_dirs_from_config({"token_id_capture": {"enabled": True, "dir": str(tmp_path)}})
     missing = trajectories_for_rollout("missing", dirs)
     assert missing["mask_sample"] is True
@@ -366,14 +375,16 @@ def test_consumer_noop_when_disabled_or_absent(tmp_path):
 
 
 def test_ambiguous_parents_are_quarantined():
-    # Two roots with identical prompt+generation, then a call extending that shared
-    # sequence: its parent is ambiguous, so the subtree is quarantined, not guessed.
+    # Two roots have identical cumulative sequences.
+    # A call extends that shared sequence.
+    # Its parent is ambiguous.
+    # The builder quarantines the subtree.
     a = _entry("a", [1, 2], [7, 8])
     b = _entry("b", [1, 2], [7, 8])
     child = _entry("child", [1, 2, 7, 8, 9], [20])
     out = prefix_merging([a, b, child])
     assert "child" in out.quarantined
-    # The quarantined child is excluded from every emitted chain.
+    # Every emitted chain excludes the quarantined child.
     for chain in out.chains:
         assert all(link.entry.model_call_id != "child" for link in chain.links)
 
@@ -397,11 +408,13 @@ def test_ambiguous_retry_evidence_cannot_collapse_to_an_empty_success(tmp_path):
 def test_the_earliest_root_becomes_the_delivered_chain():
     """The rollout's own first call completes before anything it goes on to do.
 
-    Prompt length cannot decide this: the first real call carries the whole system prompt and
-    tool definitions, so it is among the longest, while an auxiliary call is tiny. Generated
-    length cannot either: an orchestrator that delegates generates less than what it delegates to.
+    Prompt length cannot identify this call.
+    The first task call contains the system prompt and tool definitions.
+    An auxiliary call can have a much shorter prompt.
+    Generation length cannot identify this call either.
+    An orchestrator can generate fewer tokens than its delegate.
     """
-    # A short auxiliary call, dispatched after the agent's first turn was already served.
+    # This short auxiliary call starts after the first agent turn completes.
     side = _entry("side", [9000, 9001], [7, 7, 7], created_at=200.0)
     real_1 = _entry("real1", list(range(100, 160)), [200, 201, 202, 203], created_at=100.0)
     real_2 = _entry("real2", list(range(100, 160)) + [200, 201, 202, 203, 500], [300, 301, 302], created_at=150.0)
@@ -411,15 +424,19 @@ def test_the_earliest_root_becomes_the_delivered_chain():
 
     assert [link.entry.model_call_id for link in main.links] == ["real1", "real2"]
     assert out.notes.chains == 2
-    # The dropped chain is reported rather than silently discarded.
+    # Metrics report the dropped chain.
     assert out.notes.generated_tokens_captured == 10
     assert out.notes.generated_tokens_delivered == 7
     assert out.notes.delivered_fraction == 0.7
 
 
 def test_an_orchestrator_is_delivered_over_the_sub_agent_it_delegates_to():
-    """An orchestrator generates little and delegates the work, so the chain that generated
-    the most is the wrong one to deliver. It starts first, which is what selection uses."""
+    """Deliver the orchestrator instead of its sub-agent.
+
+    The orchestrator generates few tokens before delegation.
+    The longest generation is therefore the wrong selection criterion.
+    Selection uses the earlier start.
+    """
     orchestrator = _entry("orch", list(range(100, 160)), [1, 2], created_at=100.0)
     sub_agent = _entry("sub", [9000, 9001], list(range(500, 560)), created_at=120.0)
 
@@ -427,18 +444,19 @@ def test_an_orchestrator_is_delivered_over_the_sub_agent_it_delegates_to():
     main = next(c for c in out.chains if c.chain_id == "main")
 
     assert [link.entry.model_call_id for link in main.links] == ["orch"]
-    # Most of the rollout's generation was not delivered, and that is visible rather than silent.
+    # Metrics expose the undelivered generation.
     assert out.notes.chains == 2
     assert out.notes.delivered_fraction < 0.1
 
 
 def test_an_auxiliary_call_that_finishes_first_is_selected_and_reported():
-    """A known limitation, pinned so it is not mistaken for correct behaviour.
+    """Document the known auxiliary-call selection limitation.
 
-    A harness that issues an auxiliary call before the agent's first turn, and whose short prompt
-    returns sooner, has that call selected as the root. Selection cannot tell the two apart,
-    because nothing in a record says which agent made the call. The rollout is not silently wrong:
-    it reports more than one chain and a low delivered fraction.
+    A harness issues an auxiliary call before the first agent turn.
+    The short auxiliary call finishes first.
+    Selection chooses that call as the root.
+    Records do not identify the calling agent.
+    Metrics report multiple chains and a low delivered fraction.
     """
     side = _entry("side", [9000, 9001], [7, 7, 7], created_at=90.0)
     real = _entry("real", list(range(100, 160)), [200, 201, 202, 203], created_at=100.0)
@@ -466,11 +484,15 @@ def test_selection_is_deterministic_when_timestamps_tie():
 
 
 def test_post_compaction_chain_is_reported_as_dropped():
-    """A rewritten context starts a new root. Only one chain is delivered today,
-    so what is left behind has to show up in the metrics."""
+    """Report a post-compaction chain as dropped.
+
+    A rewritten context starts a new root.
+    Only one chain is delivered.
+    Metrics report the remaining chain.
+    """
     call_1 = _entry("c1", [1, 2, 3], [4, 5])
     call_2 = _entry("c2", [1, 2, 3, 4, 5, 6], [7])
-    # Compaction: the prompt no longer extends anything captured.
+    # The compacted prompt does not extend a captured sequence.
     call_3 = _entry("c3", [90, 91], [92, 93, 94, 95])
 
     out = prefix_merging([call_1, call_2, call_3])
@@ -483,12 +505,13 @@ def test_post_compaction_chain_is_reported_as_dropped():
 
 
 def test_malformed_capture_masks_the_rollout_instead_of_raising(tmp_path):
-    """The callers are a rollout-collection loop and a training framework's loop; an
-    escaping exception there kills a whole step's batch rather than dropping one
-    sample."""
+    """Mask a malformed capture instead of raising.
+
+    An escaping exception can fail a rollout collection or training batch.
+    """
     store = TokenCaptureStore(tmp_path)
     bad = _entry("c1", [1, 2, 3], [4, 5])
-    bad.generation_log_probs = [-0.1]  # one log prob for two generated tokens
+    bad.generation_log_probs = [-0.1]  # One log probability covers two generated tokens.
     store.append(bad)
 
     built = trajectories_for_rollout("t0-r0", [tmp_path])
@@ -499,8 +522,11 @@ def test_malformed_capture_masks_the_rollout_instead_of_raising(tmp_path):
 
 
 def test_incomplete_capture_masks_the_rollout(tmp_path):
-    """A rollout that lost a call can still stitch into a clean-looking chain --
-    it is just missing a turn. The marker is what makes that visible."""
+    """Mask an incomplete capture.
+
+    A missing call can still produce a clean-looking chain.
+    The incomplete marker exposes the missing turn.
+    """
     store = TokenCaptureStore(tmp_path)
     store.append(_entry("c1", [1, 2, 3], [4, 5]))
     asyncio.run(store.mark_incomplete("t0-r0", "c2"))
@@ -531,9 +557,12 @@ def _sc(mcid, prompt, gen, requested_model=""):
 
 
 def test_a_call_that_generated_nothing_is_not_a_parent():
-    """A filtered call and its retry share a prompt. If the filtered one is treated as a parent the
-    pair reads as a two-turn chain, and retry resolution never compares them because it only looks
-    at siblings under a shared parent."""
+    """Exclude an empty generation from parent inference.
+
+    A filtered call and its retry share a prompt.
+    Treating the filtered call as a parent creates a false two-turn chain.
+    Retry resolution compares only siblings.
+    """
     filtered = _entry("filtered", [1, 2, 3], [])
     retry = _entry("retry", [1, 2, 3], [9, 9])
 
@@ -571,8 +600,11 @@ def test_multiple_roots_are_masked_instead_of_rewarding_an_auxiliary_chain(tmp_p
 
 
 def test_the_builder_runs_once_per_rollout(tmp_path, monkeypatch):
-    """The metrics and the trajectories must come from the same chaining pass, and chaining is
-    quadratic in call count when parent links are absent."""
+    """Run the builder once per rollout.
+
+    Metrics and trajectories must use the same chaining pass.
+    Chaining is quadratic without parent links.
+    """
     import nemo_gym.token_id_capture.consumer as consumer_module
 
     store = TokenCaptureStore(tmp_path)
@@ -594,9 +626,12 @@ def test_the_builder_runs_once_per_rollout(tmp_path, monkeypatch):
 
 
 def test_a_chain_that_breaks_is_split_and_reported():
-    """Two calls whose prompts do not extend each other are separate sequences. Stitching them
-    would hand the trainer positions the policy never generated in that order, so they become
-    separate chains and delivered_fraction reports what was left behind."""
+    """Split calls whose prompts do not extend each other.
+
+    These calls are separate sequences.
+    Joining them would create an order that the policy never generated.
+    The delivered fraction reports the omitted chain.
+    """
     first = _entry("a", [1, 2, 3], [4, 5])
     unrelated = _entry("b", [80, 81], [82])
 


### PR DESCRIPTION
Builds one trainable Responses trajectory from a rollout's unordered token-capture records.

## Reconstruction flow

```mermaid
flowchart TD
    E[Unordered TokenEntry records] --> Z[Exclude calls with no generated tokens]
    Z --> O[Order calls by prompt length]
    O --> P[Find the earlier call whose complete tokens are the longest strict prompt prefix]
    P --> A{Several candidates share the longest prefix?}
    A -->|yes| Q[Quarantine the ambiguous call]
    A -->|no| L[Attach the inferred predecessor]
    Q --> F[Build roots and chains]
    L --> F
    F --> S{Exactly one root and one trainable chain?}
    S -->|no| M[mask_sample = true]
    S -->|yes| R[Project contiguous Responses output]
    R --> C[Assert prefix continuity and report metrics]
```

The predecessor relationship is inferred only during reconstruction: call B follows call A when A's complete token sequence is a strict prefix of B's prompt.

## Summary
- Chains calls through strict longest-prefix inference and quarantines indistinguishable candidates instead of guessing.
- Excludes empty generations so a filtered call cannot become the predecessor of its retry.
- Fails closed for incomplete capture, no trainable generation, multiple roots or chains, unresolved records, or unsafe projection.
- Reports roots, chains, quarantine, delivered-token fraction, empty generations, and parent-link failures.
- Keeps the low-level `per_request` builder for multi-trajectory consumers, while single-response delivery rejects it explicitly.
- Covers `trajectories_from_source` success, incomplete state, source failures, and unsupported single-response modes.

Depends on #2124. Consumed by #2126.