### PR TITLE
fix(observability): propagate provider cache and reasoning token counts

### DIFF
--- a/nemo_gym/anthropic_converter.py
+++ b/nemo_gym/anthropic_converter.py
@@ -804,14 +804,20 @@ class AnthropicConverter:
     def _usage_to_responses_usage(self, usage: Optional[Dict[str, Any]]) -> Optional[NeMoGymResponseUsage]:
         if usage is None:
             return None
-        input_tokens = usage.get("input_tokens", 0)
-        output_tokens = usage.get("output_tokens", 0)
+        input_tokens = usage.get("input_tokens") or 0
+        output_tokens = usage.get("output_tokens") or 0
         return NeMoGymResponseUsage(
             input_tokens=input_tokens,
+            # Anthropic sends the cache-read count as an explicit null when it has nothing to
+            # report, so ``or 0`` is needed as well as the default: the Responses schema types
+            # cached_tokens as a plain int and a null here fails validation.
             input_tokens_details=NeMoGymResponseInputTokensDetails(
-                cached_tokens=usage.get("cache_read_input_tokens", 0)
+                cached_tokens=usage.get("cache_read_input_tokens") or 0
             ),
             output_tokens=output_tokens,
+            # Anthropic has no reasoning-token counter -- thinking tokens are already inside
+            # output_tokens -- so unlike the Chat Completions path there is no upstream field to
+            # propagate here. The literal is the whole of what Anthropic reports, not a dropped value.
             output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=0),
             total_tokens=input_tokens + output_tokens,
         )

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -366,6 +366,21 @@ class NeMoGymResponse(Response):
     usage: Optional[NeMoGymResponseUsage] = None
 
 
+def accumulate_response_usage(total: NeMoGymResponseUsage, addend: NeMoGymResponseUsage) -> None:
+    """Fold one turn's usage into a running multi-turn total, in place.
+
+    Every counter is summed, including the token details. Agents used to sum the top-level counts
+    and reset ``cached_tokens``/``reasoning_tokens`` to 0, which discarded the per-turn detail the
+    model server had already reported. A turn whose provider reported no detail contributes 0, so
+    the total is the sum over the turns that did report.
+    """
+    total.input_tokens += addend.input_tokens
+    total.output_tokens += addend.output_tokens
+    total.total_tokens += addend.total_tokens
+    total.input_tokens_details.cached_tokens += addend.input_tokens_details.cached_tokens
+    total.output_tokens_details.reasoning_tokens += addend.output_tokens_details.reasoning_tokens
+
+
 ########################################
 # Chat Completion API outputs
 ########################################

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -489,11 +489,23 @@ class ResponsesConverter(BaseModel):
 
         usage = None
         if chat_completion.usage:
+            # Chat Completions carries the cache and reasoning counts in optional sub-objects
+            # (prompt_tokens_details / completion_tokens_details); the Responses schema requires
+            # both counts as plain ints. Read the provider's value whenever it reports one -- these
+            # were previously hard-coded to 0, which discarded every real cache and reasoning count.
+            # A provider that reports no detail still folds to 0, since Responses cannot encode
+            # "unknown"; see _cache_signal in base_responses_api_model.py for the consumer.
+            prompt_details = chat_completion.usage.prompt_tokens_details
+            completion_details = chat_completion.usage.completion_tokens_details
             usage = NeMoGymResponseUsage(
                 input_tokens=chat_completion.usage.prompt_tokens,
-                input_tokens_details=NeMoGymResponseInputTokensDetails(cached_tokens=0),
+                input_tokens_details=NeMoGymResponseInputTokensDetails(
+                    cached_tokens=(prompt_details.cached_tokens or 0) if prompt_details else 0
+                ),
                 output_tokens=chat_completion.usage.completion_tokens,
-                output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=0),
+                output_tokens_details=NeMoGymResponseOutputTokensDetails(
+                    reasoning_tokens=(completion_details.reasoning_tokens or 0) if completion_details else 0
+                ),
                 total_tokens=chat_completion.usage.prompt_tokens + chat_completion.usage.completion_tokens,
             )
 

