### PR TITLE
docs: link Add a Benchmark by path instead of absolute URL

### DIFF
--- a/fern/versions/latest/pages/contribute/agent-skills.mdx
+++ b/fern/versions/latest/pages/contribute/agent-skills.mdx
@@ -55,5 +55,5 @@ The [`nemo-gym-docs`](https://github.com/NVIDIA-NeMo/Gym/tree/main/.agents/skill
 ## Related Topics
 
 - [Development Setup](/contribute/development-setup) — environment setup, CI, and commit requirements
-- [Add a Benchmark](https://docs.nvidia.com/nemo/gym/contribute/environments/adding-a-benchmark) — human-readable tutorial that complements the `add-benchmark` skill
+- [Add a Benchmark](/contribute/environments/adding-a-benchmark) — human-readable tutorial that complements the `add-benchmark` skill
 - [Contribute Environments](/contribute/environments) — guidance for new training environments

--- a/tests/unit_tests/test_fern_docs_links.py
+++ b/tests/unit_tests/test_fern_docs_links.py
@@ -131,6 +131,25 @@ class TestFernDocsLinks(unittest.TestCase):
                 self.assertEqual([], broken_links)
                 self.assertEqual(2, canonical_links)
 
+    def test_internal_pages_are_linked_by_path_not_by_absolute_url(self):
+        """An absolute docs.nvidia.com link pins the reader to the default version.
+
+        Relative paths keep the reader inside the version they are already reading.
+        Prose that names the domain without linking to it is fine.
+
+        Scoped to `latest`. The frozen versions carry the same pattern but are left as
+        they shipped.
+        """
+        pages = REPO_ROOT / "fern/versions/latest/pages"
+        absolute_links = []
+
+        for page in pages.rglob("*.mdx"):
+            for line_number, line in enumerate(page.read_text().splitlines(), start=1):
+                if re.search(r'(?:\]\(|href=")https?://docs\.nvidia\.com/nemo/gym', line):
+                    absolute_links.append(f"{page.relative_to(REPO_ROOT)}:{line_number}")
+
+        self.assertEqual([], absolute_links)
+
     def test_private_cli_compat_api_link_redirects_to_the_public_cli_page(self):
         redirects = read("fern/docs.yml")
         expected_redirect = """  - source: "/nemo/gym/nemo-gym/nemo_gym/cli/_compat"


### PR DESCRIPTION
`contribute/agent-skills.mdx` links to the Add a Benchmark page with a full `docs.nvidia.com` URL that carries no version slug. The URL resolves (200), so nothing is broken, but it drops readers on the default version regardless of which version they were reading.