### PR TITLE
[fix] Standardize rollout trajectory records and document producer coverage

### DIFF
--- a/fern/versions/latest/pages/about/concepts/key-terminology.mdx
+++ b/fern/versions/latest/pages/about/concepts/key-terminology.mdx
@@ -7,7 +7,7 @@ Essential vocabulary for model training, RL workflows, and NeMo Gym. This glossa
 ## Rollout & Data Collection Terms
 **Rollout / Trajectory**
 
-**Rollout** (verb) refers to the process of executing a policy in an environment to generate data: stepping through the environment, taking actions, and recording what happens. **Rollout** (noun) is also used synonymously with **trajectory**: the resulting sequence of states, actions, and rewards: the ordered record of what happened. In practice, many people use "rollout" and "trajectory" interchangeably since a rollout produces exactly one trajectory.
+**Rollout** (verb) is the process of executing a policy in an environment. **Rollout** (noun) is one execution and its result. A **trajectory** is the ordered record of what happened during that execution. The terms are often used informally as synonyms, but a Responses API result or rollout metrics record is not necessarily a complete standardized trajectory record. See the [trajectory capability matrix](/reference/trajectory-capabilities).
 
 **Rollout Batch**
 
@@ -125,7 +125,7 @@ Models invoking external capabilities (APIs, calculators, databases) to accompli
 
 **Responses API**
 
-OpenAI's standard interface for rollouts, including function calls and multi-turn conversations. NeMo Gym's native format.
+OpenAI's interface for model interactions, including function calls and multi-turn conversation items. NeMo Gym uses it as its native agent/model protocol. It does not include every trajectory field, such as executor timing and resolution status.
 
 **Chat Completions API**
 

--- a/fern/versions/latest/pages/model-server/model-call-capture.mdx
+++ b/fern/versions/latest/pages/model-server/model-call-capture.mdx
@@ -108,11 +108,13 @@ ng_model_call_capture = {
 }
 ```
 
-`metrics.num_calls` is the number of captured model calls. Attached calls omit raw request and
-response payloads; those remain in `CaptureStore`. [`ng_trajectory`](/reference/trajectory-capabilities) includes payload copies
-in the rollout record, except for LabBench rows carrying the `multimodal_history_redacted` gap. Each call stores the exact model
-request, so cumulative multi-turn inputs can make rollout records large and should be handled with the same access controls as
-the capture directory. Resume attempts use an
+`metrics.num_calls` is the number of captured model calls. After successful trajectory projection, attached calls omit request
+and response payloads; those remain in `CaptureStore`. If projection fails, they remain attached with a
+`trajectory_projection_failed` gap. [`ng_trajectory`](/reference/trajectory-capabilities) includes payload copies in the rollout
+record, except for LabBench rows carrying the `multimodal_history_redacted` gap. Each call stores the exact model request, so
+cumulative multi-turn inputs can make rollout records large and should be handled with the same access controls as the capture
+directory. Persisted rollout JSONL retains these payloads; W&B rollout tables omit `ng_trajectory` and model-call request and
+response payloads. Resume attempts use an
 `-a<n>` suffix so their data does not mix with an earlier attempt. Before dispatch, the collector clears any existing capture
 for that exact rollout-attempt id, including a kill-shaped attempt being redispatched.
 

--- a/fern/versions/latest/pages/model-server/model-call-capture.mdx
+++ b/fern/versions/latest/pages/model-server/model-call-capture.mdx
@@ -81,8 +81,8 @@ totals = aggregate_model_call_metrics(store, rollout_id)
 `ModelCallRecord` is an observability serialization model derived from captured HTTP exchanges. It
 contains a unique server-generated `model_call_id`, the protocol `response_id` when present, typed
 `model_ref`, wall-clock `started_at` and `completed_at`, a `call_index`, API dialect, token and cache
-usage, latency, error details, tool calls, reasoning content, and the captured request and response.
-`started_at` is recorded immediately
+usage, `response_status`, normalized `finish_reason`, latency, error details, tool calls, reasoning
+content, and the captured request and response. `started_at` is recorded immediately
 before invoking the downstream ASGI application; `completed_at` is recorded when that invocation
 returns or raises, before capture parsing and persistence. Both are UTC Unix seconds for external
 trace correlation; durations use the monotonic latency fields. `call_index` reflects durable append
@@ -109,8 +109,11 @@ ng_model_call_capture = {
 ```
 
 `metrics.num_calls` is the number of captured model calls. Attached calls omit raw request and
-response payloads; those remain in `CaptureStore`. Resume attempts use an `-a<n>` suffix so their
-data does not mix with an earlier attempt. Before dispatch, the collector clears any existing capture
+response payloads; those remain in `CaptureStore`. [`ng_trajectory`](/reference/trajectory-capabilities) includes payload copies
+in the rollout record, except for LabBench rows carrying the `multimodal_history_redacted` gap. Each call stores the exact model
+request, so cumulative multi-turn inputs can make rollout records large and should be handled with the same access controls as
+the capture directory. Resume attempts use an
+`-a<n>` suffix so their data does not mix with an earlier attempt. Before dispatch, the collector clears any existing capture
 for that exact rollout-attempt id, including a kill-shaped attempt being redispatched.
 
 The attachment is additive: it does not replace or rewrite the existing response, reward,
@@ -119,17 +122,16 @@ and aggregate-metrics requests exclude it.
 
 ## Agent observations
 
-Supported Agent Servers may also attach `ng_agent_observations` when observability is enabled. It
-contains an unordered `records` list of typed agent invocations, tool-call intervals, explicit
-context-compaction events, and sandbox observations. `gaps` reports unavailable evidence. An
+Supported Agent Servers may also attach `ng_agent_observations` when observability is enabled. Agent evidence and model-call
+capture are collected independently. The attachment contains an unordered `records` list of typed agent invocations,
+tool-call intervals, explicit context-compaction events, and sandbox observations. `gaps` reports unavailable evidence. An
 invocation's `conversation` contains the ordered, normalized items exposed by that integration.
 
 Agent observations and model-call capture are separate evidence. Join an invocation's model-call
 references by `model_call_id`, or by the exact `(model_ref, response_id)` pair when the harness sees
 the protocol response ID. An integration may resolve an otherwise hidden call only through a
 producer-specific, unique exact match against its retained artifact and the raw capture. Ambiguous
-matches remain unowned; timestamps or list position alone are never sufficient. The full model
-request and response remain in `CaptureStore`; rollout attachments intentionally omit them.
+matches remain unowned; timestamps or list position alone are never sufficient.
 
 Compaction records distinguish the calls immediately before and after the context change from
 `model_calls` used to perform the compaction. Compaction calls are exact references to calls owned by
@@ -141,8 +143,9 @@ measured interval, and `timing_source` identifies executor, harness, or artifact
 
 Model-visible tool calls and results remain in `AgentInvocation.conversation` as `function_call` and
 `function_call_output` items. Execution timing and outcome, when observable, live in
-`ToolCallObservation` and join through `(invocation_id, tool_call_id)`. A tool observation may also
-reference its enclosing `sandbox_id`; concurrent calls retain independent timing and outcome.
+`ToolCallObservation` and join through `(invocation_id, tool_call_id)`. The `ng_trajectory` projection combines these fields
+with the matching model-visible output. A tool observation may also reference its enclosing `sandbox_id`; concurrent calls
+retain independent timing and outcome.
 
 Each `SandboxObservation` covers one sandbox execution. Usage fields contain measured values only;
 configured limits are never reported as usage. Integrations emit only facts available at their

--- a/fern/versions/latest/pages/reference/index.mdx
+++ b/fern/versions/latest/pages/reference/index.mdx
@@ -22,4 +22,8 @@ All CLI commands, arguments, and usage examples.
 Common questions about debugging, performance, and configuration.
 </Card>
 
+<Card title="Trajectory Capability Matrix" href="/reference/trajectory-capabilities">
+Review standardized trajectory support by criterion and producer.
+</Card>
+
 </Cards>

--- a/fern/versions/latest/pages/reference/trajectory-capabilities.mdx
+++ b/fern/versions/latest/pages/reference/trajectory-capabilities.mdx
@@ -1,0 +1,79 @@
+---
+title: "Trajectory capability matrix"
+description: "Standardized trajectory support by criterion and producer"
+position: 5
+---
+
+# Trajectory capability matrix
+
+`ng_trajectory` schema version `1.0` combines available model-call capture and agent observations in a rollout record. It
+contains task and rollout identity, model calls and token usage, semantic turns, invocation-scoped model-visible histories,
+tool attempts, resolution, step count, and explicit evidence gaps. Source attachments remain under `ng_model_call_capture` and
+`ng_agent_observations`; aggregate-metrics requests omit all three attachments.
+
+Enable model-call evidence with `observability_enabled: true` and `model_call_capture_dir: /data/model-calls`. Calls must use
+a `/ng-rollout/<rollout_id>` Gym Model Server prefix. See [Model-call capture](/model-server/model-call-capture).
+Captured request and response payloads are included in `ng_trajectory`. LabBench rows that report the
+`multimodal_history_redacted` gap omit those payload copies; direct provider calls are not captured. See
+[Model-call capture](/model-server/model-call-capture) for payload retention and access-control requirements. Token fields are
+`prompt_tokens`, `completion_tokens`, `reasoning_tokens`, `total_tokens`, and `cached_tokens`; unavailable values are `null`.
+
+## Acceptance criteria
+
+| ID | Criterion |
+|---|---|
+| C1 | Standard schema for per-model-call token statistics and response metadata |
+| C2 | Prompt, completion, reasoning, total, and cached token counts when available |
+| C3 | Task and rollout identity, turn number, timestamp, question, answer, reasoning, resolution, and step count per turn |
+| C4 | Model-visible input and output history can be reconstructed from the rollout record |
+| C5 | Tool output, status, start and completion timestamps, and duration |
+| C6 | Independent timing for parallel tool calls |
+| C7 | Resource-server-backed and custom or sandbox-backed benchmarks |
+
+## Agent coverage
+
+- `V`: complete under the documented observability configuration.
+- `O`: currently partial or path-dependent.
+- `X`: currently unavailable.
+
+| Agent | C1 | C2 | C3 | C4 | C5 | C6 | C7 |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| `anyswe_agent` | X | X | X | X | X | X | X |
+| `anyterminal_agent` | V | V | X | V | X | X | X |
+| `aviary_agent` | V | V | X | V | X | X | X |
+| `browsecomp_agent` | V | V | X | V | X | X | X |
+| `claude_code_agent` | V | V | X | V | V | V | V |
+| `codex_agent` | V | V | X | V | X | X | X |
+| `critpt_agent` | V | V | X | V | X | X | X |
+| `cvdp_agent` | O | O | X | O | X | X | X |
+| `finance_agent` | X | O | X | X | X | X | X |
+| `gymnasium_agent` | V | V | X | V | X | X | X |
+| `harbor_agent` | X | X | X | X | X | X | X |
+| `hermes_agent` | V | V | X | V | X | X | X |
+| `kilocode_agent` | V | V | X | V | X | X | X |
+| `labbench2_vlm_agent` | V | V | V | O | O | X | V |
+| `langgraph_agent` | X | X | X | X | X | X | X |
+| `mini_swe_agent` | X | X | X | X | X | X | X |
+| `mini_swe_agent_2` | V | V | X | V | X | X | X |
+| `non_executing_simple_agent` | V | V | X | V | X | X | X |
+| `openclaw_agent` | X | X | X | X | X | X | X |
+| `opencode_agent` | X | X | X | X | X | X | X |
+| `osworld_agent` | O | O | X | O | X | X | X |
+| `pi_agent` | X | X | X | X | X | X | X |
+| `pinchbench` | X | X | X | X | X | X | X |
+| `proof_refinement_agent` | V | V | X | V | X | X | X |
+| `remote_agent` | X | O | X | X | X | X | X |
+| `scicode_agent` | X | X | X | X | X | X | X |
+| `simple_agent` | V | V | V | V | O | X | V |
+| `speed_bench_agent` | V | V | X | V | X | X | X |
+| `stirrup_agent` | O | O | X | O | X | X | X |
+| `swe_agents` | X | X | X | X | X | X | X |
+| `tau2` | V | V | X | V | X | X | X |
+| `tool_simulation_agent` | V | V | X | V | X | X | X |
+| `toolsandbox_agent` | V | V | X | V | X | X | X |
+| `verifiers_agent` | X | X | X | X | X | X | X |
+
+Current `O` values reflect the CVDP Simple path, Finance and Remote aggregate usage, LabBench image redaction, OSWorld M3 and
+Pointer direct-provider routes, omitted raised failures in Simple-derived agents, and Stirrup calls outside its policy path. The
+matrix reports producer output, not schema capacity.
+C7 requires standardized agent-side trajectory evidence; model HTTP capture alone does not satisfy it.