--- a/responses_api_agents/browsecomp_agent/app.py
+++ b/responses_api_agents/browsecomp_agent/app.py
@@ -43,6 +43,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCall,
     NeMoGymResponseOutputMessage,
+    accumulate_response_usage,
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
 from responses_api_models.vllm_model.app import VLLMConverter
@@ -260,13 +261,7 @@ class BrowsecompAgent(SimpleResponsesAPIAgent):
                 model_response.usage = None
 
             if usage and model_response.usage:
-                usage.input_tokens += model_response.usage.input_tokens
-                usage.output_tokens += model_response.usage.output_tokens
-                usage.total_tokens += model_response.usage.total_tokens
-
-                # TODO support more advanced token details
-                usage.input_tokens_details.cached_tokens = 0
-                usage.output_tokens_details.reasoning_tokens = 0
+                accumulate_response_usage(usage, model_response.usage)
 
             if model_response.incomplete_details and model_response.incomplete_details.reason == "max_output_tokens":
                 break

--- a/responses_api_agents/finance_agent/app.py
+++ b/responses_api_agents/finance_agent/app.py
@@ -41,6 +41,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCall,
     NeMoGymResponseOutputMessage,
+    accumulate_response_usage,
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
 
@@ -225,13 +226,7 @@ class FinanceAgent(SimpleResponsesAPIAgent):
                 model_response.usage = None
 
             if usage and model_response.usage:
-                usage.input_tokens += model_response.usage.input_tokens
-                usage.output_tokens += model_response.usage.output_tokens
-                usage.total_tokens += model_response.usage.total_tokens
-
-                # TODO support more advanced token details
-                usage.input_tokens_details.cached_tokens = 0
-                usage.output_tokens_details.reasoning_tokens = 0
+                accumulate_response_usage(usage, model_response.usage)
 
             if model_response.incomplete_details and model_response.incomplete_details.reason == "max_output_tokens":
                 break

