### PR TITLE
[GDPVal] Better handling of deliverables file types in judge

### DIFF
--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -42,6 +42,19 @@ from resources_servers.gdpval.judge_panel import AUDIO_EXTS, VIDEO_EXTS, merge_c
 LOGGER = logging.getLogger(__name__)
 
 
+def _ignore_files() -> frozenset[str]:
+    """Run-state names that must never be judged as a submission.
+
+    Owned by the agent that writes them rather than copied into each judging
+    path. Imported lazily: ``stirrup_agent/__init__`` eagerly imports Ray and
+    FastAPI, and ``multistage_elo`` imports this module at module scope.
+    ``sys.modules`` caches it, so repeat calls are a dict lookup.
+    """
+    from responses_api_agents.stirrup_agent.file_reader import IGNORE_FILES
+
+    return IGNORE_FILES
+
+
 JUDGE_PROMPT = (
     "Given a task description and reference files, select which of two submission file(s) "
     "better completed the task. "
@@ -61,16 +74,6 @@ SUBMISSION_A_OPEN = "<SUBMISSION_A_START>\n"
 SUBMISSION_A_CLOSE = "\n<SUBMISSION_A_END>\n\n"
 SUBMISSION_B_OPEN = "<SUBMISSION_B_START>\n"
 SUBMISSION_B_CLOSE = "\n<SUBMISSION_B_END>\n\n"
-
-IGNORE_FILES = {
-    "finish_params.json",
-    "history.json",
-    "history.pkl",
-    "metadata.json",
-    "inprogress_history.json",
-    "log.txt",
-    "reference_files",
-}
 
 REQUEST_MAX_ATTEMPTS = 5
 REQUEST_INITIAL_BACKOFF_SECONDS = 5.0
@@ -404,7 +407,7 @@ def build_file_section(
 ) -> list[dict]:
     """Build OpenAI content blocks from all files in a directory.
 
-    Skips files in ``IGNORE_FILES``. Extracts zips into per-call tempdirs
+    Skips run-state files (see :func:`_ignore_files`). Extracts zips into per-call tempdirs
     (the dirs are appended to ``clean_up_list`` for the caller to ``rmtree``).
     Returns a list of content block dicts suitable for OpenAI messages.
 
@@ -433,9 +436,11 @@ def build_file_section(
                     clean_up_list.append(extract_dir)
                     extracted_dirs.append(extract_dir)
 
+    ignore_files = _ignore_files()
+
     def _emit(directory: str, file_name: str) -> None:
         nonlocal no_files
-        if file_name in IGNORE_FILES:
+        if file_name in ignore_files:
             return
         section.append({"type": "text", "text": f"\n{file_name}:\n"})
         if media_mode == "images_and_text":

--- a/resources_servers/gdpval/preconvert.py
+++ b/resources_servers/gdpval/preconvert.py
@@ -53,7 +53,12 @@ from pathlib import Path
 
 LOGGER = logging.getLogger(__name__)
 
-OFFICE_EXTENSIONS = {".docx", ".pptx", ".xlsx"}
+OOXML_EXTENSIONS = {".docx", ".pptx", ".xlsx"}
+# LibreOffice converts these fine; omitting them left the judge with no PDF.
+# The ns0 pre-pass skips them harmlessly (OLE files raise BadZipFile).
+LEGACY_OFFICE_EXTENSIONS = {".doc", ".ppt", ".xls"}
+
+OFFICE_EXTENSIONS = OOXML_EXTENSIONS | LEGACY_OFFICE_EXTENSIONS
 
 DEFAULT_MAX_CONCURRENT = 4
 
@@ -94,8 +99,17 @@ def _normalize_ooxml_zip(src: Path, dst: Path) -> None:
             zout.writestr(item, data)
 
 
-def needs_conversion(path: Path) -> bool:
-    return path.suffix.lower() in OFFICE_EXTENSIONS and not path.with_suffix(".pdf").exists()
+def sidecar_pdf(path: Path) -> Path:
+    """Injective PDF name for *path*: ``Plan.pptx`` -> ``Plan.pptx.pdf``."""
+    return path.with_name(path.name + ".pdf")
+
+
+def needs_conversion(path: Path, *, ambiguous: bool = False) -> bool:
+    if path.suffix.lower() not in OFFICE_EXTENSIONS:
+        return False
+    if ambiguous:
+        return not sidecar_pdf(path).exists()
+    return not path.with_suffix(".pdf").exists()
 
 
 def _safe_basename(name: str) -> str:
@@ -110,15 +124,20 @@ def _safe_basename(name: str) -> str:
     return re.sub(r"\s+", "_", p.stem) + p.suffix
 
 
-def convert_to_pdf(path: Path) -> tuple[Path, bool, str]:
-    """Convert one file to PDF via host LibreOffice. Returns ``(path, ok, msg)``."""
+def convert_to_pdf(path: Path, output_pdf: Path | None = None) -> tuple[Path, bool, str]:
+    """Convert one file to PDF via host LibreOffice. Returns ``(path, ok, msg)``.
+
+    *output_pdf* overrides the destination: LibreOffice names output after the
+    input stem, so same-stem files would otherwise race for one name.
+    """
     profile_dir = Path(tempfile.mkdtemp(prefix="lo-profile-"))
     stage_dir: Path | None = None
     input_path = path
     normalized = False
     needs_ns0_normalization = _ooxml_has_ns0_prefix(path)
     has_whitespace = any(c.isspace() for c in path.name)
-    needs_stage = needs_ns0_normalization or has_whitespace
+    # A custom destination always stages, else both sides write one name.
+    needs_stage = needs_ns0_normalization or has_whitespace or output_pdf is not None
     try:
         if needs_stage:
             stage_dir = Path(tempfile.mkdtemp(prefix="gdpval-stage-"))
@@ -152,7 +171,7 @@ def convert_to_pdf(path: Path) -> tuple[Path, bool, str]:
             text=True,
             timeout=120,
         )
-        final_pdf = path.with_suffix(".pdf")
+        final_pdf = output_pdf if output_pdf is not None else path.with_suffix(".pdf")
         if needs_stage:
             staged_pdf = Path(lo_outdir) / (input_path.stem + ".pdf")
             if staged_pdf.exists():
@@ -177,14 +196,36 @@ def convert_to_pdf(path: Path) -> tuple[Path, bool, str]:
             shutil.rmtree(stage_dir, ignore_errors=True)
 
 
-def find_convertible_files(root_dir: str | os.PathLike) -> list[Path]:
-    files: list[Path] = []
+def find_convertible_files(root_dir: str | os.PathLike) -> list[tuple[Path, Path | None]]:
+    """Office files needing conversion, as ``(source, explicit_destination)``.
+
+    ``Report.docx`` and ``Report.pptx`` both target ``Report.pdf`` and race for
+    it, leaving a PDF that looks like a valid render of both. Same-stem files
+    get the injective sidecar name instead; ``file_reader`` prefers it.
+    """
+    files: list[tuple[Path, Path | None]] = []
     for dirpath, _, filenames in os.walk(root_dir):
+        office_stems: dict[str, int] = {}
         for filename in filenames:
             path = Path(dirpath) / filename
-            if needs_conversion(path):
-                files.append(path)
-    return sorted(files)
+            if path.suffix.lower() in OFFICE_EXTENSIONS:
+                office_stems[path.stem] = office_stems.get(path.stem, 0) + 1
+
+        for filename in filenames:
+            path = Path(dirpath) / filename
+            ambiguous = office_stems.get(path.stem, 0) > 1
+            if not needs_conversion(path, ambiguous=ambiguous):
+                continue
+            if ambiguous:
+                LOGGER.info(
+                    "Preconverting %s to sidecar '%s': another Office file shares its stem",
+                    path,
+                    sidecar_pdf(path).name,
+                )
+                files.append((path, sidecar_pdf(path)))
+            else:
+                files.append((path, None))
+    return sorted(files, key=lambda pair: pair[0])
 
 
 def preconvert_dir(
@@ -203,15 +244,31 @@ def preconvert_dir(
     success_count = 0
     fail_count = 0
     error_messages: list[str] = []
-    with ThreadPoolExecutor(max_workers=max_concurrent) as executor:
-        futures = {executor.submit(convert_to_pdf, f): f for f in files}
-        for future in as_completed(futures):
-            _, success, message = future.result()
-            if success:
-                success_count += 1
-            else:
-                fail_count += 1
-                error_messages.append(message)
+
+    # Same-stem files convert SEQUENTIALLY: launched together LibreOffice aborts
+    # one side with rc=134, and per-conversion UserInstallation profiles do not
+    # prevent it. There are a handful per tree, so this costs almost nothing.
+    parallel = [(src, dest) for src, dest in files if dest is None]
+    serial = [(src, dest) for src, dest in files if dest is not None]
+
+    def _tally(result: tuple[Path, bool, str]) -> None:
+        nonlocal success_count, fail_count
+        _, success, message = result
+        if success:
+            success_count += 1
+        else:
+            fail_count += 1
+            error_messages.append(message)
+
+    if parallel:
+        with ThreadPoolExecutor(max_workers=max_concurrent) as executor:
+            futures = [executor.submit(convert_to_pdf, src, dest) for src, dest in parallel]
+            for future in as_completed(futures):
+                _tally(future.result())
+
+    for src, dest in serial:
+        _tally(convert_to_pdf(src, dest))
+
     return success_count, fail_count, error_messages
 
 

--- a/resources_servers/gdpval/tests/test_ignore_files_single_source.py
+++ b/resources_servers/gdpval/tests/test_ignore_files_single_source.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Both judging paths must skip the same run-state files, from one definition."""
+
+import ast
+from pathlib import Path
+
+
+COMPARISON = Path(__file__).resolve().parents[1] / "comparison.py"
+
+
+def test_comparison_does_not_keep_its_own_copy():
+    """A second literal set is how the two paths drifted in the first place."""
+    tree = ast.parse(COMPARISON.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "IGNORE_FILES":
+                    raise AssertionError("comparison.py redefines IGNORE_FILES; import it instead")
+
+
+def test_the_import_is_lazy():
+    """A module-level import drags Ray and FastAPI into every importer.
+
+    ``multistage_elo`` imports this module at module scope, so the cost would be
+    paid on any import of the comparison path.
+    """
+    tree = ast.parse(COMPARISON.read_text())
+    for node in tree.body:  # module scope only
+        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("responses_api_agents"):
+            raise AssertionError(f"module-level import of {node.module}; keep it inside _ignore_files()")
+
+
+def test_accessor_returns_the_agents_definition():
+    """The values must come from file_reader, not be re-listed here."""
+    src = COMPARISON.read_text()
+    assert "_ignore_files" in src
+    assert "from responses_api_agents.stirrup_agent.file_reader import IGNORE_FILES" in src

--- a/resources_servers/gdpval/tests/test_media_conversion.py
+++ b/resources_servers/gdpval/tests/test_media_conversion.py
@@ -253,7 +253,12 @@ class TestRubricImagesAndText:
         blocks = convert_deliverables_to_content_blocks(
             str(tmp_path), media_mode="images_and_text", audio_capable=False
         )
-        assert blocks == []
+        # Gating is correct, so no audio is forwarded. The file is still announced:
+        # silence would let the judge grade a deliverable it believes was never produced.
+        assert not any(b.get("type") in {"input_audio", "image_url", "video_url"} for b in blocks)
+        text = "".join(b.get("text", "") for b in blocks if b.get("type") == "text")
+        assert "clip.mp3" in text
+        assert "cannot decode audio" in text
 
     def test_convert_deliverables_audio_passthrough_when_av_capable(self, tmp_path) -> None:
         # images_and_text == self-hosted vLLM judge -> input_audio (not image_url).

--- a/resources_servers/gdpval/tests/test_preconvert.py
+++ b/resources_servers/gdpval/tests/test_preconvert.py
@@ -37,7 +37,9 @@ class TestFindConvertibleFiles:
         (tmp_path / "c.pdf").write_text("p")
         files = pcv.find_convertible_files(str(tmp_path))
         # Sorted by full path: top-level b.docx < sub/a.xlsx; c.pptx skipped (sibling .pdf exists).
-        assert [p.name for p in files] == ["b.docx", "a.xlsx"]
+        # Entries are (source, explicit_destination); destination is None unless the stem is ambiguous.
+        assert [src.name for src, _dest in files] == ["b.docx", "a.xlsx"]
+        assert all(dest is None for _src, dest in files)
 
 
 class TestConvertToPdfErrors:

--- a/resources_servers/gdpval/tests/test_preconvert.py
+++ b/resources_servers/gdpval/tests/test_preconvert.py
@@ -101,7 +101,7 @@ class TestPreconvertDirSurfacesFailures:
         (tmp_path / "a.docx").write_text("x")
         (tmp_path / "b.xlsx").write_text("x")
 
-        def _convert(path: Path) -> tuple[Path, bool, str]:
+        def _convert(path: Path, output_pdf: Path | None = None) -> tuple[Path, bool, str]:
             return path, False, f"forced fail on {path.name}"
 
         monkeypatch.setattr(pcv, "convert_to_pdf", _convert)
@@ -118,8 +118,8 @@ class TestPreconvertDirSurfacesFailures:
     def test_success_path_returns_no_errors(self, tmp_path: Path, monkeypatch) -> None:
         (tmp_path / "a.docx").write_text("x")
 
-        def _convert(path: Path) -> tuple[Path, bool, str]:
-            (path.with_suffix(".pdf")).write_text("p")
+        def _convert(path: Path, output_pdf: Path | None = None) -> tuple[Path, bool, str]:
+            (output_pdf or path.with_suffix(".pdf")).write_text("p")
             return path, True, "ok"
 
         monkeypatch.setattr(pcv, "convert_to_pdf", _convert)
@@ -132,7 +132,7 @@ class TestPreconvertDirSurfacesFailures:
 async def test_preconvert_dir_async_propagates_results(tmp_path: Path, monkeypatch) -> None:
     (tmp_path / "a.docx").write_text("x")
 
-    monkeypatch.setattr(pcv, "convert_to_pdf", lambda p: (p, False, "boom"))
+    monkeypatch.setattr(pcv, "convert_to_pdf", lambda p, output_pdf=None: (p, False, "boom"))
     ok, fail, errors = await pcv.preconvert_dir_async(str(tmp_path))
     assert (ok, fail) == (0, 1)
     assert errors == ["boom"]

--- a/resources_servers/gdpval/tests/test_preconvert_samestem.py
+++ b/resources_servers/gdpval/tests/test_preconvert_samestem.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Two Office files sharing a stem must not race for one PDF name."""
+
+from pathlib import Path
+
+from resources_servers.gdpval.preconvert import (
+    LEGACY_OFFICE_EXTENSIONS,
+    OFFICE_EXTENSIONS,
+    find_convertible_files,
+    needs_conversion,
+    sidecar_pdf,
+)
+
+
+def test_sidecar_name_is_injective():
+    assert sidecar_pdf(Path("/d/Plan.pptx")).name == "Plan.pptx.pdf"
+    assert sidecar_pdf(Path("/d/Plan.xlsx")).name == "Plan.xlsx.pdf"
+
+
+def test_same_stem_pair_gets_distinct_destinations(tmp_path: Path):
+    (tmp_path / "Plan.pptx").write_bytes(b"PK\x03\x04")
+    (tmp_path / "Plan.xlsx").write_bytes(b"PK\x03\x04")
+
+    dests = {src.name: dest for src, dest in find_convertible_files(tmp_path)}
+    assert dests["Plan.pptx"].name == "Plan.pptx.pdf"
+    assert dests["Plan.xlsx"].name == "Plan.xlsx.pdf"
+    assert dests["Plan.pptx"] != dests["Plan.xlsx"], "both would overwrite one PDF"
+
+
+def test_unambiguous_stem_keeps_the_plain_sibling_name(tmp_path: Path):
+    (tmp_path / "Report.docx").write_bytes(b"PK\x03\x04")
+
+    dests = dict(find_convertible_files(tmp_path))
+    assert dests[tmp_path / "Report.docx"] is None, "unambiguous files keep Report.pdf"
+
+
+def test_existing_sidecar_means_no_reconversion(tmp_path: Path):
+    (tmp_path / "Plan.pptx").write_bytes(b"PK\x03\x04")
+    (tmp_path / "Plan.xlsx").write_bytes(b"PK\x03\x04")
+    (tmp_path / "Plan.pptx.pdf").write_bytes(b"%PDF-1.4")
+
+    srcs = {src.name for src, _ in find_convertible_files(tmp_path)}
+    assert "Plan.pptx" not in srcs
+    assert "Plan.xlsx" in srcs
+
+
+def test_ambiguous_conversion_checks_the_sidecar_not_the_sibling(tmp_path: Path):
+    p = tmp_path / "Plan.pptx"
+    p.write_bytes(b"PK\x03\x04")
+    (tmp_path / "Plan.pdf").write_bytes(b"%PDF-1.4")
+
+    assert needs_conversion(p, ambiguous=True), "a shared Plan.pdf says nothing about this file"
+    assert not needs_conversion(p, ambiguous=False)
+
+
+def test_legacy_office_is_converted_too():
+    assert LEGACY_OFFICE_EXTENSIONS <= OFFICE_EXTENSIONS
+    for ext in (".doc", ".ppt", ".xls"):
+        assert ext in OFFICE_EXTENSIONS

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -42,6 +42,27 @@ from resources_servers.gdpval.judge_panel import AUDIO_EXTS, VIDEO_EXTS
 
 MAX_TOTAL_CHARS = 20_000
 
+# Run state the agent writes into the SAME directory as its deliverables. These
+# are not model output, and `.json` is in TEXT_EXTS, so without this the judge is
+# shown the agent's own transcript and grades it as work product. Single source:
+# every judging path imports it from here.
+IGNORE_FILES = frozenset(
+    {
+        "finish_params.json",
+        "history.json",
+        "history.pkl",
+        "inprogress_history.json",
+        "metadata.json",
+        "log.txt",
+        "reference_files",
+    }
+)
+
+
+def is_deliverable(path: Path) -> bool:
+    """True if *path* is agent-produced output rather than run state."""
+    return path.is_file() and path.name not in IGNORE_FILES
+
 
 def read_deliverable_files(output_dir: str) -> str:
     """Read text from all deliverable files in *output_dir*.
@@ -68,7 +89,7 @@ def read_deliverable_files(output_dir: str) -> str:
     total_len = 0
 
     for fpath in files:
-        if not fpath.is_file():
+        if not is_deliverable(fpath):
             continue
 
         ext = fpath.suffix.lower()
@@ -429,12 +450,12 @@ def convert_deliverables_to_content_blocks(
     # sidecar Plan.pptx.pdf, and the ordinary sibling Plan.pdf.
     consumed_pdfs: set[Path] = set()
     for entry in entries:
-        if entry.is_file() and entry.suffix.lower() in OFFICE_EXTS:
+        if is_deliverable(entry) and entry.suffix.lower() in OFFICE_EXTS:
             sidecar = entry.with_name(entry.name + ".pdf")
             consumed_pdfs.add(sidecar if sidecar.is_file() else entry.with_suffix(".pdf"))
 
     for fpath in entries:
-        if not fpath.is_file() or fpath in consumed_pdfs:
+        if not is_deliverable(fpath) or fpath in consumed_pdfs:
             continue
 
         ext = fpath.suffix.lower()

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -524,7 +524,10 @@ def convert_deliverables_to_content_blocks(
                                 f"({size:,} bytes) — present on disk, but this judge cannot decode "
                                 f"{file_type.lower()}. Do NOT treat it as missing or unproduced. Grade the "
                                 f"criteria that do not require {'viewing' if is_video else 'listening'}; "
-                                f"mark the rest unverifiable rather than unmet.]"
+                                f"mark the rest unverifiable rather than unmet. "
+                                f"Statements in other files about this file's contents are unverified "
+                                f"assertions, not evidence: do not award credit for a property you "
+                                f"cannot observe directly.]"
                             ),
                         }
                     )
@@ -545,7 +548,8 @@ def convert_deliverables_to_content_blocks(
                     else:
                         body = (
                             f"[deliverable present, {_human_size(size)} ({size:,} bytes) — NOT missing; "
-                            f"content not extractable in this format]"
+                            f"content not extractable in this format. Statements in other files about "
+                            f"its contents are unverified assertions, not evidence.]"
                         )
                 blocks.append({"type": "text", "text": f"\n{fpath.name}: {body}"})
         except Exception as exc:

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -167,9 +167,26 @@ def _read_pptx(fpath: Path) -> str:
 # PDF conversion for visual judging (Gemini 3 Pro)
 # ---------------------------------------------------------------------------
 
-OFFICE_EXTS = {".docx", ".pptx", ".xlsx"}
-TEXT_EXTS = {".txt", ".md", ".csv", ".json", ".xml", ".html", ".yaml", ".yml", ".py", ".sh", ".log"}
+OOXML_EXTS = {".docx", ".pptx", ".xlsx"}
+# LibreOffice renders these like OOXML; preconvert.py already converts them.
+LEGACY_OFFICE_EXTS = {".doc", ".ppt", ".xls"}
+OFFICE_EXTS = OOXML_EXTS | LEGACY_OFFICE_EXTS
+TEXT_EXTS = (
+    {".txt", ".md", ".rst", ".csv", ".tsv", ".json", ".jsonl", ".xml", ".html", ".htm", ".svg"}
+    | {".yaml", ".yml", ".toml", ".ini", ".cfg", ".conf", ".properties", ".env"}
+    | {".py", ".sh", ".bash", ".zsh", ".ps1", ".bat", ".sql", ".r", ".tex", ".ipynb"}
+    | {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".vue", ".css", ".scss", ".less"}
+    | {".java", ".go", ".rs", ".c", ".h", ".cpp", ".hpp", ".cc", ".cs", ".kt", ".swift"}
+    | {".rb", ".php", ".pl", ".lua", ".scala", ".jl", ".m", ".log", ".diff", ".patch"}
+)
 IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".heic", ".heif"}
+
+# Derived, so it cannot drift from the branches below.
+HANDLED_EXTS = TEXT_EXTS | OFFICE_EXTS | IMAGE_EXTS | AUDIO_EXTS | VIDEO_EXTS | {".pdf"}
+
+TEXT_SNIFF_BYTES = 8192
+MAX_TEXT_CHARS_PER_FILE = 20_000
+MAX_ARCHIVE_MEMBERS = 200
 # Audio/video (AUDIO_EXTS / VIDEO_EXTS, imported above) are only passed through
 # when the judge is AV-capable (e.g. MiniMax M3); image-only judges can't decode
 # them, so they are otherwise skipped. Every extension in those sets needs an
@@ -205,6 +222,53 @@ MIME_TYPES = {
     ".mpg": "video/mpeg",
     ".3gp": "video/3gpp",
 }
+
+
+def _human_size(n: int) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024 or unit == "GB":
+            return f"{n:.0f} {unit}" if unit == "B" else f"{n / 1024:.1f} {unit}"
+        n /= 1024.0
+    return f"{n:.1f} GB"
+
+
+def _sniffs_as_text(fpath: Path) -> bool:
+    """True if an unknown-extension file looks like text (Makefile, Dockerfile, ...)."""
+    try:
+        with fpath.open("rb") as fh:
+            chunk = fh.read(TEXT_SNIFF_BYTES)
+    except OSError:
+        return False
+    if not chunk or b"\x00" in chunk:
+        return False
+    text = chunk.decode("utf-8", errors="replace")
+    ctrl = sum(1 for ch in text if ord(ch) < 32 and ch not in "\t\n\r\f\v")
+    if (text.count("�") + ctrl) / len(text) < 0.01:
+        return True
+    # cp1252/latin-1 is still text; only control characters make it binary.
+    return ctrl / len(text) < 0.01
+
+
+def _archive_manifest(fpath: Path) -> str | None:
+    """Member listing, or None if not a readable archive."""
+    import zipfile
+
+    try:
+        with zipfile.ZipFile(fpath) as zf:
+            names = zf.namelist()
+    except Exception:
+        return None
+    shown = names[:MAX_ARCHIVE_MEMBERS]
+    lines = "\n".join(f"  {n}" for n in shown)
+    if len(names) > len(shown):
+        lines += f"\n  ... and {len(names) - len(shown)} more member(s)"
+    return f"{len(names)} member(s):\n{lines}"
+
+
+def _truncated(text: str) -> str:
+    if len(text) <= MAX_TEXT_CHARS_PER_FILE:
+        return text
+    return text[:MAX_TEXT_CHARS_PER_FILE] + f"\n[... truncated at {MAX_TEXT_CHARS_PER_FILE:,} characters]"
 
 
 def _convert_office_to_pdf(fpath: Path) -> Path | None:
@@ -343,7 +407,8 @@ def convert_deliverables_to_content_blocks(
     *audio_capable* / *video_capable* forward audio / video files (respectively)
     to judges that read that modality — tracked SEPARATELY because MiniMax-M3
     reads video but not audio (a video-only judge keeps video, skips audio). An
-    unreadable modality's file is skipped. The AV block dialect follows
+    unreadable modality's file is still announced by name and size rather than
+    dropped. The AV block dialect follows
     *media_mode*: ``native_pdf`` (frontier judges, e.g. Gemini) uses an
     ``image_url`` data URL, while ``images_and_text`` (self-hosted vLLM judges)
     uses the standard ``video_url`` / ``input_audio`` content types vLLM routes to
@@ -368,7 +433,11 @@ def convert_deliverables_to_content_blocks(
             if ext in TEXT_EXTS:
                 text = fpath.read_text(encoding="utf-8", errors="replace").strip()
                 if text:
-                    blocks.append({"type": "text", "text": f"\n{fpath.name}:\n{text}"})
+                    blocks.append({"type": "text", "text": f"\n{fpath.name}:\n{_truncated(text)}"})
+                else:
+                    blocks.append(
+                        {"type": "text", "text": f"\n{fpath.name}: [present but EMPTY (0 bytes of content)]"}
+                    )
 
             elif ext in OFFICE_EXTS:
                 pdf_path = _convert_office_to_pdf(fpath)
@@ -437,12 +506,48 @@ def convert_deliverables_to_content_blocks(
                 # (images_and_text) need the standard video_url / input_audio types,
                 # which vLLM routes to the media tower.
                 is_video = ext in VIDEO_EXTS
+                file_type = "VIDEO" if is_video else "AUDIO"
                 if video_capable if is_video else audio_capable:
                     mime = MIME_TYPES.get(ext, "application/octet-stream")
                     data = fpath.read_bytes()
-                    file_type = "VIDEO" if is_video else "AUDIO"
                     blocks.append({"type": "text", "text": f"\n{fpath.name}:"})
                     blocks.append(_av_block(mime, data, ext=ext, file_type=file_type, openai_native=images_and_text))
+                else:
+                    # Gating is correct; emitting nothing is not -- the judge
+                    # then grades against a file it believes was never produced.
+                    size = fpath.stat().st_size
+                    blocks.append(
+                        {
+                            "type": "text",
+                            "text": (
+                                f"\n{fpath.name}: [{file_type} deliverable, {_human_size(size)} "
+                                f"({size:,} bytes) — present on disk, but this judge cannot decode "
+                                f"{file_type.lower()}. Do NOT treat it as missing or unproduced. Grade the "
+                                f"criteria that do not require {'viewing' if is_video else 'listening'}; "
+                                f"mark the rest unverifiable rather than unmet.]"
+                            ),
+                        }
+                    )
+
+            else:
+                # Any allowlist lags reality; an unlisted extension used to emit
+                # nothing, so the judge scored it as never produced.
+                size = fpath.stat().st_size
+                if size == 0:
+                    body = "[present but EMPTY (0 bytes)]"
+                elif _sniffs_as_text(fpath):
+                    text = fpath.read_text(encoding="utf-8", errors="replace").strip()
+                    body = f"\n{_truncated(text)}" if text else "[present but EMPTY (0 bytes of content)]"
+                else:
+                    manifest = _archive_manifest(fpath)
+                    if manifest is not None:
+                        body = f"[archive, {_human_size(size)} — NOT missing] {manifest}"
+                    else:
+                        body = (
+                            f"[deliverable present, {_human_size(size)} ({size:,} bytes) — NOT missing; "
+                            f"content not extractable in this format]"
+                        )
+                blocks.append({"type": "text", "text": f"\n{fpath.name}: {body}"})
         except Exception as exc:
             blocks.append({"type": "text", "text": f"\n{fpath.name}: [Error: {exc}]"})
 

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -209,7 +209,28 @@ HANDLED_EXTS = TEXT_EXTS | OFFICE_EXTS | IMAGE_EXTS | AUDIO_EXTS | VIDEO_EXTS | 
 
 TEXT_SNIFF_BYTES = 8192
 MAX_TEXT_CHARS_PER_FILE = 20_000
-MAX_ARCHIVE_MEMBERS = 200
+MAX_ARCHIVE_ENTRIES = 200
+MAX_ARCHIVE_TEXT_CHARS = 120_000
+MAX_ARCHIVE_MEMBER_BYTES = 2_000_000
+
+# Document formats that happen to BE zip containers. Without this they open
+# cleanly as archives and the judge is handed a listing of OOXML/ODF internals
+# (`word/document.xml`, `[Content_Types].xml`) instead of the document.
+ARCHIVE_DOC_EXTS = {
+    ".xlsm",
+    ".docm",
+    ".pptm",
+    ".xlsb",
+    ".odt",
+    ".ods",
+    ".odp",
+    ".odg",
+    ".epub",
+    ".jar",
+    ".whl",
+    ".apk",
+    ".ipa",
+}
 # Audio/video (AUDIO_EXTS / VIDEO_EXTS, imported above) are only passed through
 # when the judge is AV-capable (e.g. MiniMax M3); image-only judges can't decode
 # them, so they are otherwise skipped. Every extension in those sets needs an
@@ -273,19 +294,56 @@ def _sniffs_as_text(fpath: Path) -> bool:
 
 
 def _archive_manifest(fpath: Path) -> str | None:
-    """Member listing, or None if not a readable archive."""
+    """Member listing plus text-member contents, or None if not a readable archive.
+
+    Rubrics ask both whether a bundle contains X and whether what is inside is
+    correct, so names alone cannot answer them.
+    """
     import zipfile
+
+    # Must come first: these open cleanly as zips and would otherwise be
+    # summarised as their own XML internals.
+    if fpath.suffix.lower() in ARCHIVE_DOC_EXTS:
+        return None
 
     try:
         with zipfile.ZipFile(fpath) as zf:
-            names = zf.namelist()
+            infos = zf.infolist()
+            lines = [f"  {i.filename} ({i.file_size:,} bytes)" for i in infos[:MAX_ARCHIVE_ENTRIES]]
+            if len(infos) > MAX_ARCHIVE_ENTRIES:
+                lines.append(f"  ... and {len(infos) - MAX_ARCHIVE_ENTRIES:,} more entries")
+
+            # Read IN MEMORY, never extracted: nothing is written to disk, so
+            # there is no zip-slip to defend against. Bounded by per-member size,
+            # aggregate characters, and the caller's own text budget.
+            bodies: list[str] = []
+            spent = 0
+            for info in infos:
+                if info.is_dir() or info.file_size > MAX_ARCHIVE_MEMBER_BYTES:
+                    continue
+                if Path(info.filename).suffix.lower() not in TEXT_EXTS:
+                    continue
+                if spent >= MAX_ARCHIVE_TEXT_CHARS:
+                    bodies.append("[archive text budget exhausted; remaining members listed above but not shown]")
+                    break
+                try:
+                    raw = zf.read(info)
+                except Exception:
+                    continue
+                text = raw.decode("utf-8", errors="replace").strip()
+                if not text:
+                    continue
+                take = text[: MAX_ARCHIVE_TEXT_CHARS - spent]
+                spent += len(take)
+                truncated = "\n[...member truncated]" if len(take) < len(text) else ""
+                bodies.append(f"--- {info.filename} ---\n{take}{truncated}")
     except Exception:
         return None
-    shown = names[:MAX_ARCHIVE_MEMBERS]
-    lines = "\n".join(f"  {n}" for n in shown)
-    if len(names) > len(shown):
-        lines += f"\n  ... and {len(names) - len(shown)} more member(s)"
-    return f"{len(names)} member(s):\n{lines}"
+
+    out = f"{len(infos)} member(s):\n" + "\n".join(lines)
+    if bodies:
+        out += "\n\n" + "\n\n".join(bodies)
+    return out
 
 
 def _truncated(text: str) -> str:

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -224,10 +224,10 @@ MIME_TYPES = {
 }
 
 
-def _human_size(n: int) -> str:
+def _human_size(n: float) -> str:
     for unit in ("B", "KB", "MB", "GB"):
         if n < 1024 or unit == "GB":
-            return f"{n:.0f} {unit}" if unit == "B" else f"{n / 1024:.1f} {unit}"
+            return f"{n:.0f} B" if unit == "B" else f"{n:.1f} {unit}"
         n /= 1024.0
     return f"{n:.1f} GB"
 

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -208,7 +208,14 @@ IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".heic", ".heif"}
 HANDLED_EXTS = TEXT_EXTS | OFFICE_EXTS | IMAGE_EXTS | AUDIO_EXTS | VIDEO_EXTS | {".pdf"}
 
 TEXT_SNIFF_BYTES = 8192
-MAX_TEXT_CHARS_PER_FILE = 20_000
+# Per-file ceiling, and the aggregate across all text blocks in one request.
+# Upstream has no cap at all: a big generated log produced a 720k-token request
+# that the judge rejected outright, leaving the task silently unjudged.
+MAX_TEXT_BLOCK_CHARS = 200_000
+MAX_TOTAL_TEXT_BLOCK_CHARS = 400_000
+# Header and truncation notice per block; reserved before allotting because
+# it is tokens too.
+TEXT_BLOCK_OVERHEAD_CHARS = 120
 MAX_ARCHIVE_ENTRIES = 200
 MAX_ARCHIVE_TEXT_CHARS = 120_000
 MAX_ARCHIVE_MEMBER_BYTES = 2_000_000
@@ -346,10 +353,25 @@ def _archive_manifest(fpath: Path) -> str | None:
     return out
 
 
-def _truncated(text: str) -> str:
-    if len(text) <= MAX_TEXT_CHARS_PER_FILE:
-        return text
-    return text[:MAX_TEXT_CHARS_PER_FILE] + f"\n[... truncated at {MAX_TEXT_CHARS_PER_FILE:,} characters]"
+def _fair_text_allowances(sizes: list[int], total_budget: int, per_file_cap: int) -> list[int]:
+    """Max-min fair split of *total_budget* across text deliverables of *sizes*.
+
+    Smallest first: each file may take an equal share of what is left divided by
+    how many still need one. Files under their share take only what they need and
+    hand back the surplus, so a small real deliverable is never starved by a large
+    one that happens to sort earlier -- renaming a file must not change the score.
+    Returned in the order *sizes* was given.
+    """
+    allowances = [0] * len(sizes)
+    remaining = total_budget
+    order = sorted(range(len(sizes)), key=lambda i: sizes[i])
+    for position, idx in enumerate(order):
+        still_to_serve = len(order) - position
+        share = remaining // still_to_serve
+        take = max(0, min(sizes[idx], per_file_cap, share))
+        allowances[idx] = take
+        remaining -= take
+    return allowances
 
 
 def _convert_office_to_pdf(fpath: Path, out_dir: Path | None = None) -> Path | None:
@@ -531,6 +553,47 @@ def convert_deliverables_to_content_blocks(
             elif office_stem_counts.get(entry.stem, 0) == 1:
                 consumed_pdfs.add(entry.with_suffix(".pdf"))
 
+    # Which files the judge receives AS TEXT. Decided once and reused by both the
+    # allotment and the dispatch loop: deciding it twice lets a file be emitted as
+    # text while holding no allowance, i.e. truncated to nothing.
+    texty = {
+        p
+        for p in entries
+        if is_deliverable(p)
+        and p not in consumed_pdfs
+        and (p.suffix.lower() in TEXT_EXTS or (p.suffix.lower() not in HANDLED_EXTS and _sniffs_as_text(p)))
+    }
+    text_files = [p for p in entries if p in texty]
+    body_budget = max(0, MAX_TOTAL_TEXT_BLOCK_CHARS - len(text_files) * TEXT_BLOCK_OVERHEAD_CHARS)
+    allowance_by_name = dict(
+        zip(
+            (p.name for p in text_files),
+            _fair_text_allowances([p.stat().st_size for p in text_files], body_budget, MAX_TEXT_BLOCK_CHARS),
+        )
+    )
+
+    emitted_chars = 0
+    omitted_names: list[str] = []
+
+    def _text_block(header: str, body: str, allowance: int) -> dict[str, Any] | None:
+        """A text block for *body*, trimmed to *allowance*.
+
+        None once the aggregate budget is spent: with enough files even the headers
+        alone would blow the request, so past that point they are summarised in one
+        block rather than named individually.
+        """
+        nonlocal emitted_chars
+        if emitted_chars >= MAX_TOTAL_TEXT_BLOCK_CHARS:
+            return None
+        cap = max(0, min(MAX_TEXT_BLOCK_CHARS, allowance))
+        if len(body) > cap:
+            shown = body[:cap] + f"\n[...truncated: {len(body) - cap:,} of {len(body):,} chars omitted]"
+        else:
+            shown = body
+        block = {"type": "text", "text": f"\n{header}\n{shown}"}
+        emitted_chars += len(block["text"])
+        return block
+
     for fpath in entries:
         if not is_deliverable(fpath) or fpath in consumed_pdfs:
             continue
@@ -538,14 +601,13 @@ def convert_deliverables_to_content_blocks(
         ext = fpath.suffix.lower()
 
         try:
-            if ext in TEXT_EXTS:
+            if fpath in texty:
                 text = fpath.read_text(encoding="utf-8", errors="replace").strip()
                 if text:
-                    blocks.append({"type": "text", "text": f"\n{fpath.name}:\n{_truncated(text)}"})
+                    block = _text_block(f"{fpath.name}:", text, allowance_by_name.get(fpath.name, 0))
                 else:
-                    blocks.append(
-                        {"type": "text", "text": f"\n{fpath.name}: [present but EMPTY (0 bytes of content)]"}
-                    )
+                    block = _text_block(f"{fpath.name}:", "[present but EMPTY (0 bytes of content)]", 200)
+                blocks.append(block) if block else omitted_names.append(fpath.name)
 
             elif ext in OFFICE_EXTS:
                 # Prefer a PDF preconvert already rendered. Reconverting is
@@ -587,7 +649,8 @@ def convert_deliverables_to_content_blocks(
                     # Fallback to text extraction
                     text = _extract_text(fpath, ext)
                     if text:
-                        blocks.append({"type": "text", "text": f"\n{fpath.name} (text fallback):\n{text}"})
+                        block = _text_block(f"{fpath.name} (text fallback):", text, MAX_TEXT_BLOCK_CHARS)
+                        blocks.append(block) if block else omitted_names.append(fpath.name)
 
             elif ext == ".pdf":
                 data = fpath.read_bytes()
@@ -663,7 +726,7 @@ def convert_deliverables_to_content_blocks(
                     body = "[present but EMPTY (0 bytes)]"
                 elif _sniffs_as_text(fpath):
                     text = fpath.read_text(encoding="utf-8", errors="replace").strip()
-                    body = f"\n{_truncated(text)}" if text else "[present but EMPTY (0 bytes of content)]"
+                    body = text if text else "[present but EMPTY (0 bytes of content)]"
                 else:
                     manifest = _archive_manifest(fpath)
                     if manifest is not None:
@@ -674,10 +737,23 @@ def convert_deliverables_to_content_blocks(
                             f"content not extractable in this format. Statements in other files about "
                             f"its contents are unverified assertions, not evidence.]"
                         )
-                blocks.append({"type": "text", "text": f"\n{fpath.name}: {body}"})
+                block = _text_block(f"{fpath.name}:", body, MAX_TEXT_BLOCK_CHARS)
+                blocks.append(block) if block else omitted_names.append(fpath.name)
         except Exception as exc:
             blocks.append({"type": "text", "text": f"\n{fpath.name}: [Error: {exc}]"})
 
+    if omitted_names:
+        shown = ", ".join(omitted_names[:20])
+        if len(omitted_names) > 20:
+            shown += f", and {len(omitted_names) - 20} more"
+        blocks.append(
+            {
+                "type": "text",
+                "text": f"\n[{len(omitted_names)} text deliverable(s) omitted, budget exhausted: {shown}]",
+            }
+        )
+
+    # Clean up only what this pass created; it all lives in tempdirs.
     for scratch in scratch_dirs:
         shutil.rmtree(scratch, ignore_errors=True)
 

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -117,7 +117,9 @@ def read_deliverable_files(output_dir: str) -> str:
 
 def _extract_text(fpath: Path, ext: str) -> str:
     """Dispatch to the right extractor based on file extension."""
-    if ext in (".txt", ".md", ".csv", ".json", ".html", ".xml", ".log"):
+    # TEXT_EXTS, not a second shorter list: a .ts/.py/.yaml deliverable was source
+    # on the block path and "[Binary file: ...]" here.
+    if ext in TEXT_EXTS:
         return _read_text(fpath)
     elif ext == ".docx":
         return _read_docx(fpath)

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -374,6 +374,27 @@ def _fair_text_allowances(sizes: list[int], total_budget: int, per_file_cap: int
     return allowances
 
 
+_libreoffice_unavailable_warned = False
+
+
+def _warn_libreoffice_unavailable(exc: OSError) -> None:
+    """Warn once per process that Office deliverables cannot be rendered.
+
+    Per file this would be noise; never saying it at all is worse, because the
+    silent consequence is that every Office deliverable is judged from extracted
+    text instead of its rendered pages.
+    """
+    global _libreoffice_unavailable_warned
+    if _libreoffice_unavailable_warned:
+        return
+    _libreoffice_unavailable_warned = True
+    print(
+        f"[file_reader] LibreOffice is unavailable ({exc}); Office deliverables will fall back to text "
+        "extraction. Preconvert them to PDF for full-fidelity judging.",
+        flush=True,
+    )
+
+
 def _convert_office_to_pdf(fpath: Path, out_dir: Path | None = None) -> Path | None:
     """Convert a .docx/.xlsx/.pptx file to PDF using LibreOffice headless.
 
@@ -432,6 +453,14 @@ def _convert_office_to_pdf(fpath: Path, out_dir: Path | None = None) -> Path | N
         return out_pdf
     except subprocess.TimeoutExpired:
         print(f"[file_reader] LibreOffice conversion timed out for {fpath.name}", flush=True)
+        return None
+    except OSError as exc:
+        # Usually LibreOffice simply isn't installed on this host. Returning None
+        # degrades to the caller's text-extraction fallback; letting it propagate
+        # would replace the entire deliverable with an "[Error: ...]" block, which a
+        # judge reads as a missing artifact and scores near zero. That is not
+        # hypothetical - it once manufactured a spurious "much worse" verdict.
+        _warn_libreoffice_unavailable(exc)
         return None
     finally:
         shutil.rmtree(profile_dir, ignore_errors=True)

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -352,8 +352,12 @@ def _truncated(text: str) -> str:
     return text[:MAX_TEXT_CHARS_PER_FILE] + f"\n[... truncated at {MAX_TEXT_CHARS_PER_FILE:,} characters]"
 
 
-def _convert_office_to_pdf(fpath: Path) -> Path | None:
+def _convert_office_to_pdf(fpath: Path, out_dir: Path | None = None) -> Path | None:
     """Convert a .docx/.xlsx/.pptx file to PDF using LibreOffice headless.
+
+    With *out_dir* the PDF is written there instead of beside *fpath*, so a
+    judging pass never writes into the directory it is reading. The in-place
+    default is kept because ``preconvert.py`` relies on it.
 
     Returns the path to the generated PDF, or None on failure.
     Uses a unique user profile to avoid lock conflicts in concurrent workers.
@@ -365,7 +369,8 @@ def _convert_office_to_pdf(fpath: Path) -> Path | None:
     """
     profile_dir = Path(tempfile.mkdtemp(prefix="lo-profile-"))
     user_install = f"file://{profile_dir.as_posix()}"
-    out_pdf = fpath.with_suffix(".pdf")
+    dest_dir = out_dir if out_dir is not None else fpath.parent
+    out_pdf = dest_dir / (fpath.stem + ".pdf")
     stage_dir: Path | None = None
     input_path = fpath
     has_whitespace = any(c.isspace() for c in fpath.name)
@@ -378,7 +383,7 @@ def _convert_office_to_pdf(fpath: Path) -> Path | None:
             shutil.copy2(fpath, input_path)
             lo_outdir = str(stage_dir)
         else:
-            lo_outdir = str(fpath.parent)
+            lo_outdir = str(dest_dir)
 
         cmd = [
             "libreoffice",
@@ -502,7 +507,7 @@ def convert_deliverables_to_content_blocks(
     images_and_text = media_mode == "images_and_text"
 
     blocks: list[dict[str, Any]] = []
-    converted_pdfs: list[Path] = []  # track for cleanup
+    scratch_dirs: list[Path] = []  # tempdirs holding PDFs this pass converted
 
     entries = sorted(output_path.iterdir())
     # A PDF an Office file renders from must not also be emitted standalone, or
@@ -538,9 +543,9 @@ def convert_deliverables_to_content_blocks(
                 sibling = fpath.with_suffix(".pdf")
                 pdf_path = sidecar if sidecar.is_file() else (sibling if sibling.is_file() else None)
                 if pdf_path is None:
-                    pdf_path = _convert_office_to_pdf(fpath)
-                    if pdf_path and pdf_path.exists():
-                        converted_pdfs.append(pdf_path)
+                    scratch = Path(tempfile.mkdtemp(prefix="gdpval-render-"))
+                    scratch_dirs.append(scratch)
+                    pdf_path = _convert_office_to_pdf(fpath, out_dir=scratch)
                 if pdf_path and pdf_path.exists():
                     data = pdf_path.read_bytes()
                     if images_and_text:
@@ -654,8 +659,7 @@ def convert_deliverables_to_content_blocks(
         except Exception as exc:
             blocks.append({"type": "text", "text": f"\n{fpath.name}: [Error: {exc}]"})
 
-    # Clean up converted PDFs (they live next to the originals)
-    for pdf_path in converted_pdfs:
-        pdf_path.unlink(missing_ok=True)
+    for scratch in scratch_dirs:
+        shutil.rmtree(scratch, ignore_errors=True)
 
     return blocks

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -513,11 +513,23 @@ def convert_deliverables_to_content_blocks(
     # A PDF an Office file renders from must not also be emitted standalone, or
     # the judge sees the same pages twice. Both spellings count: the same-stem
     # sidecar Plan.pptx.pdf, and the ordinary sibling Plan.pdf.
+    # How many Office files share each stem. `Report.docx` and `Report.pptx` both
+    # point at `Report.pdf`, which cannot say which of them it renders, so the
+    # plain sibling is only trustworthy when the stem is unambiguous. preconvert
+    # writes an injective `Report.docx.pdf` sidecar for the ambiguous case.
+    office_stem_counts: dict[str, int] = {}
+    for entry in entries:
+        if is_deliverable(entry) and entry.suffix.lower() in OFFICE_EXTS:
+            office_stem_counts[entry.stem] = office_stem_counts.get(entry.stem, 0) + 1
+
     consumed_pdfs: set[Path] = set()
     for entry in entries:
         if is_deliverable(entry) and entry.suffix.lower() in OFFICE_EXTS:
             sidecar = entry.with_name(entry.name + ".pdf")
-            consumed_pdfs.add(sidecar if sidecar.is_file() else entry.with_suffix(".pdf"))
+            if sidecar.is_file():
+                consumed_pdfs.add(sidecar)
+            elif office_stem_counts.get(entry.stem, 0) == 1:
+                consumed_pdfs.add(entry.with_suffix(".pdf"))
 
     for fpath in entries:
         if not is_deliverable(fpath) or fpath in consumed_pdfs:
@@ -541,7 +553,14 @@ def convert_deliverables_to_content_blocks(
                 # below would delete someone else's artifact.
                 sidecar = fpath.with_name(fpath.name + ".pdf")
                 sibling = fpath.with_suffix(".pdf")
-                pdf_path = sidecar if sidecar.is_file() else (sibling if sibling.is_file() else None)
+                if sidecar.is_file():
+                    pdf_path = sidecar
+                elif sibling.is_file() and office_stem_counts.get(fpath.stem, 0) == 1:
+                    pdf_path = sibling
+                else:
+                    # Ambiguous stem with no sidecar: rendering it ourselves is the
+                    # only way to know which file the PDF belongs to.
+                    pdf_path = None
                 if pdf_path is None:
                     scratch = Path(tempfile.mkdtemp(prefix="gdpval-render-"))
                     scratch_dirs.append(scratch)

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -423,8 +423,18 @@ def convert_deliverables_to_content_blocks(
     blocks: list[dict[str, Any]] = []
     converted_pdfs: list[Path] = []  # track for cleanup
 
-    for fpath in sorted(output_path.iterdir()):
-        if not fpath.is_file():
+    entries = sorted(output_path.iterdir())
+    # A PDF an Office file renders from must not also be emitted standalone, or
+    # the judge sees the same pages twice. Both spellings count: the same-stem
+    # sidecar Plan.pptx.pdf, and the ordinary sibling Plan.pdf.
+    consumed_pdfs: set[Path] = set()
+    for entry in entries:
+        if entry.is_file() and entry.suffix.lower() in OFFICE_EXTS:
+            sidecar = entry.with_name(entry.name + ".pdf")
+            consumed_pdfs.add(sidecar if sidecar.is_file() else entry.with_suffix(".pdf"))
+
+    for fpath in entries:
+        if not fpath.is_file() or fpath in consumed_pdfs:
             continue
 
         ext = fpath.suffix.lower()
@@ -440,9 +450,17 @@ def convert_deliverables_to_content_blocks(
                     )
 
             elif ext in OFFICE_EXTS:
-                pdf_path = _convert_office_to_pdf(fpath)
+                # Prefer a PDF preconvert already rendered. Reconverting is
+                # wasteful, needs LibreOffice on the judge host, and the cleanup
+                # below would delete someone else's artifact.
+                sidecar = fpath.with_name(fpath.name + ".pdf")
+                sibling = fpath.with_suffix(".pdf")
+                pdf_path = sidecar if sidecar.is_file() else (sibling if sibling.is_file() else None)
+                if pdf_path is None:
+                    pdf_path = _convert_office_to_pdf(fpath)
+                    if pdf_path and pdf_path.exists():
+                        converted_pdfs.append(pdf_path)
                 if pdf_path and pdf_path.exists():
-                    converted_pdfs.append(pdf_path)
                     data = pdf_path.read_bytes()
                     if images_and_text:
                         rendered = _pdf_bytes_to_image_text_blocks(

--- a/responses_api_agents/stirrup_agent/tests/test_file_reader_deliverables.py
+++ b/responses_api_agents/stirrup_agent/tests/test_file_reader_deliverables.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Run state the agent writes beside its deliverables must never reach the judge."""
+
+from pathlib import Path
+
+from responses_api_agents.stirrup_agent.file_reader import (
+    IGNORE_FILES,
+    convert_deliverables_to_content_blocks,
+    is_deliverable,
+    read_deliverable_files,
+)
+
+
+def _run_state(d: Path) -> None:
+    (d / "finish_params.json").write_text('{"summary": "did the thing"}')
+    (d / "history.json").write_text('[{"role": "assistant", "content": "internal reasoning"}]')
+    (d / "history.pkl").write_bytes(b"\x80\x04\x95")
+    (d / "inprogress_history.json").write_text("[]")
+    (d / "metadata.json").write_text('{"_model_speed": {"num_calls": 42}}')
+    (d / "log.txt").write_text("2026-01-01 agent started\n")
+
+
+def _text_of(blocks) -> str:
+    return "\n".join(b.get("text", "") for b in blocks if b.get("type") == "text")
+
+
+def test_run_state_is_not_a_deliverable(tmp_path: Path):
+    _run_state(tmp_path)
+    for name in IGNORE_FILES:
+        p = tmp_path / name
+        if p.exists():
+            assert not is_deliverable(p), f"{name} would be graded as work product"
+
+
+def test_real_deliverable_still_is_one(tmp_path: Path):
+    (tmp_path / "report.md").write_text("# findings\n")
+    assert is_deliverable(tmp_path / "report.md")
+
+
+def test_run_state_never_reaches_the_judge_blocks(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    _run_state(d)
+    (d / "report.md").write_text("# real work\n")
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d)))
+    assert "report.md" in out
+    for name in ("finish_params.json", "history.json", "metadata.json", "log.txt"):
+        assert name not in out, f"{name} was shown to the judge"
+    assert "internal reasoning" not in out
+    assert "did the thing" not in out
+
+
+def test_run_state_never_reaches_the_text_extractor(tmp_path: Path):
+    _run_state(tmp_path)
+    (tmp_path / "report.md").write_text("# real work\n")
+
+    out = read_deliverable_files(str(tmp_path))
+    assert "real work" in out
+    assert "internal reasoning" not in out
+    assert "finish_params.json" not in out
+
+
+def test_reference_files_directory_is_not_a_deliverable(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "reference_files").mkdir()
+    (d / "reference_files" / "given.pdf").write_bytes(b"%PDF-1.4\n")
+    (d / "answer.md").write_text("# answer\n")
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d)))
+    assert "answer.md" in out
+    assert "given.pdf" not in out, "an input was graded as the model's output"
+
+
+def test_a_directory_named_like_run_state_is_still_excluded(tmp_path: Path):
+    assert not is_deliverable(tmp_path / "reference_files")
+
+
+def test_office_sidecar_scan_ignores_run_state(tmp_path: Path):
+    """A run-state file must not be treated as an Office source when consuming PDFs."""
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    _run_state(d)
+    (d / "Plan.docx").write_bytes(b"PK\x03\x04")
+    (d / "Plan.pdf").write_bytes(b"%PDF-1.4\n%%EOF\n")
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d)))
+    assert "Plan.docx" in out
+    assert "Plan.pdf:" not in out, "the consumed sibling was emitted standalone"
+
+
+def test_ignore_list_covers_every_file_the_agent_writes(tmp_path: Path):
+    """Guard against the set drifting from what the agent actually produces."""
+    for name in ("finish_params.json", "history.json", "history.pkl", "metadata.json", "log.txt"):
+        assert name in IGNORE_FILES

