### PR TITLE
fix(cli): accept -v/--verbose before the subcommand; stop suggesting a flag as its own correction

### DIFF
--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -657,7 +657,10 @@ def _add_leaf(subparsers: argparse._SubParsersAction, name: str, command: Comman
     leaf = subparsers.add_parser(name, help=command.summary, description=command.summary)
     # `_parser=leaf` so error reporting (and flag "did you mean?" hints) uses this command's own options/prog.
     leaf.set_defaults(_command=command, _parser=leaf)
-    leaf.add_argument("-v", "--verbose", action="store_true", help="Set logging level to DEBUG.")
+    # SUPPRESS so an absent trailing `-v` can't overwrite one given before the subcommand (see build_parser).
+    leaf.add_argument(
+        "-v", "--verbose", action="store_true", default=argparse.SUPPRESS, help="Set logging level to DEBUG."
+    )
     for flag in command.flags:
         flag.register(leaf)
 
@@ -667,6 +670,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = _GymArgumentParser(prog="gym", add_help=True)
     parser.add_argument("--version", action="store_true", help="Show the NeMo Gym version and exit.")
     parser.add_argument("--json", action="store_true", help="With --version, output as JSON.")
+    # Also registered on every leaf, so `-v` is accepted before or after the subcommand.
+    parser.add_argument("-v", "--verbose", action="store_true", help="Set logging level to DEBUG.")
     parser.set_defaults(_parser=parser)
 
     subparsers = parser.add_subparsers()
@@ -770,7 +775,12 @@ def main() -> None:
     if unknown_flags:
         error_parser = getattr(args, "_parser", parser)
         known_options = [opt for action in error_parser._actions for opt in action.option_strings]
-        hints = "".join(did_you_mean(flag.split("=", 1)[0], known_options) for flag in unknown_flags)
+        # A flag rejected for its position (not for being unknown) is still in known_options, so exclude it
+        # from its own candidate set — otherwise it matches itself and is suggested as its own correction.
+        hints = "".join(
+            did_you_mean(name, [opt for opt in known_options if opt != name])
+            for name in (flag.split("=", 1)[0] for flag in unknown_flags)
+        )
         error_parser.error(f"unrecognized arguments: {' '.join(unknown_flags)}{hints}")
 
     # set NEMO_GYM_EXTRA_ROOTS from --search-dir for the duration of the command


### PR DESCRIPTION
Related to #1434 
Fixes DEFECT A — `-v` / `--verbose` is not global.

Issue:  `-v`/`--verbose` was registered only on leaf subparsers, so `gym -v list benchmarks` failed while the trailing form worked - it is now on the top-level parser too. The "did you mean?" hint also matched a misplaced flag against itself; the rejected token is now excluded from its own candidate set.