### PR TITLE
fix(tau2): exclude review_model from snapshot comparison

### DIFF
--- a/responses_api_agents/tau2/tests/test_app.py
+++ b/responses_api_agents/tau2/tests/test_app.py
@@ -152,6 +152,7 @@ class TestApp:
             d.pop("max_agent_steps", None)
             d["config"].pop("max_agent_steps", None)
             d["config"].pop("turns_remaining_interval", None)
+            d["config"].pop("review_model", None)
             d["result"].pop("agent_messages", None)
             d["result"].pop("agent_steps", None)
             d["result"].pop("max_agent_steps", None)


### PR DESCRIPTION
## Summary

\`test_sanity_query_input\` was failing in CI because \`review_model\` is present in \`test_data.json\` (the snapshot) but absent from the actual server response in some tau2-bench versions.

\`review_model\` was added to \`TextRunConfig\` in tau2-bench v1.0.1 with a default of \`'claude-opus-4-5'\`. Its presence in the serialized config depends on which tau2-bench commit is installed. The test's \`_clean()\` function already strips other volatile config fields (\`max_agent_steps\`, \`turns_remaining_interval\`) — adding \`review_model\` follows the same pattern and makes the comparison stable across tau2-bench versions.

## Change

One line added to \`_clean()\` in \`responses_api_agents/tau2/tests/test_app.py\`:
\`\`\`python
d["config"].pop("review_model", None)
\`\`\`

## Verified

6/6 tau2 tests pass locally.

Failure first surfaced in the full suite run off #2290:
https://github.com/NVIDIA-NeMo/Gym/actions/runs/30840804435