### PR TITLE
[GDPVal] Fix what reaches the rubric judge, and stop silent zeros

### DIFF
--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -58,12 +58,34 @@ from resources_servers.gdpval.judge_panel import (
     panel_summary,
     select_av_judges,
 )
+from resources_servers.gdpval.scoring import SCORING_ERROR_KEY
 
 
 LOGGER = logging.getLogger(__name__)
 
 _DEFAULT_JUDGE_PROMPT_FPATH = str(Path(__file__).parent / "prompts" / "judge_prompt.j2")
 _DEFAULT_REFERENCE_ELO = 1000.0
+
+
+def _is_invalid_judge_result(judge_result: Any) -> bool:
+    """True when the judge did not actually produce a usable judgement.
+
+    A missing result is obviously invalid, but the scorers also return a
+    *populated* metadata dict on failure -- ``no_valid_scores`` when every
+    structured trial failed to parse, ``truncated_json`` when only a partial
+    score could be salvaged, and ``no_score_in_response`` when the judge replied
+    with well-formed JSON carrying no score at all. Each yields reward 0.0 or a
+    biased-low partial. Testing only for ``None`` marks those rows valid, so they
+    land in the mean looking like real scores, with no way to tell them from a
+    genuinely poor deliverable.
+
+    Keyed on ``SCORING_ERROR_KEY`` rather than a plain ``error`` field: on the
+    success path the metadata *is* the judge's own parsed JSON, and a judge that
+    happens to emit an ``error`` field of its own must not be discarded.
+    """
+    if judge_result is None:
+        return True
+    return isinstance(judge_result, dict) and bool(judge_result.get(SCORING_ERROR_KEY))
 
 
 def _iter_ref_repeat_dirs(task_dir: Path) -> List[Path]:
@@ -459,7 +481,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
             reward=float(reward),
             verify_mode="rubric",
             judge_response=judge_result,
-            invalid_judge_response=(judge_result is None),
+            invalid_judge_response=_is_invalid_judge_result(judge_result),
         )
 
     async def _preconvert_and_log(self, target_dir: Path, *, label: str) -> None:

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -37,6 +37,20 @@ from openai import APITimeoutError
 from resources_servers.gdpval.judge_panel import merge_create_kwargs, sample_judge
 
 
