### PR TITLE
fix: give each connection failure kind its own retry budget

### DIFF
--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -69,6 +69,7 @@ from nemo_gym.rollout_observability import (
 
 _failures_path_for = failures_path_for  # Backwards-compatible alias
 from nemo_gym.server_utils import (
+    RequestFailedError,
     ServerClient,
     get_response_json,
     is_global_aiohttp_client_request_debug_enabled,
@@ -122,20 +123,25 @@ _DEFAULT_MAX_ROLLOUT_ATTEMPTS = 3
 AGENT_REQUEST_FAILED_FAILURE_CLASS = "agent_request_failed"
 
 
-def _agent_request_failure_result(response: Any, error: ClientResponseError) -> Dict:
-    """The row written to the failures sidecar when `/run` answers with an HTTP error.
+def _agent_request_failure_result(response: Any, error: Exception) -> Dict:
+    """The row written to the failures sidecar when a `/run` call does not produce a result.
 
-    Carries `reward` 0.0 so the row has the same shape as a scored rollout, and the upstream body
-    truncated to 2000 characters so one large error response cannot dominate the sidecar.
+    Covers both an HTTP error from the agent and `request()` giving up on reaching it. Carries
+    `reward` 0.0 so the row has the same shape as a scored rollout, and truncates the detail to
+    2000 characters so one large error response cannot dominate the sidecar.
     """
-    content = getattr(error, "response_content", b"") or b""
-    if isinstance(content, bytes):
-        content = content.decode(errors="replace")
+    if isinstance(error, RequestFailedError):
+        detail = f"/run could not be reached: {error}"
+    else:
+        content = getattr(error, "response_content", b"") or b""
+        if isinstance(content, bytes):
+            content = content.decode(errors="replace")
+        detail = f"/run returned HTTP {getattr(response, 'status', None)}: {content}"
 
     return {
         "reward": 0.0,
         NG_FAILURE_CLASS_KEY: AGENT_REQUEST_FAILED_FAILURE_CLASS,
-        "error": f"/run returned HTTP {getattr(response, 'status', None)}: {content[:2000]}",
+        "error": detail[:2000],
     }
 
 
@@ -1076,10 +1082,10 @@ Aggregate metrics: {aggregate_metrics_fpath}""")
                             f"row={json.dumps(_rollout_request_debug_summary(row), sort_keys=True)}",
                             flush=True,
                         )
-                    # Only an HTTP error from the agent becomes a failure row. Anything else
-                    # raised here is a bug in this dispatcher rather than a rollout outcome, and
-                    # must still end the run.
-                    if not isinstance(e, ClientResponseError):
+                    # An HTTP error from the agent, or `request()` giving up on reaching it,
+                    # becomes a failure row. Anything else raised here is a bug in this dispatcher
+                    # rather than a rollout outcome, and must still end the run.
+                    if not isinstance(e, (ClientResponseError, RequestFailedError)):
                         raise
                     return row, _agent_request_failure_result(res, e)
                 return row, await get_response_json(res)

--- a/nemo_gym/rollout_reverification.py
+++ b/nemo_gym/rollout_reverification.py
@@ -48,6 +48,7 @@ from nemo_gym.rollout_collection import (
     _rollout_for_wandb,
 )
 from nemo_gym.server_utils import (
+    RequestFailedError,
     ServerClient,
     get_response_json,
     is_global_aiohttp_client_request_debug_enabled,
@@ -470,7 +471,7 @@ def _run_verification_payloads(
                     )
                 # Same split as rollout collection: an HTTP error from the resources server is a
                 # failure row, anything else is a bug here and must still end the run.
-                if not isinstance(e, ClientResponseError):
+                if not isinstance(e, (ClientResponseError, RequestFailedError)):
                     raise
                 return row, _agent_request_failure_result(res, e)
             return row, await get_response_json(res)

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -16,6 +16,7 @@ import asyncio
 import atexit
 import errno as errno_module
 import json
+import random
 import resource
 import socket
 import sys
@@ -187,9 +188,10 @@ def set_global_aiohttp_client(cfg: GlobalAIOHTTPAsyncClientConfig) -> ClientSess
             ),
         ),
         # `total` stays unset: generations legitimately run for minutes and must not be cut off.
