### PR TITLE
fix(vllm): handle null request metadata

### DIFF
--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -232,7 +232,7 @@ class VLLMModel(SimpleResponsesAPIModel):
         if self.config.chat_template_kwargs:
             chat_template_kwargs = deepcopy(self.config.chat_template_kwargs)
 
-        metadata = body_dict.get("metadata", dict())
+        metadata = body_dict.get("metadata") or {}
 
         # Merge global config chat_template_kwargs with per-request overrides in metadata (e.g. per-sample reasoning on/off)
         metadata_chat_template_kwargs_str = metadata.get("chat_template_kwargs", "{}")

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -3215,6 +3215,28 @@ class TestVLLMConverter:
         assert captured_kwargs["chat_template_kwargs"]["some_other_param"] == "value1"
 
         captured_kwargs.clear()
+        request_body_null_metadata = NeMoGymResponseCreateParamsNonStreaming(
+            input=[
+                NeMoGymEasyInputMessage(
+                    type="message",
+                    role="user",
+                    content="hello",
+                )
+            ],
+            metadata=None,
+        )
+
+        response = client.post(
+            "/v1/responses",
+            json=request_body_null_metadata.model_dump(exclude_unset=True, mode="json"),
+        )
+        assert response.status_code == 200
+
+        assert "chat_template_kwargs" in captured_kwargs
+        assert captured_kwargs["chat_template_kwargs"]["enable_thinking"] is True
+        assert captured_kwargs["chat_template_kwargs"]["some_other_param"] == "value1"
+
+        captured_kwargs.clear()
         request_body_multi_override = NeMoGymResponseCreateParamsNonStreaming(
             input=[
                 NeMoGymEasyInputMessage(


### PR DESCRIPTION
Treat explicit metadata=null the same as omitted metadata when processing per-request chat-template and extra-body overrides.

Add regression coverage for Responses API requests containing null metadata.