### PR TITLE
[test-run] Pinchbench with streaming model server change

### DIFF
--- a/nemo_gym/cli/env.py
+++ b/nemo_gym/cli/env.py
@@ -185,9 +185,13 @@ class RunHelper:  # pragma: no cover
             if not isinstance(server_config_dict, DictConfig):
                 continue
 
+            if not list(server_config_dict):
+                continue
             first_key = list(server_config_dict)[0]
             server_config_dict = server_config_dict[first_key]
             if not isinstance(server_config_dict, DictConfig):
+                continue
+            if not list(server_config_dict):
                 continue
             second_key = list(server_config_dict)[0]
             server_config_dict = server_config_dict[second_key]

--- a/responses_api_agents/pinchbench/configs/pinchbench.yaml
+++ b/responses_api_agents/pinchbench/configs/pinchbench.yaml
@@ -14,8 +14,7 @@ pinchbench_agent:
       # Defaults are fine: the .sif rootfs is read-only, but the provider bind-mounts a
       # writable, per-sandbox-isolated host dir at mount_point (/sandbox) — run_task.sh
       # writes the skill copy, OpenClaw $HOME, $TMPDIR and the benchmark run-root there.
-      sandbox_provider:
-        apptainer: {}
+      sandbox_provider: ${sandbox_provider}
       sandbox_spec:
         image: ${sandbox_image}
         ready_timeout_s: 600


### PR DESCRIPTION
## Summary

Validates the streaming code path added in `feat: synthesize Chat Completions SSE for stream:true model-server requests` (branch `pr-2130`). PinchBench/OpenClaw calls the model server with `stream: true`; this run confirms it works end-to-end through a Docker sandbox.

Two fixes needed to run PinchBench locally with the Docker sandbox provider:

- **`pinchbench.yaml`**: make `sandbox_provider` overrideable via interpolation (consistent with `model_base_url`, `sandbox_image`, etc.) so the Docker provider can be selected at run time without merging into the hardcoded apptainer default
- **`env.py`**: guard against empty `DictConfig` in the `gym env start` server-detection loop, which crashed with `IndexError` (killing the Ray cluster) when any top-level dict-valued override like `+sandbox_provider={docker: {}}` was present

## Run instructions

**Prerequisites:** Docker Desktop running, `openai_model` server already up on port 19314.

**Step 1 — Build the PinchBench Docker image (one-time, ~5-10 min)**
```bash
bash responses_api_agents/pinchbench/setup_scripts/build_image.sh
```

**Step 2 — Start the PinchBench agent server (Terminal 1, keep running)**
```bash
source .venv/bin/activate && gym env start \
  "+config_paths=[responses_api_agents/pinchbench/configs/pinchbench.yaml]" \
  "+sandbox_image=docker://pinchbench-openclaw:latest" \
  "+sandbox_provider={docker: {}}" \
  "+model_base_url=http://host.docker.internal:19314/v1" \
  "+model_api_key=<key>" \
  "+model_name=<model>" \
  "+judge_model=<model>" \
  "+judge_base_url=http://host.docker.internal:19314/v1" \
  "+judge_api_key=<key>" \
  "+brave_api_key=DUMMY" \
  "+head_server.host=127.0.0.1" \
  "+head_server.port=12000" \
  "+disallowed_ports=[12000]"
```

Wait until you see the server table with `pinchbench_agent` listed.

> `head_server.port=12000` is needed when port 11000 (the default) is already taken by another `gym env start` instance. `host.docker.internal` lets containers reach the Mac's localhost.

**Step 3 — Collect rollouts (Terminal 2)**
```bash
source .venv/bin/activate && ng_collect_rollouts \
  "+config_paths=[responses_api_agents/pinchbench/configs/pinchbench.yaml]" \
  "+sandbox_image=docker://pinchbench-openclaw:latest" \
  "+sandbox_provider={docker: {}}" \
  "+model_base_url=http://host.docker.internal:19314/v1" \
  "+model_api_key=<key>" \
  "+model_name=<model>" \
  "+judge_model=<model>" \
  "+judge_base_url=http://host.docker.internal:19314/v1" \
  "+judge_api_key=<key>" \
  "+brave_api_key=DUMMY" \
  "+head_server.host=127.0.0.1" \
  "+head_server.port=12000" \
  "+disallowed_ports=[12000]" \
  +agent_name=pinchbench_agent \
  "+input_jsonl_fpath=responses_api_agents/pinchbench/data/example.jsonl" \
  "+output_jsonl_fpath=/tmp/pinchbench_results.jsonl" \
  "+num_samples_in_parallel=1" \
  "+num_repeats=1"
```

## Run results

5 tasks from `data/example.jsonl`, model: `nvidia/qwen/eccn-qwen3.6-35b-a3b`, ~38s/task.

```
mean/reward:          0.6
mean/input_tokens:    70,689.8
mean/output_tokens:   1,068.0
mean/total_tokens:    71,757.8
```

```
Collecting rollouts: 100%|█████████████| 5/5 [03:13<00:00, 38.71s/it]
```