-        # Only `sock_connect` is set, so a blackholed connect fails on our deadline rather than the
-        # kernel's SYN retry budget. Deliberately not `connect`, which also covers waiting for a
-        # free pooled connection; at Gym's concurrency that wait is normal and not a failure.
+        # Only `sock_connect` is set, so a connect to a host that silently drops packets fails on
+        # this deadline rather than on the kernel's SYN retry budget. Not `connect`, which also
+        # covers waiting for a free pooled connection; at Gym's concurrency that wait is normal and
+        # should not be counted as a failure.
         timeout=ClientTimeout(sock_connect=cfg.global_aiohttp_sock_connect_timeout_seconds),
         cookie_jar=DummyCookieJar(),
     )
@@ -328,10 +330,11 @@ _FAILURE_KIND_HELP_TEXT = {
     _RequestFailureKind.FATAL: "",
 }
 
-# Reporting on the first failure is right for one request and wrong for sixteen thousand, so the
-# full diagnostic goes out once per endpoint and kind and is then summarised on this interval.
-# Keyed by (origin, kind) -> (when it was last reported, failures suppressed since). Grows with the
-# number of distinct endpoints a process talks to, not with the number of requests.
+# The full diagnostic is printed once per endpoint and kind, then summarised on this interval.
+# Printing every failure would be fine for a single request and unusable for the thousands a run
+# can have in flight at once. Keyed by (origin, kind) -> (when it was last reported, failures
+# suppressed since), so it grows with the number of endpoints a process talks to, not with the
+# number of requests.
 _FAILURE_REPORT_INTERVAL_SECONDS: float = 30.0
 _FAILURE_REPORT_STATE: Dict[Tuple[str, _RequestFailureKind], Tuple[float, int]] = {}
 
@@ -388,6 +391,77 @@ def _report_request_failure(url: str, exc: BaseException, kind: _RequestFailureK
     )
 
 
