### PR TITLE
feat(resources_servers): opt-in Gym Sandbox API for ns_tools and math_formal_lean

### DIFF
--- a/resources_servers/math_formal_lean/app.py
+++ b/resources_servers/math_formal_lean/app.py
@@ -18,9 +18,9 @@
 import logging
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -29,7 +29,17 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from nemo_gym.sandbox import AsyncSandbox
 from resources_servers.math_formal_lean.sandbox_client import Lean4SandboxClient
+from resources_servers.sandbox_backend import (
+    SANDBOX_BACKEND_GYM,
+    SANDBOX_BACKEND_SKILLS,
+    build_sandbox_spec_from_mapping,
+    named_configs_from_server_client,
+    normalize_sandbox_backend,
+    resolve_gym_provider_config,
+    resolve_gym_provider_metadata,
+)
 
 
 LOG = logging.getLogger(__name__)
@@ -339,8 +349,18 @@ def build_correction_prompt(
 
 
 class MathFormalLeanResourcesServerConfig(BaseResourcesServerConfig):
+    # Dual path: skills_sidecar (default) keeps Lean4SandboxClient HTTP; gym_sandbox
+    # uses nemo_gym.sandbox.AsyncSandbox via sandbox_provider + sandbox_spec.
+    sandbox_backend: str = SANDBOX_BACKEND_SKILLS
     sandbox_host: str = "127.0.0.1"
     sandbox_port: int = 6000
+    # gym_sandbox only: name ref ("sandbox") or inline {provider: {...}}
+    sandbox_provider: Optional[Union[str, Dict[str, Any]]] = None
+    sandbox_spec: Dict[str, Any] = Field(default_factory=dict)
+    # Path inside the sandbox where the proof is written before compile.
+    lean_proof_path: str = "/sandbox/proof.lean"
+    # Shell command to compile; `{proof_path}` is substituted.
+    lean_compile_command: str = "lean {proof_path}"
     compilation_timeout: float = 30.0
     max_output_characters: int = 1000
     extract_code_mode: str = "last"
@@ -384,16 +404,66 @@ class MathFormalLeanResourcesServer(SimpleResourcesServer):
 
     def model_post_init(self, context: Any) -> None:
         super().model_post_init(context)
-        self._sandbox_client = Lean4SandboxClient(
-            host=self.config.sandbox_host,
-            port=self.config.sandbox_port,
-            max_output_characters=self.config.max_output_characters,
-        )
+        self._sandbox_backend = normalize_sandbox_backend(self.config.sandbox_backend)
+        self._sandbox_client: Optional[Lean4SandboxClient] = None
+        if self._sandbox_backend == SANDBOX_BACKEND_SKILLS:
+            self._sandbox_client = Lean4SandboxClient(
+                host=self.config.sandbox_host,
+                port=self.config.sandbox_port,
+                max_output_characters=self.config.max_output_characters,
+            )
+        else:
+            # Fail fast at startup if gym path is misconfigured (no silent Skills fallback).
+            named = named_configs_from_server_client(self.server_client)
+            resolve_gym_provider_config(self.config.sandbox_provider, named)
         self._proof_build_config = ProofBuildConfig(
             extract_code_mode=self.config.extract_code_mode,
             restate_formal_statement=self.config.restate_formal_statement,
             strip_theorem_from_proof=self.config.strip_theorem_from_proof,
         )
+
+    def _truncate(self, text: str) -> str:
+        if len(text) <= self.config.max_output_characters:
+            return text
+        return text[: self.config.max_output_characters]
+
+    async def _execute_lean4(self, code: str, timeout: float) -> Dict[str, Any]:
+        if self._sandbox_backend == SANDBOX_BACKEND_SKILLS:
+            assert self._sandbox_client is not None
+            return await self._sandbox_client.execute_lean4(code=code, timeout=timeout)
+        return await self._execute_lean4_gym(code=code, timeout=timeout)
+
+    async def _execute_lean4_gym(self, code: str, timeout: float) -> Dict[str, Any]:
+        named = named_configs_from_server_client(self.server_client)
+        provider_config = resolve_gym_provider_config(self.config.sandbox_provider, named)
+        default_metadata = resolve_gym_provider_metadata(self.config.sandbox_provider, named)
+        proof_path = self.config.lean_proof_path
+        spec = build_sandbox_spec_from_mapping(
+            self.config.sandbox_spec,
+            default_metadata=default_metadata,
+            extra_files={proof_path: code},
+        )
+        command = self.config.lean_compile_command.format(proof_path=proof_path)
+        try:
+            async with AsyncSandbox(provider_config, spec) as sandbox:
+                await sandbox.start()
+                result = await sandbox.exec(command, timeout_s=timeout)
+        except TimeoutError:
+            LOG.warning("Gym sandbox Lean compile timed out after %.1f seconds", timeout)
+            return {"process_status": "timeout", "stdout": "", "stderr": "Client timed out"}
+        except Exception as e:
+            LOG.error("Gym sandbox Lean compile failed: %s", e)
+            return {"process_status": "error", "stdout": "", "stderr": str(e)}
+
+        stdout = self._truncate(result.stdout or "")
+        stderr = self._truncate(result.stderr or "")
+        if result.error_type == "timeout":
+            return {"process_status": "timeout", "stdout": stdout, "stderr": stderr or "Client timed out"}
+        if result.error_type == "sandbox" or (result.return_code != 0 and result.error_type):
+            return {"process_status": "error", "stdout": stdout, "stderr": stderr or result.error_type}
+        if result.return_code != 0:
+            return {"process_status": "error", "stdout": stdout, "stderr": stderr}
+        return {"process_status": "completed", "stdout": stdout, "stderr": stderr}
 
     async def verify(self, body: MathFormalLeanVerifyRequest) -> MathFormalLeanVerifyResponse:
         """Verify a proof attempt with multi-turn self-correction support.
@@ -441,7 +511,7 @@ class MathFormalLeanResourcesServer(SimpleResourcesServer):
             config=self._proof_build_config,
         )
 
-        compiler_output = await self._sandbox_client.execute_lean4(
+        compiler_output = await self._execute_lean4(
             code=predicted_proof,
             timeout=self.config.compilation_timeout,
         )

--- a/resources_servers/math_formal_lean/configs/math_formal_lean.yaml
+++ b/resources_servers/math_formal_lean/configs/math_formal_lean.yaml
@@ -2,8 +2,19 @@ math_formal_lean:
   resources_servers:
     math_formal_lean:
       entrypoint: app.py
+      # skills_sidecar (default) | gym_sandbox (AsyncSandbox + sandbox_provider)
+      sandbox_backend: skills_sidecar
       sandbox_host: ${oc.env:NEMO_SKILLS_SANDBOX_HOST,127.0.0.1}
       sandbox_port: ${oc.env:NEMO_SKILLS_SANDBOX_PORT,6000}
+      # Used only when sandbox_backend=gym_sandbox (include opensandbox.yaml in config_paths)
+      sandbox_provider: sandbox
+      sandbox_spec:
+        image: ${oc.env:NEMO_GYM_LEAN_SANDBOX_IMAGE,leanprovercommunity/lean4:latest}
+        resources:
+          cpu: 2
+          memory_mib: 4096
+      lean_proof_path: /sandbox/proof.lean
+      lean_compile_command: "lean {proof_path}"
       compilation_timeout: 30.0
       domain: math
       verified: false

--- a/resources_servers/math_formal_lean/tests/test_app.py
+++ b/resources_servers/math_formal_lean/tests/test_app.py
@@ -209,6 +209,87 @@ theorem test : True := by
         assert verify_response.proof_status == "empty_generation"
 
     @pytest.mark.asyncio
+    async def test_gym_sandbox_backend_executes_via_async_sandbox(self):
+        """gym_sandbox path uses AsyncSandbox instead of Lean4SandboxClient."""
+        from uuid import uuid4
+
+        from nemo_gym.sandbox import SandboxExecResult, SandboxHandle, SandboxSpec, SandboxStatus, register_provider
+
+        provider_name = f"fake-lean-{uuid4().hex}"
+
+        class FakeLeanProvider:
+            last_exec_command = None
+
+            def __init__(self, **kwargs):
+                del kwargs
+
+            async def create(self, spec: SandboxSpec) -> SandboxHandle:
+                assert any(path.endswith("proof.lean") for path in (spec.files or {}))
+                return SandboxHandle(sandbox_id="lean-1", provider_name=provider_name, raw={})
+
+            async def exec(self, handle, command, **kwargs):
+                FakeLeanProvider.last_exec_command = command
+                return SandboxExecResult(stdout="", stderr="", return_code=0)
+
+            async def upload_file(self, handle, source_path, target_path):
+                return None
+
+            async def download_file(self, handle, source_path, target_path):
+                return None
+
+            async def status(self, handle):
+                return SandboxStatus.RUNNING
+
+            async def close(self, handle):
+                return None
+
+            async def aclose(self):
+                return None
+
+        register_provider(provider_name, FakeLeanProvider)
+
+        config = MathFormalLeanResourcesServerConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="math_formal_lean",
+            sandbox_backend="gym_sandbox",
+            sandbox_provider={provider_name: {}},
+            lean_proof_path="/sandbox/proof.lean",
+            lean_compile_command="lean {proof_path}",
+        )
+        server = MathFormalLeanResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+        assert server._sandbox_client is None
+
+        generation = "```lean4\ntheorem test : True := by\n  trivial\n```"
+        response = self._create_response(text=generation)
+        verify_request = MathFormalLeanVerifyRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(
+                input=[{"role": "user", "content": "Prove True"}]
+            ),
+            response=response,
+            header="import Mathlib\n\n",
+            formal_statement="theorem test : True := by\n",
+        )
+        verify_response = await server.verify(verify_request)
+        assert verify_response.reward == 1.0
+        assert FakeLeanProvider.last_exec_command == "lean /sandbox/proof.lean"
+
+    def test_gym_sandbox_requires_provider(self):
+        with pytest.raises(ValueError, match="requires sandbox_provider"):
+            MathFormalLeanResourcesServer(
+                config=MathFormalLeanResourcesServerConfig(
+                    host="0.0.0.0",
+                    port=8080,
+                    entrypoint="",
+                    name="math_formal_lean",
+                    sandbox_backend="gym_sandbox",
+                    sandbox_provider=None,
+                ),
+                server_client=MagicMock(spec=ServerClient),
+            )
+
+    @pytest.mark.asyncio
     async def test_verify_builds_correct_proof(self, server):
         """Test that the proof is built correctly with header and formal statement."""
         captured_code = None

--- a/resources_servers/ns_tools/app.py
+++ b/resources_servers/ns_tools/app.py
@@ -18,6 +18,7 @@ NeMo Skills Tools Resources Server.
 
 This resources server provides:
 - Integration with nemo_skills ToolManager for tool execution (e.g., DirectPythonTool)
+- Optional gym_sandbox backend via nemo_gym.sandbox.AsyncSandbox (stateless Python)
 - Verification delegation to math_with_judge
 """
 
@@ -27,17 +28,19 @@ import json
 import logging
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from contextlib import asynccontextmanager
-from typing import Any, Dict, List, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
 
 import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import PlainTextResponse
 from nemo_skills.mcp.tool_manager import ToolManager
 from nemo_skills.mcp.utils import locate
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, PrivateAttr
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -47,7 +50,17 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import ResourcesServerRef
+from nemo_gym.sandbox import AsyncSandbox
 from nemo_gym.server_utils import SESSION_ID_KEY
+from resources_servers.sandbox_backend import (
+    SANDBOX_BACKEND_GYM,
+    SANDBOX_BACKEND_SKILLS,
+    build_sandbox_spec_from_mapping,
+    named_configs_from_server_client,
+    normalize_sandbox_backend,
+    resolve_gym_provider_config,
+    resolve_gym_provider_metadata,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -74,9 +87,20 @@ class NSToolsConfig(BaseResourcesServerConfig):
     # Per-tool overrides for nemo_skills tools
     nemo_skills_tool_overrides: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
 
-    # Sandbox configuration for code execution tools
+    # Dual path: skills_sidecar (default) | gym_sandbox (AsyncSandbox; stateless Python)
+    sandbox_backend: str = SANDBOX_BACKEND_SKILLS
+
+    # Sandbox configuration for Skills code execution tools
     sandbox_host: str = "127.0.0.1"
     sandbox_port: str = "6000"
+
+    # gym_sandbox only
+    sandbox_provider: Optional[Union[str, Dict[str, Any]]] = None
+    sandbox_spec: Dict[str, Any] = Field(default_factory=dict)
+    python_code_path: str = "/sandbox/cell.py"
+    python_exec_command: str = "python {code_path}"
+    python_exec_timeout_s: float = 10.0
+    max_output_characters: int = 10000
 
     # Legacy python_tool HTTP server port (only used for pre-main HTTP PythonTool variants)
     python_tool_port: int = 8765
@@ -132,6 +156,17 @@ class NSToolsResourcesServer(SimpleResourcesServer):
     _python_tool_process: Optional[subprocess.Popen] = None
     _timing_by_session: Dict[str, list] = {}  # session_id -> list of timing records
     _uses_python_tool_sidecar: bool = False
+    _sandbox_backend: str = SANDBOX_BACKEND_SKILLS
+    _gym_sessions: Dict[str, AsyncSandbox] = PrivateAttr(default_factory=dict)
+    _gym_session_locks: Dict[str, asyncio.Lock] = PrivateAttr(default_factory=dict)
+    _gym_registry_lock: Optional[asyncio.Lock] = PrivateAttr(default=None)
+
+    def model_post_init(self, context: Any) -> None:
+        super().model_post_init(context)
+        self._sandbox_backend = normalize_sandbox_backend(self.config.sandbox_backend)
+        if self._sandbox_backend == SANDBOX_BACKEND_GYM:
+            named = named_configs_from_server_client(self.server_client)
+            resolve_gym_provider_config(self.config.sandbox_provider, named)
 
     def setup_webserver(self) -> FastAPI:
         app = super().setup_webserver()
@@ -154,13 +189,17 @@ class NSToolsResourcesServer(SimpleResourcesServer):
 
         # Initialize nemo_skills ToolManager if tools are configured
         if self.config.nemo_skills_tools:
-            self._uses_python_tool_sidecar = any(
-                self._tool_uses_python_tool_sidecar(tool_spec) for tool_spec in self.config.nemo_skills_tools
-            )
-            if self._uses_python_tool_sidecar:
-                # Legacy HTTP PythonTool variants require a local sidecar process.
-                self._start_python_tool_server()
-            self._initialize_nemo_skills_tools()
+            if self._sandbox_backend == SANDBOX_BACKEND_SKILLS:
+                self._uses_python_tool_sidecar = any(
+                    self._tool_uses_python_tool_sidecar(tool_spec) for tool_spec in self.config.nemo_skills_tools
+                )
+                if self._uses_python_tool_sidecar:
+                    # Legacy HTTP PythonTool variants require a local sidecar process.
+                    self._start_python_tool_server()
+                self._initialize_nemo_skills_tools()
+            else:
+                # gym_sandbox: still load tool schemas from ToolManager, but execute via AsyncSandbox.
+                self._initialize_nemo_skills_tools(for_schemas_only=True)
 
             # Register a catch-all endpoint for tool execution
             # This handles any tool name dynamically
@@ -244,7 +283,7 @@ class NSToolsResourcesServer(SimpleResourcesServer):
             self._python_tool_process.wait(timeout=5)
         raise TimeoutError(f"python_tool server did not start within {timeout}s. Check logs above for details.")
 
-    def _initialize_nemo_skills_tools(self):
+    def _initialize_nemo_skills_tools(self, *, for_schemas_only: bool = False):
         """Initialize the nemo_skills ToolManager with configured tools."""
 
         # Reduce verbosity of MCP and httpx loggers (they log every HTTP request at INFO)
@@ -294,7 +333,71 @@ class NSToolsResourcesServer(SimpleResourcesServer):
             logger.info(f"Loaded {len(tools)} nemo_skills tools: {list(self._tool_name_map.keys())}")
 
         asyncio.get_event_loop().run_until_complete(_load_tools())
-        logger.info("NeMo Skills ToolManager initialized successfully")
+        if for_schemas_only:
+            logger.info("NeMo Skills ToolManager initialized for schemas only (gym_sandbox execution path)")
+        else:
+            logger.info("NeMo Skills ToolManager initialized successfully")
+
+    def _truncate(self, text: str) -> str:
+        if len(text) <= self.config.max_output_characters:
+            return text
+        return text[: self.config.max_output_characters]
+
+    async def _acquire_gym_sandbox(self, session_id: str) -> AsyncSandbox:
+        if self._gym_registry_lock is None:
+            self._gym_registry_lock = asyncio.Lock()
+        async with self._gym_registry_lock:
+            lock = self._gym_session_locks.setdefault(session_id, asyncio.Lock())
+
+        async with lock:
+            sandbox = self._gym_sessions.get(session_id)
+            if sandbox is None:
+                named = named_configs_from_server_client(self.server_client)
+                provider_config = resolve_gym_provider_config(self.config.sandbox_provider, named)
+                default_metadata = resolve_gym_provider_metadata(self.config.sandbox_provider, named)
+                spec = build_sandbox_spec_from_mapping(
+                    self.config.sandbox_spec,
+                    default_metadata=default_metadata,
+                )
+                sandbox = await AsyncSandbox(provider_config, spec).start()
+                self._gym_sessions[session_id] = sandbox
+            return sandbox
+
+    async def _close_gym_sandbox(self, session_id: str) -> None:
+        sandbox = self._gym_sessions.pop(session_id, None)
+        self._gym_session_locks.pop(session_id, None)
+        if sandbox is None:
+            return
+        try:
+            await sandbox.stop()
+        except Exception as e:
+            logger.warning("Failed to stop gym sandbox for session %s: %s", session_id[:8], e)
+
+    async def _execute_python_gym(self, code: str, session_id: str) -> Dict[str, Any]:
+        """Stateless Python exec via AsyncSandbox (no persistent IPython kernel)."""
+        code_path = self.config.python_code_path
+        command = self.config.python_exec_command.format(code_path=code_path)
+        timeout = self.config.python_exec_timeout_s
+        try:
+            sandbox = await self._acquire_gym_sandbox(session_id)
+            with tempfile.TemporaryDirectory(prefix="ns-tools-gym-") as tmp:
+                local = Path(tmp) / "cell.py"
+                local.write_text(code, encoding="utf-8")
+                await sandbox.upload(str(local), code_path)
+            result = await sandbox.exec(command, timeout_s=timeout)
+        except TimeoutError:
+            return {"process_status": "timeout", "stdout": "", "stderr": "Client timed out"}
+        except Exception as e:
+            logger.exception("gym_sandbox python exec failed: %s", e)
+            return {"process_status": "error", "stdout": "", "stderr": str(e)}
+
+        stdout = self._truncate(result.stdout or "")
+        stderr = self._truncate(result.stderr or "")
+        if result.error_type == "timeout":
+            return {"process_status": "timeout", "stdout": stdout, "stderr": stderr or "Client timed out"}
+        if result.return_code != 0:
+            return {"process_status": "error", "stdout": stdout, "stderr": stderr}
+        return {"process_status": "completed", "stdout": stdout, "stderr": stderr}
 
     async def execute_tool(self, tool_name: str, request: Request) -> PlainTextResponse:
         """
@@ -304,11 +407,11 @@ class NSToolsResourcesServer(SimpleResourcesServer):
         Returns the result as plain text for simple_agent compatibility.
         Tracks execution timing and timeout detection per session.
         """
-        if not self.tool_manager:
+        if not self.tool_manager and self._sandbox_backend != SANDBOX_BACKEND_GYM:
             return PlainTextResponse(json.dumps({"error": "No tools configured"}))
 
-        # Check if tool is in our known tools
-        if tool_name not in self._tool_name_map:
+        # Check if tool is in our known tools (gym path still populates the map via ToolManager)
+        if self._tool_name_map and tool_name not in self._tool_name_map:
             logger.error(f"Unknown tool requested: {tool_name}")
             return PlainTextResponse(json.dumps({"error": f"Unknown tool: {tool_name}"}))
 
@@ -329,12 +432,18 @@ class NSToolsResourcesServer(SimpleResourcesServer):
         try:
             body = await request.json()
 
-            # Execute the tool
-            result = await self.tool_manager.execute_tool(
-                raw_name=tool_name,
-                args=body,
-                extra_args={"request_id": session_id},
-            )
+            if self._sandbox_backend == SANDBOX_BACKEND_GYM:
+                code = ""
+                if isinstance(body, dict):
+                    code = body.get("code") or body.get("generated_code") or ""
+                result = await self._execute_python_gym(code=str(code), session_id=session_id)
+            else:
+                # Execute the tool via Skills ToolManager
+                result = await self.tool_manager.execute_tool(
+                    raw_name=tool_name,
+                    args=body,
+                    extra_args={"request_id": session_id},
+                )
 
             # Check for internal sandbox timeout (process_status == "timeout")
             try:
@@ -453,8 +562,10 @@ class NSToolsResourcesServer(SimpleResourcesServer):
                 **metrics,
             )
         finally:
-            if self.tool_manager is not None and session_id:
+            if self.tool_manager is not None and session_id and self._sandbox_backend == SANDBOX_BACKEND_SKILLS:
                 await self.tool_manager.cleanup_request(session_id)
+            if session_id and self._sandbox_backend == SANDBOX_BACKEND_GYM:
+                await self._close_gym_sandbox(session_id)
 
     # --------------------------------------------------------
     # Cleanup
@@ -464,6 +575,9 @@ class NSToolsResourcesServer(SimpleResourcesServer):
         """Cleanup resources on server shutdown."""
         if self.tool_manager:
             await self.tool_manager.shutdown()
+
+        for session_id in list(self._gym_sessions.keys()):
+            await self._close_gym_sandbox(session_id)
 
         # Terminate the python_tool subprocess if one was started.
         if self._python_tool_process:

--- a/resources_servers/ns_tools/configs/ns_tools.yaml
+++ b/resources_servers/ns_tools/configs/ns_tools.yaml
@@ -33,10 +33,23 @@ ns_tools:
         DirectPythonTool:
           exec_timeout_s: 10
 
-      # Sandbox configuration
-      # Respects NEMO_SKILLS_SANDBOX_HOST/PORT env vars if set, else defaults
+      # Dual path: skills_sidecar (default) | gym_sandbox (AsyncSandbox; stateless Python)
+      sandbox_backend: skills_sidecar
+
+      # Skills sidecar (used when sandbox_backend=skills_sidecar)
       sandbox_host: ${oc.env:NEMO_SKILLS_SANDBOX_HOST,127.0.0.1}
       sandbox_port: ${oc.env:NEMO_SKILLS_SANDBOX_PORT,6000}
+
+      # Gym Sandbox API (used when sandbox_backend=gym_sandbox; include opensandbox.yaml in config_paths)
+      sandbox_provider: sandbox
+      sandbox_spec:
+        image: ${oc.env:NEMO_GYM_PYTHON_SANDBOX_IMAGE,python:3.12-slim}
+        resources:
+          cpu: 1
+          memory_mib: 2048
+      python_code_path: /sandbox/cell.py
+      python_exec_command: "python {code_path}"
+      python_exec_timeout_s: 10.0
 
       # Disable session replay after sandbox worker restarts (improves stability)
       disable_session_restore: true

--- a/resources_servers/ns_tools/tests/test_app.py
+++ b/resources_servers/ns_tools/tests/test_app.py
@@ -451,3 +451,75 @@ class TestSidecarTeardownWiredToLifespan:
 
         proc.terminate.assert_called_once()
         assert server._python_tool_process is None
+
+
+class TestGymSandboxBackend:
+    def test_gym_sandbox_requires_provider(self) -> None:
+        with pytest.raises(ValueError, match="requires sandbox_provider"):
+            NSToolsResourcesServer(
+                config=NSToolsConfig(
+                    host="0.0.0.0",
+                    port=8080,
+                    entrypoint="",
+                    name="ns_tools",
+                    sandbox_backend="gym_sandbox",
+                    sandbox_provider=None,
+                ),
+                server_client=MagicMock(spec=ServerClient),
+            )
+
+    async def test_execute_python_gym_uses_async_sandbox(self) -> None:
+        from uuid import uuid4
+
+        from nemo_gym.sandbox import SandboxExecResult, SandboxHandle, SandboxSpec, SandboxStatus, register_provider
+        from resources_servers.sandbox_backend import SANDBOX_BACKEND_GYM
+
+        provider_name = f"fake-ns-{uuid4().hex}"
+        uploaded: list[tuple[str, str]] = []
+
+        class FakePythonProvider:
+            def __init__(self, **kwargs):
+                del kwargs
+
+            async def create(self, spec: SandboxSpec) -> SandboxHandle:
+                return SandboxHandle(sandbox_id="py-1", provider_name=provider_name, raw={})
+
+            async def exec(self, handle, command, **kwargs):
+                return SandboxExecResult(stdout="42\n", stderr="", return_code=0)
+
+            async def upload_file(self, handle, source_path, target_path):
+                uploaded.append((str(source_path), target_path))
+
+            async def download_file(self, handle, source_path, target_path):
+                return None
+
+            async def status(self, handle):
+                return SandboxStatus.RUNNING
+
+            async def close(self, handle):
+                return None
+
+            async def aclose(self):
+                return None
+
+        register_provider(provider_name, FakePythonProvider)
+
+        server = NSToolsResourcesServer(
+            config=NSToolsConfig(
+                host="0.0.0.0",
+                port=8080,
+                entrypoint="",
+                name="ns_tools",
+                sandbox_backend=SANDBOX_BACKEND_GYM,
+                sandbox_provider={provider_name: {}},
+                python_code_path="/sandbox/cell.py",
+                python_exec_command="python {code_path}",
+            ),
+            server_client=MagicMock(spec=ServerClient),
+        )
+        result = await server._execute_python_gym("print(42)", session_id="sess-1")
+        assert result["process_status"] == "completed"
+        assert "42" in result["stdout"]
+        assert uploaded
+        assert uploaded[0][1] == "/sandbox/cell.py"
+        await server._close_gym_sandbox("sess-1")

--- a/resources_servers/sandbox_backend.py
+++ b/resources_servers/sandbox_backend.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for Skills-sidecar vs Gym Sandbox API dual-path backends."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Union
+
+from nemo_gym.sandbox import (
+    SandboxResources,
+    SandboxSpec,
+    resolve_provider_config,
+    resolve_provider_metadata,
+)
+
+
+SANDBOX_BACKEND_SKILLS = "skills_sidecar"
+SANDBOX_BACKEND_GYM = "gym_sandbox"
+VALID_SANDBOX_BACKENDS = frozenset({SANDBOX_BACKEND_SKILLS, SANDBOX_BACKEND_GYM})
+
+SandboxProviderRef = Union[str, Mapping[str, Any]]
+
+
+def normalize_sandbox_backend(value: str | None) -> str:
+    """Return a validated backend name; unset/empty defaults to Skills sidecar."""
+    if value is None or str(value).strip() == "":
+        return SANDBOX_BACKEND_SKILLS
+    backend = str(value).strip()
+    if backend not in VALID_SANDBOX_BACKENDS:
+        raise ValueError(
+            f"Unknown sandbox_backend={backend!r}. Expected one of: {sorted(VALID_SANDBOX_BACKENDS)}"
+        )
+    return backend
+
+
+def resolve_gym_provider_config(
+    sandbox_provider: SandboxProviderRef | None,
+    named_configs: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Resolve provider config for gym_sandbox; fail fast if misconfigured."""
+    if sandbox_provider is None:
+        raise ValueError(
+            "sandbox_backend=gym_sandbox requires sandbox_provider "
+            "(name reference like 'sandbox' or an inline {provider: {...}} mapping)"
+        )
+    return resolve_provider_config(sandbox_provider, named_configs)
+
+
+def resolve_gym_provider_metadata(
+    sandbox_provider: SandboxProviderRef | None,
+    named_configs: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if sandbox_provider is None:
+        return {}
+    return resolve_provider_metadata(sandbox_provider, named_configs)
+
+
+def build_sandbox_spec_from_mapping(
+    sandbox_spec: Mapping[str, Any] | None,
+    *,
+    default_metadata: Mapping[str, Any] | None = None,
+    extra_files: Mapping[str, str] | None = None,
+) -> SandboxSpec:
+    """Translate a YAML ``sandbox_spec`` mapping into a SandboxSpec."""
+    spec = dict(sandbox_spec or {})
+    files = dict(spec.pop("files", {}))
+    if extra_files:
+        files.update(extra_files)
+
+    metadata = dict(default_metadata or {})
+    metadata.update(dict(spec.pop("metadata", {})))
+
+    known = SandboxSpec(
+        image=spec.pop("image", None),
+        ttl_s=spec.pop("ttl_s", None),
+        ready_timeout_s=spec.pop("ready_timeout_s", None),
+        workdir=spec.pop("workdir", None),
+        env=dict(spec.pop("env", {})),
+        files=files,
+        metadata=metadata,
+        resources=SandboxResources.from_mapping(spec.pop("resources", {})),
+        entrypoint=spec.pop("entrypoint", None),
+        provider_options=dict(spec.pop("provider_options", {})),
+    )
+    if spec:
+        raise ValueError(f"Unknown sandbox_spec keys: {', '.join(sorted(spec))}")
+    return known
+
+
+def named_configs_from_server_client(server_client: Any) -> Mapping[str, Any] | None:
+    """Best-effort global config dict for resolving named sandbox_provider refs."""
+    global_config = getattr(server_client, "global_config_dict", None)
+    if global_config is None:
+        return None
+    try:
+        from omegaconf import OmegaConf
+
+        return OmegaConf.to_container(global_config, resolve=True)  # type: ignore[return-value]
+    except Exception:
+        if isinstance(global_config, Mapping):
+            return global_config
+        return None

--- a/resources_servers/tests/__init__.py
+++ b/resources_servers/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/resources_servers/tests/test_sandbox_backend.py
+++ b/resources_servers/tests/test_sandbox_backend.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for skills_sidecar vs gym_sandbox dual-path helpers."""
+
+import pytest
+
+from resources_servers.sandbox_backend import (
+    SANDBOX_BACKEND_GYM,
+    SANDBOX_BACKEND_SKILLS,
+    build_sandbox_spec_from_mapping,
+    normalize_sandbox_backend,
+    resolve_gym_provider_config,
+)
+
+
+def test_normalize_sandbox_backend_default() -> None:
+    assert normalize_sandbox_backend(None) == SANDBOX_BACKEND_SKILLS
+    assert normalize_sandbox_backend("") == SANDBOX_BACKEND_SKILLS
+    assert normalize_sandbox_backend("skills_sidecar") == SANDBOX_BACKEND_SKILLS
+    assert normalize_sandbox_backend("gym_sandbox") == SANDBOX_BACKEND_GYM
+
+
+def test_normalize_sandbox_backend_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="Unknown sandbox_backend"):
+        normalize_sandbox_backend("docker")
+
+
+def test_resolve_gym_provider_config_requires_provider() -> None:
+    with pytest.raises(ValueError, match="requires sandbox_provider"):
+        resolve_gym_provider_config(None, {})
+
+
+def test_resolve_gym_provider_config_inline() -> None:
+    cfg = resolve_gym_provider_config({"opensandbox": {"connection": {"domain": "x"}}}, None)
+    assert cfg == {"opensandbox": {"connection": {"domain": "x"}}}
+
+
+def test_resolve_gym_provider_config_named() -> None:
+    named = {"sandbox": {"opensandbox": {"connection": {"domain": "x"}}}}
+    cfg = resolve_gym_provider_config("sandbox", named)
+    assert "opensandbox" in cfg
+
+
+def test_build_sandbox_spec_unknown_key() -> None:
+    with pytest.raises(ValueError, match="Unknown sandbox_spec keys"):
+        build_sandbox_spec_from_mapping({"not_a_real_field": 1})


### PR DESCRIPTION
## Summary

Adds an opt-in path so `ns_tools` and `math_formal_lean` can run code/Lean through Gym's `nemo_gym.sandbox` API (for example OpenSandbox) instead of the co-located NeMo-Skills HTTP sidecar.

Default behavior is unchanged: `sandbox_backend: skills_sidecar` (or unset) keeps today's Skills host/port path.

## How it works

- Shared helpers in `resources_servers/sandbox_backend.py` (`skills_sidecar` | `gym_sandbox`)
- `sandbox_backend: gym_sandbox` plus `sandbox_provider` / `sandbox_spec` selects `AsyncSandbox`
- Misconfigured gym path fails fast (no silent fallback to Skills)
- Unit tests cover both backends with a fake provider

## Not supported yet

Stateful IPython / persistent kernel sessions on the gym path. `gym_sandbox` runs **stateless** Python (and Lean compile) only. For Super3.5-style stateful tool use, stay on `skills_sidecar` until Gym [#1942](https://github.com/NVIDIA-NeMo/Gym/issues/1942) lands.

## Opt-in (RL / Hydra)

Include the OpenSandbox provider config in gym `config_paths`, set `OPENSANDBOX_DOMAIN` / `OPENSANDBOX_API_KEY`, and override:

```text
++...ns_tools...sandbox_backend=gym_sandbox
++...math_formal_lean...sandbox_backend=gym_sandbox
```

## Test plan

- [x] `pytest resources_servers/tests/test_sandbox_backend.py`
- [x] `math_formal_lean` gym + skills unit tests
- [x] `ns_tools` gym unit tests (with `nemo-skills-tools`)
- [ ] Optional live OpenSandbox smoke (out of band)