### PR TITLE
feat(sandbox): add Tenki provider

### DIFF
--- a/nemo_gym/sandbox/providers/registry.py
+++ b/nemo_gym/sandbox/providers/registry.py
@@ -167,6 +167,12 @@ def _load_openshell_provider() -> ProviderClass:
     return OpenShellProvider
 
 
+def _load_tenki_provider() -> ProviderClass:
+    from nemo_gym.sandbox.providers.tenki import TenkiProvider
+
+    return TenkiProvider
+
+
 _BUILTIN_PROVIDER_LOADERS["apptainer"] = _load_apptainer_provider
 _BUILTIN_PROVIDER_LOADERS["daytona"] = _load_daytona_provider
 _BUILTIN_PROVIDER_LOADERS["docker"] = _load_docker_provider
@@ -174,3 +180,4 @@ _BUILTIN_PROVIDER_LOADERS["ecs_fargate"] = _load_ecs_fargate_provider
 _BUILTIN_PROVIDER_LOADERS["enroot"] = _load_enroot_provider
 _BUILTIN_PROVIDER_LOADERS["opensandbox"] = _load_opensandbox_provider
 _BUILTIN_PROVIDER_LOADERS["openshell"] = _load_openshell_provider
+_BUILTIN_PROVIDER_LOADERS["tenki"] = _load_tenki_provider