+class RequestFailedError(ClientError):
+    """`request()` exhausted the retry budget for a failure kind.
+
+    Subclasses `aiohttp.ClientError` so that callers already catching that keep working, for
+    example `finance_sec_search/app.py:530` and `ecs_fargate/engine.py:1044`. The diagnostic lives
+    in the message rather than a note: `setup_exception_middleware` returns `repr(e)` as the 500
+    body and `repr()` drops notes.
+    """
+
+
+class _RetryBudget(BaseModel):
+    """How long `request()` keeps trying one failure kind.
+
+    `max_attempts` of `None` means no attempt cap, for kinds that are self-correcting and where the
+    deadline is the real bound.
+    """
+
+    max_attempts: Optional[int]
+    deadline_seconds: float
+
+
+# Each kind gets both an attempt count and a deadline. A single counter cannot express both a
+# dead port, where more attempts add nothing, and an overloaded server, where the endpoint is
+# expected back after a while. UNREACHABLE is short on the assumption that waiting for a server
+# that has not started yet happens before the run rather than inside this loop. RESOURCE gets no
+# attempt cap because file descriptors free up on their own, so time is the useful bound.
+_RETRY_BUDGETS = {
+    _RequestFailureKind.UNREACHABLE: _RetryBudget(max_attempts=3, deadline_seconds=10.0),
+    _RequestFailureKind.RESOURCE: _RetryBudget(max_attempts=None, deadline_seconds=120.0),
+    _RequestFailureKind.PEER_DROP: _RetryBudget(max_attempts=5, deadline_seconds=60.0),
+    _RequestFailureKind.TIMEOUT: _RetryBudget(max_attempts=3, deadline_seconds=30.0),
+    _RequestFailureKind.FATAL: _RetryBudget(max_attempts=0, deadline_seconds=0.0),
+}
+
+_RETRY_INITIAL_DELAY_SECONDS = 0.5
+_RETRY_MAX_DELAY_SECONDS = 8.0
+
+
+def _retry_delay(attempts: int) -> float:
+    """Capped exponential backoff, randomised downward.
+
+    The jitter keeps every in-flight request from retrying in lockstep against a peer that is
+    already struggling. It only ever shortens the wait, so the deadline stays the real bound.
+    """
+    ceiling = min(_RETRY_INITIAL_DELAY_SECONDS * (2 ** (attempts - 1)), _RETRY_MAX_DELAY_SECONDS)
+    return ceiling * random.uniform(0.5, 1.0)
+
+
+def _retry_budget_remains(kind: _RequestFailureKind, attempts: int, elapsed_seconds: float) -> bool:
+    budget = _RETRY_BUDGETS[kind]
+    if budget.max_attempts is not None and attempts >= budget.max_attempts:
+        return False
+    return elapsed_seconds < budget.deadline_seconds
+
+
+def _request_failed_message(
+    url: str, kind: _RequestFailureKind, attempts: int, elapsed_seconds: float, exc: BaseException, internal: bool
+) -> str:
+    where = (
+        "Check `gym env status`; this is a call to another NeMo Gym server."
+        if internal
+        else "Check `policy_base_url`, your API key, and whether the provider is up."
+    )
+    help_text = _FAILURE_KIND_HELP_TEXT[kind]
+    return (
+        f"gave up on {url} after {attempts} attempt(s) over {elapsed_seconds:.1f}s "
+        f"(kind={kind.value}, last error: {type(exc).__name__}: {exc}). {where}"
+        + (f"\n{help_text}" if help_text else "")
+    )
+
+
 async def request(
     method: str, url: str, _internal: bool = False, **kwargs: Unpack[_RequestOptions]
 ) -> ClientResponse:  # pragma: no cover