--- a/fern/versions/latest/pages/reference/trajectory-capabilities.mdx
+++ b/fern/versions/latest/pages/reference/trajectory-capabilities.mdx
@@ -16,7 +16,8 @@ a `/ng-rollout/<rollout_id>` Gym Model Server prefix. See [Model-call capture](/
 Captured request and response payloads are included in `ng_trajectory`. LabBench rows that report the
 `multimodal_history_redacted` gap omit those payload copies; direct provider calls are not captured. See
 [Model-call capture](/model-server/model-call-capture) for payload retention and access-control requirements. Token fields are
-`prompt_tokens`, `completion_tokens`, `reasoning_tokens`, `total_tokens`, and `cached_tokens`; unavailable values are `null`.
+`prompt_tokens`, `completion_tokens`, `reasoning_tokens`, `total_tokens`, and `cached_tokens`. The fields are nullable, and
+provider-reported details are preserved when available.
 
 ## Acceptance criteria
 
@@ -25,16 +26,18 @@ Captured request and response payloads are included in `ng_trajectory`. LabBench
 | C1 | Standard schema for per-model-call token statistics and response metadata |
 | C2 | Prompt, completion, reasoning, total, and cached token counts when available |
 | C3 | Task and rollout identity, turn number, timestamp, question, answer, reasoning, resolution, and step count per turn |
-| C4 | Model-visible input and output history can be reconstructed from the rollout record |
+| C4 | Model-visible input and output history can be reconstructed from persisted rollout JSONL |
 | C5 | Tool output, status, start and completion timestamps, and duration |
 | C6 | Independent timing for parallel tool calls |
 | C7 | Resource-server-backed and custom or sandbox-backed benchmarks |
 
 ## Agent coverage
 
-- `V`: complete under the documented observability configuration.
+- `V`: complete for the evaluated path under the documented observability configuration.
 - `O`: currently partial or path-dependent.
 - `X`: currently unavailable.
+
+For C1, C2, and C4, `V` evaluates the correlated Gym Model Server path; direct-provider alternatives are outside capture.
 
 | Agent | C1 | C2 | C3 | C4 | C5 | C6 | C7 |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|

--- a/fern/versions/latest/pages/reference/trajectory-capabilities.mdx
+++ b/fern/versions/latest/pages/reference/trajectory-capabilities.mdx
@@ -51,7 +51,7 @@ Captured request and response payloads are included in `ng_trajectory`. LabBench
 | `harbor_agent` | X | X | X | X | X | X | X |
 | `hermes_agent` | V | V | X | V | X | X | X |
 | `kilocode_agent` | V | V | X | V | X | X | X |
-| `labbench2_vlm_agent` | V | V | V | O | O | X | V |
+| `labbench2_vlm_agent` | V | V | O | O | O | X | V |
 | `langgraph_agent` | X | X | X | X | X | X | X |
 | `mini_swe_agent` | X | X | X | X | X | X | X |
 | `mini_swe_agent_2` | V | V | X | V | X | X | X |
@@ -64,7 +64,7 @@ Captured request and response payloads are included in `ng_trajectory`. LabBench
 | `proof_refinement_agent` | V | V | X | V | X | X | X |
 | `remote_agent` | X | O | X | X | X | X | X |
 | `scicode_agent` | X | X | X | X | X | X | X |
-| `simple_agent` | V | V | V | V | O | X | V |
+| `simple_agent` | V | V | O | V | O | X | V |
 | `speed_bench_agent` | V | V | X | V | X | X | X |
 | `stirrup_agent` | O | O | X | O | X | X | X |
 | `swe_agents` | X | X | X | X | X | X | X |
@@ -73,7 +73,8 @@ Captured request and response payloads are included in `ng_trajectory`. LabBench
 | `toolsandbox_agent` | V | V | X | V | X | X | X |
 | `verifiers_agent` | X | X | X | X | X | X | X |
 
-Current `O` values reflect the CVDP Simple path, Finance and Remote aggregate usage, LabBench image redaction, OSWorld M3 and
-Pointer direct-provider routes, omitted raised failures in Simple-derived agents, and Stirrup calls outside its policy path. The
-matrix reports producer output, not schema capacity.
+Simple and LabBench C3 support is partial because verifier responses may omit resolution status. Current `O` values reflect the
+CVDP Simple path, Finance and Remote aggregate usage, LabBench image redaction, OSWorld M3 and Pointer direct-provider routes,
+omitted raised failures in Simple-derived agents, and Stirrup calls outside its policy path. The matrix reports producer output,
+not schema capacity.
 C7 requires standardized agent-side trajectory evidence; model HTTP capture alone does not satisfy it.

--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -371,6 +371,21 @@ def _token_count(value: Any) -> Optional[int]:
     return value if type(value) is int and value >= 0 else None
 
 
+def _usage_detail_token(
+    usage: Mapping[str, Any], detail_groups: tuple[str, ...], field_names: tuple[str, ...]
+) -> Optional[int]:
+    """Return the first valid token count across equivalent provider detail shapes."""
+    for group_name in detail_groups:
+        details = usage.get(group_name)
+        if not isinstance(details, Mapping):
+            continue
+        for field_name in field_names:
+            value = _token_count(details.get(field_name))
+            if value is not None:
+                return value
+    return None
+
+
 def extract_token_stats(usage: Any) -> dict[str, Optional[int]]:
     """Normalize token totals across Responses, Chat Completions, and Anthropic Messages usage.
 
@@ -402,20 +417,22 @@ def extract_token_stats(usage: Any) -> dict[str, Optional[int]]:
     cache_read = _token_count(usage.get("cache_read_input_tokens"))
     cache_creation = _token_count(usage.get("cache_creation_input_tokens"))
     if cache_read is not None or cache_creation is not None:
-        # A fully-cached response can omit input_tokens; use a 0 base so the folded prompt size is
-        # preserved rather than dropped to null. (Top-level cache_* keys are Anthropic-only, so the
-        # OpenAI/Responses path -- nested prompt_tokens_details.cached_tokens -- never enters here.)
-        tokens_in = (tokens_in or 0) + (cache_read or 0) + (cache_creation or 0)
+        cache_total = (cache_read or 0) + (cache_creation or 0)
+        # Zero cache fields alone do not establish a missing prompt count.
+        if tokens_in is not None or cache_total > 0:
+            tokens_in = (tokens_in or 0) + cache_total
     tokens_total = _token_count(usage.get("total_tokens"))
     if tokens_total is None and tokens_in is not None and tokens_out is not None:
         tokens_total = tokens_in + tokens_out
-    details = usage.get("output_tokens_details") or usage.get("completion_tokens_details") or {}
-    if not isinstance(details, Mapping):
-        details = {}
+    tokens_reasoning = _usage_detail_token(
+        usage, ("output_tokens_details", "completion_tokens_details"), ("reasoning_tokens",)
+    )
+    if tokens_reasoning is None:
+        tokens_reasoning = _token_count(usage.get("reasoning_output_tokens"))
     return {
         "tokens_in": tokens_in,
         "tokens_out": tokens_out,
-        "tokens_reasoning": _token_count(details.get("reasoning_tokens")),
+        "tokens_reasoning": tokens_reasoning,
         "tokens_total": tokens_total,
         "cache_creation_tokens": cache_creation,
     }
@@ -425,12 +442,15 @@ def _cache_signal(usage: Any) -> tuple[Optional[bool], Optional[int]]:
     """Cache hit/miss + cached-token count, from usage cache fields (OpenAI / Anthropic)."""
     if not isinstance(usage, Mapping):
         return None, None
-    details = usage.get("prompt_tokens_details") or usage.get("input_tokens_details") or {}
-    if not isinstance(details, Mapping):
-        details = {}
-    cached = _token_count(details.get("cached_tokens"))
+    cached = _usage_detail_token(
+        usage,
+        ("prompt_tokens_details", "input_tokens_details"),
+        ("cached_tokens", "cached_input_tokens"),
+    )
     if cached is None:
         cached = _token_count(usage.get("cache_read_input_tokens"))  # Anthropic
+    if cached is None:
+        cached = _token_count(usage.get("cached_input_tokens"))
     if cached is None:
         return None, None
     return cached > 0, cached
@@ -523,6 +543,7 @@ class ModelCallRecord(BaseModel):
     model: Optional[str] = None
     dialect: Optional[str] = None
     status_code: Optional[int] = None
+    response_status: Optional[str] = None
     finish_reason: Optional[str] = None
 
     # Wall-clock bounds around the downstream ASGI invocation, as UTC Unix timestamps. These are
@@ -597,6 +618,7 @@ def build_model_call_record(exchange: dict[str, Any], *, call_index: int) -> Mod
         model=model if isinstance(model, str) else None,
         dialect=exchange.get("dialect"),
         status_code=exchange.get("status_code"),
+        response_status=response.get("status") if isinstance(response.get("status"), str) else None,
         finish_reason=finish_reason,
         started_at=exchange.get("started_at"),
         completed_at=exchange.get("completed_at"),
@@ -646,6 +668,7 @@ def aggregate_model_call_records(calls: list[ModelCallRecord]) -> dict[str, Any]
         "tokens_out": _sum("tokens_out"),
         "tokens_reasoning": _sum("tokens_reasoning"),
         "tokens_total": _sum("tokens_total"),
+        "cached_tokens": _sum("cached_tokens"),
         "latency_total_ms": _sum("latency_total_ms"),
         "num_calls": len(calls),
     }

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -361,6 +361,24 @@ class NeMoGymResponseUsage(ResponseUsage):
     output_tokens_details: NeMoGymResponseOutputTokensDetails
 
 
+def accumulate_response_usage(
+    total: Optional[NeMoGymResponseUsage], additional: Optional[NeMoGymResponseUsage]
+) -> Optional[NeMoGymResponseUsage]:
+    """Accumulate top-level and detailed response token counts."""
+    if additional is None:
+        return total
+    if total is None:
+        return additional.model_copy(deep=True)
+
+    result = total.model_copy(deep=True)
+    result.input_tokens += additional.input_tokens
+    result.output_tokens += additional.output_tokens
+    result.total_tokens += additional.total_tokens
+    result.input_tokens_details.cached_tokens += additional.input_tokens_details.cached_tokens
+    result.output_tokens_details.reasoning_tokens += additional.output_tokens_details.reasoning_tokens
+    return result
+
+
 class NeMoGymResponse(Response):
     output: List[NeMoGymResponseOutputItem]
     usage: Optional[NeMoGymResponseUsage] = None

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -374,8 +374,10 @@ def accumulate_response_usage(
     result.input_tokens += additional.input_tokens
     result.output_tokens += additional.output_tokens
     result.total_tokens += additional.total_tokens
-    result.input_tokens_details.cached_tokens += additional.input_tokens_details.cached_tokens
-    result.output_tokens_details.reasoning_tokens += additional.output_tokens_details.reasoning_tokens
+    if result.input_tokens_details is not None and additional.input_tokens_details is not None:
+        result.input_tokens_details.cached_tokens += additional.input_tokens_details.cached_tokens
+    if result.output_tokens_details is not None and additional.output_tokens_details is not None:
+        result.output_tokens_details.reasoning_tokens += additional.output_tokens_details.reasoning_tokens
     return result
 
 

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -67,6 +67,26 @@ def _message_content_to_text(content: Any) -> str:
     return "".join(part.get("text", "") for part in content or [] if isinstance(part, dict))
 
 
+def _optional_token_count(value: Any) -> Optional[int]:
+    """Return a provider-reported token count without coercing missing/invalid values to zero."""
+    return value if type(value) is int and value >= 0 else None
+
+
+def _usage_detail(usage: Any, detail_group: str, detail_name: str, *top_level_aliases: str) -> Optional[int]:
+    """Read one canonical nested token detail, then named provider aliases."""
+    details = getattr(usage, detail_group, None)
+    value = details.get(detail_name) if isinstance(details, dict) else getattr(details, detail_name, None)
+    value = _optional_token_count(value)
+    if value is not None:
+        return value
+    for name in top_level_aliases:
+        value = usage.get(name) if isinstance(usage, dict) else getattr(usage, name, None)
+        value = _optional_token_count(value)
+        if value is not None:
+            return value
+    return None
+
+
 class ResponsesConverterState(BaseModel):
     return_token_id_information: bool
 
@@ -489,12 +509,30 @@ class ResponsesConverter(BaseModel):
 
         usage = None
         if chat_completion.usage:
+            cached_tokens = _usage_detail(
+                chat_completion.usage,
+                "prompt_tokens_details",
+                "cached_tokens",
+                "cached_input_tokens",
+                "cache_read_input_tokens",
+            )
+            reasoning_tokens = _usage_detail(
+                chat_completion.usage,
+                "completion_tokens_details",
+                "reasoning_tokens",
+                "reasoning_output_tokens",
+            )
             usage = NeMoGymResponseUsage(
                 input_tokens=chat_completion.usage.prompt_tokens,
-                input_tokens_details=NeMoGymResponseInputTokensDetails(cached_tokens=0),
+                input_tokens_details=NeMoGymResponseInputTokensDetails(
+                    cached_tokens=cached_tokens if cached_tokens is not None else 0,
+                ),
                 output_tokens=chat_completion.usage.completion_tokens,
-                output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=0),
-                total_tokens=chat_completion.usage.prompt_tokens + chat_completion.usage.completion_tokens,
+                output_tokens_details=NeMoGymResponseOutputTokensDetails(
+                    reasoning_tokens=reasoning_tokens if reasoning_tokens is not None else 0
+                ),
+                # Provider totals can use accounting that differs from prompt + completion.
+                total_tokens=chat_completion.usage.total_tokens,
             )
 
         incomplete_details = None
@@ -530,6 +568,7 @@ class ResponsesConverter(BaseModel):
             metadata=responses_create_params.metadata,
             instructions=responses_create_params.instructions,
             user=responses_create_params.user,
+            status="incomplete" if incomplete_details is not None else "completed",
             incomplete_details=incomplete_details,
             usage=usage,
         )

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -240,7 +240,7 @@ def _build_trajectory_record(row: dict[str, Any], result: dict[str, Any]) -> Tra
         }
         response = raw_call.get("response")
         if isinstance(response, dict) and isinstance(response.get("status"), str):
-            metadata["response_status"] = response["status"]
+            metadata.setdefault("response_status", response["status"])
         projected = TrajectoryModelCall(
             model_call_id=model_call_id,
             started_at=raw_call.get("started_at"),
@@ -354,6 +354,8 @@ def _attach_trajectory_record(row: dict[str, Any], result: dict[str, Any]) -> No
             except Exception:
                 logger.warning("Could not retain the trajectory projection failure gap.", exc_info=True)
     else:
+        # Raw capture payloads remain as a fallback on failure. After success,
+        # ng_trajectory owns them, so remove only the duplicate copies.
         _strip_capture_payloads(result)
 
 

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -15,6 +15,7 @@
 import asyncio
 import glob as glob_module
 import json
+import logging
 import os
 import warnings
 from asyncio import Future, Semaphore
@@ -51,6 +52,18 @@ from nemo_gym.global_config import (
 )
 from nemo_gym.path_utils import failures_path_for
 from nemo_gym.prompt import apply_prompt_to_row, load_prompt_config, validate_prompt_compatibility
+from nemo_gym.rollout_correlation import maybe_rollout_id_from_run_body
+from nemo_gym.rollout_observability import (
+    AgentInvocation,
+    AgentObservationBundle,
+    ObservationGap,
+    ToolCallObservation,
+    TrajectoryModelCall,
+    TrajectoryRecord,
+    TrajectoryTokenStats,
+    TrajectoryToolCall,
+    TrajectoryTurn,
+)
 
 
 _failures_path_for = failures_path_for  # Backwards-compatible alias
@@ -65,6 +78,8 @@ from nemo_gym.server_utils import (
 )
 from nemo_gym.skills import SkillsConfig, load_skill_directory
 
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Failure-routing sentinels (set by agent servers, read by the dispatcher).
@@ -95,8 +110,227 @@ from nemo_gym.skills import SkillsConfig, load_skill_directory
 NG_FAILURE_CLASS_KEY = "_ng_failure_class"
 NG_NO_PERSIST_KEY = "_ng_no_persist"
 NG_TERMINAL_KEY = "_ng_failure_terminal"
+NG_TRAJECTORY_KEY = "ng_trajectory"
 
 _DEFAULT_MAX_ROLLOUT_ATTEMPTS = 3
+
+
+def _nonnegative_int(value: Any) -> Optional[int]:
+    return value if type(value) is int and value >= 0 else None
+
+
+def _has_observation_gap(result: dict[str, Any], code: str) -> bool:
+    for key in (NG_TRAJECTORY_KEY, "ng_agent_observations"):
+        observations = result.get(key)
+        gaps = observations.get("gaps") if isinstance(observations, dict) else None
+        if isinstance(gaps, list) and any(isinstance(gap, dict) and gap.get("code") == code for gap in gaps):
+            return True
+    return False
+
+
+def _trajectory_identity(row: dict[str, Any]) -> tuple[str, str]:
+    task_id = next(
+        (str(row[key]) for key in ("task_id", "problem_id", "instance_id") if row.get(key) is not None),
+        str(row[TASK_INDEX_KEY_NAME]),
+    )
+    rollout_id = maybe_rollout_id_from_run_body(row) or f"{row[TASK_INDEX_KEY_NAME]}-{row[ROLLOUT_INDEX_KEY_NAME]}"
+    return task_id, rollout_id
+
+
+def _build_trajectory_record(row: dict[str, Any], result: dict[str, Any]) -> TrajectoryRecord:
+    task_id, rollout_id = _trajectory_identity(row)
+    gaps: list[ObservationGap] = []
+    invocations: list[AgentInvocation] = []
+    turns: list[TrajectoryTurn] = []
+    tools: list[TrajectoryToolCall] = []
+    model_calls: list[TrajectoryModelCall] = []
+
+    raw_trajectory = result.get(NG_TRAJECTORY_KEY)
+    if isinstance(raw_trajectory, dict):
+        try:
+            trajectory = TrajectoryRecord.model_validate(raw_trajectory)
+            mismatches = [
+                field
+                for field, producer, canonical in (
+                    ("task_id", trajectory.task_id, task_id),
+                    ("rollout_id", trajectory.rollout_id, rollout_id),
+                )
+                if producer != canonical
+            ]
+            if mismatches:
+                gaps.append(ObservationGap(code="producer_trajectory_identity_mismatch", detail=",".join(mismatches)))
+                turns = [
+                    turn.model_copy(update={"task_id": task_id, "rollout_id": rollout_id}) for turn in trajectory.turns
+                ]
+            else:
+                turns = trajectory.turns
+            gaps.extend(trajectory.gaps)
+            invocations = trajectory.invocations
+            tools = trajectory.tool_calls
+            model_calls = trajectory.model_calls
+        except Exception as exc:
+            gaps.append(ObservationGap(code="producer_trajectory_invalid", detail=type(exc).__name__))
+
+    raw_observations = result.get("ng_agent_observations")
+    if raw_observations is not None:
+        try:
+            observations = AgentObservationBundle.model_validate(raw_observations)
+            gaps.extend(observations.gaps)
+            observed_invocations = [record for record in observations.records if isinstance(record, AgentInvocation)]
+            if observed_invocations:
+                invocations = observed_invocations
+            observed_tools = [record for record in observations.records if isinstance(record, ToolCallObservation)]
+            if observed_tools:
+                outputs = {
+                    (invocation.invocation_id, item.call_id): item.output
+                    for invocation in invocations
+                    for item in invocation.conversation
+                    if getattr(item, "type", None) == "function_call_output"
+                }
+                positions = {(tool.invocation_id, tool.tool_call_id): index for index, tool in enumerate(tools)}
+                for observed in observed_tools:
+                    key = (observed.invocation_id, observed.tool_call_id)
+                    position = positions.get(key)
+                    existing = tools[position] if position is not None else None
+                    merged = existing.model_dump(mode="json") if existing is not None else {}
+                    update = observed.model_dump(mode="json", exclude_none=True)
+                    if existing is not None and observed.status == "unknown" and existing.status != "unknown":
+                        update.pop("status", None)
+                    merged.update(update)
+                    if key in outputs:
+                        merged["output"] = outputs[key]
+                    projected = TrajectoryToolCall.model_validate(merged)
+                    if position is None:
+                        positions[key] = len(tools)
+                        tools.append(projected)
+                    else:
+                        tools[position] = projected
+        except Exception as exc:
+            gaps.append(ObservationGap(code="agent_observations_invalid", detail=type(exc).__name__))
+
+    turns.sort(key=lambda turn: (turn.timestamp, turn.invocation_id, turn.turn_no))
+
+    capture = result.get("ng_model_call_capture")
+    capture = capture if isinstance(capture, dict) else {}
+    raw_calls = capture.get("calls") or []
+    model_call_positions = {
+        call.model_call_id: index for index, call in enumerate(model_calls) if call.model_call_id is not None
+    }
+    for raw_call in raw_calls:
+        if not isinstance(raw_call, dict):
+            continue
+        model_call_id = raw_call.get("model_call_id")
+        metadata = {
+            key: raw_call[key]
+            for key in (
+                "response_id",
+                "model_ref",
+                "model",
+                "dialect",
+                "status_code",
+                "response_status",
+                "finish_reason",
+                "error_category",
+                "latency_ttft_ms",
+            )
+            if raw_call.get(key) is not None
+        }
+        response = raw_call.get("response")
+        if isinstance(response, dict) and isinstance(response.get("status"), str):
+            metadata["response_status"] = response["status"]
+        projected = TrajectoryModelCall(
+            model_call_id=model_call_id,
+            started_at=raw_call.get("started_at"),
+            completed_at=raw_call.get("completed_at"),
+            duration_ms=raw_call.get("latency_total_ms"),
+            request=raw_call.get("request") if raw_call.get("request") is not None else raw_call.get("request_raw"),
+            response=raw_call.get("response")
+            if raw_call.get("response") is not None
+            else raw_call.get("response_raw"),
+            response_metadata=metadata,
+            token_stats=TrajectoryTokenStats(
+                prompt_tokens=_nonnegative_int(raw_call.get("tokens_in")),
+                completion_tokens=_nonnegative_int(raw_call.get("tokens_out")),
+                reasoning_tokens=_nonnegative_int(raw_call.get("tokens_reasoning")),
+                total_tokens=_nonnegative_int(raw_call.get("tokens_total")),
+                cached_tokens=_nonnegative_int(raw_call.get("cached_tokens")),
+            ),
+        )
+        position = model_call_positions.pop(model_call_id, None) if model_call_id is not None else None
+        if position is None:
+            model_calls.append(projected)
+        else:
+            merged = model_calls[position].model_dump(mode="json")
+            update = projected.model_dump(mode="json", exclude_none=True)
+            for key in ("response_metadata", "token_stats"):
+                merged[key].update(update.pop(key))
+            merged.update(update)
+            projected = TrajectoryModelCall.model_validate(merged)
+            model_calls[position] = projected
+
+    for raw_gap in capture.get("gaps") or []:
+        if isinstance(raw_gap, dict):
+            try:
+                gaps.append(ObservationGap.model_validate(raw_gap))
+            except Exception:
+                gaps.append(ObservationGap(code="model_call_capture_gap_invalid"))
+    if not model_calls:
+        gaps.append(ObservationGap(code="model_calls_unavailable"))
+    if not turns:
+        gaps.append(ObservationGap(code="turns_unavailable"))
+    if not any(invocation.conversation for invocation in invocations):
+        gaps.append(ObservationGap(code="conversation_unavailable"))
+
+    return TrajectoryRecord(
+        task_id=task_id,
+        rollout_id=rollout_id,
+        invocations=invocations,
+        turns=turns,
+        model_calls=model_calls,
+        tool_calls=tools,
+        gaps=list({(gap.code, gap.invocation_id, gap.detail): gap for gap in gaps}.values()),
+    )
+
+
+def _strip_capture_payloads(result: dict[str, Any]) -> None:
+    capture = result.get("ng_model_call_capture")
+    calls = capture.get("calls") if isinstance(capture, dict) else None
+    for call in calls if isinstance(calls, list) else []:
+        if isinstance(call, dict):
+            for key in ("request", "response", "request_raw", "response_raw"):
+                call.pop(key, None)
+
+
+def _attach_trajectory_record(row: dict[str, Any], result: dict[str, Any]) -> None:
+    try:
+        result[NG_TRAJECTORY_KEY] = _build_trajectory_record(row, result).model_dump(mode="json")
+    except Exception as exc:
+        result.pop(NG_TRAJECTORY_KEY, None)
+        logger.warning("Could not project standardized trajectory evidence.", exc_info=True)
+        gap = ObservationGap(code="trajectory_projection_failed", detail=type(exc).__name__).model_dump(
+            mode="json", exclude_none=True
+        )
+        target = result.get("ng_model_call_capture")
+        if not isinstance(target, dict):
+            target = result.get("ng_agent_observations")
+        gap_attached = False
+        if isinstance(target, dict):
+            gaps = target.setdefault("gaps", [])
+            if isinstance(gaps, list):
+                gaps.append(gap)
+                gap_attached = True
+        if not gap_attached:
+            try:
+                task_id, rollout_id = _trajectory_identity(row)
+                result[NG_TRAJECTORY_KEY] = TrajectoryRecord(
+                    task_id=task_id,
+                    rollout_id=rollout_id,
+                    gaps=[ObservationGap.model_validate(gap)],
+                ).model_dump(mode="json")
+            except Exception:
+                logger.warning("Could not retain the trajectory projection failure gap.", exc_info=True)
+    finally:
+        _strip_capture_payloads(result)
 
 
 def _get_max_rollout_attempts() -> int:
@@ -547,7 +781,14 @@ class RolloutCollectionHelper(BaseModel):
             # Fold this rollout's captured model calls into its record (uniform across agents; no-op
             # when capture is off). Never alters the harness output/reward already in `result`.
             if capture_dirs:
-                merge_model_call_capture_into_record(result, capture_dirs)
+                merge_model_call_capture_into_record(
+                    result,
+                    capture_dirs,
+                    include_payloads=not _has_observation_gap(result, "multimodal_history_redacted"),
+                )
+
+            if "ng_model_call_capture" in result or "ng_agent_observations" in result or NG_TRAJECTORY_KEY in result:
+                _attach_trajectory_record(row, result)
 
             no_persist = bool(result.get(NG_NO_PERSIST_KEY))
             failure_class = result.get(NG_FAILURE_CLASS_KEY)
@@ -661,6 +902,7 @@ Aggregate metrics: {aggregate_metrics_fpath}""")
                         "responses_create_params",
                         "ng_agent_observations",
                         "ng_model_call_capture",
