### PR TITLE
feat(environments): define the environment manifest contract

### DIFF
--- a/nemo_gym/benchmarks.py
+++ b/nemo_gym/benchmarks.py
@@ -137,13 +137,14 @@ def _benchmark_config_paths(benchmarks_dir: Path) -> List[Path]:
     """Sorted config paths under one dir that declare a benchmark, discovered by content.
 
     A config is a benchmark iff it declares a `type: benchmark` dataset, regardless of filename, so we scan
-    every yaml. :func:`_is_benchmark_config` is a cheap prefilter (pay the resolve cost only on real
-    candidates) that also catches non-`config.yaml` names like tau2's `configs/*.yaml`. Empty if dir missing.
+    every YAML except the reserved onboarding `manifest.yaml`. :func:`_is_benchmark_config` is a cheap
+    prefilter (pay the resolve cost only on real candidates) that also catches non-`config.yaml` names like
+    tau2's `configs/*.yaml`. Empty if dir missing.
     """
     if not benchmarks_dir.is_dir():
         return []
     config_paths = [benchmarks_dir / p for p in glob("**/*.yaml", root_dir=benchmarks_dir, recursive=True)]
-    return sorted(p for p in config_paths if _is_benchmark_config(p))
+    return sorted(p for p in config_paths if p.name != "manifest.yaml" and _is_benchmark_config(p))
 
 
 def _discover_benchmarks_in_dir(benchmarks_dir: Path) -> Dict[str, BenchmarkConfig]:

--- a/nemo_gym/environment_manifest.py
+++ b/nemo_gym/environment_manifest.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Typed contract for an environment ``manifest.yaml``."""
+
+from __future__ import annotations
+
+from datetime import date
+from enum import Enum
+from pathlib import Path
+from typing import Annotated, Any, Mapping
+
+import yaml
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    FiniteFloat,
+    StringConstraints,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+from nemo_gym.config_types import ConfigError, Domain
+
+
+JSON_SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema"
+SEMVER_PATTERN = (
+    r"^(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)"
+    r"(?:-(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+NAME_PATTERN = r"^[a-z0-9][a-z0-9._-]*(?:/[a-z0-9][a-z0-9._-]*)*$"
+LICENSE_PATTERN = (
+    r"^(?:internal|proprietary|unknown|[A-Za-z0-9][A-Za-z0-9.-]*|"
+    r"LicenseRef-[A-Za-z0-9][A-Za-z0-9.-]*|"
+    r"DocumentRef-[A-Za-z0-9][A-Za-z0-9.-]*:LicenseRef-[A-Za-z0-9][A-Za-z0-9.-]*)$"
+)
+SOURCE_PATTERN = r"^(?:(?:https?|ssh|git|file)://\S+|[^@\s]+@[^:\s]+:\S+)$"
+CALLABLE_PATTERN = r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*:[A-Za-z_][A-Za-z0-9_]*$"
+
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+ManifestName = Annotated[str, StringConstraints(strip_whitespace=True, pattern=NAME_PATTERN)]
+SemVer = Annotated[str, StringConstraints(strip_whitespace=True, pattern=SEMVER_PATTERN)]
+License = Annotated[str, StringConstraints(strip_whitespace=True, pattern=LICENSE_PATTERN)]
+Source = Annotated[str, StringConstraints(strip_whitespace=True, pattern=SOURCE_PATTERN)]
+GitRef = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, pattern=r"^[^\s]+$")]
+PythonCallable = Annotated[str, StringConstraints(strip_whitespace=True, pattern=CALLABLE_PATTERN)]
+
+
+class EnvironmentKind(str, Enum):
+    ENVIRONMENT = "environment"
+    BENCHMARK = "benchmark"
+
+
+class IntegrationProfile(str, Enum):
+    STOCK_LOOP = "stock-loop"
+    MEASURED_LOOP = "measured-loop"
+    EXTERNAL_LOOP = "external-loop"
+    CUSTOM_DRIVER = "custom-driver"
+
+
+class Determinism(str, Enum):
+    SEEDED = "seeded"
+    STOCHASTIC = "stochastic"
+    UNKNOWN = "unknown"
+
+
+class SessionModel(str, Enum):
+    EPISODE = "episode"
+    STEP = "step"
+
+
+class EnvironmentState(str, Enum):
+    NONE = "none"
+    PER_SESSION = "per_session"
+
+
+class Lifecycle(str, Enum):
+    ACTIVE = "active"
+    DEPRECATED = "deprecated"
+
+
+class DatasetKind(str, Enum):
+    TRAIN = "train"
+    VALIDATION = "validation"
+    EXAMPLE = "example"
+    BENCHMARK = "benchmark"
+
+
+_PROFILE_REQUIRED_FIELDS = {
+    IntegrationProfile.STOCK_LOOP: ("resources_server", "agent_server", "model_server", "datasets"),
+    IntegrationProfile.MEASURED_LOOP: ("resources_server", "agent_server", "model_server", "datasets"),
+    IntegrationProfile.EXTERNAL_LOOP: ("resources_server", "agent_server", "datasets"),
+    IntegrationProfile.CUSTOM_DRIVER: ("resources_server", "datasets", "rollout_driver"),
+}
+_BENCHMARK_REQUIRED_FIELDS = ("canonical_split", "standard_prompt_config")
+
+
+class _ManifestModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True, validate_default=True)
+
+
+class Reward(_ManifestModel):
+    range: tuple[FiniteFloat, FiniteFloat] = Field(description="Inclusive lower and upper reward endpoints.")
+    higher_is_better: bool
+
+    @model_validator(mode="after")
+    def validate_range(self) -> "Reward":
+        if self.range[0] >= self.range[1]:
+            raise ValueError("reward.range must be ordered with lower < upper")
+        return self
+
+
+class ManifestDataset(_ManifestModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        validate_default=True,
+        json_schema_extra={
+            "allOf": [
+                {
+                    "if": {"properties": {"type": {"const": "benchmark"}}, "required": ["type"]},
+                    "then": {
+                        "properties": {"prepare_script": {"minLength": 1, "type": "string"}},
+                        "required": ["prepare_script"],
+                    },
+                }
+            ]
+        },
+    )
+
+    name: NonEmptyString
+    type: DatasetKind
+    jsonl_fpath: NonEmptyString
+    prepare_script: NonEmptyString | None = None
+    prompt_config: NonEmptyString | None = None
+    num_repeats: int = Field(default=1, ge=1)
+
+    @model_validator(mode="after")
+    def validate_benchmark_dataset(self) -> "ManifestDataset":
+        if self.type == DatasetKind.BENCHMARK and self.prepare_script is None:
+            raise ValueError("a benchmark dataset requires prepare_script")
+        return self
+
+
+class AdoptedFrom(_ManifestModel):
+    source: Source
+    ref: GitRef
+    reconciled: date
+
+
+def _profile_schema_conditions() -> list[dict[str, Any]]:
+    nonempty_string = {"minLength": 1, "type": "string"}
+    nonempty_datasets = {"minItems": 1, "type": "array"}
+
+    def requires(profile: IntegrationProfile, fields: tuple[str, ...]) -> dict[str, Any]:
+        properties = {field: nonempty_datasets if field == "datasets" else nonempty_string for field in fields}
+        return {
+            "if": {
+                "properties": {"integration_profile": {"const": profile.value}},
+                "required": ["integration_profile"],
+            },
+            "then": {"properties": properties, "required": list(fields)},
+        }
+
+    return [
+        {
+            "if": {"properties": {"kind": {"const": "benchmark"}}, "required": ["kind"]},
+            "then": {
+                "properties": {
+                    "canonical_split": nonempty_string,
+                    "standard_prompt_config": nonempty_string,
+                    "datasets": {
+                        **nonempty_datasets,
+                        "contains": {
+                            "properties": {"type": {"const": "benchmark"}},
+                            "required": ["type"],
+                        },
+                    },
+                },
+                "required": list(_BENCHMARK_REQUIRED_FIELDS),
+            },
+        },
+        *(requires(profile, fields) for profile, fields in _PROFILE_REQUIRED_FIELDS.items()),
+        {
+            "if": {
+                "properties": {"integration_profile": {"const": IntegrationProfile.CUSTOM_DRIVER.value}},
+                "required": ["integration_profile"],
+            },
+            "else": {"properties": {"rollout_driver": {"type": "null"}}},
+        },
+    ]
+
+
+class EnvironmentManifest(_ManifestModel):
+    """Authored metadata plus a read-only mirror of the resolved Gym composition."""
+
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+        validate_default=True,
+        title="NeMo Gym Environment Manifest",
+        json_schema_extra={"allOf": _profile_schema_conditions()},
+    )
+
+    name: ManifestName
+    version: SemVer = Field(description="Semantic version of the resolved composition.")
+    kind: EnvironmentKind
+    integration_profile: IntegrationProfile
+    domain: Domain
+    description: NonEmptyString
+    modality: NonEmptyString
+    licensing: License = "unknown"
+    authors: list[NonEmptyString] = Field(min_length=1, json_schema_extra={"uniqueItems": True})
+    reward: Reward
+    determinism: Determinism = Determinism.UNKNOWN
+
+    resources_server: NonEmptyString | None = None
+    agent_server: NonEmptyString | None = None
+    model_server: NonEmptyString | None = None
+    datasets: list[ManifestDataset] | None = Field(default=None, min_length=1)
+    rollout_driver: PythonCallable | None = None
+    grading_mode: NonEmptyString | None = None
+
+    session_model: SessionModel | None = None
+    state: EnvironmentState | None = None
+    sandbox: NonEmptyString | None = None
+    canonical_split: NonEmptyString | None = None
+    standard_prompt_config: NonEmptyString | None = None
+    adopted_from: AdoptedFrom | None = None
+    lifecycle: Lifecycle = Lifecycle.ACTIVE
+
+    @field_validator("authors")
+    @classmethod
+    def validate_unique_authors(cls, value: list[str]) -> list[str]:
+        if len(value) != len(set(value)):
+            raise ValueError("authors must be unique")
+        return value
+
+    @model_validator(mode="after")
+    def validate_contract(self) -> "EnvironmentManifest":
+        missing = [
+            field for field in _PROFILE_REQUIRED_FIELDS[self.integration_profile] if getattr(self, field) is None
+        ]
+        if self.kind == EnvironmentKind.BENCHMARK:
+            missing.extend(field for field in _BENCHMARK_REQUIRED_FIELDS if getattr(self, field) is None)
+        if missing:
+            raise ValueError("manifest requires: " + ", ".join(dict.fromkeys(missing)))
+        if self.integration_profile != IntegrationProfile.CUSTOM_DRIVER and self.rollout_driver is not None:
+            raise ValueError("rollout_driver is only valid for the custom-driver profile")
+        if self.datasets is not None:
+            names = [dataset.name for dataset in self.datasets]
+            if len(names) != len(set(names)):
+                raise ValueError("dataset names must be unique")
+            if self.kind == EnvironmentKind.BENCHMARK and not any(
+                dataset.type == DatasetKind.BENCHMARK for dataset in self.datasets
+            ):
+                raise ValueError("a benchmark manifest requires a benchmark dataset")
+        return self
+
+
+class ManifestError(ConfigError):
+    """A manifest could not be read, parsed, or validated."""
+
+
+def _validation_error(path: Path, error: ValidationError) -> ManifestError:
+    issues = []
+    for item in error.errors(include_url=False, include_context=False, include_input=False):
+        location = ".".join(str(part) for part in item["loc"]) or "manifest"
+        issues.append(f"  - {location}: {item['msg']}")
+    return ManifestError(f"Invalid environment manifest '{path}':\n" + "\n".join(issues))
+
+
+def load_manifest(path: str | Path) -> EnvironmentManifest:
+    manifest_path = Path(path)
+    try:
+        data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise ManifestError(f"Environment manifest '{manifest_path}' was not found.") from error
+    except (OSError, UnicodeError) as error:
+        raise ManifestError(f"Could not read environment manifest '{manifest_path}': {error}") from error
+    except yaml.YAMLError as error:
+        mark = getattr(error, "problem_mark", None)
+        location = f" at line {mark.line + 1}, column {mark.column + 1}" if mark else ""
+        raise ManifestError(f"Malformed YAML in environment manifest '{manifest_path}'{location}.") from error
+    if not isinstance(data, dict):
+        raise ManifestError(f"Invalid environment manifest '{manifest_path}': expected a YAML mapping.")
+    try:
+        return EnvironmentManifest.model_validate(data)
+    except ValidationError as error:
+        raise _validation_error(manifest_path, error) from error
+
+
+def dump_manifest(manifest: EnvironmentManifest | Mapping[str, Any]) -> str:
+    if not isinstance(manifest, EnvironmentManifest):
+        try:
+            manifest = EnvironmentManifest.model_validate(manifest)
+        except ValidationError as error:
+            raise _validation_error(Path("<memory>"), error) from error
+    return yaml.safe_dump(
+        manifest.model_dump(mode="json", exclude_none=True),
+        sort_keys=False,
+        allow_unicode=True,
+    )
+
+
+def manifest_json_schema() -> dict[str, Any]:
+    return {"$schema": JSON_SCHEMA_DIALECT, **EnvironmentManifest.model_json_schema(mode="validation")}

--- a/schemas/environment-manifest.schema.json
+++ b/schemas/environment-manifest.schema.json
@@ -1,0 +1,657 @@
+{
+  "$defs": {
+    "AdoptedFrom": {
+      "additionalProperties": false,
+      "properties": {
+        "reconciled": {
+          "format": "date",
+          "title": "Reconciled",
+          "type": "string"
+        },
+        "ref": {
+          "minLength": 1,
+          "pattern": "^[^\\s]+$",
+          "title": "Ref",
+          "type": "string"
+        },
+        "source": {
+          "pattern": "^(?:(?:https?|ssh|git|file)://\\S+|[^@\\s]+@[^:\\s]+:\\S+)$",
+          "title": "Source",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source",
+        "ref",
+        "reconciled"
+      ],
+      "title": "AdoptedFrom",
+      "type": "object"
+    },
+    "DatasetKind": {
+      "enum": [
+        "train",
+        "validation",
+        "example",
+        "benchmark"
+      ],
+      "title": "DatasetKind",
+      "type": "string"
+    },
+    "Determinism": {
+      "enum": [
+        "seeded",
+        "stochastic",
+        "unknown"
+      ],
+      "title": "Determinism",
+      "type": "string"
+    },
+    "Domain": {
+      "description": "The capability a resources server primarily evaluates or trains.\n\nPick the single domain that best fits the task. If several seem to apply, choose the most\nspecific one (e.g. prefer `math` or `coding` over `agent`); use `other` only when none\nof the specific values fit. The values:\n\n- `math`                  \u2014 mathematical problem solving (e.g. AIME, MATH, GSM8K).\n- `coding`                \u2014 code generation, repair, or execution (e.g. SWE-bench, LiveCodeBench).\n- `agent`                 \u2014 multi-step, tool-using / environment-interacting tasks (e.g. tau2,\n  workplace_assistant). Prefer a more specific value when the task is really math/coding/etc.\n- `knowledge`             \u2014 factual or domain-knowledge question answering (e.g. GPQA, MMLU).\n- `instruction_following` \u2014 adherence to explicit formatting/constraints (e.g. IFEval).\n- `long_context`          \u2014 reasoning over long inputs (e.g. RULER, long-document QA).\n- `safety`                \u2014 refusing harmful content / resisting jailbreaks & prompt injection.\n- `games`                 \u2014 interactive game environments (e.g. blackjack, tetris).\n- `translation`           \u2014 machine translation quality (e.g. WMT).\n- `e2e`                   \u2014 end-to-end pipelines spanning multiple capabilities at once.\n- `rlhf`                  \u2014 preference / reward-model / LLM-as-judge evaluations.\n- `other`                 \u2014 catch-all when no specific domain above applies.",
+      "enum": [
+        "math",
+        "coding",
+        "agent",
+        "knowledge",
+        "instruction_following",
+        "long_context",
+        "safety",
+        "games",
+        "translation",
+        "e2e",
+        "rlhf",
+        "other"
+      ],
+      "title": "Domain",
+      "type": "string"
+    },
+    "EnvironmentKind": {
+      "enum": [
+        "environment",
+        "benchmark"
+      ],
+      "title": "EnvironmentKind",
+      "type": "string"
+    },
+    "EnvironmentState": {
+      "enum": [
+        "none",
+        "per_session"
+      ],
+      "title": "EnvironmentState",
+      "type": "string"
+    },
+    "IntegrationProfile": {
+      "enum": [
+        "stock-loop",
+        "measured-loop",
+        "external-loop",
+        "custom-driver"
+      ],
+      "title": "IntegrationProfile",
+      "type": "string"
+    },
+    "Lifecycle": {
+      "enum": [
+        "active",
+        "deprecated"
+      ],
+      "title": "Lifecycle",
+      "type": "string"
+    },
+    "ManifestDataset": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "benchmark"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "prepare_script": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "prepare_script"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "jsonl_fpath": {
+          "minLength": 1,
+          "title": "Jsonl Fpath",
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "num_repeats": {
+          "default": 1,
+          "minimum": 1,
+          "title": "Num Repeats",
+          "type": "integer"
+        },
+        "prepare_script": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Prepare Script"
+        },
+        "prompt_config": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Prompt Config"
+        },
+        "type": {
+          "$ref": "#/$defs/DatasetKind"
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "jsonl_fpath"
+      ],
+      "title": "ManifestDataset",
+      "type": "object"
+    },
+    "Reward": {
+      "additionalProperties": false,
+      "properties": {
+        "higher_is_better": {
+          "title": "Higher Is Better",
+          "type": "boolean"
+        },
+        "range": {
+          "description": "Inclusive lower and upper reward endpoints.",
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "title": "Range",
+          "type": "array"
+        }
+      },
+      "required": [
+        "range",
+        "higher_is_better"
+      ],
+      "title": "Reward",
+      "type": "object"
+    },
+    "SessionModel": {
+      "enum": [
+        "episode",
+        "step"
+      ],
+      "title": "SessionModel",
+      "type": "string"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "benchmark"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "properties": {
+          "canonical_split": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "datasets": {
+            "contains": {
+              "properties": {
+                "type": {
+                  "const": "benchmark"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "standard_prompt_config": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "canonical_split",
+          "standard_prompt_config"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "integration_profile": {
+            "const": "stock-loop"
+          }
+        },
+        "required": [
+          "integration_profile"
+        ]
+      },
+      "then": {
+        "properties": {
+          "agent_server": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "datasets": {
+            "minItems": 1,
+            "type": "array"
+          },
+          "model_server": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "resources_server": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "resources_server",
+          "agent_server",
+          "model_server",
+          "datasets"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "integration_profile": {
+            "const": "measured-loop"
+          }
+        },
+        "required": [
+          "integration_profile"
+        ]
+      },
+      "then": {
+        "properties": {
+          "agent_server": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "datasets": {
+            "minItems": 1,
+            "type": "array"
+          },
+          "model_server": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "resources_server": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "resources_server",
+          "agent_server",
+          "model_server",
+          "datasets"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "integration_profile": {
+            "const": "external-loop"
+          }
+        },
+        "required": [
+          "integration_profile"
+        ]
+      },
+      "then": {
+        "properties": {
+          "agent_server": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "datasets": {
+            "minItems": 1,
+            "type": "array"
+          },
+          "resources_server": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "resources_server",
+          "agent_server",
+          "datasets"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "integration_profile": {
+            "const": "custom-driver"
+          }
+        },
+        "required": [
+          "integration_profile"
+        ]
+      },
+      "then": {
+        "properties": {
+          "datasets": {
+            "minItems": 1,
+            "type": "array"
+          },
+          "resources_server": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "rollout_driver": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "resources_server",
+          "datasets",
+          "rollout_driver"
+        ]
+      }
+    },
+    {
+      "else": {
+        "properties": {
+          "rollout_driver": {
+            "type": "null"
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "integration_profile": {
+            "const": "custom-driver"
+          }
+        },
+        "required": [
+          "integration_profile"
+        ]
+      }
+    }
+  ],
+  "description": "Authored metadata plus a read-only mirror of the resolved Gym composition.",
+  "properties": {
+    "adopted_from": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/AdoptedFrom"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "agent_server": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Agent Server"
+    },
+    "authors": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "title": "Authors",
+      "type": "array",
+      "uniqueItems": true
+    },
+    "canonical_split": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Canonical Split"
+    },
+    "datasets": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/ManifestDataset"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Datasets"
+    },
+    "description": {
+      "minLength": 1,
+      "title": "Description",
+      "type": "string"
+    },
+    "determinism": {
+      "$ref": "#/$defs/Determinism",
+      "default": "unknown"
+    },
+    "domain": {
+      "$ref": "#/$defs/Domain"
+    },
+    "grading_mode": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Grading Mode"
+    },
+    "integration_profile": {
+      "$ref": "#/$defs/IntegrationProfile"
+    },
+    "kind": {
+      "$ref": "#/$defs/EnvironmentKind"
+    },
+    "licensing": {
+      "default": "unknown",
+      "pattern": "^(?:internal|proprietary|unknown|[A-Za-z0-9][A-Za-z0-9.-]*|LicenseRef-[A-Za-z0-9][A-Za-z0-9.-]*|DocumentRef-[A-Za-z0-9][A-Za-z0-9.-]*:LicenseRef-[A-Za-z0-9][A-Za-z0-9.-]*)$",
+      "title": "Licensing",
+      "type": "string"
+    },
+    "lifecycle": {
+      "$ref": "#/$defs/Lifecycle",
+      "default": "active"
+    },
+    "modality": {
+      "minLength": 1,
+      "title": "Modality",
+      "type": "string"
+    },
+    "model_server": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Model Server"
+    },
+    "name": {
+      "pattern": "^[a-z0-9][a-z0-9._-]*(?:/[a-z0-9][a-z0-9._-]*)*$",
+      "title": "Name",
+      "type": "string"
+    },
+    "resources_server": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Resources Server"
+    },
+    "reward": {
+      "$ref": "#/$defs/Reward"
+    },
+    "rollout_driver": {
+      "anyOf": [
+        {
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*:[A-Za-z_][A-Za-z0-9_]*$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Rollout Driver"
+    },
+    "sandbox": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Sandbox"
+    },
+    "session_model": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SessionModel"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "standard_prompt_config": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Standard Prompt Config"
+    },
+    "state": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/EnvironmentState"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "version": {
+      "description": "Semantic version of the resolved composition.",
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+      "title": "Version",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "version",
+    "kind",
+    "integration_profile",
+    "domain",
+    "description",
+    "modality",
+    "authors",
+    "reward"
+  ],
+  "title": "NeMo Gym Environment Manifest",
+  "type": "object"
+}

--- a/scripts/generate_environment_manifest_schema.py
+++ b/scripts/generate_environment_manifest_schema.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate or check the environment manifest JSON Schema."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "schemas" / "environment-manifest.schema.json"
+sys.path.insert(0, str(REPO_ROOT))
+
+from nemo_gym.environment_manifest import manifest_json_schema  # noqa: E402
+
+
+def rendered_schema() -> str:
+    return json.dumps(manifest_json_schema(), indent=2, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="Fail when the checked-in schema is stale.")
+    args = parser.parse_args()
+    expected = rendered_schema()
+
+    if args.check:
+        actual = SCHEMA_PATH.read_text(encoding="utf-8") if SCHEMA_PATH.exists() else ""
+        if actual != expected:
+            print(
+                f"{SCHEMA_PATH.relative_to(REPO_ROOT)} is stale; run "
+                "`python scripts/generate_environment_manifest_schema.py`.",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    SCHEMA_PATH.parent.mkdir(exist_ok=True)
+    SCHEMA_PATH.write_text(expected, encoding="utf-8")
+    print(SCHEMA_PATH.relative_to(REPO_ROOT))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit_tests/test_benchmarks.py
+++ b/tests/unit_tests/test_benchmarks.py
@@ -61,6 +61,7 @@ class TestListBenchmarks:
         (tmp_path / "flavored" / "configs" / "myflavor.yaml").write_text("x:\n  datasets:\n  - type: benchmark\n")
         (tmp_path / "notbench").mkdir()
         (tmp_path / "notbench" / "config.yaml").write_text("x:\n  prompt_config: hi.yaml\n")  # no benchmark dataset
+        (tmp_path / "standard" / "manifest.yaml").write_text("datasets:\n- type: benchmark\n")
 
         found = {str(p.relative_to(tmp_path)) for p in _benchmark_config_paths(tmp_path)}
         assert found == {"standard/config.yaml", "flavored/configs/myflavor.yaml"}

--- a/tests/unit_tests/test_environment_manifest.py
+++ b/tests/unit_tests/test_environment_manifest.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from nemo_gym.config_types import ConfigError, Domain
+from nemo_gym.environment_manifest import (
+    EnvironmentManifest,
+    ManifestError,
+    dump_manifest,
+    load_manifest,
+    manifest_json_schema,
+)
+
+
+REPO_ROOT = Path(__file__).parents[2]
+
+
+def _manifest(*, profile: str = "stock-loop", kind: str = "environment") -> dict:
+    manifest = {
+        "name": "my_eval",
+        "version": "1.0.0",
+        "kind": kind,
+        "integration_profile": profile,
+        "domain": "math",
+        "description": "Competition mathematics evaluation",
+        "modality": "text",
+        "licensing": "Apache-2.0",
+        "authors": ["alice"],
+        "reward": {"range": [0, 1], "higher_is_better": True},
+        "determinism": "seeded",
+        "resources_server": "mcqa",
+        "agent_server": "simple_agent",
+        "model_server": "policy_model",
+        "datasets": [
+            {
+                "name": "validation",
+                "type": "validation",
+                "jsonl_fpath": "data/validation.jsonl",
+            }
+        ],
+    }
+    if profile == "custom-driver":
+        manifest["rollout_driver"] = "my_eval.driver:collect"
+    if kind == "benchmark":
+        manifest["canonical_split"] = "validation"
+        manifest["standard_prompt_config"] = "prompts/standard.yaml"
+        manifest["datasets"][0]["type"] = "benchmark"
+        manifest["datasets"][0]["prepare_script"] = "prepare.py"
+    return manifest
+
+
+def test_environment_manifest_parses_and_uses_honest_defaults() -> None:
+    raw = _manifest()
+    raw.pop("licensing")
+    raw.pop("determinism")
+    manifest = EnvironmentManifest.model_validate(raw)
+
+    assert manifest.name == "my_eval"
+    assert manifest.licensing == "unknown"
+    assert manifest.determinism.value == "unknown"
+    assert manifest.lifecycle.value == "active"
+    assert manifest.session_model is None
+
+
+@pytest.mark.parametrize(
+    "profile, missing_field",
+    [
+        ("stock-loop", "model_server"),
+        ("measured-loop", "agent_server"),
+        ("external-loop", "resources_server"),
+        ("custom-driver", "rollout_driver"),
+    ],
+)
+def test_profiles_require_their_composition(profile: str, missing_field: str) -> None:
+    raw = _manifest(profile=profile)
+    raw.pop(missing_field)
+
+    with pytest.raises(ValidationError, match=missing_field):
+        EnvironmentManifest.model_validate(raw)
+
+
+def test_rollout_driver_is_custom_profile_only() -> None:
+    stock = _manifest()
+    stock["rollout_driver"] = "package.driver:collect"
+    with pytest.raises(ValidationError, match="only valid for the custom-driver"):
+        EnvironmentManifest.model_validate(stock)
+
+    custom = _manifest(profile="custom-driver")
+    custom["rollout_driver"] = "not a callable"
+    with pytest.raises(ValidationError, match="string_pattern_mismatch"):
+        EnvironmentManifest.model_validate(custom)
+
+
+@pytest.mark.parametrize("missing_field", ["canonical_split", "standard_prompt_config"])
+def test_benchmark_requires_protocol_fields(missing_field: str) -> None:
+    raw = _manifest(kind="benchmark")
+    raw.pop(missing_field)
+
+    with pytest.raises(ValidationError, match=missing_field):
+        EnvironmentManifest.model_validate(raw)
+
+
+def test_benchmark_requires_a_benchmark_dataset() -> None:
+    raw = _manifest(kind="benchmark")
+    raw["datasets"][0]["type"] = "validation"
+
+    with pytest.raises(ValidationError, match="benchmark dataset"):
+        EnvironmentManifest.model_validate(raw)
+
+    raw["datasets"][0]["type"] = "benchmark"
+    raw["datasets"][0].pop("prepare_script", None)
+    with pytest.raises(ValidationError, match="requires prepare_script"):
+        EnvironmentManifest.model_validate(raw)
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("name", "../escape"),
+        ("version", "1.0"),
+        ("integration_profile", "invented-loop"),
+        ("licensing", "not an SPDX id"),
+    ],
+)
+def test_manifest_rejects_invalid_scalar_contracts(field: str, value: str) -> None:
+    raw = _manifest()
+    raw[field] = value
+
+    with pytest.raises(ValidationError):
+        EnvironmentManifest.model_validate(raw)
+
+
+def test_manifest_rejects_bad_reward_duplicates_and_unknown_fields() -> None:
+    raw = _manifest()
+    raw["reward"]["range"] = [1, 1]
+    raw["authors"] = ["alice", "alice"]
+    raw["surprise"] = True
+
+    with pytest.raises(ValidationError) as error:
+        EnvironmentManifest.model_validate(raw)
+    message = str(error.value)
+    assert "lower < upper" in message
+    assert "authors must be unique" in message
+    assert "Extra inputs are not permitted" in message
+
+
+def test_adopted_from_is_structural_and_offline() -> None:
+    raw = _manifest()
+    raw["adopted_from"] = {
+        "source": "https://github.com/example/project.git",
+        "ref": "v1.2.0",
+        "reconciled": "2026-08-01",
+    }
+    assert EnvironmentManifest.model_validate(raw).adopted_from.ref == "v1.2.0"
+
+    raw["adopted_from"]["source"] = "github.com/example/project"
+    with pytest.raises(ValidationError):
+        EnvironmentManifest.model_validate(raw)
+
+
+def test_load_dump_round_trip_and_errors(tmp_path: Path) -> None:
+    path = tmp_path / "manifest.yaml"
+    path.write_text(dump_manifest(_manifest()))
+    assert load_manifest(path).name == "my_eval"
+
+    path.write_text("name: [broken\n")
+    with pytest.raises(ManifestError, match="Malformed YAML"):
+        load_manifest(path)
+
+    path.write_text("version: nope\n")
+    with pytest.raises(ConfigError, match=r"name.*Field required"):
+        load_manifest(path)
+
+
+def test_checked_in_schema_matches_model_and_gym_domain_enum() -> None:
+    schema = manifest_json_schema()
+    checked_in = json.loads((REPO_ROOT / "schemas/environment-manifest.schema.json").read_text())
+
+    assert checked_in == schema
+    assert schema["$defs"]["Domain"]["enum"] == [domain.value for domain in Domain]
+    assert len(schema["allOf"]) == 6


### PR DESCRIPTION
## Summary

Gym already has the deployable components of an environment. What it lacks is one stable, machine-readable contract that names them.

This PR adds that foundation:

- a strict typed `manifest.yaml` contract shared by environments and benchmarks;
- the four integration profiles and their required composition fields;
- benchmark-only protocol fields and dataset requirements;
- a checked-in JSON Schema generated from the same model and Gym's existing `Domain` enum;
- a small compatibility guard so legacy benchmark discovery ignores an adjacent `manifest.yaml`.

```yaml
name: my_eval
version: 1.0.0
kind: environment
integration_profile: stock-loop
domain: math
description: Competition mathematics evaluation
modality: text
licensing: Apache-2.0
authors: [alice]
reward: {range: [0, 1], higher_is_better: true}
determinism: seeded
resources_server: mcqa
agent_server: simple_agent
model_server: policy_model
datasets:
  - {name: validation, type: validation, jsonl_fpath: data/validation.jsonl}
```

## Boundaries

This is a deliberately narrow contract foundation. It changes no execution path:

- no runtime code reads or requires a manifest;
- existing environments continue to run unchanged;
- Hydra configuration remains authoritative for composition;
- CLI onboarding, resolved-config comparison, component-owned capability declarations, per-server `grading_mode` validation, catalog/migration, and CI remain follow-up work.

The generated schema is 657 lines; the handwritten implementation and tests are about 550 lines.

## Validation

- 54 focused manifest and benchmark-discovery tests
- Ruff lint and format checks
- generated-schema freshness check
- whitespace/diff check
