### PR TITLE
fix(pinchbench): isolate the sandbox from the host process tree

### DIFF
--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -139,23 +139,23 @@
         "filename": "responses_api_agents/pinchbench/tests/test_app.py",
         "hashed_secret": "7af5fc59b6cdbb45a6f1fde3f2f1900529c12bb0",
         "is_verified": false,
-        "line_number": 45
+        "line_number": 50
       },
       {
         "type": "Secret Keyword",
         "filename": "responses_api_agents/pinchbench/tests/test_app.py",
         "hashed_secret": "a06371a099b2c32a96b7d9e690b713c165ce5fa8",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 54
       },
       {
         "type": "Secret Keyword",
         "filename": "responses_api_agents/pinchbench/tests/test_app.py",
         "hashed_secret": "15cd4504edaccefbda7199b58ae6dac9bd32cb30",
         "is_verified": false,
-        "line_number": 50
+        "line_number": 55
       }
     ]
   },
-  "generated_at": "2026-07-10T07:53:12Z"
+  "generated_at": "2026-07-31T10:23:14Z"
 }

--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -360,7 +360,9 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         stdout_path = staging_dir / "apptainer.stdout.log"
         stderr_path = staging_dir / "apptainer.stderr.log"
         with stdout_path.open("wb") as stdout_f, stderr_path.open("wb") as stderr_f:
-            proc = await asyncio.create_subprocess_exec(*argv, stdout=stdout_f, stderr=stderr_f)
+            proc = await asyncio.create_subprocess_exec(
+                *argv, stdout=stdout_f, stderr=stderr_f, start_new_session=True
+            )
             try:
                 await asyncio.wait_for(proc.wait(), timeout=self.config.task_timeout_s)
             except asyncio.TimeoutError as exc:

--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -346,7 +346,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
 
         direct_args = apptainer_cfg.get("direct_exec_args")
         if direct_args is None:
-            direct_args = ["--cleanenv", "--no-home"]
+            direct_args = ["--cleanenv", "--no-home", "--pid"]
         elif isinstance(direct_args, str):
             direct_args = direct_args.split()
 

--- a/responses_api_agents/pinchbench/tests/test_app.py
+++ b/responses_api_agents/pinchbench/tests/test_app.py
@@ -18,8 +18,12 @@ transcript parsing) without launching a sandbox or invoking the model — so the
 fast and offline.
 """
 
+import asyncio
 import contextlib
 import json
+import os
+import signal
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -379,3 +383,45 @@ async def test_explicit_direct_exec_args_are_honoured(tmp_path):
     )
 
     assert "--pid" not in captured["argv"]
+
+
+@pytest.mark.asyncio
+async def test_direct_exec_launches_in_a_new_session(tmp_path):
+    agent = make_agent(sandbox_spec={"image": "/img.sif"})
+    captured = await _capture_apptainer_launch(agent, tmp_path, {"direct_exec": True})
+
+    assert captured["kwargs"]["start_new_session"] is True
+
+
+@pytest.mark.asyncio
+async def test_new_session_puts_the_child_in_its_own_process_group():
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "import time; time.sleep(30)",
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    try:
+        assert os.getpgid(proc.pid) == proc.pid
+        assert os.getpgid(proc.pid) != os.getpgid(0)
+    finally:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        await proc.wait()
+
+
+@pytest.mark.asyncio
+async def test_without_new_session_the_child_shares_our_process_group():
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "import time; time.sleep(30)",
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    try:
+        assert os.getpgid(proc.pid) == os.getpgid(0)
+    finally:
+        proc.kill()
+        await proc.wait()

--- a/responses_api_agents/pinchbench/tests/test_app.py
+++ b/responses_api_agents/pinchbench/tests/test_app.py
@@ -18,8 +18,9 @@ transcript parsing) without launching a sandbox or invoking the model — so the
 fast and offline.
 """
 