+                        NG_TRAJECTORY_KEY,
                     )
                 }
                 usage = (r.get("response") or {}).get("usage")

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -111,6 +111,7 @@ NG_FAILURE_CLASS_KEY = "_ng_failure_class"
 NG_NO_PERSIST_KEY = "_ng_no_persist"
 NG_TERMINAL_KEY = "_ng_failure_terminal"
 NG_TRAJECTORY_KEY = "ng_trajectory"
+_MODEL_CALL_PAYLOAD_KEYS = ("request", "response", "request_raw", "response_raw")
 
 _DEFAULT_MAX_ROLLOUT_ATTEMPTS = 3
 
@@ -177,8 +178,10 @@ def _build_trajectory_record(row: dict[str, Any], result: dict[str, Any]) -> Tra
             observations = AgentObservationBundle.model_validate(raw_observations)
             gaps.extend(observations.gaps)
             observed_invocations = [record for record in observations.records if isinstance(record, AgentInvocation)]
-            if observed_invocations:
-                invocations = observed_invocations
+            producer_invocation_ids = {record.invocation_id for record in invocations}
+            invocations.extend(
+                record for record in observed_invocations if record.invocation_id not in producer_invocation_ids
+            )
             observed_tools = [record for record in observations.records if isinstance(record, ToolCallObservation)]
             if observed_tools:
                 outputs = {
@@ -297,8 +300,29 @@ def _strip_capture_payloads(result: dict[str, Any]) -> None:
     calls = capture.get("calls") if isinstance(capture, dict) else None
     for call in calls if isinstance(calls, list) else []:
         if isinstance(call, dict):
-            for key in ("request", "response", "request_raw", "response_raw"):
+            for key in _MODEL_CALL_PAYLOAD_KEYS:
                 call.pop(key, None)
+
+
+def _rollout_for_wandb(result: dict[str, Any]) -> dict[str, Any]:
+    """Return a W&B view without the complete trajectory or raw capture payloads."""
+    sanitized = dict(result)
+    sanitized.pop(NG_TRAJECTORY_KEY, None)
+    sanitized.pop("ng_model_call_capture", None)
+    capture = result.get("ng_model_call_capture")
+    if isinstance(capture, dict):
+        sanitized_capture = dict(capture)
+        calls = capture.get("calls")
+        if isinstance(calls, list):
+            sanitized_capture["calls"] = [
+                {key: value for key, value in call.items() if key not in _MODEL_CALL_PAYLOAD_KEYS}
+                for call in calls
+                if isinstance(call, dict)
+            ]
+        else:
+            sanitized_capture.pop("calls", None)
+        sanitized["ng_model_call_capture"] = sanitized_capture
+    return sanitized
 
 
 def _attach_trajectory_record(row: dict[str, Any], result: dict[str, Any]) -> None:
@@ -329,7 +353,7 @@ def _attach_trajectory_record(row: dict[str, Any], result: dict[str, Any]) -> No
                 ).model_dump(mode="json")
             except Exception:
                 logger.warning("Could not retain the trajectory projection failure gap.", exc_info=True)
-    finally:
+    else:
         _strip_capture_payloads(result)
 
 
@@ -796,7 +820,6 @@ class RolloutCollectionHelper(BaseModel):
             rows.append(row)
             results.append(result)
             serialized = orjson.dumps(result)
-            result_strs.append([serialized])
 
             if no_persist:
                 # kill_shaped: don't write anywhere. Set-difference on resume
@@ -832,9 +855,10 @@ class RolloutCollectionHelper(BaseModel):
         results_file.close()
         failures_file.close()
 
-        if config.upload_rollouts_to_wandb and get_wandb_run():  # pragma: no cover
+        if config.upload_rollouts_to_wandb and (wandb_run := get_wandb_run()):  # pragma: no cover
             print("Uploading rollouts to W&B. This may take a few minutes if your data is large.")
-            get_wandb_run().log({"Rollouts": Table(data=result_strs, columns=["Rollout"])})
+            result_strs = [[orjson.dumps(_rollout_for_wandb(result))] for result in results]
+            wandb_run.log({"Rollouts": Table(data=result_strs, columns=["Rollout"])})
         del result_strs
 
         print("Sorting results to ensure consistent ordering")

