### PR TITLE
Request token ids for vLLM token observability

### DIFF
--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -321,9 +321,8 @@ class VLLMModel(SimpleResponsesAPIModel):
                 logprobs=True,
                 # Typically passed via OpenAI client extra_body.
                 return_tokens_as_token_ids=True,
-                # TODO add this when NeMo RL upgrades to vLLM 0.10.2 support for prompt token ids
-                # For prompt and generation token IDs
-                # return_token_ids=True,
+                # For prompt and generation token IDs.
+                # Applied after extra_body merge so callers can still override it.
                 # For prompt token IDs
                 # prompt_logprobs=0,
             )
@@ -367,6 +366,8 @@ class VLLMModel(SimpleResponsesAPIModel):
 
         if extra_body:
             body_dict = extra_body | body_dict
+        if self.config.return_token_id_information:
+            body_dict.setdefault("return_token_ids", True)
 
         # Audio sidechannel: rows can carry audio on
         # ``responses_create_params.metadata`` via three mutually exclusive

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -683,6 +683,52 @@ class TestApp:
     async def test_sanity(self, monkeypatch: MonkeyPatch) -> None:
         self._setup_server(monkeypatch)
 
+    def test_chat_completion_preprocess_does_not_request_token_ids_by_default(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._setup_server(monkeypatch)
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "hello",
+                }
+            ]
+        }
+        result = server._preprocess_chat_completion_create_params(MagicMock(), body)
+        assert "return_token_ids" not in result
+
+    def test_chat_completion_preprocess_requests_token_ids_for_observability(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        server = self._setup_server(monkeypatch)
+        server.config.return_token_id_information = True
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "hello",
+                }
+            ]
+        }
+        result = server._preprocess_chat_completion_create_params(MagicMock(), body)
+        assert result["return_token_ids"] is True
+        assert result["logprobs"] is True
+        assert result["return_tokens_as_token_ids"] is True
+
+    def test_chat_completion_preprocess_preserves_return_token_ids_override(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._setup_server(monkeypatch)
+        server.config.return_token_id_information = True
+        server.config.extra_body = {"return_token_ids": False}
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "hello",
+                }
+            ]
+        }
+        result = server._preprocess_chat_completion_create_params(MagicMock(), body)
+        assert result["return_token_ids"] is False
+
     def test_responses_multistep(self, monkeypatch: MonkeyPatch):
         server = self._setup_server(monkeypatch)
         app = server.setup_webserver()

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -727,6 +727,54 @@ class TestApp:
         result = server._preprocess_chat_completion_create_params(MagicMock(), body)
         assert result["return_token_ids"] is False
 
+    def test_responses_model_server_forwards_return_token_ids_for_observability(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        server = self._setup_server(monkeypatch)
+        server.config.return_token_id_information = True
+        app = server.setup_webserver()
+
+        mock_chat_completion = NeMoGymChatCompletion(
+            id="chtcmpl",
+            object="chat.completion",
+            created=FIXED_TIME,
+            model="dummy_model",
+            choices=[
+                NeMoGymChoice(
+                    index=0,
+                    finish_reason="stop",
+                    message=NeMoGymChatCompletionMessageForTraining(
+                        role="assistant",
+                        content="response",
+                        tool_calls=[],
+                        prompt_token_ids=[1, 2, 3],
+                        generation_token_ids=[4, 5],
+                        generation_log_probs=[-0.1, -0.2],
+                    ),
+                )
+            ],
+        )
+        captured_kwargs = {}
+
+        async def mock_create_chat_completion(**kwargs):
+            captured_kwargs.update(kwargs)
+            return mock_chat_completion.model_dump()
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock(side_effect=AssertionError("tokenize fallback should not be needed"))
+        server._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/responses",
+            json={"input": "hello", "max_output_tokens": 2},
+        )
+
+        assert response.status_code == 200
+        assert captured_kwargs["return_token_ids"] is True
+        assert captured_kwargs["return_tokens_as_token_ids"] is True
+        assert captured_kwargs["logprobs"] is True
+
     def test_responses_multistep(self, monkeypatch: MonkeyPatch):
         server = self._setup_server(monkeypatch)
         app = server.setup_webserver()

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -696,9 +696,7 @@ class TestApp:
         result = server._preprocess_chat_completion_create_params(MagicMock(), body)
         assert "return_token_ids" not in result
 
-    def test_chat_completion_preprocess_requests_token_ids_for_observability(
-        self, monkeypatch: MonkeyPatch
-    ) -> None:
+    def test_chat_completion_preprocess_requests_token_ids_for_observability(self, monkeypatch: MonkeyPatch) -> None:
         server = self._setup_server(monkeypatch)
         server.config.return_token_id_information = True
         body = {


### PR DESCRIPTION
## Summary
- Request `return_token_ids` only when the vLLM model config has `return_token_id_information: true`.
- Keep default requests unchanged: no `return_token_ids` field is sent unless token observability is enabled.
- Preserve explicit `extra_body.return_token_ids: false` overrides.
- Add a model-server route test proving Gym `/v1/responses` forwards `return_token_ids`, `return_tokens_as_token_ids`, and `logprobs` into the upstream `/chat/completions` request when observability is enabled.

## Tests
- `uv run pytest responses_api_models/vllm_model/tests/test_app.py -q` (`70 passed`)
- `uv run pytest responses_api_models/vllm_model/tests/test_app.py -k "model_server_forwards_return_token_ids or chat_completion_preprocess" -q`
- `uv run ruff check responses_api_models/vllm_model/app.py responses_api_models/vllm_model/tests/test_app.py`
- `uv run ruff format --check responses_api_models/vllm_model/app.py responses_api_models/vllm_model/tests/test_app.py`

Note: `responses_api_agents/harbor_agent/custom_agents/llms/test_nemo_gym_llm.py` could not be collected in this local checkout because the external `harbor` package is not installed.

Replaces #2145 because the first branch could not be force-pushed to add the DCO signoff.