--- a/responses_api_agents/stirrup_agent/tests/test_file_reader_no_libreoffice.py
+++ b/responses_api_agents/stirrup_agent/tests/test_file_reader_no_libreoffice.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A judge host without LibreOffice must degrade, not fabricate a missing artifact.
+
+``convert_deliverables_to_content_blocks`` reaches for LibreOffice whenever an Office
+deliverable has no unambiguous PDF beside it. When the binary is absent that call used
+to raise ``FileNotFoundError``, which the per-file handler turned into a lone
+``[Error: ...]`` block *in place of the deliverable* — indistinguishable to a judge from
+a missing work product, and worth a near-zero score. Text extraction is the correct
+degradation, and it already exists.
+"""
+
+import subprocess
+from pathlib import Path
+
+import responses_api_agents.stirrup_agent.file_reader as file_reader
+from responses_api_agents.stirrup_agent.file_reader import convert_deliverables_to_content_blocks
+
+
+def _docx(path: Path, body: str) -> None:
+    """Minimal but real .docx: a zip whose document.xml holds one paragraph."""
+    import zipfile
+
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr(
+            "[Content_Types].xml",
+            '<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+            '<Default Extension="xml" ContentType="application/xml"/>'
+            '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument'
+            '.wordprocessingml.document.main+xml"/></Types>',
+        )
+        z.writestr(
+            "_rels/.rels",
+            '<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+            '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/'
+            'officeDocument" Target="word/document.xml"/></Relationships>',
+        )
+        z.writestr(
+            "word/document.xml",
+            '<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+            f"<w:body><w:p><w:r><w:t>{body}</w:t></w:r></w:p></w:body></w:document>",
+        )
+
+
+def _text_of(blocks) -> str:
+    return "\n".join(b.get("text", "") for b in blocks if b.get("type") == "text")
+
+
+def _no_libreoffice(monkeypatch) -> None:
+    """Make any attempt to exec LibreOffice fail the way a missing binary does."""
+
+    def _boom(cmd, *args, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory", "libreoffice")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    # raising=False so these tests fail on their own assertions against code that predates
+    # the warn-once flag, rather than erroring out here and hiding what regressed.
+    monkeypatch.setattr(file_reader, "_libreoffice_unavailable_warned", False, raising=False)
+
+
+def test_missing_libreoffice_does_not_replace_the_deliverable_with_an_error(monkeypatch, tmp_path: Path):
+    _docx(tmp_path / "report.docx", "Quarterly throughput rose 12 percent.")
+    _no_libreoffice(monkeypatch)
+
+    text = _text_of(convert_deliverables_to_content_blocks(tmp_path))
+
+    assert "[Error:" not in text, "a missing binary was reported as a broken deliverable"
+    assert "report.docx" in text
+
+
+def test_missing_libreoffice_falls_back_to_extracted_text(monkeypatch, tmp_path: Path):
+    _docx(tmp_path / "report.docx", "Quarterly throughput rose 12 percent.")
+    _no_libreoffice(monkeypatch)
+
+    text = _text_of(convert_deliverables_to_content_blocks(tmp_path))
+
+    assert "Quarterly throughput rose 12 percent." in text, (
+        "the document's own content never reached the judge, so it would score as absent"
+    )
+
+
+def test_conversion_helper_returns_none_rather_than_raising(monkeypatch, tmp_path: Path):
+    _docx(tmp_path / "report.docx", "body")
+    _no_libreoffice(monkeypatch)
+
+    assert file_reader._convert_office_to_pdf(tmp_path / "report.docx", out_dir=tmp_path) is None
+
+
+def test_unavailability_is_announced_once(monkeypatch, capsys, tmp_path: Path):
+    for name in ("a.docx", "b.docx", "c.docx"):
+        _docx(tmp_path / name, "body")
+    _no_libreoffice(monkeypatch)
+
+    convert_deliverables_to_content_blocks(tmp_path)
+
+    warnings = [ln for ln in capsys.readouterr().out.splitlines() if "LibreOffice is unavailable" in ln]
+    assert len(warnings) == 1, f"expected exactly one warning for three files, got {len(warnings)}"

--- a/responses_api_agents/stirrup_agent/tests/test_file_reader_text_caps.py
+++ b/responses_api_agents/stirrup_agent/tests/test_file_reader_text_caps.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A deliverable's share of the judge's context must not depend on its filename."""
+
+from pathlib import Path
+
+from responses_api_agents.stirrup_agent.file_reader import (
+    MAX_TEXT_BLOCK_CHARS,
+    MAX_TOTAL_TEXT_BLOCK_CHARS,
+    _fair_text_allowances,
+    convert_deliverables_to_content_blocks,
+)
+
+
+def _text_of(blocks) -> str:
+    return "\n".join(b.get("text", "") for b in blocks if b.get("type") == "text")
+
+
+def test_small_deliverable_is_not_starved_by_a_large_one_sorting_first(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "000_huge.txt").write_text("A" * 500_000)
+    (d / "zzz_report.md").write_text("THE REAL DELIVERABLE\n" * 50)
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d)))
+    assert "THE REAL DELIVERABLE" in out
+    assert "truncated" in out
+
+
+def test_allotment_does_not_depend_on_filename_order(tmp_path: Path):
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "000_huge.txt").write_text("A" * 500_000)
+    (a / "zzz_report.md").write_text("PAYLOAD\n" * 50)
+
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "zzz_huge.txt").write_text("A" * 500_000)
+    (b / "000_report.md").write_text("PAYLOAD\n" * 50)
+
+    out_a = _text_of(convert_deliverables_to_content_blocks(str(a)))
+    out_b = _text_of(convert_deliverables_to_content_blocks(str(b)))
+    assert ("PAYLOAD" in out_a) == ("PAYLOAD" in out_b)
+
+
+def test_aggregate_budget_bounds_the_request(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    for i in range(60):
+        (d / f"f{i:03d}.txt").write_text("B" * 40_000)
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d)))
+    assert len(out) <= MAX_TOTAL_TEXT_BLOCK_CHARS * 1.15
+
+
+def test_files_dropped_for_budget_are_named_not_silently_lost(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    for i in range(60):
+        (d / f"f{i:03d}.txt").write_text("B" * 40_000)
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d)))
+    assert all(f"f{i:03d}.txt" in out for i in range(0, 60, 7)) or "omitted" in out
+
+
+def test_surplus_from_small_files_is_redistributed():
+    assert _fair_text_allowances([10, 10, 1_000_000], 300, 200) == [10, 10, 200]
+
+
+def test_equal_files_split_equally():
+    al = _fair_text_allowances([100, 100, 100], 150, 200)
+    assert sum(al) <= 150
+    assert max(al) - min(al) <= 1
+
+
+def test_per_file_cap_is_never_exceeded():
+    assert _fair_text_allowances([10**9], 10**9, 1234) == [1234]
+
+
+def test_allowance_of_zero_files_is_empty():
+    assert _fair_text_allowances([], 1000, 100) == []
+
+
+def test_sniffed_text_file_receives_an_allowance(tmp_path: Path):
+    """Deciding 'is this text' twice would emit it while allotting it nothing."""
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "Makefile").write_text("all:\n\tcc x.c\n" * 20)
+
+    assert "cc x.c" in _text_of(convert_deliverables_to_content_blocks(str(d)))
+
+
+def test_a_single_file_may_use_the_per_file_cap(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "only.txt").write_text("C" * (MAX_TEXT_BLOCK_CHARS + 5_000))
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d)))
+    assert "only.txt" in out
+    assert "truncated" in out