--- a/nemo_gym/rollout_observability.py
+++ b/nemo_gym/rollout_observability.py
@@ -1,13 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Small shared contract for observations exposed by Agent integrations."""
+"""Shared contracts for rollout observations and trajectories."""
 
 from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Annotated, Literal, Optional
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -35,6 +35,51 @@ class ModelCallRef(ObservationModel):
         if not self.model_call_id and not (self.model_ref is not None and self.response_id):
             raise ValueError("model_call_id or both model_ref and response_id are required")
         return self
+
+
+class TrajectoryTokenStats(ObservationModel):
+    prompt_tokens: Optional[int] = Field(default=None, ge=0)
+    completion_tokens: Optional[int] = Field(default=None, ge=0)
+    reasoning_tokens: Optional[int] = Field(default=None, ge=0)
+    total_tokens: Optional[int] = Field(default=None, ge=0)
+    cached_tokens: Optional[int] = Field(default=None, ge=0)
+
+
+class TrajectoryResponseMetadata(ObservationModel):
+    response_id: Optional[str] = None
+    model_ref: Optional[ModelServerRef] = None
+    model: Optional[str] = None
+    dialect: Optional[str] = None
+    status_code: Optional[int] = None
+    response_status: Optional[str] = None
+    finish_reason: Optional[str] = None
+    error_category: Optional[str] = None
+    latency_ttft_ms: Optional[float] = Field(default=None, ge=0)
+
+
+class TrajectoryModelCall(ObservationModel):
+    model_call_id: Optional[str] = None
+    started_at: Optional[float] = None
+    completed_at: Optional[float] = None
+    duration_ms: Optional[float] = Field(default=None, ge=0)
+    request: Optional[Any] = None
+    response: Optional[Any] = None
+    response_metadata: TrajectoryResponseMetadata = Field(default_factory=TrajectoryResponseMetadata)
+    token_stats: TrajectoryTokenStats = Field(default_factory=TrajectoryTokenStats)
+
+
+class TrajectoryTurn(ObservationModel):
+    invocation_id: str
+    task_id: str
+    rollout_id: str
+    turn_no: int = Field(ge=1, description="Turn number within this invocation.")
+    timestamp: float
+    question: Optional[Any] = None
+    answer: Optional[Any] = None
+    reasoning_content: Optional[Any] = None
+    resolved: Optional[bool] = None
+    step_count: int = Field(ge=0, description="Producer-reported cumulative step count within this invocation.")
+    model_calls: list[ModelCallRef] = Field(default_factory=list)
 
 
 class AgentInvocation(ObservationModel):
@@ -79,6 +124,12 @@ class ToolCallObservation(ObservationModel):
         if self.started_at is not None and self.completed_at is not None and self.completed_at < self.started_at:
             raise ValueError("completed_at must not precede started_at")
         return self
+
+
+class TrajectoryToolCall(ToolCallObservation):
+    """Tool observation enriched with the model-visible output in a trajectory record."""
+
+    output: Optional[Any] = None
 
 
 class SandboxObservation(ObservationModel):
@@ -188,6 +239,35 @@ class AgentObservationBundle(ObservationModel):
                     break
                 current = parent
             checked.update(chain)
+        return self
+
+
+class TrajectoryRecord(ObservationModel):
+    schema_version: Literal["1.0"] = "1.0"
+    task_id: str
+    rollout_id: str
+    invocations: list[AgentInvocation] = Field(default_factory=list)
+    turns: list[TrajectoryTurn] = Field(default_factory=list)
+    model_calls: list[TrajectoryModelCall] = Field(default_factory=list)
+    tool_calls: list[TrajectoryToolCall] = Field(default_factory=list)
+    gaps: list[ObservationGap] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_identity(self) -> "TrajectoryRecord":
+        invocation_ids = [invocation.invocation_id for invocation in self.invocations]
+        if len(invocation_ids) != len(set(invocation_ids)):
+            raise ValueError("invocation_id must be unique within a trajectory")
+        model_call_ids = [call.model_call_id for call in self.model_calls if call.model_call_id]
+        if len(model_call_ids) != len(set(model_call_ids)):
+            raise ValueError("model_call_id must be unique within a trajectory")
+        keys: set[tuple[str, int]] = set()
+        for turn in self.turns:
+            if turn.task_id != self.task_id or turn.rollout_id != self.rollout_id:
+                raise ValueError("turn identity must match the trajectory")
+            key = (turn.invocation_id, turn.turn_no)
+            if key in keys:
+                raise ValueError("turn number must be unique within an invocation")
+            keys.add(key)
         return self
 
 

--- a/nemo_gym/rollout_reverification.py
+++ b/nemo_gym/rollout_reverification.py
@@ -43,6 +43,7 @@ from nemo_gym.rollout_collection import (
     NG_NO_PERSIST_KEY,
     NG_TERMINAL_KEY,
     _get_max_rollout_attempts,
+    _rollout_for_wandb,
 )
 from nemo_gym.server_utils import (
     ServerClient,
@@ -774,9 +775,11 @@ class RolloutReverificationHelper(BaseModel):
         # reused for both the W&B rollouts export and aggregate metrics so the file is never re-read.
         results, agg_rows = _load_reverified_results(output_fpaths.output)
 
-        if config.upload_rollouts_to_wandb and get_wandb_run():  # pragma: no cover
+        if config.upload_rollouts_to_wandb and (wandb_run := get_wandb_run()):  # pragma: no cover
             print("Uploading rollouts to W&B. This may take a few minutes if your data is large.")
-            get_wandb_run().log({"Rollouts": Table(data=[[orjson.dumps(r)] for r in results], columns=["Rollout"])})
+            wandb_run.log(
+                {"Rollouts": Table(data=[[orjson.dumps(_rollout_for_wandb(r))] for r in results], columns=["Rollout"])}
+            )
 
         # Compute and write aggregate metrics via /aggregate_metrics on each agent server
         if config.disable_aggregation:

--- a/resources_servers/swerl_gen/README.md
+++ b/resources_servers/swerl_gen/README.md
@@ -191,9 +191,11 @@ Rollout example
 }
 ```
 
+> Empty `*_tokens_per_turn` arrays are placeholders, not zero-token turns. See the
+> [trajectory capability matrix](https://docs.nvidia.com/nemo/gym/main/reference/trajectory-capabilities).
+
 ### Implementation notes
 - The server extracts the last assistant message's text from the Responses output.
 
 ## Licensing information
 Code: Apache 2.0
-

--- a/resources_servers/swerl_llm_judge/README.md
+++ b/resources_servers/swerl_llm_judge/README.md
@@ -176,6 +176,9 @@ Rollout example
 
 ```
 
+> Empty `*_tokens_per_turn` arrays are placeholders, not zero-token turns. See the
+> [trajectory capability matrix](https://docs.nvidia.com/nemo/gym/main/reference/trajectory-capabilities).
+
 ### Implementation notes
 - The server extracts the last assistant message's text from the Responses output.
 - Letters are validated against the provided `options` keys.

--- a/responses_api_agents/browsecomp_agent/app.py
+++ b/responses_api_agents/browsecomp_agent/app.py
@@ -43,6 +43,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCall,
     NeMoGymResponseOutputMessage,
+    accumulate_response_usage,
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
 from responses_api_models.vllm_model.app import VLLMConverter
@@ -255,18 +256,7 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
             new_outputs.extend(output)
             full_trajectory.extend(output)
 
-            if not usage:
-                usage = model_response.usage
-                model_response.usage = None
-
-            if usage and model_response.usage:
-                usage.input_tokens += model_response.usage.input_tokens
-                usage.output_tokens += model_response.usage.output_tokens
-                usage.total_tokens += model_response.usage.total_tokens
-
-                # TODO support more advanced token details
-                usage.input_tokens_details.cached_tokens = 0
-                usage.output_tokens_details.reasoning_tokens = 0
+            usage = accumulate_response_usage(usage, model_response.usage)
 
             if model_response.incomplete_details and model_response.incomplete_details.reason == "max_output_tokens":
                 break

--- a/responses_api_agents/cvdp_agent/app.py
+++ b/responses_api_agents/cvdp_agent/app.py
@@ -64,6 +64,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCall,
     NeMoGymResponseOutputMessage,
+    accumulate_response_usage,
 )
 from nemo_gym.sandbox import AsyncSandbox, SandboxSpec
 from nemo_gym.server_utils import get_response_json, raise_for_status
@@ -292,18 +293,7 @@ class CVDPAgent(SimpleResponsesAPIAgent):
             output = model_response.output
             new_outputs.extend(output)
 
-            if not usage:
-                usage = model_response.usage
-                model_response.usage = None
-
-            if usage and model_response.usage:
-                usage.input_tokens += model_response.usage.input_tokens
-                usage.output_tokens += model_response.usage.output_tokens
-                usage.total_tokens += model_response.usage.total_tokens
-
-                # TODO support more advanced token details
-                usage.input_tokens_details.cached_tokens = 0
-                usage.output_tokens_details.reasoning_tokens = 0
+            usage = accumulate_response_usage(usage, model_response.usage)
 
             if model_response.incomplete_details and model_response.incomplete_details.reason == "max_output_tokens":
                 break

--- a/responses_api_agents/finance_agent/app.py
+++ b/responses_api_agents/finance_agent/app.py
@@ -41,6 +41,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCall,
     NeMoGymResponseOutputMessage,
+    accumulate_response_usage,
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
 
@@ -220,18 +221,7 @@ class FinanceAgent(SimpleResponsesAPIAgent):
             last_model_response = model_response
             new_outputs.extend(output)
 
-            if not usage:
-                usage = model_response.usage
-                model_response.usage = None
-
-            if usage and model_response.usage:
-                usage.input_tokens += model_response.usage.input_tokens
-                usage.output_tokens += model_response.usage.output_tokens
-                usage.total_tokens += model_response.usage.total_tokens
-
-                # TODO support more advanced token details
-                usage.input_tokens_details.cached_tokens = 0
-                usage.output_tokens_details.reasoning_tokens = 0
+            usage = accumulate_response_usage(usage, model_response.usage)
 
             if model_response.incomplete_details and model_response.incomplete_details.reason == "max_output_tokens":
                 break

--- a/responses_api_agents/gymnasium_agent/app.py
+++ b/responses_api_agents/gymnasium_agent/app.py
@@ -29,6 +29,7 @@ from nemo_gym.openai_utils import (
     NeMoGymFunctionCallOutput,
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
+    accumulate_response_usage,
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
 from resources_servers.gymnasium import EnvResetResponse, EnvStepResponse
@@ -118,15 +119,7 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
 
             new_outputs.extend(model_response.output)
 
-            if model_response.usage:
-                if usage is None:
-                    usage = model_response.usage.model_copy(deep=True)
-                else:
-                    usage.input_tokens += model_response.usage.input_tokens
-                    usage.output_tokens += model_response.usage.output_tokens
-                    usage.total_tokens += model_response.usage.total_tokens
-                    usage.input_tokens_details.cached_tokens = 0
-                    usage.output_tokens_details.reasoning_tokens = 0
+            usage = accumulate_response_usage(usage, model_response.usage)
 
             step_resp = await self.server_client.post(
                 server_name=self.config.resources_server.name,

--- a/responses_api_agents/gymnasium_agent/tests/test_app.py
+++ b/responses_api_agents/gymnasium_agent/tests/test_app.py
@@ -38,7 +38,7 @@ def _make_agent(max_steps=10, observability=True):
     return GymnasiumAgent(config=config, server_client=server_client)
 
 
-def _model_response(text: str, input_toks=1, output_toks=1) -> dict:
+def _model_response(text: str, input_toks=1, output_toks=1, cached_toks=0, reasoning_toks=0) -> dict:
     return {
         "id": "r",
         "created_at": 0.0,
@@ -58,9 +58,9 @@ def _model_response(text: str, input_toks=1, output_toks=1) -> dict:
         "tools": [],
         "usage": {
             "input_tokens": input_toks,
-            "input_tokens_details": {"cached_tokens": 0},
+            "input_tokens_details": {"cached_tokens": cached_toks},
             "output_tokens": output_toks,
-            "output_tokens_details": {"reasoning_tokens": 0},
+            "output_tokens_details": {"reasoning_tokens": reasoning_toks},
             "total_tokens": input_toks + output_toks,
         },
     }
@@ -251,8 +251,8 @@ class TestRun:
             {
                 "/reset": [{"observation": None, "info": {}}],
                 "/v1/responses": [
-                    _model_response("a", input_toks=5, output_toks=7),
-                    _model_response("b", input_toks=11, output_toks=13),
+                    _model_response("a", input_toks=5, output_toks=7, cached_toks=2, reasoning_toks=3),
+                    _model_response("b", input_toks=11, output_toks=13, cached_toks=5, reasoning_toks=7),
                 ],
                 "/step": [
                     {"observation": "o", "reward": 0.0, "terminated": False, "truncated": False, "info": {}},
@@ -268,3 +268,5 @@ class TestRun:
         assert result.response.usage.input_tokens == 16
         assert result.response.usage.output_tokens == 20
         assert result.response.usage.total_tokens == 36
+        assert result.response.usage.input_tokens_details.cached_tokens == 7
+        assert result.response.usage.output_tokens_details.reasoning_tokens == 10

--- a/responses_api_agents/labbench2_vlm_agent/README.md
+++ b/responses_api_agents/labbench2_vlm_agent/README.md
@@ -12,4 +12,5 @@ See `resources_servers/labbench2_vlm/README.md` for full documentation.
 
 - `media_base_dir`: base directory for resolving media paths (relative to Gym root)
 - `dpi`: DPI for PDF page rendering (default: 170)
-- `strip_images_from_output`: remove base64 blocks from rollout output (default: true)
+- `strip_images_from_output`: remove image blocks from the response, observations, and `ng_trajectory` (default: true);
+  `CaptureStore` retains the original request when model-call capture is enabled

--- a/responses_api_agents/labbench2_vlm_agent/app.py
+++ b/responses_api_agents/labbench2_vlm_agent/app.py
@@ -25,6 +25,7 @@ for figqa2/tableqa2). Non-protocol rows always use the image path when
 """
 
 from pathlib import Path
+from typing import Any
 
 from fastapi import Request
 from pydantic import Field
@@ -54,7 +55,7 @@ class LabbenchVLMAgentConfig(SimpleAgentConfig):
     )
     strip_images_from_output: bool = Field(
         default=True,
-        description="Remove base64 input_image blocks from the rollout output to keep files small.",
+        description="Remove base64 input_image blocks from serialized rollout artifacts.",
     )
 
 
@@ -68,16 +69,34 @@ def _effective_media_mode(agent_media_mode: str, verifier_metadata: dict | None)
 
 
 def _strip_image_blocks(result: SimpleAgentVerifyResponse) -> SimpleAgentVerifyResponse:
