### PR TITLE
docs: rewrite Configure Agents index and document external agent harnesses

### DIFF
--- a/fern/versions/latest/pages/about/ecosystem.mdx
+++ b/fern/versions/latest/pages/about/ecosystem.mdx
@@ -45,7 +45,7 @@ Use environments for SFT and RL training. If you're interested in integrating an
 
 Agent harnesses are available out of the box for evaluation and training. See [Integrate Existing Agents](/agent-server/integrate-existing-agents) for what each one does, how it is wrapped, and which ones support training.
 
-Coding CLIs, run as a subprocess with the CLI executing its own tools:
+Coding CLIs:
 
 - **[Claude Code](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/claude_code_agent)**
 - **[Codex](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/codex_agent)**
@@ -56,26 +56,26 @@ Coding CLIs, run as a subprocess with the CLI executing its own tools:
 
 Agent frameworks:
 
-- **[LangGraph](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/langgraph_agent)** - agent patterns built with LangGraph (reflection, orchestration, parallel thinking)
-- **[Hermes](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/hermes_agent)** - Nous Research Hermes Agent, usable for evaluation and training
-- **[Stirrup](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/stirrup_agent)** - Artificial Analysis agent loop, ships the GDPVal strategy
-- **[Aviary](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/aviary_agent)** - FutureHouse Aviary environments and datasets
-- **[Verifiers](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/verifiers_agent)** - Prime Intellect Verifiers environments
-- **[Harbor](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/harbor_agent)** - Harbor agents such as `terminus-2` in Harbor-managed environments
+- **[LangGraph](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/langgraph_agent)**
+- **[Hermes](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/hermes_agent)**
+- **[Stirrup](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/stirrup_agent)**
+- **[Aviary](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/aviary_agent)**
+- **[Verifiers](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/verifiers_agent)**
+- **[Harbor](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/harbor_agent)**
 
 Software engineering and benchmark harnesses:
 
-- **[OpenHands](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/swe_agents)** - software engineering agent harness
-- **[Mini SWE Agent](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/mini_swe_agent)** - software engineering agent harness
-- **[OSWorld](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/osworld_agent)** - desktop-computer tasks
-- **[ToolSandbox](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/toolsandbox_agent)** - Apple ToolSandbox multi-turn tool use with a user simulator
-- **[τ²-bench](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/tau2)** - τ²-bench, plus τ³ banking-knowledge configs
-- **[PinchBench](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/pinchbench)** - real-world tasks graded over OpenClaw
+- **[OpenHands](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/swe_agents)**
+- **[Mini SWE Agent](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/mini_swe_agent)**
+- **[OSWorld](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/osworld_agent)**
+- **[ToolSandbox](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/toolsandbox_agent)**
+- **[τ²-bench](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/tau2)**
+- **[PinchBench](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/pinchbench)**
 
 Agent-agnostic runners, which run another Gym agent server inside a benchmark's task container:
 
-- **[AnySWE](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/anyswe_agent)** - SWE-bench, SWE-bench Multilingual, and R2E-Gym
-- **[AnyTerminal](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/anyterminal_agent)** - Terminal-Bench
+- **[AnySWE](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/anyswe_agent)**
+- **[AnyTerminal](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/anyterminal_agent)**
 
 ## Related Products in the NVIDIA NeMo Ecosystem
 

--- a/fern/versions/latest/pages/about/ecosystem.mdx
+++ b/fern/versions/latest/pages/about/ecosystem.mdx
@@ -43,11 +43,39 @@ Use environments for SFT and RL training. If you're interested in integrating an
 
 ## Agent Harnesses
 
-Agent harnesses are available out of the box for evaluation and training — coding CLIs, agent frameworks, and benchmark-native harnesses. See [Integrate Existing Agents](/agent-server/integrate-existing-agents) for the full catalog and how each one is wrapped. Some examples:
+Agent harnesses are available out of the box for evaluation and training. See [Integrate Existing Agents](/agent-server/integrate-existing-agents) for what each one does, how it is wrapped, and which ones support training.
+
+Coding CLIs, run as a subprocess with the CLI executing its own tools:
+
+- **[Claude Code](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/claude_code_agent)**
+- **[Codex](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/codex_agent)**
+- **[OpenCode](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/opencode_agent)**
+- **[Kilo Code](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/kilocode_agent)**
+- **[OpenClaw](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/openclaw_agent)**
+- **[pi](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/pi_agent)**
+
+Agent frameworks:
+
+- **[LangGraph](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/langgraph_agent)** - agent patterns built with LangGraph (reflection, orchestration, parallel thinking)
+- **[Hermes](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/hermes_agent)** - Nous Research Hermes Agent, usable for evaluation and training
+- **[Stirrup](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/stirrup_agent)** - Artificial Analysis agent loop, ships the GDPVal strategy
+- **[Aviary](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/aviary_agent)** - FutureHouse Aviary environments and datasets
+- **[Verifiers](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/verifiers_agent)** - Prime Intellect Verifiers environments
+- **[Harbor](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/harbor_agent)** - Harbor agents such as `terminus-2` in Harbor-managed environments
+
+Software engineering and benchmark harnesses:
 
 - **[OpenHands](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/swe_agents)** - software engineering agent harness
 - **[Mini SWE Agent](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/mini_swe_agent)** - software engineering agent harness
-- **[LangGraph](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/langgraph_agent)** - agent patterns built with LangGraph (reflection, orchestration, parallel thinking)
+- **[OSWorld](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/osworld_agent)** - desktop-computer tasks
+- **[ToolSandbox](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/toolsandbox_agent)** - Apple ToolSandbox multi-turn tool use with a user simulator
+- **[τ²-bench](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/tau2)** - τ²-bench, plus τ³ banking-knowledge configs
+- **[PinchBench](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/pinchbench)** - real-world tasks graded over OpenClaw
+
+Agent-agnostic runners, which run another Gym agent server inside a benchmark's task container:
+
+- **[AnySWE](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/anyswe_agent)** - SWE-bench, SWE-bench Multilingual, and R2E-Gym
+- **[AnyTerminal](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/anyterminal_agent)** - Terminal-Bench
 
 ## Related Products in the NVIDIA NeMo Ecosystem
 

--- a/fern/versions/latest/pages/about/ecosystem.mdx
+++ b/fern/versions/latest/pages/about/ecosystem.mdx
@@ -54,7 +54,7 @@ Coding CLIs:
 - **[OpenClaw](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/openclaw_agent)**
 - **[pi](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/pi_agent)**
 
-Agent frameworks:
+External frameworks:
 
 - **[LangGraph](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/langgraph_agent)**
 - **[Hermes](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/hermes_agent)**

--- a/fern/versions/latest/pages/about/ecosystem.mdx
+++ b/fern/versions/latest/pages/about/ecosystem.mdx
@@ -5,7 +5,7 @@ position: 3
 ---
 NeMo Gym is one of several specialized libraries in the NVIDIA NeMo platform. Alongside NeMo RL for
 post-training, NeMo Gym focuses on the *environments* agents act in — pairing a dataset, agent harness, and
