### PR TITLE
docs: add AGENTS.md with Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+General architecture, commands, and code style live in `CLAUDE.md` at the repo root — read it first. This file only adds cloud/environment-specific caveats.
+
+## Cursor Cloud specific instructions
+
+### Environment
+- Python 3.12 + `uv` are preinstalled. `uv` lives at `~/.local/bin/uv` and is already on the login-shell `PATH`. The startup update script runs `uv sync --extra dev`, so the root venv at `.venv/` is ready.
+- Activate the environment before running anything: `source .venv/bin/activate`.
+- This VM is **CPU-only (no GPU / no `nvidia-smi`)**. Do not use GPU model paths (`local_vllm_model`, `genrm_model`, or vLLM-backed servers) — they need a GPU. The core library, resources servers, agents, and the `vllm_model` proxy are all CPU-only.
+
+### Running / testing (see `CLAUDE.md` for the full command list)
+- Set `RAY_TMPDIR=/tmp` when running anything that starts Ray (`gym dev test`, `gym eval run`). Ray's AF_UNIX socket path can otherwise exceed the 107-byte limit.
+- `gym env test --resources-server <name>` builds an **isolated per-server venv** on first run (slow, one-time). `os.environ` changes do not propagate into these venvs — set env vars (e.g. `RAY_TMPDIR`) in the outer shell.
+- `gym dev test` enforces a 96% coverage gate. With only `--extra dev` installed (no `--extra sandbox`), the sandbox provider modules are uncovered and the gate reports failure even though the tests themselves pass — this is expected, not a regression.
+- Known non-blocking failure: `tests/unit_tests/test_cli_utils.py::TestPrintRichTable::test_not_truncated_regardless_of_ambient_width` depends on `rich` console-width detection in a non-TTY and fails in this environment; unrelated to setup.
+
+### Running a full rollout without an external LLM API key (no-GPU e2e)
+There is no built-in mock model server. To exercise the full `gym env start` + `gym eval run` pipeline offline, point the `vllm_model` proxy at a local OpenAI-compatible Chat Completions mock:
+- Create `env.yaml` (gitignored) at the repo root:
+  ```yaml
+  policy_base_url: http://127.0.0.1:9000/v1
+  policy_api_key: dummy_key
+  policy_model_name: mock-model
+  ```
+- Run any OpenAI-compatible server on that URL that implements `POST /v1/chat/completions` (the `vllm_model` proxy, with default `is_responses_native: false`, converts Responses → Chat Completions and calls `{base_url}/chat/completions`; `/tokenize` is only hit when `return_token_id_information: true`).
+- Then: `gym env start --resources-server mcqa --model-type vllm_model`, and in another shell `gym eval run --no-serve --agent mcqa_simple_agent --input resources_servers/mcqa/data/example.jsonl --output results/mcqa_rollouts.jsonl --limit 5`.
+- With a real hosted model instead, use `--model-type openai_model` and put the provider `policy_base_url` / `policy_api_key` in `env.yaml`.
+
+### Git
+- Commits require DCO sign-off (`git commit -s`). Commit signing (`-S`) is configured per-developer; the cloud VM may not have a signing key, so `-s` alone is sufficient here.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and validates the NeMo Gym development environment for Cursor Cloud agents, and records durable, non-obvious caveats in a new root `AGENTS.md`.

No product code is changed — this PR only adds `AGENTS.md`. Dependency installation is handled by the cloud startup update script (`uv sync --extra dev`), not committed to the repo.

## What was verified

The environment was set up with `uv` (Python 3.12) and `uv sync --extra dev`, and the following were run successfully:

| Check | Command | Result |
|-------|---------|--------|
| Lint | `ruff check .` / `ruff format --check .` | All checks passed; 1174 files already formatted |
| Core tests | `gym dev test` | 1437 passed, 31 skipped, 1 known non-blocking failure |
| Server test | `gym env test --resources-server example_single_tool_call` | 1 passed |
| Build + run (e2e) | `gym env start --resources-server mcqa --model-type vllm_model` + `gym eval run` | 3 healthy servers; rollout `mean/reward: 1.0`, `pass@1/accuracy: 100.0` |

The end-to-end "hello world" ran a full 5-task `mcqa` rollout (seed → agent loop → model → verify → reward aggregation) against a local OpenAI-compatible mock, so it needs **no external API key and no GPU**.

### Known non-blocking issues (pre-existing, unrelated to setup)
- `tests/unit_tests/test_cli_utils.py::TestPrintRichTable::test_not_truncated_regardless_of_ambient_width` fails due to `rich` console-width detection in a non-TTY.
- `gym dev test` reports the 96% coverage gate as unmet because sandbox provider modules are uncovered without the `sandbox` extra (the tests themselves pass).

## AGENTS.md contents
- Environment: `uv` location, activating `.venv`, CPU-only (no GPU) caveat.
- `RAY_TMPDIR=/tmp` requirement for Ray-backed commands.
- Per-server isolated venvs for `gym env test`; env vars must be set in the outer shell.
- How to run a full rollout offline via a local OpenAI-compatible mock behind `vllm_model`.
- DCO sign-off note.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dea865f0-8b8b-4d41-ba1f-3dac02f69e54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dea865f0-8b8b-4d41-ba1f-3dac02f69e54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