--- a/responses_api_agents/gymnasium_agent/app.py
+++ b/responses_api_agents/gymnasium_agent/app.py
@@ -29,6 +29,7 @@ from nemo_gym.openai_utils import (
     NeMoGymFunctionCallOutput,
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
+    accumulate_response_usage,
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
 from resources_servers.gymnasium import EnvResetResponse, EnvStepResponse
@@ -122,11 +123,7 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
                 if usage is None:
                     usage = model_response.usage.model_copy(deep=True)
                 else:
-                    usage.input_tokens += model_response.usage.input_tokens
-                    usage.output_tokens += model_response.usage.output_tokens
-                    usage.total_tokens += model_response.usage.total_tokens
-                    usage.input_tokens_details.cached_tokens = 0
-                    usage.output_tokens_details.reasoning_tokens = 0
+                    accumulate_response_usage(usage, model_response.usage)
 
             step_resp = await self.server_client.post(
                 server_name=self.config.resources_server.name,

--- a/responses_api_agents/remote_agent/app.py
+++ b/responses_api_agents/remote_agent/app.py
@@ -62,6 +62,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCall,
     NeMoGymResponseOutputMessage,
+    accumulate_response_usage,
 )
 from nemo_gym.rollout_collection import NG_FAILURE_CLASS_KEY, NG_NO_PERSIST_KEY, NG_TERMINAL_KEY
 from nemo_gym.server_utils import (
@@ -189,13 +190,7 @@ class RemoteAgent(SimpleResponsesAPIAgent):
                 agent_response.usage = None
 
             if usage and agent_response.usage:
-                usage.input_tokens += agent_response.usage.input_tokens
-                usage.output_tokens += agent_response.usage.output_tokens
-                usage.total_tokens += agent_response.usage.total_tokens
-
-                # TODO support more advanced token details
-                usage.input_tokens_details.cached_tokens = 0
-                usage.output_tokens_details.reasoning_tokens = 0
+                accumulate_response_usage(usage, agent_response.usage)
 
             if agent_response.incomplete_details:
                 break

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -38,6 +38,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCall,
     NeMoGymResponseOutputMessage,
+    accumulate_response_usage,
 )
 from nemo_gym.server_utils import get_response_json, raise_for_status
 
@@ -109,13 +110,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 model_response.usage = None
 
             if usage and model_response.usage:
-                usage.input_tokens += model_response.usage.input_tokens
-                usage.output_tokens += model_response.usage.output_tokens
-                usage.total_tokens += model_response.usage.total_tokens
-
-                # TODO support more advanced token details
-                usage.input_tokens_details.cached_tokens = 0
-                usage.output_tokens_details.reasoning_tokens = 0
+                accumulate_response_usage(usage, model_response.usage)
 
             if model_response.incomplete_details:
                 break

--- a/responses_api_models/inference_provider/app.py
+++ b/responses_api_models/inference_provider/app.py
@@ -23,7 +23,6 @@ For training workloads that require token IDs, use vllm_model instead.
 from asyncio import Semaphore
 from time import time
 from typing import Any, Dict
-from uuid import uuid4
 
 from fastapi import Request
 from pydantic import Field
@@ -39,9 +38,6 @@ from nemo_gym.openai_utils import (
     NeMoGymChatCompletionCreateParamsNonStreaming,
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
-    NeMoGymResponseInputTokensDetails,
-    NeMoGymResponseOutputTokensDetails,
-    NeMoGymResponseUsage,
 )
 from nemo_gym.responses_converter import ResponsesConverter
 from nemo_gym.server_utils import is_nemo_gym_fastapi_entrypoint
@@ -79,54 +75,19 @@ class InferenceProvider(SimpleResponsesAPIModel):
 
         chat_completion_response = await self.chat_completions(request, chat_completion_create_params)
 
-        choice = chat_completion_response.choices[0]
-        response_output = self._converter.postprocess_chat_response(choice)
-        response_output_dicts = [item.model_dump() for item in response_output]
-
-        usage = None
-        if chat_completion_response.usage:
-            usage = NeMoGymResponseUsage(
-                input_tokens=chat_completion_response.usage.prompt_tokens,
-                input_tokens_details=NeMoGymResponseInputTokensDetails(cached_tokens=0),
-                output_tokens=chat_completion_response.usage.completion_tokens,
-                output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=0),
-                total_tokens=chat_completion_response.usage.prompt_tokens
-                + chat_completion_response.usage.completion_tokens,
-            )
-
-        incomplete_details = None
-        if choice.finish_reason == "length":
-            incomplete_details = {"reason": "max_output_tokens"}
-        elif choice.finish_reason == "content_filter":
-            incomplete_details = {"reason": "content_filter"}
-
-        return NeMoGymResponse(
-            id=f"resp_{uuid4().hex}",
-            created_at=int(time()),
-            model=self.config.model,
-            object="response",
-            output=response_output_dicts,
-            tool_choice=body.tool_choice if body.tool_choice is not None else "auto",
-            parallel_tool_calls=body.parallel_tool_calls,
-            tools=body.tools,
-            temperature=body.temperature,
-            top_p=body.top_p,
-            background=body.background,
-            max_output_tokens=body.max_output_tokens,
-            max_tool_calls=body.max_tool_calls,
-            previous_response_id=body.previous_response_id,
-            prompt=body.prompt,
-            reasoning=body.reasoning,
-            service_tier=body.service_tier,
-            text=body.text,
-            top_logprobs=body.top_logprobs,
-            truncation=body.truncation,
-            metadata=body.metadata,
-            instructions=body.instructions,
-            user=body.user,
-            incomplete_details=incomplete_details,
-            usage=usage,
+        # Delegate the Chat Completion -> Response mapping instead of repeating it here. This method
+        # used to build the response inline, which meant every fix (most recently propagating the
+        # provider's cache and reasoning token counts) had to be made twice to take effect on both
+        # paths. vllm_model/app.py delegates the same way.
+        body.model = self.config.model
+        response = self._converter.chat_completion_to_response(
+            responses_create_params=body, chat_completion=chat_completion_response
         )
+        # The converter stamps created_at from the provider's chat_completion.created. Keep this
+        # server's own receipt time, which is what it reported before delegating and does not
+        # depend on the provider populating (or zeroing) that field.
+        response.created_at = int(time())
+        return response
 
     async def chat_completions(
         self, request: Request, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()

--- a/responses_api_models/inference_provider/tests/test_app.py
+++ b/responses_api_models/inference_provider/tests/test_app.py
@@ -264,7 +264,6 @@ class TestResponses:
         client = TestClient(app)
 
         monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         mock_data = _mock_chat_response(content="Hello from the model!")
@@ -295,7 +294,6 @@ class TestResponses:
         client = TestClient(app)
 
         monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         async def mock_create_chat(**kwargs):
@@ -314,7 +312,6 @@ class TestResponses:
         client = TestClient(app)
 
         monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         async def mock_create_chat(**kwargs):
@@ -348,7 +345,6 @@ class TestResponses:
         client = TestClient(app)
 
         monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         mock_data = _mock_chat_response(
@@ -408,7 +404,6 @@ class TestResponses:
         client = TestClient(app)
 
         monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         mock_data = _mock_chat_response(content="<think>Let me reason about this...</think>The answer is 42.")
@@ -437,7 +432,6 @@ class TestResponses:
         client = TestClient(app)
 
         monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         mock_data = _mock_chat_response(content="<think>Let me reason about this...</think>The answer is 42.")
@@ -465,7 +459,6 @@ class TestResponses:
         client = TestClient(app)
 
         monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         mock_data = _mock_chat_response(content="Hi!")
@@ -494,7 +487,6 @@ class TestResponses:
         client = TestClient(app)
 
         monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         mock_data = _mock_chat_response(content="Truncated output...", finish_reason="length")
@@ -516,7 +508,6 @@ class TestResponses:
         client = TestClient(app)
 
         monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         mock_data = _mock_chat_response(content="", finish_reason="content_filter")
@@ -548,7 +539,6 @@ class TestResponses:
         server._client.create_chat_completion = AsyncMock(side_effect=mock_create_chat)
 
         monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         client.post("/v1/responses", json={"input": "hello world"})
@@ -562,7 +552,6 @@ class TestResponses:
         client = TestClient(app)
 
         monkeypatch.setattr("responses_api_models.inference_provider.app.time", lambda: FIXED_TIME)
-        monkeypatch.setattr("responses_api_models.inference_provider.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         called_kwargs = {}

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -24,10 +24,14 @@ from nemo_gym.openai_utils import (
     NeMoGymAsyncOpenAI,
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseInputTokensDetails,
     NeMoGymResponseMcpApprovalRequest,
     NeMoGymResponseMcpCall,
     NeMoGymResponseMcpListTools,
+    NeMoGymResponseOutputTokensDetails,
+    NeMoGymResponseUsage,
     TokenIDLogProbMixin,
+    accumulate_response_usage,
 )
 
 
@@ -147,3 +151,42 @@ class TestRoutedExpertsWireFormats:
     def test_rejects_non_list_non_string(self) -> None:
         with pytest.raises(ValidationError):
             TokenIDLogProbMixin.model_validate({**self._BASE, "routed_experts": 42})
+
+
+class TestAccumulateResponseUsage:
+    @staticmethod
+    def _usage(input_tokens: int, output_tokens: int, cached: int, reasoning: int) -> NeMoGymResponseUsage:
+        return NeMoGymResponseUsage(
+            input_tokens=input_tokens,
+            input_tokens_details=NeMoGymResponseInputTokensDetails(cached_tokens=cached),
+            output_tokens=output_tokens,
+            output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=reasoning),
+            total_tokens=input_tokens + output_tokens,
+        )
+
+    def test_sums_every_counter_including_details(self) -> None:
+        # Multi-turn agents previously reset the details to 0 while summing the top-level counts,
+        # which threw away the per-turn cache and reasoning counts the model server reported.
+        total = self._usage(10, 5, cached=4, reasoning=2)
+        accumulate_response_usage(total, self._usage(20, 7, cached=8, reasoning=3))
+
+        assert total.input_tokens == 30
+        assert total.output_tokens == 12
+        assert total.total_tokens == 42
+        assert total.input_tokens_details.cached_tokens == 12
+        assert total.output_tokens_details.reasoning_tokens == 5
+
+    def test_turn_without_detail_contributes_nothing(self) -> None:
+        total = self._usage(10, 5, cached=4, reasoning=2)
+        accumulate_response_usage(total, self._usage(1, 1, cached=0, reasoning=0))
+
+        assert total.input_tokens_details.cached_tokens == 4
+        assert total.output_tokens_details.reasoning_tokens == 2
+
+    def test_does_not_mutate_the_addend(self) -> None:
+        total = self._usage(10, 5, cached=4, reasoning=2)
+        addend = self._usage(20, 7, cached=8, reasoning=3)
+        accumulate_response_usage(total, addend)
+
+        assert addend.input_tokens == 20
+        assert addend.input_tokens_details.cached_tokens == 8

--- a/tests/unit_tests/test_responses_converter.py
+++ b/tests/unit_tests/test_responses_converter.py
@@ -15,7 +15,7 @@
 """Unit tests for the shared Responses API <-> Chat Completions converter."""
 
 import pytest
-from openai.types.completion_usage import CompletionUsage
+from openai.types.completion_usage import CompletionTokensDetails, CompletionUsage, PromptTokensDetails
 
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
@@ -566,6 +566,72 @@ def test_chat_completion_to_response_sanity(converter: ResponsesConverter):
     )
 
     assert expected_response == actual_response
+
+
+def _chat_completion_with_usage(usage: CompletionUsage) -> NeMoGymChatCompletion:
+    return NeMoGymChatCompletion(
+        id="",
+        created=0,
+        model="",
+        object="chat.completion",
+        choices=[
+            NeMoGymChoice(
+                index=0,
+                finish_reason="stop",
+                message=NeMoGymChatCompletionMessage(role="assistant", content="hi", tool_calls=[]),
+            )
+        ],
+        usage=usage,
+    )
+
+
+def _converted_usage(converter: ResponsesConverter, usage: CompletionUsage) -> NeMoGymResponseUsage:
+    response = converter.chat_completion_to_response(
+        responses_create_params=NeMoGymResponseCreateParamsNonStreaming(model="", input="hello"),
+        chat_completion=_chat_completion_with_usage(usage),
+    )
+    return response.usage
+
+
+def test_chat_completion_to_response_propagates_usage_details(converter: ResponsesConverter):
+    """A provider-reported cache/reasoning count must survive the dialect conversion.
+
+    These were previously hard-coded to 0, so a real cache hit was recorded as a miss.
+    """
+    usage = _converted_usage(
+        converter,
+        CompletionUsage(
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=64),
+            completion_tokens_details=CompletionTokensDetails(reasoning_tokens=12),
+        ),
+    )
+
+    assert usage.input_tokens_details.cached_tokens == 64
+    assert usage.output_tokens_details.reasoning_tokens == 12
+
+
+def test_chat_completion_to_response_usage_details_default_to_zero(converter: ResponsesConverter):
+    """The Responses schema types both counts as required ints, so an absent or explicitly-null
+    upstream detail folds to 0 rather than propagating None (which would fail validation)."""
+    absent = _converted_usage(converter, CompletionUsage(prompt_tokens=1, completion_tokens=2, total_tokens=3))
+    assert absent.input_tokens_details.cached_tokens == 0
+    assert absent.output_tokens_details.reasoning_tokens == 0
+
+    explicit_null = _converted_usage(
+        converter,
+        CompletionUsage(
+            prompt_tokens=1,
+            completion_tokens=2,
+            total_tokens=3,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=None),
+            completion_tokens_details=CompletionTokensDetails(reasoning_tokens=None),
+        ),
+    )
+    assert explicit_null.input_tokens_details.cached_tokens == 0
+    assert explicit_null.output_tokens_details.reasoning_tokens == 0
 
 
 # ===========================================================================


