### PR TITLE
security: bump nltk >=3.10.0 and fix inisec import blocks

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,7 +18,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_call:
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,6 +18,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_call:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/resources_servers/ifbench/app.py
+++ b/resources_servers/ifbench/app.py
@@ -16,6 +16,12 @@ import asyncio
 import logging
 from typing import List, Literal
 
+# Pre-import packages that nltk pulls in during its init so they are already in
+# sys.modules before nltk's inisec.py finder is installed. nltk>=3.9 blocks any
+# import originating from nltk if the module path falls inside the process CWD —
+# which happens in CI where the server venv lives inside the repo root.
+import defusedxml.ElementTree  # noqa: F401
+import regex  # noqa: F401
 from fastapi import FastAPI
 
 from nemo_gym.base_resources_server import (

--- a/resources_servers/ifbench/tests/conftest.py
+++ b/resources_servers/ifbench/tests/conftest.py
@@ -13,6 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Pre-import packages that nltk pulls in during its init so they are already in
+# sys.modules before nltk's inisec.py finder is installed. This must happen here
+# (before ensure_ifbench() calls _ensure_nltk_data() → import nltk) so that the
+# punkt download inside _ensure_nltk_data() is not silently blocked.
+import defusedxml.ElementTree  # noqa: F401
+import regex  # noqa: F401
+
 from resources_servers.ifbench.setup_ifbench import ensure_ifbench
 
 

--- a/resources_servers/iheval/app.py
+++ b/resources_servers/iheval/app.py
@@ -82,6 +82,12 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
+# Pre-import packages that nltk pulls in during its init so they are already in
+# sys.modules before nltk's inisec.py finder is installed. nltk>=3.9 blocks any
+# import originating from nltk if the module path falls inside the process CWD —
+# which happens in CI where the server venv lives inside the repo root.
+import defusedxml.ElementTree  # noqa: F401
+import regex  # noqa: F401
 from fastapi import FastAPI
 from pydantic import ConfigDict
 

--- a/resources_servers/iheval/requirements.txt
+++ b/resources_servers/iheval/requirements.txt
@@ -4,4 +4,4 @@ rouge-score>=0.1.2
 # Rule-following: vendored IFEval checkers (ifeval/) depend on these.
 immutabledict>=2.0
 langdetect>=1.0.9
-nltk>=3.9
+nltk>=3.10.0

--- a/resources_servers/instruction_following/app.py
+++ b/resources_servers/instruction_following/app.py
@@ -14,6 +14,12 @@
 # limitations under the License.
 from typing import Any, Dict, List
 
+# Pre-import packages that nltk pulls in during its init so they are already in
+# sys.modules before nltk's inisec.py finder is installed. nltk>=3.9 blocks any
+# import originating from nltk if the module path falls inside the process CWD —
+# which happens in CI where the server venv lives inside the repo root.
+import defusedxml.ElementTree  # noqa: F401
+import regex  # noqa: F401
 from fastapi import FastAPI
 from pydantic import model_validator
 from verifiable_instructions import instructions_registry

--- a/resources_servers/rolemrc/app.py
+++ b/resources_servers/rolemrc/app.py
@@ -42,6 +42,12 @@ from contextlib import nullcontext
 from functools import lru_cache
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
+# Pre-import packages that nltk pulls in during its init so they are already in
+# sys.modules before nltk's inisec.py finder is installed. nltk>=3.9 blocks any
+# import originating from nltk if the module path falls inside the process CWD —
+# which happens in CI where the server venv lives inside the repo root.
+import defusedxml.ElementTree  # noqa: F401
+import regex  # noqa: F401
 from fastapi import FastAPI
 from pydantic import ConfigDict, PrivateAttr
 

--- a/resources_servers/rolemrc/requirements.txt
+++ b/resources_servers/rolemrc/requirements.txt
@@ -2,7 +2,7 @@
 # Reference-metric scoring (reference mode).
 rouge-score>=0.1.2
 sacrebleu>=2.4
-nltk>=3.9
+nltk>=3.10.0
 # BERTScore is on by default in reference mode; pulls a roberta-large checkpoint
 # on first use. Drop these three deps (and set include_bertscore=false) for a
 # lightweight ROUGE/BLEU/METEOR-only install. matplotlib + pillow are declared

--- a/resources_servers/toolsandbox/app.py
+++ b/resources_servers/toolsandbox/app.py
@@ -55,7 +55,13 @@ import sys
 import uuid
 from typing import Any, Dict, List, Optional, Tuple
 
+# Pre-import packages that nltk pulls in during its init so they are already in
+# sys.modules before nltk's inisec.py finder is installed. nltk>=3.9 blocks any
+# import originating from nltk if the module path falls inside the process CWD —
+# which happens in CI where the server venv lives inside the repo root.
+import defusedxml.ElementTree  # noqa: F401
 import polars as pl
+import regex  # noqa: F401
 from fastapi import FastAPI, Request
 from openai import NOT_GIVEN
 from openai.types.chat import ChatCompletion


### PR DESCRIPTION
## Summary

Bump \`nltk>=3.10.0\` in \`iheval\` and \`rolemrc\` (CVE fix), and pre-import \`regex\` and \`defusedxml.ElementTree\` in all servers whose import chains reach nltk.

## Root cause

\`nltk>=3.9\` added \`NLTKSafeImportFinder\` (\`nltk/inisec.py\`) which blocks any import triggered by nltk if the module's resolved path is inside the process CWD. In CI, server venvs live at \`resources_servers/<name>/.venv/\` — inside the repo root — so legitimate site-packages get blocked. Pre-importing before the nltk chain fires puts packages in \`sys.modules\`, bypassing the check.

\`ifbench\` also needs the pre-imports in \`conftest.py\` so \`_ensure_nltk_data()\` can download punkt without being silently blocked during \`pytest_configure\`.

## Changes

| File | Change |
|---|---|
| \`resources_servers/{iheval,rolemrc}/requirements.txt\` | bump \`nltk>=3.10.0\` |
| \`resources_servers/{iheval,rolemrc,ifbench,instruction_following,toolsandbox}/app.py\` | pre-import \`regex\`, \`defusedxml.ElementTree\` |
| \`resources_servers/ifbench/tests/conftest.py\` | same pre-imports before \`ensure_ifbench()\` |

## Local test results

| Server | Result |
|---|---|
| iheval | 88/88 ✓ |
| rolemrc | 55/55 ✓ |
| ifbench | 15/15 ✓ |
| instruction_following | 15/15 ✓ |
| toolsandbox | 19/19 ✓ |

## Full test suite run

https://github.com/NVIDIA-NeMo/Gym/actions/runs/30840804435