### PR TITLE
feat: harden SWE against filesystem overflow

### DIFF
--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -128,6 +128,16 @@ class SWEBenchWrapperConfig(BaseResponsesAPIAgentConfig):
     container_formatter: str | list[str] = Field(
         default="docker://swebench/sweb.eval.x86_64.{instance_id}", description="Container path template"
     )
+    preserve_episode_artifacts: bool = Field(
+        default=True,
+        description=(
+            "Keep each successful episode's results directory after its /run completes. "
+            "Episode scratch is very large; long training runs may set this to False so completed "
+            "directories are reaped instead of accumulating until the filesystem fills mid-run "
+            "(failed episodes always keep their directory, including traceback.err)."
+        ),
+    )
+
     swebench_tests_timeout: int = Field(default=30 * 60, description="Timeout for running tests (seconds)")
 
     swebench_agent_timeout: int = Field(default=45 * 60, description="Timeout for running the agent (seconds)")
@@ -3159,9 +3169,13 @@ class SWEBenchWrapper(SimpleResponsesAPIAgent):
         )
         data_point = params.problem_info
 
-        # Fix localhost URLs not working sometimes
+        # Fix localhost URLs not working sometimes.
+        # Append non-fatally; a write to /etc/hosts can fail and abort the entire episode.
         container_commands = []
-        container_commands.append("echo '127.0.0.1 localhost' >/etc/hosts")
+        container_commands.append("(echo '127.0.0.1 localhost' >>/etc/hosts 2>/dev/null || true)")
+
+        # Under the overlay the repository .git can appear owned by a different uid.
+        container_commands.append("(git config --global --add safe.directory '*' 2>/dev/null || true)")
 
         # Apptainer uid namespacing makes the eval-image's `chmod` against
         # /var/run/postgresql fail with "Value too large for defined data
@@ -3469,9 +3483,16 @@ class SWEBenchWrapper(SimpleResponsesAPIAgent):
         env_args += "--env CHROME_BIN=/tmp/chrome-wrapper.sh "
         env_args += "--env CHROMIUM_BIN=/tmp/chrome-wrapper.sh "
 