### PR DESCRIPTION
## What's wrong

`ResponsesConverter.chat_completion_to_response` built `NeMoGymResponseUsage` with `cached_tokens=0` and `reasoning_tokens=0` as literals, and never read `chat_completion.usage.prompt_tokens_details` or `.completion_tokens_details`. A provider that reported `cached_tokens=512` came out of the conversion as `0`, so `_cache_signal` in `nemo_gym/base_responses_api_model.py` returned `(False, 0)` and the rollout recorded a measured cache hit as a miss.

This was filed as an "unknown recorded as 0" problem, but the larger half is plain data loss: values the provider did report were being dropped. That half has no schema tension and is what this PR fixes.

Three paths shared the defect, not two:

- `nemo_gym/responses_converter.py` — used by `vllm_model` and (now) `inference_provider`
- `responses_api_models/inference_provider/app.py` — built its response inline, duplicating the same literals
- five multi-turn agents (`simple`, `gymnasium`, `finance`, `browsecomp`, `remote`) that summed the top-level token counts across turns but reset the details to `0` on every fold, discarding whatever the model server had reported

Fixing only the converter would have left the symptom live on every multi-turn agent path.

## What changed

The converter reads the upstream sub-objects when the provider sends them.

`InferenceProvider.responses()` now delegates to `ResponsesConverter.chat_completion_to_response`, the way `vllm_model` already does, so the mapping cannot be fixed on one path and left stale on the other. It still stamps `created_at` with its own receipt time rather than the provider's `chat_completion.created`; only the usage and output mapping moved. That is a deliberate non-change — the timestamp source is unrelated to this bug.

