### PR TITLE
feat: option to skip verification

### DIFF
--- a/nemo_gym/base_responses_api_agent.py
+++ b/nemo_gym/base_responses_api_agent.py
@@ -43,7 +43,8 @@ from nemo_gym.server_utils import (
 
 
 class BaseResponsesAPIAgentConfig(BaseRunServerInstanceConfig):
-    pass
+    skip_verification: bool = False
+    skip_verification_reward: float = 0.0
 
 
 class BaseResponsesAPIAgent(BaseServer):
@@ -52,6 +53,22 @@ class BaseResponsesAPIAgent(BaseServer):
 
 class SimpleResponsesAPIAgent(BaseResponsesAPIAgent, AggregateMetricsMixin, SimpleServer):
     config: BaseResponsesAPIAgentConfig
+
+    def build_skipped_verify_response_payload(
+        self,
+        body: BaseRunRequest,
+        response: NeMoGymResponse | dict[str, Any],
+    ) -> dict[str, Any]:
+        if isinstance(response, NeMoGymResponse):
+            response_payload = response.model_dump()
+        else:
+            response_payload = response
+
+        return body.model_dump() | {
+            "response": response_payload,
+            "reward": float(self.config.skip_verification_reward),
+            "verification_skipped": True,
+        }
 
     def setup_webserver(self) -> FastAPI:
         app = FastAPI()

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -90,6 +90,8 @@ QUERY_KEY_NAME = "query"
 OBSERVABILITY_ENABLED_KEY_NAME = "observability_enabled"
 MODEL_CALL_CAPTURE_DIR_KEY_NAME = "model_call_capture_dir"
 COMPONENT_NAME_KEY_NAME = "component_name"
+SKIP_VERIFICATION_KEY_NAME = "skip_verification"
+SKIP_VERIFICATION_REWARD_KEY_NAME = "skip_verification_reward"
 NEMO_GYM_RESERVED_TOP_LEVEL_KEYS = [
     CONFIG_PATHS_KEY_NAME,
     ENTRYPOINT_KEY_NAME,
@@ -118,6 +120,8 @@ NEMO_GYM_RESERVED_TOP_LEVEL_KEYS = [
     OBSERVABILITY_ENABLED_KEY_NAME,
     MODEL_CALL_CAPTURE_DIR_KEY_NAME,
     COMPONENT_NAME_KEY_NAME,
+    SKIP_VERIFICATION_KEY_NAME,
+    SKIP_VERIFICATION_REWARD_KEY_NAME,
 ]
 
 # Data keys
@@ -325,6 +329,8 @@ Duplicate config paths:
         port_range_low: int,
         port_range_high: int,
         initial_disallowed_ports: Optional[List[int]] = None,
+        skip_verification: Optional[bool] = None,
+        skip_verification_reward: Optional[float] = None,
     ) -> List[int]:
         server_refs = [c.get_server_ref() for c in server_instance_configs]
 
@@ -367,6 +373,18 @@ Duplicate config paths:
                 else:
                     # Port already exists, add it to the disallowed list.
                     disallowed_ports.append(run_server_config_dict["port"])
+
+                if server_instance_config.SERVER_TYPE == "responses_api_agents":
+                    if (
+                        skip_verification is not None
+                        and SKIP_VERIFICATION_KEY_NAME not in run_server_config_dict
+                    ):
+                        run_server_config_dict[SKIP_VERIFICATION_KEY_NAME] = skip_verification
+                    if (
+                        skip_verification_reward is not None
+                        and SKIP_VERIFICATION_REWARD_KEY_NAME not in run_server_config_dict
+                    ):
+                        run_server_config_dict[SKIP_VERIFICATION_REWARD_KEY_NAME] = skip_verification_reward
 
         return disallowed_ports
 
@@ -674,6 +692,8 @@ Found global config dict yaml:
             initial_disallowed_ports=initial_disallowed_ports,
             port_range_low=port_range_low,
             port_range_high=port_range_high,
+            skip_verification=global_config_dict.get(SKIP_VERIFICATION_KEY_NAME),
+            skip_verification_reward=global_config_dict.get(SKIP_VERIFICATION_REWARD_KEY_NAME),
         )
 
         with open_dict(global_config_dict):

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -375,10 +375,7 @@ Duplicate config paths:
                     disallowed_ports.append(run_server_config_dict["port"])
 
                 if server_instance_config.SERVER_TYPE == "responses_api_agents":