-verifier so the same environment can drive both evaluation and training.
+verifier so the same environment can be used for both evaluation and training.
 
 <Tip>
 For what NeMo Gym does and when to use it, see the [Overview](/about) and [What NeMo Gym Provides](/about#what-nemo-gym-provides). For how environments are implemented as composable servers, see [Architecture](/about/architecture).

--- a/fern/versions/latest/pages/about/ecosystem.mdx
+++ b/fern/versions/latest/pages/about/ecosystem.mdx
@@ -43,7 +43,7 @@ Use environments for SFT and RL training. If you're interested in integrating an
 
 ## Agent Harnesses
 
-Agent harnesses are available out of the box for evaluation and training. Some examples:
+Agent harnesses are available out of the box for evaluation and training — coding CLIs, agent frameworks, and benchmark-native harnesses. See [Integrate Existing Agents](/agent-server/integrate-existing-agents) for the full catalog and how each one is wrapped. Some examples:
 
 - **[OpenHands](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/swe_agents)** - software engineering agent harness
 - **[Mini SWE Agent](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/mini_swe_agent)** - software engineering agent harness

--- a/fern/versions/latest/pages/about/ecosystem.mdx
+++ b/fern/versions/latest/pages/about/ecosystem.mdx
@@ -43,39 +43,7 @@ Use environments for SFT and RL training. If you're interested in integrating an
 
 ## Agent Harnesses
 
-Agent harnesses are available out of the box for evaluation and training. See [Integrate Existing Agents](/agent-server/integrate-existing-agents) for what each one does, how it is wrapped, and which ones support training.
-
-Coding CLIs:
-
-- **[Claude Code](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/claude_code_agent)**
-- **[Codex](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/codex_agent)**
-- **[OpenCode](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/opencode_agent)**
-- **[Kilo Code](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/kilocode_agent)**
-- **[OpenClaw](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/openclaw_agent)**
-- **[pi](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/pi_agent)**
-
-External frameworks:
-
-- **[LangGraph](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/langgraph_agent)**
-- **[Hermes](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/hermes_agent)**
-- **[Stirrup](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/stirrup_agent)**
-- **[Aviary](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/aviary_agent)**
-- **[Verifiers](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/verifiers_agent)**
-- **[Harbor](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/harbor_agent)**
-
-Software engineering and benchmark harnesses:
-
-- **[OpenHands](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/swe_agents)**
-- **[Mini SWE Agent](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/mini_swe_agent)**
-- **[OSWorld](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/osworld_agent)**
-- **[ToolSandbox](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/toolsandbox_agent)**
-- **[τ²-bench](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/tau2)**
-- **[PinchBench](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/pinchbench)**
-
-Agent-agnostic runners, which run another Gym agent server inside a benchmark's task container:
-
-- **[AnySWE](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/anyswe_agent)**
-- **[AnyTerminal](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/anyterminal_agent)**
+NeMo Gym includes agent harnesses for general tool use, coding, browser and desktop interaction, and benchmark-specific workflows. See [Integrate Existing Agents](/agent-server/integrate-existing-agents) to compare the supported harnesses, choose one, and configure it.
 
 ## Related Products in the NVIDIA NeMo Ecosystem
 

--- a/fern/versions/latest/pages/agent-server/index.mdx
+++ b/fern/versions/latest/pages/agent-server/index.mdx
@@ -55,7 +55,7 @@ class Agent:
         return conversation
 ```
 
-In an Agent server built on an external harness, the harness supplies the interaction loop with the policy model. The episode orchestration is unchanged: NeMo Gym seeds the session, verifies the finished trajectory, and reports the reward.
+In an Agent server built on an external harness, the harness supplies the interaction loop with the policy model. The three phases around it are the same: initialize the episode, produce a trajectory, score it.
 
 ## Choosing an Agent Server to Implement Your Agent
 

--- a/fern/versions/latest/pages/agent-server/index.mdx
+++ b/fern/versions/latest/pages/agent-server/index.mdx
@@ -1,9 +1,20 @@
 ---
 title: "Configure Agents"
-description: ""
+description: "The Agent server holds an environment's agent harness. Use a built-in agent, an agent that wraps an external harness, or your own."
 position: 1
 ---
-The Agent server is the central component of environment design. It defines whether a rollout is single-step or multi-step, single-turn or multi-turn, and orchestrates all interaction logic — calling the model, executing tool calls through resources, and collecting the final reward. The Agent server does not run an LLM itself, it is orchestration code that delegates all text generation to the Model server.
+
+An environment is made of four parts: a dataset, an agent harness, a verifier, and per-task state. The Agent server is where the harness lives.
+
+A harness decides how a model interacts with the world: how many turns it gets, what its system prompt says, which tools it can reach, how tool results are fed back, when it stops, and what scaffolding (planning, compaction, sub-agents) sits between the model and the task. The Agent server does not run an LLM itself. It is orchestration code that delegates text generation to the Model server and tool execution, state, and scoring to the Resources server.
+
+## Why the Harness Is Its Own Server
+
+Because the harness is a separate server rather than part of the dataset or the verifier, it can be changed independently of the rest of the environment:
+
+- Run several harnesses against one environment, with the dataset and verifier held fixed.
+- Run one harness across many environments. The Agent server references a Resources server by name, so switching benchmarks is a config change.
+- Use the same environment for evaluation and training. A harness that reports token IDs and log probabilities produces rollouts a training framework can consume, and nothing else about the environment changes.
 
 ## Rollout Lifecycle
 
@@ -44,12 +55,28 @@ class Agent:
         return conversation
 ```
 
-## Existing Agents
+An agent that wraps an external harness replaces the middle phase with the harness's own loop. The outer shape is the same: NeMo Gym seeds the session, verifies the finished trajectory, and reports the reward.
 
-See [Integrate Existing Agents](/agent-server/integrate-existing-agents) to use a built-in NeMo Gym agent, wrap an external agent harness, or decide when tool logic belongs in the Agent server versus the Resources server.
+## Choosing an Agent
 
-## Server Configuration
-<Note>
-[Agent Server Fields](/reference/configuration#agent-server-fields) for server configuration syntax and fields.
+There are three options. Use a built-in NeMo Gym agent — `simple_agent` handles multi-step tool calling against any Resources server. Use one of the agents that wraps an external harness, such as a coding CLI, an agent framework, or a benchmark's own scaffold; these need configuration but no code. Or keep your agent in your own repo and expose an endpoint that follows the OpenAI Responses contract, and let `remote_agent` drive the loop against it.
 
-</Note>
+<Cards>
+
+<Card title="Integrate Existing Agents" href="/agent-server/integrate-existing-agents">
+Built-in and external agents, how each external harness is wrapped, and what a wrapper needs to support training.
+</Card>
+
+<Card title="Drive a Remote Agent" href="/agent-server/remote-agent">
+The `remote_agent` contract, an end-to-end quickstart, configuration fields, and failure handling.
+</Card>
+
+<Card title="Agent Skills" href="/agent-server/agent-skills">
+Set [Agent Skills](https://agentskills.io/specification) per run, separately from the dataset.
+</Card>
+
+<Card title="Agent Server Fields" href="/reference/configuration#agent-server-fields">
+Configuration syntax for wiring an agent to its Resources server and Model server.
+</Card>
+
+</Cards>

--- a/fern/versions/latest/pages/agent-server/index.mdx
+++ b/fern/versions/latest/pages/agent-server/index.mdx
@@ -8,13 +8,7 @@ An environment integrates four independent components: a dataset, an agent harne
 
 A harness controls how the model interacts with the environment: the number of turns, the system prompt, which tools are available, how tool results are fed back, the stopping condition, and any scaffolding such as planning, compaction, or sub-agents. The Agent server does not run an LLM itself. It is orchestration code that delegates text generation to the Model server and tool execution, state, and scoring to the Resources server.
 
-## Why the Harness Is Its Own Server
-
-Because the harness is a separate server rather than part of the dataset or the verifier, it can be changed independently of the rest of the environment:
-
-- Run several harnesses in one environment, with the dataset and verifier held fixed.
-- Run one harness in many environments. The Agent server is linked to the Resources server by name, so switching benchmarks is a config change.
-- Use the same environment for evaluation and training. A harness that reports token IDs and log probabilities produces rollouts a training framework can consume, and nothing else about the environment changes.
+An Agent server references a Resources server and a Model server by name, so which harness an environment runs is a config change. See [Agent Server Fields](/reference/configuration#agent-server-fields) for the syntax.
 
 ## Rollout Lifecycle
 

--- a/fern/versions/latest/pages/agent-server/index.mdx
+++ b/fern/versions/latest/pages/agent-server/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Configure Agents"
-description: "The Agent server holds an environment's agent harness. Use a built-in agent, an agent that wraps an external harness, or your own."
+description: "The Agent server holds the agent harness. Use an agent server NeMo Gym ships, whether its implementation is Gym-native or a third-party harness, or drive an agent you host yourself."
 position: 1
 ---
 
-An environment is made of four parts: a dataset, an agent harness, a verifier, and per-task state. The Agent server is where the harness lives.
+An environment integrates four independent components: a dataset, an agent harness, a verifier, and per-task state. The Agent server is where the harness lives.
 
 A harness decides how a model interacts with the world: how many turns it gets, what its system prompt says, which tools it can reach, how tool results are fed back, when it stops, and what scaffolding (planning, compaction, sub-agents) sits between the model and the task. The Agent server does not run an LLM itself. It is orchestration code that delegates text generation to the Model server and tool execution, state, and scoring to the Resources server.
 
@@ -12,8 +12,8 @@ A harness decides how a model interacts with the world: how many turns it gets, 
 
 Because the harness is a separate server rather than part of the dataset or the verifier, it can be changed independently of the rest of the environment:
 
-- Run several harnesses against one environment, with the dataset and verifier held fixed.
-- Run one harness across many environments. The Agent server references a Resources server by name, so switching benchmarks is a config change.
+- Run several harnesses in one environment, with the dataset and verifier held fixed.
+- Run one harness in many environments. The Agent server is linked to the Resources server by name, so switching benchmarks is a config change.
 - Use the same environment for evaluation and training. A harness that reports token IDs and log probabilities produces rollouts a training framework can consume, and nothing else about the environment changes.
 
 ## Rollout Lifecycle
@@ -55,16 +55,18 @@ class Agent:
         return conversation
 ```
 
-An agent that wraps an external harness replaces the middle phase with the harness's own loop. The outer shape is the same: NeMo Gym seeds the session, verifies the finished trajectory, and reports the reward.
+An Agent server built on an external harness replaces the inner interaction loop with the policy model, which the harness supplies. The episode orchestration is unchanged: NeMo Gym seeds the session, verifies the finished trajectory, and reports the reward.
 
-## Choosing an Agent
+## Choosing an Agent Server to Implement Your Agent
 
-There are three options. Use a built-in NeMo Gym agent — `simple_agent` handles multi-step tool calling against any Resources server. Use one of the agents that wraps an external harness, such as a coding CLI, an agent framework, or a benchmark's own scaffold; these need configuration but no code. Or keep your agent in your own repo and expose an endpoint that follows the OpenAI Responses contract, and let `remote_agent` drive the loop against it.
+There are three options, and what separates the first two is who implements the agent, not where the code lives — both ship in the NeMo Gym repo.
+
+Use an agent server with a Gym-native implementation: `simple_agent` handles multi-step tool calling in any environment. Use an agent server that runs a third-party harness — a coding CLI, an agent framework, or a benchmark's own scaffold — where the harness owns the loop and the agent server adapts its output to NeMo Gym. Either way you write configuration, not code. The third option is `remote_agent`: keep the agent in your own repo, expose an endpoint that follows the OpenAI Responses contract, and let NeMo Gym drive the loop against that endpoint.
 
 <Cards>
 
 <Card title="Integrate Existing Agents" href="/agent-server/integrate-existing-agents">
-Built-in and external agents, how each external harness is wrapped, and what a wrapper needs to support training.
+The agent servers NeMo Gym ships, how each third-party harness is wrapped, and what a wrapper needs to support training.
 </Card>
 
 <Card title="Drive a Remote Agent" href="/agent-server/remote-agent">
@@ -76,7 +78,7 @@ Set [Agent Skills](https://agentskills.io/specification) per run, separately fro
 </Card>
 
 <Card title="Agent Server Fields" href="/reference/configuration#agent-server-fields">
-Configuration syntax for wiring an agent to its Resources server and Model server.
+Configuration syntax for wiring an agent server to a compatible Resources server and Model server.
 </Card>
 
 </Cards>

--- a/fern/versions/latest/pages/agent-server/index.mdx
+++ b/fern/versions/latest/pages/agent-server/index.mdx
@@ -6,7 +6,7 @@ position: 1
 
 An environment integrates four independent components: a dataset, an agent harness, a verifier, and per-task state. The Agent server is where the harness lives.
 
-A harness decides how a model interacts with the world: how many turns it gets, what its system prompt says, which tools it can reach, how tool results are fed back, when it stops, and what scaffolding (planning, compaction, sub-agents) sits between the model and the task. The Agent server does not run an LLM itself. It is orchestration code that delegates text generation to the Model server and tool execution, state, and scoring to the Resources server.
+A harness controls how the model interacts with the environment: the number of turns, the system prompt, which tools are available, how tool results are fed back, the stopping condition, and any scaffolding such as planning, compaction, or sub-agents. The Agent server does not run an LLM itself. It is orchestration code that delegates text generation to the Model server and tool execution, state, and scoring to the Resources server.
 
 ## Why the Harness Is Its Own Server
 
@@ -55,13 +55,13 @@ class Agent:
         return conversation
 ```
 
-An Agent server built on an external harness replaces the inner interaction loop with the policy model, which the harness supplies. The episode orchestration is unchanged: NeMo Gym seeds the session, verifies the finished trajectory, and reports the reward.
+In an Agent server built on an external harness, the harness supplies the interaction loop with the policy model. The episode orchestration is unchanged: NeMo Gym seeds the session, verifies the finished trajectory, and reports the reward.
 
 ## Choosing an Agent Server to Implement Your Agent
 
-There are three options, and what separates the first two is who implements the agent, not where the code lives — both ship in the NeMo Gym repo.
+There are three options. The first two differ by who implements the agent, not by where the code lives — both ship in the NeMo Gym repo.
 
-Use an agent server with a Gym-native implementation: `simple_agent` handles multi-step tool calling in any environment. Use an agent server that runs a third-party harness — a coding CLI, an agent framework, or a benchmark's own scaffold — where the harness owns the loop and the agent server adapts its output to NeMo Gym. Either way you write configuration, not code. The third option is `remote_agent`: keep the agent in your own repo, expose an endpoint that follows the OpenAI Responses contract, and let NeMo Gym drive the loop against that endpoint.
+Use an agent server with a Gym-native implementation, such as `simple_agent` for multi-step tool calling. Use an agent server that runs a third-party harness — a coding CLI, an agent framework, or a benchmark's own scaffold — where the harness owns the loop and the agent server translates its output. Both take configuration, not code. Third, use `remote_agent`: keep the agent in your own repo, expose an endpoint that follows the OpenAI Responses contract, and NeMo Gym drives the loop against that endpoint.
 
 <Cards>
 

--- a/fern/versions/latest/pages/agent-server/index.mdx
+++ b/fern/versions/latest/pages/agent-server/index.mdx
@@ -57,6 +57,8 @@ There are three options. The first two differ by who implements the agent, not b
 
 Use an agent server with a Gym-native implementation, such as `simple_agent` for multi-step tool calling. Use an agent server that runs a third-party harness — a coding CLI, an agent framework, or a benchmark's own scaffold — where the harness owns the loop and the agent server translates its output. Both take configuration, not code. Third, use `remote_agent`: keep the agent in your own repo, expose an endpoint that follows the OpenAI Responses contract, and NeMo Gym drives the loop against that endpoint.
 
+Run `gym list agents` to list the available harnesses and their configuration variants. Run `gym list agents <name>` to inspect one harness, then use `--agent-type <name>` to compose a compatible environment with it.
+
 <Cards>
 
 <Card title="Integrate Existing Agents" href="/agent-server/integrate-existing-agents">

--- a/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
+++ b/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
@@ -1,35 +1,37 @@
 ---
 title: "Integrate Existing Agents"
-description: "Built-in NeMo Gym agents, and the agents that run external harnesses — coding CLIs, agent frameworks, and benchmark scaffolds — against NeMo Gym environments."
+description: "The agent servers NeMo Gym ships — Gym-native implementations, and wrappers around third-party harnesses such as coding CLIs, agent frameworks, and benchmark scaffolds — and how to run them in NeMo Gym environments."
 position: 2
 ---
 
-NeMo Gym ships general-purpose agents that work with any Resources server, and agents that wrap external harnesses so a third-party agent can run against NeMo Gym benchmarks with configuration only. If neither fits, you can keep your agent in your own repo and [drive it remotely](/agent-server/remote-agent).
+All the agent servers below ship in the NeMo Gym repo. They divide by who implements the agent: some are NeMo Gym code, others hand the work to a third-party harness and adapt the result. If neither fits, you can keep your agent in your own repo and [drive it remotely](/agent-server/remote-agent).
 
-## Built-in NeMo Gym Agents
+These are the general-purpose agent servers — ones you can point at more than one environment. `responses_api_agents/` also holds benchmark-specific agent servers whose control flow is coupled to a single benchmark; those are documented with the benchmark rather than here.
 
-These are native agents with no external dependency. They call the Model server, route tool calls to the Resources server, and verify the result.
+## Agent Servers with a Gym-Native Implementation
 
-| Agent | Use it when |
+These are NeMo Gym code, with no external dependency. They call the Model server, route tool calls to the Resources server, and call the Resources server's `/verify` to score the trajectory.
+
+| Agent Server | Use it when |
 |---|---|
 | [`simple_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/simple_agent) | You want general-purpose multi-step tool calling with a configurable step budget. Works with any Resources server, and is the usual starting point. |
 | [`non_executing_simple_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/non_executing_simple_agent) | The tool call itself is the answer. Forwards one request to the model and passes the response to the verifier without executing anything. |
 | [`tool_simulation_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/tool_simulation_agent) | Tool results should be simulated rather than really executed. |
-| [`gymnasium_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/gymnasium_agent) | Your environment is a `GymnasiumServer` Resources server and the agent should drive its reset/step loop. |
+| [`gymnasium_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/gymnasium_agent) | Your environment is a `GymnasiumServer` Resources server and you need a compatible Agent server to drive its reset/step loop. |
 
-## External Agent Harnesses
+## Agent Servers That Run a Third-Party Harness
 
-Each of these runs a third-party harness as a NeMo Gym agent server. The harness keeps its own loop, prompts, and tools; NeMo Gym seeds the session, translates the resulting trajectory into Responses API format, and verifies it against the Resources server.
+Each of these hands the loop to an external harness. The harness keeps its own prompts and tools; NeMo Gym seeds the session, translates the resulting trajectory into Responses API format, and verifies it against the Resources server.
 
-Because verification stays on the NeMo Gym side, a harness that brings its own tools can often run an existing benchmark by adding a `<benchmark>_<agent>` config, leaving the dataset and verifier unchanged — only the Resources server's task data and `/verify` are used. This is how `hermes_agent` is used with the math, coding, reasoning_gym, MCQA, and instruction-following benchmarks. It does not hold for every harness: agents such as `swe_agents`, `osworld_agent`, and `tau2` are tied to specific benchmarks.
+Because verification stays on the NeMo Gym side, an agent harness that brings its own tools can often run in an existing environment by adding a `<benchmark>_<agent>` config, leaving the dataset and verifier unchanged — only the Resources server's task data and `/verify` are used. This is how `hermes_agent` is used with the math, coding, reasoning_gym, MCQA, and instruction-following benchmarks. It does not hold for every harness: agent servers such as `swe_agents`, `osworld_agent`, and `tau2` are tied to specific benchmarks.
 
 ### Coding CLIs
 
-Agents that shell out to a coding CLI. The CLI runs its own tools internally and its output stream is parsed back into NeMo Gym format.
+Agent servers that shell out to a coding CLI. The CLI runs its own tools internally and its output stream is parsed back into NeMo Gym format.
 
-| Agent | Harness | Notes |
+| Agent Server | Harness | Notes |
 |---|---|---|
-| [`claude_code_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/claude_code_agent) | Claude Code (`claude -p`) | Runs against Anthropic, or against any NeMo Gym Model server via its `POST /v1/messages` endpoint. Reference implementation for [Agent Skills](/agent-server/agent-skills). |
+| [`claude_code_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/claude_code_agent) | Claude Code (`claude -p`) | Runs against Anthropic, or against any NeMo Gym Model server, since every one serves [Anthropic Messages](/model-server/anthropic-messages) on `POST /v1/messages`. Reference implementation for [Agent Skills](/agent-server/agent-skills). |
 | [`codex_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/codex_agent) | OpenAI Codex CLI (`codex exec`) | Runs against OpenAI, or against any NeMo Gym Model server, which serves the streaming Responses dialect Codex speaks. Also supports Agent Skills. |
 | [`opencode_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/opencode_agent) | OpenCode (`opencode run`) | Reads the run's SQLite session to recover the full trajectory including tool calls. |
 | [`kilocode_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/kilocode_agent) | Kilo Code (`kilo run`) | A fork of OpenCode; mirrors `opencode_agent` but parses the CLI's JSON event stream. |
@@ -37,27 +39,27 @@ Agents that shell out to a coding CLI. The CLI runs its own tools internally and
 | [`pi_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/pi_agent) | pi (`pi --print --mode json`) | |
 
 <Note>
-Every agent in this table is evaluation-only today: token IDs and log probabilities are not threaded through, so the rollouts are not trainable. All of them except `kilocode_agent` accept an optional `model_server` ref that routes generation through NeMo Gym, which makes the model calls capturable and lets one config run against different backends. `kilocode_agent` takes a provider base URL directly. See [Evaluation-only vs training-grade](#evaluation-only-vs-training-grade).
+Every agent server in this table is evaluation-only today: token IDs and log probabilities are not threaded through, so the rollouts are not trainable. All of them accept an optional `model_server` ref that routes generation through NeMo Gym, which makes the model calls capturable and lets one config run against different backends; a configured model server takes precedence over a direct provider URL. See [Evaluation-only vs training-grade](#evaluation-only-vs-training-grade).
 </Note>
 
-### Agent Frameworks
+### External Frameworks
 
-Python agent frameworks embedded in the agent server process.
+Python agent and environment frameworks embedded in the Agent server process.
 
-| Agent | Framework | Notes |
+| Agent Server | Framework | Notes |
 |---|---|---|
 | [`langgraph_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/langgraph_agent) | [LangGraph](https://github.com/langchain-ai/langgraph) | Ships reflection, sub-agent orchestrator, parallel-thinking, and ReWOO examples. Patterns that produce non-monotonic trajectories (such as parallel thinking) work for evaluation but not for default NeMo RL training. |
 | [`hermes_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/hermes_agent) | [hermes-agent](https://github.com/NousResearch/hermes-agent) (Nous Research) | Training-capable. Pinned to a fork with token-ID tracking, chat-template, and sampling-parameter patches. Brings its own toolset, so only the Resources server's task data and `verify` are used. |
 | [`aviary_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/aviary_agent) | [Aviary](https://github.com/Future-House/aviary) (FutureHouse) | Pairs with the `resources_servers/aviary` environments and datasets. |
 | [`verifiers_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/verifiers_agent) | [Verifiers](https://github.com/PrimeIntellect-ai/verifiers) (Prime Intellect) | Runs environments from Prime Intellect's Environments Hub. Token-ID support is upstreamed into the framework's `NeMoRLChatCompletionsClient`. |
-| [`harbor_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/harbor_agent) | [Harbor](https://github.com/laude-institute/harbor) (Laude Institute) | Runs Harbor agents such as `terminus-2` in Harbor-managed environments, with a Singularity environment for HPC training. |
+| [`harbor_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/harbor_agent) | [Harbor](https://github.com/laude-institute/harbor) (Laude Institute) | Runs Harbor agents such as `terminus-2` in Harbor-managed environments. Trials can execute in a Singularity environment for HPC training, or in any NeMo Gym sandbox provider, selected by config. |
 | [`stirrup_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/stirrup_agent) | [Stirrup](https://github.com/ArtificialAnalysis/Stirrup) (Artificial Analysis) | Ships the GDPVal strategy; new benchmarks can be added in a single file. |
 
 ### Benchmark-Native Harnesses
 
 Benchmarks that come with their own agent scaffold, wired in at the agent-server level.
 
-| Agent | Harness | Benchmarks |
+| Agent Server | Harness | Benchmarks |
 |---|---|---|
 | [`swe_agents`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/swe_agents) | [nv-OpenHands](https://github.com/sdevare-nv/nv-OpenHands) (default) or [opencode](https://opencode.ai), in Apptainer containers | SWE-bench and friends. Runs the agent and the evaluation harness in separate containers, returning a binary "resolved" reward suitable for evaluation and RL. |
 | [`mini_swe_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/mini_swe_agent) | [mini-swe-agent](https://github.com/SWE-agent/mini-swe-agent) in Docker | SWE-bench |
@@ -69,23 +71,108 @@ Benchmarks that come with their own agent scaffold, wired in at the agent-server
 
 ### Agent-Agnostic Task Runners
 
-These are not harnesses. They take another NeMo Gym agent, run it inside a benchmark's task container, and grade what it leaves behind.
+These are not harnesses. They wire together another NeMo Gym Agent server, run it inside a benchmark's task container, and grade what it leaves behind.
 
-| Agent | What it does |
+| Agent Server | What it does |
 |---|---|
 | [`anyswe_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/anyswe_agent) | Runs your agent inside a SWE task image, extracts the repository patch, and grades it in a fresh sandbox. Supports SWE-bench, SWE-bench Multilingual, and R2E-Gym. |
 | [`anyterminal_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/anyterminal_agent) | Runs your agent inside a Terminal-Bench task container, then runs the task's `tests/test.sh` in that same container. |
 
-Alongside these, `responses_api_agents/` also holds benchmark-specific custom agents (for example SciCode's per-sub-step loop and CritPt's two-turn solve-then-fill-template flow). Browse the [directory](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents) for the full set; each has a README with its own quickstart.
+Alongside these, `responses_api_agents/` also holds benchmark-specific custom Agent servers (for example SciCode's per-sub-step loop and CritPt's two-turn solve-then-fill-template flow). Browse the [directory](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents) for the full set; each has a README with its own quickstart.
+
+## Choose an Agent Server
+
+Start with the simplest one that provides the interaction pattern your environment needs.
+
+- Plain tool calling, or no tools at all: `simple_agent`. Use `non_executing_simple_agent` only when the model's tool call is the final answer and must not be executed.
+- A `reset`/`step` environment: `gymnasium_agent`.
+- Tool results produced by simulation rather than real execution: `tool_simulation_agent`.
+- SWE-bench-style coding: `swe_agents` for OpenHands or opencode, `mini_swe_agent_2` for mini-swe-agent on the provider-neutral sandbox API, or `anyswe_agent` to run several different Gym agent servers through one execution and grading path. `mini_swe_agent` remains for the older Docker workflow.
+- Terminal-Bench tasks: `anyterminal_agent`, which puts the agent and the task's tests in the same container.
+- Agentic coding through an external CLI: `claude_code_agent`, `codex_agent`, `kilocode_agent`, `opencode_agent`, `openclaw_agent`, or `pi_agent`. All are evaluation-only today — check the README before planning to train on their rollouts.
+- Multi-step tool use you intend to train on: `hermes_agent`, which is pinned to a fork carrying the token-ID and sampling-parameter patches training needs.
+- LangGraph research patterns: `langgraph_agent`. Graphs that produce non-monotonic trajectories, such as parallel thinking, work for evaluation but need extra handling before NeMo RL training.
+- Environments from an external library: `aviary_agent` for FutureHouse Aviary, `verifiers_agent` for Prime Intellect Verifiers.
+- An agent you host yourself: `remote_agent`, if your service can implement the OpenAI `/v1/responses` contract.
+
+<Tip>
+For a new environment, start with `simple_agent` unless the environment protocol or an external harness requires one of the specialized adapters. It keeps the model, tools, and verifier easy to isolate while you get the task working.
+</Tip>
+
+## Configure and Run
+
+Configuration is composed from named server blocks. Agent servers do not all expose the same fields, so read the agent server's README and config files alongside the common patterns below.
+
+An agent server names its Resources server and Model server by type and ID:
+
+```yaml
+my_agent:
+  responses_api_agents:
+    simple_agent:
+      entrypoint: app.py
+      resources_server:
+        type: resources_servers
+        name: my_resources
+      model_server:
+        type: responses_api_models
+        name: policy_model
+```
+
+The `model_server` reference points at the top-level `policy_model` block selected by `--model-type` or supplied in a config file, so the same agent config runs against vLLM, OpenAI, or another backend without naming a network address. Some of the CLI-backed agent servers also accept a provider URL directly; the README says which takes precedence. See [Agent Server Fields](/reference/configuration#agent-server-fields) for the full syntax.
+
+Sandbox-backed agent servers name a provider and give a per-task `sandbox_spec`. `mini_swe_agent_2` requires `sandbox_provider` and fails at startup without it:
+
+```yaml
+mini_swe_agent_2:
+  responses_api_agents:
+    mini_swe_agent_2:
+      entrypoint: app.py
+      env: sandbox
+      sandbox_provider: sandbox
+      sandbox_spec:
+        ttl_s: 18000
+        resources:
+          cpu: 2
+          memory_mib: 8192
+          disk_gib: 30
+```
+
+The provider's own config lives in a separate file that defines the named `sandbox` block, so switching between OpenSandbox, Docker, and Apptainer means passing a different `--config` rather than editing the agent. See [Sandbox](/infrastructure/sandbox) for provider setup and `SandboxSpec` fields.
+
+An external RL trainer that routes each episode through its own recording proxy can override the policy endpoint per rollout. `mini_swe_agent` and `mini_swe_agent_2` accept optional `policy_base_url` and `policy_api_key` fields on the `/run` request:
+
+```json
+{
+  "responses_create_params": {"input": [{"role": "user", "content": "Fix the failing test."}]},
+  "policy_base_url": "http://trainer-proxy:8000/v1",
+  "policy_api_key": "EMPTY"
+}
+```
+
+When set, they take precedence over the configured `model_server` for that rollout; when absent, the configured model server is used. This is not a general Agent server field — only those two agent servers read it, and the others silently ignore it because their run-request models allow extra keys. Check the agent server's request model before relying on it.
+
+Skills are a run-level input, set with `+skills.path` on `gym eval run`. NeMo Gym records and forwards a `skills_ref`, but the agent server still has to stage the files where its runtime looks for them — `claude_code_agent` and `codex_agent` are the two with native adapters today. Rollout collection accepting `skills.path` does not by itself mean the agent server loads the skills. See [Agent Skills](/agent-server/agent-skills).
+
+To run, start the composed servers and then collect rollouts against the top-level agent server name:
+
+```bash
+gym env start --config path/to/agent-and-resources.yaml --model-type vllm_model
+```
+
+```bash
+gym eval run --no-serve --agent my_agent --input data/tasks.jsonl --output results/rollouts.jsonl
+```
+
+`gym env validate` checks the same configuration without starting Ray or any servers, which is worth doing before a long run.
 
 ## How an External Harness Is Wrapped
 
 The wrappers vary in size — the container-based ones do considerably more setup than the CLI ones — but they share four responsibilities. The `swe_agents` opencode integration states the underlying rule as "swap the transport, keep the loop": leave the harness's prompts, tools, and control flow alone, and change only where it gets tokens from and where its trajectory goes.
 
-1. Run the harness, inside the agent server's `run()`. A subprocess for a CLI, an in-process import for a Python framework, a container for a sandboxed benchmark.
+1. Run the harness from the Agent server's `responses()`. A subprocess for a CLI, an in-process import for a Python framework, a container for a sandboxed benchmark. `run()` stays the episode orchestrator — it seeds the session, calls `responses()`, and verifies — so the harness is confined to the one method that produces a trajectory.
 2. Point it at a NeMo Gym Model server by setting whatever base URL the harness uses. Model servers accept `POST /v1/responses` (including the streaming form Codex uses), `POST /v1/chat/completions`, and `POST /v1/messages` for Anthropic-style clients, so most harnesses need no change on this step. Going through the Model server is what lets one harness run against vLLM, OpenAI, or an inference provider, and it is required for training.
 3. Translate the harness's output into Responses API items. The source varies — a JSON event stream, a SQLite session, per-turn files on disk — so this is the per-harness part of the code and usually the bulk of the wrapper.
-4. Send the finished trajectory to the Resources server's `/verify` and return the reward. Harnesses that bring their own tools use only the Resources server's task data and verifier; harnesses that accept externally supplied tools can also route tool calls to it.
+4. From `run()`, send the finished trajectory to the Resources server's `/verify` and return the reward. Harnesses that bring their own tools use only the Resources server's task data and verifier; harnesses that accept externally supplied tools can also route tool calls to it.
 
 ## Evaluation-Only vs Training-Grade
 

--- a/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
+++ b/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
@@ -52,7 +52,7 @@ Python agent and environment frameworks that the Agent server imports and drives
 | [`hermes_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/hermes_agent) | [hermes-agent](https://github.com/NousResearch/hermes-agent) (Nous Research) | Training-capable. Pinned to a fork with token-ID tracking, chat-template, and sampling-parameter patches. Brings its own toolset, so only the Resources server's task data and `verify` are used. |
 | [`aviary_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/aviary_agent) | [Aviary](https://github.com/Future-House/aviary) (FutureHouse) | Pairs with the `resources_servers/aviary` environments and datasets. |
 | [`verifiers_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/verifiers_agent) | [Verifiers](https://github.com/PrimeIntellect-ai/verifiers) (Prime Intellect) | Runs environments from Prime Intellect's Environments Hub. Token-ID support is upstreamed into the framework's `NeMoRLChatCompletionsClient`. |
-| [`harbor_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/harbor_agent) | [Harbor](https://github.com/laude-institute/harbor) (Laude Institute) | Runs Harbor agents such as `terminus-2` in Harbor-managed environments. Trials can execute in a Singularity environment for HPC training, or in any NeMo Gym sandbox provider, selected by config. |
+| [`harbor_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/harbor_agent) | [Harbor](https://github.com/laude-institute/harbor) (Laude Institute) | Runs a Harbor agent such as `terminus-2` in a Harbor-managed environment. Trials can execute in a Singularity environment for HPC training, or in any NeMo Gym sandbox provider, selected by config. |
 | [`stirrup_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/stirrup_agent) | [Stirrup](https://github.com/ArtificialAnalysis/Stirrup) (Artificial Analysis) | Ships the GDPVal strategy; new benchmarks can be added in a single file. |
 
 ### Benchmark-Native Harnesses
@@ -87,7 +87,7 @@ Match the agent server to the interaction pattern the environment needs.
 - Tool calling, or no tools: `simple_agent`.
 - One model call with no tool execution: `non_executing_simple_agent`, or `tool_simulation_agent` if the dataset supplies simulated tool results. The two behave almost identically, so follow whichever the environment's existing configs use.
 - A `reset`/`step` environment: `gymnasium_agent`.
-- SWE-bench-style coding: `swe_agents` for OpenHands or opencode, `mini_swe_agent_2` for mini-swe-agent on the sandbox API, or `anyswe_agent` to run several Gym agent servers through one execution and grading path. `mini_swe_agent` uses the older Docker workflow.
+- SWE-bench-style coding: `swe_agents` for OpenHands or opencode, `mini_swe_agent_2` for mini-swe-agent on the sandbox API, or `anyswe_agent` to put a choice of Gym agent server behind one execution and grading path, one per rollout. `mini_swe_agent` uses the older Docker workflow.
 - Terminal-Bench tasks: `anyterminal_agent`, which runs the agent and the task's tests in the same container.
 - Coding through an external CLI: `claude_code_agent`, `codex_agent`, `kilocode_agent`, `opencode_agent`, `openclaw_agent`, or `pi_agent`. All are evaluation-only; check the README before training on their rollouts.
 - Multi-step tool use for training: `hermes_agent`, pinned to a fork with the token-ID and sampling-parameter patches training requires.

--- a/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
+++ b/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
@@ -1,18 +1,112 @@
 ---
 title: "Integrate Existing Agents"
-description: "Use built-in NeMo Gym agents or wrap external agent harnesses."
+description: "Built-in NeMo Gym agents, and the agents that run external harnesses — coding CLIs, agent frameworks, and benchmark scaffolds — against NeMo Gym environments."
 position: 2
 ---
 
-You can use an existing agent in NeMo Gym, integrate an external one, or build your own from scratch.
+NeMo Gym ships general-purpose agents that work with any Resources server, and agents that wrap external harnesses so a third-party agent can run against NeMo Gym benchmarks with configuration only. If neither fits, you can keep your agent in your own repo and [drive it remotely](/agent-server/remote-agent).
 
-[`SimpleAgent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/simple_agent) is a native NeMo Gym agent that handles general-purpose multi-step tool calling with configurable max steps, and works with any Resources server out of the box. NeMo Gym also includes agents that integrate external tools: for example, [`MiniSWEAgent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/mini_swe_agent) wraps an external coding harness running in Docker containers and converts its output back into the NeMo Gym format, and [`claude_code_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/claude_code_agent) runs the Claude Code CLI. Because every Gym model server speaks Anthropic Messages, you can point Claude Code at any backend — see [Anthropic Messages](/model-server/anthropic-messages).
+## Built-in NeMo Gym Agents
+
+These are native agents with no external dependency. They call the Model server, route tool calls to the Resources server, and verify the result.
+
+| Agent | Use it when |
+|---|---|
+| [`simple_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/simple_agent) | You want general-purpose multi-step tool calling with a configurable step budget. Works with any Resources server, and is the usual starting point. |
+| [`non_executing_simple_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/non_executing_simple_agent) | The tool call itself is the answer. Forwards one request to the model and passes the response to the verifier without executing anything. |
+| [`tool_simulation_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/tool_simulation_agent) | Tool results should be simulated rather than really executed. |
+| [`gymnasium_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/gymnasium_agent) | Your environment is a `GymnasiumServer` Resources server and the agent should drive its reset/step loop. |
+
+## External Agent Harnesses
+
+Each of these runs a third-party harness as a NeMo Gym agent server. The harness keeps its own loop, prompts, and tools; NeMo Gym seeds the session, translates the resulting trajectory into Responses API format, and verifies it against the Resources server.
+
+Because verification stays on the NeMo Gym side, a harness that brings its own tools can often run an existing benchmark by adding a `<benchmark>_<agent>` config, leaving the dataset and verifier unchanged — only the Resources server's task data and `/verify` are used. This is how `hermes_agent` is used with the math, coding, reasoning_gym, MCQA, and instruction-following benchmarks. It does not hold for every harness: agents such as `swe_agents`, `osworld_agent`, and `tau2` are tied to specific benchmarks.
+
+### Coding CLIs
+
+Agents that shell out to a coding CLI. The CLI runs its own tools internally and its output stream is parsed back into NeMo Gym format.
+
+| Agent | Harness | Notes |
+|---|---|---|
+| [`claude_code_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/claude_code_agent) | Claude Code (`claude -p`) | Runs against Anthropic, or against any NeMo Gym Model server via its `POST /v1/messages` endpoint. Reference implementation for [Agent Skills](/agent-server/agent-skills). |
+| [`codex_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/codex_agent) | OpenAI Codex CLI (`codex exec`) | Runs against OpenAI, or against any NeMo Gym Model server, which serves the streaming Responses dialect Codex speaks. Also supports Agent Skills. |
+| [`opencode_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/opencode_agent) | OpenCode (`opencode run`) | Reads the run's SQLite session to recover the full trajectory including tool calls. |
+| [`kilocode_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/kilocode_agent) | Kilo Code (`kilo run`) | A fork of OpenCode; mirrors `opencode_agent` but parses the CLI's JSON event stream. |
+| [`openclaw_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/openclaw_agent) | OpenClaw (`openclaw agent --local --json`) | |
+| [`pi_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/pi_agent) | pi (`pi --print --mode json`) | |
+
+<Note>
+Every agent in this table is evaluation-only today: token IDs and log probabilities are not threaded through, so the rollouts are not trainable. All of them except `kilocode_agent` accept an optional `model_server` ref that routes generation through NeMo Gym, which makes the model calls capturable and lets one config run against different backends. `kilocode_agent` takes a provider base URL directly. See [Evaluation-only vs training-grade](#evaluation-only-vs-training-grade).
+</Note>
+
+### Agent Frameworks
+
+Python agent frameworks embedded in the agent server process.
+
+| Agent | Framework | Notes |
+|---|---|---|
+| [`langgraph_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/langgraph_agent) | [LangGraph](https://github.com/langchain-ai/langgraph) | Ships reflection, sub-agent orchestrator, parallel-thinking, and ReWOO examples. Patterns that produce non-monotonic trajectories (such as parallel thinking) work for evaluation but not for default NeMo RL training. |
+| [`hermes_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/hermes_agent) | [hermes-agent](https://github.com/NousResearch/hermes-agent) (Nous Research) | Training-capable. Pinned to a fork with token-ID tracking, chat-template, and sampling-parameter patches. Brings its own toolset, so only the Resources server's task data and `verify` are used. |
+| [`aviary_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/aviary_agent) | [Aviary](https://github.com/Future-House/aviary) (FutureHouse) | Pairs with the `resources_servers/aviary` environments and datasets. |
+| [`verifiers_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/verifiers_agent) | [Verifiers](https://github.com/PrimeIntellect-ai/verifiers) (Prime Intellect) | Runs environments from Prime Intellect's Environments Hub. Token-ID support is upstreamed into the framework's `NeMoRLChatCompletionsClient`. |
+| [`harbor_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/harbor_agent) | [Harbor](https://github.com/laude-institute/harbor) (Laude Institute) | Runs Harbor agents such as `terminus-2` in Harbor-managed environments, with a Singularity environment for HPC training. |
+| [`stirrup_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/stirrup_agent) | [Stirrup](https://github.com/ArtificialAnalysis/Stirrup) (Artificial Analysis) | Ships the GDPVal strategy; new benchmarks can be added in a single file. |
+
+### Benchmark-Native Harnesses
+
+Benchmarks that come with their own agent scaffold, wired in at the agent-server level.
+
+| Agent | Harness | Benchmarks |
+|---|---|---|
+| [`swe_agents`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/swe_agents) | [nv-OpenHands](https://github.com/sdevare-nv/nv-OpenHands) (default) or [opencode](https://opencode.ai), in Apptainer containers | SWE-bench and friends. Runs the agent and the evaluation harness in separate containers, returning a binary "resolved" reward suitable for evaluation and RL. |
+| [`mini_swe_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/mini_swe_agent) | [mini-swe-agent](https://github.com/SWE-agent/mini-swe-agent) in Docker | SWE-bench |
+| [`mini_swe_agent_2`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/mini_swe_agent_2) | mini-swe-agent v2 via the public `nemo_gym.sandbox` API | SWE-bench-style tasks |
+| [`osworld_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/osworld_agent) | OSWorld `DesktopEnv`, with the desktop container/VM lifecycle in the NeMo Gym Docker Sandbox | OSWorld desktop-computer tasks |
+| [`toolsandbox_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/toolsandbox_agent) | [ToolSandbox](https://github.com/apple/ToolSandbox) (Apple) | Multi-turn tool use with a user simulator — a natural-language reply continues the conversation instead of ending the rollout. |
+| [`tau2`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/tau2) | τ²-bench, checked out and installed at setup | τ²-bench, plus τ³ banking-knowledge configs that reuse the same bridge |
+| [`pinchbench`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/pinchbench) | [PinchBench](https://github.com/pinchbench/skill) over [OpenClaw](https://github.com/openclaw/openclaw) | 147 real-world tasks (calendar, email triage, log analysis, coding, research, writing) |
+
+### Agent-Agnostic Task Runners
+
+These are not harnesses. They take another NeMo Gym agent, run it inside a benchmark's task container, and grade what it leaves behind.
+
+| Agent | What it does |
+|---|---|
+| [`anyswe_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/anyswe_agent) | Runs your agent inside a SWE task image, extracts the repository patch, and grades it in a fresh sandbox. Supports SWE-bench, SWE-bench Multilingual, and R2E-Gym. |
+| [`anyterminal_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/anyterminal_agent) | Runs your agent inside a Terminal-Bench task container, then runs the task's `tests/test.sh` in that same container. |
+
+Alongside these, `responses_api_agents/` also holds benchmark-specific custom agents (for example SciCode's per-sub-step loop and CritPt's two-turn solve-then-fill-template flow). Browse the [directory](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents) for the full set; each has a README with its own quickstart.
+
+## How an External Harness Is Wrapped
+
+The wrappers vary in size — the container-based ones do considerably more setup than the CLI ones — but they share four responsibilities. The `swe_agents` opencode integration states the underlying rule as "swap the transport, keep the loop": leave the harness's prompts, tools, and control flow alone, and change only where it gets tokens from and where its trajectory goes.
+
+1. Run the harness, inside the agent server's `run()`. A subprocess for a CLI, an in-process import for a Python framework, a container for a sandboxed benchmark.
+2. Point it at a NeMo Gym Model server by setting whatever base URL the harness uses. Model servers accept `POST /v1/responses` (including the streaming form Codex uses), `POST /v1/chat/completions`, and `POST /v1/messages` for Anthropic-style clients, so most harnesses need no change on this step. Going through the Model server is what lets one harness run against vLLM, OpenAI, or an inference provider, and it is required for training.
+3. Translate the harness's output into Responses API items. The source varies — a JSON event stream, a SQLite session, per-turn files on disk — so this is the per-harness part of the code and usually the bulk of the wrapper.
+4. Send the finished trajectory to the Resources server's `/verify` and return the reward. Harnesses that bring their own tools use only the Resources server's task data and verifier; harnesses that accept externally supplied tools can also route tool calls to it.
+
+## Evaluation-Only vs Training-Grade
+
+Producing scores is easier than producing rollouts that can be trained on. For RL, the harness must:
+
+- Call through NeMo Gym's Model server rather than the provider directly.
+- Include prompt and generation token IDs in requests, so trainers can apply on-policy token-ID correction instead of re-tokenizing.
+- Not override sampling parameters such as `temperature` and `top_p` set by the run.
+- Keep the trajectory monotonic: no dropping earlier reasoning content, no context compaction, no parallel branches. NeMo RL expects a monotonically growing conversation. Non-monotonic harnesses still work for evaluation and rollout collection.
+
+`hermes_agent`, `verifiers_agent`, `harbor_agent`, and `swe_agents` implement these guarantees. See [Integrate external libraries](/environment-tutorials/integrate-external-environments#ensuring-proper-token-id-handling-in-custom-client-calls) for the token-ID details.
 
 ## Tools in Agent vs. Resources Server
 
 Existing agents may come with predefined tools, allowing you to leverage them directly and use the Resources server to supplement with any additional external tools. When building a new environment, prefer defining tools in the Resources server rather than the Agent server. This separation of concerns allows different agents to share the same Resources server without duplicating tool logic.
 
 <Cards>
+
+<Card title="Drive a Remote Agent" href="/agent-server/remote-agent">
+No wrapper at all — keep your agent in your own repo and expose one Responses-compatible endpoint.
+</Card>
 
 <Card title="Agent Server" href="/agent-server">
 Review the Agent server lifecycle and orchestration role.

--- a/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
+++ b/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
@@ -21,7 +21,7 @@ These are NeMo Gym code, with no external dependency. They call the Model server
 
 ## Agent Servers That Run a Third-Party Harness
 
-In these, the external harness owns the agent loop and keeps its own prompts and tools. NeMo Gym seeds the session, translates the resulting trajectory into Responses API format, and verifies it against the Resources server.
+In these, the external harness owns the agent loop and keeps its own prompts and tools. NeMo Gym usually seeds the session, translates the resulting trajectory into Responses API format, and verifies it against the Resources server; a few whose benchmark harness owns scoring compute the reward themselves.
 
 Because verification stays on the NeMo Gym side, an agent harness that brings its own tools can often run in an existing environment by adding a `<benchmark>_<agent>` config, leaving the dataset and verifier unchanged — only the Resources server's task data and `/verify` are used. This is how `hermes_agent` is used with the math, coding, reasoning_gym, MCQA, and instruction-following benchmarks. It does not hold for every harness: agent servers such as `swe_agents`, `osworld_agent`, and `tau2` are tied to specific benchmarks.
 
@@ -167,10 +167,12 @@ gym eval run --no-serve --agent my_agent --input data/tasks.jsonl --output resul
 
 Wrappers differ in size, but share four responsibilities. The `swe_agents` opencode integration states the rule as "swap the transport, keep the loop": leave the harness's prompts, tools, and control flow unchanged, and change only where it gets tokens from and where its trajectory goes.
 
-1. Run the harness from the Agent server's `responses()` — a subprocess for a CLI, an in-process import for a Python framework, a container for a sandboxed benchmark. `run()` remains the episode orchestrator: it seeds the session, calls `responses()`, and verifies.
+1. Run the harness — a subprocess for a CLI, an in-process import for a Python framework, a container for a sandboxed benchmark.
 2. Point the harness at a NeMo Gym Model server by setting whatever base URL it uses. Model servers accept `POST /v1/responses` (including the streaming form Codex uses), `POST /v1/chat/completions`, and `POST /v1/messages`, so most harnesses need no change here. This is what lets one harness run against vLLM, OpenAI, or an inference provider, and it is required for training.
 3. Translate the harness's output into Responses API items. The source varies — a JSON event stream, a SQLite session, per-turn files on disk — so this is the per-harness part of the code and usually the bulk of the wrapper.
-4. From `run()`, send the finished trajectory to the Resources server's `/verify` and return the reward. Harnesses that bring their own tools use only the Resources server's task data and verifier; harnesses that accept externally supplied tools can also route tool calls to it.
+4. Return a reward. Harnesses that bring their own tools use only the Resources server's task data and verifier; harnesses that accept externally supplied tools can also route tool calls to it.
+
+Which method holds steps 1 and 4 differs by agent server. Most run the harness in `responses()` and use `run()` to orchestrate the episode: seed the session, call `responses()`, send the trajectory to the Resources server's `/verify`. `mini_swe_agent`, `mini_swe_agent_2`, `harbor_agent`, and `tau2` do everything in `run()` and raise `NotImplementedError` from `responses()`; these also compute the reward from their harness's own evaluation output instead of calling `/verify`.
 
 ## Evaluation-Only vs Training-Grade
 

--- a/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
+++ b/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
@@ -4,30 +4,30 @@ description: "The agent servers NeMo Gym ships — Gym-native implementations, a
 position: 2
 ---
 
-All the agent servers below ship in the NeMo Gym repo. They divide by who implements the agent: some are NeMo Gym code, others hand the work to a third-party harness and adapt the result. If neither fits, you can keep your agent in your own repo and [drive it remotely](/agent-server/remote-agent).
+All the agent servers below ship in the NeMo Gym repo. Some are NeMo Gym code; others run a third-party harness and translate its output. If neither fits, you can keep your agent in your own repo and [drive it remotely](/agent-server/remote-agent).
 
-These are the general-purpose agent servers — ones you can point at more than one environment. `responses_api_agents/` also holds benchmark-specific agent servers whose control flow is coupled to a single benchmark; those are documented with the benchmark rather than here.
+These are the general-purpose agent servers, meaning they work with more than one environment. `responses_api_agents/` also holds agent servers whose control flow is specific to a single benchmark; those are documented with that benchmark.
 
 ## Agent Servers with a Gym-Native Implementation
 
 These are NeMo Gym code, with no external dependency. They call the Model server, route tool calls to the Resources server, and call the Resources server's `/verify` to score the trajectory.
 
-| Agent Server | Use it when |
+| Agent Server | What it does |
 |---|---|
-| [`simple_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/simple_agent) | You want general-purpose multi-step tool calling with a configurable step budget. Works with any Resources server, and is the usual starting point. |
-| [`non_executing_simple_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/non_executing_simple_agent) | The tool call itself is the answer. Forwards one request to the model and passes the response to the verifier without executing anything. |
-| [`tool_simulation_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/tool_simulation_agent) | Tool results should be simulated rather than really executed. |
-| [`gymnasium_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/gymnasium_agent) | Your environment is a `GymnasiumServer` Resources server and you need a compatible Agent server to drive its reset/step loop. |
+| [`simple_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/simple_agent) | Calls the model, executes any tool calls against the Resources server, appends the results, and repeats until the model returns no tool calls or the step limit is reached. Works with any Resources server. |
+| [`non_executing_simple_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/non_executing_simple_agent) | Makes one model call and passes the response to the verifier. Does not execute tool calls. Normalizes a string `input` into a message list and propagates session cookies. |
+| [`tool_simulation_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/tool_simulation_agent) | Makes one model call and passes the response to the verifier. Does not execute tool calls. Used with datasets that supply simulated tool results. |
+| [`gymnasium_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/gymnasium_agent) | Drives the reset/step loop of a `GymnasiumServer` Resources server. |
 
 ## Agent Servers That Run a Third-Party Harness
 
-Each of these hands the loop to an external harness. The harness keeps its own prompts and tools; NeMo Gym seeds the session, translates the resulting trajectory into Responses API format, and verifies it against the Resources server.
+In these, the external harness owns the agent loop and keeps its own prompts and tools. NeMo Gym seeds the session, translates the resulting trajectory into Responses API format, and verifies it against the Resources server.
 
 Because verification stays on the NeMo Gym side, an agent harness that brings its own tools can often run in an existing environment by adding a `<benchmark>_<agent>` config, leaving the dataset and verifier unchanged — only the Resources server's task data and `/verify` are used. This is how `hermes_agent` is used with the math, coding, reasoning_gym, MCQA, and instruction-following benchmarks. It does not hold for every harness: agent servers such as `swe_agents`, `osworld_agent`, and `tau2` are tied to specific benchmarks.
 
 ### Coding CLIs
 
-Agent servers that shell out to a coding CLI. The CLI runs its own tools internally and its output stream is parsed back into NeMo Gym format.
+Agent servers that run a coding CLI as a subprocess. The CLI executes its own tools, and its output is parsed back into NeMo Gym format.
 
 | Agent Server | Harness | Notes |
 |---|---|---|
@@ -71,7 +71,7 @@ Benchmarks that come with their own agent scaffold, wired in at the agent-server
 
 ### Agent-Agnostic Task Runners
 
-These are not harnesses. They wire together another NeMo Gym Agent server, run it inside a benchmark's task container, and grade what it leaves behind.
+These are not harnesses. They run another NeMo Gym Agent server inside a benchmark's task container, then grade the container's final state.
 
 | Agent Server | What it does |
 |---|---|
@@ -82,22 +82,20 @@ Alongside these, `responses_api_agents/` also holds benchmark-specific custom Ag
 
 ## Choose an Agent Server
 
-Start with the simplest one that provides the interaction pattern your environment needs.
+Match the agent server to the interaction pattern the environment needs.
 
-- Plain tool calling, or no tools at all: `simple_agent`. Use `non_executing_simple_agent` only when the model's tool call is the final answer and must not be executed.
+- Tool calling, or no tools: `simple_agent`.
+- One model call with no tool execution: `non_executing_simple_agent`, or `tool_simulation_agent` if the dataset supplies simulated tool results. The two behave almost identically, so follow whichever the environment's existing configs use.
 - A `reset`/`step` environment: `gymnasium_agent`.
-- Tool results produced by simulation rather than real execution: `tool_simulation_agent`.
-- SWE-bench-style coding: `swe_agents` for OpenHands or opencode, `mini_swe_agent_2` for mini-swe-agent on the provider-neutral sandbox API, or `anyswe_agent` to run several different Gym agent servers through one execution and grading path. `mini_swe_agent` remains for the older Docker workflow.
-- Terminal-Bench tasks: `anyterminal_agent`, which puts the agent and the task's tests in the same container.
-- Agentic coding through an external CLI: `claude_code_agent`, `codex_agent`, `kilocode_agent`, `opencode_agent`, `openclaw_agent`, or `pi_agent`. All are evaluation-only today — check the README before planning to train on their rollouts.
-- Multi-step tool use you intend to train on: `hermes_agent`, which is pinned to a fork carrying the token-ID and sampling-parameter patches training needs.
-- LangGraph research patterns: `langgraph_agent`. Graphs that produce non-monotonic trajectories, such as parallel thinking, work for evaluation but need extra handling before NeMo RL training.
+- SWE-bench-style coding: `swe_agents` for OpenHands or opencode, `mini_swe_agent_2` for mini-swe-agent on the sandbox API, or `anyswe_agent` to run several Gym agent servers through one execution and grading path. `mini_swe_agent` uses the older Docker workflow.
+- Terminal-Bench tasks: `anyterminal_agent`, which runs the agent and the task's tests in the same container.
+- Coding through an external CLI: `claude_code_agent`, `codex_agent`, `kilocode_agent`, `opencode_agent`, `openclaw_agent`, or `pi_agent`. All are evaluation-only; check the README before training on their rollouts.
+- Multi-step tool use for training: `hermes_agent`, pinned to a fork with the token-ID and sampling-parameter patches training requires.
+- LangGraph graphs: `langgraph_agent`. Graphs with non-monotonic trajectories, such as parallel thinking, work for evaluation but need extra handling before NeMo RL training.
 - Environments from an external library: `aviary_agent` for FutureHouse Aviary, `verifiers_agent` for Prime Intellect Verifiers.
-- An agent you host yourself: `remote_agent`, if your service can implement the OpenAI `/v1/responses` contract.
+- An agent you host: `remote_agent`, if your service implements the OpenAI `/v1/responses` contract.
 
-<Tip>
-For a new environment, start with `simple_agent` unless the environment protocol or an external harness requires one of the specialized adapters. It keeps the model, tools, and verifier easy to isolate while you get the task working.
-</Tip>
+For a new environment, start with `simple_agent` unless the environment protocol or an external harness requires one of the others.
 
 ## Configure and Run
 
@@ -139,7 +137,7 @@ mini_swe_agent_2:
 
 The provider's own config lives in a separate file that defines the named `sandbox` block, so switching between OpenSandbox, Docker, and Apptainer means passing a different `--config` rather than editing the agent. See [Sandbox](/infrastructure/sandbox) for provider setup and `SandboxSpec` fields.
 
-An external RL trainer that routes each episode through its own recording proxy can override the policy endpoint per rollout. `mini_swe_agent` and `mini_swe_agent_2` accept optional `policy_base_url` and `policy_api_key` fields on the `/run` request:
+`mini_swe_agent` and `mini_swe_agent_2` accept optional `policy_base_url` and `policy_api_key` fields on the `/run` request, so a caller can point one rollout at its own OpenAI-compatible endpoint. External RL trainers use this to route each episode through a per-episode recording proxy:
 
 ```json
 {
@@ -163,20 +161,20 @@ gym env start --config path/to/agent-and-resources.yaml --model-type vllm_model
 gym eval run --no-serve --agent my_agent --input data/tasks.jsonl --output results/rollouts.jsonl
 ```
 
-`gym env validate` checks the same configuration without starting Ray or any servers, which is worth doing before a long run.
+`gym env validate` checks the same configuration without starting Ray or any servers.
 
 ## How an External Harness Is Wrapped
 
-The wrappers vary in size — the container-based ones do considerably more setup than the CLI ones — but they share four responsibilities. The `swe_agents` opencode integration states the underlying rule as "swap the transport, keep the loop": leave the harness's prompts, tools, and control flow alone, and change only where it gets tokens from and where its trajectory goes.
+Wrappers differ in size, but share four responsibilities. The `swe_agents` opencode integration states the rule as "swap the transport, keep the loop": leave the harness's prompts, tools, and control flow unchanged, and change only where it gets tokens from and where its trajectory goes.
 
-1. Run the harness from the Agent server's `responses()`. A subprocess for a CLI, an in-process import for a Python framework, a container for a sandboxed benchmark. `run()` stays the episode orchestrator — it seeds the session, calls `responses()`, and verifies — so the harness is confined to the one method that produces a trajectory.
-2. Point it at a NeMo Gym Model server by setting whatever base URL the harness uses. Model servers accept `POST /v1/responses` (including the streaming form Codex uses), `POST /v1/chat/completions`, and `POST /v1/messages` for Anthropic-style clients, so most harnesses need no change on this step. Going through the Model server is what lets one harness run against vLLM, OpenAI, or an inference provider, and it is required for training.
+1. Run the harness from the Agent server's `responses()` — a subprocess for a CLI, an in-process import for a Python framework, a container for a sandboxed benchmark. `run()` remains the episode orchestrator: it seeds the session, calls `responses()`, and verifies.
+2. Point the harness at a NeMo Gym Model server by setting whatever base URL it uses. Model servers accept `POST /v1/responses` (including the streaming form Codex uses), `POST /v1/chat/completions`, and `POST /v1/messages`, so most harnesses need no change here. This is what lets one harness run against vLLM, OpenAI, or an inference provider, and it is required for training.
 3. Translate the harness's output into Responses API items. The source varies — a JSON event stream, a SQLite session, per-turn files on disk — so this is the per-harness part of the code and usually the bulk of the wrapper.
 4. From `run()`, send the finished trajectory to the Resources server's `/verify` and return the reward. Harnesses that bring their own tools use only the Resources server's task data and verifier; harnesses that accept externally supplied tools can also route tool calls to it.
 
 ## Evaluation-Only vs Training-Grade
 
-Producing scores is easier than producing rollouts that can be trained on. For RL, the harness must:
+For rollouts to be trainable, the harness must:
 
 - Call through NeMo Gym's Model server rather than the provider directly.
 - Include prompt and generation token IDs in requests, so trainers can apply on-policy token-ID correction instead of re-tokenizing.
@@ -192,7 +190,7 @@ Existing agents may come with predefined tools, allowing you to leverage them di
 <Cards>
 
 <Card title="Drive a Remote Agent" href="/agent-server/remote-agent">
-No wrapper at all — keep your agent in your own repo and expose one Responses-compatible endpoint.
+Keep your agent in your own repo and expose one Responses-compatible endpoint.
 </Card>
 
 <Card title="Agent Server" href="/agent-server">

--- a/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
+++ b/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
@@ -6,11 +6,11 @@ position: 2
 
 All the agent servers below ship in the NeMo Gym repo. Some are NeMo Gym code; others run a third-party harness and translate its output. If neither fits, you can keep your agent in your own repo and [drive it remotely](/agent-server/remote-agent).
 
-These are the general-purpose agent servers, meaning they work with more than one environment. `responses_api_agents/` also holds agent servers whose control flow is specific to a single benchmark; those are documented with that benchmark.
+Some work with any Resources server; others are built around a single benchmark and are grouped that way below.
 
 ## Agent Servers with a Gym-Native Implementation
 
-These are NeMo Gym code, with no external dependency. They call the Model server, route tool calls to the Resources server, and call the Resources server's `/verify` to score the trajectory.
+These are NeMo Gym code; their only dependency is `nemo_gym` itself. They call the Model server and score against the Resources server, though how differs: `simple_agent`, `non_executing_simple_agent`, and `tool_simulation_agent` call `/verify`, while `gymnasium_agent` sums the per-step rewards returned by `/reset` and `/step`.
 
 | Agent Server | What it does |
 |---|---|
@@ -36,7 +36,7 @@ Agent servers that run a coding CLI as a subprocess. The CLI executes its own to
 | [`opencode_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/opencode_agent) | OpenCode (`opencode run`) | Reads the run's SQLite session to recover the full trajectory including tool calls. |
 | [`kilocode_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/kilocode_agent) | Kilo Code (`kilo run`) | A fork of OpenCode; mirrors `opencode_agent` but parses the CLI's JSON event stream. |
 | [`openclaw_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/openclaw_agent) | OpenClaw (`openclaw agent --local --json`) | |
-| [`pi_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/pi_agent) | pi (`pi --print --mode json`) | |
+| [`pi_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/pi_agent) | pi (`pi --print --mode json --no-session`) | |
 
 <Note>
 Every agent server in this table is evaluation-only today: token IDs and log probabilities are not threaded through, so the rollouts are not trainable. All of them accept an optional `model_server` ref that routes generation through NeMo Gym, which makes the model calls capturable and lets one config run against different backends; a configured model server takes precedence over a direct provider URL. See [Evaluation-only vs training-grade](#evaluation-only-vs-training-grade).
@@ -44,7 +44,7 @@ Every agent server in this table is evaluation-only today: token IDs and log pro
 
 ### External Frameworks
 
-Python agent and environment frameworks embedded in the Agent server process.
+Python agent and environment frameworks that the Agent server imports and drives in-process. Several then manage their own execution backends: `harbor_agent` runs trials in Singularity, Docker, Daytona, or a NeMo Gym sandbox depending on `harbor_environment_type`, and `stirrup_agent` executes code through Stirrup's own tool backends.
 
 | Agent Server | Framework | Notes |
 |---|---|---|
@@ -118,7 +118,7 @@ my_agent:
 
 The `model_server` reference points at the top-level `policy_model` block selected by `--model-type` or supplied in a config file, so the same agent config runs against vLLM, OpenAI, or another backend without naming a network address. Some of the CLI-backed agent servers also accept a provider URL directly; the README says which takes precedence. See [Agent Server Fields](/reference/configuration#agent-server-fields) for the full syntax.
 
-Sandbox-backed agent servers name a provider and give a per-task `sandbox_spec`. `mini_swe_agent_2` requires `sandbox_provider` and fails at startup without it:
+Sandbox-backed agent servers name a provider and give a per-task `sandbox_spec`. `mini_swe_agent_2` requires `sandbox_provider`; without it, the server starts but every `/run` request fails:
 
 ```yaml
 mini_swe_agent_2:
@@ -149,7 +149,7 @@ The provider's own config lives in a separate file that defines the named `sandb
 
 When set, they take precedence over the configured `model_server` for that rollout; when absent, the configured model server is used. This is not a general Agent server field — only those two agent servers read it, and the others silently ignore it because their run-request models allow extra keys. Check the agent server's request model before relying on it.
 
-Skills are a run-level input, set with `+skills.path` on `gym eval run`. NeMo Gym records and forwards a `skills_ref`, but the agent server still has to stage the files where its runtime looks for them — `claude_code_agent` and `codex_agent` are the two with native adapters today. Rollout collection accepting `skills.path` does not by itself mean the agent server loads the skills. See [Agent Skills](/agent-server/agent-skills).
+Skills are a run-level input, set with `+skills.path` on `gym eval run`. NeMo Gym records and forwards a `skills_ref`, but the agent server still has to stage the files where its runtime looks for them — `claude_code_agent` and `codex_agent` are the two with native adapters today. Rollout collection accepting `skills.path` does not by itself mean the agent server loads the skills; `remote_agent`, for instance, logs a warning that it cannot stage them. See [Agent Skills](/agent-server/agent-skills).
 
 To run, start the composed servers and then collect rollouts against the top-level agent server name:
 

--- a/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
+++ b/fern/versions/latest/pages/agent-server/integrate-existing-agents.mdx
@@ -4,20 +4,22 @@ description: "The agent servers NeMo Gym ships — Gym-native implementations, a
 position: 2
 ---
 
-All the agent servers below ship in the NeMo Gym repo. Some are NeMo Gym code; others run a third-party harness and translate its output. If neither fits, you can keep your agent in your own repo and [drive it remotely](/agent-server/remote-agent).
+NeMo Gym ships agent servers implemented in Gym and adapters for third-party harnesses. If neither fits, you can keep your agent in your own repo and [drive it remotely](/agent-server/remote-agent).
 
-Some work with any Resources server; others are built around a single benchmark and are grouped that way below.
+Run `gym list agents` for the complete list available in your checkout, including each agent's configuration variants and whether it is composable with a separate Resources server or self-contained with its environment. Run `gym list agents <name>` to inspect one agent. The sections below explain how the reusable harnesses differ and identify the major benchmark-specific integrations.
 
 ## Agent Servers with a Gym-Native Implementation
 
-These are NeMo Gym code; their only dependency is `nemo_gym` itself. They call the Model server and score against the Resources server, though how differs: `simple_agent`, `non_executing_simple_agent`, and `tool_simulation_agent` call `/verify`, while `gymnasium_agent` sums the per-step rewards returned by `/reset` and `/step`.
+These agent loops are implemented in NeMo Gym. `simple_agent`, `simple_agent_with_compaction`, `non_executing_simple_agent`, `tool_simulation_agent`, and `image_tools_agent` send the completed result to a Resources server for verification. `gymnasium_agent` instead sums the per-step rewards returned by `/reset` and `/step`.
 
 | Agent Server | What it does |
 |---|---|
 | [`simple_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/simple_agent) | Calls the model, executes any tool calls against the Resources server, appends the results, and repeats until the model returns no tool calls or the step limit is reached. Works with any Resources server. |
+| [`simple_agent_with_compaction`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/simple_agent_with_compaction) | Runs the `simple_agent` model and tool loop with an opt-in context-compaction policy applied before model calls. |
 | [`non_executing_simple_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/non_executing_simple_agent) | Makes one model call and passes the response to the verifier. Does not execute tool calls. Normalizes a string `input` into a message list and propagates session cookies. |
 | [`tool_simulation_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/tool_simulation_agent) | Makes one model call and passes the response to the verifier. Does not execute tool calls. Used with datasets that supply simulated tool results. |
 | [`gymnasium_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/gymnasium_agent) | Drives the reset/step loop of a `GymnasiumServer` Resources server. |
+| [`image_tools_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/image_tools_agent) | Adds iterative image-inspection tools to another agent workflow, then sends the final response to the selected Resources server for verification. |
 
 ## Agent Servers That Run a Third-Party Harness
 
@@ -25,18 +27,20 @@ In these, the external harness owns the agent loop and keeps its own prompts and
 
 Because verification stays on the NeMo Gym side, an agent harness that brings its own tools can often run in an existing environment by adding a `<benchmark>_<agent>` config, leaving the dataset and verifier unchanged — only the Resources server's task data and `/verify` are used. This is how `hermes_agent` is used with the math, coding, reasoning_gym, MCQA, and instruction-following benchmarks. It does not hold for every harness: agent servers such as `swe_agents`, `osworld_agent`, and `tau2` are tied to specific benchmarks.
 
-### Coding CLIs
+### Command-Line Harnesses
 
-Agent servers that run a coding CLI as a subprocess. The CLI executes its own tools, and its output is parsed back into NeMo Gym format.
+These agent servers run an external agent harness as a subprocess. The harness executes its own tools, and the agent server parses its output back into NeMo Gym format.
 
-| Agent Server | Harness | Notes |
+| Agent Server | Harness | Summary |
 |---|---|---|
 | [`claude_code_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/claude_code_agent) | Claude Code (`claude -p`) | Runs against Anthropic, or against any NeMo Gym Model server, since every one serves [Anthropic Messages](/model-server/anthropic-messages) on `POST /v1/messages`. Reference implementation for [Agent Skills](/agent-server/agent-skills). |
+| [`cline_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/cline_agent) | Cline (`cline --json`) | Isolates Cline's settings and session state per rollout and parses its JSON event stream into messages, tool calls, tool outputs, reasoning, and usage. |
 | [`codex_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/codex_agent) | OpenAI Codex CLI (`codex exec`) | Runs against OpenAI, or against any NeMo Gym Model server, which serves the streaming Responses dialect Codex speaks. Also supports Agent Skills. |
 | [`opencode_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/opencode_agent) | OpenCode (`opencode run`) | Reads the run's SQLite session to recover the full trajectory including tool calls. |
 | [`kilocode_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/kilocode_agent) | Kilo Code (`kilo run`) | A fork of OpenCode; mirrors `opencode_agent` but parses the CLI's JSON event stream. |
-| [`openclaw_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/openclaw_agent) | OpenClaw (`openclaw agent --local --json`) | |
-| [`pi_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/pi_agent) | pi (`pi --print --mode json --no-session`) | |
+| [`openclaw_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/openclaw_agent) | OpenClaw (`openclaw agent --local --json`) | Creates an isolated workspace per rollout, runs OpenClaw's tools locally, and parses the JSON result for verification. |
+| [`pi_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/pi_agent) | pi (`pi --print --mode json --no-session`) | Creates an isolated home directory per rollout, writes the model provider configuration there, and converts pi's JSONL `message_end` events into the trajectory. |
+| [`prime_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/prime_agent) | Prime Agent | Runs a one-shot Prime Agent worker in an isolated home directory while reusing a shared IPython environment. |
 
 <Note>
 Every agent server in this table is evaluation-only today: token IDs and log probabilities are not threaded through, so the rollouts are not trainable. All of them accept an optional `model_server` ref that routes generation through NeMo Gym, which makes the model calls capturable and lets one config run against different backends; a configured model server takes precedence over a direct provider URL. See [Evaluation-only vs training-grade](#evaluation-only-vs-training-grade).
@@ -46,14 +50,26 @@ Every agent server in this table is evaluation-only today: token IDs and log pro
 
 Python agent and environment frameworks that the Agent server imports and drives in-process. Several then manage their own execution backends: `harbor_agent` runs trials in Singularity, Docker, Daytona, or a NeMo Gym sandbox depending on `harbor_environment_type`, and `stirrup_agent` executes code through Stirrup's own tool backends.
 
-| Agent Server | Framework | Notes |
+| Agent Server | Framework | Summary |
 |---|---|---|
 | [`langgraph_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/langgraph_agent) | [LangGraph](https://github.com/langchain-ai/langgraph) | Ships reflection, sub-agent orchestrator, parallel-thinking, and ReWOO examples. Patterns that produce non-monotonic trajectories (such as parallel thinking) work for evaluation but not for default NeMo RL training. |
 | [`hermes_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/hermes_agent) | [hermes-agent](https://github.com/NousResearch/hermes-agent) (Nous Research) | Training-capable. Pinned to a fork with token-ID tracking, chat-template, and sampling-parameter patches. Brings its own toolset, so only the Resources server's task data and `verify` are used. |
+| [`nemo_fabric_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/nemo_fabric_agent) | [NeMo Fabric](https://github.com/NVIDIA/NeMo-Fabric) | Runs an installed harness through NeMo Fabric's typed lifecycle. Shipped variants include Claude Code, Codex, Deep Agents, Hermes, and mini-swe-agent adapters. |
+| [`simple_strands_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/simple_strands_agent) | Simple Strands Agent | Runs a tool-using coding agent with shell and file-editing tools while retaining the harness's native system prompt. |
+| [`terminus_2_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/terminus_2_agent) | [Harbor Terminus-2](https://github.com/harbor-framework/harbor/tree/main/src/harbor/agents/terminus_2) | Runs Terminus-2 in a temporary or configured workspace and converts its terminal trajectory into Responses API messages and tool calls. |
 | [`aviary_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/aviary_agent) | [Aviary](https://github.com/Future-House/aviary) (FutureHouse) | Pairs with the `resources_servers/aviary` environments and datasets. |
 | [`verifiers_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/verifiers_agent) | [Verifiers](https://github.com/PrimeIntellect-ai/verifiers) (Prime Intellect) | Runs environments from Prime Intellect's Environments Hub. Token-ID support is upstreamed into the framework's `NeMoRLChatCompletionsClient`. |
 | [`harbor_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/harbor_agent) | [Harbor](https://github.com/laude-institute/harbor) (Laude Institute) | Runs a Harbor agent such as `terminus-2` in a Harbor-managed environment. Trials can execute in a Singularity environment for HPC training, or in any NeMo Gym sandbox provider, selected by config. |
 | [`stirrup_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/stirrup_agent) | [Stirrup](https://github.com/ArtificialAnalysis/Stirrup) (Artificial Analysis) | Ships the GDPVal strategy; new benchmarks can be added in a single file. |
+
+### Harnesses That Run in a Resources Server Sandbox
+
+These adapters run the third-party harness inside the task sandbox supplied by the Resources server, so task state remains isolated there.
+
+| Agent Server | Harness | Summary |
+|---|---|---|
+| [`opencode_sandboxed_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/opencode_sandboxed_agent) | OpenCode | Runs OpenCode in the task sandbox and converts its exported session into a NeMo Gym trajectory. |
+| [`terminus_2_sandboxed_agent`](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/terminus_2_sandboxed_agent) | Harbor Terminus-2 | Adapts Terminus-2's terminal interface to the Resources server's `AsyncSandbox` and returns every model request and response. |
 
 ### Benchmark-Native Harnesses
 
@@ -85,11 +101,14 @@ Alongside these, `responses_api_agents/` also holds benchmark-specific custom Ag
 Match the agent server to the interaction pattern the environment needs.
 
 - Tool calling, or no tools: `simple_agent`.
+- Tool calling with context compaction: `simple_agent_with_compaction`.
 - One model call with no tool execution: `non_executing_simple_agent`, or `tool_simulation_agent` if the dataset supplies simulated tool results. The two behave almost identically, so follow whichever the environment's existing configs use.
 - A `reset`/`step` environment: `gymnasium_agent`.
 - SWE-bench-style coding: `swe_agents` for OpenHands or opencode, `mini_swe_agent_2` for mini-swe-agent on the sandbox API, or `anyswe_agent` to put a choice of Gym agent server behind one execution and grading path, one per rollout. `mini_swe_agent` uses the older Docker workflow.
 - Terminal-Bench tasks: `anyterminal_agent`, which runs the agent and the task's tests in the same container.
-- Coding through an external CLI: `claude_code_agent`, `codex_agent`, `kilocode_agent`, `opencode_agent`, `openclaw_agent`, or `pi_agent`. All are evaluation-only; check the README before training on their rollouts.
+- An external command-line harness: `claude_code_agent`, `cline_agent`, `codex_agent`, `kilocode_agent`, `opencode_agent`, `openclaw_agent`, `pi_agent`, or `prime_agent`. These adapters are evaluation-only; check the README before training on their rollouts.
+- A harness that should execute inside the Resources server's task sandbox: `opencode_sandboxed_agent` or `terminus_2_sandboxed_agent`.
+- An interchangeable harness behind one typed lifecycle: `nemo_fabric_agent`.
 - Multi-step tool use for training: `hermes_agent`, pinned to a fork with the token-ID and sampling-parameter patches training requires.
 - LangGraph graphs: `langgraph_agent`. Graphs with non-monotonic trajectories, such as parallel thinking, work for evaluation but need extra handling before NeMo RL training.
 - Environments from an external library: `aviary_agent` for FutureHouse Aviary, `verifiers_agent` for Prime Intellect Verifiers.
@@ -149,7 +168,7 @@ The provider's own config lives in a separate file that defines the named `sandb
 
 When set, they take precedence over the configured `model_server` for that rollout; when absent, the configured model server is used. This is not a general Agent server field — only those two agent servers read it, and the others silently ignore it because their run-request models allow extra keys. Check the agent server's request model before relying on it.
 
-Skills are a run-level input, set with `+skills.path` on `gym eval run`. NeMo Gym records and forwards a `skills_ref`, but the agent server still has to stage the files where its runtime looks for them — `claude_code_agent` and `codex_agent` are the two with native adapters today. Rollout collection accepting `skills.path` does not by itself mean the agent server loads the skills; `remote_agent`, for instance, logs a warning that it cannot stage them. See [Agent Skills](/agent-server/agent-skills).
+Skills are a run-level input, set with `+skills.path` on `gym eval run`. NeMo Gym records and forwards a `skills_ref`, but the agent server still has to stage the files where its runtime looks for them. `claude_code_agent`, `codex_agent`, and `nemo_fabric_agent` handle this input today. Rollout collection accepting `skills.path` does not by itself mean the agent server loads the skills; `remote_agent`, for instance, logs a warning that it cannot stage them. See [Agent Skills](/agent-server/agent-skills).
 
 To run, start the composed servers and then collect rollouts against the top-level agent server name:
 


### PR DESCRIPTION
Closes NVIDIA-NeMo/Gym#1132.

The Configure Agents index page described the Agent server's role in a rollout but did not say that the Agent server is where an environment's agent harness lives, or that NeMo Gym ships agent servers that wrap external harnesses. Integrate Existing Agents was a stub naming two agents.

index.mdx: lead with the Agent server as the home of the agent harness, add a section on why the harness is a separate server, and replace the prose pointer with cards to the three sub-pages and the agent server configuration reference. This keeps the rollout lifecycle pseudocode.

integrate-existing-agents.mdx: list the built-in agent servers, then the agent servers that run external harnesses, grouped as coding CLIs, agent frameworks, benchmark-native harnesses, and the agent-agnostic task runners. Adds the four responsibilities every wrapper has, and the requirements a wrapper must meet for its rollouts to be trainable (route through the model server, carry token IDs, leave sampling parameters alone, keep the trajectory monotonic).

ecosystem.mdx: point the Agent Harnesses are listed in the catalog