--- a/responses_api_agents/stirrup_agent/tests/test_file_reader_unhandled.py
+++ b/responses_api_agents/stirrup_agent/tests/test_file_reader_unhandled.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Silence must never read as absence: every deliverable is named, whatever its type."""
+
+import zipfile
+from pathlib import Path
+
+from responses_api_agents.stirrup_agent.file_reader import (
+    HANDLED_EXTS,
+    LEGACY_OFFICE_EXTS,
+    OFFICE_EXTS,
+    TEXT_EXTS,
+    convert_deliverables_to_content_blocks,
+)
+
+
+def _text_of(blocks) -> str:
+    return "\n".join(b.get("text", "") for b in blocks if b.get("type") == "text")
+
+
+def test_every_deliverable_is_named_whatever_its_extension(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "proxy.ts").write_text("export const x = 1;\n")
+    (d / "pyproject.toml").write_text("[project]\nname='x'\n")
+    (d / "notebook.ipynb").write_text('{"cells": []}')
+    (d / "diagram.svg").write_text("<svg></svg>")
+    (d / "Makefile").write_text("all:\n\tcc x.c\n")
+    (d / "blob.bin").write_bytes(b"\x00\x01\x02" * 500)
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d)))
+    for name in ("proxy.ts", "pyproject.toml", "notebook.ipynb", "diagram.svg", "Makefile", "blob.bin"):
+        assert name in out, f"{name} reached the judge as nothing"
+
+
+def test_source_file_contents_reach_the_judge_not_just_the_name(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "handler.ts").write_text("export function handler() { return 42; }\n")
+
+    assert "export function handler" in _text_of(convert_deliverables_to_content_blocks(str(d)))
+
+
+def test_unreadable_binary_is_announced_as_present(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "model.onnx").write_bytes(b"\x00\x01\x02\x03" * 400)
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d)))
+    assert "model.onnx" in out
+    assert "NOT missing" in out
+
+
+def test_zip_deliverable_lists_its_members(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    with zipfile.ZipFile(d / "bundle.zip", "w") as zf:
+        zf.writestr("src/main.py", "print('hi')\n")
+        zf.writestr("README.md", "# hi\n")
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d)))
+    assert "bundle.zip" in out
+    assert "src/main.py" in out
+
+
+def test_empty_file_is_announced_as_empty(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "report.md").write_text("")
+    (d / "notes.unknownext").write_bytes(b"")
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d)))
+    assert "report.md" in out and "EMPTY" in out
+    assert "notes.unknownext" in out
+
+
+def test_legacy_office_is_office_not_an_unknown_blob(tmp_path: Path):
+    assert LEGACY_OFFICE_EXTS <= OFFICE_EXTS
+
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "memo.doc").write_bytes(b"\xd0\xcf\x11\xe0" + b"\x00" * 200)
+
+    assert "memo.doc" in _text_of(convert_deliverables_to_content_blocks(str(d)))
+
+
+def test_audio_is_disclosed_when_the_judge_cannot_decode_it(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "mix.wav").write_bytes(b"RIFF" + b"\x00" * 2048)
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d), audio_capable=False))
+    assert "mix.wav" in out and "AUDIO" in out
+    assert "Do NOT treat it as missing" in out
+    assert "unverifiable rather than unmet" in out
+
+
+def test_audio_still_forwarded_when_the_judge_can_decode_it(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "mix.wav").write_bytes(b"RIFF" + b"\x00" * 2048)
+
+    blocks = convert_deliverables_to_content_blocks(str(d), audio_capable=True)
+    assert any(b.get("type") != "text" for b in blocks)
+    assert "Do NOT treat it as missing" not in _text_of(blocks)
+
+
+def test_handled_exts_is_derived_not_hand_maintained(tmp_path: Path):
+    assert TEXT_EXTS <= HANDLED_EXTS
+    assert OFFICE_EXTS <= HANDLED_EXTS
+    assert ".pdf" in HANDLED_EXTS
+
+
+def test_legacy_encoded_text_is_shown_not_withheld(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "notes.oldtxt").write_bytes("Café — naïve résumé\n".encode("cp1252") * 20)
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d)))
+    assert "notes.oldtxt" in out
+    assert "NOT missing" not in out

--- a/responses_api_agents/stirrup_agent/tests/test_file_reader_unhandled.py
+++ b/responses_api_agents/stirrup_agent/tests/test_file_reader_unhandled.py
@@ -95,6 +95,18 @@ def test_audio_is_disclosed_when_the_judge_cannot_decode_it(tmp_path: Path):
     assert "unverifiable rather than unmet" in out
 
 
+def test_undecodable_artifact_says_accompanying_prose_is_not_evidence(tmp_path: Path):
+    """Otherwise the judge credits the agent's own claims about a file it cannot inspect."""
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    (d / "mix.wav").write_bytes(b"RIFF" + b"\x00" * 2048)
+    (d / "model.onnx").write_bytes(b"\x00\x01\x02\x03" * 400)
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d), audio_capable=False))
+    assert out.count("unverified assertions") == 2, "both undecodable artifacts must carry the warning"
+    assert "do not award credit for a property you cannot observe directly" in out
+
+
 def test_audio_still_forwarded_when_the_judge_can_decode_it(tmp_path: Path):
     d = tmp_path / "repeat_0"
     d.mkdir()

