### PR TITLE
fix: tolerate null metadata values and messages

### DIFF
--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -263,7 +263,10 @@ class ResponsesConverter(BaseModel):
         match m["role"]:
             case "assistant":
                 final_content = ""
-                if isinstance(m["content"], list):
+                if m["content"] is None:
+                    # Tool-call only turns have "None" according to the official API spec.
+                    pass
+                elif isinstance(m["content"], list):
                     content_str = "".join([part.get("text", "") for part in m["content"]])
                     final_content += content_str
                 elif isinstance(m["content"], str):

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -304,7 +304,7 @@ class VLLMModel(SimpleResponsesAPIModel):
         metadata = body_dict.get("metadata") or {}
 
         # Merge global config chat_template_kwargs with per-request overrides in metadata (e.g. per-sample reasoning on/off)
-        metadata_chat_template_kwargs_str = metadata.get("chat_template_kwargs", "{}")
+        metadata_chat_template_kwargs_str = metadata.get("chat_template_kwargs") or "{}"
         chat_template_kwargs.update(json.loads(metadata_chat_template_kwargs_str))
 
         if chat_template_kwargs:
@@ -315,7 +315,7 @@ class VLLMModel(SimpleResponsesAPIModel):
         if self.config.extra_body:
             extra_body = deepcopy(self.config.extra_body)
 
-        metadata_extra_body_str = metadata.get("extra_body", "{}")
+        metadata_extra_body_str = metadata.get("extra_body") or "{}"
         extra_body.update(json.loads(metadata_extra_body_str))
 
         if self.config.return_token_id_information:
@@ -748,7 +748,7 @@ class VLLMModel(SimpleResponsesAPIModel):
         if self.config.chat_template_kwargs:
             chat_template_kwargs.update(deepcopy(self.config.chat_template_kwargs))
         metadata = body_dict.get("metadata") or {}
-        metadata_kwargs_str = metadata.get("chat_template_kwargs", "{}")
+        metadata_kwargs_str = metadata.get("chat_template_kwargs") or "{}"
         chat_template_kwargs.update(json.loads(metadata_kwargs_str))
 
         return self._chat_template_tokenizer.apply_chat_template(


### PR DESCRIPTION
Follow-up to #2139 and #1180 