-    """Remove input_image blocks from responses_create_params in the output.
+    """Remove input_image blocks from the serialized rollout result.
 
     Operates on a dict dump to avoid Pydantic model mutation/serialization issues,
     then re-validates into the response model.
     """
-    data = result.model_dump()
-    for msg in data.get("responses_create_params", {}).get("input", []):
-        content = msg.get("content")
-        if isinstance(content, list):
-            msg["content"] = [b for b in content if b.get("type") != "input_image"]
+
+    removed_image = False
+
+    def scrub(value: Any) -> Any:
+        nonlocal removed_image
+        if isinstance(value, list):
+            cleaned = []
+            for item in value:
+                if isinstance(item, dict) and item.get("type") == "input_image":
+                    removed_image = True
+                    continue
+                cleaned.append(scrub(item))
+            return cleaned
+        if isinstance(value, dict):
+            return {key: scrub(item) for key, item in value.items()}
+        return value
+
+    data = scrub(result.model_dump(mode="json"))
+    if removed_image:
+        for key in ("ng_trajectory", "ng_agent_observations"):
+            observations = data.get(key)
+            if isinstance(observations, dict):
+                observations.setdefault("gaps", []).append({"code": "multimodal_history_redacted"})
     return SimpleAgentVerifyResponse.model_validate(data)
 
 

--- a/responses_api_agents/labbench2_vlm_agent/tests/test_app.py
+++ b/responses_api_agents/labbench2_vlm_agent/tests/test_app.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
@@ -21,6 +22,7 @@ from responses_api_agents.labbench2_vlm_agent.app import (
     LabbenchVLMAgent,
     LabbenchVLMAgentConfig,
     _effective_media_mode,
+    _strip_image_blocks,
 )
 from responses_api_agents.simple_agent.app import SimpleAgent, SimpleAgentRunRequest, SimpleAgentVerifyResponse
 
@@ -84,3 +86,41 @@ async def test_run_preserves_unset_model_during_media_embedding(monkeypatch) -> 
 
     forwarded_body = super_run.call_args.args[1]
     assert "model" not in forwarded_body.responses_create_params.model_fields_set
+
+
+def test_strip_images_removes_media_from_response_and_trajectory() -> None:
+    image = {"type": "input_image", "image_url": "data:image/png;base64,cGF5bG9hZA==", "detail": "auto"}
+    message = {"role": "user", "content": [{"type": "input_text", "text": "question"}, image]}
+    result = SimpleAgentVerifyResponse.model_validate(
+        {
+            "responses_create_params": {"input": [message]},
+            "response": {
+                "id": "response-1",
+                "created_at": 1,
+                "model": "model",
+                "object": "response",
+                "output": [],
+                "parallel_tool_calls": True,
+                "tool_choice": "auto",
+                "tools": [],
+            },
+            "reward": 1.0,
+            "ng_trajectory": {
+                "schema_version": "1.0",
+                "task_id": "task",
+                "rollout_id": "rollout",
+                "invocations": [{"kind": "agent_invocation", "invocation_id": "root", "conversation": [message]}],
+            },
+        }
+    )
+
+    stripped = _strip_image_blocks(result)
+    serialized = json.dumps(stripped.model_dump(mode="json"))
+
+    assert "input_image" not in serialized
+    assert "cGF5bG9hZA==" not in serialized
+    assert "question" in serialized
+    assert [gap["code"] for gap in stripped.model_dump(mode="json")["ng_trajectory"]["gaps"]] == [
+        "multimodal_history_redacted"
+    ]
+    assert len(_strip_image_blocks(stripped).model_dump(mode="json")["ng_trajectory"]["gaps"]) == 1

--- a/responses_api_agents/remote_agent/app.py
+++ b/responses_api_agents/remote_agent/app.py
@@ -62,6 +62,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCall,
     NeMoGymResponseOutputMessage,
+    accumulate_response_usage,
 )
 from nemo_gym.rollout_collection import NG_FAILURE_CLASS_KEY, NG_NO_PERSIST_KEY, NG_TERMINAL_KEY
 from nemo_gym.server_utils import (
@@ -184,18 +185,8 @@ class RemoteAgent(SimpleResponsesAPIAgent):
             output = agent_response.output
             new_outputs.extend(output)
 
-            if not usage:
-                usage = agent_response.usage
-                agent_response.usage = None
-
-            if usage and agent_response.usage:
-                usage.input_tokens += agent_response.usage.input_tokens
-                usage.output_tokens += agent_response.usage.output_tokens
-                usage.total_tokens += agent_response.usage.total_tokens
-
-                # TODO support more advanced token details
-                usage.input_tokens_details.cached_tokens = 0
-                usage.output_tokens_details.reasoning_tokens = 0
+            usage = accumulate_response_usage(usage, agent_response.usage)
+            agent_response.usage = None
 
             if agent_response.incomplete_details:
                 break

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -33,7 +33,6 @@ from nemo_gym.base_responses_api_agent import (
     SimpleResponsesAPIAgent,
 )
 from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
-from nemo_gym.global_config import OBSERVABILITY_ENABLED_KEY_NAME
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymFunctionCallOutput,
@@ -43,7 +42,6 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseOutputMessage,
     accumulate_response_usage,
 )
-from nemo_gym.rollout_correlation import maybe_rollout_id_from_run_body
 from nemo_gym.rollout_observability import (
     AgentInvocation,
     ModelCallRef,
@@ -53,6 +51,9 @@ from nemo_gym.rollout_observability import (
     TrajectoryTurn,
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
+
+
+_INTERNAL_TRAJECTORY_KEY = "_ng_trajectory"
 
 
 class SimpleAgentConfig(BaseResponsesAPIAgentConfig):
@@ -254,14 +255,23 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         response: Response,
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
-        model_response, _, model_server_cookies, resources_server_cookies = await self._create_episode(
+        path_params = getattr(request, "path_params", None)
+        rollout_id = path_params.get("rollout_id") if isinstance(path_params, Mapping) else None
+        collect_trajectory = self._model_call_capture_enabled() and isinstance(rollout_id, str)
+        model_response, trajectory, model_server_cookies, resources_server_cookies = await self._create_episode(
             body,
             model_url_path=self.url_path_for_request("/v1/responses", request),
             resources_server_cookies=request.cookies,
+            rollout_id=rollout_id or "unscoped",
+            collect_trajectory=collect_trajectory,
         )
         # Propogate any extra cookies necessary for downstream verification
         for k, v in (*resources_server_cookies.items(), *model_server_cookies.items()):
             response.set_cookie(k, v)
+        if trajectory is not None:
+            model_response = model_response.model_copy(
+                update={_INTERNAL_TRAJECTORY_KEY: trajectory.model_dump(mode="json")}
+            )
         return model_response
 
     async def run(self, request: Request, body: SimpleAgentRunRequest) -> SimpleAgentVerifyResponse:
@@ -276,25 +286,23 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         await raise_for_status(seed_session_response)
         cookies = seed_session_response.cookies
 
-        trajectory = None
-        # Token-id capture also uses rollout correlation but does not enable trajectory collection.
-        global_config = getattr(self.server_client, "global_config_dict", None)
-        collect_trajectory = isinstance(global_config, Mapping) and bool(
-            global_config.get(OBSERVABILITY_ENABLED_KEY_NAME, False)
+        response = await self.server_client.post(
+            server_name=self.config.name,
+            url_path=self.url_path_for_run("/v1/responses", body),
+            json=body.responses_create_params,
+            cookies=cookies,
         )
-        # Direct collection bypasses the self-call route. Keep HTTP dispatch for overridden
-        # responses() methods so their custom handler and middleware behavior remains active.
-        if not collect_trajectory or type(self).responses is not SimpleAgent.responses:
-            response = await self.server_client.post(
-                server_name=self.config.name,
-                url_path=self.url_path_for_run("/v1/responses", body),
-                json=body.responses_create_params,
-                cookies=cookies,
-            )
-            await raise_for_status(response)
-            model_response_json = await get_response_json(response)
-            cookies = response.cookies
-        else:
+        await raise_for_status(response)
+        model_response_json = await get_response_json(response)
+        cookies = response.cookies
+
+        trajectory = None
+        expected_rollout_id = self.rollout_id_from_run(body)
+        raw_trajectory = (
+            model_response_json.pop(_INTERNAL_TRAJECTORY_KEY, None) if expected_rollout_id is not None else None
+        )
+        if isinstance(raw_trajectory, dict):
+            trajectory = TrajectoryRecord.model_validate(raw_trajectory)
             extra = body.model_extra or {}
             task_id = next(
                 (
@@ -304,17 +312,17 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 ),
                 "unknown",
             )
-            model_response, trajectory, model_server_cookies, cookies = await self._create_episode(
-                body.responses_create_params,
-                model_url_path=self.url_path_for_run("/v1/responses", body),
-                resources_server_cookies=cookies,
-                task_id=task_id,
-                rollout_id=maybe_rollout_id_from_run_body(body) or "unknown",
-                collect_trajectory=True,
+            rollout_id = expected_rollout_id or trajectory.rollout_id
+            trajectory = trajectory.model_copy(
+                update={
+                    "task_id": task_id,
+                    "rollout_id": rollout_id,
+                    "turns": [
+                        turn.model_copy(update={"task_id": task_id, "rollout_id": rollout_id})
+                        for turn in trajectory.turns
+                    ],
+                }
             )
-            if model_server_cookies:
-                cookies.update(model_server_cookies)
-            model_response_json = model_response.model_dump(mode="json")
 
         verify_request = SimpleAgentVerifyRequest.model_validate(body.model_dump() | {"response": model_response_json})
 

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-from typing import List
+from collections.abc import Mapping
+from time import perf_counter, time
+from typing import Any, List
 
 from fastapi import Request, Response
 from pydantic import ConfigDict, ValidationError
@@ -31,6 +33,7 @@ from nemo_gym.base_responses_api_agent import (
     SimpleResponsesAPIAgent,
 )
 from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
+from nemo_gym.global_config import OBSERVABILITY_ENABLED_KEY_NAME
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymFunctionCallOutput,
@@ -38,6 +41,16 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCall,
     NeMoGymResponseOutputMessage,
+    accumulate_response_usage,
+)
+from nemo_gym.rollout_correlation import maybe_rollout_id_from_run_body
+from nemo_gym.rollout_observability import (
+    AgentInvocation,
+    ModelCallRef,
+    ObservationGap,
+    TrajectoryRecord,
+    TrajectoryToolCall,
+    TrajectoryTurn,
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
 
@@ -63,12 +76,21 @@ class SimpleAgentVerifyResponse(BaseVerifyResponse):
 class SimpleAgent(SimpleResponsesAPIAgent):
     config: SimpleAgentConfig
 
-    async def responses(
+    async def _create_episode(
         self,
-        request: Request,
-        response: Response,
-        body: NeMoGymResponseCreateParamsNonStreaming = Body(),
-    ) -> NeMoGymResponse:
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        *,
+        model_url_path: str,
+        resources_server_cookies: Any = None,
+        task_id: str = "unscoped",
+        rollout_id: str = "unscoped",
+        collect_trajectory: bool = False,
+    ) -> tuple[NeMoGymResponse, TrajectoryRecord | None, Any, Any]:
+        invocation_id = "root"
+        tool_records: list[TrajectoryToolCall] = []
+        model_calls: list[ModelCallRef] = []
+        turns: list[TrajectoryTurn] = []
+        trajectory_gaps: list[ObservationGap] = []
         body = body.model_copy(deep=True)
 
         if isinstance(body.input, str):
@@ -77,16 +99,18 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         new_outputs = []
         usage = None
         step = 0
-        model_server_cookies = None  # update the cookies on every model response
-        resources_server_cookies = request.cookies  # update the cookies on every resources server response
+        invocation_status = "completed"
+        model_server_cookies = None
 
         while True:
             step += 1
             new_body = body.model_copy(update={"input": body.input + new_outputs})
+            if collect_trajectory:
+                turn_timestamp = time()
 
             model_response = await self.server_client.post(
                 server_name=self.config.model_server.name,
-                url_path=self.url_path_for_request("/v1/responses", request),
+                url_path=model_url_path,
                 json=new_body,
                 cookies=model_server_cookies,
             )
@@ -103,21 +127,40 @@ class SimpleAgent(SimpleResponsesAPIAgent):
 
             output = model_response.output
             new_outputs.extend(output)
+            if collect_trajectory:
+                turn_model_calls = []
+                if model_response.id:
+                    model_call_ref = ModelCallRef(model_ref=self.config.model_server, response_id=model_response.id)
+                    model_calls.append(model_call_ref)
+                    turn_model_calls.append(model_call_ref)
+                else:
+                    trajectory_gaps.append(
+                        ObservationGap(
+                            code="model_call_reference_unavailable", invocation_id=invocation_id, detail=f"turn:{step}"
+                        )
+                    )
+                reasoning = [item.model_dump(mode="json") for item in output if item.type == "reasoning"] or None
+                answer = [item for item in output if item.type != "reasoning"]
+                turns.append(
+                    TrajectoryTurn(
+                        invocation_id=invocation_id,
+                        task_id=task_id,
+                        rollout_id=rollout_id,
+                        turn_no=step,
+                        timestamp=turn_timestamp,
+                        question=new_body.input,
+                        answer=answer,
+                        reasoning_content=reasoning,
+                        step_count=len(tool_records),
+                        model_calls=turn_model_calls,
+                    )
+                )
 
-            if not usage:
-                usage = model_response.usage
-                model_response.usage = None
-
-            if usage and model_response.usage:
-                usage.input_tokens += model_response.usage.input_tokens
-                usage.output_tokens += model_response.usage.output_tokens
-                usage.total_tokens += model_response.usage.total_tokens
-
-                # TODO support more advanced token details
-                usage.input_tokens_details.cached_tokens = 0
-                usage.output_tokens_details.reasoning_tokens = 0
+            usage = accumulate_response_usage(usage, model_response.usage)
+            model_response.usage = None
 
             if model_response.incomplete_details:
+                invocation_status = "incomplete"
                 break
 
             all_fn_calls: List[NeMoGymResponseFunctionToolCall] = [o for o in output if o.type == "function_call"]
@@ -128,49 +171,97 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 break
 
             for output_function_call in all_fn_calls:
+                if collect_trajectory:
+                    started_at = time()
+                    started_monotonic = perf_counter()
                 try:
                     parsed_arguments = json.loads(output_function_call.arguments)
                 except (json.JSONDecodeError, TypeError) as e:
-                    # Model produced malformed tool-call arguments. Surface the
-                    # error back as a tool response so the rollout can continue
-                    # (or terminate with a low reward) instead of crashing the
-                    # whole batch on json.loads.
-                    tool_response = NeMoGymFunctionCallOutput(
+                    tool_output = json.dumps({"error": f"Invalid tool call arguments: {e!r}"})
+                    if collect_trajectory:
+                        error_type = type(e).__name__
+                        tool_status = "failed"
+                else:
+                    # Resource-server errors are valid model-visible tool outputs.
+                    api_response = await self.server_client.post(
+                        server_name=self.config.resources_server.name,
+                        url_path=f"/{output_function_call.name}",
+                        json=parsed_arguments,
+                        cookies=resources_server_cookies,
+                    )
+                    tool_output = (await api_response.content.read()).decode()
+                    resources_server_cookies = api_response.cookies
+                    if collect_trajectory:
+                        completed = 200 <= api_response.status < 400
+                        tool_status = "completed" if completed else "failed"
+                        error_type = None if completed else f"http_{api_response.status}"
+
+                if collect_trajectory:
+                    tool_records.append(
+                        TrajectoryToolCall(
+                            invocation_id=invocation_id,
+                            tool_call_id=output_function_call.call_id,
+                            tool_name=output_function_call.name,
+                            started_at=started_at,
+                            completed_at=max(started_at, time()),
+                            duration_ms=(perf_counter() - started_monotonic) * 1000,
+                            timing_source="executor",
+                            status=tool_status,
+                            error_type=error_type,
+                            output=tool_output,
+                        )
+                    )
+
+                new_outputs.append(
+                    NeMoGymFunctionCallOutput(
                         type="function_call_output",
                         call_id=output_function_call.call_id,
-                        # Use repr(e) so the exception type name is always
-                        # included even when str(e) would be empty.
-                        output=json.dumps({"error": f"Invalid tool call arguments: {e!r}"}),
+                        output=tool_output,
                     )
-                    new_outputs.append(tool_response)
-                    continue
-
-                api_response = await self.server_client.post(
-                    server_name=self.config.resources_server.name,
-                    url_path=f"/{output_function_call.name}",
-                    json=parsed_arguments,
-                    cookies=resources_server_cookies,
                 )
-                # We don't raise for status here since it's a valid return for the API to error e.g. if the model outputs an invalid call or something.
-                resources_server_cookies = api_response.cookies
 
-                tool_response = NeMoGymFunctionCallOutput(
-                    type="function_call_output",
-                    call_id=output_function_call.call_id,
-                    output=(await api_response.content.read()).decode(),
-                )
-                new_outputs.append(tool_response)
+            if collect_trajectory and all_fn_calls:
+                turns[-1].step_count = len(tool_records)
 
             # Check if max steps is not None and if we have exhausted it.
             if self.config.max_steps and step >= self.config.max_steps:
+                invocation_status = "incomplete"
                 break
-
-        # Propogate any extra cookies necessary for downstream verification
-        for k, v in (*resources_server_cookies.items(), *model_server_cookies.items()):
-            response.set_cookie(k, v)
 
         model_response.output = new_outputs
         model_response.usage = usage
+        trajectory = None
+        if collect_trajectory:
+            invocation = AgentInvocation(
+                invocation_id=invocation_id,
+                status=invocation_status,
+                model_calls=model_calls,
+                conversation=[*body.input, *new_outputs],
+            )
+            trajectory = TrajectoryRecord(
+                task_id=task_id,
+                rollout_id=rollout_id,
+                invocations=[invocation],
+                turns=turns,
+                tool_calls=tool_records,
+                gaps=trajectory_gaps,
+            )
+        return model_response, trajectory, model_server_cookies, resources_server_cookies
+
+    async def responses(
+        self,
+        request: Request,
+        response: Response,
+        body: NeMoGymResponseCreateParamsNonStreaming = Body(),
+    ) -> NeMoGymResponse:
+        model_response, _, model_server_cookies, resources_server_cookies = await self._create_episode(
+            body,
+            model_url_path=self.url_path_for_request("/v1/responses", request),
+            resources_server_cookies=request.cookies,
+        )
+        # Propogate any extra cookies necessary for downstream verification
+        for k, v in (*resources_server_cookies.items(), *model_server_cookies.items()):
+            response.set_cookie(k, v)
         return model_response
 
     async def run(self, request: Request, body: SimpleAgentRunRequest) -> SimpleAgentVerifyResponse:
@@ -185,18 +276,47 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         await raise_for_status(seed_session_response)
         cookies = seed_session_response.cookies
 
-        response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path=self.url_path_for_run("/v1/responses", body),
-            json=body.responses_create_params,
-            cookies=cookies,
+        trajectory = None
+        # Token-id capture also uses rollout correlation but does not enable trajectory collection.
+        global_config = getattr(self.server_client, "global_config_dict", None)
+        collect_trajectory = isinstance(global_config, Mapping) and bool(
+            global_config.get(OBSERVABILITY_ENABLED_KEY_NAME, False)
         )
-        await raise_for_status(response)
-        cookies = response.cookies
+        # Direct collection bypasses the self-call route. Keep HTTP dispatch for overridden
+        # responses() methods so their custom handler and middleware behavior remains active.
+        if not collect_trajectory or type(self).responses is not SimpleAgent.responses:
+            response = await self.server_client.post(
+                server_name=self.config.name,
+                url_path=self.url_path_for_run("/v1/responses", body),
+                json=body.responses_create_params,
+                cookies=cookies,
+            )
+            await raise_for_status(response)
+            model_response_json = await get_response_json(response)
+            cookies = response.cookies
+        else:
+            extra = body.model_extra or {}
+            task_id = next(
+                (
+                    str(extra[key])
+                    for key in ("task_id", "problem_id", "instance_id", "_ng_task_index")
+                    if extra.get(key) is not None
+                ),
+                "unknown",
+            )
+            model_response, trajectory, model_server_cookies, cookies = await self._create_episode(
+                body.responses_create_params,
+                model_url_path=self.url_path_for_run("/v1/responses", body),
+                resources_server_cookies=cookies,
+                task_id=task_id,
+                rollout_id=maybe_rollout_id_from_run_body(body) or "unknown",
+                collect_trajectory=True,
+            )
+            if model_server_cookies:
+                cookies.update(model_server_cookies)
+            model_response_json = model_response.model_dump(mode="json")
 
-        verify_request = SimpleAgentVerifyRequest.model_validate(
-            body.model_dump() | {"response": await get_response_json(response)}
-        )
+        verify_request = SimpleAgentVerifyRequest.model_validate(body.model_dump() | {"response": model_response_json})
 
         verify_response = await self.server_client.post(
             server_name=self.config.resources_server.name,
@@ -205,7 +325,15 @@ class SimpleAgent(SimpleResponsesAPIAgent):
             cookies=cookies,
         )
         await raise_for_status(verify_response)
-        return SimpleAgentVerifyResponse.model_validate(await get_response_json(verify_response))
+        result = await get_response_json(verify_response)
+        if trajectory is not None:
+            resolved = result.get("resolved")
+            if isinstance(resolved, bool) and trajectory.turns:
+                trajectory.turns[-1].resolved = resolved
+            else:
+                trajectory.gaps.append(ObservationGap(code="resolution_unavailable", invocation_id="root"))
+            result["ng_trajectory"] = trajectory.model_dump(mode="json")
+        return SimpleAgentVerifyResponse.model_validate(result)
 
     async def aggregate_metrics(self, body: AggregateMetricsRequest = Body()) -> AggregateMetrics:
         """Proxy aggregate_metrics to the resources server."""

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, call
 
 import orjson
 import pytest
+from fastapi import Response
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 
@@ -98,6 +99,7 @@ class TestApp:
             ),
         )
         server = SimpleAgent(config=config, server_client=MagicMock(spec=ServerClient))
+        server.server_client.global_config_dict = {"observability_enabled": True}
         app = server.setup_webserver()
         client = TestClient(app)
 
@@ -193,6 +195,12 @@ class TestApp:
         }
         assert expected_responses_dict == actual_responses_dict
 
+        prefixed_response = client.post(
+            "/ng-rollout/0-0/v1/responses", json={"input": [{"role": "user", "content": "hello"}]}
+        )
+        assert prefixed_response.status_code == 200
+        assert prefixed_response.json()["_ng_trajectory"]["rollout_id"] == "0-0"
+
     @pytest.mark.parametrize("resolved", [False, None])
     async def test_run_emits_standard_turns_and_tool_observation(self, resolved: bool | None) -> None:
         server, server_client = _make_agent(True)
@@ -243,10 +251,14 @@ class TestApp:
             )
         )
 
-        async def post(*, url_path, **kwargs):
+        async def post(*, server_name, url_path, **kwargs):
             if url_path == "/seed_session":
                 return _mock_response()
-            if url_path.endswith("/v1/responses"):
+            if server_name == "simple":
+                nested_request = MagicMock(cookies=kwargs["cookies"], path_params={"rollout_id": "4-1"})
+                model_response = await server.responses(nested_request, Response(), kwargs["json"])
+                return _mock_response(model_response.model_dump(mode="json"))
+            if server_name == "model":
                 return _mock_response(next(model_payloads))
             if url_path == "/lookup":
                 return _mock_response(status=422, content="bad input")
@@ -268,6 +280,17 @@ class TestApp:
         request = MagicMock()
         request.cookies = {}
         result = await server.run(request, body)
+
+        assert [
+            (item.kwargs["server_name"], item.kwargs["url_path"]) for item in server_client.post.await_args_list
+        ] == [
+            ("resources", "/seed_session"),
+            ("simple", "/ng-rollout/4-1/v1/responses"),
+            ("model", "/ng-rollout/4-1/v1/responses"),
+            ("resources", "/lookup"),
+            ("model", "/ng-rollout/4-1/v1/responses"),
+            ("resources", "/verify"),
+        ]
 
         result_data = result.model_dump(mode="json")
         result_data["ng_model_call_capture"] = {
@@ -316,7 +339,7 @@ class TestApp:
         assert (tool.output, tool.status, tool.error_type) == ("bad input", "failed", "http_422")
         assert tool.started_at is not None and tool.completed_at is not None and tool.duration_ms is not None
 
-    @pytest.mark.parametrize(("capture_enabled", "override_responses"), ((False, False), (True, True)))
+    @pytest.mark.parametrize(("capture_enabled", "override_responses"), ((False, False), (True, False), (True, True)))
     async def test_run_preserves_self_dispatch(self, capture_enabled: bool, override_responses: bool) -> None:
         agent_type = SimpleAgent
         if override_responses:

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -15,9 +15,12 @@
 import json
 from unittest.mock import AsyncMock, MagicMock, call
 
+import orjson
+import pytest
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 
+from nemo_gym.global_config import ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymFunctionCallOutput,
@@ -26,13 +29,39 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseReasoningItem,
     NeMoGymSummary,
 )
+from nemo_gym.rollout_collection import _attach_trajectory_record
+from nemo_gym.rollout_observability import TrajectoryRecord
 from nemo_gym.server_utils import ServerClient
 from responses_api_agents.simple_agent.app import (
     ModelServerRef,
     ResourcesServerRef,
     SimpleAgent,
     SimpleAgentConfig,
+    SimpleAgentRunRequest,
 )
+
+
+def _make_agent(
+    observability_enabled: bool, agent_type: type[SimpleAgent] = SimpleAgent
+) -> tuple[SimpleAgent, MagicMock]:
+    config = SimpleAgentConfig(
+        host="0.0.0.0",
+        port=8080,
+        entrypoint="",
+        name="simple",
+        model_server=ModelServerRef(type="responses_api_models", name="model"),
+        resources_server=ResourcesServerRef(type="resources_servers", name="resources"),
+    )
+    server_client = MagicMock(spec=ServerClient)
+    server_client.global_config_dict = {"observability_enabled": observability_enabled}
+    return agent_type(config=config, server_client=server_client), server_client
+
+
+def _mock_response(payload=None, *, status=200, content="") -> MagicMock:
+    response = MagicMock(status=status, cookies={}, ok=status < 400)
+    response.read = AsyncMock(return_value=json.dumps(payload or {}))
+    response.content.read = AsyncMock(return_value=content.encode())
+    return response
 
 
 class TestApp:
@@ -163,6 +192,178 @@ class TestApp:
             "safety_identifier": None,
         }
         assert expected_responses_dict == actual_responses_dict
+
+    @pytest.mark.parametrize("resolved", [False, None])
+    async def test_run_emits_standard_turns_and_tool_observation(self, resolved: bool | None) -> None:
+        server, server_client = _make_agent(True)
+        response_base = {
+            "created_at": 1.0,
+            "model": "model",
+            "object": "response",
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+        model_payloads = iter(
+            (
+                response_base
+                | {
+                    "id": "resp-tool",
+                    "output": [
+                        {
+                            "id": "reasoning-1",
+                            "summary": [{"text": "look up the answer", "type": "summary_text"}],
+                            "status": "completed",
+                            "type": "reasoning",
+                        },
+                        {
+                            "id": "fc-1",
+                            "call_id": "call-1",
+                            "name": "lookup",
+                            "arguments": '{"q":"x"}',
+                            "type": "function_call",
+                            "status": "completed",
+                        },
+                    ],
+                },
+                response_base
+                | {
+                    "id": "resp-final",
+                    "created_at": 2.0,
+                    "output": [
+                        {
+                            "id": "msg-1",
+                            "content": [{"annotations": [], "text": "done", "type": "output_text"}],
+                            "role": "assistant",
+                            "status": "completed",
+                            "type": "message",
+                        }
+                    ],
+                },
+            )
+        )
+
+        async def post(*, url_path, **kwargs):
+            if url_path == "/seed_session":
+                return _mock_response()
+            if url_path.endswith("/v1/responses"):
+                return _mock_response(next(model_payloads))
+            if url_path == "/lookup":
+                return _mock_response(status=422, content="bad input")
+            assert url_path == "/verify"
+            result = kwargs["json"] | {"reward": 0.0}
+            if resolved is not None:
+                result["resolved"] = resolved
+            return _mock_response(result)
+
+        server_client.post = AsyncMock(side_effect=post)
+        body = SimpleAgentRunRequest.model_validate(
+            {
+                "responses_create_params": {"input": [{"role": "user", "content": "question"}]},
+                "instance_id": 0,
+                "_ng_task_index": 4,
+                "_ng_rollout_index": 1,
+            }
+        )
+        request = MagicMock()
+        request.cookies = {}
+        result = await server.run(request, body)
+
+        result_data = result.model_dump(mode="json")
+        result_data["ng_model_call_capture"] = {
+            "calls": [
+                {
+                    "model_call_id": f"model-call-{index}",
+                    "response_id": response_id,
+                    "request": {"input": f"model-visible-input-{index}"},
+                    "response": {"status": "completed", "output": f"model-visible-output-{index}"},
+                }
+                for index, response_id in enumerate(("resp-tool", "resp-final"), start=1)
+            ]
+        }
+        row = {TASK_INDEX_KEY_NAME: 4, ROLLOUT_INDEX_KEY_NAME: 1, "instance_id": 0}
+        _attach_trajectory_record(row, result_data)
+        serialized = orjson.loads(orjson.dumps(result_data))
+        trajectory = TrajectoryRecord.model_validate(serialized["ng_trajectory"])
+
+        assert trajectory.schema_version == "1.0"
+        assert [call.response_metadata.response_id for call in trajectory.model_calls] == ["resp-tool", "resp-final"]
+        assert all(call.response_metadata.response_status == "completed" for call in trajectory.model_calls)
+        assert trajectory.model_calls[0].request == {"input": "model-visible-input-1"}
+        assert trajectory.model_calls[0].response == {"status": "completed", "output": "model-visible-output-1"}
+        assert trajectory.invocations[0].conversation[-1].type == "message"
+        turns = trajectory.turns
+        assert [(turn.task_id, turn.rollout_id, turn.turn_no, turn.step_count) for turn in turns] == [
+            ("0", "4-1", 1, 1),
+            ("0", "4-1", 2, 1),
+        ]
+        assert all(turn.timestamp > 0 for turn in turns)
+        assert [turn.model_calls[0].response_id for turn in turns] == ["resp-tool", "resp-final"]
+        assert turns[0].model_dump(mode="json")["question"] == [
+            {"role": "user", "content": "question", "type": "message"}
+        ]
+        assert [item["type"] for item in turns[1].model_dump(mode="json")["question"]] == [
+            "message",
+            "reasoning",
+            "function_call",
+            "function_call_output",
+        ]
+        assert [item["type"] for item in turns[0].model_dump(mode="json")["answer"]] == ["function_call"]
+        assert turns[0].reasoning_content[0]["summary"][0]["text"] == "look up the answer"
+        assert turns[-1].resolved is resolved
+        assert ("resolution_unavailable" in {gap.code for gap in trajectory.gaps}) is (resolved is None)
+        [tool] = trajectory.tool_calls
+        assert (tool.output, tool.status, tool.error_type) == ("bad input", "failed", "http_422")
+        assert tool.started_at is not None and tool.completed_at is not None and tool.duration_ms is not None
+
+    @pytest.mark.parametrize(("capture_enabled", "override_responses"), ((False, False), (True, True)))
+    async def test_run_preserves_self_dispatch(self, capture_enabled: bool, override_responses: bool) -> None:
+        agent_type = SimpleAgent
+        if override_responses:
+
+            async def overridden_responses(*args, **kwargs):
+                raise AssertionError("run must preserve self-dispatch for responses overrides")
+
+            agent_type = type("OverriddenSimpleAgent", (SimpleAgent,), {"responses": overridden_responses})
+        server, server_client = _make_agent(capture_enabled, agent_type)
+
+        model_response = {
+            "id": "response-1",
+            "created_at": 1.0,
+            "model": "model",
+            "object": "response",
+            "output": [],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+
+        async def post(*, url_path, **kwargs):
+            if url_path == "/seed_session":
+                return _mock_response()
+            if url_path.endswith("/v1/responses"):
+                return _mock_response(model_response)
+            assert url_path == "/verify"
+            return _mock_response(kwargs["json"] | {"reward": 1.0})
+
+        server_client.post = AsyncMock(side_effect=post)
+        body = SimpleAgentRunRequest.model_validate(
+            {
+                "responses_create_params": {"input": "question"},
+                TASK_INDEX_KEY_NAME: 0,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+            }
+        )
+        request = MagicMock(cookies={})
+
+        result = await server.run(request, body)
+
+        assert [call.kwargs["url_path"] for call in server_client.post.await_args_list] == [
+            "/seed_session",
+            "/ng-rollout/0-0/v1/responses" if capture_enabled else "/v1/responses",
+            "/verify",
+        ]
+        assert "ng_trajectory" not in result.model_dump(mode="json")
 
     async def test_responses_continues_on_malformed_tool_call_arguments(self, monkeypatch: MonkeyPatch) -> None:
         """Malformed JSON in a tool-call's arguments must not crash the rollout.

