### PR TITLE
feat(vllm-model): pin sampling params for on-policy training

### DIFF
--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -167,6 +167,23 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
 
     chat_template_kwargs: Optional[Dict[str, Any]] = None
 
+    # Sampling params this server puts on every request it sends to the engine, replacing what the caller sent.
+    # On-policy training requires generation to use the sampling distribution the policy is optimized under,
+    # and a caller outside the training loop has no way to know it.
+    #
+    # The common case is an absent parameter rather than a conflicting one.
+    # A caller need not send sampling params at all.
+    # Converters forward a field only when it was set, so the outbound body can carry no temperature or top_p,
+    # and the engine applies a default of its own that has no relation to the configured one.
+    # Replacing rather than filling in covers the other case, a caller that sends values it chose itself.
+    #
+    # Read from config only, never from a request, so the server and not the caller decides them.
+    # Applied at every site that builds a request for the engine,
+    # since a pin that covers some endpoints and not others is off-policy while reporting that sampling is pinned.
+    #
+    # Unset means no pin.
+    sampling_overrides: Optional[Dict[str, Any]] = None
+
     # Corresponds to the extra_body of OpenAI Client.
     extra_body: Optional[Dict[str, Any]] = None
 
@@ -226,6 +243,13 @@ class VLLMModel(SimpleResponsesAPIModel):
         return super().model_post_init(context)
 
     def _post_init(self) -> None:
+        if self.config.sampling_overrides:
+            LOG.info(
+                "`%s` pins sampling on every request to the engine: %s",
+                self.config.name,
+                self.config.sampling_overrides,
+            )
+
         self._clients = [
             NeMoGymAsyncOpenAI(
                 base_url=base_url,
@@ -301,6 +325,19 @@ class VLLMModel(SimpleResponsesAPIModel):
             responses_create_params=body, chat_completion=chat_completion_response
         )
 
+    def _apply_sampling_overrides(self, body_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """Force ``config.sampling_overrides`` onto an outbound body, in place.
+
+        Applied last at every site that builds a request for the engine, so the pinned values win
+        over both what the client sent and anything ``extra_body`` merged in, and are present when
+        the client sent nothing. Every path has to call this: a harness picks its own endpoint, and
+        a pin that covers only one of them yields off-policy generation while reporting that
+        sampling is pinned.
+        """
+        if self.config.sampling_overrides:
+            body_dict.update(self.config.sampling_overrides)
+        return body_dict
+
     async def _responses_native(
         self, request: Request, body: NeMoGymResponseCreateParamsNonStreaming
     ) -> NeMoGymResponse:
@@ -322,6 +359,7 @@ class VLLMModel(SimpleResponsesAPIModel):
             body_dict["chat_template_kwargs"] = deepcopy(self.config.chat_template_kwargs)
         if self.config.extra_body:
             body_dict = self.config.extra_body | body_dict
+        self._apply_sampling_overrides(body_dict)
 
         client = self._resolve_client(request)
         response_dict = await client.create_response(**body_dict)
@@ -552,7 +590,7 @@ class VLLMModel(SimpleResponsesAPIModel):
                 # No user message found — create one with just the audio blocks.
                 body_dict.setdefault("messages", []).append({"role": "user", "content": list(audio_blocks)})
 
-        return body_dict
+        return self._apply_sampling_overrides(body_dict)
 
     async def chat_completions(
         self, request: Request, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
@@ -1000,7 +1038,11 @@ class VLLMModel(SimpleResponsesAPIModel):
             out["return_token_ids"] = True
             out["return_tokens_as_token_ids"] = True
 
-        return out
+        # This path never runs _preprocess_chat_completion_create_params;
+        # chat_completions() branches here before preprocessing, so the pin has to be applied again.
+        # vLLM accepts the same sampling field names on /v1/completions, and the body is forwarded as raw JSON,
+        # so params without a first-class OpenAI completion field (top_k, min_p) pass through.
+        return self._apply_sampling_overrides(out)
 
     def _completion_dict_to_chat_completion(self, completion_dict: Dict[str, Any]) -> NeMoGymChatCompletion:
         """Wrap a /v1/completions response as a NeMoGymChatCompletion.

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -4797,3 +4797,84 @@ class TestTopLogprobsHandling:
             )
         # The tokenize endpoint must not be reached once the contract check fails.
         mock_client.create_tokenize.assert_not_called()
+
+
+class TestSamplingOverrides:
+    """Forcing the sampling params on every request.
+
+    An external harness picks its own temperature and top_p. On-policy RL requires
+    generation to match the distribution the policy is optimized under, so the
+    server overrides whatever the client sent rather than trusting it.
+    """
+
+    @staticmethod
+    def _server(overrides: dict[str, object] | None, **kwargs: object) -> VLLMModel:
+        config = VLLMModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            base_url="http://api.openai.com/v1",
+            api_key="dummy_key",  # pragma: allowlist secret
+            model="dummy_model",
+            entrypoint="",
+            name="",
+            return_token_id_information=False,
+            uses_reasoning_parser=False,
+            sampling_overrides=overrides,
+            **kwargs,
+        )
+        return VLLMModel(config=config, server_client=MagicMock(spec=ServerClient, global_config_dict={}))
+
+    def test_overrides_replace_what_the_client_sent(self) -> None:
+        server = self._server({"temperature": 1.0, "top_p": 1.0})
+        out = server._preprocess_chat_completion_create_params(
+            MagicMock(), {"messages": [{"role": "user", "content": "hi"}], "temperature": 0.2, "top_p": 0.5}
+        )
+        assert out["temperature"] == 1.0
+        assert out["top_p"] == 1.0
+
+    def test_overrides_apply_even_when_the_client_sent_nothing(self) -> None:
+        server = self._server({"temperature": 1.0})
+        out = server._preprocess_chat_completion_create_params(
+            MagicMock(), {"messages": [{"role": "user", "content": "hi"}]}
+        )
+        assert out["temperature"] == 1.0
+
+    def test_unset_leaves_the_request_alone(self) -> None:
+        server = self._server(None)
+        out = server._preprocess_chat_completion_create_params(
+            MagicMock(), {"messages": [{"role": "user", "content": "hi"}], "temperature": 0.2}
+        )
+        assert out["temperature"] == 0.2
+
+    def test_overrides_reach_the_completions_api_path(self) -> None:
+        """``use_completions_api`` skips chat preprocessing entirely.
+
+        ``chat_completions`` branches into ``_chat_completions_via_completions_api`` before
+        ``_preprocess_chat_completion_create_params`` runs, so a pin applied only there would be
+        silently inert on the path base-model training uses.
+        """
+        server = self._server({"temperature": 1.0, "top_p": 1.0, "top_k": -1}, use_completions_api=True)
+        out = server._build_completion_body_from_chat_body(
+            {"messages": [{"role": "user", "content": "hi"}], "temperature": 0.2, "top_p": 0.5, "top_k": 50},
+            "hi",
+        )
+        assert out["temperature"] == 1.0
+        assert out["top_p"] == 1.0
+        # No first-class /v1/completions field; the body is forwarded as raw JSON so it still lands.
+        assert out["top_k"] == -1
+
+    def test_overrides_win_over_extra_body_on_the_completions_path(self) -> None:
+        """``extra_body`` merges under the request body; the pin is applied after both."""
+        server = self._server(
+            {"temperature": 1.0},
+            use_completions_api=True,
+            extra_body={"temperature": 0.7, "min_p": 0.05},
+        )
+        out = server._build_completion_body_from_chat_body({"messages": [], "temperature": 0.2}, "hi")
+        assert out["temperature"] == 1.0
+        assert out["min_p"] == 0.05
+
+    def test_overrides_reach_the_responses_native_path(self) -> None:
+        server = self._server({"temperature": 1.0}, is_responses_native=True)
+        body = {"model": "dummy_model", "temperature": 0.2}
+        assert server._apply_sampling_overrides(body)["temperature"] == 1.0


### PR DESCRIPTION
Lets a model server put a fixed set of sampling parameters on every request it sends to the engine.

## Why an absent parameter is the problem

Gym's converters forward only what the caller set.

1. Some harnesses built for interactive serving generally send no sampling fields at all, so the outbound body carries no sampling keys and the engine applies a default of its own rather than the configured one.
- On a backend that validates the request, this fails outright.
- On one that does not, nothing errors and the run trains on samples drawn from a distribution the policy is not being optimized under.

2. Alternatively, a harness could send its own value: a harness that hardcodes `temperature` on an auxiliary call such as a title generator or a context compressor. That value is not the configured one either.

`top_k` is a third case, since the Anthropic converter never maps it, so whatever arrives is always a default.

## Where it hooks in

```mermaid
flowchart LR
    C["caller request"] --> R{"which API?"}
    R -->|/v1/responses| P["_apply_sampling_overrides<br/>\napplied last"]
    R -->|/v1/chat/completions| P
    R -->|/v1/completions| P
    P --> E["engine request"]
    R -->|/tokenize| T["unchanged<br/>\ntakes no sampling params"]
```

All three generation paths. The completions path matters specifically: `chat_completions` branches to `_chat_completions_via_completions_api` before the usual preprocessing, so an override applied only in preprocessing would be silently inert there. A pin covering some endpoints and not others is off-policy while reporting that sampling is pinned.

## Precedence

The pin is applied last, so it wins over both what the caller sent and anything `extra_body` merged in. Values replace rather than fill in, because both failure shapes above are real: an absent parameter and a caller-chosen one.

This makes the server authoritative for sampling, which is what #2253 sets out to do through `extra_body_override_keys`. Configuring sampling through `extra_body` today would mean moving those values to `sampling_overrides` to get the same authority.

## Configuration

Unset by default, and no config in this repo sets it, so merging this adds a capability and changes no existing run.

```yaml
policy_model:
  responses_api_models:
    vllm_model:
      sampling_overrides:
        temperature: 1.0
        top_p: 1.0
```

Configure it on the model server whose callers cannot supply their own sampling params, and leave alone the servers used by callers that already do. A Gym agent builds its request from `responses_create_params` on the row, which the integrating framework has already stamped with the right values, including a per-rollout validation profile. Pinning that server would replace those values with themselves at best, and discard a deliberate validation profile at worst. Two kinds of caller therefore want two model server instances, which is an existing pattern.

Gym holds no knowledge of any particular framework here. It enforces whatever profile it is given.

## What this does not do

A caller that never reads the row cannot receive a per-rollout profile by any mechanism, so a pinned server serves validation rollouts at the profile it was configured with. That is invisible while a run's validation and training profiles are equal, and it is a limitation of the caller rather than of the pin: without the pin, the same run does not work at all.

## Testing

`responses_api_models/vllm_model/tests/test_app.py::TestSamplingOverrides` covers five cases: replacing a value the caller sent, applying when the caller sent nothing, staying a no-op when unset, reaching the completions-API path that skips preprocessing, and winning over `extra_body` on that path.

The pin runs after the `extra_body` merge on each of the three paths, so its precedence does not depend on which endpoint a caller picks.

## Changed since the approving review

Three things, all narrowing:

- The `sampling_overrides` block is no longer added to `vllm_model_for_training.yaml`. That file is overlaid by every training run, including native-agent runs whose sampling is already correct.
- The per-parameter interpolation keys are gone. They resolved through defaults that happened to equal the value every config already used, so no run could tell a wired pin from an unwired one.
- A startup log states which profile the server will enforce, or that it will not pin.

The diff is now two files: `vllm_model/app.py` and its tests.

## Why it is first in the stack

Without it, token capture records ids sampled at the wrong distribution, so everything above this is capturing the wrong thing correctly. It also stands alone and is useful without the rest.

Followed by #2124.
