### PR TITLE
fix: keep the synthesized chat SSE alive during slow generations

### DIFF
--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -48,8 +48,10 @@ from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from nemo_gym.anthropic_converter import AnthropicConverter
 from nemo_gym.chat_streaming import (
+    DEFAULT_HEARTBEAT_INTERVAL_S,
     sanitize_streaming_chat_body,
     synthesize_chat_completion_sse,
+    synthesize_chat_completion_sse_with_heartbeat,
     validate_streaming_chat_params,
 )
 from nemo_gym.config_types import ROLLOUT_PATH_PREFIX, ModelServerRef
@@ -84,6 +86,9 @@ class BaseResponsesAPIModelConfig(BaseRunServerInstanceConfig):
 
 class BaseResponsesAPIModel(BaseServer):
     config: BaseResponsesAPIModelConfig
+
+    # Doubles as the grace window before a slow generation switches to a heartbeated stream.
+    chat_stream_heartbeat_interval_s: float = DEFAULT_HEARTBEAT_INTERVAL_S
 
 
 class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
@@ -127,6 +132,13 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
         first sanitized from the streaming wire dialect (drop ``stream``/``stream_options``; see
         ``nemo_gym.chat_streaming``), delegated to the same ``chat_completions()``, and the
         complete response is re-emitted as a synthesized ``chat.completion.chunk`` SSE stream.
+
+        Because that backend call is non-streaming, a slow generation would otherwise leave the
+        socket completely silent -- no headers, no bytes -- until it finished, which streaming
+        clients read as a hung endpoint (the OpenClaw agent aborts at 120s idle). Generations
+        that outrun a short grace window therefore switch to a heartbeated stream. Anything that
+        completes or fails inside the window keeps the original semantics, so fast failures still
+        surface with their normal status code rather than as a half-written stream.
         """
         if not body.get("stream"):
             params = _validate_chat_params(body)
@@ -137,8 +149,26 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
             params = validate_streaming_chat_params(cleaned)
         except ValidationError as exc:
             raise RequestValidationError([{**error, "loc": ("body", *error["loc"])} for error in exc.errors()])
-        completion = await self._invoke_chat_completions(request, params)
-        completion_json = completion.model_dump(mode="json") if isinstance(completion, BaseModel) else dict(completion)
+
+        async def _completion_json() -> dict:
+            completion = await self._invoke_chat_completions(request, params)
+            return completion.model_dump(mode="json") if isinstance(completion, BaseModel) else dict(completion)
+
+        pending = asyncio.ensure_future(_completion_json())
+        try:
+            # shield: a timeout here means "still generating", never "abandon the call".
+            completion_json = await asyncio.wait_for(
+                asyncio.shield(pending), timeout=self.chat_stream_heartbeat_interval_s
+            )
+        except asyncio.TimeoutError:
+            return StreamingResponse(
+                synthesize_chat_completion_sse_with_heartbeat(
+                    pending,
+                    include_usage=include_usage,
+                    interval_s=self.chat_stream_heartbeat_interval_s,
+                ),
+                media_type="text/event-stream",
+            )
         return StreamingResponse(
             synthesize_chat_completion_sse(completion_json, include_usage=include_usage),
             media_type="text/event-stream",

--- a/nemo_gym/chat_streaming.py
+++ b/nemo_gym/chat_streaming.py
@@ -35,10 +35,11 @@ error-normalization behavior is fully preserved on this path, and token-id / log
 the backend response is unaffected (those fields simply do not ride in the chunk schema).
 """
 
+import asyncio
 import json
 import logging
 from copy import deepcopy
-from typing import Any, Iterator
+from typing import Any, AsyncIterator, Awaitable, Iterator
 
 from pydantic import ValidationError
 
@@ -46,6 +47,13 @@ from nemo_gym.openai_utils import NeMoGymChatCompletionCreateParamsNonStreaming
 
 
 LOG = logging.getLogger(__name__)