--- a/responses_api_agents/speed_bench_agent/app.py
+++ b/responses_api_agents/speed_bench_agent/app.py
@@ -68,6 +68,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseOutputMessage,
     NeMoGymResponseOutputText,
+    accumulate_response_usage,
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
 
@@ -203,14 +204,7 @@ class SpeedBenchAgent(SimpleResponsesAPIAgent):
             last_response, model_server_cookies = await _call_model(running_input)
             accumulated_outputs.extend(last_response.output)
             accumulated_text_parts.append(_gather_assistant_text(last_response))
-            if usage and last_response.usage:
-                usage.input_tokens += last_response.usage.input_tokens
-                usage.output_tokens += last_response.usage.output_tokens
-                usage.total_tokens += last_response.usage.total_tokens
-                usage.input_tokens_details.cached_tokens = 0
-                usage.output_tokens_details.reasoning_tokens = 0
-            elif last_response.usage and not usage:
-                usage = last_response.usage
+            usage = accumulate_response_usage(usage, last_response.usage)
             last_response.usage = None
 
         # Propagate any cookies the resources server set so /verify sees them.

--- a/responses_api_models/inference_provider/app.py
+++ b/responses_api_models/inference_provider/app.py
@@ -23,7 +23,6 @@ For training workloads that require token IDs, use vllm_model instead.
 from asyncio import Semaphore
 from time import time
 from typing import Any, Dict
-from uuid import uuid4
 
 from fastapi import Request
 from pydantic import Field
@@ -39,9 +38,6 @@ from nemo_gym.openai_utils import (
     NeMoGymChatCompletionCreateParamsNonStreaming,
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
-    NeMoGymResponseInputTokensDetails,
-    NeMoGymResponseOutputTokensDetails,
-    NeMoGymResponseUsage,
 )
 from nemo_gym.responses_converter import ResponsesConverter
 from nemo_gym.server_utils import is_nemo_gym_fastapi_entrypoint
@@ -76,57 +72,15 @@ class InferenceProvider(SimpleResponsesAPIModel):
         self, request: Request, body: NeMoGymResponseCreateParamsNonStreaming = Body()
     ) -> NeMoGymResponse:
         chat_completion_create_params = self._converter.responses_to_chat_completion_create_params(body)
+        body.model = self.config.model
 
         chat_completion_response = await self.chat_completions(request, chat_completion_create_params)
 
