### PR TITLE
feat: accept stream:true on /v1/chat/completions via synthesized SSE

### DIFF
--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -47,6 +47,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from nemo_gym.anthropic_converter import AnthropicConverter
+from nemo_gym.chat_streaming import sanitize_streaming_chat_body, synthesize_chat_completion_sse
 from nemo_gym.config_types import ROLLOUT_PATH_PREFIX, ModelServerRef
 from nemo_gym.global_config import (
     ATTEMPT_INDEX_KEY_NAME,
@@ -95,7 +96,7 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
         capture_config = ModelCallCaptureConfig.model_validate(self.server_client.global_config_dict)
         install_model_call_capture(app, capture_config, model_server_name=self.config.name)
 
-        app.post("/v1/chat/completions")(self.chat_completions)
+        app.post("/v1/chat/completions")(self.chat_completions_dispatch)
 
         app.post("/v1/responses")(self.responses_dispatch)
 
@@ -157,6 +158,47 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
             media_type="text/event-stream",
         )
 
+    async def chat_completions_dispatch(self, request: Request, body: dict = Body()):
+        """Default ``/v1/chat/completions`` entrypoint shared by every Gym model server.
+
+        A non-streaming request validates strictly against
+        ``NeMoGymChatCompletionCreateParamsNonStreaming`` and delegates to this server's own
+        ``chat_completions()``, preserving the historical non-streaming behavior (including the
+        standard 422 shape). When the client sends ``stream: true`` (blackbox
+        Chat-Completions-over-SSE harnesses like the OpenClaw agent always do), the request is
+        sanitized onto that same strict model (drop ``stream``/``stream_options``; see
+        ``nemo_gym.chat_streaming``), validated identically, delegated to the same
+        ``chat_completions()``, and the complete response is buffered and re-emitted as a
+        synthesized ``chat.completion.chunk`` SSE stream. This is buffer-then-replay, not
+        token-by-token streaming.
+
+        Only a genuine boolean ``stream: true`` takes the streaming path; any other value
+        (e.g. ``"false"`` or ``1``) stays on the strict non-streaming path, which rejects the
+        malformed ``stream`` with the same 422 as before.
+        """
+        if body.get("stream") is not True:
+            params = _validate_chat_params(body)
+            return await self._invoke_chat_completions(request, params)
+
+        cleaned, include_usage = sanitize_streaming_chat_body(body)
+        params = _validate_chat_params(cleaned)
+        completion = await self._invoke_chat_completions(request, params)
+        completion_json = completion.model_dump(mode="json") if isinstance(completion, BaseModel) else dict(completion)
+        return StreamingResponse(
+            synthesize_chat_completion_sse(completion_json, include_usage=include_usage),
+            media_type="text/event-stream",
+        )
+
+    async def _invoke_chat_completions(
+        self, request: Request, params: NeMoGymChatCompletionCreateParamsNonStreaming
+    ) -> NeMoGymChatCompletion:
+        # chat_completions() signatures vary across servers: some take a leading `request`, some
+        # only `body`. Dispatch on whichever this server declares so the shared dispatch works for
+        # all of them.
+        if "request" in inspect.signature(self.chat_completions).parameters:
+            return await self.chat_completions(request=request, body=params)
+        return await self.chat_completions(body=params)
+
     async def messages(self, request: Request, body: dict = Body()):
         """Default Anthropic Messages <-> Responses mapping shared by every Gym model server.
 
@@ -194,6 +236,21 @@ def _validate_responses_params(body: dict) -> NeMoGymResponseCreateParamsNonStre
         return NeMoGymResponseCreateParamsNonStreaming.model_validate(body)
     except ValidationError as exc:
         raise RequestValidationError([{**error, "loc": ("body", *error["loc"])} for error in exc.errors()])
+
+
+def _validate_chat_params(body: dict) -> NeMoGymChatCompletionCreateParamsNonStreaming:
+    """Validate a /v1/chat/completions body dict, surfacing failures as FastAPI's standard 422.
+
+    ``include_url=False`` mirrors FastAPI's native body validation, which strips the
+    ``errors.pydantic.dev`` url from each detail entry, so the 422 body stays byte-for-byte
+    identical to the previous typed-``Body()`` binding.
+    """
+    try:
+        return NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(body)
+    except ValidationError as exc:
+        raise RequestValidationError(
+            [{**error, "loc": ("body", *error["loc"])} for error in exc.errors(include_url=False)]
+        )
 
 
 # --- Capture configuration + rollout-keyed storage ---

--- a/nemo_gym/chat_streaming.py
+++ b/nemo_gym/chat_streaming.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Streaming Chat Completions-dialect support shared by every Gym model server.
+
+Blackbox harnesses that speak the OpenAI Chat Completions API over SSE (e.g. the OpenClaw
+agent PinchBench runs) send requests the strict ``NeMoGymChatCompletionCreateParamsNonStreaming``
+model rejects: a ``stream: true`` flag (its ``stream`` field is typed ``Literal[False]``, since a
+Gym model server calls its backend non-streaming and buffers the whole response) plus a
+``stream_options`` block, which is only meaningful alongside ``stream: true``.
+
+A Gym model server can still serve these clients by computing the complete Chat Completion with
+its existing non-streaming backend call and re-emitting it as an SSE stream. This module provides:
+
+- the request-side sanitizer that maps the streaming wire body onto the strict params shape
+  (drops ``stream``/``stream_options``, remembers whether usage was requested);
+- the response-side synthesizer that re-emits a complete ``NeMoGymChatCompletion`` as the
+  ``chat.completion.chunk`` SSE sequence a streaming client expects, terminated by ``data: [DONE]``.
+
+Only the SSE envelope is synthesized -- there is no true token-by-token streaming. The backend
+call completes before the first byte is emitted, so the model server's retry and
+error-normalization behavior is fully preserved on this path. This path is intended for eval-only
+streaming clients: token ids and logprobs from the backend response are not carried in the
+``chat.completion.chunk`` schema, and a client that does not set ``stream_options.include_usage``
+gets no usage chunk, so a model-call record reconstructed from this stream will lack token counts.
+"""
+
+import json
+import logging
+from copy import deepcopy
+from typing import Any, Iterator
+
+from nemo_gym.openai_utils import NeMoGymChatCompletionCreateParamsNonStreaming
+
+
+LOG = logging.getLogger(__name__)
+
+_PARAM_FIELDS = frozenset(NeMoGymChatCompletionCreateParamsNonStreaming.model_fields)
+
+
+def _wants_usage(stream_options: Any) -> bool:
+    """Whether the client asked for a terminal usage chunk (``stream_options.include_usage``)."""
+    return bool(isinstance(stream_options, dict) and stream_options.get("include_usage"))
+
+
+def sanitize_streaming_chat_body(body: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Map a streaming-dialect chat body onto the strict non-streaming params shape.
+
+    Returns the cleaned body dict (ready for ``NeMoGymChatCompletionCreateParamsNonStreaming``
+    validation) and whether a terminal usage chunk was requested via
+    ``stream_options.include_usage``.
+
+    ``stream`` and ``stream_options`` are removed: the params model's ``stream`` field is typed
+    ``Literal[False]``, and ``stream_options`` is only meaningful with ``stream: true``, so it has
+    no effect on the non-streaming backend call. Remaining fields are filtered to the known params
+    fields, so a harness's extra bookkeeping never reaches the backend.
+    """
+    body = deepcopy(body)
+    include_usage = _wants_usage(body.get("stream_options"))
+    body.pop("stream", None)
+    body.pop("stream_options", None)
+
+    dropped = sorted(set(body) - _PARAM_FIELDS)
+    if dropped:
+        LOG.debug("Dropping unsupported fields from a streaming /v1/chat/completions request: %s", dropped)
+    return {key: value for key, value in body.items() if key in _PARAM_FIELDS}, include_usage
+
+
+def _sse_data(payload: dict[str, Any]) -> str:
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+def _chunk(completion: dict[str, Any], choices: list[dict[str, Any]], usage: Any = None) -> dict[str, Any]:
+    """Build one ``chat.completion.chunk`` object sharing the completion's id/created/model."""
+    chunk: dict[str, Any] = {
+        "id": completion.get("id"),
+        "object": "chat.completion.chunk",
+        "created": completion.get("created"),
+        "model": completion.get("model"),
+        "choices": choices,
+    }
+    system_fingerprint = completion.get("system_fingerprint")
+    if system_fingerprint is not None:
+        chunk["system_fingerprint"] = system_fingerprint
+    if usage is not None:
+        chunk["usage"] = usage
+    return chunk
+
+
+def _choice_deltas(index: int, choice: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """Yield the ``chat.completion.chunk`` choice deltas for one completed choice.
+
+    A role delta opens the choice; reasoning, content, and tool-call deltas follow (each emitted
+    only when present); a terminal delta carries the ``finish_reason``. Splitting the message this
+    way keeps every field a client tracks (role, reasoning, content, tool-call name/arguments,
+    finish reason) in the delta position that client expects, even though it is a single logical
+    chunk sequence rather than incremental tokens.
+    """
+    message = choice.get("message") or {}
+    finish_reason = choice.get("finish_reason")
+
+    yield {"index": index, "delta": {"role": message.get("role") or "assistant"}, "finish_reason": None}
+
+    reasoning = message.get("reasoning_content") or message.get("reasoning")
+    if reasoning:
+        yield {"index": index, "delta": {"reasoning_content": reasoning}, "finish_reason": None}
+
+    content = message.get("content")
+    if content:
+        yield {"index": index, "delta": {"content": content}, "finish_reason": None}
+
+    tool_calls = message.get("tool_calls")
+    if tool_calls:
+        delta_tool_calls = []
+        for tool_index, tool_call in enumerate(tool_calls):
+            function = tool_call.get("function") or {}
+            delta_tool_calls.append(
+                {
+                    "index": tool_index,
+                    "id": tool_call.get("id"),
+                    "type": tool_call.get("type") or "function",
+                    "function": {"name": function.get("name"), "arguments": function.get("arguments") or ""},
+                }
+            )
+        yield {"index": index, "delta": {"tool_calls": delta_tool_calls}, "finish_reason": None}
+
+    yield {"index": index, "delta": {}, "finish_reason": finish_reason}
+
+
+def synthesize_chat_completion_sse(completion: dict[str, Any], include_usage: bool = False) -> Iterator[str]:
+    """Re-emit a complete Chat Completion object as a ``chat.completion.chunk`` SSE stream.
+
+    Emits, per choice, a role chunk -> optional reasoning/content/tool-call chunks -> a terminal
+    chunk carrying ``finish_reason``. When ``include_usage`` is set and the completion reports
+    usage, a final ``choices: []`` chunk carries the usage block (OpenAI's contract). The stream
+    always ends with the ``data: [DONE]`` sentinel streaming clients treat as terminal.
+    """
+    for index, choice in enumerate(completion.get("choices") or []):
+        for delta in _choice_deltas(index, choice):
+            yield _sse_data(_chunk(completion, [delta]))
+
+    usage = completion.get("usage")
+    if include_usage and usage is not None:
+        yield _sse_data(_chunk(completion, [], usage=usage))
+
+    yield "data: [DONE]\n\n"

--- a/tests/unit_tests/test_chat_completions_streaming.py
+++ b/tests/unit_tests/test_chat_completions_streaming.py
@@ -1,0 +1,392 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the streaming Chat Completions dialect on ``SimpleResponsesAPIModel``.
+
+Every Gym model server's ``/v1/chat/completions`` accepts the wire dialect Chat-Completions
+streaming harnesses (e.g. the OpenClaw agent PinchBench runs) speak: ``stream: true`` plus a
+``stream_options`` block. The request is sanitized onto the strict params model and the complete
+response is re-emitted as a synthesized ``chat.completion.chunk`` SSE stream. Non-streaming
+requests keep the historical strict-validation behavior.
+"""
+
+import json
+from time import time
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import Body, FastAPI, Request
+from fastapi.testclient import TestClient
+
+from nemo_gym.base_responses_api_model import (
+    BaseResponsesAPIModelConfig,
+    SimpleResponsesAPIModel,
+    _parse_sse_events,
+    _reconstruct_chat_sse,
+)
+from nemo_gym.chat_streaming import (
+    sanitize_streaming_chat_body,
+    synthesize_chat_completion_sse,
+)
+from nemo_gym.openai_utils import (
+    NeMoGymChatCompletion,
+    NeMoGymChatCompletionCreateParamsNonStreaming,
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+)
+from nemo_gym.server_utils import ServerClient
+
+
+def _completion(
+    *,
+    content=None,
+    tool_calls=None,
+    reasoning=None,
+    finish_reason="stop",
+    usage=None,
+    choices=None,
+) -> NeMoGymChatCompletion:
+    if choices is None:
+        message = {"role": "assistant", "content": content}
+        if reasoning:
+            message["reasoning_content"] = reasoning
+        if tool_calls:
+            message["tool_calls"] = tool_calls
+        choices = [{"index": 0, "finish_reason": finish_reason, "message": message}]
+    data = {
+        "id": f"chatcmpl-{uuid4().hex}",
+        "object": "chat.completion",
+        "created": int(time()),
+        "model": "downstream-model",
+        "choices": choices,
+    }
+    if usage is not None:
+        data["usage"] = usage
+    return NeMoGymChatCompletion.model_validate(data)
+
+
+_USAGE = {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10}
+_TOOL_CALL = {"id": "call_1", "type": "function", "function": {"name": "get_weather", "arguments": '{"city":"SF"}'}}
+
+
+def _events(sse_text: str) -> list[dict]:
+    """Parse the JSON ``data:`` payloads out of a chat SSE stream (excluding the ``[DONE]`` marker)."""
+    events = []
+    for block in sse_text.split("\n\n"):
+        for line in block.splitlines():
+            if line.startswith("data: "):
+                payload = line[len("data: ") :]
+                if payload == "[DONE]":
+                    continue
+                events.append(json.loads(payload))
+    return events
+
+
+class TestSanitizeStreamingChatBody:
+    def test_drops_stream_and_stream_options(self) -> None:
+        cleaned, include_usage = sanitize_streaming_chat_body(
+            {"messages": [], "stream": True, "stream_options": {"include_usage": True}}
+        )
+        assert set(cleaned) == {"messages"}
+        assert include_usage is True
+        NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(cleaned)
+
+    def test_include_usage_false_by_default(self) -> None:
+        _, include_usage = sanitize_streaming_chat_body({"messages": [], "stream": True})
+        assert include_usage is False
+
+    def test_include_usage_false_when_flag_unset(self) -> None:
+        _, include_usage = sanitize_streaming_chat_body(
+            {"messages": [], "stream": True, "stream_options": {"include_usage": False}}
+        )
+        assert include_usage is False
+
+    def test_drops_unknown_top_level_fields(self) -> None:
+        cleaned, _ = sanitize_streaming_chat_body(
+            {"messages": [], "stream": True, "client_bookkeeping": {"x": 1}, "temperature": 0.5}
+        )
+        assert set(cleaned) == {"messages", "temperature"}
+        NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(cleaned)
+
+    def test_keeps_known_sampling_and_tool_fields(self) -> None:
+        body = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+            "temperature": 0.7,
+            "max_tokens": 128,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {"name": "get_weather", "parameters": {"type": "object", "properties": {}}},
+                }
+            ],
+        }
+        cleaned, _ = sanitize_streaming_chat_body(body)
+        params = NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(cleaned)
+        assert params.temperature == 0.7
+        assert params.max_tokens == 128
+        assert params.tools[0]["function"]["name"] == "get_weather"
+
+    def test_does_not_mutate_caller_body(self) -> None:
+        body = {"messages": [], "stream": True, "stream_options": {"include_usage": True}}
+        sanitize_streaming_chat_body(body)
+        assert body["stream"] is True
+        assert body["stream_options"] == {"include_usage": True}
+
+
+class TestSynthesizeChatSSE:
+    def test_text_event_sequence(self) -> None:
+        completion = _completion(content="hello world", usage=_USAGE).model_dump(mode="json")
+        text = "".join(synthesize_chat_completion_sse(completion))
+        assert text.endswith("data: [DONE]\n\n")
+        events = _events(text)
+        # role delta first, terminal finish_reason last
+        assert events[0]["choices"][0]["delta"] == {"role": "assistant"}
+        assert events[0]["object"] == "chat.completion.chunk"
+        assert events[-1]["choices"][0]["finish_reason"] == "stop"
+        assert events[-1]["choices"][0]["delta"] == {}
+        # every chunk shares the completion identity
+        assert {e["id"] for e in events} == {completion["id"]}
+
+    def test_content_roundtrips_via_capture_reconstructor(self) -> None:
+        completion = _completion(content="hello world", usage=_USAGE).model_dump(mode="json")
+        text = "".join(synthesize_chat_completion_sse(completion))
+        rebuilt = _reconstruct_chat_sse(_parse_sse_events(text.encode()))
+        assert rebuilt["choices"][0]["message"]["content"] == "hello world"
+        assert rebuilt["choices"][0]["finish_reason"] == "stop"
+
+    def test_reasoning_delta_emitted(self) -> None:
+        completion = _completion(content="answer", reasoning="let me think").model_dump(mode="json")
+        text = "".join(synthesize_chat_completion_sse(completion))
+        rebuilt = _reconstruct_chat_sse(_parse_sse_events(text.encode()))
+        assert rebuilt["choices"][0]["message"]["reasoning_content"] == "let me think"
+        assert rebuilt["choices"][0]["message"]["content"] == "answer"
+
+    def test_tool_calls_roundtrip(self) -> None:
+        completion = _completion(content=None, tool_calls=[_TOOL_CALL], finish_reason="tool_calls").model_dump(
+            mode="json"
+        )
+        text = "".join(synthesize_chat_completion_sse(completion))
+        rebuilt = _reconstruct_chat_sse(_parse_sse_events(text.encode()))
+        tool_calls = rebuilt["choices"][0]["message"]["tool_calls"]
+        assert tool_calls[0]["function"]["name"] == "get_weather"
+        assert json.loads(tool_calls[0]["function"]["arguments"]) == {"city": "SF"}
+        assert rebuilt["choices"][0]["finish_reason"] == "tool_calls"
+        assert rebuilt["choices"][0]["message"]["content"] is None
+
+    def test_no_content_chunk_when_content_empty(self) -> None:
+        completion = _completion(content=None, tool_calls=[_TOOL_CALL], finish_reason="tool_calls").model_dump(
+            mode="json"
+        )
+        events = _events("".join(synthesize_chat_completion_sse(completion)))
+        assert all("content" not in e["choices"][0]["delta"] for e in events)
+
+    def test_usage_chunk_emitted_only_when_requested(self) -> None:
+        completion = _completion(content="hi", usage=_USAGE).model_dump(mode="json")
+
+        without = _events("".join(synthesize_chat_completion_sse(completion, include_usage=False)))
+        assert all(e.get("usage") is None for e in without)
+
+        with_usage = _events("".join(synthesize_chat_completion_sse(completion, include_usage=True)))
+        usage_chunks = [e for e in with_usage if e.get("usage") is not None]
+        assert len(usage_chunks) == 1
+        assert usage_chunks[0]["choices"] == []
+        assert usage_chunks[0]["usage"]["total_tokens"] == 10
+
+    def test_usage_chunk_skipped_when_usage_absent(self) -> None:
+        completion = _completion(content="hi", usage=None).model_dump(mode="json")
+        events = _events("".join(synthesize_chat_completion_sse(completion, include_usage=True)))
+        assert all(e.get("usage") is None for e in events)
+
+    def test_multiple_choices(self) -> None:
+        choices = [
+            {"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": "a"}},
+            {"index": 1, "finish_reason": "stop", "message": {"role": "assistant", "content": "b"}},
+        ]
+        completion = _completion(choices=choices).model_dump(mode="json")
+        events = _events("".join(synthesize_chat_completion_sse(completion)))
+        seen_indices = {e["choices"][0]["index"] for e in events}
+        assert seen_indices == {0, 1}
+
+    def test_empty_choices_still_terminates(self) -> None:
+        completion = _completion(choices=[]).model_dump(mode="json")
+        text = "".join(synthesize_chat_completion_sse(completion))
+        assert text == "data: [DONE]\n\n"
+
+
+class _EchoChatModel(SimpleResponsesAPIModel):
+    """Fake model server capturing the params its chat_completions() receives and echoing input."""
+
+    config: BaseResponsesAPIModelConfig
+    last_params: object = None
+    model_config = {"arbitrary_types_allowed": True}
+
+    async def chat_completions(
+        self, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
+    ) -> NeMoGymChatCompletion:
+        object.__setattr__(self, "last_params", body)
+        text = "hi"
+        for message in body.messages:
+            if message.get("role") == "user" and isinstance(message.get("content"), str):
+                text = message["content"]
+        return _completion(content=text, usage=_USAGE)
+
+    async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:
+        raise NotImplementedError
+
+
+class _RequestAwareEchoChatModel(_EchoChatModel):
+    saw_request: bool = False
+
+    async def chat_completions(
+        self, request: Request, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
+    ) -> NeMoGymChatCompletion:
+        object.__setattr__(self, "saw_request", isinstance(request, Request))
+        return await super().chat_completions(body)
+
+
+def _client(model_cls) -> tuple[TestClient, SimpleResponsesAPIModel]:
+    server = model_cls(
+        config=BaseResponsesAPIModelConfig(host="0.0.0.0", port=8099, entrypoint="", name=""),
+        server_client=MagicMock(spec=ServerClient, global_config_dict={}),
+    )
+    return TestClient(server.setup_webserver()), server
+
+
+class TestChatDispatchRoute:
+    def test_non_streaming_request_returns_plain_json(self) -> None:
+        client, server = _client(_EchoChatModel)
+        resp = client.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hi there"}]})
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/json")
+        assert resp.json()["choices"][0]["message"]["content"] == "hi there"
+        assert server.last_params.messages[0]["content"] == "hi there"
+
+    def test_non_streaming_request_still_validates_strictly(self) -> None:
+        client, _ = _client(_EchoChatModel)
+        resp = client.post("/v1/chat/completions", json={"model": "x"})  # missing required messages
+        assert resp.status_code == 422
+        assert resp.json()["detail"][0]["loc"][0] == "body"
+
+    def test_streaming_request_returns_synthesized_sse(self) -> None:
+        client, server = _client(_EchoChatModel)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"stream": True, "messages": [{"role": "user", "content": "hello"}]},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        assert resp.text.endswith("data: [DONE]\n\n")
+        # the server saw sanitized params (no stream flag reaches the strict model)
+        assert server.last_params.stream is None
+        rebuilt = _reconstruct_chat_sse(_parse_sse_events(resp.text.encode()))
+        assert rebuilt["choices"][0]["message"]["content"] == "hello"
+
+    def test_streaming_request_strips_bookkeeping_and_options(self) -> None:
+        client, server = _client(_EchoChatModel)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "stream": True,
+                "stream_options": {"include_usage": True},
+                "client_bookkeeping": {"cli": "openclaw"},
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        assert resp.status_code == 200
+        # include_usage propagated -> a usage chunk is present
+        usage_chunks = [e for e in _events(resp.text) if e.get("usage") is not None]
+        assert len(usage_chunks) == 1
+        assert usage_chunks[0]["usage"]["total_tokens"] == 10
+
+    def test_streaming_request_invalid_params_returns_422(self) -> None:
+        client, _ = _client(_EchoChatModel)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"stream": True, "messages": [{"role": "user", "content": "hi"}], "temperature": "not-a-number"},
+        )
+        assert resp.status_code == 422
+        assert resp.json()["detail"][0]["loc"][0] == "body"
+
+    def test_dispatch_handles_request_aware_signature(self) -> None:
+        client, server = _client(_RequestAwareEchoChatModel)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"stream": True, "messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert resp.status_code == 200
+        assert server.saw_request is True
+
+    @pytest.mark.parametrize("stream_value", ["false", "true", 1])
+    def test_malformed_stream_value_stays_on_strict_path(self, stream_value) -> None:
+        # Only a genuine boolean True streams; any other value is validated against the strict
+        # model, where a non-``Literal[False]`` stream is rejected with a 422, as before.
+        client, _ = _client(_EchoChatModel)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"stream": stream_value, "messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert resp.status_code == 422
+        assert resp.json()["detail"][0]["loc"][0] == "body"
+
+
+def _legacy_app() -> TestClient:
+    """A FastAPI app with the pre-PR direct typed-body binding, to compare 422 parity against."""
+    app = FastAPI()
+
+    async def chat_completions(body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()):
+        return {"ok": True}
+
+    app.post("/v1/chat/completions")(chat_completions)
+    return TestClient(app)
+
+
+_BAD_BODIES = [
+    {"model": "x"},  # missing required messages
+    {"messages": [], "temperature": "not-a-number"},  # wrong scalar type
+    {"messages": "not-a-list"},  # messages wrong type
+    {"messages": [{"role": "user"}]},  # user message missing required content
+]
+
+
+class Test422Parity:
+    """The dispatch's 422 body must be byte-for-byte identical to the pre-PR typed-body binding."""
+
+    @pytest.mark.parametrize("bad", _BAD_BODIES)
+    def test_non_streaming_422_matches_legacy(self, bad) -> None:
+        legacy, (client, _) = _legacy_app(), _client(_EchoChatModel)
+        legacy_resp = legacy.post("/v1/chat/completions", json=bad)
+        new_resp = client.post("/v1/chat/completions", json=bad)
+        assert legacy_resp.status_code == 422 and new_resp.status_code == 422
+        assert new_resp.json()["detail"] == legacy_resp.json()["detail"]
+
+    @pytest.mark.parametrize("bad", _BAD_BODIES)
+    def test_streaming_422_matches_legacy(self, bad) -> None:
+        # The sanitized streaming body validates through the same path, so its 422 matches too
+        # (stream:true is dropped by the sanitizer before validation).
+        legacy, (client, _) = _legacy_app(), _client(_EchoChatModel)
+        legacy_resp = legacy.post("/v1/chat/completions", json=bad)
+        new_resp = client.post("/v1/chat/completions", json={**bad, "stream": True})
+        assert legacy_resp.status_code == 422 and new_resp.status_code == 422
+        assert new_resp.json()["detail"] == legacy_resp.json()["detail"]
+
+
+class TestSynthesizeSystemFingerprint:
+    def test_system_fingerprint_propagated_into_every_chunk(self) -> None:
+        completion = _completion(content="hi", usage=_USAGE).model_dump(mode="json")
+        completion["system_fingerprint"] = "fp_abc123"
+        events = _events("".join(synthesize_chat_completion_sse(completion)))
+        assert events
+        assert all(event.get("system_fingerprint") == "fp_abc123" for event in events)


### PR DESCRIPTION
## Summary

fixes https://github.com/NVIDIA-NeMo/Gym/issues/2099

Some tools that run a model through Gym only work if the model server accepts streaming requests. They send `stream: true` on `/v1/chat/completions` and expect the reply back as a series of small events. Today Gym model servers reject `stream: true` — the request fails validation — so these tools can't point at a Gym model server and have to call the model endpoint directly. When they do that, they lose what the Gym model server adds: one consistent request format across providers, and per-call capture. The OpenClaw agent that PinchBench runs is the case that prompted this.

This change makes `/v1/chat/completions` accept `stream: true`. The model server still calls its backend exactly as it does now: one normal request, wait for the complete reply. Once it has the full reply, it sends it back to the caller as a stream of standard `chat.completion.chunk` events ending with `data: [DONE]`. This is the same approach already used for `/v1/messages` (Claude Code) and, in #2095, for `/v1/responses` (Codex).

Because the server still waits for the whole reply before sending anything, this does not make responses arrive sooner — the only goal is to accept the streaming request shape these tools require. Two useful consequences of keeping the backend call non-streaming: the existing retry and error handling still apply (nothing has been sent to the caller yet when a failure happens), and token id / logprob capture is unchanged (streaming here is for eval-only tools, and those fields aren't part of the chunk format anyway).

## How it works

- Non-streaming requests are unchanged, including the same validation errors.
- For `stream: true`, the server removes the streaming-only fields (`stream`, `stream_options`) and any unknown fields the tool added, validates the rest against the normal request model, calls the server's existing `chat_completions()`, then turns the complete reply into chunks: the role, then reasoning / content / tool calls when present, then a final chunk carrying the finish reason, then a usage chunk if the caller asked for usage, then `data: [DONE]`.

New file `nemo_gym/chat_streaming.py` does the request cleanup, validation, and chunk generation. The routing change is in `SimpleResponsesAPIModel`. This covers only `/v1/chat/completions`; streaming for `/v1/responses` is a separate change (#2095).

## Test plan

- New `tests/unit_tests/test_chat_completions_streaming.py` (23 tests): request cleanup, validation, chunk generation (content, reasoning, tool calls, usage, multiple choices, empty choices), and the route over an HTTP test client (non-streaming JSON, strict 422, streaming SSE, dropping unknown fields, invalid params → 422, and servers whose `chat_completions()` takes a leading `request` argument). Fidelity is checked by feeding the generated stream back through the capture code that rebuilds a reply from chunks.
- No regressions: `test_base_responses_api_model.py` and `test_openai_utils.py` (71 passed), and the `openai_model` and `vllm_model` server suites (80 passed), which exercise both `chat_completions()` argument shapes over real HTTP.
- Live check: a real uvicorn server driven by the real `openai` Python client with `stream: true` and `include_usage` rebuilt the full reply (content, reasoning, tool call, finish reason, usage) from the streamed chunks.
- ruff and pre-commit are clean.
