### PR TITLE
docs: link training tutorials under the /tutorials/ section prefix

### DIFF
--- a/fern/versions/latest/pages/about/architecture.mdx
+++ b/fern/versions/latest/pages/about/architecture.mdx
@@ -115,7 +115,7 @@ Browse available environments for evaluation and training.
 Explore available agent harnesses and learn how to integrate your own agent.
 </Card>
 
-<Card title="Training" href="/training-tutorials">
+<Card title="Training" href="/tutorials/training-tutorials">
 Improve your agent or model with RL or fine-tuning.
 </Card>
 

--- a/fern/versions/latest/pages/about/concepts/training.mdx
+++ b/fern/versions/latest/pages/about/concepts/training.mdx
@@ -70,7 +70,7 @@ This turns an environment into a synthetic data generation (SDG) pipeline.
 
 <Cards>
 
-<Card title="Training Tutorials" href="/training-tutorials">
+<Card title="Training Tutorials" href="/tutorials/training-tutorials">
 Hands-on guides for training with NeMo Gym.
 </Card>
 

--- a/fern/versions/latest/pages/about/ecosystem.mdx
+++ b/fern/versions/latest/pages/about/ecosystem.mdx
@@ -37,9 +37,9 @@ Seamlessly combine environments and benchmarks from other libraries alongside Ne
 
 Use environments for SFT and RL training. If you're interested in integrating another training framework, see the [Training Framework Integration Guide](/contribute/rl-framework-integration).
 
-- **[NeMo RL](/training-tutorials/nemo-rl-grpo)**
-- **[Unsloth](/training-tutorials/unsloth)**
-- **[VeRL](/training-tutorials/verl)**
+- **[NeMo RL](/tutorials/training-tutorials/nemo-rl-grpo)**
+- **[Unsloth](/tutorials/training-tutorials/unsloth)**
+- **[VeRL](/tutorials/training-tutorials/verl)**
 
 ## Agent Harnesses
 

--- a/fern/versions/latest/pages/about/index.mdx
+++ b/fern/versions/latest/pages/about/index.mdx
@@ -52,7 +52,7 @@ Browse available environments for evaluation and training.
 Explore available agent harnesses and learn how to integrate your own agent.
 </Card>
 
-<Card title="Training" href="/training-tutorials">
+<Card title="Training" href="/tutorials/training-tutorials">
 Improve your agent or model with RL or fine-tuning.
 </Card>
 

--- a/fern/versions/latest/pages/contribute/rl-framework-integration/index.mdx
+++ b/fern/versions/latest/pages/contribute/rl-framework-integration/index.mdx
@@ -9,7 +9,7 @@ These guides cover how to integrate NeMo Gym into a new RL training framework. U
 - Contributing NeMo Gym integration for a training framework that does not have one yet
 
 <Tip>
-Just want to train models? See [Training Tutorials](/training-tutorials) for supported frameworks.
+Just want to train models? See [Training Tutorials](/tutorials/training-tutorials) for supported frameworks.
 
 </Tip>
 

--- a/fern/versions/latest/pages/data/download-huggingface.mdx
+++ b/fern/versions/latest/pages/data/download-huggingface.mdx
@@ -290,7 +290,7 @@ rm -rf ~/.cache/huggingface/hub/datasets--<org>--<dataset>
 Preprocess raw data, run `gym dataset collate`, and add `agent_ref` routing.
 </Card>
 
-<Card title="Training Tutorials" href="/training-tutorials">
+<Card title="Training Tutorials" href="/tutorials/training-tutorials">
 
 Use validated data to train with your preferred RL framework.
 </Card>

--- a/fern/versions/latest/pages/data/prepare-validate.mdx
+++ b/fern/versions/latest/pages/data/prepare-validate.mdx
@@ -388,6 +388,6 @@ datasets:
 
 ## Next Steps
 
-<Card title="Training Tutorials" href="/training-tutorials">
+<Card title="Training Tutorials" href="/tutorials/training-tutorials">
 Use validated data for RL training or fine-tuning.
 </Card>

