### PR TITLE
fix: bound how long a socket connect can hang

### DIFF
--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -85,6 +85,9 @@ from nemo_gym.rollout_correlation import current_rollout_id, maybe_rollout_id_fr
 
 _GLOBAL_AIOHTTP_CLIENT: Union[None, ClientSession] = None
 _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG: bool = False
+# `ClientTimeout` is per session, so the session carries the external deadline and
+# `ServerClient.request` passes this one explicitly for server-to-server calls.
+_GLOBAL_AIOHTTP_INTERNAL_SOCK_CONNECT_TIMEOUT_SECONDS: float = 10.0
 
 
 class GlobalAIOHTTPAsyncClientConfig(BaseModel):
@@ -104,6 +107,25 @@ class GlobalAIOHTTPAsyncClientConfig(BaseModel):
     global_aiohttp_tcp_keepalive_probes: int = Field(
         default=3,
         description=("TCP_KEEPCNT: number of unanswered probes before the kernel drops the connection."),
+    )
+
+    global_aiohttp_sock_connect_timeout_seconds: float = Field(
+        default=30.0,
+        description=(
+            "Deadline for opening a new socket to an external endpoint, in seconds. Bounds a host "
+            "that silently drops connection attempts rather than refusing them, which the kernel "
+            "otherwise abandons only after roughly two minutes. This is aiohttp's own default for "
+            "`sock_connect`. It covers the socket connect alone, not waiting for a pooled "
+            "connection, so a saturated pool is never failed by it."
+        ),
+    )
+    global_aiohttp_internal_sock_connect_timeout_seconds: float = Field(
+        default=10.0,
+        description=(
+            "The same deadline for calls to other NeMo Gym servers, which are near or on the same "
+            "machine. Not lower than this: under load a localhost accept queue can fill, the kernel "
+            "drops the SYN, and the retransmit does not arrive for a full second."
+        ),
     )
 
 
@@ -164,7 +186,11 @@ def set_global_aiohttp_client(cfg: GlobalAIOHTTPAsyncClientConfig) -> ClientSess
                 probes=cfg.global_aiohttp_tcp_keepalive_probes,
             ),
         ),
-        timeout=ClientTimeout(),
+        # `total` stays unset: generations legitimately run for minutes and must not be cut off.
+        # Only `sock_connect` is set, so a blackholed connect fails on our deadline rather than the
+        # kernel's SYN retry budget. Deliberately not `connect`, which also covers waiting for a
+        # free pooled connection; at Gym's concurrency that wait is normal and not a failure.
+        timeout=ClientTimeout(sock_connect=cfg.global_aiohttp_sock_connect_timeout_seconds),
         cookie_jar=DummyCookieJar(),
     )
 
@@ -173,6 +199,9 @@ def set_global_aiohttp_client(cfg: GlobalAIOHTTPAsyncClientConfig) -> ClientSess
 
     global _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG
     _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG = cfg.global_aiohttp_client_request_debug
+
+    global _GLOBAL_AIOHTTP_INTERNAL_SOCK_CONNECT_TIMEOUT_SECONDS
+    _GLOBAL_AIOHTTP_INTERNAL_SOCK_CONNECT_TIMEOUT_SECONDS = cfg.global_aiohttp_internal_sock_connect_timeout_seconds
 
     return _GLOBAL_AIOHTTP_CLIENT
 
@@ -183,6 +212,15 @@ def is_global_aiohttp_client_setup() -> bool:  # pragma: no cover
 
 def is_global_aiohttp_client_request_debug_enabled() -> bool:
     return _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG
+
+
+def internal_client_timeout() -> ClientTimeout:
+    """The per-call timeout for a request to another NeMo Gym server.
+
+    Only `sock_connect` is set. Everything else stays unset, so a `/run` that legitimately takes an
+    hour is not cut off, and a request queued behind a saturated connection pool is not failed.
+    """
+    return ClientTimeout(sock_connect=_GLOBAL_AIOHTTP_INTERNAL_SOCK_CONNECT_TIMEOUT_SECONDS)
 
 
 def global_aiohttp_client_exit():  # pragma: no cover
@@ -486,6 +524,7 @@ class ServerClient(BaseModel):
         ):
             url_path = f"{rollout_path_prefix(rollout_id)}{url_path}"
 
