### PR TITLE
feat: add switchyard_model server for router-backed evals with condition provenance

### DIFF
--- a/fern/versions/latest/pages/model-server/index.mdx
+++ b/fern/versions/latest/pages/model-server/index.mdx
@@ -50,6 +50,12 @@ Serve multiple request-time configs (e.g. reasoning on/off) from one Local vLLM 
 <Badge minimal outlined>self-hosted</Badge> <Badge minimal outlined>gym-managed</Badge> <Badge minimal outlined>training</Badge>
 </Card>
 
+<Card title="Switchyard" href="/model-server/switchyard">
+Route each model call across a fleet of models with a Switchyard routing proxy Gym hosts for you.
+
+<Badge minimal outlined>router</Badge> <Badge minimal outlined>gym-managed</Badge>
+</Card>
+
 </Cards>
 
 ## Observe model calls

--- a/fern/versions/latest/pages/model-server/switchyard.mdx
+++ b/fern/versions/latest/pages/model-server/switchyard.mdx
@@ -1,0 +1,104 @@
+---
+title: "Switchyard"
+description: "Route model calls across a fleet of models with a Gym-managed Switchyard proxy"
+position: 8
+---
+
+[Switchyard](https://github.com/NVIDIA-NeMo/Switchyard) is a routing proxy: it decides, per request, which model should carry the work. The `switchyard_model` server (in `responses_api_models/switchyard_model`) puts that decision behind a NeMo Gym model server, so any benchmark Gym already supports can be run against a router without changing the agent harness.
+
+NeMo Gym launches and manages the proxy for you, the same way [Local vLLM](/model-server/local-vllm) manages a vLLM engine. You supply a Switchyard routing profile; Gym starts the proxy when the model server starts, waits for it to become healthy, and shuts it down when the server exits.
+
+## Use SwitchyardModel
+
+Launching drives the `switchyard` CLI, so install it first. It is deliberately not a dependency of NeMo Gym — this keeps Gym free of Switchyard, and lets you pin the exact Switchyard build your results are reported against.
+
+```bash
+pip install 'nemo-switchyard[server]'
+```
+
+Then point `routing_profiles` at your routing config and run an eval:
+
+```bash
+gym eval run \
+    --benchmark <name> \
+    --model-type switchyard_model \
+    --model <route-name> \
+    ++policy_model.responses_api_models.switchyard_model.routing_profiles=/abs/path/routes.yaml
+```
+
+Or start a persistent environment:
+
+```bash
+gym env start \
+    --resources-server example_single_tool_call \
+    --model-type switchyard_model \
+    --model <route-name> \
+    ++policy_model.responses_api_models.switchyard_model.routing_profiles=/abs/path/routes.yaml
+```
+
+`routing_profiles` can also come from the `SWITCHYARD_ROUTING_PROFILES` environment variable, in which case the override can be dropped.
+
+<Warning>
+Use an absolute path for `routing_profiles`. The proxy runs as a subprocess and relative paths are not resolved against the config file's location.
+</Warning>
+
+Under the hood, Gym runs the following on a free port that does not collide with its own servers, polls `/health` until the proxy answers, and points the model server at `http://127.0.0.1:<port>/v1`:
+
+```bash
+switchyard --routing-profiles /abs/path/routes.yaml -- serve --host 0.0.0.0 --port <auto>
+```
+
+## `--model` names a route, not a model
+
+For other model servers, `--model` is the model to serve. Here it is the **route name** Switchyard resolves — it must match a route in your routing profile. Which concrete model actually served a call is Switchyard's decision, made per request, and comes back on the response.
+
+<Note>
+A caller-supplied `model` in the request body is always overridden with the configured route name. Otherwise an agent that sets its own model would bypass the router, and the eval would silently measure something other than routing.
+</Note>
+
+## Attach to a proxy you run yourself
+
+Set `switchyard_base_url` instead of `routing_profiles` and Gym will use an existing proxy rather than starting one:
+
+```bash
+switchyard --routing-profiles routes.yaml -- serve --port 4000
+
+gym eval run \
+    --benchmark <name> \
+    --model-type switchyard_model \
+    --model <route-name> \
+    ++policy_model.responses_api_models.switchyard_model.switchyard_base_url=http://127.0.0.1:4000/v1
+```
+
+The mode is inferred from whichever of the two you set; configuring neither is a startup error. Two reasons to attach:
+
+- **Pinning.** Running the proxy yourself lets an eval target a specific Switchyard build, so a Gym run can be compared against another harness's run of the same commit.
+- **Shared state.** Routing strategies that use session or agent affinity are stateful. If several model servers each launch their own proxy, calls that belong together can land on different instances, and routing will not behave the way a single deployed proxy does. One attached proxy shared by all of them avoids this. Stateless strategies — task classification, for example — are unaffected.
+
+## Correlating routing decisions with rollouts
+
+Gym sends its rollout-attempt id to Switchyard as an opaque session id, using the `proxy_x_session_id` header. That lets proxy-side records — which model was chosen, what it cost — be joined back to the rollout that produced them. Set `forward_session_id: false` to disable it, or `session_id_header` to change the header name.
+
+To see which model served each call from Gym's side, enable [model-call capture](/model-server/model-call-capture). Each captured exchange records the response, so the routed model is visible per call.
+
+<Warning>
+Read routing attribution from the capture records, not from the rollout response. Some agent harnesses overwrite the top-level response `model` with the configured policy model name, which would report the route name for every call regardless of what actually served it.
+</Warning>
+
+## Configuration reference
+
+| Field | Default | Purpose |
+|---|---|---|
+| `routing_profiles` | `null` | Switchyard routing config. Gym launches a proxy when this is set. |
+| `switchyard_base_url` | `null` | Attach to an existing proxy instead of launching one. |
+| `switchyard_model` | `${policy_model_name}` | Route name to request. |
+| `switchyard_api_key` | `dummy` | Sent as the bearer token to the proxy. |
+| `proxy_host` | `0.0.0.0` | Bind address for a launched proxy. Gym reaches its own child over loopback. |
+| `proxy_port` | `null` | Fixed port. `null` picks a free one. |
+| `proxy_startup_timeout_s` | `120.0` | How long to wait for `/health` before failing. |
+| `switchyard_executable` | `switchyard` | CLI to launch. |
+| `session_id_header` | `proxy_x_session_id` | Header carrying the rollout id. |
+| `forward_session_id` | `true` | Whether to send it at all. |
+| `extra_body` | `{}` | Merged into every upstream request body. |
+| `default_headers` | `{}` | Sent on every upstream request. |
+| `max_concurrent_requests` | `null` | Cap on in-flight upstream requests. `null` is unlimited. |

--- a/fern/versions/latest/pages/model-server/switchyard.mdx
+++ b/fern/versions/latest/pages/model-server/switchyard.mdx
@@ -25,6 +25,10 @@ If you set both, Gym attaches to `switchyard_base_url` and logs a warning that `
 
 Nothing to install. Switchyard is a dependency of this model server, so NeMo Gym installs it into the server's virtual environment when the server starts. It is scoped to this server rather than to Gym's core dependencies — Gym itself never imports Switchyard, and runs that do not route through it are unaffected.
 
+<Note>
+While `nemo-switchyard` is pinned to a git commit rather than a release, installing it compiles Switchyard's Rust extension instead of using its published wheels. You do not need a Rust toolchain — maturin bootstraps one if the machine has none — but the first startup spends an extra minute or two building, and the build reaches `static.rust-lang.org` and `crates.io` in addition to PyPI and GitHub. Allow those two hosts if your egress is restricted. Neither applies to the self-managed mode below, which installs nothing.
+</Note>
+
 Point `routing_profiles` at your routing config and run an eval:
 
 ```bash

--- a/fern/versions/latest/pages/model-server/switchyard.mdx
+++ b/fern/versions/latest/pages/model-server/switchyard.mdx
@@ -12,7 +12,7 @@ Both are fully supported; pick whichever fits how you work.
 
 | | Set | Gym does | Use when |
 |---|---|---|---|
-| **Gym manages it** | `routing_profiles` | Starts the proxy, health-checks it, stops it at exit | You want one command and no processes to babysit |
+| **Gym manages it** | `routing_profiles` | Installs Switchyard, starts the proxy, health-checks it, stops it at exit | You want one command and nothing to install or babysit |
 | **You manage it** | `switchyard_base_url` | Points at your proxy and nothing else | You need to pin a specific Switchyard build, share one proxy across servers, or already have one running |
 
 The mode is inferred from whichever field you set — there is no separate switch. Setting neither is a startup error naming both.
@@ -23,13 +23,9 @@ If you set both, Gym attaches to `switchyard_base_url` and logs a warning that `
 
 ## Let Gym manage the proxy
 
-Launching drives the `switchyard` CLI, so install it first. It is deliberately not a dependency of NeMo Gym — this keeps Gym free of Switchyard, and lets you pin the exact Switchyard build your results are reported against.
+Nothing to install. Switchyard is a dependency of this model server, so NeMo Gym installs it into the server's virtual environment when the server starts. It is scoped to this server rather than to Gym's core dependencies — Gym itself never imports Switchyard, and runs that do not route through it are unaffected.
 
-```bash
-pip install 'nemo-switchyard[server]'
-```
-
-Then point `routing_profiles` at your routing config and run an eval:
+Point `routing_profiles` at your routing config and run an eval:
 
 ```bash
 gym eval run \

--- a/fern/versions/latest/pages/model-server/switchyard.mdx
+++ b/fern/versions/latest/pages/model-server/switchyard.mdx
@@ -1,14 +1,27 @@
 ---
 title: "Switchyard"
-description: "Route model calls across a fleet of models with a Gym-managed Switchyard proxy"
+description: "Route model calls across a fleet of models, with a proxy Gym manages or one you run yourself"
 position: 8
 ---
 
 [Switchyard](https://github.com/NVIDIA-NeMo/Switchyard) is a routing proxy: it decides, per request, which model should carry the work. The `switchyard_model` server (in `responses_api_models/switchyard_model`) puts that decision behind a NeMo Gym model server, so any benchmark Gym already supports can be run against a router without changing the agent harness.
 
-NeMo Gym launches and manages the proxy for you, the same way [Local vLLM](/model-server/local-vllm) manages a vLLM engine. You supply a Switchyard routing profile; Gym starts the proxy when the model server starts, waits for it to become healthy, and shuts it down when the server exits.
+## Two ways to run the proxy
 
-## Use SwitchyardModel
+Both are fully supported; pick whichever fits how you work.
+
+| | Set | Gym does | Use when |
+|---|---|---|---|
+| **Gym manages it** | `routing_profiles` | Starts the proxy, health-checks it, stops it at exit | You want one command and no processes to babysit |
+| **You manage it** | `switchyard_base_url` | Points at your proxy and nothing else | You need to pin a specific Switchyard build, share one proxy across servers, or already have one running |
+
+The mode is inferred from whichever field you set — there is no separate switch. Setting neither is a startup error naming both.
+
+<Note>
+If you set both, Gym attaches to `switchyard_base_url` and logs a warning that `routing_profiles` is not being used. The routing profile is served by whatever proxy you pointed at, not by Gym.
+</Note>
+
+## Let Gym manage the proxy
 
 Launching drives the `switchyard` CLI, so install it first. It is deliberately not a dependency of NeMo Gym — this keeps Gym free of Switchyard, and lets you pin the exact Switchyard build your results are reported against.
 
@@ -56,9 +69,9 @@ For other model servers, `--model` is the model to serve. Here it is the **route
 A caller-supplied `model` in the request body is always overridden with the configured route name. Otherwise an agent that sets its own model would bypass the router, and the eval would silently measure something other than routing.
 </Note>
 
-## Attach to a proxy you run yourself
+## Manage the proxy yourself
 
-Set `switchyard_base_url` instead of `routing_profiles` and Gym will use an existing proxy rather than starting one:
+Start Switchyard however you normally would, then set `switchyard_base_url` instead of `routing_profiles`. Gym will use that proxy and never start one of its own — it does not need the `switchyard` CLI installed in this mode, and does not care how the proxy got there (a local process, a container, a shared service on another host).
 
 ```bash
 switchyard --routing-profiles routes.yaml -- serve --port 4000
@@ -70,10 +83,12 @@ gym eval run \
     ++policy_model.responses_api_models.switchyard_model.switchyard_base_url=http://127.0.0.1:4000/v1
 ```
 
-The mode is inferred from whichever of the two you set; configuring neither is a startup error. Two reasons to attach:
+`switchyard_base_url` can also come from the `SWITCHYARD_BASE_URL` environment variable, and `switchyard_api_key` from `SWITCHYARD_API_KEY`.
+
+Two reasons to prefer this mode:
 
 - **Pinning.** Running the proxy yourself lets an eval target a specific Switchyard build, so a Gym run can be compared against another harness's run of the same commit.
-- **Shared state.** Routing strategies that use session or agent affinity are stateful. If several model servers each launch their own proxy, calls that belong together can land on different instances, and routing will not behave the way a single deployed proxy does. One attached proxy shared by all of them avoids this. Stateless strategies — task classification, for example — are unaffected.
+- **Shared state.** Routing strategies that use session or agent affinity are stateful. If several model servers each launch their own proxy, calls that belong together can land on different instances, and routing will not behave the way a single deployed proxy does. One proxy shared by all of them avoids this. Stateless strategies — task classification, for example — are unaffected.
 
 ## Correlating routing decisions with rollouts
 

--- a/fern/versions/latest/pages/model-server/switchyard.mdx
+++ b/fern/versions/latest/pages/model-server/switchyard.mdx
@@ -26,7 +26,7 @@ If you set both, Gym attaches to `switchyard_base_url` and logs a warning that `
 Nothing to install. Switchyard is a dependency of this model server, so NeMo Gym installs it into the server's virtual environment when the server starts. It is scoped to this server rather than to Gym's core dependencies — Gym itself never imports Switchyard, and runs that do not route through it are unaffected.
 
 <Note>
-While `nemo-switchyard` is pinned to a git commit rather than a release, installing it compiles Switchyard's Rust extension instead of using its published wheels. You do not need a Rust toolchain — maturin bootstraps one if the machine has none — but the first startup spends an extra minute or two building, and the build reaches `static.rust-lang.org` and `crates.io` in addition to PyPI and GitHub. Allow those two hosts if your egress is restricted. Neither applies to the self-managed mode below, which installs nothing.
+While `nemo-switchyard` is pinned to a git commit rather than a release, installing it compiles Switchyard's Rust extension instead of using its published wheels. You do not need a Rust toolchain — maturin bootstraps one if the machine has none — but the first startup spends an extra minute or two building, and the build reaches `static.rust-lang.org` and `crates.io` in addition to PyPI and GitHub. Allow those two hosts if your egress is restricted. This applies in both modes — the dependency is unconditional, so the environment is built the same way even when you attach to a proxy you run yourself, where the CLI simply goes unused. It goes away once the pin moves to a released wheel.
 </Note>
 
 Point `routing_profiles` at your routing config and run an eval:

--- a/fern/versions/latest/pages/model-server/switchyard.mdx
+++ b/fern/versions/latest/pages/model-server/switchyard.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Switchyard"
 description: "Route model calls across a fleet of models, with a proxy Gym hosts or one you run yourself"
-position: 8
+position: 9
 ---
 
 [Switchyard](https://github.com/NVIDIA-NeMo/Switchyard) is a routing proxy: it decides, per request, which model should carry the work. The `switchyard_model` server (in `responses_api_models/switchyard_model`) puts that decision behind a NeMo Gym model server, so any benchmark Gym already supports can be run against a router without changing the agent harness.
@@ -65,7 +65,7 @@ A caller-supplied `model` in the request body is always overridden with the conf
 
 ## Manage the proxy yourself
 
-Start Switchyard however you normally would — the standalone `switchyard-server` binary, a container, a shared service on another host — then set `switchyard_base_url` instead of `deployment`. Gym will use that proxy and never start one of its own.
+Start Switchyard however you normally would — the standalone `switchyard-server` binary (built from the [Switchyard repo](https://github.com/NVIDIA-NeMo/Switchyard) with `cargo build --release`; it is not part of the `nemo-switchyard` wheel), a container, a shared service on another host — then set `switchyard_base_url` instead of `deployment`. Gym will use that proxy and never start one of its own.
 
 ```bash
 switchyard-server --config routes.toml --port 4000

--- a/fern/versions/latest/pages/model-server/switchyard.mdx
+++ b/fern/versions/latest/pages/model-server/switchyard.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Switchyard"
-description: "Route model calls across a fleet of models, with a proxy Gym manages or one you run yourself"
+description: "Route model calls across a fleet of models, with a proxy Gym hosts or one you run yourself"
 position: 8
 ---
 
@@ -12,31 +12,27 @@ Both are fully supported; pick whichever fits how you work.
 
 | | Set | Gym does | Use when |
 |---|---|---|---|
-| **Gym manages it** | `routing_profiles` | Installs Switchyard, starts the proxy, health-checks it, stops it at exit | You want one command and nothing to install or babysit |
+| **Gym hosts it** | `deployment` | Installs Switchyard and hosts its native server in-process, stopping it at exit | You want one command and nothing to install or babysit |
 | **You manage it** | `switchyard_base_url` | Points at your proxy and nothing else | You need to pin a specific Switchyard build, share one proxy across servers, or already have one running |
 
 The mode is inferred from whichever field you set — there is no separate switch. Setting neither is a startup error naming both.
 
 <Note>
-If you set both, Gym attaches to `switchyard_base_url` and logs a warning that `routing_profiles` is not being used. The routing profile is served by whatever proxy you pointed at, not by Gym.
+If you set both, Gym attaches to `switchyard_base_url` and logs a warning that `deployment` is not being used. The deployment is served by whatever proxy you pointed at, not by Gym.
 </Note>
 
-## Let Gym manage the proxy
+## Let Gym host the proxy
 
-Nothing to install. Switchyard is a dependency of this model server, so NeMo Gym installs it into the server's virtual environment when the server starts. It is scoped to this server rather than to Gym's core dependencies — Gym itself never imports Switchyard, and runs that do not route through it are unaffected.
+Nothing to install. Switchyard is a dependency of this model server, so NeMo Gym installs its published wheel into the server's virtual environment when the server starts. It is scoped to this server rather than to Gym's core dependencies — Gym itself never imports Switchyard on Gym's side of the boundary, and runs that do not route through it are unaffected.
 
-<Note>
-While `nemo-switchyard` is pinned to a git commit rather than a release, installing it compiles Switchyard's Rust extension instead of using its published wheels. You do not need a Rust toolchain — maturin bootstraps one if the machine has none — but the first startup spends an extra minute or two building, and the build reaches `static.rust-lang.org` and `crates.io` in addition to PyPI and GitHub. Allow those two hosts if your egress is restricted. This applies in both modes — the dependency is unconditional, so the environment is built the same way even when you attach to a proxy you run yourself, where the CLI simply goes unused. It goes away once the pin moves to a released wheel.
-</Note>
-
-Point `routing_profiles` at your routing config and run an eval:
+Point `deployment` at a native Switchyard TOML deployment — the `llm_clients`, `targets`, and `routes` the proxy serves — and run an eval:
 
 ```bash
 gym eval run \
     --benchmark <name> \
     --model-type switchyard_model \
     --model <route-name> \
-    ++policy_model.responses_api_models.switchyard_model.routing_profiles=/abs/path/routes.yaml
+    ++policy_model.responses_api_models.switchyard_model.deployment=/abs/path/routes.toml
 ```
 
 Or start a persistent environment:
@@ -46,24 +42,22 @@ gym env start \
     --resources-server example_single_tool_call \
     --model-type switchyard_model \
     --model <route-name> \
-    ++policy_model.responses_api_models.switchyard_model.routing_profiles=/abs/path/routes.yaml
+    ++policy_model.responses_api_models.switchyard_model.deployment=/abs/path/routes.toml
 ```
 
-`routing_profiles` can also come from the `SWITCHYARD_ROUTING_PROFILES` environment variable, in which case the override can be dropped.
+`deployment` can also come from the `SWITCHYARD_DEPLOYMENT` environment variable, in which case the override can be dropped.
 
 <Warning>
-Use an absolute path for `routing_profiles`. The proxy runs as a subprocess and relative paths are not resolved against the config file's location.
+Use an absolute path for `deployment`. The path is opened by the server process and relative paths are not resolved against the config file's location.
 </Warning>
 
-Under the hood, Gym runs the following on a free port that does not collide with its own servers, polls `/health` until the proxy answers, and points the model server at `http://127.0.0.1:<port>/v1`:
+Under the hood, Gym hosts Switchyard's native Rust server inside the model-server process (`switchyard_rust.server.Server`) on a free loopback port that does not collide with Gym's own servers, and points its client at `http://127.0.0.1:<port>/v1`. The deployment is loaded and validated when the server starts, so a bad routing config fails immediately with Switchyard's validation error rather than as a timeout mid-run. Because the proxy lives in the server's process, it also cannot outlive it — there is no subprocess to leak or reap.
 
-```bash
-switchyard --routing-profiles /abs/path/routes.yaml -- serve --host 0.0.0.0 --port <auto>
-```
+The deployment file is the routing condition the eval runs under — an explicit, diffable artifact. Comparing routing conditions means running the same benchmark with two deployment files and comparing the results.
 
 ## `--model` names a route, not a model
 
-For other model servers, `--model` is the model to serve. Here it is the **route name** Switchyard resolves — it must match a route in your routing profile. Which concrete model actually served a call is Switchyard's decision, made per request, and comes back on the response.
+For other model servers, `--model` is the model to serve. Here it is the **route name** Switchyard resolves — it must match a route in your deployment. Which concrete model actually served a call is Switchyard's decision, made per request, and comes back on the response.
 
 <Note>
 A caller-supplied `model` in the request body is always overridden with the configured route name. Otherwise an agent that sets its own model would bypass the router, and the eval would silently measure something other than routing.
@@ -71,10 +65,10 @@ A caller-supplied `model` in the request body is always overridden with the conf
 
 ## Manage the proxy yourself
 
-Start Switchyard however you normally would, then set `switchyard_base_url` instead of `routing_profiles`. Gym will use that proxy and never start one of its own — it does not need the `switchyard` CLI installed in this mode, and does not care how the proxy got there (a local process, a container, a shared service on another host).
+Start Switchyard however you normally would — the standalone `switchyard-server` binary, a container, a shared service on another host — then set `switchyard_base_url` instead of `deployment`. Gym will use that proxy and never start one of its own.
 
 ```bash
-switchyard --routing-profiles routes.yaml -- serve --port 4000
+switchyard-server --config routes.toml --port 4000
 
 gym eval run \
     --benchmark <name> \
@@ -88,11 +82,13 @@ gym eval run \
 Two reasons to prefer this mode:
 
 - **Pinning.** Running the proxy yourself lets an eval target a specific Switchyard build, so a Gym run can be compared against another harness's run of the same commit.
-- **Shared state.** Routing strategies that use session or agent affinity are stateful. If several model servers each launch their own proxy, calls that belong together can land on different instances, and routing will not behave the way a single deployed proxy does. One proxy shared by all of them avoids this. Stateless strategies — task classification, for example — are unaffected.
+- **Shared state.** Routing strategies that use session or agent affinity are stateful. If several model servers each host their own proxy, calls that belong together can land on different instances, and routing will not behave the way a single deployed proxy does. One proxy shared by all of them avoids this. Stateless strategies — task classification, for example — are unaffected. A hosted proxy also binds loopback only, so anything that must reach the proxy from another machine needs this mode.
 
 ## Correlating routing decisions with rollouts
 
 Gym sends its rollout-attempt id to Switchyard as an opaque session id, using the `proxy_x_session_id` header. That lets proxy-side records — which model was chosen, what it cost — be joined back to the rollout that produced them. Set `forward_session_id: false` to disable it, or `session_id_header` to change the header name.
+
+On the Switchyard side, aggregate routing statistics are on `/v1/stats`, and with a durable routing log enabled in the deployment, per-session decisions are on `/v1/routing/session-stats` — queryable by the rollout-attempt ids Gym sent.
 
 To see which model served each call from Gym's side, enable [model-call capture](/model-server/model-call-capture). Each captured exchange records the response, so the routed model is visible per call.
 
@@ -104,14 +100,11 @@ Read routing attribution from the capture records, not from the rollout response
 
 | Field | Default | Purpose |
 |---|---|---|
-| `routing_profiles` | `null` | Switchyard routing config. Gym launches a proxy when this is set. |
-| `switchyard_base_url` | `null` | Attach to an existing proxy instead of launching one. |
+| `deployment` | `null` | Native Switchyard TOML deployment. Gym hosts a proxy when this is set. |
+| `switchyard_base_url` | `null` | Attach to an existing proxy instead of hosting one. |
 | `switchyard_model` | `${policy_model_name}` | Route name to request. |
 | `switchyard_api_key` | `dummy` | Sent as the bearer token to the proxy. |
-| `proxy_host` | `0.0.0.0` | Bind address for a launched proxy. Gym reaches its own child over loopback. |
-| `proxy_port` | `null` | Fixed port. `null` picks a free one. |
-| `proxy_startup_timeout_s` | `120.0` | How long to wait for `/health` before failing. |
-| `switchyard_executable` | `switchyard` | CLI to launch. |
+| `proxy_port` | `null` | Fixed loopback port for the hosted proxy. `null` picks a free one. |
 | `session_id_header` | `proxy_x_session_id` | Header carrying the rollout id. |
 | `forward_session_id` | `true` | Whether to send it at all. |
 | `extra_body` | `{}` | Merged into every upstream request body. |

--- a/fern/versions/latest/pages/model-server/switchyard.mdx
+++ b/fern/versions/latest/pages/model-server/switchyard.mdx
@@ -33,7 +33,7 @@ schema_version = 1
 [llm_clients.nvidia]
 format = "openai_chat"
 base_url = "https://integrate.api.nvidia.com/v1"
-api_key_env = "NVIDIA_API_KEY"
+api_key_env = "NVIDIA_API_KEY" # pragma: allowlist secret
 
 [targets.strong]
 id = "meta/llama-3.3-70b-instruct"
@@ -85,6 +85,8 @@ gym env start \
 Use an absolute path for `deployment`. The path is opened by the server process and relative paths are not resolved against the config file's location.
 </Warning>
 
+Hosted mode is single-process by design: `num_workers` greater than 1 is rejected at startup, because each worker process would host its own proxy — splitting session affinity and statistics, and colliding on a fixed `proxy_port`. To parallelize workers, run one proxy yourself and attach every worker to it.
+
 Under the hood, Gym hosts Switchyard's native Rust server inside the model-server process (`switchyard_rust.server.Server`) on a free loopback port that does not collide with Gym's own servers, and points its client at `http://127.0.0.1:<port>/v1`. The deployment is loaded and validated when the server starts, so a bad routing config fails immediately with Switchyard's validation error rather than as a timeout mid-run. Because the proxy lives in the server's process, it also cannot outlive it — there is no subprocess to leak or reap.
 
 The deployment file plus the selected route is the routing condition the eval runs under — an explicit, diffable artifact. Comparing routing conditions means running the same benchmark per condition and comparing the results: either two routes from one deployment file (as in the example above) or two deployment files.
@@ -122,6 +124,10 @@ Two reasons to prefer this mode:
 
 Gym sends its rollout-attempt id to Switchyard as an opaque session id, using the `x-switchyard-session-id` header — the name the native server parses into its routing metadata, where it reaches request logs, OpenTelemetry spans, and session-affinity routing. Set `forward_session_id: false` to disable it, or `session_id_headers` to change the names sent.
 
+<Warning>
+The rollout id reaches this server on the `/ng-rollout/<id>/` URL prefix, which agents add only when [model-call capture](/model-server/model-call-capture) (`++observability_enabled=true` with a capture directory) or training-token capture is enabled. Without one of those, there is nothing to forward and Switchyard sees no session. The server checks this at startup: it warns when `forward_session_id` is on by default, and refuses to start when you set it explicitly.
+</Warning>
+
 On the Switchyard side, aggregate routing statistics are on `/v1/stats`. Per-session decision snapshots on `/v1/routing/session-stats` require a durable routing log, which at Switchyard 0.2.0 only the standalone binary can enable — run `switchyard-server --routing-log-file <path>`, attach with `switchyard_base_url`, and add `proxy_x_session_id` to `session_id_headers`, the name that log keys sessions on. Add header names knowingly: Switchyard forwards headers it does not recognize (and, at 0.2.0, the session header itself) through to the upstream provider.
 
 To see which model served each call from Gym's side, enable [model-call capture](/model-server/model-call-capture). Each captured exchange records the response, so the routed model is visible per call.
@@ -150,24 +156,43 @@ gym eval run --benchmark <name> --model-type switchyard_model \
     ++policy_model.responses_api_models.switchyard_model.condition_dir=results/policy-model
 ```
 
-Each results directory now identifies its condition. `switchyard-condition.json` is the provenance manifest — the route, the deployment's SHA-256 and archived contents (credential values redacted), and the `nemo-switchyard` version — written when the proxy starts. `switchyard-stats.json` is the proxy's `/v1/stats` at shutdown: per-target requests, tokens, retries, and latency, which for a hosted proxy would otherwise die with the process. Two runs are fairly comparable when their manifests differ only in `route`; a run is reproducible from the archived deployment alone.
+Each results directory now identifies its condition. `switchyard-condition.json` is the provenance manifest — the route, the deployment's SHA-256 and archived contents (inline `api_key` and all `extra_headers` values redacted), and the `nemo-switchyard` version — written when the proxy starts. `switchyard-stats.json` wraps the proxy's `/v1/stats` at shutdown: per-target requests, errors, tokens, and latency, plus the classifier-side usage of LLM-classifier routes, which for a hosted proxy would otherwise die with the process. Two runs are fairly comparable when their manifests differ only in `route`; a hosted run is reproducible from the archived deployment alone.
 
-Scores and token cost come straight from the rollout rows:
+Comparing scores and cost means aligning the two runs' rollout rows first — a rollout that failed in one condition must not be counted in the other — and remembering that a routed call can cost more than its selected model: an `llm_classifier` route also spends classifier tokens, which appear in the stats snapshot rather than the rollout's own usage. Rollout rows carry `_ng_task_index` and `_ng_rollout_index` for exactly this kind of join:
 
 ```bash
 python3 - <<'EOF'
 import json
 
-for condition in ("strong-only", "policy-model"):
-    rows = [json.loads(line) for line in open(f"results/{condition}/rollouts.jsonl")]
-    rewards = [row["reward"] for row in rows]
-    tokens = [row["response"]["usage"]["total_tokens"] for row in rows]
-    print(f"{condition}: mean reward {sum(rewards)/len(rewards):.3f}, total tokens {sum(tokens)}")
+def rollouts(condition):
+    with open(f"results/{condition}/rollouts.jsonl") as lines:
+        rows = [json.loads(line) for line in lines]
+    return {(row["_ng_task_index"], row["_ng_rollout_index"]): row for row in rows}
+
+conditions = {name: rollouts(name) for name in ("strong-only", "policy-model")}
+shared = set.intersection(*(set(rows) for rows in conditions.values()))
+for name, rows in conditions.items():
+    if len(rows) != len(shared):
+        print(f"{name}: {len(rows) - len(shared)} rollouts have no counterpart; comparing the {len(shared)} shared")
+
+for name, rows in conditions.items():
+    rewards = [rows[key]["reward"] for key in shared]
+    selected_tokens = sum(rows[key]["response"]["usage"]["total_tokens"] for key in shared)
+    stats = json.load(open(f"results/{name}/switchyard-stats.json"))["stats"]
+    classifier_tokens = stats["classifier"]["total_tokens"]["total"]
+    print(
+        f"{name}: mean reward {sum(rewards) / len(rewards):.3f}, "
+        f"selected-model tokens {selected_tokens}, classifier tokens {classifier_tokens}"
+    )
 EOF
 ```
 
+<Note>
+The stats snapshot counts from the proxy's start, not the run's — its `scope` field says which you have. A hosted proxy lives for exactly one run, so its counters (including the classifier tokens above) are run-scoped. An attached proxy's counters aggregate every run and neighbor it has served; for run-level accounting in attach mode, give the run its own proxy.
+</Note>
+
 <Tip>
-Routing strategies with session affinity are stateful — compare them through one shared proxy (attach mode) rather than per-replica hosted proxies, so calls that belong together route together. The stats snapshot works in attach mode too.
+Routing strategies with session affinity are stateful — compare them through one shared proxy (attach mode) rather than per-replica hosted proxies, so calls that belong together route together. The stats snapshot works in attach mode too. An attached proxy is a build Gym cannot identify, so the manifest's `nemo_switchyard_version` is null there — record the build yourself via `proxy_provenance`, e.g. `++policy_model.responses_api_models.switchyard_model.proxy_provenance.switchyard_commit=<sha>`.
 </Tip>
 
 ## Configuration reference
@@ -182,6 +207,7 @@ Routing strategies with session affinity are stateful — compare them through o
 | `session_id_headers` | `[x-switchyard-session-id]` | Header names carrying the rollout id. |
 | `forward_session_id` | `true` | Whether to send it at all. |
 | `condition_dir` | `null` | Directory receiving the condition manifest (startup) and `/v1/stats` snapshot (shutdown). One per run. |
+| `proxy_provenance` | `{}` | Caller-supplied identity of an attached proxy (build commit, deployment hash), copied into the manifest. |
 | `extra_body` | `{}` | Merged into every upstream request body. |
 | `default_headers` | `{}` | Sent on every upstream request. |
 | `max_concurrent_requests` | `null` | Cap on in-flight upstream requests. `null` is unlimited. |

--- a/fern/versions/latest/pages/model-server/switchyard.mdx
+++ b/fern/versions/latest/pages/model-server/switchyard.mdx
@@ -130,6 +130,46 @@ To see which model served each call from Gym's side, enable [model-call capture]
 Read routing attribution from the capture records, not from the rollout response. Some agent harnesses overwrite the top-level response `model` with the configured policy model name, which would report the route name for every call regardless of what actually served it.
 </Warning>
 
+## Compare routing conditions
+
+A routing condition is a deployment file plus a selected route. To measure what routing does to a benchmark, run it once per condition and compare — the example deployment above defines two conditions ready for exactly that: `strong-only` (a fixed baseline) and `policy-model` (the strong/weak router).
+
+Run each condition with its own output file and `condition_dir`:
+
+```bash
+gym eval run --benchmark <name> --model-type switchyard_model \
+    --model strong-only \
+    -o results/strong-only/rollouts.jsonl \
+    ++policy_model.responses_api_models.switchyard_model.deployment=/abs/path/routes.toml \
+    ++policy_model.responses_api_models.switchyard_model.condition_dir=results/strong-only
+
+gym eval run --benchmark <name> --model-type switchyard_model \
+    --model policy-model \
+    -o results/policy-model/rollouts.jsonl \
+    ++policy_model.responses_api_models.switchyard_model.deployment=/abs/path/routes.toml \
+    ++policy_model.responses_api_models.switchyard_model.condition_dir=results/policy-model
+```
+
+Each results directory now identifies its condition. `switchyard-condition.json` is the provenance manifest — the route, the deployment's SHA-256 and archived contents (credential values redacted), and the `nemo-switchyard` version — written when the proxy starts. `switchyard-stats.json` is the proxy's `/v1/stats` at shutdown: per-target requests, tokens, retries, and latency, which for a hosted proxy would otherwise die with the process. Two runs are fairly comparable when their manifests differ only in `route`; a run is reproducible from the archived deployment alone.
+
+Scores and token cost come straight from the rollout rows:
+
+```bash
+python3 - <<'EOF'
+import json
+
+for condition in ("strong-only", "policy-model"):
+    rows = [json.loads(line) for line in open(f"results/{condition}/rollouts.jsonl")]
+    rewards = [row["reward"] for row in rows]
+    tokens = [row["response"]["usage"]["total_tokens"] for row in rows]
+    print(f"{condition}: mean reward {sum(rewards)/len(rewards):.3f}, total tokens {sum(tokens)}")
+EOF
+```
+
+<Tip>
+Routing strategies with session affinity are stateful — compare them through one shared proxy (attach mode) rather than per-replica hosted proxies, so calls that belong together route together. The stats snapshot works in attach mode too.
+</Tip>
+
 ## Configuration reference
 
 | Field | Default | Purpose |
@@ -141,6 +181,7 @@ Read routing attribution from the capture records, not from the rollout response
 | `proxy_port` | `null` | Fixed loopback port for the hosted proxy. `null` picks a free one. |
 | `session_id_headers` | `[x-switchyard-session-id]` | Header names carrying the rollout id. |
 | `forward_session_id` | `true` | Whether to send it at all. |
+| `condition_dir` | `null` | Directory receiving the condition manifest (startup) and `/v1/stats` snapshot (shutdown). One per run. |
 | `extra_body` | `{}` | Merged into every upstream request body. |
 | `default_headers` | `{}` | Sent on every upstream request. |
 | `max_concurrent_requests` | `null` | Cap on in-flight upstream requests. `null` is unlimited. |

--- a/fern/versions/latest/pages/model-server/switchyard.mdx
+++ b/fern/versions/latest/pages/model-server/switchyard.mdx
@@ -25,7 +25,41 @@ If you set both, Gym attaches to `switchyard_base_url` and logs a warning that `
 
 Nothing to install. Switchyard is a dependency of this model server, so NeMo Gym installs its published wheel into the server's virtual environment when the server starts. It is scoped to this server rather than to Gym's core dependencies — Gym itself never imports Switchyard on Gym's side of the boundary, and runs that do not route through it are unaffected.
 
-Point `deployment` at a native Switchyard TOML deployment — the `llm_clients`, `targets`, and `routes` the proxy serves — and run an eval:
+A deployment is a TOML file declaring the `llm_clients`, `targets`, and `routes` the proxy serves. A minimal one with a fixed baseline route and a strong/weak classifier route looks like this (see the [Switchyard documentation](https://github.com/NVIDIA-NeMo/Switchyard/tree/main/docs) for the full schema and the other routing algorithms):
+
+```toml
+schema_version = 1
+
+[llm_clients.nvidia]
+format = "openai_chat"
+base_url = "https://integrate.api.nvidia.com/v1"
+api_key_env = "NVIDIA_API_KEY"
+
+[targets.strong]
+id = "meta/llama-3.3-70b-instruct"
+llm_client = "nvidia"
+
+[targets.weak]
+id = "meta/llama-3.1-8b-instruct"
+llm_client = "nvidia"
+
+[routes.strong-only]
+id = "strong-only"
+type = "passthrough"
+target = "strong"
+
+[routes.policy-model]
+id = "policy-model"
+type = "llm_classifier"
+classifier_target = "weak"
+strong_target = "strong"
+weak_target = "weak"
+base_threshold = 0.5
+```
+
+Each route is a routing condition an eval can run under, and `--model` selects one — so running the same benchmark twice, once with `--model strong-only` and once with `--model policy-model`, compares the fixed baseline against the router on identical tasks.
+
+Point `deployment` at your TOML file and run an eval:
 
 ```bash
 gym eval run \
@@ -53,7 +87,7 @@ Use an absolute path for `deployment`. The path is opened by the server process 
 
 Under the hood, Gym hosts Switchyard's native Rust server inside the model-server process (`switchyard_rust.server.Server`) on a free loopback port that does not collide with Gym's own servers, and points its client at `http://127.0.0.1:<port>/v1`. The deployment is loaded and validated when the server starts, so a bad routing config fails immediately with Switchyard's validation error rather than as a timeout mid-run. Because the proxy lives in the server's process, it also cannot outlive it — there is no subprocess to leak or reap.
 
-The deployment file is the routing condition the eval runs under — an explicit, diffable artifact. Comparing routing conditions means running the same benchmark with two deployment files and comparing the results.
+The deployment file plus the selected route is the routing condition the eval runs under — an explicit, diffable artifact. Comparing routing conditions means running the same benchmark per condition and comparing the results: either two routes from one deployment file (as in the example above) or two deployment files.
 
 ## `--model` names a route, not a model
 

--- a/fern/versions/latest/pages/model-server/switchyard.mdx
+++ b/fern/versions/latest/pages/model-server/switchyard.mdx
@@ -86,9 +86,9 @@ Two reasons to prefer this mode:
 
 ## Correlating routing decisions with rollouts
 
-Gym sends its rollout-attempt id to Switchyard as an opaque session id, using the `proxy_x_session_id` header. That lets proxy-side records — which model was chosen, what it cost — be joined back to the rollout that produced them. Set `forward_session_id: false` to disable it, or `session_id_header` to change the header name.
+Gym sends its rollout-attempt id to Switchyard as an opaque session id, using the `x-switchyard-session-id` header — the name the native server parses into its routing metadata, where it reaches request logs, OpenTelemetry spans, and session-affinity routing. Set `forward_session_id: false` to disable it, or `session_id_headers` to change the names sent.
 
-On the Switchyard side, aggregate routing statistics are on `/v1/stats`, and with a durable routing log enabled in the deployment, per-session decisions are on `/v1/routing/session-stats` — queryable by the rollout-attempt ids Gym sent.
+On the Switchyard side, aggregate routing statistics are on `/v1/stats`. Per-session decision snapshots on `/v1/routing/session-stats` require a durable routing log, which at Switchyard 0.2.0 only the standalone binary can enable — run `switchyard-server --routing-log-file <path>`, attach with `switchyard_base_url`, and add `proxy_x_session_id` to `session_id_headers`, the name that log keys sessions on. Add header names knowingly: Switchyard forwards headers it does not recognize (and, at 0.2.0, the session header itself) through to the upstream provider.
 
 To see which model served each call from Gym's side, enable [model-call capture](/model-server/model-call-capture). Each captured exchange records the response, so the routed model is visible per call.
 
@@ -105,7 +105,7 @@ Read routing attribution from the capture records, not from the rollout response
 | `switchyard_model` | `${policy_model_name}` | Route name to request. |
 | `switchyard_api_key` | `dummy` | Sent as the bearer token to the proxy. |
 | `proxy_port` | `null` | Fixed loopback port for the hosted proxy. `null` picks a free one. |
-| `session_id_header` | `proxy_x_session_id` | Header carrying the rollout id. |
+| `session_id_headers` | `[x-switchyard-session-id]` | Header names carrying the rollout id. |
 | `forward_session_id` | `true` | Whether to send it at all. |
 | `extra_body` | `{}` | Merged into every upstream request body. |
 | `default_headers` | `{}` | Sent on every upstream request. |

--- a/responses_api_models/switchyard_model/README.md
+++ b/responses_api_models/switchyard_model/README.md
@@ -21,6 +21,18 @@ gym eval run --benchmark <name> --model-type switchyard_model \
   ++policy_model.responses_api_models.switchyard_model.routing_profiles=/path/to/routes.yaml
 ```
 
+### The first startup builds Switchyard from source
+
+While `nemo-switchyard` is pinned to a git commit rather than a release, installing it compiles
+Switchyard's Rust extension instead of using its published wheels. This needs no setup on your
+part — maturin bootstraps a Rust toolchain if the machine has none — but it does mean the first
+`gym env start` for this server spends an extra minute or two building, and that the build reaches
+`static.rust-lang.org` and `crates.io` on top of PyPI and GitHub. Behind a restrictive egress
+policy those two hosts are the ones to allow.
+
+Neither applies once the pin moves to a released wheel, and neither applies to the self-managed
+mode below, which installs nothing.
+
 **Attaching instead.** Set `switchyard_base_url` to use a proxy you already run — worth doing when
 an eval needs to pin a specific Switchyard build, or when several servers should share one
 instance (routing strategies that use session or agent affinity are stateful, so replicas each

--- a/responses_api_models/switchyard_model/README.md
+++ b/responses_api_models/switchyard_model/README.md
@@ -23,9 +23,12 @@ gym eval run --benchmark <name> --model-type switchyard_model \
   ++policy_model.responses_api_models.switchyard_model.switchyard_base_url=http://127.0.0.1:4000/v1
 ```
 
-**Launch.** Gym starts the proxy itself and shuts it down at exit, for a single-command run.
+**Launch.** Gym starts the proxy itself and shuts it down at exit, for a single-command run. This
+drives the `switchyard` CLI, so the executable has to be on PATH:
 
 ```bash
+pip install 'nemo-switchyard[server]'
+
 gym eval run --benchmark <name> --model-type switchyard_model \
   ++policy_model.responses_api_models.switchyard_model.launch_proxy=true \
   ++policy_model.responses_api_models.switchyard_model.routing_profiles=/path/to/routes.yaml
@@ -44,9 +47,12 @@ attribution should be read from the model-call capture records rather than the r
 
 ## Dependency direction
 
-Gym knows Switchyard; Switchyard does not know Gym. The `nemo-switchyard` dependency is scoped to
-this package rather than Gym's core dependencies, so only runs that route through Switchyard pay
-for it. Attach mode needs no dependency at all — the proxy is a plain OpenAI-compatible endpoint.
+Gym knows Switchyard; Switchyard does not know Gym.
+
+This server takes no dependency on `nemo-switchyard` and never imports it — it speaks
+OpenAI-compatible HTTP to the proxy, and launch mode drives the CLI. Installing Switchyard is left
+to whoever wants launch mode, which also lets an eval pin the exact Switchyard build its numbers
+are reported against rather than inheriting Gym's.
 
 # Licensing information
 Code: Apache 2.0
@@ -54,4 +60,6 @@ Data: N/A
 
 Dependencies
 - nemo_gym: Apache 2.0
+
+Optional, installed separately for `launch_proxy` mode
 - nemo-switchyard: Apache 2.0

--- a/responses_api_models/switchyard_model/README.md
+++ b/responses_api_models/switchyard_model/README.md
@@ -13,11 +13,10 @@ gym eval run --benchmark <name> --model-type switchyard_model
 ## Gym runs the proxy for you
 
 Point `routing_profiles` at your Switchyard routing config; the proxy is started with this server
-and stopped when it exits. You never manage it.
+and stopped when it exits. You never install or manage it — `nemo-switchyard` is a dependency of
+this server, so Gym installs it into the server's virtual environment on startup.
 
 ```bash
-pip install 'nemo-switchyard[server]'   # launching drives the `switchyard` CLI
-
 gym eval run --benchmark <name> --model-type switchyard_model \
   ++policy_model.responses_api_models.switchyard_model.routing_profiles=/path/to/routes.yaml
 ```
@@ -49,10 +48,13 @@ attribution should be read from the model-call capture records rather than the r
 
 Gym knows Switchyard; Switchyard does not know Gym.
 
-This server takes no dependency on `nemo-switchyard` and never imports it — it speaks
-OpenAI-compatible HTTP to the proxy, and launch mode drives the CLI. Installing Switchyard is left
-to whoever wants launch mode, which also lets an eval pin the exact Switchyard build its numbers
-are reported against rather than inheriting Gym's.
+`nemo-switchyard` is a dependency of this server only, not of Gym's core — so only runs that route
+through Switchyard pay for it. No Gym code imports Switchyard; this server speaks
+OpenAI-compatible HTTP to the proxy and drives the CLI to launch one.
+
+The dependency is pinned to `==0.1.0` with a `[tool.uv] override-dependencies` entry relaxing that
+release's stale `openai>=2.34.0` floor. See the comments in `pyproject.toml` — both should be
+removed once a Switchyard release carrying the widened floor ships.
 
 # Licensing information
 Code: Apache 2.0
@@ -60,6 +62,4 @@ Data: N/A
 
 Dependencies
 - nemo_gym: Apache 2.0
-
-Optional, installed separately for `launch_proxy` mode
 - nemo-switchyard: Apache 2.0

--- a/responses_api_models/switchyard_model/README.md
+++ b/responses_api_models/switchyard_model/README.md
@@ -30,8 +30,9 @@ part — maturin bootstraps a Rust toolchain if the machine has none — but it 
 `static.rust-lang.org` and `crates.io` on top of PyPI and GitHub. Behind a restrictive egress
 policy those two hosts are the ones to allow.
 
-Neither applies once the pin moves to a released wheel, and neither applies to the self-managed
-mode below, which installs nothing.
+Both apply in either mode. The dependency is unconditional, so this server's environment is built
+the same way whether or not you end up launching a proxy — attaching to your own proxy means the
+CLI goes unused, not uninstalled. Both go away once the pin moves to a released wheel.
 
 **Attaching instead.** Set `switchyard_base_url` to use a proxy you already run — worth doing when
 an eval needs to pin a specific Switchyard build, or when several servers should share one
@@ -64,9 +65,11 @@ Gym knows Switchyard; Switchyard does not know Gym.
 through Switchyard pay for it. No Gym code imports Switchyard; this server speaks
 OpenAI-compatible HTTP to the proxy and drives the CLI to launch one.
 
-The dependency is pinned to `==0.1.0` with a `[tool.uv] override-dependencies` entry relaxing that
-release's stale `openai>=2.34.0` floor. See the comments in `pyproject.toml` — both should be
-removed once a Switchyard release carrying the widened floor ships.
+The dependency is pinned to a git commit rather than a release, because published 0.1.0 cannot
+serve this server's `/v1/responses` endpoint at all — its chat→responses translation omits the
+usage detail objects the Responses schema requires, so every response fails validation. The fix is
+merged upstream but unreleased. See the comment in `pyproject.toml`; the pin should move to a
+released version as soon as one carries the fix.
 
 # Licensing information
 Code: Apache 2.0

--- a/responses_api_models/switchyard_model/README.md
+++ b/responses_api_models/switchyard_model/README.md
@@ -10,28 +10,28 @@ can be run against a router without changing harness code:
 gym eval run --benchmark <name> --model-type switchyard_model
 ```
 
-## Modes
+## Gym runs the proxy for you
 
-**Attach (default).** You run the proxy; Gym points at it. Keeping the proxy outside Gym is what
-lets an eval pin a specific Switchyard build and compare against scaled-evals runs of the same
-commit.
+Point `routing_profiles` at your Switchyard routing config; the proxy is started with this server
+and stopped when it exits. You never manage it.
+
+```bash
+pip install 'nemo-switchyard[server]'   # launching drives the `switchyard` CLI
+
+gym eval run --benchmark <name> --model-type switchyard_model \
+  ++policy_model.responses_api_models.switchyard_model.routing_profiles=/path/to/routes.yaml
+```
+
+**Attaching instead.** Set `switchyard_base_url` to use a proxy you already run — worth doing when
+an eval needs to pin a specific Switchyard build, or when several servers should share one
+instance (routing strategies that use session or agent affinity are stateful, so replicas each
+running their own proxy would not route the way a single deployed proxy does).
 
 ```bash
 switchyard --routing-profiles routes.yaml -- serve --port 4000
 
 gym eval run --benchmark <name> --model-type switchyard_model \
   ++policy_model.responses_api_models.switchyard_model.switchyard_base_url=http://127.0.0.1:4000/v1
-```
-
-**Launch.** Gym starts the proxy itself and shuts it down at exit, for a single-command run. This
-drives the `switchyard` CLI, so the executable has to be on PATH:
-
-```bash
-pip install 'nemo-switchyard[server]'
-
-gym eval run --benchmark <name> --model-type switchyard_model \
-  ++policy_model.responses_api_models.switchyard_model.launch_proxy=true \
-  ++policy_model.responses_api_models.switchyard_model.routing_profiles=/path/to/routes.yaml
 ```
 
 ## Rollout correlation

--- a/responses_api_models/switchyard_model/README.md
+++ b/responses_api_models/switchyard_model/README.md
@@ -1,0 +1,57 @@
+# Description
+
+Serves Gym model calls through a [Switchyard](https://github.com/NVIDIA-NeMo/Switchyard) routing
+proxy. Switchyard decides, per request, which upstream model should carry the work.
+
+Because this is a model server rather than an agent integration, any benchmark Gym already supports
+can be run against a router without changing harness code:
+
+```bash
+gym eval run --benchmark <name> --model-type switchyard_model
+```
+
+## Modes
+
+**Attach (default).** You run the proxy; Gym points at it. Keeping the proxy outside Gym is what
+lets an eval pin a specific Switchyard build and compare against scaled-evals runs of the same
+commit.
+
+```bash
+switchyard --routing-profiles routes.yaml -- serve --port 4000
+
+gym eval run --benchmark <name> --model-type switchyard_model \
+  ++policy_model.responses_api_models.switchyard_model.switchyard_base_url=http://127.0.0.1:4000/v1
+```
+
+**Launch.** Gym starts the proxy itself and shuts it down at exit, for a single-command run.
+
+```bash
+gym eval run --benchmark <name> --model-type switchyard_model \
+  ++policy_model.responses_api_models.switchyard_model.launch_proxy=true \
+  ++policy_model.responses_api_models.switchyard_model.routing_profiles=/path/to/routes.yaml
+```
+
+## Rollout correlation
+
+Gym's rollout-attempt id is forwarded as Switchyard's session id (`proxy_x_session_id`), so
+proxy-side routing decisions and costs can be joined back to the rollout that produced them.
+
+Note that `switchyard_model` is the *route* name, not a provider model id — Switchyard maps it to a
+concrete target. Which model actually served a call comes back on the response, and is recorded per
+call when `observability_enabled` is set. Be aware that some agents overwrite the top-level
+response `model` with the configured policy model name (`harbor_agent` does), so routing
+attribution should be read from the model-call capture records rather than the rollout response.
+
+## Dependency direction
+
+Gym knows Switchyard; Switchyard does not know Gym. The `nemo-switchyard` dependency is scoped to
+this package rather than Gym's core dependencies, so only runs that route through Switchyard pay
+for it. Attach mode needs no dependency at all — the proxy is a plain OpenAI-compatible endpoint.
+
+# Licensing information
+Code: Apache 2.0
+Data: N/A
+
+Dependencies
+- nemo_gym: Apache 2.0
+- nemo-switchyard: Apache 2.0

--- a/responses_api_models/switchyard_model/README.md
+++ b/responses_api_models/switchyard_model/README.md
@@ -45,6 +45,11 @@ Gym's rollout-attempt id is forwarded as Switchyard's session id (`x-switchyard-
 proxy-side routing decisions and costs — request logs, spans, session-affinity state, and the
 aggregates on `/v1/stats` — can be joined back to the rollout that produced them.
 
+The id arrives on the `/ng-rollout/<id>/` URL prefix, which agents add only when model-call
+capture (`observability_enabled` plus a capture directory) or training-token capture is enabled.
+The server checks this at startup: it warns when `forward_session_id` is merely the default, and
+refuses to start when forwarding was requested explicitly but no capture is on.
+
 For per-session snapshots on `/v1/routing/session-stats`, run `switchyard-server` yourself with
 `--routing-log-file`, attach with `switchyard_base_url`, and add `proxy_x_session_id` to
 `session_id_headers` — the name the 0.2.0 routing log keys on. Add names knowingly: Switchyard
@@ -61,11 +66,15 @@ attribution should be read from the model-call capture records rather than the r
 
 Set `condition_dir` (one directory per run) and the server records the routing condition the run
 served under: `switchyard-condition.json` at startup — route, mode, deployment SHA-256 and
-archived contents (credential values redacted), `nemo-switchyard` version — and
-`switchyard-stats.json` at shutdown, the proxy's `/v1/stats` (per-target requests, tokens,
-retries, latency), which for a hosted proxy would otherwise die with the process. This is what
-makes two routed runs comparable and one routed run reproducible after the fact; the documented
-comparison workflow in the docs page builds on it.
+archived contents (inline `api_key` and all `extra_headers` values redacted), `nemo-switchyard`
+version when hosting — and `switchyard-stats.json` at shutdown, wrapping the proxy's `/v1/stats`
+(per-target requests, errors, tokens, latency, and classifier-side usage), which for a hosted
+proxy would otherwise die with the process. The snapshot's `scope` field says what the counters
+cover: a hosted proxy lives for exactly the run, while an attached proxy aggregates everything it
+has served. An attached proxy is also a build Gym cannot identify, so its manifest takes identity
+from the caller-supplied `proxy_provenance` mapping instead of the local wheel version. This is
+what makes two routed runs comparable and one routed run reproducible after the fact; the
+documented comparison workflow in the docs page builds on it.
 
 ## Dependency direction
 

--- a/responses_api_models/switchyard_model/README.md
+++ b/responses_api_models/switchyard_model/README.md
@@ -57,6 +57,16 @@ call when `observability_enabled` is set. Be aware that some agents overwrite th
 response `model` with the configured policy model name (`harbor_agent` does), so routing
 attribution should be read from the model-call capture records rather than the rollout response.
 
+## Routing-condition record
+
+Set `condition_dir` (one directory per run) and the server records the routing condition the run
+served under: `switchyard-condition.json` at startup — route, mode, deployment SHA-256 and
+archived contents (credential values redacted), `nemo-switchyard` version — and
+`switchyard-stats.json` at shutdown, the proxy's `/v1/stats` (per-target requests, tokens,
+retries, latency), which for a hosted proxy would otherwise die with the process. This is what
+makes two routed runs comparable and one routed run reproducible after the fact; the documented
+comparison workflow in the docs page builds on it.
+
 ## Dependency direction
 
 Gym knows Switchyard; Switchyard does not know Gym.

--- a/responses_api_models/switchyard_model/README.md
+++ b/responses_api_models/switchyard_model/README.md
@@ -10,37 +10,30 @@ can be run against a router without changing harness code:
 gym eval run --benchmark <name> --model-type switchyard_model
 ```
 
-## Gym runs the proxy for you
+## Gym hosts the proxy for you
 
-Point `routing_profiles` at your Switchyard routing config; the proxy is started with this server
-and stopped when it exits. You never install or manage it — `nemo-switchyard` is a dependency of
-this server, so Gym installs it into the server's virtual environment on startup.
+Point `deployment` at a native Switchyard TOML deployment — the `llm_clients`, `targets`, and
+`routes` the proxy serves. The proxy is Switchyard's native server, hosted inside this server's
+process: it starts with the server, binds a loopback port, and stops when the server exits. You
+never install or manage a separate process — `nemo-switchyard` is a dependency of this server, so
+Gym installs its published wheel into the server's virtual environment on startup.
 
 ```bash
 gym eval run --benchmark <name> --model-type switchyard_model \
-  ++policy_model.responses_api_models.switchyard_model.routing_profiles=/path/to/routes.yaml
+  ++policy_model.responses_api_models.switchyard_model.deployment=/path/to/routes.toml
 ```
 
-### The first startup builds Switchyard from source
-
-While `nemo-switchyard` is pinned to a git commit rather than a release, installing it compiles
-Switchyard's Rust extension instead of using its published wheels. This needs no setup on your
-part — maturin bootstraps a Rust toolchain if the machine has none — but it does mean the first
-`gym env start` for this server spends an extra minute or two building, and that the build reaches
-`static.rust-lang.org` and `crates.io` on top of PyPI and GitHub. Behind a restrictive egress
-policy those two hosts are the ones to allow.
-
-Both apply in either mode. The dependency is unconditional, so this server's environment is built
-the same way whether or not you end up launching a proxy — attaching to your own proxy means the
-CLI goes unused, not uninstalled. Both go away once the pin moves to a released wheel.
+The deployment file is the routing condition the eval runs under — an explicit, diffable artifact.
+Running the same benchmark against two deployment files is how routed runs are compared. A bad
+deployment fails at startup with Switchyard's validation error, not as a timeout mid-run.
 
 **Attaching instead.** Set `switchyard_base_url` to use a proxy you already run — worth doing when
 an eval needs to pin a specific Switchyard build, or when several servers should share one
 instance (routing strategies that use session or agent affinity are stateful, so replicas each
-running their own proxy would not route the way a single deployed proxy does).
+hosting their own proxy would not route the way a single deployed proxy does).
 
 ```bash
-switchyard --routing-profiles routes.yaml -- serve --port 4000
+switchyard-server --config routes.toml --port 4000
 
 gym eval run --benchmark <name> --model-type switchyard_model \
   ++policy_model.responses_api_models.switchyard_model.switchyard_base_url=http://127.0.0.1:4000/v1
@@ -49,7 +42,9 @@ gym eval run --benchmark <name> --model-type switchyard_model \
 ## Rollout correlation
 
 Gym's rollout-attempt id is forwarded as Switchyard's session id (`proxy_x_session_id`), so
-proxy-side routing decisions and costs can be joined back to the rollout that produced them.
+proxy-side routing decisions and costs can be joined back to the rollout that produced them. With a
+durable routing log enabled in the deployment, Switchyard exposes those decisions per session on
+`/v1/routing/session-stats`, and aggregates on `/v1/stats`.
 
 Note that `switchyard_model` is the *route* name, not a provider model id — Switchyard maps it to a
 concrete target. Which model actually served a call comes back on the response, and is recorded per
@@ -62,14 +57,13 @@ attribution should be read from the model-call capture records rather than the r
 Gym knows Switchyard; Switchyard does not know Gym.
 
 `nemo-switchyard` is a dependency of this server only, not of Gym's core — so only runs that route
-through Switchyard pay for it. No Gym code imports Switchyard; this server speaks
-OpenAI-compatible HTTP to the proxy and drives the CLI to launch one.
+through Switchyard pay for it. No Gym code imports Switchyard on Gym's side of the boundary; this
+server speaks OpenAI-compatible HTTP to the proxy and hosts the native server when asked to.
 
-The dependency is pinned to a git commit rather than a release, because published 0.1.0 cannot
-serve this server's `/v1/responses` endpoint at all — its chat→responses translation omits the
-usage detail objects the Responses schema requires, so every response fails validation. The fix is
-merged upstream but unreleased. See the comment in `pyproject.toml`; the pin should move to a
-released version as soon as one carries the fix.
+The dependency is pinned exactly (`nemo-switchyard==0.2.0`) because this server hosts the pinned
+code in-process and depends on its wire behavior — the TOML deployment schema, the session header,
+and the endpoint set are all version-coupled, and Switchyard is evolving quickly. Upgrades should
+be deliberate, tested events; see the comment in `pyproject.toml`.
 
 # Licensing information
 Code: Apache 2.0

--- a/responses_api_models/switchyard_model/README.md
+++ b/responses_api_models/switchyard_model/README.md
@@ -41,10 +41,15 @@ gym eval run --benchmark <name> --model-type switchyard_model \
 
 ## Rollout correlation
 
-Gym's rollout-attempt id is forwarded as Switchyard's session id (`proxy_x_session_id`), so
-proxy-side routing decisions and costs can be joined back to the rollout that produced them. With a
-durable routing log enabled in the deployment, Switchyard exposes those decisions per session on
-`/v1/routing/session-stats`, and aggregates on `/v1/stats`.
+Gym's rollout-attempt id is forwarded as Switchyard's session id (`x-switchyard-session-id`), so
+proxy-side routing decisions and costs — request logs, spans, session-affinity state, and the
+aggregates on `/v1/stats` — can be joined back to the rollout that produced them.
+
+For per-session snapshots on `/v1/routing/session-stats`, run `switchyard-server` yourself with
+`--routing-log-file`, attach with `switchyard_base_url`, and add `proxy_x_session_id` to
+`session_id_headers` — the name the 0.2.0 routing log keys on. Add names knowingly: Switchyard
+forwards headers it does not recognize (and, at 0.2.0, the session header itself) to the upstream
+provider.
 
 Note that `switchyard_model` is the *route* name, not a provider model id — Switchyard maps it to a
 concrete target. Which model actually served a call comes back on the response, and is recorded per

--- a/responses_api_models/switchyard_model/app.py
+++ b/responses_api_models/switchyard_model/app.py
@@ -74,7 +74,11 @@ _ROLLOUT_ID: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "switchyard_model_rollout_id", default=None
 )
 
-_ROLLOUT_PATH_RE = re.compile(rf"^/{re.escape(ROLLOUT_PATH_PREFIX)}/(?P<rollout_id>[^/]+)(?P<rest>/.*)$")
+# Charset kept in step with nemo_gym.rollout_correlation.RolloutContextMiddleware and the
+# _validate_rollout_id check on the capture path. It matters more here than it does there: this id
+# leaves the process as an HTTP header value, so anything outside the contract's alphabet is
+# dropped rather than forwarded.
+_ROLLOUT_PATH_RE = re.compile(rf"^/{re.escape(ROLLOUT_PATH_PREFIX)}/(?P<rollout_id>[A-Za-z0-9][A-Za-z0-9._-]*)/.*$")
 
 
 class _RolloutSessionMiddleware:

--- a/responses_api_models/switchyard_model/app.py
+++ b/responses_api_models/switchyard_model/app.py
@@ -29,14 +29,17 @@ and costs join back to the rollout that produced them.
 import asyncio
 import atexit
 import contextvars
+import ctypes
 import logging
 import re
 import shutil
+import signal
 import subprocess
+import sys
 import time
 import urllib.error
 import urllib.request
-from contextlib import nullcontext
+from contextlib import asynccontextmanager, nullcontext
 from typing import Any, Dict, Optional
 
 from pydantic import Field, model_validator
@@ -95,6 +98,29 @@ class _RolloutSessionMiddleware:
             await self._app(scope, receive, send)
         finally:
             _ROLLOUT_ID.reset(token)
+
+
+_PR_SET_PDEATHSIG = 1
+
+
+def _set_parent_death_signal() -> None:  # pragma: no cover - runs post-fork, in the child
+    """Ask the kernel to SIGTERM this child when its parent dies.
+
+    Gym's orchestrator stops a server with SIGINT and escalates to SIGKILL after one second, and a
+    SIGKILLed parent runs no handler -- not the shutdown event, not atexit. Without a kernel-level
+    tie the proxy survives its owner and keeps holding its port, so every eval that cycles servers
+    leaks one. prctl is Linux-only; elsewhere this is a no-op and the shutdown handler is the only
+    line of defence.
+
+    Raising here would fail the spawn, which is a worse outcome than a proxy that needs reaping, so
+    a platform without prctl is tolerated silently.
+    """
+    if sys.platform != "linux":
+        return
+    try:
+        ctypes.CDLL("libc.so.6", use_errno=True).prctl(_PR_SET_PDEATHSIG, signal.SIGTERM)
+    except (OSError, AttributeError):
+        pass
 
 
 class SwitchyardModelConfig(BaseResponsesAPIModelConfig):
@@ -195,7 +221,27 @@ class SwitchyardModel(SimpleResponsesAPIModel):
         app = super().setup_webserver()
         # Added last, so it wraps the capture middleware and still sees the correlation prefix.
         app.add_middleware(_RolloutSessionMiddleware)
+        self.setup_proxy_shutdown(app)
         return app
+
+    def setup_proxy_shutdown(self, app) -> None:
+        """Stop the proxy when the app shuts down.
+
+        The graceful half of proxy cleanup. atexit does not cover this on its own: uvicorn's
+        signal handling ends the process without running interpreter exit hooks, so a proxy
+        launched here outlived every orchestrated shutdown. See _set_parent_death_signal for the
+        other half, which covers shutdowns too abrupt for any handler to run.
+        """
+        main_app_lifespan = app.router.lifespan_context
+
+        @asynccontextmanager
+        async def lifespan_wrapper(app):
+            async with main_app_lifespan(app) as maybe_state:
+                yield maybe_state
+
+            self.stop_proxy()
+
+        app.router.lifespan_context = lifespan_wrapper
 
     # --- Proxy lifecycle ---
 
@@ -229,7 +275,10 @@ class SwitchyardModel(SimpleResponsesAPIModel):
             str(port),
         ]
         logger.info("Starting Switchyard proxy: %s", " ".join(command))
-        process = subprocess.Popen(command)
+        # preexec_fn runs between fork and exec, which is the only point where the child can ask
+        # the kernel to tie its lifetime to this process. It carries the documented thread-safety
+        # caveat, but this runs once at startup before the server serves traffic.
+        process = subprocess.Popen(command, preexec_fn=_set_parent_death_signal)
         self._proxy_process = process
         atexit.register(self.stop_proxy)
 

--- a/responses_api_models/switchyard_model/app.py
+++ b/responses_api_models/switchyard_model/app.py
@@ -103,7 +103,7 @@ class _RolloutSessionMiddleware:
 _PR_SET_PDEATHSIG = 1
 
 
-def _set_parent_death_signal() -> None:  # pragma: no cover - runs post-fork, in the child
+def _set_parent_death_signal() -> None:
     """Ask the kernel to SIGTERM this child when its parent dies.
 
     Gym's orchestrator stops a server with SIGINT and escalates to SIGKILL after one second, and a
@@ -236,10 +236,14 @@ class SwitchyardModel(SimpleResponsesAPIModel):
 
         @asynccontextmanager
         async def lifespan_wrapper(app):
-            async with main_app_lifespan(app) as maybe_state:
-                yield maybe_state
-
-            self.stop_proxy()
+            # finally, not a trailing statement: startup can fail after the proxy is already
+            # serving, and a proxy that outlives a server which never finished starting is the
+            # same leak as one that outlives a server which did.
+            try:
+                async with main_app_lifespan(app) as maybe_state:
+                    yield maybe_state
+            finally:
+                self.stop_proxy()
 
         app.router.lifespan_context = lifespan_wrapper
 

--- a/responses_api_models/switchyard_model/app.py
+++ b/responses_api_models/switchyard_model/app.py
@@ -149,6 +149,16 @@ class SwitchyardModelConfig(BaseResponsesAPIModelConfig):
                 "switchyard_model needs either routing_profiles (Gym launches the proxy) or "
                 "switchyard_base_url (attach to a proxy you run yourself)"
             )
+        if self.switchyard_base_url and self.routing_profiles:
+            # Both fields default from environment variables, so this is easy to hit by accident.
+            # Attaching wins, but say so -- silently ignoring a routing profile the user supplied
+            # would look like their routing config was in effect when it was not.
+            logger.warning(
+                "switchyard_model: both switchyard_base_url and routing_profiles are set. Attaching to %s; "
+                "the routing profile %s is served by that proxy, not by Gym, and is otherwise ignored.",
+                self.switchyard_base_url,
+                self.routing_profiles,
+            )
         return self
 
 

--- a/responses_api_models/switchyard_model/app.py
+++ b/responses_api_models/switchyard_model/app.py
@@ -202,15 +202,16 @@ class SwitchyardModel(SimpleResponsesAPIModel):
     def start_proxy(self) -> str:
         """Start `switchyard ... serve` and block until it answers /health.
 
-        Switchyard is not a dependency of this package -- launching drives its CLI, so the
-        executable has to be on PATH. Check that up front rather than surfacing it as an opaque
-        FileNotFoundError from Popen.
+        nemo-switchyard is a dependency of this server, so the CLI is normally installed with it.
+        Check anyway -- a custom switchyard_executable or a hand-built environment can leave it
+        missing, and an explicit message beats an opaque FileNotFoundError from Popen.
         """
         if shutil.which(self.config.switchyard_executable) is None:
             raise RuntimeError(
-                f"switchyard_model needs the {self.config.switchyard_executable!r} executable on PATH to "
-                "launch a proxy. Install it with `pip install 'nemo-switchyard[server]'`, or set "
-                "switchyard_base_url to attach to a proxy you run yourself."
+                f"switchyard_model could not find the {self.config.switchyard_executable!r} executable on PATH, "
+                "so it cannot launch a proxy. It ships with this server's nemo-switchyard dependency; if you "
+                "are running a custom environment, install it with `pip install 'nemo-switchyard[server]'` or "
+                "set switchyard_base_url to attach to a proxy you run yourself."
             )
 
         port = self.config.proxy_port or find_open_port(

--- a/responses_api_models/switchyard_model/app.py
+++ b/responses_api_models/switchyard_model/app.py
@@ -100,13 +100,13 @@ class _RolloutSessionMiddleware:
 class SwitchyardModelConfig(BaseResponsesAPIModelConfig):
     """Configuration for serving Gym model calls through a Switchyard proxy.
 
-    Two modes. In *attach* mode (the default) the proxy is run by whoever owns the eval -- set
-    ``switchyard_base_url`` and Gym points at it, which keeps proxy lifecycle and image pinning
-    outside Gym. In *launch* mode Gym starts the proxy itself from ``routing_profiles`` so a run is
-    a single command.
+    By default Gym launches the proxy itself from ``routing_profiles``, so a routed eval is one
+    command and the user never manages a proxy. Setting ``switchyard_base_url`` instead attaches to
+    a proxy someone else runs -- useful when an eval needs to pin a specific Switchyard build, or
+    when several servers should share one instance.
     """
 
-    # Attach mode. Required unless launch_proxy is set.
+    # Set to attach to an already-running proxy instead of launching one.
     switchyard_base_url: Optional[str] = None
     switchyard_api_key: str = "dummy"  # pragma: allowlist secret
 
@@ -115,10 +115,10 @@ class SwitchyardModelConfig(BaseResponsesAPIModelConfig):
     # the response.
     switchyard_model: str
 
-    # Launch mode.
-    launch_proxy: bool = False
+    # Used when launching. routing_profiles is the routing config Switchyard serves.
     routing_profiles: Optional[str] = None
-    proxy_host: str = "127.0.0.1"
+    # 0.0.0.0 so the proxy is reachable off-box; this server always talks to it over loopback.
+    proxy_host: str = "0.0.0.0"
     proxy_port: Optional[int] = None
     proxy_startup_timeout_s: float = 120.0
     switchyard_executable: str = "switchyard"
@@ -138,13 +138,17 @@ class SwitchyardModelConfig(BaseResponsesAPIModelConfig):
         ),
     )
 
+    @property
+    def launches_proxy(self) -> bool:
+        return self.switchyard_base_url is None
+
     @model_validator(mode="after")
     def validate_target(self) -> "SwitchyardModelConfig":
-        if self.launch_proxy:
-            if not self.routing_profiles:
-                raise ValueError("routing_profiles is required when launch_proxy=true")
-        elif not self.switchyard_base_url:
-            raise ValueError("switchyard_base_url is required when launch_proxy=false")
+        if self.launches_proxy and not self.routing_profiles:
+            raise ValueError(
+                "switchyard_model needs either routing_profiles (Gym launches the proxy) or "
+                "switchyard_base_url (attach to a proxy you run yourself)"
+            )
         return self
 
 
@@ -152,43 +156,51 @@ class SwitchyardModel(SimpleResponsesAPIModel):
     config: SwitchyardModelConfig
 
     def model_post_init(self, context: Any) -> None:
-        base_url = self.config.switchyard_base_url
-        if self.config.launch_proxy:
-            base_url = self.start_proxy()
-
-        self._client = NeMoGymAsyncOpenAI(
-            base_url=base_url,
-            api_key=self.config.switchyard_api_key,
-            default_headers=self.config.default_headers,
-        )
         self._semaphore = (
             asyncio.Semaphore(self.config.max_concurrent_requests)
             if self.config.max_concurrent_requests is not None
             else nullcontext()
         )
-
+        # When launching, the address does not exist yet -- setup_webserver builds the client once
+        # the proxy is serving.
+        if not self.config.launches_proxy:
+            self._build_client(self.config.switchyard_base_url)
         return super().model_post_init(context)
 
+    def _build_client(self, base_url: str) -> None:
+        self._client = NeMoGymAsyncOpenAI(
+            base_url=base_url,
+            api_key=self.config.switchyard_api_key,
+            default_headers=self.config.default_headers,
+        )
+
     def setup_webserver(self):
+        # Launch here rather than in model_post_init so the proxy only starts when this server is
+        # actually going to serve -- matching local_vllm_model, and keeping config validation and
+        # tests free of side effects.
+        if self.config.launches_proxy:
+            print("Starting Switchyard proxy...")
+            self._build_client(self.start_proxy())
+
         app = super().setup_webserver()
         # Added last, so it wraps the capture middleware and still sees the correlation prefix.
         app.add_middleware(_RolloutSessionMiddleware)
         return app
 
-    # --- Proxy lifecycle (launch mode) ---
+    # --- Proxy lifecycle ---
 
     def start_proxy(self) -> str:
         """Start `switchyard ... serve` and block until it answers /health.
 
-        Switchyard is not a dependency of this package -- launch mode drives its CLI, so the
+        Switchyard is not a dependency of this package -- launching drives its CLI, so the
         executable has to be on PATH. Check that up front rather than surfacing it as an opaque
         FileNotFoundError from Popen.
         """
         if shutil.which(self.config.switchyard_executable) is None:
             raise RuntimeError(
-                f"launch_proxy=true needs the {self.config.switchyard_executable!r} executable on PATH. "
-                "Install it with `pip install 'nemo-switchyard[server]'`, or set launch_proxy=false "
-                "and point switchyard_base_url at a proxy you run yourself."
+                f"switchyard_model needs the {self.config.switchyard_executable!r} executable on PATH to "
+                "launch a proxy. Install it with `pip install 'nemo-switchyard[server]'`, or set "
+                "switchyard_base_url to attach to a proxy you run yourself."
             )
 
         port = self.config.proxy_port or find_open_port(
@@ -210,7 +222,10 @@ class SwitchyardModel(SimpleResponsesAPIModel):
         self._proxy_process = process
         atexit.register(self.stop_proxy)
 
-        root_url = f"http://{self.config.proxy_host}:{port}"
+        # The proxy binds a wildcard address so it is reachable off-box, but a wildcard is not a
+        # destination -- this server always reaches its own child over loopback.
+        host = "127.0.0.1" if self.config.proxy_host in ("0.0.0.0", "::") else self.config.proxy_host
+        root_url = f"http://{host}:{port}"
         self.wait_for_proxy(root_url, process)
         return f"{root_url}/v1"
 

--- a/responses_api_models/switchyard_model/app.py
+++ b/responses_api_models/switchyard_model/app.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Gym model server that serves model calls through a Switchyard routing proxy.
+
+Switchyard decides, per request, which upstream model should carry the work. Exposing it as a
+Responses API model rather than wiring it into a single agent means every benchmark Gym already
+supports can be run against a router without touching harness code::
+
+    gym eval run --benchmark <name> --model-type switchyard_model
+
+The dependency direction is one-way: Gym knows Switchyard, Switchyard does not know Gym. This
+server owns the mapping between Gym concepts and Switchyard's generic proxy contract -- notably
+Gym's rollout-attempt id becomes Switchyard's opaque session id, so proxy-side routing decisions
+and costs join back to the rollout that produced them.
+"""
+
+import asyncio
+import atexit
+import contextvars
+import logging
+import re
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from contextlib import nullcontext
+from typing import Any, Dict, Optional
+
+from pydantic import Field, model_validator
+
+from nemo_gym.base_responses_api_model import (
+    BaseResponsesAPIModelConfig,
+    Body,
+    SimpleResponsesAPIModel,
+)
+from nemo_gym.config_types import ROLLOUT_PATH_PREFIX
+from nemo_gym.global_config import (
+    DISALLOWED_PORTS_KEY_NAME,
+    find_open_port,
+    get_global_config_dict,
+)
+from nemo_gym.openai_utils import (
+    NeMoGymAsyncOpenAI,
+    NeMoGymChatCompletion,
+    NeMoGymChatCompletionCreateParamsNonStreaming,
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# Gym's capture middleware strips the /ng-rollout/<id> correlation prefix before routing, so by the
+# time a handler runs the rollout id is gone. _RolloutSessionMiddleware runs outside it and
+# republishes the id here for the duration of the request.
+_ROLLOUT_ID: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "switchyard_model_rollout_id", default=None
+)
+
+_ROLLOUT_PATH_RE = re.compile(rf"^/{re.escape(ROLLOUT_PATH_PREFIX)}/(?P<rollout_id>[^/]+)(?P<rest>/.*)$")
+
+
+class _RolloutSessionMiddleware:
+    """Pure-ASGI middleware that publishes the rollout id on a ContextVar.
+
+    Installed last so it sits outside Gym's capture middleware and still sees the correlation
+    prefix. The path is forwarded untouched -- stripping it stays the capture middleware's job.
+    """
+
+    def __init__(self, app: Any) -> None:
+        self._app = app
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        if scope.get("type") != "http":
+            await self._app(scope, receive, send)
+            return
+
+        match = _ROLLOUT_PATH_RE.match(scope.get("path", ""))
+        token = _ROLLOUT_ID.set(match.group("rollout_id") if match else None)
+        try:
+            await self._app(scope, receive, send)
+        finally:
+            _ROLLOUT_ID.reset(token)
+
+
+class SwitchyardModelConfig(BaseResponsesAPIModelConfig):
+    """Configuration for serving Gym model calls through a Switchyard proxy.
+
+    Two modes. In *attach* mode (the default) the proxy is run by whoever owns the eval -- set
+    ``switchyard_base_url`` and Gym points at it, which keeps proxy lifecycle and image pinning
+    outside Gym. In *launch* mode Gym starts the proxy itself from ``routing_profiles`` so a run is
+    a single command.
+    """
+
+    # Attach mode. Required unless launch_proxy is set.
+    switchyard_base_url: Optional[str] = None
+    switchyard_api_key: str = "dummy"  # pragma: allowlist secret
+
+    # The route name to request. Switchyard maps it to a concrete provider model, so this is a
+    # routing label rather than a model id -- which target actually served the call comes back on
+    # the response.
+    switchyard_model: str
+
+    # Launch mode.
+    launch_proxy: bool = False
+    routing_profiles: Optional[str] = None
+    proxy_host: str = "127.0.0.1"
+    proxy_port: Optional[int] = None
+    proxy_startup_timeout_s: float = 120.0
+    switchyard_executable: str = "switchyard"
+
+    # Header Switchyard reads as its opaque session id. Gym sends its rollout-attempt id so
+    # per-call routing decisions can be joined back to the rollout after the run.
+    session_id_header: str = "proxy_x_session_id"
+    forward_session_id: bool = True
+
+    extra_body: Dict[str, Any] = Field(default_factory=dict)
+    default_headers: Dict[str, str] = Field(default_factory=dict)
+
+    max_concurrent_requests: Optional[int] = Field(
+        default=None,
+        description=(
+            "Cap on in-flight upstream requests from this server (per-process asyncio.Semaphore). None = unlimited."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_target(self) -> "SwitchyardModelConfig":
+        if self.launch_proxy:
+            if not self.routing_profiles:
+                raise ValueError("routing_profiles is required when launch_proxy=true")
+        elif not self.switchyard_base_url:
+            raise ValueError("switchyard_base_url is required when launch_proxy=false")
+        return self
+
+
+class SwitchyardModel(SimpleResponsesAPIModel):
+    config: SwitchyardModelConfig
+
+    def model_post_init(self, context: Any) -> None:
+        base_url = self.config.switchyard_base_url
+        if self.config.launch_proxy:
+            base_url = self.start_proxy()
+
+        self._client = NeMoGymAsyncOpenAI(
+            base_url=base_url,
+            api_key=self.config.switchyard_api_key,
+            default_headers=self.config.default_headers,
+        )
+        self._semaphore = (
+            asyncio.Semaphore(self.config.max_concurrent_requests)
+            if self.config.max_concurrent_requests is not None
+            else nullcontext()
+        )
+
+        return super().model_post_init(context)
+
+    def setup_webserver(self):
+        app = super().setup_webserver()
+        # Added last, so it wraps the capture middleware and still sees the correlation prefix.
+        app.add_middleware(_RolloutSessionMiddleware)
+        return app
+
+    # --- Proxy lifecycle (launch mode) ---
+
+    def start_proxy(self) -> str:
+        """Start `switchyard ... serve` and block until it answers /health."""
+        port = self.config.proxy_port or find_open_port(
+            disallowed_ports=get_global_config_dict()[DISALLOWED_PORTS_KEY_NAME]
+        )
+        command = [
+            self.config.switchyard_executable,
+            "--routing-profiles",
+            str(self.config.routing_profiles),
+            "--",
+            "serve",
+            "--host",
+            self.config.proxy_host,
+            "--port",
+            str(port),
+        ]
+        logger.info("Starting Switchyard proxy: %s", " ".join(command))
+        process = subprocess.Popen(command)
+        self._proxy_process = process
+        atexit.register(self.stop_proxy)
+
+        root_url = f"http://{self.config.proxy_host}:{port}"
+        self.wait_for_proxy(root_url, process)
+        return f"{root_url}/v1"
+
+    def wait_for_proxy(self, root_url: str, process: subprocess.Popen) -> None:
+        deadline = time.monotonic() + self.config.proxy_startup_timeout_s
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                raise RuntimeError(f"Switchyard proxy exited during startup with code {process.returncode}")
+            try:
+                with urllib.request.urlopen(f"{root_url}/health", timeout=5) as response:
+                    if response.status == 200:
+                        logger.info("Switchyard proxy is up at %s", root_url)
+                        return
+            except (urllib.error.URLError, OSError):
+                pass
+            time.sleep(1)
+
+        self.stop_proxy()
+        raise TimeoutError(f"Switchyard proxy did not become healthy within {self.config.proxy_startup_timeout_s}s")
+
+    def stop_proxy(self) -> None:
+        process = getattr(self, "_proxy_process", None)
+        if process is None or process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+    # --- Model calls ---
+
+    def client_for_request(self) -> NeMoGymAsyncOpenAI:
+        """Return the upstream client, carrying this rollout's session id when there is one.
+
+        The client's headers are fixed at construction, so a request that must be correlated gets
+        a copy with the session header merged in. The copy is a plain Pydantic model over Gym's
+        shared aiohttp client, so this costs an object allocation, not a connection.
+        """
+        rollout_id = _ROLLOUT_ID.get()
+        if rollout_id is None or not self.config.forward_session_id:
+            return self._client
+
+        headers = {**self._client.default_headers, self.config.session_id_header: rollout_id}
+        return self._client.model_copy(update={"default_headers": headers})
+
+    async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:
+        body_dict = self.config.extra_body | body.model_dump(exclude_unset=True)
+        body_dict["model"] = self.config.switchyard_model
+        async with self._semaphore:
+            response_dict = await self.client_for_request().create_response(**body_dict)
+        return NeMoGymResponse.model_validate(response_dict)
+
+    async def chat_completions(
+        self, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
+    ) -> NeMoGymChatCompletion:
+        body_dict = self.config.extra_body | body.model_dump(exclude_unset=True)
+        body_dict["model"] = self.config.switchyard_model
+        async with self._semaphore:
+            response_dict = await self.client_for_request().create_chat_completion(**body_dict)
+        return NeMoGymChatCompletion.model_validate(response_dict)
+
+
+if __name__ == "__main__":
+    SwitchyardModel.run_webserver()

--- a/responses_api_models/switchyard_model/app.py
+++ b/responses_api_models/switchyard_model/app.py
@@ -31,6 +31,7 @@ import atexit
 import contextvars
 import logging
 import re
+import shutil
 import subprocess
 import time
 import urllib.error
@@ -177,7 +178,19 @@ class SwitchyardModel(SimpleResponsesAPIModel):
     # --- Proxy lifecycle (launch mode) ---
 
     def start_proxy(self) -> str:
-        """Start `switchyard ... serve` and block until it answers /health."""
+        """Start `switchyard ... serve` and block until it answers /health.
+
+        Switchyard is not a dependency of this package -- launch mode drives its CLI, so the
+        executable has to be on PATH. Check that up front rather than surfacing it as an opaque
+        FileNotFoundError from Popen.
+        """
+        if shutil.which(self.config.switchyard_executable) is None:
+            raise RuntimeError(
+                f"launch_proxy=true needs the {self.config.switchyard_executable!r} executable on PATH. "
+                "Install it with `pip install 'nemo-switchyard[server]'`, or set launch_proxy=false "
+                "and point switchyard_base_url at a proxy you run yourself."
+            )
+
         port = self.config.proxy_port or find_open_port(
             disallowed_ports=get_global_config_dict()[DISALLOWED_PORTS_KEY_NAME]
         )

--- a/responses_api_models/switchyard_model/app.py
+++ b/responses_api_models/switchyard_model/app.py
@@ -31,7 +31,7 @@ import contextvars
 import logging
 import re
 from contextlib import asynccontextmanager, nullcontext
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import Field, model_validator
 
@@ -121,9 +121,14 @@ class SwitchyardModelConfig(BaseResponsesAPIModelConfig):
     # The hosted proxy binds loopback only; this server is the network-facing piece.
     proxy_port: Optional[int] = None
 
-    # Header Switchyard reads as its opaque session id. Gym sends its rollout-attempt id so
+    # Headers Switchyard reads as its opaque session id. Gym sends its rollout-attempt id so
     # per-call routing decisions can be joined back to the rollout after the run.
-    session_id_header: str = "proxy_x_session_id"
+    # x-switchyard-session-id is the name the native server parses into routing metadata (session
+    # affinity, request logs, spans). A list because attach-mode proxies can key other subsystems
+    # on other names -- e.g. proxy_x_session_id for switchyard-server durable routing logs -- but
+    # add names knowingly: Switchyard strips only the headers it recognizes, so an unrecognized
+    # name is forwarded verbatim to the upstream provider.
+    session_id_headers: List[str] = Field(default_factory=lambda: ["x-switchyard-session-id"])
     forward_session_id: bool = True
 
     extra_body: Dict[str, Any] = Field(default_factory=dict)
@@ -183,34 +188,32 @@ class SwitchyardModel(SimpleResponsesAPIModel):
         )
 
     def setup_webserver(self):
-        # Launch here rather than in model_post_init so the proxy only starts when this server is
-        # actually going to serve -- matching local_vllm_model, and keeping config validation and
-        # tests free of side effects.
-        if self.config.launches_proxy:
-            print("Starting Switchyard proxy...")
-            self._build_client(self.start_proxy())
-
         app = super().setup_webserver()
         # Added last, so it wraps the capture middleware and still sees the correlation prefix.
         app.add_middleware(_RolloutSessionMiddleware)
-        self.setup_proxy_shutdown(app)
+        self.setup_proxy_lifespan(app)
         return app
 
-    def setup_proxy_shutdown(self, app) -> None:
-        """Stop the proxy when the app shuts down.
+    def setup_proxy_lifespan(self, app) -> None:
+        """Host the proxy for exactly as long as the app serves.
 
-        The proxy runs in this process, so it cannot outlive an orchestrated SIGKILL the way a
-        subprocess could -- this hook exists for the graceful path, where an explicit close()
-        stops the listener promptly and flushes Switchyard's telemetry instead of relying on
-        interpreter teardown.
+        Startup and shutdown must share a thread: the native server's PyO3 binding is
+        thread-affine (unsendable), so the thread that constructs it is the only one allowed to
+        close it. Running both ends inside the lifespan guarantees that on any host -- uvicorn
+        runs the lifespan on the main thread, test clients on a worker thread, and either way
+        construction and close land together. It also keeps config validation, app assembly, and
+        tests free of side effects; the proxy exists only while the app serves.
         """
         main_app_lifespan = app.router.lifespan_context
 
         @asynccontextmanager
         async def lifespan_wrapper(app):
+            if self.config.launches_proxy:
+                print("Starting Switchyard proxy...")
+                self._build_client(self.start_proxy())
             # finally, not a trailing statement: startup can fail after the proxy is already
-            # serving, and a proxy that outlives a server which never finished starting is the
-            # same leak as one that outlives a server which did.
+            # serving, and a proxy left serving by a server which never finished starting is the
+            # same waste as one left serving by a server which did.
             try:
                 async with main_app_lifespan(app) as maybe_state:
                     yield maybe_state
@@ -270,7 +273,9 @@ class SwitchyardModel(SimpleResponsesAPIModel):
         if rollout_id is None or not self.config.forward_session_id:
             return self._client
 
-        headers = {**self._client.default_headers, self.config.session_id_header: rollout_id}
+        headers = {**self._client.default_headers}
+        for name in self.config.session_id_headers:
+            headers[name] = rollout_id
         return self._client.model_copy(update={"default_headers": headers})
 
     async def responses(self, body: NeMoGymResponseCreateParamsNonStreaming = Body()) -> NeMoGymResponse:

--- a/responses_api_models/switchyard_model/app.py
+++ b/responses_api_models/switchyard_model/app.py
@@ -27,18 +27,9 @@ and costs join back to the rollout that produced them.
 """
 
 import asyncio
-import atexit
 import contextvars
-import ctypes
 import logging
 import re
-import shutil
-import signal
-import subprocess
-import sys
-import time
-import urllib.error
-import urllib.request
 from contextlib import asynccontextmanager, nullcontext
 from typing import Any, Dict, Optional
 
@@ -104,39 +95,17 @@ class _RolloutSessionMiddleware:
             _ROLLOUT_ID.reset(token)
 
 
-_PR_SET_PDEATHSIG = 1
-
-
-def _set_parent_death_signal() -> None:
-    """Ask the kernel to SIGTERM this child when its parent dies.
-
-    Gym's orchestrator stops a server with SIGINT and escalates to SIGKILL after one second, and a
-    SIGKILLed parent runs no handler -- not the shutdown event, not atexit. Without a kernel-level
-    tie the proxy survives its owner and keeps holding its port, so every eval that cycles servers
-    leaks one. prctl is Linux-only; elsewhere this is a no-op and the shutdown handler is the only
-    line of defence.
-
-    Raising here would fail the spawn, which is a worse outcome than a proxy that needs reaping, so
-    a platform without prctl is tolerated silently.
-    """
-    if sys.platform != "linux":
-        return
-    try:
-        ctypes.CDLL("libc.so.6", use_errno=True).prctl(_PR_SET_PDEATHSIG, signal.SIGTERM)
-    except (OSError, AttributeError):
-        pass
-
-
 class SwitchyardModelConfig(BaseResponsesAPIModelConfig):
     """Configuration for serving Gym model calls through a Switchyard proxy.
 
-    By default Gym launches the proxy itself from ``routing_profiles``, so a routed eval is one
-    command and the user never manages a proxy. Setting ``switchyard_base_url`` instead attaches to
-    a proxy someone else runs -- useful when an eval needs to pin a specific Switchyard build, or
-    when several servers should share one instance.
+    By default Gym hosts the proxy itself from ``deployment``, so a routed eval is one command and
+    the user never manages a proxy. Setting ``switchyard_base_url`` instead attaches to a proxy
+    someone else runs -- useful when an eval needs to pin a specific Switchyard build, or when
+    several servers should share one instance (routing strategies with session or agent affinity
+    are stateful, so replicas each hosting their own proxy would not route like one shared proxy).
     """
 
-    # Set to attach to an already-running proxy instead of launching one.
+    # Set to attach to an already-running proxy instead of hosting one.
     switchyard_base_url: Optional[str] = None
     switchyard_api_key: str = "dummy"  # pragma: allowlist secret
 
@@ -145,13 +114,12 @@ class SwitchyardModelConfig(BaseResponsesAPIModelConfig):
     # the response.
     switchyard_model: str
 
-    # Used when launching. routing_profiles is the routing config Switchyard serves.
-    routing_profiles: Optional[str] = None
-    # 0.0.0.0 so the proxy is reachable off-box; this server always talks to it over loopback.
-    proxy_host: str = "0.0.0.0"
+    # Used when hosting. A native Switchyard TOML deployment: llm_clients, targets, and routes,
+    # validated by the server when it loads. This is the routing condition an eval runs under --
+    # an explicit, diffable artifact, which is what makes routed runs comparable.
+    deployment: Optional[str] = None
+    # The hosted proxy binds loopback only; this server is the network-facing piece.
     proxy_port: Optional[int] = None
-    proxy_startup_timeout_s: float = 120.0
-    switchyard_executable: str = "switchyard"
 
     # Header Switchyard reads as its opaque session id. Gym sends its rollout-attempt id so
     # per-call routing decisions can be joined back to the rollout after the run.
@@ -174,20 +142,20 @@ class SwitchyardModelConfig(BaseResponsesAPIModelConfig):
 
     @model_validator(mode="after")
     def validate_target(self) -> "SwitchyardModelConfig":
-        if self.launches_proxy and not self.routing_profiles:
+        if self.launches_proxy and not self.deployment:
             raise ValueError(
-                "switchyard_model needs either routing_profiles (Gym launches the proxy) or "
-                "switchyard_base_url (attach to a proxy you run yourself)"
+                "switchyard_model needs either deployment (Gym hosts the proxy from a native "
+                "Switchyard TOML deployment) or switchyard_base_url (attach to a proxy you run yourself)"
             )
-        if self.switchyard_base_url and self.routing_profiles:
+        if self.switchyard_base_url and self.deployment:
             # Both fields default from environment variables, so this is easy to hit by accident.
-            # Attaching wins, but say so -- silently ignoring a routing profile the user supplied
-            # would look like their routing config was in effect when it was not.
+            # Attaching wins, but say so -- silently ignoring a deployment the user supplied would
+            # look like their routing config was in effect when it was not.
             logger.warning(
-                "switchyard_model: both switchyard_base_url and routing_profiles are set. Attaching to %s; "
-                "the routing profile %s is served by that proxy, not by Gym, and is otherwise ignored.",
+                "switchyard_model: both switchyard_base_url and deployment are set. Attaching to %s; "
+                "the deployment %s is served by that proxy, not by Gym, and is otherwise ignored.",
                 self.switchyard_base_url,
-                self.routing_profiles,
+                self.deployment,
             )
         return self
 
@@ -231,10 +199,10 @@ class SwitchyardModel(SimpleResponsesAPIModel):
     def setup_proxy_shutdown(self, app) -> None:
         """Stop the proxy when the app shuts down.
 
-        The graceful half of proxy cleanup. atexit does not cover this on its own: uvicorn's
-        signal handling ends the process without running interpreter exit hooks, so a proxy
-        launched here outlived every orchestrated shutdown. See _set_parent_death_signal for the
-        other half, which covers shutdowns too abrupt for any handler to run.
+        The proxy runs in this process, so it cannot outlive an orchestrated SIGKILL the way a
+        subprocess could -- this hook exists for the graceful path, where an explicit close()
+        stops the listener promptly and flushes Switchyard's telemetry instead of relying on
+        interpreter teardown.
         """
         main_app_lifespan = app.router.lifespan_context
 
@@ -254,75 +222,40 @@ class SwitchyardModel(SimpleResponsesAPIModel):
     # --- Proxy lifecycle ---
 
     def start_proxy(self) -> str:
-        """Start `switchyard ... serve` and block until it answers /health.
+        """Host the native Switchyard server in-process and return its base URL.
 
-        nemo-switchyard is a dependency of this server, so the CLI is normally installed with it.
-        Check anyway -- a custom switchyard_executable or a hand-built environment can leave it
-        missing, and an explicit message beats an opaque FileNotFoundError from Popen.
+        The constructor loads and validates the TOML deployment, binds loopback, and returns
+        already serving -- a bad deployment or an unbindable port is an exception here, not a
+        timeout later, so there is no health polling and no subprocess to reap.
+
+        nemo-switchyard is a dependency of this server, so the import normally succeeds. Catch
+        anyway -- a hand-built environment can leave it missing, and an explicit message beats a
+        bare ModuleNotFoundError.
         """
-        if shutil.which(self.config.switchyard_executable) is None:
+        try:
+            from switchyard_rust.server import Server
+        except ImportError as error:
             raise RuntimeError(
-                f"switchyard_model could not find the {self.config.switchyard_executable!r} executable on PATH, "
-                "so it cannot launch a proxy. It ships with this server's nemo-switchyard dependency; if you "
-                "are running a custom environment, install it with `pip install 'nemo-switchyard[server]'` or "
-                "set switchyard_base_url to attach to a proxy you run yourself."
-            )
+                "switchyard_model could not import switchyard_rust, so it cannot host a proxy. It ships "
+                "with this server's nemo-switchyard dependency; if you are running a custom environment, "
+                "install it with `pip install nemo-switchyard==0.2.0` or set switchyard_base_url to attach "
+                "to a proxy you run yourself."
+            ) from error
 
         port = self.config.proxy_port or find_open_port(
             disallowed_ports=get_global_config_dict()[DISALLOWED_PORTS_KEY_NAME]
         )
-        command = [
-            self.config.switchyard_executable,
-            "--routing-profiles",
-            str(self.config.routing_profiles),
-            "--",
-            "serve",
-            "--host",
-            self.config.proxy_host,
-            "--port",
-            str(port),
-        ]
-        logger.info("Starting Switchyard proxy: %s", " ".join(command))
-        # preexec_fn runs between fork and exec, which is the only point where the child can ask
-        # the kernel to tie its lifetime to this process. It carries the documented thread-safety
-        # caveat, but this runs once at startup before the server serves traffic.
-        process = subprocess.Popen(command, preexec_fn=_set_parent_death_signal)
-        self._proxy_process = process
-        atexit.register(self.stop_proxy)
-
-        # The proxy binds a wildcard address so it is reachable off-box, but a wildcard is not a
-        # destination -- this server always reaches its own child over loopback.
-        host = "127.0.0.1" if self.config.proxy_host in ("0.0.0.0", "::") else self.config.proxy_host
-        root_url = f"http://{host}:{port}"
-        self.wait_for_proxy(root_url, process)
-        return f"{root_url}/v1"
-
-    def wait_for_proxy(self, root_url: str, process: subprocess.Popen) -> None:
-        deadline = time.monotonic() + self.config.proxy_startup_timeout_s
-        while time.monotonic() < deadline:
-            if process.poll() is not None:
-                raise RuntimeError(f"Switchyard proxy exited during startup with code {process.returncode}")
-            try:
-                with urllib.request.urlopen(f"{root_url}/health", timeout=5) as response:
-                    if response.status == 200:
-                        logger.info("Switchyard proxy is up at %s", root_url)
-                        return
-            except (urllib.error.URLError, OSError):
-                pass
-            time.sleep(1)
-
-        self.stop_proxy()
-        raise TimeoutError(f"Switchyard proxy did not become healthy within {self.config.proxy_startup_timeout_s}s")
+        logger.info("Hosting Switchyard proxy from deployment %s on port %d", self.config.deployment, port)
+        self._proxy_server = Server(str(self.config.deployment), port=port)
+        logger.info("Switchyard proxy is up at %s", self._proxy_server.base_url)
+        return f"{self._proxy_server.base_url}/v1"
 
     def stop_proxy(self) -> None:
-        process = getattr(self, "_proxy_process", None)
-        if process is None or process.poll() is not None:
+        server = getattr(self, "_proxy_server", None)
+        if server is None:
             return
-        process.terminate()
-        try:
-            process.wait(timeout=30)
-        except subprocess.TimeoutExpired:
-            process.kill()
+        self._proxy_server = None
+        server.close()
 
     # --- Model calls ---
 

--- a/responses_api_models/switchyard_model/app.py
+++ b/responses_api_models/switchyard_model/app.py
@@ -33,13 +33,14 @@ import importlib.metadata
 import json
 import logging
 import re
-import urllib.error
-import urllib.request
+import tomllib
+from collections.abc import Mapping
 from contextlib import asynccontextmanager, nullcontext
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import aiohttp
 from pydantic import Field, model_validator
 
 from nemo_gym.base_responses_api_model import (
@@ -50,6 +51,8 @@ from nemo_gym.base_responses_api_model import (
 from nemo_gym.config_types import ROLLOUT_PATH_PREFIX
 from nemo_gym.global_config import (
     DISALLOWED_PORTS_KEY_NAME,
+    OBSERVABILITY_ENABLED_KEY_NAME,
+    TOKEN_ID_CAPTURE_BLOCK,
     find_open_port,
     get_global_config_dict,
 )
@@ -60,6 +63,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
 )
+from nemo_gym.server_utils import is_nemo_gym_fastapi_entrypoint, request
 
 
 logger = logging.getLogger(__name__)
@@ -145,11 +149,18 @@ class SwitchyardModelConfig(BaseResponsesAPIModelConfig):
     # proxy is gone. None disables both writes.
     condition_dir: Optional[str] = None
 
+    # Caller-supplied provenance for an attached proxy, copied verbatim into the condition
+    # manifest. Gym cannot see what an external proxy runs, so whoever operates it supplies the
+    # identity -- e.g. {"switchyard_commit": ..., "deployment_sha256": ...}. Ignored when hosting:
+    # the manifest already identifies the hosted proxy exactly.
+    proxy_provenance: Dict[str, Any] = Field(default_factory=dict)
+
     extra_body: Dict[str, Any] = Field(default_factory=dict)
     default_headers: Dict[str, str] = Field(default_factory=dict)
 
     max_concurrent_requests: Optional[int] = Field(
         default=None,
+        gt=0,
         description=(
             "Cap on in-flight upstream requests from this server (per-process asyncio.Semaphore). None = unlimited."
         ),
@@ -165,6 +176,15 @@ class SwitchyardModelConfig(BaseResponsesAPIModelConfig):
             raise ValueError(
                 "switchyard_model needs either deployment (Gym hosts the proxy from a native "
                 "Switchyard TOML deployment) or switchyard_base_url (attach to a proxy you run yourself)"
+            )
+        if self.launches_proxy and (self.num_workers or 1) > 1:
+            # Each uvicorn worker is its own process, so each would host its own proxy: stateful
+            # routing splits across instances, /v1/stats fragments, and a fixed proxy_port
+            # collides. One shared proxy is the coherent shape for parallel workers.
+            raise ValueError(
+                "switchyard_model cannot host the proxy with num_workers > 1: every worker would "
+                "start its own proxy, splitting session affinity and stats. Run one proxy yourself "
+                "and attach all workers to it with switchyard_base_url."
             )
         if self.switchyard_base_url and self.deployment:
             # Both fields default from environment variables, so this is easy to hit by accident.
@@ -225,16 +245,18 @@ class SwitchyardModel(SimpleResponsesAPIModel):
             if self.config.launches_proxy:
                 print("Starting Switchyard proxy...")
                 self._build_client(self.start_proxy())
-            self.write_condition_manifest()
-            # finally, not a trailing statement: startup can fail after the proxy is already
-            # serving, and a proxy left serving by a server which never finished starting is the
-            # same waste as one left serving by a server which did.
+            # finally, not a trailing statement -- and entered the moment the proxy serves:
+            # anything that fails between here and a finished startup (the manifest write, the
+            # inner lifespan) must still close the proxy, or it outlives the server that never
+            # finished starting.
             try:
+                self.check_rollout_correlation()
+                self.write_condition_manifest()
                 async with main_app_lifespan(app) as maybe_state:
                     yield maybe_state
             finally:
                 # Stats before stop: the snapshot needs the proxy still answering.
-                self.snapshot_proxy_stats()
+                await self.snapshot_proxy_stats()
                 self.stop_proxy()
 
         app.router.lifespan_context = lifespan_wrapper
@@ -288,68 +310,162 @@ class SwitchyardModel(SimpleResponsesAPIModel):
             return self.config.switchyard_base_url.rstrip("/").removesuffix("/v1")
         return None
 
+    def check_rollout_correlation(self) -> None:
+        """Fail or warn at startup when the rollout id cannot reach this server.
+
+        The id arrives on the ``/ng-rollout/<id>/`` URL prefix, which agents add only when
+        model-call observability or training-token capture is enabled. Without one of those,
+        forward_session_id has nothing to forward -- Switchyard sees no session and the documented
+        correlation and session-affinity behavior silently does not happen. Asking for forwarding
+        explicitly makes that an error; leaving the default on makes it a warning, because plain
+        evals that never look at sessions should not have to care.
+        """
+        if not self.config.forward_session_id:
+            return
+        global_config = getattr(self.server_client, "global_config_dict", None)
+        if not isinstance(global_config, Mapping):
+            return
+        token_capture_block = global_config.get(TOKEN_ID_CAPTURE_BLOCK) or {}
+        correlation_active = bool(global_config.get(OBSERVABILITY_ENABLED_KEY_NAME, False)) or (
+            isinstance(token_capture_block, Mapping) and bool(token_capture_block.get("enabled", False))
+        )
+        if correlation_active:
+            return
+        message = (
+            "switchyard_model: forward_session_id is on, but neither observability_enabled nor "
+            "token_id_capture is -- so requests carry no /ng-rollout prefix, and no session id "
+            "will reach Switchyard. Enable ++observability_enabled=true (or token capture) to "
+            "correlate rollouts, or set forward_session_id=false to accept uncorrelated routing."
+        )
+        if "forward_session_id" in self.config.model_fields_set:
+            raise RuntimeError(message)
+        logger.warning(message)
+
     def write_condition_manifest(self) -> None:
         """Record the routing condition this run serves under, if condition_dir is set.
 
         The manifest is the run's provenance: which route, against which deployment (hash and
-        archived contents), on which nemo-switchyard version. Two runs are comparable when their
-        manifests differ only in the route or deployment, and a run is reproducible from the
-        archive alone. Failing to write it must not take down serving -- provenance is worth a
-        warning, not an outage.
+        archived contents), on which proxy. Two runs are comparable when their manifests differ
+        only in the route or deployment, and a hosted run is reproducible from the archive alone.
+        Failing to write it must not take down serving -- provenance is worth a warning, not an
+        outage -- so every step, including reading the deployment, stays inside the handler.
         """
         if not self.config.condition_dir:
             return
-
-        deployment_sha256: Optional[str] = None
-        deployment_toml: Optional[str] = None
-        if self.config.launches_proxy:
-            deployment_bytes = Path(str(self.config.deployment)).read_bytes()
-            deployment_sha256 = hashlib.sha256(deployment_bytes).hexdigest()
-            # The native schema references credentials by environment variable name, but an
-            # inline literal would be a secret -- drop the value, keep the line visible.
-            deployment_toml = re.sub(
-                r"^(\s*api_key\s*=\s*).*$",
-                r"\1'<redacted>'",
-                deployment_bytes.decode(errors="replace"),
-                flags=re.MULTILINE,
-            )
-
-        manifest = {
-            "route": self.config.switchyard_model,
-            "mode": "hosted" if self.config.launches_proxy else "attached",
-            "proxy_root_url": self.proxy_root_url(),
-            "nemo_switchyard_version": self._nemo_switchyard_version(),
-            "deployment_path": str(self.config.deployment) if self.config.deployment else None,
-            "deployment_sha256": deployment_sha256,
-            "deployment_toml": deployment_toml,
-            "session_id_headers": list(self.config.session_id_headers),
-            "written_at": datetime.now(timezone.utc).isoformat(),
-        }
         try:
+            deployment_sha256: Optional[str] = None
+            deployment_toml: Optional[str] = None
+            if self.config.launches_proxy:
+                deployment_bytes = Path(str(self.config.deployment)).read_bytes()
+                deployment_sha256 = hashlib.sha256(deployment_bytes).hexdigest()
+                deployment_toml = self._redacted_deployment_toml(deployment_bytes.decode(errors="replace"))
+
+            manifest = {
+                "route": self.config.switchyard_model,
+                "mode": "hosted" if self.config.launches_proxy else "attached",
+                "proxy_root_url": self.proxy_root_url(),
+                # Only the hosted proxy runs the local wheel. An attached proxy is someone else's
+                # build -- reporting the local version there would name code that never served a
+                # request, so identity comes from caller-supplied proxy_provenance instead.
+                "nemo_switchyard_version": self._nemo_switchyard_version() if self.config.launches_proxy else None,
+                "proxy_provenance": dict(self.config.proxy_provenance) or None,
+                "deployment_path": str(self.config.deployment) if self.config.deployment else None,
+                "deployment_sha256": deployment_sha256,
+                "deployment_toml": deployment_toml,
+                "session_id_headers": list(self.config.session_id_headers),
+                "written_at": datetime.now(timezone.utc).isoformat(),
+            }
             condition_dir = Path(self.config.condition_dir)
             condition_dir.mkdir(parents=True, exist_ok=True)
             (condition_dir / "switchyard-condition.json").write_text(json.dumps(manifest, indent=2) + "\n")
-        except OSError:
+        except Exception:
             logger.warning("switchyard_model: could not write the condition manifest", exc_info=True)
 
-    def snapshot_proxy_stats(self) -> None:
+    def _redacted_deployment_toml(self, text: str) -> Optional[str]:
+        """Archive-safe copy of the deployment, or None when safety cannot be shown.
+
+        The native schema carries credentials by environment-variable name (api_key_env), which
+        is safe to archive -- but extra_headers values are sent to providers verbatim, so an
+        Authorization header there is a live secret. Parse the TOML, collect every extra_headers
+        value and every api_key-named value wherever they appear, and blank those exact strings
+        in the raw text. A deployment that does not parse cannot be searched for secrets, so it
+        is not archived at all; the hash still identifies it.
+        """
+        try:
+            parsed = tomllib.loads(text)
+        except tomllib.TOMLDecodeError:
+            logger.warning(
+                "switchyard_model: deployment is not parseable TOML, so it cannot be checked for "
+                "secrets and will not be archived in the condition manifest"
+            )
+            return None
+
+        secrets: List[str] = []
+
+        def collect(node: Any, under_extra_headers: bool = False) -> None:
+            if isinstance(node, dict):
+                for key, value in node.items():
+                    if isinstance(value, str) and (under_extra_headers or key == "api_key"):
+                        secrets.append(value)
+                    else:
+                        collect(value, under_extra_headers or key == "extra_headers")
+            elif isinstance(node, list):
+                for item in node:
+                    collect(item, under_extra_headers)
+
+        collect(parsed)
+        for secret in secrets:
+            if secret:
+                text = text.replace(secret, "<redacted>")
+        return text
+
+    async def snapshot_proxy_stats(self) -> None:
         """Persist the proxy's /v1/stats before it goes away, if condition_dir is set.
 
         A hosted proxy's counters die with the process, so this is the only chance to keep the
-        proxy-side view of the run -- per-target requests, tokens, retries, latency -- next to
-        the eval outputs it explains. Best-effort for the same reason as the manifest.
+        proxy-side view of the run -- per-target requests, errors, tokens, latency -- next to the
+        eval outputs it explains. Best-effort for the same reason as the manifest, and hard-capped
+        well inside Gym's shutdown window: this runs on the event loop during lifespan shutdown,
+        and Gym escalates to SIGKILL about a second after asking servers to stop.
         """
         root_url = self.proxy_root_url()
         if not self.config.condition_dir or root_url is None:
             return
         try:
-            with urllib.request.urlopen(f"{root_url}/v1/stats", timeout=5) as response:
-                stats = response.read()
+            stats = await asyncio.wait_for(self._fetch_proxy_stats(f"{root_url}/v1/stats"), timeout=0.5)
+            snapshot = {
+                # A proxy counts from its own start, not this run's. Hosted, the two coincide;
+                # attached, a shared proxy's counters span every run and neighbor it has served,
+                # so the file says what it holds instead of implying run-level accounting.
+                "scope": "proxy-lifetime aggregate"
+                if not self.config.launches_proxy
+                else "this run (proxy hosted for exactly this run)",
+                "mode": "hosted" if self.config.launches_proxy else "attached",
+                "written_at": datetime.now(timezone.utc).isoformat(),
+                "stats": stats,
+            }
             condition_dir = Path(self.config.condition_dir)
             condition_dir.mkdir(parents=True, exist_ok=True)
-            (condition_dir / "switchyard-stats.json").write_bytes(stats + b"\n")
-        except (OSError, urllib.error.URLError):
+            (condition_dir / "switchyard-stats.json").write_text(json.dumps(snapshot, indent=2) + "\n")
+        except Exception:
             logger.warning("switchyard_model: could not snapshot proxy stats", exc_info=True)
+
+    async def _fetch_proxy_stats(self, url: str) -> Any:
+        """GET /v1/stats through Gym's shared aiohttp client, as the proxy's configured caller.
+
+        The model path authenticates with switchyard_api_key and default_headers; an attached
+        proxy that requires them would serve model calls and still 401 an anonymous stats read,
+        so the snapshot authenticates the same way.
+        """
+        response = await request(
+            "GET",
+            url,
+            headers={**self.config.default_headers, "Authorization": f"Bearer {self.config.switchyard_api_key}"},
+            timeout=aiohttp.ClientTimeout(total=0.5),
+        )
+        async with response:
+            response.raise_for_status()
+            return await response.json()
 
     def _nemo_switchyard_version(self) -> Optional[str]:
         try:
@@ -394,3 +510,8 @@ class SwitchyardModel(SimpleResponsesAPIModel):
 
 if __name__ == "__main__":
     SwitchyardModel.run_webserver()
+elif is_nemo_gym_fastapi_entrypoint(__file__):  # pragma: no cover - process-entry glue
+    # Multi-worker uvicorn imports this module by string and looks up ``app``. Config validation
+    # has already rejected hosted mode with num_workers > 1, so every worker built here attaches
+    # to one shared external proxy.
+    app = SwitchyardModel.run_webserver()  # noqa: F401

--- a/responses_api_models/switchyard_model/app.py
+++ b/responses_api_models/switchyard_model/app.py
@@ -28,9 +28,16 @@ and costs join back to the rollout that produced them.
 
 import asyncio
 import contextvars
+import hashlib
+import importlib.metadata
+import json
 import logging
 import re
+import urllib.error
+import urllib.request
 from contextlib import asynccontextmanager, nullcontext
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from pydantic import Field, model_validator
@@ -131,6 +138,13 @@ class SwitchyardModelConfig(BaseResponsesAPIModelConfig):
     session_id_headers: List[str] = Field(default_factory=lambda: ["x-switchyard-session-id"])
     forward_session_id: bool = True
 
+    # Directory that receives this run's routing-condition record: a manifest written at startup
+    # (route, mode, deployment hash and archived contents, nemo-switchyard version) and a
+    # /v1/stats snapshot written at shutdown. Point it at the run's output directory, one per
+    # run -- the manifest is what makes a routed run identifiable and reproducible after the
+    # proxy is gone. None disables both writes.
+    condition_dir: Optional[str] = None
+
     extra_body: Dict[str, Any] = Field(default_factory=dict)
     default_headers: Dict[str, str] = Field(default_factory=dict)
 
@@ -211,6 +225,7 @@ class SwitchyardModel(SimpleResponsesAPIModel):
             if self.config.launches_proxy:
                 print("Starting Switchyard proxy...")
                 self._build_client(self.start_proxy())
+            self.write_condition_manifest()
             # finally, not a trailing statement: startup can fail after the proxy is already
             # serving, and a proxy left serving by a server which never finished starting is the
             # same waste as one left serving by a server which did.
@@ -218,6 +233,8 @@ class SwitchyardModel(SimpleResponsesAPIModel):
                 async with main_app_lifespan(app) as maybe_state:
                     yield maybe_state
             finally:
+                # Stats before stop: the snapshot needs the proxy still answering.
+                self.snapshot_proxy_stats()
                 self.stop_proxy()
 
         app.router.lifespan_context = lifespan_wrapper
@@ -259,6 +276,86 @@ class SwitchyardModel(SimpleResponsesAPIModel):
             return
         self._proxy_server = None
         server.close()
+
+    # --- Routing-condition record ---
+
+    def proxy_root_url(self) -> Optional[str]:
+        """The proxy's root URL (no /v1), in whichever mode is active."""
+        server = getattr(self, "_proxy_server", None)
+        if server is not None:
+            return server.base_url
+        if self.config.switchyard_base_url:
+            return self.config.switchyard_base_url.rstrip("/").removesuffix("/v1")
+        return None
+
+    def write_condition_manifest(self) -> None:
+        """Record the routing condition this run serves under, if condition_dir is set.
+
+        The manifest is the run's provenance: which route, against which deployment (hash and
+        archived contents), on which nemo-switchyard version. Two runs are comparable when their
+        manifests differ only in the route or deployment, and a run is reproducible from the
+        archive alone. Failing to write it must not take down serving -- provenance is worth a
+        warning, not an outage.
+        """
+        if not self.config.condition_dir:
+            return
+
+        deployment_sha256: Optional[str] = None
+        deployment_toml: Optional[str] = None
+        if self.config.launches_proxy:
+            deployment_bytes = Path(str(self.config.deployment)).read_bytes()
+            deployment_sha256 = hashlib.sha256(deployment_bytes).hexdigest()
+            # The native schema references credentials by environment variable name, but an
+            # inline literal would be a secret -- drop the value, keep the line visible.
+            deployment_toml = re.sub(
+                r"^(\s*api_key\s*=\s*).*$",
+                r"\1'<redacted>'",
+                deployment_bytes.decode(errors="replace"),
+                flags=re.MULTILINE,
+            )
+
+        manifest = {
+            "route": self.config.switchyard_model,
+            "mode": "hosted" if self.config.launches_proxy else "attached",
+            "proxy_root_url": self.proxy_root_url(),
+            "nemo_switchyard_version": self._nemo_switchyard_version(),
+            "deployment_path": str(self.config.deployment) if self.config.deployment else None,
+            "deployment_sha256": deployment_sha256,
+            "deployment_toml": deployment_toml,
+            "session_id_headers": list(self.config.session_id_headers),
+            "written_at": datetime.now(timezone.utc).isoformat(),
+        }
+        try:
+            condition_dir = Path(self.config.condition_dir)
+            condition_dir.mkdir(parents=True, exist_ok=True)
+            (condition_dir / "switchyard-condition.json").write_text(json.dumps(manifest, indent=2) + "\n")
+        except OSError:
+            logger.warning("switchyard_model: could not write the condition manifest", exc_info=True)
+
+    def snapshot_proxy_stats(self) -> None:
+        """Persist the proxy's /v1/stats before it goes away, if condition_dir is set.
+
+        A hosted proxy's counters die with the process, so this is the only chance to keep the
+        proxy-side view of the run -- per-target requests, tokens, retries, latency -- next to
+        the eval outputs it explains. Best-effort for the same reason as the manifest.
+        """
+        root_url = self.proxy_root_url()
+        if not self.config.condition_dir or root_url is None:
+            return
+        try:
+            with urllib.request.urlopen(f"{root_url}/v1/stats", timeout=5) as response:
+                stats = response.read()
+            condition_dir = Path(self.config.condition_dir)
+            condition_dir.mkdir(parents=True, exist_ok=True)
+            (condition_dir / "switchyard-stats.json").write_bytes(stats + b"\n")
+        except (OSError, urllib.error.URLError):
+            logger.warning("switchyard_model: could not snapshot proxy stats", exc_info=True)
+
+    def _nemo_switchyard_version(self) -> Optional[str]:
+        try:
+            return importlib.metadata.version("nemo-switchyard")
+        except importlib.metadata.PackageNotFoundError:
+            return None
 
     # --- Model calls ---
 

--- a/responses_api_models/switchyard_model/configs/switchyard_model.yaml
+++ b/responses_api_models/switchyard_model/configs/switchyard_model.yaml
@@ -1,35 +1,38 @@
 # Route Gym model calls through a Switchyard proxy, so any benchmark Gym supports can be run
 # against a router.
 #
-# Attach mode (default): start the proxy yourself, then point Gym at it. Keeping the proxy outside
-# Gym is what lets an eval pin a specific Switchyard build and compare against scaled-evals runs.
-#
-#   switchyard --routing-profiles routes.yaml -- serve --port 4000
-#   gym eval run --benchmark <name> --model-type switchyard_model \
-#     ++policy_model.responses_api_models.switchyard_model.switchyard_base_url=http://127.0.0.1:4000/v1
-#
-# Launch mode: Gym starts the proxy itself, for a single-command run.
+# Gym launches and manages the proxy for you. Point routing_profiles at your Switchyard routing
+# config and run:
 #
 #   gym eval run --benchmark <name> --model-type switchyard_model \
-#     ++policy_model.responses_api_models.switchyard_model.launch_proxy=true \
 #     ++policy_model.responses_api_models.switchyard_model.routing_profiles=/path/to/routes.yaml
+#
+# Launching drives the `switchyard` CLI, so it must be on PATH (`pip install
+# 'nemo-switchyard[server]'`). The proxy is started when this server starts and stopped when it
+# exits.
+#
+# To attach to a proxy you already run instead -- to pin a specific Switchyard build, or to share
+# one instance across servers -- set switchyard_base_url and routing_profiles is not needed:
+#
+#   ++policy_model.responses_api_models.switchyard_model.switchyard_base_url=http://127.0.0.1:4000/v1
 policy_model:
   responses_api_models:
     switchyard_model:
       entrypoint: app.py
 
-      # Attach mode.
-      switchyard_base_url: ${oc.env:SWITCHYARD_BASE_URL,null}
-      switchyard_api_key: ${oc.env:SWITCHYARD_API_KEY,dummy}
+      # The routing config Switchyard serves. Required unless switchyard_base_url is set.
+      routing_profiles: ${oc.env:SWITCHYARD_ROUTING_PROFILES,null}
 
       # Route name to request. Switchyard maps it to a concrete target; the model that actually
       # served each call comes back on the response.
       switchyard_model: ${policy_model_name}
 
-      # Launch mode. routing_profiles is required when launch_proxy is true.
-      launch_proxy: false
-      routing_profiles: null
-      proxy_host: 127.0.0.1
+      # Set to attach to an already-running proxy instead of launching one.
+      switchyard_base_url: ${oc.env:SWITCHYARD_BASE_URL,null}
+      switchyard_api_key: ${oc.env:SWITCHYARD_API_KEY,dummy}
+
+      # Wildcard bind so the proxy is reachable off-box; this server talks to it over loopback.
+      proxy_host: 0.0.0.0
       # null picks a free port that does not collide with Gym's own servers.
       proxy_port: null
       proxy_startup_timeout_s: 120.0

--- a/responses_api_models/switchyard_model/configs/switchyard_model.yaml
+++ b/responses_api_models/switchyard_model/configs/switchyard_model.yaml
@@ -7,9 +7,8 @@
 #   gym eval run --benchmark <name> --model-type switchyard_model \
 #     ++policy_model.responses_api_models.switchyard_model.routing_profiles=/path/to/routes.yaml
 #
-# Launching drives the `switchyard` CLI, so it must be on PATH (`pip install
-# 'nemo-switchyard[server]'`). The proxy is started when this server starts and stopped when it
-# exits.
+# Launching drives the `switchyard` CLI, which is installed with this server -- nemo-switchyard is
+# one of its dependencies. The proxy is started when this server starts and stopped when it exits.
 #
 # To attach to a proxy you already run instead -- to pin a specific Switchyard build, or to share
 # one instance across servers -- set switchyard_base_url and routing_profiles is not needed:

--- a/responses_api_models/switchyard_model/configs/switchyard_model.yaml
+++ b/responses_api_models/switchyard_model/configs/switchyard_model.yaml
@@ -1,0 +1,45 @@
+# Route Gym model calls through a Switchyard proxy, so any benchmark Gym supports can be run
+# against a router.
+#
+# Attach mode (default): start the proxy yourself, then point Gym at it. Keeping the proxy outside
+# Gym is what lets an eval pin a specific Switchyard build and compare against scaled-evals runs.
+#
+#   switchyard --routing-profiles routes.yaml -- serve --port 4000
+#   gym eval run --benchmark <name> --model-type switchyard_model \
+#     ++policy_model.responses_api_models.switchyard_model.switchyard_base_url=http://127.0.0.1:4000/v1
+#
+# Launch mode: Gym starts the proxy itself, for a single-command run.
+#
+#   gym eval run --benchmark <name> --model-type switchyard_model \
+#     ++policy_model.responses_api_models.switchyard_model.launch_proxy=true \
+#     ++policy_model.responses_api_models.switchyard_model.routing_profiles=/path/to/routes.yaml
+policy_model:
+  responses_api_models:
+    switchyard_model:
+      entrypoint: app.py
+
+      # Attach mode.
+      switchyard_base_url: ${oc.env:SWITCHYARD_BASE_URL,null}
+      switchyard_api_key: ${oc.env:SWITCHYARD_API_KEY,dummy}
+
+      # Route name to request. Switchyard maps it to a concrete target; the model that actually
+      # served each call comes back on the response.
+      switchyard_model: ${policy_model_name}
+
+      # Launch mode. routing_profiles is required when launch_proxy is true.
+      launch_proxy: false
+      routing_profiles: null
+      proxy_host: 127.0.0.1
+      # null picks a free port that does not collide with Gym's own servers.
+      proxy_port: null
+      proxy_startup_timeout_s: 120.0
+      switchyard_executable: switchyard
+
+      # Gym's rollout-attempt id is sent as Switchyard's opaque session id, so routing decisions
+      # and costs can be joined back to the rollout that produced them.
+      session_id_header: proxy_x_session_id
+      forward_session_id: true
+
+      extra_body: {}
+      default_headers: {}
+      max_concurrent_requests: null

--- a/responses_api_models/switchyard_model/configs/switchyard_model.yaml
+++ b/responses_api_models/switchyard_model/configs/switchyard_model.yaml
@@ -45,6 +45,11 @@ policy_model:
         - x-switchyard-session-id
       forward_session_id: true
 
+      # Directory for this run's routing-condition record: a provenance manifest at startup
+      # (route, deployment hash + archived contents, nemo-switchyard version) and a /v1/stats
+      # snapshot at shutdown. Use one directory per run; null disables.
+      condition_dir: ${oc.env:SWITCHYARD_CONDITION_DIR,null}
+
       extra_body: {}
       default_headers: {}
       max_concurrent_requests: null

--- a/responses_api_models/switchyard_model/configs/switchyard_model.yaml
+++ b/responses_api_models/switchyard_model/configs/switchyard_model.yaml
@@ -43,7 +43,10 @@ policy_model:
       # on that name.
       session_id_headers:
         - x-switchyard-session-id
-      forward_session_id: true
+      # forward_session_id defaults to true, and the id only exists when observability or token
+      # capture is on -- without one the server warns and sends nothing. Deliberately NOT set
+      # here: an explicitly set true is a promise, and the server refuses to start when it
+      # cannot keep it.
 
       # Directory for this run's routing-condition record: a provenance manifest at startup
       # (route, deployment hash + archived contents, nemo-switchyard version) and a /v1/stats

--- a/responses_api_models/switchyard_model/configs/switchyard_model.yaml
+++ b/responses_api_models/switchyard_model/configs/switchyard_model.yaml
@@ -50,6 +50,11 @@ policy_model:
       # snapshot at shutdown. Use one directory per run; null disables.
       condition_dir: ${oc.env:SWITCHYARD_CONDITION_DIR,null}
 
+      # Identity of an attached proxy, copied verbatim into the condition manifest -- Gym cannot
+      # see what an external proxy runs, so its operator says (e.g. switchyard_commit, the
+      # deployment's hash). Ignored when hosting.
+      proxy_provenance: {}
+
       extra_body: {}
       default_headers: {}
       max_concurrent_requests: null

--- a/responses_api_models/switchyard_model/configs/switchyard_model.yaml
+++ b/responses_api_models/switchyard_model/configs/switchyard_model.yaml
@@ -1,17 +1,18 @@
 # Route Gym model calls through a Switchyard proxy, so any benchmark Gym supports can be run
 # against a router.
 #
-# Gym launches and manages the proxy for you. Point routing_profiles at your Switchyard routing
-# config and run:
+# Gym hosts the proxy for you, in-process. Point deployment at a native Switchyard TOML
+# deployment -- the llm_clients, targets, and routes the proxy serves -- and run:
 #
 #   gym eval run --benchmark <name> --model-type switchyard_model \
-#     ++policy_model.responses_api_models.switchyard_model.routing_profiles=/path/to/routes.yaml
+#     ++policy_model.responses_api_models.switchyard_model.deployment=/path/to/routes.toml
 #
-# Launching drives the `switchyard` CLI, which is installed with this server -- nemo-switchyard is
-# one of its dependencies. The proxy is started when this server starts and stopped when it exits.
+# Hosting uses the native server that ships with this server's nemo-switchyard dependency; there
+# is no separate process to install or manage. The proxy starts when this server starts and stops
+# when it exits.
 #
 # To attach to a proxy you already run instead -- to pin a specific Switchyard build, or to share
-# one instance across servers -- set switchyard_base_url and routing_profiles is not needed:
+# one instance across servers -- set switchyard_base_url and deployment is not needed:
 #
 #   ++policy_model.responses_api_models.switchyard_model.switchyard_base_url=http://127.0.0.1:4000/v1
 policy_model:
@@ -19,23 +20,21 @@ policy_model:
     switchyard_model:
       entrypoint: app.py
 
-      # The routing config Switchyard serves. Required unless switchyard_base_url is set.
-      routing_profiles: ${oc.env:SWITCHYARD_ROUTING_PROFILES,null}
+      # The native TOML deployment the hosted proxy serves. Required unless switchyard_base_url
+      # is set.
+      deployment: ${oc.env:SWITCHYARD_DEPLOYMENT,null}
 
       # Route name to request. Switchyard maps it to a concrete target; the model that actually
       # served each call comes back on the response.
       switchyard_model: ${policy_model_name}
 
-      # Set to attach to an already-running proxy instead of launching one.
+      # Set to attach to an already-running proxy instead of hosting one.
       switchyard_base_url: ${oc.env:SWITCHYARD_BASE_URL,null}
       switchyard_api_key: ${oc.env:SWITCHYARD_API_KEY,dummy}
 
-      # Wildcard bind so the proxy is reachable off-box; this server talks to it over loopback.
-      proxy_host: 0.0.0.0
+      # The hosted proxy binds loopback; this server is the network-facing piece.
       # null picks a free port that does not collide with Gym's own servers.
       proxy_port: null
-      proxy_startup_timeout_s: 120.0
-      switchyard_executable: switchyard
 
       # Gym's rollout-attempt id is sent as Switchyard's opaque session id, so routing decisions
       # and costs can be joined back to the rollout that produced them.

--- a/responses_api_models/switchyard_model/configs/switchyard_model.yaml
+++ b/responses_api_models/switchyard_model/configs/switchyard_model.yaml
@@ -37,8 +37,12 @@ policy_model:
       proxy_port: null
 
       # Gym's rollout-attempt id is sent as Switchyard's opaque session id, so routing decisions
-      # and costs can be joined back to the rollout that produced them.
-      session_id_header: proxy_x_session_id
+      # and costs can be joined back to the rollout that produced them. x-switchyard-session-id is
+      # the name the native server reads into routing metadata; add proxy_x_session_id when
+      # attaching to a switchyard-server running with --routing-log-file, whose session log keys
+      # on that name.
+      session_id_headers:
+        - x-switchyard-session-id
       forward_session_id: true
 
       extra_body: {}

--- a/responses_api_models/switchyard_model/pyproject.toml
+++ b/responses_api_models/switchyard_model/pyproject.toml
@@ -31,10 +31,20 @@ dependencies = [
     # server rather than Gym's core dependencies, so only runs that route through Switchyard pay
     # for it -- Gym itself never imports Switchyard.
     #
-    # Pinned exactly, not to a range: see the openai override below.
-    # Updated Fri Jul 24, 2026 with nemo-switchyard[server]==0.1.0
+    # Pinned to a git commit rather than a release because the published 0.1.0 cannot serve this
+    # server's /v1/responses endpoint at all: its chat->responses translation omits the
+    # input_tokens_details and output_tokens_details objects that the Responses schema requires,
+    # so every response fails NeMoGymResponse validation. Fixed in
+    # NVIDIA-NeMo/Switchyard#144, which is merged but not yet released -- PyPI still carries only
+    # 0.1.0. Move to `>=0.1.1,<0.2.0` as soon as a release carrying that fix ships.
+    #
+    # Installing from git builds Switchyard's Rust extension (maturin), so this needs a cargo
+    # toolchain on the installing machine. Gym's CI does not provide one, so `gym env test` for
+    # this server will not run there until the pin moves to a released wheel.
+    #
+    # Updated Sun Jul 26, 2026 with nemo-switchyard[server] @ 0a03235
     # License: Apache 2.0 https://github.com/NVIDIA-NeMo/Switchyard/blob/main/LICENSE
-    "nemo-switchyard[server]==0.1.0",
+    "nemo-switchyard[server] @ git+https://github.com/NVIDIA-NeMo/Switchyard@0a03235ba9cacb439e6981f44754965f64347dea",
 ]
 
 [build-system]
@@ -44,25 +54,6 @@ requires = ["setuptools>=61", "setuptools-scm"]
 [tool.setuptools.packages.find]
 where = [".."]
 include = ["switchyard_model"]
-
-[tool.uv]
-# Neutralizes a stale floor in nemo-switchyard 0.1.0, which declares openai>=2.34.0 and so will not
-# co-install with Gym's openai<=2.7.2. That floor was never a real requirement -- it was whatever
-# version was current when the package metadata was written -- and it was widened to >=2.7 in
-# NVIDIA-NeMo/Switchyard#142. PyPI releases are immutable, so the published 0.1.0 keeps the old
-# metadata regardless. Switchyard's own suite at v0.1.0 passes identically on 2.7.0, 2.7.1, 2.7.2,
-# 2.34.0 and 2.48.0, so the constraint is not describing anything the code needs.
-#
-# This deliberately restates Gym's own openai pin rather than expressing a preference of its own:
-# the intent is "whatever openai Gym resolves", not "some particular openai". uv overrides apply to
-# every requirement for a package, not just the offending one, so an unbounded override here would
-# also erase Gym's deliberate ceiling and pull in a much newer openai than Gym is tested against --
-# hence the ceiling is repeated rather than omitted. Keep it in sync with Gym's openai pin.
-#
-# Because this asserts something about one specific published artifact, nemo-switchyard is pinned
-# to ==0.1.0 above. Delete both the pin and this override once a release carrying the widened floor
-# ships; a plain >=0.1.1,<0.2.0 range is enough after that.
-override-dependencies = ["openai<=2.7.2"]
 
 [tool.uv.sources]
 nemo-gym = { path = "../..", editable = true }

--- a/responses_api_models/switchyard_model/pyproject.toml
+++ b/responses_api_models/switchyard_model/pyproject.toml
@@ -38,9 +38,10 @@ dependencies = [
     # NVIDIA-NeMo/Switchyard#144, which is merged but not yet released -- PyPI still carries only
     # 0.1.0. Move to `>=0.1.1,<0.2.0` as soon as a release carrying that fix ships.
     #
-    # Installing from git builds Switchyard's Rust extension (maturin), so this needs a cargo
-    # toolchain on the installing machine. Gym's CI does not provide one, so `gym env test` for
-    # this server will not run there until the pin moves to a released wheel.
+    # Installing from git bypasses Switchyard's published cp312-abi3 wheels and builds its Rust
+    # extension through maturin, so this needs a cargo toolchain on the installing machine and
+    # adds roughly a minute to a cold environment build. CI runners carry one, so this server's
+    # suite builds and runs there normally.
     #
     # Updated Sun Jul 26, 2026 with nemo-switchyard[server] @ 0a03235
     # License: Apache 2.0 https://github.com/NVIDIA-NeMo/Switchyard/blob/main/LICENSE

--- a/responses_api_models/switchyard_model/pyproject.toml
+++ b/responses_api_models/switchyard_model/pyproject.toml
@@ -39,9 +39,11 @@ dependencies = [
     # 0.1.0. Move to `>=0.1.1,<0.2.0` as soon as a release carrying that fix ships.
     #
     # Installing from git bypasses Switchyard's published cp312-abi3 wheels and builds its Rust
-    # extension through maturin, so this needs a cargo toolchain on the installing machine and
-    # adds roughly a minute to a cold environment build. CI runners carry one, so this server's
-    # suite builds and runs there normally.
+    # extension through maturin. That needs no toolchain on the installing machine -- maturin
+    # pulls in puccinialin and bootstraps rustup when it finds none, verified on a host with no
+    # cargo, no rustup and a cold cache -- but it does add a minute or two to a cold environment
+    # build, and the build fetches from static.rust-lang.org and crates.io on top of PyPI and
+    # GitHub. Restricted egress is the failure mode to warn users about, not a missing compiler.
     #
     # Updated Sun Jul 26, 2026 with nemo-switchyard[server] @ 0a03235
     # License: Apache 2.0 https://github.com/NVIDIA-NeMo/Switchyard/blob/main/LICENSE

--- a/responses_api_models/switchyard_model/pyproject.toml
+++ b/responses_api_models/switchyard_model/pyproject.toml
@@ -17,18 +17,24 @@
 name = "switchyard-model"
 version = "0.1.0"
 requires-python = ">=3.12"
-# This server deliberately takes no dependency on nemo-switchyard. It never imports Switchyard:
-# it speaks OpenAI-compatible HTTP to the proxy, and launch_proxy mode shells out to the
-# `switchyard` CLI, which only needs the executable on PATH. Users who want launch mode install
-# it themselves (`pip install 'nemo-switchyard[server]'`), which also lets them pin the exact
-# Switchyard build an eval is reported against rather than inheriting Gym's.
-#
-# Declaring it here is not currently possible in any case: the published nemo-switchyard 0.1.0
-# pins openai>=2.34.0 and Gym pins openai<=2.7.2, so the two cannot co-install. The Switchyard
-# floor was widened to >=2.7 in NVIDIA-NeMo/Switchyard#142, but PyPI releases are immutable, so
-# that only takes effect from the next release onward.
 dependencies = [
+    ########################################
+    # Every dependency listed here contains the following information:
+    # 1. Why this dependency is here in NeMo Gym
+    # 2. When this dependency was last updated
+    # 3. The license of the dependencies.
+    ########################################
+
     "nemo-gym[dev]",
+
+    # nemo-switchyard: provides the `switchyard` CLI this server launches. Scoped to this model
+    # server rather than Gym's core dependencies, so only runs that route through Switchyard pay
+    # for it -- Gym itself never imports Switchyard.
+    #
+    # Pinned exactly, not to a range: see the openai override below.
+    # Updated Fri Jul 24, 2026 with nemo-switchyard[server]==0.1.0
+    # License: Apache 2.0 https://github.com/NVIDIA-NeMo/Switchyard/blob/main/LICENSE
+    "nemo-switchyard[server]==0.1.0",
 ]
 
 [build-system]
@@ -38,6 +44,25 @@ requires = ["setuptools>=61", "setuptools-scm"]
 [tool.setuptools.packages.find]
 where = [".."]
 include = ["switchyard_model"]
+
+[tool.uv]
+# Neutralizes a stale floor in nemo-switchyard 0.1.0, which declares openai>=2.34.0 and so will not
+# co-install with Gym's openai<=2.7.2. That floor was never a real requirement -- it was whatever
+# version was current when the package metadata was written -- and it was widened to >=2.7 in
+# NVIDIA-NeMo/Switchyard#142. PyPI releases are immutable, so the published 0.1.0 keeps the old
+# metadata regardless. Switchyard's own suite at v0.1.0 passes identically on 2.7.0, 2.7.1, 2.7.2,
+# 2.34.0 and 2.48.0, so the constraint is not describing anything the code needs.
+#
+# This deliberately restates Gym's own openai pin rather than expressing a preference of its own:
+# the intent is "whatever openai Gym resolves", not "some particular openai". uv overrides apply to
+# every requirement for a package, not just the offending one, so an unbounded override here would
+# also erase Gym's deliberate ceiling and pull in a much newer openai than Gym is tested against --
+# hence the ceiling is repeated rather than omitted. Keep it in sync with Gym's openai pin.
+#
+# Because this asserts something about one specific published artifact, nemo-switchyard is pinned
+# to ==0.1.0 above. Delete both the pin and this override once a release carrying the widened floor
+# ships; a plain >=0.1.1,<0.2.0 range is enough after that.
+override-dependencies = ["openai<=2.7.2"]
 
 [tool.uv.sources]
 nemo-gym = { path = "../..", editable = true }

--- a/responses_api_models/switchyard_model/pyproject.toml
+++ b/responses_api_models/switchyard_model/pyproject.toml
@@ -17,27 +17,18 @@
 name = "switchyard-model"
 version = "0.1.0"
 requires-python = ">=3.12"
+# This server deliberately takes no dependency on nemo-switchyard. It never imports Switchyard:
+# it speaks OpenAI-compatible HTTP to the proxy, and launch_proxy mode shells out to the
+# `switchyard` CLI, which only needs the executable on PATH. Users who want launch mode install
+# it themselves (`pip install 'nemo-switchyard[server]'`), which also lets them pin the exact
+# Switchyard build an eval is reported against rather than inheriting Gym's.
+#
+# Declaring it here is not currently possible in any case: the published nemo-switchyard 0.1.0
+# pins openai>=2.34.0 and Gym pins openai<=2.7.2, so the two cannot co-install. The Switchyard
+# floor was widened to >=2.7 in NVIDIA-NeMo/Switchyard#142, but PyPI releases are immutable, so
+# that only takes effect from the next release onward.
 dependencies = [
-    ########################################
-    # Every dependency listed here contains the following information:
-    # 1. Why this dependency is here in NeMo Gym
-    # 2. When this dependency was last updated
-    # 3. The license of the dependencies.
-    ########################################
-
     "nemo-gym[dev]",
-
-    # nemo-switchyard: provides the `switchyard` CLI this server launches in launch_proxy mode.
-    # Scoped to this model server rather than Gym's core dependencies, so only runs that route
-    # through Switchyard pay for it. Not needed in attach mode, where the proxy is a plain
-    # OpenAI-compatible endpoint run outside Gym.
-    #
-    # Requires >=0.1.1: the published 0.1.0 pins openai>=2.34.0, which is unsatisfiable against
-    # Gym's openai<=2.7.2. The floor was widened to >=2.7 in NVIDIA-NeMo/Switchyard#142.
-    # Upper-bounded at the 0.1 line -- Switchyard is alpha and its crates are being restructured.
-    # Updated Fri Jul 24, 2026 with nemo-switchyard>=0.1.1,<0.2.0
-    # License: Apache 2.0 https://github.com/NVIDIA-NeMo/Switchyard/blob/main/LICENSE
-    "nemo-switchyard[server]>=0.1.1,<0.2.0",
 ]
 
 [build-system]

--- a/responses_api_models/switchyard_model/pyproject.toml
+++ b/responses_api_models/switchyard_model/pyproject.toml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[project]
+name = "switchyard-model"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    ########################################
+    # Every dependency listed here contains the following information:
+    # 1. Why this dependency is here in NeMo Gym
+    # 2. When this dependency was last updated
+    # 3. The license of the dependencies.
+    ########################################
+
+    "nemo-gym[dev]",
+
+    # nemo-switchyard: provides the `switchyard` CLI this server launches in launch_proxy mode.
+    # Scoped to this model server rather than Gym's core dependencies, so only runs that route
+    # through Switchyard pay for it. Not needed in attach mode, where the proxy is a plain
+    # OpenAI-compatible endpoint run outside Gym.
+    #
+    # Requires >=0.1.1: the published 0.1.0 pins openai>=2.34.0, which is unsatisfiable against
+    # Gym's openai<=2.7.2. The floor was widened to >=2.7 in NVIDIA-NeMo/Switchyard#142.
+    # Upper-bounded at the 0.1 line -- Switchyard is alpha and its crates are being restructured.
+    # Updated Fri Jul 24, 2026 with nemo-switchyard>=0.1.1,<0.2.0
+    # License: Apache 2.0 https://github.com/NVIDIA-NeMo/Switchyard/blob/main/LICENSE
+    "nemo-switchyard[server]>=0.1.1,<0.2.0",
+]
+
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools>=61", "setuptools-scm"]
+
+[tool.setuptools.packages.find]
+where = [".."]
+include = ["switchyard_model"]
+
+[tool.uv.sources]
+nemo-gym = { path = "../..", editable = true }

--- a/responses_api_models/switchyard_model/pyproject.toml
+++ b/responses_api_models/switchyard_model/pyproject.toml
@@ -27,27 +27,28 @@ dependencies = [
 
     "nemo-gym[dev]",
 
-    # nemo-switchyard: provides the `switchyard` CLI this server launches. Scoped to this model
-    # server rather than Gym's core dependencies, so only runs that route through Switchyard pay
-    # for it -- Gym itself never imports Switchyard.
+    # nemo-switchyard: provides the native in-process Switchyard server this model server hosts
+    # (switchyard_rust.server.Server). Scoped to this model server rather than Gym's core
+    # dependencies, so only runs that route through Switchyard pay for it -- Gym itself never
+    # imports Switchyard.
     #
-    # Pinned to a git commit rather than a release because the published 0.1.0 cannot serve this
-    # server's /v1/responses endpoint at all: its chat->responses translation omits the
-    # input_tokens_details and output_tokens_details objects that the Responses schema requires,
-    # so every response fails NeMoGymResponse validation. Fixed in
-    # NVIDIA-NeMo/Switchyard#144, which is merged but not yet released -- PyPI still carries only
-    # 0.1.0. Move to `>=0.1.1,<0.2.0` as soon as a release carrying that fix ships.
+    # Pinned exactly, like vllm in local_vllm_model, because this server hosts the pinned code
+    # in-process and depends on its wire behavior: the TOML deployment schema, the
+    # proxy_x_session_id session header, and the /v1 endpoint set are all version-coupled.
+    # Switchyard is moving fast (0.2.0 deprecates its Python serve stack and the next release
+    # removes it), so upgrades should be deliberate, tested events rather than resolver drift.
+    # No extras: the [server] extra covers only Switchyard's deprecated Python serve path, which
+    # this server does not use.
     #
-    # Installing from git bypasses Switchyard's published cp312-abi3 wheels and builds its Rust
-    # extension through maturin. That needs no toolchain on the installing machine -- maturin
-    # pulls in puccinialin and bootstraps rustup when it finds none, verified on a host with no
-    # cargo, no rustup and a cold cache -- but it does add a minute or two to a cold environment
-    # build, and the build fetches from static.rust-lang.org and crates.io on top of PyPI and
-    # GitHub. Restricted egress is the failure mode to warn users about, not a missing compiler.
+    # 0.2.0 is the floor as well as the pin -- it is the first release whose chat->responses
+    # translation emits the input_tokens_details and output_tokens_details objects the Responses
+    # schema requires (NVIDIA-NeMo/Switchyard#144); published 0.1.0 fails NeMoGymResponse
+    # validation on every /v1/responses call. Installs from PyPI cp312-abi3 wheels; no Rust
+    # toolchain, no git, no non-PyPI egress.
     #
-    # Updated Sun Jul 26, 2026 with nemo-switchyard[server] @ 0a03235
+    # Updated Mon Aug 17, 2026 with nemo-switchyard==0.2.0
     # License: Apache 2.0 https://github.com/NVIDIA-NeMo/Switchyard/blob/main/LICENSE
-    "nemo-switchyard[server] @ git+https://github.com/NVIDIA-NeMo/Switchyard@0a03235ba9cacb439e6981f44754965f64347dea",
+    "nemo-switchyard==0.2.0",
 ]
 
 [build-system]

--- a/responses_api_models/switchyard_model/tests/test_app.py
+++ b/responses_api_models/switchyard_model/tests/test_app.py
@@ -250,12 +250,22 @@ class TestProxyLifecycle:
 
     def _launch_server(self, monkeypatch: MonkeyPatch) -> SwitchyardModel:
         """Build a launch-mode server without actually spawning a proxy."""
+        monkeypatch.setattr(app_module.shutil, "which", lambda executable: f"/usr/bin/{executable}")
         monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: MagicMock(spec=_REAL_POPEN))
         monkeypatch.setattr(SwitchyardModel, "wait_for_proxy", lambda self, root_url, proc: None)
         return SwitchyardModel(
             config=self._launch_config(),
             server_client=MagicMock(spec=ServerClient, global_config_dict={}),
         )
+
+    def test_missing_executable_explains_how_to_fix(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(app_module.shutil, "which", lambda executable: None)
+
+        with pytest.raises(RuntimeError, match="nemo-switchyard"):
+            SwitchyardModel(
+                config=self._launch_config(),
+                server_client=MagicMock(spec=ServerClient, global_config_dict={}),
+            )
 
     def test_start_proxy_builds_command_and_waits(self, monkeypatch: MonkeyPatch) -> None:
         commands: list = []
@@ -266,6 +276,7 @@ class TestProxyLifecycle:
             commands.append(command)
             return process
 
+        monkeypatch.setattr(app_module.shutil, "which", lambda executable: f"/usr/bin/{executable}")
         monkeypatch.setattr(subprocess, "Popen", mock_popen)
         monkeypatch.setattr(SwitchyardModel, "wait_for_proxy", lambda self, root_url, proc: None)
 

--- a/responses_api_models/switchyard_model/tests/test_app.py
+++ b/responses_api_models/switchyard_model/tests/test_app.py
@@ -1,0 +1,360 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import subprocess
+import urllib.error
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
+
+import responses_api_models.switchyard_model.app as app_module
+from nemo_gym.server_utils import ServerClient
+from responses_api_models.switchyard_model.app import (
+    NeMoGymAsyncOpenAI,
+    SwitchyardModel,
+    SwitchyardModelConfig,
+    _RolloutSessionMiddleware,
+)
+
+
+# Captured before any test monkeypatches subprocess.Popen, so mocks keep a real spec.
+_REAL_POPEN = subprocess.Popen
+
+
+def _response_data() -> dict:
+    return {
+        "id": "resp_688babb004988199b26c5250ba69c1e80abdf302bcd600d3",
+        "created_at": 1753983920.0,
+        "model": "openai/gpt-5.2",
+        "object": "response",
+        "output": [
+            {
+                "id": "msg_688babb17a7881998cc7a42d53c8e5790abdf302bcd600d3",
+                "content": [{"annotations": [], "text": "Hello!", "type": "output_text"}],
+                "role": "assistant",
+                "status": "completed",
+                "type": "message",
+            }
+        ],
+        "parallel_tool_calls": True,
+        "tool_choice": "auto",
+        "tools": [],
+    }
+
+
+def _chat_data() -> dict:
+    return {
+        "id": "chatcmpl-BzRdCFjIEIp59xXLBNYjdPPrcpDaa",  # pragma: allowlist secret
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "index": 0,
+                "message": {"content": "Hello!", "role": "assistant"},
+            }
+        ],
+        "created": 1753983922,
+        "model": "openai/gpt-5.2",
+        "object": "chat.completion",
+    }
+
+
+class TestConfig:
+    def test_attach_mode_requires_base_url(self) -> None:
+        with pytest.raises(ValueError, match="switchyard_base_url is required"):
+            SwitchyardModelConfig(host="0.0.0.0", port=8081, entrypoint="", name="sy", switchyard_model="policy-model")
+
+    def test_launch_mode_requires_routing_profiles(self) -> None:
+        with pytest.raises(ValueError, match="routing_profiles is required"):
+            SwitchyardModelConfig(
+                host="0.0.0.0",
+                port=8081,
+                entrypoint="",
+                name="sy",
+                switchyard_model="policy-model",
+                launch_proxy=True,
+            )
+
+    def test_launch_mode_accepts_routing_profiles(self) -> None:
+        config = SwitchyardModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            entrypoint="",
+            name="sy",
+            switchyard_model="policy-model",
+            launch_proxy=True,
+            routing_profiles="/tmp/routes.yaml",
+        )
+        assert config.routing_profiles == "/tmp/routes.yaml"
+
+
+class TestRolloutSessionMiddleware:
+    async def test_non_http_scope_is_forwarded_untouched(self) -> None:
+        seen: dict = {}
+
+        async def inner(scope, receive, send):
+            seen["scope"] = scope
+
+        middleware = _RolloutSessionMiddleware(inner)
+        await middleware({"type": "lifespan"}, None, None)
+
+        assert seen["scope"] == {"type": "lifespan"}
+
+
+class TestApp:
+    def _setup_server(self, **overrides) -> SwitchyardModel:
+        config = SwitchyardModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            entrypoint="",
+            name="test_switchyard_model",
+            switchyard_base_url="http://127.0.0.1:4000/v1",
+            switchyard_api_key="dummy_key",  # pragma: allowlist secret
+            switchyard_model="policy-model",
+            **overrides,
+        )
+        return SwitchyardModel(config=config, server_client=MagicMock(spec=ServerClient, global_config_dict={}))
+
+    def test_sanity(self) -> None:
+        server = self._setup_server()
+        assert server._client.base_url == "http://127.0.0.1:4000/v1"
+
+    def test_max_concurrent_requests_builds_semaphore(self) -> None:
+        server = self._setup_server(max_concurrent_requests=2)
+        assert server._semaphore._value == 2
+
+    def test_responses_forwards_route_and_session_id(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._setup_server()
+        seen: dict = {}
+
+        async def mock_create_response(self, **kwargs):
+            seen["headers"] = self.default_headers
+            seen["kwargs"] = kwargs
+            return _response_data()
+
+        monkeypatch.setattr(NeMoGymAsyncOpenAI, "create_response", mock_create_response)
+        client = TestClient(server.setup_webserver())
+
+        response = client.post(
+            "/ng-rollout/task0-r1-a0/v1/responses",
+            json={"input": [{"role": "user", "content": "hi"}], "model": "ignored"},
+        )
+
+        assert response.status_code == 200
+        # The route name always wins -- a caller-supplied model must not bypass routing.
+        assert seen["kwargs"]["model"] == "policy-model"
+        assert seen["headers"]["proxy_x_session_id"] == "task0-r1-a0"
+        # The routed target is visible on the response.
+        assert response.json()["model"] == "openai/gpt-5.2"
+
+    def test_chat_completions_forwards_route_and_session_id(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._setup_server()
+        seen: dict = {}
+
+        async def mock_create_chat_completion(self, **kwargs):
+            seen["headers"] = self.default_headers
+            seen["kwargs"] = kwargs
+            return _chat_data()
+
+        monkeypatch.setattr(NeMoGymAsyncOpenAI, "create_chat_completion", mock_create_chat_completion)
+        client = TestClient(server.setup_webserver())
+
+        response = client.post(
+            "/ng-rollout/task0-r1/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        assert seen["kwargs"]["model"] == "policy-model"
+        assert seen["headers"]["proxy_x_session_id"] == "task0-r1"
+
+    def test_uncorrelated_call_sends_no_session_id(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._setup_server(default_headers={"x-team": "gym"})
+        seen: dict = {}
+
+        async def mock_create_response(self, **kwargs):
+            seen["headers"] = self.default_headers
+            return _response_data()
+
+        monkeypatch.setattr(NeMoGymAsyncOpenAI, "create_response", mock_create_response)
+        client = TestClient(server.setup_webserver())
+
+        response = client.post("/v1/responses", json={"input": [{"role": "user", "content": "hi"}]})
+
+        assert response.status_code == 200
+        assert "proxy_x_session_id" not in seen["headers"]
+        assert seen["headers"]["x-team"] == "gym"
+
+    def test_forward_session_id_disabled(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._setup_server(forward_session_id=False)
+        seen: dict = {}
+
+        async def mock_create_response(self, **kwargs):
+            seen["headers"] = self.default_headers
+            return _response_data()
+
+        monkeypatch.setattr(NeMoGymAsyncOpenAI, "create_response", mock_create_response)
+        client = TestClient(server.setup_webserver())
+
+        response = client.post(
+            "/ng-rollout/task0-r1/v1/responses",
+            json={"input": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        assert "proxy_x_session_id" not in seen["headers"]
+
+    def test_extra_body_is_merged(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._setup_server(extra_body={"max_output_tokens": 16})
+        seen: dict = {}
+
+        async def mock_create_response(self, **kwargs):
+            seen.update(kwargs)
+            return _response_data()
+
+        monkeypatch.setattr(NeMoGymAsyncOpenAI, "create_response", mock_create_response)
+        client = TestClient(server.setup_webserver())
+
+        response = client.post("/v1/responses", json={"input": [{"role": "user", "content": "hi"}]})
+
+        assert response.status_code == 200
+        assert seen["max_output_tokens"] == 16
+
+
+class TestProxyLifecycle:
+    def _launch_config(self, **overrides) -> SwitchyardModelConfig:
+        return SwitchyardModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            entrypoint="",
+            name="test_switchyard_model",
+            switchyard_model="policy-model",
+            launch_proxy=True,
+            routing_profiles="/tmp/routes.yaml",
+            proxy_port=4123,
+            **overrides,
+        )
+
+    def _launch_server(self, monkeypatch: MonkeyPatch) -> SwitchyardModel:
+        """Build a launch-mode server without actually spawning a proxy."""
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: MagicMock(spec=_REAL_POPEN))
+        monkeypatch.setattr(SwitchyardModel, "wait_for_proxy", lambda self, root_url, proc: None)
+        return SwitchyardModel(
+            config=self._launch_config(),
+            server_client=MagicMock(spec=ServerClient, global_config_dict={}),
+        )
+
+    def test_start_proxy_builds_command_and_waits(self, monkeypatch: MonkeyPatch) -> None:
+        commands: list = []
+        process = MagicMock(spec=_REAL_POPEN)
+        process.poll.return_value = None
+
+        def mock_popen(command, *args, **kwargs):
+            commands.append(command)
+            return process
+
+        monkeypatch.setattr(subprocess, "Popen", mock_popen)
+        monkeypatch.setattr(SwitchyardModel, "wait_for_proxy", lambda self, root_url, proc: None)
+
+        server = SwitchyardModel(
+            config=self._launch_config(),
+            server_client=MagicMock(spec=ServerClient, global_config_dict={}),
+        )
+
+        assert server._client.base_url == "http://127.0.0.1:4123/v1"
+        assert commands[0] == [
+            "switchyard",
+            "--routing-profiles",
+            "/tmp/routes.yaml",
+            "--",
+            "serve",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "4123",
+        ]
+
+    def test_wait_for_proxy_raises_when_process_dies(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._launch_server(monkeypatch)
+        # Drop the construction-time patches so the real wait_for_proxy runs below.
+        monkeypatch.undo()
+
+        dead = MagicMock(spec=_REAL_POPEN)
+        dead.poll.return_value = 1
+        dead.returncode = 1
+
+        with pytest.raises(RuntimeError, match="exited during startup"):
+            server.wait_for_proxy("http://127.0.0.1:4123", dead)
+
+    def test_stop_proxy_terminates_then_kills(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._launch_server(monkeypatch)
+
+        process = MagicMock(spec=_REAL_POPEN)
+        process.poll.return_value = None
+        process.wait.side_effect = subprocess.TimeoutExpired(cmd="switchyard", timeout=30)
+        server._proxy_process = process
+
+        server.stop_proxy()
+
+        process.terminate.assert_called_once()
+        process.kill.assert_called_once()
+
+    def test_wait_for_proxy_returns_once_healthy(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._launch_server(monkeypatch)
+        monkeypatch.undo()
+
+        alive = MagicMock(spec=_REAL_POPEN)
+        alive.poll.return_value = None
+
+        attempts = {"count": 0}
+
+        @contextmanager
+        def mock_urlopen(url, timeout=None):
+            attempts["count"] += 1
+            # First probe refused, as it is while the proxy is still binding.
+            if attempts["count"] == 1:
+                raise urllib.error.URLError("connection refused")
+            yield MagicMock(status=200)
+
+        monkeypatch.setattr(app_module.urllib.request, "urlopen", mock_urlopen)
+        monkeypatch.setattr(app_module.time, "sleep", lambda seconds: None)
+
+        server.wait_for_proxy("http://127.0.0.1:4123", alive)
+
+        assert attempts["count"] == 2
+
+    def test_wait_for_proxy_times_out(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._launch_server(monkeypatch)
+        monkeypatch.undo()
+        server.config.proxy_startup_timeout_s = 0.0
+        server._proxy_process = None
+
+        alive = MagicMock(spec=_REAL_POPEN)
+        alive.poll.return_value = None
+
+        with pytest.raises(TimeoutError, match="did not become healthy"):
+            server.wait_for_proxy("http://127.0.0.1:4123", alive)
+
+    def test_stop_proxy_is_noop_when_already_exited(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._launch_server(monkeypatch)
+
+        process = MagicMock(spec=_REAL_POPEN)
+        process.poll.return_value = 0
+        server._proxy_process = process
+
+        server.stop_proxy()
+
+        process.terminate.assert_not_called()

--- a/responses_api_models/switchyard_model/tests/test_app.py
+++ b/responses_api_models/switchyard_model/tests/test_app.py
@@ -73,32 +73,31 @@ def _chat_data() -> dict:
 
 
 class TestConfig:
-    def test_attach_mode_requires_base_url(self) -> None:
-        with pytest.raises(ValueError, match="switchyard_base_url is required"):
+    def test_requires_a_routing_profile_or_a_base_url(self) -> None:
+        with pytest.raises(ValueError, match="routing_profiles"):
             SwitchyardModelConfig(host="0.0.0.0", port=8081, entrypoint="", name="sy", switchyard_model="policy-model")
 
-    def test_launch_mode_requires_routing_profiles(self) -> None:
-        with pytest.raises(ValueError, match="routing_profiles is required"):
-            SwitchyardModelConfig(
-                host="0.0.0.0",
-                port=8081,
-                entrypoint="",
-                name="sy",
-                switchyard_model="policy-model",
-                launch_proxy=True,
-            )
-
-    def test_launch_mode_accepts_routing_profiles(self) -> None:
+    def test_routing_profiles_alone_means_gym_launches(self) -> None:
         config = SwitchyardModelConfig(
             host="0.0.0.0",
             port=8081,
             entrypoint="",
             name="sy",
             switchyard_model="policy-model",
-            launch_proxy=True,
             routing_profiles="/tmp/routes.yaml",
         )
-        assert config.routing_profiles == "/tmp/routes.yaml"
+        assert config.launches_proxy is True
+
+    def test_base_url_alone_means_attach(self) -> None:
+        config = SwitchyardModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            entrypoint="",
+            name="sy",
+            switchyard_model="policy-model",
+            switchyard_base_url="http://127.0.0.1:4000/v1",
+        )
+        assert config.launches_proxy is False
 
 
 class TestRolloutSessionMiddleware:
@@ -242,30 +241,40 @@ class TestProxyLifecycle:
             entrypoint="",
             name="test_switchyard_model",
             switchyard_model="policy-model",
-            launch_proxy=True,
             routing_profiles="/tmp/routes.yaml",
             proxy_port=4123,
             **overrides,
         )
 
-    def _launch_server(self, monkeypatch: MonkeyPatch) -> SwitchyardModel:
-        """Build a launch-mode server without actually spawning a proxy."""
-        monkeypatch.setattr(app_module.shutil, "which", lambda executable: f"/usr/bin/{executable}")
-        monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: MagicMock(spec=_REAL_POPEN))
-        monkeypatch.setattr(SwitchyardModel, "wait_for_proxy", lambda self, root_url, proc: None)
+    def _build(self) -> SwitchyardModel:
         return SwitchyardModel(
             config=self._launch_config(),
             server_client=MagicMock(spec=ServerClient, global_config_dict={}),
         )
 
+    def _launch_server(self, monkeypatch: MonkeyPatch) -> SwitchyardModel:
+        """Build a launch-mode server with the spawn stubbed out."""
+        monkeypatch.setattr(app_module.shutil, "which", lambda executable: f"/usr/bin/{executable}")
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: MagicMock(spec=_REAL_POPEN))
+        monkeypatch.setattr(SwitchyardModel, "wait_for_proxy", lambda self, root_url, proc: None)
+        return self._build()
+
+    def test_constructing_the_server_does_not_spawn_a_proxy(self, monkeypatch: MonkeyPatch) -> None:
+        """The proxy belongs to serving, not to config validation."""
+
+        def explode(*args, **kwargs):
+            raise AssertionError("constructing SwitchyardModel must not spawn a proxy")
+
+        monkeypatch.setattr(subprocess, "Popen", explode)
+
+        self._build()
+
     def test_missing_executable_explains_how_to_fix(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._build()
         monkeypatch.setattr(app_module.shutil, "which", lambda executable: None)
 
         with pytest.raises(RuntimeError, match="nemo-switchyard"):
-            SwitchyardModel(
-                config=self._launch_config(),
-                server_client=MagicMock(spec=ServerClient, global_config_dict={}),
-            )
+            server.setup_webserver()
 
     def test_start_proxy_builds_command_and_waits(self, monkeypatch: MonkeyPatch) -> None:
         commands: list = []
@@ -280,12 +289,10 @@ class TestProxyLifecycle:
         monkeypatch.setattr(subprocess, "Popen", mock_popen)
         monkeypatch.setattr(SwitchyardModel, "wait_for_proxy", lambda self, root_url, proc: None)
 
-        server = SwitchyardModel(
-            config=self._launch_config(),
-            server_client=MagicMock(spec=ServerClient, global_config_dict={}),
-        )
+        server = self._build()
+        server.setup_webserver()
 
-        assert server._client.base_url == "http://127.0.0.1:4123/v1"
+        # Bound on the wildcard so the proxy is reachable off-box, but addressed over loopback.
         assert commands[0] == [
             "switchyard",
             "--routing-profiles",
@@ -293,10 +300,11 @@ class TestProxyLifecycle:
             "--",
             "serve",
             "--host",
-            "127.0.0.1",
+            "0.0.0.0",
             "--port",
             "4123",
         ]
+        assert server._client.base_url == "http://127.0.0.1:4123/v1"
 
     def test_wait_for_proxy_raises_when_process_dies(self, monkeypatch: MonkeyPatch) -> None:
         server = self._launch_server(monkeypatch)

--- a/responses_api_models/switchyard_model/tests/test_app.py
+++ b/responses_api_models/switchyard_model/tests/test_app.py
@@ -15,10 +15,11 @@
 import signal
 import subprocess
 import urllib.error
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 
@@ -435,6 +436,31 @@ class TestProxyOutlivesNothing:
         # Entering and leaving the TestClient context runs the app's startup/shutdown events.
         with TestClient(app):
             process.terminate.assert_not_called()
+
+        process.terminate.assert_called_once()
+
+    def test_failed_startup_still_stops_the_proxy(self, monkeypatch: MonkeyPatch) -> None:
+        """The proxy is up before the app finishes starting, so a failed startup must still reap it."""
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: MagicMock(spec=_REAL_POPEN))
+        server = self._launch_server(monkeypatch)
+
+        process = MagicMock(spec=_REAL_POPEN)
+        process.poll.return_value = None
+        server._proxy_process = process
+
+        app = FastAPI()
+
+        @asynccontextmanager
+        async def failing_lifespan(_app):
+            raise RuntimeError("startup failed")
+            yield  # pragma: no cover - unreachable; present so this is a generator
+
+        app.router.lifespan_context = failing_lifespan
+        server.setup_proxy_shutdown(app)
+
+        with pytest.raises(RuntimeError, match="startup failed"):
+            with TestClient(app):
+                pass  # pragma: no cover - startup raises before the body runs
 
         process.terminate.assert_called_once()
 

--- a/responses_api_models/switchyard_model/tests/test_app.py
+++ b/responses_api_models/switchyard_model/tests/test_app.py
@@ -88,6 +88,20 @@ class TestConfig:
         )
         assert config.launches_proxy is True
 
+    def test_both_set_attaches_and_warns(self, caplog) -> None:
+        config = SwitchyardModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            entrypoint="",
+            name="sy",
+            switchyard_model="policy-model",
+            routing_profiles="/tmp/routes.yaml",
+            switchyard_base_url="http://127.0.0.1:4000/v1",
+        )
+
+        assert config.launches_proxy is False
+        assert "both switchyard_base_url and routing_profiles are set" in caplog.text
+
     def test_base_url_alone_means_attach(self) -> None:
         config = SwitchyardModelConfig(
             host="0.0.0.0",

--- a/responses_api_models/switchyard_model/tests/test_app.py
+++ b/responses_api_models/switchyard_model/tests/test_app.py
@@ -117,6 +117,22 @@ class TestConfig:
 
 
 class TestRolloutSessionMiddleware:
+    async def _rollout_id_for(self, path: str) -> object:
+        seen: dict = {}
+
+        async def inner(scope, receive, send):
+            seen["rollout_id"] = app_module._ROLLOUT_ID.get()
+
+        await _RolloutSessionMiddleware(inner)({"type": "http", "path": path}, None, None)
+        return seen["rollout_id"]
+
+    async def test_well_formed_rollout_id_is_published(self) -> None:
+        assert await self._rollout_id_for("/ng-rollout/task0-r1-a0/v1/responses") == "task0-r1-a0"
+
+    async def test_rollout_id_outside_the_contract_charset_is_ignored(self) -> None:
+        """The id becomes an upstream header value, so anything off-contract is dropped, not sent."""
+        assert await self._rollout_id_for("/ng-rollout/bad\r\nx-injected: 1/v1/responses") is None
+
     async def test_non_http_scope_is_forwarded_untouched(self) -> None:
         seen: dict = {}
 

--- a/responses_api_models/switchyard_model/tests/test_app.py
+++ b/responses_api_models/switchyard_model/tests/test_app.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import signal
 import subprocess
 import urllib.error
 from contextlib import contextmanager
@@ -391,3 +392,98 @@ class TestProxyLifecycle:
         server.stop_proxy()
 
         process.terminate.assert_not_called()
+
+
+class TestProxyOutlivesNothing:
+    """The proxy is a child process, so it must not survive the server that launched it.
+
+    Gym's orchestrator sends SIGINT and escalates to SIGKILL after one second, so cleanup needs
+    both a graceful handler and a kernel-level tie for the shutdowns too abrupt to run one.
+    """
+
+    def _launch_config(self, **overrides) -> SwitchyardModelConfig:
+        return SwitchyardModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            entrypoint="",
+            name="test_switchyard_model",
+            switchyard_model="policy-model",
+            routing_profiles="/tmp/routes.yaml",
+            proxy_port=4123,
+            **overrides,
+        )
+
+    def _launch_server(self, monkeypatch: MonkeyPatch) -> SwitchyardModel:
+        monkeypatch.setattr(app_module.shutil, "which", lambda executable: f"/usr/bin/{executable}")
+        monkeypatch.setattr(SwitchyardModel, "wait_for_proxy", lambda self, root_url, proc: None)
+        return SwitchyardModel(
+            config=self._launch_config(),
+            server_client=MagicMock(spec=ServerClient, global_config_dict={}),
+        )
+
+    def test_graceful_shutdown_stops_the_proxy(self, monkeypatch: MonkeyPatch) -> None:
+        """A clean shutdown must reap the proxy. atexit does not run on uvicorn's signal exit."""
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: MagicMock(spec=_REAL_POPEN))
+        server = self._launch_server(monkeypatch)
+
+        app = server.setup_webserver()
+
+        process = MagicMock(spec=_REAL_POPEN)
+        process.poll.return_value = None
+        server._proxy_process = process
+
+        # Entering and leaving the TestClient context runs the app's startup/shutdown events.
+        with TestClient(app):
+            process.terminate.assert_not_called()
+
+        process.terminate.assert_called_once()
+
+    def test_spawn_ties_proxy_lifetime_to_this_process(self, monkeypatch: MonkeyPatch) -> None:
+        """A SIGKILLed parent runs no handler, so the kernel must reap the child instead."""
+        spawns: list = []
+
+        def mock_popen(command, *args, **kwargs):
+            spawns.append(kwargs)
+            return MagicMock(spec=_REAL_POPEN)
+
+        monkeypatch.setattr(subprocess, "Popen", mock_popen)
+        server = self._launch_server(monkeypatch)
+
+        server.setup_webserver()
+
+        assert spawns[0]["preexec_fn"] is app_module._set_parent_death_signal
+
+    def test_parent_death_signal_is_requested_on_linux(self, monkeypatch: MonkeyPatch) -> None:
+        calls: list = []
+        monkeypatch.setattr(app_module.sys, "platform", "linux")
+        monkeypatch.setattr(
+            app_module.ctypes,
+            "CDLL",
+            lambda name, use_errno=False: MagicMock(prctl=lambda *args: calls.append(args)),
+        )
+
+        app_module._set_parent_death_signal()
+
+        assert calls == [(app_module._PR_SET_PDEATHSIG, signal.SIGTERM)]
+
+    def test_parent_death_signal_is_skipped_off_linux(self, monkeypatch: MonkeyPatch) -> None:
+        """macOS has no prctl; the spawn must still succeed there."""
+
+        def explode(*args, **kwargs):
+            raise AssertionError("must not touch libc off Linux")
+
+        monkeypatch.setattr(app_module.sys, "platform", "darwin")
+        monkeypatch.setattr(app_module.ctypes, "CDLL", explode)
+
+        app_module._set_parent_death_signal()
+
+    def test_missing_prctl_does_not_break_the_spawn(self, monkeypatch: MonkeyPatch) -> None:
+        """Losing the kernel tie is worse than nothing, but failing to launch is worse still."""
+        monkeypatch.setattr(app_module.sys, "platform", "linux")
+
+        def no_libc(name, use_errno=False):
+            raise OSError("libc.so.6 not found")
+
+        monkeypatch.setattr(app_module.ctypes, "CDLL", no_libc)
+
+        app_module._set_parent_death_signal()

--- a/responses_api_models/switchyard_model/tests/test_app.py
+++ b/responses_api_models/switchyard_model/tests/test_app.py
@@ -13,11 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib.util
+import json
 import socket
 import sys
+import threading
 import types
 import urllib.request
 from contextlib import asynccontextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from unittest.mock import MagicMock
 
 import pytest
@@ -39,14 +42,19 @@ class _FakeNativeServer:
     """Stands in for switchyard_rust.server.Server: bound once constructed, closed explicitly.
 
     The real constructor loads the TOML deployment, binds loopback, and returns serving -- so the
-    fake's contract is just to record what it was asked to host and whether it was closed.
+    fake's contract is just to record what it was asked to host and whether it was closed. Every
+    instance registers on the class-level list, which _install_fake_switchyard resets, so a test
+    can reach a proxy that stop_proxy has already unlinked from the model server.
     """
+
+    instances: list = []
 
     def __init__(self, config: str, *, port: int = 0) -> None:
         self.config = config
         self.port = port
         self.base_url = f"http://127.0.0.1:{port}"
         self.close_calls = 0
+        type(self).instances.append(self)
 
     def close(self, *, timeout_secs: float = 2.0) -> None:
         self.close_calls += 1
@@ -58,6 +66,8 @@ def _install_fake_switchyard(monkeypatch: MonkeyPatch, server_cls: type) -> None
     app.py imports the native server lazily inside start_proxy, so seeding both sys.modules
     entries is enough -- the import system returns them without touching any installed wheel.
     """
+    if issubclass(server_cls, _FakeNativeServer):
+        server_cls.instances = []
     module = types.ModuleType("switchyard_rust.server")
     module.Server = server_cls
     package = types.ModuleType("switchyard_rust")
@@ -216,7 +226,7 @@ class TestApp:
         assert response.status_code == 200
         # The route name always wins -- a caller-supplied model must not bypass routing.
         assert seen["kwargs"]["model"] == "policy-model"
-        assert seen["headers"]["proxy_x_session_id"] == "task0-r1-a0"
+        assert seen["headers"]["x-switchyard-session-id"] == "task0-r1-a0"
         # The routed target is visible on the response.
         assert response.json()["model"] == "openai/gpt-5.2"
 
@@ -239,6 +249,27 @@ class TestApp:
 
         assert response.status_code == 200
         assert seen["kwargs"]["model"] == "policy-model"
+        assert seen["headers"]["x-switchyard-session-id"] == "task0-r1"
+
+    def test_extra_session_id_headers_all_carry_the_id(self, monkeypatch: MonkeyPatch) -> None:
+        """Attach-mode proxies can key other subsystems on other names; every configured name is sent."""
+        server = self._setup_server(session_id_headers=["x-switchyard-session-id", "proxy_x_session_id"])
+        seen: dict = {}
+
+        async def mock_create_response(self, **kwargs):
+            seen["headers"] = self.default_headers
+            return _response_data()
+
+        monkeypatch.setattr(NeMoGymAsyncOpenAI, "create_response", mock_create_response)
+        client = TestClient(server.setup_webserver())
+
+        response = client.post(
+            "/ng-rollout/task0-r1/v1/responses",
+            json={"input": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        assert seen["headers"]["x-switchyard-session-id"] == "task0-r1"
         assert seen["headers"]["proxy_x_session_id"] == "task0-r1"
 
     def test_uncorrelated_call_sends_no_session_id(self, monkeypatch: MonkeyPatch) -> None:
@@ -256,6 +287,7 @@ class TestApp:
 
         assert response.status_code == 200
         assert "proxy_x_session_id" not in seen["headers"]
+        assert "x-switchyard-session-id" not in seen["headers"]
         assert seen["headers"]["x-team"] == "gym"
 
     def test_forward_session_id_disabled(self, monkeypatch: MonkeyPatch) -> None:
@@ -276,6 +308,7 @@ class TestApp:
 
         assert response.status_code == 200
         assert "proxy_x_session_id" not in seen["headers"]
+        assert "x-switchyard-session-id" not in seen["headers"]
 
     def test_extra_body_is_merged(self, monkeypatch: MonkeyPatch) -> None:
         server = self._setup_server(extra_body={"max_output_tokens": 16})
@@ -313,16 +346,17 @@ class TestProxyLifecycle:
             server_client=MagicMock(spec=ServerClient, global_config_dict={}),
         )
 
-    def test_constructing_the_server_does_not_host_a_proxy(self, monkeypatch: MonkeyPatch) -> None:
-        """The proxy belongs to serving, not to config validation."""
+    def test_building_the_app_does_not_host_a_proxy(self, monkeypatch: MonkeyPatch) -> None:
+        """The proxy belongs to serving: neither construction nor app assembly may host one."""
 
         class Explode:
             def __init__(self, *args, **kwargs):
-                raise AssertionError("constructing SwitchyardModel must not host a proxy")
+                raise AssertionError("only app startup may host a proxy")
 
         _install_fake_switchyard(monkeypatch, Explode)
 
-        self._build()
+        server = self._build()
+        server.setup_webserver()
 
     def test_missing_dependency_explains_how_to_fix(self, monkeypatch: MonkeyPatch) -> None:
         server = self._build()
@@ -331,27 +365,22 @@ class TestProxyLifecycle:
         monkeypatch.setitem(sys.modules, "switchyard_rust.server", None)
 
         with pytest.raises(RuntimeError, match="nemo-switchyard"):
-            server.setup_webserver()
+            server.start_proxy()
 
-    def test_start_proxy_hosts_the_deployment(self, monkeypatch: MonkeyPatch) -> None:
-        _install_fake_switchyard(monkeypatch, _FakeNativeServer)
-
-        server = self._build()
-        server.setup_webserver()
-
-        # The deployment and the configured port reach the native server; the client is built on
-        # the address the server reports, not one assembled independently.
-        assert server._proxy_server.config == "/tmp/routes.toml"
-        assert server._proxy_server.port == 4123
-        assert server._client.base_url == "http://127.0.0.1:4123/v1"
-
-    def test_stop_proxy_closes_the_server(self, monkeypatch: MonkeyPatch) -> None:
+    def test_serving_hosts_the_deployment(self, monkeypatch: MonkeyPatch) -> None:
         _install_fake_switchyard(monkeypatch, _FakeNativeServer)
         server = self._build()
-        server.setup_webserver()
-        hosted = server._proxy_server
+        app = server.setup_webserver()
 
-        server.stop_proxy()
+        # Entering the TestClient context runs the app's startup, which hosts the proxy.
+        with TestClient(app):
+            hosted = server._proxy_server
+            # The deployment and the configured port reach the native server; the client is
+            # built on the address the server reports, not one assembled independently.
+            assert hosted.config == "/tmp/routes.toml"
+            assert hosted.port == 4123
+            assert server._client.base_url == "http://127.0.0.1:4123/v1"
+            assert hosted.close_calls == 0
 
         assert hosted.close_calls == 1
 
@@ -359,8 +388,8 @@ class TestProxyLifecycle:
         """Shutdown converges from several paths (lifespan, explicit); close must not double-fire."""
         _install_fake_switchyard(monkeypatch, _FakeNativeServer)
         server = self._build()
-        server.setup_webserver()
-        hosted = server._proxy_server
+        server.start_proxy()
+        (hosted,) = _FakeNativeServer.instances
 
         server.stop_proxy()
         server.stop_proxy()
@@ -396,23 +425,9 @@ class TestProxyShutdown:
             server_client=MagicMock(spec=ServerClient, global_config_dict={}),
         )
 
-    def test_graceful_shutdown_closes_the_proxy(self, monkeypatch: MonkeyPatch) -> None:
-        server = self._launch_server(monkeypatch)
-
-        app = server.setup_webserver()
-        hosted = server._proxy_server
-
-        # Entering and leaving the TestClient context runs the app's startup/shutdown events.
-        with TestClient(app):
-            assert hosted.close_calls == 0
-
-        assert hosted.close_calls == 1
-
     def test_failed_startup_still_closes_the_proxy(self, monkeypatch: MonkeyPatch) -> None:
         """The proxy is up before the app finishes starting, so a failed startup must still close it."""
         server = self._launch_server(monkeypatch)
-        server._build_client(server.start_proxy())
-        hosted = server._proxy_server
 
         app = FastAPI()
 
@@ -422,12 +437,13 @@ class TestProxyShutdown:
             yield  # pragma: no cover - unreachable; present so this is a generator
 
         app.router.lifespan_context = failing_lifespan
-        server.setup_proxy_shutdown(app)
+        server.setup_proxy_lifespan(app)
 
         with pytest.raises(RuntimeError, match="startup failed"):
             with TestClient(app):
                 pass  # pragma: no cover - startup raises before the body runs
 
+        (hosted,) = _FakeNativeServer.instances
         assert hosted.close_calls == 1
 
 
@@ -512,3 +528,182 @@ target = "policy"
 
         with pytest.raises(RuntimeError):
             server.start_proxy()
+
+
+class _StubUpstream(BaseHTTPRequestHandler):
+    """A loopback OpenAI-chat upstream that records what the proxy sends it.
+
+    Serving chat completions only is deliberate: a Responses call through the chain then proves
+    Switchyard's responses<->chat translation, which is the code path the 0.2.0 pin exists for.
+    """
+
+    requests: list  # (path, headers, body) tuples, appended per call; reset by the fixture
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's contract
+        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        type(self).requests.append((self.path, dict(self.headers), body))
+        payload = json.dumps(
+            {
+                "id": "chatcmpl-stub",
+                "object": "chat.completion",
+                "created": 1755400000,
+                "model": body.get("model", "upstream/model"),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "Hello from upstream!"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10},
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Keep test output clean; the recorded requests are the observable."""
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("switchyard_rust") is None,
+    reason="nemo-switchyard is not installed",
+)
+class TestFullChainIntegration:
+    """Drive Gym's own app through a real hosted proxy to a local stub upstream -- no mocks.
+
+    Chain under test: Gym FastAPI app -> NeMoGymAsyncOpenAI -> native Switchyard server
+    (routing + wire-format translation in Rust) -> stub upstream. This is the integration the
+    exact 0.2.0 pin protects: the TOML schema, the /v1 endpoints, the session header, and the
+    chat->responses translation emitting the usage detail objects NeMoGymResponse requires.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fresh_upstream_requests(self):
+        _StubUpstream.requests = []
+
+    # Class-scoped on purpose: Gym's aiohttp client is a process-wide singleton bound to the
+    # first event loop that uses it, so all of these tests must share one TestClient loop.
+    @pytest.fixture(scope="class")
+    def upstream(self):
+        httpd = ThreadingHTTPServer(("127.0.0.1", 0), _StubUpstream)
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        try:
+            yield httpd.server_address[1]
+        finally:
+            httpd.shutdown()
+            thread.join(timeout=5)
+
+    @pytest.fixture(scope="class")
+    def gym_app(self, upstream, tmp_path_factory):
+        monkeypatch = MonkeyPatch()
+        # A present config dict keeps Gym's client stack from booting Hydra inside the request.
+        monkeypatch.setenv("NEMO_GYM_CONFIG_DICT", "test_switchyard_model: {}\n")
+        monkeypatch.setenv("SWITCHYARD_TEST_API_KEY", "stub-upstream-key")  # pragma: allowlist secret
+        deployment = tmp_path_factory.mktemp("deployment") / "routes.toml"
+        deployment.write_text(
+            f"""
+schema_version = 1
+
+[llm_clients.upstream]
+format = "openai_chat"
+base_url = "http://127.0.0.1:{upstream}/v1"
+api_key_env = "SWITCHYARD_TEST_API_KEY"
+
+[targets.policy]
+id = "upstream/model"
+llm_client = "upstream"
+
+[routes.policy-model]
+id = "policy-model"
+type = "passthrough"
+target = "policy"
+"""
+        )
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            proxy_port = probe.getsockname()[1]
+
+        server = SwitchyardModel(
+            config=SwitchyardModelConfig(
+                host="0.0.0.0",
+                port=8081,
+                entrypoint="",
+                name="test_switchyard_model",
+                switchyard_model="policy-model",
+                deployment=str(deployment),
+                proxy_port=proxy_port,
+            ),
+            server_client=MagicMock(spec=ServerClient, global_config_dict={}),
+        )
+        app = server.setup_webserver()
+        try:
+            with TestClient(app) as client:
+                yield client, proxy_port
+        finally:
+            monkeypatch.undo()
+
+    def test_responses_round_trip_translates_usage(self, gym_app, capfd) -> None:
+        client, _ = gym_app
+
+        response = client.post(
+            "/ng-rollout/task0-r1-a0/v1/responses",
+            json={"input": [{"role": "user", "content": "hi"}], "model": "caller-supplied"},
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["output"][0]["content"][0]["text"] == "Hello from upstream!"
+        # The routed target, not the route name, is what served the call.
+        assert data["model"] == "upstream/model"
+        # The usage detail objects are the reason the pin starts at 0.2.0: published 0.1.0
+        # omitted them and every response failed NeMoGymResponse validation.
+        assert data["usage"]["input_tokens"] == 7
+        assert data["usage"]["output_tokens"] == 3
+        assert "cached_tokens" in data["usage"]["input_tokens_details"]
+        assert "reasoning_tokens" in data["usage"]["output_tokens_details"]
+
+        # The rollout id reached Switchyard's routing metadata: its request log (Rust tracing on
+        # stderr, captured by capfd) records the session id it parsed from Gym's header.
+        assert 'session_id="task0-r1-a0"' in capfd.readouterr().err
+
+        # The upstream saw one translated chat call for the target model, not the route name,
+        # carrying the deployment's credential.
+        (path, headers, body) = _StubUpstream.requests[0]
+        headers_lower = {name.lower(): value for name, value in headers.items()}
+        assert path == "/v1/chat/completions"
+        assert body["model"] == "upstream/model"
+        assert headers_lower["authorization"] == "Bearer stub-upstream-key"  # pragma: allowlist secret
+        # Switchyard 0.2.0 parses x-switchyard-session-id into routing metadata but does not
+        # strip it before forwarding, so the upstream also sees the opaque rollout id. Asserted
+        # as-is so a change in either direction on upgrade is caught, not discovered in the field.
+        assert headers_lower["x-switchyard-session-id"] == "task0-r1-a0"
+
+    def test_chat_completions_round_trip(self, gym_app) -> None:
+        client, _ = gym_app
+
+        response = client.post(
+            "/ng-rollout/task0-r1/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["choices"][0]["message"]["content"] == "Hello from upstream!"
+        assert data["model"] == "upstream/model"
+        assert data["usage"]["prompt_tokens"] == 7
+
+    def test_proxy_counts_the_traffic(self, gym_app) -> None:
+        """/v1/stats is the surface routing-aware evals read; a routed call must show up there."""
+        client, proxy_port = gym_app
+
+        response = client.post("/v1/responses", json={"input": [{"role": "user", "content": "hi"}]})
+        assert response.status_code == 200, response.text
+
+        with urllib.request.urlopen(f"http://127.0.0.1:{proxy_port}/v1/stats", timeout=5) as stats_response:
+            stats = json.loads(stats_response.read())
+        assert json.dumps(stats).count("upstream/model"), stats

--- a/responses_api_models/switchyard_model/tests/test_app.py
+++ b/responses_api_models/switchyard_model/tests/test_app.py
@@ -12,10 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import signal
-import subprocess
-import urllib.error
-from contextlib import asynccontextmanager, contextmanager
+import importlib.util
+import socket
+import sys
+import types
+import urllib.request
+from contextlib import asynccontextmanager
 from unittest.mock import MagicMock
 
 import pytest
@@ -33,8 +35,35 @@ from responses_api_models.switchyard_model.app import (
 )
 
 
-# Captured before any test monkeypatches subprocess.Popen, so mocks keep a real spec.
-_REAL_POPEN = subprocess.Popen
+class _FakeNativeServer:
+    """Stands in for switchyard_rust.server.Server: bound once constructed, closed explicitly.
+
+    The real constructor loads the TOML deployment, binds loopback, and returns serving -- so the
+    fake's contract is just to record what it was asked to host and whether it was closed.
+    """
+
+    def __init__(self, config: str, *, port: int = 0) -> None:
+        self.config = config
+        self.port = port
+        self.base_url = f"http://127.0.0.1:{port}"
+        self.close_calls = 0
+
+    def close(self, *, timeout_secs: float = 2.0) -> None:
+        self.close_calls += 1
+
+
+def _install_fake_switchyard(monkeypatch: MonkeyPatch, server_cls: type) -> None:
+    """Publish a stand-in switchyard_rust.server module without importing the real package.
+
+    app.py imports the native server lazily inside start_proxy, so seeding both sys.modules
+    entries is enough -- the import system returns them without touching any installed wheel.
+    """
+    module = types.ModuleType("switchyard_rust.server")
+    module.Server = server_cls
+    package = types.ModuleType("switchyard_rust")
+    package.server = module
+    monkeypatch.setitem(sys.modules, "switchyard_rust", package)
+    monkeypatch.setitem(sys.modules, "switchyard_rust.server", module)
 
 
 def _response_data() -> dict:
@@ -75,18 +104,18 @@ def _chat_data() -> dict:
 
 
 class TestConfig:
-    def test_requires_a_routing_profile_or_a_base_url(self) -> None:
-        with pytest.raises(ValueError, match="routing_profiles"):
+    def test_requires_a_deployment_or_a_base_url(self) -> None:
+        with pytest.raises(ValueError, match="deployment"):
             SwitchyardModelConfig(host="0.0.0.0", port=8081, entrypoint="", name="sy", switchyard_model="policy-model")
 
-    def test_routing_profiles_alone_means_gym_launches(self) -> None:
+    def test_deployment_alone_means_gym_hosts(self) -> None:
         config = SwitchyardModelConfig(
             host="0.0.0.0",
             port=8081,
             entrypoint="",
             name="sy",
             switchyard_model="policy-model",
-            routing_profiles="/tmp/routes.yaml",
+            deployment="/tmp/routes.toml",
         )
         assert config.launches_proxy is True
 
@@ -97,12 +126,12 @@ class TestConfig:
             entrypoint="",
             name="sy",
             switchyard_model="policy-model",
-            routing_profiles="/tmp/routes.yaml",
+            deployment="/tmp/routes.toml",
             switchyard_base_url="http://127.0.0.1:4000/v1",
         )
 
         assert config.launches_proxy is False
-        assert "both switchyard_base_url and routing_profiles are set" in caplog.text
+        assert "both switchyard_base_url and deployment are set" in caplog.text
 
     def test_base_url_alone_means_attach(self) -> None:
         config = SwitchyardModelConfig(
@@ -273,7 +302,7 @@ class TestProxyLifecycle:
             entrypoint="",
             name="test_switchyard_model",
             switchyard_model="policy-model",
-            routing_profiles="/tmp/routes.yaml",
+            deployment="/tmp/routes.toml",
             proxy_port=4123,
             **overrides,
         )
@@ -284,185 +313,106 @@ class TestProxyLifecycle:
             server_client=MagicMock(spec=ServerClient, global_config_dict={}),
         )
 
-    def _launch_server(self, monkeypatch: MonkeyPatch) -> SwitchyardModel:
-        """Build a launch-mode server with the spawn stubbed out."""
-        monkeypatch.setattr(app_module.shutil, "which", lambda executable: f"/usr/bin/{executable}")
-        monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: MagicMock(spec=_REAL_POPEN))
-        monkeypatch.setattr(SwitchyardModel, "wait_for_proxy", lambda self, root_url, proc: None)
-        return self._build()
-
-    def test_constructing_the_server_does_not_spawn_a_proxy(self, monkeypatch: MonkeyPatch) -> None:
+    def test_constructing_the_server_does_not_host_a_proxy(self, monkeypatch: MonkeyPatch) -> None:
         """The proxy belongs to serving, not to config validation."""
 
-        def explode(*args, **kwargs):
-            raise AssertionError("constructing SwitchyardModel must not spawn a proxy")
+        class Explode:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError("constructing SwitchyardModel must not host a proxy")
 
-        monkeypatch.setattr(subprocess, "Popen", explode)
+        _install_fake_switchyard(monkeypatch, Explode)
 
         self._build()
 
-    def test_missing_executable_explains_how_to_fix(self, monkeypatch: MonkeyPatch) -> None:
+    def test_missing_dependency_explains_how_to_fix(self, monkeypatch: MonkeyPatch) -> None:
         server = self._build()
-        monkeypatch.setattr(app_module.shutil, "which", lambda executable: None)
+        # None in sys.modules makes the import fail the way an uninstalled package does.
+        monkeypatch.setitem(sys.modules, "switchyard_rust", None)
+        monkeypatch.setitem(sys.modules, "switchyard_rust.server", None)
 
         with pytest.raises(RuntimeError, match="nemo-switchyard"):
             server.setup_webserver()
 
-    def test_start_proxy_builds_command_and_waits(self, monkeypatch: MonkeyPatch) -> None:
-        commands: list = []
-        process = MagicMock(spec=_REAL_POPEN)
-        process.poll.return_value = None
-
-        def mock_popen(command, *args, **kwargs):
-            commands.append(command)
-            return process
-
-        monkeypatch.setattr(app_module.shutil, "which", lambda executable: f"/usr/bin/{executable}")
-        monkeypatch.setattr(subprocess, "Popen", mock_popen)
-        monkeypatch.setattr(SwitchyardModel, "wait_for_proxy", lambda self, root_url, proc: None)
+    def test_start_proxy_hosts_the_deployment(self, monkeypatch: MonkeyPatch) -> None:
+        _install_fake_switchyard(monkeypatch, _FakeNativeServer)
 
         server = self._build()
         server.setup_webserver()
 
-        # Bound on the wildcard so the proxy is reachable off-box, but addressed over loopback.
-        assert commands[0] == [
-            "switchyard",
-            "--routing-profiles",
-            "/tmp/routes.yaml",
-            "--",
-            "serve",
-            "--host",
-            "0.0.0.0",
-            "--port",
-            "4123",
-        ]
+        # The deployment and the configured port reach the native server; the client is built on
+        # the address the server reports, not one assembled independently.
+        assert server._proxy_server.config == "/tmp/routes.toml"
+        assert server._proxy_server.port == 4123
         assert server._client.base_url == "http://127.0.0.1:4123/v1"
 
-    def test_wait_for_proxy_raises_when_process_dies(self, monkeypatch: MonkeyPatch) -> None:
-        server = self._launch_server(monkeypatch)
-        # Drop the construction-time patches so the real wait_for_proxy runs below.
-        monkeypatch.undo()
-
-        dead = MagicMock(spec=_REAL_POPEN)
-        dead.poll.return_value = 1
-        dead.returncode = 1
-
-        with pytest.raises(RuntimeError, match="exited during startup"):
-            server.wait_for_proxy("http://127.0.0.1:4123", dead)
-
-    def test_stop_proxy_terminates_then_kills(self, monkeypatch: MonkeyPatch) -> None:
-        server = self._launch_server(monkeypatch)
-
-        process = MagicMock(spec=_REAL_POPEN)
-        process.poll.return_value = None
-        process.wait.side_effect = subprocess.TimeoutExpired(cmd="switchyard", timeout=30)
-        server._proxy_process = process
+    def test_stop_proxy_closes_the_server(self, monkeypatch: MonkeyPatch) -> None:
+        _install_fake_switchyard(monkeypatch, _FakeNativeServer)
+        server = self._build()
+        server.setup_webserver()
+        hosted = server._proxy_server
 
         server.stop_proxy()
 
-        process.terminate.assert_called_once()
-        process.kill.assert_called_once()
+        assert hosted.close_calls == 1
 
-    def test_wait_for_proxy_returns_once_healthy(self, monkeypatch: MonkeyPatch) -> None:
-        server = self._launch_server(monkeypatch)
-        monkeypatch.undo()
-
-        alive = MagicMock(spec=_REAL_POPEN)
-        alive.poll.return_value = None
-
-        attempts = {"count": 0}
-
-        @contextmanager
-        def mock_urlopen(url, timeout=None):
-            attempts["count"] += 1
-            # First probe refused, as it is while the proxy is still binding.
-            if attempts["count"] == 1:
-                raise urllib.error.URLError("connection refused")
-            yield MagicMock(status=200)
-
-        monkeypatch.setattr(app_module.urllib.request, "urlopen", mock_urlopen)
-        monkeypatch.setattr(app_module.time, "sleep", lambda seconds: None)
-
-        server.wait_for_proxy("http://127.0.0.1:4123", alive)
-
-        assert attempts["count"] == 2
-
-    def test_wait_for_proxy_times_out(self, monkeypatch: MonkeyPatch) -> None:
-        server = self._launch_server(monkeypatch)
-        monkeypatch.undo()
-        server.config.proxy_startup_timeout_s = 0.0
-        server._proxy_process = None
-
-        alive = MagicMock(spec=_REAL_POPEN)
-        alive.poll.return_value = None
-
-        with pytest.raises(TimeoutError, match="did not become healthy"):
-            server.wait_for_proxy("http://127.0.0.1:4123", alive)
-
-    def test_stop_proxy_is_noop_when_already_exited(self, monkeypatch: MonkeyPatch) -> None:
-        server = self._launch_server(monkeypatch)
-
-        process = MagicMock(spec=_REAL_POPEN)
-        process.poll.return_value = 0
-        server._proxy_process = process
+    def test_stop_proxy_closes_only_once(self, monkeypatch: MonkeyPatch) -> None:
+        """Shutdown converges from several paths (lifespan, explicit); close must not double-fire."""
+        _install_fake_switchyard(monkeypatch, _FakeNativeServer)
+        server = self._build()
+        server.setup_webserver()
+        hosted = server._proxy_server
 
         server.stop_proxy()
+        server.stop_proxy()
 
-        process.terminate.assert_not_called()
+        assert hosted.close_calls == 1
+
+    def test_stop_proxy_is_noop_when_nothing_was_hosted(self) -> None:
+        server = self._build()
+
+        server.stop_proxy()  # attach mode and pre-startup both reach here with no proxy
 
 
-class TestProxyOutlivesNothing:
-    """The proxy is a child process, so it must not survive the server that launched it.
+class TestProxyShutdown:
+    """The proxy runs in-process, so shutdown is about promptness, not survival.
 
-    Gym's orchestrator sends SIGINT and escalates to SIGKILL after one second, so cleanup needs
-    both a graceful handler and a kernel-level tie for the shutdowns too abrupt to run one.
+    An in-process server cannot outlive its owner the way a subprocess could -- what these tests
+    pin down is that the graceful paths close it explicitly, which stops the listener without
+    waiting for interpreter teardown and flushes Switchyard's telemetry.
     """
 
-    def _launch_config(self, **overrides) -> SwitchyardModelConfig:
-        return SwitchyardModelConfig(
-            host="0.0.0.0",
-            port=8081,
-            entrypoint="",
-            name="test_switchyard_model",
-            switchyard_model="policy-model",
-            routing_profiles="/tmp/routes.yaml",
-            proxy_port=4123,
-            **overrides,
-        )
-
     def _launch_server(self, monkeypatch: MonkeyPatch) -> SwitchyardModel:
-        monkeypatch.setattr(app_module.shutil, "which", lambda executable: f"/usr/bin/{executable}")
-        monkeypatch.setattr(SwitchyardModel, "wait_for_proxy", lambda self, root_url, proc: None)
+        _install_fake_switchyard(monkeypatch, _FakeNativeServer)
         return SwitchyardModel(
-            config=self._launch_config(),
+            config=SwitchyardModelConfig(
+                host="0.0.0.0",
+                port=8081,
+                entrypoint="",
+                name="test_switchyard_model",
+                switchyard_model="policy-model",
+                deployment="/tmp/routes.toml",
+                proxy_port=4123,
+            ),
             server_client=MagicMock(spec=ServerClient, global_config_dict={}),
         )
 
-    def test_graceful_shutdown_stops_the_proxy(self, monkeypatch: MonkeyPatch) -> None:
-        """A clean shutdown must reap the proxy. atexit does not run on uvicorn's signal exit."""
-        monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: MagicMock(spec=_REAL_POPEN))
+    def test_graceful_shutdown_closes_the_proxy(self, monkeypatch: MonkeyPatch) -> None:
         server = self._launch_server(monkeypatch)
 
         app = server.setup_webserver()
-
-        process = MagicMock(spec=_REAL_POPEN)
-        process.poll.return_value = None
-        server._proxy_process = process
+        hosted = server._proxy_server
 
         # Entering and leaving the TestClient context runs the app's startup/shutdown events.
         with TestClient(app):
-            process.terminate.assert_not_called()
+            assert hosted.close_calls == 0
 
-        process.terminate.assert_called_once()
+        assert hosted.close_calls == 1
 
-    def test_failed_startup_still_stops_the_proxy(self, monkeypatch: MonkeyPatch) -> None:
-        """The proxy is up before the app finishes starting, so a failed startup must still reap it."""
-        monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: MagicMock(spec=_REAL_POPEN))
+    def test_failed_startup_still_closes_the_proxy(self, monkeypatch: MonkeyPatch) -> None:
+        """The proxy is up before the app finishes starting, so a failed startup must still close it."""
         server = self._launch_server(monkeypatch)
-
-        process = MagicMock(spec=_REAL_POPEN)
-        process.poll.return_value = None
-        server._proxy_process = process
+        server._build_client(server.start_proxy())
+        hosted = server._proxy_server
 
         app = FastAPI()
 
@@ -478,54 +428,87 @@ class TestProxyOutlivesNothing:
             with TestClient(app):
                 pass  # pragma: no cover - startup raises before the body runs
 
-        process.terminate.assert_called_once()
+        assert hosted.close_calls == 1
 
-    def test_spawn_ties_proxy_lifetime_to_this_process(self, monkeypatch: MonkeyPatch) -> None:
-        """A SIGKILLed parent runs no handler, so the kernel must reap the child instead."""
-        spawns: list = []
 
-        def mock_popen(command, *args, **kwargs):
-            spawns.append(kwargs)
-            return MagicMock(spec=_REAL_POPEN)
+@pytest.mark.skipif(
+    importlib.util.find_spec("switchyard_rust") is None,
+    reason="nemo-switchyard is not installed",
+)
+class TestNativeServerIntegration:
+    """Host a real native server from a real TOML deployment -- no mocks.
 
-        monkeypatch.setattr(subprocess, "Popen", mock_popen)
-        server = self._launch_server(monkeypatch)
+    The upstream target points at a closed port, which is fine: these tests exercise hosting,
+    health, and shutdown, none of which call upstream.
+    """
 
-        server.setup_webserver()
+    _DEPLOYMENT = """
+schema_version = 1
 
-        assert spawns[0]["preexec_fn"] is app_module._set_parent_death_signal
+[llm_clients.upstream]
+format = "openai_chat"
+base_url = "http://127.0.0.1:9/v1"
+api_key_env = "SWITCHYARD_TEST_API_KEY"
 
-    def test_parent_death_signal_is_requested_on_linux(self, monkeypatch: MonkeyPatch) -> None:
-        calls: list = []
-        monkeypatch.setattr(app_module.sys, "platform", "linux")
-        monkeypatch.setattr(
-            app_module.ctypes,
-            "CDLL",
-            lambda name, use_errno=False: MagicMock(prctl=lambda *args: calls.append(args)),
+[targets.policy]
+id = "upstream/model"
+llm_client = "upstream"
+
+[routes.policy-model]
+id = "policy-model"
+type = "passthrough"
+target = "policy"
+"""
+
+    def test_hosts_serves_health_and_stops(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setenv("SWITCHYARD_TEST_API_KEY", "dummy")  # pragma: allowlist secret
+        deployment = tmp_path / "routes.toml"
+        deployment.write_text(self._DEPLOYMENT)
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            port = probe.getsockname()[1]
+
+        server = SwitchyardModel(
+            config=SwitchyardModelConfig(
+                host="0.0.0.0",
+                port=8081,
+                entrypoint="",
+                name="test_switchyard_model",
+                switchyard_model="policy-model",
+                deployment=str(deployment),
+                proxy_port=port,
+            ),
+            server_client=MagicMock(spec=ServerClient, global_config_dict={}),
         )
 
-        app_module._set_parent_death_signal()
+        base_url = server.start_proxy()
+        try:
+            assert base_url == f"http://127.0.0.1:{port}/v1"
+            with urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=5) as response:
+                assert response.status == 200
+        finally:
+            server.stop_proxy()
 
-        assert calls == [(app_module._PR_SET_PDEATHSIG, signal.SIGTERM)]
+    def test_invalid_deployment_fails_at_startup(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        """A bad routing config is a startup error with the validator's message, not a timeout."""
+        deployment = tmp_path / "routes.toml"
+        deployment.write_text("schema_version = 1\n[routes.broken]\n")
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            port = probe.getsockname()[1]
 
-    def test_parent_death_signal_is_skipped_off_linux(self, monkeypatch: MonkeyPatch) -> None:
-        """macOS has no prctl; the spawn must still succeed there."""
+        server = SwitchyardModel(
+            config=SwitchyardModelConfig(
+                host="0.0.0.0",
+                port=8081,
+                entrypoint="",
+                name="test_switchyard_model",
+                switchyard_model="policy-model",
+                deployment=str(deployment),
+                proxy_port=port,
+            ),
+            server_client=MagicMock(spec=ServerClient, global_config_dict={}),
+        )
 
-        def explode(*args, **kwargs):
-            raise AssertionError("must not touch libc off Linux")
-
-        monkeypatch.setattr(app_module.sys, "platform", "darwin")
-        monkeypatch.setattr(app_module.ctypes, "CDLL", explode)
-
-        app_module._set_parent_death_signal()
-
-    def test_missing_prctl_does_not_break_the_spawn(self, monkeypatch: MonkeyPatch) -> None:
-        """Losing the kernel tie is worse than nothing, but failing to launch is worse still."""
-        monkeypatch.setattr(app_module.sys, "platform", "linux")
-
-        def no_libc(name, use_errno=False):
-            raise OSError("libc.so.6 not found")
-
-        monkeypatch.setattr(app_module.ctypes, "CDLL", no_libc)
-
-        app_module._set_parent_death_signal()
+        with pytest.raises(RuntimeError):
+            server.start_proxy()

--- a/responses_api_models/switchyard_model/tests/test_app.py
+++ b/responses_api_models/switchyard_model/tests/test_app.py
@@ -23,6 +23,7 @@ import types
 import urllib.request
 from contextlib import asynccontextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import aiohttp
@@ -791,6 +792,17 @@ class TestRolloutCorrelationCheck:
         server.check_rollout_correlation()
 
         assert "no session id will reach Switchyard" not in caplog.text
+
+    def test_shipped_config_does_not_restate_the_forwarding_default(self) -> None:
+        """The yaml restating forward_session_id would make every run look like an explicit
+        request for it, turning the intended startup warning into a refusal for any eval that
+        runs without observability. Found live; pinned here."""
+        import yaml
+
+        config_path = Path(__file__).parents[1] / "configs" / "switchyard_model.yaml"
+        block = yaml.safe_load(config_path.read_text())["policy_model"]["responses_api_models"]["switchyard_model"]
+
+        assert "forward_session_id" not in block
 
 
 @pytest.mark.skipif(

--- a/responses_api_models/switchyard_model/tests/test_app.py
+++ b/responses_api_models/switchyard_model/tests/test_app.py
@@ -521,6 +521,41 @@ class TestConditionRecord:
 
         assert not (tmp_path / "condition" / "switchyard-stats.json").exists()
 
+    def test_unwritable_condition_dir_does_not_fail_startup(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        """Provenance is worth a warning, not an outage: a bad dir must not stop serving."""
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("a file where the condition dir should be")
+        server = self._launch_server(monkeypatch, tmp_path, condition_dir=str(blocker))
+
+        # Startup raising would fail this test; the manifest is the only casualty.
+        with TestClient(server.setup_webserver()):
+            pass
+
+        assert blocker.read_text() == "a file where the condition dir should be"
+
+    def test_missing_distribution_yields_null_version(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        """A source checkout without dist metadata still gets a manifest, with version null."""
+
+        def not_installed(name):
+            raise app_module.importlib.metadata.PackageNotFoundError(name)
+
+        monkeypatch.setattr(app_module.importlib.metadata, "version", not_installed)
+        server = self._launch_server(monkeypatch, tmp_path)
+
+        with TestClient(server.setup_webserver()):
+            manifest = json.loads((tmp_path / "condition" / "switchyard-condition.json").read_text())
+
+        assert manifest["nemo_switchyard_version"] is None
+
+    def test_stats_snapshot_needs_a_proxy_to_ask(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        """Before hosting starts there is no proxy URL; the snapshot must no-op, not guess."""
+        server = self._launch_server(monkeypatch, tmp_path)
+
+        assert server.proxy_root_url() is None
+        server.snapshot_proxy_stats()
+
+        assert not (tmp_path / "condition").exists()
+
 
 @pytest.mark.skipif(
     importlib.util.find_spec("switchyard_rust") is None,

--- a/responses_api_models/switchyard_model/tests/test_app.py
+++ b/responses_api_models/switchyard_model/tests/test_app.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import hashlib
 import importlib.util
 import json
 import socket
@@ -445,6 +446,157 @@ class TestProxyShutdown:
 
         (hosted,) = _FakeNativeServer.instances
         assert hosted.close_calls == 1
+
+
+class TestConditionRecord:
+    """The routing-condition record is what makes routed runs comparable after the fact."""
+
+    def _launch_server(self, monkeypatch: MonkeyPatch, tmp_path, **overrides) -> SwitchyardModel:
+        _install_fake_switchyard(monkeypatch, _FakeNativeServer)
+        deployment = tmp_path / "routes.toml"
+        deployment.write_text(
+            'schema_version = 1\n[llm_clients.up]\napi_key_env = "K"\napi_key = "sk-inline-secret"\n'
+        )
+        config = {
+            "host": "0.0.0.0",
+            "port": 8081,
+            "entrypoint": "",
+            "name": "test_switchyard_model",
+            "switchyard_model": "policy-model",
+            "deployment": str(deployment),
+            "proxy_port": 4123,
+            "condition_dir": str(tmp_path / "condition"),
+            **overrides,
+        }
+        return SwitchyardModel(
+            config=SwitchyardModelConfig(**config),
+            server_client=MagicMock(spec=ServerClient, global_config_dict={}),
+        )
+
+    def test_hosted_manifest_records_the_condition(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        server = self._launch_server(monkeypatch, tmp_path)
+
+        with TestClient(server.setup_webserver()):
+            manifest = json.loads((tmp_path / "condition" / "switchyard-condition.json").read_text())
+
+        assert manifest["route"] == "policy-model"
+        assert manifest["mode"] == "hosted"
+        assert manifest["proxy_root_url"] == "http://127.0.0.1:4123"
+        deployment_bytes = (tmp_path / "routes.toml").read_bytes()
+        assert manifest["deployment_sha256"] == hashlib.sha256(deployment_bytes).hexdigest()
+        # The archive keeps env-var references but never an inline credential.
+        assert 'api_key_env = "K"' in manifest["deployment_toml"]
+        assert "sk-inline-secret" not in manifest["deployment_toml"]
+
+    def test_attached_manifest_records_the_proxy(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        server = self._launch_server(
+            monkeypatch,
+            tmp_path,
+            deployment=None,
+            switchyard_base_url="http://127.0.0.1:4000/v1",
+        )
+
+        with TestClient(server.setup_webserver()):
+            manifest = json.loads((tmp_path / "condition" / "switchyard-condition.json").read_text())
+
+        assert manifest["mode"] == "attached"
+        assert manifest["proxy_root_url"] == "http://127.0.0.1:4000"
+        assert manifest["deployment_sha256"] is None
+        assert manifest["deployment_toml"] is None
+
+    def test_no_condition_dir_writes_nothing(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        server = self._launch_server(monkeypatch, tmp_path, condition_dir=None)
+
+        with TestClient(server.setup_webserver()):
+            pass
+
+        assert not (tmp_path / "condition").exists()
+
+    def test_unreachable_stats_endpoint_does_not_fail_shutdown(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        """The fake proxy's port answers nothing; shutdown must shrug, not raise."""
+        server = self._launch_server(monkeypatch, tmp_path)
+
+        with TestClient(server.setup_webserver()):
+            pass
+
+        assert not (tmp_path / "condition" / "switchyard-stats.json").exists()
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("switchyard_rust") is None,
+    reason="nemo-switchyard is not installed",
+)
+class TestConditionRecordIntegration:
+    """Real wheel, real traffic, no Gym client: the record survives the proxy's shutdown.
+
+    Requests go to the proxy directly over urllib so this test never touches Gym's
+    process-singleton aiohttp client, which other classes bind to their own event loop.
+    """
+
+    def test_manifest_and_stats_written_across_a_run(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setenv("SWITCHYARD_TEST_API_KEY", "stub-upstream-key")  # pragma: allowlist secret
+        _StubUpstream.requests = []
+        httpd = ThreadingHTTPServer(("127.0.0.1", 0), _StubUpstream)
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        deployment = tmp_path / "routes.toml"
+        deployment.write_text(
+            f"""
+schema_version = 1
+
+[llm_clients.upstream]
+format = "openai_chat"
+base_url = "http://127.0.0.1:{httpd.server_address[1]}/v1"
+api_key_env = "SWITCHYARD_TEST_API_KEY"
+
+[targets.policy]
+id = "upstream/model"
+llm_client = "upstream"
+
+[routes.policy-model]
+id = "policy-model"
+type = "passthrough"
+target = "policy"
+"""
+        )
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            proxy_port = probe.getsockname()[1]
+        server = SwitchyardModel(
+            config=SwitchyardModelConfig(
+                host="0.0.0.0",
+                port=8081,
+                entrypoint="",
+                name="test_switchyard_model",
+                switchyard_model="policy-model",
+                deployment=str(deployment),
+                proxy_port=proxy_port,
+                condition_dir=str(tmp_path / "condition"),
+            ),
+            server_client=MagicMock(spec=ServerClient, global_config_dict={}),
+        )
+
+        try:
+            with TestClient(server.setup_webserver()):
+                request = urllib.request.Request(
+                    f"http://127.0.0.1:{proxy_port}/v1/chat/completions",
+                    data=json.dumps(
+                        {"model": "policy-model", "messages": [{"role": "user", "content": "hi"}]}
+                    ).encode(),
+                    headers={"Content-Type": "application/json", "Authorization": "Bearer dummy"},
+                )
+                with urllib.request.urlopen(request, timeout=10) as response:
+                    assert response.status == 200
+        finally:
+            httpd.shutdown()
+            thread.join(timeout=5)
+
+        manifest = json.loads((tmp_path / "condition" / "switchyard-condition.json").read_text())
+        assert manifest["route"] == "policy-model"
+        assert manifest["nemo_switchyard_version"] == "0.2.0"
+
+        stats = json.loads((tmp_path / "condition" / "switchyard-stats.json").read_text())
+        assert "upstream/model" in json.dumps(stats)
 
 
 @pytest.mark.skipif(

--- a/responses_api_models/switchyard_model/tests/test_app.py
+++ b/responses_api_models/switchyard_model/tests/test_app.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import hashlib
 import importlib.util
 import json
@@ -24,11 +25,13 @@ from contextlib import asynccontextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from unittest.mock import MagicMock
 
+import aiohttp
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 
+import nemo_gym.server_utils as server_utils
 import responses_api_models.switchyard_model.app as app_module
 from nemo_gym.server_utils import ServerClient
 from responses_api_models.switchyard_model.app import (
@@ -75,6 +78,42 @@ def _install_fake_switchyard(monkeypatch: MonkeyPatch, server_cls: type) -> None
     package.server = module
     monkeypatch.setitem(sys.modules, "switchyard_rust", package)
     monkeypatch.setitem(sys.modules, "switchyard_rust.server", module)
+
+
+def _install_fake_stats_endpoint(
+    monkeypatch: MonkeyPatch, payload: dict | None = None, error: Exception | None = None
+) -> list:
+    """Stand in for nemo_gym.server_utils.request on the stats path; return the recorded calls.
+
+    Unit tests must not touch Gym's real aiohttp singleton: it parses the process's CLI args the
+    first time it is built, which under pytest is a SystemExit, and it binds to whichever event
+    loop builds it. The fake keeps the calls observable -- (method, url, kwargs) tuples -- so a
+    test can assert what would have gone on the wire.
+    """
+    calls: list = []
+    payload = payload if payload is not None else {"total_requests": 1, "models": {}}
+
+    class _FakeStatsResponse:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        def raise_for_status(self):
+            pass
+
+        async def json(self):
+            return payload
+
+    async def fake_request(method: str, url: str, **kwargs):
+        calls.append((method, url, kwargs))
+        if error is not None:
+            raise error
+        return _FakeStatsResponse()
+
+    monkeypatch.setattr(app_module, "request", fake_request)
+    return calls
 
 
 def _response_data() -> dict:
@@ -154,6 +193,44 @@ class TestConfig:
             switchyard_base_url="http://127.0.0.1:4000/v1",
         )
         assert config.launches_proxy is False
+
+    def test_hosting_rejects_multiple_workers(self) -> None:
+        """Each worker process would host its own proxy -- split affinity, split stats."""
+        with pytest.raises(ValueError, match="num_workers"):
+            SwitchyardModelConfig(
+                host="0.0.0.0",
+                port=8081,
+                entrypoint="",
+                name="sy",
+                switchyard_model="policy-model",
+                deployment="/tmp/routes.toml",
+                num_workers=2,
+            )
+
+    def test_attaching_allows_multiple_workers(self) -> None:
+        """All workers share the one external proxy, so parallelism is coherent here."""
+        config = SwitchyardModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            entrypoint="",
+            name="sy",
+            switchyard_model="policy-model",
+            switchyard_base_url="http://127.0.0.1:4000/v1",
+            num_workers=2,
+        )
+        assert config.launches_proxy is False
+
+    def test_max_concurrent_requests_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="greater than 0"):
+            SwitchyardModelConfig(
+                host="0.0.0.0",
+                port=8081,
+                entrypoint="",
+                name="sy",
+                switchyard_model="policy-model",
+                switchyard_base_url="http://127.0.0.1:4000/v1",
+                max_concurrent_requests=0,
+            )
 
 
 class TestRolloutSessionMiddleware:
@@ -455,7 +532,15 @@ class TestConditionRecord:
         _install_fake_switchyard(monkeypatch, _FakeNativeServer)
         deployment = tmp_path / "routes.toml"
         deployment.write_text(
-            'schema_version = 1\n[llm_clients.up]\napi_key_env = "K"\napi_key = "sk-inline-secret"\n'
+            "schema_version = 1\n"
+            "[llm_clients.up]\n"
+            'api_key_env = "K"\n'
+            'api_key = "sk-inline-secret"\n'
+            "[llm_clients.up.extra_headers]\n"
+            'Authorization = "Bearer header-secret"\n'
+            'X-Team = "routing"\n'
+            "[targets.t]\n"
+            'mirrors = [{ extra_headers = { Authorization = "Bearer list-secret" } }]\n'
         )
         config = {
             "host": "0.0.0.0",
@@ -474,6 +559,7 @@ class TestConditionRecord:
         )
 
     def test_hosted_manifest_records_the_condition(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        _install_fake_stats_endpoint(monkeypatch)
         server = self._launch_server(monkeypatch, tmp_path)
 
         with TestClient(server.setup_webserver()):
@@ -484,11 +570,29 @@ class TestConditionRecord:
         assert manifest["proxy_root_url"] == "http://127.0.0.1:4123"
         deployment_bytes = (tmp_path / "routes.toml").read_bytes()
         assert manifest["deployment_sha256"] == hashlib.sha256(deployment_bytes).hexdigest()
-        # The archive keeps env-var references but never an inline credential.
+        # The archive keeps env-var references but never an inline credential -- neither an
+        # api_key literal nor any extra_headers value, which providers receive verbatim.
         assert 'api_key_env = "K"' in manifest["deployment_toml"]
         assert "sk-inline-secret" not in manifest["deployment_toml"]
+        assert "Bearer header-secret" not in manifest["deployment_toml"]
+        assert "routing" not in manifest["deployment_toml"]
+        assert "Bearer list-secret" not in manifest["deployment_toml"]
+
+    def test_unparseable_deployment_is_hashed_but_not_archived(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        """A file that does not parse cannot be searched for secrets, so only its hash is kept."""
+        _install_fake_stats_endpoint(monkeypatch)
+        server = self._launch_server(monkeypatch, tmp_path)
+        deployment = tmp_path / "routes.toml"
+        deployment.write_text("this is [not TOML")
+
+        with TestClient(server.setup_webserver()):
+            manifest = json.loads((tmp_path / "condition" / "switchyard-condition.json").read_text())
+
+        assert manifest["deployment_sha256"] == hashlib.sha256(deployment.read_bytes()).hexdigest()
+        assert manifest["deployment_toml"] is None
 
     def test_attached_manifest_records_the_proxy(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        _install_fake_stats_endpoint(monkeypatch)
         server = self._launch_server(
             monkeypatch,
             tmp_path,
@@ -503,8 +607,29 @@ class TestConditionRecord:
         assert manifest["proxy_root_url"] == "http://127.0.0.1:4000"
         assert manifest["deployment_sha256"] is None
         assert manifest["deployment_toml"] is None
+        # The local wheel never served a request in attach mode, so its version says nothing
+        # about the proxy; identity is the caller's to supply.
+        assert manifest["nemo_switchyard_version"] is None
+        assert manifest["proxy_provenance"] is None
+
+    def test_attached_manifest_carries_caller_provenance(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        _install_fake_stats_endpoint(monkeypatch)
+        provenance = {"switchyard_commit": "1fc9ab8", "deployment_sha256": "abc123"}
+        server = self._launch_server(
+            monkeypatch,
+            tmp_path,
+            deployment=None,
+            switchyard_base_url="http://127.0.0.1:4000/v1",
+            proxy_provenance=provenance,
+        )
+
+        with TestClient(server.setup_webserver()):
+            manifest = json.loads((tmp_path / "condition" / "switchyard-condition.json").read_text())
+
+        assert manifest["proxy_provenance"] == provenance
 
     def test_no_condition_dir_writes_nothing(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        _install_fake_stats_endpoint(monkeypatch)
         server = self._launch_server(monkeypatch, tmp_path, condition_dir=None)
 
         with TestClient(server.setup_webserver()):
@@ -512,8 +637,49 @@ class TestConditionRecord:
 
         assert not (tmp_path / "condition").exists()
 
+    def test_stats_snapshot_authenticates_as_the_configured_caller(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        """A proxy that requires auth serves model calls and would 401 an anonymous stats read."""
+        calls = _install_fake_stats_endpoint(monkeypatch, payload={"total_requests": 7})
+        server = self._launch_server(
+            monkeypatch,
+            tmp_path,
+            switchyard_api_key="stats-key",  # pragma: allowlist secret
+            default_headers={"x-org": "nv"},
+        )
+
+        with TestClient(server.setup_webserver()):
+            pass
+
+        (call,) = calls
+        method, url, kwargs = call
+        assert (method, url) == ("GET", "http://127.0.0.1:4123/v1/stats")
+        assert kwargs["headers"] == {"x-org": "nv", "Authorization": "Bearer stats-key"}
+        snapshot = json.loads((tmp_path / "condition" / "switchyard-stats.json").read_text())
+        assert snapshot["mode"] == "hosted"
+        assert snapshot["scope"] == "this run (proxy hosted for exactly this run)"
+        assert snapshot["stats"] == {"total_requests": 7}
+
+    def test_attached_stats_snapshot_is_labeled_an_aggregate(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        """A shared proxy counts every run it has served; the file must say so, not imply run scope."""
+        _install_fake_stats_endpoint(monkeypatch, payload={"total_requests": 900})
+        server = self._launch_server(
+            monkeypatch,
+            tmp_path,
+            deployment=None,
+            switchyard_base_url="http://127.0.0.1:4000/v1",
+        )
+
+        with TestClient(server.setup_webserver()):
+            pass
+
+        snapshot = json.loads((tmp_path / "condition" / "switchyard-stats.json").read_text())
+        assert snapshot["mode"] == "attached"
+        assert snapshot["scope"] == "proxy-lifetime aggregate"
+        assert snapshot["stats"] == {"total_requests": 900}
+
     def test_unreachable_stats_endpoint_does_not_fail_shutdown(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
-        """The fake proxy's port answers nothing; shutdown must shrug, not raise."""
+        """A proxy that answers nothing must cost a warning at shutdown, not a raise."""
+        _install_fake_stats_endpoint(monkeypatch, error=aiohttp.ClientError("connection refused"))
         server = self._launch_server(monkeypatch, tmp_path)
 
         with TestClient(server.setup_webserver()):
@@ -523,6 +689,7 @@ class TestConditionRecord:
 
     def test_unwritable_condition_dir_does_not_fail_startup(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
         """Provenance is worth a warning, not an outage: a bad dir must not stop serving."""
+        _install_fake_stats_endpoint(monkeypatch)
         blocker = tmp_path / "not-a-dir"
         blocker.write_text("a file where the condition dir should be")
         server = self._launch_server(monkeypatch, tmp_path, condition_dir=str(blocker))
@@ -535,6 +702,7 @@ class TestConditionRecord:
 
     def test_missing_distribution_yields_null_version(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
         """A source checkout without dist metadata still gets a manifest, with version null."""
+        _install_fake_stats_endpoint(monkeypatch)
 
         def not_installed(name):
             raise app_module.importlib.metadata.PackageNotFoundError(name)
@@ -549,12 +717,80 @@ class TestConditionRecord:
 
     def test_stats_snapshot_needs_a_proxy_to_ask(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
         """Before hosting starts there is no proxy URL; the snapshot must no-op, not guess."""
+        _install_fake_stats_endpoint(monkeypatch)
         server = self._launch_server(monkeypatch, tmp_path)
 
         assert server.proxy_root_url() is None
-        server.snapshot_proxy_stats()
+        asyncio.run(server.snapshot_proxy_stats())
 
         assert not (tmp_path / "condition").exists()
+
+
+class TestRolloutCorrelationCheck:
+    """forward_session_id only works when requests arrive with the /ng-rollout prefix.
+
+    Agents add that prefix only when observability or token capture is enabled, so a run without
+    either silently loses the documented correlation. Startup makes that explicit: an error when
+    the user asked for forwarding, a warning when it is merely the default.
+    """
+
+    def _server(self, global_config: object, **overrides) -> SwitchyardModel:
+        config = SwitchyardModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            entrypoint="",
+            name="test_switchyard_model",
+            switchyard_model="policy-model",
+            switchyard_base_url="http://127.0.0.1:4000/v1",
+            **overrides,
+        )
+        return SwitchyardModel(
+            config=config, server_client=MagicMock(spec=ServerClient, global_config_dict=global_config)
+        )
+
+    def test_explicit_forwarding_without_capture_fails_startup(self) -> None:
+        server = self._server({}, forward_session_id=True)
+
+        with pytest.raises(RuntimeError, match="observability_enabled"):
+            with TestClient(server.setup_webserver()):
+                pass  # pragma: no cover - startup raises before the body runs
+
+    def test_default_forwarding_without_capture_warns(self, caplog) -> None:
+        server = self._server({})
+
+        with TestClient(server.setup_webserver()):
+            pass
+
+        assert "no session id will reach Switchyard" in caplog.text
+
+    def test_observability_enables_correlation_silently(self, caplog) -> None:
+        server = self._server({"observability_enabled": True}, forward_session_id=True)
+
+        server.check_rollout_correlation()
+
+        assert "no session id will reach Switchyard" not in caplog.text
+
+    def test_token_capture_enables_correlation_silently(self, caplog) -> None:
+        server = self._server({"token_id_capture": {"enabled": True}}, forward_session_id=True)
+
+        server.check_rollout_correlation()
+
+        assert "no session id will reach Switchyard" not in caplog.text
+
+    def test_forwarding_disabled_needs_no_capture(self, caplog) -> None:
+        server = self._server({}, forward_session_id=False)
+
+        server.check_rollout_correlation()
+
+        assert "no session id will reach Switchyard" not in caplog.text
+
+    def test_unknown_global_config_is_left_alone(self, caplog) -> None:
+        """Without a config dict to consult there is nothing to validate against."""
+        server = self._server(None, forward_session_id=True)
+
+        server.check_rollout_correlation()
+
+        assert "no session id will reach Switchyard" not in caplog.text
 
 
 @pytest.mark.skipif(
@@ -562,13 +798,16 @@ class TestConditionRecord:
     reason="nemo-switchyard is not installed",
 )
 class TestConditionRecordIntegration:
-    """Real wheel, real traffic, no Gym client: the record survives the proxy's shutdown.
+    """Real wheel, real traffic: the record survives the proxy's shutdown.
 
-    Requests go to the proxy directly over urllib so this test never touches Gym's
-    process-singleton aiohttp client, which other classes bind to their own event loop.
+    Model calls go to the proxy directly over urllib, but the stats snapshot rides Gym's real
+    shared aiohttp path -- which binds the process-singleton client to this test's event loop, so
+    the singleton is torn down afterwards for the classes that bind their own.
     """
 
     def test_manifest_and_stats_written_across_a_run(self, tmp_path, monkeypatch: MonkeyPatch) -> None:
+        # A present config dict keeps the aiohttp client stack from booting Hydra mid-request.
+        monkeypatch.setenv("NEMO_GYM_CONFIG_DICT", "test_switchyard_model: {}\n")
         monkeypatch.setenv("SWITCHYARD_TEST_API_KEY", "stub-upstream-key")  # pragma: allowlist secret
         _StubUpstream.requests = []
         httpd = ThreadingHTTPServer(("127.0.0.1", 0), _StubUpstream)
@@ -625,13 +864,20 @@ target = "policy"
         finally:
             httpd.shutdown()
             thread.join(timeout=5)
+            # The snapshot built the process-singleton aiohttp client on this test's loop; leaving
+            # it behind would break later classes that bind it to theirs.
+            try:
+                server_utils.global_aiohttp_client_exit()
+            except Exception:
+                server_utils._GLOBAL_AIOHTTP_CLIENT = None
 
         manifest = json.loads((tmp_path / "condition" / "switchyard-condition.json").read_text())
         assert manifest["route"] == "policy-model"
         assert manifest["nemo_switchyard_version"] == "0.2.0"
 
-        stats = json.loads((tmp_path / "condition" / "switchyard-stats.json").read_text())
-        assert "upstream/model" in json.dumps(stats)
+        snapshot = json.loads((tmp_path / "condition" / "switchyard-stats.json").read_text())
+        assert snapshot["mode"] == "hosted"
+        assert "upstream/model" in json.dumps(snapshot["stats"])
 
 
 @pytest.mark.skipif(

--- a/responses_api_models/switchyard_model/tests/test_app.py
+++ b/responses_api_models/switchyard_model/tests/test_app.py
@@ -536,7 +536,7 @@ class TestConditionRecord:
             "schema_version = 1\n"
             "[llm_clients.up]\n"
             'api_key_env = "K"\n'
-            'api_key = "sk-inline-secret"\n'
+            'api_key = "sk-inline-secret"\n'  # pragma: allowlist secret
             "[llm_clients.up.extra_headers]\n"
             'Authorization = "Bearer header-secret"\n'
             'X-Team = "routing"\n'
@@ -833,7 +833,7 @@ schema_version = 1
 [llm_clients.upstream]
 format = "openai_chat"
 base_url = "http://127.0.0.1:{httpd.server_address[1]}/v1"
-api_key_env = "SWITCHYARD_TEST_API_KEY"
+api_key_env = "SWITCHYARD_TEST_API_KEY" # pragma: allowlist secret
 
 [targets.policy]
 id = "upstream/model"
@@ -909,7 +909,7 @@ schema_version = 1
 [llm_clients.upstream]
 format = "openai_chat"
 base_url = "http://127.0.0.1:9/v1"
-api_key_env = "SWITCHYARD_TEST_API_KEY"
+api_key_env = "SWITCHYARD_TEST_API_KEY" # pragma: allowlist secret
 
 [targets.policy]
 id = "upstream/model"
@@ -1057,7 +1057,7 @@ schema_version = 1
 [llm_clients.upstream]
 format = "openai_chat"
 base_url = "http://127.0.0.1:{upstream}/v1"
-api_key_env = "SWITCHYARD_TEST_API_KEY"
+api_key_env = "SWITCHYARD_TEST_API_KEY" # pragma: allowlist secret
 
 [targets.policy]
 id = "upstream/model"


### PR DESCRIPTION
Part of #2088. This PR now also absorbs #2600 (routing-condition provenance) so the whole feature reviews in one place.

Adds `responses_api_models/switchyard_model/`, a model server that routes Gym model calls through a Switchyard proxy, so any benchmark Gym supports can run against a router without harness changes — unlike the per-harness integrations in #2026/#2080, which are right for RL trace capture but not for evaluating the router itself. Gym either hosts the router in-process from a native Switchyard TOML deployment (`deployment=routes.toml`; a bad deployment fails at startup, nothing outlives the process, and multi-worker configs are rejected since each worker would host its own proxy) or attaches to an externally run proxy via `switchyard_base_url`, which does support multiple workers. A caller-supplied `model` is always overridden with the configured route so an agent can't bypass the router, and Gym forwards its rollout-attempt id as the Switchyard session id (`x-switchyard-session-id`) so routing decisions and costs join back to the rollout that produced them. That id only arrives when model-call capture or token capture is enabled, so the server validates the requirement at startup: a warning under the default config, a refusal to start when forwarding was requested explicitly but no capture is on.

From #2600: set `condition_dir` and the server records the routing condition the run served under — `switchyard-condition.json` at startup (route, mode, proxy URL, deployment SHA-256 plus an archive with inline `api_key` and all `extra_headers` values redacted, and the proxy's identity: the local wheel version when hosting, a caller-supplied `proxy_provenance` mapping when attaching) and `switchyard-stats.json` at shutdown (per-target requests, errors, tokens, and latency plus classifier-side usage from `/v1/stats`, fetched through Gym's shared async client as the configured caller and hard-capped inside the shutdown window). The snapshot labels its scope, since a hosted proxy's counters cover exactly the run while an attached proxy's aggregate everything it has served. Both writes are best-effort and cannot take down serving. This makes two routed runs comparable and a hosted run reproducible from the archived deployment; the docs page gains a "Compare routing conditions" workflow that aligns rollout rows by task and rollout index, reports rollouts missing a counterpart, and includes the classifier tokens the selected model's usage omits.

The only dependency is `nemo-switchyard==0.2.0`, pinned exactly in this server's own pyproject.toml (Gym core never imports Switchyard); 0.2.0 is the floor because it is the first release whose Responses translation passes `NeMoGymResponse` validation (NVIDIA-NeMo/Switchyard#144), and the ceiling because upstream has already removed the Python serve stack this PR originally drove. 47 tests pass with 100% coverage on app.py, including an integration suite that drives the real 0.2.0 wheel with no mocks (chat/responses round trips, route override, stats, provenance files written across a real shutdown), and a live routed rollout ran against this revision with reward 1.0 (results in [this comment](https://github.com/NVIDIA-NeMo/Gym/pull/2141#issuecomment-5324849341)).

Two reviewer notes. `ModelCallRecord.model_ref` names the Gym model server, not the routed target, so per-call attribution must be read from captured payloads — promoting it to a first-class record field is the follow-up flagged for #2088 and needs a core-schema design pass. And `harbor_agent` overwrites `response["model"]` with the policy model name, so Harbor-run benchmarks report the route name for every call; flagging in case that overwrite is unintentional.