The five agents share a new `accumulate_response_usage()` in `nemo_gym/openai_utils.py`, which sums the details along with the top-level counts.

`anthropic_converter._usage_to_responses_usage` now hardens its cache mapping against an explicit null (`or 0`, not just a `.get` default), which would otherwise fail validation. Its `reasoning_tokens=0` literal stays: Anthropic has no reasoning-token counter, so there is nothing upstream to propagate.

## What this deliberately does not change

Absent detail still folds to `0` rather than `null`. The Responses schema types `cached_tokens` and `reasoning_tokens` as required non-nullable ints, where Chat Completions makes both optional — that mismatch is the root cause, and Responses has no way to encode "unknown". These payloads also go over the wire to external clients: the Codex CLI points at a Gym model server's `/v1/responses` (`responses_api_agents/codex_agent/app.py:290`), and `nemo_gym/responses_streaming.py:261` re-emits the same object in `response.completed`.

So the cache-miss-vs-unknown ambiguity in `_cache_signal` is unchanged and still open. If we want to close it without deviating from the schema, an additive field (e.g. `cached_tokens_reported: bool`) is lower risk than making a required field nullable, since extra fields are ignored by both Pydantic and serde. Worth deciding separately.

Also unfixed: `claude_code_agent`, `opencode_agent`, `pi_agent`, `hermes_agent`, `kilocode_agent`, and `openclaw_agent` still hard-code `cached_tokens=0` when building usage from their CLI transcripts. Claude Code does report `cache_read_input_tokens`, but extracting it means changing each CLI's transcript parser.

