### PR TITLE
feat(sandbox): add e2b sandbox provider

### DIFF
--- a/nemo_gym/sandbox/providers/e2b/__init__.py
+++ b/nemo_gym/sandbox/providers/e2b/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""E2B provider package."""
+
+from nemo_gym.sandbox.providers.e2b.provider import (
+    E2BConnectionConfig,
+    E2BCreateConfig,
+    E2BCreateError,
+    E2BExecConfig,
+    E2BOperationConfig,
+    E2BProvider,
+)
+
+
+__all__ = [
+    "E2BConnectionConfig",
+    "E2BCreateConfig",
+    "E2BCreateError",
+    "E2BExecConfig",
+    "E2BOperationConfig",
+    "E2BProvider",
+]

--- a/nemo_gym/sandbox/providers/e2b/build.py
+++ b/nemo_gym/sandbox/providers/e2b/build.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build E2B templates from OCI images.
+
+E2B cannot start a sandbox from an OCI reference: ``POST /sandboxes`` accepts
+only a template ID, and an image reference is rejected outright (*"snapshot
+alias only supports ASCII letters, digits, hyphens, and underscores"*).
+Building a template from the image is the only path from an OCI reference to a
+running sandbox.
+
+This module is deliberately **outside** the sandbox public API and the
+:class:`SandboxProvider` protocol. Building a template is a *provisioning*
+step -- slow, one-off, and shared across runs -- whereas the provider API is
+about starting and driving sandboxes. Keeping them apart means
+:meth:`E2BProvider.create` never blocks on an image build, and provisioning can
+run ahead of time from CI, a notebook, or the CLI below.
+
+Typical use: build templates once, then feed the resulting mapping into the
+provider's ``create.template_map``.
+
+    python -m nemo_gym.sandbox.providers.e2b.build \\
+        --image ghcr.io/acme/task-a:1.0 --image ghcr.io/acme/task-b:1.0 \\
+        --cpu-count 8 --memory-mb 16384 --output template_map.yaml
+"""
+
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import re
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+
+LOGGER = logging.getLogger(__name__)
+
+# E2B template aliases accept ASCII letters, digits, hyphens and underscores.
+_ALIAS_SAFE_RE = re.compile(r"[^A-Za-z0-9_-]")
+
+DEFAULT_CPU_COUNT = 2
+DEFAULT_MEMORY_MB = 1024
+DEFAULT_BUILD_TIMEOUT_S = 3600.0
+
+
+class E2BTemplateBuildError(RuntimeError):
+    """Raised when a template cannot be built from an image."""
+
+
+def _require_e2b_sdk() -> Any:
+    try:
+        import e2b
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch in tests
+        raise ImportError(
+            "Building e2b templates requires the 'e2b' package. Install it with `pip install 'e2b>=2.25.0'`."
+        ) from exc
+    return e2b
+
+
+def derive_alias(image: str, cpu_count: int = DEFAULT_CPU_COUNT, memory_mb: int = DEFAULT_MEMORY_MB) -> str:
+    """Return a deterministic, charset-safe alias for an image + build size.
+
+    The digest covers the resources as well as the image because E2B bakes
+    cpu/memory into the template: two sandboxes wanting different sizes must
+    not share one, or the second silently inherits the first's sizing.
+    """
+    digest = hashlib.sha256(f"{image}|cpu={cpu_count}|mem={memory_mb}".encode()).hexdigest()[:12]
+    stem = image.rsplit("/", 1)[-1].split("@", 1)[0].replace(":", "-")
+    stem = _ALIAS_SAFE_RE.sub("-", stem).strip("-") or "image"
+    return f"{stem[:48]}__{digest}"
+
+
+async def template_exists(alias: str, **api_params: Any) -> bool:
+    """Whether ``alias`` already exists on the target deployment."""
+    e2b = _require_e2b_sdk()
+    try:
+        return bool(await e2b.AsyncTemplate.alias_exists(alias, **api_params))
+    except Exception as exc:  # noqa: BLE001 - existence check is best-effort
+        LOGGER.debug("e2b alias_exists(%s) failed: %s", alias, exc)
+        return False
+
+
+async def build_template(
+    image: str,
+    *,
+    alias: str | None = None,
+    cpu_count: int = DEFAULT_CPU_COUNT,
+    memory_mb: int = DEFAULT_MEMORY_MB,
+    build_timeout_s: float = DEFAULT_BUILD_TIMEOUT_S,
+    registry_username: str | None = None,
+    registry_password: str | None = None,
+    skip_existing: bool = True,
+    on_build_logs: Any = None,
+    **api_params: Any,
+) -> str:
+    """Build one template from an OCI image and return its alias."""
+    e2b = _require_e2b_sdk()
+    resolved_alias = alias or derive_alias(image, cpu_count, memory_mb)
+
+    if skip_existing and await template_exists(resolved_alias, **api_params):
+        LOGGER.info("e2b template %s already exists; skipping build", resolved_alias)
+        return resolved_alias
+
+    LOGGER.info(
+        "Building e2b template %s from image %s (cpu_count=%d, memory_mb=%d)",
+        resolved_alias,
+        image,
+        cpu_count,
+        memory_mb,
+    )
+    builder = e2b.AsyncTemplate().from_image(image, username=registry_username, password=registry_password)
+    build_kwargs: dict[str, Any] = {
+        "alias": resolved_alias,
+        "cpu_count": cpu_count,
+        "memory_mb": memory_mb,
+        **api_params,
+    }
+    if on_build_logs is not None:
+        build_kwargs["on_build_logs"] = on_build_logs
+    try:
+        await asyncio.wait_for(e2b.AsyncTemplate.build(builder, **build_kwargs), timeout=build_timeout_s)
+    except asyncio.TimeoutError as exc:
+        raise E2BTemplateBuildError(
+            f"Timed out after {build_timeout_s}s building e2b template {resolved_alias!r} from image {image!r}."
+        ) from exc
+    except Exception as exc:
+        raise E2BTemplateBuildError(
+            f"Failed to build e2b template {resolved_alias!r} from image {image!r}: {exc}"
+        ) from exc
+    return resolved_alias
+
+
+async def build_templates(
+    images: Iterable[str],
+    *,
+    cpu_count: int = DEFAULT_CPU_COUNT,
+    memory_mb: int = DEFAULT_MEMORY_MB,
+    concurrency: int = 4,
+    continue_on_error: bool = False,
+    **kwargs: Any,
+) -> dict[str, str]:
+    """Build templates for many images, returning an image -> alias mapping.
+
+    The result is exactly the shape of the provider's ``create.template_map``.
+    With ``continue_on_error`` the failures are logged and omitted, so one bad
+    image does not discard a long batch.
+    """
+    unique_images = list(dict.fromkeys(images))
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+    mapping: dict[str, str] = {}
+
+    async def _one(image: str) -> None:
+        async with semaphore:
+            try:
+                mapping[image] = await build_template(image, cpu_count=cpu_count, memory_mb=memory_mb, **kwargs)
+            except Exception as exc:  # noqa: BLE001 - reported per image below
+                if not continue_on_error:
+                    raise
+                LOGGER.error("e2b template build failed for %s: %s", image, exc)
+
+    await asyncio.gather(*(_one(image) for image in unique_images))
+    return {image: mapping[image] for image in unique_images if image in mapping}
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--image", action="append", default=[], help="OCI image to build (repeatable).")
+    parser.add_argument("--images-file", help="File with one OCI image per line ('#' comments allowed).")
+    parser.add_argument("--cpu-count", type=int, default=DEFAULT_CPU_COUNT)
+    parser.add_argument("--memory-mb", type=int, default=DEFAULT_MEMORY_MB)
+    parser.add_argument("--concurrency", type=int, default=4)
+    parser.add_argument("--build-timeout-s", type=float, default=DEFAULT_BUILD_TIMEOUT_S)
+    parser.add_argument("--registry-username", default=None)
+    parser.add_argument("--registry-password", default=None)
+    parser.add_argument("--rebuild", action="store_true", help="Rebuild even if the alias already exists.")
+    parser.add_argument("--continue-on-error", action="store_true", help="Skip failures instead of aborting.")
+    parser.add_argument(
+        "--output",
+        help="Write the image -> alias mapping here (.yaml or .json). Defaults to stdout as JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    args = _parse_args(argv)
+
+    images = list(args.image)
+    if args.images_file:
+        with open(args.images_file) as handle:
+            images.extend(line.strip() for line in handle if line.strip() and not line.lstrip().startswith("#"))
+    if not images:
+        raise SystemExit("No images given: pass --image and/or --images-file.")
+
+    mapping = asyncio.run(
+        build_templates(
+            images,
+            cpu_count=args.cpu_count,
+            memory_mb=args.memory_mb,
+            concurrency=args.concurrency,
+            build_timeout_s=args.build_timeout_s,
+            registry_username=args.registry_username,
+            registry_password=args.registry_password,
+            skip_existing=not args.rebuild,
+            continue_on_error=args.continue_on_error,
+        )
+    )
+
+    if args.output and args.output.endswith((".yaml", ".yml")):
+        import yaml
+
+        with open(args.output, "w") as handle:
+            yaml.safe_dump({"template_map": mapping}, handle, sort_keys=True)
+    elif args.output:
+        with open(args.output, "w") as handle:
+            json.dump(mapping, handle, indent=2, sort_keys=True)
+    else:
+        print(json.dumps(mapping, indent=2, sort_keys=True))
+
+    failed = len(dict.fromkeys(images)) - len(mapping)
+    if failed:
+        LOGGER.error("%d image(s) failed to build", failed)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/nemo_gym/sandbox/providers/e2b/configs/e2b.yaml
+++ b/nemo_gym/sandbox/providers/e2b/configs/e2b.yaml
@@ -40,13 +40,32 @@ sandbox:
       #   1. SandboxSpec.provider_options.template
       #   2. this template_map, keyed by SandboxSpec.image
       #   3. SandboxSpec.image itself, when it is already a valid alias
-      #   4. this `template` fallback
+      #   4. build one from the image, when auto_build_from_image is true
+      #   5. this `template` fallback
       #
       # Map image references that are not valid aliases, e.g.:
       #   template_map:
       #     "ghcr.io/acme/task:1.0": acme-task-1-0
       template: null
       template_map: {}
+
+      # Build a template from SandboxSpec.image on first use, so callers can
+      # pass ordinary OCI references instead of pre-registering every image.
+      # The alias is derived deterministically as `<image-stem>__<12-hex>`,
+      # built once per process (concurrent creates on the same image wait on a
+      # single build) and reused afterwards. Requires a working template
+      # builder on the target deployment.
+      auto_build_from_image: false
+      # Resources for auto-built templates. E2B fixes cpu/memory at BUILD time,
+      # so on this path a SandboxSpec.resources request IS honoured and takes
+      # precedence over these defaults. The digest above covers the resources,
+      # so differing requests never share one template.
+      build_cpu_count: 2
+      build_memory_mb: 1024
+      build_timeout_s: 3600.0
+      # Credentials for pulling from a private registry during the build.
+      registry_username: null
+      registry_password: null
       # Sandbox lifetime; E2B kills the sandbox when it elapses. Overridden per
       # sandbox by SandboxSpec.ttl_s.
       timeout_s: 3600.0

--- a/nemo_gym/sandbox/providers/e2b/configs/e2b.yaml
+++ b/nemo_gym/sandbox/providers/e2b/configs/e2b.yaml
@@ -70,12 +70,14 @@ sandbox:
       # The command keeps running inside the sandbox when the stream dies, so a
       # gateway rollout or proxy restart mid-command no longer fails it.
       #
-      # Off by default because reattaching is lossy: the stream is live rather
-      # than replayed, so stdout/stderr cover only from the reattach onwards
-      # (exit codes are unaffected), and a command that finishes while
-      # disconnected cannot be recovered at all. Worth enabling for long
-      # commands on a busy or frequently-redeployed gateway.
-      background: false
+      # On by default, matching Harbor's own e2b environment, which dispatches
+      # every command with background=True.
+      #
+      # Reattaching is lossy, so it is a fallback rather than the happy path:
+      # the stream is live rather than replayed, so stdout/stderr cover only
+      # from the reattach onwards (exit codes are unaffected), and a command
+      # that finishes while disconnected cannot be recovered at all.
+      background: true
       reconnect_attempts: 2
     operations:
       # Retries for transient transport/5xx failures. Deterministic errors

--- a/nemo_gym/sandbox/providers/e2b/configs/e2b.yaml
+++ b/nemo_gym/sandbox/providers/e2b/configs/e2b.yaml
@@ -61,7 +61,22 @@ sandbox:
       # often run for many minutes.
       default_timeout_s: 1800.0
       user: null
+      # Per-HTTP-request timeout for the command. Leave null to derive it from
+      # the command timeout: the SDK applies this to the whole streaming RPC
+      # carrying the command's output, so a value below the command timeout
+      # tears the stream down mid-command.
       request_timeout_s: null
+      # Start commands detached and reattach by pid if the output stream drops.
+      # The command keeps running inside the sandbox when the stream dies, so a
+      # gateway rollout or proxy restart mid-command no longer fails it.
+      #
+      # Off by default because reattaching is lossy: the stream is live rather
+      # than replayed, so stdout/stderr cover only from the reattach onwards
+      # (exit codes are unaffected), and a command that finishes while
+      # disconnected cannot be recovered at all. Worth enabling for long
+      # commands on a busy or frequently-redeployed gateway.
+      background: false
+      reconnect_attempts: 2
     operations:
       # Retries for transient transport/5xx failures. Deterministic errors
       # (not-found, auth, invalid-argument, timeout) are never retried.

--- a/nemo_gym/sandbox/providers/e2b/configs/e2b.yaml
+++ b/nemo_gym/sandbox/providers/e2b/configs/e2b.yaml
@@ -1,0 +1,72 @@
+# E2B sandbox provider config.
+#
+# `sandbox` is the instance name an agent references via `sandbox_provider: sandbox`;
+# the child key `e2b` selects the provider class and its value is passed to the
+# provider constructor.
+#
+# Every shipped provider config binds the same name `sandbox`, so swapping providers is
+# swapping this config path in `+config_paths` (no agent edit):
+#
+#   AGENT=responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+#   MODEL=responses_api_models/vllm_model/configs/vllm_model.yaml
+#   ng_run "+config_paths=[$AGENT, nemo_gym/sandbox/providers/e2b/configs/e2b.yaml, $MODEL]"
+#
+# Requires the SDK: `pip install 'e2b>=2.25.0'`.
+#
+# Works against e2b.dev and against any e2b-compatible gateway -- point
+# `connection.api_url`/`connection.sandbox_url` at the gateway.
+#
+# `default_metadata` (optional) is merged into every sandbox's spec metadata
+# (SandboxSpec.metadata); an agent's own sandbox_spec.metadata overrides it.
+sandbox:
+  default_metadata:
+    sandbox-api: e2b
+  e2b:
+    connection:
+      # Leave unset to use the SDK's own env vars: E2B_API_KEY, E2B_API_URL,
+      # E2B_SANDBOX_URL, E2B_DOMAIN, E2B_ACCESS_TOKEN.
+      api_key: ${oc.env:E2B_API_KEY,null}
+      # Self-hosted / e2b-compatible gateway. Both are usually the same host.
+      api_url: ${oc.env:E2B_API_URL,null}
+      sandbox_url: ${oc.env:E2B_SANDBOX_URL,null}
+      # Per-HTTP-request timeout. Keep well below `exec.default_timeout_s`, which
+      # bounds the command itself rather than a single request.
+      request_timeout_s: 120.0
+    create:
+      # E2B starts sandboxes from a pre-built TEMPLATE ALIAS, not a registry
+      # reference: aliases allow only letters, digits, '-' and '_'.
+      #
+      # Resolution order for each sandbox:
+      #   1. SandboxSpec.provider_options.template
+      #   2. this template_map, keyed by SandboxSpec.image
+      #   3. SandboxSpec.image itself, when it is already a valid alias
+      #   4. this `template` fallback
+      #
+      # Map image references that are not valid aliases, e.g.:
+      #   template_map:
+      #     "ghcr.io/acme/task:1.0": acme-task-1-0
+      template: null
+      template_map: {}
+      # Sandbox lifetime; E2B kills the sandbox when it elapses. Overridden per
+      # sandbox by SandboxSpec.ttl_s.
+      timeout_s: 3600.0
+      allow_internet_access: true
+      secure: true
+      # E2B fixes cpu/memory when the TEMPLATE IS BUILT (`cpu_count`/`memory_mb`
+      # arguments to the build), so a per-sandbox SandboxSpec.resources request
+      # cannot be applied at create time. false: log a warning once per template.
+      # true: raise instead, so an unsatisfiable resource request fails loudly.
+      strict_resources: false
+    exec:
+      # Applied when a caller passes no timeout. The SDK's own default is 60s,
+      # which silently truncates builds and test suites; verifiers in particular
+      # often run for many minutes.
+      default_timeout_s: 1800.0
+      user: null
+      request_timeout_s: null
+    operations:
+      # Retries for transient transport/5xx failures. Deterministic errors
+      # (not-found, auth, invalid-argument, timeout) are never retried.
+      retries: 2
+      retry_delay_s: 0.5
+      retry_max_delay_s: 8.0

--- a/nemo_gym/sandbox/providers/e2b/configs/e2b.yaml
+++ b/nemo_gym/sandbox/providers/e2b/configs/e2b.yaml
@@ -40,42 +40,21 @@ sandbox:
       #   1. SandboxSpec.provider_options.template
       #   2. this template_map, keyed by SandboxSpec.image
       #   3. SandboxSpec.image itself, when it is already a valid alias
-      #   4. build one from the image, when auto_build_from_image is true
-      #   5. this `template` fallback
+      #   4. this `template` fallback
       #
       # Map image references that are not valid aliases, e.g.:
       #   template_map:
       #     "ghcr.io/acme/task:1.0": acme-task-1-0
+      #
+      # Building templates from OCI images is provisioning, not part of
+      # starting a sandbox, so it lives outside this provider in
+      # nemo_gym/sandbox/providers/e2b/build.py. It emits exactly this mapping:
+      #   python -m nemo_gym.sandbox.providers.e2b.build \
+      #       --image ghcr.io/acme/task:1.0 --cpu-count 8 --memory-mb 16384 \
+      #       --output template_map.yaml
       template: null
       template_map: {}
 
-      # Build a template from SandboxSpec.image on first use, so callers can
-      # pass ordinary OCI references instead of pre-registering every image.
-      # The alias is derived deterministically as `<image-stem>__<12-hex>`,
-      # built once per process (concurrent creates on the same image wait on a
-      # single build) and reused afterwards. Requires a working template
-      # builder on the target deployment.
-      auto_build_from_image: false
-      # Resources for auto-built templates. E2B fixes cpu/memory at BUILD time,
-      # so on this path a SandboxSpec.resources request IS honoured and takes
-      # precedence over these defaults. The digest above covers the resources,
-      # so differing requests never share one template.
-      build_cpu_count: 2
-      build_memory_mb: 1024
-      build_timeout_s: 3600.0
-      # Credentials for pulling from a private registry during the build.
-      registry_username: null
-      registry_password: null
-      # Sandbox lifetime; E2B kills the sandbox when it elapses. Overridden per
-      # sandbox by SandboxSpec.ttl_s.
-      timeout_s: 3600.0
-      allow_internet_access: true
-      secure: true
-      # E2B fixes cpu/memory when the TEMPLATE IS BUILT (`cpu_count`/`memory_mb`
-      # arguments to the build), so a per-sandbox SandboxSpec.resources request
-      # cannot be applied at create time. false: log a warning once per template.
-      # true: raise instead, so an unsatisfiable resource request fails loudly.
-      strict_resources: false
     exec:
       # Applied when a caller passes no timeout. The SDK's own default is 60s,
       # which silently truncates builds and test suites; verifiers in particular

--- a/nemo_gym/sandbox/providers/e2b/provider.py
+++ b/nemo_gym/sandbox/providers/e2b/provider.py
@@ -162,6 +162,14 @@ class E2BExecConfig:
     default_timeout_s: float | None = 1800.0
     user: str | None = None
     request_timeout_s: float | None = None
+    # Start commands detached and reattach by pid if the output stream drops.
+    # The command keeps running inside the sandbox when the stream dies, so its
+    # exit code survives a control-plane restart that would otherwise fail the
+    # command outright. Off by default: reattaching loses the output emitted
+    # before it (see :meth:`_run_background`).
+    background: bool = False
+    # How many times to reattach before giving up.
+    reconnect_attempts: int = 2
 
 
 @dataclass(frozen=True)
@@ -421,6 +429,61 @@ class E2BProvider:
 
     # -------------------------------------------------------------- commands
 
+    async def _run_background(self, sandbox: Any, kwargs: dict[str, Any]) -> Any:
+        """Run a command detached, reattaching by pid if the stream drops.
+
+        ``commands.run(background=True)`` returns as soon as the process has
+        started, handing back its pid. The command then keeps running inside
+        the sandbox independently of the stream carrying its output, so losing
+        that stream -- a gateway rollout, a proxy restart, a network blip --
+        no longer destroys the command: reattach with ``commands.connect(pid)``
+        and the real exit code still arrives.
+
+        Two limits are inherent to reattaching, which is why this is opt-in:
+
+        * **Output before the reattach is lost.** The stream is live, not
+          replayed, so ``stdout``/``stderr`` cover only from the reattach on.
+          Exit codes are unaffected.
+        * **The process must still be running.** ``connect`` raises
+          not-found once it has exited, so a command that finishes during the
+          gap cannot be recovered.
+        """
+        e2b = _require_e2b_sdk()
+        handle = await sandbox.commands.run(**kwargs, background=True)
+        pid = getattr(handle, "pid", None)
+
+        # Never swallow these while reattaching: a non-zero exit and a command
+        # timeout are real outcomes, not transport failures.
+        terminal = tuple(
+            exc
+            for exc in (getattr(e2b, "CommandExitException", None), getattr(e2b, "TimeoutException", None))
+            if isinstance(exc, type)
+        )
+
+        for attempt in range(self._exec.reconnect_attempts + 1):
+            try:
+                return await handle.wait()
+            except terminal:
+                raise
+            except Exception as exc:  # noqa: BLE001 - transport failure; try to reattach
+                if pid is None or attempt >= self._exec.reconnect_attempts:
+                    raise
+                LOGGER.warning(
+                    "e2b command stream lost (pid=%s, attempt %d/%d): %s; reattaching",
+                    pid,
+                    attempt + 1,
+                    self._exec.reconnect_attempts,
+                    exc,
+                )
+                try:
+                    handle = await sandbox.commands.connect(pid, timeout=kwargs.get("timeout"))
+                except Exception as reconnect_exc:
+                    # Typically not-found: the command finished while we were
+                    # disconnected, so its result is gone. Report the original
+                    # transport failure, which explains what actually happened.
+                    raise exc from reconnect_exc
+        raise AssertionError("unreachable")  # pragma: no cover
+
     async def exec(
         self,
         handle: SandboxHandle,
@@ -450,7 +513,10 @@ class E2BProvider:
         timeout_exc = getattr(e2b, "TimeoutException", None)
         exit_exc = getattr(e2b, "CommandExitException", None)
         try:
-            result = await sandbox.commands.run(**kwargs)
+            if self._exec.background:
+                result = await self._run_background(sandbox, kwargs)
+            else:
+                result = await sandbox.commands.run(**kwargs)
         except Exception as exc:
             # A non-zero exit is a normal outcome, not a provider failure.
             if isinstance(exit_exc, type) and isinstance(exc, exit_exc):

--- a/nemo_gym/sandbox/providers/e2b/provider.py
+++ b/nemo_gym/sandbox/providers/e2b/provider.py
@@ -34,7 +34,6 @@ instead of being dropped quietly.
 """
 
 import asyncio
-import hashlib
 import logging
 import re
 from collections.abc import Mapping
@@ -145,21 +144,6 @@ class E2BCreateConfig:
     # per sandbox (they are fixed when the template is built).
     strict_resources: bool = False
 
-    # --- on-demand template building -------------------------------------
-    # E2B cannot start a sandbox from an OCI reference; it only starts from a
-    # pre-built template alias. With this enabled the provider builds a
-    # template from ``SandboxSpec.image`` on first use and reuses it after,
-    # so callers can supply ordinary image references.
-    auto_build_from_image: bool = False
-    # Resources for auto-built templates. E2B fixes cpu/memory at build time,
-    # so a spec's own resources are applied here (and take precedence).
-    build_cpu_count: int = 2
-    build_memory_mb: int = 1024
-    build_timeout_s: float = 3600.0
-    # Private registry credentials for ``from_image``.
-    registry_username: str | None = None
-    registry_password: str | None = None
-
 
 @dataclass(frozen=True)
 class E2BExecConfig:
@@ -199,10 +183,6 @@ class E2BProvider:
         self._exec = _config_from_mapping(E2BExecConfig, exec)
         self._operations = _config_from_mapping(E2BOperationConfig, operations)
         self._warned_resource_specs: set[str] = set()
-        # Aliases this process has already built or confirmed, plus a per-alias
-        # lock so N concurrent sandboxes on the same image build it once.
-        self._built_aliases: set[str] = set()
-        self._build_locks: dict[str, asyncio.Lock] = {}
 
     # ---------------------------------------------------------------- helpers
 
@@ -214,86 +194,15 @@ class E2BProvider:
             params["request_timeout"] = self._connection.request_timeout_s
         return params
 
-    def _build_resources(self, spec: SandboxSpec) -> tuple[int, int]:
-        """cpu/memory for an auto-built template; the spec wins over config."""
-        resources = spec.resources
-        cpu = resources.cpu if getattr(resources, "cpu", None) else None
-        memory_mib = resources.memory_mib if getattr(resources, "memory_mib", None) else None
-        cpu_count = max(1, int(cpu)) if cpu else self._create.build_cpu_count
-        memory_mb = int(memory_mib) if memory_mib else self._create.build_memory_mb
-        return cpu_count, memory_mb
-
-    def _derive_alias(self, image: str, cpu_count: int, memory_mb: int) -> str:
-        """Deterministic, charset-safe alias for an image + its build resources.
-
-        The digest covers the resources because E2B bakes them into the
-        template: two sandboxes asking for different cpu/memory must not share
-        one template, or the second silently gets the first one's sizing.
-        """
-        digest = hashlib.sha256(f"{image}|cpu={cpu_count}|mem={memory_mb}".encode()).hexdigest()[:12]
-        stem = image.rsplit("/", 1)[-1].split("@", 1)[0].replace(":", "-")
-        stem = re.sub(r"[^A-Za-z0-9_-]", "-", stem).strip("-") or "image"
-        return f"{stem[:48]}__{digest}"
-
-    async def _ensure_template_for_image(self, image: str, spec: SandboxSpec) -> str:
-        """Build (once) and return a template alias for an OCI image."""
-        e2b = _require_e2b_sdk()
-        cpu_count, memory_mb = self._build_resources(spec)
-        alias = self._derive_alias(image, cpu_count, memory_mb)
-        if alias in self._built_aliases:
-            return alias
-
-        lock = self._build_locks.setdefault(alias, asyncio.Lock())
-        async with lock:
-            if alias in self._built_aliases:
-                return alias
-            api_params = self._api_params()
-            try:
-                if await e2b.AsyncTemplate.alias_exists(alias, **api_params):
-                    self._built_aliases.add(alias)
-                    return alias
-            except Exception as exc:  # noqa: BLE001 - existence check is best-effort
-                LOGGER.debug("e2b alias_exists(%s) failed, attempting build: %s", alias, exc)
-
-            LOGGER.info(
-                "Building e2b template %s from image %s (cpu_count=%d, memory_mb=%d)",
-                alias,
-                image,
-                cpu_count,
-                memory_mb,
-            )
-            builder = e2b.AsyncTemplate().from_image(
-                image,
-                username=self._create.registry_username,
-                password=self._create.registry_password,
-            )
-            try:
-                await asyncio.wait_for(
-                    e2b.AsyncTemplate.build(
-                        builder,
-                        alias=alias,
-                        cpu_count=cpu_count,
-                        memory_mb=memory_mb,
-                        **api_params,
-                    ),
-                    timeout=self._create.build_timeout_s,
-                )
-            except asyncio.TimeoutError as exc:
-                raise E2BCreateError(
-                    f"Timed out after {self._create.build_timeout_s}s building e2b template {alias!r} "
-                    f"from image {image!r}."
-                ) from exc
-            except Exception as exc:
-                raise E2BCreateError(f"Failed to build e2b template {alias!r} from image {image!r}: {exc}") from exc
-            self._built_aliases.add(alias)
-            return alias
-
-    async def _resolve_template(self, spec: SandboxSpec) -> str:
+    def _resolve_template(self, spec: SandboxSpec) -> str:
         """Map a spec onto an E2B template alias.
 
         Precedence: ``provider_options.template`` -> ``create.template_map`` ->
-        ``spec.image`` when it is already a valid alias -> build from the image
-        (``create.auto_build_from_image``) -> ``create.template``.
+        ``spec.image`` when it is already a valid alias -> ``create.template``.
+
+        Building a template from an image is provisioning, not part of starting
+        a sandbox, so it lives in :mod:`nemo_gym.sandbox.providers.e2b.build`
+        and never runs on this path.
         """
         option = (spec.provider_options or {}).get("template")
         if option:
@@ -305,12 +214,11 @@ class E2BProvider:
                 return str(mapped)
             if _TEMPLATE_ALIAS_RE.match(spec.image):
                 return spec.image
-            if self._create.auto_build_from_image:
-                return await self._ensure_template_for_image(spec.image, spec)
             raise E2BCreateError(
                 f"E2B starts sandboxes from a template alias, but SandboxSpec.image={spec.image!r} is not a valid "
                 "alias (allowed: letters, digits, '-', '_'). Map it with create.template_map, set "
-                "provider_options.template, or enable create.auto_build_from_image to build one from the image."
+                "provider_options.template, or build a template first with "
+                "nemo_gym.sandbox.providers.e2b.build (its output is a ready-made template_map)."
             )
 
         if self._create.template:
@@ -320,14 +228,8 @@ class E2BProvider:
             "No E2B template to start from: set SandboxSpec.image, provider_options.template, or create.template."
         )
 
-    def _check_resources(self, spec: SandboxSpec, template: str, *, applied_at_build: bool = False) -> None:
-        """Surface resource requests E2B cannot honour per sandbox.
-
-        ``applied_at_build`` suppresses the report: when the provider built the
-        template itself, the request *was* satisfied (as build arguments).
-        """
-        if applied_at_build:
-            return
+    def _check_resources(self, spec: SandboxSpec, template: str) -> None:
+        """Surface resource requests E2B cannot honour per sandbox."""
         resources = spec.resources
         requested = {
             name: getattr(resources, name)
@@ -392,10 +294,8 @@ class E2BProvider:
 
     async def create(self, spec: SandboxSpec) -> SandboxHandle:
         e2b = _require_e2b_sdk()
-        template = await self._resolve_template(spec)
-        # When we built the template ourselves the spec's resources became the
-        # build's cpu_count/memory_mb, so there is nothing to report.
-        self._check_resources(spec, template, applied_at_build=template in self._built_aliases)
+        template = self._resolve_template(spec)
+        self._check_resources(spec, template)
 
         timeout_s = spec.ttl_s if spec.ttl_s is not None else self._create.timeout_s
         kwargs: dict[str, Any] = {

--- a/nemo_gym/sandbox/providers/e2b/provider.py
+++ b/nemo_gym/sandbox/providers/e2b/provider.py
@@ -57,6 +57,14 @@ T = TypeVar("T")
 # E2B template aliases accept ASCII letters, digits, hyphens and underscores.
 _TEMPLATE_ALIAS_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
+# The SDK reads 0 as "no request timeout"; None would fall back to the
+# connection's, which is sized for short control-plane calls.
+_NO_REQUEST_TIMEOUT = 0.0
+
+# Head-room over a command's own timeout, so the sandbox-side timeout fires
+# first and the stream is never cut mid-command.
+_EXEC_REQUEST_TIMEOUT_MARGIN_S = 60.0
+
 # Passed straight through to the SDK (``ApiParams``) on every call.
 _API_PARAM_KEYS = (
     "api_key",
@@ -210,6 +218,29 @@ class E2BProvider:
         if self._connection.request_timeout_s is None:
             return {}
         return {"request_timeout": self._connection.request_timeout_s}
+
+    def _exec_request_timeout(self, command_timeout_s: float | None) -> float:
+        """Per-request timeout for ``commands.run``.
+
+        The SDK applies ``request_timeout`` to the whole streaming RPC that
+        carries the command's output, not just to starting it, so any value
+        below the command timeout tears the stream down mid-command::
+
+            httpcore.RemoteProtocolError: peer closed connection without
+            sending complete message body (incomplete chunked read)
+
+        ``connection.request_timeout_s`` is sized for short control-plane calls
+        and must not be inherited here. Absent an explicit override, derive the
+        value from the command timeout plus head-room, so the sandbox-side
+        timeout fires first and the caller gets a clean ``TimeoutError``.
+        """
+        if self._exec.request_timeout_s is not None:
+            return self._exec.request_timeout_s
+        if command_timeout_s is None:
+            # SDK sentinel: 0 means "no request timeout" (None would inherit
+            # the connection's).
+            return _NO_REQUEST_TIMEOUT
+        return float(command_timeout_s) + _EXEC_REQUEST_TIMEOUT_MARGIN_S
 
     def _resolve_template(self, spec: SandboxSpec) -> str:
         """Map a spec onto an E2B template alias.
@@ -405,7 +436,7 @@ class E2BProvider:
 
         effective_timeout = timeout_s if timeout_s is not None else self._exec.default_timeout_s
         effective_user = user if user is not None else self._exec.user
-        kwargs: dict[str, Any] = {"cmd": command, **self._request_params()}
+        kwargs: dict[str, Any] = {"cmd": command}
         if cwd is not None:
             kwargs["cwd"] = cwd
         if env:
@@ -414,8 +445,7 @@ class E2BProvider:
             kwargs["user"] = str(effective_user)
         # E2B treats ``timeout`` as "no timeout" when falsy; keep None explicit.
         kwargs["timeout"] = float(effective_timeout) if effective_timeout is not None else None
-        if self._exec.request_timeout_s is not None:
-            kwargs["request_timeout"] = self._exec.request_timeout_s
+        kwargs["request_timeout"] = self._exec_request_timeout(effective_timeout)
 
         timeout_exc = getattr(e2b, "TimeoutException", None)
         exit_exc = getattr(e2b, "CommandExitException", None)

--- a/nemo_gym/sandbox/providers/e2b/provider.py
+++ b/nemo_gym/sandbox/providers/e2b/provider.py
@@ -187,12 +187,29 @@ class E2BProvider:
     # ---------------------------------------------------------------- helpers
 
     def _api_params(self) -> dict[str, Any]:
-        """SDK ``ApiParams`` for every call; omitted keys fall back to env."""
+        """SDK ``ApiParams`` for connection-scoped calls; omitted keys fall back to env.
+
+        Only ``create``/``connect``/``kill`` open a connection and accept these.
+        Everything else runs against an already-connected sandbox -- see
+        :meth:`_request_params`.
+        """
         params = {key: getattr(self._connection, key) for key in _API_PARAM_KEYS}
         params = {key: value for key, value in params.items() if value is not None}
         if self._connection.request_timeout_s is not None:
             params["request_timeout"] = self._connection.request_timeout_s
         return params
+
+    def _request_params(self) -> dict[str, Any]:
+        """Per-request options for calls on an existing sandbox object.
+
+        ``commands.run``, ``files.*`` and ``is_running`` take ``request_timeout``
+        only -- the sandbox already carries the connection config, and handing
+        them the full ``ApiParams`` raises ``TypeError: unexpected keyword
+        argument 'api_key'``.
+        """
+        if self._connection.request_timeout_s is None:
+            return {}
+        return {"request_timeout": self._connection.request_timeout_s}
 
     def _resolve_template(self, spec: SandboxSpec) -> str:
         """Map a spec onto an E2B template alias.
@@ -342,7 +359,7 @@ class E2BProvider:
             if isinstance(exc, type)
         )
         try:
-            running = await sandbox.is_running(**self._api_params())
+            running = await sandbox.is_running(**self._request_params())
         except not_found:
             return SandboxStatus.STOPPED
         except Exception:  # noqa: BLE001 - status must not raise for transient issues
@@ -388,7 +405,7 @@ class E2BProvider:
 
         effective_timeout = timeout_s if timeout_s is not None else self._exec.default_timeout_s
         effective_user = user if user is not None else self._exec.user
-        kwargs: dict[str, Any] = {"cmd": command, **self._api_params()}
+        kwargs: dict[str, Any] = {"cmd": command, **self._request_params()}
         if cwd is not None:
             kwargs["cwd"] = cwd
         if env:
@@ -429,14 +446,14 @@ class E2BProvider:
     async def write_file(self, handle: SandboxHandle, target_path: str, data: str | bytes) -> None:
         sandbox = self._sandbox(handle)
         await self._with_retries(
-            lambda: sandbox.files.write(target_path, data, **self._api_params()),
+            lambda: sandbox.files.write(target_path, data, **self._request_params()),
             operation="write_file",
         )
 
     async def read_file(self, handle: SandboxHandle, source_path: str) -> bytes:
         sandbox = self._sandbox(handle)
         data = await self._with_retries(
-            lambda: sandbox.files.read(source_path, format="bytes", **self._api_params()),
+            lambda: sandbox.files.read(source_path, format="bytes", **self._request_params()),
             operation="read_file",
         )
         return data if isinstance(data, bytes) else bytes(data)

--- a/nemo_gym/sandbox/providers/e2b/provider.py
+++ b/nemo_gym/sandbox/providers/e2b/provider.py
@@ -34,6 +34,7 @@ instead of being dropped quietly.
 """
 
 import asyncio
+import hashlib
 import logging
 import re
 from collections.abc import Mapping
@@ -144,6 +145,21 @@ class E2BCreateConfig:
     # per sandbox (they are fixed when the template is built).
     strict_resources: bool = False
 
+    # --- on-demand template building -------------------------------------
+    # E2B cannot start a sandbox from an OCI reference; it only starts from a
+    # pre-built template alias. With this enabled the provider builds a
+    # template from ``SandboxSpec.image`` on first use and reuses it after,
+    # so callers can supply ordinary image references.
+    auto_build_from_image: bool = False
+    # Resources for auto-built templates. E2B fixes cpu/memory at build time,
+    # so a spec's own resources are applied here (and take precedence).
+    build_cpu_count: int = 2
+    build_memory_mb: int = 1024
+    build_timeout_s: float = 3600.0
+    # Private registry credentials for ``from_image``.
+    registry_username: str | None = None
+    registry_password: str | None = None
+
 
 @dataclass(frozen=True)
 class E2BExecConfig:
@@ -183,6 +199,10 @@ class E2BProvider:
         self._exec = _config_from_mapping(E2BExecConfig, exec)
         self._operations = _config_from_mapping(E2BOperationConfig, operations)
         self._warned_resource_specs: set[str] = set()
+        # Aliases this process has already built or confirmed, plus a per-alias
+        # lock so N concurrent sandboxes on the same image build it once.
+        self._built_aliases: set[str] = set()
+        self._build_locks: dict[str, asyncio.Lock] = {}
 
     # ---------------------------------------------------------------- helpers
 
@@ -194,11 +214,86 @@ class E2BProvider:
             params["request_timeout"] = self._connection.request_timeout_s
         return params
 
-    def _resolve_template(self, spec: SandboxSpec) -> str:
+    def _build_resources(self, spec: SandboxSpec) -> tuple[int, int]:
+        """cpu/memory for an auto-built template; the spec wins over config."""
+        resources = spec.resources
+        cpu = resources.cpu if getattr(resources, "cpu", None) else None
+        memory_mib = resources.memory_mib if getattr(resources, "memory_mib", None) else None
+        cpu_count = max(1, int(cpu)) if cpu else self._create.build_cpu_count
+        memory_mb = int(memory_mib) if memory_mib else self._create.build_memory_mb
+        return cpu_count, memory_mb
+
+    def _derive_alias(self, image: str, cpu_count: int, memory_mb: int) -> str:
+        """Deterministic, charset-safe alias for an image + its build resources.
+
+        The digest covers the resources because E2B bakes them into the
+        template: two sandboxes asking for different cpu/memory must not share
+        one template, or the second silently gets the first one's sizing.
+        """
+        digest = hashlib.sha256(f"{image}|cpu={cpu_count}|mem={memory_mb}".encode()).hexdigest()[:12]
+        stem = image.rsplit("/", 1)[-1].split("@", 1)[0].replace(":", "-")
+        stem = re.sub(r"[^A-Za-z0-9_-]", "-", stem).strip("-") or "image"
+        return f"{stem[:48]}__{digest}"
+
+    async def _ensure_template_for_image(self, image: str, spec: SandboxSpec) -> str:
+        """Build (once) and return a template alias for an OCI image."""
+        e2b = _require_e2b_sdk()
+        cpu_count, memory_mb = self._build_resources(spec)
+        alias = self._derive_alias(image, cpu_count, memory_mb)
+        if alias in self._built_aliases:
+            return alias
+
+        lock = self._build_locks.setdefault(alias, asyncio.Lock())
+        async with lock:
+            if alias in self._built_aliases:
+                return alias
+            api_params = self._api_params()
+            try:
+                if await e2b.AsyncTemplate.alias_exists(alias, **api_params):
+                    self._built_aliases.add(alias)
+                    return alias
+            except Exception as exc:  # noqa: BLE001 - existence check is best-effort
+                LOGGER.debug("e2b alias_exists(%s) failed, attempting build: %s", alias, exc)
+
+            LOGGER.info(
+                "Building e2b template %s from image %s (cpu_count=%d, memory_mb=%d)",
+                alias,
+                image,
+                cpu_count,
+                memory_mb,
+            )
+            builder = e2b.AsyncTemplate().from_image(
+                image,
+                username=self._create.registry_username,
+                password=self._create.registry_password,
+            )
+            try:
+                await asyncio.wait_for(
+                    e2b.AsyncTemplate.build(
+                        builder,
+                        alias=alias,
+                        cpu_count=cpu_count,
+                        memory_mb=memory_mb,
+                        **api_params,
+                    ),
+                    timeout=self._create.build_timeout_s,
+                )
+            except asyncio.TimeoutError as exc:
+                raise E2BCreateError(
+                    f"Timed out after {self._create.build_timeout_s}s building e2b template {alias!r} "
+                    f"from image {image!r}."
+                ) from exc
+            except Exception as exc:
+                raise E2BCreateError(f"Failed to build e2b template {alias!r} from image {image!r}: {exc}") from exc
+            self._built_aliases.add(alias)
+            return alias
+
+    async def _resolve_template(self, spec: SandboxSpec) -> str:
         """Map a spec onto an E2B template alias.
 
         Precedence: ``provider_options.template`` -> ``create.template_map`` ->
-        ``spec.image`` when it is already a valid alias -> ``create.template``.
+        ``spec.image`` when it is already a valid alias -> build from the image
+        (``create.auto_build_from_image``) -> ``create.template``.
         """
         option = (spec.provider_options or {}).get("template")
         if option:
@@ -210,10 +305,12 @@ class E2BProvider:
                 return str(mapped)
             if _TEMPLATE_ALIAS_RE.match(spec.image):
                 return spec.image
+            if self._create.auto_build_from_image:
+                return await self._ensure_template_for_image(spec.image, spec)
             raise E2BCreateError(
                 f"E2B starts sandboxes from a template alias, but SandboxSpec.image={spec.image!r} is not a valid "
                 "alias (allowed: letters, digits, '-', '_'). Map it with create.template_map, set "
-                "provider_options.template, or build a template for the image first."
+                "provider_options.template, or enable create.auto_build_from_image to build one from the image."
             )
 
         if self._create.template:
@@ -223,8 +320,14 @@ class E2BProvider:
             "No E2B template to start from: set SandboxSpec.image, provider_options.template, or create.template."
         )
 
-    def _check_resources(self, spec: SandboxSpec, template: str) -> None:
-        """Surface resource requests E2B cannot honour per sandbox."""
+    def _check_resources(self, spec: SandboxSpec, template: str, *, applied_at_build: bool = False) -> None:
+        """Surface resource requests E2B cannot honour per sandbox.
+
+        ``applied_at_build`` suppresses the report: when the provider built the
+        template itself, the request *was* satisfied (as build arguments).
+        """
+        if applied_at_build:
+            return
         resources = spec.resources
         requested = {
             name: getattr(resources, name)
@@ -289,8 +392,10 @@ class E2BProvider:
 
     async def create(self, spec: SandboxSpec) -> SandboxHandle:
         e2b = _require_e2b_sdk()
-        template = self._resolve_template(spec)
-        self._check_resources(spec, template)
+        template = await self._resolve_template(spec)
+        # When we built the template ourselves the spec's resources became the
+        # build's cpu_count/memory_mb, so there is nothing to report.
+        self._check_resources(spec, template, applied_at_build=template in self._built_aliases)
 
         timeout_s = spec.ttl_s if spec.ttl_s is not None else self._create.timeout_s
         kwargs: dict[str, Any] = {

--- a/nemo_gym/sandbox/providers/e2b/provider.py
+++ b/nemo_gym/sandbox/providers/e2b/provider.py
@@ -165,9 +165,13 @@ class E2BExecConfig:
     # Start commands detached and reattach by pid if the output stream drops.
     # The command keeps running inside the sandbox when the stream dies, so its
     # exit code survives a control-plane restart that would otherwise fail the
-    # command outright. Off by default: reattaching loses the output emitted
-    # before it (see :meth:`_run_background`).
-    background: bool = False
+    # command outright.
+    #
+    # On by default, matching Harbor's own e2b environment, which dispatches
+    # every command with ``background=True``. Set False to have the SDK block
+    # on the stream instead; note that reattaching is lossy (see
+    # :meth:`_run_background`).
+    background: bool = True
     # How many times to reattach before giving up.
     reconnect_attempts: int = 2
 

--- a/nemo_gym/sandbox/providers/e2b/provider.py
+++ b/nemo_gym/sandbox/providers/e2b/provider.py
@@ -1,0 +1,448 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sandbox provider backed by the E2B Python SDK.
+
+Works against e2b.dev itself and against any e2b-compatible gateway (point
+``connection.api_url``/``connection.sandbox_url`` at it).
+
+Two E2B concepts differ from the provider-neutral :class:`SandboxSpec` and are
+handled explicitly rather than silently:
+
+**Templates, not images.** E2B starts sandboxes from a pre-built *template*
+alias, not from an arbitrary registry reference, and rejects anything outside
+``[A-Za-z0-9_-]``. ``SandboxSpec.image`` is therefore resolved to a template
+via :meth:`E2BProvider._resolve_template`; supply ``create.template_map`` when
+your image references are not already valid aliases.
+
+**Resources are fixed at template build time.** ``cpu_count``/``memory_mb`` are
+arguments to the template *build*, so a per-sandbox
+``SandboxSpec.resources`` cannot be honoured at create time. Requests are
+reported once per provider instance (or raise, with ``create.strict_resources``)
+instead of being dropped quietly.
+"""
+
+import asyncio
+import logging
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field, fields
+from pathlib import Path
+from typing import Any, Awaitable, Callable, TypeVar
+
+from nemo_gym.sandbox.providers.base import (
+    SandboxCreateError,
+    SandboxExecResult,
+    SandboxHandle,
+    SandboxSpec,
+    SandboxStatus,
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# E2B template aliases accept ASCII letters, digits, hyphens and underscores.
+_TEMPLATE_ALIAS_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+# Passed straight through to the SDK (``ApiParams``) on every call.
+_API_PARAM_KEYS = (
+    "api_key",
+    "access_token",
+    "api_url",
+    "sandbox_url",
+    "domain",
+    "debug",
+    "validate_api_key",
+    "headers",
+    "api_headers",
+    "proxy",
+)
+
+
+class E2BCreateError(SandboxCreateError):
+    """Raised when a sandbox cannot be created."""
+
+
+def _require_e2b_sdk() -> Any:
+    """Import the optional ``e2b`` dependency with an actionable error."""
+    try:
+        import e2b
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch in tests
+        raise ImportError(
+            "The e2b sandbox provider requires the 'e2b' package. Install it with `pip install 'e2b>=2.25.0'`."
+        ) from exc
+    return e2b
+
+
+def _config_from_mapping(cls: type[T], value: Any) -> T:
+    """Build a config dataclass from a mapping, rejecting unknown keys."""
+    if value is None:
+        return cls()
+    if isinstance(value, cls):
+        return value
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{cls.__name__} expects a mapping, got {type(value).__name__}")
+    allowed = {f.name for f in fields(cls)}
+    unknown = set(value) - allowed
+    if unknown:
+        raise ValueError(
+            f"Unknown {cls.__name__} keys: {', '.join(sorted(unknown))}. Expected: {', '.join(sorted(allowed))}"
+        )
+    return cls(**dict(value))
+
+
+@dataclass(frozen=True)
+class E2BConnectionConfig:
+    """Connection settings forwarded to the SDK.
+
+    Any field left ``None`` falls back to the SDK's own environment variables
+    (``E2B_API_KEY``, ``E2B_API_URL``, ``E2B_SANDBOX_URL``, ``E2B_DOMAIN``, ...).
+    """
+
+    api_key: str | None = None
+    access_token: str | None = None
+    api_url: str | None = None
+    sandbox_url: str | None = None
+    domain: str | None = None
+    debug: bool | None = None
+    validate_api_key: bool | None = None
+    headers: dict[str, str] | None = None
+    api_headers: dict[str, str] | None = None
+    proxy: str | None = None
+    request_timeout_s: float | None = None
+
+
+@dataclass(frozen=True)
+class E2BCreateConfig:
+    """Sandbox creation settings."""
+
+    # Template alias used when the spec does not resolve to one.
+    template: str | None = None
+    # Explicit ``SandboxSpec.image`` -> template alias mapping. Needed whenever
+    # image references are not themselves valid aliases (registry refs contain
+    # '/' and ':', which E2B rejects).
+    template_map: dict[str, str] = field(default_factory=dict)
+    # Sandbox lifetime in seconds; E2B kills the sandbox when it elapses.
+    # ``SandboxSpec.ttl_s`` overrides it per sandbox.
+    timeout_s: float = 3600.0
+    allow_internet_access: bool = True
+    secure: bool = True
+    # Raise instead of warning when a spec requests resources E2B cannot apply
+    # per sandbox (they are fixed when the template is built).
+    strict_resources: bool = False
+
+
+@dataclass(frozen=True)
+class E2BExecConfig:
+    """Command execution settings."""
+
+    # Applied when the caller passes no ``timeout_s``. E2B's own default is 60s,
+    # which silently truncates long-running commands (builds, test suites).
+    default_timeout_s: float | None = 1800.0
+    user: str | None = None
+    request_timeout_s: float | None = None
+
+
+@dataclass(frozen=True)
+class E2BOperationConfig:
+    """Retry policy for transient SDK/transport failures."""
+
+    retries: int = 2
+    retry_delay_s: float = 0.5
+    retry_max_delay_s: float = 8.0
+
+
+class E2BProvider:
+    """Provider backed by the E2B Python SDK."""
+
+    name = "e2b"
+
+    def __init__(
+        self,
+        *,
+        connection: E2BConnectionConfig | Mapping[str, Any] | None = None,
+        create: E2BCreateConfig | Mapping[str, Any] | None = None,
+        exec: E2BExecConfig | Mapping[str, Any] | None = None,
+        operations: E2BOperationConfig | Mapping[str, Any] | None = None,
+    ) -> None:
+        self._connection = _config_from_mapping(E2BConnectionConfig, connection)
+        self._create = _config_from_mapping(E2BCreateConfig, create)
+        self._exec = _config_from_mapping(E2BExecConfig, exec)
+        self._operations = _config_from_mapping(E2BOperationConfig, operations)
+        self._warned_resource_specs: set[str] = set()
+
+    # ---------------------------------------------------------------- helpers
+
+    def _api_params(self) -> dict[str, Any]:
+        """SDK ``ApiParams`` for every call; omitted keys fall back to env."""
+        params = {key: getattr(self._connection, key) for key in _API_PARAM_KEYS}
+        params = {key: value for key, value in params.items() if value is not None}
+        if self._connection.request_timeout_s is not None:
+            params["request_timeout"] = self._connection.request_timeout_s
+        return params
+
+    def _resolve_template(self, spec: SandboxSpec) -> str:
+        """Map a spec onto an E2B template alias.
+
+        Precedence: ``provider_options.template`` -> ``create.template_map`` ->
+        ``spec.image`` when it is already a valid alias -> ``create.template``.
+        """
+        option = (spec.provider_options or {}).get("template")
+        if option:
+            return str(option)
+
+        if spec.image:
+            mapped = self._create.template_map.get(spec.image)
+            if mapped:
+                return str(mapped)
+            if _TEMPLATE_ALIAS_RE.match(spec.image):
+                return spec.image
+            raise E2BCreateError(
+                f"E2B starts sandboxes from a template alias, but SandboxSpec.image={spec.image!r} is not a valid "
+                "alias (allowed: letters, digits, '-', '_'). Map it with create.template_map, set "
+                "provider_options.template, or build a template for the image first."
+            )
+
+        if self._create.template:
+            return self._create.template
+
+        raise E2BCreateError(
+            "No E2B template to start from: set SandboxSpec.image, provider_options.template, or create.template."
+        )
+
+    def _check_resources(self, spec: SandboxSpec, template: str) -> None:
+        """Surface resource requests E2B cannot honour per sandbox."""
+        resources = spec.resources
+        requested = {
+            name: getattr(resources, name)
+            for name in ("cpu", "memory_mib", "disk_gib", "gpu")
+            if getattr(resources, name, None)
+        }
+        if not requested:
+            return
+        detail = ", ".join(f"{key}={value}" for key, value in sorted(requested.items()))
+        message = (
+            f"E2B fixes sandbox resources when the template is built, so {detail} requested for template "
+            f"{template!r} cannot be applied at create time. Build a template with the desired "
+            "cpu_count/memory_mb instead."
+        )
+        if self._create.strict_resources:
+            raise E2BCreateError(message)
+        if template not in self._warned_resource_specs:
+            self._warned_resource_specs.add(template)
+            LOGGER.warning("%s", message)
+
+    async def _with_retries(self, factory: Callable[[], Awaitable[T]], *, operation: str) -> T:
+        """Retry transient failures with exponential backoff."""
+        e2b = _require_e2b_sdk()
+        # Never retry these: they are deterministic and retrying only adds latency.
+        non_retryable = tuple(
+            exc
+            for exc in (
+                getattr(e2b, "NotFoundException", None),
+                getattr(e2b, "SandboxNotFoundException", None),
+                getattr(e2b, "AuthenticationException", None),
+                getattr(e2b, "InvalidArgumentException", None),
+                getattr(e2b, "TimeoutException", None),
+            )
+            if isinstance(exc, type)
+        )
+        attempts = max(0, self._operations.retries) + 1
+        delay = self._operations.retry_delay_s
+        last_exc: BaseException | None = None
+        for attempt in range(attempts):
+            try:
+                return await factory()
+            except non_retryable:
+                raise
+            except Exception as exc:  # noqa: BLE001 - transport/5xx errors are provider-specific
+                last_exc = exc
+                if attempt == attempts - 1:
+                    break
+                LOGGER.debug("e2b %s failed (attempt %d/%d): %s", operation, attempt + 1, attempts, exc)
+                await asyncio.sleep(min(delay, self._operations.retry_max_delay_s))
+                delay *= 2
+        assert last_exc is not None
+        raise last_exc
+
+    @staticmethod
+    def _sandbox(handle: SandboxHandle) -> Any:
+        sandbox = handle.raw
+        if sandbox is None:
+            raise RuntimeError(f"Sandbox handle {handle.sandbox_id} carries no e2b sandbox object")
+        return sandbox
+
+    # ------------------------------------------------------------- lifecycle
+
+    async def create(self, spec: SandboxSpec) -> SandboxHandle:
+        e2b = _require_e2b_sdk()
+        template = self._resolve_template(spec)
+        self._check_resources(spec, template)
+
+        timeout_s = spec.ttl_s if spec.ttl_s is not None else self._create.timeout_s
+        kwargs: dict[str, Any] = {
+            "template": template,
+            "timeout": int(timeout_s) if timeout_s is not None else None,
+            "allow_internet_access": self._create.allow_internet_access,
+            "secure": self._create.secure,
+            **self._api_params(),
+        }
+        if spec.env:
+            kwargs["envs"] = {str(k): str(v) for k, v in spec.env.items()}
+        if spec.metadata:
+            kwargs["metadata"] = {str(k): str(v) for k, v in spec.metadata.items()}
+
+        try:
+            sandbox = await self._with_retries(
+                lambda: e2b.AsyncSandbox.create(**kwargs),
+                operation="create",
+            )
+        except Exception as exc:
+            raise E2BCreateError(f"Failed to create e2b sandbox from template {template!r}: {exc}") from exc
+
+        handle = SandboxHandle(sandbox_id=sandbox.sandbox_id, provider_name=self.name, raw=sandbox)
+        if spec.files:
+            for target_path, contents in spec.files.items():
+                await self.write_file(handle, target_path, contents)
+        return handle
+
+    async def connect(self, sandbox_id: str) -> SandboxHandle:
+        """Attach to an already-running sandbox."""
+        e2b = _require_e2b_sdk()
+        sandbox = await self._with_retries(
+            lambda: e2b.AsyncSandbox.connect(sandbox_id, **self._api_params()),
+            operation="connect",
+        )
+        return SandboxHandle(sandbox_id=sandbox_id, provider_name=self.name, raw=sandbox)
+
+    async def status(self, handle: SandboxHandle) -> SandboxStatus:
+        e2b = _require_e2b_sdk()
+        sandbox = self._sandbox(handle)
+        not_found = tuple(
+            exc
+            for exc in (getattr(e2b, "SandboxNotFoundException", None), getattr(e2b, "NotFoundException", None))
+            if isinstance(exc, type)
+        )
+        try:
+            running = await sandbox.is_running(**self._api_params())
+        except not_found:
+            return SandboxStatus.STOPPED
+        except Exception:  # noqa: BLE001 - status must not raise for transient issues
+            return SandboxStatus.UNKNOWN
+        return SandboxStatus.RUNNING if running else SandboxStatus.STOPPED
+
+    async def close(self, handle: SandboxHandle) -> None:
+        e2b = _require_e2b_sdk()
+        sandbox = handle.raw
+        if sandbox is None:
+            return
+        not_found = tuple(
+            exc
+            for exc in (getattr(e2b, "SandboxNotFoundException", None), getattr(e2b, "NotFoundException", None))
+            if isinstance(exc, type)
+        )
+        try:
+            await sandbox.kill(**self._api_params())
+        except not_found:
+            # Already gone (expired TTL or killed elsewhere) - closing is idempotent.
+            LOGGER.debug("e2b sandbox %s already gone on close", handle.sandbox_id)
+        finally:
+            handle.raw = None
+
+    async def aclose(self) -> None:
+        """No provider-scoped client to close; sandboxes own their connections."""
+        return None
+
+    # -------------------------------------------------------------- commands
+
+    async def exec(
+        self,
+        handle: SandboxHandle,
+        command: str,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_s: int | float | None = None,
+        user: str | int | None = None,
+    ) -> SandboxExecResult:
+        e2b = _require_e2b_sdk()
+        sandbox = self._sandbox(handle)
+
+        effective_timeout = timeout_s if timeout_s is not None else self._exec.default_timeout_s
+        effective_user = user if user is not None else self._exec.user
+        kwargs: dict[str, Any] = {"cmd": command, **self._api_params()}
+        if cwd is not None:
+            kwargs["cwd"] = cwd
+        if env:
+            kwargs["envs"] = {str(k): str(v) for k, v in env.items()}
+        if effective_user is not None:
+            kwargs["user"] = str(effective_user)
+        # E2B treats ``timeout`` as "no timeout" when falsy; keep None explicit.
+        kwargs["timeout"] = float(effective_timeout) if effective_timeout is not None else None
+        if self._exec.request_timeout_s is not None:
+            kwargs["request_timeout"] = self._exec.request_timeout_s
+
+        timeout_exc = getattr(e2b, "TimeoutException", None)
+        exit_exc = getattr(e2b, "CommandExitException", None)
+        try:
+            result = await sandbox.commands.run(**kwargs)
+        except Exception as exc:
+            # A non-zero exit is a normal outcome, not a provider failure.
+            if isinstance(exit_exc, type) and isinstance(exc, exit_exc):
+                return SandboxExecResult(
+                    stdout=getattr(exc, "stdout", None),
+                    stderr=getattr(exc, "stderr", None),
+                    return_code=int(getattr(exc, "exit_code", 1) or 1),
+                )
+            # Surface timeouts as TimeoutError so callers can treat a wedged
+            # command as a command timeout rather than an infra error.
+            if isinstance(timeout_exc, type) and isinstance(exc, timeout_exc):
+                raise TimeoutError(f"e2b command timed out after {effective_timeout}s: {exc}") from exc
+            raise
+
+        return SandboxExecResult(
+            stdout=getattr(result, "stdout", None),
+            stderr=getattr(result, "stderr", None),
+            return_code=int(getattr(result, "exit_code", 0) or 0),
+        )
+
+    # ----------------------------------------------------------------- files
+
+    async def write_file(self, handle: SandboxHandle, target_path: str, data: str | bytes) -> None:
+        sandbox = self._sandbox(handle)
+        await self._with_retries(
+            lambda: sandbox.files.write(target_path, data, **self._api_params()),
+            operation="write_file",
+        )
+
+    async def read_file(self, handle: SandboxHandle, source_path: str) -> bytes:
+        sandbox = self._sandbox(handle)
+        data = await self._with_retries(
+            lambda: sandbox.files.read(source_path, format="bytes", **self._api_params()),
+            operation="read_file",
+        )
+        return data if isinstance(data, bytes) else bytes(data)
+
+    async def upload_file(self, handle: SandboxHandle, source_path: Path, target_path: str) -> None:
+        source = Path(source_path)
+        if not source.is_file():
+            raise FileNotFoundError(f"Source file not found: {source}")
+        await self.write_file(handle, target_path, source.read_bytes())
+
+    async def download_file(self, handle: SandboxHandle, source_path: str, target_path: Path) -> None:
+        target = Path(target_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(await self.read_file(handle, source_path))

--- a/nemo_gym/sandbox/providers/registry.py
+++ b/nemo_gym/sandbox/providers/registry.py
@@ -155,8 +155,15 @@ def _load_ecs_fargate_provider() -> ProviderClass:
     return EcsFargateProvider
 
 
+def _load_e2b_provider() -> ProviderClass:
+    from nemo_gym.sandbox.providers.e2b import E2BProvider
+
+    return E2BProvider
+
+
 _BUILTIN_PROVIDER_LOADERS["apptainer"] = _load_apptainer_provider
 _BUILTIN_PROVIDER_LOADERS["daytona"] = _load_daytona_provider
 _BUILTIN_PROVIDER_LOADERS["docker"] = _load_docker_provider
+_BUILTIN_PROVIDER_LOADERS["e2b"] = _load_e2b_provider
 _BUILTIN_PROVIDER_LOADERS["ecs_fargate"] = _load_ecs_fargate_provider
 _BUILTIN_PROVIDER_LOADERS["opensandbox"] = _load_opensandbox_provider

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,6 +239,12 @@ sandbox = [
     # License: Apache 2.0 https://pypi.org/project/daytona/
     "daytona>=0.179.0",
 
+    # E2B SDK: used by the E2B sandbox provider for create/exec/kill and file operations.
+    # Also drives any e2b-compatible gateway via connection.api_url/sandbox_url.
+    # Updated: Tue Jul 28, 2026 with e2b>=2.25.0
+    # License: Apache 2.0 https://github.com/e2b-dev/E2B/blob/main/LICENSE
+    "e2b>=2.25.0",
+
     # boto3: AWS SDK used by the ECS Fargate sandbox provider for ECS/EC2/ECR/
     # CodeBuild/S3/SSM/Secrets Manager calls.
     # Updated: Tue Jun 03, 2026 with boto3>=1.34

--- a/tests/unit_tests/test_e2b_build.py
+++ b/tests/unit_tests/test_e2b_build.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for e2b template building (SDK faked; no network)."""
+
+import asyncio
+import json
+import re
+import types
+
+import pytest
+
+from nemo_gym.sandbox.providers.e2b import build as e2b_build
+from nemo_gym.sandbox.providers.e2b.build import (
+    E2BTemplateBuildError,
+    build_template,
+    build_templates,
+    derive_alias,
+    template_exists,
+)
+
+
+class FakeTemplateBuilder:
+    def __init__(self, image: str, username=None, password=None) -> None:
+        self.image = image
+        self.username = username
+        self.password = password
+
+
+class FakeTemplate:
+    """Records build calls; ``existing_aliases`` fakes server-side state."""
+
+    builds: list[dict] = []
+    existing_aliases: set[str] = set()
+    build_error: Exception | None = None
+    build_delay_s: float = 0.0
+    fail_images: set[str] = set()
+    max_concurrent: int = 0
+    _in_flight: int = 0
+
+    def from_image(self, image, username=None, password=None):
+        return FakeTemplateBuilder(image, username, password)
+
+    @staticmethod
+    async def alias_exists(alias, **kwargs):
+        return alias in FakeTemplate.existing_aliases
+
+    @staticmethod
+    async def build(builder, *, alias=None, cpu_count=None, memory_mb=None, **kwargs):
+        FakeTemplate._in_flight += 1
+        FakeTemplate.max_concurrent = max(FakeTemplate.max_concurrent, FakeTemplate._in_flight)
+        try:
+            if FakeTemplate.build_delay_s:
+                await asyncio.sleep(FakeTemplate.build_delay_s)
+            if FakeTemplate.build_error is not None:
+                raise FakeTemplate.build_error
+            if builder.image in FakeTemplate.fail_images:
+                raise RuntimeError(f"boom: {builder.image}")
+            FakeTemplate.builds.append(
+                {
+                    "image": builder.image,
+                    "alias": alias,
+                    "cpu_count": cpu_count,
+                    "memory_mb": memory_mb,
+                    "username": builder.username,
+                    "password": builder.password,
+                    **kwargs,
+                }
+            )
+            FakeTemplate.existing_aliases.add(alias)
+            return types.SimpleNamespace(alias=alias)
+        finally:
+            FakeTemplate._in_flight -= 1
+
+
+@pytest.fixture(autouse=True)
+def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeTemplate.builds.clear()
+    FakeTemplate.existing_aliases.clear()
+    FakeTemplate.build_error = None
+    FakeTemplate.build_delay_s = 0.0
+    FakeTemplate.fail_images = set()
+    FakeTemplate.max_concurrent = 0
+    FakeTemplate._in_flight = 0
+    monkeypatch.setattr(e2b_build, "_require_e2b_sdk", lambda: types.SimpleNamespace(AsyncTemplate=FakeTemplate))
+
+
+class TestDeriveAlias:
+    def test_alias_is_charset_safe_and_traceable(self) -> None:
+        alias = derive_alias("ghcr.io/acme/my_task:1.0", 8, 16384)
+        assert re.fullmatch(r"[A-Za-z0-9_-]+", alias), "E2B rejects anything outside [A-Za-z0-9_-]"
+        assert alias.startswith("my_task-1-0__")
+
+    def test_alias_is_deterministic(self) -> None:
+        assert derive_alias("img:1", 2, 1024) == derive_alias("img:1", 2, 1024)
+
+    def test_resources_change_the_alias(self) -> None:
+        # E2B bakes cpu/memory into the template, so differing requests must
+        # not collide onto one alias.
+        assert derive_alias("img:1", 2, 1024) != derive_alias("img:1", 8, 1024)
+        assert derive_alias("img:1", 2, 1024) != derive_alias("img:1", 2, 16384)
+
+    def test_digest_disambiguates_same_stem_from_different_repos(self) -> None:
+        a = derive_alias("ghcr.io/one/task:1.0", 2, 1024)
+        b = derive_alias("ghcr.io/two/task:1.0", 2, 1024)
+        assert a.split("__")[0] == b.split("__")[0]
+        assert a != b
+
+    def test_handles_digest_references_and_odd_characters(self) -> None:
+        alias = derive_alias("registry.io/org/img@sha256:abc123", 2, 1024)
+        assert re.fullmatch(r"[A-Za-z0-9_-]+", alias)
+
+
+class TestBuildTemplate:
+    async def test_builds_and_returns_alias(self) -> None:
+        alias = await build_template("ghcr.io/acme/task:1.0", cpu_count=8, memory_mb=16384)
+        assert alias == derive_alias("ghcr.io/acme/task:1.0", 8, 16384)
+        build = FakeTemplate.builds[0]
+        assert build["image"] == "ghcr.io/acme/task:1.0"
+        assert (build["cpu_count"], build["memory_mb"]) == (8, 16384)
+
+    async def test_explicit_alias_is_used(self) -> None:
+        alias = await build_template("ghcr.io/acme/task:1.0", alias="my-alias")
+        assert alias == "my-alias"
+        assert FakeTemplate.builds[0]["alias"] == "my-alias"
+
+    async def test_existing_template_is_skipped(self) -> None:
+        alias = derive_alias("ghcr.io/acme/task:1.0")
+        FakeTemplate.existing_aliases.add(alias)
+        assert await build_template("ghcr.io/acme/task:1.0") == alias
+        assert FakeTemplate.builds == []
+
+    async def test_rebuild_when_skip_existing_false(self) -> None:
+        alias = derive_alias("ghcr.io/acme/task:1.0")
+        FakeTemplate.existing_aliases.add(alias)
+        await build_template("ghcr.io/acme/task:1.0", skip_existing=False)
+        assert len(FakeTemplate.builds) == 1
+
+    async def test_registry_credentials_forwarded(self) -> None:
+        await build_template("ghcr.io/acme/task:1.0", registry_username="u", registry_password="p")
+        assert (FakeTemplate.builds[0]["username"], FakeTemplate.builds[0]["password"]) == ("u", "p")
+
+    async def test_api_params_forwarded(self) -> None:
+        await build_template("ghcr.io/acme/task:1.0", api_key="k", api_url="http://gw:8080")
+        assert FakeTemplate.builds[0]["api_key"] == "k"
+        assert FakeTemplate.builds[0]["api_url"] == "http://gw:8080"
+
+    async def test_failure_is_wrapped(self) -> None:
+        FakeTemplate.build_error = RuntimeError("builder offline")
+        with pytest.raises(E2BTemplateBuildError, match="builder offline"):
+            await build_template("ghcr.io/acme/task:1.0")
+
+    async def test_timeout_is_reported(self) -> None:
+        FakeTemplate.build_delay_s = 0.2
+        with pytest.raises(E2BTemplateBuildError, match="Timed out"):
+            await build_template("ghcr.io/acme/task:1.0", build_timeout_s=0.01)
+
+    async def test_template_exists_is_best_effort(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def boom(alias, **kwargs):
+            raise RuntimeError("gateway down")
+
+        monkeypatch.setattr(FakeTemplate, "alias_exists", boom)
+        # A failed existence probe must not abort provisioning.
+        assert await template_exists("whatever") is False
+
+
+class TestBuildTemplates:
+    async def test_returns_image_to_alias_mapping(self) -> None:
+        images = ["ghcr.io/acme/a:1", "ghcr.io/acme/b:1"]
+        mapping = await build_templates(images, cpu_count=4, memory_mb=2048)
+        assert set(mapping) == set(images)
+        assert mapping["ghcr.io/acme/a:1"] == derive_alias("ghcr.io/acme/a:1", 4, 2048)
+        assert len(FakeTemplate.builds) == 2
+
+    async def test_duplicate_images_are_built_once(self) -> None:
+        mapping = await build_templates(["img:1", "img:1", "img:1"])
+        assert len(mapping) == 1
+        assert len(FakeTemplate.builds) == 1
+
+    async def test_concurrency_is_bounded(self) -> None:
+        FakeTemplate.build_delay_s = 0.01
+        await build_templates([f"img:{i}" for i in range(8)], concurrency=3)
+        assert FakeTemplate.max_concurrent <= 3
+        assert len(FakeTemplate.builds) == 8
+
+    async def test_failure_aborts_by_default(self) -> None:
+        FakeTemplate.fail_images = {"img:2"}
+        with pytest.raises(E2BTemplateBuildError):
+            await build_templates(["img:1", "img:2"], concurrency=1)
+
+    async def test_continue_on_error_omits_failures(self) -> None:
+        # One bad image must not discard a long batch.
+        FakeTemplate.fail_images = {"img:2"}
+        mapping = await build_templates(["img:1", "img:2", "img:3"], concurrency=1, continue_on_error=True)
+        assert set(mapping) == {"img:1", "img:3"}
+
+
+class TestCli:
+    def test_writes_json_mapping(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        out = tmp_path / "map.json"
+        rc = e2b_build.main(["--image", "ghcr.io/acme/a:1", "--output", str(out)])
+        assert rc == 0
+        assert json.loads(out.read_text()) == {"ghcr.io/acme/a:1": derive_alias("ghcr.io/acme/a:1")}
+
+    def test_writes_yaml_template_map(self, tmp_path) -> None:
+        yaml = pytest.importorskip("yaml")
+        out = tmp_path / "map.yaml"
+        assert e2b_build.main(["--image", "ghcr.io/acme/a:1", "--output", str(out)]) == 0
+        loaded = yaml.safe_load(out.read_text())
+        # Shaped so it can be pasted straight under the provider's create block.
+        assert list(loaded) == ["template_map"]
+        assert loaded["template_map"] == {"ghcr.io/acme/a:1": derive_alias("ghcr.io/acme/a:1")}
+
+    def test_reads_images_file_ignoring_comments(self, tmp_path) -> None:
+        images_file = tmp_path / "images.txt"
+        images_file.write_text("# comment\nghcr.io/acme/a:1\n\nghcr.io/acme/b:1\n")
+        out = tmp_path / "map.json"
+        assert e2b_build.main(["--images-file", str(images_file), "--output", str(out)]) == 0
+        assert set(json.loads(out.read_text())) == {"ghcr.io/acme/a:1", "ghcr.io/acme/b:1"}
+
+    def test_requires_at_least_one_image(self) -> None:
+        with pytest.raises(SystemExit):
+            e2b_build.main([])
+
+    def test_nonzero_exit_when_a_build_fails(self, tmp_path) -> None:
+        FakeTemplate.fail_images = {"ghcr.io/acme/b:1"}
+        out = tmp_path / "map.json"
+        rc = e2b_build.main(
+            [
+                "--image",
+                "ghcr.io/acme/a:1",
+                "--image",
+                "ghcr.io/acme/b:1",
+                "--continue-on-error",
+                "--concurrency",
+                "1",
+                "--output",
+                str(out),
+            ]
+        )
+        assert rc == 1
+        assert set(json.loads(out.read_text())) == {"ghcr.io/acme/a:1"}

--- a/tests/unit_tests/test_e2b_provider.py
+++ b/tests/unit_tests/test_e2b_provider.py
@@ -22,7 +22,7 @@ import pytest
 from nemo_gym.sandbox.providers import e2b as e2b_pkg
 from nemo_gym.sandbox.providers.base import SandboxSpec, SandboxStatus
 from nemo_gym.sandbox.providers.e2b import provider as e2b_provider
-from nemo_gym.sandbox.providers.e2b.provider import E2BCreateError, E2BProvider
+from nemo_gym.sandbox.providers.e2b.provider import _API_PARAM_KEYS, E2BCreateError, E2BProvider
 from nemo_gym.sandbox.providers.registry import get_provider_class
 
 
@@ -54,11 +54,25 @@ class FakeCommandResult:
         self.exit_code = exit_code
 
 
+# The real SDK's sandbox-scoped methods take `request_timeout` only -- they are
+# bound to an already-connected sandbox. Mirroring that here (rather than a
+# permissive **kwargs) is what catches connection params leaking onto them:
+# the SDK raises `TypeError: unexpected keyword argument 'api_key'`.
+_SANDBOX_SCOPED_ALLOWED = {"request_timeout"}
+
+
+def _reject_connection_params(method: str, kwargs: dict) -> None:
+    leaked = sorted((set(kwargs) & set(_API_PARAM_KEYS)) - _SANDBOX_SCOPED_ALLOWED)
+    if leaked:
+        raise TypeError(f"{method}() got an unexpected keyword argument {leaked[0]!r}")
+
+
 class FakeCommands:
     def __init__(self, sandbox: "FakeSandbox") -> None:
         self._sandbox = sandbox
 
     async def run(self, **kwargs):
+        _reject_connection_params("Commands.run", kwargs)
         self._sandbox.exec_calls.append(kwargs)
         behaviour = self._sandbox.exec_behaviour
         if isinstance(behaviour, Exception):
@@ -71,10 +85,12 @@ class FakeFiles:
         self._sandbox = sandbox
 
     async def write(self, path, data, **kwargs):
+        _reject_connection_params("Filesystem.write", kwargs)
         self._sandbox.files_written[path] = data
         return None
 
     async def read(self, path, **kwargs):
+        _reject_connection_params("Filesystem.read", kwargs)
         if path not in self._sandbox.files_written:
             raise FakeSandboxNotFound(path)
         data = self._sandbox.files_written[path]
@@ -105,6 +121,7 @@ class FakeSandbox:
         return cls(sandbox_id=sandbox_id, **kwargs)
 
     async def is_running(self, **kwargs):
+        _reject_connection_params("Sandbox.is_running", kwargs)
         return self.running
 
     async def kill(self, **kwargs):
@@ -208,6 +225,52 @@ class TestResourceHandling:
         with caplog.at_level("WARNING"):
             await provider.create(_spec())
         assert not [r for r in caplog.records if "fixes sandbox resources" in r.message]
+
+
+# --------------------------------------------------------------------------
+# Connection params are connection-scoped, not per-call
+# --------------------------------------------------------------------------
+
+
+class TestConnectionParamScoping:
+    """Only create/connect/kill open a connection and accept ``ApiParams``.
+
+    ``commands.run``, ``files.*`` and ``is_running`` run against an
+    already-connected sandbox and take ``request_timeout`` only. Passing them
+    the full set raises ``TypeError: Commands.run() got an unexpected keyword
+    argument 'api_key'`` -- which aborted every trial of a benchmark run at the
+    first exec, since the sandbox had already been created successfully.
+    """
+
+    @staticmethod
+    def _provider() -> E2BProvider:
+        return E2BProvider(
+            connection={"api_key": "k", "api_url": "http://gw:8080", "request_timeout_s": 30.0},
+            create={"template": "base"},
+        )
+
+    async def test_exec_passes_only_request_timeout(self) -> None:
+        provider = self._provider()
+        handle = await provider.create(_spec())
+        await provider.exec(handle, "echo hi")
+        kwargs = handle.raw.exec_calls[0]
+        assert not set(kwargs) & set(_API_PARAM_KEYS), "connection params must not reach commands.run"
+        assert kwargs["request_timeout"] == 30.0
+
+    async def test_file_and_status_calls_do_not_leak_connection_params(self) -> None:
+        provider = self._provider()
+        handle = await provider.create(_spec())
+        # Each of these would raise TypeError from the fake (as the real SDK does).
+        await provider.write_file(handle, "/tmp/f", b"data")
+        assert await provider.read_file(handle, "/tmp/f") == b"data"
+        assert await provider.status(handle) is SandboxStatus.RUNNING
+
+    async def test_create_still_receives_full_connection_params(self) -> None:
+        # The narrowing must not strip params from the call that needs them.
+        provider = self._provider()
+        handle = await provider.create(_spec())
+        assert handle.raw.create_kwargs["api_key"] == "k"
+        assert handle.raw.create_kwargs["api_url"] == "http://gw:8080"
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit_tests/test_e2b_provider.py
+++ b/tests/unit_tests/test_e2b_provider.py
@@ -14,8 +14,6 @@
 
 """Unit tests for the e2b sandbox provider (SDK faked; no network)."""
 
-import asyncio
-import re
 import types
 from pathlib import Path
 
@@ -113,45 +111,9 @@ class FakeSandbox:
         self.killed = True
 
 
-class FakeTemplateBuilder:
-    def __init__(self, image: str, username=None, password=None) -> None:
-        self.image = image
-        self.username = username
-        self.password = password
-
-
-class FakeTemplate:
-    """Records build calls; ``existing_aliases`` fakes server-side state."""
-
-    builds: list[dict] = []
-    existing_aliases: set[str] = set()
-    build_error: Exception | None = None
-    build_delay_s: float = 0.0
-
-    def from_image(self, image, username=None, password=None):
-        return FakeTemplateBuilder(image, username, password)
-
-    @staticmethod
-    async def alias_exists(alias, **kwargs):
-        return alias in FakeTemplate.existing_aliases
-
-    @staticmethod
-    async def build(builder, *, alias=None, cpu_count=None, memory_mb=None, **kwargs):
-        if FakeTemplate.build_delay_s:
-            await asyncio.sleep(FakeTemplate.build_delay_s)
-        if FakeTemplate.build_error is not None:
-            raise FakeTemplate.build_error
-        FakeTemplate.builds.append(
-            {"image": builder.image, "alias": alias, "cpu_count": cpu_count, "memory_mb": memory_mb, **kwargs}
-        )
-        FakeTemplate.existing_aliases.add(alias)
-        return types.SimpleNamespace(alias=alias)
-
-
 def _fake_sdk() -> types.SimpleNamespace:
     return types.SimpleNamespace(
         AsyncSandbox=FakeSandbox,
-        AsyncTemplate=FakeTemplate,
         SandboxNotFoundException=FakeSandboxNotFound,
         NotFoundException=FakeSandboxNotFound,
         TimeoutException=FakeTimeout,
@@ -164,10 +126,6 @@ def _fake_sdk() -> types.SimpleNamespace:
 @pytest.fixture(autouse=True)
 def fake_e2b_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
     FakeSandbox.instances.clear()
-    FakeTemplate.builds.clear()
-    FakeTemplate.existing_aliases.clear()
-    FakeTemplate.build_error = None
-    FakeTemplate.build_delay_s = 0.0
     monkeypatch.setattr(e2b_provider, "_require_e2b_sdk", _fake_sdk)
 
 
@@ -216,117 +174,13 @@ class TestTemplateResolution:
         # Silently starting the wrong template would corrupt a benchmark run,
         # so an unmappable image must fail loudly.
         provider = E2BProvider()
-        with pytest.raises(E2BCreateError, match="auto_build_from_image"):
+        with pytest.raises(E2BCreateError, match="template_map"):
             await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
 
     async def test_no_template_at_all_raises(self) -> None:
         provider = E2BProvider()
         with pytest.raises(E2BCreateError, match="No E2B template"):
             await provider.create(_spec())
-
-
-# --------------------------------------------------------------------------
-# On-demand template building from an OCI image
-# --------------------------------------------------------------------------
-
-
-class TestAutoBuildFromImage:
-    async def test_builds_template_then_starts_sandbox_from_it(self) -> None:
-        provider = E2BProvider(create={"auto_build_from_image": True})
-        handle = await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
-
-        assert len(FakeTemplate.builds) == 1
-        build = FakeTemplate.builds[0]
-        assert build["image"] == "ghcr.io/acme/task:1.0"
-        # Alias must be charset-safe for E2B and traceable back to the image.
-        alias = build["alias"]
-        assert re.fullmatch(r"[A-Za-z0-9_-]+", alias)
-        assert alias.startswith("task-1-0__")
-        assert handle.raw.create_kwargs["template"] == alias
-
-    async def test_spec_resources_become_build_arguments(self) -> None:
-        # The whole point of building ourselves: E2B fixes cpu/memory at build
-        # time, so a spec's resources CAN be honoured on this path.
-        provider = E2BProvider(create={"auto_build_from_image": True})
-        await provider.create(_spec(image="ghcr.io/acme/task:1.0", resources={"cpu": 8, "memory_mib": 16384}))
-        build = FakeTemplate.builds[0]
-        assert build["cpu_count"] == 8
-        assert build["memory_mb"] == 16384
-
-    async def test_no_resource_warning_when_applied_at_build(self, caplog) -> None:
-        provider = E2BProvider(create={"auto_build_from_image": True})
-        with caplog.at_level("WARNING"):
-            await provider.create(_spec(image="ghcr.io/acme/task:1.0", resources={"cpu": 8}))
-        assert not [r for r in caplog.records if "fixes sandbox resources" in r.message]
-
-    async def test_different_resources_get_different_templates(self) -> None:
-        # Sharing one template across differing resource requests would
-        # silently give the second sandbox the first one's sizing.
-        provider = E2BProvider(create={"auto_build_from_image": True})
-        a = await provider.create(_spec(image="ghcr.io/acme/task:1.0", resources={"cpu": 2}))
-        b = await provider.create(_spec(image="ghcr.io/acme/task:1.0", resources={"cpu": 8}))
-        assert a.raw.create_kwargs["template"] != b.raw.create_kwargs["template"]
-        assert len(FakeTemplate.builds) == 2
-
-    async def test_template_is_built_once_and_reused(self) -> None:
-        provider = E2BProvider(create={"auto_build_from_image": True})
-        await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
-        await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
-        assert len(FakeTemplate.builds) == 1
-
-    async def test_concurrent_creates_build_only_once(self) -> None:
-        # N sandboxes on one image must not trigger N builds.
-        FakeTemplate.build_delay_s = 0.02
-        provider = E2BProvider(create={"auto_build_from_image": True})
-        handles = await asyncio.gather(*(provider.create(_spec(image="ghcr.io/acme/task:1.0")) for _ in range(6)))
-        assert len(FakeTemplate.builds) == 1
-        assert len({h.raw.create_kwargs["template"] for h in handles}) == 1
-
-    async def test_preexisting_alias_is_not_rebuilt(self) -> None:
-        provider = E2BProvider(create={"auto_build_from_image": True})
-        alias = provider._derive_alias("ghcr.io/acme/task:1.0", 2, 1024)
-        FakeTemplate.existing_aliases.add(alias)
-        handle = await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
-        assert FakeTemplate.builds == []
-        assert handle.raw.create_kwargs["template"] == alias
-
-    async def test_registry_credentials_are_forwarded(self) -> None:
-        provider = E2BProvider(
-            create={"auto_build_from_image": True, "registry_username": "u", "registry_password": "p"}
-        )
-        captured: dict = {}
-        original = FakeTemplate.from_image
-
-        def spy(self, image, username=None, password=None):
-            captured.update({"username": username, "password": password})
-            return original(self, image, username, password)
-
-        FakeTemplate.from_image = spy
-        try:
-            await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
-        finally:
-            FakeTemplate.from_image = original
-        assert captured == {"username": "u", "password": "p"}
-
-    async def test_build_failure_is_wrapped(self) -> None:
-        FakeTemplate.build_error = RuntimeError("builder offline")
-        provider = E2BProvider(create={"auto_build_from_image": True})
-        with pytest.raises(E2BCreateError, match="builder offline"):
-            await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
-
-    async def test_build_timeout_is_reported(self) -> None:
-        FakeTemplate.build_delay_s = 0.2
-        provider = E2BProvider(create={"auto_build_from_image": True, "build_timeout_s": 0.01})
-        with pytest.raises(E2BCreateError, match="Timed out"):
-            await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
-
-    async def test_explicit_mapping_still_wins_over_building(self) -> None:
-        provider = E2BProvider(
-            create={"auto_build_from_image": True, "template_map": {"ghcr.io/acme/task:1.0": "preset"}}
-        )
-        handle = await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
-        assert handle.raw.create_kwargs["template"] == "preset"
-        assert FakeTemplate.builds == []
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit_tests/test_e2b_provider.py
+++ b/tests/unit_tests/test_e2b_provider.py
@@ -255,7 +255,9 @@ class TestConnectionParamScoping:
         await provider.exec(handle, "echo hi")
         kwargs = handle.raw.exec_calls[0]
         assert not set(kwargs) & set(_API_PARAM_KEYS), "connection params must not reach commands.run"
-        assert kwargs["request_timeout"] == 30.0
+        # request_timeout is derived from the command timeout, not inherited
+        # from the connection -- see TestExecRequestTimeout.
+        assert kwargs["request_timeout"] > 0
 
     async def test_file_and_status_calls_do_not_leak_connection_params(self) -> None:
         provider = self._provider()
@@ -264,6 +266,43 @@ class TestConnectionParamScoping:
         await provider.write_file(handle, "/tmp/f", b"data")
         assert await provider.read_file(handle, "/tmp/f") == b"data"
         assert await provider.status(handle) is SandboxStatus.RUNNING
+
+    async def test_long_command_is_not_bounded_by_connection_timeout(self) -> None:
+        # The SDK applies request_timeout to the streaming RPC carrying the
+        # command's output. Inheriting the 30s connection timeout would tear
+        # down any command running longer than that.
+        provider = E2BProvider(
+            connection={"api_key": "k", "request_timeout_s": 30.0},
+            create={"template": "base"},
+        )
+        handle = await provider.create(_spec())
+        await provider.exec(handle, "make -j8", timeout_s=1800)
+        kwargs = handle.raw.exec_calls[0]
+        assert kwargs["timeout"] == 1800.0
+        assert kwargs["request_timeout"] > 1800.0, "request timeout must outlast the command"
+
+    async def test_exec_request_timeout_override_is_honoured(self) -> None:
+        provider = E2BProvider(
+            connection={"request_timeout_s": 30.0},
+            create={"template": "base"},
+            exec={"request_timeout_s": 900.0},
+        )
+        handle = await provider.create(_spec())
+        await provider.exec(handle, "sleep 1", timeout_s=60)
+        assert handle.raw.exec_calls[0]["request_timeout"] == 900.0
+
+    async def test_untimed_command_disables_the_request_timeout(self) -> None:
+        provider = E2BProvider(
+            connection={"request_timeout_s": 30.0},
+            create={"template": "base"},
+            exec={"default_timeout_s": None},
+        )
+        handle = await provider.create(_spec())
+        await provider.exec(handle, "sleep forever")
+        kwargs = handle.raw.exec_calls[0]
+        assert kwargs["timeout"] is None
+        # 0 is the SDK's "no request timeout"; None would inherit the 30s.
+        assert kwargs["request_timeout"] == 0.0
 
     async def test_create_still_receives_full_connection_params(self) -> None:
         # The narrowing must not strip params from the call that needs them.

--- a/tests/unit_tests/test_e2b_provider.py
+++ b/tests/unit_tests/test_e2b_provider.py
@@ -1,0 +1,403 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the e2b sandbox provider (SDK faked; no network)."""
+
+import types
+from pathlib import Path
+
+import pytest
+
+from nemo_gym.sandbox.providers import e2b as e2b_pkg
+from nemo_gym.sandbox.providers.base import SandboxSpec, SandboxStatus
+from nemo_gym.sandbox.providers.e2b import provider as e2b_provider
+from nemo_gym.sandbox.providers.e2b.provider import E2BCreateError, E2BProvider
+from nemo_gym.sandbox.providers.registry import get_provider_class
+
+
+# --------------------------------------------------------------------------
+# Fake e2b SDK
+# --------------------------------------------------------------------------
+
+
+class FakeSandboxNotFound(Exception):
+    pass
+
+
+class FakeTimeout(Exception):
+    pass
+
+
+class FakeCommandExit(Exception):
+    def __init__(self, exit_code: int, stdout: str = "", stderr: str = "") -> None:
+        super().__init__(f"exit {exit_code}")
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class FakeCommandResult:
+    def __init__(self, stdout: str = "", stderr: str = "", exit_code: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_code = exit_code
+
+
+class FakeCommands:
+    def __init__(self, sandbox: "FakeSandbox") -> None:
+        self._sandbox = sandbox
+
+    async def run(self, **kwargs):
+        self._sandbox.exec_calls.append(kwargs)
+        behaviour = self._sandbox.exec_behaviour
+        if isinstance(behaviour, Exception):
+            raise behaviour
+        return behaviour or FakeCommandResult(stdout="ok")
+
+
+class FakeFiles:
+    def __init__(self, sandbox: "FakeSandbox") -> None:
+        self._sandbox = sandbox
+
+    async def write(self, path, data, **kwargs):
+        self._sandbox.files_written[path] = data
+        return None
+
+    async def read(self, path, **kwargs):
+        if path not in self._sandbox.files_written:
+            raise FakeSandboxNotFound(path)
+        data = self._sandbox.files_written[path]
+        return data if isinstance(data, bytes) else str(data).encode()
+
+
+class FakeSandbox:
+    instances: list["FakeSandbox"] = []
+
+    def __init__(self, sandbox_id: str = "sbx-1", **create_kwargs) -> None:
+        self.sandbox_id = sandbox_id
+        self.create_kwargs = create_kwargs
+        self.exec_calls: list[dict] = []
+        self.files_written: dict[str, object] = {}
+        self.killed = False
+        self.running = True
+        self.exec_behaviour = None
+        self.commands = FakeCommands(self)
+        self.files = FakeFiles(self)
+        FakeSandbox.instances.append(self)
+
+    @classmethod
+    async def create(cls, **kwargs):
+        return cls(**kwargs)
+
+    @classmethod
+    async def connect(cls, sandbox_id, **kwargs):
+        return cls(sandbox_id=sandbox_id, **kwargs)
+
+    async def is_running(self, **kwargs):
+        return self.running
+
+    async def kill(self, **kwargs):
+        self.killed = True
+
+
+def _fake_sdk() -> types.SimpleNamespace:
+    return types.SimpleNamespace(
+        AsyncSandbox=FakeSandbox,
+        SandboxNotFoundException=FakeSandboxNotFound,
+        NotFoundException=FakeSandboxNotFound,
+        TimeoutException=FakeTimeout,
+        CommandExitException=FakeCommandExit,
+        AuthenticationException=type("FakeAuth", (Exception,), {}),
+        InvalidArgumentException=type("FakeInvalid", (Exception,), {}),
+    )
+
+
+@pytest.fixture(autouse=True)
+def fake_e2b_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeSandbox.instances.clear()
+    monkeypatch.setattr(e2b_provider, "_require_e2b_sdk", _fake_sdk)
+
+
+def _spec(**kwargs) -> SandboxSpec:
+    return SandboxSpec(**kwargs)
+
+
+# --------------------------------------------------------------------------
+# Registration
+# --------------------------------------------------------------------------
+
+
+def test_provider_is_registered_as_builtin() -> None:
+    assert get_provider_class("e2b") is E2BProvider
+    assert E2BProvider.name == "e2b"
+    assert e2b_pkg.E2BProvider is E2BProvider
+
+
+# --------------------------------------------------------------------------
+# Template resolution -- E2B starts from an alias, not a registry reference
+# --------------------------------------------------------------------------
+
+
+class TestTemplateResolution:
+    async def test_provider_options_template_wins(self) -> None:
+        provider = E2BProvider(create={"template": "fallback"})
+        handle = await provider.create(_spec(image="also-valid", provider_options={"template": "chosen"}))
+        assert handle.raw.create_kwargs["template"] == "chosen"
+
+    async def test_template_map_translates_registry_reference(self) -> None:
+        provider = E2BProvider(create={"template_map": {"ghcr.io/acme/task:1.0": "acme-task"}})
+        handle = await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
+        assert handle.raw.create_kwargs["template"] == "acme-task"
+
+    async def test_image_used_directly_when_already_an_alias(self) -> None:
+        provider = E2BProvider()
+        handle = await provider.create(_spec(image="build-cython-ext__c9fba49d4bd3"))
+        assert handle.raw.create_kwargs["template"] == "build-cython-ext__c9fba49d4bd3"
+
+    async def test_falls_back_to_configured_template(self) -> None:
+        provider = E2BProvider(create={"template": "base-template"})
+        handle = await provider.create(_spec())
+        assert handle.raw.create_kwargs["template"] == "base-template"
+
+    async def test_registry_reference_without_mapping_raises_actionable_error(self) -> None:
+        # Silently starting the wrong template would corrupt a benchmark run,
+        # so an unmappable image must fail loudly.
+        provider = E2BProvider()
+        with pytest.raises(E2BCreateError, match="template_map"):
+            await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
+
+    async def test_no_template_at_all_raises(self) -> None:
+        provider = E2BProvider()
+        with pytest.raises(E2BCreateError, match="No E2B template"):
+            await provider.create(_spec())
+
+
+# --------------------------------------------------------------------------
+# Resources -- fixed at template build time, must not be dropped silently
+# --------------------------------------------------------------------------
+
+
+class TestResourceHandling:
+    async def test_resource_request_warns_once_per_template(self, caplog) -> None:
+        provider = E2BProvider(create={"template": "base"})
+        with caplog.at_level("WARNING"):
+            await provider.create(_spec(resources={"cpu": 8, "memory_mib": 16384}))
+            await provider.create(_spec(resources={"cpu": 8, "memory_mib": 16384}))
+        warnings = [r for r in caplog.records if "fixes sandbox resources" in r.message]
+        assert len(warnings) == 1
+        assert "cpu=8" in warnings[0].message and "memory_mib=16384" in warnings[0].message
+
+    async def test_strict_resources_raises(self) -> None:
+        provider = E2BProvider(create={"template": "base", "strict_resources": True})
+        with pytest.raises(E2BCreateError, match="fixes sandbox resources"):
+            await provider.create(_spec(resources={"cpu": 8}))
+
+    async def test_no_warning_without_resource_request(self, caplog) -> None:
+        provider = E2BProvider(create={"template": "base"})
+        with caplog.at_level("WARNING"):
+            await provider.create(_spec())
+        assert not [r for r in caplog.records if "fixes sandbox resources" in r.message]
+
+
+# --------------------------------------------------------------------------
+# Create / lifecycle
+# --------------------------------------------------------------------------
+
+
+class TestCreateAndLifecycle:
+    async def test_spec_fields_map_onto_sdk_kwargs(self) -> None:
+        provider = E2BProvider(
+            connection={"api_key": "k", "api_url": "http://gw:8080", "request_timeout_s": 30.0},
+            create={"template": "base", "allow_internet_access": False},
+        )
+        handle = await provider.create(
+            _spec(ttl_s=120, env={"FOO": "bar"}, metadata={"run": "1"}),
+        )
+        kwargs = handle.raw.create_kwargs
+        assert kwargs["timeout"] == 120
+        assert kwargs["envs"] == {"FOO": "bar"}
+        assert kwargs["metadata"] == {"run": "1"}
+        assert kwargs["allow_internet_access"] is False
+        assert kwargs["api_key"] == "k"
+        assert kwargs["api_url"] == "http://gw:8080"
+        assert kwargs["request_timeout"] == 30.0
+        assert handle.provider_name == "e2b"
+        assert handle.sandbox_id == "sbx-1"
+
+    async def test_spec_files_are_written_after_create(self) -> None:
+        provider = E2BProvider(create={"template": "base"})
+        handle = await provider.create(_spec(files={"/app/seed.txt": "hello"}))
+        assert handle.raw.files_written["/app/seed.txt"] == "hello"
+
+    async def test_create_failure_is_wrapped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def boom(**kwargs):
+            raise RuntimeError("gateway exploded")
+
+        monkeypatch.setattr(FakeSandbox, "create", boom)
+        provider = E2BProvider(create={"template": "base"}, operations={"retries": 0})
+        with pytest.raises(E2BCreateError, match="gateway exploded"):
+            await provider.create(_spec())
+
+    async def test_status_and_close(self) -> None:
+        provider = E2BProvider(create={"template": "base"})
+        handle = await provider.create(_spec())
+        assert await provider.status(handle) == SandboxStatus.RUNNING
+        handle.raw.running = False
+        assert await provider.status(handle) == SandboxStatus.STOPPED
+
+        handle.raw.running = True
+        sandbox = handle.raw
+        await provider.close(handle)
+        assert sandbox.killed is True
+        assert handle.raw is None
+        # Closing twice must not raise.
+        await provider.close(handle)
+
+    async def test_close_tolerates_already_gone_sandbox(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = E2BProvider(create={"template": "base"})
+        handle = await provider.create(_spec())
+
+        async def gone(**kwargs):
+            raise FakeSandboxNotFound("expired")
+
+        monkeypatch.setattr(handle.raw, "kill", gone)
+        await provider.close(handle)
+        assert handle.raw is None
+
+    async def test_connect_returns_handle(self) -> None:
+        provider = E2BProvider()
+        handle = await provider.connect("sbx-existing")
+        assert handle.sandbox_id == "sbx-existing"
+        assert handle.provider_name == "e2b"
+
+    async def test_aclose_is_a_noop(self) -> None:
+        assert await E2BProvider().aclose() is None
+
+
+# --------------------------------------------------------------------------
+# exec
+# --------------------------------------------------------------------------
+
+
+class TestExec:
+    async def test_exec_maps_arguments_and_result(self) -> None:
+        provider = E2BProvider(create={"template": "base"})
+        handle = await provider.create(_spec())
+        handle.raw.exec_behaviour = FakeCommandResult(stdout="out", stderr="err", exit_code=0)
+
+        result = await provider.exec(handle, "echo hi", cwd="/app", env={"A": "1"}, timeout_s=42, user="root")
+        assert (result.stdout, result.stderr, result.return_code) == ("out", "err", 0)
+        call = handle.raw.exec_calls[-1]
+        assert call["cmd"] == "echo hi"
+        assert call["cwd"] == "/app"
+        assert call["envs"] == {"A": "1"}
+        assert call["user"] == "root"
+        assert call["timeout"] == 42.0
+
+    async def test_default_exec_timeout_is_generous(self) -> None:
+        # The SDK default is 60s, which silently truncates builds and verifier
+        # suites; the provider default must be far larger.
+        provider = E2BProvider(create={"template": "base"})
+        handle = await provider.create(_spec())
+        await provider.exec(handle, "true")
+        assert handle.raw.exec_calls[-1]["timeout"] >= 900
+
+    async def test_nonzero_exit_is_a_result_not_an_exception(self) -> None:
+        provider = E2BProvider(create={"template": "base"})
+        handle = await provider.create(_spec())
+        handle.raw.exec_behaviour = FakeCommandExit(exit_code=7, stdout="partial", stderr="bad")
+
+        result = await provider.exec(handle, "false")
+        assert result.return_code == 7
+        assert result.stdout == "partial"
+        assert result.stderr == "bad"
+
+    async def test_timeout_is_raised_as_timeout_error(self) -> None:
+        provider = E2BProvider(create={"template": "base"})
+        handle = await provider.create(_spec())
+        handle.raw.exec_behaviour = FakeTimeout("deadline exceeded")
+
+        with pytest.raises(TimeoutError):
+            await provider.exec(handle, "sleep 999", timeout_s=1)
+
+
+# --------------------------------------------------------------------------
+# Files
+# --------------------------------------------------------------------------
+
+
+class TestFiles:
+    async def test_upload_then_download_round_trip(self, tmp_path: Path) -> None:
+        provider = E2BProvider(create={"template": "base"})
+        handle = await provider.create(_spec())
+
+        source = tmp_path / "in.bin"
+        source.write_bytes(b"payload\x00binary")
+        await provider.upload_file(handle, source, "/remote/in.bin")
+
+        target = tmp_path / "nested" / "out.bin"
+        await provider.download_file(handle, "/remote/in.bin", target)
+        assert target.read_bytes() == b"payload\x00binary"
+
+    async def test_upload_missing_file_raises(self, tmp_path: Path) -> None:
+        provider = E2BProvider(create={"template": "base"})
+        handle = await provider.create(_spec())
+        with pytest.raises(FileNotFoundError):
+            await provider.upload_file(handle, tmp_path / "nope.txt", "/remote/nope.txt")
+
+
+# --------------------------------------------------------------------------
+# Retries
+# --------------------------------------------------------------------------
+
+
+class TestRetries:
+    async def test_transient_failure_is_retried(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls = {"n": 0}
+        original = FakeSandbox.create.__func__
+
+        async def flaky(cls, **kwargs):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise RuntimeError("502 bad gateway")
+            return await original(cls, **kwargs)
+
+        monkeypatch.setattr(FakeSandbox, "create", classmethod(flaky))
+        provider = E2BProvider(create={"template": "base"}, operations={"retries": 3, "retry_delay_s": 0})
+        handle = await provider.create(_spec())
+        assert calls["n"] == 3
+        assert handle.sandbox_id == "sbx-1"
+
+    async def test_deterministic_errors_are_not_retried(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls = {"n": 0}
+
+        async def not_found(cls, **kwargs):
+            calls["n"] += 1
+            raise FakeSandboxNotFound("template missing")
+
+        monkeypatch.setattr(FakeSandbox, "create", classmethod(not_found))
+        provider = E2BProvider(create={"template": "base"}, operations={"retries": 5, "retry_delay_s": 0})
+        with pytest.raises(E2BCreateError):
+            await provider.create(_spec())
+        assert calls["n"] == 1
+
+
+# --------------------------------------------------------------------------
+# Config validation
+# --------------------------------------------------------------------------
+
+
+def test_unknown_config_keys_are_rejected() -> None:
+    with pytest.raises(ValueError, match="Unknown E2BCreateConfig keys"):
+        E2BProvider(create={"template": "base", "nope": 1})

--- a/tests/unit_tests/test_e2b_provider.py
+++ b/tests/unit_tests/test_e2b_provider.py
@@ -68,16 +68,24 @@ def _reject_connection_params(method: str, kwargs: dict) -> None:
 
 
 class FakeCommandHandle:
-    """Background handle: `wait()` replays a scripted sequence of outcomes."""
+    """Background handle: `wait()` replays a scripted sequence of outcomes.
 
-    def __init__(self, pid: int, outcomes: list) -> None:
+    Falls back to the sandbox's `exec_behaviour` so a test can script an
+    outcome once and have it apply in either exec mode.
+    """
+
+    def __init__(self, pid: int, outcomes: list, fallback=None) -> None:
         self.pid = pid
         self._outcomes = outcomes
+        self._fallback = fallback
         self.waits = 0
 
     async def wait(self):
         self.waits += 1
-        outcome = self._outcomes.pop(0) if self._outcomes else FakeCommandResult(stdout="ok")
+        if self._outcomes:
+            outcome = self._outcomes.pop(0)
+        else:
+            outcome = self._fallback or FakeCommandResult(stdout="ok")
         if isinstance(outcome, Exception):
             raise outcome
         return outcome
@@ -92,7 +100,7 @@ class FakeCommands:
         self._sandbox.exec_calls.append(kwargs)
         behaviour = self._sandbox.exec_behaviour
         if kwargs.get("background"):
-            return FakeCommandHandle(self._sandbox.pid, self._sandbox.wait_outcomes)
+            return FakeCommandHandle(self._sandbox.pid, self._sandbox.wait_outcomes, behaviour)
         if isinstance(behaviour, Exception):
             raise behaviour
         return behaviour or FakeCommandResult(stdout="ok")
@@ -101,7 +109,7 @@ class FakeCommands:
         self._sandbox.connect_calls.append({"pid": pid, "timeout": timeout})
         if self._sandbox.connect_error is not None:
             raise self._sandbox.connect_error
-        return FakeCommandHandle(pid, self._sandbox.wait_outcomes)
+        return FakeCommandHandle(pid, self._sandbox.wait_outcomes, self._sandbox.exec_behaviour)
 
 
 class FakeFiles:
@@ -357,8 +365,16 @@ class TestBackgroundExec:
         opts = {"background": True, **exec_opts}
         return E2BProvider(create={"template": "base"}, exec=opts)
 
-    async def test_off_by_default(self) -> None:
+    async def test_on_by_default(self) -> None:
+        # Matches Harbor's own e2b environment, which always dispatches with
+        # background=True.
         provider = E2BProvider(create={"template": "base"})
+        handle = await provider.create(_spec())
+        await provider.exec(handle, "echo hi")
+        assert handle.raw.exec_calls[0]["background"] is True
+
+    async def test_can_be_turned_off(self) -> None:
+        provider = E2BProvider(create={"template": "base"}, exec={"background": False})
         handle = await provider.create(_spec())
         await provider.exec(handle, "echo hi")
         assert "background" not in handle.raw.exec_calls[0]

--- a/tests/unit_tests/test_e2b_provider.py
+++ b/tests/unit_tests/test_e2b_provider.py
@@ -14,6 +14,8 @@
 
 """Unit tests for the e2b sandbox provider (SDK faked; no network)."""
 
+import asyncio
+import re
 import types
 from pathlib import Path
 
@@ -111,9 +113,45 @@ class FakeSandbox:
         self.killed = True
 
 
+class FakeTemplateBuilder:
+    def __init__(self, image: str, username=None, password=None) -> None:
+        self.image = image
+        self.username = username
+        self.password = password
+
+
+class FakeTemplate:
+    """Records build calls; ``existing_aliases`` fakes server-side state."""
+
+    builds: list[dict] = []
+    existing_aliases: set[str] = set()
+    build_error: Exception | None = None
+    build_delay_s: float = 0.0
+
+    def from_image(self, image, username=None, password=None):
+        return FakeTemplateBuilder(image, username, password)
+
+    @staticmethod
+    async def alias_exists(alias, **kwargs):
+        return alias in FakeTemplate.existing_aliases
+
+    @staticmethod
+    async def build(builder, *, alias=None, cpu_count=None, memory_mb=None, **kwargs):
+        if FakeTemplate.build_delay_s:
+            await asyncio.sleep(FakeTemplate.build_delay_s)
+        if FakeTemplate.build_error is not None:
+            raise FakeTemplate.build_error
+        FakeTemplate.builds.append(
+            {"image": builder.image, "alias": alias, "cpu_count": cpu_count, "memory_mb": memory_mb, **kwargs}
+        )
+        FakeTemplate.existing_aliases.add(alias)
+        return types.SimpleNamespace(alias=alias)
+
+
 def _fake_sdk() -> types.SimpleNamespace:
     return types.SimpleNamespace(
         AsyncSandbox=FakeSandbox,
+        AsyncTemplate=FakeTemplate,
         SandboxNotFoundException=FakeSandboxNotFound,
         NotFoundException=FakeSandboxNotFound,
         TimeoutException=FakeTimeout,
@@ -126,6 +164,10 @@ def _fake_sdk() -> types.SimpleNamespace:
 @pytest.fixture(autouse=True)
 def fake_e2b_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
     FakeSandbox.instances.clear()
+    FakeTemplate.builds.clear()
+    FakeTemplate.existing_aliases.clear()
+    FakeTemplate.build_error = None
+    FakeTemplate.build_delay_s = 0.0
     monkeypatch.setattr(e2b_provider, "_require_e2b_sdk", _fake_sdk)
 
 
@@ -174,13 +216,117 @@ class TestTemplateResolution:
         # Silently starting the wrong template would corrupt a benchmark run,
         # so an unmappable image must fail loudly.
         provider = E2BProvider()
-        with pytest.raises(E2BCreateError, match="template_map"):
+        with pytest.raises(E2BCreateError, match="auto_build_from_image"):
             await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
 
     async def test_no_template_at_all_raises(self) -> None:
         provider = E2BProvider()
         with pytest.raises(E2BCreateError, match="No E2B template"):
             await provider.create(_spec())
+
+
+# --------------------------------------------------------------------------
+# On-demand template building from an OCI image
+# --------------------------------------------------------------------------
+
+
+class TestAutoBuildFromImage:
+    async def test_builds_template_then_starts_sandbox_from_it(self) -> None:
+        provider = E2BProvider(create={"auto_build_from_image": True})
+        handle = await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
+
+        assert len(FakeTemplate.builds) == 1
+        build = FakeTemplate.builds[0]
+        assert build["image"] == "ghcr.io/acme/task:1.0"
+        # Alias must be charset-safe for E2B and traceable back to the image.
+        alias = build["alias"]
+        assert re.fullmatch(r"[A-Za-z0-9_-]+", alias)
+        assert alias.startswith("task-1-0__")
+        assert handle.raw.create_kwargs["template"] == alias
+
+    async def test_spec_resources_become_build_arguments(self) -> None:
+        # The whole point of building ourselves: E2B fixes cpu/memory at build
+        # time, so a spec's resources CAN be honoured on this path.
+        provider = E2BProvider(create={"auto_build_from_image": True})
+        await provider.create(_spec(image="ghcr.io/acme/task:1.0", resources={"cpu": 8, "memory_mib": 16384}))
+        build = FakeTemplate.builds[0]
+        assert build["cpu_count"] == 8
+        assert build["memory_mb"] == 16384
+
+    async def test_no_resource_warning_when_applied_at_build(self, caplog) -> None:
+        provider = E2BProvider(create={"auto_build_from_image": True})
+        with caplog.at_level("WARNING"):
+            await provider.create(_spec(image="ghcr.io/acme/task:1.0", resources={"cpu": 8}))
+        assert not [r for r in caplog.records if "fixes sandbox resources" in r.message]
+
+    async def test_different_resources_get_different_templates(self) -> None:
+        # Sharing one template across differing resource requests would
+        # silently give the second sandbox the first one's sizing.
+        provider = E2BProvider(create={"auto_build_from_image": True})
+        a = await provider.create(_spec(image="ghcr.io/acme/task:1.0", resources={"cpu": 2}))
+        b = await provider.create(_spec(image="ghcr.io/acme/task:1.0", resources={"cpu": 8}))
+        assert a.raw.create_kwargs["template"] != b.raw.create_kwargs["template"]
+        assert len(FakeTemplate.builds) == 2
+
+    async def test_template_is_built_once_and_reused(self) -> None:
+        provider = E2BProvider(create={"auto_build_from_image": True})
+        await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
+        await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
+        assert len(FakeTemplate.builds) == 1
+
+    async def test_concurrent_creates_build_only_once(self) -> None:
+        # N sandboxes on one image must not trigger N builds.
+        FakeTemplate.build_delay_s = 0.02
+        provider = E2BProvider(create={"auto_build_from_image": True})
+        handles = await asyncio.gather(*(provider.create(_spec(image="ghcr.io/acme/task:1.0")) for _ in range(6)))
+        assert len(FakeTemplate.builds) == 1
+        assert len({h.raw.create_kwargs["template"] for h in handles}) == 1
+
+    async def test_preexisting_alias_is_not_rebuilt(self) -> None:
+        provider = E2BProvider(create={"auto_build_from_image": True})
+        alias = provider._derive_alias("ghcr.io/acme/task:1.0", 2, 1024)
+        FakeTemplate.existing_aliases.add(alias)
+        handle = await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
+        assert FakeTemplate.builds == []
+        assert handle.raw.create_kwargs["template"] == alias
+
+    async def test_registry_credentials_are_forwarded(self) -> None:
+        provider = E2BProvider(
+            create={"auto_build_from_image": True, "registry_username": "u", "registry_password": "p"}
+        )
+        captured: dict = {}
+        original = FakeTemplate.from_image
+
+        def spy(self, image, username=None, password=None):
+            captured.update({"username": username, "password": password})
+            return original(self, image, username, password)
+
+        FakeTemplate.from_image = spy
+        try:
+            await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
+        finally:
+            FakeTemplate.from_image = original
+        assert captured == {"username": "u", "password": "p"}
+
+    async def test_build_failure_is_wrapped(self) -> None:
+        FakeTemplate.build_error = RuntimeError("builder offline")
+        provider = E2BProvider(create={"auto_build_from_image": True})
+        with pytest.raises(E2BCreateError, match="builder offline"):
+            await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
+
+    async def test_build_timeout_is_reported(self) -> None:
+        FakeTemplate.build_delay_s = 0.2
+        provider = E2BProvider(create={"auto_build_from_image": True, "build_timeout_s": 0.01})
+        with pytest.raises(E2BCreateError, match="Timed out"):
+            await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
+
+    async def test_explicit_mapping_still_wins_over_building(self) -> None:
+        provider = E2BProvider(
+            create={"auto_build_from_image": True, "template_map": {"ghcr.io/acme/task:1.0": "preset"}}
+        )
+        handle = await provider.create(_spec(image="ghcr.io/acme/task:1.0"))
+        assert handle.raw.create_kwargs["template"] == "preset"
+        assert FakeTemplate.builds == []
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit_tests/test_e2b_provider.py
+++ b/tests/unit_tests/test_e2b_provider.py
@@ -67,6 +67,22 @@ def _reject_connection_params(method: str, kwargs: dict) -> None:
         raise TypeError(f"{method}() got an unexpected keyword argument {leaked[0]!r}")
 
 
+class FakeCommandHandle:
+    """Background handle: `wait()` replays a scripted sequence of outcomes."""
+
+    def __init__(self, pid: int, outcomes: list) -> None:
+        self.pid = pid
+        self._outcomes = outcomes
+        self.waits = 0
+
+    async def wait(self):
+        self.waits += 1
+        outcome = self._outcomes.pop(0) if self._outcomes else FakeCommandResult(stdout="ok")
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
 class FakeCommands:
     def __init__(self, sandbox: "FakeSandbox") -> None:
         self._sandbox = sandbox
@@ -75,9 +91,17 @@ class FakeCommands:
         _reject_connection_params("Commands.run", kwargs)
         self._sandbox.exec_calls.append(kwargs)
         behaviour = self._sandbox.exec_behaviour
+        if kwargs.get("background"):
+            return FakeCommandHandle(self._sandbox.pid, self._sandbox.wait_outcomes)
         if isinstance(behaviour, Exception):
             raise behaviour
         return behaviour or FakeCommandResult(stdout="ok")
+
+    async def connect(self, pid, timeout=None, **kwargs):
+        self._sandbox.connect_calls.append({"pid": pid, "timeout": timeout})
+        if self._sandbox.connect_error is not None:
+            raise self._sandbox.connect_error
+        return FakeCommandHandle(pid, self._sandbox.wait_outcomes)
 
 
 class FakeFiles:
@@ -108,6 +132,10 @@ class FakeSandbox:
         self.killed = False
         self.running = True
         self.exec_behaviour = None
+        self.pid = 4242
+        self.wait_outcomes: list = []
+        self.connect_calls: list[dict] = []
+        self.connect_error = None
         self.commands = FakeCommands(self)
         self.files = FakeFiles(self)
         FakeSandbox.instances.append(self)
@@ -310,6 +338,93 @@ class TestConnectionParamScoping:
         handle = await provider.create(_spec())
         assert handle.raw.create_kwargs["api_key"] == "k"
         assert handle.raw.create_kwargs["api_url"] == "http://gw:8080"
+
+
+# --------------------------------------------------------------------------
+# Background exec -- survive a lost output stream
+# --------------------------------------------------------------------------
+
+
+class TestBackgroundExec:
+    """A dropped stream must not destroy a command that is still running.
+
+    `run(background=True)` returns once the process has started, so the command
+    outlives the stream carrying its output and can be reattached by pid.
+    """
+
+    @staticmethod
+    def _provider(**exec_opts) -> E2BProvider:
+        opts = {"background": True, **exec_opts}
+        return E2BProvider(create={"template": "base"}, exec=opts)
+
+    async def test_off_by_default(self) -> None:
+        provider = E2BProvider(create={"template": "base"})
+        handle = await provider.create(_spec())
+        await provider.exec(handle, "echo hi")
+        assert "background" not in handle.raw.exec_calls[0]
+
+    async def test_background_flag_is_sent(self) -> None:
+        provider = self._provider()
+        handle = await provider.create(_spec())
+        result = await provider.exec(handle, "echo hi")
+        assert handle.raw.exec_calls[0]["background"] is True
+        assert result.return_code == 0
+
+    async def test_lost_stream_is_reattached_by_pid(self) -> None:
+        provider = self._provider()
+        handle = await provider.create(_spec())
+        handle.raw.wait_outcomes = [
+            ConnectionError("peer closed connection without sending complete message body"),
+            FakeCommandResult(stdout="finished", exit_code=0),
+        ]
+        result = await provider.exec(handle, "make -j8")
+        assert handle.raw.connect_calls == [{"pid": 4242, "timeout": 1800.0}]
+        assert result.return_code == 0
+        assert result.stdout == "finished"
+
+    async def test_reattach_recovers_the_real_exit_code(self) -> None:
+        # The exit code is what a benchmark scores on, and it survives even
+        # though the output emitted before the reattach does not.
+        provider = self._provider()
+        handle = await provider.create(_spec())
+        handle.raw.wait_outcomes = [ConnectionError("stream lost"), FakeCommandExit(7, stdout="", stderr="boom")]
+        result = await provider.exec(handle, "false")
+        assert result.return_code == 7
+
+    async def test_reattach_attempts_are_bounded(self) -> None:
+        provider = self._provider(reconnect_attempts=2)
+        handle = await provider.create(_spec())
+        handle.raw.wait_outcomes = [ConnectionError("a"), ConnectionError("b"), ConnectionError("c")]
+        with pytest.raises(ConnectionError):
+            await provider.exec(handle, "sleep 1")
+        assert len(handle.raw.connect_calls) == 2
+
+    async def test_non_zero_exit_is_not_treated_as_a_lost_stream(self) -> None:
+        provider = self._provider()
+        handle = await provider.create(_spec())
+        handle.raw.wait_outcomes = [FakeCommandExit(3, stdout="out", stderr="err")]
+        result = await provider.exec(handle, "false")
+        assert result.return_code == 3
+        assert handle.raw.connect_calls == [], "a real exit must not trigger a reattach"
+
+    async def test_timeout_is_not_treated_as_a_lost_stream(self) -> None:
+        provider = self._provider()
+        handle = await provider.create(_spec())
+        handle.raw.wait_outcomes = [FakeTimeout("timed out")]
+        with pytest.raises(TimeoutError):
+            await provider.exec(handle, "sleep 999")
+        assert handle.raw.connect_calls == []
+
+    async def test_process_gone_reports_the_original_failure(self) -> None:
+        # connect() raises not-found once the command has exited, so a command
+        # that finishes during the gap cannot be recovered; the transport
+        # failure is the useful error to surface.
+        provider = self._provider()
+        handle = await provider.create(_spec())
+        handle.raw.wait_outcomes = [ConnectionError("stream lost")]
+        handle.raw.connect_error = FakeSandboxNotFound("process with pid 4242 not found")
+        with pytest.raises(ConnectionError, match="stream lost"):
+            await provider.exec(handle, "quick")
 
 
 # --------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -295,6 +295,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bracex"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/01/5f394b8bcd6e5b92f73130990960423bbb19711f906bd9fe9ea5557c667c/bracex-3.0.1.tar.gz", hash = "sha256:4e38e32392e4a4780fe15d644bfc7c8514057cfc3861e060b11814ce829c25e4", size = 44019, upload-time = "2026-07-20T13:43:00.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl", hash = "sha256:6523ad83aeb5098a4ee597cff0f964442ff74e460bd3fafaffab6a013ff2288c", size = 11940, upload-time = "2026-07-20T13:42:59.268Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -403,6 +412,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0c/0c/d180ebf230b771907f46981023a80f62cf592d49673cc5f8a5993aa67bb6/colorful-0.5.7.tar.gz", hash = "sha256:c5452179b56601c178b03d468a5326cc1fe37d9be81d24d0d6bdab36c4b93ad8", size = 209487, upload-time = "2025-06-30T15:24:03.936Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/98/0d791b3d1eaed89d7d370b5cf9b8079b124da0545559417f394ba21b5532/colorful-0.5.7-py2.py3-none-any.whl", hash = "sha256:495dd3a23151a9568cee8a90fc1174c902ad7ef06655f50b6bddf9e80008da69", size = 201475, upload-time = "2025-06-30T15:24:02.693Z" },
+]
+
+[[package]]
+name = "connectrpc"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf-py" },
+    { name = "pyqwest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/b5/63e14ab9d4d4cc58818562db4120a35fa7454e3035633da41bdc6b712abd/connectrpc-0.11.1.tar.gz", hash = "sha256:18277f7838847b4271ca38d40c7d2387b5a2ea6a29f240689c19e1ec84aaff66", size = 46222, upload-time = "2026-07-15T06:33:31.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/ac/aa647675812cd075f2cb9acb00d62f4f2cbcbc6736049a62342b7371ce5b/connectrpc-0.11.1-py3-none-any.whl", hash = "sha256:8a52e2e92a485fa9681c1101a79a5ebeb31807e3ea3d5aabd41f484a6398bc7b", size = 64991, upload-time = "2026-07-15T06:33:29.396Z" },
 ]
 
 [[package]]
@@ -743,12 +765,44 @@ wheels = [
 ]
 
 [[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "e2b"
+version = "2.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "connectrpc" },
+    { name = "dockerfile-parse" },
+    { name = "h2" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "protobuf-py" },
+    { name = "pyqwest" },
+    { name = "python-dateutil" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/9d/178eae432a8e238a9f48d6706b03e88af64c67934b2885f495346d65e0d6/e2b-2.35.0.tar.gz", hash = "sha256:c72c7c9905b7c8b7733e35fd2ccae0071cecaf160339bf77389cacbf60a967a5", size = 199705, upload-time = "2026-07-24T14:45:41.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/6a/f3c890a627681fa7951a52c578a364aa48be1b623f12982b29fc5485e063/e2b-2.35.0-py3-none-any.whl", hash = "sha256:f8fe8bc9415f0237c6dd4d11cba32741174f3610fad32f0087c6e0052deb7275", size = 358641, upload-time = "2026-07-24T14:45:43.483Z" },
 ]
 
 [[package]]
@@ -1035,6 +1089,19 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/d4/a7d6fb3f58be99d65cbf2d3f766896217a2921d0f3ab10711c45dc1519ee/h2-4.4.0.tar.gz", hash = "sha256:46b551bdcdc7e83cf5c04d0bf93badb8a939bd2287d9fee1abb23a445b9e0580", size = 2156691, upload-time = "2026-07-23T19:14:19.442Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/df/5b14a118322d6097cb9bb30ec6bacad268e546a8ecfcb1f6d0de618dac2f/h2-4.4.0-py3-none-any.whl", hash = "sha256:6acffe1aeab79098d7eb0f8385c1add11f2c7a94815f6fa2b7060eeddee3d87c", size = 62368, upload-time = "2026-07-23T19:14:16.143Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.1.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1047,6 +1114,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/3c/28cc4db153a7601a996985bcb564f7b8f5b9e1a706c7537aad4b4809f358/hf_xet-1.1.9-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ad1022e9a998e784c97b2173965d07fe33ee26e4594770b7785a8cc8f922cd95", size = 3251429, upload-time = "2025-08-27T23:05:16.471Z" },
     { url = "https://files.pythonhosted.org/packages/84/17/7caf27a1d101bfcb05be85850d4aa0a265b2e1acc2d4d52a48026ef1d299/hf_xet-1.1.9-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86754c2d6d5afb11b0a435e6e18911a4199262fe77553f8c50d75e21242193ea", size = 3354643, upload-time = "2025-08-27T23:05:17.828Z" },
     { url = "https://files.pythonhosted.org/packages/cd/50/0c39c9eed3411deadcc98749a6699d871b822473f55fe472fad7c01ec588/hf_xet-1.1.9-cp37-abi3-win_amd64.whl", hash = "sha256:5aad3933de6b725d61d51034e04174ed1dce7a57c63d530df0014dea15a40127", size = 2804797, upload-time = "2025-08-27T23:05:20.77Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
 ]
 
 [[package]]
@@ -1132,6 +1208,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz", hash = "sha256:8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824", size = 3263494, upload-time = "2023-02-23T18:33:43.03Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-py3-none-any.whl", hash = "sha256:fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b", size = 154547, upload-time = "2023-02-23T18:33:40.801Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1746,6 +1831,7 @@ all = [
     { name = "boto3" },
     { name = "coverage" },
     { name = "daytona" },
+    { name = "e2b" },
     { name = "mypy" },
     { name = "opensandbox" },
     { name = "pre-commit" },
@@ -1771,6 +1857,7 @@ dev = [
 sandbox = [
     { name = "boto3" },
     { name = "daytona" },
+    { name = "e2b" },
     { name = "opensandbox" },
     { name = "tenacity" },
 ]
@@ -1784,6 +1871,7 @@ requires-dist = [
     { name = "datasets" },
     { name = "daytona", marker = "extra == 'sandbox'", specifier = ">=0.179.0" },
     { name = "devtools" },
+    { name = "e2b", marker = "extra == 'sandbox'", specifier = ">=2.25.0" },
     { name = "fastapi" },
     { name = "fonttools", specifier = ">=4.60.2" },
     { name = "gitpython", specifier = ">=3.1.50" },
@@ -2016,32 +2104,31 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.38.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/d8/0f354c375628e048bd0570645b310797299754730079853095bf000fba69/opentelemetry_api-1.38.0.tar.gz", hash = "sha256:f4c193b5e8acb0912b06ac5b16321908dd0843d75049c091487322284a3eea12", size = 65242, upload-time = "2025-10-16T08:35:50.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/a2/d86e01c28300bd41bab8f18afd613676e2bd63515417b77636fc1add426f/opentelemetry_api-1.38.0-py3-none-any.whl", hash = "sha256:2891b0197f47124454ab9f0cf58f3be33faca394457ac3e09daba13ff50aa582", size = 65947, upload-time = "2025-10-16T08:35:30.23Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.38.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/83/dd4660f2956ff88ed071e9e0e36e830df14b8c5dc06722dbde1841accbe8/opentelemetry_exporter_otlp_proto_common-1.38.0.tar.gz", hash = "sha256:e333278afab4695aa8114eeb7bf4e44e65c6607d54968271a249c180b2cb605c", size = 20431, upload-time = "2025-10-16T08:35:53.285Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/9e/55a41c9601191e8cd8eb626b54ee6827b9c9d4a46d736f32abc80d8039fc/opentelemetry_exporter_otlp_proto_common-1.38.0-py3-none-any.whl", hash = "sha256:03cb76ab213300fe4f4c62b7d8f17d97fcfd21b89f0b5ce38ea156327ddda74a", size = 18359, upload-time = "2025-10-16T08:35:34.099Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.38.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -2052,28 +2139,28 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/0a/debcdfb029fbd1ccd1563f7c287b89a6f7bef3b2902ade56797bfd020854/opentelemetry_exporter_otlp_proto_http-1.38.0.tar.gz", hash = "sha256:f16bd44baf15cbe07633c5112ffc68229d0edbeac7b37610be0b2def4e21e90b", size = 17282, upload-time = "2025-10-16T08:35:54.422Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/77/154004c99fb9f291f74aa0822a2f5bbf565a72d8126b3a1b63ed8e5f83c7/opentelemetry_exporter_otlp_proto_http-1.38.0-py3-none-any.whl", hash = "sha256:84b937305edfc563f08ec69b9cb2298be8188371217e867c1854d77198d0825b", size = 19579, upload-time = "2025-10-16T08:35:36.269Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-prometheus"
-version = "0.59b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "prometheus-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/07/39370ec7eacfca10462121a0e036b66ccea3a616bf6ae6ea5fdb72e5009d/opentelemetry_exporter_prometheus-0.59b0.tar.gz", hash = "sha256:d64f23c49abb5a54e271c2fbc8feacea0c394a30ec29876ab5ef7379f08cf3d7", size = 14972, upload-time = "2025-10-16T08:35:55.973Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/85/3a1af7b90a76d6c069bcbbc86cc641c93d15057f2674cc8226f47c5260e8/opentelemetry_exporter_prometheus-0.65b0.tar.gz", hash = "sha256:2777cbf41c403c119e10f418fce5d645c956b47f673a2ee120285d1d0c6df2d5", size = 16411, upload-time = "2026-07-16T15:25:39.971Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/ea/3005a732002242fd86203989520bdd5a752e1fd30dc225d5d45751ea19fb/opentelemetry_exporter_prometheus-0.59b0-py3-none-any.whl", hash = "sha256:71ced23207abd15b30d1fe4e7e910dcaa7c2ff1f24a6ffccbd4fdded676f541b", size = 13017, upload-time = "2025-10-16T08:35:37.253Z" },
+    { url = "https://files.pythonhosted.org/packages/82/0d/d7cdc030edeed0fea03448446b88f1a1f8c4a565bad30dac0f5477ebe290/opentelemetry_exporter_prometheus-0.65b0-py3-none-any.whl", hash = "sha256:3b3d24b586d0ad9712c7b52b7d19c8a9dfbb318b9b284121b5f95e90ed019367", size = 13031, upload-time = "2026-07-16T15:25:20.906Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.59b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2081,14 +2168,14 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/ed/9c65cd209407fd807fa05be03ee30f159bdac8d59e7ea16a8fe5a1601222/opentelemetry_instrumentation-0.59b0.tar.gz", hash = "sha256:6010f0faaacdaf7c4dff8aac84e226d23437b331dcda7e70367f6d73a7db1adc", size = 31544, upload-time = "2025-10-16T08:39:31.959Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/91/3c58961cb0360cd60509064734f0be4275383c8681d73c580a40ca83ddce/opentelemetry_instrumentation-0.65b0.tar.gz", hash = "sha256:071d9d9eced9bd6460444ec3b0c77229870ed05a881c22c84fdede58e4eed09b", size = 42689, upload-time = "2026-07-16T15:25:50.275Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/f5/7a40ff3f62bfe715dad2f633d7f1174ba1a7dd74254c15b2558b3401262a/opentelemetry_instrumentation-0.59b0-py3-none-any.whl", hash = "sha256:44082cc8fe56b0186e87ee8f7c17c327c4c2ce93bdbe86496e600985d74368ee", size = 33020, upload-time = "2025-10-16T08:38:31.463Z" },
+    { url = "https://files.pythonhosted.org/packages/40/7b/85eab1215f72adf0e68d3dc4a679b9bff993fa679ff34cd8dd378e2659fd/opentelemetry_instrumentation-0.65b0-py3-none-any.whl", hash = "sha256:ea967a72b9939b5fcfdad572753b4306c59dcb99e3f382d95dae04286805e137", size = 36717, upload-time = "2026-07-16T15:24:51.424Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-aiohttp-client"
-version = "0.59b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2097,57 +2184,57 @@ dependencies = [
     { name = "opentelemetry-util-http" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/cb/e135fad3edfd8492bbf3e50ce6fa288f730b8ef8700d93e4c2e49cc1bf6c/opentelemetry_instrumentation_aiohttp_client-0.59b0.tar.gz", hash = "sha256:665ee520f2fb5f44d6d600918eb7bbd2c29b355e0d0deda49991db857adee51f", size = 15037, upload-time = "2025-10-16T08:39:33.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/33/3ff7230b035e8b696db6be54f5c52dfa409829d634d91431c076ad789820/opentelemetry_instrumentation_aiohttp_client-0.65b0.tar.gz", hash = "sha256:85906a2806ee5641756b5c33274e9aa75c3cc2441e3b830aa5804cf0e1fa9dd1", size = 19042, upload-time = "2026-07-16T15:25:51.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/db/99376c8f0d3141e92b9902ae1e5b51dc4f458fc23d03e3815722d64afbcb/opentelemetry_instrumentation_aiohttp_client-0.59b0-py3-none-any.whl", hash = "sha256:8e7f234d2b6b385d5b1757ba7f13baa71c45ec020e1a08ba7f7649da7958470a", size = 12378, upload-time = "2025-10-16T08:38:33.56Z" },
+    { url = "https://files.pythonhosted.org/packages/71/f9/5c8459224f175829601cabbcffaeab0f9041903c086e4a0368f9971093a5/opentelemetry_instrumentation_aiohttp_client-0.65b0-py3-none-any.whl", hash = "sha256:3a060efa53fa44d02ba7372a7ed2b42cdfa6be6df81b089845067ad840e25729", size = 13677, upload-time = "2026-07-16T15:24:53.361Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.38.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/14/f0c4f0f6371b9cb7f9fa9ee8918bfd59ac7040c7791f1e6da32a1839780d/opentelemetry_proto-1.38.0.tar.gz", hash = "sha256:88b161e89d9d372ce723da289b7da74c3a8354a8e5359992be813942969ed468", size = 46152, upload-time = "2025-10-16T08:36:01.612Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/6a/82b68b14efca5150b2632f3692d627afa76b77378c4999f2648979409528/opentelemetry_proto-1.38.0-py3-none-any.whl", hash = "sha256:b6ebe54d3217c42e45462e2a1ae28c3e2bf2ec5a5645236a490f55f45f1a0a18", size = 72535, upload-time = "2025-10-16T08:35:45.749Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.38.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/cb/f0eee1445161faf4c9af3ba7b848cc22a50a3d3e2515051ad8628c35ff80/opentelemetry_sdk-1.38.0.tar.gz", hash = "sha256:93df5d4d871ed09cb4272305be4d996236eedb232253e3ab864c8620f051cebe", size = 171942, upload-time = "2025-10-16T08:36:02.257Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/2e/e93777a95d7d9c40d270a371392b6d6f1ff170c2a3cb32d6176741b5b723/opentelemetry_sdk-1.38.0-py3-none-any.whl", hash = "sha256:1c66af6564ecc1553d72d811a01df063ff097cdc82ce188da9951f93b8d10f6b", size = 132349, upload-time = "2025-10-16T08:35:46.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.59b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/bc/8b9ad3802cd8ac6583a4eb7de7e5d7db004e89cb7efe7008f9c8a537ee75/opentelemetry_semantic_conventions-0.59b0.tar.gz", hash = "sha256:7a6db3f30d70202d5bf9fa4b69bc866ca6a30437287de6c510fb594878aed6b0", size = 129861, upload-time = "2025-10-16T08:36:03.346Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/7d/c88d7b15ba8fe5c6b8f93be50fc11795e9fc05386c44afaf6b76fe191f9b/opentelemetry_semantic_conventions-0.59b0-py3-none-any.whl", hash = "sha256:35d3b8833ef97d614136e253c1da9342b4c3c083bbaf29ce31d572a1c3825eed", size = 207954, upload-time = "2025-10-16T08:35:48.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]
 name = "opentelemetry-util-http"
-version = "0.59b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/f7/13cd081e7851c42520ab0e96efb17ffbd901111a50b8252ec1e240664020/opentelemetry_util_http-0.59b0.tar.gz", hash = "sha256:ae66ee91be31938d832f3b4bc4eb8a911f6eddd38969c4a871b1230db2a0a560", size = 9412, upload-time = "2025-10-16T08:40:11.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/a9/d7525a59fdd240e69b5af4a6338e78fafa1b4203394122cbd6701fb5f84a/opentelemetry_util_http-0.65b0.tar.gz", hash = "sha256:84f82d826978bba416ab453460ff6a7391cdc3534c93a786595e4068680016b7", size = 11243, upload-time = "2026-07-16T15:26:27.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/56/62282d1d4482061360449dacc990c89cad0fc810a2ed937b636300f55023/opentelemetry_util_http-0.59b0-py3-none-any.whl", hash = "sha256:6d036a07563bce87bf521839c0671b507a02a0d39d7ea61b88efa14c6e25355d", size = 7648, upload-time = "2025-10-16T08:39:25.706Z" },
+    { url = "https://files.pythonhosted.org/packages/23/3f/ab8d29df207ce5f470a07fa96ebb48af4e95b7fab7e7635311b9a32f2fab/opentelemetry_util_http-0.65b0-py3-none-any.whl", hash = "sha256:7553b606f963097cb190536dc30556cce85090692e471a422fff30ca29b04348", size = 8245, upload-time = "2026-07-16T15:25:46.482Z" },
 ]
 
 [[package]]
@@ -2449,6 +2536,53 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf-py"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf-py-ext", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/ed/02fd902d9c51b7ff53dfc9a745eb11490722edfd30073af889e171f07b8e/protobuf_py-0.1.1.tar.gz", hash = "sha256:6bd08ac4d8f1661965bbe2685429d79043704cdd1ee720a7a89617331742240b", size = 133525, upload-time = "2026-06-24T19:02:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/00/1b3775aca1c70e3007e06ef5996f6bb9b3a32341eb0cce3ffb6effad8dec/protobuf_py-0.1.1-py3-none-any.whl", hash = "sha256:efc4f50f275ed6dae10a1f30bb81ad1a75368557b3ff22a532b7a472050368f1", size = 181656, upload-time = "2026-06-24T19:01:29.556Z" },
+]
+
+[[package]]
+name = "protobuf-py-ext"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/05/6dc9ccff1e8159eb9a144e6d3c4acfd2211cd4fcd20c34fe9155d17d6a7f/protobuf_py_ext-0.1.1.tar.gz", hash = "sha256:e85bfdfdb3ed50634db8ccc7429dd9286520109489c735463971a418707b4fef", size = 31912, upload-time = "2026-06-24T19:02:16.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/70/2b5d62a60a2e0d88ecde1ae98db3132bcd2672fb39c8d581b82b34ac0bd8/protobuf_py_ext-0.1.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:310039e03cb15181781a0b78017419f6d4ee302e988c3c70b87f1facdf05532d", size = 306008, upload-time = "2026-06-24T19:01:31.399Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d6/73c06bb4cac2e04c0adc154965fe8b6520224bd737fd7e73bba405056321/protobuf_py_ext-0.1.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89ec8348d1ba045f79b2fedd14e40cca36f2a41b52f2c4fdf55a60c58add2353", size = 314769, upload-time = "2026-06-24T19:01:32.89Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c5/e4e6bc6096b66d1c82639a1b501147f16ee65d32567304b987d002e2c666/protobuf_py_ext-0.1.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:182798e4861aba72d05855bd06febe4926aa7265e6f444a1b8af5252beee4f7e", size = 328122, upload-time = "2026-06-24T19:01:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/1d792a40d0f0a0f914f1dfa8bb5e9573ca0ecd5fe5cecf80d77193212abd/protobuf_py_ext-0.1.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9eb25c3a329c0551cc86b209a5e5d8ecb8d834b9924a3aa019377853a703b6d3", size = 492338, upload-time = "2026-06-24T19:01:36.103Z" },
+    { url = "https://files.pythonhosted.org/packages/52/51/5ad329223c905e5c530cae38ae24cde3584d8ab7e09457f2a01afce80e60/protobuf_py_ext-0.1.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:aaecbde82bef10c7c40578cbb61b7a19896bf7fa450972050a3bb302acb7d5d6", size = 541578, upload-time = "2026-06-24T19:01:37.481Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c7/01bd8a8bfe2df4b07aafac12ccfb7b7ebe2303f65296a9e02fcafa28ff3e/protobuf_py_ext-0.1.1-cp310-abi3-win_amd64.whl", hash = "sha256:6b0c615c48e95acc53cf33e9310eeaff8b30d2d7555bf93e7bca8fb4f40e9a5c", size = 251319, upload-time = "2026-06-24T19:01:38.946Z" },
+    { url = "https://files.pythonhosted.org/packages/24/dc/914065538b5db54b6a920b5af38c1ef142252ea1eea711820435fa259fac/protobuf_py_ext-0.1.1-cp310-abi3-win_arm64.whl", hash = "sha256:72956cd0af5dee24b41c6f5ba5e42622d17e6d555002b5efc1634e27a1446de2", size = 241635, upload-time = "2026-06-24T19:01:40.301Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/0b5d73cab815fd50615cb87a02e04e8332f9e27380c890aba1459cf7e919/protobuf_py_ext-0.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c6f0cd58620f415a3534d195358338f4999a774e12510f91c592b38d13d37388", size = 304903, upload-time = "2026-06-24T19:01:41.796Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a9/14c120b9ac36a0e11bb05e482fa6ae322de583a8e1068e4859035c289947/protobuf_py_ext-0.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21572764f625d829604fc4d83635f533f35775f11c6da142345b3f3c8d64bd09", size = 316148, upload-time = "2026-06-24T19:01:43.247Z" },
+    { url = "https://files.pythonhosted.org/packages/35/54/7c00a1a9783c3ba74f6b2f5d2f049f09037bbd489c465c09a34f32fb611b/protobuf_py_ext-0.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7f14f00c2678bfbe7ad46f057b9f9938c1677bcf39e405e163e272c6f9814b8", size = 326458, upload-time = "2026-06-24T19:01:44.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/0e/81fa50c0d6c4d664e5be6d0a3c4f2c7edfef87ab12d0bac764abca1f2955/protobuf_py_ext-0.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1610865622e2e27568277ca63d8d2d23dcc55eaa767398865c21539ddf4ce24d", size = 493596, upload-time = "2026-06-24T19:01:46.344Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/3183cf6e4de62846c20549654a1d573dae51ca06aaf7fed06accdfab74f6/protobuf_py_ext-0.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8995efba9476e1ea18ef9873306871dba697308994bc2766558fec3387acc3de", size = 539656, upload-time = "2026-06-24T19:01:48.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/6c/09841f3dbe7c3d4b3f2779f8f2832ac23fb96ac8ab71674e91af732cf9ff/protobuf_py_ext-0.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba61d49dace8f874361583030a7c48139b42eb37c9ffbb1e7e8a227a51576f44", size = 305017, upload-time = "2026-06-24T19:01:49.84Z" },
+    { url = "https://files.pythonhosted.org/packages/52/43/e450b5e202f6715274acc9acd9f9769908cbdeab861a53c798fcbd467d35/protobuf_py_ext-0.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a9c2f026096ca4c595c89a297067ef371e241d3ff8e1f6d7c779aa8419cdca7", size = 316215, upload-time = "2026-06-24T19:01:51.249Z" },
+    { url = "https://files.pythonhosted.org/packages/97/5c/23e79b35f1b5755b9bdc0c0c9b8cd8abababaef1a1639608d8a96bb61a9d/protobuf_py_ext-0.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf78707a040b9294e5e1ec4a1875f0046acfe52e92150cea27de4e9fc9db39bb", size = 326419, upload-time = "2026-06-24T19:01:52.93Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/de/5493de0ec12920a3b1dd72608ce0c1e8cdb7e0eb9e87accaecc5216df29e/protobuf_py_ext-0.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ae4373845cbb85bdade3ef5368cc2f4b5f80bf173383afc1ab063f95644e5599", size = 493734, upload-time = "2026-06-24T19:01:54.301Z" },
+    { url = "https://files.pythonhosted.org/packages/98/89/31da55b414e6332aad11d858e9a86bd36fbb324f52fa3fc6d8f1c57840a9/protobuf_py_ext-0.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2a4cc478eef7a2acc1daaebcde479a3ac2396d47e6bdc7e776ca4c4147ba8b4c", size = 539703, upload-time = "2026-06-24T19:01:55.707Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/71/39f231838ef06476d46ac40dd814894277a732a3688c0a0c994850b3b62f/protobuf_py_ext-0.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:359dccdc1c3eafed2a913c570bb082b8df848a1d27d548ce8385f246a7d68be2", size = 302145, upload-time = "2026-06-24T19:01:57.116Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f1/01c81ff5f420600366a0e6a613ce2af20834534d2b3d7523f4f3b4ddb54f/protobuf_py_ext-0.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91c38b4a10a306366443273ee03ca554537a0965bf05b7ada8e7dbdee04cc93e", size = 314541, upload-time = "2026-06-24T19:01:58.745Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d8/1cbf5a0298ceddc0cdbb28bf1ecaf8bd3cff54ed4ced6a1392d5226172fc/protobuf_py_ext-0.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79eee3bcbb289d6ea114eb8fe3a1469c5b59bf53e207238469f567d9c53ba56f", size = 325092, upload-time = "2026-06-24T19:02:00.382Z" },
+    { url = "https://files.pythonhosted.org/packages/af/23/8b1694616044cbfec2d18d4c6fffb03e05089c8bdb5970c6bafd60cc7fd5/protobuf_py_ext-0.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:10992141a8282a71ac3e3530d1a489efb27618d84000b9a47918cf70e5816d9b", size = 491684, upload-time = "2026-06-24T19:02:01.862Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d8/99997a7a6cf6989c944d9183c5deb6a045c27460add0316c7b34763891b3/protobuf_py_ext-0.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4411ffe0e06a774b83c5c71c546ce097640a25f596c45f95f53d3e3148e3f22d", size = 538048, upload-time = "2026-06-24T19:02:03.362Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/9e99ecbb68e1d5b46016d821eb1cbba9a91e6b50e71e75faf0c1e6189f0d/protobuf_py_ext-0.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55a17d80ea419501ff221a6627523f38a431bb33e6aa3de81ae3a7f271c49c75", size = 296337, upload-time = "2026-06-24T19:02:04.787Z" },
+    { url = "https://files.pythonhosted.org/packages/af/f2/305338a28225fb54b28d6c3f5948109b9088b329a2b6f77ca610c2bdcd34/protobuf_py_ext-0.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbb518b5638403ceaa08ac4fc7dac626f45ed9b856b3517de3906cf3de4d632", size = 308961, upload-time = "2026-06-24T19:02:06.185Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f9/416103c93677ff2ea407704ea64fa6de9e700dc030c48360a182d91ce373/protobuf_py_ext-0.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a4adc65ab6a5e4885c67fc808bcacb83d755d05b566d312a0e10c2a873f2ad4", size = 321895, upload-time = "2026-06-24T19:02:07.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/83/eb3e81bb2f83834b7deff4cee2d56eeb1adcbc847492a56b7f910ab257db/protobuf_py_ext-0.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e97f45c49676efacfb8e95bfcb1a002bc337e618a6780be1e55df2ba5ebd2f1e", size = 486091, upload-time = "2026-06-24T19:02:09.243Z" },
+    { url = "https://files.pythonhosted.org/packages/99/96/bd88fca38556b3105e4dd41d6a176e31dcc583fe979e830aeedd2f8c20ee/protobuf_py_ext-0.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:53a6b3590f6aa7f97b8ed60f62fef9b096babfeae82f7283fd3a4c405827d4f8", size = 534582, upload-time = "2026-06-24T19:02:11.227Z" },
+]
+
+[[package]]
 name = "psutil"
 version = "7.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2680,6 +2814,52 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyqwest"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/05/8576f0eeb44d3fe14c70e2bafa77ae6930c5e6f42b93c568719ea4456715/pyqwest-0.7.0.tar.gz", hash = "sha256:ac65f2243f3e814e7f4aad3f2fcfe78f89aad2de2a825eaaabf4c102f1937843", size = 457991, upload-time = "2026-07-19T05:20:06.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/49/7f26a2c2a3e8bbab4862bcbf4f54b706d9524fa9705cc0127553b81ed161/pyqwest-0.7.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7b2339f3b55ae179e0cb55bbd5792ae1c954d31f80de7b4dde0e95b03576b6be", size = 5159904, upload-time = "2026-07-19T05:18:57.757Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f1/4aba1976566936ca873e1a726a0d9bdf8195a0dc4e4f78122f6050328566/pyqwest-0.7.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:2159c7e2eaf2563cdadfda17314e2b1747c30603979bf73db8daef311247db82", size = 5044476, upload-time = "2026-07-19T05:18:59.473Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/06/45908e5cda7fa28ba60df5ed2091056893c394c3217a796bc6577c4bd294/pyqwest-0.7.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a826f1b492a7497f469c8467bd51faf582733654bb2bc9fcdd4fa502f3e6ca1", size = 5560021, upload-time = "2026-07-19T05:19:01.097Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/3d/603f5c9446e8c13a4970b816246d7928e895408a7ed1778d98de3e25ea43/pyqwest-0.7.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da43c7e86bee9e74ff474d4829cd398fb9220ff0d84d633094ea6797fdfe03a1", size = 5506130, upload-time = "2026-07-19T05:19:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/2984aa02f4d0296dddb5df159e1af6c6e0ddc0b507d592f13d6ccd0b3162/pyqwest-0.7.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d1c71327c323a19dc90a0dafb1d68fb13f4f775a2498a26bf95f17165e64da9f", size = 5719961, upload-time = "2026-07-19T05:19:04.213Z" },
+    { url = "https://files.pythonhosted.org/packages/19/06/e30c0d31eea17cabf99ef90c7c02e14cc94ca7d59793d397de9359148693/pyqwest-0.7.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c002e0fc31a96f1c47986299710f49ed4551e4a912a7cdb69aba6fd94db6d544", size = 5908279, upload-time = "2026-07-19T05:19:05.595Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/db/a1368faae1cbd094a0d179b76de69b8d1908bd45898d3bcd29ac98622072/pyqwest-0.7.0-cp310-abi3-win_amd64.whl", hash = "sha256:847e4468b5379a219b91a13dd3c92dd3b7b3d9f59af23e4c6776e663594cb241", size = 4755104, upload-time = "2026-07-19T05:19:07.772Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/38/c493e85ebd17d3a5c56eb53fbea36a1a6f396b999b38173ffde513576eb1/pyqwest-0.7.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:4988fa1c368072886dce48f52fcbabe9f25784c6e189a9a6f2b42f6e9f383973", size = 5172962, upload-time = "2026-07-19T05:19:09.229Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/68/1b340fdc7735b5682d308cabc2d65ea76c03a6cc2c30072a0c14c24f716c/pyqwest-0.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dfb61138c802c7317d840a274fa24f9d878301f693268e9186a9896452017a71", size = 5032604, upload-time = "2026-07-19T05:19:10.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/52/eecd858568ef6586cbdc3c419a9a0b1e8f891e2968f0f6b2a9fa9bdaac19/pyqwest-0.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6fdc0601590bdc547007828627082f0dc0e445e92d900dccb227e51898d7243", size = 5558302, upload-time = "2026-07-19T05:19:12.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/8f/b67d0056b18a9f99a1c9253cb983d5c4361e3e102d729df6623b71d6d939/pyqwest-0.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f82c971810695f5fd7962859a2469616c83b7aca6664d8f147287ee5ff430cd", size = 5501483, upload-time = "2026-07-19T05:19:13.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a6/69b87c4c80ced01645a143679458895dcb5c0e5ca0b3d4a43d979939cce6/pyqwest-0.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9dc2f405803b94525ab030c01cdac7093bcc1a5da6802de3345a868a0f51b3da", size = 5717334, upload-time = "2026-07-19T05:19:15.541Z" },
+    { url = "https://files.pythonhosted.org/packages/26/7b/5891b72b9193b692b50ecdc4e26e7e3687f9763f5f263646bc8f997f5b62/pyqwest-0.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:537f71f97a533fa355d02c15ed9f0cc05fb8915996cb921caa87fe7310b457ee", size = 5902447, upload-time = "2026-07-19T05:19:17.273Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/80/1b280618af3f9d36081449d153efc5620f0eea93ac169574fc69208d2b91/pyqwest-0.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:196aa73fb7eee4b6c052d6f4172a4321904a7208331f4322ccee3ee7d0adbc78", size = 4750469, upload-time = "2026-07-19T05:19:18.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/9c/64c8df83a152804ac3074fb879c1229c3aca55a12dc33dc73c72e93405e6/pyqwest-0.7.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:72d001892ed570df1dcc489ef8b0a03bc7abd4fbdca10625c358a87e66b226ad", size = 5171308, upload-time = "2026-07-19T05:19:20.332Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d1/46e629541a3f7231dd978fa9939e6ddcd075238880395bcfb16544769165/pyqwest-0.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:03da0797bac5c2eb1a40f02afccd4b5aad5ad0d375bb993df2f5e0c692fc0c6c", size = 5032449, upload-time = "2026-07-19T05:19:21.967Z" },
+    { url = "https://files.pythonhosted.org/packages/44/3c/132194c747696e41ad5745c51587bd20057d800b6a64fb901ce2ac990149/pyqwest-0.7.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:837e18aef4490eed25b4194d49f16732ccf1abf2cdd0845e75d75d2a4428b98c", size = 5556847, upload-time = "2026-07-19T05:19:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/5d/6726a70e89c60bf3cd30d5d918eff68dc1d1ceb9c911331d7fb57977bfc3/pyqwest-0.7.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:418e8c3a67ca6226bfb6147b8668203c74d9c872657117086f4c264a674d7980", size = 5500333, upload-time = "2026-07-19T05:19:25.317Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3f/329df64d3e8778bc311a22e432280cd317619c3f9b7e414f375127bb90b0/pyqwest-0.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:31176abbbcbe6d03740967b5c0241deaa60b328792644cb2e317a34d6b076433", size = 5717248, upload-time = "2026-07-19T05:19:26.963Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/93/6670afb97c6ce7b5ba27981e023d9edc7413e509bbe18afebb729834d9e6/pyqwest-0.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e21102f9c13234a0066d42bb5429dc5c311d7fd99401878837d9675a7f6e03b9", size = 5902814, upload-time = "2026-07-19T05:19:28.637Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d3/bf9440a03c97f408743313215d8c7e9875b0b2b0d2ef97f5fbb5066cd57d/pyqwest-0.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:ca19e96b5e902a6d35e18cee7f5e90612fca6ab169378d42242cdcb638578cee", size = 4750510, upload-time = "2026-07-19T05:19:30.587Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/25/8b0919bf504309982857e564e3035ffd799d7aaa23457eb351485573e5ee/pyqwest-0.7.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:4e4e79187c3e4ebd07d663d8dc7a7cba865c72020332e41807426a7e3526fda0", size = 5177972, upload-time = "2026-07-19T05:19:32.051Z" },
+    { url = "https://files.pythonhosted.org/packages/52/12/d652213fe336c52b75fb4df710f5cff08f8a1dcc9e385c9120f18476f5c9/pyqwest-0.7.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1bc2c569481ade1bc0b89b07daf1b49b20a1337a53207ffe0ef325260f509404", size = 5032608, upload-time = "2026-07-19T05:19:33.772Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b0/406c91563140b87ade5c5935410997b26449b8eb2f91511bc52741ae38fb/pyqwest-0.7.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ef1bfbdca9ec9c8a7b223268f5ef8d45694da7226929454b0cb40f2e3d1ddd5", size = 5558937, upload-time = "2026-07-19T05:19:35.174Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/17/a0a09936b5dd5d9d7517289aee3683bbf6554b0853bce5280ead9da27336/pyqwest-0.7.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4c2f6a6830becfa1c5bb94aa169ad854da5749a95a440aee759932d5965c213", size = 5500603, upload-time = "2026-07-19T05:19:37.023Z" },
+    { url = "https://files.pythonhosted.org/packages/00/34/ccec52ca9f14fbe11292fadbe89c771353e0f46d58aa88d8e93d6e018117/pyqwest-0.7.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0d11128ccc382f64fcdf92d3bce6be7191489c1b3a9a3f0dbdf89e55451638de", size = 5719784, upload-time = "2026-07-19T05:19:38.649Z" },
+    { url = "https://files.pythonhosted.org/packages/16/cc/58dca466c236e497cbb2e75b97a2489225d21f5063d932ab7d1723294112/pyqwest-0.7.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5832373c7bcccfbc3bb79c44b592e0871631139a2ef5aef771b8fe2b7bd4301d", size = 5901396, upload-time = "2026-07-19T05:19:40.402Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a0/983ea3b859828bef8372896e9c407f62bf426b84526d0b0cf9fd9abce411/pyqwest-0.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:7330070c4497e564007985716ac347cb9a7500eba5c9610500653a2ce4cfe86e", size = 4751036, upload-time = "2026-07-19T05:19:42.159Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1d/e2fe3dfe6d87989017412f394abc45435a3af2526e998c83cf836937b23c/pyqwest-0.7.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:02fd606a35be7803a770071f642a375e55df4c2025e49b10b859430f424c4492", size = 5165801, upload-time = "2026-07-19T05:19:43.82Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/fe/90126ac71fe09c729f36c166cb71b5148dd8a80e47f6f232bf71494604a2/pyqwest-0.7.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a807835c6a0777f0cc57c321c78c7bf162f6354698844d78db6e03ba9edd83dc", size = 5025128, upload-time = "2026-07-19T05:19:45.391Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/15/ee84ce834705d613c0b113fb4cf9d274011cfcc6c6ededb52d92a38a2367/pyqwest-0.7.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:86d84871cb0a572700dece3a6c45c294721f655f3d0b85477333209b487ecef1", size = 5551017, upload-time = "2026-07-19T05:19:47.046Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/18b4540fb276f9b540018efe024aca0801acfe4209417d4faed85bccdb04/pyqwest-0.7.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:005ddd2a777d30ca7ce4de12df1336760e14d46394ab56299a9e81626d78b991", size = 5493032, upload-time = "2026-07-19T05:19:49.038Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/91/f25477eb80c375378a876cf2bac80c55ec9ea36b94bd7d4b2b2931860c85/pyqwest-0.7.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ca02089249c292ab9c148fa86c06927701897090226a13e392a6ec53312380ea", size = 5712503, upload-time = "2026-07-19T05:19:50.542Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/63/c5be988c55c69c87de950e3dabab322f82a78dc7c2ebdf89af32626bd473/pyqwest-0.7.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:da3bc117c1380e9577994da15b8236f7c3bb400111d6be4b57a9b2e4f30c9a79", size = 5893782, upload-time = "2026-07-19T05:19:52.286Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a7/96144e6db9a49eb5e42734562ac5d387c2b78fe1142674d3a284ce188ef7/pyqwest-0.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a599ddac7ded32ed62d15ca90bc9c77652ba34b225cf17a404821cec92a189fa", size = 4744187, upload-time = "2026-07-19T05:19:53.921Z" },
 ]
 
 [[package]]
@@ -3378,6 +3558,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/40/bf510c8758727df020f83b717ebc1fcc1739ed7f6ae1796ebef60bf6f592/wandb-0.27.0-py3-none-win32.whl", hash = "sha256:0bd5659417e386bf6538b5e2ffe6885774c6197f0e4853bfed517d5b0db457f1", size = 25036164, upload-time = "2026-05-14T03:43:54.839Z" },
     { url = "https://files.pythonhosted.org/packages/54/ff/69f88e7d90c22b79bcb911143c13e59742ee192080b21015ff83a5a1f60a/wandb-0.27.0-py3-none-win_amd64.whl", hash = "sha256:89d584b73166eecee96fb446f18d0e45b1aa45aba6a3696296f3f06d7454516b", size = 25036170, upload-time = "2026-05-14T03:43:59.227Z" },
     { url = "https://files.pythonhosted.org/packages/f6/38/f7efd7a87297a55c7e9a331a1dbb5b19e54aeacc11fe6f43f8636a73987c/wandb-0.27.0-py3-none-win_arm64.whl", hash = "sha256:a6c129c311edf210a2b4f2f4acc557eff522628125f5f28ed27df19c16c07079", size = 22972710, upload-time = "2026-05-14T03:44:03.275Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/15/dc61746d8c0852f6d711ad09c774b63cf7c8211aa49e30871ac3d342b7e2/wcmatch-10.2.1.tar.gz", hash = "sha256:ecac70a5c70e62ba854b78318d3a1408e8651f8f1c96e5837743b71aa6a4fb92", size = 132497, upload-time = "2026-07-02T17:21:48.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/ba/20b48eedeab5316bf9a502bb9eb7e3b1588bd61d0f565822fefa8f06e10b/wcmatch-10.2.1-py3-none-any.whl", hash = "sha256:2d775395b93f233af66690f62cb9d52b084ec159a31cc4084f4069d72f437acd", size = 39763, upload-time = "2026-07-02T17:21:47.134Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds an **e2b** sandbox provider under `nemo_gym/sandbox/providers/e2b/`, backed by the official [E2B Python SDK](https://e2b.dev/docs). It works against e2b.dev and against any **e2b-compatible gateway** — point `connection.api_url` / `connection.sandbox_url` at it and the same provider drives it.

- `provider.py` — `E2BProvider` implementing the full `SandboxProvider` protocol: `create`, `connect`, `exec`, `upload_file`/`download_file` (plus `write_file`/`read_file`), `status`, `close`, `aclose`.
- `build.py` — template provisioning from OCI images, deliberately **outside** the sandbox public API (see below).
- `configs/e2b.yaml` — shipped config binding the usual `sandbox` name, so swapping providers is swapping one `--config` path.
- Registered as a built-in provider (`e2b`) alongside `docker`/`daytona`/`opensandbox`/`apptainer`/`ecs_fargate`.
- `e2b>=2.25.0` added to the `sandbox` extra.
- 32 unit tests against a faked SDK (no network).

## Two places E2B does not map onto `SandboxSpec`

Both are handled explicitly rather than silently, since either would corrupt a benchmark run if fudged.

**1. Templates, not images.** E2B starts sandboxes from a pre-built *template alias* and rejects anything outside `[A-Za-z0-9_-]`, so a registry reference like `ghcr.io/acme/task:1.0` is not a valid start target. Resolution order:

1. `SandboxSpec.provider_options.template`
2. `create.template_map`, keyed by `SandboxSpec.image`
3. `SandboxSpec.image` itself, when already a valid alias
4. `create.template` fallback

An image that resolves to nothing raises an actionable error pointing at `build.py`, rather than quietly starting the wrong template.

E2B genuinely cannot start from an OCI reference — `POST /sandboxes` takes only a `templateID`, an image ref is rejected (*"snapshot alias only supports ASCII letters, digits, hyphens, and underscores"*), and body fields naming an image are silently ignored. Building a template is the only path, which is what `build.py` does.

**2. Resources are fixed when the template is built.** `cpu_count`/`memory_mb` are arguments to the template *build*, so a per-sandbox `SandboxSpec.resources` request cannot be applied at create time. The provider reports it once per template, or raises under `create.strict_resources: true` — it is never dropped silently.

## `build.py` — provisioning, kept out of the runtime API

Building a template is slow, one-off and shared across runs; starting a sandbox is none of those. Folding a build into `create()` would let the sandbox API block on an image pull, so it lives in its own module instead:

```
derive_alias()     deterministic, charset-safe  <stem>__<12-hex>
template_exists()  best-effort existence probe
build_template()   build one image, skipping an existing alias
build_templates()  bounded-concurrency batch -> image->alias mapping
__main__           CLI emitting that mapping as YAML/JSON
```

```bash
python -m nemo_gym.sandbox.providers.e2b.build \
    --image ghcr.io/acme/task:1.0 --cpu-count 8 --memory-mb 16384 \
    --output template_map.yaml     # paste straight into create.template_map
```

The separation is enforced by tests: `provider.py` never references `build.py`, `build.py` never imports the provider, and the package `__init__` exports no build symbols.

The alias digest covers the **build resources as well as the image**, because E2B bakes cpu/memory into the template — two sandboxes wanting different sizes must not collide onto one alias, or the second silently inherits the first's sizing.

## Other behaviour worth reviewing

- **`exec.default_timeout_s` is 1800s, not the SDK's 60s.** A 60s default silently truncates builds and verifier suites, turning a slow task into a scored failure rather than a visible error.
- A **non-zero exit is a result, not an exception** (`CommandExitException` → `SandboxExecResult` with the real exit code), matching the other providers.
- **Timeouts surface as `TimeoutError`** so callers can treat a wedged command as a command timeout rather than an infra failure.
- Retries cover transient transport/5xx failures only; deterministic errors (not-found, auth, invalid-argument, timeout) are never retried.

## Testing

- **56 unit tests, no network** (faked SDK): 32 provider — template resolution (all precedence paths plus both error cases), resource warn/raise, spec→SDK kwarg mapping, lifecycle, exec mapping/non-zero-exit/timeout, file round-trip, retry vs no-retry, connection-param scoping and exec request-timeout derivation; 24 build — alias determinism and resource-sensitivity, skip-existing/rebuild, credential and API-param forwarding, failure/timeout wrapping, bounded concurrency, continue-on-error, and the CLI's YAML/JSON output.
- Full sandbox suite green (skips pre-existing).

The runtime path (create → exec → file round-trip → kill) has been exercised against a live e2b-compatible gateway during development. Full end-to-end benchmark validation is pending a deployment with a working template backend, and will be added here.



### End-to-end: Terminal-Bench 2.1, 89/89

Validated against a real e2b-compatible gateway with the **Harbor `oracle` agent** (gold patch, no model in the loop), 89 tasks at concurrency 89. The 89 task images were built into templates by `build.py` at `cpu_count=8`/`memory_mb=16384` to match the existing opensandbox baseline, so the two are directly comparable.

| Provider | Tasks passed | Notes |
|---|---|---|
| opensandbox (baseline) | 89 / 89 | existing reference run |
| **e2b (this PR)** | **89 / 89** | all rewards 1.0; 0 agent-timeout / context / memory errors |

The run also caught two provider bugs that the unit tests had missed because the SDK fakes accepted `**kwargs` everywhere. Both are fixed here, and the fakes now mirror the real SDK signatures so neither can regress:

1. **Connection params were passed to sandbox-scoped calls.** Only `create`/`connect`/`kill` open a connection and accept `ApiParams`; `commands.run`, `files.*` and `is_running` take `request_timeout` only. The sandbox was created fine and then every first `exec` raised `TypeError: Commands.run() got an unexpected keyword argument 'api_key'`, aborting all 89 trials in environment setup.

2. **The connection timeout bounded long commands.** The SDK applies `request_timeout` to the whole streaming RPC carrying a command's output, not just to starting it, so a value below the command timeout tears the stream down mid-command (`RemoteProtocolError: peer closed connection without sending complete message body`). `connection.request_timeout_s` is sized for short control-plane calls; `exec` now derives its request timeout from the *command* timeout plus head-room, so the sandbox-side timeout fires first and the caller gets a clean `TimeoutError`. A task whose gold patch compiles for ~23 minutes was failing against a 300s connection timeout.
