### PR TITLE
[GDPVal] Fix Stirrup reference paths and make head-server wait configurable

### DIFF
--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -330,9 +330,14 @@ def _build_gdpval_user_prompt(task_prompt: str, input_files_dir: Optional[str] =
     """Build the full GDPVal user prompt from our template.
 
     Replaces the former ``gdpval_mode`` fork feature by constructing the prompt
-    externally before passing to Stirrup.  File paths are listed relative
-    to the parent of *input_files_dir* (e.g. ``gdpval_ref_files_xxx/file.pdf``)
-    to match the fork's ``state.uploaded_file_paths`` format.
+    externally before passing to Stirrup.
+
+    Paths are listed relative to *input_files_dir* itself (e.g. ``file.pdf``),
+    because Stirrup copies the *contents* of that directory into the sandbox
+    working directory. Listing them relative to its parent instead advertised a
+    ``gdpval_ref_files_<random>/`` prefix that does not exist inside the
+    sandbox, so every reference-bearing task burned ~3 turns on failed
+    ``ls``/``cd`` before recovering via ``pwd && ls -la``.
     """
     global _GDPVAL_PROMPT_TEMPLATE
     if _GDPVAL_PROMPT_TEMPLATE is None:
@@ -343,12 +348,11 @@ def _build_gdpval_user_prompt(task_prompt: str, input_files_dir: Optional[str] =
         import os
 
         ref_dir = input_files_dir.rstrip("/")
-        parent = os.path.dirname(ref_dir)
         files_section = ""
         for root, _dirs, fnames in os.walk(ref_dir):
             for fname in sorted(fnames):
                 fpath = os.path.join(root, fname)
-                rel = os.path.relpath(fpath, parent)
+                rel = os.path.relpath(fpath, ref_dir)
                 files_section += f"- {rel}\n"
         if not files_section:
             files_section = "None"

--- a/responses_api_agents/stirrup_agent/tests/test_gdpval_prompt_paths.py
+++ b/responses_api_agents/stirrup_agent/tests/test_gdpval_prompt_paths.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Reference paths advertised in the GDPVal prompt must match the sandbox layout.
+
+Stirrup copies the *contents* of ``input_files_dir`` into the sandbox working
+directory, so the prompt must name files as they appear there.
+"""
+
+from responses_api_agents.stirrup_agent.app import _build_gdpval_user_prompt
+
+
+def _section(prompt: str) -> str:
+    return prompt.split("<reference_files>", 1)[1].split("</reference_files>", 1)[0]
+
+
+def test_reference_paths_are_relative_to_the_staging_dir(tmp_path):
+    ref_dir = tmp_path / "gdpval_ref_files_abc123"
+    ref_dir.mkdir()
+    (ref_dir / "Comp_Plan.docx").write_text("x")
+    (ref_dir / "Quota.xlsx").write_text("x")
+
+    section = _section(_build_gdpval_user_prompt("do the thing", str(ref_dir)))
+
+    assert "- Comp_Plan.docx" in section
+    assert "- Quota.xlsx" in section
+    # The staging dir name does not exist inside the sandbox; advertising it
+    # sent the agent chasing a nonexistent directory.
+    assert "gdpval_ref_files_abc123" not in section
+
+
+def test_nested_reference_paths_keep_their_subdirectory(tmp_path):
+    ref_dir = tmp_path / "gdpval_ref_files_xyz"
+    (ref_dir / "source").mkdir(parents=True)
+    (ref_dir / "source" / "Ledger.xlsx").write_text("x")
+
+    section = _section(_build_gdpval_user_prompt("t", str(ref_dir)))
+
+    assert "- source/Ledger.xlsx" in section
+    assert "gdpval_ref_files_xyz" not in section
+
+
+def test_no_reference_files_renders_none(tmp_path):
+    assert "None" in _section(_build_gdpval_user_prompt("t", None))

--- a/scripts/wait_for_servers.sh
+++ b/scripts/wait_for_servers.sh
@@ -13,6 +13,9 @@ set -euo pipefail
 NG_RUN_PID="${1:?Usage: wait_for_servers.sh <gym_env_start_pid> [head_server_port] [max_wait_seconds]}"
 HEAD_PORT="${2:-11000}"
 MAX_WAIT="${3:-180}"
+# Ray's API server routinely needs 52-60s on a Lustre-backed checkout; a hardcoded
+# 60s head wait was chronically marginal and eventually failed a real run.
+HEAD_MAX_WAIT="${HEAD_MAX_WAIT:-180}"
 
 HEAD_URL="http://127.0.0.1:${HEAD_PORT}"
 POLL_INTERVAL=2
@@ -24,11 +27,11 @@ check_pid() {
   fi
 }
 
-# Phase 1: Wait for head server to respond on /server_instances (max 60s)
+# Phase 1: Wait for head server to respond on /server_instances (max HEAD_MAX_WAIT)
 # The head server has no root route, but /server_instances returns 200.
 echo "Waiting for head server on port ${HEAD_PORT}..."
 HEAD_READY="false"
-for i in $(seq 1 $((60 / POLL_INTERVAL))); do
+for i in $(seq 1 $((HEAD_MAX_WAIT / POLL_INTERVAL))); do
   if curl -sf "${HEAD_URL}/server_instances" > /dev/null 2>&1; then
     echo "Head server up after $((i * POLL_INTERVAL))s"
     HEAD_READY="true"
@@ -38,7 +41,7 @@ for i in $(seq 1 $((60 / POLL_INTERVAL))); do
   sleep "$POLL_INTERVAL"
 done
 if [ "$HEAD_READY" != "true" ]; then
-  echo "Head server did not respond within 60s"
+  echo "Head server did not respond within ${HEAD_MAX_WAIT}s"
   exit 1
 fi
 


### PR DESCRIPTION
### `stirrup_agent`: reference paths did not match the sandbox

`_build_gdpval_user_prompt` listed reference files relative to the *parent* of
`input_files_dir`, advertising a `gdpval_ref_files_<random>/` prefix. Stirrup copies the
*contents* of that directory into the sandbox working directory, so the prefix does not
exist there. Every reference-bearing task spent ~3 turns on failed `ls`/`cd` before
recovering via `pwd && ls -la`.

Paths are now relative to `input_files_dir` itself. Adds 3 regression tests covering flat
paths, nested subdirectories, and the no-references case.

### `scripts/wait_for_servers.sh`: hardcoded 60s head-server wait

The phase-1 wait was fixed at 60s. On a Lustre-backed checkout Ray's API server routinely
takes 52-60s to come up — measured at 52s, 52s and 54s across separate runs before one
crossed the line and failed a 4-hour allocation. Now `HEAD_MAX_WAIT`, default 180s.

Both verified against the real component venv; the 3 new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
