### PR TITLE
feat(cli): check model endpoints before starting a run

### DIFF
--- a/fern/versions/latest/pages/get-started/quickstart.mdx
+++ b/fern/versions/latest/pages/get-started/quickstart.mdx
@@ -82,6 +82,8 @@ Aggregate metrics: results/mcqa_rollouts_aggregate_metrics.json
 
 <Warning>
 If `gym eval run` fails with a `500 Internal Server Error` on the `/run` endpoint, the most common cause is an invalid or missing API key. Verify that `policy_api_key` and `policy_base_url` in your `env.yaml` are correct.
+
+If `gym env start` instead stops with `model endpoint(s) never answered`, nothing is listening at the endpoint it names. See [Model Endpoint Unreachable](/troubleshooting/configuration#model-endpoint-unreachable).
 </Warning>
 
 For per-task pass rates, see `gym eval profile` in the [CLI Reference](/reference/cli-commands).

--- a/fern/versions/latest/pages/troubleshooting/configuration.mdx
+++ b/fern/versions/latest/pages/troubleshooting/configuration.mdx
@@ -3,7 +3,7 @@ title: "Configuration Errors"
 description: ""
 position: 1
 ---
-These errors appear when running `gym env start` or `gym eval run --no-serve`. NeMo Gym validates configuration at startup before launching servers.
+These errors appear when running `gym env start` or `gym eval run --no-serve`. NeMo Gym validates configuration at startup before launching servers, and checks the model endpoints the config names once its own servers are up.
 
 <Note>
 See the [Configuration reference](/reference/configuration) for complete configuration syntax and options.
@@ -171,3 +171,40 @@ gym env start \
 Bypassing validation means invalid servers won't start. Use this only for debugging, not production.
 
 </Warning>
+
+---
+
+## Connection Errors
+
+Errors where the config is valid but an endpoint it names cannot be reached.
+
+### Model Endpoint Unreachable
+
+```
+2 model endpoint(s) never answered within 600s:
+  - http://localhost:8000/v1 (from `openai_base_url`)
+  - http://judge-host:9000/v1 (from `judge_base_url`)
+
+Nothing accepted a connection there. The server was never started, is still starting up, or the URL
+in your config does not match where it is listening.
+```
+
+**When**: `gym env start` finished starting Gym's own servers, but a model endpoint named in the config is not answering. Gym's model server is a proxy that answers as soon as it starts, whether or not an inference server is behind it, so this check is separate from the server readiness check above it.
+
+**Fix**: Check the config key named beside each URL, and confirm something answers there. The check probes `/models` under a base URL ending in `/v1`, and the URL itself otherwise, so mirror whichever applies:
+
+```bash
+curl -i https://example.com/v1/models
+curl -i https://example.com
+```
+
+Any response, including `401` or `404`, means something is listening. Then correct that config key, or start the server it names. The [Quickstart](/get-started/quickstart) uses a hosted endpoint (`https://api.openai.com/v1`); a `localhost` URL means you serve the model yourself (see [Configure Model](/model-server)).
+
+<Note>
+The check waits up to `model_endpoint_readiness_timeout_seconds` (default 600) so an inference server still loading weights is not treated as a failure. Raise it to wait longer, or set it to `0` to skip the check entirely.
+
+An endpoint whose hostname does not resolve is reported once and not waited on, since waiting cannot create a DNS record. This is what happens to a config that leaves a judge or user model at its placeholder default: you get one line about it rather than a stalled startup.
+
+Any HTTP answer counts as listening, including 401 and 404. A completed TLS handshake counts too, even against a certificate this machine does not trust, because it proves something is there.
+
+</Note>

--- a/nemo_gym/cli/env.py
+++ b/nemo_gym/cli/env.py
@@ -25,13 +25,14 @@ from shutil import rmtree
 from signal import SIGINT
 from subprocess import Popen, TimeoutExpired
 from threading import Thread
-from time import sleep, time
+from time import monotonic, sleep, time
 from typing import Dict, List, Optional, Tuple
 
+import requests
 import rich
 import uvicorn
 from devtools import pprint
-from omegaconf import DictConfig, OmegaConf
+from omegaconf import DictConfig, ListConfig, OmegaConf
 from pydantic import Field
 from rich.table import Table
 from tqdm.auto import tqdm
@@ -46,11 +47,12 @@ from nemo_gym.cli.utils import (
     print_rich_table,
     render_component_inspection,
 )
-from nemo_gym.config_types import BaseNeMoGymCLIConfig
+from nemo_gym.config_types import BaseNeMoGymCLIConfig, ConfigError
 from nemo_gym.global_config import (
     COMPONENT_NAME_KEY_NAME,
     DRY_RUN_KEY_NAME,
     JSON_OUTPUT_KEY_NAME,
+    MODEL_ENDPOINT_READINESS_TIMEOUT_KEY_NAME,
     NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME,
     NEMO_GYM_CONFIG_PATH_ENV_VAR_NAME,
     NEMO_GYM_RESERVED_TOP_LEVEL_KEYS,
@@ -75,6 +77,200 @@ from nemo_gym.server_utils import (
 _GRACEFUL_SHUTDOWN_TIMEOUT_SEC: int = 1
 # Grace period after SIGKILL for the kernel to reap the child and avoid <defunct> entries.
 _FORCE_KILL_REAP_TIMEOUT_SEC: int = 2
+
+
+# Model servers name their upstream endpoint inconsistently: `openai_base_url` (openai_model,
+# azure_openai_model), `base_url` (inference_provider, vllm_model, and the local vLLM servers),
+# `anthropic_base_url`. Matching on the shape of the key rather than a fixed list also covers
+# configs that carry a provider URL literally instead of interpolating `policy_base_url`, which
+# most inference_provider variants do.
+_MODEL_SERVER_TYPE = "responses_api_models"
+_BASE_URL_KEY_SUFFIX = "base_url"
+_ENDPOINT_PROBE_TIMEOUT_SEC: float = 5.0
+_ENDPOINT_POLL_INTERVAL_SEC: float = 3.0
+
+# What a probe found. The distinction that matters is whether waiting could change the answer: a
+# name that does not resolve will not start resolving, while a refused connection may be a server
+# that is still coming up.
+_ENDPOINT_ANSWERING = "answering"
+_ENDPOINT_REFUSED = "refused"
+_ENDPOINT_UNRESOLVABLE = "unresolvable"
+
+
+def _collect_model_endpoints(global_config_dict: DictConfig) -> List[Tuple[str, str]]:
+    """The upstream model endpoints named in the resolved config, as (config key, url) pairs.
+
+    `wait_for_spinup` only polls Gym's own servers, and the Gym-side model server answers as soon
+    as it starts whether or not anything is behind it, so these are the URLs nothing checks.
+
+    `base_url` is typed `Union[str, List[str]]` on vllm_model and the local vLLM servers, where the
+    list form spreads load across replicas. The local ones default to an empty list and are filled
+    in after Gym launches vLLM, so an empty list means "not yet" rather than "misconfigured" and is
+    skipped, as is an unset value.
+
+    The key travels with the url because the endpoint that fails may be a judge or user model, and
+    a message naming `policy_base_url` would then be wrong.
+    """
+    endpoints: List[Tuple[str, str]] = []
+    seen: set[str] = set()
+    for top_level_path, top_level_value in global_config_dict.items():
+        if top_level_path in NEMO_GYM_RESERVED_TOP_LEVEL_KEYS or not isinstance(top_level_value, DictConfig):
+            continue
+
+        model_servers = top_level_value.get(_MODEL_SERVER_TYPE)
+        if not isinstance(model_servers, DictConfig):
+            continue
+
+        for server_config_dict in model_servers.values():
+            if not isinstance(server_config_dict, DictConfig):
+                continue
+
+            for key, value in server_config_dict.items():
+                if not str(key).endswith(_BASE_URL_KEY_SUFFIX):
+                    continue
+
+                urls = (
+                    [value] if isinstance(value, str) else list(value) if isinstance(value, (list, ListConfig)) else []
+                )
+                for url in urls:
+                    if not isinstance(url, str) or not url:
+                        continue
+                    # `http://x/v1` and `http://x/v1/` probe the same place.
+                    trimmed = url.rstrip("/")
+                    if trimmed in seen:
+                        continue
+                    seen.add(trimmed)
+                    endpoints.append((str(key), url))
+
+    return endpoints
+
+
+def _endpoint_probe_url(base_url: str) -> str:
+    """What to GET to find out whether `base_url` is being served.
+
+    `GET /v1/models` is part of the OpenAI API, so most endpoints behind a `/v1` base URL answer it,
+    but nothing here depends on that: any HTTP response counts as answering, so an endpoint without
+    it replies 404 and still passes. URLs that do not end in `/v1` are probed at their root.
+    """
+    trimmed = base_url.rstrip("/")
+    return f"{trimmed}/models" if trimmed.endswith("/v1") else trimmed
+
+
+def _is_dns_failure(error: BaseException) -> bool:
+    """Whether a `requests` connection error was a name that does not resolve.
+
+    `requests` reports this as a `ConnectionError` like any other, with the resolver failure nested
+    inside, so the cause chain has to be walked rather than the class inspected.
+    """
+    seen = set()
+    while error is not None and id(error) not in seen:
+        seen.add(id(error))
+        if type(error).__name__ in ("NameResolutionError", "gaierror"):
+            return True
+        nested = next((arg for arg in getattr(error, "args", ()) if isinstance(arg, BaseException)), None)
+        error = nested or error.__cause__ or error.__context__
+    return False
+
+
+def _probe_endpoint(base_url: str, timeout_seconds: float = _ENDPOINT_PROBE_TIMEOUT_SEC) -> str:
+    """Whether anything answers at `base_url`, and if not, whether waiting could help.
+
+    Answering is the bar, not healthy: a 401 or 404 means something is there, and requiring a 200
+    would reject endpoints that need auth. A completed TLS handshake counts too, even against a
+    certificate this process does not trust, which is why `SSLError` is checked before
+    `ConnectionError` it inherits from.
+    """
+    try:
+        requests.get(_endpoint_probe_url(base_url), timeout=timeout_seconds)
+        return _ENDPOINT_ANSWERING
+    except requests.exceptions.SSLError:
+        return _ENDPOINT_ANSWERING
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+        return _ENDPOINT_UNRESOLVABLE if _is_dns_failure(e) else _ENDPOINT_REFUSED
+    except requests.exceptions.RequestException:
+        # Not probeable at all, such as a bad scheme or a redirect loop. Not a reason to hold up
+        # startup; the request path reports it if it matters.
+        return _ENDPOINT_ANSWERING
+
+
+def _wait_for_model_endpoints(
+    endpoints: List[Tuple[str, str]],
+    timeout_seconds: float,
+    poll_interval_seconds: float = _ENDPOINT_POLL_INTERVAL_SEC,
+    monotonic=monotonic,
+    sleep_fn=sleep,
+) -> List[Tuple[str, str]]:
+    """Wait for every endpoint to answer. Returns the ones that never did.
+
+    Unresolvable names are reported once and not waited on. Refused connections are waited on,
+    because an inference server can take minutes to load weights and someone who starts thirty
+    seconds early should not have to start over.
+    """
+    if timeout_seconds <= 0 or not endpoints:
+        return []
+
+    # The clock starts before the first round, not after it. That round is not free: an
+    # unresolvable name costs a full resolver timeout, so several of them would otherwise push the
+    # real wall time well past the bound the caller asked for.
+    started_at = monotonic()
+
+    waiting = []
+    for key, url in endpoints:
+        result = _probe_endpoint(url)
+        if result == _ENDPOINT_UNRESOLVABLE:
+            print(
+                f"Model endpoint {url} ({key}) does not resolve. Waiting cannot fix a hostname, so it is not retried."
+            )
+        elif result == _ENDPOINT_REFUSED:
+            waiting.append((key, url))
+    if not waiting:
+        return []
+
+    print(
+        f"Waiting for {len(waiting)} model endpoint(s) to answer: "
+        + ", ".join(f"{url} ({key})" for key, url in waiting)
+        + f"\nIf an inference server is still loading weights this is expected. Waiting up to {timeout_seconds:.0f}s..."
+    )
+
+    poll_count = 0
+    while True:
+        if monotonic() - started_at >= timeout_seconds:
+            return waiting
+
+        sleep_fn(poll_interval_seconds)
+        waiting = [(key, url) for key, url in waiting if _probe_endpoint(url) != _ENDPOINT_ANSWERING]
+        if not waiting:
+            print(f"All model endpoints are answering after {monotonic() - started_at:.0f}s.")
+            return []
+
+        poll_count += 1
+        if poll_count % 10 == 0:
+            print(f"  still waiting, {monotonic() - started_at:.0f}s elapsed")
+
+
+# Matches the value `GlobalConfigDictParser` sets, so a caller that builds a config without going
+# through the parser gets the same behaviour instead of silently skipping the check.
+_DEFAULT_MODEL_ENDPOINT_READINESS_TIMEOUT_SEC: float = 600.0
+
+
+def _model_endpoint_timeout_seconds(global_config_dict: DictConfig) -> float:
+    """How long to wait for model endpoints, from config. 0 or a negative value skips the check.
+
+    An unset key falls back to the same default the config parser applies. A value that is not a
+    number is a configuration mistake, so it is reported as one rather than surfacing as a
+    `ValueError` traceback from `float()`.
+    """
+    value = global_config_dict.get(MODEL_ENDPOINT_READINESS_TIMEOUT_KEY_NAME)
+    if value is None:
+        return _DEFAULT_MODEL_ENDPOINT_READINESS_TIMEOUT_SEC
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        raise ConfigError(
+            f"`{MODEL_ENDPOINT_READINESS_TIMEOUT_KEY_NAME}` must be a number of seconds, got {value!r}. "
+            "Set it to 0 to skip waiting for model endpoints."
+        ) from None
 
 
 def _resolve_server_dir(rel_path: Path) -> Path:
@@ -265,6 +461,7 @@ class RunHelper:  # pragma: no cover
             self.wait_for_dry_run_spinup()
         else:
             self.wait_for_spinup()
+            self.wait_for_model_endpoints(global_config_dict)
 
     def display_server_instance_info(self) -> None:
         if not self._server_instance_display_configs:
@@ -411,6 +608,38 @@ rpc_client.h:203: Failed to connect to GCS within 60 seconds. GCS may have been 
             pass
         finally:
             self.shutdown()
+
+    def wait_for_model_endpoints(self, global_config_dict: DictConfig) -> None:
+        """Block until every model endpoint named in the config answers, then return.
+
+        Reads the bound from `model_endpoint_readiness_timeout_seconds`, where 0 skips the check
+        entirely. Raises `ConfigError` naming the endpoints that never answered and the config key
+        each came from. It raises rather than exits because `RunHelper` is imported and driven as a
+        library, so the caller decides what an unreachable endpoint means; the CLI entrypoints turn
+        it into an exit.
+
+        The servers spawned above are shut down first. They hold ports and have neither a process
+        group nor an atexit handler, and every caller reaches its own `shutdown()` only after
+        `start()` returns.
+        """
+        timeout_seconds = _model_endpoint_timeout_seconds(global_config_dict)
+        unreachable = _wait_for_model_endpoints(_collect_model_endpoints(global_config_dict), timeout_seconds)
+        if not unreachable:
+            return
+
+        listed = "\n".join(f"  - {url} (from `{key}`)" for key, url in unreachable)
+        self.shutdown()
+        raise ConfigError(
+            f"""{len(unreachable)} model endpoint(s) never answered within {timeout_seconds:.0f}s:
+{listed}
+
+Nothing accepted a connection there. The server was never started, is still starting up, or the URL
+in your config does not match where it is listening.
+  - Check the config key named beside each URL. Verify with `curl -i <base_url>/models` for a
+    `/v1` endpoint, or `curl -i <base_url>` otherwise.
+  - Any response, including 401 or 404, means something is listening.
+  - Raise `{MODEL_ENDPOINT_READINESS_TIMEOUT_KEY_NAME}` to wait longer, or set it to 0 to skip this check."""
+        )
 
     def check_http_server_statuses(self, successful_servers: List[str]) -> List[Tuple[str, ServerStatus]]:
         statuses = []

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -76,6 +76,7 @@ RAY_HEAD_NODE_ADDRESS_KEY_NAME = "ray_head_node_address"
 PORT_RANGE_LOW_KEY_NAME = "port_range_low"
 PORT_RANGE_HIGH_KEY_NAME = "port_range_high"
 DRY_RUN_KEY_NAME = "dry_run"
+MODEL_ENDPOINT_READINESS_TIMEOUT_KEY_NAME = "model_endpoint_readiness_timeout_seconds"
 UV_CACHE_DIR_KEY_NAME = "uv_cache_dir"
 UV_VENV_DIR_KEY_NAME = "uv_venv_dir"
 INHERIT_FROM_KEY_NAME = "_inherit_from"
@@ -110,6 +111,7 @@ NEMO_GYM_RESERVED_TOP_LEVEL_KEYS = [
     PORT_RANGE_LOW_KEY_NAME,
     PORT_RANGE_HIGH_KEY_NAME,
     DRY_RUN_KEY_NAME,
+    MODEL_ENDPOINT_READINESS_TIMEOUT_KEY_NAME,
     UV_CACHE_DIR_KEY_NAME,
     UV_VENV_DIR_KEY_NAME,
     INHERIT_FROM_KEY_NAME,
@@ -706,6 +708,10 @@ Found global config dict yaml:
             global_config_dict.setdefault(SKIP_VENV_IF_PRESENT_KEY_NAME, False)
 
             global_config_dict.setdefault(DRY_RUN_KEY_NAME, False)
+
+            # How long `gym env start` waits for the model endpoints named in the config to accept
+            # a connection. Generous because vLLM can take minutes to load weights; 0 skips it.
+            global_config_dict.setdefault(MODEL_ENDPOINT_READINESS_TIMEOUT_KEY_NAME, 600)
 
             # UV related configuration
             # UV caching directory overrides to local folders.

--- a/tests/unit_tests/test_cli_endpoint_readiness.py
+++ b/tests/unit_tests/test_cli_endpoint_readiness.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import MagicMock
+
+import requests
+from omegaconf import DictConfig
+from pytest import MonkeyPatch, raises
+
+import nemo_gym.cli.env
+from nemo_gym.cli.env import (
+    _ENDPOINT_POLL_INTERVAL_SEC,
+    RunHelper,
+    _collect_model_endpoints,
+    _model_endpoint_timeout_seconds,
+    _probe_endpoint,
+    _wait_for_model_endpoints,
+)
+from nemo_gym.config_types import ConfigError
+
+
+class _FakeClock:
+    """Stand-in for `time` and `sleep` so the wait loop runs without real waiting."""
+
+    def __init__(self) -> None:
+        self._now = 0.0
+
+    def __call__(self) -> float:
+        return self._now
+
+    def sleep(self, seconds: float) -> None:
+        self._now += seconds
+
+
+def _config(**model_servers) -> DictConfig:
+    return DictConfig(
+        {
+            "dry_run": False,
+            "head_server": {"host": "127.0.0.1", "port": 11000},
+            **model_servers,
+        }
+    )
+
+
+class TestEndpointsFromConfigShapes:
+    """Driven from the model server config classes so a new server or a changed field type fails
+    here rather than quietly shrinking what the check covers."""
+
+    def test_reads_a_string_base_url(self) -> None:
+        config = _config(
+            policy_model={
+                "responses_api_models": {
+                    "openai_model": {"entrypoint": "app.py", "openai_base_url": "https://api.openai.com/v1"}
+                }
+            }
+        )
+        assert [("openai_base_url", "https://api.openai.com/v1")] == _collect_model_endpoints(config)
+
+    def test_reads_a_list_base_url(self) -> None:
+        """vllm_model and the local vLLM servers type base_url as Union[str, List[str]] for load
+        balancing, which is the shape a training run is most likely to use."""
+        config = _config(
+            policy_model={
+                "responses_api_models": {
+                    "vllm_model": {
+                        "entrypoint": "app.py",
+                        "base_url": ["http://replica-a:8000/v1", "http://replica-b:8000/v1"],
+                    }
+                }
+            }
+        )
+        assert [
+            ("base_url", "http://replica-a:8000/v1"),
+            ("base_url", "http://replica-b:8000/v1"),
+        ] == _collect_model_endpoints(config)
+
+    def test_skips_an_empty_list(self) -> None:
+        """local_vllm_model carries [] until Gym launches vLLM and fills it in."""
+        config = _config(
+            policy_model={"responses_api_models": {"local_vllm_model": {"entrypoint": "app.py", "base_url": []}}}
+        )
+        assert [] == _collect_model_endpoints(config)
+
+    def test_skips_null(self) -> None:
+        config = _config(
+            judge={"responses_api_models": {"openai_model": {"entrypoint": "app.py", "openai_base_url": None}}}
+        )
+        assert [] == _collect_model_endpoints(config)
+
+    def test_carries_the_config_key_for_the_report(self) -> None:
+        config = _config(
+            judge={
+                "responses_api_models": {
+                    "openai_model": {"entrypoint": "app.py", "openai_base_url": "http://judge:8000/v1"}
+                }
+            }
+        )
+        assert [("openai_base_url", "http://judge:8000/v1")] == _collect_model_endpoints(config)
+
+
+class TestProbeClassification:
+    def test_any_http_answer_is_reachable(self, monkeypatch: MonkeyPatch) -> None:
+        for status_code in (200, 401, 404, 500):
+            monkeypatch.setattr(
+                nemo_gym.cli.env.requests, "get", MagicMock(return_value=MagicMock(status_code=status_code))
+            )
+            assert nemo_gym.cli.env._ENDPOINT_ANSWERING == _probe_endpoint("http://x:8000/v1")
+
+    def test_untrusted_certificate_is_reachable(self, monkeypatch: MonkeyPatch) -> None:
+        """A completed TLS handshake proves something is listening. SSLError subclasses
+        ConnectionError, so deciding on the parent class would reject it."""
+        monkeypatch.setattr(
+            nemo_gym.cli.env.requests, "get", MagicMock(side_effect=requests.exceptions.SSLError("bad cert"))
+        )
+        assert nemo_gym.cli.env._ENDPOINT_ANSWERING == _probe_endpoint("https://x:8000/v1")
+
+    def test_refused_is_worth_waiting_for(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            nemo_gym.cli.env.requests, "get", MagicMock(side_effect=requests.exceptions.ConnectionError("refused"))
+        )
+        assert nemo_gym.cli.env._ENDPOINT_REFUSED == _probe_endpoint("http://x:8000/v1")
+
+    def test_an_unresolvable_name_is_not_worth_waiting_for(self, monkeypatch: MonkeyPatch) -> None:
+        """Waiting cannot create a DNS record, so a placeholder like unset.local is reported once
+        instead of costing the whole timeout."""
+        dns_failure = requests.exceptions.ConnectionError(
+            requests.packages.urllib3.exceptions.NameResolutionError("unset.local", None, Exception("no such host"))
+        )
+        monkeypatch.setattr(nemo_gym.cli.env.requests, "get", MagicMock(side_effect=dns_failure))
+        assert nemo_gym.cli.env._ENDPOINT_UNRESOLVABLE == _probe_endpoint("http://unset.local/v1")
+
+
+class TestCheckStopsStartupCleanly:
+    def test_unresolvable_endpoints_do_not_block(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            nemo_gym.cli.env, "_probe_endpoint", MagicMock(return_value=nemo_gym.cli.env._ENDPOINT_UNRESOLVABLE)
+        )
+        sleep_mock = MagicMock()
+        unreachable = _wait_for_model_endpoints(
+            [("openai_base_url", "http://unset.local/v1")], timeout_seconds=600, sleep_fn=sleep_mock
+        )
+
+        assert [] == unreachable
+        sleep_mock.assert_not_called()
+
+    def test_servers_are_shut_down_before_the_error(self, monkeypatch: MonkeyPatch) -> None:
+        """The Popens have no process group and no atexit handler, and every caller reaches
+        shutdown() only after start() returns."""
+        monkeypatch.setattr(
+            nemo_gym.cli.env, "_wait_for_model_endpoints", MagicMock(return_value=[("openai_base_url", "http://x/v1")])
+        )
+        helper = RunHelper.__new__(RunHelper)
+        shutdown_mock = MagicMock()
+        helper.shutdown = shutdown_mock
+
+        with raises(ConfigError):
+            RunHelper.wait_for_model_endpoints(helper, _config(model_endpoint_readiness_timeout_seconds=1))
+
+        shutdown_mock.assert_called_once()
+
+    def test_failure_is_a_config_error_not_a_system_exit(self, monkeypatch: MonkeyPatch) -> None:
+        """NeMo-RL imports RunHelper, so a library method must not exit the process."""
+        monkeypatch.setattr(
+            nemo_gym.cli.env, "_wait_for_model_endpoints", MagicMock(return_value=[("openai_base_url", "http://x/v1")])
+        )
+        helper = RunHelper.__new__(RunHelper)
+        helper.shutdown = MagicMock()
+
+        with raises(ConfigError) as exc_info:
+            RunHelper.wait_for_model_endpoints(helper, _config(model_endpoint_readiness_timeout_seconds=1))
+
+        assert not isinstance(exc_info.value, SystemExit)
+        # The report names the config key, since the endpoint may not be the policy model.
+        assert "openai_base_url" in str(exc_info.value)
+
+
+class TestTimeoutFromConfig:
+    def test_absent_key_uses_the_same_default_as_the_config_parser(self) -> None:
+        """A caller that builds a config directly should not silently skip the check."""
+        assert 600.0 == _model_endpoint_timeout_seconds(_config())
+
+    def test_zero_and_negative_skip_the_check(self) -> None:
+        assert 0.0 == _model_endpoint_timeout_seconds(_config(model_endpoint_readiness_timeout_seconds=0))
+        assert -1.0 == _model_endpoint_timeout_seconds(_config(model_endpoint_readiness_timeout_seconds=-1))
+
+    def test_a_non_numeric_value_is_reported_as_a_config_mistake(self) -> None:
+        with raises(ConfigError) as exc_info:
+            _model_endpoint_timeout_seconds(_config(model_endpoint_readiness_timeout_seconds="10m"))
+
+        assert "model_endpoint_readiness_timeout_seconds" in str(exc_info.value)
+        assert "10m" in str(exc_info.value)
+
+    def test_null_uses_the_default_rather_than_skipping(self) -> None:
+        assert 600.0 == _model_endpoint_timeout_seconds(_config(model_endpoint_readiness_timeout_seconds=None))
+
+    def test_the_bound_covers_the_first_probe_round(self) -> None:
+        """An unresolvable name costs a full resolver timeout in the first round. If the clock
+        started after that round, several of them would push the real wall time past the bound."""
+        clock = _FakeClock()
+
+        def slow_probe(url: str, timeout_seconds: float = 5.0) -> str:
+            clock.sleep(5.0)
+            return nemo_gym.cli.env._ENDPOINT_UNRESOLVABLE if "unset" in url else nemo_gym.cli.env._ENDPOINT_REFUSED
+
+        with MonkeyPatch.context() as mp:
+            mp.setattr(nemo_gym.cli.env, "_probe_endpoint", slow_probe)
+            _wait_for_model_endpoints(
+                [("a", "http://unset-1/v1"), ("b", "http://unset-2/v1"), ("c", "http://down/v1")],
+                timeout_seconds=12,
+                monotonic=clock,
+                sleep_fn=clock.sleep,
+            )
+
+        # Three probes at 5s each already exceed the 12s bound, so the wait loop must not add more.
+        assert clock() <= 12 + _ENDPOINT_POLL_INTERVAL_SEC + 5.0, f"overran the bound: {clock():.0f}s"

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -67,6 +67,7 @@ class TestGlobalConfig:
             "python_version": "test python version",
             "skip_venv_if_present": False,
             "dry_run": False,
+            "model_endpoint_readiness_timeout_seconds": 600,
             "uv_cache_dir": str(CACHE_DIR / "uv"),
             "uv_venv_dir": str(WORKING_DIR),
         }


### PR DESCRIPTION
Partially addresses #2216, and fixes the quickstart report behind it: `gym env start` prints "All 3 / 3 servers ready" against a `policy_base_url` that nothing is serving, and `gym eval run` then sits at `Collecting rollouts: 0%`.

Gym reports ready because `wait_for_spinup` in the env CLI polls only Gym's own servers. The Gym-side model server is a proxy that answers as soon as it starts, whether or not an inference server is behind it, so the endpoint the
run depends on is never checked. The existing troubleshooting note for this path blames a bad API key, which fails differently.

This collects the model endpoints from the resolved config, waits for each to answer, and stops startup if one never does.

Reading the endpoints has to handle every shape the model servers declare:
- `base_url` is `Union[str, List[str]]` on vllm_model and both local vLLM servers, where the list spreads load across replicas, so a string-only reader would do nothing at all for a multi-replica training run.
- The local servers default to an empty list and are filled in after Gym launches vLLM, so an empty list means "not yet" and is skipped, as is an unset value.
- The config key travels with each URL, because the endpoint that fails may be a judge or user model and a message naming `policy_base_url` would then be wrong.

Each probe result is sorted by whether waiting could change it. A hostname that does not resolve will not begin resolving because we waited, so it is reported once and not retried; this is what happens to a config left at a
placeholder default, which costs one lookup instead of the whole timeout. 

A refused connection may be a server still coming up, so it is waited on. 

Any HTTP answer counts as listening, including 401 and 404, and so does a completed TLS handshake against a certificate this machine does not trust.

`requests.exceptions.SSLError` subclasses `ConnectionError`, so deciding on the parent class would reject an HTTPS endpoint with an internal certificate authority even though its handshake proved something was there.

On failure, the spawned servers are shut down before anything is raised. They hold ports and have neither a process group nor an atexit handler, and every caller reaches its own `shutdown()` only after `start()` returns.

The failure is a `ConfigError` that the CLI entrypoints translate into an exit. `RunHelper` is imported and
driven directly by NeMo-RL, so the caller decides what an unreachable endpoint means.

Probing uses the synchronous `requests` library, matching `poll_for_status` in server utils, because this runs in the CLI process before any event loop exists.



## The change in flow

Before:

```mermaid
flowchart TD
    S["gym env start"] --> P["start mcqa, agent, policy_model"]
    P --> W["wait_for_spinup()"]
    W --> Q{"do Gym's own servers answer on /?"}
    Q -->|yes| OK["All 3 / 3 servers ready"]
    OK --> U["gym eval run"]
    U --> M["policy_model calls its configured endpoint"]
    M --> X["nothing listening<br>Collecting rollouts: 0% indefinitely"]
```

After:

```mermaid
flowchart TD
    S["gym env start"] --> P["start mcqa, agent, policy_model"]
    P --> W["wait_for_spinup()"]
    W --> N["collect model endpoints from the resolved config<br>string and list base_url, skipping unset and empty"]
    N --> PR{"probe each endpoint"}
    PR -->|"any HTTP answer, or a completed TLS handshake"| OK["All 3 / 3 servers ready"]
    PR -->|"name does not resolve"| REP["report once, do not wait<br>waiting cannot create a DNS record"]
    REP --> OK
    PR -->|"connection refused"| WAIT["wait, a server may still be starting"]
    WAIT -->|answers in time| OK
    WAIT -->|"still refusing at the timeout"| SD["shut down the spawned servers"]
    SD --> CE["raise ConfigError naming each URL<br>and the config key it came from"]
```