### PR TITLE
feat: judge failure handling

### DIFF
--- a/resources_servers/proof_judge/app.py
+++ b/resources_servers/proof_judge/app.py
@@ -203,11 +203,16 @@ class ProofWithJudgeResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class ProofWithJudgeVerifyRequest(BaseVerifyRequest):
-    problem: str = ""
+    # Force a 422 error if the problem is empty.
+    problem: str
 
 
 class ProofWithJudgeVerifyResponse(BaseVerifyResponse):
-    pass
+    # None represents no failure.
+    # A format reason means the policy failed to follow the format and received an automatic 0.
+    # "judge_unparseable" means that the judge itself failed to produce a parseable score.
+    # Distinguishing between these cases is needed for judge error-proofing.
+    failure_reason: Optional[str] = None
 
 
 class IncorrectGroupCoordinator(BaseModel):
@@ -231,7 +236,7 @@ class ProofWithJudgeResourcesServer(SimpleResourcesServer):
     )
 
     async def verify(self, body: ProofWithJudgeVerifyRequest) -> ProofWithJudgeVerifyResponse:
-        problem = getattr(body, "problem", "") or (body.model_dump().get("problem") or "")
+        problem = body.problem
         full_response = self._extract_assistant_text(body.response)
         if not full_response:
             reward, details = 0.0, {"r_format": 0.0, "reason": "empty_response", "judge_generated_tokens": 0}
@@ -248,7 +253,7 @@ class ProofWithJudgeResourcesServer(SimpleResourcesServer):
                 reward=reward,
                 details=details,
             )
-        return ProofWithJudgeVerifyResponse(**body.model_dump(), reward=reward)
+        return ProofWithJudgeVerifyResponse(**body.model_dump(), reward=reward, failure_reason=details.get("reason"))
 
     async def _append_log_jsonl(
         self,
@@ -460,22 +465,29 @@ class ProofWithJudgeResourcesServer(SimpleResourcesServer):
             beta=beta,
         )
         verifier_response, verifier_generated_tokens = verifier_result
-        r_y = extract_boxed_score(verifier_response) or 0.0
+        r_y_score = extract_boxed_score(verifier_response)
+        # Distinguish between 0 score and unparseable score.
+        r_y = r_y_score if r_y_score is not None else 0.0
+        judge_unparseable = r_y_score is None
 
         if beta == 0:
