### PR TITLE
[VLLMModel] Make the reasoning field configurable

### DIFF
--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -18,7 +18,7 @@ import json
 import os
 from copy import deepcopy
 from time import time
-from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
 
 from aiohttp.client_exceptions import ClientResponseError
 from fastapi import Request
@@ -46,6 +46,17 @@ from nemo_gym.responses_converter import (
 from nemo_gym.server_utils import SESSION_ID_KEY, is_nemo_gym_fastapi_entrypoint
 
 
+ReasoningField = Literal["both", "reasoning", "reasoning_content"]
+
+
+def _set_reasoning(message_dict: dict[str, Any], reasoning: str, field: ReasoningField) -> None:
+    """Attach reasoning to an outgoing assistant message under the configured key(s)."""
+    if field in ("both", "reasoning_content"):
+        message_dict["reasoning_content"] = reasoning
+    if field in ("both", "reasoning"):
+        message_dict["reasoning"] = reasoning
+
+
 class VLLMModelConfig(BaseResponsesAPIModelConfig):
     base_url: Union[str, List[str]]
     api_key: str
@@ -55,6 +66,14 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
     uses_reasoning_parser: bool
     uses_interleaved_reasoning: bool = True
     replace_developer_role_with_system: bool = False
+
+    # Which key(s) carry reasoning back to the server on an assistant message.
+    # "both" (the default) is the historically safe choice: vLLM < 0.16.0 reads
+    # `reasoning_content`, >= 0.16.0 reads `reasoning`, and each ignores the key it
+    # does not know. Some servers instead treat the two as aliases of one field and
+    # reject the pair -- Kimi-K3's Rust frontend answers
+    # `400 duplicate field 'reasoning'` -- so those need exactly one.
+    reasoning_field: ReasoningField = "both"
 
     # Whether or not the model can generate a reasoning output, and called again to produce additional reasoning output.
     sequential_reasoning_allowed: bool = True
@@ -345,11 +364,9 @@ class VLLMModel(SimpleResponsesAPIModel):
                     reasoning_matches, remaining_content = self._converter._extract_reasoning_from_content(content)
                     message_dict["content"] = remaining_content
                     if reasoning_matches and self.config.uses_interleaved_reasoning:
-                        message_dict["reasoning_content"] = reasoning_matches[0]
-
-                        # TODO when NeMo RL migrates to vLLM>=0.16.0, remove the reasoning_content support above.
-                        # Starting with vLLM 0.16.0, the `reasoning_content` field has been deprecated in favor of just `reasoning`
-                        message_dict["reasoning"] = reasoning_matches[0]
+                        # TODO when NeMo RL migrates to vLLM>=0.16.0, drop reasoning_content.
+                        # Starting with vLLM 0.16.0, `reasoning_content` is deprecated in favor of `reasoning`.
+                        _set_reasoning(message_dict, reasoning_matches[0], self.config.reasoning_field)
                 elif isinstance(content, list):
                     reasoning_content = None
                     for content_item_dict in content:
@@ -363,9 +380,8 @@ class VLLMModel(SimpleResponsesAPIModel):
                         # Even though we set the reasoning content already here, we still loop through all the content item dicts for the assert above.
                         content_item_dict["text"] = remaining_content
                         if reasoning_matches and self.config.uses_interleaved_reasoning:
-                            message_dict["reasoning_content"] = reasoning_matches[0]
                             # See the TODO wrt reasoning_content above
-                            message_dict["reasoning"] = reasoning_matches[0]
+                            _set_reasoning(message_dict, reasoning_matches[0], self.config.reasoning_field)
                 elif not content:
                     # No content or content None is a no-op
                     pass

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -17,6 +17,7 @@ from typing import Any, Union
 from unittest.mock import AsyncMock, MagicMock
 
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 from pytest import MonkeyPatch, mark, raises
 
 import nemo_gym.server_utils
@@ -2494,6 +2495,62 @@ class TestApp:
         ]
         actual_messages = mock_method.call_args.kwargs["messages"]
         assert expected_messages == actual_messages
+
+    @mark.parametrize(
+        "reasoning_field,expected_keys",
+        [
+            ("both", {"reasoning_content", "reasoning"}),
+            ("reasoning_content", {"reasoning_content"}),
+            ("reasoning", {"reasoning"}),
+        ],
+    )
+    def test_reasoning_field_controls_emitted_keys(
+        self, monkeypatch: MonkeyPatch, reasoning_field: str, expected_keys: set
+    ):
+        """`reasoning_field` selects which alias(es) reach the server.
+
+        Sending both is right for vLLM (each version ignores the key it does not
+        know) but fatal for servers that alias them -- Kimi-K3's Rust frontend
+        answers `400 duplicate field 'reasoning'`.
+        """
+        server = self._setup_server(monkeypatch)
+        server.config.uses_reasoning_parser = True
+        server.config.reasoning_field = reasoning_field
+        server._converter.uses_reasoning_parser = True
+
+        body_dict = {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "Answer.<think>Some reasoning.</think>"},
+            ]
+        }
+        result = server._preprocess_chat_completion_create_params(MagicMock(), body_dict)
+
+        assistant = result["messages"][1]
+        assert {k for k in ("reasoning_content", "reasoning") if k in assistant} == expected_keys
+        for key in expected_keys:
+            assert assistant[key] == "Some reasoning."
+        # the reasoning markup is always stripped out of the content itself
+        assert assistant["content"] == "Answer."
+
+    def test_reasoning_field_defaults_to_both(self, monkeypatch: MonkeyPatch):
+        """Default must stay `both` so existing deployments are unaffected."""
+        assert self._setup_server(monkeypatch).config.reasoning_field == "both"
+
+    def test_reasoning_field_rejects_unknown_value(self, monkeypatch: MonkeyPatch):
+        with raises(ValidationError):
+            VLLMModelConfig(
+                host="0.0.0.0",
+                port=8081,
+                base_url="http://api.openai.com/v1",
+                api_key="dummy_key",  # pragma: allowlist secret
+                model="dummy_model",
+                entrypoint="",
+                name="",
+                return_token_id_information=False,
+                uses_reasoning_parser=True,
+                reasoning_field="reasoning_contents",
+            )
 
     def test_responses_sequential_reasoning_allowed_False(self, monkeypatch: MonkeyPatch):
         server = self._setup_server(monkeypatch)


### PR DESCRIPTION
Gym previously set both reasoning_content and reasoning on every outgoing assistant message. That's correct for vLLM, where each version ignores the key it doesn't know but fatal for servers that treat them as aliases of one field. Kimi-K3's Rust frontend answers 400 duplicate field 'reasoning', which killed every agentic rollout on turn 2. I confirmed the behaviour by probing the live server rather than inferring it: content alone, reasoning_content alone, and reasoning alone are all accepted; only the pair is rejected.

The fix adds reasoning_field: Literal["both","reasoning","reasoning_content"] = "both" to VLLMModelConfig. Default is unchanged, so nothing existing is affected. Five tests: parametrized across all three modes asserting exactly which keys reach the server, one pinning the default, one confirming pydantic rejects a bad value. 110/110 pass, ruff clean, DCO signed-off and SSH-signed.

If it's useful for the PR description, the failure signature reviewers would recognise is:

openai.InternalServerError: Error code: 500 - ... "Failed to deserialize the JSON body
into the target type: messages[2]: duplicate field `reasoning`"