@@ -398,37 +472,35 @@ async def request(
         kwargs["headers"]["Content-Type"] = "application/json"
 
     client = get_global_aiohttp_client()
-    num_tries = 1
+    attempts = 0
+    first_failure_at: Optional[float] = None
     while True:
         try:
             return await client.request(method=method, url=url, **kwargs)
-        except (ServerDisconnectedError, ClientOSError) as e:
-            # Both were already retried without a limit, and still are; the kind only selects the
-            # diagnostic. `ClientConnectorError` arrives here as a `ClientOSError` subclass, which
-            # is why a refused connection used to be reported as an overloaded server.
-            _report_request_failure(url, e, _classify_request_failure(e), time.monotonic())
-
-            await asyncio.sleep(0.5)
         except Exception as e:
+            # `asyncio.CancelledError` is a `BaseException`, so it is never caught here and
+            # cancellation still propagates.
             if _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG:
                 print_exc()
 
-            # Don't increment internal since we know we are ok. If we are not, the head server will shut everything down anyways.
-            if not _internal:
-                kind = _classify_request_failure(e)
-                help_text = _FAILURE_KIND_HELP_TEXT[kind]
-                print(
-                    f"""Hit an exception while making a request (try {num_tries}, kind {kind.value}): {type(e)}: {e}
-Sleeping 0.5s and retrying...
-"""
-                    + (f"{help_text}\n" if help_text else "")
-                )
-                if num_tries >= MAX_NUM_TRIES:
-                    raise e
+            kind = _classify_request_failure(e)
+            attempts += 1
+            now = time.monotonic()
+            if first_failure_at is None:
+                # From the first failure, not from the start of the request: a twenty-minute
+                # generation that fails at the end would otherwise have spent every deadline
+                # before it got a single retry.
+                first_failure_at = now
+            elapsed = now - first_failure_at
 
-                num_tries += 1
+            _report_request_failure(url, e, kind, now)
 
-            await asyncio.sleep(0.5)
+            if kind is _RequestFailureKind.FATAL:
+                raise
+            if not _retry_budget_remains(kind, attempts, elapsed):
+                raise RequestFailedError(_request_failed_message(url, kind, attempts, elapsed, e, _internal)) from e
+
+            await asyncio.sleep(_retry_delay(attempts))
 
 
 async def raise_for_status(

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -68,6 +68,19 @@ def _connection_key() -> ConnectionKey:
     )
 
 
+class _FakeClock:
+    """Drop-in for the `time` module so deadlines can be exercised without real waiting."""
+
+    def __init__(self) -> None:
+        self._now = 0.0
+
+    def monotonic(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+
 _TCP_KEEPALIVE_TEST_IDLE = 42
 _TCP_KEEPALIVE_TEST_INTERVAL = 7
 _TCP_KEEPALIVE_TEST_PROBES = 2
@@ -539,59 +552,32 @@ class TestServerUtils:
 
         assert 1 == capsys.readouterr().out.count("[request_retry")
 
-    async def test_request_still_retries_unreachable_endpoints_forever(self, monkeypatch: MonkeyPatch) -> None:
-        """M1 changes reporting only. A refused connect must still retry without limit."""
+    async def test_request_gives_up_on_a_peer_that_keeps_dropping(self, monkeypatch: MonkeyPatch) -> None:
         monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
-        refused = ClientConnectorError(_connection_key(), OSError(errno.ECONNREFUSED, "refused"))
-
-        num_calls = 0
-
-        async def request_mock(**_kwargs) -> str:
-            nonlocal num_calls
-            num_calls += 1
-            if num_calls < 200:
-                raise refused
-            return "my mock response"
-
         monkeypatch.setattr(nemo_gym.server_utils.asyncio, "sleep", AsyncMock())
+
         client_mock = MagicMock()
-        client_mock.return_value.request = request_mock
+        client_mock.return_value.request = AsyncMock(side_effect=ServerDisconnectedError())
         monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
 
-        assert "my mock response" == await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
-        assert 200 == num_calls
-
-    async def test_request_still_retries_dropped_connections_forever(self, monkeypatch: MonkeyPatch) -> None:
-        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
-
-        num_calls = 0
-
-        async def request_mock(**_kwargs) -> str:
-            nonlocal num_calls
-            num_calls += 1
-            if num_calls < 200:
-                raise ServerDisconnectedError()
-            return "my mock response"
-
-        monkeypatch.setattr(nemo_gym.server_utils.asyncio, "sleep", AsyncMock())
-        client_mock = MagicMock()
-        client_mock.return_value.request = request_mock
-        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
-
-        assert "my mock response" == await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
-        assert 200 == num_calls
-
-    async def test_request_still_raises_unknown_errors_after_max_num_tries(self, monkeypatch: MonkeyPatch) -> None:
-        """The generic branch keeps its 3-tries-then-raise behaviour for external calls."""
-        monkeypatch.setattr(nemo_gym.server_utils.asyncio, "sleep", AsyncMock())
-        client_mock = MagicMock()
-        client_mock.return_value.request = AsyncMock(side_effect=TypeError("programming error"))
-        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
-
-        with raises(TypeError):
+        with raises(nemo_gym.server_utils.RequestFailedError) as exc_info:
             await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
 
-        assert nemo_gym.server_utils.MAX_NUM_TRIES == client_mock.return_value.request.await_count
+        assert "peer_drop" in str(exc_info.value)
+        # PEER_DROP is the overload case, so it gets more attempts than UNREACHABLE.
+        assert 5 == client_mock.return_value.request.await_count
+
+    async def test_request_rides_out_a_burst_of_dropped_connections(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+        monkeypatch.setattr(nemo_gym.server_utils.asyncio, "sleep", AsyncMock())
+
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(
+            side_effect=[ServerDisconnectedError(), ServerDisconnectedError(), "my mock response"]
+        )
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        assert "my mock response" == await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
 
     async def test_request_success_path_is_untouched(self, monkeypatch: MonkeyPatch, capsys: CaptureFixture) -> None:
         client_mock = MagicMock()
@@ -658,3 +644,106 @@ class TestServerUtils:
         await server_client.get(server_name="my_server", url_path="/blah", timeout=caller_timeout)
 
         assert caller_timeout is client_mock.return_value.request.await_args.kwargs["timeout"]
+
+    def test_retry_budgets_cover_every_kind(self) -> None:
+        assert set(_RequestFailureKind) == set(nemo_gym.server_utils._RETRY_BUDGETS)
+
+        budgets = nemo_gym.server_utils._RETRY_BUDGETS
+        # Self-correcting, so bounded by time rather than by a count.
+        assert budgets[_RequestFailureKind.RESOURCE].max_attempts is None
+        # Waiting cannot help, so no retry at all.
+        assert 0 == budgets[_RequestFailureKind.FATAL].max_attempts
+
+    def test_retry_budget_remains_stops_on_attempts_and_on_deadline(self) -> None:
+        remains = nemo_gym.server_utils._retry_budget_remains
+        unreachable = _RequestFailureKind.UNREACHABLE
+
+        assert remains(unreachable, attempts=1, elapsed_seconds=0.0)
+        # The attempt cap fires with the deadline nowhere near.
+        assert not remains(unreachable, attempts=3, elapsed_seconds=0.0)
+        # The deadline fires with attempts to spare.
+        assert not remains(unreachable, attempts=1, elapsed_seconds=10.0)
+        # RESOURCE has no attempt cap, so only its deadline stops it.
+        assert remains(_RequestFailureKind.RESOURCE, attempts=10_000, elapsed_seconds=0.0)
+        assert not remains(_RequestFailureKind.RESOURCE, attempts=1, elapsed_seconds=120.0)
+
+    def test_retry_delay_grows_then_caps_and_only_ever_shortens(self) -> None:
+        delay = nemo_gym.server_utils._retry_delay
+        initial = nemo_gym.server_utils._RETRY_INITIAL_DELAY_SECONDS
+        cap = nemo_gym.server_utils._RETRY_MAX_DELAY_SECONDS
+
+        for attempts in range(1, 12):
+            ceiling = min(initial * (2 ** (attempts - 1)), cap)
+            for _ in range(20):
+                seconds = delay(attempts)
+                # Jitter only ever shortens the wait, so the deadline stays the real bound.
+                assert ceiling / 2 <= seconds <= ceiling
+
+        assert cap / 2 <= delay(50) <= cap
+
+    async def test_request_gives_up_on_an_unreachable_endpoint(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+        monkeypatch.setattr(nemo_gym.server_utils.asyncio, "sleep", AsyncMock())
+        refused = ClientConnectorError(_connection_key(), OSError(errno.ECONNREFUSED, "refused"))
+
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(side_effect=refused)
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        with raises(nemo_gym.server_utils.RequestFailedError) as exc_info:
+            await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
+
+        assert "http://localhost:8000/v1/responses" in str(exc_info.value)
+        assert "unreachable" in str(exc_info.value)
+        assert exc_info.value.__cause__ is refused
+        # Callers already catching aiohttp errors keep working.
+        assert isinstance(exc_info.value, ClientError)
+        assert 3 == client_mock.return_value.request.await_count
+
+    async def test_request_recovers_inside_the_budget(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+        monkeypatch.setattr(nemo_gym.server_utils.asyncio, "sleep", AsyncMock())
+        refused = ClientConnectorError(_connection_key(), OSError(errno.ECONNREFUSED, "refused"))
+
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(side_effect=[refused, refused, "my mock response"])
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        assert "my mock response" == await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
+
+    async def test_request_raises_fatal_immediately_and_unwrapped(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+        monkeypatch.setattr(nemo_gym.server_utils.asyncio, "sleep", AsyncMock())
+
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(side_effect=TypeError("programming error"))
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        # Not wrapped in RequestFailedError: a programming error should surface as itself.
+        with raises(TypeError):
+            await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
+
+        assert 1 == client_mock.return_value.request.await_count
+
+    async def test_request_deadline_runs_from_the_first_failure(self, monkeypatch: MonkeyPatch) -> None:
+        """A long call that fails at the end must still get its retries."""
+        monkeypatch.setattr(nemo_gym.server_utils, "_FAILURE_REPORT_STATE", {})
+        monkeypatch.setattr(nemo_gym.server_utils.asyncio, "sleep", AsyncMock())
+        clock = _FakeClock()
+        clock.advance(1200.0)
+        monkeypatch.setattr(nemo_gym.server_utils, "time", clock)
+
+        refused = ClientConnectorError(_connection_key(), OSError(errno.ECONNREFUSED, "refused"))
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(side_effect=[refused, refused, "my mock response"])
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        assert "my mock response" == await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")
+
+    async def test_request_still_propagates_cancellation(self, monkeypatch: MonkeyPatch) -> None:
+        client_mock = MagicMock()
+        client_mock.return_value.request = AsyncMock(side_effect=asyncio.CancelledError())
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_aiohttp_client", client_mock)
+
+        with raises(asyncio.CancelledError):
+            await nemo_gym.server_utils.request("POST", "http://localhost:8000/v1/responses")


### PR DESCRIPTION
Closes the hang reported in #2216. Stacked on #2366.

Until now `request()` retried connection failures without any limit. The
earlier PRs in this stack made those failures legible (#2361) and gave a
failed rollout somewhere to go (#2363). This one stops the retrying.

Each kind gets two limits, attempts and a deadline, because a dead port and an
overloaded server want different shapes and one counter cannot express both:

| kind | attempts | deadline |
|---|---|---|
| `unreachable` | 3 | 10s |
| `resource` | no cap | 120s |
| `peer_drop` | 5 | 60s |
| `timeout` | 3 | 30s |
| `fatal` | 0 | raises unwrapped |

`unreachable` can be this short because `gym env start` now waits for the
model endpoints before a run (#2362), so waiting for a server that has not
started is no longer this loop's job. `resource` gets no attempt cap because
file descriptors free up on their own; that is the case the unbounded loop was
genuinely good at, and time is the right bound for it.

The deadline runs from the first failure rather than from the start of the
request. Measured from request start, a twenty-minute generation that fails at
the end would already have exceeded every deadline and would get no retries at
all.

Delay between attempts is `min(0.5 * 2**n, 8.0)` scaled by a random factor in
[0.5, 1.0]. The jitter stops every in-flight request from retrying in lockstep
against a peer that is already struggling, and since it only ever shortens the
wait, the deadline stays the real bound.

On giving up, `RequestFailedError` carries the diagnostic in its message. It
subclasses `aiohttp.ClientError` so callers already catching that keep
working, and the message rather than a note carries the detail because
`setup_exception_middleware` returns `repr(e)` as the 500 body and `repr()`
drops notes. The original is chained with `raise ... from`.

`fatal` raises the original exception unwrapped: a `TypeError` or a malformed
URL is a programming error, and dressing it up as a request failure would hide
it.

Rollout collection and re-verification now route `RequestFailedError` to the
failures sidecar alongside `ClientResponseError`, so an endpoint that cannot
be reached costs the rollouts that needed it rather than the run.

Three tests from #2361 asserted the old unbounded behaviour and that the
generic branch allowed `MAX_NUM_TRIES` attempts. They were there to prove that
PR changed nothing; this one changes exactly that, so they are replaced with
tests for the new bounds.

`asyncio.CancelledError` is a `BaseException` and is still never caught here,
so cancellation propagates unchanged.


