### PR TITLE
feat(mini_swe_agent, mini_swe_agent_2): allow per-request policy endpoint override in /run

### DIFF
--- a/responses_api_agents/mini_swe_agent/app.py
+++ b/responses_api_agents/mini_swe_agent/app.py
@@ -64,6 +64,12 @@ class MiniSWEAgentConfig(BaseResponsesAPIAgentConfig):
 
 class MiniSWEAgentRunRequest(BaseRunRequest):
     model_config = ConfigDict(extra="allow")
+    # Optional per-request policy endpoint override. External trainers that
+    # route each episode through its own OpenAI-compatible URL (e.g. RL
+    # trainers recording rollouts via a per-episode proxy) set these per /run;
+    # when unset, the configured model_server is used, as before.
+    policy_base_url: Optional[str] = None
+    policy_api_key: Optional[str] = None
 
 
 class MiniSWEAgentVerifyRequest(BaseVerifyRequest):
@@ -119,8 +125,8 @@ class MiniSWEAgent(SimpleResponsesAPIAgent):
             workers = 1
             cache_dir_template = self.config.cache_dir_template
             run_golden = self.config.run_golden
-            base_url = f"http://{model_server_config['host']}:{model_server_config['port']}/v1"
-            dummy_key = "dummy_key"
+            base_url = body.policy_base_url or f"http://{model_server_config['host']}:{model_server_config['port']}/v1"
+            api_key = body.policy_api_key or "dummy_key"
             model_name = f"hosted_vllm/{policy_model_name}"
             step_timeout = self.config.step_timeout
             eval_timeout = self.config.eval_timeout
@@ -174,7 +180,7 @@ class MiniSWEAgent(SimpleResponsesAPIAgent):
                     workers=workers,
                     output=output_file_dir,
                     model=model_name,
-                    api_key=dummy_key,
+                    api_key=api_key,
                     base_url=base_url,
                     cache_dir_template=cache_dir_template,
                     env=env,

--- a/responses_api_agents/mini_swe_agent_2/app.py
+++ b/responses_api_agents/mini_swe_agent_2/app.py
@@ -78,6 +78,12 @@ class MiniSWEAgentConfig(BaseResponsesAPIAgentConfig):
 
 class MiniSWEAgentRunRequest(BaseRunRequest):
     model_config = ConfigDict(extra="allow")
+    # Optional per-request policy endpoint override. External trainers that
+    # route each episode through its own OpenAI-compatible URL (e.g. RL
+    # trainers recording rollouts via a per-episode proxy) set these per /run;
+    # when unset, the configured model_server is used, as before.
+    policy_base_url: Optional[str] = None
+    policy_api_key: Optional[str] = None
 
 
 class MiniSWEAgentVerifyRequest(BaseVerifyRequest):
@@ -714,9 +720,15 @@ class MiniSWEAgent(SimpleResponsesAPIAgent):
             split = body.split
             workers = 1
             run_golden = self.config.run_golden
-            base_url = f"http://{model_server_config['host']}:{model_server_config['port']}"
-            base_url = f"{self.base_url_for_run(base_url, body)}/v1"
-            dummy_key = "dummy_key"
+            if body.policy_base_url:
+                # The caller owns routing (and any per-rollout correlation) for
+                # its own endpoint; the ng-rollout capture prefix only applies
+                # to the built-in model server.
+                base_url = body.policy_base_url
+            else:
+                base_url = f"http://{model_server_config['host']}:{model_server_config['port']}"
+                base_url = f"{self.base_url_for_run(base_url, body)}/v1"
+            api_key = body.policy_api_key or "dummy_key"
             model_name = f"hosted_vllm/{policy_model_name}"
             step_timeout = self.config.step_timeout
             eval_timeout = self.config.eval_timeout
@@ -787,7 +799,7 @@ class MiniSWEAgent(SimpleResponsesAPIAgent):
                     workers=workers,
                     output=output_file_dir,
                     model=model_name,
-                    api_key=dummy_key,
+                    api_key=api_key,
                     base_url=base_url,
                     env="sandbox",
                     run_golden=run_golden,


### PR DESCRIPTION
## What does this PR do?

Adds optional `policy_base_url` / `policy_api_key` fields to the `/run` request of both mini-SWE agents (`mini_swe_agent` and the sandbox-backed `mini_swe_agent_2`), letting a caller point that one episode at its own OpenAI-compatible policy endpoint. When the fields are absent, the configured `model_server` is used — **default behavior is unchanged**.

On `mini_swe_agent_2`, the `ng-rollout` capture prefix is applied only on the built-in model-server path: a caller supplying its own endpoint owns routing (and any per-rollout correlation) for it.

## Motivation

We are integrating NeMo Gym as an environment ecosystem for RL training in [miles](https://github.com/radixark/miles) (an open-source RL training framework), driving the mini-SWE agents with one `POST /run` per training episode.

For lossless on-policy training (token-in/token-out), the trainer routes every policy call of an episode through a per-episode recording proxy: each episode gets its **own** OpenAI-compatible URL (e.g. `http://trainer:30000/sessions/<session_id>/v1`), and the proxy captures token ids / logprobs / loss masks for exactly that episode. This pattern isn't specific to our trainer — any external RL framework that records or routes rollouts per episode needs a per-request policy endpoint.

Today `run()` builds the endpoint from the statically configured model server, fixed for the lifetime of the server process, so this integration currently requires carrying a fork of `app.py`. Everything downstream is already per-request capable — the swegym/sandbox runners accept `base_url` / `api_key` per invocation and inject them into `model_kwargs` — so this PR only wires the request fields through.

The field names mirror the existing global-config keys (`policy_base_url`, `policy_api_key`). If this pattern proves useful beyond the mini-SWE agents, the fields could later be promoted to `BaseRunRequest`; a complementary general mechanism (per-rollout outbound routing at the model-server layer, building on the existing `ng-rollout` correlation prefix) could serve agents that call the policy through `server_client` — happy to open a separate issue to discuss that.

## Testing

- `ruff check` / `ruff format --check` pass on the touched files.
- No behavior change when the new fields are unset (they default to `None`; the existing paths are taken).
- Happy to add unit tests for the override path if you can point me at the preferred test location for responses-API agents.