### PR TITLE
ci: bump claude review workflow to FW-CI-templates v1.8.4

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -109,7 +109,7 @@ jobs:
 
   manual-review:
     if: github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v1.8.4
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@209ac7913b0419a5ccbac47b02d00fbea4939243 # v1.8.4
     with:
       model: ${{ vars.CLAUDE_MODEL }}
       prompt: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -109,7 +109,7 @@ jobs:
 
   manual-review:
     if: github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v1.7.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v1.8.4
     with:
       model: ${{ vars.CLAUDE_MODEL }}
       prompt: |


### PR DESCRIPTION
## Summary

- Bumps `/claude review` workflow from FW-CI-templates `v1.7.0` → `v1.8.4`
- `v1.7.0` had a bug where Claude generated the review but never posted it to the PR (see #2158 — workflow reported success, no comment appeared)
- Fixed upstream in FW-CI-templates by [fix: allow Claude review top-level PR comments (#523)](https://github.com/NVIDIA-NeMo/FW-CI-templates/pull/523) and [fix: Claude review comment identity and publish contract (#525)](https://github.com/NVIDIA-NeMo/FW-CI-templates/pull/525)


🤖 Generated with [Claude Code](https://claude.com/claude-code)