### PR TITLE
cp: fix(tau2): exclude review_model from snapshot comparison into r0.5.0

### DIFF
--- a/responses_api_agents/tau2/tests/test_app.py
+++ b/responses_api_agents/tau2/tests/test_app.py
@@ -152,6 +152,7 @@ class TestApp:
             d.pop("max_agent_steps", None)
             d["config"].pop("max_agent_steps", None)
             d["config"].pop("turns_remaining_interval", None)
+            d["config"].pop("review_model", None)
             d["result"].pop("agent_messages", None)
             d["result"].pop("agent_steps", None)
             d["result"].pop("max_agent_steps", None)


### PR DESCRIPTION
## Summary

Cherry-pick of a8626cb7 into r0.5.0.

- Adds `d["config"].pop("review_model", None)` to `_clean()` in `test_sanity_query_input`
- `review_model` is present in `test_data.json` but absent from the actual server response at tau2-bench v1.0.1, causing the assertion to fail
- Unblocks PR #2320 (mlflow bump to r0.5.0) which fails CI due to this missing fix



🤖 Generated with [Claude Code](https://claude.com/claude-code)