### PR TITLE
PinchBench: route model-server observability on main

### DIFF
--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -46,7 +46,13 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from nemo_gym.anthropic_converter import AnthropicConverter
-from nemo_gym.chat_streaming import sanitize_streaming_chat_body, synthesize_chat_completion_sse
+from nemo_gym.chat_streaming import (
+    DEFAULT_HEARTBEAT_INTERVAL_S,
+    sanitize_streaming_chat_body,
+    synthesize_chat_completion_sse,
+    synthesize_chat_completion_sse_with_heartbeat,
+    validate_streaming_chat_params,
+)
 from nemo_gym.config_types import ROLLOUT_PATH_PREFIX, ModelServerRef
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
@@ -82,6 +88,9 @@ class BaseResponsesAPIModelConfig(BaseRunServerInstanceConfig):
 
 class BaseResponsesAPIModel(BaseServer):
     config: BaseResponsesAPIModelConfig
+
+    # Doubles as the grace window before a slow generation switches to a heartbeated stream.
+    chat_stream_heartbeat_interval_s: float = DEFAULT_HEARTBEAT_INTERVAL_S
 
 
 class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
@@ -162,11 +171,17 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
         ``chat_completions()``, preserving the historical non-streaming behavior (including the
         standard 422 shape). When the client sends ``stream: true`` (blackbox
         Chat-Completions-over-SSE harnesses like the OpenClaw agent always do), the request is
-        sanitized onto that same strict model (drop ``stream``/``stream_options``; see
-        ``nemo_gym.chat_streaming``), validated identically, delegated to the same
-        ``chat_completions()``, and the complete response is buffered and re-emitted as a
-        synthesized ``chat.completion.chunk`` SSE stream. This is buffer-then-replay, not
-        token-by-token streaming.
+        first sanitized from the streaming wire dialect (drop ``stream``/``stream_options``; see
+        ``nemo_gym.chat_streaming``), delegated to the same ``chat_completions()``, and the
+        complete response is buffered and re-emitted as a synthesized ``chat.completion.chunk``
+        SSE stream. This is buffer-then-replay, not token-by-token streaming.
+
+        Because that backend call is non-streaming, a slow generation would otherwise leave the
+        socket completely silent -- no headers, no bytes -- until it finished, which streaming
+        clients read as a hung endpoint (the OpenClaw agent aborts at 120s idle). Generations
+        that outrun a short grace window therefore switch to a heartbeated stream. Anything that
+        completes or fails inside the window keeps the original semantics, so fast failures still
+        surface with their normal status code rather than as a half-written stream.
 
         Only a genuine boolean ``stream: true`` takes the streaming path; any other value
         (e.g. ``"false"`` or ``1``) stays on the strict non-streaming path, which rejects the
@@ -177,9 +192,32 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
             return await self._invoke_chat_completions(request, params)
 
         cleaned, include_usage = sanitize_streaming_chat_body(body)
