### PR TITLE
docs: Update NeMo RL v0.7.0 compatibility guidance (#2257)

### DIFF
--- a/fern/versions/latest/pages/get-started/installation.mdx
+++ b/fern/versions/latest/pages/get-started/installation.mdx
@@ -41,7 +41,13 @@ uv sync
 
 Container choice depends on your NeMo Gym version and model recipe. See [RL Framework Compatibility](/reference/rl-framework-compatibility) for the full mapping.
 
-For NeMo Gym **v0.3.0** with the Nemotron 3 Ultra recipe, build the container from the NeMo RL `ultra-v3` branch (there is no pre-built NGC tag for this pairing):
+For NeMo Gym **v0.4.0** with the Nemotron 3 Super recipe, pull the NeMo RL v0.7.0 container. This container includes NeMo Gym v0.4.0:
+
+```bash
+docker pull nvcr.io/nvidia/nemo-rl:v0.7.0
+```
+
+For the historical NeMo Gym **v0.3.0** and Nemotron 3 Ultra pairing, build the container from the NeMo RL `ultra-v3` branch (there is no pre-built NGC tag for this pairing):
 
 This command uses Docker Buildx and Docker 23+ syntax. By default, Docker builds for your host platform; add `--platform` only if you need to target a different architecture.
 
@@ -59,7 +65,7 @@ docker buildx build \
   .
 ```
 
-For other recipes (for example Nemotron 3 Nano or Super), use the NGC container listed in the compatibility table for that recipe.
+For other Gym versions and recipes (for example Nemotron 3 Nano), use the container listed in the compatibility table for that pairing.
 
 </Tab>
 </Tabs>

--- a/fern/versions/latest/pages/model-recipes/nemotron-3-super.mdx
+++ b/fern/versions/latest/pages/model-recipes/nemotron-3-super.mdx
@@ -3,6 +3,6 @@ title: "Nemotron 3 Super"
 description: ""
 position: 3
 ---
-The recipe for training Nemotron 3 Super with NeMo Gym and NeMo RL can be found in this [NeMo RL guide](https://github.com/NVIDIA-NeMo/RL/blob/super-v3/docs/guides/nemotron-3-super.md).
+The recipe for training Nemotron 3 Super with NeMo Gym and NeMo RL v0.7.0 can be found in this [NeMo RL guide](https://github.com/NVIDIA-NeMo/RL/blob/v0.7.0/docs/guides/nemotron-3-super.md).
 
 The steps for training Nemotron 3 Super are similar to those for [Nemotron 3 Nano](/model-recipes/nemotron-3-nano), and a dedicated tutorial will be posted in this document soon!

--- a/fern/versions/latest/pages/reference/rl-framework-compatibility.mdx
+++ b/fern/versions/latest/pages/reference/rl-framework-compatibility.mdx
@@ -21,6 +21,7 @@ Match the container to your **model recipe**, not only your NeMo Gym version. Fo
 
 | NeMo Gym Version | Container / Docker File | Recipe |
 | --- | --- | --- |
+| v0.4.0 | [`nvcr.io/nvidia/nemo-rl:v0.7.0`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-rl/tags?version=v0.7.0) | [Nemotron 3 Super](/model-recipes/nemotron-3-super) |
 | v0.3.0 | [Dockerfile](https://github.com/NVIDIA-NeMo/RL/blob/ultra-v3/docker/Dockerfile) | [Nemotron 3 Ultra](https://github.com/NVIDIA-NeMo/RL/blob/ultra-v3/docs/guides/nemotron-3-ultra.md) |
 | v0.2.0 | [`nvcr.io/nvidia/nemo-rl:v0.5.0.nemotron_3_super`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-rl/tags?version=v0.5.0) | [Nemotron 3 Super](/model-recipes/nemotron-3-super) |
 | v0.1.1 | [`nvcr.io/nvidia/nemo-rl:v0.4.0.nemotron_3_nano`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-rl/tags?version=v0.4.0) | [Nemotron 3 Nano](/model-recipes/nemotron-3-nano) |

--- a/fern/versions/v0.4.0/pages/get-started/installation.mdx
+++ b/fern/versions/v0.4.0/pages/get-started/installation.mdx
@@ -41,7 +41,13 @@ uv sync
 
 Container choice depends on your NeMo Gym version and model recipe. See [RL Framework Compatibility](/reference/rl-framework-compatibility) for the full mapping.
 
-For NeMo Gym **v0.3.0** with the Nemotron 3 Ultra recipe, build the container from the NeMo RL `ultra-v3` branch (there is no pre-built NGC tag for this pairing):
+For NeMo Gym **v0.4.0** with the Nemotron 3 Super recipe, pull the NeMo RL v0.7.0 container. This container includes NeMo Gym v0.4.0:
+
+```bash
+docker pull nvcr.io/nvidia/nemo-rl:v0.7.0
+```
+
+For the historical NeMo Gym **v0.3.0** and Nemotron 3 Ultra pairing, build the container from the NeMo RL `ultra-v3` branch (there is no pre-built NGC tag for this pairing):
 
 This command uses Docker Buildx and Docker 23+ syntax. By default, Docker builds for your host platform; add `--platform` only if you need to target a different architecture.
 
@@ -59,7 +65,7 @@ docker buildx build \
   .
 ```
 
-For other recipes (for example Nemotron 3 Nano or Super), use the NGC container listed in the compatibility table for that recipe.
+For other Gym versions and recipes (for example Nemotron 3 Nano), use the container listed in the compatibility table for that pairing.
 
 </Tab>
 </Tabs>

--- a/fern/versions/v0.4.0/pages/model-recipes/nemotron-3-super.mdx
+++ b/fern/versions/v0.4.0/pages/model-recipes/nemotron-3-super.mdx
@@ -3,6 +3,6 @@ title: "Nemotron 3 Super"
 description: ""
 position: 3
 ---
-The recipe for training Nemotron 3 Super with NeMo Gym and NeMo RL can be found in this [NeMo RL guide](https://github.com/NVIDIA-NeMo/RL/blob/super-v3/docs/guides/nemotron-3-super.md).
+The recipe for training Nemotron 3 Super with NeMo Gym and NeMo RL v0.7.0 can be found in this [NeMo RL guide](https://github.com/NVIDIA-NeMo/RL/blob/v0.7.0/docs/guides/nemotron-3-super.md).
 
 The steps for training Nemotron 3 Super are similar to those for [Nemotron 3 Nano](/model-recipes/nemotron-3-nano), and a dedicated tutorial will be posted in this document soon!

--- a/fern/versions/v0.4.0/pages/reference/rl-framework-compatibility.mdx
+++ b/fern/versions/v0.4.0/pages/reference/rl-framework-compatibility.mdx
@@ -21,6 +21,7 @@ Match the container to your **model recipe**, not only your NeMo Gym version. Fo
 
 | NeMo Gym Version | Container / Docker File | Recipe |
 | --- | --- | --- |
+| v0.4.0 | [`nvcr.io/nvidia/nemo-rl:v0.7.0`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-rl/tags?version=v0.7.0) | [Nemotron 3 Super](/model-recipes/nemotron-3-super) |
 | v0.3.0 | [Dockerfile](https://github.com/NVIDIA-NeMo/RL/blob/ultra-v3/docker/Dockerfile) | [Nemotron 3 Ultra](https://github.com/NVIDIA-NeMo/RL/blob/ultra-v3/docs/guides/nemotron-3-ultra.md) |
 | v0.2.0 | [`nvcr.io/nvidia/nemo-rl:v0.5.0.nemotron_3_super`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-rl/tags?version=v0.5.0) | [Nemotron 3 Super](/model-recipes/nemotron-3-super) |
 | v0.1.1 | [`nvcr.io/nvidia/nemo-rl:v0.4.0.nemotron_3_nano`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-rl/tags?version=v0.4.0) | [Nemotron 3 Nano](/model-recipes/nemotron-3-nano) |


### PR DESCRIPTION
## Summary
- Add NeMo Gym v0.4.0 compatibility with the NeMo RL v0.7.0 container
- Update installation guidance and Nemotron 3 Super recipe links
- Apply changes to both `latest` and `v0.4.0` Fern docs
Closes #2257

## Testing
- `git diff --check`
- Verified no MDX lint errors