### PR TITLE
feat(pinchbench): make the stalled-run abort threshold configurable

### DIFF
--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -114,6 +114,11 @@ class PinchBenchAgentConfig(BaseResponsesAPIAgentConfig):
     context_window: int = 131072
     # Optional OpenClaw provider request timeout in seconds. None keeps OpenClaw's 120s default.
     openclaw_provider_timeout_seconds: Optional[int] = None
+    # Optional no-progress age before OpenClaw abort-drains a stalled run
+    # (`diagnostics.stuckSessionAbortMs`). None keeps OpenClaw's default, which is at least
+    # 5 minutes and 3x the warn threshold; under a saturated model endpoint that default
+    # truncates merely-slow sessions, which scores as a task failure rather than a timeout.
+    openclaw_stuck_session_abort_seconds: Optional[int] = None
     work_root: str = "/tmp/pinchbench_gym"
     # Where per-task transcripts are archived (kept on disk for inspection, like
     # swe_agents' persistent_dir). `raw_rollout` keeps a pointer to this archive.
@@ -212,6 +217,8 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         env["OPENCLAW_GATEWAY_TOKEN"] = self.config.gateway_token
         if self.config.openclaw_provider_timeout_seconds:
             env["PINCHBENCH_PROVIDER_TIMEOUT_SECONDS"] = str(self.config.openclaw_provider_timeout_seconds)
+        if self.config.openclaw_stuck_session_abort_seconds:
+            env["PINCHBENCH_STUCK_SESSION_ABORT_SECONDS"] = str(self.config.openclaw_stuck_session_abort_seconds)
         if self.config.brave_api_key:
             env["BRAVE_API_KEY"] = self.config.brave_api_key
         if self.config.tavily_api_key:
@@ -283,6 +290,11 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
             max_tokens = int(os.environ.get("PINCHBENCH_MAX_TOKENS", "65536"))
             context_window = int(os.environ.get("PINCHBENCH_CONTEXT_WINDOW", "131072"))
             provider_timeout_s = int(os.environ["PINCHBENCH_PROVIDER_TIMEOUT_SECONDS"]) if os.environ.get("PINCHBENCH_PROVIDER_TIMEOUT_SECONDS") else None
