### PR TITLE
docs(fern): migrate remaining examples to unified CLI

### DIFF
--- a/fern/versions/latest/pages/infrastructure/sandbox/ecs-fargate.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/ecs-fargate.mdx
@@ -108,7 +108,10 @@ asyncio.run(main())
 For an end-to-end agent run, add this provider config to `mini_swe_agent_2`'s config paths — the agent config is unchanged:
 
 ```bash
-ng_run "+config_paths=[responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml, nemo_gym/sandbox/providers/ecs_fargate/configs/ecs_fargate.yaml, <MODEL_CONFIG>]"
+gym env start \
+    --config responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml \
+    --config nemo_gym/sandbox/providers/ecs_fargate/configs/ecs_fargate.yaml \
+    --config <MODEL_CONFIG>
 ```
 
 ## Troubleshooting

--- a/fern/versions/latest/pages/model-server/vllm.mdx
+++ b/fern/versions/latest/pages/model-server/vllm.mdx
@@ -217,17 +217,17 @@ When `return_token_id_information: true`, the completions backend automatically 
 The end-to-end flow is identical to the [Use VLLMModel](#use-vllmmodel) walkthrough above; just swap the model-server config:
 
 ```bash
-config_paths="resources_servers/example_multi_step/configs/example_multi_step.yaml,\
-responses_api_models/vllm_model/configs/vllm_model_completions.yaml"
+gym env start \
+    --config resources_servers/example_multi_step/configs/example_multi_step.yaml \
+    --config responses_api_models/vllm_model/configs/vllm_model_completions.yaml \
+    --model-url http://0.0.0.0:10240/v1 \
+    --model <your-model> \
+    --model-api-key dummy_key
 
-ng_run "+config_paths=[$config_paths]" \
-    ++policy_base_url=http://0.0.0.0:10240/v1 \
-    ++policy_model_name=<your-model> \
-    ++policy_api_key=dummy_key
-
-ng_collect_rollouts +agent_name=<your_agent> \
-    +input_jsonl_fpath=<your_data.jsonl> \
-    +output_jsonl_fpath=results/rollouts_completions.jsonl
+gym eval run --no-serve \
+    --agent <your_agent> \
+    --input <your_data.jsonl> \
+    --output results/rollouts_completions.jsonl
 ```
 
 Make sure your input JSONL respects the selected mode in the [Constraint matrix](#constraint-matrix) above.


### PR DESCRIPTION
## Summary

- migrate the vLLM completions-backend walkthrough from `ng_run` to `gym env start`
- migrate its rollout command from `ng_collect_rollouts` to `gym eval run --no-serve`
- update the ECS Fargate end-to-end example to use repeated `--config` flags

Closes #2237
