### PR TITLE
fix(resources_servers): add missing READMEs for string_match and gui_coordinate

### DIFF
--- a/resources_servers/gui_coordinate/README.md
+++ b/resources_servers/gui_coordinate/README.md
@@ -1,0 +1,55 @@
+# Description
+
+GUI coordinate grounding verifier for visual pointing tasks. The model is shown an image and asked to point at a target; the server scores how close the predicted point is to the ground-truth coordinate.
+
+The model must emit its prediction as `<point>(x, y)</point>`, where `x` and `y` are in thousandths of the image width and height (0-1000). The verifier divides them by 1000 to get normalized coordinates and compares against `expected_answer`, which is `"x,y"` in the same normalized 0-1 space.
+
+Reward is a smooth quadratic falloff in Euclidean distance:
+
+- `dist >= max_dist` (default 0.15) → reward 0.0
+- otherwise → reward `(1 - dist / max_dist) ** 2`, so an exact hit scores 1.0
+
+If the response contains no parseable `<point>` tag, or `expected_answer` is not a two-number `"x,y"` string, the reward is 0.0.
+
+Data links: ?
+
+# Input format
+
+Each JSONL row carries the prompt (image + instruction) plus the verifier fields:
+
+```json
+{
+  "responses_create_params": {"input": [{"role": "user", "type": "message", "content": [
+    {"type": "input_image", "image_url": "data:image/png;base64,..."},
+    {"type": "input_text", "text": "... Respond with the coordinates as <point>(x, y)</point> ..."}
+  ]}]},
+  "expected_answer": "0.6640,0.8410",
+  "max_dist": 0.15,
+  "metadata": {"target_color": "yellow"}
+}
+```
+
+`max_dist` is per-row and optional (defaults to 0.15). `metadata` is passed through and is not used for scoring.
+
+# Example usage
+
+```bash
+gym env start \
+    --resources-server gui_coordinate \
+    --model-type vllm_model &
+gym eval run --no-serve \
+    --agent gui_coordinate_simple_agent \
+    --input resources_servers/gui_coordinate/data/example.jsonl \
+    --output resources_servers/gui_coordinate/data/example_rollouts.jsonl
+```
+
+The example data needs a vision-capable policy model.
+
+# Licensing information
+
+Code: Apache 2.0
+Data: the example images are the ones used by the `circle_click` resources server.
+
+Dependencies
+- nemo_gym: Apache 2.0
+- fastapi: MIT

--- a/resources_servers/string_match/README.md
+++ b/resources_servers/string_match/README.md
@@ -1,0 +1,53 @@
+# Description
+
+General-purpose string matching verifier for free-form text answers. It pulls a candidate answer out of the model response, then compares it to `expected_answer` with the NeMo RL string-match grader (no format reward).
+
+Extraction is controlled per row by `extraction_mode`:
+
+- `boxed` — the last `\boxed{...}`, with `\text{...}` wrappers stripped
+- `final_answer` (default) — the last `Final answer: ...` / `Answer: ...` line, falling back to `\boxed{...}`
+- `last_line` — the last non-empty line
+- `full_response` — the whole assistant text
+
+Comparison depends on `case_sensitive`:
+
+- `true` — exact string equality after stripping whitespace
+- `false` (default) — the grader: NFKC normalization, quote/trailing-punctuation stripping, lowercasing, then a series of equivalence checks (float, comma-separated numbers, LaTeX command stripping, list reordering, US state name/abbreviation, unit stripping). An exact match under any of these scores 1.0; a numeric answer within relative error small enough to score above 0.98 gets 0.98. Everything else is 0.0.
+
+Data links: ?
+
+# Input format
+
+```json
+{
+  "responses_create_params": {"input": [{"role": "user", "type": "message", "content": [
+    {"type": "input_text", "text": "What is the capital of France? Put your final answer in \\boxed{}."}
+  ]}]},
+  "expected_answer": "Paris",
+  "extraction_mode": "boxed",
+  "case_sensitive": false
+}
+```
+
+The verify response echoes `expected_answer` and the `extracted_answer` the grader actually saw, which is what to look at when a reward is unexpectedly 0.0.
+
+# Example usage
+
+```bash
+gym env start \
+    --resources-server string_match \
+    --model-type vllm_model &
+gym eval run --no-serve \
+    --agent string_match_simple_agent \
+    --input resources_servers/string_match/data/example.jsonl \
+    --output resources_servers/string_match/data/example_rollouts.jsonl
+```
+
+# Licensing information
+
+Code: Apache 2.0
+Data: the example rows are hand-written prompts, Apache 2.0.
+
+Dependencies
+- nemo_gym: Apache 2.0
+- fastapi: MIT


### PR DESCRIPTION
`gym env test` counts every directory under `resources_servers/` etc. as a candidate module, but only tests the ones containing a `README.md` (`nemo_gym/cli/env.py:717`), then asserts the two counts match. #2332 added `string_match` and `gui_coordinate` without READMEs, so main fails with `Mismatch on the number of total modules found (144) and the number of actual modules tested (142)`.

This adds a README to each, describing the extraction/scoring behavior, the input JSONL fields, and how to run them.

Both servers' tests now run: 10 passed for `string_match`, 12 for `gui_coordinate`. Data validation preconditions hold for both (5 examples, 5 rollouts, `"Number of examples": 5`).