### PR TITLE
fix(stirrup): cap stirrup<0.2 on r0.5.0 release branch

### DIFF
--- a/responses_api_agents/stirrup_agent/requirements.txt
+++ b/responses_api_agents/stirrup_agent/requirements.txt
@@ -2,7 +2,10 @@
 # Stirrup agent framework + HF tokenizer for dynamic max_tokens sizing.
 # Kept out of the outer nemo-gym pyproject.toml so core users don't pay
 # the PyTorch/transformers install cost.
-stirrup>=0.1.12
+# The DynamicMaxTokensChatCompletionsClient integration targets Stirrup's 0.1
+# client API. Stirrup 0.2 makes context_window_tokens a required constructor
+# argument and needs a separately reviewed migration.
+stirrup>=0.1.12,<0.2
 transformers>=5.8.1
 # Deliverable-processing deps for file_reader.py AND the libraries the agent
 # tells the policy model are available in the sandbox (see


### PR DESCRIPTION
## Summary

- stirrup 0.2.0 (published 2026-08-04) made `context_window_tokens` a required constructor argument in `ChatCompletionsClient`, breaking the stirrup_agent unit tests on the r0.5.0 release branch
- Caps `stirrup<0.2` so CI stays green until the 0.2 migration is ready
- Identical change to what landed on `main` via #1408
