### PR TITLE
Pin IFBench NLTK baseline

### DIFF
--- a/resources_servers/ifbench/requirements.txt
+++ b/resources_servers/ifbench/requirements.txt
@@ -2,7 +2,8 @@
 setuptools<71
 absl-py
 langdetect
-nltk
+# NLTK 3.10.1 rejects imports from Gym's nested server venv; 3.10.0 is the verified IFBench baseline.
+nltk==3.10.0
 immutabledict
 spacy
 emoji


### PR DESCRIPTION
## What changed

Pin IFBench's NLTK dependency to 3.10.0.

## Why

NLTK 3.10.1 rejects imports from Gym's server virtual environment when that environment is nested under `resources_servers/ifbench`. The previously successful IFBench environment resolved NLTK 3.10.0.

## Validation

- Created the same nested server-venv layout used by Gym.
- Installed the pinned requirements dependency.
- Successfully imported both `nltk` 3.10.0 and `regex`.
