### PR TITLE
fix: create the rollout output directory before the first write

### DIFF
--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -736,6 +736,13 @@ class RolloutCollectionHelper(BaseModel):
     async def run_from_config(self, config: RolloutCollectionConfig) -> Tuple[List[Dict]]:
         output_fpath = Path(config.output_jsonl_fpath)
 
+        # Create the output directory up front: every artifact this run writes (materialized inputs,
+        # rollouts, failures sidecar, aggregate metrics) is derived from output_fpath and keeps its
+        # parent, and the materialized-inputs write below is the first one. Keep this above that
+        # write -- a user pointing --output at a not-yet-existing directory is the common case
+        # outside a git clone.
+        output_fpath.parent.mkdir(parents=True, exist_ok=True)
+
         if config.resume_from_cache and config.materialized_jsonl_fpath.exists() and output_fpath.exists():
             (
                 input_rows,
@@ -776,7 +783,6 @@ class RolloutCollectionHelper(BaseModel):
             print(f"Querying with {config.num_samples_in_parallel} concurrent requests")
             semaphore = Semaphore(config.num_samples_in_parallel)
 
-        output_fpath.parent.mkdir(exist_ok=True, parents=True)
         failures_fpath = failures_path_for(output_fpath)
 
         # Resolve capture dirs once so each rollout's captured model calls can be folded

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -859,6 +859,51 @@ class TestRolloutCollection:
         assert expected_aggregate_metrics == actual_aggregate_metrics
 
     @pytest.mark.parametrize("resume_from_cache", [False, True])
+    async def test_run_from_config_creates_missing_output_dir(
+        self, tmp_path: Path, empty_global_config: MagicMock, resume_from_cache: bool
+    ) -> None:
+        """--output under a directory that doesn't exist yet must not raise.
+
+        The first artifact written is the materialized inputs, so a mkdir placed after it (or only
+        alongside the rollouts write) leaves this failing. resume_from_cache=True takes the same
+        path here because neither cached file exists, and must not be tripped up by the new dir.
+        """
+        input_jsonl_fpath = tmp_path / "input.jsonl"
+        input_jsonl_fpath.write_text(
+            json.dumps({"responses_create_params": {"input": []}, "agent_ref": {"name": "my agent name"}}) + "\n"
+        )
+        # Two levels deep so `parents=True` is exercised, not just a single missing dir.
+        output_jsonl_fpath = tmp_path / "results" / "nested" / "rollouts.jsonl"
+
+        config = RolloutCollectionConfig(
+            input_jsonl_fpath=str(input_jsonl_fpath),
+            output_jsonl_fpath=str(output_jsonl_fpath),
+            resume_from_cache=resume_from_cache,
+        )
+
+        class Helper(RolloutCollectionHelper):
+            def run_examples(self, examples, *args, **kwargs):
+                futures = []
+                for example in examples:
+                    future = Future()
+                    future.set_result((example, {"response": {"usage": {"abc usage": 1}}}))
+                    futures.append(future)
+                return futures
+
+            async def _call_aggregate_metrics(self, results, rows, output_fpath):
+                metrics_fpath = output_fpath.with_stem(output_fpath.stem + "_aggregate_metrics").with_suffix(".json")
+                metrics_fpath.write_bytes(orjson.dumps([]))
+                return metrics_fpath
+
+        await Helper().run_from_config(config)
+
+        # All four artifacts share output_fpath's parent, so one mkdir has to cover all of them.
+        assert config.materialized_jsonl_fpath.exists()
+        assert output_jsonl_fpath.exists()
+        assert _failures_path_for(output_jsonl_fpath).exists()
+        assert output_jsonl_fpath.with_name("rollouts_aggregate_metrics.json").exists()
+
+    @pytest.mark.parametrize("resume_from_cache", [False, True])
     @pytest.mark.parametrize("redact_payloads", [False, True])
     async def test_run_from_config_replaces_stale_capture_before_dispatch(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, resume_from_cache: bool, redact_payloads: bool


### PR DESCRIPTION
Fixes #2217

## Problem

`gym eval run --no-serve --output results/mcqa_rollouts.jsonl` — the quickstart command in the README — raises `FileNotFoundError` when `results/` does not exist yet:

```
File "nemo_gym/rollout_collection.py", line 508, in run_from_config
    with config.materialized_jsonl_fpath.open("wb") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'results/mcqa_rollouts_materialized_inputs.jsonl'
```

The mkdir was already present in `run_from_config`, but it is called too late. It ran at the top of the dispatch section, while the first thing the run writes is the materialized inputs.

## Fix

Move `output_fpath.parent.mkdir(parents=True, exist_ok=True)` to the top of `run_from_config`, above both the resume and fresh branches.

The issue suggested adding a mkdir at each of the four output paths. One is enough: all four derive from `output_fpath` and keep its parent: materialized inputs and aggregate metrics via `with_stem`, the failures sidecar via `with_name`, rollouts is the path itself.

Resume semantics are unchanged: creating an empty directory does not make `output_fpath.exists()` or `materialized_jsonl_fpath.exists()` true, so resume eligibility is decided the same way as before.

## Why this only showed up on the PyPI install path

Two things were hiding it:

- Without `--no-serve`, `gym eval run` dispatches to `e2e_rollout_collection`, which sets `output_dirpath = <output parent>/preprocessed_datasets` and lets `TrainDataProcessor` create it, incidentally creating the output parent. Only the `--no-serve` path goes straight to `collect_rollouts`.
- The repo tracks a `results/.gitignore` placeholder, so `results/` exists in a git clone. A PyPI install running from an arbitrary cwd has no such directory.

## Scope

This was the only affected entry point. The others already create their output parent first, so this brings rollout collection in line with the existing convention:

- `gym eval reverify` — `rollout_reverification.py`, in `_prepare_output_fpaths`
- `gym eval aggregate` — `rollout_collection.py`, in `RolloutAggregationHelper.run_from_config`
- `gym dataset render` — `prompt.py`, in `materialize_prompts`
- `gym eval profile` — writes next to an input rollouts file that must already exist

## Testing

Added `test_run_from_config_creates_missing_output_dir`, parametrized over `resume_from_cache`, writing to a two-level-deep missing directory and asserting all four artifacts land there. Both parametrizations fail on `main` and pass with this change.