-            return alpha * r_y, {
+            details = {
                 "r_y": r_y,
                 "s_prime": s_prime,
                 "judge_generated_tokens": verifier_generated_tokens,
                 "verifier_generated_tokens": verifier_generated_tokens,
                 "verifier_response": verifier_response,
             }
+            if judge_unparseable:
+                details["reason"] = "judge_unparseable"
+            return alpha * r_y, details
 
         assert meta_result is not None
         meta_response, meta_generated_tokens = meta_result
-        r_meta = extract_boxed_score(meta_response) or 0.0
+        r_meta_score = extract_boxed_score(meta_response)
+        r_meta = r_meta_score if r_meta_score is not None else 0.0
         r_z = (1.0 - abs(s_prime - r_y)) * r_meta
-        return alpha * r_y + beta * r_z, {
+        details = {
             "judge_generated_tokens": verifier_generated_tokens + meta_generated_tokens,
             "r_y": r_y,
             "r_meta": r_meta,
@@ -485,6 +497,9 @@ class ProofWithJudgeResourcesServer(SimpleResourcesServer):
             "verifier_response": verifier_response,
             "meta_response": meta_response,
         }
+        if judge_unparseable or r_meta_score is None:
+            details["reason"] = "judge_unparseable"
+        return alpha * r_y + beta * r_z, details
 
 
 if __name__ == "__main__":

--- a/resources_servers/proof_judge/app.py
+++ b/resources_servers/proof_judge/app.py
@@ -203,8 +203,8 @@ class ProofWithJudgeResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class ProofWithJudgeVerifyRequest(BaseVerifyRequest):
-    # Force a 422 error if the problem is empty.
-    problem: str
+    # Force a 422 error if the problem is missing or empty.
+    problem: str = Field(min_length=1)
 
 
 class ProofWithJudgeVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/proof_judge/app.py
+++ b/resources_servers/proof_judge/app.py
@@ -285,8 +285,6 @@ class ProofWithJudgeResourcesServer(SimpleResourcesServer):
     ) -> tuple[float, dict[str, Any]]:
         if not self.config.zero_reward_incorrect_groups:
             return reward, details
-        if not problem:
-            raise ValueError("problem must be set when zero_reward_incorrect_groups is enabled")
 
         verifier_reward = float(details["r_y"]) if "r_y" in details else 0.0
         coordinator = self._incorrect_group_coordinators[problem]

--- a/resources_servers/proof_judge/tests/test_app.py
+++ b/resources_servers/proof_judge/tests/test_app.py
@@ -1,23 +1,109 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+from pytest import MonkeyPatch, mark, raises
 
 from nemo_gym.config_types import ModelServerRef
+from nemo_gym.openai_utils import NeMoGymResponse
 from nemo_gym.server_utils import ServerClient
 from resources_servers.proof_judge.app import (
     ProofWithJudgeResourcesServer,
     ProofWithJudgeResourcesServerConfig,
+    ProofWithJudgeVerifyRequest,
 )
+
+
+MINIMAL_RESPONSES_CREATE_PARAMS = {
+    "input": [{"role": "user", "content": "test"}],
+    "parallel_tool_calls": True,
+}
+
+# Parses into (proof, self_analysis, s_prime=1.0).
+VALID_POLICY_RESPONSE = "thinking</think>\n## Solution\nA rigorous proof.\n## Self Evaluation\nConfident. \\boxed{1}"
+
+
+def _make_server(**config_overrides) -> ProofWithJudgeResourcesServer:
+    params = dict(
+        host="0.0.0.0",
+        port=8080,
+        entrypoint="",
+        name="",
+        judge_model_server=ModelServerRef(type="responses_api_models", name="judge"),
+    )
+    params.update(config_overrides)
+    config = ProofWithJudgeResourcesServerConfig(**params)
+    return ProofWithJudgeResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+
+
+def _make_response(assistant_text: str) -> NeMoGymResponse:
+    return NeMoGymResponse(
+        id="resp_test",
+        created_at=0.0,
+        model="dummy",
+        object="response",
+        output=[
+            {
+                "id": "msg_1",
+                "role": "assistant",
+                "type": "message",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": assistant_text, "annotations": []}],
+            }
+        ],
+        parallel_tool_calls=False,
+        tool_choice="none",
+        tools=[],
+    )
+
+
+def _make_body(response_text: str = VALID_POLICY_RESPONSE) -> ProofWithJudgeVerifyRequest:
+    return ProofWithJudgeVerifyRequest(
+        responses_create_params=MINIMAL_RESPONSES_CREATE_PARAMS,
+        response=_make_response(response_text),
+        problem="Prove P.",
+    )
 
 
 class TestApp:
     def test_sanity(self) -> None:
-        config = ProofWithJudgeResourcesServerConfig(
-            host="0.0.0.0",
-            port=8080,
-            entrypoint="",
-            name="",
-            judge_model_server=ModelServerRef(type="responses_api_models", name="judge"),
-        )
-        ProofWithJudgeResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+        _make_server()
+
+
+class TestFailureReason:
+    @mark.parametrize(
+        ("policy_text", "judge_reply", "reward", "reason", "judge_calls"),
+        [
+            # Genuine judged verdict: no failure reason.
+            (VALID_POLICY_RESPONSE, "Fine. \\boxed{1}", 1.0, None, 1),
+            # Judge answered without a parseable score: named, reward still 0.
+            (VALID_POLICY_RESPONSE, "I refuse to answer.", 0.0, "judge_unparseable", 1),
+            # Policy broke the format contract: named, judge never consulted.
+            ("No solution headers anywhere here.", "Fine. \\boxed{1}", 0.0, "missing_solution_header", 0),
+        ],
+    )
+    async def test_failure_reason_decomposes_zero_rewards(
+        self,
+        monkeypatch: MonkeyPatch,
+        policy_text: str,
+        judge_reply: str,
+        reward: float,
+        reason: str | None,
+        judge_calls: int,
+    ) -> None:
+        judge = AsyncMock(return_value=(judge_reply, 7))
+        monkeypatch.setattr(ProofWithJudgeResourcesServer, "_call_judge", judge)
+
+        result = await _make_server().verify(_make_body(response_text=policy_text))
+
+        assert result.reward == reward
+        assert result.failure_reason == reason
+        assert judge.await_count == judge_calls
+
+    def test_problem_is_required(self) -> None:
+        with raises(Exception):
+            ProofWithJudgeVerifyRequest(
+                responses_create_params=MINIMAL_RESPONSES_CREATE_PARAMS,
+                response=_make_response(VALID_POLICY_RESPONSE),
+            )

--- a/resources_servers/proof_judge/tests/test_app.py
+++ b/resources_servers/proof_judge/tests/test_app.py
@@ -101,9 +101,11 @@ class TestFailureReason:
         assert result.failure_reason == reason
         assert judge.await_count == judge_calls
 
-    def test_problem_is_required(self) -> None:
+    @mark.parametrize("problem_kwargs", [{}, {"problem": ""}], ids=["missing", "empty"])
+    def test_problem_is_required_and_nonempty(self, problem_kwargs) -> None:
         with raises(Exception):
             ProofWithJudgeVerifyRequest(
                 responses_create_params=MINIMAL_RESPONSES_CREATE_PARAMS,
                 response=_make_response(VALID_POLICY_RESPONSE),
+                **problem_kwargs,
             )


### PR DESCRIPTION
A zero reward from a judge model has three distinct causes that are currently indistinguishable:

- The response was malformatted, and thus never judged.
- The judge's judging response was itself malformatted.
- The judge genuinely provided a score of 0.

The middle case leads to severe training run degradation, should the judge model become corrupted - which is not uncommon.

This PR merely surfaces the failure reason, emitting `judge_unparseable` if the problem is with the judge, allowing upstream training infrastructure to decide how to best handle such judge degradation.