### PR TITLE
docs: add experimental Fystash sandbox provider page

### DIFF
--- a/fern/versions/latest/pages/infrastructure/sandbox/fystash.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/fystash.mdx
@@ -23,7 +23,7 @@ Install / vendor the Fystash adapter (see [docs.fystash.ai/guides/nemo-gym](http
 Register before starting envs:
 
 ```python
-from integrations.nemo_gym import register  # from fystash-infra adapter
+from integrations.nemo_gym import register  # see https://docs.fystash.ai/guides/nemo-gym
 
 register()  # register_provider("fystash", FystashProvider)
 ```
@@ -73,4 +73,4 @@ If you already run Harbor-backed NeMo Gym agents (`harbor_agent`), point Harbor 
 
 - Not a built-in provider until an in-tree `nemo_gym.sandbox.providers.fystash` lands
 - Not GPU scheduling / multi-host placement / NGC packaging
-- Full how-to: [docs.fystash.ai/guides/nemo-gym](https://docs.fystash.ai/guides/nemo-gym) · adapter: [fystash/fystash-infra integrations/nemo_gym](https://github.com/fystash/fystash-infra/tree/main/integrations/nemo_gym)
+- Full how-to: [docs.fystash.ai/guides/nemo-gym](https://docs.fystash.ai/guides/nemo-gym)

--- a/fern/versions/latest/pages/infrastructure/sandbox/fystash.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/fystash.mdx
@@ -1,0 +1,76 @@
+---
+title: "Fystash Provider"
+description: "Configure NeMo Gym sandboxes backed by Fystash warm Firecracker rooms (experimental, out-of-tree)."
+position: 5
+---
+
+The `fystash` provider creates sandboxes through the [Fystash](https://fystash.ai) Room API — warm Firecracker microVMs for agent and rollout isolation. It is an **experimental, out-of-tree** backend today: register the provider from the Fystash adapter (or Harbor cascade) rather than expecting a built-in under `nemo_gym.sandbox.providers`.
+
+<Note>
+Fystash v1 is **template_id**-oriented. Unlike Daytona or OpenSandbox, `SandboxSpec.image` is not pulled as an arbitrary container image. Pass `provider_options.template_id` or set `FYSTASH_TEMPLATE_ID`.
+</Note>
+
+## Setup
+
+Install / vendor the Fystash adapter (see [docs.fystash.ai/guides/nemo-gym](https://docs.fystash.ai/guides/nemo-gym)), then set:
+
+| Variable | Purpose |
+| --- | --- |
+| `FYSTASH_API` | Control-plane URL. Defaults to `https://api.fystash.ai`. |
+| `FYSTASH_API_KEY` | API key from [fystash.ai/signup](https://fystash.ai/signup) → Account. |
+| `FYSTASH_TEMPLATE_ID` | Room template (`default`, `docker`, …). |
+
+Register before starting envs:
+
+```python
+from integrations.nemo_gym import register  # from fystash-infra adapter
+
+register()  # register_provider("fystash", FystashProvider)
+```
+
+## Provider Config
+
+Example named `sandbox` block (agents reference with `sandbox_provider: sandbox`):
+
+```yaml
+sandbox:
+  default_metadata:
+    sandbox-api: fystash-room-api
+  fystash:
+    connection:
+      endpoint: ${oc.env:FYSTASH_API,https://api.fystash.ai}
+      api_key: ${oc.env:FYSTASH_API_KEY}
+```
+
+```bash
+gym env start \
+  --config responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml \
+  --config path/to/fystash.yaml \
+  --config responses_api_models/vllm_model/configs/vllm_model.yaml
+```
+
+## Harbor cascade
+
+If you already run Harbor-backed NeMo Gym agents (`harbor_agent`), point Harbor at Fystash with `harbor_environment_type: fystash` after the Harbor Fystash provider lands ([harbor#2491](https://github.com/harbor-framework/harbor/pull/2491)). That path does not require the native `SandboxProvider` registration.
+
+## SandboxSpec Provider Options
+
+| Option | Purpose |
+| --- | --- |
+| `template_id` | Fystash room template used instead of pulling `SandboxSpec.image`. |
+
+## Relevant SandboxSpec Fields
+
+| Field | Fystash behavior |
+| --- | --- |
+| `image` | Not pulled in v1; ignored unless you map it yourself. Prefer `template_id`. |
+| `workdir` | Guest working directory for exec. |
+| `env` | Best-effort export into the guest shell. |
+| `files` | Upload via room drive after create. |
+| `metadata` | Stored on the handle; not all keys are forwarded to the control plane. |
+
+## Honesty
+
+- Not a built-in provider until an in-tree `nemo_gym.sandbox.providers.fystash` lands
+- Not GPU scheduling / multi-host placement / NGC packaging
+- Full how-to: [docs.fystash.ai/guides/nemo-gym](https://docs.fystash.ai/guides/nemo-gym) · adapter: [fystash/fystash-infra integrations/nemo_gym](https://github.com/fystash/fystash-infra/tree/main/integrations/nemo_gym)

--- a/fern/versions/latest/pages/infrastructure/sandbox/fystash.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/fystash.mdx
@@ -73,4 +73,4 @@ If you already run Harbor-backed NeMo Gym agents (`harbor_agent`), point Harbor 
 
 - Not a built-in provider until an in-tree `nemo_gym.sandbox.providers.fystash` lands
 - Not GPU scheduling / multi-host placement / NGC packaging
-- Full how-to: [docs.fystash.ai/guides/nemo-gym](https://docs.fystash.ai/guides/nemo-gym)
+- Full how-to: [docs.fystash.ai/guides/nemo-gym](https://docs.fystash.ai/guides/nemo-gym) · adapter: [fystash/sdk integrations/nemo_gym](https://github.com/fystash/sdk/tree/main/integrations/nemo_gym)

--- a/fern/versions/latest/pages/infrastructure/sandbox/fystash.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/fystash.mdx
@@ -69,7 +69,7 @@ If you already run Harbor-backed NeMo Gym agents (`harbor_agent`), point Harbor 
 | `files` | Upload via room drive after create. |
 | `metadata` | Stored on the handle; not all keys are forwarded to the control plane. |
 
-## Honesty
+## Limitations
 
 - Not a built-in provider until an in-tree `nemo_gym.sandbox.providers.fystash` lands
 - Not GPU scheduling / multi-host placement / NGC packaging

--- a/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
@@ -42,6 +42,12 @@ Run sandboxes as AWS ECS Fargate tasks reached over an SSH sidecar.
 <Badge minimal outlined>provider</Badge> <Badge minimal outlined>ecs-fargate</Badge>
 </Card>
 
+<Card title="Fystash Provider" href="/infrastructure/sandbox/fystash">
+Run sandboxes as warm Firecracker rooms via Fystash (experimental, out-of-tree).
+
+<Badge minimal outlined>provider</Badge> <Badge minimal outlined>fystash</Badge> <Badge minimal outlined>experimental</Badge>
+</Card>
+
 <Card title="Adding a Provider" href="/infrastructure/sandbox/adding-a-provider">
 Implement the `SandboxProvider` protocol and register a new runtime backend.
 


### PR DESCRIPTION
## Summary

- Adds `fern/versions/latest/pages/infrastructure/sandbox/fystash.mdx` documenting Fystash as an **experimental, out-of-tree** `SandboxProvider` backend (warm Firecracker rooms).
- Adds a card on the sandbox index.
- Honest about v1 **template_id** semantics (not arbitrary image pull like Daytona/OpenSandbox) and Harbor cascade via `harbor_environment_type: fystash` after [harbor#2491](https://github.com/harbor-framework/harbor/pull/2491).

This is docs-only — no in-tree `nemo_gym.sandbox.providers.fystash` yet.

- Public guide: https://docs.fystash.ai/guides/nemo-gym
- Public adapter: https://github.com/fystash/sdk/tree/main/integrations/nemo_gym

## Test plan

- [ ] Fern docs preview builds
- [ ] Sandbox index card links to `/infrastructure/sandbox/fystash`
- [ ] Page renders Note + YAML + Harbor section


Made with [Cursor](https://cursor.com)