### PR TITLE
fix: bound the model-call retry loop and keep the endpoint's error body

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ For guidance on how to build environments, see `fern/versions/latest/pages/envir
 
 ## Communication & Async Patterns
 
-Servers communicate via `ServerClient`, which wraps aiohttp with retry logic (3 tries, exponential backoff) and connection pooling via a singleton aiohttp client.
+Servers communicate via `ServerClient`, which wraps aiohttp with retry logic and connection pooling via a singleton aiohttp client. See `nemo_gym/server_utils.py::request` for the retry policy.
 
 - **Use aiohttp, not httpx, for async HTTP.** All async HTTP calls must go through NeMo Gym's global aiohttp client (`nemo_gym.server_utils.request()`). Do not use `httpx.AsyncClient` — httpx/httpcore has O(n^2) connection pooling that causes hangs at high concurrency (16k+ requests). When wrapping external libraries that use httpx internally, replace their HTTP transport with an aiohttp adapter. See `resources_servers/tavily_search/app.py` (`TavilySearchAIOHTTPClient`) for the adapter pattern.
 - **Propagate session cookies** through all downstream calls (`cookies=request.cookies`) for stateful environments.

--- a/fern/versions/latest/pages/about/architecture.mdx
+++ b/fern/versions/latest/pages/about/architecture.mdx
@@ -96,7 +96,7 @@ An agent can use both simultaneously — its own tools and the environment's too
 
 Servers communicate over async HTTP (aiohttp) with:
 - **Session cookies** propagated through the call stack for stateful environments
-- **Retry logic** with exponential backoff (3 attempts)
+- **Retry logic** for transient connection failures
 - **Connection pooling** via a singleton aiohttp client for high-concurrency workloads
 
 ## Next Steps

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import json
 from asyncio import sleep
+from time import monotonic
 from typing import (
     Any,
     Dict,
@@ -545,6 +546,12 @@ class NeMoGymChatCompletionCreateParamsNonStreaming(BaseModel):
 # 500 is internal server error, which may sporadically occur
 # 502 is Bad gateway (when the endpoint is overloaded)
 # 504 is Gateway timeout (when the endpoint config has too low of a gateway timeout setting for the model to finish generating)
+# Absolute bounds on one logical model call, whichever comes first. Without them a rate limit
+# raises `max_num_tries` every time it fires, so an endpoint that always answers 429 is retried
+# forever and the rollout holding this call never releases its concurrency slot.
+MODEL_RETRY_MAX_ATTEMPTS = 10
+MODEL_RETRY_DEADLINE_SECONDS = 300.0
+
 RATE_LIMIT_ERROR_CODES = [429, 502, 503, 504, 520]
 RETRY_ERROR_CODES = RATE_LIMIT_ERROR_CODES + [500]
 
@@ -578,12 +585,17 @@ class NeMoGymAsyncOpenAI(BaseModel):  # pragma: no cover
     async def _request_with_retry(self, **request_kwargs: Dict) -> ClientResponse:
         max_num_tries = MAX_NUM_TRIES
         tries = 0
+        started_at = monotonic()
+        content = ""
         while tries < max_num_tries:
             tries += 1
             response = await request(**request_kwargs)
 
             if response.status in RETRY_ERROR_CODES:
-                # If we hit a rate limit, we don't want to hit max num tries, so we increment both.
+                # A rate limit raises this call's own budget, so waiting out a long throttle does
+                # not consume the allowance for server errors. The absolute ceiling and the deadline
+                # below are what stop that from running forever against an endpoint that always
+                # answers 429.
                 if response.status in RATE_LIMIT_ERROR_CODES:
                     max_num_tries += 1
 
@@ -593,13 +605,19 @@ class NeMoGymAsyncOpenAI(BaseModel):  # pragma: no cover
                     f"[model_retry url={request_kwargs.get('url')} status={response.status} kind={kind} try={tries} max_tries={max_num_tries} error_msg={content[:200]}]",
                     flush=True,
                 )
+
+                elapsed = monotonic() - started_at
+                if tries >= MODEL_RETRY_MAX_ATTEMPTS or elapsed >= MODEL_RETRY_DEADLINE_SECONDS:
+                    break
+
                 await sleep(0.5)
                 continue
             else:
                 return response
 
-        # We've exited the loop
-        await raise_for_status(response)
+        # Out of budget. `content` holds the body already read above; re-reading it here would
+        # return empty and lose the endpoint's own explanation of what went wrong.
+        await raise_for_status(response, response_content=content)
 
     async def _raise_for_status(self, response: ClientResponse, request_kwargs: Dict[str, Any]) -> None:
         if not response.ok and _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG:

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Literal, Optional, Tuple, Union
 
 import orjson
+from aiohttp import ClientResponseError
 from omegaconf import OmegaConf
 from pydantic import BaseModel, Field, field_validator, model_validator
 from tqdm.asyncio import tqdm
@@ -114,6 +115,55 @@ NG_TRAJECTORY_KEY = "ng_trajectory"
 _MODEL_CALL_PAYLOAD_KEYS = ("request", "response", "request_raw", "response_raw")
 
 _DEFAULT_MAX_ROLLOUT_ATTEMPTS = 3
+
+# `/run` answered with an HTTP error, so this rollout never produced a result. Non-terminal: the
+# assumption is that an agent unreachable on one attempt is often reachable on the next, so resume
+# re-dispatches these up to `NEMO_GYM_MAX_ROLLOUT_ATTEMPTS`.
+AGENT_REQUEST_FAILED_FAILURE_CLASS = "agent_request_failed"
+
+
+def _agent_request_failure_result(response: Any, error: ClientResponseError) -> Dict:
+    """The row written to the failures sidecar when `/run` answers with an HTTP error.
+
+    Carries `reward` 0.0 so the row has the same shape as a scored rollout, and the upstream body
+    truncated to 2000 characters so one large error response cannot dominate the sidecar.
+    """
+    content = getattr(error, "response_content", b"") or b""
+    if isinstance(content, bytes):
+        content = content.decode(errors="replace")
+
+    return {
+        "reward": 0.0,
+        NG_FAILURE_CLASS_KEY: AGENT_REQUEST_FAILED_FAILURE_CLASS,
+        "error": f"/run returned HTTP {getattr(response, 'status', None)}: {content[:2000]}",
+    }
+
+
+def summarize_rollout_failures(results: List[Dict]) -> Dict[str, int]:
+    """Count the dispatched rollouts that produced a failure row, by class."""
+    counts: Dict[str, int] = {}
+    for result in results:
+        failure_class = result.get(NG_FAILURE_CLASS_KEY)
+        if failure_class is not None:
+            counts[failure_class] = counts.get(failure_class, 0) + 1
+
+    return counts
+
+
+def format_rollout_failure_summary(counts: Dict[str, int], num_results: int, failures_fpath: Any) -> str:
+    """The end-of-run line reporting how many rollouts produced a failure row.
+
+    Reports rather than judges. What failure rate is acceptable depends on the job, so the counts
+    and the sidecar path go to the user and the exit code is left alone. `_ng_failure_class` on each
+    sidecar row is the machine-readable form.
+    """
+    total = sum(counts.values())
+    by_class = ", ".join(f"{name}={count}" for name, count in sorted(counts.items()))
+    return (
+        f"{total} / {num_results} rollouts produced a failure row ({by_class}), written to "
+        f"{failures_fpath} rather than the rollouts jsonl. Aggregate metrics exclude them, so the "
+        f"scores above cover the {num_results - total} rollouts that produced a result."
+    )
 
 
 def _nonnegative_int(value: Any) -> Optional[int]:
@@ -895,6 +945,10 @@ Fully materialized inputs: {config.materialized_jsonl_fpath}
 Rollouts: {output_fpath}
 Aggregate metrics: {aggregate_metrics_fpath}""")
 
+        failure_counts = summarize_rollout_failures(results)
+        if failure_counts:
+            print(format_rollout_failure_summary(failure_counts, len(results), failures_fpath))
+
         return results
 
     async def _call_aggregate_metrics(
@@ -1014,7 +1068,7 @@ Aggregate metrics: {aggregate_metrics_fpath}""")
                 res = await server_client.post(server_name=row["agent_ref"]["name"], url_path="/run", json=row)
                 try:
                     await raise_for_status(res)
-                except Exception:
+                except Exception as e:
                     if is_global_aiohttp_client_request_debug_enabled():
                         print(
                             "[rollout_collection] /run failed "
@@ -1022,7 +1076,12 @@ Aggregate metrics: {aggregate_metrics_fpath}""")
                             f"row={json.dumps(_rollout_request_debug_summary(row), sort_keys=True)}",
                             flush=True,
                         )
-                    raise
+                    # Only an HTTP error from the agent becomes a failure row. Anything else
+                    # raised here is a bug in this dispatcher rather than a rollout outcome, and
+                    # must still end the run.
+                    if not isinstance(e, ClientResponseError):
+                        raise
+                    return row, _agent_request_failure_result(res, e)
                 return row, await get_response_json(res)
 
         return tqdm.as_completed(

--- a/nemo_gym/rollout_reverification.py
+++ b/nemo_gym/rollout_reverification.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import orjson
+from aiohttp import ClientResponseError
 from omegaconf import DictConfig
 from pydantic import BaseModel, Field, model_validator
 from tqdm.asyncio import tqdm
@@ -42,6 +43,7 @@ from nemo_gym.rollout_collection import (
     NG_FAILURE_CLASS_KEY,
     NG_NO_PERSIST_KEY,
     NG_TERMINAL_KEY,
+    _agent_request_failure_result,
     _get_max_rollout_attempts,
     _rollout_for_wandb,
 )
@@ -457,11 +459,8 @@ def _run_verification_payloads(
             rs_name = agent_to_rs[row[AGENT_REF_KEY_NAME]["name"]]
             res = await server_client.post(server_name=rs_name, url_path="/verify", json=row)
             try:
-                await raise_for_status(
-                    res
-                )  # this code works similarly to the rollout collection code, so *_failures.jsonl is empty now
-            # IMO we need another task to unify dealing with failed cases (and writing to the *_failures.jsonl file if needed)
-            except Exception:
+                await raise_for_status(res)
+            except Exception as e:
                 if is_global_aiohttp_client_request_debug_enabled():
                     print(
                         "[rollout_reverification] /verify failed "
@@ -469,7 +468,11 @@ def _run_verification_payloads(
                         f"row={json.dumps(_rollout_verify_debug_summary(row, rs_name), sort_keys=True)}",
                         flush=True,
                     )
-                raise
+                # Same split as rollout collection: an HTTP error from the resources server is a
+                # failure row, anything else is a bug here and must still end the run.
+                if not isinstance(e, ClientResponseError):
+                    raise
+                return row, _agent_request_failure_result(res, e)
             return row, await get_response_json(res)
 
     return tqdm.as_completed(

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import asyncio
 import atexit
+import errno as errno_module
 import json
 import resource
 import socket
@@ -21,13 +22,15 @@ import sys
 import time
 from abc import abstractmethod
 from contextlib import asynccontextmanager
+from enum import Enum
 from logging import Filter as LoggingFilter
 from logging import LogRecord, getLogger
 from os import environ, getenv
 from pathlib import Path
 from threading import Thread
 from traceback import format_exc, print_exc
-from typing import Any, List, Literal, Optional, TextIO, Tuple, Type, Union, Unpack
+from typing import Any, Dict, List, Literal, Optional, TextIO, Tuple, Type, Union, Unpack
+from urllib.parse import urlsplit
 from uuid import uuid4
 
 import orjson
@@ -35,13 +38,18 @@ import ray
 import requests
 import uvicorn
 from aiohttp import (
+    ClientConnectionResetError,
+    ClientConnectorError,
+    ClientError,
     ClientOSError,
     ClientResponse,
     ClientResponseError,
     ClientSession,
     ClientTimeout,
     DummyCookieJar,
+    InvalidURL,
     ServerDisconnectedError,
+    ServerTimeoutError,
     TCPConnector,
 )
 from aiohttp.client import _RequestOptions
@@ -193,16 +201,153 @@ atexit.register(global_aiohttp_client_exit)
 # This is not intended to be changed. If you want to increase this, we should probably figure out how to improve server-side robustness.
 MAX_NUM_TRIES = 3
 
-_NUM_SERVER_DISCONNECTED_ERROR: int = 0
-_NUM_CLIENT_OS_ERROR: int = 0
-DISCONNECTED_CLIENT_OS_PRINT_INTERVAL: int = 100
-DISCONNECTED_CLIENT_OS_HELP_TEXT = """We've run into this issue in two different scenarios previously:
-1. Too many open connections and not enough sockets due to the file descriptor limit being hit.
+
+class _RequestFailureKind(str, Enum):
+    """The categories `_classify_request_failure` sorts a failed `request()` call into.
+
+    Private to this module and specific to the `request()` path. This is not a general error
+    taxonomy for NeMo Gym.
+    """
+
+    # The connection was never established: `ClientConnectorError` and its DNS and proxy
+    # subclasses, for a refused connect, an unreachable host or network, or a failed lookup.
+    UNREACHABLE = "unreachable"
+    # A local resource ran out while connecting: EMFILE, ENFILE, ENOBUFS or ENOMEM, read from
+    # `ClientConnectorError.os_error`.
+    RESOURCE = "resource"
+    # A connection was established and then lost: `ServerDisconnectedError`,
+    # `ClientConnectionResetError`, a bare `ClientOSError`, or an unrecognised `ClientError`.
+    PEER_DROP = "peer_drop"
+    # A deadline expired: `ServerTimeoutError` and its connect and read subclasses, or
+    # `asyncio.TimeoutError`.
+    TIMEOUT = "timeout"
+    # A malformed URL (`InvalidURL`) or anything that is not a `ClientError` at all, which means a
+    # programming error rather than a network one.
+    FATAL = "fatal"
+
+
+_RESOURCE_ERRNOS = frozenset({errno_module.EMFILE, errno_module.ENFILE, errno_module.ENOBUFS, errno_module.ENOMEM})
+
+
+def _classify_request_failure(exc: BaseException) -> _RequestFailureKind:
+    """Sort an exception from `client.request()` into a `_RequestFailureKind`.
+
+    Every exception maps to a kind; there is no "unknown". Two fallbacks make that true. An
+    `aiohttp.ClientError` this function does not recognise is treated as `PEER_DROP`, so a new
+    exception type in a future aiohttp is retried and reported rather than raised immediately.
+    Anything that is not a `ClientError` at all is `FATAL`, on the grounds that it is a programming
+    error rather than a network one.
+
+    Order matters and breaking it is silent. `ClientConnectorError` subclasses `ClientOSError`, so
+    testing the parent first would swallow every refused connection into `PEER_DROP`, which is the
+    bug this classification exists to fix. `InvalidURL` is both a `ClientError` and a `ValueError`,
+    so it has to be tested before either.
+    """
+    if isinstance(exc, InvalidURL):
+        return _RequestFailureKind.FATAL
+    if isinstance(exc, ClientConnectorError):
+        # Includes the DNS and proxy subclasses. Read `.os_error` rather than `.errno`: a bare
+        # `ClientOSError` has neither, and this runs inside an `except` block where an
+        # `AttributeError` would turn a retryable failure into a crash.
+        os_error = getattr(exc, "os_error", None)
+        if os_error is not None and getattr(os_error, "errno", None) in _RESOURCE_ERRNOS:
+            return _RequestFailureKind.RESOURCE
+        return _RequestFailureKind.UNREACHABLE
+    if isinstance(exc, (ServerTimeoutError, asyncio.TimeoutError)):
+        return _RequestFailureKind.TIMEOUT
+    if isinstance(exc, (ServerDisconnectedError, ClientConnectionResetError, ClientOSError)):
+        return _RequestFailureKind.PEER_DROP
+    if isinstance(exc, ClientError):
+        # An aiohttp error we do not recognise. Retried rather than failed fast, so a new
+        # exception type in a future aiohttp is reported after retries instead of raised at once.
+        return _RequestFailureKind.PEER_DROP
+    return _RequestFailureKind.FATAL
+
+
+_UNREACHABLE_HELP_TEXT = """Nothing accepted a connection at that address, so this is a configuration or startup problem rather than load.
+1. Check the URL. For the policy model that is `policy_base_url` in `env.yaml`.
+    - Verify with: curl <base_url>/models
+    - A `localhost` URL means you serve the model yourself (e.g. vLLM) before collecting rollouts.
+2. If the endpoint is still starting up, this resolves on its own once it is serving."""
+
+_RESOURCE_HELP_TEXT = """Too many open connections and not enough sockets due to the file descriptor limit being hit.
     - Increase ulimit.
     - Bash example: https://github.com/NVIDIA-NeMo/RL/blob/de55be7777bbf034c04e41c40382c44725e8aa4b/ray.sub#L81
-    - Python example: https://github.com/NVIDIA-NeMo/Gym/blob/c74ffddb3d8190cd717508b0830916b19a26e6cd/nemo_gym/server_utils.py#L495
-2. Depending on the serving framework and config, the server may be overloaded and is dropping connections.
-    - Increase adapter server replicas."""
+    - Python example: https://github.com/NVIDIA-NeMo/Gym/blob/c74ffddb3d8190cd717508b0830916b19a26e6cd/nemo_gym/server_utils.py#L495"""
+
+_PEER_DROP_HELP_TEXT = """Depending on the serving framework and config, the server may be overloaded and is dropping connections.
+    - Increase adapter server replicas.
+    - If this is a file descriptor problem rather than load, it surfaces separately as `resource`."""
+
+_TIMEOUT_HELP_TEXT = """The endpoint accepted the connection but did not answer inside the deadline.
+    - Check whether the endpoint is saturated, or raise the timeout for this call."""
+
+_FAILURE_KIND_HELP_TEXT = {
+    _RequestFailureKind.UNREACHABLE: _UNREACHABLE_HELP_TEXT,
+    _RequestFailureKind.RESOURCE: _RESOURCE_HELP_TEXT,
+    _RequestFailureKind.PEER_DROP: _PEER_DROP_HELP_TEXT,
+    _RequestFailureKind.TIMEOUT: _TIMEOUT_HELP_TEXT,
+    _RequestFailureKind.FATAL: "",
+}
+
+# Reporting on the first failure is right for one request and wrong for sixteen thousand, so the
+# full diagnostic goes out once per endpoint and kind and is then summarised on this interval.
+# Keyed by (origin, kind) -> (when it was last reported, failures suppressed since). Grows with the
+# number of distinct endpoints a process talks to, not with the number of requests.
+_FAILURE_REPORT_INTERVAL_SECONDS: float = 30.0
+_FAILURE_REPORT_STATE: Dict[Tuple[str, _RequestFailureKind], Tuple[float, int]] = {}
+
+
+def _request_origin(url: str) -> str:
+    """`scheme://host:port` for `url`. Failures are grouped and reported per origin."""
+    split = urlsplit(url)
+    return f"{split.scheme}://{split.netloc}" if split.netloc else url
+
+
+def _next_failure_report(origin: str, kind: _RequestFailureKind, now: float) -> Optional[int]:
+    """Whether to report this failure, and what to say.
+
+    Returns 0 the first time an (origin, kind) pair is seen, meaning print the full diagnostic; a
+    positive count once the interval has passed, meaning report that many suppressed failures; and
+    `None` in between, meaning print nothing.
+    """
+    state = _FAILURE_REPORT_STATE.get((origin, kind))
+    if state is None:
+        _FAILURE_REPORT_STATE[(origin, kind)] = (now, 0)
+        return 0
+
+    last_reported, suppressed = state
+    suppressed += 1
+    if now - last_reported < _FAILURE_REPORT_INTERVAL_SECONDS:
+        _FAILURE_REPORT_STATE[(origin, kind)] = (last_reported, suppressed)
+        return None
+
+    _FAILURE_REPORT_STATE[(origin, kind)] = (now, 0)
+    return suppressed
+
+
+def _report_request_failure(url: str, exc: BaseException, kind: _RequestFailureKind, now: float) -> None:
+    """Print the diagnostic for a failed request, at most once per endpoint and kind per interval."""
+    origin = _request_origin(url)
+    suppressed = _next_failure_report(origin, kind, now)
+    if suppressed is None:
+        return
+
+    if suppressed:
+        print(
+            f"[request_retry url={origin} kind={kind.value}] "
+            f"{suppressed} more `{type(exc).__name__}` failures in the last "
+            f"{_FAILURE_REPORT_INTERVAL_SECONDS:.0f}s. Still retrying.",
+            flush=True,
+        )
+        return
+
+    help_text = _FAILURE_KIND_HELP_TEXT[kind]
+    print(
+        f"[request_retry url={url} kind={kind.value} error={type(exc).__name__}] {exc}"
+        + (f"\n{help_text}" if help_text else ""),
+        flush=True,
+    )
 
 
 async def request(
@@ -216,33 +361,14 @@ async def request(
 
     client = get_global_aiohttp_client()
     num_tries = 1
-    retries = 0
-    retry_start = time.monotonic()
     while True:
         try:
             return await client.request(method=method, url=url, **kwargs)
-        except ServerDisconnectedError:
-            global _NUM_SERVER_DISCONNECTED_ERROR
-            _NUM_SERVER_DISCONNECTED_ERROR += 1
-            retries += 1
-            if _NUM_SERVER_DISCONNECTED_ERROR % DISCONNECTED_CLIENT_OS_PRINT_INTERVAL == 0:
-                print(
-                    f"[request_retry url={url} error=ServerDisconnectedError retry={retries} elapsed_s={time.monotonic() - retry_start:.1f}] "
-                    f"Hit {_NUM_SERVER_DISCONNECTED_ERROR} global `ServerDisconnectedError` while querying {url}.\n{DISCONNECTED_CLIENT_OS_HELP_TEXT}",
-                    flush=True,
-                )
-
-            await asyncio.sleep(0.5)
-        except ClientOSError:
-            global _NUM_CLIENT_OS_ERROR
-            _NUM_CLIENT_OS_ERROR += 1
-            retries += 1
-            if _NUM_CLIENT_OS_ERROR % DISCONNECTED_CLIENT_OS_PRINT_INTERVAL == 0:
-                print(
-                    f"[request_retry url={url} error=ClientOSError retry={retries} elapsed_s={time.monotonic() - retry_start:.1f}] "
-                    f"Hit {_NUM_CLIENT_OS_ERROR} global `ClientOSError` while querying {url}.\n{DISCONNECTED_CLIENT_OS_HELP_TEXT}",
-                    flush=True,
-                )
+        except (ServerDisconnectedError, ClientOSError) as e:
+            # Both were already retried without a limit, and still are; the kind only selects the
+            # diagnostic. `ClientConnectorError` arrives here as a `ClientOSError` subclass, which
+            # is why a refused connection used to be reported as an overloaded server.
+            _report_request_failure(url, e, _classify_request_failure(e), time.monotonic())
 
             await asyncio.sleep(0.5)
         except Exception as e:
@@ -251,10 +377,13 @@ async def request(
 
             # Don't increment internal since we know we are ok. If we are not, the head server will shut everything down anyways.
             if not _internal:
+                kind = _classify_request_failure(e)
+                help_text = _FAILURE_KIND_HELP_TEXT[kind]
                 print(
-                    f"""Hit an exception while making a request (try {num_tries}): {type(e)}: {e}
+                    f"""Hit an exception while making a request (try {num_tries}, kind {kind.value}): {type(e)}: {e}
 Sleeping 0.5s and retrying...
 """
+                    + (f"{help_text}\n" if help_text else "")
                 )
                 if num_tries >= MAX_NUM_TRIES:
                     raise e

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -85,6 +85,9 @@ from nemo_gym.rollout_correlation import current_rollout_id, maybe_rollout_id_fr
 
 _GLOBAL_AIOHTTP_CLIENT: Union[None, ClientSession] = None
 _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG: bool = False
+# `ClientTimeout` is per session, so the session carries the external deadline and
+# `ServerClient.request` passes this one explicitly for server-to-server calls.
+_GLOBAL_AIOHTTP_INTERNAL_SOCK_CONNECT_TIMEOUT_SECONDS: float = 10.0
 
 
 class GlobalAIOHTTPAsyncClientConfig(BaseModel):
@@ -104,6 +107,25 @@ class GlobalAIOHTTPAsyncClientConfig(BaseModel):
     global_aiohttp_tcp_keepalive_probes: int = Field(
         default=3,
         description=("TCP_KEEPCNT: number of unanswered probes before the kernel drops the connection."),
+    )
+
+    global_aiohttp_sock_connect_timeout_seconds: float = Field(
+        default=30.0,
+        description=(
+            "Deadline for opening a new socket to an external endpoint, in seconds. Bounds a host "
+            "that silently drops connection attempts rather than refusing them, which the kernel "
+            "otherwise abandons only after roughly two minutes. This is aiohttp's own default for "
+            "`sock_connect`. It covers the socket connect alone, not waiting for a pooled "
+            "connection, so a saturated pool is never failed by it."
+        ),
+    )
+    global_aiohttp_internal_sock_connect_timeout_seconds: float = Field(
+        default=10.0,
+        description=(
+            "The same deadline for calls to other NeMo Gym servers, which are near or on the same "
+            "machine. Not lower than this: under load a localhost accept queue can fill, the kernel "
+            "drops the SYN, and the retransmit does not arrive for a full second."
+        ),
     )
 
 
@@ -164,7 +186,11 @@ def set_global_aiohttp_client(cfg: GlobalAIOHTTPAsyncClientConfig) -> ClientSess
                 probes=cfg.global_aiohttp_tcp_keepalive_probes,
             ),
         ),
-        timeout=ClientTimeout(),
+        # `total` stays unset: generations legitimately run for minutes and must not be cut off.
+        # Only `sock_connect` is set, so a blackholed connect fails on our deadline rather than the
+        # kernel's SYN retry budget. Deliberately not `connect`, which also covers waiting for a
+        # free pooled connection; at Gym's concurrency that wait is normal and not a failure.
+        timeout=ClientTimeout(sock_connect=cfg.global_aiohttp_sock_connect_timeout_seconds),
         cookie_jar=DummyCookieJar(),
     )
 
@@ -173,6 +199,9 @@ def set_global_aiohttp_client(cfg: GlobalAIOHTTPAsyncClientConfig) -> ClientSess
 
     global _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG
     _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG = cfg.global_aiohttp_client_request_debug
+
+    global _GLOBAL_AIOHTTP_INTERNAL_SOCK_CONNECT_TIMEOUT_SECONDS
+    _GLOBAL_AIOHTTP_INTERNAL_SOCK_CONNECT_TIMEOUT_SECONDS = cfg.global_aiohttp_internal_sock_connect_timeout_seconds
 
     return _GLOBAL_AIOHTTP_CLIENT
 
@@ -183,6 +212,15 @@ def is_global_aiohttp_client_setup() -> bool:  # pragma: no cover
 
 def is_global_aiohttp_client_request_debug_enabled() -> bool:
     return _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG
+
+
+def internal_client_timeout() -> ClientTimeout:
+    """The per-call timeout for a request to another NeMo Gym server.
+
+    Only `sock_connect` is set. Everything else stays unset, so a `/run` that legitimately takes an
+    hour is not cut off, and a request queued behind a saturated connection pool is not failed.
+    """
+    return ClientTimeout(sock_connect=_GLOBAL_AIOHTTP_INTERNAL_SOCK_CONNECT_TIMEOUT_SECONDS)
 
 
 def global_aiohttp_client_exit():  # pragma: no cover
@@ -486,6 +524,7 @@ class ServerClient(BaseModel):
         ):
             url_path = f"{rollout_path_prefix(rollout_id)}{url_path}"
 
+        kwargs.setdefault("timeout", internal_client_timeout())
         return await request(method=method, url=f"{base_url}{url_path}", _internal=True, **kwargs)
 
     async def get(

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -431,9 +431,17 @@ Sleeping 0.5s and retrying...
             await asyncio.sleep(0.5)
 
 
-async def raise_for_status(response: ClientResponse) -> None:  # pragma: no cover
+async def raise_for_status(
+    response: ClientResponse, response_content: Optional[Union[str, bytes]] = None
+) -> None:  # pragma: no cover
+    """Raise `ClientResponseError` for an error status, carrying the body on `.response_content`.
+
+    Pass `response_content` when the caller already read the body. `response.content` is a stream
+    that yields nothing on a second read, so re-reading it here would attach an empty body and lose
+    the server's explanation.
+    """
     if not response.ok:
-        content = await response.content.read()
+        content = await response.content.read() if response_content is None else response_content
         if _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG:
             print(f"""Request info: {response.request_info}
 Response content: {content}""")

--- a/tests/unit_tests/test_model_retry_ceiling.py
+++ b/tests/unit_tests/test_model_retry_ceiling.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List
+from unittest.mock import AsyncMock, MagicMock
+
+from pytest import MonkeyPatch, raises
+
+import nemo_gym.openai_utils
+from nemo_gym.openai_utils import MODEL_RETRY_MAX_ATTEMPTS, NeMoGymAsyncOpenAI
+
+
+def _response(status: int, body: bytes = b"") -> MagicMock:
+    response = MagicMock()
+    response.status = status
+    response.ok = 200 <= status < 400
+    response.content.read = AsyncMock(return_value=body)
+    return response
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def _patch_loop(monkeypatch: MonkeyPatch, responses: List[MagicMock], clock: _Clock) -> AsyncMock:
+    request_mock = AsyncMock(side_effect=responses)
+    monkeypatch.setattr(nemo_gym.openai_utils, "request", request_mock)
+    monkeypatch.setattr(nemo_gym.openai_utils, "sleep", AsyncMock())
+    monkeypatch.setattr(nemo_gym.openai_utils, "monotonic", clock)
+    return request_mock
+
+
+class TestModelRetryCeiling:
+    async def test_persistent_rate_limit_stops_at_the_attempt_ceiling(self, monkeypatch: MonkeyPatch) -> None:
+        """429 raises the loop's own budget every time, so only the ceiling ends this."""
+        clock = _Clock()
+        request_mock = _patch_loop(monkeypatch, [_response(429, b"slow down") for _ in range(50)], clock)
+        raise_mock = AsyncMock()
+        monkeypatch.setattr(nemo_gym.openai_utils, "raise_for_status", raise_mock)
+
+        client = NeMoGymAsyncOpenAI(base_url="http://endpoint/v1", api_key="k")
+        await client._request_with_retry(method="POST", url="http://endpoint/v1/chat/completions")
+
+        assert MODEL_RETRY_MAX_ATTEMPTS == request_mock.await_count
+        raise_mock.assert_awaited_once()
+
+    async def test_persistent_rate_limit_stops_on_the_deadline(self, monkeypatch: MonkeyPatch) -> None:
+        clock = _Clock()
+        request_mock = _patch_loop(monkeypatch, [_response(429, b"slow down") for _ in range(50)], clock)
+        monkeypatch.setattr(nemo_gym.openai_utils, "raise_for_status", AsyncMock())
+
+        async def advancing_sleep(_seconds: float) -> None:
+            clock.now += 200.0
+
+        monkeypatch.setattr(nemo_gym.openai_utils, "sleep", advancing_sleep)
+
+        client = NeMoGymAsyncOpenAI(base_url="http://endpoint/v1", api_key="k")
+        await client._request_with_retry(method="POST", url="http://endpoint/v1/chat/completions")
+
+        # The deadline fires well before the attempt ceiling would.
+        assert request_mock.await_count < MODEL_RETRY_MAX_ATTEMPTS
+
+    async def test_transient_rate_limit_then_success_does_not_spend_the_budget(self, monkeypatch: MonkeyPatch) -> None:
+        clock = _Clock()
+        request_mock = _patch_loop(
+            monkeypatch, [_response(429, b"slow"), _response(429, b"slow"), _response(200)], clock
+        )
+
+        client = NeMoGymAsyncOpenAI(base_url="http://endpoint/v1", api_key="k")
+        response = await client._request_with_retry(method="POST", url="http://endpoint/v1/chat/completions")
+
+        assert 200 == response.status
+        assert 3 == request_mock.await_count
+
+    async def test_non_retryable_status_returns_immediately(self, monkeypatch: MonkeyPatch) -> None:
+        clock = _Clock()
+        request_mock = _patch_loop(monkeypatch, [_response(400, b"bad request")], clock)
+
+        client = NeMoGymAsyncOpenAI(base_url="http://endpoint/v1", api_key="k")
+        response = await client._request_with_retry(method="POST", url="http://endpoint/v1/chat/completions")
+
+        assert 400 == response.status
+        assert 1 == request_mock.await_count
+
+    async def test_the_final_error_carries_the_endpoint_body(self, monkeypatch: MonkeyPatch) -> None:
+        """`response.content` yields nothing on a second read, so the body has to be passed through."""
+        clock = _Clock()
+        _patch_loop(monkeypatch, [_response(500, b"upstream detail") for _ in range(50)], clock)
+
+        captured = {}
+
+        async def raise_for_status(response, response_content=None):
+            captured["content"] = response_content
+            raise RuntimeError("gave up")
+
+        monkeypatch.setattr(nemo_gym.openai_utils, "raise_for_status", raise_for_status)
+
+        client = NeMoGymAsyncOpenAI(base_url="http://endpoint/v1", api_key="k")
+        with raises(RuntimeError):
+            await client._request_with_retry(method="POST", url="http://endpoint/v1/chat/completions")
+
+        assert "upstream detail" == captured["content"]

--- a/tests/unit_tests/test_rollout_failure_routing.py
+++ b/tests/unit_tests/test_rollout_failure_routing.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import MagicMock
+
+from aiohttp import ClientResponseError
+
+from nemo_gym.rollout_collection import (
+    AGENT_REQUEST_FAILED_FAILURE_CLASS,
+    NG_FAILURE_CLASS_KEY,
+    NG_TERMINAL_KEY,
+    _agent_request_failure_result,
+    format_rollout_failure_summary,
+    summarize_rollout_failures,
+)
+
+
+def _client_response_error(content: bytes = b"upstream exploded") -> ClientResponseError:
+    error = ClientResponseError(MagicMock(), (), status=500, message="Internal Server Error")
+    error.response_content = content
+    return error
+
+
+class TestAgentRequestFailureResult:
+    def test_carries_the_routing_key_and_a_zero_reward(self) -> None:
+        result = _agent_request_failure_result(MagicMock(status=500), _client_response_error())
+
+        assert AGENT_REQUEST_FAILED_FAILURE_CLASS == result[NG_FAILURE_CLASS_KEY]
+        assert 0.0 == result["reward"]
+        assert "500" in result["error"]
+        assert "upstream exploded" in result["error"]
+
+    def test_is_not_terminal_so_resume_re_dispatches_it(self) -> None:
+        """An agent unreachable for one attempt is usually reachable for the next."""
+        result = _agent_request_failure_result(MagicMock(status=500), _client_response_error())
+
+        assert NG_TERMINAL_KEY not in result
+
+    def test_truncates_a_large_upstream_body(self) -> None:
+        result = _agent_request_failure_result(MagicMock(status=500), _client_response_error(b"x" * 10_000))
+
+        assert len(result["error"]) < 2_200
+
+    def test_tolerates_a_missing_or_undecodable_body(self) -> None:
+        error = ClientResponseError(MagicMock(), (), status=502, message="Bad Gateway")
+        assert "502" in _agent_request_failure_result(MagicMock(status=502), error)["error"]
+
+        assert (
+            "502" in _agent_request_failure_result(MagicMock(status=502), _client_response_error(b"\xff\xfe"))["error"]
+        )
+
+
+class TestFailureSummary:
+    def test_counts_by_class_and_ignores_successes(self) -> None:
+        results = [
+            {"reward": 1.0},
+            {"reward": 0.0, NG_FAILURE_CLASS_KEY: AGENT_REQUEST_FAILED_FAILURE_CLASS},
+            {"reward": 0.0, NG_FAILURE_CLASS_KEY: AGENT_REQUEST_FAILED_FAILURE_CLASS},
+            {"reward": 0.0, NG_FAILURE_CLASS_KEY: "judge_failed"},
+        ]
+
+        assert {AGENT_REQUEST_FAILED_FAILURE_CLASS: 2, "judge_failed": 1} == summarize_rollout_failures(results)
+
+    def test_no_failures_summarises_to_nothing(self) -> None:
+        assert {} == summarize_rollout_failures([{"reward": 1.0}, {"reward": 0.0}])
+
+    def test_summary_names_the_counts_the_surviving_total_and_the_sidecar(self) -> None:
+        summary = format_rollout_failure_summary(
+            {AGENT_REQUEST_FAILED_FAILURE_CLASS: 3}, num_results=10, failures_fpath="out_failures.jsonl"
+        )
+
+        assert "3 / 10" in summary
+        assert AGENT_REQUEST_FAILED_FAILURE_CLASS in summary
+        assert "out_failures.jsonl" in summary
+        # The scores that get reported cover only the 7 that produced a result.
+        assert "cover the 7" in summary
+
+    def test_summary_counts_every_class_without_judging_any(self) -> None:
+        """Reporting is not policy: no failure class is singled out or gated on here."""
+        counts = summarize_rollout_failures(
+            [
+                {NG_FAILURE_CLASS_KEY: AGENT_REQUEST_FAILED_FAILURE_CLASS},
+                {NG_FAILURE_CLASS_KEY: "judge_failed"},
+                {NG_FAILURE_CLASS_KEY: "verify_failed"},
+            ]
+        )
+        summary = format_rollout_failure_summary(counts, num_results=3, failures_fpath="out_failures.jsonl")
+
+        for failure_class in (AGENT_REQUEST_FAILED_FAILURE_CLASS, "judge_failed", "verify_failed"):
+            assert failure_class in summary

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -12,10 +12,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
+import errno
 import socket
 from unittest.mock import AsyncMock, MagicMock
 
-from pytest import MonkeyPatch, raises
+from aiohttp import (
+    ClientConnectionResetError,
+    ClientConnectorDNSError,
+    ClientConnectorError,
+    ClientError,
+    ClientOSError,
+    ClientPayloadError,
+    ClientProxyConnectionError,
+    ServerDisconnectedError,
+)
+from aiohttp.client_exceptions import ConnectionTimeoutError, InvalidUrlClientError, SocketTimeoutError
+from aiohttp.client_reqrep import ConnectionKey
+from pytest import CaptureFixture, MonkeyPatch, raises
 
 import nemo_gym.global_config
 import nemo_gym.server_utils
@@ -31,9 +45,26 @@ from nemo_gym.server_utils import (
     HeadServer,
     ServerClient,
     SimpleServer,
+    _classify_request_failure,
     _make_keepalive_socket_factory,
+    _next_failure_report,
+    _report_request_failure,
+    _request_origin,
+    _RequestFailureKind,
     initialize_ray,
 )
+
+
+def _connection_key() -> ConnectionKey:
+    return ConnectionKey(
+        host="localhost",
+        port=8000,
+        is_ssl=False,
+        ssl=True,
+        proxy=None,
+        proxy_auth=None,
+        proxy_headers_hash=None,
+    )
 
 
 _TCP_KEEPALIVE_TEST_IDLE = 42
@@ -375,3 +406,206 @@ class TestServerUtils:
             response = client.get("/session")
             assert response.json()["session_id"]
             assert 1 == len(response.headers.get_list("set-cookie"))
+
+    def test_classify_request_failure_never_connected(self) -> None:
+        key = _connection_key()
+
+        assert _RequestFailureKind.UNREACHABLE == _classify_request_failure(
+            ClientConnectorError(key, OSError(errno.ECONNREFUSED, "refused"))
+        )
+        assert _RequestFailureKind.UNREACHABLE == _classify_request_failure(
+            ClientConnectorDNSError(key, OSError("name resolution failed"))
+        )
+        # A ClientConnectorError subclass, and easy to miss.
+        assert _RequestFailureKind.UNREACHABLE == _classify_request_failure(
+            ClientProxyConnectionError(key, OSError(errno.ECONNREFUSED, "refused"))
+        )
+
+    def test_classify_request_failure_resource_exhaustion(self) -> None:
+        key = _connection_key()
+
+        for err in (errno.EMFILE, errno.ENFILE, errno.ENOBUFS, errno.ENOMEM):
+            assert _RequestFailureKind.RESOURCE == _classify_request_failure(
+                ClientConnectorError(key, OSError(err, "out of descriptors"))
+            )
+
+    def test_classify_request_failure_peer_drop(self) -> None:
+        assert _RequestFailureKind.PEER_DROP == _classify_request_failure(ServerDisconnectedError())
+        assert _RequestFailureKind.PEER_DROP == _classify_request_failure(ClientConnectionResetError("reset"))
+        assert _RequestFailureKind.PEER_DROP == _classify_request_failure(ClientOSError(errno.ECONNRESET, "reset"))
+        # An aiohttp error we do not recognise is retried rather than failed fast.
+        assert _RequestFailureKind.PEER_DROP == _classify_request_failure(ClientPayloadError("truncated"))
+
+    def test_classify_request_failure_timeout_and_fatal(self) -> None:
+        assert _RequestFailureKind.TIMEOUT == _classify_request_failure(ConnectionTimeoutError())
+        assert _RequestFailureKind.TIMEOUT == _classify_request_failure(SocketTimeoutError())
+        assert _RequestFailureKind.TIMEOUT == _classify_request_failure(asyncio.TimeoutError())
+
+        assert _RequestFailureKind.FATAL == _classify_request_failure(InvalidUrlClientError("http://[bad"))
+        assert _RequestFailureKind.FATAL == _classify_request_failure(TypeError("programming error"))
+        assert _RequestFailureKind.FATAL == _classify_request_failure(ValueError("programming error"))
+
+    def test_classify_request_failure_subclass_ordering(self) -> None:
+        """Both orderings fail silently if broken, and breaking the first reinstates the bug."""
+        # ClientConnectorError subclasses ClientOSError; testing the parent first would sort every
+        # refused connection into PEER_DROP.
+        refused = ClientConnectorError(_connection_key(), OSError(errno.ECONNREFUSED, "refused"))
+        assert isinstance(refused, ClientOSError)
+        assert _RequestFailureKind.UNREACHABLE == _classify_request_failure(refused)
+
+        # InvalidURL is both a ClientError and a ValueError.
+        bad_url = InvalidUrlClientError("http://[bad")
+        assert isinstance(bad_url, ClientError) and isinstance(bad_url, ValueError)
+        assert _RequestFailureKind.FATAL == _classify_request_failure(bad_url)
+
+    def test_classify_request_failure_tolerates_missing_os_error(self) -> None:
+        """`classify` runs inside an `except` block, so raising here would crash a retryable call."""
+        # A bare ClientOSError carries no `os_error` attribute at all.
+        assert not hasattr(ClientOSError(), "os_error")
+        assert _RequestFailureKind.PEER_DROP == _classify_request_failure(ClientOSError())
+
+        # An OSError carrying no errno at all still classifies rather than raising.
+        assert _RequestFailureKind.UNREACHABLE == _classify_request_failure(
+            ClientConnectorError(_connection_key(), OSError("no errno"))
+        )
+
+    def test_request_origin(self) -> None:
+        assert "http://localhost:8000" == _request_origin("http://localhost:8000/v1/responses")
+        assert "https://api.openai.com" == _request_origin("https://api.openai.com/v1/responses")
+        assert "/v1/responses" == _request_origin("/v1/responses")
+
+    def test_next_failure_report_throttles_per_origin_and_kind(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+        interval = nemo_gym.server_utils._FAILURE_REPORT_INTERVAL_SECONDS
+
+        # First sighting prints in full.
+        assert 0 == _next_failure_report("http://a:8000", _RequestFailureKind.UNREACHABLE, 0.0)
+        # Inside the interval, quiet, but counting.
+        assert _next_failure_report("http://a:8000", _RequestFailureKind.UNREACHABLE, 1.0) is None
+        assert _next_failure_report("http://a:8000", _RequestFailureKind.UNREACHABLE, 2.0) is None
+        # Once it passes, one line carrying the suppressed count.
+        assert 3 == _next_failure_report("http://a:8000", _RequestFailureKind.UNREACHABLE, interval)
+        # The count restarts after a report.
+        assert _next_failure_report("http://a:8000", _RequestFailureKind.UNREACHABLE, interval + 1) is None
+
+        # A different kind at the same origin, and a different origin, are tracked separately.
+        assert 0 == _next_failure_report("http://a:8000", _RequestFailureKind.PEER_DROP, 1.0)
+        assert 0 == _next_failure_report("http://b:8000", _RequestFailureKind.UNREACHABLE, 1.0)
+
+    def test_report_request_failure_message_matches_the_kind(
+        self, monkeypatch: MonkeyPatch, capsys: CaptureFixture
+    ) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+        key = _connection_key()
+
+        _report_request_failure(
+            "http://localhost:8000/v1/responses",
+            ClientConnectorError(key, OSError(errno.ECONNREFUSED, "refused")),
+            _RequestFailureKind.UNREACHABLE,
+            0.0,
+        )
+        unreachable = capsys.readouterr().out
+        assert "http://localhost:8000/v1/responses" in unreachable
+        assert "policy_base_url" in unreachable
+        # The ulimit and replica advice cannot apply when no socket was opened.
+        assert "Increase ulimit" not in unreachable
+        assert "adapter server replicas" not in unreachable
+
+        _report_request_failure(
+            "http://localhost:8000/v1/responses",
+            ClientConnectorError(key, OSError(errno.EMFILE, "too many open files")),
+            _RequestFailureKind.RESOURCE,
+            0.0,
+        )
+        assert "Increase ulimit" in capsys.readouterr().out
+
+        _report_request_failure(
+            "http://localhost:8000/v1/responses", ServerDisconnectedError(), _RequestFailureKind.PEER_DROP, 0.0
+        )
+        assert "adapter server replicas" in capsys.readouterr().out
+
+    def test_report_request_failure_bounds_output_volume(
+        self, monkeypatch: MonkeyPatch, capsys: CaptureFixture
+    ) -> None:
+        """500 in-flight requests against one dead endpoint must not print 500 diagnostics."""
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+        refused = ClientConnectorError(_connection_key(), OSError(errno.ECONNREFUSED, "refused"))
+
+        for _ in range(500):
+            _report_request_failure(
+                "http://localhost:8000/v1/responses", refused, _RequestFailureKind.UNREACHABLE, 0.0
+            )
+
+        assert 1 == capsys.readouterr().out.count("[request_retry")
+
+    async def test_request_still_retries_unreachable_endpoints_forever(self, monkeypatch: MonkeyPatch) -> None:
+        """M1 changes reporting only. A refused connect must still retry without limit."""
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+        refused = ClientConnectorError(_connection_key(), OSError(errno.ECONNREFUSED, "refused"))
+
+        num_calls = 0
+
+        async def request_mock(**_kwargs) -> str:
+            nonlocal num_calls
+            num_calls += 1
+            if num_calls < 200:
+                raise refused
+            return "my mock response"
+
+        monkeypatch.setattr(nemo_gym.server_utils.asyncio, "sleep", AsyncMock())
+        client_mock = MagicMock()
+        client_mock.return_value.request = request_mock
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        assert "my mock response" == await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
+        assert 200 == num_calls
+
+    async def test_request_still_retries_dropped_connections_forever(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+
+        num_calls = 0
+
+        async def request_mock(**_kwargs) -> str:
+            nonlocal num_calls
+            num_calls += 1
+            if num_calls < 200:
+                raise ServerDisconnectedError()
+            return "my mock response"
+
+        monkeypatch.setattr(nemo_gym.server_utils.asyncio, "sleep", AsyncMock())
+        client_mock = MagicMock()
+        client_mock.return_value.request = request_mock
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        assert "my mock response" == await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
+        assert 200 == num_calls
+
+    async def test_request_still_raises_unknown_errors_after_max_num_tries(self, monkeypatch: MonkeyPatch) -> None:
+        """The generic branch keeps its 3-tries-then-raise behaviour for external calls."""
+        monkeypatch.setattr(nemo_gym.server_utils.asyncio, "sleep", AsyncMock())
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(side_effect=TypeError("programming error"))
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        with raises(TypeError):
+            await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
+
+        assert nemo_gym.server_utils.MAX_NUM_TRIES == client_mock.return_value.request.await_count
+
+    async def test_request_success_path_is_untouched(self, monkeypatch: MonkeyPatch, capsys: CaptureFixture) -> None:
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(return_value="my mock response")
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        assert "my mock response" == await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
+        assert 1 == client_mock.return_value.request.await_count
+        assert "" == capsys.readouterr().out
+
+    async def test_request_propagates_cancellation(self, monkeypatch: MonkeyPatch) -> None:
+        """CancelledError is a BaseException, so `except Exception` must never swallow it."""
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(side_effect=asyncio.CancelledError())
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        with raises(asyncio.CancelledError):
+            await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -25,6 +25,7 @@ from aiohttp import (
     ClientOSError,
     ClientPayloadError,
     ClientProxyConnectionError,
+    ClientTimeout,
     ServerDisconnectedError,
 )
 from aiohttp.client_exceptions import ConnectionTimeoutError, InvalidUrlClientError, SocketTimeoutError
@@ -609,3 +610,51 @@ class TestServerUtils:
 
         with raises(asyncio.CancelledError):
             await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
+
+    def test_GlobalAIOHTTPAsyncClientConfig_sock_connect_defaults(self) -> None:
+        config = GlobalAIOHTTPAsyncClientConfig()
+
+        # aiohttp's own default for sock_connect, restored rather than newly chosen.
+        assert 30.0 == config.global_aiohttp_sock_connect_timeout_seconds
+        assert 10.0 == config.global_aiohttp_internal_sock_connect_timeout_seconds
+
+    def test_internal_client_timeout_bounds_only_the_socket_connect(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_GLOBAL_AIOHTTP_INTERNAL_SOCK_CONNECT_TIMEOUT_SECONDS", 7.0)
+        timeout = nemo_gym.server_utils.internal_client_timeout()
+
+        assert 7.0 == timeout.sock_connect
+        # `total` unset keeps long generations alive; `connect` unset keeps a request queued behind a
+        # saturated pool from being failed as a connect timeout.
+        assert timeout.total is None
+        assert timeout.connect is None
+        assert timeout.sock_read is None
+
+    async def test_ServerClient_request_applies_the_internal_connect_deadline(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_GLOBAL_AIOHTTP_INTERNAL_SOCK_CONNECT_TIMEOUT_SECONDS", 9.0)
+        server_client = ServerClient(
+            head_server_config=BaseServerConfig(host="abcdef", port=12345),
+            global_config_dict=DictConfig({"my_server": {"a": {"b": {"host": "xyz", "port": 54321}}}}),
+        )
+
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(return_value="my mock response")
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        await server_client.get(server_name="my_server", url_path="/blah")
+
+        assert 9.0 == client_mock.return_value.request.await_args.kwargs["timeout"].sock_connect
+
+    async def test_ServerClient_request_does_not_override_a_caller_timeout(self, monkeypatch: MonkeyPatch) -> None:
+        server_client = ServerClient(
+            head_server_config=BaseServerConfig(host="abcdef", port=12345),
+            global_config_dict=DictConfig({"my_server": {"a": {"b": {"host": "xyz", "port": 54321}}}}),
+        )
+
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(return_value="my mock response")
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        caller_timeout = ClientTimeout(total=123.0)
+        await server_client.get(server_name="my_server", url_path="/blah", timeout=caller_timeout)
+
+        assert caller_timeout is client_mock.return_value.request.await_args.kwargs["timeout"]


### PR DESCRIPTION
Partially addresses #2216. Stacked on #2363, which is what lets the resulting
failure become a failed rollout rather than a dead run.

`_request_with_retry` raises its own limit on every rate-limit response.
`max_num_tries += 1` fires whenever the status is in `RATE_LIMIT_ERROR_CODES`,
so against an endpoint that always answers 429 the loop condition is never
reached and the call retries indefinitely. The rollout holding it never
releases its concurrency slot.

Raising the budget on a rate limit is the right instinct: waiting out a
throttle should not consume the allowance reserved for server errors. It just
needs an outer bound. This adds two, whichever comes first: an absolute
ceiling of 10 attempts, and a 300 second deadline measured from the first
attempt.

A second defect in the same function: when the loop ended,
`raise_for_status(response)` re-read `response.content`, which the loop body
had already consumed. `response.content` is a stream and yields nothing on a
second read, so the error that surfaced carried an empty body and the
endpoint's own explanation was lost. `raise_for_status` now takes the
already-read body as an optional argument, and the loop passes it.

Note that `request()` retries underneath this loop, so one logical model call
can make more connection attempts than the numbers here suggest. This bounds
the status-code loop only.


