### PR TITLE
docs: correct Workplace Assistant tool and database counts

### DIFF
--- a/environments/workplace_assistant/README.md
+++ b/environments/workplace_assistant/README.md
@@ -1,6 +1,6 @@
 # Description
 
-1. Environment: This is a tool use - multi step agentic environment that tests the agents ability to execute tasks in a workplace setting. Workplace assistant contains a sandbox environment with five databases, 26 tools, and 690 tasks. These tasks represent common business activities, such as sending emails and scheduling meetings.
+1. Environment: This is a tool use - multi step agentic environment that tests the agents ability to execute tasks in a workplace setting. Workplace assistant contains a sandbox environment with five databases, 27 tools, and 690 tasks. These tasks represent common business activities, such as sending emails and scheduling meetings.
 2. Domain: Business activities
 3. Source of prompts: 
 - Full set of prompts (1260): https://huggingface.co/datasets/nvidia/Nemotron-RL-agent-workplace_assistant

--- a/fern/versions/latest/pages/environment-tutorials/real-world-environment/generating-training-data.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/real-world-environment/generating-training-data.mdx
@@ -7,7 +7,7 @@ import { NavButton } from "../../../../../components/NavButton";
 
 Generate synthetic task data (user queries) for the [Workplace Assistant](/environment-tutorials/real-world-environment) environment using [NeMo Data Designer](https://github.com/NVIDIA-NeMo/DataDesigner). 
 
-This pipeline focuses on generating tasks for use with the environment. It also simulates agent trajectories, but these are used for quality filtering and validation — the environment itself produces the actual model responses during rollout collection. The Workplace Assistant uses 27 tools across 6 databases, and NeMo Data Designer can produce realistic multi-step user queries at scale.
+This pipeline focuses on generating tasks for use with the environment. It also simulates agent trajectories, but these are used for quality filtering and validation — the environment itself produces the actual model responses during rollout collection. The Workplace Assistant uses 27 tools across five databases plus a company directory lookup, and NeMo Data Designer can produce realistic multi-step user queries at scale.
 
 <NavButton href="/environment-tutorials/real-world-environment" label="Back to Workplace Assistant" direction="back" />
 

--- a/fern/versions/latest/pages/evaluation/environment-list.mdx
+++ b/fern/versions/latest/pages/evaluation/environment-list.mdx
@@ -76,7 +76,7 @@ gym list benchmarks --json   # machine-readable output for scripting or CI
 
 | Environment | Description | Verification | Benchmark |
 |---|---|---|---|
-| [workplace_assistant](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/workplace_assistant) | Workplace tasks: 26 tools, 5 databases, 690 tasks | Rule-based (task completion) | ✓ |
+| [workplace_assistant](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/workplace_assistant) | Workplace tasks: 27 tools, 5 databases, 690 tasks | Rule-based (task completion) | ✓ |
 | [aviary](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/aviary) | Multi-hop QA with Wikipedia search + GSM8k with calculator | LLM judge + execution | ✓ |
 | [tavily_search](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/tavily_search) | Web search tool use (Tavily API) | Execution + optional LLM judge | ✓ |
 | [calendar](https://github.com/NVIDIA-NeMo/Gym/tree/main/resources_servers/calendar) | Multi-turn calendar scheduling with constraint satisfaction | Rule-based (constraints) | ✓ |

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/about-workplace-assistant.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/about-workplace-assistant.mdx
@@ -136,7 +136,7 @@ Each task is a `responses_create_params` object:
 }
 ```
 
-The full task includes all 27 tools across the 5 databases.
+The full task includes all 27 tools: the five databases plus the company directory lookup.
 
 </Tab>
 

--- a/resources_servers/workplace_assistant/README.md
+++ b/resources_servers/workplace_assistant/README.md
@@ -1,6 +1,6 @@
 # Description
 
-1. Environment: This is a tool use - multi step agentic environment that tests the agents ability to execute tasks in a workplace setting. Workplace assistant contains a sandbox environment with five databases, 26 tools, and 690 tasks. These tasks represent common business activities, such as sending emails and scheduling meetings.
+1. Environment: This is a tool use - multi step agentic environment that tests the agents ability to execute tasks in a workplace setting. Workplace assistant contains a sandbox environment with five databases, 27 tools, and 690 tasks. These tasks represent common business activities, such as sending emails and scheduling meetings.
 2. Domain: Business activities
 3. Source of prompts: 
 - Full set of prompts (1260): https://huggingface.co/datasets/nvidia/Nemotron-RL-agent-workplace_assistant

--- a/resources_servers/workplace_assistant/tests/test_docs_counts.py
+++ b/resources_servers/workplace_assistant/tests/test_docs_counts.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Keep the documented Workplace Assistant tool and database counts in sync with the code.
+
+`get_tools` is the single source of truth: it always registers the company directory
+lookup and then adds one toolkit per name in `TOOLKITS`. Pages and READMEs that quote a
+tool count are listed here so adding or removing a tool fails this test instead of
+silently making the docs wrong.
+"""
+
+from pathlib import Path
+
+from resources_servers.workplace_assistant.utils import get_tools
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# The toolkits `app.py` seeds every session with. The company directory is not listed
+# because `get_tools` registers it unconditionally.
+TOOLKITS = [
+    "email",
+    "calendar",
+    "analytics",
+    "project_management",
+    "customer_relationship_manager",
+]
+
+# Every place that quotes the tool count, and the exact text it must contain.
+DOCUMENTED_TOOL_COUNTS = {
+    "fern/versions/latest/pages/evaluation/environment-list.mdx": "Workplace tasks: {n} tools, 5 databases",
+    "fern/versions/latest/pages/environment-tutorials/mcp-resources-server.mdx": "a real environment with {n} tools",
+    "fern/versions/latest/pages/environment-tutorials/real-world-environment/generating-training-data.mdx": (
+        "The Workplace Assistant uses {n} tools across five databases plus a company directory lookup"
+    ),
+    "fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/about-workplace-assistant.mdx": (
+        "The full task includes all {n} tools"
+    ),
+    "environments/workplace_assistant/README.md": "five databases, {n} tools",
+    "resources_servers/workplace_assistant/README.md": "five databases, {n} tools",
+    "resources_servers/workplace_assistant/app.py": "Register all {n} workplace tools",
+}
+
+
+class TestDocsCounts:
+    def test_get_tools_registers_one_container_per_toolkit_plus_the_company_directory(self):
+        tool_env = get_tools(TOOLKITS)
+
+        assert sorted(tool_env["containers"]) == sorted(TOOLKITS + ["company_directory"])
+        assert sorted(s["name"] for s in tool_env["schemas"]) == sorted(tool_env["functions"])
+
+    def test_documented_tool_count_matches_get_tools(self):
+        tool_count = len(get_tools(TOOLKITS)["functions"])
+
+        for path, template in DOCUMENTED_TOOL_COUNTS.items():
+            text = (REPO_ROOT / path).read_text()
+            expected = template.format(n=tool_count)
+            assert expected in text, f"{path} does not say {expected!r}; get_tools returns {tool_count} tools"
+
+    def test_only_the_company_directory_is_read_only(self):
+        """The five toolkits back a mutable database; the company directory only looks up addresses."""
+        tool_env = get_tools(TOOLKITS)
+
+        company_directory_tools = [name for name in tool_env["functions"] if name.startswith("company_directory_")]
+        assert company_directory_tools == ["company_directory_find_email_address"]


### PR DESCRIPTION
The Workplace Assistant docs quote four different figures for the same environment: 26 tools / 5 databases, 27 tools / 5 databases, 27 tools / 6 databases, and 27 tools split as five toolkits plus a company directory.

`get_tools` in `resources_servers/workplace_assistant/utils.py` is the source of truth. It always registers the company directory lookup, then adds one toolkit per requested name. Running it with the five toolkits `app.py` seeds each session with:

```
functions: 27   schemas: 27
containers: analytics, calendar, company_directory, customer_relationship_manager, email, project_management
per-toolkit: email 6, analytics 6, calendar 5, project_management 5, crm 4, company_directory 1
```

So: 27 tools across five mutable databases plus a read-only company directory. `is_correct` (utils.py:166) compares final state for the five databases and not the company directory, which only exposes `find_email_address`.

## Changes

- `evaluation/environment-list.mdx`: 26 tools to 27 tools
- `generating-training-data.mdx`: "27 tools across 6 databases" to five databases plus a company directory lookup
- `about-workplace-assistant.mdx`: the 27 tools are the five databases plus the company directory, not 27 tools spread across five databases
- `environments/workplace_assistant/README.md` and `resources_servers/workplace_assistant/README.md`: 26 tools to 27 tools

`mcp-resources-server.mdx` already matched the code and is unchanged.

## Test

`resources_servers/workplace_assistant/tests/test_docs_counts.py` derives the count from `get_tools` and asserts every page and README that quotes it. Adding or removing a tool now fails a test instead of leaving the docs stale.