### PR TITLE
test(vllm): cover upstream token metadata fast path

### DIFF
--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -3784,6 +3784,55 @@ class TestTopLogprobsHandling:
         assert message["generation_log_probs"] == [-0.1, -0.2]
         assert message["prompt_token_ids"] == [10, 20, 30]
 
+    def test_capture_path_preserves_upstream_token_metadata_without_tokenizing(
+        self,
+    ) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+
+        async def mock_create_chat_completion(**kwargs):
+            return self._capture_chat_completion_dict(
+                logprobs={
+                    "content": [
+                        {
+                            "token": "token_id:123",
+                            "logprob": -0.1,
+                            "bytes": None,
+                            "top_logprobs": [],
+                        },
+                        {
+                            "token": "token_id:456",
+                            "logprob": -0.2,
+                            "bytes": None,
+                            "top_logprobs": [],
+                        },
+                    ]
+                },
+                message_extra={
+                    "prompt_token_ids": [10, 20, 30],
+                    "generation_token_ids": [123, 456],
+                    "generation_log_probs": [-0.1, -0.2],
+                },
+            )
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock()
+        model._clients = [mock_client]
+
+        client = TestClient(app)
+        response = client.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 200
+        message = response.json()["choices"][0]["message"]
+        assert message["prompt_token_ids"] == [10, 20, 30]
+        assert message["generation_token_ids"] == [123, 456]
+        assert message["generation_log_probs"] == [-0.1, -0.2]
+        mock_client.create_tokenize.assert_not_awaited()
+
     def test_capture_path_preserves_routed_experts(self) -> None:
         model = _make_top_logprobs_model(return_token_id_information=True)
         app = model.setup_webserver()


### PR DESCRIPTION
## Summary

- add regression coverage for producer-supplied prompt token IDs, generation token IDs, and generation log probabilities
- verify the vLLM model proxy preserves those fields through response validation
- verify the existing compatibility `/tokenize` fallback is not awaited when native metadata is present

## Why

NeMo-RL can return the exact token metadata already held by its vLLM engine. Gym already supports that response contract and skips its compatibility tokenization request, but the native fast path was not covered directly.

This is intentionally test-only; the existing fallback remains unchanged.

## Testing

- `uv run pytest tests/test_app.py -k preserves_upstream_token_metadata_without_tokenizing -q` (1 passed)
- `ruff check tests/test_app.py`
- `ruff format --check tests/test_app.py`

Producer implementation: https://github.com/NVIDIA-NeMo/RL/pull/3390