+        kwargs.setdefault("timeout", internal_client_timeout())
         return await request(method=method, url=f"{base_url}{url_path}", _internal=True, **kwargs)
 
     async def get(

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -25,6 +25,7 @@ from aiohttp import (
     ClientOSError,
     ClientPayloadError,
     ClientProxyConnectionError,
+    ClientTimeout,
     ServerDisconnectedError,
 )
 from aiohttp.client_exceptions import ConnectionTimeoutError, InvalidUrlClientError, SocketTimeoutError
@@ -609,3 +610,51 @@ class TestServerUtils:
 
         with raises(asyncio.CancelledError):
             await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
+
+    def test_GlobalAIOHTTPAsyncClientConfig_sock_connect_defaults(self) -> None:
+        config = GlobalAIOHTTPAsyncClientConfig()
+
+        # aiohttp's own default for sock_connect, restored rather than newly chosen.
+        assert 30.0 == config.global_aiohttp_sock_connect_timeout_seconds
+        assert 10.0 == config.global_aiohttp_internal_sock_connect_timeout_seconds
+
+    def test_internal_client_timeout_bounds_only_the_socket_connect(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_GLOBAL_AIOHTTP_INTERNAL_SOCK_CONNECT_TIMEOUT_SECONDS", 7.0)
+        timeout = nemo_gym.server_utils.internal_client_timeout()
+
+        assert 7.0 == timeout.sock_connect
+        # `total` unset keeps long generations alive; `connect` unset keeps a request queued behind a
+        # saturated pool from being failed as a connect timeout.
+        assert timeout.total is None
+        assert timeout.connect is None
+        assert timeout.sock_read is None
+
+    async def test_ServerClient_request_applies_the_internal_connect_deadline(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_GLOBAL_AIOHTTP_INTERNAL_SOCK_CONNECT_TIMEOUT_SECONDS", 9.0)
+        server_client = ServerClient(
+            head_server_config=BaseServerConfig(host="abcdef", port=12345),
+            global_config_dict=DictConfig({"my_server": {"a": {"b": {"host": "xyz", "port": 54321}}}}),
+        )
+
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(return_value="my mock response")
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        await server_client.get(server_name="my_server", url_path="/blah")
+
+        assert 9.0 == client_mock.return_value.request.await_args.kwargs["timeout"].sock_connect
+
+    async def test_ServerClient_request_does_not_override_a_caller_timeout(self, monkeypatch: MonkeyPatch) -> None:
+        server_client = ServerClient(
+            head_server_config=BaseServerConfig(host="abcdef", port=12345),
+            global_config_dict=DictConfig({"my_server": {"a": {"b": {"host": "xyz", "port": 54321}}}}),
+        )
+
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(return_value="my mock response")
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        caller_timeout = ClientTimeout(total=123.0)
+        await server_client.get(server_name="my_server", url_path="/blah", timeout=caller_timeout)
+
+        assert caller_timeout is client_mock.return_value.request.await_args.kwargs["timeout"]


### PR DESCRIPTION
Partially addresses #2216. Stacked directly on #2361. This change bounds each socket connection attempt; #2363 remains separate and is not inherited by this branch.

`set_global_aiohttp_client` passes a bare `ClientTimeout()`, which sets
`total`, `connect`, `sock_read` and `sock_connect` all to `None`. aiohttp's
default when the argument is omitted entirely is `ClientTimeout(total=5*60,
sock_connect=30)`, so passing an empty one turns off both.

Disabling `total` is deliberate and correct: a generation can legitimately run
for minutes. Disabling `sock_connect` looks like collateral damage rather than
a decision.

Without it, a host that silently drops connection attempts rather than
refusing them, such as a firewall DROP rule or a machine that went away, is
bounded only by the kernel's SYN retry budget. At the default `tcp_syn_retries
= 6` that is roughly 127 seconds per attempt, inside a retry loop that does
not stop.

This sets `sock_connect` and leaves the rest alone: 30s for external
endpoints, which is aiohttp's own default and therefore a restoration rather
than a new number, and 10s for calls to other Gym servers, which are near or
on the same machine.

Not `connect`. The aiohttp docs describe `connect` as covering acquisition of
a connection from the pool, which "consists connection establishment for a new
connection or waiting for a free connection from a pool if pool connection
limits are exceeded", while `sock_connect` covers "connecting to a peer for a
new connection, not given from a pool". The source agrees: `connect` wraps all
of `_get_connection`, `sock_connect` wraps only the socket connect. At Gym's
concurrency, waiting for a pool slot is normal and must not be counted as a
failure.

Not below 10s for internal calls either. Under load a localhost accept queue
can fill, the kernel drops the SYN, and the retransmit does not arrive for a
full second. A one-second deadline would manufacture failures under exactly
the conditions this is meant to survive.

`ClientTimeout` is set per session rather than per call, so the session
carries the external value and `ServerClient.request` passes the internal one
explicitly. A caller that supplies its own `timeout` keeps it.