### PR TITLE
fix: classify connection failures and report them on the first occurrence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ For guidance on how to build environments, see `fern/versions/latest/pages/envir
 
 ## Communication & Async Patterns
 
-Servers communicate via `ServerClient`, which wraps aiohttp with retry logic (3 tries, exponential backoff) and connection pooling via a singleton aiohttp client.
+Servers communicate via `ServerClient`, which wraps aiohttp with retry logic and connection pooling via a singleton aiohttp client. See `nemo_gym/server_utils.py::request` for the retry policy.
 
 - **Use aiohttp, not httpx, for async HTTP.** All async HTTP calls must go through NeMo Gym's global aiohttp client (`nemo_gym.server_utils.request()`). Do not use `httpx.AsyncClient` — httpx/httpcore has O(n^2) connection pooling that causes hangs at high concurrency (16k+ requests). When wrapping external libraries that use httpx internally, replace their HTTP transport with an aiohttp adapter. See `resources_servers/tavily_search/app.py` (`TavilySearchAIOHTTPClient`) for the adapter pattern.
 - **Propagate session cookies** through all downstream calls (`cookies=request.cookies`) for stateful environments.

--- a/fern/versions/latest/pages/about/architecture.mdx
+++ b/fern/versions/latest/pages/about/architecture.mdx
@@ -96,7 +96,7 @@ An agent can use both simultaneously — its own tools and the environment's too
 
 Servers communicate over async HTTP (aiohttp) with:
 - **Session cookies** propagated through the call stack for stateful environments
-- **Retry logic** with exponential backoff (3 attempts)
+- **Retry logic** for transient connection failures
 - **Connection pooling** via a singleton aiohttp client for high-concurrency workloads
 
 ## Next Steps

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import asyncio
 import atexit
+import errno as errno_module
 import json
 import resource
 import socket
@@ -21,11 +22,13 @@ import sys
 import time
 from abc import abstractmethod
 from contextlib import asynccontextmanager
+from enum import Enum
 from os import environ, getenv
 from pathlib import Path
 from threading import Thread
 from traceback import format_exc, print_exc
-from typing import Any, List, Literal, Optional, TextIO, Tuple, Type, Union, Unpack
+from typing import Any, Dict, List, Literal, Optional, TextIO, Tuple, Type, Union, Unpack
+from urllib.parse import urlsplit
 from uuid import uuid4
 
 import orjson
@@ -33,13 +36,18 @@ import ray
 import requests
 import uvicorn
 from aiohttp import (
+    ClientConnectionResetError,
+    ClientConnectorError,
+    ClientError,
     ClientOSError,
     ClientResponse,
     ClientResponseError,
     ClientSession,
     ClientTimeout,
     DummyCookieJar,
+    InvalidURL,
     ServerDisconnectedError,
+    ServerTimeoutError,
     TCPConnector,
 )
 from aiohttp.client import _RequestOptions
@@ -193,16 +201,153 @@ atexit.register(global_aiohttp_client_exit)
 # This is not intended to be changed. If you want to increase this, we should probably figure out how to improve server-side robustness.
 MAX_NUM_TRIES = 3
 
-_NUM_SERVER_DISCONNECTED_ERROR: int = 0
-_NUM_CLIENT_OS_ERROR: int = 0
-DISCONNECTED_CLIENT_OS_PRINT_INTERVAL: int = 100
-DISCONNECTED_CLIENT_OS_HELP_TEXT = """We've run into this issue in two different scenarios previously:
-1. Too many open connections and not enough sockets due to the file descriptor limit being hit.
+
+class _RequestFailureKind(str, Enum):
+    """The categories `_classify_request_failure` sorts a failed `request()` call into.
+
+    Private to this module and specific to the `request()` path. This is not a general error
+    taxonomy for NeMo Gym.
+    """
+
+    # The connection was never established: `ClientConnectorError` and its DNS and proxy
+    # subclasses, for a refused connect, an unreachable host or network, or a failed lookup.
+    UNREACHABLE = "unreachable"
+    # A local resource ran out while connecting: EMFILE, ENFILE, ENOBUFS or ENOMEM, read from
+    # `ClientConnectorError.os_error`.
+    RESOURCE = "resource"
+    # A connection was established and then lost: `ServerDisconnectedError`,
+    # `ClientConnectionResetError`, a bare `ClientOSError`, or an unrecognised `ClientError`.
+    PEER_DROP = "peer_drop"
+    # A deadline expired: `ServerTimeoutError` and its connect and read subclasses, or
+    # `asyncio.TimeoutError`.
+    TIMEOUT = "timeout"
+    # A malformed URL (`InvalidURL`) or anything that is not a `ClientError` at all, which means a
+    # programming error rather than a network one.
+    FATAL = "fatal"
+
+
+_RESOURCE_ERRNOS = frozenset({errno_module.EMFILE, errno_module.ENFILE, errno_module.ENOBUFS, errno_module.ENOMEM})
+
+
+def _classify_request_failure(exc: BaseException) -> _RequestFailureKind:
+    """Sort an exception from `client.request()` into a `_RequestFailureKind`.
+
+    Every exception maps to a kind; there is no "unknown". Two fallbacks make that true. An
+    `aiohttp.ClientError` this function does not recognise is treated as `PEER_DROP`, so a new
+    exception type in a future aiohttp is retried and reported rather than raised immediately.
+    Anything that is not a `ClientError` at all is `FATAL`, on the grounds that it is a programming
+    error rather than a network one.
+
+    Order matters and breaking it is silent. `ClientConnectorError` subclasses `ClientOSError`, so
+    testing the parent first would swallow every refused connection into `PEER_DROP`, which is the
+    bug this classification exists to fix. `InvalidURL` is both a `ClientError` and a `ValueError`,
+    so it has to be tested before either.
+    """
+    if isinstance(exc, InvalidURL):
+        return _RequestFailureKind.FATAL
+    if isinstance(exc, ClientConnectorError):
+        # Includes the DNS and proxy subclasses. Read `.os_error` rather than `.errno`: a bare
+        # `ClientOSError` has neither, and this runs inside an `except` block where an
+        # `AttributeError` would turn a retryable failure into a crash.
+        os_error = getattr(exc, "os_error", None)
+        if os_error is not None and getattr(os_error, "errno", None) in _RESOURCE_ERRNOS:
+            return _RequestFailureKind.RESOURCE
+        return _RequestFailureKind.UNREACHABLE
+    if isinstance(exc, (ServerTimeoutError, asyncio.TimeoutError)):
+        return _RequestFailureKind.TIMEOUT
+    if isinstance(exc, (ServerDisconnectedError, ClientConnectionResetError, ClientOSError)):
+        return _RequestFailureKind.PEER_DROP
+    if isinstance(exc, ClientError):
+        # An aiohttp error we do not recognise. Retried rather than failed fast, so a new
+        # exception type in a future aiohttp is reported after retries instead of raised at once.
+        return _RequestFailureKind.PEER_DROP
+    return _RequestFailureKind.FATAL
+
+
+_UNREACHABLE_HELP_TEXT = """Nothing accepted a connection at that address, so this is a configuration or startup problem rather than load.
+1. Check the URL. For the policy model that is `policy_base_url` in `env.yaml`.
+    - Verify with: curl <base_url>/models
+    - A `localhost` URL means you serve the model yourself (e.g. vLLM) before collecting rollouts.
+2. If the endpoint is still starting up, this resolves on its own once it is serving."""
+
+_RESOURCE_HELP_TEXT = """Too many open connections and not enough sockets due to the file descriptor limit being hit.
     - Increase ulimit.
     - Bash example: https://github.com/NVIDIA-NeMo/RL/blob/de55be7777bbf034c04e41c40382c44725e8aa4b/ray.sub#L81
-    - Python example: https://github.com/NVIDIA-NeMo/Gym/blob/c74ffddb3d8190cd717508b0830916b19a26e6cd/nemo_gym/server_utils.py#L495
-2. Depending on the serving framework and config, the server may be overloaded and is dropping connections.
-    - Increase adapter server replicas."""
+    - Python example: https://github.com/NVIDIA-NeMo/Gym/blob/c74ffddb3d8190cd717508b0830916b19a26e6cd/nemo_gym/server_utils.py#L495"""
+
+_PEER_DROP_HELP_TEXT = """Depending on the serving framework and config, the server may be overloaded and is dropping connections.
+    - Increase adapter server replicas.
+    - If this is a file descriptor problem rather than load, it surfaces separately as `resource`."""
+
+_TIMEOUT_HELP_TEXT = """The endpoint accepted the connection but did not answer inside the deadline.
+    - Check whether the endpoint is saturated, or raise the timeout for this call."""
+
+_FAILURE_KIND_HELP_TEXT = {
+    _RequestFailureKind.UNREACHABLE: _UNREACHABLE_HELP_TEXT,
+    _RequestFailureKind.RESOURCE: _RESOURCE_HELP_TEXT,
+    _RequestFailureKind.PEER_DROP: _PEER_DROP_HELP_TEXT,
+    _RequestFailureKind.TIMEOUT: _TIMEOUT_HELP_TEXT,
+    _RequestFailureKind.FATAL: "",
+}
+
+# Reporting on the first failure is right for one request and wrong for sixteen thousand, so the
+# full diagnostic goes out once per endpoint and kind and is then summarised on this interval.
+# Keyed by (origin, kind) -> (when it was last reported, failures suppressed since). Grows with the
+# number of distinct endpoints a process talks to, not with the number of requests.
+_FAILURE_REPORT_INTERVAL_SECONDS: float = 30.0
+_FAILURE_REPORT_STATE: Dict[Tuple[str, _RequestFailureKind], Tuple[float, int]] = {}
+
+
+def _request_origin(url: str) -> str:
+    """`scheme://host:port` for `url`. Failures are grouped and reported per origin."""
+    split = urlsplit(url)
+    return f"{split.scheme}://{split.netloc}" if split.netloc else url
+
+
+def _next_failure_report(origin: str, kind: _RequestFailureKind, now: float) -> Optional[int]:
+    """Whether to report this failure, and what to say.
+
+    Returns 0 the first time an (origin, kind) pair is seen, meaning print the full diagnostic; a
+    positive count once the interval has passed, meaning report that many suppressed failures; and
+    `None` in between, meaning print nothing.
+    """
+    state = _FAILURE_REPORT_STATE.get((origin, kind))
+    if state is None:
+        _FAILURE_REPORT_STATE[(origin, kind)] = (now, 0)
+        return 0
+
+    last_reported, suppressed = state
+    suppressed += 1
+    if now - last_reported < _FAILURE_REPORT_INTERVAL_SECONDS:
+        _FAILURE_REPORT_STATE[(origin, kind)] = (last_reported, suppressed)
+        return None
+
+    _FAILURE_REPORT_STATE[(origin, kind)] = (now, 0)
+    return suppressed
+
+
+def _report_request_failure(url: str, exc: BaseException, kind: _RequestFailureKind, now: float) -> None:
+    """Print the diagnostic for a failed request, at most once per endpoint and kind per interval."""
+    origin = _request_origin(url)
+    suppressed = _next_failure_report(origin, kind, now)
+    if suppressed is None:
+        return
+
+    if suppressed:
+        print(
+            f"[request_retry url={origin} kind={kind.value}] "
+            f"{suppressed} more `{type(exc).__name__}` failures in the last "
+            f"{_FAILURE_REPORT_INTERVAL_SECONDS:.0f}s. Still retrying.",
+            flush=True,
+        )
+        return
+
+    help_text = _FAILURE_KIND_HELP_TEXT[kind]
+    print(
+        f"[request_retry url={url} kind={kind.value} error={type(exc).__name__}] {exc}"
+        + (f"\n{help_text}" if help_text else ""),
+        flush=True,
+    )
 
 
 async def request(
@@ -216,33 +361,14 @@ async def request(
 
     client = get_global_aiohttp_client()
     num_tries = 1
-    retries = 0
-    retry_start = time.monotonic()
     while True:
         try:
             return await client.request(method=method, url=url, **kwargs)
-        except ServerDisconnectedError:
-            global _NUM_SERVER_DISCONNECTED_ERROR
-            _NUM_SERVER_DISCONNECTED_ERROR += 1
-            retries += 1
-            if _NUM_SERVER_DISCONNECTED_ERROR % DISCONNECTED_CLIENT_OS_PRINT_INTERVAL == 0:
-                print(
-                    f"[request_retry url={url} error=ServerDisconnectedError retry={retries} elapsed_s={time.monotonic() - retry_start:.1f}] "
-                    f"Hit {_NUM_SERVER_DISCONNECTED_ERROR} global `ServerDisconnectedError` while querying {url}.\n{DISCONNECTED_CLIENT_OS_HELP_TEXT}",
-                    flush=True,
-                )
-
-            await asyncio.sleep(0.5)
-        except ClientOSError:
-            global _NUM_CLIENT_OS_ERROR
-            _NUM_CLIENT_OS_ERROR += 1
-            retries += 1
-            if _NUM_CLIENT_OS_ERROR % DISCONNECTED_CLIENT_OS_PRINT_INTERVAL == 0:
-                print(
-                    f"[request_retry url={url} error=ClientOSError retry={retries} elapsed_s={time.monotonic() - retry_start:.1f}] "
-                    f"Hit {_NUM_CLIENT_OS_ERROR} global `ClientOSError` while querying {url}.\n{DISCONNECTED_CLIENT_OS_HELP_TEXT}",
-                    flush=True,
-                )
+        except (ServerDisconnectedError, ClientOSError) as e:
+            # Both were already retried without a limit, and still are; the kind only selects the
+            # diagnostic. `ClientConnectorError` arrives here as a `ClientOSError` subclass, which
+            # is why a refused connection used to be reported as an overloaded server.
+            _report_request_failure(url, e, _classify_request_failure(e), time.monotonic())
 
             await asyncio.sleep(0.5)
         except Exception as e:
@@ -251,10 +377,13 @@ async def request(
 
             # Don't increment internal since we know we are ok. If we are not, the head server will shut everything down anyways.
             if not _internal:
+                kind = _classify_request_failure(e)
+                help_text = _FAILURE_KIND_HELP_TEXT[kind]
                 print(
-                    f"""Hit an exception while making a request (try {num_tries}): {type(e)}: {e}
+                    f"""Hit an exception while making a request (try {num_tries}, kind {kind.value}): {type(e)}: {e}
 Sleeping 0.5s and retrying...
 """
+                    + (f"{help_text}\n" if help_text else "")
                 )
                 if num_tries >= MAX_NUM_TRIES:
                     raise e

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -12,10 +12,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
+import errno
 import socket
 from unittest.mock import AsyncMock, MagicMock
 
-from pytest import MonkeyPatch, raises
+from aiohttp import (
+    ClientConnectionResetError,
+    ClientConnectorDNSError,
+    ClientConnectorError,
+    ClientError,
+    ClientOSError,
+    ClientPayloadError,
+    ClientProxyConnectionError,
+    ServerDisconnectedError,
+)
+from aiohttp.client_exceptions import ConnectionTimeoutError, InvalidUrlClientError, SocketTimeoutError
+from aiohttp.client_reqrep import ConnectionKey
+from pytest import CaptureFixture, MonkeyPatch, raises
 
 import nemo_gym.global_config
 import nemo_gym.server_utils
@@ -31,9 +45,26 @@ from nemo_gym.server_utils import (
     HeadServer,
     ServerClient,
     SimpleServer,
+    _classify_request_failure,
     _make_keepalive_socket_factory,
+    _next_failure_report,
+    _report_request_failure,
+    _request_origin,
+    _RequestFailureKind,
     initialize_ray,
 )
+
+
+def _connection_key() -> ConnectionKey:
+    return ConnectionKey(
+        host="localhost",
+        port=8000,
+        is_ssl=False,
+        ssl=True,
+        proxy=None,
+        proxy_auth=None,
+        proxy_headers_hash=None,
+    )
 
 
 _TCP_KEEPALIVE_TEST_IDLE = 42
@@ -375,3 +406,206 @@ class TestServerUtils:
             response = client.get("/session")
             assert response.json()["session_id"]
             assert 1 == len(response.headers.get_list("set-cookie"))
+
+    def test_classify_request_failure_never_connected(self) -> None:
+        key = _connection_key()
+
+        assert _RequestFailureKind.UNREACHABLE == _classify_request_failure(
+            ClientConnectorError(key, OSError(errno.ECONNREFUSED, "refused"))
+        )
+        assert _RequestFailureKind.UNREACHABLE == _classify_request_failure(
+            ClientConnectorDNSError(key, OSError("name resolution failed"))
+        )
+        # A ClientConnectorError subclass, and easy to miss.
+        assert _RequestFailureKind.UNREACHABLE == _classify_request_failure(
+            ClientProxyConnectionError(key, OSError(errno.ECONNREFUSED, "refused"))
+        )
+
+    def test_classify_request_failure_resource_exhaustion(self) -> None:
+        key = _connection_key()
+
+        for err in (errno.EMFILE, errno.ENFILE, errno.ENOBUFS, errno.ENOMEM):
+            assert _RequestFailureKind.RESOURCE == _classify_request_failure(
+                ClientConnectorError(key, OSError(err, "out of descriptors"))
+            )
+
+    def test_classify_request_failure_peer_drop(self) -> None:
+        assert _RequestFailureKind.PEER_DROP == _classify_request_failure(ServerDisconnectedError())
+        assert _RequestFailureKind.PEER_DROP == _classify_request_failure(ClientConnectionResetError("reset"))
+        assert _RequestFailureKind.PEER_DROP == _classify_request_failure(ClientOSError(errno.ECONNRESET, "reset"))
+        # An aiohttp error we do not recognise is retried rather than failed fast.
+        assert _RequestFailureKind.PEER_DROP == _classify_request_failure(ClientPayloadError("truncated"))
+
+    def test_classify_request_failure_timeout_and_fatal(self) -> None:
+        assert _RequestFailureKind.TIMEOUT == _classify_request_failure(ConnectionTimeoutError())
+        assert _RequestFailureKind.TIMEOUT == _classify_request_failure(SocketTimeoutError())
+        assert _RequestFailureKind.TIMEOUT == _classify_request_failure(asyncio.TimeoutError())
+
+        assert _RequestFailureKind.FATAL == _classify_request_failure(InvalidUrlClientError("http://[bad"))
+        assert _RequestFailureKind.FATAL == _classify_request_failure(TypeError("programming error"))
+        assert _RequestFailureKind.FATAL == _classify_request_failure(ValueError("programming error"))
+
+    def test_classify_request_failure_subclass_ordering(self) -> None:
+        """Both orderings fail silently if broken, and breaking the first reinstates the bug."""
+        # ClientConnectorError subclasses ClientOSError; testing the parent first would sort every
+        # refused connection into PEER_DROP.
+        refused = ClientConnectorError(_connection_key(), OSError(errno.ECONNREFUSED, "refused"))
+        assert isinstance(refused, ClientOSError)
+        assert _RequestFailureKind.UNREACHABLE == _classify_request_failure(refused)
+
+        # InvalidURL is both a ClientError and a ValueError.
+        bad_url = InvalidUrlClientError("http://[bad")
+        assert isinstance(bad_url, ClientError) and isinstance(bad_url, ValueError)
+        assert _RequestFailureKind.FATAL == _classify_request_failure(bad_url)
+
+    def test_classify_request_failure_tolerates_missing_os_error(self) -> None:
+        """`classify` runs inside an `except` block, so raising here would crash a retryable call."""
+        # A bare ClientOSError carries no `os_error` attribute at all.
+        assert not hasattr(ClientOSError(), "os_error")
+        assert _RequestFailureKind.PEER_DROP == _classify_request_failure(ClientOSError())
+
+        # An OSError carrying no errno at all still classifies rather than raising.
+        assert _RequestFailureKind.UNREACHABLE == _classify_request_failure(
+            ClientConnectorError(_connection_key(), OSError("no errno"))
+        )
+
+    def test_request_origin(self) -> None:
+        assert "http://localhost:8000" == _request_origin("http://localhost:8000/v1/responses")
+        assert "https://api.openai.com" == _request_origin("https://api.openai.com/v1/responses")
+        assert "/v1/responses" == _request_origin("/v1/responses")
+
+    def test_next_failure_report_throttles_per_origin_and_kind(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+        interval = nemo_gym.server_utils._FAILURE_REPORT_INTERVAL_SECONDS
+
+        # First sighting prints in full.
+        assert 0 == _next_failure_report("http://a:8000", _RequestFailureKind.UNREACHABLE, 0.0)
+        # Inside the interval, quiet, but counting.
+        assert _next_failure_report("http://a:8000", _RequestFailureKind.UNREACHABLE, 1.0) is None
+        assert _next_failure_report("http://a:8000", _RequestFailureKind.UNREACHABLE, 2.0) is None
+        # Once it passes, one line carrying the suppressed count.
+        assert 3 == _next_failure_report("http://a:8000", _RequestFailureKind.UNREACHABLE, interval)
+        # The count restarts after a report.
+        assert _next_failure_report("http://a:8000", _RequestFailureKind.UNREACHABLE, interval + 1) is None
+
+        # A different kind at the same origin, and a different origin, are tracked separately.
+        assert 0 == _next_failure_report("http://a:8000", _RequestFailureKind.PEER_DROP, 1.0)
+        assert 0 == _next_failure_report("http://b:8000", _RequestFailureKind.UNREACHABLE, 1.0)
+
+    def test_report_request_failure_message_matches_the_kind(
+        self, monkeypatch: MonkeyPatch, capsys: CaptureFixture
+    ) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+        key = _connection_key()
+
+        _report_request_failure(
+            "http://localhost:8000/v1/responses",
+            ClientConnectorError(key, OSError(errno.ECONNREFUSED, "refused")),
+            _RequestFailureKind.UNREACHABLE,
+            0.0,
+        )
+        unreachable = capsys.readouterr().out
+        assert "http://localhost:8000/v1/responses" in unreachable
+        assert "policy_base_url" in unreachable
+        # The ulimit and replica advice cannot apply when no socket was opened.
+        assert "Increase ulimit" not in unreachable
+        assert "adapter server replicas" not in unreachable
+
+        _report_request_failure(
+            "http://localhost:8000/v1/responses",
+            ClientConnectorError(key, OSError(errno.EMFILE, "too many open files")),
+            _RequestFailureKind.RESOURCE,
+            0.0,
+        )
+        assert "Increase ulimit" in capsys.readouterr().out
+
+        _report_request_failure(
+            "http://localhost:8000/v1/responses", ServerDisconnectedError(), _RequestFailureKind.PEER_DROP, 0.0
+        )
+        assert "adapter server replicas" in capsys.readouterr().out
+
+    def test_report_request_failure_bounds_output_volume(
+        self, monkeypatch: MonkeyPatch, capsys: CaptureFixture
+    ) -> None:
+        """500 in-flight requests against one dead endpoint must not print 500 diagnostics."""
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+        refused = ClientConnectorError(_connection_key(), OSError(errno.ECONNREFUSED, "refused"))
+
+        for _ in range(500):
+            _report_request_failure(
+                "http://localhost:8000/v1/responses", refused, _RequestFailureKind.UNREACHABLE, 0.0
+            )
+
+        assert 1 == capsys.readouterr().out.count("[request_retry")
+
+    async def test_request_still_retries_unreachable_endpoints_forever(self, monkeypatch: MonkeyPatch) -> None:
+        """M1 changes reporting only. A refused connect must still retry without limit."""
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+        refused = ClientConnectorError(_connection_key(), OSError(errno.ECONNREFUSED, "refused"))
+
+        num_calls = 0
+
+        async def request_mock(**_kwargs) -> str:
+            nonlocal num_calls
+            num_calls += 1
+            if num_calls < 200:
+                raise refused
+            return "my mock response"
+
+        monkeypatch.setattr(nemo_gym.server_utils.asyncio, "sleep", AsyncMock())
+        client_mock = MagicMock()
+        client_mock.return_value.request = request_mock
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        assert "my mock response" == await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
+        assert 200 == num_calls
+
+    async def test_request_still_retries_dropped_connections_forever(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+
+        num_calls = 0
+
+        async def request_mock(**_kwargs) -> str:
+            nonlocal num_calls
+            num_calls += 1
+            if num_calls < 200:
+                raise ServerDisconnectedError()
+            return "my mock response"
+
+        monkeypatch.setattr(nemo_gym.server_utils.asyncio, "sleep", AsyncMock())
+        client_mock = MagicMock()
+        client_mock.return_value.request = request_mock
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        assert "my mock response" == await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
+        assert 200 == num_calls
+
+    async def test_request_still_raises_unknown_errors_after_max_num_tries(self, monkeypatch: MonkeyPatch) -> None:
+        """The generic branch keeps its 3-tries-then-raise behaviour for external calls."""
+        monkeypatch.setattr(nemo_gym.server_utils.asyncio, "sleep", AsyncMock())
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(side_effect=TypeError("programming error"))
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        with raises(TypeError):
+            await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
+
+        assert nemo_gym.server_utils.MAX_NUM_TRIES == client_mock.return_value.request.await_count
+
+    async def test_request_success_path_is_untouched(self, monkeypatch: MonkeyPatch, capsys: CaptureFixture) -> None:
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(return_value="my mock response")
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        assert "my mock response" == await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
+        assert 1 == client_mock.return_value.request.await_count
+        assert "" == capsys.readouterr().out
+
+    async def test_request_propagates_cancellation(self, monkeypatch: MonkeyPatch) -> None:
+        """CancelledError is a BaseException, so `except Exception` must never swallow it."""
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(side_effect=asyncio.CancelledError())
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        with raises(asyncio.CancelledError):
+            await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")


### PR DESCRIPTION
Partially addresses #2216.

`request()` retries two exception types without a limit: `ServerDisconnectedError` and `ClientOSError`. Both mean a connection was established and then lost, which is a condition that usually clears, so retrying them is right.

`ClientConnectorError` is a subclass of `ClientOSError`. A connection that was refused, or whose host was unreachable, or whose DNS lookup failed, therefore lands in that same branch. In those cases nothing is serving the address, so the retry cannot succeed no matter how long it runs.

The message the user gets is wrong too. Both branches share one help text, which covers two causes: file descriptor exhaustion, and an overloaded server dropping connections. Neither can apply when no socket was ever opened.

The message is also slow. The counter is global and prints every 100th failure, and each retry sleeps 0.5s, so a single request against a dead endpoint prints nothing at all for the first 50 seconds.

This change sorts failures before reporting them.

`_classify_request_failure` maps what `client.request()` raises onto five kinds: `unreachable`, `resource`, `peer_drop`, `timeout` and `fatal`. Each kind gets its own help text. Both it and `_RequestFailureKind` are private to
`server_utils.py`: they describe the `request()` path specifically and are not a general error taxonomy for Gym. 

The shared text splits in two:
- `resource` takes the file descriptor advice
- `peer_drop` takes the overloaded-server advice. 
- `unreachable` gets new text that names the URL and points at `policy_base_url`.

Reporting changes from every 100th global failure to the first failure for each (origin, kind) pair, then one summary line every 30 seconds carrying the count suppressed in between. A single request now reports in under a second.
Sixteen thousand concurrent requests against one dead endpoint still produce one message rather than sixteen thousand.

Retry behaviour does not change. The loop gains no `raise`, `return` or `break`, so every failure that retried before still retries, still without a limit, and the generic branch still allows `MAX_NUM_TRIES` attempts before raising on external calls. No new exception type is introduced, so no existing `except` clause changes meaning.


Every exception maps to a kind. An `aiohttp.ClientError` the function does not recognise falls back to `peer_drop`, so a new exception type in a future aiohttp is retried and reported rather than raised at once. Anything that is not a `ClientError` falls back to `fatal`, on the grounds that it is a programming error rather than a network one.

`resource` is detected by reading an errno from `.os_error`, not by exception type, because `ClientConnectorError` is what aiohttp raises when it runs out of file descriptors. The read uses `getattr`, because a bare `ClientOSError`
has no `.os_error` attribute and this code runs inside an `except` block, where an `AttributeError` would turn a retryable failure into a crash.

[architecture.mdx](https://github.com/NVIDIA-NeMo/Gym/blob/62505d4f2513304176425ebed3a62dc71e69f4e6/fern/versions/latest/pages/about/architecture.mdx#L99) and [AGENTS.md](https://github.com/NVIDIA-NeMo/Gym/blob/1a6714f391730a7343875c1ff06a4acf8f70a4f5/AGENTS.md#L71) both describe the retry policy as 3 attempts with exponential backoff. Neither the count nor the backoff is accurate, so this corrects them.



## The change in flow

Before:

```mermaid
flowchart TD
    C["client.request()"] -->|success| OK["return response"]
    C -->|raises| E{"except"}
    E -->|ServerDisconnectedError| B1["_NUM_SERVER_DISCONNECTED_ERROR += 1"]
    E -->|"ClientOSError<br>refused, DNS, proxy and reset all land here"| B2["_NUM_CLIENT_OS_ERROR += 1"]
    E -->|other Exception| B3["3 tries, then raise<br>external calls only"]
    B1 --> H["print every 100th:<br>ulimit AND adapter replicas"]
    B2 --> H
    H --> S["sleep 0.5s, retry without limit"]
    S --> C
```

After:

```mermaid
flowchart TD
    C["client.request()"] -->|success| OK["return response"]
    C -->|raises| K["classify_request_failure(e)"]
    K -->|unreachable| D1["nothing is serving this address<br>check policy_base_url"]
    K -->|resource| D2["ulimit advice"]
    K -->|peer_drop| D3["adapter replica advice"]
    K -->|timeout| D4["deadline advice"]
    K -->|fatal| D5["bad URL or programming error"]
    D1 --> R["report first failure per origin and kind,<br>then summarise every 30s"]
    D2 --> R
    D3 --> R
    D4 --> R
    D5 --> R
    R --> S["sleep 0.5s, retry without limit<br>unchanged"]
    S --> C
```

