### PR TITLE
PinchBench: configurable OpenClaw LLM idle timeout

### DIFF
--- a/responses_api_agents/pinchbench/README.md
+++ b/responses_api_agents/pinchbench/README.md
@@ -124,3 +124,41 @@ make single-run scores noisy; trust aggregates / `num_repeats`.)
 - Integration code: Apache 2.0.
 - PinchBench skill (cloned at build, not vendored): MIT — see `LICENSE` and the repo `ATTRIBUTIONS.md`.
   `setup_scripts/nvidia-pinchbench.patch` is the NVIDIA integration delta applied over upstream `v2.0.0`.
+
+## Increasing the LLM idle timeout (past 120s)
+
+OpenClaw aborts a model request if the endpoint produces no tokens within its
+**stream-idle watchdog** window — **120s by default** (`DEFAULT_LLM_IDLE_TIMEOUT_MS`).
+Under high concurrency, or with slow / self-hosted endpoints, a legitimate-but-slow
+generation can trip this and fail the task with `[llm-idle-timeout]`.
+
+Raise it with the `openclaw_provider_timeout_seconds` agent-config field (seconds). It maps
+to OpenClaw's `models.providers.<id>.timeoutSeconds`, which governs the connect / headers /
+body request timeout **and** the stream-idle watchdog (OpenClaw's own error message points
+here). Unlike `agents.defaults.timeoutSeconds`, an explicit provider timeout is **not**
+clamped back down to 120s.
+
+```yaml
+my_pinchbench_agent:
+  responses_api_agents:
+    pinchbench:
+      # ... model / sandbox / judge config ...
+      openclaw_provider_timeout_seconds: 600   # raise the 120s LLM idle watchdog to 600s
+```
+
+Then run as usual:
+
+```bash
+ng_run "+config_paths=[<your_pinchbench_config>.yaml]"
+ng_collect_rollouts +agent_name=my_pinchbench_agent \
+  +input_jsonl_fpath=<data>.jsonl +output_jsonl_fpath=results/rollouts.jsonl +num_repeats=1
+```
+
+Notes:
+- **No image rebuild required.** In the default (instance) sandbox mode the agent injects
+  `timeoutSeconds` into the in-container OpenClaw provider config before the run; in
+  `direct_exec` mode it is written into the generated `openclaw.json`.
+- Nothing else clamps this: PinchBench does not set OpenClaw's `agents.defaults.timeoutSeconds`
+  (the ceiling that *would* cap the watchdog). `task_timeout_s` (the per-task sandbox exec
+  bound, default `1800`) is a separate outer limit — only raise it if you set a provider
+  timeout above 1800s.

--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -112,6 +112,11 @@ class PinchBenchAgentConfig(BaseResponsesAPIAgentConfig):
     max_concurrent: int = 4
     max_tokens: int = 16384
     context_window: int = 131072
+    # Raise the OpenClaw provider model HTTP request timeout — which includes the LLM
+    # stream-idle watchdog (default 120s) — to this many seconds. Maps to
+    # `models.providers.<id>.timeoutSeconds` in OpenClaw. None keeps the 120s default.
+    # See README § "Increasing the LLM idle timeout".
+    openclaw_provider_timeout_seconds: Optional[int] = None
     work_root: str = "/tmp/pinchbench_gym"
     # Where per-task transcripts are archived (kept on disk for inspection, like
     # swe_agents' persistent_dir). `raw_rollout` keeps a pointer to this archive.
@@ -188,6 +193,8 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         # it never hits the shared-workspace WorkspaceVanishedError cliff). The client
         # in-container picks up the token from this env var.
         env["OPENCLAW_GATEWAY_TOKEN"] = self.config.gateway_token
+        if self.config.openclaw_provider_timeout_seconds:
+            env["PINCHBENCH_PROVIDER_TIMEOUT_SECONDS"] = str(self.config.openclaw_provider_timeout_seconds)
         if self.config.brave_api_key:
             env["BRAVE_API_KEY"] = self.config.brave_api_key
         if self.config.tavily_api_key:
@@ -222,7 +229,20 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         sb = AsyncSandbox(self.config.sandbox_provider)
         try:
             await sb.start(self._build_spec(task_id))
-            await sb.exec("bash /opt/run_task.sh", timeout_s=self.config.task_timeout_s)
+            run_cmd = "bash /opt/run_task.sh"
+            prov_timeout_s = self.config.openclaw_provider_timeout_seconds
+            if prov_timeout_s:
+                # Raise the OpenClaw provider request timeout (incl. the LLM stream-idle
+                # watchdog, default 120s) WITHOUT rebuilding the image: inject
+                # models.providers.custom.timeoutSeconds into the in-container lib_agent.py
+                # before run_task.sh copies + uses it.
+                inject = (
+                    'sed -i \'s#"api": "openai-completions",#'
+                    '"api": "openai-completions", "timeoutSeconds": %d,#\' '
+                    '/opt/pinchbench-skill/scripts/lib_agent.py'
+                ) % prov_timeout_s
+                run_cmd = inject + " && " + run_cmd
+            await sb.exec(run_cmd, timeout_s=self.config.task_timeout_s)
             await sb.download(archive, out_dir / "out.tgz")
         finally:
             await sb.stop()
@@ -291,6 +311,9 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
                     }
                 ],
             }
+            provider_timeout = int(os.environ.get("PINCHBENCH_PROVIDER_TIMEOUT_SECONDS", "0"))
+            if provider_timeout > 0:
+                custom_provider["timeoutSeconds"] = provider_timeout
             models = cfg.setdefault("models", {})
             models["mode"] = "merge"
             models.setdefault("providers", {})["custom"] = custom_provider


### PR DESCRIPTION
## What
Adds `openclaw_provider_timeout_seconds` to the PinchBench agent config to raise OpenClaw's LLM **stream-idle** timeout above its 120s default.

## Why
OpenClaw aborts a model request if the endpoint is idle for its stream-idle watchdog window — `DEFAULT_LLM_IDLE_TIMEOUT_MS = 120s`. Under high concurrency, or with slow / self-hosted endpoints, a legitimate-but-slow generation trips this and the task fails with `[llm-idle-timeout]`. OpenClaw's own error message tells you to raise `models.providers.<id>.timeoutSeconds` — which this config maps to. Unlike `agents.defaults.timeoutSeconds`, an explicit provider timeout is **not** clamped back to 120s.

## How
```yaml
responses_api_agents:
  pinchbench:
    openclaw_provider_timeout_seconds: 600   # raise the 120s idle watchdog to 600s
```
- **No image rebuild required:** instance mode injects `timeoutSeconds` into the in-container OpenClaw provider config before `run_task.sh`; `direct_exec` writes it into the generated `openclaw.json`.
- Nothing else clamps this: PinchBench does not set OpenClaw's `agents.defaults.timeoutSeconds` (the ceiling that *would* cap the watchdog). `task_timeout_s` (per-task sandbox exec bound, default `1800`) is a separate outer limit — only raise it if you set a provider timeout above 1800s.

## Validation
Verified end-to-end through the gym docker-sandbox path against a mock endpoint that idles 140s before responding:
- **default (120s):** watchdog fired at ~120s → OpenClaw aborted + retried (a fresh request arrived at +121s), original connection dropped.
- **`openclaw_provider_timeout_seconds: 600`:** OpenClaw held the request the full 140s and received the response — no idle-timeout, no retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)