### PR TITLE
fix(sandbox): health-check on connect in the OpenSandbox provider

### DIFF
--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -660,7 +660,16 @@ class OpenSandboxProvider:
         return {"sandbox_id": handle.sandbox_id}
 
     async def connect(self, descriptor: Mapping[str, Any]) -> SandboxHandle:
-        """Rebuild a live handle from an OpenSandbox sandbox id via the SDK."""
+        """Rebuild a live handle from an OpenSandbox sandbox id via the SDK.
+
+        The health check is on by default here. A sandbox id only tells us the
+        workload exists, not that execd is listening yet: the server reports a
+        sandbox ready once its pod is Running with an IP, which happens before
+        execd binds its port. Returning an unchecked handle pushes that gap onto
+        the first real call, which then fails with a 502 instead of waiting.
+        Honour ``skip_health_check`` so callers that deliberately want an
+        unchecked handle can still opt out.
+        """
         Sandbox, _, _, _, _ = _require_opensandbox_sdk()
         sandbox_id = str(descriptor["sandbox_id"])
         timeout_s = self._create.connect_attempt_timeout_s
@@ -669,7 +678,7 @@ class OpenSandboxProvider:
                 sandbox_id,
                 connection_config=self._connection_config(request_timeout_s=timeout_s),
                 connect_timeout=timedelta(seconds=timeout_s),
-                skip_health_check=True,
+                skip_health_check=self._create.skip_health_check,
             ),
             timeout=timeout_s,
         )

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -847,7 +847,7 @@ class OpenSandboxProvider:
                         handle.sandbox_id,
                         connection_config=self._connection_config(),
                         connect_timeout=timedelta(seconds=attempt_timeout_s),
-                        skip_health_check=True,
+                        skip_health_check=self._create.skip_health_check,
                     ),
                     timeout=attempt_timeout_s,
                 )

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -662,13 +662,9 @@ class OpenSandboxProvider:
     async def connect(self, descriptor: Mapping[str, Any]) -> SandboxHandle:
         """Rebuild a live handle from an OpenSandbox sandbox id via the SDK.
 
-        The health check is on by default here. A sandbox id only tells us the
-        workload exists, not that execd is listening yet: the server reports a
-        sandbox ready once its pod is Running with an IP, which happens before
-        execd binds its port. Returning an unchecked handle pushes that gap onto
-        the first real call, which then fails with a 502 instead of waiting.
-        Honour ``skip_health_check`` so callers that deliberately want an
-        unchecked handle can still opt out.
+        Health-checks unless the caller opts out: a sandbox id only proves the
+        workload exists, not that its exec daemon is listening yet, so an
+        unchecked handle turns that gap into a 502 on the first call.
         """
         Sandbox, _, _, _, _ = _require_opensandbox_sdk()
         sandbox_id = str(descriptor["sandbox_id"])

--- a/resources_servers/litmus_agent/configs/litmus_agent.yaml
+++ b/resources_servers/litmus_agent/configs/litmus_agent.yaml
@@ -30,8 +30,12 @@ litmus_agent:
             use_server_proxy: true
           create:
             request_timeout_s: 1200
-            timeout_s: 1200
-            skip_health_check: true
+            # Must exceed the spec's ready_timeout_s below: this bounds the
+            # whole create call, which includes the readiness wait.
+            timeout_s: 1500
+            # Skipping the check lets the first command race a pod whose exec
+            # daemon is not listening yet, which returns a 502.
+            skip_health_check: false
             retries: 10
             retry_delay_s: 5.0
             retry_max_delay_s: 90.0

--- a/resources_servers/litmus_agent/configs/litmus_agent.yaml
+++ b/resources_servers/litmus_agent/configs/litmus_agent.yaml
@@ -30,11 +30,9 @@ litmus_agent:
             use_server_proxy: true
           create:
             request_timeout_s: 1200
-            # Must exceed the spec's ready_timeout_s below: this bounds the
-            # whole create call, which includes the readiness wait.
+            # Must exceed ready_timeout_s below: this bounds the whole create
+            # call, which includes the readiness wait.
             timeout_s: 1500
-            # Skipping the check lets the first command race a pod whose exec
-            # daemon is not listening yet, which returns a 502.
             skip_health_check: false
             retries: 10
             retry_delay_s: 5.0