+        # Back the container's writable layer with a directory overlay.
+        # The tmpfs layer is capped, but SWE working trees routinely exceed it.
+        # A `git reset --hard` call is often sufficient to kill the episode otherwise.
+        overlay_prefix = f"apptainer_overlay_{command.mode}_"
+
         # Launch Apptainer container and execute the script file
         apptainer_cmd = (
-            f"apptainer exec --writable-tmpfs --cleanenv --pid --no-mount home,tmp,bind-paths "
+            f'OVERLAY_DIR="$(mktemp -d "${{TMPDIR:-/tmp}}/{overlay_prefix}XXXXXX")" && '
+            f"trap 'rm -rf \"$OVERLAY_DIR\"' EXIT TERM INT && "
+            f'apptainer exec --overlay "$OVERLAY_DIR" --cleanenv --pid --no-mount home,tmp,bind-paths '
             f"{env_args}"
             f"{mount_str} "
             f" {params.container} bash {container_script_path}"
@@ -3671,7 +3692,10 @@ class SWEBenchWrapper(SimpleResponsesAPIAgent):
             f.write(params.model_dump_json(indent=4))
 
         try:
-            return await self._inner_responses(params, dataset_processor)
+            response = await self._inner_responses(params, dataset_processor)
+            if not self.config.preserve_episode_artifacts:
+                rmtree(params.persistent_dir, ignore_errors=True)
+            return response
         except Exception as e:
             traceback_file = params.persistent_dir / "traceback.err"
             with traceback_file.open("w") as f:

--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -226,6 +226,7 @@ class ExecuteContainerCommandArgs(BaseModel):
     expected_file_pattern: str
     mode: Union[Literal["agent"], Literal["eval"]]
     timeout: int
+    overlay_dirname: Optional[str] = None
 
 
 class SWEBenchWrapperInstanceConfig(SWEBenchWrapperServerConfig, SWEBenchWrapperConfig):
@@ -2448,12 +2449,20 @@ def _kill_container_tree(root_pid: int) -> None:
             pass
 
 
+def _reap_overlay_dir(overlay_dirname: Optional[str]) -> None:
+    """Remove a container's overlay upperdir after a SIGKILL teardown."""
+    if not overlay_dirname:
+        return
+    rmtree(Path(os.environ.get("TMPDIR") or "/tmp") / overlay_dirname, ignore_errors=True)
+
+
 class ActiveContainerCommand(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     process: Process
     log_file: Any
     log_file_path: Path
+    overlay_dirname: Optional[str] = None
     watchdog_task: Optional[Any] = None
     watchdog_stats: Dict[str, Any] = Field(default_factory=dict)
 
@@ -2596,7 +2605,12 @@ class RunOpenHandsAgent(BaseModel):
             apptainer_cmd, stdout=log_file, stderr=log_file, start_new_session=True
         )
 
-        active_command = ActiveContainerCommand(process=process, log_file=log_file, log_file_path=log_file_path)
+        active_command = ActiveContainerCommand(
+            process=process,
+            log_file=log_file,
+            log_file_path=log_file_path,
+            overlay_dirname=command.overlay_dirname,
+        )
         if self.config.memory_watchdog_enabled:
             active_command.watchdog_task = asyncio.create_task(
                 self._memory_watchdog(process.pid, active_command.watchdog_stats, command.mode)
@@ -2624,6 +2638,8 @@ class RunOpenHandsAgent(BaseModel):
             active_command.log_file.close()
             if active_command.watchdog_task is not None:
                 active_command.watchdog_task.cancel()
+            if active_command.process.returncode is not None:
+                _reap_overlay_dir(active_command.overlay_dirname)
 
         if active_command.watchdog_stats.get("oom_killed"):
             raise RuntimeError(
@@ -2667,6 +2683,7 @@ class RunOpenHandsAgent(BaseModel):
         active_command.log_file.close()
         if active_command.watchdog_task is not None:
             active_command.watchdog_task.cancel()
+        _reap_overlay_dir(active_command.overlay_dirname)
 
     async def process_single_datapoint(self) -> Optional[Path]:
         if self.config.verify_golden_patch:
@@ -3486,11 +3503,14 @@ class SWEBenchWrapper(SimpleResponsesAPIAgent):
         # Back the container's writable layer with a directory overlay.
         # The tmpfs layer is capped, but SWE working trees routinely exceed it.
         # A `git reset --hard` call is often sufficient to kill the episode otherwise.
-        overlay_prefix = f"apptainer_overlay_{command.mode}_"
+        # The dir name is generated here rather than by shell mktemp so the kill paths
+        # can reap the dir after a SIGKILL, which never runs the shell's cleanup trap.
+        command.overlay_dirname = f"apptainer_overlay_{command.mode}_{uuid.uuid4().hex}"
 
         # Launch Apptainer container and execute the script file
         apptainer_cmd = (
-            f'OVERLAY_DIR="$(mktemp -d "${{TMPDIR:-/tmp}}/{overlay_prefix}XXXXXX")" && '
+            f'OVERLAY_DIR="${{TMPDIR:-/tmp}}/{command.overlay_dirname}" && '
+            f'rm -rf "$OVERLAY_DIR" && mkdir "$OVERLAY_DIR" && '
             f"trap 'rm -rf \"$OVERLAY_DIR\"' EXIT TERM INT && "
             f'apptainer exec --overlay "$OVERLAY_DIR" --cleanenv --pid --no-mount home,tmp,bind-paths '
             f"{env_args}"

--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -134,6 +134,16 @@ class SWEBenchWrapperConfig(BaseResponsesAPIAgentConfig):
     container_formatter: str | list[str] = Field(
         default="docker://swebench/sweb.eval.x86_64.{instance_id}", description="Container path template"
     )
+    preserve_episode_artifacts: bool = Field(
+        default=True,
+        description=(
+            "Keep each successful episode's results directory after its /run completes. "
+            "Episode scratch is very large; long training runs may set this to False so completed "
+            "directories are reaped instead of accumulating until the filesystem fills mid-run "
+            "(failed episodes always keep their directory, including traceback.err)."
+        ),
+    )
+
     swebench_tests_timeout: int = Field(default=30 * 60, description="Timeout for running tests (seconds)")
 
     swebench_agent_timeout: int = Field(default=45 * 60, description="Timeout for running the agent (seconds)")
@@ -3274,9 +3284,13 @@ class SWEBenchWrapper(SimpleResponsesAPIAgent):
         )
         data_point = params.problem_info
 
-        # Fix localhost URLs not working sometimes
+        # Fix localhost URLs not working sometimes.
+        # Append non-fatally; a write to /etc/hosts can fail and abort the entire episode.
         container_commands = []
-        container_commands.append("echo '127.0.0.1 localhost' >/etc/hosts")
+        container_commands.append("(echo '127.0.0.1 localhost' >>/etc/hosts 2>/dev/null || true)")
+
+        # Under the overlay the repository .git can appear owned by a different uid.
+        container_commands.append("(git config --global --add safe.directory '*' 2>/dev/null || true)")
 
         # Apptainer uid namespacing makes the eval-image's `chmod` against
         # /var/run/postgresql fail with "Value too large for defined data
@@ -3589,9 +3603,16 @@ class SWEBenchWrapper(SimpleResponsesAPIAgent):
         env_args += "--env CHROME_BIN=/tmp/chrome-wrapper.sh "
         env_args += "--env CHROMIUM_BIN=/tmp/chrome-wrapper.sh "
 
+        # Back the container's writable layer with a directory overlay.
+        # The tmpfs layer is capped, but SWE working trees routinely exceed it.
+        # A `git reset --hard` call is often sufficient to kill the episode otherwise.
+        overlay_prefix = f"apptainer_overlay_{command.mode}_"
+
         # Launch Apptainer container and execute the script file
         apptainer_cmd = (
-            f"apptainer exec --writable-tmpfs --cleanenv --pid --no-mount home,tmp,bind-paths "
+            f'OVERLAY_DIR="$(mktemp -d "${{TMPDIR:-/tmp}}/{overlay_prefix}XXXXXX")" && '
+            f"trap 'rm -rf \"$OVERLAY_DIR\"' EXIT TERM INT && "
+            f'apptainer exec --overlay "$OVERLAY_DIR" --cleanenv --pid --no-mount home,tmp,bind-paths '
             f"{env_args}"
             f"{mount_str} "
             f" {params.container} bash {container_script_path}"
@@ -3808,7 +3829,10 @@ class SWEBenchWrapper(SimpleResponsesAPIAgent):
             f.write(params.model_dump_json(indent=4))
 
         try:
-            return await self._inner_responses(params, dataset_processor)
+            response = await self._inner_responses(params, dataset_processor)
+            if not self.config.preserve_episode_artifacts:
+                rmtree(params.persistent_dir, ignore_errors=True)
+            return response
         except Exception as e:
             traceback_file = params.persistent_dir / "traceback.err"
             with traceback_file.open("w") as f:

--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -251,6 +251,7 @@ class ExecuteContainerCommandArgs(BaseModel):
     expected_file_pattern: str
     mode: Union[Literal["agent"], Literal["eval"]]
     timeout: int
+    overlay_dirname: Optional[str] = None
 
 
 class SWEBenchWrapperInstanceConfig(SWEBenchWrapperServerConfig, SWEBenchWrapperConfig):
@@ -2552,12 +2553,20 @@ def _kill_container_tree(root_pid: int) -> None:
             pass
 
 
+def _reap_overlay_dir(overlay_dirname: Optional[str]) -> None:
+    """Remove a container's overlay upperdir after a SIGKILL teardown."""
+    if not overlay_dirname:
+        return
+    rmtree(Path(os.environ.get("TMPDIR") or "/tmp") / overlay_dirname, ignore_errors=True)
+
+
 class ActiveContainerCommand(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     process: Process
     log_file: Any
     log_file_path: Path
+    overlay_dirname: Optional[str] = None
     watchdog_task: Optional[Any] = None
     watchdog_stats: Dict[str, Any] = Field(default_factory=dict)
 
@@ -2700,7 +2709,12 @@ class RunOpenHandsAgent(BaseModel):
             apptainer_cmd, stdout=log_file, stderr=log_file, start_new_session=True
         )
 
-        active_command = ActiveContainerCommand(process=process, log_file=log_file, log_file_path=log_file_path)
+        active_command = ActiveContainerCommand(
+            process=process,
+            log_file=log_file,
+            log_file_path=log_file_path,
+            overlay_dirname=command.overlay_dirname,
+        )
         if self.config.memory_watchdog_enabled:
             active_command.watchdog_task = asyncio.create_task(
                 self._memory_watchdog(process.pid, active_command.watchdog_stats, command.mode)
@@ -2728,6 +2742,8 @@ class RunOpenHandsAgent(BaseModel):
             active_command.log_file.close()
             if active_command.watchdog_task is not None:
                 active_command.watchdog_task.cancel()
+            if active_command.process.returncode is not None:
+                _reap_overlay_dir(active_command.overlay_dirname)
 
         if active_command.watchdog_stats.get("oom_killed"):
             raise RuntimeError(
@@ -2771,6 +2787,7 @@ class RunOpenHandsAgent(BaseModel):
         active_command.log_file.close()
         if active_command.watchdog_task is not None:
             active_command.watchdog_task.cancel()
+        _reap_overlay_dir(active_command.overlay_dirname)
 
     async def process_single_datapoint(self) -> Optional[Path]:
         if self.config.verify_golden_patch:
@@ -3606,11 +3623,14 @@ class SWEBenchWrapper(SimpleResponsesAPIAgent):
         # Back the container's writable layer with a directory overlay.
         # The tmpfs layer is capped, but SWE working trees routinely exceed it.
         # A `git reset --hard` call is often sufficient to kill the episode otherwise.
-        overlay_prefix = f"apptainer_overlay_{command.mode}_"
+        # The dir name is generated here rather than by shell mktemp so the kill paths
+        # can reap the dir after a SIGKILL, which never runs the shell's cleanup trap.
+        command.overlay_dirname = f"apptainer_overlay_{command.mode}_{uuid.uuid4().hex}"
 
         # Launch Apptainer container and execute the script file
         apptainer_cmd = (
-            f'OVERLAY_DIR="$(mktemp -d "${{TMPDIR:-/tmp}}/{overlay_prefix}XXXXXX")" && '
+            f'OVERLAY_DIR="${{TMPDIR:-/tmp}}/{command.overlay_dirname}" && '
+            f'rm -rf "$OVERLAY_DIR" && mkdir "$OVERLAY_DIR" && '
             f"trap 'rm -rf \"$OVERLAY_DIR\"' EXIT TERM INT && "
             f'apptainer exec --overlay "$OVERLAY_DIR" --cleanenv --pid --no-mount home,tmp,bind-paths '
             f"{env_args}"

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import os
 import shutil
+import subprocess
 import tempfile
 import time
 from contextlib import ExitStack
@@ -2016,8 +2017,72 @@ class TestSWEBenchWrapperBuildApptainerCommand:
             )
             result = wrapper._build_apptainer_command(params, cmd_args)
             assert "apptainer exec" in result
-            assert "--writable-tmpfs" in result
+            # The writable layer is a fresh TMPDIR-backed directory overlay
+            # (the session tmpfs is capped by sessiondir max size, which SWE
+            # working trees exceed).
+            assert '--overlay "$OVERLAY_DIR"' in result
             assert params.container in result
+
+    def test_sandbox_hardening_overlay_wrapper_and_script(self, monkeypatch, tmp_path) -> None:
+        """The writable layer is a fresh TMPDIR-backed directory overlay per
+        container execution, and the container script fixes /etc/hosts
+        non-fatally and grants git safe.directory."""
+        wrapper = _create_wrapper(monkeypatch)
+        params = _make_instance_config(str(tmp_path))
+
+        commands = {
+            mode: wrapper._build_apptainer_command(
+                params,
+                ExecuteContainerCommandArgs(
+                    command=f"echo {mode}", expected_file_pattern="output*.jsonl", mode=mode, timeout=60
+                ),
+            )
+            for mode in ("agent", "eval")
+        }
+
+        for mode, cmd in commands.items():
+            assert f"apptainer_overlay_{mode}_" in cmd
+            assert '--overlay "$OVERLAY_DIR"' in cmd
+            assert "trap 'rm -rf \"$OVERLAY_DIR\"' EXIT TERM INT" in cmd
+            assert "--writable-tmpfs" not in cmd
+
+        script = (params.persistent_dir / "container_scripts" / "agent_script.sh").read_text()
+        assert "(echo '127.0.0.1 localhost' >>/etc/hosts 2>/dev/null || true)" in script
+        assert "echo '127.0.0.1 localhost' >/etc/hosts" not in script
+        assert "git config --global --add safe.directory '*'" in script
+
+    def test_overlay_upperdir_lives_and_dies_with_the_container(self, monkeypatch, tmp_path) -> None:
+        """Run the built command with a stub apptainer: the upperdir must
+        exist (fresh, under TMPDIR) while the container runs and be removed
+        when the shell exits."""
+        wrapper = _create_wrapper(monkeypatch)
+        params = _make_instance_config(str(tmp_path))
+        cmd = wrapper._build_apptainer_command(
+            params,
+            ExecuteContainerCommandArgs(
+                command="echo hi", expected_file_pattern="output*.jsonl", mode="agent", timeout=60
+            ),
+        )
+
+        stub_bin = tmp_path / "stub_bin"
+        stub_bin.mkdir()
+        witness = tmp_path / "overlay_during_run.txt"
+        # argv: apptainer exec --overlay <dir> ... -> "$3" is the upperdir.
+        (stub_bin / "apptainer").write_text(
+            f'#!/bin/sh\nprintf "%s\\n" "$3" > {witness}\n[ -d "$3" ] && echo EXISTS >> {witness}\n'
+        )
+        (stub_bin / "apptainer").chmod(0o755)
+        scratch_tmp = tmp_path / "scratch_tmp"
+        scratch_tmp.mkdir()
+
+        env = {**os.environ, "PATH": f"{stub_bin}:{os.environ['PATH']}", "TMPDIR": str(scratch_tmp)}
+        result = subprocess.run(["/bin/sh", "-c", cmd], env=env, capture_output=True, text=True)
+
+        assert result.returncode == 0, result.stderr
+        overlay_path, exists_flag = witness.read_text().splitlines()
+        assert exists_flag == "EXISTS"
+        assert overlay_path.startswith(str(scratch_tmp))
+        assert not Path(overlay_path).exists()
 
     def test_eval_mode_swebench_mounts(self, monkeypatch) -> None:
         wrapper = _create_wrapper(monkeypatch)
@@ -2515,6 +2580,22 @@ class TestSWEBenchWrapperResponses:
             ):
                 with pytest.raises(RuntimeError, match="test error"):
                     await wrapper.responses(body)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("preserve", [False, True])
+    async def test_episode_scratch_reaped_only_when_preservation_off(self, monkeypatch, tmp_path, preserve) -> None:
+        wrapper = _create_wrapper(monkeypatch)
+        monkeypatch.setattr(wrapper.config, "preserve_episode_artifacts", preserve, raising=False)
+        params = _make_instance_config(str(tmp_path))
+        params.eval_private_dir.mkdir(parents=True, exist_ok=True)
+        (params.persistent_dir / "episode_artifact.txt").write_text("heavy")
+
+        monkeypatch.setattr(SWEBenchWrapper, "_setup_params", lambda self, body: (params, MagicMock()))
+        monkeypatch.setattr(SWEBenchWrapper, "_inner_responses", AsyncMock(return_value=MagicMock()))
+
+        await wrapper.responses(NeMoGymResponseCreateParamsNonStreaming(input=[]))
+
+        assert params.persistent_dir.exists() is preserve
 
 
 class TestSWEBenchWrapperRun:

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import os
 import shutil
+import signal
 import subprocess
 import tempfile
 import time
@@ -1725,6 +1726,56 @@ class TestRunOpenHandsAgent:
             assert "output2.json" in result  # should pick latest
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("kill_path", ["watchdog_sigkill", "finish_timeout"])
+    async def test_overlay_reaped_after_sigkill_teardown(self, monkeypatch, tmp_path, kill_path) -> None:
+        """SIGKILL teardown never runs the launch shell's trap (the leak); the
+        Python-side kill paths must reap the upperdir by name instead."""
+        wrapper = _create_wrapper(monkeypatch)
+        params = _make_instance_config(str(tmp_path))
+        cmd_args = ExecuteContainerCommandArgs(
+            command="echo hi",
+            expected_file_pattern="output*.jsonl",
+            mode="agent",
+            timeout=1 if kill_path == "finish_timeout" else 60,
+        )
+        apptainer_cmd = wrapper._build_apptainer_command(params, cmd_args)
+
+        stub_bin = tmp_path / "stub_bin"
+        stub_bin.mkdir()
+        (stub_bin / "apptainer").write_text("#!/bin/sh\nsleep 300\n")  # a container that never exits
+        (stub_bin / "apptainer").chmod(0o755)
+        scratch_tmp = tmp_path / "scratch_tmp"
+        scratch_tmp.mkdir()
+        # The spawned shell and the reap read the same process environment.
+        monkeypatch.setenv("PATH", f"{stub_bin}:{os.environ['PATH']}")
+        monkeypatch.setenv("TMPDIR", str(scratch_tmp))
+
+        agent = RunOpenHandsAgent(config=params)
+        active = await agent._start_container_command(cmd_args, apptainer_cmd)
+        assert active.overlay_dirname == cmd_args.overlay_dirname
+        overlay_dir = scratch_tmp / cmd_args.overlay_dirname
+        for _ in range(200):
+            if overlay_dir.is_dir():
+                break
+            await asyncio.sleep(0.05)
+        assert overlay_dir.is_dir()
+
+        if kill_path == "finish_timeout":
+            # The timeout branch SIGKILLs the tree and reaps on its way out.
+            with pytest.raises(ValueError, match="Command timed out"):
+                await agent._finish_container_command(active, cmd_args)
+        else:
+            # Kill the tree the way the watchdog does: the shell dies without
+            # running its trap, so the upperdir outlives the container.
+            os.killpg(os.getpgid(active.process.pid), signal.SIGKILL)
+            await active.process.wait()
+            assert overlay_dir.is_dir()
+            swe_app._reap_overlay_dir(None)  # a command with no overlay is a no-op
+            await agent._kill_active_command(active)
+        assert active.process.returncode is not None
+        assert not overlay_dir.exists()
+
+    @pytest.mark.asyncio
     async def test_finish_container_command_timeout(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             agent = self._make_agent(tmpdir)
@@ -2030,21 +2081,23 @@ class TestSWEBenchWrapperBuildApptainerCommand:
         wrapper = _create_wrapper(monkeypatch)
         params = _make_instance_config(str(tmp_path))
 
-        commands = {
-            mode: wrapper._build_apptainer_command(
-                params,
-                ExecuteContainerCommandArgs(
-                    command=f"echo {mode}", expected_file_pattern="output*.jsonl", mode=mode, timeout=60
-                ),
+        args = {
+            mode: ExecuteContainerCommandArgs(
+                command=f"echo {mode}", expected_file_pattern="output*.jsonl", mode=mode, timeout=60
             )
             for mode in ("agent", "eval")
         }
+        commands = {mode: wrapper._build_apptainer_command(params, cmd_args) for mode, cmd_args in args.items()}
 
         for mode, cmd in commands.items():
-            assert f"apptainer_overlay_{mode}_" in cmd
+            # The upperdir name is recorded on the command args (for the kill-path reap).
+            dirname = args[mode].overlay_dirname
+            assert dirname is not None and dirname.startswith(f"apptainer_overlay_{mode}_")
+            assert f'OVERLAY_DIR="${{TMPDIR:-/tmp}}/{dirname}"' in cmd
             assert '--overlay "$OVERLAY_DIR"' in cmd
             assert "trap 'rm -rf \"$OVERLAY_DIR\"' EXIT TERM INT" in cmd
             assert "--writable-tmpfs" not in cmd
+        assert args["agent"].overlay_dirname != args["eval"].overlay_dirname
 
         script = (params.persistent_dir / "container_scripts" / "agent_script.sh").read_text()
         assert "(echo '127.0.0.1 localhost' >>/etc/hosts 2>/dev/null || true)" in script
@@ -2057,12 +2110,10 @@ class TestSWEBenchWrapperBuildApptainerCommand:
         when the shell exits."""
         wrapper = _create_wrapper(monkeypatch)
         params = _make_instance_config(str(tmp_path))
-        cmd = wrapper._build_apptainer_command(
-            params,
-            ExecuteContainerCommandArgs(
-                command="echo hi", expected_file_pattern="output*.jsonl", mode="agent", timeout=60
-            ),
+        cmd_args = ExecuteContainerCommandArgs(
+            command="echo hi", expected_file_pattern="output*.jsonl", mode="agent", timeout=60
         )
+        cmd = wrapper._build_apptainer_command(params, cmd_args)
 
         stub_bin = tmp_path / "stub_bin"
         stub_bin.mkdir()
@@ -2082,6 +2133,7 @@ class TestSWEBenchWrapperBuildApptainerCommand:
         overlay_path, exists_flag = witness.read_text().splitlines()
         assert exists_flag == "EXISTS"
         assert overlay_path.startswith(str(scratch_tmp))
+        assert Path(overlay_path).name == cmd_args.overlay_dirname
         assert not Path(overlay_path).exists()
 
     def test_eval_mode_swebench_mounts(self, monkeypatch) -> None:

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import os
 import shutil
+import signal
 import subprocess
 import tempfile
 import time
@@ -2027,6 +2028,56 @@ class TestRunOpenHandsAgent:
             assert "output2.json" in result  # should pick latest
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("kill_path", ["watchdog_sigkill", "finish_timeout"])
+    async def test_overlay_reaped_after_sigkill_teardown(self, monkeypatch, tmp_path, kill_path) -> None:
+        """SIGKILL teardown never runs the launch shell's trap (the leak); the
+        Python-side kill paths must reap the upperdir by name instead."""
+        wrapper = _create_wrapper(monkeypatch)
+        params = _make_instance_config(str(tmp_path))
+        cmd_args = ExecuteContainerCommandArgs(
+            command="echo hi",
+            expected_file_pattern="output*.jsonl",
+            mode="agent",
+            timeout=1 if kill_path == "finish_timeout" else 60,
+        )
+        apptainer_cmd = wrapper._build_apptainer_command(params, cmd_args)
+
+        stub_bin = tmp_path / "stub_bin"
+        stub_bin.mkdir()
+        (stub_bin / "apptainer").write_text("#!/bin/sh\nsleep 300\n")  # a container that never exits
+        (stub_bin / "apptainer").chmod(0o755)
+        scratch_tmp = tmp_path / "scratch_tmp"
+        scratch_tmp.mkdir()
+        # The spawned shell and the reap read the same process environment.
+        monkeypatch.setenv("PATH", f"{stub_bin}:{os.environ['PATH']}")
+        monkeypatch.setenv("TMPDIR", str(scratch_tmp))
+
+        agent = RunOpenHandsAgent(config=params)
+        active = await agent._start_container_command(cmd_args, apptainer_cmd)
+        assert active.overlay_dirname == cmd_args.overlay_dirname
+        overlay_dir = scratch_tmp / cmd_args.overlay_dirname
+        for _ in range(200):
+            if overlay_dir.is_dir():
+                break
+            await asyncio.sleep(0.05)
+        assert overlay_dir.is_dir()
+
+        if kill_path == "finish_timeout":
+            # The timeout branch SIGKILLs the tree and reaps on its way out.
+            with pytest.raises(ValueError, match="Command timed out"):
+                await agent._finish_container_command(active, cmd_args)
+        else:
+            # Kill the tree the way the watchdog does: the shell dies without
+            # running its trap, so the upperdir outlives the container.
+            os.killpg(os.getpgid(active.process.pid), signal.SIGKILL)
+            await active.process.wait()
+            assert overlay_dir.is_dir()
+            swe_app._reap_overlay_dir(None)  # a command with no overlay is a no-op
+            await agent._kill_active_command(active)
+        assert active.process.returncode is not None
+        assert not overlay_dir.exists()
+
+    @pytest.mark.asyncio
     async def test_finish_container_command_timeout(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             agent = self._make_agent(tmpdir)
@@ -2332,21 +2383,23 @@ class TestSWEBenchWrapperBuildApptainerCommand:
         wrapper = _create_wrapper(monkeypatch)
         params = _make_instance_config(str(tmp_path))
 
-        commands = {
-            mode: wrapper._build_apptainer_command(
-                params,
-                ExecuteContainerCommandArgs(
-                    command=f"echo {mode}", expected_file_pattern="output*.jsonl", mode=mode, timeout=60
-                ),
+        args = {
+            mode: ExecuteContainerCommandArgs(
+                command=f"echo {mode}", expected_file_pattern="output*.jsonl", mode=mode, timeout=60
             )
             for mode in ("agent", "eval")
         }
+        commands = {mode: wrapper._build_apptainer_command(params, cmd_args) for mode, cmd_args in args.items()}
 
         for mode, cmd in commands.items():
-            assert f"apptainer_overlay_{mode}_" in cmd
+            # The upperdir name is recorded on the command args (for the kill-path reap).
+            dirname = args[mode].overlay_dirname
+            assert dirname is not None and dirname.startswith(f"apptainer_overlay_{mode}_")
+            assert f'OVERLAY_DIR="${{TMPDIR:-/tmp}}/{dirname}"' in cmd
             assert '--overlay "$OVERLAY_DIR"' in cmd
             assert "trap 'rm -rf \"$OVERLAY_DIR\"' EXIT TERM INT" in cmd
             assert "--writable-tmpfs" not in cmd
+        assert args["agent"].overlay_dirname != args["eval"].overlay_dirname
 
         script = (params.persistent_dir / "container_scripts" / "agent_script.sh").read_text()
         assert "(echo '127.0.0.1 localhost' >>/etc/hosts 2>/dev/null || true)" in script
@@ -2359,12 +2412,10 @@ class TestSWEBenchWrapperBuildApptainerCommand:
         when the shell exits."""
         wrapper = _create_wrapper(monkeypatch)
         params = _make_instance_config(str(tmp_path))
-        cmd = wrapper._build_apptainer_command(
-            params,
-            ExecuteContainerCommandArgs(
-                command="echo hi", expected_file_pattern="output*.jsonl", mode="agent", timeout=60
-            ),
+        cmd_args = ExecuteContainerCommandArgs(
+            command="echo hi", expected_file_pattern="output*.jsonl", mode="agent", timeout=60
         )
+        cmd = wrapper._build_apptainer_command(params, cmd_args)
 
         stub_bin = tmp_path / "stub_bin"
         stub_bin.mkdir()
@@ -2384,6 +2435,7 @@ class TestSWEBenchWrapperBuildApptainerCommand:
         overlay_path, exists_flag = witness.read_text().splitlines()
         assert exists_flag == "EXISTS"
         assert overlay_path.startswith(str(scratch_tmp))
+        assert Path(overlay_path).name == cmd_args.overlay_dirname
         assert not Path(overlay_path).exists()
 
     def test_eval_mode_swebench_mounts(self, monkeypatch) -> None:

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import os
 import shutil
+import subprocess
 import tempfile
 import time
 from contextlib import ExitStack
@@ -2318,8 +2319,72 @@ class TestSWEBenchWrapperBuildApptainerCommand:
             )
             result = wrapper._build_apptainer_command(params, cmd_args)
             assert "apptainer exec" in result
-            assert "--writable-tmpfs" in result
+            # The writable layer is a fresh TMPDIR-backed directory overlay
+            # (the session tmpfs is capped by sessiondir max size, which SWE
+            # working trees exceed).
+            assert '--overlay "$OVERLAY_DIR"' in result
             assert params.container in result
+
+    def test_sandbox_hardening_overlay_wrapper_and_script(self, monkeypatch, tmp_path) -> None:
+        """The writable layer is a fresh TMPDIR-backed directory overlay per
+        container execution, and the container script fixes /etc/hosts
+        non-fatally and grants git safe.directory."""
+        wrapper = _create_wrapper(monkeypatch)
+        params = _make_instance_config(str(tmp_path))
+
+        commands = {
+            mode: wrapper._build_apptainer_command(
+                params,
+                ExecuteContainerCommandArgs(
+                    command=f"echo {mode}", expected_file_pattern="output*.jsonl", mode=mode, timeout=60
+                ),
+            )
+            for mode in ("agent", "eval")
+        }
+
+        for mode, cmd in commands.items():
+            assert f"apptainer_overlay_{mode}_" in cmd
+            assert '--overlay "$OVERLAY_DIR"' in cmd
+            assert "trap 'rm -rf \"$OVERLAY_DIR\"' EXIT TERM INT" in cmd
+            assert "--writable-tmpfs" not in cmd
+
+        script = (params.persistent_dir / "container_scripts" / "agent_script.sh").read_text()
+        assert "(echo '127.0.0.1 localhost' >>/etc/hosts 2>/dev/null || true)" in script
+        assert "echo '127.0.0.1 localhost' >/etc/hosts" not in script
+        assert "git config --global --add safe.directory '*'" in script
+
+    def test_overlay_upperdir_lives_and_dies_with_the_container(self, monkeypatch, tmp_path) -> None:
+        """Run the built command with a stub apptainer: the upperdir must
+        exist (fresh, under TMPDIR) while the container runs and be removed
+        when the shell exits."""
+        wrapper = _create_wrapper(monkeypatch)
+        params = _make_instance_config(str(tmp_path))
+        cmd = wrapper._build_apptainer_command(
+            params,
+            ExecuteContainerCommandArgs(
+                command="echo hi", expected_file_pattern="output*.jsonl", mode="agent", timeout=60
+            ),
+        )
+
+        stub_bin = tmp_path / "stub_bin"
+        stub_bin.mkdir()
+        witness = tmp_path / "overlay_during_run.txt"
+        # argv: apptainer exec --overlay <dir> ... -> "$3" is the upperdir.
+        (stub_bin / "apptainer").write_text(
+            f'#!/bin/sh\nprintf "%s\\n" "$3" > {witness}\n[ -d "$3" ] && echo EXISTS >> {witness}\n'
+        )
+        (stub_bin / "apptainer").chmod(0o755)
+        scratch_tmp = tmp_path / "scratch_tmp"
+        scratch_tmp.mkdir()
+
+        env = {**os.environ, "PATH": f"{stub_bin}:{os.environ['PATH']}", "TMPDIR": str(scratch_tmp)}
+        result = subprocess.run(["/bin/sh", "-c", cmd], env=env, capture_output=True, text=True)
+
+        assert result.returncode == 0, result.stderr
+        overlay_path, exists_flag = witness.read_text().splitlines()
+        assert exists_flag == "EXISTS"
+        assert overlay_path.startswith(str(scratch_tmp))
+        assert not Path(overlay_path).exists()
 
     def test_eval_mode_swebench_mounts(self, monkeypatch) -> None:
         wrapper = _create_wrapper(monkeypatch)
@@ -2817,6 +2882,24 @@ class TestSWEBenchWrapperResponses:
             ):
                 with pytest.raises(RuntimeError, match="test error"):
                     await wrapper.responses(body)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("preserve", [False, True])
+    async def test_episode_scratch_reaped_only_when_preservation_off(self, monkeypatch, tmp_path, preserve) -> None:
+        wrapper = _create_wrapper(monkeypatch)
+        monkeypatch.setattr(wrapper.config, "preserve_episode_artifacts", preserve, raising=False)
+        params = _make_instance_config(str(tmp_path))
+        params.eval_private_dir.mkdir(parents=True, exist_ok=True)
+        (params.persistent_dir / "episode_artifact.txt").write_text("heavy")
+
+        monkeypatch.setattr(
+            SWEBenchWrapper, "_setup_params", lambda self, body, *args, **kwargs: (params, MagicMock())
+        )
+        monkeypatch.setattr(SWEBenchWrapper, "_inner_responses", AsyncMock(return_value=MagicMock()))
+
+        await wrapper.responses(NeMoGymResponseCreateParamsNonStreaming(input=[]))
+
+        assert params.persistent_dir.exists() is preserve
 
 
 class TestSWEBenchWrapperRun:


### PR DESCRIPTION
apptainer's per-container session tmpfs has a size capped by `sessiondir max size`. SWE commonly exceeds the default value, with a simple `git reset --hard` usually killing the episode.

This PR backs the writable layer with a directory overlay that is freshly created under `TMPDIR` and removed when the container exits.

Episode results currently land next to the server sources and accumulate forever. This PR adds `results_root` to be able to specify a different root directory - and avoid disk overflow - and `preserve_episode_artifacts` which can clean up stale episode results if set to False.