### PR TITLE
feat(vllm): forward session IDs to upstream routers

### DIFF
--- a/fern/versions/latest/pages/model-server/vllm.mdx
+++ b/fern/versions/latest/pages/model-server/vllm.mdx
@@ -244,6 +244,9 @@ Make sure your input JSONL respects the selected mode in the [Constraint matrix]
 | `replace_developer_role_with_system` | `bool` | `false` | Convert "developer" role to "system" for models that don't support developer role. |
 | `chat_template_kwargs` | `dict` | `null` | Override chat template parameters. Forwarded to upstream chat completions when `use_completions_api: false`, or to `apply_chat_template` when `use_completions_api: true` and `render_chat_template: true`. |
 | `extra_body` | `dict` | `null` | Pass additional vLLM-specific parameters (e.g., `guided_json`). |
+| `default_headers` | `dict[str, str]` | `{}` | Headers included in every upstream model request. |
+| `session_affinity_header` | `str` | `null` | Forward each NeMo Gym session ID in this header, for routers that use header-based session affinity. |
+| `forward_session_id_in_body` | `bool` | `false` | On Chat Completions requests, also forward the session ID as `session_params.session_id`, for cache-aware routers that read their routing key from the request body. |
 | `use_completions_api` | `bool` | `false` | When `true`, drives vLLM's `/v1/completions` instead of `/v1/chat/completions`. See [Two upstream backends](#two-upstream-backends). |
 | `render_chat_template` | `bool` | `false` | Only consulted when `use_completions_api: true`. When `true`, renders messages to the `prompt` string client-side via `AutoTokenizer.apply_chat_template`. Lifts the multi-turn restriction. See [Render modes](#render-modes). |
 | `tokenizer` | `str` | `null` | Only consulted when `use_completions_api: true` and `render_chat_template: true`. HF identifier or local path passed to `AutoTokenizer.from_pretrained`. When `null`, falls back to `model`. Use this to borrow a chat template from a different model. |
@@ -267,6 +270,21 @@ extra_body:
   min_tokens: 10
   repetition_penalty: 1.1
 ```
+
+### Advanced: router session affinity
+
+Routers differ in where they read a session key. Header-based policies can use
+`session_affinity_header`; cache-aware Chat Completions policies that inspect
+`session_params.session_id` additionally need `forward_session_id_in_body`:
+
+```yaml
+session_affinity_header: X-Session-ID
+forward_session_id_in_body: true
+```
+
+Both settings are opt-in. When body forwarding is enabled, the live Gym session
+ID overrides any static `session_params.session_id` from `extra_body`, while
+other `session_params` fields are preserved.
 
 ## Use VLLMModel with multiple replicas of a model endpoint
 

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -359,6 +359,10 @@ def _attach_trajectory_record(row: dict[str, Any], result: dict[str, Any]) -> No
         _strip_capture_payloads(result)
 
 
+# Public integration point for callers that use ``run_examples`` directly.
+attach_trajectory_record = _attach_trajectory_record
+
+
 def _get_max_rollout_attempts() -> int:
     """Read ``NEMO_GYM_MAX_ROLLOUT_ATTEMPTS`` (positive int) or default to 3."""
     raw = os.environ.get("NEMO_GYM_MAX_ROLLOUT_ATTEMPTS")

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -171,6 +171,10 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
     extra_body: Optional[Dict[str, Any]] = None
 
     default_headers: Dict[str, str] = Field(default_factory=dict)
+    session_affinity_header: Optional[str] = Field(
+        default=None,
+        description="Header used to forward the NeMo Gym session ID to an upstream router.",
+    )
     # Optional prefix for resolving relative ``metadata.audio_path`` (or
     # entries in ``metadata.audio_paths``) against. Absolute paths are used
     # as-is. When unset, relative paths raise. Audio is always inlined as a
@@ -1097,6 +1101,12 @@ class VLLMModel(SimpleResponsesAPIModel):
             digest = hashlib.sha256(session_id.encode("utf-8")).digest()
             client_idx = int.from_bytes(digest[:8], byteorder="big") % len(self._clients)
             client = self._clients[client_idx]
+            if self.config.session_affinity_header is not None:
+                client = client.model_copy(
+                    update={
+                        "default_headers": client.default_headers | {self.config.session_affinity_header: session_id}
+                    }
+                )
             self._session_id_to_client[session_id] = client
         client = self._session_id_to_client[session_id]
 

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -436,11 +436,8 @@ class VLLMModel(SimpleResponsesAPIModel):
                 top_logprobs=0,
                 # Typically passed via OpenAI client extra_body.
                 return_tokens_as_token_ids=True,
-                # TODO add this when NeMo RL upgrades to vLLM 0.10.2 support for prompt token ids
-                # For prompt and generation token IDs
-                # return_token_ids=True,
-                # For prompt token IDs
-                # prompt_logprobs=0,
+                # Return prompt and generation token IDs inline when supported.
+                return_token_ids=True,
             )
 
         if self.config.uses_reasoning_parser and not self.config.preserve_reasoning_in_assistant_content:
@@ -711,37 +708,28 @@ class VLLMModel(SimpleResponsesAPIModel):
             log_probs = logprobs_block["content"]
             generation_log_probs = [log_prob["logprob"] for log_prob in log_probs]
 
-            """
-            START TODO remove this when NeMo RL upgrades to vLLM 0.10.2 support for prompt token ids
-            """
-            # Looks like `"token_id:151667"`
-            generation_token_ids = [log_prob["token"].removeprefix("token_id:") for log_prob in log_probs]
+            generation_token_ids = choice_dict.pop("token_ids", None)
+            if generation_token_ids is None:
+                # Older vLLM versions encode token IDs as `"token_id:151667"`.
+                generation_token_ids = [log_prob["token"].removeprefix("token_id:") for log_prob in log_probs]
 
-            # The tokenize endpoint doesn't accept any sampling parameters
-            # The only relevant params are model, messages, and tools.
-            #
-            # IMPORTANT: pass through chat-template knobs (e.g. enable_thinking)
-            # when tokenizing, otherwise `prompt_token_ids` (and therefore logged
-            # `prompt_str`) can be built with different chat template settings than
-            # the actual generation request.
-            tokenize_body_dict = dict()
-            for key in ("model", "messages", "tools", "chat_template_kwargs"):
-                if key in body_dict:
-                    tokenize_body_dict[key] = body_dict[key]
+            prompt_token_ids = chat_completion_dict.pop("prompt_token_ids", None)
+            if prompt_token_ids is None:
+                # The tokenize endpoint doesn't accept sampling parameters. Pass
+                # through chat-template knobs so fallback tokenization matches the
+                # actual generation request.
+                tokenize_body_dict = dict()
+                for key in ("model", "messages", "tools", "chat_template_kwargs"):
+                    if key in body_dict:
+                        tokenize_body_dict[key] = body_dict[key]
 
-            # The base url has /v1 at the end but vLLM's tokenize endpoint does not have v1, hence the ..
-            tokenize_response = await client.create_tokenize(**tokenize_body_dict)
-            """
-            END
-            """
+                tokenize_response = await client.create_tokenize(**tokenize_body_dict)
+                prompt_token_ids = tokenize_response["tokens"]
 
             message_dict = choice_dict["message"]
             message_dict.update(
                 dict(
-                    # TODO add this when NeMo RL upgrades to vLLM 0.10.2 support for prompt token ids
-                    # prompt_token_ids=chat_completion_dict["prompt_token_ids"],
-                    prompt_token_ids=tokenize_response["tokens"],
-                    # generation_token_ids=choice_dict["token_ids"],
+                    prompt_token_ids=prompt_token_ids,
                     generation_token_ids=generation_token_ids,
                     generation_log_probs=generation_log_probs,
                 )
@@ -749,9 +737,6 @@ class VLLMModel(SimpleResponsesAPIModel):
 
             # Clean the duplicated information
             choice_dict.pop("logprobs")
-            # TODO add this when NeMo RL upgrades to vLLM 0.10.2 support for prompt token ids
-            # chat_completion_dict.pop("prompt_token_ids")
-            # choice_dict.pop("token_ids")
 
         return NeMoGymChatCompletion.model_validate(chat_completion_dict)
 

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -175,6 +175,14 @@ class VLLMModelConfig(BaseResponsesAPIModelConfig):
         default=None,
         description="Header used to forward the NeMo Gym session ID to an upstream router.",
     )
+    forward_session_id_in_body: bool = Field(
+        default=False,
+        description=(
+            "Also forward the NeMo Gym session ID as "
+            "session_params.session_id for upstream routers whose "
+            "cache-aware Chat Completions policy reads the request body."
+        ),
+    )
     # Optional prefix for resolving relative ``metadata.audio_path`` (or
     # entries in ``metadata.audio_paths``) against. Absolute paths are used
     # as-is. When unset, relative paths raise. Audio is always inlined as a
@@ -552,6 +560,21 @@ class VLLMModel(SimpleResponsesAPIModel):
             else:
                 # No user message found — create one with just the audio blocks.
                 body_dict.setdefault("messages", []).append({"role": "user", "content": list(audio_blocks)})
+
+        if self.config.forward_session_id_in_body:
+            configured_session_params = body_dict.get("session_params")
+            if configured_session_params is None:
+                session_params = {}
+            elif isinstance(configured_session_params, dict):
+                # Do not mutate config.extra_body or a per-request metadata dict.
+                session_params = deepcopy(configured_session_params)
+            else:
+                raise ValueError(
+                    "forward_session_id_in_body requires session_params to be a mapping "
+                    f"when it is also supplied through extra_body; got {type(configured_session_params).__name__}."
+                )
+            session_params["session_id"] = request.session[SESSION_ID_KEY]
+            body_dict["session_params"] = session_params
 
         return body_dict
 

--- a/responses_api_models/vllm_model/configs/vllm_model.yaml
+++ b/responses_api_models/vllm_model/configs/vllm_model.yaml
@@ -11,3 +11,5 @@ policy_model:
       chat_template_kwargs: null
       extra_body: null
       default_headers: {}
+      session_affinity_header: null
+      forward_session_id_in_body: false

--- a/responses_api_models/vllm_model/configs/vllm_model_completions.yaml
+++ b/responses_api_models/vllm_model/configs/vllm_model_completions.yaml
@@ -18,3 +18,6 @@ policy_model:
       use_completions_api: true
       chat_template_kwargs: null
       extra_body: null
+      default_headers: {}
+      session_affinity_header: null
+      forward_session_id_in_body: false

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -4653,6 +4653,7 @@ class TestTopLogprobsHandling:
         assert result["top_logprobs"] == 0
         assert result["logprobs"] is True
         assert result["return_tokens_as_token_ids"] is True
+        assert result["return_token_ids"] is True
 
         # Inbound non-zero value must also be overridden, not inherited.
         result = model._preprocess_chat_completion_create_params(
@@ -4720,8 +4721,9 @@ class TestTopLogprobsHandling:
     def test_capture_path_succeeds_with_inbound_null_top_logprobs(self) -> None:
         """End-to-end regression: a request with top_logprobs=null no longer empties capture;
         token ids and logprobs come back populated (and coerced to int)."""
+        import asyncio
+
         model = _make_top_logprobs_model(return_token_id_information=True)
-        app = model.setup_webserver()
 
         captured_kwargs: dict[str, Any] = {}
 
@@ -4742,22 +4744,73 @@ class TestTopLogprobsHandling:
         mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
         mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
         mock_client.create_tokenize = AsyncMock(side_effect=mock_create_tokenize)
-        model._clients = [mock_client]
+        model._resolve_client = lambda _request: mock_client  # type: ignore[assignment]
 
-        client = TestClient(app)
-        response = client.post(
-            "/v1/chat/completions",
-            json={"messages": [{"role": "user", "content": "hi"}], "top_logprobs": None},
+        response = asyncio.run(
+            model.chat_completions(
+                MagicMock(),
+                NeMoGymChatCompletionCreateParamsNonStreaming(
+                    messages=[{"role": "user", "content": "hi"}],
+                    top_logprobs=None,
+                ),
+            )
         )
-        assert response.status_code == 200
 
         # The request forwarded to vLLM had top_logprobs pinned to 0, not the inbound null.
         assert captured_kwargs["top_logprobs"] == 0
+        assert captured_kwargs["return_token_ids"] is True
+        mock_client.create_tokenize.assert_awaited_once()
 
-        message = response.json()["choices"][0]["message"]
-        assert message["generation_token_ids"] == [123, 456]
-        assert message["generation_log_probs"] == [-0.1, -0.2]
-        assert message["prompt_token_ids"] == [10, 20, 30]
+        message = response.choices[0].message
+        assert isinstance(message, NeMoGymChatCompletionMessageForTraining)
+        assert message.generation_token_ids == [123, 456]
+        assert message.generation_log_probs == [-0.1, -0.2]
+        assert message.prompt_token_ids == [10, 20, 30]
+
+    def test_capture_path_prefers_inline_token_ids(self) -> None:
+        import asyncio
+
+        model = _make_top_logprobs_model(return_token_id_information=True)
+
+        captured_kwargs: dict[str, Any] = {}
+
+        async def mock_create_chat_completion(**kwargs):
+            captured_kwargs.update(kwargs)
+            completion = self._capture_chat_completion_dict(
+                logprobs={
+                    "content": [
+                        {"token": "ignored", "logprob": -0.1, "bytes": None, "top_logprobs": []},
+                        {"token": "ignored", "logprob": -0.2, "bytes": None, "top_logprobs": []},
+                    ]
+                }
+            )
+            completion["prompt_token_ids"] = [10, 20, 30]
+            completion["choices"][0]["token_ids"] = [123, 456]
+            return completion
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=mock_create_chat_completion)
+        mock_client.create_tokenize = AsyncMock(
+            side_effect=AssertionError("create_tokenize must not be called when inline IDs are present")
+        )
+        model._resolve_client = lambda _request: mock_client  # type: ignore[assignment]
+
+        response = asyncio.run(
+            model.chat_completions(
+                MagicMock(),
+                NeMoGymChatCompletionCreateParamsNonStreaming(
+                    messages=[{"role": "user", "content": "hi"}],
+                ),
+            )
+        )
+
+        assert captured_kwargs["return_token_ids"] is True
+        mock_client.create_tokenize.assert_not_awaited()
+        message = response.choices[0].message
+        assert isinstance(message, NeMoGymChatCompletionMessageForTraining)
+        assert message.prompt_token_ids == [10, 20, 30]
+        assert message.generation_token_ids == [123, 456]
+        assert message.generation_log_probs == [-0.1, -0.2]
 
     def test_capture_path_preserves_routed_experts(self) -> None:
         model = _make_top_logprobs_model(return_token_id_information=True)

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -758,6 +758,42 @@ class TestApp:
 
         assert client_indices[0] == client_indices[1]
 
+    def test_resolve_client_adds_session_affinity_header(self) -> None:
+        config = VLLMModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            base_url="http://router/v1",
+            api_key="dummy_key",  # pragma: allowlist secret
+            model="dummy_model",
+            entrypoint="",
+            name="",
+            return_token_id_information=False,
+            uses_reasoning_parser=False,
+            default_headers={"X-Static": "keep"},
+            session_affinity_header="X-Session-ID",
+        )
+        model = VLLMModel(
+            config=config,
+            server_client=MagicMock(spec=ServerClient, global_config_dict={}),
+        )
+        first_request = MagicMock(session={SESSION_ID_KEY: "session-0"})
+        second_request = MagicMock(session={SESSION_ID_KEY: "session-1"})
+
+        first_client = model._resolve_client(first_request)
+        second_client = model._resolve_client(second_request)
+
+        assert first_client.base_url == "http://router/v1"
+        assert first_client.default_headers == {
+            "X-Static": "keep",
+            "X-Session-ID": "session-0",
+        }
+        assert second_client.base_url == "http://router/v1"
+        assert second_client.default_headers == {
+            "X-Static": "keep",
+            "X-Session-ID": "session-1",
+        }
+        assert model._resolve_client(first_request) is first_client
+
     def test_responses_multistep(self, monkeypatch: MonkeyPatch):
         server = self._setup_server(monkeypatch)
         app = server.setup_webserver()

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -794,6 +794,108 @@ class TestApp:
         }
         assert model._resolve_client(first_request) is first_client
 
+    def test_preprocess_adds_session_affinity_body_without_mutating_config(self) -> None:
+        config = VLLMModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            base_url="http://router/v1",
+            api_key="dummy_key",  # pragma: allowlist secret
+            model="dummy_model",
+            entrypoint="",
+            name="",
+            return_token_id_information=False,
+            uses_reasoning_parser=False,
+            extra_body={
+                "session_params": {
+                    "session_id": "static-value-must-not-win",
+                    "keep": "value",
+                }
+            },
+            forward_session_id_in_body=True,
+        )
+        model = VLLMModel(
+            config=config,
+            server_client=MagicMock(spec=ServerClient, global_config_dict={}),
+        )
+        request = MagicMock(session={SESSION_ID_KEY: "session-0"})
+
+        result = model._preprocess_chat_completion_create_params(
+            request,
+            {"messages": [{"role": "user", "content": "hello"}]},
+        )
+
+        assert result["session_params"] == {
+            "session_id": "session-0",
+            "keep": "value",
+        }
+        assert config.extra_body == {
+            "session_params": {
+                "session_id": "static-value-must-not-win",
+                "keep": "value",
+            }
+        }
+
+    def test_preprocess_adds_session_affinity_body_without_existing_params(self) -> None:
+        config = VLLMModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            base_url="http://router/v1",
+            api_key="dummy_key",  # pragma: allowlist secret
+            model="dummy_model",
+            entrypoint="",
+            name="",
+            return_token_id_information=False,
+            uses_reasoning_parser=False,
+            forward_session_id_in_body=True,
+        )
+        model = VLLMModel(
+            config=config,
+            server_client=MagicMock(spec=ServerClient, global_config_dict={}),
+        )
+
+        result = model._preprocess_chat_completion_create_params(
+            MagicMock(session={SESSION_ID_KEY: "session-0"}),
+            {"messages": [{"role": "user", "content": "hello"}]},
+        )
+
+        assert result["session_params"] == {"session_id": "session-0"}
+        assert config.extra_body is None
+
+    def test_preprocess_rejects_non_mapping_session_affinity_body(self) -> None:
+        config = VLLMModelConfig(
+            host="0.0.0.0",
+            port=8081,
+            base_url="http://router/v1",
+            api_key="dummy_key",  # pragma: allowlist secret
+            model="dummy_model",
+            entrypoint="",
+            name="",
+            return_token_id_information=False,
+            uses_reasoning_parser=False,
+            extra_body={"session_params": "invalid"},
+            forward_session_id_in_body=True,
+        )
+        model = VLLMModel(
+            config=config,
+            server_client=MagicMock(spec=ServerClient, global_config_dict={}),
+        )
+
+        with raises(ValueError, match="requires session_params to be a mapping"):
+            model._preprocess_chat_completion_create_params(
+                MagicMock(session={SESSION_ID_KEY: "session-0"}),
+                {"messages": [{"role": "user", "content": "hello"}]},
+            )
+
+    def test_preprocess_does_not_add_session_affinity_body_by_default(self, monkeypatch: MonkeyPatch) -> None:
+        model = self._setup_server(monkeypatch)
+
+        result = model._preprocess_chat_completion_create_params(
+            MagicMock(session={SESSION_ID_KEY: "session-0"}),
+            {"messages": [{"role": "user", "content": "hello"}]},
+        )
+
+        assert "session_params" not in result
+
     def test_responses_multistep(self, monkeypatch: MonkeyPatch):
         server = self._setup_server(monkeypatch)
         app = server.setup_webserver()


### PR DESCRIPTION
## Summary

- add optional session-affinity header forwarding to the vLLM model configuration
- optionally forward the stable NeMo Gym session ID in `session_params.session_id` for cache-aware routers that consume request-body identity
- preserve existing default headers, other `session_params` fields, and session-to-client reuse
- request and consume inline prompt/generation token IDs while retaining token-string and `/tokenize` fallbacks
- expose `attach_trajectory_record` as the public integration point for callers that use `run_examples` directly

## Motivation

When NeMo Gym sends requests through one upstream Router endpoint, its in-process session-to-client mapping does not by itself expose a stable session identity to that Router. Header forwarding supports consistent-hash routing, while the optional request-body field supports vLLM Router 0.1.15 cache-aware routing.

NeMo RL also uses Gym's low-level `run_examples` path. Exporting the existing trajectory attachment helper lets that caller fold captured model-call timing, token usage, response metadata, and observation gaps into the standard `ng_trajectory` result without duplicating Gym logic or relying on out-of-band state.

## Compatibility

Session-affinity forwarding is opt-in, so existing configurations retain their previous request shape. Existing `session_params` fields are preserved. Invalid non-mapping values are rejected instead of being silently overwritten.

## External audit provenance

The two incremental commits originally published as `9ad35b3` and `f075ce8` were consolidated only to correct the Git author identity. The current commit `4d6b55a` has:

- author and committer: `Nolen Liang <nliang@nvidia.com>`
- DCO sign-off: `Nolen Liang <nliang@nvidia.com>`
- source tree: `e0807bfc5c40cf282c07b33aa8178c124dda4e9f`, exactly identical to the former `f075ce8` tree

The parent NeMo RL Phase 2 matrix observed complete model-call timing for all six accepted formal runs using this source tree.

## Testing

- focused tests for header forwarding, request-body session identity, field preservation, invalid types, inline token IDs, and capture behavior
- parent NeMo RL integration tests for cache-aware body forwarding and consistent-hash compatibility
- Ruff check and format check for the modified Gym files
- DCO check
