### PR TITLE
Add PinchBench model server support

### DIFF
--- a/responses_api_agents/pinchbench/README.md
+++ b/responses_api_agents/pinchbench/README.md
@@ -55,13 +55,17 @@ small NVIDIA integration patch:
 | `sandbox_work_base` | writable, per-sandbox-isolated working mount (default `/sandbox`); run_task.sh puts the skill copy, `$HOME`, `$TMPDIR` and the benchmark run-root here |
 | `task_timeout_s` | per-task exec timeout |
 | `openclaw_provider_timeout_seconds` | optional OpenClaw model idle/request timeout in seconds; written to both the provider timeout and agent timeout ceiling so values above OpenClaw's 120s default are effective |
-| `model_base_url` / `model_api_key` / `model_name` | policy model OpenClaw runs against |
+| `model_server` | optional Gym policy-model reference; preferred over `model_base_url` when set |
+| `model_base_url` / `model_api_key` / `model_name` | direct policy-endpoint fallback and model credentials/name |
 | `judge_model` / `judge_base_url` / `judge_api_key` | judge for hybrid / `llm_judge` tasks |
 | `max_tokens`, `context_window`, `max_concurrent`, `timeout_multiplier` | run tuning |
 
-> **Model wiring:** OpenClaw must point at a **streaming-capable** endpoint directly — *not* a Gym
-> model server, which is non-streaming (`stream: Literal[False]`) and would 422 OpenClaw's streamed
-> requests. So the policy/judge endpoints are passed straight through to OpenClaw.
+> **Model wiring:** When `model_server` is configured, `/run` resolves that Gym model server before
+> passing its `/v1` URL to OpenClaw. If global `observability_enabled` is true and the request has
+> `_ng_task_index` plus `_ng_rollout_index`, the resolved URL includes the rollout-correlation
+> prefix; otherwise it remains unprefixed. Gym synthesizes the Chat Completions SSE that OpenClaw
+> requests. With `model_server: null`, `model_base_url` is passed through unchanged for
+> compatibility. The judge endpoint remains configured directly.
 
 ## Setup
 

--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -54,6 +54,7 @@ from nemo_gym.base_responses_api_agent import (
     Body,
     SimpleResponsesAPIAgent,
 )
