### PR TITLE
docs: Sync docs Gym Configuration YAML with NeMo RL upstream keys.

### DIFF
--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/gym-configuration.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/gym-configuration.mdx
@@ -29,11 +29,9 @@ Before running GRPO training, you need to configure how NeMo RL connects to NeMo
 
 ## Configuration File Location
 
-The full training configuration file lives in the **NeMo RL repository**, not in NeMo Gym:
+The full training configuration file lives in the [NeMo RL repository](https://github.com/NVIDIA-NeMo/RL), not in NeMo Gym:
 
-```
-examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
-```
+[`examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml`](https://github.com/NVIDIA-NeMo/RL/blob/main/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml)
 
 Paths in that file are relative to the NeMo RL repo root. After [Setup](/training-tutorials/nemo-rl-grpo/setup), NeMo Gym is checked out inside that repo at `3rdparty/Gym-workspace/Gym/`, which is why the data paths below point there.
 

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/gym-configuration.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/gym-configuration.mdx
@@ -29,11 +29,13 @@ Before running GRPO training, you need to configure how NeMo RL connects to NeMo
 
 ## Configuration File Location
 
-The full training configuration file is located at:
+The full training configuration file lives in the **NeMo RL repository**, not in NeMo Gym:
 
 ```
 examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
 ```
+
+Paths in that file are relative to the NeMo RL repo root. After [Setup](/training-tutorials/nemo-rl-grpo/setup), NeMo Gym is checked out inside that repo at `3rdparty/Gym-workspace/Gym/`, which is why the data paths below point there.
 
 ---
 
@@ -45,41 +47,73 @@ There are two Gym-specific sections in the NeMo RL training config: `data` and `
 
 ```yaml
 data:
-  train_jsonl_fpath: 3rdparty/Gym-workspace/Gym/data/workplace_assistant/train.jsonl
-  validation_jsonl_fpath: 3rdparty/Gym-workspace/Gym/data/workplace_assistant/validation.jsonl
+  train:
+    data_path: 3rdparty/Gym-workspace/Gym/data/workplace_assistant/train.jsonl
+  validation:
+    data_path: 3rdparty/Gym-workspace/Gym/data/workplace_assistant/validation.jsonl
+  default:
+    dataset_name: NemoGymDataset
+    env_name: "nemo_gym"
+    processor: "nemo_gym_data_processor"
 ```
 
 | Parameter | Description |
 |-----------|-------------|
-| `train_jsonl_fpath` | Path to training dataset (prepared in [Setup](/training-tutorials/nemo-rl-grpo/setup)) |
-| `validation_jsonl_fpath` | Path to validation dataset |
+| `train.data_path` | Path to training dataset (created later in [Setup](/training-tutorials/nemo-rl-grpo/setup)) |
+| `validation.data_path` | Path to validation dataset |
+| `default.dataset_name` | Must be `NemoGymDataset` so NeMo RL reads Gym-format JSONL |
+| `default.env_name` | Must be `nemo_gym` so batches are routed to the Gym environment |
+| `default.processor` | Must be `nemo_gym_data_processor` |
 
 ### Environment Section
 
 ```yaml
 env:
   should_use_nemo_gym: true
-  nemo_gym:
+  should_log_nemo_gym_responses: true
+  should_mask_flagged_samples: true
+  nemo_gym:  # This is passed into NeMo Gym as the initial_global_config_dict
+    port_range_low: 5000
+    port_range_high: 5999
+    is_trajectory_collection: false
     config_paths:
     - responses_api_models/vllm_model/configs/vllm_model_for_training.yaml
     - resources_servers/workplace_assistant/configs/workplace_assistant.yaml
-    workplace_assistant_simple_agent:
-      responses_api_agents:
-        simple_agent:
-          max_steps: 6
 ```
 
 | Parameter | Description |
 |-----------|-------------|
 | `should_use_nemo_gym` | Set to `true` to enable Gym |
-| `nemo_gym` | Everything under this key is a Gym config |
-| `nemo_gym.config_paths` | Gym config files: vLLM model config and Workplace Assistant agent/resources config |
-| `max_steps` | Maximum tool-calling steps per task (6 for Workplace Assistant) |
+| `should_log_nemo_gym_responses` | `true` skips writing the large per-step `train_data_step*.jsonl` files; prefer `true` if disk is tight |
+| `should_mask_flagged_samples` | `false` ignores environment `mask_sample` flags so the loss trains on every sample |
+| `nemo_gym` | Everything under this key is passed to Gym as its global config |
+| `nemo_gym.port_range_low` / `port_range_high` | Port range for Gym HTTP servers, kept clear of NeMo RL (3000-4999) and vLLM (7000-8999) |
+| `nemo_gym.is_trajectory_collection` | Set to `true` to collect trajectories without training |
+| `nemo_gym.config_paths` | Gym config files, relative to the Gym checkout: vLLM model config and Workplace Assistant agent/resources config |
 
 <Info>
 The `vllm_model_for_training.yaml` config is required for NeMo RL training integration.
 
 </Info>
+
+<Note>
+Agent behavior such as `max_steps` is **not** set in the NeMo RL config. It comes from the Gym-side config listed in `config_paths` — for this tutorial, `max_steps: 6` under `workplace_assistant_simple_agent.responses_api_agents.simple_agent` in `resources_servers/workplace_assistant/configs/workplace_assistant.yaml`.
+
+To override a Gym config value from NeMo RL, nest it under `env.nemo_gym` using the same key path as the Gym config. The upstream example does this for the policy model:
+
+```yaml
+env:
+  nemo_gym:
+    policy_model:
+      responses_api_models:
+        vllm_model:
+          uses_reasoning_parser: false
+          extra_body:
+            chat_template_kwargs:
+              enable_thinking: false
+```
+
+</Note>
 
 ---
 


### PR DESCRIPTION
## Summary

* Sync the Gym Configuration tutorial YAML with the real NeMo RL schema (`data.train.data_path` / `data.validation.data_path`) so readers stop editing keys that silently no-op.
* Drop the fabricated `workplace_assistant_simple_agent` override and document that `max_steps` lives in the Gym-side `workplace_assistant.yaml`, with a note on how real `env.nemo_gym` overrides work.
* State clearly that the config file lives in the NeMo RL repo, and reword Setup references to look forward (Setup comes later in the tutorial flow).

Closes NVIDIA-NeMo/Gym#2232

## Test plan

- [ ] Confirm snippets match `examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml` on NeMo RL `main`
- [ ] `cd fern && npm run check` passes
- [ ] Preview the page and walk About → Gym Configuration → NeMo RL Configuration → Setup; Setup links read as forward references
- [ ] Confirm frozen GA snapshots were intentionally not back-ported