### PR TITLE
fix: keep the synthesized chat SSE alive during slow generations

### DIFF
--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -48,8 +48,10 @@ from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from nemo_gym.anthropic_converter import AnthropicConverter
 from nemo_gym.chat_streaming import (
+    DEFAULT_HEARTBEAT_INTERVAL_S,
     sanitize_streaming_chat_body,
     synthesize_chat_completion_sse,
+    synthesize_chat_completion_sse_with_heartbeat,
     validate_streaming_chat_params,
 )
 from nemo_gym.config_types import ROLLOUT_PATH_PREFIX, ModelServerRef
@@ -84,6 +86,9 @@ class BaseResponsesAPIModelConfig(BaseRunServerInstanceConfig):
 
 class BaseResponsesAPIModel(BaseServer):
     config: BaseResponsesAPIModelConfig
+
+    # Doubles as the grace window before a slow generation switches to a heartbeated stream.
+    chat_stream_heartbeat_interval_s: float = DEFAULT_HEARTBEAT_INTERVAL_S
 
 
 class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
@@ -127,6 +132,13 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
         first sanitized from the streaming wire dialect (drop ``stream``/``stream_options``; see
         ``nemo_gym.chat_streaming``), delegated to the same ``chat_completions()``, and the
         complete response is re-emitted as a synthesized ``chat.completion.chunk`` SSE stream.
+
+        Because that backend call is non-streaming, a slow generation would otherwise leave the
+        socket completely silent -- no headers, no bytes -- until it finished, which streaming
+        clients read as a hung endpoint (the OpenClaw agent aborts at 120s idle). Generations
+        that outrun a short grace window therefore switch to a heartbeated stream. Anything that
+        completes or fails inside the window keeps the original semantics, so fast failures still
+        surface with their normal status code rather than as a half-written stream.
         """
         if not body.get("stream"):
             params = _validate_chat_params(body)
@@ -137,8 +149,26 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
             params = validate_streaming_chat_params(cleaned)
         except ValidationError as exc:
             raise RequestValidationError([{**error, "loc": ("body", *error["loc"])} for error in exc.errors()])
-        completion = await self._invoke_chat_completions(request, params)
-        completion_json = completion.model_dump(mode="json") if isinstance(completion, BaseModel) else dict(completion)
+
+        async def _completion_json() -> dict:
+            completion = await self._invoke_chat_completions(request, params)
+            return completion.model_dump(mode="json") if isinstance(completion, BaseModel) else dict(completion)
+
+        pending = asyncio.ensure_future(_completion_json())
+        try:
+            # shield: a timeout here means "still generating", never "abandon the call".
+            completion_json = await asyncio.wait_for(
+                asyncio.shield(pending), timeout=self.chat_stream_heartbeat_interval_s
+            )
+        except asyncio.TimeoutError:
+            return StreamingResponse(
+                synthesize_chat_completion_sse_with_heartbeat(
+                    pending,
+                    include_usage=include_usage,
+                    interval_s=self.chat_stream_heartbeat_interval_s,
+                ),
+                media_type="text/event-stream",
+            )
         return StreamingResponse(
             synthesize_chat_completion_sse(completion_json, include_usage=include_usage),
             media_type="text/event-stream",

--- a/nemo_gym/chat_streaming.py
+++ b/nemo_gym/chat_streaming.py
@@ -35,10 +35,11 @@ error-normalization behavior is fully preserved on this path, and token-id / log
 the backend response is unaffected (those fields simply do not ride in the chunk schema).
 """
 
+import asyncio
 import json
 import logging
 from copy import deepcopy
-from typing import Any, Iterator
+from typing import Any, AsyncIterator, Awaitable, Iterator
 
 from pydantic import ValidationError
 
@@ -46,6 +47,13 @@ from nemo_gym.openai_utils import NeMoGymChatCompletionCreateParamsNonStreaming
 
 
 LOG = logging.getLogger(__name__)