+from nemo_gym.config_types import ModelServerRef
 from nemo_gym.openai_utils import (
     NeMoGymFunctionCallOutput,
     NeMoGymResponse,
@@ -71,11 +72,12 @@ from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
 
 
 class PinchBenchAgentConfig(BaseResponsesAPIAgentConfig):
-    # Policy model OpenClaw runs against (streaming-capable endpoint, NOT a Gym
-    # non-streaming model server — see README).
+    # Policy model OpenClaw runs against. A configured Gym model server takes
+    # precedence; model_base_url remains the direct-endpoint fallback.
     model_base_url: str
     model_api_key: str
     model_name: str
+    model_server: Optional[ModelServerRef] = None
 
     # Judge for hybrid / llm_judge tasks (OpenAI-compatible endpoint).
     judge_model: str
@@ -170,11 +172,16 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         raise NotImplementedError("PinchBench is an external benchmark; use /run.")
 
     # --- task env ----------------------------------------------------------
-    def _task_env(self, task_id: str) -> dict:
+    def _task_env(self, task_id: str, rollout_id: Optional[str] = None) -> dict:
+        model_base_url = (
+            self.resolve_model_base_url(self.config.model_server.name, rollout_id)
+            if self.config.model_server is not None
+            else self.config.model_base_url
+        )
         env = {
             "TASK_ID": task_id,
             "MODEL_NAME": self.config.model_name,
-            "MODEL_BASE_URL": self.config.model_base_url,
+            "MODEL_BASE_URL": model_base_url,
             "MODEL_API_KEY": self.config.model_api_key,
             "JUDGE_MODEL": self.config.judge_model,
             "JUDGE_BASE_URL": self.config.judge_base_url,
@@ -199,7 +206,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         return env
 
     # --- per-task sandbox (Gym Sandbox API; provider-neutral) ---------------
-    def _build_spec(self, task_id: str) -> SandboxSpec:
+    def _build_spec(self, task_id: str, rollout_id: Optional[str] = None) -> SandboxSpec:
         cfg = dict(self.config.sandbox_spec)
         return SandboxSpec(
             image=cfg.get("image"),
@@ -208,16 +215,16 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
             workdir=cfg.get("workdir"),
             resources=SandboxResources.from_mapping(cfg.get("resources", {})),
             provider_options=cfg.get("provider_options", {}),
-            env=self._task_env(task_id),
+            env=self._task_env(task_id, rollout_id),
             metadata={"task_id": task_id},
         )
 
-    async def _run_in_sandbox(self, task_id: str, out_dir: Path) -> None:
+    async def _run_in_sandbox(self, task_id: str, out_dir: Path, rollout_id: Optional[str] = None) -> None:
         """Run one PinchBench task and pull its /out archive back."""
         provider = self.config.sandbox_provider or {}
         apptainer_cfg = provider.get("apptainer") if isinstance(provider, dict) else None
         if isinstance(apptainer_cfg, dict) and apptainer_cfg.get("direct_exec"):
-            await self._run_in_apptainer_direct(task_id, out_dir, apptainer_cfg)
+            await self._run_in_apptainer_direct(task_id, out_dir, apptainer_cfg, rollout_id=rollout_id)
             return
 
         if not self.config.sandbox_provider:
@@ -225,7 +232,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         archive = f"{self.config.sandbox_work_base.rstrip('/')}/out/out.tgz"
         sb = AsyncSandbox(self.config.sandbox_provider)
         try:
-            await sb.start(self._build_spec(task_id))
+            await sb.start(self._build_spec(task_id, rollout_id))
             await sb.exec("bash /opt/run_task.sh", timeout_s=self.config.task_timeout_s)
             await sb.download(archive, out_dir / "out.tgz")
         finally:
@@ -342,7 +349,13 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         wrapper_path.chmod(0o755)
         return wrapper_path
 
-    async def _run_in_apptainer_direct(self, task_id: str, out_dir: Path, apptainer_cfg: dict[str, Any]) -> None:
+    async def _run_in_apptainer_direct(
+        self,
+        task_id: str,
+        out_dir: Path,
+        apptainer_cfg: dict[str, Any],
+        rollout_id: Optional[str] = None,
+    ) -> None:
         image = self.config.sandbox_spec.get("image")
         if not image:
             raise ValueError("pinchbench sandbox_spec.image is required for direct Apptainer exec")
@@ -362,7 +375,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         elif isinstance(direct_args, str):
             direct_args = direct_args.split()
 
-        task_env = self._task_env(task_id)
+        task_env = self._task_env(task_id, rollout_id)
         argv = ["apptainer", "exec", *[str(arg) for arg in direct_args]]
         argv += ["--bind", f"{staging_dir}:{work_base}"]
         for key, value in task_env.items():
@@ -676,9 +689,10 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         response = self._empty_response(task_id)
         transcript_events: list = []
         archive_path = ""
+        rollout_id = self.rollout_id_from_run(body)
         try:
             async with self._sem:
-                await self._run_in_sandbox(task_id, out_dir)  # one sandbox per task
+                await self._run_in_sandbox(task_id, out_dir, rollout_id=rollout_id)  # one sandbox per task
             result = self._parse_result(task_id, out_dir)
             response = self._response_from_transcript(task_id, out_dir)
             transcript_events, archive_path = self._collect_transcript(task_id, out_dir, run_id)

--- a/responses_api_agents/pinchbench/configs/pinchbench.yaml
+++ b/responses_api_agents/pinchbench/configs/pinchbench.yaml
@@ -23,11 +23,12 @@ pinchbench_agent:
           cpu: 4
           memory_mib: 8192
       task_timeout_s: 1800
-      # Policy model OpenClaw runs against (streaming-capable endpoint; secrets
-      # supplied via CLI/env overrides at run time — never committed).
+      # Policy model OpenClaw runs against. Set model_server to a Gym model-server
+      # reference; when null, model_base_url remains the direct-endpoint fallback.
       model_base_url: ${model_base_url}
       model_api_key: ${model_api_key}
       model_name: ${model_name}
+      model_server: null
       # Judge for hybrid / llm_judge tasks (OpenAI-compatible endpoint).
       judge_model: ${judge_model}
       judge_base_url: ${judge_base_url}

--- a/responses_api_agents/pinchbench/tests/test_app.py
+++ b/responses_api_agents/pinchbench/tests/test_app.py
@@ -19,10 +19,11 @@ fast and offline.
 """
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nemo_gym.config_types import ModelServerRef
 from nemo_gym.server_utils import ServerClient
 from responses_api_agents.pinchbench.app import (
     NG_FAILURE_CLASS_KEY,
@@ -30,6 +31,7 @@ from responses_api_agents.pinchbench.app import (
     NG_TERMINAL_KEY,
     PinchBenchAgent,
     PinchBenchAgentConfig,
+    PinchBenchRunRequest,
     SandboxKilledError,
     _classify_task_failure,
 )
@@ -76,6 +78,7 @@ def test_task_env_gateway_mode():
     assert env["OPENCLAW_GATEWAY_TOKEN"]  # gateway daemon mode
     assert "PINCHBENCH_FORCE_LOCAL" not in env
     assert env["MODEL_NAME"] == "vendor/model"
+    assert env["MODEL_BASE_URL"] == "http://endpoint/v1"
     assert env["JUDGE_BASE_URL"] == "http://endpoint/v1"
     assert env["BRAVE_API_KEY"] == "brave-key"
 
@@ -88,6 +91,20 @@ def test_direct_exec_wrapper_sets_provider_and_agent_timeout_ceiling(tmp_path):
     assert 'custom_provider["timeoutSeconds"] = provider_timeout_s' in wrapper_text
     assert 'defaults["timeoutSeconds"] = provider_timeout_s' in wrapper_text
     assert 'agent["timeoutSeconds"] = provider_timeout_s' in wrapper_text
+
+
+def test_task_env_resolves_configured_gym_model_server():
+    agent = make_agent(model_server=ModelServerRef(type="responses_api_models", name="policy_model"))
+    with patch.object(
+        PinchBenchAgent,
+        "resolve_model_base_url",
+        autospec=True,
+        return_value="http://model-server/ng-rollout/7-2/v1",
+    ) as resolve:
+        env = agent._task_env("task_x", "7-2")
+
+    resolve.assert_called_once_with(agent, "policy_model", "7-2")
+    assert env["MODEL_BASE_URL"] == "http://model-server/ng-rollout/7-2/v1"
 
 
 def test_build_spec_from_config():
@@ -242,7 +259,7 @@ async def test_run_returns_zero_on_failure_never_raises(tmp_path, monkeypatch):
     otherwise ng_collect_rollouts (fail-fast) aborts the whole collection."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def boom(task_id, out_dir):
+    async def boom(task_id, out_dir, rollout_id=None):
         raise RuntimeError("sandbox exploded")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", boom)
@@ -277,7 +294,7 @@ async def test_generic_failure_routes_to_sidecar_not_main(tmp_path, monkeypatch)
     """A failed task must carry a failure class so it never lands in the main jsonl."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def boom(task_id, out_dir):
+    async def boom(task_id, out_dir, rollout_id=None):
         raise RuntimeError("sandbox exploded")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", boom)
@@ -293,7 +310,7 @@ async def test_signal_killed_sandbox_is_kill_shaped_and_unpersisted(tmp_path, mo
     """Walltime SIGTERM shape: no row anywhere; resume's set-difference re-dispatches."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def killed(task_id, out_dir):
+    async def killed(task_id, out_dir, rollout_id=None):
         raise SandboxKilledError("direct apptainer exec killed (rc=-15) for task task_x")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", killed)
@@ -308,7 +325,7 @@ async def test_task_timeout_is_terminal_sidecar(tmp_path, monkeypatch):
     """Per-task timeout consumed its budget: one sidecar row, never retried."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def slow(task_id, out_dir):
+    async def slow(task_id, out_dir, rollout_id=None):
         raise TimeoutError("direct apptainer exec timed out for task task_x")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", slow)
@@ -324,7 +341,7 @@ async def test_successful_task_carries_no_routing_sentinels(tmp_path, monkeypatc
     """Scored rollouts must keep landing in the main jsonl (no sentinel keys)."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def ok(task_id, out_dir):
+    async def ok(task_id, out_dir, rollout_id=None):
         return None
 
     monkeypatch.setattr(agent, "_run_in_sandbox", ok)
@@ -346,6 +363,68 @@ async def test_successful_task_carries_no_routing_sentinels(tmp_path, monkeypatc
     assert dumped["reward"] == 1.0
     for key in (NG_FAILURE_CLASS_KEY, NG_NO_PERSIST_KEY, NG_TERMINAL_KEY):
         assert key not in dumped
+
+
+@pytest.mark.parametrize(
+    ("observability_enabled", "expected_rollout_id", "model_base_url"),
+    [
+        (True, "7-2", "http://model-server/ng-rollout/7-2/v1"),
+        (False, None, "http://model-server/v1"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_run_resolves_model_server_with_optional_rollout_correlation(
+    tmp_path,
+    monkeypatch,
+    observability_enabled,
+    expected_rollout_id,
+    model_base_url,
+):
+    agent = make_agent(
+        work_root=str(tmp_path / "work"),
+        transcripts_dir=str(tmp_path / "arch"),
+        model_server=ModelServerRef(type="responses_api_models", name="policy_model"),
+    )
+    agent.server_client.global_config_dict = {"observability_enabled": observability_enabled}
+    captured = {}
+
+    async def capture_env(task_id, out_dir, rollout_id=None):
+        captured["env"] = agent._task_env(task_id, rollout_id)
+
+    monkeypatch.setattr(agent, "_run_in_sandbox", capture_env)
+    monkeypatch.setattr(
+        agent,
+        "_parse_result",
+        lambda task_id, out_dir: {
+            "reward": 1.0,
+            "grading_type": "automated",
+            "breakdown": {},
+            "notes": "ok",
+            "status": "success",
+        },
+    )
+    monkeypatch.setattr(agent, "_response_from_transcript", lambda task_id, out_dir: agent._empty_response(task_id))
+    monkeypatch.setattr(agent, "_collect_transcript", lambda task_id, out_dir, run_id: ([], ""))
+    body = PinchBenchRunRequest.model_validate(
+        {
+            "responses_create_params": {"input": "solve"},
+            "verifier_metadata": {"task_id": "task_x"},
+            "_ng_task_index": 7,
+            "_ng_rollout_index": 2,
+        }
+    )
+
+    with patch.object(
+        PinchBenchAgent,
+        "resolve_model_base_url",
+        autospec=True,
+        return_value=model_base_url,
+    ) as resolve:
+        response = await agent.run(body=body)
+
+    assert response.reward == 1.0
+    resolve.assert_called_once_with(agent, "policy_model", expected_rollout_id)
+    assert captured["env"]["MODEL_BASE_URL"] == model_base_url
 
 
 def test_classify_task_failure_mapping():


### PR DESCRIPTION
## Summary

This is the PinchBench model-server support from #2147 applied to current `main`.

Only the #2147 model-server routing change is included:

- add optional `pinchbench.model_server`
- resolve the configured Gym `responses_api_models` server for PinchBench `/run`
- pass the rollout-correlation prefix when observability is enabled
- keep the direct `model_base_url` path as the fallback

No SSE keepalive changes and no unrelated files are included.

## Validation

```bash
uv run --with pytest --with pytest-asyncio python -m pytest   responses_api_agents/pinchbench/tests/test_app.py::test_task_env_resolves_configured_gym_model_server   responses_api_agents/pinchbench/tests/test_app.py::test_run_resolves_model_server_with_optional_rollout_correlation   -q
```

Result: `3 passed`.

cc @laszkiewiczp