+import contextlib
 import json
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -343,3 +344,38 @@ def test_classify_task_failure_mapping():
     assert _classify_task_failure(TimeoutError("timed out")) == "timeout_exceeded"
     assert _classify_task_failure(RuntimeError("exec failed")) == "legitimate"
     assert _classify_task_failure(FileNotFoundError("apptainer")) == "legitimate"
+
+
+async def _capture_apptainer_launch(agent, tmp_path, apptainer_cfg):
+    captured = {}
+
+    async def fake_exec(*argv, **kwargs):
+        captured["argv"] = list(argv)
+        captured["kwargs"] = kwargs
+        proc = MagicMock()
+        proc.wait = AsyncMock(return_value=0)
+        proc.returncode = 0
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        with contextlib.suppress(Exception):
+            await agent._run_in_apptainer_direct("task_x", tmp_path, apptainer_cfg)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_direct_exec_isolates_the_pid_namespace_by_default(tmp_path):
+    agent = make_agent(sandbox_spec={"image": "/img.sif"})
+    captured = await _capture_apptainer_launch(agent, tmp_path, {"direct_exec": True})
+
+    assert "--pid" in captured["argv"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_direct_exec_args_are_honoured(tmp_path):
+    agent = make_agent(sandbox_spec={"image": "/img.sif"})
+    captured = await _capture_apptainer_launch(
+        agent, tmp_path, {"direct_exec": True, "direct_exec_args": ["--cleanenv"]}
+    )
+
+    assert "--pid" not in captured["argv"]


### PR DESCRIPTION
The direct apptainer sandbox was not isolated from the host process tree in two independent ways. Both let a sandbox terminate the infrastructure running the evaluation, and both produced rollouts that are silently recorded as zero-score successes rather than retried.

## 1. Shared PID namespace

The sandbox ran with `["--cleanenv", "--no-home"]` — no `--pid`. Tasks execute shell commands, so a pattern-matching kill inside the sandbox matches processes on the host:

```
18:58:03.133Z  sandbox: pkill -f tar
18:58:03       vLLM:    RayWorkerProc rank=[1] died unexpectedly, shutting down executor
                        EngineCore encountered a fatal error
```

This is not a one-off pattern. Observed in sandboxes: `pkill -f pip`, `pkill -f wget`, `pkill -f tar`, `pkill -f "venv/bin/pip"`, `killall find`. An earlier incident had `pkill -f pip` matching `--pipeline-parallel-size` on a server command line. Substring matching means patching individual flags is whack-a-mole; the namespace is the fix.

## 2. Inherited process group

`asyncio.create_subprocess_exec` was called without `start_new_session`, so the sandbox — and everything inside it, including the in-sandbox teardown — inherited the server's process group. The teardown signals a process group (`kill -TERM -- "-$PID"`), which terminated the server and all of its workers simultaneously, followed by a restart and a burst of connection failures while in-flight requests retried against a server still coming up.

The sandbox providers under `nemo_gym/sandbox/providers/` already pass `start_new_session=True`; only this direct path did not.

## Impact

Affected rollouts carry `output_tokens: 0` with `status=success` and no failure class, so they are cached as legitimate zeros. In one full run this silently removed 18% of rollouts and depressed the reported score by roughly 0.11 versus the surviving-rollout mean.

## Verification

Re-ran the exact tasks that had killed a worker, with both fixes: zero vLLM errors, zero zero-token rollouts, sandboxes started normally. Nested unprivileged PID namespaces are permitted in the environments tested.

## Tests

Five tests, split across the two commits. Two are true regression guards — reverting the fixes fails them:

- `test_direct_exec_isolates_the_pid_namespace_by_default` — drives `_run_in_apptainer_direct` with a mocked spawn, asserts `--pid` in argv
- `test_direct_exec_launches_in_a_new_session` — same path, asserts `start_new_session=True`
- `test_explicit_direct_exec_args_are_honoured` — an explicit `direct_exec_args` still wins, so existing configs are unaffected
- `test_new_session_puts_the_child_in_its_own_process_group` — spawns a child, asserts it leads its own group
- `test_without_new_session_the_child_shares_our_process_group` — demonstrates the pre-fix condition directly