+
+# An SSE comment: ignored by every conforming client parser, but still bytes on the wire, so it
+# refreshes read/idle timers while the buffered backend call is still running.
+SSE_HEARTBEAT = ": keepalive\n\n"
+
+# Well under the 120s idle timeout the OpenClaw agent applies to its model endpoint.
+DEFAULT_HEARTBEAT_INTERVAL_S = 15.0
 
 _PARAM_FIELDS = frozenset(NeMoGymChatCompletionCreateParamsNonStreaming.model_fields)
 
@@ -201,3 +209,36 @@ def synthesize_chat_completion_sse(completion: dict[str, Any], include_usage: bo
         yield _sse_data(_chunk(completion, [], usage=usage))
 
     yield "data: [DONE]\n\n"
+
+
+async def synthesize_chat_completion_sse_with_heartbeat(
+    pending: Awaitable[dict[str, Any]],
+    include_usage: bool = False,
+    interval_s: float = DEFAULT_HEARTBEAT_INTERVAL_S,
+) -> AsyncIterator[str]:
+    """Emit SSE heartbeats until ``pending`` resolves, then the synthesized completion stream.
+
+    The backend call is non-streaming, so nothing can be emitted until it returns. On a slow
+    model that silence is indistinguishable from a hung endpoint: the OpenClaw agent aborts the
+    session after 120s of quiet ("LLM idle timeout"), and the rollout is graded as an empty
+    failure even though the model is still working. Heartbeating keeps the socket alive for the
+    whole generation without changing what the client ultimately parses.
+
+    A failure after the first heartbeat cannot be reported as an HTTP status (the response has
+    already begun), so it is logged and the stream is terminated with ``data: [DONE]`` rather
+    than left hanging. Callers should therefore await a short grace window first, so fast
+    failures still surface with their normal status code.
+    """
+    while True:
+        try:
+            completion = await asyncio.wait_for(asyncio.shield(pending), timeout=interval_s)
+            break
+        except asyncio.TimeoutError:
+            yield SSE_HEARTBEAT
+        except Exception:
+            LOG.exception("Chat completion failed after the SSE stream had already started")
+            yield "data: [DONE]\n\n"
+            return
+
+    for chunk in synthesize_chat_completion_sse(completion, include_usage=include_usage):
+        yield chunk

--- a/responses_api_agents/pinchbench/README.md
+++ b/responses_api_agents/pinchbench/README.md
@@ -54,13 +54,17 @@ small NVIDIA integration patch:
 | `sandbox_spec` | the per-task sandbox: `image` (`${sandbox_image}` — a `.sif` path or `docker://` ref built from `Dockerfile.benchmark`), `resources`, `ready_timeout_s`, … |
 | `sandbox_work_base` | writable, per-sandbox-isolated working mount (default `/sandbox`); run_task.sh puts the skill copy, `$HOME`, `$TMPDIR` and the benchmark run-root here |
 | `task_timeout_s` | per-task exec timeout |
-| `model_base_url` / `model_api_key` / `model_name` | policy model OpenClaw runs against |
+| `model_server` | optional Gym policy-model reference; preferred over `model_base_url` when set |
+| `model_base_url` / `model_api_key` / `model_name` | direct policy-endpoint fallback and model credentials/name |
 | `judge_model` / `judge_base_url` / `judge_api_key` | judge for hybrid / `llm_judge` tasks |
 | `max_tokens`, `context_window`, `max_concurrent`, `timeout_multiplier` | run tuning |
 
-> **Model wiring:** OpenClaw must point at a **streaming-capable** endpoint directly — *not* a Gym
-> model server, which is non-streaming (`stream: Literal[False]`) and would 422 OpenClaw's streamed
-> requests. So the policy/judge endpoints are passed straight through to OpenClaw.
+> **Model wiring:** When `model_server` is configured, `/run` resolves that Gym model server before
+> passing its `/v1` URL to OpenClaw. If global `observability_enabled` is true and the request has
+> `_ng_task_index` plus `_ng_rollout_index`, the resolved URL includes the rollout-correlation
+> prefix; otherwise it remains unprefixed. Gym synthesizes the Chat Completions SSE that OpenClaw
+> requests. With `model_server: null`, `model_base_url` is passed through unchanged for
+> compatibility. The judge endpoint remains configured directly.
 
 ## Setup
 

--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -54,6 +54,7 @@ from nemo_gym.base_responses_api_agent import (
     Body,
     SimpleResponsesAPIAgent,
 )
+from nemo_gym.config_types import ModelServerRef
 from nemo_gym.openai_utils import (
     NeMoGymFunctionCallOutput,
     NeMoGymResponse,
@@ -71,11 +72,12 @@ from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
 
 
 class PinchBenchAgentConfig(BaseResponsesAPIAgentConfig):
-    # Policy model OpenClaw runs against (streaming-capable endpoint, NOT a Gym
-    # non-streaming model server — see README).
+    # Policy model OpenClaw runs against. A configured Gym model server takes
+    # precedence; model_base_url remains the direct-endpoint fallback.
     model_base_url: str
     model_api_key: str
     model_name: str
+    model_server: Optional[ModelServerRef] = None
 
     # Judge for hybrid / llm_judge tasks (OpenAI-compatible endpoint).
     judge_model: str
@@ -168,11 +170,16 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         raise NotImplementedError("PinchBench is an external benchmark; use /run.")
 
     # --- task env ----------------------------------------------------------
-    def _task_env(self, task_id: str) -> dict:
+    def _task_env(self, task_id: str, rollout_id: Optional[str] = None) -> dict:
+        model_base_url = (
+            self.resolve_model_base_url(self.config.model_server.name, rollout_id)
+            if self.config.model_server is not None
+            else self.config.model_base_url
+        )
         env = {
             "TASK_ID": task_id,
             "MODEL_NAME": self.config.model_name,
-            "MODEL_BASE_URL": self.config.model_base_url,
+            "MODEL_BASE_URL": model_base_url,
             "MODEL_API_KEY": self.config.model_api_key,
             "JUDGE_MODEL": self.config.judge_model,
             "JUDGE_BASE_URL": self.config.judge_base_url,
@@ -195,7 +202,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         return env
 
     # --- per-task sandbox (Gym Sandbox API; provider-neutral) ---------------
-    def _build_spec(self, task_id: str) -> SandboxSpec:
+    def _build_spec(self, task_id: str, rollout_id: Optional[str] = None) -> SandboxSpec:
         cfg = dict(self.config.sandbox_spec)
         return SandboxSpec(
             image=cfg.get("image"),
@@ -204,16 +211,16 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
             workdir=cfg.get("workdir"),
             resources=SandboxResources.from_mapping(cfg.get("resources", {})),
             provider_options=cfg.get("provider_options", {}),
-            env=self._task_env(task_id),
+            env=self._task_env(task_id, rollout_id),
             metadata={"task_id": task_id},
         )
 
-    async def _run_in_sandbox(self, task_id: str, out_dir: Path) -> None:
+    async def _run_in_sandbox(self, task_id: str, out_dir: Path, rollout_id: Optional[str] = None) -> None:
         """Run one PinchBench task and pull its /out archive back."""
         provider = self.config.sandbox_provider or {}
         apptainer_cfg = provider.get("apptainer") if isinstance(provider, dict) else None
         if isinstance(apptainer_cfg, dict) and apptainer_cfg.get("direct_exec"):
-            await self._run_in_apptainer_direct(task_id, out_dir, apptainer_cfg)
+            await self._run_in_apptainer_direct(task_id, out_dir, apptainer_cfg, rollout_id=rollout_id)
             return
 
         if not self.config.sandbox_provider:
@@ -221,7 +228,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         archive = f"{self.config.sandbox_work_base.rstrip('/')}/out/out.tgz"
         sb = AsyncSandbox(self.config.sandbox_provider)
         try:
-            await sb.start(self._build_spec(task_id))
+            await sb.start(self._build_spec(task_id, rollout_id))
             await sb.exec("bash /opt/run_task.sh", timeout_s=self.config.task_timeout_s)
             await sb.download(archive, out_dir / "out.tgz")
         finally:
@@ -330,7 +337,13 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         wrapper_path.chmod(0o755)
         return wrapper_path
 
-    async def _run_in_apptainer_direct(self, task_id: str, out_dir: Path, apptainer_cfg: dict[str, Any]) -> None:
+    async def _run_in_apptainer_direct(
+        self,
+        task_id: str,
+        out_dir: Path,
+        apptainer_cfg: dict[str, Any],
+        rollout_id: Optional[str] = None,
+    ) -> None:
         image = self.config.sandbox_spec.get("image")
         if not image:
             raise ValueError("pinchbench sandbox_spec.image is required for direct Apptainer exec")
@@ -350,7 +363,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         elif isinstance(direct_args, str):
             direct_args = direct_args.split()
 
-        task_env = self._task_env(task_id)
+        task_env = self._task_env(task_id, rollout_id)
         argv = ["apptainer", "exec", *[str(arg) for arg in direct_args]]
         argv += ["--bind", f"{staging_dir}:{work_base}"]
         for key, value in task_env.items():
@@ -662,9 +675,10 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         response = self._empty_response(task_id)
         transcript_events: list = []
         archive_path = ""
+        rollout_id = self.rollout_id_from_run(body)
         try:
             async with self._sem:
-                await self._run_in_sandbox(task_id, out_dir)  # one sandbox per task
+                await self._run_in_sandbox(task_id, out_dir, rollout_id=rollout_id)  # one sandbox per task
             result = self._parse_result(task_id, out_dir)
             response = self._response_from_transcript(task_id, out_dir)
             transcript_events, archive_path = self._collect_transcript(task_id, out_dir, run_id)

--- a/responses_api_agents/pinchbench/configs/pinchbench.yaml
+++ b/responses_api_agents/pinchbench/configs/pinchbench.yaml
@@ -23,11 +23,12 @@ pinchbench_agent:
           cpu: 4
           memory_mib: 8192
       task_timeout_s: 1800
-      # Policy model OpenClaw runs against (streaming-capable endpoint; secrets
-      # supplied via CLI/env overrides at run time — never committed).
+      # Policy model OpenClaw runs against. Set model_server to a Gym model-server
+      # reference; when null, model_base_url remains the direct-endpoint fallback.
       model_base_url: ${model_base_url}
       model_api_key: ${model_api_key}
       model_name: ${model_name}
+      model_server: null
       # Judge for hybrid / llm_judge tasks (OpenAI-compatible endpoint).
       judge_model: ${judge_model}
       judge_base_url: ${judge_base_url}

--- a/responses_api_agents/pinchbench/tests/test_app.py
+++ b/responses_api_agents/pinchbench/tests/test_app.py
@@ -19,10 +19,11 @@ fast and offline.
 """
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nemo_gym.config_types import ModelServerRef
 from nemo_gym.server_utils import ServerClient
 from responses_api_agents.pinchbench.app import (
     NG_FAILURE_CLASS_KEY,
@@ -30,6 +31,7 @@ from responses_api_agents.pinchbench.app import (
     NG_TERMINAL_KEY,
     PinchBenchAgent,
     PinchBenchAgentConfig,
+    PinchBenchRunRequest,
     SandboxKilledError,
     _classify_task_failure,
 )
@@ -76,8 +78,23 @@ def test_task_env_gateway_mode():
     assert env["OPENCLAW_GATEWAY_TOKEN"]  # gateway daemon mode
     assert "PINCHBENCH_FORCE_LOCAL" not in env
     assert env["MODEL_NAME"] == "vendor/model"
+    assert env["MODEL_BASE_URL"] == "http://endpoint/v1"
     assert env["JUDGE_BASE_URL"] == "http://endpoint/v1"
     assert env["BRAVE_API_KEY"] == "brave-key"
+
+
+def test_task_env_resolves_configured_gym_model_server():
+    agent = make_agent(model_server=ModelServerRef(type="responses_api_models", name="policy_model"))
+    with patch.object(
+        PinchBenchAgent,
+        "resolve_model_base_url",
+        autospec=True,
+        return_value="http://model-server/ng-rollout/7-2/v1",
+    ) as resolve:
+        env = agent._task_env("task_x", "7-2")
+
+    resolve.assert_called_once_with(agent, "policy_model", "7-2")
+    assert env["MODEL_BASE_URL"] == "http://model-server/ng-rollout/7-2/v1"
 
 
 def test_build_spec_from_config():
@@ -232,7 +249,7 @@ async def test_run_returns_zero_on_failure_never_raises(tmp_path, monkeypatch):
     otherwise ng_collect_rollouts (fail-fast) aborts the whole collection."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def boom(task_id, out_dir):
+    async def boom(task_id, out_dir, rollout_id=None):
         raise RuntimeError("sandbox exploded")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", boom)
@@ -267,7 +284,7 @@ async def test_generic_failure_routes_to_sidecar_not_main(tmp_path, monkeypatch)
     """A failed task must carry a failure class so it never lands in the main jsonl."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def boom(task_id, out_dir):
+    async def boom(task_id, out_dir, rollout_id=None):
         raise RuntimeError("sandbox exploded")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", boom)
@@ -283,7 +300,7 @@ async def test_signal_killed_sandbox_is_kill_shaped_and_unpersisted(tmp_path, mo
     """Walltime SIGTERM shape: no row anywhere; resume's set-difference re-dispatches."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def killed(task_id, out_dir):
+    async def killed(task_id, out_dir, rollout_id=None):
         raise SandboxKilledError("direct apptainer exec killed (rc=-15) for task task_x")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", killed)
@@ -298,7 +315,7 @@ async def test_task_timeout_is_terminal_sidecar(tmp_path, monkeypatch):
     """Per-task timeout consumed its budget: one sidecar row, never retried."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def slow(task_id, out_dir):
+    async def slow(task_id, out_dir, rollout_id=None):
         raise TimeoutError("direct apptainer exec timed out for task task_x")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", slow)
@@ -314,7 +331,7 @@ async def test_successful_task_carries_no_routing_sentinels(tmp_path, monkeypatc
     """Scored rollouts must keep landing in the main jsonl (no sentinel keys)."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def ok(task_id, out_dir):
+    async def ok(task_id, out_dir, rollout_id=None):
         return None
 
     monkeypatch.setattr(agent, "_run_in_sandbox", ok)
@@ -336,6 +353,68 @@ async def test_successful_task_carries_no_routing_sentinels(tmp_path, monkeypatc
     assert dumped["reward"] == 1.0
     for key in (NG_FAILURE_CLASS_KEY, NG_NO_PERSIST_KEY, NG_TERMINAL_KEY):
         assert key not in dumped
+
+
+@pytest.mark.parametrize(
+    ("observability_enabled", "expected_rollout_id", "model_base_url"),
+    [
+        (True, "7-2", "http://model-server/ng-rollout/7-2/v1"),
+        (False, None, "http://model-server/v1"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_run_resolves_model_server_with_optional_rollout_correlation(
+    tmp_path,
+    monkeypatch,
+    observability_enabled,
+    expected_rollout_id,
+    model_base_url,
+):
+    agent = make_agent(
+        work_root=str(tmp_path / "work"),
+        transcripts_dir=str(tmp_path / "arch"),
+        model_server=ModelServerRef(type="responses_api_models", name="policy_model"),
+    )
+    agent.server_client.global_config_dict = {"observability_enabled": observability_enabled}
+    captured = {}
+
+    async def capture_env(task_id, out_dir, rollout_id=None):
+        captured["env"] = agent._task_env(task_id, rollout_id)
+
+    monkeypatch.setattr(agent, "_run_in_sandbox", capture_env)
+    monkeypatch.setattr(
+        agent,
+        "_parse_result",
+        lambda task_id, out_dir: {
+            "reward": 1.0,
+            "grading_type": "automated",
+            "breakdown": {},
+            "notes": "ok",
+            "status": "success",
+        },
+    )
+    monkeypatch.setattr(agent, "_response_from_transcript", lambda task_id, out_dir: agent._empty_response(task_id))
+    monkeypatch.setattr(agent, "_collect_transcript", lambda task_id, out_dir, run_id: ([], ""))
+    body = PinchBenchRunRequest.model_validate(
+        {
+            "responses_create_params": {"input": "solve"},
+            "verifier_metadata": {"task_id": "task_x"},
+            "_ng_task_index": 7,
+            "_ng_rollout_index": 2,
+        }
+    )
+
+    with patch.object(
+        PinchBenchAgent,
+        "resolve_model_base_url",
+        autospec=True,
+        return_value=model_base_url,
+    ) as resolve:
+        response = await agent.run(body=body)
+
+    assert response.reward == 1.0
+    resolve.assert_called_once_with(agent, "policy_model", expected_rollout_id)
+    assert captured["env"]["MODEL_BASE_URL"] == model_base_url
 
 
 def test_classify_task_failure_mapping():

--- a/tests/unit_tests/test_chat_completions_streaming.py
+++ b/tests/unit_tests/test_chat_completions_streaming.py
@@ -21,6 +21,7 @@ response is re-emitted as a synthesized ``chat.completion.chunk`` SSE stream. No
 requests keep the historical strict-validation behavior.
 """
 
+import asyncio
 import json
 from time import time
 from unittest.mock import MagicMock
@@ -38,8 +39,10 @@ from nemo_gym.base_responses_api_model import (
     _reconstruct_chat_sse,
 )
 from nemo_gym.chat_streaming import (
+    SSE_HEARTBEAT,
     sanitize_streaming_chat_body,
     synthesize_chat_completion_sse,
+    synthesize_chat_completion_sse_with_heartbeat,
     validate_streaming_chat_params,
 )
 from nemo_gym.openai_utils import (
@@ -340,3 +343,155 @@ class TestChatDispatchRoute:
         )
         assert resp.status_code == 200
         assert server.saw_request is True
+
+
+class _SlowChatModel(_EchoChatModel):
+    """Echo model whose generation outlasts the heartbeat grace window."""
+
+    delay_s: float = 0.3
+
+    async def chat_completions(
+        self, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
+    ) -> NeMoGymChatCompletion:
+        await asyncio.sleep(self.delay_s)
+        return await super().chat_completions(body)
+
+
+class _FailingChatModel(_EchoChatModel):
+    """Echo model that raises, optionally only after the grace window has elapsed."""
+
+    delay_s: float = 0.0
+
+    async def chat_completions(
+        self, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
+    ) -> NeMoGymChatCompletion:
+        if self.delay_s:
+            await asyncio.sleep(self.delay_s)
+        raise RuntimeError("backend exploded")
+
+
+class TestChatStreamHeartbeat:
+    """A non-streaming backend leaves the socket silent; slow generations must not read as hung.
+
+    The OpenClaw agent aborts a session after 120s without bytes ("LLM idle timeout"). Slow
+    models routinely exceed that while generating normally, and every such session is graded as
+    an empty failure.
+    """
+
+    def test_slow_generation_emits_heartbeats_before_the_completion(self) -> None:
+        client, server = _client(_SlowChatModel)
+        server.chat_stream_heartbeat_interval_s = 0.05
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"stream": True, "messages": [{"role": "user", "content": "hello"}]},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        assert SSE_HEARTBEAT in resp.text
+        # the payload still arrives intact after the heartbeats
+        assert resp.text.endswith("data: [DONE]\n\n")
+        rebuilt = _reconstruct_chat_sse(_parse_sse_events(resp.text.encode()))
+        assert rebuilt["choices"][0]["message"]["content"] == "hello"
+
+    def test_heartbeats_are_sse_comments_ignored_by_reconstruction(self) -> None:
+        # A comment carries bytes (refreshing idle timers) without adding a parsed event.
+        assert SSE_HEARTBEAT.startswith(":")
+        assert not _parse_sse_events(SSE_HEARTBEAT.encode())
+
+    def test_fast_generation_emits_no_heartbeats(self) -> None:
+        client, _ = _client(_EchoChatModel)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"stream": True, "messages": [{"role": "user", "content": "hello"}]},
+        )
+        assert resp.status_code == 200
+        assert SSE_HEARTBEAT not in resp.text
+
+    def test_fast_failure_still_surfaces_as_an_error_not_a_stream(self) -> None:
+        # Errors inside the grace window keep their status code, so retries still see failures.
+        client, _ = _client(_FailingChatModel)
+        with pytest.raises(RuntimeError):
+            client.post(
+                "/v1/chat/completions",
+                json={"stream": True, "messages": [{"role": "user", "content": "hi"}]},
+            )
+
+    def test_failure_after_stream_started_terminates_cleanly(self) -> None:
+        # Past the grace window the response has begun, so the client gets a terminated stream
+        # rather than a hang.
+        async def _drain() -> list[str]:
+            async def _boom() -> dict:
+                await asyncio.sleep(0.15)
+                raise RuntimeError("late failure")
+
+            pending = asyncio.ensure_future(_boom())
+            return [chunk async for chunk in synthesize_chat_completion_sse_with_heartbeat(pending, interval_s=0.05)]
+
+        chunks = asyncio.run(_drain())
+        assert SSE_HEARTBEAT in chunks
+        assert chunks[-1] == "data: [DONE]\n\n"
+
+    def test_bytes_reach_the_wire_before_generation_completes(self) -> None:
+        """Regression: the socket must not stay silent for a whole slow generation.
+
+        Driven at the ASGI layer on purpose. ``TestClient`` buffers a streaming response, so it
+        reports the same time-to-first-byte whether or not the server heartbeats -- it cannot
+        observe this defect at all. Only the raw send() timeline shows what a socket peer, and
+        therefore an idle timeout, actually sees.
+        """
+        gen_s, grace_s = 0.6, 0.1
+
+        async def _timeline() -> list[tuple[float, str]]:
+            client, server = _client(_SlowChatModel)
+            server.delay_s = gen_s
+            server.chat_stream_heartbeat_interval_s = grace_s
+            app = server.setup_webserver()
+
+            body = b'{"stream": true, "messages": [{"role": "user", "content": "hi"}]}'
+            scope = {
+                "type": "http",
+                "asgi": {"version": "3.0", "spec_version": "2.3"},
+                "http_version": "1.1",
+                "method": "POST",
+                "scheme": "http",
+                "path": "/v1/chat/completions",
+                "raw_path": b"/v1/chat/completions",
+                "query_string": b"",
+                "root_path": "",
+                "headers": [
+                    (b"host", b"testserver"),
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode()),
+                ],
+                "client": ("127.0.0.1", 12345),
+                "server": ("testserver", 80),
+            }
+
+            start = asyncio.get_running_loop().time()
+            seen: list[tuple[float, str]] = []
+            delivered = False
+
+            async def receive():
+                # Body once, then stay connected: starlette also polls receive() for disconnects.
+                nonlocal delivered
+                if not delivered:
+                    delivered = True
+                    return {"type": "http.request", "body": body, "more_body": False}
+                await asyncio.Event().wait()
+
+            async def send(message):
+                elapsed = asyncio.get_running_loop().time() - start
+                if message["type"] == "http.response.body" and message.get("body"):
+                    seen.append((elapsed, message["body"].decode()))
+
+            await asyncio.wait_for(app(scope, receive, send), timeout=gen_s * 10)
+            return seen
+
+        seen = asyncio.run(_timeline())
+        assert seen, "no bytes were ever written to the wire"
+        first_at, first_payload = seen[0]
+        assert first_at < gen_s, f"socket stayed silent {first_at:.2f}s for a {gen_s:.2f}s generation"
+        assert first_payload == SSE_HEARTBEAT
+        # the real completion still lands, after the heartbeats
+        assert seen[-1][0] >= gen_s
+        assert "".join(payload for _, payload in seen).endswith("data: [DONE]\n\n")


### PR DESCRIPTION
Targeting this branch rather than main, since it only matters once `model_server` routing is enabled.

## The problem

`chat_completions_dispatch` awaits the backend call *before* constructing the `StreamingResponse`:

```python
completion = await self._invoke_chat_completions(request, params)   # blocks for the whole generation
...
return StreamingResponse(...)                                        # only now do headers exist
```

So on the `stream: true` path nothing reaches the socket — **not even the response headers** — until generation completes. A streaming client can't distinguish that from a hung endpoint. The OpenClaw agent aborts a session after 120s without bytes (`LLM idle timeout (120s): no response from model`), and that session is then graded as an empty failure even though the model was generating normally the whole time. Slow models exceed 120s routinely.

This matters specifically for `model_server` routing: on `main` PinchBench points at a streaming-capable endpoint directly (the config comment says as much), so it gets real SSE and the idle timer is continuously refreshed. Routing through a Gym model server swaps that for a non-streaming backend, and the synthesized envelope restores the *shape* of streaming but not the liveness the client relies on.

## Reproduction

Driving the ASGI app directly with a 3.00s generation and timestamping each `send()`:

**Before**
```
  wire timeline:
      3.01s  headers
      3.01s  body (195B)
      3.01s  body (193B)
      ...
  first payload byte at: 3.01s   <- socket silent for the entire generation
```

**After**
```
  wire timeline:
      0.26s  headers
      0.51s  body (13B)
      0.76s  body (13B)
      ...
  first payload byte at: 0.51s
```

## The fix

Generations that outrun a short grace window switch to a heartbeated stream: SSE comments (`: keepalive`, ignored by every conforming parser but still bytes on the wire) keep the socket warm until the completion lands, then the synthesized chunks are emitted unchanged.

Anything that completes *or fails* inside the grace window keeps the original semantics, so fast failures still surface with their normal status code rather than a half-written `200` stream. Interval/grace is `chat_stream_heartbeat_interval_s` on `BaseResponsesAPIModel`, default 15s.

Only envelope timing changes — what the client ultimately parses is identical, and retry / error-normalization / capture on the backend call are untouched.

## Scope — what this does *not* do

This is **not** token-by-token streaming. First-token latency still equals full generation time; the heartbeat buys correctness, not latency. Real pass-through streaming looks feasible (the capture middleware already forwards SSE chunks immediately and `_reconstruct_chat_sse` reassembles them), but it costs transparent retry and error normalization on that path, so it deserves its own change and its own decision.

## Testing

29 passing, ruff clean. The new `test_bytes_reach_the_wire_before_generation_completes` is deliberately ASGI-level: the existing streaming tests all go through `TestClient`, which buffers streaming responses and is therefore structurally incapable of observing this defect — my first attempt at a repro measured identical time-to-first-byte with and without the fix for exactly that reason.