-        choice = chat_completion_response.choices[0]
-        response_output = self._converter.postprocess_chat_response(choice)
-        response_output_dicts = [item.model_dump() for item in response_output]
-
-        usage = None
-        if chat_completion_response.usage:
-            usage = NeMoGymResponseUsage(
-                input_tokens=chat_completion_response.usage.prompt_tokens,
-                input_tokens_details=NeMoGymResponseInputTokensDetails(cached_tokens=0),
-                output_tokens=chat_completion_response.usage.completion_tokens,
-                output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=0),
-                total_tokens=chat_completion_response.usage.prompt_tokens
-                + chat_completion_response.usage.completion_tokens,
-            )
-
-        incomplete_details = None
-        if choice.finish_reason == "length":
-            incomplete_details = {"reason": "max_output_tokens"}
-        elif choice.finish_reason == "content_filter":
-            incomplete_details = {"reason": "content_filter"}
-
-        return NeMoGymResponse(
-            id=f"resp_{uuid4().hex}",
-            created_at=int(time()),
-            model=self.config.model,
-            object="response",
-            output=response_output_dicts,
-            tool_choice=body.tool_choice if body.tool_choice is not None else "auto",
-            parallel_tool_calls=body.parallel_tool_calls,
-            tools=body.tools,
-            temperature=body.temperature,
-            top_p=body.top_p,
-            background=body.background,
-            max_output_tokens=body.max_output_tokens,
-            max_tool_calls=body.max_tool_calls,
-            previous_response_id=body.previous_response_id,
-            prompt=body.prompt,
-            reasoning=body.reasoning,
-            service_tier=body.service_tier,
-            text=body.text,
-            top_logprobs=body.top_logprobs,
-            truncation=body.truncation,
-            metadata=body.metadata,
-            instructions=body.instructions,
-            user=body.user,
-            incomplete_details=incomplete_details,
-            usage=usage,
+        response = self._converter.chat_completion_to_response(
+            responses_create_params=body,
+            chat_completion=chat_completion_response,
         )
+        return response.model_copy(update={"created_at": int(time())})
 
     async def chat_completions(
         self, request: Request, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()

--- a/responses_api_models/inference_provider/tests/test_app.py
+++ b/responses_api_models/inference_provider/tests/test_app.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 
+from nemo_gym.base_responses_api_model import CaptureStore, read_model_call_records
 from nemo_gym.openai_utils import NeMoGymAsyncOpenAI
 from nemo_gym.server_utils import ServerClient
 from responses_api_models.inference_provider.app import (
@@ -258,13 +259,15 @@ class TestInferenceProvider:
 
 
 class TestResponses:
-    async def test_basic_responses(self, monkeypatch: MonkeyPatch) -> None:
+    async def test_basic_responses(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
         server = _make_server()
+        server.server_client.global_config_dict = {
+            "observability_enabled": True,
+            "model_call_capture_dir": str(tmp_path),
+        }
         app = server.setup_webserver()
         client = TestClient(app)
 
-        monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         mock_data = _mock_chat_response(content="Hello from the model!")
@@ -276,7 +279,7 @@ class TestResponses:
         server._client.create_chat_completion = AsyncMock(side_effect=mock_create_chat)
 
         response = client.post(
-            "/v1/responses",
+            "/ng-rollout/0-0/v1/responses",
             json={"input": "hello"},
         )
         assert response.status_code == 200
@@ -285,6 +288,10 @@ class TestResponses:
         assert data["id"] == f"resp_{FIXED_UUID}"
         assert data["model"] == "test-model"
         assert data["object"] == "response"
+        assert data["status"] == "completed"
+        [record] = read_model_call_records(CaptureStore(tmp_path), "0-0")
+        assert record.response_status == "completed"
+        assert record.finish_reason is None
         assert len(data["output"]) == 1
         assert data["output"][0]["type"] == "message"
         assert data["output"][0]["content"][0]["text"] == "Hello from the model!"
@@ -294,8 +301,6 @@ class TestResponses:
         app = server.setup_webserver()
         client = TestClient(app)
 
-        monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         async def mock_create_chat(**kwargs):
@@ -313,8 +318,6 @@ class TestResponses:
         app = server.setup_webserver()
         client = TestClient(app)
 
-        monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         async def mock_create_chat(**kwargs):
@@ -347,8 +350,6 @@ class TestResponses:
         app = server.setup_webserver()
         client = TestClient(app)
 
-        monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         mock_data = _mock_chat_response(
@@ -407,8 +408,6 @@ class TestResponses:
         app = server.setup_webserver()
         client = TestClient(app)
 
-        monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         mock_data = _mock_chat_response(content="<think>Let me reason about this...</think>The answer is 42.")
@@ -436,8 +435,6 @@ class TestResponses:
         app = server.setup_webserver()
         client = TestClient(app)
 
-        monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         mock_data = _mock_chat_response(content="<think>Let me reason about this...</think>The answer is 42.")
@@ -464,15 +461,15 @@ class TestResponses:
         app = server.setup_webserver()
         client = TestClient(app)
 
-        monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         mock_data = _mock_chat_response(content="Hi!")
         mock_data["usage"] = {
             "prompt_tokens": 10,
             "completion_tokens": 5,
-            "total_tokens": 15,
+            "total_tokens": 19,
+            "prompt_tokens_details": {"cached_tokens": 4},
+            "completion_tokens_details": {"reasoning_tokens": 2},
         }
 
         async def mock_create_chat(**kwargs):
@@ -486,15 +483,15 @@ class TestResponses:
 
         assert data["usage"]["input_tokens"] == 10
         assert data["usage"]["output_tokens"] == 5
-        assert data["usage"]["total_tokens"] == 15
+        assert data["usage"]["total_tokens"] == 19
+        assert data["usage"]["input_tokens_details"]["cached_tokens"] == 4
+        assert data["usage"]["output_tokens_details"]["reasoning_tokens"] == 2
 
     async def test_responses_incomplete_max_tokens(self, monkeypatch: MonkeyPatch) -> None:
         server = _make_server()
         app = server.setup_webserver()
         client = TestClient(app)
 
-        monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         mock_data = _mock_chat_response(content="Truncated output...", finish_reason="length")
@@ -508,6 +505,7 @@ class TestResponses:
         response = client.post("/v1/responses", json={"input": "Write a long essay"})
         data = response.json()
 
+        assert data["status"] == "incomplete"
         assert data["incomplete_details"] == {"reason": "max_output_tokens"}
 
     async def test_responses_incomplete_content_filter(self, monkeypatch: MonkeyPatch) -> None:
@@ -515,8 +513,6 @@ class TestResponses:
         app = server.setup_webserver()
         client = TestClient(app)
 
-        monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         mock_data = _mock_chat_response(content="", finish_reason="content_filter")
@@ -530,6 +526,7 @@ class TestResponses:
         response = client.post("/v1/responses", json={"input": "test"})
         data = response.json()
 
+        assert data["status"] == "incomplete"
         assert data["incomplete_details"] == {"reason": "content_filter"}
 
     async def test_responses_converts_string_input(self, monkeypatch: MonkeyPatch) -> None:
@@ -547,8 +544,6 @@ class TestResponses:
         server._client = MagicMock(spec=NeMoGymAsyncOpenAI)
         server._client.create_chat_completion = AsyncMock(side_effect=mock_create_chat)
 
-        monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         client.post("/v1/responses", json={"input": "hello world"})
@@ -561,8 +556,6 @@ class TestResponses:
         app = server.setup_webserver()
         client = TestClient(app)
 
-        monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         called_kwargs = {}

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -126,6 +126,7 @@ class FakeUUID:
 
 COMMON_RESPONSE_PARAMS = dict(
     parallel_tool_calls=True,
+    status="completed",
     tool_choice="auto",
 )
 
@@ -2577,7 +2578,7 @@ class TestApp:
         ]
 
         expected_response = NeMoGymResponse(
-            **COMMON_RESPONSE_PARAMS,
+            **(COMMON_RESPONSE_PARAMS | {"status": "incomplete"}),
             id="resp_123",
             object="response",
             tools=[],

--- a/tests/unit_tests/test_base_responses_api_model.py
+++ b/tests/unit_tests/test_base_responses_api_model.py
@@ -176,6 +176,7 @@ def test_build_model_call_record_from_exchange():
         "model",
         "dialect",
         "status_code",
+        "response_status",
         "finish_reason",
         "started_at",
         "completed_at",
@@ -197,19 +198,24 @@ def test_build_model_call_record_from_exchange():
         "latency_ttft_ms",
     } <= type(rec).model_json_schema()["properties"].keys()
 
+    aliases = {"cached_input_tokens": 4, "reasoning_output_tokens": 3}
+    aliased = build_model_call_record({"response": {"usage": aliases}}, call_index=0)
+    assert (aliased.cached_tokens, aliased.tokens_reasoning) == (4, 3)
+
 
 @pytest.mark.parametrize(
-    "response,expected",
+    "response,expected_finish_reason,expected_response_status",
     [
-        ({"choices": [{"finish_reason": "tool_calls"}]}, "tool_calls"),
-        ({"stop_reason": "end_turn"}, "end_turn"),
-        ({"incomplete_details": {"reason": "max_output_tokens"}}, "max_output_tokens"),
-        ({"status": "completed"}, None),
-        ({"choices": {"finish_reason": "invalid"}, "incomplete_details": []}, None),
+        ({"choices": [{"finish_reason": "tool_calls"}]}, "tool_calls", None),
+        ({"stop_reason": "end_turn"}, "end_turn", None),
+        ({"incomplete_details": {"reason": "max_output_tokens"}}, "max_output_tokens", None),
+        ({"status": "completed"}, None, "completed"),
+        ({"choices": {"finish_reason": "invalid"}, "incomplete_details": []}, None, None),
     ],
 )
-def test_build_model_call_record_normalizes_finish_reason(response, expected):
-    assert build_model_call_record({"response": response}, call_index=0).finish_reason == expected
+def test_build_model_call_record_normalizes_termination(response, expected_finish_reason, expected_response_status):
+    record = build_model_call_record({"response": response}, call_index=0)
+    assert (record.finish_reason, record.response_status) == (expected_finish_reason, expected_response_status)
 
 
 def test_build_model_call_record_tolerates_malformed_nested_shapes():
@@ -703,6 +709,12 @@ def test_cache_signal():
     assert _cache_signal(None) == (None, None)
     assert _cache_signal({"prompt_tokens_details": {"cached_tokens": 4}}) == (True, 4)
     assert _cache_signal({"input_tokens_details": {"cached_tokens": 0}}) == (False, 0)
+    assert _cache_signal(
+        {
+            "prompt_tokens_details": {"cached_tokens": 4},
+            "input_tokens_details": {"cached_tokens": 9},
+        }
+    ) == (True, 4)
     assert _cache_signal({"cache_read_input_tokens": 5}) == (True, 5)  # Anthropic
     assert _cache_signal({"unrelated": 1}) == (None, None)
 
@@ -1100,6 +1112,7 @@ def test_merge_capture_attaches_metrics_without_raw_payloads(tmp_path):
         {"input_tokens": 3, "output_tokens": 2, "total_tokens": 5},
         {
             "id": "resp-A",
+            "status": "completed",
             "output": [{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "ok"}]}],
         },
     )
@@ -1140,6 +1153,7 @@ def test_merge_capture_attaches_metrics_without_raw_payloads(tmp_path):
     assert attached_call["response_id"] == "resp-A"
     assert attached_call["model_ref"] == {"type": "responses_api_models", "name": "A"}
     assert attached_call["model"] == "m"
+    assert attached_call["response_status"] == "completed"
     assert attached_call["started_at"] == 100.0 and attached_call["completed_at"] == 100.01
     assert attached_call["tokens_in"] == 3
     assert {"request", "response", "request_raw", "response_raw"}.isdisjoint(attached_call)
@@ -1254,11 +1268,16 @@ def test_aggregate_model_call_records_sums_and_counts():
     from nemo_gym.base_responses_api_model import ModelCallRecord, aggregate_model_call_records
 
     calls = [
-        ModelCallRecord(call_index=0, tokens_in=10, tokens_out=5, tokens_total=15, latency_total_ms=2.0),
-        ModelCallRecord(call_index=1, tokens_in=20, tokens_out=3, tokens_total=23, latency_total_ms=1.0),
+        ModelCallRecord(
+            call_index=0, tokens_in=10, tokens_out=5, tokens_total=15, cached_tokens=4, latency_total_ms=2.0
+        ),
+        ModelCallRecord(
+            call_index=1, tokens_in=20, tokens_out=3, tokens_total=23, cached_tokens=0, latency_total_ms=1.0
+        ),
     ]
     agg = aggregate_model_call_records(calls)
     assert (agg["tokens_in"], agg["tokens_out"], agg["tokens_total"]) == (30, 8, 38)
+    assert agg["cached_tokens"] == 4
     assert agg["latency_total_ms"] == 3.0 and agg["num_calls"] == 2
     # empty -> all-None totals but a well-formed shape (num_calls 0)
     assert aggregate_model_call_records([]) == {
@@ -1266,6 +1285,7 @@ def test_aggregate_model_call_records_sums_and_counts():
         "tokens_out": None,
         "tokens_reasoning": None,
         "tokens_total": None,
+        "cached_tokens": None,
         "latency_total_ms": None,
         "num_calls": 0,
     }
@@ -1319,6 +1339,8 @@ def test_extract_token_stats_anthropic_fully_cached_zero_base():
     assert stats["tokens_in"] == 500  # 0 base + cache_read 500 + cache_creation 0
     assert stats["tokens_out"] == 12
     assert stats["cache_creation_tokens"] == 0
+    empty = extract_token_stats({"output_tokens": 12, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0})
+    assert (empty["tokens_in"], empty["tokens_total"], empty["cache_creation_tokens"]) == (None, None, 0)
 
 
 def test_extract_token_stats_openai_cached_not_double_counted():

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -174,3 +174,15 @@ def test_accumulate_response_usage_preserves_all_counts_and_missing_values() -> 
     assert (result.input_tokens_details.cached_tokens, result.output_tokens_details.reasoning_tokens) == (7, 5)
     assert first.input_tokens_details.cached_tokens == 0
     assert accumulate_response_usage(result, None) == result
+
+
+def test_accumulate_response_usage_tolerates_missing_detail_objects() -> None:
+    first = _usage(cached_tokens=0, reasoning_tokens=1).model_copy(update={"input_tokens_details": None})
+    second = _usage(cached_tokens=7, reasoning_tokens=4).model_copy(update={"output_tokens_details": None})
+
+    result = accumulate_response_usage(first, second)
+
+    assert result is not None
+    assert (result.input_tokens, result.output_tokens, result.total_tokens) == (20, 10, 30)
+    assert result.input_tokens_details is None
+    assert result.output_tokens_details.reasoning_tokens == 1

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -24,10 +24,14 @@ from nemo_gym.openai_utils import (
     NeMoGymAsyncOpenAI,
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseInputTokensDetails,
     NeMoGymResponseMcpApprovalRequest,
     NeMoGymResponseMcpCall,
     NeMoGymResponseMcpListTools,
+    NeMoGymResponseOutputTokensDetails,
+    NeMoGymResponseUsage,
     TokenIDLogProbMixin,
+    accumulate_response_usage,
 )
 
 
@@ -147,3 +151,26 @@ class TestRoutedExpertsWireFormats:
     def test_rejects_non_list_non_string(self) -> None:
         with pytest.raises(ValidationError):
             TokenIDLogProbMixin.model_validate({**self._BASE, "routed_experts": 42})
+
+
+def _usage(*, cached_tokens: int, reasoning_tokens: int) -> NeMoGymResponseUsage:
+    return NeMoGymResponseUsage(
+        input_tokens=10,
+        input_tokens_details=NeMoGymResponseInputTokensDetails(cached_tokens=cached_tokens),
+        output_tokens=5,
+        output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=reasoning_tokens),
+        total_tokens=15,
+    )
+
+
+def test_accumulate_response_usage_preserves_all_counts_and_missing_values() -> None:
+    first = _usage(cached_tokens=0, reasoning_tokens=1)
+    second = _usage(cached_tokens=7, reasoning_tokens=4)
+
+    assert accumulate_response_usage(None, first) == first
+    result = accumulate_response_usage(first, second)
+    assert result is not None
+    assert (result.input_tokens, result.output_tokens, result.total_tokens) == (20, 10, 30)
+    assert (result.input_tokens_details.cached_tokens, result.output_tokens_details.reasoning_tokens) == (7, 5)
+    assert first.input_tokens_details.cached_tokens == 0
+    assert accumulate_response_usage(result, None) == result

--- a/tests/unit_tests/test_responses_converter.py
+++ b/tests/unit_tests/test_responses_converter.py
@@ -15,7 +15,7 @@
 """Unit tests for the shared Responses API <-> Chat Completions converter."""
 
 import pytest
-from openai.types.completion_usage import CompletionUsage
+from openai.types.completion_usage import CompletionTokensDetails, CompletionUsage, PromptTokensDetails
 
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
@@ -43,6 +43,7 @@ from nemo_gym.responses_converter import (
     ResponsesConverterState,
     VLLMConverter,
     VLLMConverterResponsesToChatCompletionsState,
+    _usage_detail,
     split_responses_input_output_items,
 )
 
@@ -72,6 +73,12 @@ def _fixed_uuid(monkeypatch: pytest.MonkeyPatch):
 def test_backwards_compatible_aliases():
     assert VLLMConverter is ResponsesConverter
     assert VLLMConverterResponsesToChatCompletionsState is ResponsesConverterState
+
+
+def test_usage_detail_ignores_ambiguous_top_level_names():
+    usage = {"cached_tokens": 99, "cached_input_tokens": 7, "reasoning_tokens": 88, "reasoning_output_tokens": 3}
+    assert _usage_detail(usage, "prompt_tokens_details", "cached_tokens", "cached_input_tokens") == 7
+    assert _usage_detail(usage, "completion_tokens_details", "reasoning_tokens", "reasoning_output_tokens") == 3
 
 
 # ===========================================================================
@@ -504,7 +511,15 @@ def test_chat_messages_to_responses_items_unrecognized_role_raises(converter: Re
 # ===========================================================================
 
 
-def test_chat_completion_to_response_sanity(converter: ResponsesConverter):
+@pytest.mark.parametrize(
+    ("finish_reason", "status", "incomplete_details"),
+    [
+        ("tool_calls", "completed", None),
+        ("length", "incomplete", {"reason": "max_output_tokens"}),
+        ("content_filter", "incomplete", {"reason": "content_filter"}),
+    ],
+)
+def test_chat_completion_to_response_sanity(converter: ResponsesConverter, finish_reason, status, incomplete_details):
     actual_response = converter.chat_completion_to_response(
         responses_create_params=NeMoGymResponseCreateParamsNonStreaming(
             model="",
@@ -523,7 +538,7 @@ def test_chat_completion_to_response_sanity(converter: ResponsesConverter):
             choices=[
                 NeMoGymChoice(
                     index=0,
-                    finish_reason="tool_calls",
+                    finish_reason=finish_reason,
                     message=NeMoGymChatCompletionMessage(
                         role="assistant",
                         content="hi",
@@ -532,9 +547,11 @@ def test_chat_completion_to_response_sanity(converter: ResponsesConverter):
                 )
             ],
             usage=CompletionUsage(
-                prompt_tokens=1,
-                completion_tokens=2,
-                total_tokens=3,
+                prompt_tokens=11,
+                completion_tokens=5,
+                total_tokens=19,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=7),
+                completion_tokens_details=CompletionTokensDetails(reasoning_tokens=3),
             ),
         ),
     )
@@ -554,12 +571,14 @@ def test_chat_completion_to_response_sanity(converter: ResponsesConverter):
             )
         ],
         parallel_tool_calls=True,
+        status=status,
+        incomplete_details=incomplete_details,
         usage=NeMoGymResponseUsage(
-            input_tokens=1,
-            input_tokens_details=NeMoGymResponseInputTokensDetails(cached_tokens=0),
-            output_tokens=2,
-            output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=0),
-            total_tokens=3,
+            input_tokens=11,
+            input_tokens_details=NeMoGymResponseInputTokensDetails(cached_tokens=7),
+            output_tokens=5,
+            output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=3),
+            total_tokens=19,
         ),
         tool_choice="auto",
         tools=[],

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -204,7 +204,12 @@ class TestRolloutCollection:
             },
             "ng_model_call_capture": {
                 "calls": [
-                    {"model_call_id": "shared", "request": "captured", "response_status": "completed"},
+                    {
+                        "model_call_id": "shared",
+                        "request": "captured",
+                        "response": {"status": "incomplete"},
+                        "response_status": "completed",
+                    },
                     {"model_call_id": "capture-only", "request": "new"},
                 ]
             },

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -41,6 +41,7 @@ from nemo_gym.rollout_collection import (
     _expand_input_glob,
     _failures_path_for,
     _get_max_rollout_attempts,
+    _rollout_for_wandb,
     _rollout_request_debug_summary,
     loads_jsonl_line,
 )
