### PR TITLE
default port range to the 5000-5999 band

### DIFF
--- a/fern/versions/latest/pages/infrastructure/engineering-notes/system-design.mdx
+++ b/fern/versions/latest/pages/infrastructure/engineering-notes/system-design.mdx
@@ -34,7 +34,9 @@ Configuration is loaded from multiple sources in order of priority (later source
 2. Local `env.yaml` file (for sensitive values like API keys)
 3. Command-line arguments (highest priority)
 
-**Port allocation**: Users can explicitly specify `host` and `port` in their config. If not provided, the framework automatically allocates ports from available system ports, tracking used ports to prevent conflicts.
+**Port allocation**: Users can explicitly specify `host` and `port` in their config. If not provided, the framework automatically allocates a port from `port_range_low` to `port_range_high` (default 5000 to 5999), tracking used ports to prevent conflicts.
+
+The default band sits below the OS ephemeral port range, which the kernel draws from for outgoing connections. A port in that range can be taken between the time the framework probes it and the time the server binds it, and startup then fails with `EADDRINUSE`. Where that range starts varies by OS and is configurable, so the band stays low. Set `port_range_low` and `port_range_high` to move Gym elsewhere, and keep the head server port inside the band.
 
 ### Phase 3: Initialize Ray
 
@@ -48,7 +50,7 @@ Servers are started in two stages:
 %%{init: {'theme': 'default', 'themeVariables': { 'lineColor': '#5c6bc0', 'primaryTextColor': '#333'}}}%%
 flowchart TB
     Main["Main Process<br/>gym env start"]
-    Head["Head Server<br/>Port 11000"]
+    Head["Head Server<br/>Port 5999"]
     Model["Model Server<br/>Own venv + port"]
     Agent["Agent Server<br/>Own venv + port"]
     Resources["Resources Server<br/>Own venv + port"]

--- a/fern/versions/latest/pages/reference/cli-commands.mdx
+++ b/fern/versions/latest/pages/reference/cli-commands.mdx
@@ -517,7 +517,7 @@ NeMo Gym Server Status:
 {
     'server_type': 'resources_servers',
     'name': 'example_single_tool_call',
-    'port': 58117,
+    'port': 5117,
     'pid': 89904,
     'uptime_seconds': '0d 0h 0m 41.5s',
 }
@@ -706,7 +706,7 @@ Servers that report `unsupported` or `unknown` cause the command to abort unless
 gym eval reverify \
     --config my_resources_server.yaml \
     "++head_server.host=127.0.0.1" \
-    "++head_server.port=9500" \
+    "++head_server.port=5998" \
     --inputs results/rollouts_materialized_inputs.jsonl \
     --rollouts results/rollouts.jsonl \
     --output results/rollouts_reverified.jsonl

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -136,7 +136,17 @@ POLICY_API_KEY_KEY_NAME = "policy_api_key"  # pragma: allowlist secret
 POLICY_MODEL_NAME_KEY_NAME = "policy_model_name"
 POLICY_MODEL_KEY_NAME = "policy_model"
 
-DEFAULT_HEAD_SERVER_PORT = 11000
+# Ports must stay below the OS ephemeral port range, which the kernel draws from for outgoing
+# connections. A port in that range can be taken between the time we probe it and the time a server
+# binds it, and startup then fails with EADDRINUSE. Where that range starts varies by OS and is
+# configurable, so keep the band low.
+DEFAULT_PORT_RANGE_LOW: int = 5000
+DEFAULT_PORT_RANGE_HIGH: int = 5999
+
+# Gym probes for every other port but pins this one, so it has to be free or the run fails. Take it
+# from the top of the band, since the bottom is more contended: 5000 is a common default for local
+# dev servers. This port is seeded into disallowed_ports so the allocator never hands it out again.
+DEFAULT_HEAD_SERVER_PORT: int = DEFAULT_PORT_RANGE_HIGH
 
 
 # W&B
@@ -665,8 +675,8 @@ Found global config dict yaml:
         initial_disallowed_ports = [head_server_port] if head_server_port is not None else []
 
         with open_dict(global_config_dict):
-            port_range_low = global_config_dict.setdefault(PORT_RANGE_LOW_KEY_NAME, 10_001)
-            port_range_high = global_config_dict.setdefault(PORT_RANGE_HIGH_KEY_NAME, 20_000)
+            port_range_low = global_config_dict.setdefault(PORT_RANGE_LOW_KEY_NAME, DEFAULT_PORT_RANGE_LOW)
+            port_range_high = global_config_dict.setdefault(PORT_RANGE_HIGH_KEY_NAME, DEFAULT_PORT_RANGE_HIGH)
 
         disallowed_ports = self.validate_and_populate_defaults(
             server_instance_configs=server_instance_configs,
@@ -866,6 +876,15 @@ def _find_open_port_using_range(
     max_retries: int = 50,
 ) -> int:  # pragma: no cover
     # Find an open port that doesn't conflict with disallowed ports.
+
+    # max_retries bounds the retry loop below, but not the rejection loop inside it, which resamples
+    # until it draws a port that is not disallowed. If the whole range is disallowed it never draws
+    # one, so check for that up front.
+    if set(range(port_range_low, port_range_high + 1)).issubset(disallowed_ports):
+        raise RuntimeError(
+            f"Every port in the range [{port_range_low}, {port_range_high}] is already taken by this run. "
+            f"Widen {PORT_RANGE_LOW_KEY_NAME}/{PORT_RANGE_HIGH_KEY_NAME} or start fewer servers."
+        )
 
     with socket() as s:
         for _ in range(max_retries):

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -61,6 +61,8 @@ from nemo_gym.config_types import (
     BaseServerConfig,
 )
 from nemo_gym.global_config import (
+    # Re-exported: global_config owns this value, but re-exporting here for backwards compatibility
+    DEFAULT_HEAD_SERVER_PORT,  # noqa: F401
     DRY_RUN_KEY_NAME,
     HEAD_SERVER_KEY_NAME,
     NEMO_GYM_CONFIG_PATH_ENV_VAR_NAME,
@@ -282,8 +284,6 @@ Response content: {content}""")
 async def get_response_json(response: ClientResponse) -> Any:
     return orjson.loads(await response.read())
 
-
-DEFAULT_HEAD_SERVER_PORT = 11000
 
 ServerStatus = Union[Literal["success"], Literal["connection_error"], Literal["timeout"], Literal["unknown_error"]]
 

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -34,6 +34,8 @@ from nemo_gym.config_types import (
 )
 from nemo_gym.global_config import (
     DEFAULT_HEAD_SERVER_PORT,
+    DEFAULT_PORT_RANGE_HIGH,
+    DEFAULT_PORT_RANGE_LOW,
     NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME,
     GlobalConfigDictParser,
     GlobalConfigDictParserConfig,
@@ -58,10 +60,10 @@ class TestGlobalConfig:
     def _default_global_config_dict_values(self) -> dict:
         return {
             "use_absolute_ip": False,
-            "head_server": {"host": "127.0.0.1", "port": 11000},
-            "disallowed_ports": [11000],
-            "port_range_low": 10_001,
-            "port_range_high": 20_000,
+            "head_server": {"host": "127.0.0.1", "port": DEFAULT_HEAD_SERVER_PORT},
+            "disallowed_ports": [DEFAULT_HEAD_SERVER_PORT],
+            "port_range_low": DEFAULT_PORT_RANGE_LOW,
+            "port_range_high": DEFAULT_PORT_RANGE_HIGH,
             # From self._mock_versions_for_testing
             "head_server_deps": ["ray[default]==test ray version", "openai==test openai version"],
             "python_version": "test python version",
@@ -248,7 +250,7 @@ class TestGlobalConfig:
                 "a": {"responses_api_models": {"c": {"entrypoint": "app.py", "host": "127.0.0.1", "port": 12345}}},
                 "b": {"c": {"d": {}}},
                 "c": 2,
-                "disallowed_ports": [11000, 12345],
+                "disallowed_ports": [DEFAULT_HEAD_SERVER_PORT, 12345],
             }
             == global_config_dict
         )
@@ -332,7 +334,7 @@ class TestGlobalConfig:
                         }
                     }
                 },
-                "disallowed_ports": [11000, 12345, 123456],
+                "disallowed_ports": [DEFAULT_HEAD_SERVER_PORT, 12345, 123456],
             }
             == global_config_dict
         )
@@ -772,7 +774,7 @@ class TestGlobalConfig:
         """Test that find_open_port retries when the head server port is returned."""
         randint_mock = MagicMock()
         randint_mock.side_effect = [
-            DEFAULT_HEAD_SERVER_PORT,  # first attempt: 11000 (conflict)
+            DEFAULT_HEAD_SERVER_PORT,  # first attempt: the head server port (conflict)
             12345,  # second attempt (safe)
         ]
         monkeypatch.setattr(nemo_gym.global_config, "randint", randint_mock)
@@ -784,7 +786,10 @@ class TestGlobalConfig:
         monkeypatch.setattr(nemo_gym.global_config, "socket", socket_mock)
 
         get_global_config_dict_mock = MagicMock()
-        get_global_config_dict_mock.return_value = {"port_range_low": 10_001, "port_range_high": 20_000}
+        get_global_config_dict_mock.return_value = {
+            "port_range_low": DEFAULT_PORT_RANGE_LOW,
+            "port_range_high": DEFAULT_PORT_RANGE_HIGH,
+        }
         monkeypatch.setattr(nemo_gym.global_config, "get_global_config_dict", get_global_config_dict_mock)
 
         port = find_open_port(disallowed_ports=[DEFAULT_HEAD_SERVER_PORT])
@@ -802,7 +807,10 @@ class TestGlobalConfig:
         monkeypatch.setattr(nemo_gym.global_config, "socket", socket_mock)
 
         get_global_config_dict_mock = MagicMock()
-        get_global_config_dict_mock.return_value = {"port_range_low": 10_001, "port_range_high": 20_000}
+        get_global_config_dict_mock.return_value = {
+            "port_range_low": DEFAULT_PORT_RANGE_LOW,
+            "port_range_high": DEFAULT_PORT_RANGE_HIGH,
+        }
         monkeypatch.setattr(nemo_gym.global_config, "get_global_config_dict", get_global_config_dict_mock)
 
         with raises(RuntimeError) as exc_info:
@@ -843,10 +851,10 @@ class TestGlobalConfig:
         head_port = global_config_dict["head_server"]["port"]
 
         assert resource_port == 12345
-        assert head_port == 11000
+        assert head_port == DEFAULT_HEAD_SERVER_PORT
         assert resource_port != head_port
         assert "disallowed_ports" in global_config_dict
-        assert 11000 in global_config_dict["disallowed_ports"]
+        assert DEFAULT_HEAD_SERVER_PORT in global_config_dict["disallowed_ports"]
         assert 12345 in global_config_dict["disallowed_ports"]
 
     def test_almost_servers_detection_and_warning(self, monkeypatch) -> None:
@@ -1088,7 +1096,7 @@ class TestGlobalConfig:
             "test_resource_3_copy2": {
                 "responses_api_models": {"test_model": {"entrypoint": "app2.py", "host": "127.0.0.1", "port": 12345}},
             },
-            "disallowed_ports": [11000, 12345, 12345, 12345, 12345, 12345],
+            "disallowed_ports": [DEFAULT_HEAD_SERVER_PORT, 12345, 12345, 12345, 12345, 12345],
             "a": {"b": {}},
             "a_prime": {"b_prime": 3},
             "test_resource_3_copy3_delete": {
@@ -1140,7 +1148,7 @@ class TestGlobalConfig:
             "policy_model_2": {
                 "responses_api_models": {"test_model": {"entrypoint": "app2.py", "host": "127.0.0.1", "port": 12345}}
             },
-            "disallowed_ports": [11000, 12345, 12345],
+            "disallowed_ports": [DEFAULT_HEAD_SERVER_PORT, 12345, 12345],
             "a": {"b": {}},
             "a_prime": {"b_prime": 3},
         }
@@ -1178,7 +1186,7 @@ class TestGlobalConfig:
             )
         )
         expected_global_config_dict = self._default_global_config_dict_values | {
-            "disallowed_ports": [11000, 12345],
+            "disallowed_ports": [DEFAULT_HEAD_SERVER_PORT, 12345],
             "policy_model": {
                 "responses_api_models": {
                     "dummy_model": {
@@ -1230,7 +1238,7 @@ class TestGlobalConfig:
             )
         )
         expected_global_config_dict = self._default_global_config_dict_values | {
-            "disallowed_ports": [11000, 12345],
+            "disallowed_ports": [DEFAULT_HEAD_SERVER_PORT, 12345],
             "policy_model": {
                 "responses_api_models": {
                     "test_model": {
@@ -1405,7 +1413,7 @@ class TestConfigLoadErrors:
 
     def test_raise_on_no_server_instances_raises_when_empty(self) -> None:
         parser = GlobalConfigDictParser()
-        config = DictConfig({"config_paths": [], "head_server": {"port": 11000}})
+        config = DictConfig({"config_paths": [], "head_server": {"port": DEFAULT_HEAD_SERVER_PORT}})
         with raises(NoServerInstancesError) as exc_info:
             parser.raise_on_no_server_instances(config)
         assert "gym env start" in str(exc_info.value)


### PR DESCRIPTION
The default port range was 10001-20000 and the head server was pinned to 11000. On some clusters' nodes, the ephemeral range can sit as low as 9000 for the OS ephemeral range. A port drawn from there can be handed to an outgoing connection between our bind probe and the server's real bind, so startup fails with EADDRINUSE.

for instance, NeMo RL already reserves 5000-5999 for Gym and passes down the range here: https://github.com/NVIDIA-NeMo/RL/blob/aa5c74edec9657f3aca3c570255970e24fa6768d/ray.sub#L163

Adopting the same defaults here means a standalone Gym run lands in the same band. The head server port needed to move too: it is the only port Gym pins rather than probes for, so leaving it at 11000 would have kept the one port every client must reach potentially inside the ephemeral zone. It now defaults to the top of the band and is still seeded into disallowed_ports.

Also:

- Hoist the range into `DEFAULT_PORT_RANGE_LOW/HIGH` and drop the duplicate `DEFAULT_HEAD_SERVER_PORT` in server_utils
- Fail fast in `_find_open_port_using_range` when the whole range is disallowed instead of infinite looping