-                    if (
-                        skip_verification is not None
-                        and SKIP_VERIFICATION_KEY_NAME not in run_server_config_dict
-                    ):
+                    if skip_verification is not None and SKIP_VERIFICATION_KEY_NAME not in run_server_config_dict:
                         run_server_config_dict[SKIP_VERIFICATION_KEY_NAME] = skip_verification
                     if (
                         skip_verification_reward is not None

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -200,9 +200,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 self.build_skipped_verify_response_payload(body, response_json)
             )
 
-        verify_request = SimpleAgentVerifyRequest.model_validate(
-            body.model_dump() | {"response": response_json}
-        )
+        verify_request = SimpleAgentVerifyRequest.model_validate(body.model_dump() | {"response": response_json})
 
         verify_response = await self.server_client.post(
             server_name=self.config.resources_server.name,

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -194,8 +194,14 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         await raise_for_status(response)
         cookies = response.cookies
 
+        response_json = await get_response_json(response)
+        if self.config.skip_verification:
+            return SimpleAgentVerifyResponse.model_validate(
+                self.build_skipped_verify_response_payload(body, response_json)
+            )
+
         verify_request = SimpleAgentVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(response)}
+            body.model_dump() | {"response": response_json}
         )
 
         verify_response = await self.server_client.post(
@@ -209,6 +215,9 @@ class SimpleAgent(SimpleResponsesAPIAgent):
 
     async def aggregate_metrics(self, body: AggregateMetricsRequest = Body()) -> AggregateMetrics:
         """Proxy aggregate_metrics to the resources server."""
+        if self.config.skip_verification:
+            return await super().aggregate_metrics(body)
+
         response = await self.server_client.post(
             server_name=self.config.resources_server.name,
             url_path="/aggregate_metrics",

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -726,9 +726,7 @@ class TestApp:
         assert response_json["verification_skipped"] is True
         assert response_json["response"]["id"] == "response_id"
 
-        post_call_kwargs = [
-            post_call.kwargs for post_call in server.server_client.post.call_args_list
-        ]
+        post_call_kwargs = [post_call.kwargs for post_call in server.server_client.post.call_args_list]
         assert [kwargs["url_path"] for kwargs in post_call_kwargs] == [
             "/seed_session",
             "/v1/responses",

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -672,3 +672,67 @@ class TestApp:
             "safety_identifier": None,
         }
         assert expected_responses_dict == actual_responses_dict
+
+    async def test_run_skip_verification_uses_configured_reward(self) -> None:
+        config = SimpleAgentConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="simple_agent",
+            model_server=ModelServerRef(
+                type="responses_api_models",
+                name="my model server",
+            ),
+            resources_server=ResourcesServerRef(
+                type="resources_servers",
+                name="my resources server",
+            ),
+            skip_verification=True,
+            skip_verification_reward=0.25,
+        )
+        server = SimpleAgent(config=config, server_client=MagicMock(spec=ServerClient))
+        app = server.setup_webserver()
+        client = TestClient(app)
+
+        seed_response = AsyncMock()
+        seed_response.ok = True
+        seed_response.cookies = {"session": "seeded"}
+
+        model_response_payload = {
+            "id": "response_id",
+            "created_at": 1,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+        model_response = AsyncMock()
+        model_response.ok = True
+        model_response.cookies = {"session": "model"}
+        model_response.read.return_value = json.dumps(model_response_payload).encode()
+
+        server.server_client.post.side_effect = [seed_response, model_response]
+
+        response = client.post(
+            "/run",
+            json={"responses_create_params": {"input": [{"role": "user", "content": "hello"}]}},
+        )
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert response_json["reward"] == 0.25
+        assert response_json["verification_skipped"] is True
+        assert response_json["response"]["id"] == "response_id"
+
+        post_call_kwargs = [
+            post_call.kwargs for post_call in server.server_client.post.call_args_list
+        ]
+        assert [kwargs["url_path"] for kwargs in post_call_kwargs] == [
+            "/seed_session",
+            "/v1/responses",
+        ]
+        assert post_call_kwargs[0]["server_name"] == "my resources server"
+        assert post_call_kwargs[1]["server_name"] == "simple_agent"
+        assert post_call_kwargs[1]["cookies"] == {"session": "seeded"}

--- a/responses_api_agents/tau2/tests/test_app.py
+++ b/responses_api_agents/tau2/tests/test_app.py
@@ -152,7 +152,6 @@ class TestApp:
             d.pop("max_agent_steps", None)
             d["config"].pop("max_agent_steps", None)
             d["config"].pop("turns_remaining_interval", None)
-            d["config"].pop("review_model", None)
             d["result"].pop("agent_messages", None)
             d["result"].pop("agent_steps", None)
             d["result"].pop("max_agent_steps", None)

--- a/responses_api_agents/tau2/tests/test_app.py
+++ b/responses_api_agents/tau2/tests/test_app.py
@@ -152,6 +152,7 @@ class TestApp:
             d.pop("max_agent_steps", None)
             d["config"].pop("max_agent_steps", None)
             d["config"].pop("turns_remaining_interval", None)
+            d["config"].pop("review_model", None)
             d["result"].pop("agent_messages", None)
             d["result"].pop("agent_steps", None)
             d["result"].pop("max_agent_steps", None)

--- a/responses_api_agents/tool_simulation_agent/app.py
+++ b/responses_api_agents/tool_simulation_agent/app.py
@@ -73,8 +73,14 @@ class ToolSimulationAgent(SimpleResponsesAPIAgent):
         )
         await raise_for_status(response)
 
+        response_json = await response.json()
+        if self.config.skip_verification:
+            return ToolSimulationAgentVerifyResponse.model_validate(
+                self.build_skipped_verify_response_payload(body, response_json)
+            )
+
         verify_request_body = body.model_dump()
-        verify_request_body["response"] = await response.json()
+        verify_request_body["response"] = response_json
         verify_request = ToolSimulationAgentVerifyRequest.model_validate(verify_request_body)
 
         verify_response = await self.server_client.post(

--- a/responses_api_agents/tool_simulation_agent/tests/test_app.py
+++ b/responses_api_agents/tool_simulation_agent/tests/test_app.py
@@ -444,3 +444,65 @@ class TestApp:
         }
         assert valid_verify_response.json() == expected_valid_verify_response_json
         assert server_client_post_mock.call_args_list == expected_invalid_verify_response_calls
+
+    async def test_run_skip_verification_uses_configured_reward(
+        self, agent_config: ToolSimulationAgentConfig
+    ) -> None:
+        server_client_post_mock = AsyncMock()
+        server_client_mock = MagicMock(spec=ServerClient)
+        server_client_mock.post = server_client_post_mock
+        agent_server = ToolSimulationAgent(
+            config=agent_config.model_copy(
+                update={
+                    "skip_verification": True,
+                    "skip_verification_reward": 0.5,
+                }
+            ),
+            server_client=server_client_mock,
+        )
+        webserver = agent_server.setup_webserver()
+        test_client = TestClient(webserver)
+
+        response_object = {
+            "id": "chat_response_id",
+            "created_at": 1,
+            "model": "response_model",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": False,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+        self._set_server_client_post_responses(server_client_post_mock, response_object)
+
+        response = test_client.post(
+            "/run",
+            json={
+                "responses_create_params": {
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": "Please answer directly.",
+                        }
+                    ]
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert response_json["reward"] == 0.5
+        assert response_json["verification_skipped"] is True
+        assert response_json["response"]["id"] == "chat_response_id"
+        server_client_post_mock.assert_called_once_with(
+            server_name="tool_agent",
+            url_path="/v1/responses",
+            json=NeMoGymResponseCreateParamsNonStreaming(
+                input=[
+                    NeMoGymEasyInputMessage(
+                        role="user",
+                        content="Please answer directly.",
+                    )
+                ],
+            ),
+        )

--- a/responses_api_agents/tool_simulation_agent/tests/test_app.py
+++ b/responses_api_agents/tool_simulation_agent/tests/test_app.py
@@ -445,9 +445,7 @@ class TestApp:
         assert valid_verify_response.json() == expected_valid_verify_response_json
         assert server_client_post_mock.call_args_list == expected_invalid_verify_response_calls
 
-    async def test_run_skip_verification_uses_configured_reward(
-        self, agent_config: ToolSimulationAgentConfig
-    ) -> None:
+    async def test_run_skip_verification_uses_configured_reward(self, agent_config: ToolSimulationAgentConfig) -> None:
         server_client_post_mock = AsyncMock()
         server_client_mock = MagicMock(spec=ServerClient)
         server_client_mock.post = server_client_post_mock

--- a/tests/unit_tests/test_base_responses_api_agent.py
+++ b/tests/unit_tests/test_base_responses_api_agent.py
@@ -39,9 +39,7 @@ class TestBaseResponsesAPIAgent:
             async def run(self, body=...):
                 raise NotImplementedError
 
-        agent = TestSimpleResponsesAPIAgent(
-            config=config, server_client=MagicMock(spec=ServerClient)
-        )
+        agent = TestSimpleResponsesAPIAgent(config=config, server_client=MagicMock(spec=ServerClient))
         agent.setup_webserver()
 
     def test_build_skipped_verify_response_payload(self) -> None:
@@ -61,12 +59,8 @@ class TestBaseResponsesAPIAgent:
             async def run(self, body=...):
                 raise NotImplementedError
 
-        agent = TestSimpleResponsesAPIAgent(
-            config=config, server_client=MagicMock(spec=ServerClient)
-        )
-        body = BaseRunRequest(
-            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[])
-        )
+        agent = TestSimpleResponsesAPIAgent(config=config, server_client=MagicMock(spec=ServerClient))
+        body = BaseRunRequest(responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[]))
         payload = agent.build_skipped_verify_response_payload(body, {"id": "response_id"})
 
         assert payload == {

--- a/tests/unit_tests/test_base_responses_api_agent.py
+++ b/tests/unit_tests/test_base_responses_api_agent.py
@@ -14,11 +14,13 @@
 # limitations under the License.
 from unittest.mock import MagicMock
 
+from nemo_gym.base_resources_server import BaseRunRequest
 from nemo_gym.base_responses_api_agent import (
     BaseResponsesAPIAgent,
     BaseResponsesAPIAgentConfig,
     SimpleResponsesAPIAgent,
 )
+from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
 from nemo_gym.server_utils import ServerClient
 
 
@@ -37,5 +39,39 @@ class TestBaseResponsesAPIAgent:
             async def run(self, body=...):
                 raise NotImplementedError
 
-        agent = TestSimpleResponsesAPIAgent(config=config, server_client=MagicMock(spec=ServerClient))
+        agent = TestSimpleResponsesAPIAgent(
+            config=config, server_client=MagicMock(spec=ServerClient)
+        )
         agent.setup_webserver()
+
+    def test_build_skipped_verify_response_payload(self) -> None:
+        config = BaseResponsesAPIAgentConfig(
+            host="",
+            port=0,
+            entrypoint="",
+            name="",
+            skip_verification=True,
+            skip_verification_reward=0.75,
+        )
+
+        class TestSimpleResponsesAPIAgent(SimpleResponsesAPIAgent):
+            async def responses(self, body=...):
+                raise NotImplementedError
+
+            async def run(self, body=...):
+                raise NotImplementedError
+
+        agent = TestSimpleResponsesAPIAgent(
+            config=config, server_client=MagicMock(spec=ServerClient)
+        )
+        body = BaseRunRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[])
+        )
+        payload = agent.build_skipped_verify_response_payload(body, {"id": "response_id"})
+
+        assert payload == {
+            "responses_create_params": NeMoGymResponseCreateParamsNonStreaming(input=[]).model_dump(),
+            "response": {"id": "response_id"},
+            "reward": 0.75,
+            "verification_skipped": True,
+        }

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -222,9 +222,7 @@ class TestGlobalConfig:
         # Fix the port returned
         find_open_port_mock = MagicMock()
         find_open_port_mock.return_value = 12345