+
+# An SSE comment: ignored by every conforming client parser, but still bytes on the wire, so it
+# refreshes read/idle timers while the buffered backend call is still running.
+SSE_HEARTBEAT = ": keepalive\n\n"
+
+# Well under the 120s idle timeout the OpenClaw agent applies to its model endpoint.
+DEFAULT_HEARTBEAT_INTERVAL_S = 15.0
 
 _PARAM_FIELDS = frozenset(NeMoGymChatCompletionCreateParamsNonStreaming.model_fields)
 
@@ -201,3 +209,36 @@ def synthesize_chat_completion_sse(completion: dict[str, Any], include_usage: bo
         yield _sse_data(_chunk(completion, [], usage=usage))
 
     yield "data: [DONE]\n\n"
+
+
+async def synthesize_chat_completion_sse_with_heartbeat(
+    pending: Awaitable[dict[str, Any]],
+    include_usage: bool = False,
+    interval_s: float = DEFAULT_HEARTBEAT_INTERVAL_S,
+) -> AsyncIterator[str]:
+    """Emit SSE heartbeats until ``pending`` resolves, then the synthesized completion stream.
+
+    The backend call is non-streaming, so nothing can be emitted until it returns. On a slow
+    model that silence is indistinguishable from a hung endpoint: the OpenClaw agent aborts the
+    session after 120s of quiet ("LLM idle timeout"), and the rollout is graded as an empty
+    failure even though the model is still working. Heartbeating keeps the socket alive for the
+    whole generation without changing what the client ultimately parses.
+
+    A failure after the first heartbeat cannot be reported as an HTTP status (the response has
+    already begun), so it is logged and the stream is terminated with ``data: [DONE]`` rather
+    than left hanging. Callers should therefore await a short grace window first, so fast
+    failures still surface with their normal status code.
+    """
+    while True:
+        try:
+            completion = await asyncio.wait_for(asyncio.shield(pending), timeout=interval_s)
+            break
+        except asyncio.TimeoutError:
+            yield SSE_HEARTBEAT
+        except Exception:
+            LOG.exception("Chat completion failed after the SSE stream had already started")
+            yield "data: [DONE]\n\n"
+            return
+
+    for chunk in synthesize_chat_completion_sse(completion, include_usage=include_usage):
+        yield chunk

--- a/tests/unit_tests/test_chat_completions_streaming.py
+++ b/tests/unit_tests/test_chat_completions_streaming.py
@@ -21,6 +21,7 @@ response is re-emitted as a synthesized ``chat.completion.chunk`` SSE stream. No
 requests keep the historical strict-validation behavior.
 """
 
+import asyncio
 import json
 from time import time
 from unittest.mock import MagicMock
@@ -38,8 +39,10 @@ from nemo_gym.base_responses_api_model import (
     _reconstruct_chat_sse,
 )
 from nemo_gym.chat_streaming import (
+    SSE_HEARTBEAT,
     sanitize_streaming_chat_body,
     synthesize_chat_completion_sse,
+    synthesize_chat_completion_sse_with_heartbeat,
     validate_streaming_chat_params,
 )
 from nemo_gym.openai_utils import (
@@ -340,3 +343,155 @@ class TestChatDispatchRoute:
         )
         assert resp.status_code == 200
         assert server.saw_request is True
+
+
+class _SlowChatModel(_EchoChatModel):
+    """Echo model whose generation outlasts the heartbeat grace window."""
+
+    delay_s: float = 0.3
+
+    async def chat_completions(
+        self, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
+    ) -> NeMoGymChatCompletion:
+        await asyncio.sleep(self.delay_s)
+        return await super().chat_completions(body)
+
+
+class _FailingChatModel(_EchoChatModel):
+    """Echo model that raises, optionally only after the grace window has elapsed."""
+
+    delay_s: float = 0.0
+
+    async def chat_completions(
+        self, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
+    ) -> NeMoGymChatCompletion:
+        if self.delay_s:
+            await asyncio.sleep(self.delay_s)
+        raise RuntimeError("backend exploded")
+
+
+class TestChatStreamHeartbeat:
+    """A non-streaming backend leaves the socket silent; slow generations must not read as hung.
+
+    The OpenClaw agent aborts a session after 120s without bytes ("LLM idle timeout"). Slow
+    models routinely exceed that while generating normally, and every such session is graded as
+    an empty failure.
+    """
+
+    def test_slow_generation_emits_heartbeats_before_the_completion(self) -> None:
+        client, server = _client(_SlowChatModel)
+        server.chat_stream_heartbeat_interval_s = 0.05
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"stream": True, "messages": [{"role": "user", "content": "hello"}]},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        assert SSE_HEARTBEAT in resp.text
+        # the payload still arrives intact after the heartbeats
+        assert resp.text.endswith("data: [DONE]\n\n")
+        rebuilt = _reconstruct_chat_sse(_parse_sse_events(resp.text.encode()))
+        assert rebuilt["choices"][0]["message"]["content"] == "hello"
+
+    def test_heartbeats_are_sse_comments_ignored_by_reconstruction(self) -> None:
+        # A comment carries bytes (refreshing idle timers) without adding a parsed event.
+        assert SSE_HEARTBEAT.startswith(":")
+        assert not _parse_sse_events(SSE_HEARTBEAT.encode())
+
+    def test_fast_generation_emits_no_heartbeats(self) -> None:
+        client, _ = _client(_EchoChatModel)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"stream": True, "messages": [{"role": "user", "content": "hello"}]},
+        )
+        assert resp.status_code == 200
+        assert SSE_HEARTBEAT not in resp.text
+
+    def test_fast_failure_still_surfaces_as_an_error_not_a_stream(self) -> None:
+        # Errors inside the grace window keep their status code, so retries still see failures.
+        client, _ = _client(_FailingChatModel)
+        with pytest.raises(RuntimeError):
+            client.post(
+                "/v1/chat/completions",
+                json={"stream": True, "messages": [{"role": "user", "content": "hi"}]},
+            )
+
+    def test_failure_after_stream_started_terminates_cleanly(self) -> None:
+        # Past the grace window the response has begun, so the client gets a terminated stream
+        # rather than a hang.
+        async def _drain() -> list[str]:
+            async def _boom() -> dict:
+                await asyncio.sleep(0.15)
+                raise RuntimeError("late failure")
+
+            pending = asyncio.ensure_future(_boom())
+            return [chunk async for chunk in synthesize_chat_completion_sse_with_heartbeat(pending, interval_s=0.05)]
+
+        chunks = asyncio.run(_drain())
+        assert SSE_HEARTBEAT in chunks
+        assert chunks[-1] == "data: [DONE]\n\n"
+
+    def test_bytes_reach_the_wire_before_generation_completes(self) -> None:
+        """Regression: the socket must not stay silent for a whole slow generation.
+
+        Driven at the ASGI layer on purpose. ``TestClient`` buffers a streaming response, so it
+        reports the same time-to-first-byte whether or not the server heartbeats -- it cannot
+        observe this defect at all. Only the raw send() timeline shows what a socket peer, and
+        therefore an idle timeout, actually sees.
+        """
+        gen_s, grace_s = 0.6, 0.1
+
+        async def _timeline() -> list[tuple[float, str]]:
+            client, server = _client(_SlowChatModel)
+            server.delay_s = gen_s
+            server.chat_stream_heartbeat_interval_s = grace_s
+            app = server.setup_webserver()
+
+            body = b'{"stream": true, "messages": [{"role": "user", "content": "hi"}]}'
+            scope = {
+                "type": "http",
+                "asgi": {"version": "3.0", "spec_version": "2.3"},
+                "http_version": "1.1",
+                "method": "POST",
+                "scheme": "http",
+                "path": "/v1/chat/completions",
+                "raw_path": b"/v1/chat/completions",
+                "query_string": b"",
+                "root_path": "",
+                "headers": [
+                    (b"host", b"testserver"),
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode()),
+                ],
+                "client": ("127.0.0.1", 12345),
+                "server": ("testserver", 80),
+            }
+
+            start = asyncio.get_running_loop().time()
+            seen: list[tuple[float, str]] = []
+            delivered = False
+
+            async def receive():
+                # Body once, then stay connected: starlette also polls receive() for disconnects.
+                nonlocal delivered
+                if not delivered:
+                    delivered = True
+                    return {"type": "http.request", "body": body, "more_body": False}
+                await asyncio.Event().wait()
+
+            async def send(message):
+                elapsed = asyncio.get_running_loop().time() - start
+                if message["type"] == "http.response.body" and message.get("body"):
+                    seen.append((elapsed, message["body"].decode()))
+
+            await asyncio.wait_for(app(scope, receive, send), timeout=gen_s * 10)
+            return seen
+
+        seen = asyncio.run(_timeline())
+        assert seen, "no bytes were ever written to the wire"
+        first_at, first_payload = seen[0]
+        assert first_at < gen_s, f"socket stayed silent {first_at:.2f}s for a {gen_s:.2f}s generation"
+        assert first_payload == SSE_HEARTBEAT
+        # the real completion still lands, after the heartbeats
+        assert seen[-1][0] >= gen_s
+        assert "".join(payload for _, payload in seen).endswith("data: [DONE]\n\n")


### PR DESCRIPTION
Targeting this branch rather than main, since it only matters once `model_server` routing is enabled.

## The problem

`chat_completions_dispatch` awaits the backend call *before* constructing the `StreamingResponse`:

```python
completion = await self._invoke_chat_completions(request, params)   # blocks for the whole generation
...
return StreamingResponse(...)                                        # only now do headers exist
```

So on the `stream: true` path nothing reaches the socket — **not even the response headers** — until generation completes. A streaming client can't distinguish that from a hung endpoint. The OpenClaw agent aborts a session after 120s without bytes (`LLM idle timeout (120s): no response from model`), and that session is then graded as an empty failure even though the model was generating normally the whole time. Slow models exceed 120s routinely.

This matters specifically for `model_server` routing: on `main` PinchBench points at a streaming-capable endpoint directly (the config comment says as much), so it gets real SSE and the idle timer is continuously refreshed. Routing through a Gym model server swaps that for a non-streaming backend, and the synthesized envelope restores the *shape* of streaming but not the liveness the client relies on.

## Reproduction

Driving the ASGI app directly with a 3.00s generation and timestamping each `send()`:

**Before**
```
  wire timeline:
      3.01s  headers
      3.01s  body (195B)
      3.01s  body (193B)
      ...
  first payload byte at: 3.01s   <- socket silent for the entire generation
```

**After**
```
  wire timeline:
      0.26s  headers
      0.51s  body (13B)
      0.76s  body (13B)
      ...
  first payload byte at: 0.51s
```

## The fix

Generations that outrun a short grace window switch to a heartbeated stream: SSE comments (`: keepalive`, ignored by every conforming parser but still bytes on the wire) keep the socket warm until the completion lands, then the synthesized chunks are emitted unchanged.

Anything that completes *or fails* inside the grace window keeps the original semantics, so fast failures still surface with their normal status code rather than a half-written `200` stream. Interval/grace is `chat_stream_heartbeat_interval_s` on `BaseResponsesAPIModel`, default 15s.

Only envelope timing changes — what the client ultimately parses is identical, and retry / error-normalization / capture on the backend call are untouched.

## Scope — what this does *not* do

This is **not** token-by-token streaming. First-token latency still equals full generation time; the heartbeat buys correctness, not latency. Real pass-through streaming looks feasible (the capture middleware already forwards SSE chunks immediately and `_reconstruct_chat_sse` reassembles them), but it costs transparent retry and error normalization on that path, so it deserves its own change and its own decision.

## Testing

29 passing, ruff clean. The new `test_bytes_reach_the_wire_before_generation_completes` is deliberately ASGI-level: the existing streaming tests all go through `TestClient`, which buffers streaming responses and is therefore structurally incapable of observing this defect — my first attempt at a repro measured identical time-to-first-byte with and without the fix for exactly that reason.