### PR TITLE
docs(swe_agents): replace leftover ng_viewer with jq

### DIFF
--- a/responses_api_agents/swe_agents/README.md
+++ b/responses_api_agents/swe_agents/README.md
@@ -500,7 +500,7 @@ gym eval run --no-serve \
 `gym eval run` defaults to a concurrency of 100; tune to your hardware. View the results with:
 
 ```bash
-ng_viewer +jsonl_fpath=swebench-verified.openhands.qwen3-30b-coder.jsonl
+jq -C . swebench-verified.openhands.qwen3-30b-coder.jsonl | less -R
 ```
 
 ---


### PR DESCRIPTION
`ng_viewer` was removed in #726 and swept from the READMEs in 490138dbb, but this file had a second occurrence that was missed. Fixes defect C.