+def _ignore_files() -> frozenset[str]:
+    """Run-state artefact names that must never be judged as a submission.
+
+    Owned by the agent that writes those files, not copied into each judging path
+    that has to skip them. Imported lazily on purpose: ``stirrup_agent/__init__``
+    eagerly imports its app, so a module-level import costs ~3 s of Ray and FastAPI
+    on every import of this module -- and ``multistage_elo`` imports it at module
+    scope. ``sys.modules`` caches the result, so repeat calls are a dict lookup.
+    """
+    from responses_api_agents.stirrup_agent.file_reader import IGNORE_FILES
+
+    return IGNORE_FILES
+
+
 JUDGE_PROMPT = (
     "Given a task description and reference files, select which of two submission file(s) "
     "better completed the task. "
@@ -56,16 +70,6 @@ SUBMISSION_A_OPEN = "<SUBMISSION_A_START>\n"
 SUBMISSION_A_CLOSE = "\n<SUBMISSION_A_END>\n\n"
 SUBMISSION_B_OPEN = "<SUBMISSION_B_START>\n"
 SUBMISSION_B_CLOSE = "\n<SUBMISSION_B_END>\n\n"
-
-IGNORE_FILES = {
-    "finish_params.json",
-    "history.json",
-    "history.pkl",
-    "metadata.json",
-    "inprogress_history.json",
-    "log.txt",
-    "reference_files",
-}
 
 REQUEST_MAX_ATTEMPTS = 5
 REQUEST_INITIAL_BACKOFF_SECONDS = 5.0
@@ -271,9 +275,11 @@ def build_file_section(file_dir: str | None, clean_up_list: list[Path] | None = 
                     clean_up_list.append(extract_dir)
                     extracted_dirs.append(extract_dir)
 
+    ignore_files = _ignore_files()
+
     def _emit(directory: str, file_name: str) -> None:
         nonlocal no_files
-        if file_name in IGNORE_FILES:
+        if file_name in ignore_files:
             return
         section.append({"type": "text", "text": f"\n{file_name}:\n"})
         block = get_file_content_block(directory, file_name)

--- a/resources_servers/gdpval/preconvert.py
+++ b/resources_servers/gdpval/preconvert.py
@@ -53,7 +53,18 @@ from pathlib import Path
 
 LOGGER = logging.getLogger(__name__)
 
-OFFICE_EXTENSIONS = {".docx", ".pptx", ".xlsx"}
+# OOXML (zip) packages -- these are the ones the ns0 normalization below can
+# apply to.
+OOXML_EXTENSIONS = {".docx", ".pptx", ".xlsx"}
+# Pre-2007 binary Office formats. LibreOffice converts them fine, but they were
+# previously omitted here, so a deliverable in one of these formats silently
+# never got a companion PDF and the judge scored the task as having produced
+# nothing. The ns0 pre-pass skips them harmlessly: they are OLE compound files,
+# so ``zipfile`` raises ``BadZipFile`` and ``_ooxml_has_ns0_prefix`` returns
+# False.
+LEGACY_OFFICE_EXTENSIONS = {".doc", ".ppt", ".xls"}
+
+OFFICE_EXTENSIONS = OOXML_EXTENSIONS | LEGACY_OFFICE_EXTENSIONS
 
 DEFAULT_MAX_CONCURRENT = 4
 
@@ -180,10 +191,30 @@ def convert_to_pdf(path: Path) -> tuple[Path, bool, str]:
 def find_convertible_files(root_dir: str | os.PathLike) -> list[Path]:
     files: list[Path] = []
     for dirpath, _, filenames in os.walk(root_dir):
+        # ``Report.docx`` and ``Report.pptx`` in one directory both convert to
+        # ``Report.pdf``. Whichever is seen first wins, and the other is either
+        # skipped (its sibling now exists) or races it for that one output name in
+        # the thread pool below. Neither is detectable afterwards -- the surviving
+        # PDF looks like a valid render of both. Leave these to the judging path,
+        # which renders an ambiguous file to a tempdir instead of guessing.
+        office_stems: dict[str, int] = {}
         for filename in filenames:
             path = Path(dirpath) / filename
-            if needs_conversion(path):
-                files.append(path)
+            if path.suffix.lower() in OFFICE_EXTENSIONS:
+                office_stems[path.stem] = office_stems.get(path.stem, 0) + 1
+
+        for filename in filenames:
+            path = Path(dirpath) / filename
+            if not needs_conversion(path):
+                continue
+            if office_stems.get(path.stem, 0) > 1:
+                LOGGER.warning(
+                    "Not preconverting %s: another Office file shares its stem, so '%s.pdf' is ambiguous",
+                    path,
+                    path.stem,
+                )
+                continue
+            files.append(path)
     return sorted(files)
 
 

--- a/resources_servers/gdpval/scoring.py
+++ b/resources_servers/gdpval/scoring.py
@@ -34,6 +34,13 @@ from typing import Any, Optional
 from resources_servers.gdpval.judge_panel import ResolvedJudge, merge_create_kwargs, sample_judge
 
 
+# Marker the scorers set when they did not produce a real judgement. Deliberately
+# not plain ``"error"``: the metadata returned on the success path is the judge's
+# own parsed JSON, and a judge is free to put its own ``error`` field in there --
+# flagging on that would mark good judgements invalid.
+SCORING_ERROR_KEY = "scoring_error"
+
+
 # ---------------------------------------------------------------------------
 # Structured scoring constants (structured format)
 # ---------------------------------------------------------------------------
@@ -187,7 +194,11 @@ async def score_with_rubric(
         except json.JSONDecodeError:
             score = _score_from_truncated_json(response_text)
             print(f"Rubric JSON was truncated, computed partial score: {score}", flush=True)
-            return score, None
+            # A partial score is a salvage, not a judgement: criteria the judge
+            # never emitted are simply absent, so the number is biased low. Tag
+            # it so the caller can flag the row rather than averaging it in as
+            # though the whole rubric had been scored.
+            return score, {SCORING_ERROR_KEY: "truncated_json", "partial_score": score}
 
         print(f"Rubric judge parsed keys: {list(result.keys())}", flush=True)
         if "criteria_scores" in result:
@@ -208,13 +219,19 @@ async def score_with_rubric(
                 score = sum(scores) / len(scores)
                 print(f"No overall_score key found, computed mean of criteria: {score}", flush=True)
 
-        if score is None:
+        score_missing = score is None
+        if score_missing:
             print(f"Could not extract score. Full result: {json.dumps(result)[:1000]}", flush=True)
             score = 0.0
 
         print(f"Rubric final score: {score} (judge: {judge.name})", flush=True)
         if isinstance(result, dict):
             result["judge_name"] = judge.name
+            if score_missing:
+                # The judge replied with well-formed JSON that simply carries no
+                # score. That is a 0.0 indistinguishable from a genuinely bad
+                # deliverable unless it is tagged here.
+                result[SCORING_ERROR_KEY] = "no_score_in_response"
             if include_raw_responses:
                 result["raw_responses"] = [raw_response_text]
         return max(0.0, min(1.0, score)), result
@@ -326,7 +343,9 @@ async def score_with_rubric_visual(
         except json.JSONDecodeError:
             score = _score_from_truncated_json(response_text)
             print(f"Visual judge JSON was truncated, computed partial score: {score}", flush=True)
-            return score, None
+            # See the text path above: tag the salvage so it is flagged, not
+            # silently averaged in as a real score.
+            return score, {SCORING_ERROR_KEY: "truncated_json", "partial_score": score}
 
         print(f"Visual judge parsed keys: {list(result.keys())}", flush=True)
         if "criteria_scores" in result:
@@ -346,13 +365,17 @@ async def score_with_rubric_visual(
                 score = sum(scores) / len(scores)
                 print(f"No overall_score key found, computed mean of criteria: {score}", flush=True)
 
-        if score is None:
+        score_missing = score is None
+        if score_missing:
             print(f"Could not extract score. Full result: {json.dumps(result)[:1000]}", flush=True)
             score = 0.0
 
         print(f"Visual judge final score: {score} (judge: {judge.name})", flush=True)
         if isinstance(result, dict):
             result["judge_name"] = judge.name
+            if score_missing:
+                # See the text path above.
+                result[SCORING_ERROR_KEY] = "no_score_in_response"
             if include_raw_responses:
                 result["raw_responses"] = [raw_response_text]
         return max(0.0, min(1.0, score)), result
@@ -520,7 +543,11 @@ async def score_with_rubric_structured(
 
     if not scores:
         print("[structured-rubric] no valid scores from any trial", flush=True)
-        no_valid_metadata: dict = {"error": "no_valid_scores", "num_trials": num_trials}
+        no_valid_metadata: dict = {
+            "error": "no_valid_scores",  # retained: pre-existing key, read by operators
+            SCORING_ERROR_KEY: "no_valid_scores",
+            "num_trials": num_trials,
+        }
         if include_raw_responses:
             no_valid_metadata["raw_responses"] = trial_responses
         return 0.0, no_valid_metadata

--- a/resources_servers/gdpval/scoring.py
+++ b/resources_servers/gdpval/scoring.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import random
 import re
 from pathlib import Path
@@ -39,6 +40,18 @@ from resources_servers.gdpval.judge_panel import ResolvedJudge, merge_create_kwa
 # own parsed JSON, and a judge is free to put its own ``error`` field in there --
 # flagging on that would mark good judgements invalid.
 SCORING_ERROR_KEY = "scoring_error"
+
+# Rubric judge requests had no timeout: ``AsyncOpenAI`` defaults to 600 s with two
+# silent retries, so a legitimately long request -- a multi-page PDF rasterised to
+# page images, say -- burns 30 minutes across three attempts and then surfaces to
+# the caller as a plain transient 500, with nothing to indicate a timeout was
+# involved. ``comparison.py`` already bounds its own judge calls this way; the
+# rubric path did not.
+#
+# ``max_retries=0`` is deliberate: a request too slow to finish once is too slow
+# three times, so the SDK retries only multiply wall-clock. One bounded attempt
+# fails in a third of the time and says what happened.
+JUDGE_REQUEST_TIMEOUT_SECONDS = float(os.environ.get("GDPVAL_JUDGE_REQUEST_TIMEOUT_SECONDS", "1800"))
 
 
 # ---------------------------------------------------------------------------
@@ -127,7 +140,12 @@ async def score_with_rubric(
         deliverable_text=deliverable_text,
     )
 
-    client = AsyncOpenAI(base_url=judge.base_url, api_key=judge.api_key)
+    client = AsyncOpenAI(
+        base_url=judge.base_url,
+        api_key=judge.api_key,
+        timeout=JUDGE_REQUEST_TIMEOUT_SECONDS,
+        max_retries=0,
+    )
 
     max_retries = 5
     base_delay = 2.0
@@ -285,7 +303,12 @@ async def score_with_rubric_visual(
     content: list[dict] = [{"type": "text", "text": judge_text}]
     content.extend(deliverable_content_blocks)
 
-    client = AsyncOpenAI(base_url=judge.base_url, api_key=judge.api_key)
+    client = AsyncOpenAI(
+        base_url=judge.base_url,
+        api_key=judge.api_key,
+        timeout=JUDGE_REQUEST_TIMEOUT_SECONDS,
+        max_retries=0,
+    )
 
     max_retries = 5
     base_delay = 2.0
@@ -426,7 +449,12 @@ async def score_with_rubric_structured(
     def _client_for(judge: ResolvedJudge) -> Any:
         key = (judge.base_url, judge.api_key)
         if key not in client_cache:
-            client_cache[key] = AsyncOpenAI(base_url=judge.base_url, api_key=judge.api_key)
+            client_cache[key] = AsyncOpenAI(
+                base_url=judge.base_url,
+                api_key=judge.api_key,
+                timeout=JUDGE_REQUEST_TIMEOUT_SECONDS,
+                max_retries=0,
+            )
         return client_cache[key]
 
     # Compute max possible score from rubric. Different upstream formats name

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -173,6 +173,33 @@ class TestApp:
         assert resp.judge_response == canned_result
 
     @pytest.mark.asyncio
+    async def test_verify_rubric_flags_a_failed_judgement(self) -> None:
+        """A scorer failure must surface on the response, not only in the helper.
+
+        Testing ``_is_invalid_judge_result`` alone leaves this call site free to
+        regress to ``judge_result is None`` with the suite still green, and the row
+        then lands in the mean looking like a genuine 0.0.
+        """
+        from resources_servers.gdpval.scoring import SCORING_ERROR_KEY
+
+        server = _server(reward_mode="rubric")
+        failed = {SCORING_ERROR_KEY: "no_valid_scores", "num_trials": 2}
+
+        async def fake_score_with_rubric(**_kwargs):
+            return 0.0, failed
+
+        body = _verify_request(rubric_json=[{"criterion": "clarity", "score": 1}])
+
+        with (
+            patch("resources_servers.gdpval.scoring.score_with_rubric", side_effect=fake_score_with_rubric),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+        ):
+            resp = await server.verify(body)
+
+        assert resp.reward == 0.0
+        assert resp.invalid_judge_response is True, "a failed judgement was reported as a valid score"
+
+    @pytest.mark.asyncio
     async def test_verify_rubric_passes_create_overrides_through(self) -> None:
         """``judge_responses_create_params_overrides`` must reach the scoring fn.
 

--- a/resources_servers/gdpval/tests/test_ignore_files_single_source.py
+++ b/resources_servers/gdpval/tests/test_ignore_files_single_source.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run-state exclusions have exactly one definition.
+
+Both judging paths -- rubric scoring via ``file_reader`` and pairwise comparison
+via ``comparison`` -- must skip the same files. When each kept its own copy they
+could drift, and a file dropped from only one list leaks the agent's own
+trajectory into that judge's prompt without anything failing.
+"""
+
+from pathlib import Path
+
+from resources_servers.gdpval import comparison
+from responses_api_agents.stirrup_agent import file_reader
+
+
+def test_comparison_reuses_the_agents_definition():
+    assert comparison._ignore_files() is file_reader.IGNORE_FILES, (
+        "comparison.py must import IGNORE_FILES, not define its own copy"
+    )
+
+
+def test_comparison_does_not_pull_the_agent_in_at_import_time():
+    """The lazy import is load-bearing, not stylistic.
+
+    ``stirrup_agent/__init__`` imports its app, which imports Ray and FastAPI. A
+    module-level import here took comparison.py from 0.69 s to 3.77 s, and
+    ``multistage_elo`` imports this module at module scope.
+    """
+    source = Path(comparison.__file__).read_text()
+    module_level = [
+        line
+        for line in source.splitlines()
+        if line.startswith(("import ", "from ")) and "responses_api_agents" in line
+    ]
+    assert not module_level, f"import responses_api_agents lazily, not at module scope: {module_level}"
+
+
+def test_the_definition_still_covers_every_stirrup_run_artefact():
+    """Pinned as an exact set.
+
+    Asserting membership for a few names cannot catch a *deletion* from the list,
+    which is the change that would silently start leaking a run-state file into
+    judged submissions.
+    """
+    assert set(file_reader.IGNORE_FILES) == {
+        "finish_params.json",
+        "history.json",
+        "history.pkl",
+        "metadata.json",
+        "inprogress_history.json",
+        "log.txt",
+        "reference_files",
+    }

--- a/resources_servers/gdpval/tests/test_invalid_judge_result.py
+++ b/resources_servers/gdpval/tests/test_invalid_judge_result.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A failed judgement must be flagged, not averaged in as a real score.
+
+The rubric scorers return a populated metadata dict on failure: ``no_valid_scores``
+when every structured trial failed to parse, ``truncated_json`` when only a partial
+score could be salvaged, and ``no_score_in_response`` when the judge returned
+well-formed JSON with no score in it. All three produce 0.0 or a biased-low partial.
+Flagging only ``judge_result is None`` marks those rows valid, so a broken judge is
+indistinguishable from a bad deliverable.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from resources_servers.gdpval.app import _is_invalid_judge_result
+from resources_servers.gdpval.scoring import (
+    SCORING_ERROR_KEY,
+    score_with_rubric,
+    score_with_rubric_structured,
+    score_with_rubric_visual,
+)
+
+
+def test_missing_result_is_invalid():
+    assert _is_invalid_judge_result(None)
+
+
+def test_structured_no_valid_scores_is_invalid():
+    assert _is_invalid_judge_result({SCORING_ERROR_KEY: "no_valid_scores", "num_trials": 2})
+
+
+def test_truncated_partial_score_is_invalid():
+    assert _is_invalid_judge_result({SCORING_ERROR_KEY: "truncated_json", "partial_score": 0.536})
+
+
+def test_judge_returning_no_score_is_invalid():
+    assert _is_invalid_judge_result({SCORING_ERROR_KEY: "no_score_in_response", "overall_rationale": "unreadable"})
+
+
+def test_a_real_judgement_is_valid():
+    judged = {
+        "judge_name": "minimax-m3",
+        "overall_score": 0.52,
+        "overall_rationale": "Meets most criteria.",
+        "criteria_scores": [{"criterion": "Creates the deck", "score": 1.0}],
+    }
+    assert not _is_invalid_judge_result(judged)
+
+
+def test_structured_trial_metadata_is_valid():
+    assert not _is_invalid_judge_result(
+        {"trial_scores": [11.0, 11.0], "max_possible": 40.0, "percentages": [27.5, 27.5]}
+    )
+
+
+def test_a_judges_own_error_field_does_not_flag_the_row():
+    """Success-path metadata IS the judge's parsed JSON, so ``error`` may be its own field.
+
+    Keying the predicate on a plain ``error`` would discard a perfectly good
+    judgement just because the rubric made the judge mention one.
+    """
+    assert not _is_invalid_judge_result(
+        {"overall_score": 0.6, "error": "candidate made a minor formula error", "judge_name": "minimax-m3"}
+    )
+
+
+def test_empty_marker_value_does_not_flag():
+    assert not _is_invalid_judge_result({SCORING_ERROR_KEY: "", "overall_score": 0.4})
+
+
+# ---------------------------------------------------------------------------
+# The scorers must actually set the marker. Testing the predicate alone leaves
+# the scorer return statements free to regress with the suite still green.
+# ---------------------------------------------------------------------------
+
+
+def _stub_judge_and_response(text: str):
+    judge = type(
+        "J",
+        (),
+        {"name": "stub", "model": "stub", "base_url": "http://stub", "api_key": "k", "create_overrides": {}},
+    )()
+    message = type("M", (), {"content": text, "tool_calls": None})()
+    choice = type("C", (), {"message": message, "finish_reason": "stop"})()
+    response = type("R", (), {"choices": [choice]})()
+    return judge, response
+
+
+async def _score(tmp_path, judge_text: str):
+    template = tmp_path / "judge.j2"
+    template.write_text("{{ task_prompt }} {{ rubric }} {{ deliverable_text }}")
+    judge, response = _stub_judge_and_response(judge_text)
+    with patch("openai.AsyncOpenAI") as client_cls:
+        client_cls.return_value.chat.completions.create = AsyncMock(return_value=response)
+        return await score_with_rubric("text", [], "rubric", "prompt", str(template), [judge])
+
+
+@pytest.mark.asyncio
+async def test_score_with_rubric_tags_truncated_json(tmp_path):
+    score, meta = await _score(tmp_path, '{"criteria_scores": [{"score": 0.5}, {"score": 0.7}')
+
+    assert meta is not None, "a truncated salvage must not be reported as a clean failure"
+    assert meta[SCORING_ERROR_KEY] == "truncated_json"
+    assert _is_invalid_judge_result(meta), "the salvage must reach verify() as invalid"
+    assert score == pytest.approx(0.6)
+
+
+@pytest.mark.asyncio
+async def test_score_with_rubric_tags_a_response_carrying_no_score(tmp_path):
+    score, meta = await _score(tmp_path, json.dumps({"overall_rationale": "the attachment was unreadable"}))
+
+    assert score == 0.0
+    assert meta[SCORING_ERROR_KEY] == "no_score_in_response"
+    assert _is_invalid_judge_result(meta), "a scoreless 0.0 must not look like a bad deliverable"
+
+
+@pytest.mark.asyncio
+async def test_a_good_judgement_is_not_tagged(tmp_path):
+    score, meta = await _score(tmp_path, json.dumps({"overall_score": 0.75, "overall_rationale": "solid"}))
+
+    assert score == pytest.approx(0.75)
+    assert SCORING_ERROR_KEY not in meta
+    assert not _is_invalid_judge_result(meta)
+
+
+async def _score_visual(tmp_path, judge_text: str):
+    template = tmp_path / "judge.j2"
+    template.write_text("{{ task_prompt }} {{ rubric }}")
+    judge, response = _stub_judge_and_response(judge_text)
+    with patch("openai.AsyncOpenAI") as client_cls:
+        client_cls.return_value.chat.completions.create = AsyncMock(return_value=response)
+        return await score_with_rubric_visual([], [], "rubric", "prompt", str(template), [judge])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "judge_text,expected",
+    [
+        ('{"criteria_scores": [{"score": 0.5}, {"score": 0.7}', "truncated_json"),
+        ('{"overall_rationale": "the render was blank"}', "no_score_in_response"),
+    ],
+)
+async def test_visual_scorer_tags_its_failures_too(tmp_path, judge_text, expected):
+    """The multimodal path is a parallel implementation and regresses independently."""
+    _, meta = await _score_visual(tmp_path, judge_text)
+
+    assert meta[SCORING_ERROR_KEY] == expected
+    assert _is_invalid_judge_result(meta)
+
+
+@pytest.mark.asyncio
+async def test_structured_scorer_tags_a_run_with_no_parsable_trial(tmp_path):
+    """Every trial failing to emit the score tags is the classic silent 0.0."""
+    judge, response = _stub_judge_and_response("I could not evaluate this submission.")
+
+    with patch("openai.AsyncOpenAI") as client_cls:
+        client_cls.return_value.chat.completions.create = AsyncMock(return_value=response)
+        score, meta = await score_with_rubric_structured(
+            "text", [], "rubric", "prompt", [judge], num_trials=1, formatting_retries=1
+        )
+
+    assert score == 0.0
+    assert meta[SCORING_ERROR_KEY] == "no_valid_scores"
+    assert _is_invalid_judge_result(meta)

--- a/resources_servers/gdpval/tests/test_judge_request_timeout.py
+++ b/resources_servers/gdpval/tests/test_judge_request_timeout.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Rubric judge requests must be bounded, and must not retry.
+
+Without an explicit timeout the OpenAI SDK applies its own default (600 s) plus
+two silent retries, so a request that legitimately runs long burns three times
+that before failing — and it surfaces as a bare transient 500 with nothing to
+say a timeout was involved. That is how a task ends up unjudged three runs in a
+row while every knob that looks like a timeout is set correctly somewhere else.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from resources_servers.gdpval import scoring
+
+
+def _stub_judge_and_response(text: str):
+    judge = type(
+        "J",
+        (),
+        {"name": "stub", "model": "stub", "base_url": "http://stub", "api_key": "k", "create_overrides": {}},
+    )()
+    message = type("M", (), {"content": text, "tool_calls": None})()
+    choice = type("C", (), {"message": message, "finish_reason": "stop"})()
+    return judge, type("R", (), {"choices": [choice]})()
+
+
+def test_timeout_is_configurable_and_not_the_sdk_default():
+    assert scoring.JUDGE_REQUEST_TIMEOUT_SECONDS > 600, (
+        "must exceed the SDK default, or a long judge request still dies at 600 s"
+    )
+
+
+async def _run_visual(tmp_path, judge, response):
+    template = tmp_path / "judge.j2"
+    template.write_text("{{ task_prompt }} {{ rubric }}")
+    with patch("openai.AsyncOpenAI") as client_cls:
+        client_cls.return_value.chat.completions.create = AsyncMock(return_value=response)
+        await scoring.score_with_rubric_visual([], [], "rubric", "prompt", str(template), [judge])
+    return client_cls
+
+
+async def _run_structured(judge, response):
+    with patch("openai.AsyncOpenAI") as client_cls:
+        client_cls.return_value.chat.completions.create = AsyncMock(return_value=response)
+        await scoring.score_with_rubric_structured(
+            "text", [], "rubric", "prompt", [judge], num_trials=1, formatting_retries=1
+        )
+    return client_cls
+
+
+@pytest.mark.asyncio
+async def test_rubric_client_receives_timeout_and_no_retries(tmp_path):
+    template = tmp_path / "judge.j2"
+    template.write_text("{{ task_prompt }} {{ rubric }} {{ deliverable_text }}")
+    judge, response = _stub_judge_and_response('{"overall_score": 0.5}')
+
+    with patch("openai.AsyncOpenAI") as client_cls:
+        client_cls.return_value.chat.completions.create = AsyncMock(return_value=response)
+        await scoring.score_with_rubric("text", [], "rubric", "prompt", str(template), [judge])
+
+    kwargs = client_cls.call_args.kwargs
+    assert kwargs["timeout"] == scoring.JUDGE_REQUEST_TIMEOUT_SECONDS
+    assert kwargs["max_retries"] == 0, "SDK retries triple the wall-clock cost of a slow request"
+
+
+def test_environment_override_is_honoured(monkeypatch):
+    monkeypatch.setenv("GDPVAL_JUDGE_REQUEST_TIMEOUT_SECONDS", "42")
+    import importlib
+
+    reloaded = importlib.reload(scoring)
+    try:
+        assert reloaded.JUDGE_REQUEST_TIMEOUT_SECONDS == 42.0
+    finally:
+        monkeypatch.delenv("GDPVAL_JUDGE_REQUEST_TIMEOUT_SECONDS", raising=False)
+        importlib.reload(scoring)
+
+
+@pytest.mark.asyncio
+async def test_visual_client_is_bounded_too(tmp_path):
+    """The multimodal path is where long requests actually happen."""
+    judge, response = _stub_judge_and_response('{"overall_score": 0.5}')
+    client_cls = await _run_visual(tmp_path, judge, response)
+
+    kwargs = client_cls.call_args.kwargs
+    assert kwargs["timeout"] == scoring.JUDGE_REQUEST_TIMEOUT_SECONDS
+    assert kwargs["max_retries"] == 0
+
+
+@pytest.mark.asyncio
+async def test_structured_client_is_bounded_too():
+    """Structured scoring caches a client per upstream; that one needs it as well."""
+    judge, response = _stub_judge_and_response("FINAL_SCORE[8] out of MAX_POSSIBLE_SCORE[10]")
+    client_cls = await _run_structured(judge, response)
+
+    kwargs = client_cls.call_args.kwargs
+    assert kwargs["timeout"] == scoring.JUDGE_REQUEST_TIMEOUT_SECONDS
+    assert kwargs["max_retries"] == 0

--- a/resources_servers/gdpval/tests/test_preconvert_legacy_office.py
+++ b/resources_servers/gdpval/tests/test_preconvert_legacy_office.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Legacy binary Office deliverables are preconverted too.
+
+A deliverable the preconverter does not recognise silently never gets a
+companion PDF, and the judge — which reads the PDF, not the Office file — scores
+the task as having produced nothing. That is a scoring bug, not a rendering one.
+"""
+
+from pathlib import Path
+
+from resources_servers.gdpval.preconvert import (
+    LEGACY_OFFICE_EXTENSIONS,
+    OFFICE_EXTENSIONS,
+    OOXML_EXTENSIONS,
+    find_convertible_files,
+    needs_conversion,
+)
+
+
+def test_legacy_binary_formats_are_convertible():
+    for ext in (".doc", ".ppt", ".xls"):
+        assert ext in OFFICE_EXTENSIONS, f"{ext} deliverables would never get a PDF"
+    assert OFFICE_EXTENSIONS == OOXML_EXTENSIONS | LEGACY_OFFICE_EXTENSIONS
+
+
+def test_needs_conversion_covers_legacy_and_respects_existing_pdf(tmp_path: Path):
+    legacy = tmp_path / "Report.doc"
+    legacy.write_bytes(b"\xd0\xcf\x11\xe0")  # OLE compound-file magic
+    assert needs_conversion(legacy)
+
+    # An already-preconverted sibling means there is nothing to do.
+    (tmp_path / "Report.pdf").write_bytes(b"%PDF-1.4\n")
+    assert not needs_conversion(legacy)
+
+
+def test_extension_match_is_case_insensitive(tmp_path: Path):
+    shouty = tmp_path / "MINUTES.DOC"
+    shouty.write_bytes(b"\xd0\xcf\x11\xe0")
+    assert needs_conversion(shouty), "uppercase extensions must still convert"
+
+
+def test_find_convertible_files_picks_up_legacy(tmp_path: Path):
+    (tmp_path / "a.docx").write_bytes(b"PK\x03\x04")
+    (tmp_path / "b.ppt").write_bytes(b"\xd0\xcf\x11\xe0")
+    (tmp_path / "c.txt").write_text("not office")
+
+    found = {p.name for p in find_convertible_files(tmp_path)}
+
+    assert found == {"a.docx", "b.ppt"}
+
+
+def test_same_stem_office_files_are_left_to_the_judging_path(tmp_path: Path):
+    """Both would convert to ``Report.pdf`` -- one racing the other in the thread pool.
+
+    Observed once in the 200-task Mercor corpus
+    (``Pineloten_Capital_Structure.{docx,pptx}``): the single PDF present is the
+    .docx render (612x792 portrait), so the .pptx was silently never converted.
+    """
+    (tmp_path / "Report.docx").write_bytes(b"PK\x03\x04")
+    (tmp_path / "Report.pptx").write_bytes(b"PK\x03\x04")
+    (tmp_path / "Unique.docx").write_bytes(b"PK\x03\x04")
+
+    found = {p.name for p in find_convertible_files(tmp_path)}
+
+    assert found == {"Unique.docx"}, "ambiguous stems must not be preconverted"

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -35,6 +35,22 @@ from typing import Any
 
 MAX_TOTAL_CHARS = 20_000
 
+# Caps on *text* content blocks in the multimodal judging path. ``read_deliverable_files``
+# has always bounded its output at ``MAX_TOTAL_CHARS``; ``convert_deliverables_to_content_blocks``
+# bounded nothing, so a single large text file went into the judge prompt whole. Observed:
+# a 2.8 MB file produced a 720,898-token request against a 786,432-token judge, came back
+# 400, and surfaced to the caller as a transient 500 -- so the task was not judged badly,
+# it was not judged at all, and the run still exited 0.
+#
+# The largest genuine text deliverable in the GDPVal/Mercor corpus is 101 KB (per-task
+# total also 101 KB), so these caps leave real submissions byte-for-byte intact and only
+# bite pathological files. Truncating loses a tail; not truncating loses the task.
+MAX_TEXT_BLOCK_CHARS = 200_000
+MAX_TOTAL_TEXT_BLOCK_CHARS = 400_000
+# Reserved per text block for its header and any truncation notice, so a directory
+# of many small files cannot blow the request on framing alone.
+TEXT_BLOCK_OVERHEAD_CHARS = 120
+
 # Stirrup persists its own run state into the very directory it writes
 # deliverables to: the finish payload, the full message history, and run
 # metadata. ``.json`` is in ``TEXT_EXTS``, so without this filter the judge is
@@ -266,6 +282,26 @@ def _convert_office_to_pdf(fpath: Path, out_dir: Path | None = None) -> Path | N
             shutil.rmtree(stage_dir, ignore_errors=True)
 
 
+def _fair_text_allowances(sizes: list[int], total_budget: int, per_file_cap: int) -> list[int]:
+    """Max-min fair split of *total_budget* across text deliverables of *sizes*.
+
+    Smallest first: each file may take an equal share of what is left divided by how
+    many files still need one. Files under their share take only what they need and
+    hand the surplus back, so a small real deliverable is never starved by a large
+    one that happens to sort earlier. Returned in the order *sizes* was given.
+    """
+    allowances = [0] * len(sizes)
+    remaining = total_budget
+    order = sorted(range(len(sizes)), key=lambda i: sizes[i])
+    for position, idx in enumerate(order):
+        still_to_serve = len(order) - position
+        share = remaining // still_to_serve
+        take = max(0, min(sizes[idx], per_file_cap, share))
+        allowances[idx] = take
+        remaining -= take
+    return allowances
+
+
 def convert_deliverables_to_content_blocks(output_dir: str) -> list[dict[str, Any]]:
     """Convert deliverable files to OpenAI-compatible content blocks for multimodal judging.
 
@@ -297,6 +333,43 @@ def convert_deliverables_to_content_blocks(output_dir: str) -> list[dict[str, An
         if is_deliverable(entry) and entry.suffix.lower() in OFFICE_EXTS:
             office_stem_counts[entry.stem] = office_stem_counts.get(entry.stem, 0) + 1
 
+    # Allot the aggregate budget up front rather than first-come-first-served. Files
+    # are visited in sorted order, so a spend-as-you-go budget would let two big
+    # ``000_*.txt`` files starve a real ``Report.md`` -- renaming a file would change
+    # the score. Max-min fair shares make a deliverable's allowance independent of
+    # what it is called. Per-block overhead (header, truncation notice) is reserved
+    # before allotting, because it is tokens too.
+    text_files = [p for p in entries if is_deliverable(p) and p.suffix.lower() in TEXT_EXTS]
+    body_budget = max(0, MAX_TOTAL_TEXT_BLOCK_CHARS - len(text_files) * TEXT_BLOCK_OVERHEAD_CHARS)
+    allowance_by_name = dict(
+        zip(
+            (p.name for p in text_files),
+            _fair_text_allowances([p.stat().st_size for p in text_files], body_budget, MAX_TEXT_BLOCK_CHARS),
+        )
+    )
+
+    emitted_chars = 0
+    omitted_names: list[str] = []
+
+    def _text_block(header: str, body: str, allowance: int) -> dict[str, Any] | None:
+        """A text block for *body*, trimmed to *allowance*.
+
+        Returns ``None`` once the aggregate budget is spent: with enough files even
+        the headers alone would blow the request, so past that point they are counted
+        into a single summary block rather than named one by one.
+        """
+        nonlocal emitted_chars
+        if emitted_chars >= MAX_TOTAL_TEXT_BLOCK_CHARS:
+            return None
+        cap = max(0, min(MAX_TEXT_BLOCK_CHARS, allowance))
+        if len(body) > cap:
+            shown = body[:cap] + f"\n[...truncated: {len(body) - cap:,} of {len(body):,} chars omitted]"
+        else:
+            shown = body
+        block = {"type": "text", "text": f"\n{header}\n{shown}"}
+        emitted_chars += len(block["text"])
+        return block
+
     for fpath in entries:
         if not is_deliverable(fpath):
             continue
@@ -307,7 +380,8 @@ def convert_deliverables_to_content_blocks(output_dir: str) -> list[dict[str, An
             if ext in TEXT_EXTS:
                 text = fpath.read_text(encoding="utf-8", errors="replace").strip()
                 if text:
-                    blocks.append({"type": "text", "text": f"\n{fpath.name}:\n{text}"})
+                    block = _text_block(f"{fpath.name}:", text, allowance_by_name.get(fpath.name, 0))
+                    blocks.append(block) if block else omitted_names.append(fpath.name)
 
             elif ext in OFFICE_EXTS:
                 # A preconversion pass may already have written a sibling PDF
@@ -338,9 +412,12 @@ def convert_deliverables_to_content_blocks(output_dir: str) -> list[dict[str, An
                     )
                 else:
                     # Fallback to text extraction
+                    # No pre-allotted share: an Office file only lands here when its
+                    # conversion failed, so it competes for whatever budget is left.
                     text = _extract_text(fpath, ext)
                     if text:
-                        blocks.append({"type": "text", "text": f"\n{fpath.name} (text fallback):\n{text}"})
+                        block = _text_block(f"{fpath.name} (text fallback):", text, MAX_TEXT_BLOCK_CHARS)
+                        blocks.append(block) if block else omitted_names.append(fpath.name)
 
             elif ext == ".pdf":
                 data = fpath.read_bytes()
@@ -366,6 +443,17 @@ def convert_deliverables_to_content_blocks(output_dir: str) -> list[dict[str, An
                 )
         except Exception as exc:
             blocks.append({"type": "text", "text": f"\n{fpath.name}: [Error: {exc}]"})
+
+    if omitted_names:
+        shown = ", ".join(omitted_names[:20])
+        if len(omitted_names) > 20:
+            shown += f", and {len(omitted_names) - 20} more"
+        blocks.append(
+            {
+                "type": "text",
+                "text": f"\n[{len(omitted_names)} text deliverable(s) omitted, budget exhausted: {shown}]",
+            }
+        )
 
     # Clean up only what this pass created, which lives entirely in tempdirs.
     for scratch in scratch_dirs:

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -35,6 +35,33 @@ from typing import Any
 
 MAX_TOTAL_CHARS = 20_000
 
+# Stirrup persists its own run state into the very directory it writes
+# deliverables to: the finish payload, the full message history, and run
+# metadata. ``.json`` is in ``TEXT_EXTS``, so without this filter the judge is
+# handed the agent's own reasoning trace as part of the "submission" and can
+# grade what the agent *said it did* rather than the artefact it produced -- a
+# false positive for any "states/reports <value>" rubric criterion.
+#
+# This is the single definition: the agent that writes these files owns the
+# list, and every judging path imports it from here (pairwise comparison in
+# ``resources_servers/gdpval/comparison.py`` previously kept its own copy).
+IGNORE_FILES = frozenset(
+    {
+        "finish_params.json",
+        "history.json",
+        "history.pkl",
+        "metadata.json",
+        "inprogress_history.json",
+        "log.txt",
+        "reference_files",
+    }
+)
+
+
+def is_deliverable(path: Path) -> bool:
+    """True if *path* is an agent-produced deliverable rather than run state."""
+    return path.is_file() and path.name not in IGNORE_FILES
+
 
 def read_deliverable_files(output_dir: str) -> str:
     """Read text from all deliverable files in *output_dir*.
@@ -53,7 +80,7 @@ def read_deliverable_files(output_dir: str) -> str:
     if not output_path.is_dir():
         return ""
 
-    files = sorted(output_path.iterdir())
+    files = sorted(p for p in output_path.iterdir() if p.name not in IGNORE_FILES)
     if not files:
         return ""
 
@@ -175,20 +202,24 @@ MIME_TYPES = {
 }
 
 
-def _convert_office_to_pdf(fpath: Path) -> Path | None:
+def _convert_office_to_pdf(fpath: Path, out_dir: Path | None = None) -> Path | None:
     """Convert a .docx/.xlsx/.pptx file to PDF using LibreOffice headless.
 
     Returns the path to the generated PDF, or None on failure.
     Uses a unique user profile to avoid lock conflicts in concurrent workers.
 
+    With *out_dir*, the PDF is written there instead of next to *fpath*. Judging
+    passes use that so reading a deliverables directory never also writes to it.
+
     Whitespace in the input filename makes LibreOffice's batch-convert mode
     silently drop the file (the URI it builds isn't percent-encoded), so we
     stage the input to a tempdir with a sanitized basename and move the PDF
-    back to the original location.
+    back to the intended location.
     """
     profile_dir = Path(tempfile.mkdtemp(prefix="lo-profile-"))
     user_install = f"file://{profile_dir.as_posix()}"
-    out_pdf = fpath.with_suffix(".pdf")
+    dest_dir = out_dir if out_dir is not None else fpath.parent
+    out_pdf = dest_dir / (fpath.stem + ".pdf")
     stage_dir: Path | None = None
     input_path = fpath
     has_whitespace = any(c.isspace() for c in fpath.name)
@@ -201,7 +232,7 @@ def _convert_office_to_pdf(fpath: Path) -> Path | None:
             shutil.copy2(fpath, input_path)
             lo_outdir = str(stage_dir)
         else:
-            lo_outdir = str(fpath.parent)
+            lo_outdir = str(dest_dir)
 
         cmd = [
             "libreoffice",
@@ -252,10 +283,22 @@ def convert_deliverables_to_content_blocks(output_dir: str) -> list[dict[str, An
         return []
 
     blocks: list[dict[str, Any]] = []
-    converted_pdfs: list[Path] = []  # track for cleanup
+    scratch_dirs: list[Path] = []  # tempdirs holding PDFs this pass converted
 
-    for fpath in sorted(output_path.iterdir()):
-        if not fpath.is_file():
+    entries = sorted(output_path.iterdir())
+
+    # ``Report.docx`` and ``Report.pptx`` both map to ``Report.pdf``. A sibling PDF
+    # is then ambiguous -- it can only be the render of one of them -- so reusing it
+    # for the other would show the judge the first file's content twice and the
+    # second file's content never. Count the stems and only take the fast path when
+    # the mapping is unambiguous.
+    office_stem_counts: dict[str, int] = {}
+    for entry in entries:
+        if is_deliverable(entry) and entry.suffix.lower() in OFFICE_EXTS:
+            office_stem_counts[entry.stem] = office_stem_counts.get(entry.stem, 0) + 1
+
+    for fpath in entries:
+        if not is_deliverable(fpath):
             continue
 
         ext = fpath.suffix.lower()
@@ -267,9 +310,23 @@ def convert_deliverables_to_content_blocks(output_dir: str) -> list[dict[str, An
                     blocks.append({"type": "text", "text": f"\n{fpath.name}:\n{text}"})
 
             elif ext in OFFICE_EXTS:
-                pdf_path = _convert_office_to_pdf(fpath)
+                # A preconversion pass may already have written a sibling PDF
+                # (see resources_servers/gdpval/preconvert.py, which guards on
+                # exactly this). Reuse it when it unambiguously belongs to this
+                # file, rather than regenerating over the top of a corpus we did
+                # not create -- a judging pass that rewrites its own inputs makes
+                # the next run over the same tree a different experiment.
+                existing_pdf = fpath.with_suffix(".pdf")
+                if existing_pdf.is_file() and office_stem_counts.get(fpath.stem, 0) == 1:
+                    pdf_path = existing_pdf
+                else:
+                    # Convert into a tempdir, never next to the original: that keeps
+                    # the deliverables directory read-only for judging and stops two
+                    # same-stem Office files fighting over one output name.
+                    scratch = Path(tempfile.mkdtemp(prefix="deliverable-pdf-"))
+                    scratch_dirs.append(scratch)
+                    pdf_path = _convert_office_to_pdf(fpath, out_dir=scratch)
                 if pdf_path and pdf_path.exists():
-                    converted_pdfs.append(pdf_path)
                     data = pdf_path.read_bytes()
                     b64 = base64.b64encode(data).decode("ascii")
                     blocks.append({"type": "text", "text": f"\n{fpath.name} (converted to PDF):"})
@@ -310,8 +367,8 @@ def convert_deliverables_to_content_blocks(output_dir: str) -> list[dict[str, An
         except Exception as exc:
             blocks.append({"type": "text", "text": f"\n{fpath.name}: [Error: {exc}]"})
 
-    # Clean up converted PDFs (they live next to the originals)
-    for pdf_path in converted_pdfs:
-        pdf_path.unlink(missing_ok=True)
+    # Clean up only what this pass created, which lives entirely in tempdirs.
+    for scratch in scratch_dirs:
+        shutil.rmtree(scratch, ignore_errors=True)
 
     return blocks

--- a/responses_api_agents/stirrup_agent/tests/test_file_reader_deliverables.py
+++ b/responses_api_agents/stirrup_agent/tests/test_file_reader_deliverables.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Only agent-produced deliverables are shown to the judge, and judging is read-only.
+
+Stirrup writes its run state (finish payload, message history, metadata) into the
+same directory as the deliverables. Feeding those back to the judge lets it grade
+the agent's reasoning trace instead of the artefact.
+"""
+
+import subprocess
+from pathlib import Path
+
+from responses_api_agents.stirrup_agent.file_reader import (
+    IGNORE_FILES,
+    convert_deliverables_to_content_blocks,
+    is_deliverable,
+    read_deliverable_files,
+)
+
+
+def _mk_run_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    # The actual deliverable.
+    (d / "Report.md").write_text("# Findings\nRevenue grew 12%.\n")
+    # Stirrup run state that must never reach the judge.
+    (d / "finish_params.json").write_text('{"paths": ["/root/Report.md"], "reason": "Completed."}')
+    (d / "history.json").write_text('[{"role": "assistant", "content": "I will claim revenue grew 99%."}]')
+    (d / "metadata.json").write_text('{"token_usage": ["input=1 answer=2"]}')
+    (d / "inprogress_history.json").write_text("[]")
+    (d / "log.txt").write_text("verbose agent log\n")
+    (d / "reference_files").mkdir()
+    return d
+
+
+def test_run_state_is_not_read_as_deliverable_text(tmp_path):
+    d = _mk_run_dir(tmp_path)
+
+    text = read_deliverable_files(str(d))
+
+    assert "Revenue grew 12%" in text, "the real deliverable must still be read"
+    # None of the agent's own trace may leak into the judged submission.
+    assert "revenue grew 99%" not in text.lower()
+    assert "Completed." not in text
+    assert "token_usage" not in text
+    assert "verbose agent log" not in text
+
+
+def test_run_state_is_not_sent_as_content_blocks(tmp_path):
+    d = _mk_run_dir(tmp_path)
+
+    blocks = convert_deliverables_to_content_blocks(str(d))
+
+    joined = "\n".join(b.get("text", "") for b in blocks if b.get("type") == "text")
+    assert "Revenue grew 12%" in joined
+    for leaked in ("history.json", "finish_params.json", "metadata.json", "log.txt"):
+        assert leaked not in joined
+
+
+def test_is_deliverable_rejects_every_ignored_name(tmp_path):
+    for name in IGNORE_FILES:
+        p = tmp_path / name
+        if name == "reference_files":
+            p.mkdir()
+        else:
+            p.write_text("x")
+        assert not is_deliverable(p), f"{name} must not count as a deliverable"
+    real = tmp_path / "Deliverable.docx"
+    real.write_text("x")
+    assert is_deliverable(real)
+
+
+def test_preexisting_sibling_pdf_is_reused_and_not_deleted(tmp_path, monkeypatch):
+    """A judging pass must not destroy a preconverted corpus it did not create.
+
+    The converter is stubbed to *succeed*: without a stub it fails wherever
+    LibreOffice is absent, nothing is registered for cleanup, and the test would
+    pass against the unfixed code for the wrong reason.
+    """
+    from responses_api_agents.stirrup_agent import file_reader
+
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "Deck.pptx").write_bytes(b"not really a pptx")
+    sibling = d / "Deck.pdf"
+    sibling.write_bytes(b"%PDF-1.4 preconverted\n")
+
+    calls: list[Path] = []
+
+    def _fake_convert(fpath: Path, out_dir: Path | None = None):
+        calls.append(fpath)
+        out = (out_dir or fpath.parent) / (fpath.stem + ".pdf")
+        out.write_bytes(b"%PDF-1.4 REGENERATED\n")  # clobbers, as the real one does
+        return out
+
+    monkeypatch.setattr(file_reader, "_convert_office_to_pdf", _fake_convert)
+
+    file_reader.convert_deliverables_to_content_blocks(str(d))
+
+    assert calls == [], "should not reconvert when a sibling PDF already exists"
+    assert sibling.is_file(), "pre-existing sibling PDF was deleted by a judging pass"
+    assert sibling.read_bytes() == b"%PDF-1.4 preconverted\n", "sibling PDF was overwritten"
+
+
+def test_judging_never_writes_into_the_deliverables_dir(tmp_path, monkeypatch):
+    """Conversions land in a tempdir, so reading a corpus never mutates it."""
+    from responses_api_agents.stirrup_agent import file_reader
+
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "Sheet.xlsx").write_bytes(b"not really an xlsx")
+    before = {p.name for p in d.iterdir()}
+
+    def _fake_convert(fpath: Path, out_dir: Path | None = None):
+        assert out_dir is not None, "judging must convert into a tempdir, not in place"
+        out = out_dir / (fpath.stem + ".pdf")
+        out.write_bytes(b"%PDF-1.4 generated\n")
+        return out
+
+    monkeypatch.setattr(file_reader, "_convert_office_to_pdf", _fake_convert)
+
+    blocks = file_reader.convert_deliverables_to_content_blocks(str(d))
+
+    assert any(b.get("type") == "image_url" for b in blocks), "converted PDF was not sent"
+    assert {p.name for p in d.iterdir()} == before, "judging pass altered the deliverables dir"
+
+
+def test_convert_office_to_pdf_honours_out_dir(tmp_path, monkeypatch):
+    """``out_dir`` is what keeps a judging pass out of the deliverables tree."""
+    from responses_api_agents.stirrup_agent import file_reader
+
+    src = tmp_path / "Deck.pptx"
+    src.write_bytes(b"not really a pptx")
+    dest = tmp_path / "scratch"
+    dest.mkdir()
+
+    captured: dict = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["outdir"] = cmd[cmd.index("--outdir") + 1]
+        (Path(captured["outdir"]) / "Deck.pdf").write_bytes(b"%PDF-1.4\n")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(file_reader.subprocess, "run", _fake_run)
+
+    out = file_reader._convert_office_to_pdf(src, out_dir=dest)
+
+    assert out == dest / "Deck.pdf"
+    assert captured["outdir"] == str(dest)
+    assert not (tmp_path / "Deck.pdf").exists(), "conversion leaked into the source dir"
+
+
+def test_convert_office_to_pdf_defaults_to_writing_beside_the_source(tmp_path, monkeypatch):
+    """Preconversion still depends on the in-place default."""
+    from responses_api_agents.stirrup_agent import file_reader
+
+    src = tmp_path / "Sheet.xlsx"
+    src.write_bytes(b"not really an xlsx")
+
+    def _fake_run(cmd, **kwargs):
+        (Path(cmd[cmd.index("--outdir") + 1]) / "Sheet.pdf").write_bytes(b"%PDF-1.4\n")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(file_reader.subprocess, "run", _fake_run)
+
+    assert file_reader._convert_office_to_pdf(src) == tmp_path / "Sheet.pdf"
+
+
+def test_same_stem_office_files_do_not_share_one_render(tmp_path, monkeypatch):
+    """``Report.docx`` and ``Report.pptx`` both map to ``Report.pdf``.
+
+    Reusing that one sibling for both would show the judge the first file's content
+    twice and the second file's content never. One such collision exists in the
+    200-task Mercor corpus (``Pineloten_Capital_Structure.{docx,pptx}``), where the
+    preconverted PDF is the .docx render — 612x792 portrait — so the .pptx has no
+    render of its own to reuse.
+    """
+    from responses_api_agents.stirrup_agent import file_reader
+
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "Report.docx").write_bytes(b"docx bytes")
+    (d / "Report.pptx").write_bytes(b"pptx bytes")
+    (d / "Report.pdf").write_bytes(b"%PDF-1.4 render of the DOCX\n")
+
+    converted: list[str] = []
+
+    def _fake_convert(fpath: Path, out_dir: Path | None = None):
+        converted.append(fpath.name)
+        out = (out_dir or fpath.parent) / (fpath.stem + ".pdf")
+        out.write_bytes(f"%PDF-1.4 render of {fpath.name}\n".encode())
+        return out
+
+    monkeypatch.setattr(file_reader, "_convert_office_to_pdf", _fake_convert)
+
+    blocks = file_reader.convert_deliverables_to_content_blocks(str(d))
+    pdf_payloads = [b["image_url"]["url"] for b in blocks if b.get("type") == "image_url"]
+
+    assert "Report.pptx" in converted and "Report.docx" in converted, (
+        "an ambiguous sibling PDF must not be reused for either file"
+    )
+    assert len(set(pdf_payloads)) == len(pdf_payloads), "two deliverables were sent the same render"
+    assert (d / "Report.pdf").read_bytes() == b"%PDF-1.4 render of the DOCX\n", "sibling PDF was overwritten"

--- a/responses_api_agents/stirrup_agent/tests/test_file_reader_text_caps.py
+++ b/responses_api_agents/stirrup_agent/tests/test_file_reader_text_caps.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""One oversized text deliverable must not cost the whole judgement.
+
+``convert_deliverables_to_content_blocks`` fed text files to the judge uncapped.
+A 2.8 MB file became a 720,898-token request against a 786,432-token judge; the
+judge returned 400, the resources server turned that into a 500, and the task
+was recorded as a *transient* failure with no score at all. Bounding the text
+loses a tail; not bounding it loses the task.
+"""
+
+from pathlib import Path
+
+from responses_api_agents.stirrup_agent.file_reader import (
+    MAX_TEXT_BLOCK_CHARS,
+    MAX_TOTAL_TEXT_BLOCK_CHARS,
+    convert_deliverables_to_content_blocks,
+)
+
+
+def _text_of(blocks) -> str:
+    return "\n".join(b.get("text", "") for b in blocks if b.get("type") == "text")
+
+
+def test_oversized_text_deliverable_is_truncated_not_dropped(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    huge = "A" * (MAX_TEXT_BLOCK_CHARS * 3)
+    (d / "Notes.md").write_text(huge)
+
+    blocks = convert_deliverables_to_content_blocks(str(d))
+    joined = _text_of(blocks)
+
+    assert "Notes.md" in joined, "the judge must still be told the deliverable exists"
+    assert "truncated" in joined
+    # The whole point: the payload is bounded rather than 3x the per-file cap.
+    assert len(joined) < MAX_TEXT_BLOCK_CHARS * 1.1
+
+
+def test_normal_deliverable_is_passed_through_untouched(tmp_path: Path):
+    """The largest genuine text deliverable in the corpus is ~101 KB — well under the cap."""
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    body = "Revenue grew 12%.\n" * 5_000  # ~90 KB, realistic
+    (d / "Report.md").write_text(body)
+
+    joined = _text_of(convert_deliverables_to_content_blocks(str(d)))
+
+    assert body.strip() in joined, "a real deliverable must not be trimmed"
+    assert "truncated" not in joined
+    assert "omitted" not in joined
+
+
+def test_many_files_cannot_blow_the_request_between_them(tmp_path: Path):
+    """A per-file cap alone is not enough — N files at the cap still exceed any context."""
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    for i in range(6):
+        (d / f"part_{i}.txt").write_text("B" * MAX_TEXT_BLOCK_CHARS)
+
+    blocks = convert_deliverables_to_content_blocks(str(d))
+    joined = _text_of(blocks)
+
+    assert len(joined) < MAX_TOTAL_TEXT_BLOCK_CHARS * 1.2, "aggregate text budget was not enforced"
+    # Every file is still named, and each gets a share rather than the first two
+    # consuming everything.
+    for i in range(6):
+        assert f"part_{i}.txt" in joined
+        assert f"part_{i}.txt:\nB" in joined, "every file should get some of the budget"
+
+
+def test_a_big_file_cannot_starve_a_small_one_by_sorting_first(tmp_path: Path):
+    """Allocation must not depend on filename order.
+
+    With a spend-as-you-go budget, ``000_dump.txt`` eats everything and the real
+    deliverable that sorts after it is reduced to a marker — so *renaming* a file
+    would change the score.
+    """
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "000_dump.txt").write_text("X" * (MAX_TOTAL_TEXT_BLOCK_CHARS * 2))
+    (d / "001_dump.txt").write_text("Y" * (MAX_TOTAL_TEXT_BLOCK_CHARS * 2))
+    report = "Revenue grew 12%.\n" * 100
+    (d / "zzz_Report.md").write_text(report)
+
+    joined = _text_of(convert_deliverables_to_content_blocks(str(d)))
+
+    assert report.strip() in joined, "a small real deliverable was starved by larger files"
+
+
+def test_file_exactly_at_the_cap_is_not_marked_truncated(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "atcap.txt").write_text("Z" * MAX_TEXT_BLOCK_CHARS)
+
+    joined = _text_of(convert_deliverables_to_content_blocks(str(d)))
+
+    assert "truncated" not in joined
+    assert joined.count("Z") == MAX_TEXT_BLOCK_CHARS, "an exactly-at-cap file must pass through whole"
+
+
+def test_empty_and_whitespace_only_files_produce_no_block(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "Empty.txt").write_text("")
+    (d / "Blank.txt").write_text("   \n\t\n")
+    (d / "Real.md").write_text("content")
+
+    joined = _text_of(convert_deliverables_to_content_blocks(str(d)))
+
+    assert "Empty.txt" not in joined and "Blank.txt" not in joined
+    assert "content" in joined
+
+
+def test_office_text_fallback_is_capped_too(tmp_path: Path, monkeypatch):
+    """When conversion fails the Office file falls back to text — also uncapped before."""
+    from responses_api_agents.stirrup_agent import file_reader
+
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "Deck.pptx").write_bytes(b"not really a pptx")
+
+    monkeypatch.setattr(file_reader, "_convert_office_to_pdf", lambda fpath, out_dir=None: None)
+    monkeypatch.setattr(file_reader, "_extract_text", lambda fpath, ext: "Z" * (MAX_TEXT_BLOCK_CHARS * 3))
+
+    joined = _text_of(file_reader.convert_deliverables_to_content_blocks(str(d)))
+
+    assert "Deck.pptx (text fallback)" in joined
+    assert "truncated" in joined
+    assert len(joined) < MAX_TEXT_BLOCK_CHARS * 1.1
+
+
+def test_enough_files_stop_being_named_one_by_one(tmp_path: Path):
+    """Headers alone are tokens: past the budget the remainder collapses to a summary.
+
+    Otherwise the framing for a pathological number of files blows the request even
+    though every individual body stayed inside its cap.
+    """
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    for i in range(25_000):
+        (d / f"f{i:05d}.txt").write_text("x")
+
+    joined = _text_of(convert_deliverables_to_content_blocks(str(d)))
+
+    assert "text deliverable(s) omitted, budget exhausted" in joined
+    assert len(joined) < MAX_TOTAL_TEXT_BLOCK_CHARS * 1.2, "framing was not bounded"
+
+
+def test_binary_deliverables_are_unaffected_by_the_text_budget(tmp_path: Path):
+    """Images/PDFs go through the base64 path; the text cap must not suppress them."""
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "Big.txt").write_text("C" * (MAX_TOTAL_TEXT_BLOCK_CHARS * 2))
+    (d / "Chart.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+
+    blocks = convert_deliverables_to_content_blocks(str(d))
+
+    assert any(b.get("type") == "image_url" for b in blocks), "image block was dropped"


### PR DESCRIPTION
### `file_reader.py`: the judge was reading the agent's own trajectory

Stirrup persists its run state (`history.json`, `metadata.json`, `finish_params.json`)
into the same directory it writes deliverables to. `.json` is in `TEXT_EXTS`, so all of it
was handed to the judge as part of the "submission" — letting it grade what the agent
*said it did* rather than the artefact it produced. `comparison.py` already excluded
exactly this set for pairwise judging; that list is now defined once, agent-side, and
imported.

An A/B over the same tasks (deliverables as-is vs. run state removed) put the scoring
effect at **+0.0151 mean, max +0.037**, never negative. The bigger problem is that it can
stop a task being judged at all: one 2.8 MB `history.json` produced a **720,898-token
request against a 786,432-token judge**, came back 400, surfaced as a transient 500, and
the run still exited 0. Across a 200-task corpus, **78% of tasks carry enough trajectory
to blow a 128k-context judge** (37% for 200k).

Same commit: a preconverted sibling PDF is now reused instead of regenerated over the top
of it, and conversions go to a tempdir. Reading a deliverables directory no longer writes
to it, so a judging pass cannot delete a corpus it did not create.

### `file_reader.py` / `preconvert.py`: two Office files sharing a stem

`Report.docx` and `Report.pptx` both map to `Report.pdf`. The judging path would reuse one
render for both — showing the judge the first file's content twice and the second file's
never — and `preconvert.py` would either skip the second or race it for the same output
name in its thread pool. Neither is detectable afterwards: the surviving PDF looks like a
valid render of both.

Confirmed live: one such collision in a 200-task corpus, where the single PDF present is
the `.docx` render (612x792 portrait) and the `.pptx` had never been converted at all. An
ambiguous sibling is no longer trusted; preconversion skips those stems with a warning.

### `preconvert.py`: legacy `.doc`/`.ppt`/`.xls` were never converted

`OFFICE_EXTENSIONS` covered only the OOXML formats, so a deliverable in a pre-2007 binary
format silently never got a companion PDF and the judge scored the task as having produced
nothing. That is a scoring bug, not a rendering one. The `ns0` pre-pass skips them
harmlessly — they are OLE compound files, so `zipfile` raises `BadZipFile`.

### `scoring.py` / `app.py`: failed judgements were reported as valid scores

`invalid_judge_response` tested only `judge_result is None`. The scorers also return a
*populated* metadata dict on failure — `no_valid_scores` when every structured trial fails
to parse, `truncated_json` when only a partial score is salvaged, and (previously untagged)
a well-formed judge response carrying no score at all. Each yields 0.0 or a biased-low
partial, and each was landing in the mean indistinguishable from a genuinely poor
deliverable.

Failures are now tagged at source under a reserved key rather than a plain `error` field:
on the success path the metadata *is* the judge's own parsed JSON, so flagging `error`
would discard good judgements whose rubric made the judge mention one.

### `file_reader.py`: text deliverables sent to the judge are now bounded

`read_deliverable_files` has always capped its output; the multimodal path capped nothing,
which is why a single large file could make the request unanswerable. Text blocks are now
allotted max-min fair shares of a whole-request budget, so a deliverable's allowance does
not depend on what it is called — with a spend-as-you-go budget, renaming a file changed
the score. Per-block framing is charged too, so a pathological file count cannot blow the
request on headers alone.

Caps are 200k chars per file and 400k aggregate; the largest genuine text deliverable in
the corpus is 101 KB, so real submissions pass through byte-for-byte.

### `scoring.py`: rubric judge requests were unbounded

All three scorers built `AsyncOpenAI(...)` with no `timeout` and no `max_retries`, so the
SDK defaults applied: 600 s with two silent retries. A request that legitimately runs long
— a multi-page PDF rasterised to page images — burns ~30 minutes across three attempts and
then surfaces to the caller as a bare transient 500, with nothing to indicate a timeout was
involved. `comparison.py` has bounded its own judge calls all along via
`GDPVAL_JUDGE_REQUEST_TIMEOUT_SECONDS`; the rubric path ignored it.

One task in a 200-task corpus failed exactly this way in three consecutive runs, while the
env var that looked like the fix was being set and silently doing nothing.

`max_retries=0` is deliberate: a request too slow to finish once is too slow three times, so
the SDK retries only multiply wall-clock. One bounded attempt fails in a third of the time
and says what happened.

---

352 tests pass. Changed-line coverage is 100%. Every new test was checked against
the unfixed code to confirm it actually fails there.

Known limitations: exclusion is by basename, so a deliverable genuinely named
`metadata.json` would be dropped — the agent overwrites that name regardless. PDF and image
blocks remain uncapped; `comparison.py` bounds those separately via
`MAX_FILE_BYTES_FOR_JUDGE`.