--- a/responses_api_agents/stirrup_agent/tests/test_file_reader_unhandled.py
+++ b/responses_api_agents/stirrup_agent/tests/test_file_reader_unhandled.py
@@ -131,3 +131,36 @@ def test_legacy_encoded_text_is_shown_not_withheld(tmp_path: Path):
     out = _text_of(convert_deliverables_to_content_blocks(str(d)))
     assert "notes.oldtxt" in out
     assert "NOT missing" not in out
+
+
+def test_zip_member_contents_are_read_not_just_named(tmp_path: Path):
+    """Rubrics ask whether what is inside the bundle is correct."""
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    with zipfile.ZipFile(d / "bundle.zip", "w") as zf:
+        zf.writestr("src/main.py", "def handler():\n    return 42\n")
+        zf.writestr("logo.png", b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d)))
+    assert "src/main.py" in out
+    assert "def handler()" in out, "member listed but its contents withheld"
+    assert "\x89PNG" not in out, "a binary member was dumped as text"
+
+
+def test_zip_container_documents_are_not_treated_as_archives(tmp_path: Path):
+    """.odt/.xlsm open cleanly as zips; summarising them lists XML internals."""
+    import io
+
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("mimetype", "application/vnd.oasis.opendocument.text")
+        zf.writestr("content.xml", "<office:document-content/>")
+        zf.writestr("META-INF/manifest.xml", "<manifest/>")
+    (d / "Report.odt").write_bytes(buf.getvalue())
+
+    out = _text_of(convert_deliverables_to_content_blocks(str(d)))
+    assert "Report.odt" in out
+    assert "content.xml" not in out
+    assert "META-INF" not in out


### PR DESCRIPTION
This PR adds:
- More robust handling of file types
- Handle ambiguous files and files that can be actually be read as text but were ignored.
- Add same-stem handling: Report.docx and Report.pptx both render to Report.pdf and race for it, leaving a PDF that looks like a valid render of both