--- a/fern/versions/latest/pages/environment-tutorials/real-world-environment/generating-training-data.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/real-world-environment/generating-training-data.mdx
@@ -35,6 +35,6 @@ The tutorial is provided as a Jupyter notebook. See the [notebook README](https:
 
 ## What's Next?
 
-After generating your tasks, let's perform [GRPO training](/training-tutorials/nemo-rl-grpo) with NeMo RL by having an agent attempt the tasks in the Workplace Assistant environment.
+After generating your tasks, let's perform [GRPO training](/tutorials/training-tutorials/nemo-rl-grpo) with NeMo RL by having an agent attempt the tasks in the Workplace Assistant environment.
 
 <NavButton href="/environment-tutorials/real-world-environment/resources-server-implementation" label="Resources Server Implementation" direction="next" />

--- a/fern/versions/latest/pages/environment-tutorials/single-step-environment.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/single-step-environment.mdx
@@ -496,11 +496,11 @@ Once you've collected rollouts and validated your environment, run training with
 
 <Cards>
 
-<Card title="NeMo RL (GRPO)" href="/training-tutorials/nemo-rl-grpo">
+<Card title="NeMo RL (GRPO)" href="/tutorials/training-tutorials/nemo-rl-grpo">
 Train models using GRPO with NeMo RL.
 </Card>
 
-<Card title="Unsloth" href="/training-tutorials/unsloth">
+<Card title="Unsloth" href="/tutorials/training-tutorials/unsloth">
 Train with Unsloth for fast fine-tuning.
 </Card>
 

--- a/fern/versions/latest/pages/evaluation/index.mdx
+++ b/fern/versions/latest/pages/evaluation/index.mdx
@@ -105,7 +105,7 @@ Compute per-task pass rates and variance with <code>gym eval profile</code>.
 Recompute rewards from existing rollouts without re-running inference using <code>gym eval reverify</code>.
 </Card>
 
-<Card title="Training" href="/training-tutorials">
+<Card title="Training" href="/tutorials/training-tutorials">
 Use evaluation results to drive post-training.
 </Card>
 

--- a/fern/versions/latest/pages/get-started/quickstart.mdx
+++ b/fern/versions/latest/pages/get-started/quickstart.mdx
@@ -133,7 +133,7 @@ Browse available environments for evaluation and training.
 Explore available agent harnesses and learn how to integrate your own agent.
 </Card>
 
-<Card title="Training" href="/training-tutorials">
+<Card title="Training" href="/tutorials/training-tutorials">
 Improve your agent or model with RL or fine-tuning.
 </Card>
 

--- a/fern/versions/latest/pages/infrastructure/deployment-topology.mdx
+++ b/fern/versions/latest/pages/infrastructure/deployment-topology.mdx
@@ -146,7 +146,7 @@ flowchart LR
 Implement NeMo Gym integration into a new training framework.
 </Card>
 
-<Card title="NeMo RL GRPO Training" href="/training-tutorials/nemo-rl-grpo">
+<Card title="NeMo RL GRPO Training" href="/tutorials/training-tutorials/nemo-rl-grpo">
 End-to-end GRPO training tutorial with NeMo RL.
 </Card>
 

--- a/fern/versions/latest/pages/model-recipes/nemotron-3-nano.mdx
+++ b/fern/versions/latest/pages/model-recipes/nemotron-3-nano.mdx
@@ -22,7 +22,7 @@ This tutorial walks through the complete setup for distributed training of Nemot
 
 ## Prerequisites
 
-Before starting, complete the [NeMo RL GRPO tutorial](/training-tutorials/nemo-rl-grpo) to understand the NeMo RL training workflow and GRPO fundamentals.
+Before starting, complete the [NeMo RL GRPO tutorial](/tutorials/training-tutorials/nemo-rl-grpo) to understand the NeMo RL training workflow and GRPO fundamentals.
 
 You'll also need:
 

--- a/fern/versions/latest/pages/reference/rl-framework-compatibility.mdx
+++ b/fern/versions/latest/pages/reference/rl-framework-compatibility.mdx
@@ -17,7 +17,7 @@ The following table maps NeMo Gym versions to compatible NeMo RL containers for 
 
 **v0.4.0 and later:** NeMo RL plans to publish an NGC container for every Gym release. New rows should use NGC tags; Dockerfile references should not be added unless the same gap recurs.
 
-Match the container to your **model recipe**, not only your NeMo Gym version. For example, the [NeMo RL GRPO](/training-tutorials/nemo-rl-grpo) tutorial trains Nemotron Nano 9B v2 and uses the Nano NGC container from the v0.1.1 row below—not the v0.3.0 Ultra Dockerfile.
+Match the container to your **model recipe**, not only your NeMo Gym version. For example, the [NeMo RL GRPO](/tutorials/training-tutorials/nemo-rl-grpo) tutorial trains Nemotron Nano 9B v2 and uses the Nano NGC container from the v0.1.1 row below—not the v0.3.0 Ultra Dockerfile.
 
 | NeMo Gym Version | Container / Docker File | Recipe |
 | --- | --- | --- |
@@ -27,7 +27,7 @@ Match the container to your **model recipe**, not only your NeMo Gym version. Fo
 | v0.1.1 | [`nvcr.io/nvidia/nemo-rl:v0.4.0.nemotron_3_nano`](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-rl/tags?version=v0.4.0) | [Nemotron 3 Nano](/model-recipes/nemotron-3-nano) |
 
 <Note>
-[NeMo RL GRPO](/training-tutorials/nemo-rl-grpo) for the NeMo RL training tutorial.
+[NeMo RL GRPO](/tutorials/training-tutorials/nemo-rl-grpo) for the NeMo RL training tutorial.
 
 </Note>
 
@@ -38,7 +38,7 @@ Match the container to your **model recipe**, not only your NeMo Gym version. Fo
 The NeMo Gym integration with Unsloth is tested on `unsloth==2026.1.4` and `unsloth_zoo==2026.1.4`. Other versions are not guaranteed to work.
 
 <Note>
-[Unsloth](/training-tutorials/unsloth) for the Unsloth training tutorial.
+[Unsloth](/tutorials/training-tutorials/unsloth) for the Unsloth training tutorial.
 
 </Note>
 
@@ -49,6 +49,6 @@ The NeMo Gym integration with Unsloth is tested on `unsloth==2026.1.4` and `unsl
 NeMo Gym 0.2.1+ is compatible with verl pinned to the commit in [`REQUIRED_VERL.txt`](https://github.com/verl-project/verl-recipe/blob/main/nemo_gym/REQUIRED_VERL.txt), tested on the `verlai/verl:vllm017.latest` container (vLLM 0.17.0). Other versions are not guaranteed to work.
 
 <Note>
-[Training with VeRL](/training-tutorials/verl) for the verl training tutorial.
+[Training with VeRL](/tutorials/training-tutorials/verl) for the verl training tutorial.
 
 </Note>

--- a/fern/versions/latest/pages/training-tutorials/index.mdx
+++ b/fern/versions/latest/pages/training-tutorials/index.mdx
@@ -14,19 +14,19 @@ See [Training](/about/concepts/training) for a refresher on when to use GRPO, SF
 
 <Cards>
 
-<Card title="NeMo RL" href="/training-tutorials/nemo-rl-grpo">
+<Card title="NeMo RL" href="/tutorials/training-tutorials/nemo-rl-grpo">
 Tutorial-series: GRPO training to improve multi-step tool calling on the Workplace Assistant environment, scaling from single-node to multi-node training.
 
 <Badge minimal outlined>nemo rl</Badge> <Badge minimal outlined>grpo</Badge> <Badge minimal outlined>3-5 hours</Badge>
 </Card>
 
-<Card title="Unsloth" href="/training-tutorials/unsloth">
+<Card title="Unsloth" href="/tutorials/training-tutorials/unsloth">
 Example GRPO training on instruction following and reasoning environments.
 
 <Badge minimal outlined>unsloth</Badge> <Badge minimal outlined>single-gpu</Badge> <Badge minimal outlined>30 min</Badge>
 </Card>
 
-<Card title="VeRL" href="/training-tutorials/verl">
+<Card title="VeRL" href="/tutorials/training-tutorials/verl">
 Example DAPO training on math and agentic environments using VeRL, with single and multi-environment support.
 
 <Badge minimal outlined>verl</Badge> <Badge minimal outlined>dapo</Badge> <Badge minimal outlined>multi-node</Badge> <Badge minimal outlined>1 hour</Badge>
@@ -38,7 +38,7 @@ Example DAPO training on math and agentic environments using VeRL, with single a
 
 <Cards>
 
-<Card title="Multi-Environment Training" href="/training-tutorials/multi-environment-training">
+<Card title="Multi-Environment Training" href="/tutorials/training-tutorials/multi-environment-training">
 Run multiple training environments simultaneously for rollout collection.
 
 <Badge minimal outlined>multi-environment</Badge> <Badge minimal outlined>multi-verifier</Badge>
@@ -50,7 +50,7 @@ Run multiple training environments simultaneously for rollout collection.
 
 <Cards>
 
-<Card title="Offline Training with Rollouts" href="/training-tutorials/offline-training-w-rollouts">
+<Card title="Offline Training with Rollouts" href="/tutorials/training-tutorials/offline-training-w-rollouts">
 Transform rollouts into training data for supervised fine-tuning (SFT) and direct preference optimization (DPO).
 
 <Badge minimal outlined>sft</Badge> <Badge minimal outlined>dpo</Badge>

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/about-workplace-assistant.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/about-workplace-assistant.mdx
@@ -20,11 +20,11 @@ Workplace Assistant is a **multi-step agentic tool-use training environment** th
 
 </Info>
 
-<NavButton href="/training-tutorials/nemo-rl-grpo" label="Back to Tutorial Overview" direction="back" />
+<NavButton href="/tutorials/training-tutorials/nemo-rl-grpo" label="Back to Tutorial Overview" direction="back" />
 
 ## Prerequisites
 
-- Read the [tutorial overview](/training-tutorials/nemo-rl-grpo) to understand the training goals
+- Read the [tutorial overview](/tutorials/training-tutorials/nemo-rl-grpo) to understand the training goals
 
 ---
 
@@ -236,4 +236,4 @@ async def route_to_python_function(self, path, body, request):
 
 Now that you understand the Workplace Assistant environment, learn how to configure NeMo Gym for training:
 
-<NavButton href="/training-tutorials/nemo-rl-grpo/gym-configuration" label="Continue to Gym Configuration" direction="next" />
+<NavButton href="/tutorials/training-tutorials/nemo-rl-grpo/gym-configuration" label="Continue to Gym Configuration" direction="next" />

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/gym-configuration.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/gym-configuration.mdx
@@ -19,11 +19,11 @@ Before running GRPO training, you need to configure how NeMo RL connects to NeMo
 
 </Info>
 
-<NavButton href="/training-tutorials/nemo-rl-grpo/about-workplace-assistant" label="Previous: About Workplace Assistant" direction="prev" />
+<NavButton href="/tutorials/training-tutorials/nemo-rl-grpo/about-workplace-assistant" label="Previous: About Workplace Assistant" direction="prev" />
 
 ## Prerequisites
 
-- Read [About Workplace Assistant](/training-tutorials/nemo-rl-grpo/about-workplace-assistant) to understand the training environment
+- Read [About Workplace Assistant](/tutorials/training-tutorials/nemo-rl-grpo/about-workplace-assistant) to understand the training environment
 
 ---
 
@@ -33,7 +33,7 @@ The full training configuration file lives in the [NeMo RL repository](https://g
 
 [`examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml`](https://github.com/NVIDIA-NeMo/RL/blob/main/examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml)
 
-Paths in that file are relative to the NeMo RL repo root. After [Setup](/training-tutorials/nemo-rl-grpo/setup), NeMo Gym is checked out inside that repo at `3rdparty/Gym-workspace/Gym/`, which is why the data paths below point there.
+Paths in that file are relative to the NeMo RL repo root. After [Setup](/tutorials/training-tutorials/nemo-rl-grpo/setup), NeMo Gym is checked out inside that repo at `3rdparty/Gym-workspace/Gym/`, which is why the data paths below point there.
 
 ---
 
@@ -57,7 +57,7 @@ data:
 
 | Parameter | Description |
 |-----------|-------------|
-| `train.data_path` | Path to training dataset (created later in [Setup](/training-tutorials/nemo-rl-grpo/setup)) |
+| `train.data_path` | Path to training dataset (created later in [Setup](/tutorials/training-tutorials/nemo-rl-grpo/setup)) |
 | `validation.data_path` | Path to validation dataset |
 | `default.dataset_name` | Must be `NemoGymDataset` so NeMo RL reads Gym-format JSONL |
 | `default.env_name` | Must be `nemo_gym` so batches are routed to the Gym environment |
@@ -119,4 +119,4 @@ env:
 
 With the Gym configuration understood, learn about the GRPO training parameters:
 
-<NavButton href="/training-tutorials/nemo-rl-grpo/nemo-rl-configuration" label="Continue to NeMo RL Configuration" direction="next" />
+<NavButton href="/tutorials/training-tutorials/nemo-rl-grpo/nemo-rl-configuration" label="Continue to NeMo RL Configuration" direction="next" />

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/index.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/index.mdx
@@ -22,7 +22,7 @@ Workplace Assistant is a realistic office simulation (calendar, email, project m
 
 </Info>
 
-> **TL;DR:** Want to jump straight to running commands? Skip to [Setup](/training-tutorials/nemo-rl-grpo/setup).
+> **TL;DR:** Want to jump straight to running commands? Skip to [Setup](/tutorials/training-tutorials/nemo-rl-grpo/setup).
 
 ---
 
@@ -58,42 +58,42 @@ Follow these steps sequentially to complete the tutorial:
 
 <Cards>
 
-<Card title="1. About the Workplace Assistant Training Environment" href="/training-tutorials/nemo-rl-grpo/about-workplace-assistant">
+<Card title="1. About the Workplace Assistant Training Environment" href="/tutorials/training-tutorials/nemo-rl-grpo/about-workplace-assistant">
 
 Understand the dataset you will train on and its multi-step tool calling tasks.
 
 <Badge minimal outlined>background</Badge>
 </Card>
 
-<Card title="2. Gym Configuration" href="/training-tutorials/nemo-rl-grpo/gym-configuration">
+<Card title="2. Gym Configuration" href="/tutorials/training-tutorials/nemo-rl-grpo/gym-configuration">
 
 Understand the Gym configuration component in the NeMo RL training config file.
 
 <Badge minimal outlined>configuration</Badge>
 </Card>
 
-<Card title="3. NeMo RL Configuration" href="/training-tutorials/nemo-rl-grpo/nemo-rl-configuration">
+<Card title="3. NeMo RL Configuration" href="/tutorials/training-tutorials/nemo-rl-grpo/nemo-rl-configuration">
 
 Understand the GRPO and NeMo RL configuration components in the training config file.
 
 <Badge minimal outlined>configuration</Badge>
 </Card>
 
-<Card title="4. Setup" href="/training-tutorials/nemo-rl-grpo/setup">
+<Card title="4. Setup" href="/tutorials/training-tutorials/nemo-rl-grpo/setup">
 
 Clone repositories, install dependencies, and prepare the training data.
 
 <Badge intent="success" minimal outlined>prerequisite</Badge>
 </Card>
 
-<Card title="5. Single Node Training" href="/training-tutorials/nemo-rl-grpo/single-node-training">
+<Card title="5. Single Node Training" href="/tutorials/training-tutorials/nemo-rl-grpo/single-node-training">
 
 Perform a single node GRPO training run with success criteria.
 
 <Badge intent="success" minimal outlined>training</Badge>
 </Card>
 
-<Card title="6. Multi-Node Training" href="/training-tutorials/nemo-rl-grpo/multi-node-training">
+<Card title="6. Multi-Node Training" href="/tutorials/training-tutorials/nemo-rl-grpo/multi-node-training">
 
 Scale to multi-node GRPO training for production.
 

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/multi-node-training.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/multi-node-training.mdx
@@ -19,14 +19,14 @@ Your single-node test run confirmed that the environment, model, and training lo
 
 </Info>
 
-<NavButton href="/training-tutorials/nemo-rl-grpo/single-node-training" label="Previous: Single Node Training" direction="prev" />
+<NavButton href="/tutorials/training-tutorials/nemo-rl-grpo/single-node-training" label="Previous: Single Node Training" direction="prev" />
 
 ---
 
 ## Prerequisites
 
 <Info>
-**Complete the [Single Node Training](/training-tutorials/nemo-rl-grpo/single-node-training) first. Do not skip it.** The single-node setup validates that your environment is configured correctly before attempting multi-node training.
+**Complete the [Single Node Training](/tutorials/training-tutorials/nemo-rl-grpo/single-node-training) first. Do not skip it.** The single-node setup validates that your environment is configured correctly before attempting multi-node training.
 
 </Info>
 
@@ -74,7 +74,7 @@ SLURM_PARTITION={your Slurm partition} \
 ```
 
 <Tip>
-If you are using enroot following the steps in the [Setup](/training-tutorials/nemo-rl-grpo/setup) doc and downloaded the container locally, use the local container filepath instead:
+If you are using enroot following the steps in the [Setup](/tutorials/training-tutorials/nemo-rl-grpo/setup) doc and downloaded the container locally, use the local container filepath instead:
 
 ```bash
 CONTAINER_IMAGE_PATH=$PWD/../nvcr.io/nvidia/nemo-rl:v0.4.0.nemotron_3_nano \

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/nemo-rl-configuration.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/nemo-rl-configuration.mdx
@@ -20,11 +20,11 @@ With the Gym configuration in place, the next step is understanding the core tra
 
 </Info>
 
-<NavButton href="/training-tutorials/nemo-rl-grpo/gym-configuration" label="Previous: Gym Configuration" direction="prev" />
+<NavButton href="/tutorials/training-tutorials/nemo-rl-grpo/gym-configuration" label="Previous: Gym Configuration" direction="prev" />
 
 ## Prerequisites
 
-- Read [Gym Configuration](/training-tutorials/nemo-rl-grpo/gym-configuration) to understand the Gym-specific parameters
+- Read [Gym Configuration](/tutorials/training-tutorials/nemo-rl-grpo/gym-configuration) to understand the Gym-specific parameters
 
 ---
 
@@ -78,4 +78,4 @@ examples/nemo_gym/grpo_workplace_assistant_nemotron_nano_v2_9b.yaml
 
 With the configuration parameters understood, set up your training environment:
 
-<NavButton href="/training-tutorials/nemo-rl-grpo/setup" label="Continue to Setup" direction="next" />
+<NavButton href="/tutorials/training-tutorials/nemo-rl-grpo/setup" label="Continue to Setup" direction="next" />

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/setup.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/setup.mdx
@@ -22,7 +22,7 @@ Now that you understand the configuration parameters for GRPO training, it's tim
 
 </Info>
 
-<NavButton href="/training-tutorials/nemo-rl-grpo/nemo-rl-configuration" label="Previous: NeMo RL Configuration" direction="prev" />
+<NavButton href="/tutorials/training-tutorials/nemo-rl-grpo/nemo-rl-configuration" label="Previous: NeMo RL Configuration" direction="prev" />
 
 ---
 
@@ -254,4 +254,4 @@ cd ../../..
 
 With your environment set up and data prepared, run your first training session:
 
-<NavButton href="/training-tutorials/nemo-rl-grpo/single-node-training" label="Continue to Single Node Training" direction="next" />
+<NavButton href="/tutorials/training-tutorials/nemo-rl-grpo/single-node-training" label="Continue to Single Node Training" direction="next" />

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/single-node-training.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/single-node-training.mdx
@@ -21,7 +21,7 @@ With your environment set up and data prepared, you're ready to run training. Bu
 
 </Info>
 
-<NavButton href="/training-tutorials/nemo-rl-grpo/setup" label="Previous: Setup" direction="prev" />
+<NavButton href="/tutorials/training-tutorials/nemo-rl-grpo/setup" label="Previous: Setup" direction="prev" />
 
 ---
 
@@ -29,7 +29,7 @@ With your environment set up and data prepared, you're ready to run training. Bu
 
 Make sure you have:
 
-- ✅ Completed the [Setup](/training-tutorials/nemo-rl-grpo/setup) instructions
+- ✅ Completed the [Setup](/tutorials/training-tutorials/nemo-rl-grpo/setup) instructions
 - ✅ Access to a running container session with GPUs
 - ✅ (Optional) Weights & Biases API key for experiment tracking
 
@@ -154,4 +154,4 @@ The end of the command above does the following:
 
 Your single-node run validated the environment. Scale to multiple nodes for production training:
 
-<NavButton href="/training-tutorials/nemo-rl-grpo/multi-node-training" label="Continue to Multi-Node Training" direction="next" />
+<NavButton href="/tutorials/training-tutorials/nemo-rl-grpo/multi-node-training" label="Continue to Multi-Node Training" direction="next" />

--- a/fern/versions/latest/pages/training-tutorials/offline-training-w-rollouts.mdx
+++ b/fern/versions/latest/pages/training-tutorials/offline-training-w-rollouts.mdx
@@ -387,7 +387,7 @@ You now know how to transform rollouts into training data:
 
 <Cards>
 
-<Card title="GRPO Training" href="/training-tutorials/nemo-rl-grpo">
+<Card title="GRPO Training" href="/tutorials/training-tutorials/nemo-rl-grpo">
 
 Train with GRPO for more powerful optimization than offline methods.
 </Card>

--- a/tests/unit_tests/test_fern_docs_links.py
+++ b/tests/unit_tests/test_fern_docs_links.py
@@ -73,6 +73,29 @@ class TestFernDocsLinks(unittest.TestCase):
         self.assertEqual([], broken_links)
         self.assertEqual(8, canonical_links)
 
+    def test_main_training_tutorial_links_include_the_tutorials_section(self):
+        """`training-tutorials` sits under the same `section: Tutorials` as `evaluation-tutorials`.
+
+        Both therefore publish under `/tutorials/`. `/training-tutorials/...` still resolves
+        via a 308 from Fern, but the redirect is not something to rely on, and having the two
+        sibling folders linked differently is what makes the prefix look optional.
+
+        No exact link count here: there are enough of these that pinning a total would just
+        mean editing this test every time a tutorial gains a cross-reference.
+        """
+        pages = REPO_ROOT / "fern/versions/latest/pages"
+        redirected_links = []
+        canonical_links = 0
+
+        for page in pages.rglob("*.mdx"):
+            for line_number, line in enumerate(page.read_text().splitlines(), start=1):
+                if re.search(r'(?:\]\(|href=")/training-tutorials(?:[/#")])', line):
+                    redirected_links.append(f"{page.relative_to(REPO_ROOT)}:{line_number}")
+                canonical_links += line.count("/tutorials/training-tutorials")
+
+        self.assertEqual([], redirected_links)
+        self.assertGreater(canonical_links, 0)
+
     def test_v040_evaluation_tutorial_links_stay_in_the_frozen_version(self):
         pages = REPO_ROOT / "fern/versions/v0.4.0/pages"
         versionless_links = []


### PR DESCRIPTION
`fern/versions/main.yml` puts `training-tutorials` and `evaluation-tutorials` in the same `section: Tutorials`, so both publish under `/tutorials/`. Evaluation tutorials are already linked that way. Training tutorials are not.

Against the published site:

```
/nemo/gym/tutorials/training-tutorials/nemo-rl-grpo/   200
/nemo/gym/training-tutorials/nemo-rl-grpo/             308 -> /tutorials/training-tutorials/nemo-rl-grpo
/nemo/gym/tutorials/evaluation-tutorials/evalplus/     200
/nemo/gym/evaluation-tutorials/evalplus/               404
```

The old training form works, but only because Fern redirects it. The evaluation form has no such redirect. Having two sibling folders under one section linked two different ways makes the prefix look optional, and it isn't