--- a/responses_api_agents/mini_swe_agent_2/README.md
+++ b/responses_api_agents/mini_swe_agent_2/README.md
@@ -218,11 +218,9 @@ sandbox:                      # name referenced by the agent's sandbox_provider
       use_server_proxy: true
     create:
       request_timeout_s: 1200
-      # Must exceed the spec's ready_timeout_s above: this bounds the whole
-      # create call, which includes the readiness wait.
+      # Must exceed ready_timeout_s above: this bounds the whole create call,
+      # which includes the readiness wait.
       timeout_s: 1500
-      # Skipping the check lets the first command race a pod whose exec
-      # daemon is not listening yet, which returns a 502.
       skip_health_check: false
       retries: 10
       retry_delay_s: 5.0

--- a/responses_api_agents/mini_swe_agent_2/README.md
+++ b/responses_api_agents/mini_swe_agent_2/README.md
@@ -218,8 +218,12 @@ sandbox:                      # name referenced by the agent's sandbox_provider
       use_server_proxy: true
     create:
       request_timeout_s: 1200
-      timeout_s: 1200
-      skip_health_check: true
+      # Must exceed the spec's ready_timeout_s above: this bounds the whole
+      # create call, which includes the readiness wait.
+      timeout_s: 1500
+      # Skipping the check lets the first command race a pod whose exec
+      # daemon is not listening yet, which returns a 502.
+      skip_health_check: false
       retries: 10
       retry_delay_s: 5.0
       retry_max_delay_s: 90.0

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -1000,3 +1000,30 @@ async def test_create_attribution_run_id_generated(
 def test_attribution_invalid_key_prefix_raises(key_prefix: str) -> None:
     with pytest.raises(ValueError, match="key_prefix"):
         opensandbox_provider.OpenSandboxAttributionConfig(key_prefix=key_prefix)
+
+
+async def test_connect_health_checks_by_default(fake_opensandbox_sdk: None) -> None:
+    """connect() must hand back a handle that is actually usable.
+
+    A sandbox id only proves the workload exists; the server reports a sandbox
+    ready once its pod is Running with an IP, which is before execd binds its
+    port. Skipping the check here defers that gap to the first real call, which
+    surfaces as a 502 rather than a wait.
+    """
+    provider = opensandbox_provider.OpenSandboxProvider(probe={"command": None})
+
+    await provider.connect({"sandbox_id": "sandbox-9"})
+
+    assert FakeSandbox.connected_kwargs["skip_health_check"] is False
+
+
+async def test_connect_honours_skip_health_check_opt_out(fake_opensandbox_sdk: None) -> None:
+    """Callers that explicitly opt out still get an unchecked handle."""
+    provider = opensandbox_provider.OpenSandboxProvider(
+        create={"skip_health_check": True},
+        probe={"command": None},
+    )
+
+    await provider.connect({"sandbox_id": "sandbox-9"})
+
+    assert FakeSandbox.connected_kwargs["skip_health_check"] is True

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -1003,13 +1003,7 @@ def test_attribution_invalid_key_prefix_raises(key_prefix: str) -> None:
 
 
 async def test_connect_health_checks_by_default(fake_opensandbox_sdk: None) -> None:
-    """connect() must hand back a handle that is actually usable.
-
-    A sandbox id only proves the workload exists; the server reports a sandbox
-    ready once its pod is Running with an IP, which is before execd binds its
-    port. Skipping the check here defers that gap to the first real call, which
-    surfaces as a 502 rather than a wait.
-    """
+    """An unchecked handle would defer the exec-daemon startup gap to the first call."""
     provider = opensandbox_provider.OpenSandboxProvider(probe={"command": None})
 
     await provider.connect({"sandbox_id": "sandbox-9"})

--- a/tests/unit_tests/test_sandbox.py
+++ b/tests/unit_tests/test_sandbox.py
@@ -836,7 +836,8 @@ async def _assert_opensandbox_connect_after_create_preserves_request_timeout(mon
     assert handle.sandbox_id == "sdk-sandbox-1"
     assert isinstance(handle.raw, FakeSDKSandbox)
     connect_call = FakeSDKSandbox.connect_calls[0]
-    assert connect_call["skip_health_check"] is True
+    # This provider does not opt out, so the reconnect health-checks too.
+    assert connect_call["skip_health_check"] is False
     connection_kwargs = dict(connect_call["connection_config"].kwargs)
     # Transport identity is asserted in test_opensandbox_provider.py.
     connection_kwargs.pop("transport", None)

--- a/tests/unit_tests/test_sandbox.py
+++ b/tests/unit_tests/test_sandbox.py
@@ -1330,7 +1330,6 @@ async def _assert_opensandbox_implements_connectable_provider(monkeypatch) -> No
     assert isinstance(handle.raw, FakeSDKSandbox)
     connect_call = FakeSDKSandbox.connect_calls[0]
     assert connect_call["sandbox_id"] == "sdk-sandbox-9"
-    # connect() health-checks by default so the handle it returns is usable;
-    # otherwise the first call pays the execd startup gap as a 502.
+    # connect() health-checks by default so the handle it returns is usable.
     assert connect_call["skip_health_check"] is False
     assert connect_call["connection_config"].kwargs["domain"] == "sandbox.example"

--- a/tests/unit_tests/test_sandbox.py
+++ b/tests/unit_tests/test_sandbox.py
@@ -1329,5 +1329,7 @@ async def _assert_opensandbox_implements_connectable_provider(monkeypatch) -> No
     assert isinstance(handle.raw, FakeSDKSandbox)
     connect_call = FakeSDKSandbox.connect_calls[0]
     assert connect_call["sandbox_id"] == "sdk-sandbox-9"
-    assert connect_call["skip_health_check"] is True
+    # connect() health-checks by default so the handle it returns is usable;
+    # otherwise the first call pays the execd startup gap as a 502.
+    assert connect_call["skip_health_check"] is False
     assert connect_call["connection_config"].kwargs["domain"] == "sandbox.example"


### PR DESCRIPTION
## What

The OpenSandbox provider health-checks by default now:

- `connect()` and the reconnect in `_connect_after_create()` no longer hardcode `skip_health_check=True`; both derive it from configuration, whose default is `False`.
- Two shipped configs that turned the check off (`litmus_agent.yaml`, and the example in the `mini_swe_agent_2` README) are flipped back on.

## Why

A sandbox id only proves the workload exists, not that its exec daemon is listening. The server reports a sandbox ready once its pod is Running with an IP, which happens before the daemon binds its port. A handle returned without a health check defers that gap to the first real call, where it surfaces as:

```
502 {"code":"GENERAL::UNKNOWN_ERROR","message":"Could not connect to the backend sandbox endpoint=..."}
```

Because `connect()` skipped the check unconditionally, the setting was effectively opt-in rather than opt-out, and the two paths disagreed: `create()` honoured `skip_health_check` while `connect()` ignored it.

`_verify_created_handle()` did not cover this either — it is a no-op unless `probe.command` is configured.

This mirrors the reasoning already documented in the provider's own reference config (`configs/opensandbox.yaml`), which sets `skip_health_check: false`; this PR brings the code and the remaining configs in line with it.

## Behaviour change

`connect()` now waits for the sandbox to answer instead of returning immediately, so it can raise where it previously returned an unusable handle. That is the intent: fail or wait at connect, rather than error on the first command.

The opt-out is preserved via `skip_health_check` for callers that deliberately want an unchecked handle.

Both updated configs also raise `create.timeout_s` above their `ready_timeout_s`, following the guidance in the reference config: that timeout bounds the whole create call, which now includes the readiness wait, so leaving the two equal would turn the wait into a timeout.

## Testing

- Added `test_connect_health_checks_by_default` and `test_connect_honours_skip_health_check_opt_out`.
- Updated two existing assertions that encoded the old hardcoded value.
- `tests/unit_tests/test_opensandbox_provider.py` and `tests/unit_tests/test_sandbox.py`: all pass except `test_resolve_provider_config_named_reference`, which fails on `ModuleNotFoundError: No module named 'omegaconf'` and was confirmed pre-existing by reproducing it with this change stashed.

Local runs used a minimal virtualenv: this repo pins a Python version the local toolchain could not fetch, and one dependency does not build on the newer interpreter available. Full-matrix verification is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)