-        params = _validate_chat_params(cleaned)
-        completion = await self._invoke_chat_completions(request, params)
-        completion_json = completion.model_dump(mode="json") if isinstance(completion, BaseModel) else dict(completion)
+        try:
+            params = validate_streaming_chat_params(cleaned)
+        except ValidationError as exc:
+            raise RequestValidationError(
+                [{**error, "loc": ("body", *error["loc"])} for error in exc.errors(include_url=False)]
+            )
+
+        async def _completion_json() -> dict:
+            completion = await self._invoke_chat_completions(request, params)
+            return completion.model_dump(mode="json") if isinstance(completion, BaseModel) else dict(completion)
+
+        pending = asyncio.ensure_future(_completion_json())
+        try:
+            # shield: a timeout here means "still generating", never "abandon the call".
+            completion_json = await asyncio.wait_for(
+                asyncio.shield(pending), timeout=self.chat_stream_heartbeat_interval_s
+            )
+        except asyncio.TimeoutError:
+            return StreamingResponse(
+                synthesize_chat_completion_sse_with_heartbeat(
+                    pending,
+                    include_usage=include_usage,
+                    interval_s=self.chat_stream_heartbeat_interval_s,
+                ),
+                media_type="text/event-stream",
+            )
         return StreamingResponse(
             synthesize_chat_completion_sse(completion_json, include_usage=include_usage),
             media_type="text/event-stream",

--- a/nemo_gym/chat_streaming.py
+++ b/nemo_gym/chat_streaming.py
@@ -25,26 +25,35 @@ its existing non-streaming backend call and re-emitting it as an SSE stream. Thi
 
 - the request-side sanitizer that maps the streaming wire body onto the strict params shape
   (drops ``stream``/``stream_options``, remembers whether usage was requested);
+- the request-side validator that prunes fields newer than the pinned SDK types before validating;
 - the response-side synthesizer that re-emits a complete ``NeMoGymChatCompletion`` as the
   ``chat.completion.chunk`` SSE sequence a streaming client expects, terminated by ``data: [DONE]``.
 
-Only the SSE envelope is synthesized -- there is no true token-by-token streaming. The backend
-call completes before the first byte is emitted, so the model server's retry and
-error-normalization behavior is fully preserved on this path. This path is intended for eval-only
-streaming clients: token ids and logprobs from the backend response are not carried in the
-``chat.completion.chunk`` schema, and a client that does not set ``stream_options.include_usage``
-gets no usage chunk, so a model-call record reconstructed from this stream will lack token counts.
+Only the SSE envelope is synthesized -- there is no true token-by-token streaming. Because the
+backend call completes before the first byte is emitted, the model server's retry and
+error-normalization behavior is fully preserved on this path, and token-id / logprob capture on
+the backend response is unaffected (those fields simply do not ride in the chunk schema).
 """
 
+import asyncio
 import json
 import logging
 from copy import deepcopy
-from typing import Any, Iterator
+from typing import Any, AsyncIterator, Awaitable, Iterator
+
+from pydantic import ValidationError
 
 from nemo_gym.openai_utils import NeMoGymChatCompletionCreateParamsNonStreaming
 
 
 LOG = logging.getLogger(__name__)
+
+# An SSE comment: ignored by every conforming client parser, but still bytes on the wire, so it
+# refreshes read/idle timers while the buffered backend call is still running.
+SSE_HEARTBEAT = ": keepalive\n\n"
+
+# Well under the 120s idle timeout the OpenClaw agent applies to its model endpoint.
+DEFAULT_HEARTBEAT_INTERVAL_S = 15.0
 
 _PARAM_FIELDS = frozenset(NeMoGymChatCompletionCreateParamsNonStreaming.model_fields)
 
@@ -75,6 +84,42 @@ def sanitize_streaming_chat_body(body: dict[str, Any]) -> tuple[dict[str, Any], 
     if dropped:
         LOG.debug("Dropping unsupported fields from a streaming /v1/chat/completions request: %s", dropped)
     return {key: value for key, value in body.items() if key in _PARAM_FIELDS}, include_usage
+
+
+def _delete_loc(body: Any, loc: tuple) -> bool:
+    """Delete the value at a pydantic error loc from a nested dict/list structure."""
+    node = body
+    for part in loc[:-1]:
+        if isinstance(node, dict) and part in node:
+            node = node[part]
+        elif isinstance(node, list) and isinstance(part, int) and part < len(node):
+            node = node[part]
+        else:
+            return False
+    last = loc[-1]
+    if isinstance(node, dict) and last in node:
+        del node[last]
+        return True
+    return False
+
+
+def validate_streaming_chat_params(body: dict[str, Any]) -> NeMoGymChatCompletionCreateParamsNonStreaming:
+    """Validate a sanitized streaming body, pruning fields newer than the params model."""
+    body = deepcopy(body)
+    while True:
+        try:
+            return NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(body)
+        except ValidationError as exc:
+            removed = False
+            for error in exc.errors():
+                if error["type"] == "extra_forbidden" and _delete_loc(body, tuple(error["loc"])):
+                    LOG.warning(
+                        "Dropping unsupported field %s from a streaming /v1/chat/completions request.",
+                        ".".join(str(part) for part in error["loc"]),
+                    )
+                    removed = True
+            if not removed:
+                raise
 
 
 def _sse_data(payload: dict[str, Any]) -> str:
@@ -155,3 +200,36 @@ def synthesize_chat_completion_sse(completion: dict[str, Any], include_usage: bo
         yield _sse_data(_chunk(completion, [], usage=usage))
 
     yield "data: [DONE]\n\n"
+
+
+async def synthesize_chat_completion_sse_with_heartbeat(
+    pending: Awaitable[dict[str, Any]],
+    include_usage: bool = False,
+    interval_s: float = DEFAULT_HEARTBEAT_INTERVAL_S,
+) -> AsyncIterator[str]:
+    """Emit SSE heartbeats until ``pending`` resolves, then the synthesized completion stream.
+
+    The backend call is non-streaming, so nothing can be emitted until it returns. On a slow
+    model that silence is indistinguishable from a hung endpoint: the OpenClaw agent aborts the
+    session after 120s of quiet ("LLM idle timeout"), and the rollout is graded as an empty
+    failure even though the model is still working. Heartbeating keeps the socket alive for the
+    whole generation without changing what the client ultimately parses.
+
+    A failure after the first heartbeat cannot be reported as an HTTP status (the response has
+    already begun), so it is logged and the stream is terminated with ``data: [DONE]`` rather
+    than left hanging. Callers should therefore await a short grace window first, so fast
+    failures still surface with their normal status code.
+    """
+    while True:
+        try:
+            completion = await asyncio.wait_for(asyncio.shield(pending), timeout=interval_s)
+            break
+        except asyncio.TimeoutError:
+            yield SSE_HEARTBEAT
+        except Exception:
+            LOG.exception("Chat completion failed after the SSE stream had already started")
+            yield "data: [DONE]\n\n"
+            return
+
+    for chunk in synthesize_chat_completion_sse(completion, include_usage=include_usage):
+        yield chunk

--- a/responses_api_agents/pinchbench/README.md
+++ b/responses_api_agents/pinchbench/README.md
@@ -55,13 +55,17 @@ small NVIDIA integration patch:
 | `sandbox_work_base` | writable, per-sandbox-isolated working mount (default `/sandbox`); run_task.sh puts the skill copy, `$HOME`, `$TMPDIR` and the benchmark run-root here |
 | `task_timeout_s` | per-task exec timeout |
 | `openclaw_provider_timeout_seconds` | optional OpenClaw model idle/request timeout in seconds; written to both the provider timeout and agent timeout ceiling so values above OpenClaw's 120s default are effective |
-| `model_base_url` / `model_api_key` / `model_name` | policy model OpenClaw runs against |
+| `model_server` | optional Gym policy-model reference; preferred over `model_base_url` when set |
+| `model_base_url` / `model_api_key` / `model_name` | direct policy-endpoint fallback and model credentials/name |
 | `judge_model` / `judge_base_url` / `judge_api_key` | judge for hybrid / `llm_judge` tasks |
 | `max_tokens`, `context_window`, `max_concurrent`, `timeout_multiplier` | run tuning |
 
-> **Model wiring:** OpenClaw must point at a **streaming-capable** endpoint directly — *not* a Gym
-> model server, which is non-streaming (`stream: Literal[False]`) and would 422 OpenClaw's streamed
-> requests. So the policy/judge endpoints are passed straight through to OpenClaw.
+> **Model wiring:** When `model_server` is configured, `/run` resolves that Gym model server before
+> passing its `/v1` URL to OpenClaw. If global `observability_enabled` is true and the request has
+> `_ng_task_index` plus `_ng_rollout_index`, the resolved URL includes the rollout-correlation
+> prefix; otherwise it remains unprefixed. Gym synthesizes the Chat Completions SSE that OpenClaw
+> requests. With `model_server: null`, `model_base_url` is passed through unchanged for
+> compatibility. The judge endpoint remains configured directly.
 
 ## Setup
 

--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -54,6 +54,7 @@ from nemo_gym.base_responses_api_agent import (
     Body,
     SimpleResponsesAPIAgent,
 )
+from nemo_gym.config_types import ModelServerRef
 from nemo_gym.openai_utils import (
     NeMoGymFunctionCallOutput,
     NeMoGymResponse,
@@ -71,11 +72,12 @@ from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
 
 
 class PinchBenchAgentConfig(BaseResponsesAPIAgentConfig):
-    # Policy model OpenClaw runs against (streaming-capable endpoint, NOT a Gym
-    # non-streaming model server — see README).
+    # Policy model OpenClaw runs against. A configured Gym model server takes
+    # precedence; model_base_url remains the direct-endpoint fallback.
     model_base_url: str
     model_api_key: str
     model_name: str
+    model_server: Optional[ModelServerRef] = None
 
     # Judge for hybrid / llm_judge tasks (OpenAI-compatible endpoint).
     judge_model: str
@@ -170,11 +172,16 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         raise NotImplementedError("PinchBench is an external benchmark; use /run.")
 
     # --- task env ----------------------------------------------------------
-    def _task_env(self, task_id: str) -> dict:
+    def _task_env(self, task_id: str, rollout_id: Optional[str] = None) -> dict:
+        model_base_url = (
+            self.resolve_model_base_url(self.config.model_server.name, rollout_id)
+            if self.config.model_server is not None
+            else self.config.model_base_url
+        )
         env = {
             "TASK_ID": task_id,
             "MODEL_NAME": self.config.model_name,
-            "MODEL_BASE_URL": self.config.model_base_url,
+            "MODEL_BASE_URL": model_base_url,
             "MODEL_API_KEY": self.config.model_api_key,
             "JUDGE_MODEL": self.config.judge_model,
             "JUDGE_BASE_URL": self.config.judge_base_url,
@@ -199,7 +206,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         return env
 
     # --- per-task sandbox (Gym Sandbox API; provider-neutral) ---------------
-    def _build_spec(self, task_id: str) -> SandboxSpec:
+    def _build_spec(self, task_id: str, rollout_id: Optional[str] = None) -> SandboxSpec:
         cfg = dict(self.config.sandbox_spec)
         return SandboxSpec(
             image=cfg.get("image"),
@@ -208,16 +215,16 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
             workdir=cfg.get("workdir"),
             resources=SandboxResources.from_mapping(cfg.get("resources", {})),
             provider_options=cfg.get("provider_options", {}),
-            env=self._task_env(task_id),
+            env=self._task_env(task_id, rollout_id),
             metadata={"task_id": task_id},
         )
 
-    async def _run_in_sandbox(self, task_id: str, out_dir: Path) -> None:
+    async def _run_in_sandbox(self, task_id: str, out_dir: Path, rollout_id: Optional[str] = None) -> None:
         """Run one PinchBench task and pull its /out archive back."""
         provider = self.config.sandbox_provider or {}
         apptainer_cfg = provider.get("apptainer") if isinstance(provider, dict) else None
         if isinstance(apptainer_cfg, dict) and apptainer_cfg.get("direct_exec"):
-            await self._run_in_apptainer_direct(task_id, out_dir, apptainer_cfg)
+            await self._run_in_apptainer_direct(task_id, out_dir, apptainer_cfg, rollout_id=rollout_id)
             return
 
         if not self.config.sandbox_provider:
@@ -225,7 +232,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         archive = f"{self.config.sandbox_work_base.rstrip('/')}/out/out.tgz"
         sb = AsyncSandbox(self.config.sandbox_provider)
         try:
-            await sb.start(self._build_spec(task_id))
+            await sb.start(self._build_spec(task_id, rollout_id))
             await sb.exec("bash /opt/run_task.sh", timeout_s=self.config.task_timeout_s)
             await sb.download(archive, out_dir / "out.tgz")
         finally:
@@ -342,7 +349,13 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         wrapper_path.chmod(0o755)
         return wrapper_path
 
-    async def _run_in_apptainer_direct(self, task_id: str, out_dir: Path, apptainer_cfg: dict[str, Any]) -> None:
+    async def _run_in_apptainer_direct(
+        self,
+        task_id: str,
+        out_dir: Path,
+        apptainer_cfg: dict[str, Any],
+        rollout_id: Optional[str] = None,
+    ) -> None:
         image = self.config.sandbox_spec.get("image")
         if not image:
             raise ValueError("pinchbench sandbox_spec.image is required for direct Apptainer exec")
@@ -362,7 +375,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         elif isinstance(direct_args, str):
             direct_args = direct_args.split()
 
-        task_env = self._task_env(task_id)
+        task_env = self._task_env(task_id, rollout_id)
         argv = ["apptainer", "exec", *[str(arg) for arg in direct_args]]
         argv += ["--bind", f"{staging_dir}:{work_base}"]
         for key, value in task_env.items():
@@ -676,9 +689,10 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         response = self._empty_response(task_id)
         transcript_events: list = []
         archive_path = ""
+        rollout_id = self.rollout_id_from_run(body)
         try:
             async with self._sem:
-                await self._run_in_sandbox(task_id, out_dir)  # one sandbox per task
+                await self._run_in_sandbox(task_id, out_dir, rollout_id=rollout_id)  # one sandbox per task
             result = self._parse_result(task_id, out_dir)
             response = self._response_from_transcript(task_id, out_dir)
             transcript_events, archive_path = self._collect_transcript(task_id, out_dir, run_id)

--- a/responses_api_agents/pinchbench/configs/pinchbench.yaml
+++ b/responses_api_agents/pinchbench/configs/pinchbench.yaml
@@ -23,11 +23,12 @@ pinchbench_agent:
           cpu: 4
           memory_mib: 8192
       task_timeout_s: 1800
-      # Policy model OpenClaw runs against (streaming-capable endpoint; secrets
-      # supplied via CLI/env overrides at run time — never committed).
+      # Policy model OpenClaw runs against. Set model_server to a Gym model-server
+      # reference; when null, model_base_url remains the direct-endpoint fallback.
       model_base_url: ${model_base_url}
       model_api_key: ${model_api_key}
       model_name: ${model_name}
+      model_server: null
       # Judge for hybrid / llm_judge tasks (OpenAI-compatible endpoint).
       judge_model: ${judge_model}
       judge_base_url: ${judge_base_url}

--- a/responses_api_agents/pinchbench/requirements.txt
+++ b/responses_api_agents/pinchbench/requirements.txt
@@ -1,4 +1,6 @@
-# The agent process is a thin launcher/parser. It needs nemo-gym + the [sandbox] extra
-# (Gym's provider-neutral Sandbox API, PR #1377). The PinchBench harness + OpenClaw run
+# The agent process is a thin launcher/parser. The PinchBench harness + OpenClaw run
 # INSIDE the per-task sandbox image (built from Dockerfile.benchmark), not in this venv.
--e nemo-gym[dev,sandbox] @ ../../
+#
+# Do not install the broad [sandbox] extra here: the direct Apptainer path uses Gym's
+# in-repo sandbox types/provider code and does not need optional remote-provider SDKs.
+-e nemo-gym[dev] @ ../../

--- a/responses_api_agents/pinchbench/tests/test_app.py
+++ b/responses_api_agents/pinchbench/tests/test_app.py
@@ -19,10 +19,11 @@ fast and offline.
 """
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nemo_gym.config_types import ModelServerRef
 from nemo_gym.server_utils import ServerClient
 from responses_api_agents.pinchbench.app import (
     NG_FAILURE_CLASS_KEY,
@@ -30,6 +31,7 @@ from responses_api_agents.pinchbench.app import (
     NG_TERMINAL_KEY,
     PinchBenchAgent,
     PinchBenchAgentConfig,
+    PinchBenchRunRequest,
     SandboxKilledError,
     _classify_task_failure,
 )
@@ -76,6 +78,7 @@ def test_task_env_gateway_mode():
     assert env["OPENCLAW_GATEWAY_TOKEN"]  # gateway daemon mode
     assert "PINCHBENCH_FORCE_LOCAL" not in env
     assert env["MODEL_NAME"] == "vendor/model"
+    assert env["MODEL_BASE_URL"] == "http://endpoint/v1"
     assert env["JUDGE_BASE_URL"] == "http://endpoint/v1"
     assert env["BRAVE_API_KEY"] == "brave-key"
 
@@ -88,6 +91,20 @@ def test_direct_exec_wrapper_sets_provider_and_agent_timeout_ceiling(tmp_path):
     assert 'custom_provider["timeoutSeconds"] = provider_timeout_s' in wrapper_text
     assert 'defaults["timeoutSeconds"] = provider_timeout_s' in wrapper_text
     assert 'agent["timeoutSeconds"] = provider_timeout_s' in wrapper_text
+
+
+def test_task_env_resolves_configured_gym_model_server():
+    agent = make_agent(model_server=ModelServerRef(type="responses_api_models", name="policy_model"))
+    with patch.object(
+        PinchBenchAgent,
+        "resolve_model_base_url",
+        autospec=True,
+        return_value="http://model-server/ng-rollout/7-2/v1",
+    ) as resolve:
+        env = agent._task_env("task_x", "7-2")
+
+    resolve.assert_called_once_with(agent, "policy_model", "7-2")
+    assert env["MODEL_BASE_URL"] == "http://model-server/ng-rollout/7-2/v1"
 
 
 def test_build_spec_from_config():
@@ -242,7 +259,7 @@ async def test_run_returns_zero_on_failure_never_raises(tmp_path, monkeypatch):
     otherwise ng_collect_rollouts (fail-fast) aborts the whole collection."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def boom(task_id, out_dir):
+    async def boom(task_id, out_dir, rollout_id=None):
         raise RuntimeError("sandbox exploded")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", boom)
@@ -277,7 +294,7 @@ async def test_generic_failure_routes_to_sidecar_not_main(tmp_path, monkeypatch)
     """A failed task must carry a failure class so it never lands in the main jsonl."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def boom(task_id, out_dir):
+    async def boom(task_id, out_dir, rollout_id=None):
         raise RuntimeError("sandbox exploded")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", boom)
@@ -293,7 +310,7 @@ async def test_signal_killed_sandbox_is_kill_shaped_and_unpersisted(tmp_path, mo
     """Walltime SIGTERM shape: no row anywhere; resume's set-difference re-dispatches."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def killed(task_id, out_dir):
+    async def killed(task_id, out_dir, rollout_id=None):
         raise SandboxKilledError("direct apptainer exec killed (rc=-15) for task task_x")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", killed)
@@ -308,7 +325,7 @@ async def test_task_timeout_is_terminal_sidecar(tmp_path, monkeypatch):
     """Per-task timeout consumed its budget: one sidecar row, never retried."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def slow(task_id, out_dir):
+    async def slow(task_id, out_dir, rollout_id=None):
         raise TimeoutError("direct apptainer exec timed out for task task_x")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", slow)
@@ -324,7 +341,7 @@ async def test_successful_task_carries_no_routing_sentinels(tmp_path, monkeypatc
     """Scored rollouts must keep landing in the main jsonl (no sentinel keys)."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def ok(task_id, out_dir):
+    async def ok(task_id, out_dir, rollout_id=None):
         return None
 
     monkeypatch.setattr(agent, "_run_in_sandbox", ok)
@@ -346,6 +363,68 @@ async def test_successful_task_carries_no_routing_sentinels(tmp_path, monkeypatc
     assert dumped["reward"] == 1.0
     for key in (NG_FAILURE_CLASS_KEY, NG_NO_PERSIST_KEY, NG_TERMINAL_KEY):
         assert key not in dumped
+
+
+@pytest.mark.parametrize(
+    ("observability_enabled", "expected_rollout_id", "model_base_url"),
+    [
+        (True, "7-2", "http://model-server/ng-rollout/7-2/v1"),
+        (False, None, "http://model-server/v1"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_run_resolves_model_server_with_optional_rollout_correlation(
+    tmp_path,
+    monkeypatch,
+    observability_enabled,
+    expected_rollout_id,
+    model_base_url,
+):
+    agent = make_agent(
+        work_root=str(tmp_path / "work"),
+        transcripts_dir=str(tmp_path / "arch"),
+        model_server=ModelServerRef(type="responses_api_models", name="policy_model"),
+    )
+    agent.server_client.global_config_dict = {"observability_enabled": observability_enabled}
+    captured = {}
+
+    async def capture_env(task_id, out_dir, rollout_id=None):
+        captured["env"] = agent._task_env(task_id, rollout_id)
+
+    monkeypatch.setattr(agent, "_run_in_sandbox", capture_env)
+    monkeypatch.setattr(
+        agent,
+        "_parse_result",
+        lambda task_id, out_dir: {
+            "reward": 1.0,
+            "grading_type": "automated",
+            "breakdown": {},
+            "notes": "ok",
+            "status": "success",
+        },
+    )
+    monkeypatch.setattr(agent, "_response_from_transcript", lambda task_id, out_dir: agent._empty_response(task_id))
+    monkeypatch.setattr(agent, "_collect_transcript", lambda task_id, out_dir, run_id: ([], ""))
+    body = PinchBenchRunRequest.model_validate(
+        {
+            "responses_create_params": {"input": "solve"},
+            "verifier_metadata": {"task_id": "task_x"},
+            "_ng_task_index": 7,
+            "_ng_rollout_index": 2,
+        }
+    )
+
+    with patch.object(
+        PinchBenchAgent,
+        "resolve_model_base_url",
+        autospec=True,
+        return_value=model_base_url,
+    ) as resolve:
+        response = await agent.run(body=body)
+
+    assert response.reward == 1.0
+    resolve.assert_called_once_with(agent, "policy_model", expected_rollout_id)
+    assert captured["env"]["MODEL_BASE_URL"] == model_base_url
 
 
 def test_classify_task_failure_mapping():

--- a/tests/unit_tests/test_chat_completions_streaming.py
+++ b/tests/unit_tests/test_chat_completions_streaming.py
@@ -21,6 +21,7 @@ response is re-emitted as a synthesized ``chat.completion.chunk`` SSE stream. No
 requests keep the historical strict-validation behavior.
 """
 
+import asyncio
 import json
 from time import time
 from unittest.mock import MagicMock
@@ -37,8 +38,11 @@ from nemo_gym.base_responses_api_model import (
     _reconstruct_chat_sse,
 )
 from nemo_gym.chat_streaming import (
+    SSE_HEARTBEAT,
     sanitize_streaming_chat_body,
     synthesize_chat_completion_sse,
+    synthesize_chat_completion_sse_with_heartbeat,
+    validate_streaming_chat_params,
 )
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
@@ -390,3 +394,155 @@ class TestSynthesizeSystemFingerprint:
         events = _events("".join(synthesize_chat_completion_sse(completion)))
         assert events
         assert all(event.get("system_fingerprint") == "fp_abc123" for event in events)
+
+
+class _SlowChatModel(_EchoChatModel):
+    """Echo model whose generation outlasts the heartbeat grace window."""
+
+    delay_s: float = 0.3
+
+    async def chat_completions(
+        self, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
+    ) -> NeMoGymChatCompletion:
+        await asyncio.sleep(self.delay_s)
+        return await super().chat_completions(body)
+
+
+class _FailingChatModel(_EchoChatModel):
+    """Echo model that raises, optionally only after the grace window has elapsed."""
+
+    delay_s: float = 0.0
+
+    async def chat_completions(
+        self, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
+    ) -> NeMoGymChatCompletion:
+        if self.delay_s:
+            await asyncio.sleep(self.delay_s)
+        raise RuntimeError("backend exploded")
+
+
+class TestChatStreamHeartbeat:
+    """A non-streaming backend leaves the socket silent; slow generations must not read as hung.
+
+    The OpenClaw agent aborts a session after 120s without bytes ("LLM idle timeout"). Slow
+    models routinely exceed that while generating normally, and every such session is graded as
+    an empty failure.
+    """
+
+    def test_slow_generation_emits_heartbeats_before_the_completion(self) -> None:
+        client, server = _client(_SlowChatModel)
+        server.chat_stream_heartbeat_interval_s = 0.05
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"stream": True, "messages": [{"role": "user", "content": "hello"}]},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        assert SSE_HEARTBEAT in resp.text
+        # the payload still arrives intact after the heartbeats
+        assert resp.text.endswith("data: [DONE]\n\n")
+        rebuilt = _reconstruct_chat_sse(_parse_sse_events(resp.text.encode()))
+        assert rebuilt["choices"][0]["message"]["content"] == "hello"
+
+    def test_heartbeats_are_sse_comments_ignored_by_reconstruction(self) -> None:
+        # A comment carries bytes (refreshing idle timers) without adding a parsed event.
+        assert SSE_HEARTBEAT.startswith(":")
+        assert not _parse_sse_events(SSE_HEARTBEAT.encode())
+
+    def test_fast_generation_emits_no_heartbeats(self) -> None:
+        client, _ = _client(_EchoChatModel)
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"stream": True, "messages": [{"role": "user", "content": "hello"}]},
+        )
+        assert resp.status_code == 200
+        assert SSE_HEARTBEAT not in resp.text
+
+    def test_fast_failure_still_surfaces_as_an_error_not_a_stream(self) -> None:
+        # Errors inside the grace window keep their status code, so retries still see failures.
+        client, _ = _client(_FailingChatModel)
+        with pytest.raises(RuntimeError):
+            client.post(
+                "/v1/chat/completions",
+                json={"stream": True, "messages": [{"role": "user", "content": "hi"}]},
+            )
+
+    def test_failure_after_stream_started_terminates_cleanly(self) -> None:
+        # Past the grace window the response has begun, so the client gets a terminated stream
+        # rather than a hang.
+        async def _drain() -> list[str]:
+            async def _boom() -> dict:
+                await asyncio.sleep(0.15)
+                raise RuntimeError("late failure")
+
+            pending = asyncio.ensure_future(_boom())
+            return [chunk async for chunk in synthesize_chat_completion_sse_with_heartbeat(pending, interval_s=0.05)]
+
+        chunks = asyncio.run(_drain())
+        assert SSE_HEARTBEAT in chunks
+        assert chunks[-1] == "data: [DONE]\n\n"
+
+    def test_bytes_reach_the_wire_before_generation_completes(self) -> None:
+        """Regression: the socket must not stay silent for a whole slow generation.
+
+        Driven at the ASGI layer on purpose. ``TestClient`` buffers a streaming response, so it
+        reports the same time-to-first-byte whether or not the server heartbeats -- it cannot
+        observe this defect at all. Only the raw send() timeline shows what a socket peer, and
+        therefore an idle timeout, actually sees.
+        """
+        gen_s, grace_s = 0.6, 0.1
+
+        async def _timeline() -> list[tuple[float, str]]:
+            client, server = _client(_SlowChatModel)
+            server.delay_s = gen_s
+            server.chat_stream_heartbeat_interval_s = grace_s
+            app = server.setup_webserver()
+
+            body = b'{"stream": true, "messages": [{"role": "user", "content": "hi"}]}'
+            scope = {
+                "type": "http",
+                "asgi": {"version": "3.0", "spec_version": "2.3"},
+                "http_version": "1.1",
+                "method": "POST",
+                "scheme": "http",
+                "path": "/v1/chat/completions",
+                "raw_path": b"/v1/chat/completions",
+                "query_string": b"",
+                "root_path": "",
+                "headers": [
+                    (b"host", b"testserver"),
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode()),
+                ],
+                "client": ("127.0.0.1", 12345),
+                "server": ("testserver", 80),
+            }
+
+            start = asyncio.get_running_loop().time()
+            seen: list[tuple[float, str]] = []
+            delivered = False
+
+            async def receive():
+                # Body once, then stay connected: starlette also polls receive() for disconnects.
+                nonlocal delivered
+                if not delivered:
+                    delivered = True
+                    return {"type": "http.request", "body": body, "more_body": False}
+                await asyncio.Event().wait()
+
+            async def send(message):
+                elapsed = asyncio.get_running_loop().time() - start
+                if message["type"] == "http.response.body" and message.get("body"):
+                    seen.append((elapsed, message["body"].decode()))
+
+            await asyncio.wait_for(app(scope, receive, send), timeout=gen_s * 10)
+            return seen
+
+        seen = asyncio.run(_timeline())
+        assert seen, "no bytes were ever written to the wire"
+        first_at, first_payload = seen[0]
+        assert first_at < gen_s, f"socket stayed silent {first_at:.2f}s for a {gen_s:.2f}s generation"
+        assert first_payload == SSE_HEARTBEAT
+        # the real completion still lands, after the heartbeats
+        assert seen[-1][0] >= gen_s
+        assert "".join(payload for _, payload in seen).endswith("data: [DONE]\n\n")


### PR DESCRIPTION
## Summary

Re-applies the PinchBench model-server routing from #2147 onto current `main`, where PinchBench still bypasses `responses_api_models` and therefore does not produce model-call captures when observability is enabled.

This also adds SSE keepalives for Gym's synthesized streaming chat-completions path. OpenClaw uses streamed chat completions; without keepalives, a slow non-streaming backend call can leave the client socket silent long enough to trigger idle-timeout behavior.

## Validation

- `uv run --with pytest --with pytest-asyncio python -m pytest responses_api_agents/pinchbench/tests/test_app.py::test_task_env_resolves_configured_gym_model_server responses_api_agents/pinchbench/tests/test_app.py::test_run_resolves_model_server_with_optional_rollout_correlation -q`
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/unit_tests/test_chat_completions_streaming.py -q`

## Config shape

```bash
++observability_enabled=true
++model_call_capture_dir=/results/model_call_captures
++pinchbench_agent.responses_api_agents.pinchbench.model_server.type=responses_api_models
++pinchbench_agent.responses_api_agents.pinchbench.model_server.name=policy_model
```

cc @laszkiewiczp (@plaszkiewicz in git author/email)