-        monkeypatch.setattr(
-            nemo_gym.global_config, "_find_open_port_using_range", find_open_port_mock
-        )
+        monkeypatch.setattr(nemo_gym.global_config, "_find_open_port_using_range", find_open_port_mock)
 
         # Override the hydra main wrapper call. At runtime, this will use sys.argv.
         # Here we assume that the user sets sys.argv correctly (we are not trying to test Hydra) and just return some DictConfig for our test.
@@ -255,9 +253,7 @@ class TestGlobalConfig:
             == global_config_dict
         )
 
-    def test_get_global_config_dict_skip_verification_defaults_for_agents(
-        self, monkeypatch: MonkeyPatch
-    ) -> None:
+    def test_get_global_config_dict_skip_verification_defaults_for_agents(self, monkeypatch: MonkeyPatch) -> None:
         self._mock_versions_for_testing(monkeypatch)
 
         find_open_port_mock = MagicMock()
@@ -302,9 +298,7 @@ class TestGlobalConfig:
         assert agent_config["skip_verification"] is True
         assert agent_config["skip_verification_reward"] == -1.5
 
-        explicit_agent_config = global_config_dict["explicit_agent_name"]["responses_api_agents"][
-            "agent_type"
-        ]
+        explicit_agent_config = global_config_dict["explicit_agent_name"]["responses_api_agents"]["agent_type"]
         assert explicit_agent_config["skip_verification"] is False
         assert explicit_agent_config["skip_verification_reward"] == 0.25
 

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -222,7 +222,9 @@ class TestGlobalConfig:
         # Fix the port returned
         find_open_port_mock = MagicMock()
         find_open_port_mock.return_value = 12345