## On the filed report's suggested fix

The report proposed `input_tokens_details=None` when the detail is absent. That would raise `AttributeError` at five sites that do attribute access on the sub-object (`usage.input_tokens_details.cached_tokens = 0` in `remote_agent/app.py:197` and the four other agents) — in exactly the common case the fix targets.

The report also states that `tests/unit_tests/test_responses_converter.py:559,561` pins the defect and must be updated. It does not: that test feeds usage with no details, so `cached_tokens=0` is the correct expectation there. It is unchanged and still passes.

## Testing

New tests: propagation of reported values, the absent and explicitly-null cases, and three cases for `accumulate_response_usage` including that it does not mutate the addend.

Verified directly against unfixed code: a provider reporting `cached_tokens=512` / `reasoning_tokens=30` previously converted to `0`/`0` with `_cache_signal` returning `(False, 0)`; it now converts to `512`/`30` with `(True, 512)`.

1968 tests pass across `tests/unit_tests/`, `inference_provider`, `vllm_model`, and the five agents.

The only edit to existing tests was removing 11 now-redundant `monkeypatch.setattr(...app.uuid4...)` lines in `inference_provider/tests/test_app.py`; each already patched `nemo_gym.responses_converter.uuid4` on the following line, and the id is now minted in the converter.

Not run: the `model_call_capture_known_defects` QA case. Its A1/A2 assertions require `cached_tokens` to be `None`, so they stay red under the contract above — that is expected, not a regression.