+            stuck_abort_s = (
+                int(os.environ["PINCHBENCH_STUCK_SESSION_ABORT_SECONDS"])
+                if os.environ.get("PINCHBENCH_STUCK_SESSION_ABORT_SECONDS")
+                else None
+            )
             runtime_params = {
                 "temperature": 1,
                 "top_p": 0.95,
@@ -331,6 +343,8 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
                 for agent in agents.get("list", []):
                     if isinstance(agent, dict):
                         agent["timeoutSeconds"] = provider_timeout_s
+            if stuck_abort_s is not None:
+                cfg.setdefault("diagnostics", {})["stuckSessionAbortMs"] = stuck_abort_s * 1000
             cfg_path.write_text(json.dumps(cfg, indent=2, ensure_ascii=False), "utf-8")
             PYCFG
 

--- a/responses_api_agents/pinchbench/tests/test_stuck_session_abort.py
+++ b/responses_api_agents/pinchbench/tests/test_stuck_session_abort.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OpenClaw's stalled-run abort threshold (``diagnostics.stuckSessionAbortMs``).
+
+Left unset, OpenClaw abort-drains a stalled run after at least 5 minutes and 3x
+the warn threshold. A saturated model endpoint makes ordinary generations exceed
+that, so sessions are cut mid-task and the partial work grades as a failure
+rather than surfacing as a timeout.
+"""
+
+from responses_api_agents.pinchbench.tests.test_app import make_agent
+
+
+def test_threshold_is_not_sent_when_unset():
+    env = make_agent()._task_env("task_x")
+
+    assert "PINCHBENCH_STUCK_SESSION_ABORT_SECONDS" not in env
+
+
+def test_threshold_reaches_the_sandbox_in_seconds():
+    env = make_agent(openclaw_stuck_session_abort_seconds=3600)._task_env("task_x")
+
+    assert env["PINCHBENCH_STUCK_SESSION_ABORT_SECONDS"] == "3600"
+
+
+def test_threshold_is_independent_of_the_provider_timeout():
+    env = make_agent(openclaw_provider_timeout_seconds=14400)._task_env("task_x")
+
+    assert env["PINCHBENCH_PROVIDER_TIMEOUT_SECONDS"] == "14400"
+    assert "PINCHBENCH_STUCK_SESSION_ABORT_SECONDS" not in env
+
+
+def test_the_sandbox_writes_it_to_openclaw_config_as_milliseconds(tmp_path):
+    wrapper = make_agent()._write_direct_exec_wrapper(tmp_path).read_text()
+
+    assert "PINCHBENCH_STUCK_SESSION_ABORT_SECONDS" in wrapper
+    assert 'cfg.setdefault("diagnostics", {})["stuckSessionAbortMs"] = stuck_abort_s * 1000' in wrapper


### PR DESCRIPTION
## Problem

OpenClaw abort-drains a stalled run after `diagnostics.stuckSessionAbortMs`. Left unset it uses "at least 5 minutes and 3x `stuckSessionWarnMs`" — its own docs describe the field as the guard against *"cutting off merely slow runs"*.

Under a saturated model endpoint, ordinary generations exceed that window. OpenClaw cuts the session mid-task and **nothing surfaces as a timeout**: the endpoint still answers 200, no failure class is set, the rollout is recorded as a success, and the partial work grades as a low score.

The agent already writes `models.providers.custom.timeoutSeconds`, `agents.defaults.timeoutSeconds` and per-agent timeouts into the OpenClaw config, but never touched `diagnostics` — so raising the provider timeout does not move this ceiling.

## Evidence

A concurrency scan holding model, endpoint and config fixed, varying only rollout concurrency across a 16x range. Mean reward fell monotonically at every step, with no plateau. The diagnostic signal is the shape of the failures, not the score:

| rollout concurrency | zero-reward share | median transcript events, zeros vs non-zeros | model calls / rollout |
|---|---|---|---|
| lowest | ~5% | 26 vs 21 | 12.6 |
| mid | ~22% | 13 vs 17 | 9.3 |
| highest | ~38% | 11 vs 15 | 7.5 |

At low concurrency zero-reward rollouts are the **longest** — hard tasks the agent worked at and failed. Above it the relation **inverts**: zeros become the **shortest** rollouts. Generated tokens per rollout fell 3.6x while call count fell only 1.7x, i.e. sessions are being cut, not merely slowed.

Across every run: zero LLM timeout errors, zero non-200 responses, `_ng_failure_class` unset on every rollout. Live sandboxes show OpenClaw's own watchdog firing instead:

```
stalled_agent_run activeWorkKind=model_call lastProg...
stalled session: sessionId=<task>
```

`activeWorkKind=model_call` — the session is aborted while waiting on the model.

### Before/after at the highest concurrency point

Same model, endpoint, config and pin; only this setting changed. The run was verified at the sandbox level to have the option applied, checked on every poll for its full duration:

| | mean | median | zero-reward | output tokens / rollout |
|---|---|---|---|---|
| default (~360s) | 0.3623 | 0.133 | 38.0% | 1794 |
| this option at 1500s | **0.4205** | **0.334** | **32.3%** | **2168** |

The median rises 2.5x and zeros fall by a sixth — sessions that were being cut now finish. It does not recover the whole concurrency gap, which is expected: the harness's own per-task budget becomes the next binding constraint.

## Change

`openclaw_stuck_session_abort_seconds` on the agent config; when set, the sandbox writes `diagnostics.stuckSessionAbortMs` (seconds x 1000) next to the existing timeout writes. **Default unset**, so runs that do not opt in keep OpenClaw's current behaviour.

This does not make anything faster — it converts silent truncation into honest slowness, so opted-in runs at high concurrency take longer and press against the per-task and job walltimes. Set it below the harness's own per-task budget or it has no effect.

## Tests

`tests/test_stuck_session_abort.py`, a separate module so the detect-secrets baseline line numbers in `test_app.py` do not shift.

Covers: unset sends nothing; a set value reaches the sandbox; it is independent of the provider timeout; and the sandbox wrapper writes it to the OpenClaw config in milliseconds.

30 passed.