-        monkeypatch.setattr(nemo_gym.global_config, "_find_open_port_using_range", find_open_port_mock)
+        monkeypatch.setattr(
+            nemo_gym.global_config, "_find_open_port_using_range", find_open_port_mock
+        )
 
         # Override the hydra main wrapper call. At runtime, this will use sys.argv.
         # Here we assume that the user sets sys.argv correctly (we are not trying to test Hydra) and just return some DictConfig for our test.
@@ -252,6 +254,63 @@ class TestGlobalConfig:
             }
             == global_config_dict
         )
+
+    def test_get_global_config_dict_skip_verification_defaults_for_agents(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        self._mock_versions_for_testing(monkeypatch)
+
+        find_open_port_mock = MagicMock()
+        find_open_port_mock.side_effect = [12345, 12346, 12347]
+        monkeypatch.setattr(nemo_gym.global_config, "_find_open_port_using_range", find_open_port_mock)
+
+        parser = GlobalConfigDictParser()
+        global_config_dict = parser.parse_no_environment(
+            DictConfig(
+                {
+                    "skip_verification": True,
+                    "skip_verification_reward": -1.5,
+                    "agent_name": {
+                        "responses_api_agents": {
+                            "agent_type": {
+                                "entrypoint": "app.py",
+                            }
+                        }
+                    },
+                    "explicit_agent_name": {
+                        "responses_api_agents": {
+                            "agent_type": {
+                                "entrypoint": "app.py",
+                                "skip_verification": False,
+                                "skip_verification_reward": 0.25,
+                            }
+                        }
+                    },
+                    "resources_name": {
+                        "resources_servers": {
+                            "resources_type": {
+                                "entrypoint": "app.py",
+                                "domain": "other",
+                            }
+                        }
+                    },
+                }
+            )
+        )
+
+        agent_config = global_config_dict["agent_name"]["responses_api_agents"]["agent_type"]
+        assert agent_config["skip_verification"] is True
+        assert agent_config["skip_verification_reward"] == -1.5
+
+        explicit_agent_config = global_config_dict["explicit_agent_name"]["responses_api_agents"][
+            "agent_type"
+        ]
+        assert explicit_agent_config["skip_verification"] is False
+        assert explicit_agent_config["skip_verification_reward"] == 0.25
+
+        resources_config = global_config_dict["resources_name"]["resources_servers"]["resources_type"]
+        assert "skip_verification" not in resources_config
+        assert "skip_verification_reward" not in resources_config
 
     def test_get_global_config_dict_server_refs_sanity(self, monkeypatch: MonkeyPatch) -> None:
         self._mock_versions_for_testing(monkeypatch)


### PR DESCRIPTION
## Summary
Adds a response API agent option to skip resources-server verification during `/run`.

When `skip_verification=true`, agents return a synthetic verify response using `skip_verification_reward` and mark it with `verification_skipped=true`. Top-level config values are propagated to response API agents unless the agent explicitly sets its own values.

## Changes
- Add `skip_verification` and `skip_verification_reward` to base response API agent config.
- Add skipped-verification response payload helper.
- Wire skip behavior into `simple_agent` and `tool_simulation_agent`.
- Add global config propagation for top-level skip-verification defaults.
- Add tests for config defaults, payload construction, and agent `/run` behavior.


Cherry pick from [here](https://gitlab-master.nvidia.com/dl/nemo/gym/-/commit/74d48fb213dc1a8c961c634546eab3cf868868df)