--- a/nemo_gym/sandbox/providers/tenki/README.md
+++ b/nemo_gym/sandbox/providers/tenki/README.md
@@ -1,0 +1,92 @@
+# Tenki sandbox provider
+
+Runs NeMo Gym sandboxes on [Tenki](https://tenki.cloud/) through Tenki's asynchronous Python SDK.
+The provider creates an ephemeral sandbox, waits until it can execute commands, and terminates it
+when the Gym sandbox closes.
+
+## Install and authenticate
+
+The Tenki SDK is included in the `nemo-gym[sandbox]` extra:
+
+```bash
+uv sync --extra sandbox
+export TENKI_API_KEY="..."
+```
+
+The hosted API and gateway are the SDK defaults. For another deployment, set `TENKI_BASE_URL` and
+`TENKI_GATEWAY_URL`, or configure `connection.base_url` and `connection.gateway_url`.
+
+## Use with `ng_run`
+
+Add the bundled provider config to the normal config stack:
+
+```bash
+ng_run "+config_paths=[$AGENT, nemo_gym/sandbox/providers/tenki/configs/tenki.yaml, $MODEL]"
+```
+
+## Use from Python
+
+```python
+from nemo_gym.sandbox import AsyncSandbox, SandboxSpec
+
+sandbox = AsyncSandbox({"tenki": {}}, SandboxSpec(ttl_s=900))
+await sandbox.start()
+try:
+    result = await sandbox.exec("python --version")
+    print(result.stdout)
+finally:
+    await sandbox.stop()
+```
+
+Tenki's default managed base image is sufficient for the integration. A template, snapshot, or
+volume is not required. To select a Tenki registry image, set `SandboxSpec.image` to its managed
+registry reference. Tenki does not pull arbitrary public OCI references at sandbox-create time;
+import or build the image in Tenki's registry first.
+
+## Field mapping
+
+| `SandboxSpec` field                   | Tenki behavior                                                            |
+| ------------------------------------- | ------------------------------------------------------------------------- |
+| `image`                               | Tenki managed registry image; unset uses Tenki's default base image       |
+| `ttl_s`                               | `max_duration`; defaults to the provider's finite `create.max_duration_s` |
+| `ready_timeout_s`                     | SDK create wait deadline                                                  |
+| `workdir`                             | Default `cwd` for commands and relative file transfers                    |
+| `env`                                 | Sandbox environment at creation; per-command values are also supported    |
+| `metadata`                            | Tenki metadata, merged with Gym team/user/workload/run attribution        |
+| `resources.cpu`                       | Rounded up to integer `cpu_cores`                                         |
+| `resources.memory_mib`                | `memory_mb`                                                               |
+| `resources.disk_gib`                  | `disk_size_gb`                                                            |
+| `resources.gpu`, `resources.gpu_type` | Unsupported; raises instead of silently ignoring the request              |
+| `files`                               | Uploaded by Gym after readiness; arbitrary absolute paths are supported   |
+| `ports`                               | Exposed during creation and resolved through `sandbox.endpoint(port)`     |
+| `entrypoint`                          | Unsupported because Tenki owns the sandbox runtime entrypoint             |
+
+`provider_options` accepts:
+
+- `workspace_id`, `name`, `allow_inbound`, `allow_outbound`, and `idle_timeout_minutes`
+- `tags`, `sticky`, and `wait_for_runtime`
+- `template`, `snapshot_id`, or `volumes` for optional Tenki-native provisioning
+
+Only one of `SandboxSpec.image`, `provider_options.template`, and
+`provider_options.snapshot_id` may be set. Unknown or incorrectly typed options raise before
+creation.
+
+Provider-specific options do not carry across backends. For example, the bundled mini-SWE config
+contains OpenSandbox's `resource_requests` option; remove or override that mapping when selecting
+Tenki. Its common `resources` block already maps to Tenki's CPU, memory, and disk fields.
+
+## Lifecycle and permissions
+
+Every sandbox receives a server-enforced maximum duration, including when `ttl_s` is omitted.
+Normal shutdown requests termination and waits until Tenki reports a terminal state. A sandbox
+admitted before a readiness, probe, port, or initial-file failure is terminated on the failure
+path as well.
+
+Commands run as the image's `tenki` user by default. Pass `user="root"` for Tenki's privileged
+execution mode. File upload and download use the SDK filesystem API under `/home/tenki`; transfers
+to other paths use a temporary staging file and a privileged copy so Gym workloads can keep their
+existing absolute paths.
+
+Tenki sandboxes are addressable by session ID, so Gym can serialize a handle and reconnect from a
+second process through the provider's standard `ConnectableProvider` capability. The receiving
+process needs the same Tenki authentication and connection settings.

--- a/nemo_gym/sandbox/providers/tenki/__init__.py
+++ b/nemo_gym/sandbox/providers/tenki/__init__.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tenki sandbox provider package."""
+
+from nemo_gym.sandbox.providers.tenki.provider import (
+    TenkiConnectionConfig,
+    TenkiCreateConfig,
+    TenkiCreateError,
+    TenkiCreateVerificationError,
+    TenkiOperationsConfig,
+    TenkiProvider,
+    TenkiProviderOptions,
+)
+
+
+__all__ = [
+    "TenkiConnectionConfig",
+    "TenkiCreateConfig",
+    "TenkiCreateError",
+    "TenkiCreateVerificationError",
+    "TenkiOperationsConfig",
+    "TenkiProvider",
+    "TenkiProviderOptions",
+]

--- a/nemo_gym/sandbox/providers/tenki/configs/tenki.yaml
+++ b/nemo_gym/sandbox/providers/tenki/configs/tenki.yaml
@@ -1,0 +1,25 @@
+# Tenki sandbox provider config.
+#
+# TENKI_API_KEY is read by the SDK. Do not put credentials in this file.
+# TENKI_BASE_URL and TENKI_GATEWAY_URL may be set to override the hosted service.
+#
+# Usage:
+#   ng_run "+config_paths=[$AGENT, nemo_gym/sandbox/providers/tenki/configs/tenki.yaml, $MODEL]"
+
+sandbox:
+  default_metadata:
+    sandbox-api: tenki-sdk
+  tenki:
+    connection:
+      timeout_s: 60
+    create:
+      ready_timeout_s: 300
+      # Bounds every sandbox even when SandboxSpec.ttl_s is omitted.
+      max_duration_s: 3600
+      probe_command: printf nemo-gym-tenki-ready
+      probe_expected_stdout: nemo-gym-tenki-ready
+      probe_timeout_s: 30
+    operations:
+      close_timeout_s: 120
+      close_poll_interval_s: 0.5
+      transfer_timeout_s: 300

--- a/nemo_gym/sandbox/providers/tenki/provider.py
+++ b/nemo_gym/sandbox/providers/tenki/provider.py
@@ -1,0 +1,589 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tenki provider implementation."""
+
+import asyncio
+import logging
+import math
+import posixpath
+import shlex
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass, field, fields
+from pathlib import Path
+from typing import Any
+
+from nemo_gym.sandbox.attribution import RUN_KEY, log_attribution_once, resolve_attribution, resolve_run_id
+from nemo_gym.sandbox.providers.base import (
+    SandboxCreateError,
+    SandboxCreateVerificationError,
+    SandboxEndpoint,
+    SandboxExecResult,
+    SandboxHandle,
+    SandboxResources,
+    SandboxSpec,
+    SandboxStatus,
+)
+
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_TRANSFER_ROOT = "/home/tenki/.nemo-gym-transfers"
+SANDBOX_RUNTIME_RETURN_CODE = 125
+
+
+class TenkiCreateError(SandboxCreateError):
+    """Raised when Tenki cannot create a sandbox."""
+
+
+class TenkiCreateVerificationError(SandboxCreateVerificationError):
+    """Raised when a newly-created Tenki sandbox cannot execute a probe command."""
+
+
+def _require_tenki_sdk() -> tuple[Any, Any, Any, Any]:
+    try:
+        from tenki import AsyncClient, CommandTimeoutError, SessionNotFoundError, SessionTerminatedError
+    except ImportError as exc:
+        raise ModuleNotFoundError(
+            "The Tenki SDK is required for the tenki sandbox provider. Install nemo-gym[sandbox] "
+            "before using env.sandbox.provider.name=tenki."
+        ) from exc
+    return AsyncClient, CommandTimeoutError, SessionNotFoundError, SessionTerminatedError
+
+
+class TenkiConfigBase:
+    """Shared strict construction for Tenki provider config blocks."""
+
+    @classmethod
+    def from_mapping(cls, value: Any) -> Any:
+        if value is None:
+            return cls()
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, Mapping):
+            raise TypeError(f"{cls.__name__} must be a mapping or {cls.__name__} instance")
+        allowed = {item.name for item in fields(cls) if item.init}
+        unknown = sorted(str(key) for key in value if key not in allowed)
+        if unknown:
+            raise ValueError(f"Unsupported Tenki {cls.__name__} settings: {', '.join(unknown)}")
+        return cls(**dict(value))
+
+
+@dataclass(frozen=True)
+class TenkiConnectionConfig(TenkiConfigBase):
+    """Tenki API client connection settings."""
+
+    auth_token: str | None = None
+    base_url: str | None = None
+    gateway_url: str | None = None
+    timeout_s: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.timeout_s is not None and (not math.isfinite(self.timeout_s) or self.timeout_s <= 0):
+            raise ValueError("connection.timeout_s must be > 0")
+
+
+@dataclass(frozen=True)
+class TenkiCreateConfig(TenkiConfigBase):
+    """Tenki sandbox creation and readiness settings."""
+
+    ready_timeout_s: float = 300.0
+    max_duration_s: float = 3600.0
+    probe_command: str | None = "printf nemo-gym-tenki-ready"
+    probe_expected_stdout: str | None = "nemo-gym-tenki-ready"
+    probe_timeout_s: float = 30.0
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.ready_timeout_s) or self.ready_timeout_s <= 0:
+            raise ValueError("create.ready_timeout_s must be > 0")
+        if not math.isfinite(self.max_duration_s) or self.max_duration_s <= 0:
+            raise ValueError("create.max_duration_s must be > 0")
+        if self.probe_command is not None and not isinstance(self.probe_command, str):
+            raise TypeError("create.probe_command must be a string or null")
+        if self.probe_expected_stdout is not None and not isinstance(self.probe_expected_stdout, str):
+            raise TypeError("create.probe_expected_stdout must be a string or null")
+        if self.probe_command is not None and (not math.isfinite(self.probe_timeout_s) or self.probe_timeout_s <= 0):
+            raise ValueError("create.probe_timeout_s must be > 0")
+
+
+@dataclass(frozen=True)
+class TenkiOperationsConfig(TenkiConfigBase):
+    """Tenki post-create operation settings."""
+
+    close_timeout_s: float = 120.0
+    close_poll_interval_s: float = 0.5
+    transfer_timeout_s: float = 300.0
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.close_timeout_s) or self.close_timeout_s <= 0:
+            raise ValueError("operations.close_timeout_s must be > 0")
+        if not math.isfinite(self.close_poll_interval_s) or self.close_poll_interval_s <= 0:
+            raise ValueError("operations.close_poll_interval_s must be > 0")
+        if not math.isfinite(self.transfer_timeout_s) or self.transfer_timeout_s <= 0:
+            raise ValueError("operations.transfer_timeout_s must be > 0")
+
+
+@dataclass(frozen=True)
+class TenkiProviderOptions:
+    """Recognized per-sandbox options carried in ``SandboxSpec.provider_options``."""
+
+    workspace_id: str | None = None
+    name: str | None = None
+    allow_inbound: bool = True
+    allow_outbound: bool = True
+    idle_timeout_minutes: int | None = None
+    template: str | None = None
+    snapshot_id: str | None = None
+    volumes: tuple[Mapping[str, Any], ...] = ()
+    tags: tuple[str, ...] = ()
+    sticky: bool = False
+    wait_for_runtime: bool = False
+
+    @classmethod
+    def from_mapping(cls, options: Mapping[str, Any] | None) -> "TenkiProviderOptions":
+        if options is None:
+            return cls()
+        if not isinstance(options, Mapping):
+            raise TypeError("Tenki provider_options must be a mapping")
+        allowed = set(cls.__dataclass_fields__)
+        unknown = sorted(str(key) for key in options if key not in allowed)
+        if unknown:
+            raise ValueError(f"Unknown Tenki provider_options keys: {unknown}. Allowed keys: {sorted(allowed)}")
+
+        volumes = options.get("volumes", ())
+        if not isinstance(volumes, (list, tuple)) or not all(isinstance(item, Mapping) for item in volumes):
+            raise TypeError("provider_options['volumes'] must be a list of mappings")
+        tags = options.get("tags", ())
+        if isinstance(tags, str):
+            tags = (tags,)
+        if not isinstance(tags, (list, tuple)) or not all(isinstance(item, str) for item in tags):
+            raise TypeError("provider_options['tags'] must be a string or list of strings")
+
+        normalized: dict[str, Any] = dict(options)
+        normalized["volumes"] = tuple(dict(item) for item in volumes)
+        normalized["tags"] = tuple(tags)
+        return cls(**normalized)
+
+    def __post_init__(self) -> None:
+        if isinstance(self.idle_timeout_minutes, bool):
+            raise TypeError("provider_options.idle_timeout_minutes must be an integer")
+        if self.idle_timeout_minutes is not None and self.idle_timeout_minutes <= 0:
+            raise ValueError("provider_options.idle_timeout_minutes must be > 0")
+        for name in ("workspace_id", "name", "template", "snapshot_id"):
+            value = getattr(self, name)
+            if value is not None and (not isinstance(value, str) or not value.strip()):
+                raise ValueError(f"provider_options.{name} must be a non-empty string")
+        for name in ("allow_inbound", "allow_outbound", "sticky", "wait_for_runtime"):
+            if not isinstance(getattr(self, name), bool):
+                raise TypeError(f"provider_options.{name} must be a boolean")
+
+
+@dataclass
+class _TenkiSandbox:
+    sdk: Any
+    workdir: str | None = None
+    endpoints: dict[int, SandboxEndpoint] = field(default_factory=dict)
+
+
+def _to_sandbox_status(value: Any) -> SandboxStatus:
+    state = str(value or "").upper()
+    if state in {"RUNNING", "READY"}:
+        return SandboxStatus.RUNNING
+    if state in {"CREATING", "PENDING", "PROVISIONING", "STARTING"}:
+        return SandboxStatus.STARTING
+    if state in {"PAUSED", "TERMINATING", "TERMINATED", "STOPPED"}:
+        return SandboxStatus.STOPPED
+    if state in {"ERROR", "FAILED", "UNHEALTHY"}:
+        return SandboxStatus.ERROR
+    return SandboxStatus.UNKNOWN
+
+
+def _resource_kwargs(resources: SandboxResources) -> dict[str, int]:
+    if resources.gpu is not None or resources.gpu_type is not None:
+        raise ValueError("The Tenki SDK does not expose GPU selection; resources.gpu and gpu_type are unsupported")
+    result: dict[str, int] = {}
+    if resources.cpu is not None:
+        if resources.cpu <= 0:
+            raise ValueError("resources.cpu must be > 0")
+        result["cpu_cores"] = math.ceil(resources.cpu)
+    if resources.memory_mib is not None:
+        if resources.memory_mib <= 0:
+            raise ValueError("resources.memory_mib must be > 0")
+        result["memory_mb"] = resources.memory_mib
+    if resources.disk_gib is not None:
+        if resources.disk_gib <= 0:
+            raise ValueError("resources.disk_gib must be > 0")
+        result["disk_size_gb"] = resources.disk_gib
+    return result
+
+
+def _effective_remote_path(state: _TenkiSandbox, path: str) -> str:
+    if posixpath.isabs(path):
+        return posixpath.normpath(path)
+    return posixpath.normpath(posixpath.join(state.workdir or "/home/tenki", path))
+
+
+def _is_home_path(path: str) -> bool:
+    normalized = posixpath.normpath(path)
+    return normalized == "/home/tenki" or normalized.startswith("/home/tenki/")
+
+
+class TenkiProvider:
+    """Run Gym sandboxes with the asynchronous Tenki SDK."""
+
+    name = "tenki"
+
+    def __init__(
+        self,
+        connection: TenkiConnectionConfig | Mapping[str, Any] | None = None,
+        create: TenkiCreateConfig | Mapping[str, Any] | None = None,
+        operations: TenkiOperationsConfig | Mapping[str, Any] | None = None,
+        attribution: Mapping[str, str | None] | None = None,
+    ) -> None:
+        self._connection = TenkiConnectionConfig.from_mapping(connection)
+        self._create = TenkiCreateConfig.from_mapping(create)
+        self._operations = TenkiOperationsConfig.from_mapping(operations)
+        if attribution is not None and not isinstance(attribution, Mapping):
+            raise TypeError("attribution must be a mapping")
+        allowed_attribution = {"team", "user", "workload", "run"}
+        unknown_attribution = sorted(str(key) for key in (attribution or {}) if key not in allowed_attribution)
+        if unknown_attribution:
+            raise ValueError(f"Unsupported Tenki attribution settings: {', '.join(unknown_attribution)}")
+        self._attribution = dict(attribution or {})
+        self._client_instance: Any | None = None
+
+    def _client(self) -> Any:
+        if self._client_instance is None:
+            AsyncClient, _, _, _ = _require_tenki_sdk()
+            kwargs = {
+                "auth_token": self._connection.auth_token,
+                "base_url": self._connection.base_url,
+                "gateway_url": self._connection.gateway_url,
+                "timeout": self._connection.timeout_s,
+            }
+            self._client_instance = AsyncClient(**{key: value for key, value in kwargs.items() if value is not None})
+        return self._client_instance
+
+    def _metadata(self, metadata: Mapping[str, Any]) -> dict[str, str]:
+        resolved = resolve_attribution(
+            team=self._attribution.get("team"),
+            user=self._attribution.get("user"),
+            workload=self._attribution.get("workload"),
+        )
+        resolved[RUN_KEY] = resolve_run_id(self._attribution.get("run"))
+        resolved.update({str(key): str(value) for key, value in metadata.items()})
+        log_attribution_once(resolved)
+        return resolved
+
+    async def serialize_handle(self, handle: SandboxHandle, *, scope: str | None = None) -> dict[str, Any]:
+        """Return a descriptor for reconnecting to a Tenki sandbox from another process."""
+        state: _TenkiSandbox = handle.raw
+        return {"sandbox_id": handle.sandbox_id, "workdir": state.workdir}
+
+    async def connect(self, descriptor: Mapping[str, Any]) -> SandboxHandle:
+        """Rebuild a live handle from a Tenki sandbox id."""
+        if not isinstance(descriptor, Mapping):
+            raise TypeError("Tenki sandbox descriptor must be a mapping")
+        sandbox_id = descriptor.get("sandbox_id")
+        if not isinstance(sandbox_id, str) or not sandbox_id.strip():
+            raise ValueError("Tenki sandbox descriptor requires a non-empty sandbox_id")
+        workdir = descriptor.get("workdir")
+        if workdir is not None and not isinstance(workdir, str):
+            raise TypeError("Tenki sandbox descriptor workdir must be a string or null")
+        sandbox = await self._client().get(sandbox_id.strip())
+        state = _TenkiSandbox(sdk=sandbox, workdir=workdir)
+        return SandboxHandle(sandbox_id=str(sandbox.id), provider_name=self.name, raw=state)
+
+    async def _terminate_partial(self, sandbox: Any, sandbox_id: str) -> None:
+        _, _, SessionNotFoundError, SessionTerminatedError = _require_tenki_sdk()
+        try:
+            await asyncio.wait_for(sandbox.close_if_open(), timeout=self._operations.close_timeout_s)
+        except (SessionNotFoundError, SessionTerminatedError):
+            return
+        except Exception as cleanup_error:
+            LOGGER.warning(
+                "Failed to terminate Tenki sandbox after create failure; sandbox_id=%s; error=%r",
+                sandbox_id,
+                cleanup_error,
+            )
+            return
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._operations.close_timeout_s
+        while True:
+            try:
+                info = await sandbox.refresh()
+            except (SessionNotFoundError, SessionTerminatedError):
+                return
+            except Exception as cleanup_error:
+                LOGGER.warning(
+                    "Failed to verify Tenki sandbox termination after create failure; sandbox_id=%s; error=%r",
+                    sandbox_id,
+                    cleanup_error,
+                )
+                return
+            if _to_sandbox_status(info.state) is SandboxStatus.STOPPED:
+                return
+            if loop.time() >= deadline:
+                LOGGER.warning(
+                    "Tenki sandbox did not terminate after create failure; sandbox_id=%s; last_state=%r",
+                    sandbox_id,
+                    info.state,
+                )
+                return
+            await asyncio.sleep(self._operations.close_poll_interval_s)
+
+    async def _verify_created_handle(self, handle: SandboxHandle) -> None:
+        if self._create.probe_command is None:
+            return
+        result = await self.exec(handle, self._create.probe_command, timeout_s=self._create.probe_timeout_s)
+        if result.return_code != 0 or (
+            self._create.probe_expected_stdout is not None
+            and self._create.probe_expected_stdout not in (result.stdout or "")
+        ):
+            raise TenkiCreateVerificationError(
+                f"Tenki sandbox {handle.sandbox_id!r} failed readiness probe: "
+                f"return_code={result.return_code}, stderr={(result.stderr or '')[:200]!r}"
+            )
+
+    async def create(self, spec: SandboxSpec) -> SandboxHandle:
+        """Create a ready Tenki sandbox and clean up every admitted failure."""
+        if spec.entrypoint is not None:
+            raise ValueError("The Tenki provider does not support SandboxSpec.entrypoint")
+        if isinstance(spec.ttl_s, bool) or isinstance(spec.ready_timeout_s, bool):
+            raise ValueError("ttl_s and ready_timeout_s must be numeric durations, not booleans")
+        options = TenkiProviderOptions.from_mapping(spec.provider_options)
+        source_count = sum(value is not None for value in (spec.image, options.template, options.snapshot_id))
+        if source_count > 1:
+            raise ValueError("Set only one of SandboxSpec.image, provider_options.template, or snapshot_id")
+        ready_timeout_s = float(
+            spec.ready_timeout_s if spec.ready_timeout_s is not None else self._create.ready_timeout_s
+        )
+        if not math.isfinite(ready_timeout_s) or ready_timeout_s <= 0:
+            raise ValueError("ready_timeout_s must be > 0")
+        max_duration_s = float(spec.ttl_s if spec.ttl_s is not None else self._create.max_duration_s)
+        if not math.isfinite(max_duration_s) or max_duration_s <= 0:
+            raise ValueError("ttl_s must be > 0")
+
+        kwargs: dict[str, Any] = {
+            "workspace_id": options.workspace_id,
+            "name": options.name or f"nemo-gym-{uuid.uuid4().hex[:20]}",
+            "wait": True,
+            "timeout": ready_timeout_s,
+            "allow_inbound": options.allow_inbound,
+            "allow_outbound": options.allow_outbound,
+            "max_duration": max_duration_s,
+            "idle_timeout_minutes": options.idle_timeout_minutes,
+            "metadata": self._metadata(spec.metadata),
+            "tags": list(options.tags) or None,
+            "env": {str(key): str(value) for key, value in spec.env.items()} or None,
+            "image": spec.image,
+            "from_template_spec": options.template,
+            "snapshot_id": options.snapshot_id,
+            "volumes": [dict(item) for item in options.volumes] or None,
+            "sticky": options.sticky,
+            "wait_for_runtime": options.wait_for_runtime,
+            **_resource_kwargs(spec.resources),
+        }
+        create_task = asyncio.create_task(self._client().create(**kwargs))
+        try:
+            # asyncio.wait does not cancel its child task when this caller is cancelled.
+            # That lets us observe an admitted sandbox and terminate it before propagating cancellation.
+            await asyncio.wait({create_task})
+            sandbox = create_task.result()
+        except asyncio.CancelledError:
+            try:
+                sandbox = await create_task
+            except Exception as exc:
+                partial = getattr(exc, "sandbox", None)
+                if partial is not None:
+                    await self._terminate_partial(partial, str(getattr(partial, "id", "<unknown>")))
+            else:
+                await self._terminate_partial(sandbox, str(sandbox.id))
+            raise
+        except Exception as exc:
+            partial = getattr(exc, "sandbox", None)
+            if partial is not None:
+                await self._terminate_partial(partial, str(getattr(partial, "id", "<unknown>")))
+            raise TenkiCreateError(
+                f"Failed to create Tenki sandbox within {ready_timeout_s:g}s; image={spec.image!r}"
+            ) from exc
+
+        state = _TenkiSandbox(sdk=sandbox, workdir=spec.workdir)
+        handle = SandboxHandle(sandbox_id=str(sandbox.id), provider_name=self.name, raw=state)
+        try:
+            await self._verify_created_handle(handle)
+            for port in spec.ports:
+                exposed = await sandbox.expose_port(port, ttl=max_duration_s)
+                state.endpoints[port] = SandboxEndpoint(endpoint=str(exposed.url))
+        except BaseException:
+            await self._terminate_partial(sandbox, handle.sandbox_id)
+            raise
+        return handle
+
+    @staticmethod
+    def _privileged(user: str | int | None) -> bool:
+        if isinstance(user, bool):
+            raise NotImplementedError("The Tenki provider does not accept a boolean command user")
+        if user in (None, "tenki", 1000):
+            return False
+        if user in ("root", 0):
+            return True
+        raise NotImplementedError(
+            "The Tenki provider supports the default tenki user and root only; use user='root' for privileged exec"
+        )
+
+    async def exec(
+        self,
+        handle: SandboxHandle,
+        command: str,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_s: int | float | None = None,
+        user: str | int | None = None,
+    ) -> SandboxExecResult:
+        """Run a shell command inside a Tenki sandbox."""
+        state: _TenkiSandbox = handle.raw
+        _, CommandTimeoutError, SessionNotFoundError, SessionTerminatedError = _require_tenki_sdk()
+        try:
+            result = await state.sdk.exec(
+                "bash",
+                "-lc",
+                command,
+                cwd=cwd if cwd is not None else state.workdir,
+                env={str(key): str(value) for key, value in (env or {}).items()} or None,
+                timeout=timeout_s,
+                privileged=self._privileged(user),
+            )
+        except CommandTimeoutError as exc:
+            return SandboxExecResult(stdout=None, stderr=str(exc), return_code=124, error_type="timeout")
+        except (SessionNotFoundError, SessionTerminatedError) as exc:
+            return SandboxExecResult(
+                stdout=None,
+                stderr=str(exc),
+                return_code=SANDBOX_RUNTIME_RETURN_CODE,
+                error_type="sandbox",
+            )
+        return SandboxExecResult(
+            stdout=bytes(result.stdout).decode("utf-8", errors="replace") if result.stdout is not None else None,
+            stderr=bytes(result.stderr).decode("utf-8", errors="replace") if result.stderr is not None else None,
+            return_code=int(result.exit_code),
+        )
+
+    async def upload_file(self, handle: SandboxHandle, source_path: Path, target_path: str) -> None:
+        """Upload one local file, including to paths that require privileged access."""
+        state: _TenkiSandbox = handle.raw
+        destination = _effective_remote_path(state, target_path)
+        data = await asyncio.to_thread(source_path.read_bytes)
+        if _is_home_path(destination):
+            parent = posixpath.dirname(destination)
+            await asyncio.wait_for(state.sdk.fs.mkdir(parent), timeout=self._operations.transfer_timeout_s)
+            await asyncio.wait_for(
+                state.sdk.fs.write_bytes(destination, data), timeout=self._operations.transfer_timeout_s
+            )
+            return
+
+        staging = f"{DEFAULT_TRANSFER_ROOT}/{uuid.uuid4().hex}"
+        await asyncio.wait_for(state.sdk.fs.mkdir(DEFAULT_TRANSFER_ROOT), timeout=self._operations.transfer_timeout_s)
+        await asyncio.wait_for(state.sdk.fs.write_bytes(staging, data), timeout=self._operations.transfer_timeout_s)
+        parent = posixpath.dirname(destination)
+        command = f"mkdir -p -- {shlex.quote(parent)} && cp -- {shlex.quote(staging)} {shlex.quote(destination)}"
+        try:
+            result = await self.exec(handle, command, timeout_s=self._operations.transfer_timeout_s, user="root")
+            if result.return_code != 0:
+                raise RuntimeError(
+                    f"Tenki upload to {target_path!r} failed with code {result.return_code}: "
+                    f"{(result.stderr or '').strip()}"
+                )
+        finally:
+            try:
+                await state.sdk.fs.remove(staging)
+            except Exception as cleanup_error:
+                LOGGER.debug("Failed to remove Tenki upload staging file %s: %r", staging, cleanup_error)
+
+    async def download_file(self, handle: SandboxHandle, source_path: str, target_path: Path) -> None:
+        """Download one sandbox file, including paths that require privileged access."""
+        state: _TenkiSandbox = handle.raw
+        source = _effective_remote_path(state, source_path)
+        if _is_home_path(source):
+            data = await asyncio.wait_for(state.sdk.fs.read_bytes(source), timeout=self._operations.transfer_timeout_s)
+        else:
+            result = await state.sdk.exec(
+                "cat",
+                "--",
+                source,
+                timeout=self._operations.transfer_timeout_s,
+                privileged=True,
+            )
+            if result.exit_code != 0:
+                stderr = bytes(result.stderr).decode("utf-8", errors="replace")
+                raise RuntimeError(f"Tenki download from {source_path!r} failed: {stderr.strip()}")
+            data = bytes(result.stdout)
+        await asyncio.to_thread(target_path.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(target_path.write_bytes, data)
+
+    async def status(self, handle: SandboxHandle) -> SandboxStatus:
+        state: _TenkiSandbox = handle.raw
+        _, _, SessionNotFoundError, SessionTerminatedError = _require_tenki_sdk()
+        try:
+            info = await state.sdk.refresh()
+        except (SessionNotFoundError, SessionTerminatedError):
+            return SandboxStatus.STOPPED
+        return _to_sandbox_status(info.state)
+
+    async def endpoint(self, handle: SandboxHandle, port: int) -> SandboxEndpoint:
+        state: _TenkiSandbox = handle.raw
+        endpoint = state.endpoints.get(port)
+        if endpoint is not None:
+            return endpoint
+        for exposed in await state.sdk.list_exposed_ports():
+            if int(exposed.port) == port:
+                endpoint = SandboxEndpoint(endpoint=str(exposed.url))
+                state.endpoints[port] = endpoint
+                return endpoint
+        raise ValueError(f"Tenki sandbox {handle.sandbox_id!r} has no exposed port {port}")
+
+    async def close(self, handle: SandboxHandle) -> None:
+        """Terminate the sandbox and wait until Tenki reports it stopped."""
+        state: _TenkiSandbox = handle.raw
+        _, _, SessionNotFoundError, SessionTerminatedError = _require_tenki_sdk()
+        try:
+            await asyncio.wait_for(state.sdk.close_if_open(), timeout=self._operations.close_timeout_s)
+        except (SessionNotFoundError, SessionTerminatedError):
+            return
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._operations.close_timeout_s
+        while True:
+            try:
+                info = await state.sdk.refresh()
+            except (SessionNotFoundError, SessionTerminatedError):
+                return
+            if _to_sandbox_status(info.state) is SandboxStatus.STOPPED:
+                return
+            if loop.time() >= deadline:
+                raise TimeoutError(
+                    f"Tenki sandbox {handle.sandbox_id!r} did not terminate within "
+                    f"{self._operations.close_timeout_s:g}s; last state={info.state!r}"
+                )
+            await asyncio.sleep(self._operations.close_poll_interval_s)
+
+    async def aclose(self) -> None:
+        """Close the provider-scoped Tenki SDK client."""
+        if self._client_instance is None:
+            return
+        client, self._client_instance = self._client_instance, None
+        await client.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,6 +264,13 @@ sandbox = [
     # License: Apache 2.0 https://github.com/NVIDIA/OpenShell/blob/main/LICENSE
     "openshell>=0.0.92,<0.1",
 
+    # Tenki SDK: used by the Tenki sandbox provider for create/exec/files/ports/terminate.
+    # Lower bound 0.5.4: first version validated against this provider's complete async API usage.
+    # Upper bound <0.6: the SDK is pre-1.0; the SDK-conformance unit test guards raising this ceiling.
+    # Updated: Wed Aug 05, 2026 with tenki>=0.5.4,<0.6
+    # License: MIT https://github.com/LuxorLabs/tenki-sdk-python/blob/main/LICENSE
+    "tenki>=0.5.4,<0.6",
+
     # Daytona SDK: used by the Daytona sandbox provider for create/exec/delete and file operations.
     # License: Apache 2.0 https://pypi.org/project/daytona/
     "daytona>=0.179.0",

--- a/tests/unit_tests/test_tenki_provider.py
+++ b/tests/unit_tests/test_tenki_provider.py
@@ -1,0 +1,738 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Tenki sandbox provider."""
+
+import asyncio
+import builtins
+import inspect
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import yaml
+
+from nemo_gym.sandbox.config import resolve_provider_config, resolve_provider_metadata
+from nemo_gym.sandbox.providers.base import ConnectableProvider, SandboxEndpoint, SandboxSpec, SandboxStatus
+from nemo_gym.sandbox.providers.registry import get_provider_class
+from nemo_gym.sandbox.providers.tenki import provider as tenki_provider
+from nemo_gym.sandbox.providers.tenki.provider import (
+    TenkiConnectionConfig,
+    TenkiCreateConfig,
+    TenkiCreateError,
+    TenkiCreateVerificationError,
+    TenkiOperationsConfig,
+    TenkiProvider,
+    TenkiProviderOptions,
+    _TenkiSandbox,
+)
+
+
+pytestmark = pytest.mark.sandbox
+
+
+class FakeCommandTimeoutError(Exception):
+    pass
+
+
+class FakeSessionNotFoundError(Exception):
+    pass
+
+
+class FakeSessionTerminatedError(Exception):
+    pass
+
+
+class FakeFS:
+    def __init__(self) -> None:
+        self.files: dict[str, bytes] = {}
+        self.mkdirs: list[str] = []
+        self.removes: list[str] = []
+
+    async def mkdir(self, path: str) -> None:
+        self.mkdirs.append(path)
+
+    async def write_bytes(self, path: str, data: bytes) -> None:
+        self.files[path] = data
+
+    async def read_bytes(self, path: str) -> bytes:
+        return self.files[path]
+
+    async def remove(self, path: str) -> None:
+        self.removes.append(path)
+        self.files.pop(path, None)
+
+
+class FakeSandbox:
+    def __init__(self, sandbox_id: str = "sb-1") -> None:
+        self.id = sandbox_id
+        self.state = "RUNNING"
+        self.fs = FakeFS()
+        self.exec_calls: list[tuple[tuple[str, ...], dict[str, Any]]] = []
+        self.exec_results: list[Any] = []
+        self.expose_calls: list[tuple[int, dict[str, Any]]] = []
+        self.exposed = []
+        self.refresh_results: list[Any] = []
+        self.close_calls = 0
+        self.close_error: Exception | None = None
+
+    async def exec(self, *argv: str, **kwargs: Any) -> Any:
+        self.exec_calls.append((argv, kwargs))
+        if self.exec_results:
+            result = self.exec_results.pop(0)
+            if isinstance(result, BaseException):
+                raise result
+            return result
+        return SimpleNamespace(stdout=b"nemo-gym-tenki-ready", stderr=b"", exit_code=0)
+
+    async def expose_port(self, port: int, **kwargs: Any) -> Any:
+        self.expose_calls.append((port, kwargs))
+        exposed = SimpleNamespace(port=port, url=f"https://{port}.example.test")
+        self.exposed.append(exposed)
+        return exposed
+
+    async def list_exposed_ports(self) -> list[Any]:
+        return self.exposed
+
+    async def close_if_open(self) -> None:
+        self.close_calls += 1
+        if self.close_error is not None:
+            raise self.close_error
+        self.state = "TERMINATING"
+
+    async def refresh(self) -> Any:
+        if self.refresh_results:
+            value = self.refresh_results.pop(0)
+            if isinstance(value, BaseException):
+                raise value
+            self.state = value
+        elif self.state == "TERMINATING":
+            self.state = "TERMINATED"
+        return SimpleNamespace(state=self.state)
+
+
+class FakeClient:
+    def __init__(self, sandbox: FakeSandbox | None = None) -> None:
+        self.sandbox = sandbox or FakeSandbox()
+        self.create_calls: list[dict[str, Any]] = []
+        self.create_error: Exception | None = None
+        self.close_calls = 0
+        self.get_calls: list[str] = []
+
+    async def create(self, **kwargs: Any) -> FakeSandbox:
+        self.create_calls.append(kwargs)
+        if self.create_error is not None:
+            raise self.create_error
+        return self.sandbox
+
+    async def get(self, sandbox_id: str) -> FakeSandbox:
+        self.get_calls.append(sandbox_id)
+        return self.sandbox
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+class FakeWaitReadyError(Exception):
+    def __init__(self, sandbox: FakeSandbox) -> None:
+        super().__init__("not ready")
+        self.sandbox = sandbox
+
+
+def fake_sdk_types() -> tuple[Any, Any, Any, Any]:
+    return object, FakeCommandTimeoutError, FakeSessionNotFoundError, FakeSessionTerminatedError
+
+
+@pytest.fixture
+def provider_and_client(monkeypatch: pytest.MonkeyPatch) -> tuple[TenkiProvider, FakeClient]:
+    monkeypatch.setattr(tenki_provider, "_require_tenki_sdk", fake_sdk_types)
+    client = FakeClient()
+    provider = TenkiProvider(attribution={"team": "rl", "user": "test", "workload": "unit", "run": "run-1"})
+    provider._client_instance = client
+    return provider, client
+
+
+def make_handle(sandbox: FakeSandbox, *, workdir: str | None = None) -> Any:
+    return SimpleNamespace(sandbox_id=sandbox.id, provider_name="tenki", raw=_TenkiSandbox(sandbox, workdir))
+
+
+def test_registry_resolves_tenki() -> None:
+    assert get_provider_class("tenki") is TenkiProvider
+
+
+def test_sdk_call_shapes_match_installed_version() -> None:
+    tenki = pytest.importorskip("tenki", reason="tenki optional sandbox dependency is not installed")
+    assert tenki_provider._require_tenki_sdk()[0] is tenki.AsyncClient
+    inspect.signature(tenki.AsyncClient).bind(
+        auth_token="token", base_url="https://api", gateway_url="https://gateway", timeout=60
+    )
+    inspect.signature(tenki.AsyncClient.create).bind(
+        object(),
+        workspace_id=None,
+        name="nemo-gym-test",
+        wait=True,
+        timeout=300,
+        allow_inbound=True,
+        allow_outbound=True,
+        max_duration=3600,
+        idle_timeout_minutes=None,
+        metadata={},
+        tags=None,
+        env=None,
+        image=None,
+        from_template_spec=None,
+        snapshot_id=None,
+        volumes=None,
+        sticky=False,
+        wait_for_runtime=False,
+        cpu_cores=2,
+        memory_mb=2048,
+        disk_size_gb=20,
+    )
+    inspect.signature(tenki.AsyncClient.get).bind(object(), "sandbox-id")
+    inspect.signature(tenki.AsyncSandbox.exec).bind(
+        object(), "bash", "-lc", "true", cwd=None, env=None, timeout=30, privileged=False
+    )
+    inspect.signature(tenki.AsyncSandbox.expose_port).bind(object(), 8000, ttl=3600)
+    inspect.signature(tenki.AsyncSandbox.close_if_open).bind(object())
+
+
+def test_missing_sdk_has_actionable_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def fail_tenki_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "tenki":
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_tenki_import)
+    with pytest.raises(ModuleNotFoundError, match=r"nemo-gym\[sandbox\]"):
+        tenki_provider._require_tenki_sdk()
+
+
+@pytest.mark.parametrize(
+    ("block", "value"),
+    [
+        ("connection", {"timeout_s": 0}),
+        ("create", {"ready_timeout_s": 0}),
+        ("create", {"max_duration_s": 0}),
+        ("create", {"probe_timeout_s": 0}),
+        ("operations", {"close_timeout_s": 0}),
+        ("operations", {"close_poll_interval_s": 0}),
+        ("operations", {"transfer_timeout_s": 0}),
+    ],
+)
+def test_config_validation(block: str, value: dict[str, Any]) -> None:
+    with pytest.raises(ValueError):
+        TenkiProvider(**{block: value})
+
+
+def test_config_strict_mapping_and_instances() -> None:
+    connection = TenkiConnectionConfig(timeout_s=10)
+    provider = TenkiProvider(connection=connection, create=TenkiCreateConfig(), operations=TenkiOperationsConfig())
+    assert provider._connection is connection
+    with pytest.raises(TypeError, match="TenkiConnectionConfig"):
+        TenkiProvider(connection=42)
+    with pytest.raises(ValueError, match="unknown"):
+        TenkiProvider(connection={"unknown": True})
+    with pytest.raises(TypeError, match="attribution"):
+        TenkiProvider(attribution=42)
+    with pytest.raises(ValueError, match="extra"):
+        TenkiProvider(attribution={"extra": "x"})
+    with pytest.raises(TypeError, match="probe_command"):
+        TenkiProvider(create={"probe_command": 3})
+    with pytest.raises(TypeError, match="probe_expected_stdout"):
+        TenkiProvider(create={"probe_expected_stdout": 3})
+
+
+def test_bundled_config_resolves_to_tenki_provider() -> None:
+    root = Path(__file__).parents[2]
+    config = yaml.safe_load((root / "nemo_gym/sandbox/providers/tenki/configs/tenki.yaml").read_text(encoding="utf-8"))
+    resolved = resolve_provider_config("sandbox", config)
+    assert resolved["tenki"]["create"]["max_duration_s"] == 3600
+    assert resolve_provider_metadata("sandbox", config) == {"sandbox-api": "tenki-sdk"}
+
+
+def test_provider_options_validation() -> None:
+    assert TenkiProviderOptions.from_mapping(None) == TenkiProviderOptions()
+    options = TenkiProviderOptions.from_mapping({"tags": "one", "volumes": [{"volume_id": "v"}]})
+    assert options.tags == ("one",)
+    assert options.volumes == ({"volume_id": "v"},)
+    assert TenkiProviderOptions.from_mapping(options.__dict__) == options
+    with pytest.raises(TypeError, match="mapping"):
+        TenkiProviderOptions.from_mapping([])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="Unknown"):
+        TenkiProviderOptions.from_mapping({"typo": True})
+    with pytest.raises(TypeError, match="volumes"):
+        TenkiProviderOptions.from_mapping({"volumes": ["bad"]})
+    with pytest.raises(TypeError, match="tags"):
+        TenkiProviderOptions.from_mapping({"tags": 3})
+    with pytest.raises(ValueError, match="name"):
+        TenkiProviderOptions.from_mapping({"name": ""})
+    with pytest.raises(ValueError, match="idle_timeout_minutes"):
+        TenkiProviderOptions.from_mapping({"idle_timeout_minutes": 0})
+    with pytest.raises(TypeError, match="idle_timeout_minutes"):
+        TenkiProviderOptions.from_mapping({"idle_timeout_minutes": True})
+    with pytest.raises(TypeError, match="sticky"):
+        TenkiProviderOptions.from_mapping({"sticky": "yes"})
+
+
+def test_client_is_built_lazily(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs: Any) -> None:
+            calls.append(kwargs)
+
+    monkeypatch.setattr(
+        tenki_provider,
+        "_require_tenki_sdk",
+        lambda: (FakeAsyncClient, FakeCommandTimeoutError, FakeSessionNotFoundError, FakeSessionTerminatedError),
+    )
+    provider = TenkiProvider(connection={"auth_token": "token", "timeout_s": 10})
+    assert provider._client() is provider._client()
+    assert calls == [{"auth_token": "token", "timeout": 10}]
+
+
+@pytest.mark.asyncio
+async def test_serialize_and_connect_round_trip(provider_and_client: tuple[TenkiProvider, FakeClient]) -> None:
+    provider, client = provider_and_client
+    assert isinstance(provider, ConnectableProvider)
+    original = make_handle(client.sandbox, workdir="/work")
+    descriptor = await provider.serialize_handle(original, scope="ignored")
+    assert descriptor == {"sandbox_id": "sb-1", "workdir": "/work"}
+    connected = await provider.connect(descriptor)
+    assert connected.sandbox_id == "sb-1"
+    assert connected.raw.workdir == "/work"
+    assert client.get_calls == ["sb-1"]
+
+    with pytest.raises(TypeError, match="mapping"):
+        await provider.connect([])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="sandbox_id"):
+        await provider.connect({})
+    with pytest.raises(TypeError, match="workdir"):
+        await provider.connect({"sandbox_id": "sb-1", "workdir": 3})
+
+
+@pytest.mark.asyncio
+async def test_create_maps_spec_and_default_lifetime(provider_and_client: tuple[TenkiProvider, FakeClient]) -> None:
+    provider, client = provider_and_client
+    handle = await provider.create(
+        SandboxSpec(
+            image="workspace/base:latest",
+            ready_timeout_s=45,
+            workdir="/work",
+            env={"A": "1"},
+            metadata={"purpose": "test"},
+            resources={"cpu": 1.2, "memory_mib": 2048, "disk_gib": 30},
+            provider_options={
+                "workspace_id": "ws-1",
+                "name": "gym-one",
+                "allow_inbound": False,
+                "tags": ["gym"],
+                "idle_timeout_minutes": 10,
+            },
+        )
+    )
+    assert handle.sandbox_id == "sb-1"
+    call = client.create_calls[0]
+    assert call["image"] == "workspace/base:latest"
+    assert call["timeout"] == 45
+    assert call["max_duration"] == 3600
+    assert call["cpu_cores"] == 2
+    assert call["memory_mb"] == 2048
+    assert call["disk_size_gb"] == 30
+    assert call["workspace_id"] == "ws-1"
+    assert call["allow_inbound"] is False
+    assert call["tags"] == ["gym"]
+    assert call["metadata"] == {"team": "rl", "user": "test", "workload": "unit", "run": "run-1", "purpose": "test"}
+    assert client.sandbox.exec_calls[0][1]["cwd"] == "/work"
+
+
+@pytest.mark.asyncio
+async def test_create_maps_optional_tenki_sources_and_ports(
+    provider_and_client: tuple[TenkiProvider, FakeClient],
+) -> None:
+    provider, client = provider_and_client
+    handle = await provider.create(
+        SandboxSpec(
+            ttl_s=90,
+            ports=[8000],
+            provider_options={
+                "template": "python-template",
+                "volumes": [{"volume_id": "vol-1", "mount_path": "/data"}],
+                "sticky": True,
+                "wait_for_runtime": True,
+            },
+        )
+    )
+    call = client.create_calls[0]
+    assert call["from_template_spec"] == "python-template"
+    assert call["volumes"] == [{"volume_id": "vol-1", "mount_path": "/data"}]
+    assert call["max_duration"] == 90
+    assert client.sandbox.expose_calls == [(8000, {"ttl": 90.0})]
+    assert await provider.endpoint(handle, 8000) == SandboxEndpoint("https://8000.example.test")
+
+
+@pytest.mark.asyncio
+async def test_endpoint_recovers_from_sdk(provider_and_client: tuple[TenkiProvider, FakeClient]) -> None:
+    provider, client = provider_and_client
+    client.sandbox.exposed = [SimpleNamespace(port=9000, url="https://port.example.test")]
+    handle = make_handle(client.sandbox)
+    assert await provider.endpoint(handle, 9000) == SandboxEndpoint("https://port.example.test")
+    with pytest.raises(ValueError, match="no exposed port"):
+        await provider.endpoint(handle, 9001)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "spec",
+    [
+        SandboxSpec(entrypoint=["sleep", "1"]),
+        SandboxSpec(ttl_s=True),
+        SandboxSpec(ready_timeout_s=True),
+        SandboxSpec(image="image", provider_options={"template": "template"}),
+        SandboxSpec(resources={"gpu": 1}),
+        SandboxSpec(resources={"gpu_type": "a100"}),
+        SandboxSpec(resources={"cpu": 0}),
+        SandboxSpec(resources={"memory_mib": 0}),
+        SandboxSpec(resources={"disk_gib": 0}),
+        SandboxSpec(ttl_s=-1),
+        SandboxSpec(ttl_s=0),
+        SandboxSpec(ttl_s=float("inf")),
+        SandboxSpec(ready_timeout_s=-1),
+        SandboxSpec(ready_timeout_s=0),
+        SandboxSpec(ready_timeout_s=float("nan")),
+    ],
+)
+async def test_create_rejects_unsupported_or_invalid_spec(
+    provider_and_client: tuple[TenkiProvider, FakeClient], spec: SandboxSpec
+) -> None:
+    provider, _ = provider_and_client
+    with pytest.raises(ValueError):
+        await provider.create(spec)
+
+
+@pytest.mark.asyncio
+async def test_create_failure_terminates_admitted_sandbox(
+    provider_and_client: tuple[TenkiProvider, FakeClient],
+) -> None:
+    provider, client = provider_and_client
+    partial = FakeSandbox("partial")
+    client.create_error = FakeWaitReadyError(partial)
+    with pytest.raises(TenkiCreateError) as error:
+        await provider.create(SandboxSpec())
+    assert partial.close_calls == 1
+    assert isinstance(error.value.__cause__, FakeWaitReadyError)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_create_waits_for_admission_then_terminates(
+    provider_and_client: tuple[TenkiProvider, FakeClient],
+) -> None:
+    provider, _ = provider_and_client
+    sandbox = FakeSandbox("cancelled")
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class SlowClient(FakeClient):
+        async def create(self, **kwargs: Any) -> FakeSandbox:
+            self.create_calls.append(kwargs)
+            started.set()
+            await release.wait()
+            return self.sandbox
+
+    provider._client_instance = SlowClient(sandbox)
+    task = asyncio.create_task(provider.create(SandboxSpec()))
+    await started.wait()
+    task.cancel()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert sandbox.close_calls == 1
+    assert sandbox.state == "TERMINATED"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_create_cleans_sdk_partial_failure(
+    provider_and_client: tuple[TenkiProvider, FakeClient],
+) -> None:
+    provider, _ = provider_and_client
+    partial = FakeSandbox("cancelled-partial")
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class SlowFailingClient(FakeClient):
+        async def create(self, **kwargs: Any) -> FakeSandbox:
+            started.set()
+            await release.wait()
+            raise FakeWaitReadyError(partial)
+
+    provider._client_instance = SlowFailingClient()
+    task = asyncio.create_task(provider.create(SandboxSpec()))
+    await started.wait()
+    task.cancel()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert partial.close_calls == 1
+    assert partial.state == "TERMINATED"
+
+
+@pytest.mark.asyncio
+async def test_failed_create_cleanup_errors_are_logged(
+    provider_and_client: tuple[TenkiProvider, FakeClient], caplog: pytest.LogCaptureFixture
+) -> None:
+    provider, _ = provider_and_client
+    caplog.set_level(logging.WARNING)
+
+    close_failure = FakeSandbox("close-failure")
+    close_failure.close_error = RuntimeError("close failed")
+    await provider._terminate_partial(close_failure, close_failure.id)
+    assert "Failed to terminate Tenki sandbox" in caplog.text
+
+    refresh_failure = FakeSandbox("refresh-failure")
+    refresh_failure.refresh_results = [RuntimeError("refresh failed")]
+    await provider._terminate_partial(refresh_failure, refresh_failure.id)
+    assert "Failed to verify Tenki sandbox termination" in caplog.text
+
+    provider._operations = TenkiOperationsConfig(close_timeout_s=0.001, close_poll_interval_s=0.001)
+    timeout = FakeSandbox("timeout")
+    timeout.refresh_results = ["RUNNING", "RUNNING", "RUNNING"]
+    await provider._terminate_partial(timeout, timeout.id)
+    assert "did not terminate after create failure" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_probe_and_port_failures_terminate_sandbox(
+    provider_and_client: tuple[TenkiProvider, FakeClient],
+) -> None:
+    provider, client = provider_and_client
+    client.sandbox.exec_results = [SimpleNamespace(stdout=b"bad", stderr=b"probe", exit_code=1)]
+    with pytest.raises(TenkiCreateVerificationError):
+        await provider.create(SandboxSpec())
+    assert client.sandbox.close_calls == 1
+
+    client.sandbox = FakeSandbox("port-fail")
+
+    async def fail_expose(port: int, **kwargs: Any) -> Any:
+        raise RuntimeError(f"cannot expose {port}: {kwargs}")
+
+    client.sandbox.expose_port = fail_expose  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="cannot expose"):
+        await provider.create(SandboxSpec(ports=[8080]))
+    assert client.sandbox.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_create_can_disable_probe(provider_and_client: tuple[TenkiProvider, FakeClient]) -> None:
+    provider, client = provider_and_client
+    provider._create = TenkiCreateConfig(probe_command=None)
+    await provider.create(SandboxSpec())
+    assert client.sandbox.exec_calls == []
+
+
+@pytest.mark.asyncio
+async def test_exec_maps_shell_user_and_results(provider_and_client: tuple[TenkiProvider, FakeClient]) -> None:
+    provider, client = provider_and_client
+    handle = make_handle(client.sandbox, workdir="/default")
+    client.sandbox.exec_results = [SimpleNamespace(stdout=b"hello\xff", stderr=b"warn", exit_code=3)]
+    result = await provider.exec(handle, "echo hi", env={"X": "2"}, timeout_s=12, user="root")
+    assert result.stdout == "hello�"
+    assert result.stderr == "warn"
+    assert result.return_code == 3
+    assert client.sandbox.exec_calls[0] == (
+        ("bash", "-lc", "echo hi"),
+        {"cwd": "/default", "env": {"X": "2"}, "timeout": 12, "privileged": True},
+    )
+    with pytest.raises(NotImplementedError, match="default tenki user"):
+        await provider.exec(handle, "true", user="nobody")
+    with pytest.raises(NotImplementedError, match="boolean"):
+        await provider.exec(handle, "true", user=False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "return_code", "error_type"),
+    [
+        (FakeCommandTimeoutError("late"), 124, "timeout"),
+        (FakeSessionNotFoundError("gone"), 125, "sandbox"),
+        (FakeSessionTerminatedError("done"), 125, "sandbox"),
+    ],
+)
+async def test_exec_maps_sdk_runtime_errors(
+    provider_and_client: tuple[TenkiProvider, FakeClient],
+    error: Exception,
+    return_code: int,
+    error_type: str,
+) -> None:
+    provider, client = provider_and_client
+    client.sandbox.exec_results = [error]
+    result = await provider.exec(make_handle(client.sandbox), "true")
+    assert result.return_code == return_code
+    assert result.error_type == error_type
+
+
+@pytest.mark.asyncio
+async def test_upload_home_and_privileged_paths(
+    provider_and_client: tuple[TenkiProvider, FakeClient], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider, client = provider_and_client
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"payload\x00")
+    handle = make_handle(client.sandbox, workdir="/home/tenki/work")
+    await provider.upload_file(handle, source, "relative.bin")
+    assert client.sandbox.fs.files["/home/tenki/work/relative.bin"] == b"payload\x00"
+
+    monkeypatch.setattr(tenki_provider.uuid, "uuid4", lambda: SimpleNamespace(hex="stage-id"))
+    await provider.upload_file(handle, source, "/opt/data/file.bin")
+    assert client.sandbox.exec_calls[-1][1]["privileged"] is True
+    assert client.sandbox.exec_calls[-1][0] == (
+        "bash",
+        "-lc",
+        "mkdir -p -- /opt/data && cp -- /home/tenki/.nemo-gym-transfers/stage-id /opt/data/file.bin",
+    )
+    assert client.sandbox.fs.removes == ["/home/tenki/.nemo-gym-transfers/stage-id"]
+
+
+@pytest.mark.asyncio
+async def test_upload_reports_copy_failure_and_cleans_staging(
+    provider_and_client: tuple[TenkiProvider, FakeClient], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider, client = provider_and_client
+    source = tmp_path / "source"
+    source.write_text("x")
+    monkeypatch.setattr(tenki_provider.uuid, "uuid4", lambda: SimpleNamespace(hex="stage-id"))
+    client.sandbox.exec_results = [SimpleNamespace(stdout=b"", stderr=b"denied", exit_code=1)]
+    with pytest.raises(RuntimeError, match="denied"):
+        await provider.upload_file(make_handle(client.sandbox), source, "/root/file")
+    assert client.sandbox.fs.removes == ["/home/tenki/.nemo-gym-transfers/stage-id"]
+
+
+@pytest.mark.asyncio
+async def test_upload_ignores_staging_cleanup_failure(
+    provider_and_client: tuple[TenkiProvider, FakeClient], tmp_path: Path
+) -> None:
+    provider, client = provider_and_client
+    source = tmp_path / "source"
+    source.write_text("x")
+
+    async def fail_remove(path: str) -> None:
+        raise RuntimeError(f"cannot remove {path}")
+
+    client.sandbox.fs.remove = fail_remove  # type: ignore[method-assign]
+    await provider.upload_file(make_handle(client.sandbox), source, "/root/file")
+
+
+@pytest.mark.asyncio
+async def test_download_home_and_privileged_paths(
+    provider_and_client: tuple[TenkiProvider, FakeClient], tmp_path: Path
+) -> None:
+    provider, client = provider_and_client
+    handle = make_handle(client.sandbox)
+    client.sandbox.fs.files["/home/tenki/a"] = b"home"
+    home_target = tmp_path / "nested" / "home"
+    await provider.download_file(handle, "/home/tenki/a", home_target)
+    assert home_target.read_bytes() == b"home"
+
+    client.sandbox.exec_results = [SimpleNamespace(stdout=b"root\x00", stderr=b"", exit_code=0)]
+    root_target = tmp_path / "root"
+    await provider.download_file(handle, "/root/a", root_target)
+    assert root_target.read_bytes() == b"root\x00"
+    assert client.sandbox.exec_calls[-1] == (
+        ("cat", "--", "/root/a"),
+        {"timeout": 300.0, "privileged": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_reports_privileged_failure(
+    provider_and_client: tuple[TenkiProvider, FakeClient], tmp_path: Path
+) -> None:
+    provider, client = provider_and_client
+    client.sandbox.exec_results = [SimpleNamespace(stdout=b"", stderr=b"missing", exit_code=1)]
+    with pytest.raises(RuntimeError, match="missing"):
+        await provider.download_file(make_handle(client.sandbox), "/root/missing", tmp_path / "target")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ("RUNNING", SandboxStatus.RUNNING),
+        ("PROVISIONING", SandboxStatus.STARTING),
+        ("TERMINATED", SandboxStatus.STOPPED),
+        ("FAILED", SandboxStatus.ERROR),
+        ("MYSTERY", SandboxStatus.UNKNOWN),
+    ],
+)
+async def test_status_mapping(
+    provider_and_client: tuple[TenkiProvider, FakeClient], state: str, expected: SandboxStatus
+) -> None:
+    provider, client = provider_and_client
+    client.sandbox.refresh_results = [state]
+    assert await provider.status(make_handle(client.sandbox)) is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [FakeSessionNotFoundError("gone"), FakeSessionTerminatedError("done")])
+async def test_status_missing_is_stopped(
+    provider_and_client: tuple[TenkiProvider, FakeClient], error: Exception
+) -> None:
+    provider, client = provider_and_client
+    client.sandbox.refresh_results = [error]
+    assert await provider.status(make_handle(client.sandbox)) is SandboxStatus.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_terminal_state(provider_and_client: tuple[TenkiProvider, FakeClient]) -> None:
+    provider, client = provider_and_client
+    client.sandbox.refresh_results = ["TERMINATING", "TERMINATED"]
+    await provider.close(make_handle(client.sandbox))
+    assert client.sandbox.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_close_treats_missing_as_stopped(provider_and_client: tuple[TenkiProvider, FakeClient]) -> None:
+    provider, client = provider_and_client
+    client.sandbox.close_error = FakeSessionNotFoundError("gone")
+    await provider.close(make_handle(client.sandbox))
+
+
+@pytest.mark.asyncio
+async def test_close_refresh_missing_is_stopped(provider_and_client: tuple[TenkiProvider, FakeClient]) -> None:
+    provider, client = provider_and_client
+    client.sandbox.refresh_results = [FakeSessionTerminatedError("done")]
+    await provider.close(make_handle(client.sandbox))
+
+
+@pytest.mark.asyncio
+async def test_close_timeout(provider_and_client: tuple[TenkiProvider, FakeClient]) -> None:
+    provider, client = provider_and_client
+    provider._operations = TenkiOperationsConfig(close_timeout_s=0.001, close_poll_interval_s=0.001)
+    client.sandbox.refresh_results = ["RUNNING", "RUNNING", "RUNNING"]
+    with pytest.raises(TimeoutError, match="did not terminate"):
+        await provider.close(make_handle(client.sandbox))
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_and_releases_client(provider_and_client: tuple[TenkiProvider, FakeClient]) -> None:
+    provider, client = provider_and_client
+    await provider.aclose()
+    assert client.close_calls == 1
+    assert provider._client_instance is None
+    await provider.aclose()

--- a/uv.lock
+++ b/uv.lock
@@ -2495,6 +2495,7 @@ all = [
     { name = "requests-mock" },
     { name = "ruff" },
     { name = "tenacity" },
+    { name = "tenki" },
 ]
 dev = [
     { name = "coverage" },
@@ -2513,6 +2514,7 @@ sandbox = [
     { name = "opensandbox" },
     { name = "openshell" },
     { name = "tenacity" },
+    { name = "tenki" },
 ]
 vllm = [
     { name = "flashinfer-python" },
@@ -2562,6 +2564,7 @@ requires-dist = [
     { name = "rich" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "tenacity", marker = "extra == 'sandbox'", specifier = ">=9.1.4" },
+    { name = "tenki", marker = "extra == 'sandbox'", specifier = ">=0.5.4,<0.6" },
     { name = "tqdm" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn" },
@@ -4810,6 +4813,20 @@ wheels = [
 ]
 
 [[package]]
+name = "tenki"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "protobuf" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/85/9f311f784b92639de2d0aaae7c6d67c76c5ebfd60543d56739724c07683a/tenki-0.5.4.tar.gz", hash = "sha256:3d900ca3eedf98aea0ace315246a3f2bbdc19149d966a320cdb99fd406b681fa", size = 186073, upload-time = "2026-07-29T11:08:41.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/de/244e8d8bffe6673ae3a58423016b8c03465214ab9101a3e61234b5d4c076/tenki-0.5.4-py3-none-any.whl", hash = "sha256:d5df29fa5f7f93fc6c420d3a0b50e68e0b35fda63e17ed57c0f302a522cbf9ef", size = 158916, upload-time = "2026-07-29T11:08:40.023Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5358,6 +5375,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
     { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
     { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add a built-in asynchronous Tenki sandbox provider with lifecycle, command execution, file transfer, resource, metadata, endpoint, and cross-process reconnect support.

The provider uses `tenki>=0.5.4,<0.6`, defaults to Tenki's managed base image, and supports templates, snapshots, and volumes as optional provider-specific inputs.

## Lifecycle safety

- Apply a finite server-enforced lifetime even when `ttl_s` is omitted.
- Wait for terminal state during normal and failed-create cleanup.
- Preserve in-flight creation across caller cancellation until an admitted sandbox can be terminated.
- Clean up readiness probe, port exposure, and initial-file failures.

## Compatibility notes

- Tenki's default base image requires no template or volume.
- Arbitrary Gym OCI workload images must first exist in Tenki's managed registry.
- OSWorld remains out of scope because it requires Docker, KVM, host mounts, capabilities, and a custom entrypoint.
- Provider-specific options such as OpenSandbox's `resource_requests` must be removed when selecting Tenki.

## Testing

- 105 provider and adjacent sandbox tests passed; 11 optional OpenSandbox tests skipped.
- New provider coverage: 99%.
- Scoped pre-commit and `uv lock --check` passed.
- Three consecutive live E2E runs passed exec, arbitrary-path binary transfer, exposed-port HTTP access, and teardown.
- Startup times: 5.50s, 4.38s, and 4.70s; 4.86s average.
- Four forced-failure sessions were independently verified `TERMINATED`.

The complete sharded suite will run in upstream CI.