@@ -106,6 +107,16 @@ class TestRolloutCollection:
             "ng_trajectory": {
                 "task_id": "2",
                 "rollout_id": "2-3",
+                "invocations": [
+                    {
+                        "invocation_id": "root",
+                        "status": "completed",
+                        "conversation": [
+                            {"type": "function_call_output", "call_id": "tool-1", "output": "result"},
+                            {"type": "function_call_output", "call_id": "observed-only", "output": "new"},
+                        ],
+                    }
+                ],
                 "tool_calls": [
                     {"invocation_id": "root", "tool_call_id": "producer-only", "output": "kept"},
                     {
@@ -125,10 +136,10 @@ class TestRolloutCollection:
                     {
                         "kind": "agent_invocation",
                         "invocation_id": "root",
-                        "conversation": [
-                            {"type": "function_call_output", "call_id": "tool-1", "output": "result"},
-                            {"type": "function_call_output", "call_id": "observed-only", "output": "new"},
-                        ],
+                    },
+                    {
+                        "kind": "agent_invocation",
+                        "invocation_id": "observed",
                     },
                     {
                         "kind": "tool_call",
@@ -152,6 +163,9 @@ class TestRolloutCollection:
         trajectory = _build_trajectory_record(row, result)
         producer_only, merged, observed_only = trajectory.tool_calls
 
+        assert [invocation.invocation_id for invocation in trajectory.invocations] == ["root", "observed"]
+        assert trajectory.invocations[0].status == "completed"
+        assert len(trajectory.invocations[0].conversation) == 2
         assert [call.model_call_id for call in trajectory.model_calls] == ["capture-only"]
         assert producer_only.tool_call_id == "producer-only" and producer_only.output == "kept"
         assert (merged.output, merged.status, merged.started_at, merged.completed_at, merged.duration_ms) == (
@@ -227,8 +241,8 @@ class TestRolloutCollection:
 
         assert "ng_trajectory" not in result
         assert result["ng_model_call_capture"]["gaps"][-1]["code"] == "trajectory_projection_failed"
-        assert "request" not in result["ng_model_call_capture"]["calls"][0]
-        assert "response" not in result["ng_model_call_capture"]["calls"][0]
+        assert result["ng_model_call_capture"]["calls"][0]["request"] == {"input": "question"}
+        assert result["ng_model_call_capture"]["calls"][0]["response"] == {"output": "answer"}
 
     def test_trajectory_projection_failure_without_attachment_keeps_gap(self, monkeypatch) -> None:
         row = {TASK_INDEX_KEY_NAME: 2, ROLLOUT_INDEX_KEY_NAME: 3}
@@ -240,6 +254,39 @@ class TestRolloutCollection:
         assert result["ng_trajectory"]["gaps"] == [
             {"code": "trajectory_projection_failed", "invocation_id": None, "detail": "ValueError"}
         ]
+
+    def test_rollout_for_wandb_omits_new_trajectory_and_raw_capture_payloads(self) -> None:
+        result = {
+            "response": {"output": "existing rollout content"},
+            "ng_trajectory": {"invocations": [{"conversation": ["trajectory secret"]}]},
+            "ng_model_call_capture": {
+                "calls": [
+                    {
+                        "model_call_id": "model-1",
+                        "request": {"input": "request secret"},
+                        "response": {"output": "response secret"},
+                        "request_raw": "raw request secret",
+                        "response_raw": "raw response secret",
+                    }
+                ],
+            },
+        }
+
+        sanitized = _rollout_for_wandb(result)
+
+        assert "ng_trajectory" not in sanitized
+        assert sanitized["ng_model_call_capture"]["calls"] == [{"model_call_id": "model-1"}]
+        assert sanitized["response"] == result["response"]
+        assert result["ng_model_call_capture"]["calls"][0]["request"] == {"input": "request secret"}
+        assert "ng_trajectory" in result
+        malformed = (
+            {"ng_model_call_capture": "secret"},
+            {"ng_model_call_capture": {"calls": {"request": "secret"}}},
+            {"ng_model_call_capture": {"calls": ["secret", {"request": "secret"}]}},
+        )
+        for malformed_result in malformed:
+            sanitized = _rollout_for_wandb(malformed_result)
+            assert b"secret" not in orjson.dumps(sanitized)
 
     @pytest.mark.parametrize("request_debug_enabled", [True, False])
     async def test_run_examples_logs_failed_run_when_request_debug_enabled(

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -36,6 +36,8 @@ from nemo_gym.rollout_collection import (
     RolloutAggregationHelper,
     RolloutCollectionConfig,
     RolloutCollectionHelper,
+    _attach_trajectory_record,
+    _build_trajectory_record,
     _expand_input_glob,
     _failures_path_for,
     _get_max_rollout_attempts,
@@ -97,6 +99,147 @@ class TestRolloutCollection:
             TASK_INDEX_KEY_NAME: 12,
             ROLLOUT_INDEX_KEY_NAME: 3,
         }
+
+    def test_build_trajectory_record_merges_all_evidence_sources(self) -> None:
+        row = {TASK_INDEX_KEY_NAME: 2, ROLLOUT_INDEX_KEY_NAME: 3}
+        result = {
+            "ng_trajectory": {
+                "task_id": "2",
+                "rollout_id": "2-3",
+                "tool_calls": [
+                    {"invocation_id": "root", "tool_call_id": "producer-only", "output": "kept"},
+                    {
+                        "invocation_id": "root",
+                        "tool_call_id": "tool-1",
+                        "output": "stale",
+                        "status": "failed",
+                        "started_at": 10.2,
+                        "completed_at": 10.4,
+                        "duration_ms": 200.0,
+                    },
+                ],
+            },
+            "ng_agent_observations": {
+                "source": "test",
+                "records": [
+                    {
+                        "kind": "agent_invocation",
+                        "invocation_id": "root",
+                        "conversation": [
+                            {"type": "function_call_output", "call_id": "tool-1", "output": "result"},
+                            {"type": "function_call_output", "call_id": "observed-only", "output": "new"},
+                        ],
+                    },
+                    {
+                        "kind": "tool_call",
+                        "invocation_id": "root",
+                        "tool_call_id": "tool-1",
+                    },
+                    {
+                        "kind": "tool_call",
+                        "invocation_id": "root",
+                        "tool_call_id": "observed-only",
+                        "status": "completed",
+                        "started_at": 10.2,
+                        "completed_at": 10.4,
+                        "duration_ms": 200.0,
+                    },
+                ],
+            },
+            "ng_model_call_capture": {"calls": [{"model_call_id": "capture-only"}]},
+        }
+
+        trajectory = _build_trajectory_record(row, result)
+        producer_only, merged, observed_only = trajectory.tool_calls
+
+        assert [call.model_call_id for call in trajectory.model_calls] == ["capture-only"]
+        assert producer_only.tool_call_id == "producer-only" and producer_only.output == "kept"
+        assert (merged.output, merged.status, merged.started_at, merged.completed_at, merged.duration_ms) == (
+            "result",
+            "failed",
+            10.2,
+            10.4,
+            200.0,
+        )
+        assert observed_only.tool_call_id == "observed-only" and observed_only.output == "new"
+
+    def test_build_trajectory_record_normalizes_identity_and_merges_model_calls(self) -> None:
+        row = {TASK_INDEX_KEY_NAME: 2, ROLLOUT_INDEX_KEY_NAME: 3, "task_id": "collector-task"}
+        result = {
+            "ng_trajectory": {
+                "task_id": "producer-task",
+                "rollout_id": "producer-rollout",
+                "turns": [
+                    {
+                        "invocation_id": "root",
+                        "task_id": "producer-task",
+                        "rollout_id": "producer-rollout",
+                        "turn_no": 1,
+                        "timestamp": 1.0,
+                        "step_count": 0,
+                    }
+                ],
+                "model_calls": [
+                    {"model_call_id": "producer-only", "request": "kept"},
+                    {
+                        "model_call_id": "shared",
+                        "request": "stale",
+                        "response_metadata": {"model": "producer-model"},
+                    },
+                ],
+            },
+            "ng_model_call_capture": {
+                "calls": [
+                    {"model_call_id": "shared", "request": "captured", "response_status": "completed"},
+                    {"model_call_id": "capture-only", "request": "new"},
+                ]
+            },
+        }
+
+        trajectory = _build_trajectory_record(row, result)
+
+        assert (trajectory.task_id, trajectory.rollout_id) == ("collector-task", "2-3")
+        assert (trajectory.turns[0].task_id, trajectory.turns[0].rollout_id) == ("collector-task", "2-3")
+        assert {gap.code for gap in trajectory.gaps} >= {"producer_trajectory_identity_mismatch"}
+        assert [call.model_call_id for call in trajectory.model_calls] == ["producer-only", "shared", "capture-only"]
+        assert [call.request for call in trajectory.model_calls] == ["kept", "captured", "new"]
+        assert trajectory.model_calls[1].response_metadata.model_dump(exclude_none=True) == {
+            "model": "producer-model",
+            "response_status": "completed",
+        }
+
+    def test_trajectory_projection_failure_preserves_rollout(self) -> None:
+        row = {TASK_INDEX_KEY_NAME: 2, ROLLOUT_INDEX_KEY_NAME: 3}
+        result = {
+            "ng_model_call_capture": {
+                "calls": [
+                    {
+                        "model_call_id": "model-1",
+                        "latency_total_ms": -1,
+                        "request": {"input": "question"},
+                        "response": {"output": "answer"},
+                    }
+                ]
+            }
+        }
+
+        _attach_trajectory_record(row, result)
+
+        assert "ng_trajectory" not in result
+        assert result["ng_model_call_capture"]["gaps"][-1]["code"] == "trajectory_projection_failed"
+        assert "request" not in result["ng_model_call_capture"]["calls"][0]
+        assert "response" not in result["ng_model_call_capture"]["calls"][0]
+
+    def test_trajectory_projection_failure_without_attachment_keeps_gap(self, monkeypatch) -> None:
+        row = {TASK_INDEX_KEY_NAME: 2, ROLLOUT_INDEX_KEY_NAME: 3}
+        result = {"ng_trajectory": {}}
+        monkeypatch.setattr(nemo_gym.rollout_collection, "_build_trajectory_record", MagicMock(side_effect=ValueError))
+
+        _attach_trajectory_record(row, result)
+
+        assert result["ng_trajectory"]["gaps"] == [
+            {"code": "trajectory_projection_failed", "invocation_id": None, "detail": "ValueError"}
+        ]
 
     @pytest.mark.parametrize("request_debug_enabled", [True, False])
     async def test_run_examples_logs_failed_run_when_request_debug_enabled(
@@ -664,8 +807,9 @@ class TestRolloutCollection:
         assert expected_aggregate_metrics == actual_aggregate_metrics
 
     @pytest.mark.parametrize("resume_from_cache", [False, True])
+    @pytest.mark.parametrize("redact_payloads", [False, True])
     async def test_run_from_config_replaces_stale_capture_before_dispatch(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, resume_from_cache: bool
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, resume_from_cache: bool, redact_payloads: bool
     ) -> None:
         from nemo_gym.base_responses_api_model import CaptureStore
 
@@ -700,18 +844,37 @@ class TestRolloutCollection:
                 [example] = examples
                 assert example[TASK_INDEX_KEY_NAME] == 0 and example[ROLLOUT_INDEX_KEY_NAME] == 0
                 assert store.read("0-0") == []
+                request = {"input": [{"type": "input_image", "image_url": "data:image/png;base64,secret"}]}
                 store.record(
                     "0-0",
-                    {"model_call_id": "fresh", "dialect": "responses", "request": {}, "response": {}},
+                    {"model_call_id": "fresh", "dialect": "responses", "request": request, "response": {}},
                 )
                 future = Future()
-                future.set_result((example, {"response": {"usage": {}}}))
+                result = {"response": {"usage": {}}}
+                if redact_payloads:
+                    result["ng_trajectory"] = {
+                        "schema_version": "1.0",
+                        "task_id": "0",
+                        "rollout_id": "0-0",
+                        "gaps": [{"code": "multimodal_history_redacted"}],
+                    }
+                future.set_result((example, result))
                 return [future]
 
         results = await Helper().run_from_config(config)
 
         assert [exchange["model_call_id"] for exchange in store.read("0-0")] == ["fresh"]
         assert [call["model_call_id"] for call in results[0]["ng_model_call_capture"]["calls"]] == ["fresh"]
+        trajectory_request = results[0]["ng_trajectory"]["model_calls"][0]["request"]
+        trajectory_response = results[0]["ng_trajectory"]["model_calls"][0]["response"]
+        if redact_payloads:
+            assert trajectory_request is None and trajectory_response is None
+        else:
+            assert trajectory_request["input"][0]["type"] == "input_image" and trajectory_response == {}
+        assert "request" not in results[0]["ng_model_call_capture"]["calls"][0]
+        assert store.read("0-0")[0]["request"]["input"][0]["type"] == "input_image"
+        if redact_payloads:
+            assert "data:image/png;base64,secret" not in orjson.dumps(results[0]).decode()
 
     async def test_run_from_config_sorted(self, tmp_path: Path, empty_global_config: MagicMock) -> None:
         input_jsonl_fpath = tmp_path / "input.jsonl"
@@ -1000,6 +1163,7 @@ class TestRolloutCollection:
                 "response": {"usage": {"tokens": 10}},
                 "ng_agent_observations": {"invocations": [{"conversation": ["large"]}]},
                 "ng_model_call_capture": {"calls": [{"request": "large"}]},
+                "ng_trajectory": {"model_calls": [{"request": "large"}]},
             },
             {TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 1, "reward": 0.0, "response": {"usage": {"tokens": 12}}},
             {TASK_INDEX_KEY_NAME: 1, ROLLOUT_INDEX_KEY_NAME: 0, "reward": 1.0, "response": {"usage": {"tokens": 8}}},
@@ -1031,6 +1195,7 @@ class TestRolloutCollection:
             assert "responses_create_params" not in item
             assert "ng_agent_observations" not in item
             assert "ng_model_call_capture" not in item
+            assert "ng_trajectory" not in item
             assert "usage" in item["response"]
 
     async def test_call_aggregate_metrics_multiple_agents(

--- a/tests/unit_tests/test_rollout_observability.py
+++ b/tests/unit_tests/test_rollout_observability.py
@@ -14,6 +14,8 @@ from nemo_gym.rollout_observability import (
     ObservationGap,
     SandboxObservation,
     ToolCallObservation,
+    TrajectoryModelCall,
+    TrajectoryRecord,
     join_model_call_observations,
 )
 
@@ -61,6 +63,24 @@ def test_observation_bundle_allows_missing_parent() -> None:
 def test_observation_models_reject_unknown_fields() -> None:
     with pytest.raises(ValidationError, match="producer_extension"):
         ModelCallRef.model_validate({"model_call_id": "call-1", "producer_extension": "unexpected"})
+    with pytest.raises(ValidationError, match="output"):
+        ToolCallObservation.model_validate(
+            {"invocation_id": "root", "tool_call_id": "tool-1", "output": "trajectory-only"}
+        )
+
+
+def test_turns_are_versioned_trajectory_records_not_legacy_observations() -> None:
+    with pytest.raises(ValidationError, match="turn"):
+        AgentObservationBundle.model_validate({"source": "test", "records": [{"kind": "turn"}]})
+
+
+def test_trajectory_rejects_duplicate_model_call_ids() -> None:
+    with pytest.raises(ValidationError, match="model_call_id must be unique"):
+        TrajectoryRecord(
+            task_id="task",
+            rollout_id="rollout",
+            model_calls=[TrajectoryModelCall(model_call_id="call-1"), TrajectoryModelCall(model_call_id="call-1")],
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add a versioned `ng_trajectory` projection for normalized model calls, token statistics, semantic turns, tool observations, and invocation-scoped model-visible history
- preserve provider-reported cached, reasoning, and total token usage across capture, conversion, and multi-turn agent loops
- preserve Responses lifecycle status as `response_status` without reinterpreting dialect-specific `finish_reason`
- add an opt-in reference trajectory producer for Simple Agent and document current V/O/X coverage for C1-C7 across all 34 agents

This PR establishes the shared schema and one reference producer. The capability matrix reports current support; it does not claim that every producer satisfies C1-C7.

## Correctness and compatibility

- collector-derived task and rollout identities are canonical; producer mismatches are recorded and turn identities are normalized without dropping the producer trajectory
- producer invocations remain authoritative on duplicate IDs, observation-only invocations are appended, and model and tool records are merged only by exact identifiers
- projection failures retain an explicit gap and captured request and response payloads; successful projections remove the duplicate capture payloads
- Simple Agent records the actual per-turn model input, cumulative tool-step count, and an explicit gap when resolution is unavailable
- no existing fields are removed; response lifecycle status, provider token details and totals, and cached-token aggregation are intentional correctness changes; `ng_trajectory` is additive
- Simple Agent retains self-dispatch when observability is disabled or `responses()` is overridden
- trajectory collection remains gated by observability and independent of the token-ID capture correlation introduced by #2124
- captured request and response payloads are retained in persisted `ng_trajectory`; LabBench's `multimodal_history_redacted` gap omits those copies
- W&B rollout tables omit `ng_trajectory` and model-call request and response payloads during collection and reverification
- payload projection has no separate size cap or trajectory-specific opt-out; model-call capture remains opt-in

## NVBug alignment

- NVBug 6535274 is addressed with its preferred lossless option: completed Responses calls preserve `response_status="completed"`; `finish_reason` remains unset when the dialect does not provide one. The `inference_provider` path now uses the shared Chat-to-Responses converter, so the fix applies to the backend named in the report.
- This is the schema and reference-producer phase of NVBug 6555643 / #1867. The capability matrix marks unsupported and path-dependent producers as `X` or `O`; it is not a claim of full producer coverage.

## Follow-up pull requests

PRs #2115 and #2117-#2120 are stacked; later PRs include earlier stack changes. Open PRs describe planned evidence and do not affect the current capability matrix. #2153 provides Claude Code tool timing and status; this PR joins tool results to those observations. No available PR from #2115 through #2122 adds canonical C3 turns.

| PR | Producer or path | Evidence added | Remaining gap |
|---|---|---|---|
| #2115 | OpenClaw, PinchBench | Correlated model calls, conversations, parallel tool timing, and sandbox observations | No C3 turns |
| #2116 | Claude Code | Superseded by #2153 | See #2153 and this PR |
| #2117 | Hermes | Parallel tool timing and agent observations | No C3 turns |
| #2118 | Pi | Correlated model calls, conversations, and parallel tool timing | No C3 turns |
| #2119 | OpenCode | Rollout-level model calls, retained conversations, and parallel tool timing | No exact per-invocation model-call ownership; no C3 turns |
| #2120 | SWE OpenCode, OpenHands | OpenCode model-call correlation plus retained conversations and sandbox observations for both paths | OpenHands calls, tool timing, and C3 turns remain unavailable |
| #2121 | — | No PR exists | — |
| #2122 | Stirrup, GDPVal | GDPVal judge-call correlation; Stirrup and Tau2 model-call correlation is already present | No agent turns or tool observations |

## Validation

- 354 capture, conversion, trajectory, collector, reverification, Fern-link, and inference-provider tests passed, plus 5 subtests
- 10 Simple Agent producer and dispatch tests passed
- in-process endpoint-to-record test passed: prefixed Responses request → `inference_provider` → capture middleware → `CaptureStore` → `ModelCallRecord`
- producer-to-collector-to-JSON trajectory round trip passed with both available and unavailable resolution status
- 110 vLLM model and Responses conversion tests passed
- 67 Claude Code observation tests and 4 LabBench redaction tests passed
- the trajectory patch merges cleanly with #2124; combined-stack token-capture and trajectory tests passed
- Ruff check, Ruff format check, and `git diff --check` passed

Part of #1867.
