### PR TITLE
fix(stirrup): adapt DynamicMaxTokensChatCompletionsClient to stirrup 0.2.0 API

### DIFF
--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -455,7 +455,7 @@ async def _run_stirrup_agent(
         model=model_name,
         base_url=model_base_url,
         api_key=api_key,
-        max_tokens=max_tokens,
+        context_window_tokens=max_tokens,
         model_id=model_id,
         completion_token_buffer=completion_token_buffer,
         temperature=temperature,

--- a/responses_api_agents/stirrup_agent/nemo_client.py
+++ b/responses_api_agents/stirrup_agent/nemo_client.py
@@ -197,6 +197,7 @@ class DynamicMaxTokensChatCompletionsClient(ChatCompletionsClient):
     def __init__(
         self,
         *args: Any,
+        context_window_tokens: int,
         model_id: Optional[str] = None,
         completion_token_buffer: int = 1000,
         temperature: float = 1.0,
@@ -205,7 +206,7 @@ class DynamicMaxTokensChatCompletionsClient(ChatCompletionsClient):
         max_completion_tokens_cap: int = _DEFAULT_MAX_COMPLETION_TOKENS_CAP,
         **kwargs: Any,
     ) -> None:
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, context_window_tokens=context_window_tokens, **kwargs)
         self._completion_token_buffer = completion_token_buffer
         self._temperature = temperature
         self._top_p = top_p
@@ -307,7 +308,7 @@ class DynamicMaxTokensChatCompletionsClient(ChatCompletionsClient):
     ) -> AssistantMessage:
         provider_messages = to_provider_openai_messages(messages)
         input_tokens = self._count_input_tokens(provider_messages, tools)
-        context_window = self._max_tokens
+        context_window = self._context_window_tokens
         dynamic_max = max(
             context_window - input_tokens - self._completion_token_buffer,
             _MIN_COMPLETION_TOKENS,

--- a/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
+++ b/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
@@ -59,7 +59,7 @@ async def test_generate_forwards_configured_sampling_kwargs() -> None:
     ``max_completion_tokens`` should land on the wire request_kwargs."""
     client = DynamicMaxTokensChatCompletionsClient(
         model="m",
-        max_tokens=10_000,
+        context_window_tokens=131_072,
         base_url="http://test",
         api_key="k",
         temperature=0.42,
@@ -88,7 +88,7 @@ async def test_generate_restores_tool_result_messages_for_openai_payload() -> No
     """Normal model calls must use provider-valid tool-call history."""
     client = DynamicMaxTokensChatCompletionsClient(
         model="m",
-        max_tokens=10_000,
+        context_window_tokens=131_072,
         base_url="http://test",
         api_key="k",
     )
@@ -142,7 +142,7 @@ async def test_max_completion_tokens_cap_overrides_dynamic_size() -> None:
     """When the dynamic computation exceeds the cap, the cap should win."""
     client = DynamicMaxTokensChatCompletionsClient(
         model="m",
-        max_tokens=1_000_000,  # huge context window → dynamic_max would exceed cap
+        context_window_tokens=1_000_000,  # huge context window → dynamic_max would exceed cap
         base_url="http://test",
         api_key="k",
         max_completion_tokens_cap=512,
@@ -163,7 +163,7 @@ def test_defaults_match_pre_lift_behaviour() -> None:
     deployments that don't set the new config fields are unaffected."""
     client = DynamicMaxTokensChatCompletionsClient(
         model="m",
-        max_tokens=10_000,
+        context_window_tokens=131_072,
         base_url="http://test",
         api_key="k",
     )


### PR DESCRIPTION
## Summary
- stirrup 0.2.0 split the old single \`max_tokens\` (context window) parameter into two: \`max_tokens\` (generation limit, defaults to 64k) and \`context_window_tokens\` (context capacity, now required)
- Updates \`DynamicMaxTokensChatCompletionsClient\` to pass \`context_window_tokens\` explicitly to the parent class
- Updates \`generate()\` to read \`self._context_window_tokens\` instead of \`self._max_tokens\` for context window sizing
- Updates call site in \`app.py\` and tests accordingly

## Test plan
- [ ] CI green (this failure was pre-existing on main, independent of any recent dependency changes)