### PR TITLE
[GDPVal] Add the Slurm bootstrap, model server and continuation harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,4 @@ env.yaml
 responses_api_agents/cvdp_agent/deps/
 resources_servers/cvdp/data/gym_agentic_code_generation_no_commercial.jsonl
 resources_servers/cvdp/data/gym_cvdp_nonagentic_code_generation_no_commercial.jsonl
+benchmarks/gdpval/slurm/cluster.env

--- a/benchmarks/gdpval/models/example.env
+++ b/benchmarks/gdpval/models/example.env
@@ -1,0 +1,78 @@
+# GDPVal model profile — template.
+#
+# One profile per served model. Everything model-specific lives here so the
+# launcher and submitter stay model-agnostic:
+#
+#   set -a; . ./cluster.env; . ../models/my-model.env; set +a
+#   ./submit_model_server.sh submit
+#
+# Weights and image paths come from cluster.env (GDPVAL_MODEL_PATH,
+# GDPVAL_VLLM_IMAGE) because those are site paths, not model properties.
+
+# Served model name. The submitter validates /v1/models against this before
+# releasing any rollout client, so a stale or wrong server is caught early.
+export GDPVAL_MODEL_BASE_NAME="my-model"
+
+# ---------------------------------------------------------------------------
+# Serving shape
+# ---------------------------------------------------------------------------
+
+# Nodes per server job, and how the replica is split across their GPUs.
+export GDPVAL_NUM_NODES="2"
+export GDPVAL_TENSOR_PARALLEL_SIZE="8"
+export GDPVAL_PIPELINE_PARALLEL_SIZE="1"
+
+# Ray data parallelism. Leave at 1 for a single replica; raise it (with more
+# nodes) to serve N replicas behind one endpoint. Aggregate throughput scales
+# close to linearly with replicas, so this is the first knob to reach for when
+# rollout collection is serving-bound.
+export GDPVAL_DATA_PARALLEL_SIZE="1"
+export GDPVAL_DATA_PARALLEL_SIZE_LOCAL="1"
+
+export GDPVAL_GPU_MEMORY_UTILIZATION="0.90"
+export GDPVAL_API_SERVER_COUNT="1"
+
+# Served context, prompt + output. Must cover the rollout token budget or long
+# requests are truncated. Do not just use the model maximum: context trades
+# directly against per-replica concurrency through the KV cache.
+export GDPVAL_MAX_MODEL_LEN="262144"
+
+# ---------------------------------------------------------------------------
+# Model-specific vLLM behaviour
+# ---------------------------------------------------------------------------
+
+# Tool-call and reasoning parsers, as named by vLLM. Both optional: unset means
+# the flag is not passed. Getting these wrong is quiet and expensive — tool
+# calls silently stop parsing and every rollout degrades to plain text.
+export GDPVAL_TOOL_CALL_PARSER=""
+export GDPVAL_REASONING_PARSER=""
+
+# fp8 halves KV-cache footprint, buying concurrency at some accuracy cost.
+# Empty means vLLM's default (unquantized).
+export GDPVAL_KV_CACHE_DTYPE=""
+
+# 1 for mixture-of-experts models, 0 for dense.
+export GDPVAL_EXPERT_PARALLEL="1"
+
+# 1 disables CUDA graph capture / Inductor autotuning. Needed where startup
+# compilation fails on some ranks; costs throughput, so leave 0 unless you hit it.
+export GDPVAL_ENFORCE_EAGER="0"
+
+# ---------------------------------------------------------------------------
+# Batch scheduling
+# ---------------------------------------------------------------------------
+
+# Maximum sequences the engine will run concurrently, and the per-step token
+# budget shared between prefill chunks and decode. Set these explicitly rather
+# than inheriting the container defaults: they decide how much of the requested
+# agent concurrency actually runs at once, and a data-parallel run that is really
+# capped here is indistinguishable from one where scaling failed.
+#
+# Rule of thumb: max-num-seqs comfortably above (agent concurrency / replicas).
+# Empty means do not pass the flag.
+export GDPVAL_MAX_NUM_SEQS=""
+export GDPVAL_MAX_NUM_BATCHED_TOKENS=""
+
+# Anything else to pass to `vllm serve`, word-split. Escape hatch so a new model
+# never requires editing the launcher.
+export GDPVAL_VLLM_EXTRA_ARGS=""

--- a/benchmarks/gdpval/models/glm-5.2-bf16.env
+++ b/benchmarks/gdpval/models/glm-5.2-bf16.env
@@ -1,0 +1,28 @@
+# GLM-5.2 (bf16) — throughput-oriented shape: 16 nodes, TP=4, 16 Ray replicas.
+#
+# Use when you have the allocation and want aggregate throughput rather than
+# lowest per-request latency. KV cache is unquantized here, so context is capped
+# well below the model maximum to preserve per-replica concurrency.
+
+export GDPVAL_MODEL_BASE_NAME="GLM-52-bf16"
+
+export GDPVAL_NUM_NODES="16"
+export GDPVAL_TENSOR_PARALLEL_SIZE="4"
+export GDPVAL_PIPELINE_PARALLEL_SIZE="1"
+export GDPVAL_DATA_PARALLEL_SIZE="16"
+export GDPVAL_DATA_PARALLEL_SIZE_LOCAL="1"
+export GDPVAL_GPU_MEMORY_UTILIZATION="0.85"
+export GDPVAL_API_SERVER_COUNT="1"
+export GDPVAL_MAX_MODEL_LEN="262144"
+
+export GDPVAL_TOOL_CALL_PARSER="glm47"
+export GDPVAL_REASONING_PARSER="glm45"
+export GDPVAL_KV_CACHE_DTYPE=""
+export GDPVAL_EXPERT_PARALLEL="1"
+# Startup compilation has failed on a subset of Blackwell/SM100 ranks with a
+# CUDA driver error inside Inductor autotuning; eager keeps every rank out of it.
+export GDPVAL_ENFORCE_EAGER="1"
+export GDPVAL_MAX_NUM_SEQS=""
+export GDPVAL_MAX_NUM_BATCHED_TOKENS=""
+
+export GDPVAL_VLLM_EXTRA_ARGS=""

--- a/benchmarks/gdpval/models/glm-5.2-fp8.env
+++ b/benchmarks/gdpval/models/glm-5.2-fp8.env
@@ -1,0 +1,26 @@
+# GLM-5.2 (fp8) — the shape measured fastest on 2-node GB200 for GDPVal rollouts.
+#
+# A single TP=8 replica across 2 nodes. fp8 halves weight-memory traffic versus
+# bf16, so decode is materially faster and the freed HBM goes to KV cache.
+# Point GDPVAL_MODEL_PATH at fp8 weights in cluster.env.
+
+export GDPVAL_MODEL_BASE_NAME="GLM-52-fp8"
+
+export GDPVAL_NUM_NODES="2"
+export GDPVAL_TENSOR_PARALLEL_SIZE="8"
+export GDPVAL_PIPELINE_PARALLEL_SIZE="1"
+export GDPVAL_DATA_PARALLEL_SIZE="1"
+export GDPVAL_DATA_PARALLEL_SIZE_LOCAL="1"
+export GDPVAL_GPU_MEMORY_UTILIZATION="0.90"
+export GDPVAL_API_SERVER_COUNT="1"
+export GDPVAL_MAX_MODEL_LEN="262144"
+
+export GDPVAL_TOOL_CALL_PARSER="glm47"
+export GDPVAL_REASONING_PARSER="glm45"
+export GDPVAL_KV_CACHE_DTYPE="fp8"
+export GDPVAL_EXPERT_PARALLEL="1"
+export GDPVAL_ENFORCE_EAGER="0"
+export GDPVAL_MAX_NUM_SEQS=""
+export GDPVAL_MAX_NUM_BATCHED_TOKENS=""
+
+export GDPVAL_VLLM_EXTRA_ARGS=""

--- a/benchmarks/gdpval/slurm/README.md
+++ b/benchmarks/gdpval/slurm/README.md
@@ -1,0 +1,128 @@
+# GDPVal rollout orchestration on Slurm
+
+Reference scripts for collecting GDPVal rollouts on a Slurm cluster with a
+self-hosted vLLM endpoint, across more wall-clock time than one allocation
+gives you.
+
+They exist because a GDPVal rollout batch does not fit in a single job. Tasks
+run for tens of minutes each, allocations are time-boxed, and a run that is
+merely *restarted* after an allocation expires silently loses or duplicates
+work. These scripts keep the model server and the rollout client in separate
+jobs, hand off between allocations, and validate that a resume is safe before
+it is allowed to proceed.
+
+Nothing here is required to run GDPVal — `gym eval run` is. Reach for these
+when a batch is too large for one allocation.
+
+## Configuration
+
+Three layers, so swapping any one of them does not touch the others:
+
+| Layer | File | Holds |
+|---|---|---|
+| Site | `slurm/cluster.env` | Slurm account, partition, filesystem paths, weights + image location |
+| Model | `models/<model>.env` | Parallelism, context, tool/reasoning parsers, KV dtype |
+| Batch | `datasets/<batch>.env` | Input JSONL, expected count/hash, task-id pattern, turn budget |
+
+```bash
+cd benchmarks/gdpval/slurm
+cp cluster.env.example cluster.env
+$EDITOR cluster.env                          # account, model path, container image
+
+set -a
+. ./cluster.env
+. ../models/glm-5.2-fp8.env                  # or your own profile
+. ../datasets/my_batch.env
+set +a
+```
+
+Serving a different model is a new file in `models/`, not an edit to any
+script. Start from `models/example.env`. The two GLM-5.2 profiles are worked
+examples of the same weights deployed two ways:
+
+| Profile | Shape | For |
+|---|---|---|
+| `glm-5.2-fp8.env` | 2 nodes, TP=8, 1 replica | Lowest per-request latency |
+| `glm-5.2-bf16.env` | 16 nodes, TP=4, 16 replicas | Aggregate throughput |
+
+Sizing tensor parallelism is not a free choice: the weights have to leave room
+for KV cache. GLM-5.2 fp8 is ~756 GB, so TP=4 puts ~189 GB on each GPU and vLLM
+starts and then dies with `No available memory for the cache blocks`. TP=8 puts
+~95 GB per GPU and leaves most of the card for KV. Check that arithmetic before
+inventing a topology — the failure comes minutes into startup, after the weights
+have loaded.
+
+For rollout collection the binding constraint is replicas, not the agent loop:
+aggregate throughput on a single replica was still scaling at ~0.84 efficiency
+per doubling of agent concurrency with no sign of flattening. Reach for data
+parallelism before tuning concurrency, and set concurrency to roughly 16 per
+replica so the replicas stay fed.
+
+Four settings are required and deliberately have no default —
+`GDPVAL_SLURM_ACCOUNT`, `GDPVAL_MODEL_PATH`, `GDPVAL_VLLM_IMAGE` and
+`GDPVAL_MODEL_BASE_NAME` (the last comes from the model profile). A default
+that looks plausible but points at the wrong model or account fails hours later
+as bad numbers instead of immediately as an error.
+
+## Running a batch
+
+```bash
+# 1. one-time: build an isolated checkout + runtime so an in-flight run is
+#    never disturbed by edits to your working checkout
+./bootstrap_gdpval_runtime.sh
+
+# 2. submit the model server and wait for /v1/models to serve the expected name
+./submit_model_server.sh
+
+# 3. submit exactly one rollout client against that endpoint
+./monitor_gdpval_pipeline.sh
+
+# 4. when the allocation is nearly up, chain the next one
+./submit_gdpval_continuation.sh
+```
+
+`run_parallel_vllm.sh` is the underlying multi-instance vLLM launcher;
+`submit_model_server.sh` drives it and validates the endpoint before any rollout
+client is released. Run either with `--help` for its own flags.
+
+## Dataset profiles
+
+Per-dataset settings (input JSONL, expected row count, task-id pattern, model
+name, concurrency) live in `benchmarks/gdpval/datasets/*.env` (see `example.env`) and are selected
+with `GDPVAL_ENV_FILE`. Adding a new batch means adding a profile, not editing
+these scripts.
+
+## Resuming safely
+
+`validate_gdpval_resume_state.py` is the gate. It checks that a partial run's
+state is internally consistent — no duplicate or missing task indices, launch
+and source files unchanged since the run started — before another allocation is
+allowed to continue it.
+
+Editing the launcher or validator mid-run changes their hashes and the
+continuation gate will refuse to resume. That is deliberate: silently resuming
+against changed code produces a batch that is two experiments stitched
+together.
+
+## What each script does
+
+| Script | Purpose |
+|---|---|
+| `bootstrap_gdpval_runtime.sh` | Build an isolated checkout + venv so a running batch is insulated from edits |
+| `submit_model_server.sh` | Submit the vLLM server, wait for readiness, validate the served model name |
+| `monitor_gdpval_pipeline.sh` | Wait for the endpoint, then submit exactly one rollout client |
+| `run_gdpval_client.sbatch` | The rollout client job itself (CPU-only) |
+| `submit_gdpval_continuation.sh` | Chain the next allocation once the current one is nearly spent |
+| `run_gdpval_continuation_gate.sbatch` | Validate resume state, then release the next hop |
+| `run_gdpval_continuation_monitor.sbatch` | Passive watcher for the continuation chain |
+| `validate_gdpval_resume_state.py` | Standalone resume-safety check |
+| `run_parallel_vllm.sh` | Multi-instance vLLM launcher, shaped entirely by the model profile |
+| `wait_for_slurm_account.sh` | Poll until a Slurm account/QOS association exists; never submits or cancels |
+| `smoke_apptainer_worker.sh` | Verify Apptainer works on a compute node before committing an allocation |
+| `rpm2cpio_stdin.sh` | Shim: BusyBox `rpm2cpio` rejects `-` for stdin, which the unprivileged Apptainer installer needs |
+
+## Portability
+
+Written against Slurm with pyxis/enroot or Apptainer, and tested on one
+cluster. Job shapes (partition names, QOS, GPUs per node) are configurable but
+the defaults reflect that cluster; expect to adjust `cluster.env` for yours.

--- a/benchmarks/gdpval/slurm/bootstrap_gdpval_runtime.sh
+++ b/benchmarks/gdpval/slurm/bootstrap_gdpval_runtime.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build isolated, reproducible component environments for the AfterQuery
+# GDPVal rollout without modifying the concurrent gym-lj checkout.
+
+umask 077
+
+CHECKOUT="${GDPVAL_SLURM_CHECKOUT:-${GDPVAL_SLURM_STAGING_ROOT:-${SCRATCH:-$HOME}/gdpval-rollouts}/checkout}"
+BOOT_ROOT="${GDPVAL_BOOT_ROOT:-${GDPVAL_SLURM_STAGING_ROOT:-${SCRATCH:-$HOME}/gdpval-rollouts}/bootstrap}"
+REFERENCE="${GDPVAL_REFERENCE_CHECKOUT:-}"
+UV_BIN="${GDPVAL_UV_BIN:-${CHECKOUT}/.venv/bin/uv}"
+PYTHON_BIN="${GDPVAL_BOOTSTRAP_PYTHON:-/cm/local/apps/python3/bin/python3.12}"
+CONSTRAINTS_DIR="${BOOT_ROOT}/constraints"
+VENV_ROOT="${BOOT_ROOT}/venvs"
+UV_CACHE_DIR="${BOOT_ROOT}/uv-cache"
+READY_MARKER="${BOOT_ROOT}/READY"
+
+COMPONENTS=(
+  responses_api_agents/stirrup_agent
+  responses_api_models/vllm_model
+  responses_api_models/openai_model
+  resources_servers/gdpval
+)
+
+usage() {
+  cat <<'EOF'
+Usage: bootstrap_gdpval_runtime.sh ACTION
+
+Actions:
+  bootstrap  Snapshot known-good constraints and build four isolated venvs.
+  validate   Verify imports and the recorded READY marker.
+EOF
+}
+
+preflight() {
+  [[ -x "${UV_BIN}" ]] || { echo "ERROR: uv not executable: ${UV_BIN}" >&2; return 1; }
+  [[ -x "${PYTHON_BIN}" ]] || { echo "ERROR: Python not executable: ${PYTHON_BIN}" >&2; return 1; }
+  [[ -f "${CHECKOUT}/pyproject.toml" ]] || { echo "ERROR: invalid checkout: ${CHECKOUT}" >&2; return 1; }
+  local component
+  for component in "${COMPONENTS[@]}"; do
+    [[ -d "${CHECKOUT}/${component}" ]] || { echo "ERROR: missing checkout component: ${component}" >&2; return 1; }
+    [[ -x "${REFERENCE}/${component}/.venv/bin/python" ]] || {
+      echo "ERROR: missing reference component venv: ${REFERENCE}/${component}/.venv" >&2
+      return 1
+    }
+  done
+}
+
+constraint_path() {
+  local component="$1"
+  printf '%s/%s.txt' "${CONSTRAINTS_DIR}" "${component//\//__}"
+}
+
+target_python() {
+  local component="$1"
+  printf '%s/%s/.venv/bin/python' "${VENV_ROOT}" "${component}"
+}
+
+snapshot_constraints() {
+  local component constraints
+  for component in "${COMPONENTS[@]}"; do
+    constraints="$(constraint_path "${component}")"
+    "${UV_BIN}" pip freeze \
+      --exclude-editable \
+      --python "${REFERENCE}/${component}/.venv/bin/python" \
+      >"${constraints}"
+    [[ -s "${constraints}" ]] || { echo "ERROR: empty constraints for ${component}" >&2; return 1; }
+  done
+}
+
+create_component_venv() {
+  local component="$1"
+  local target="${VENV_ROOT}/${component}/.venv"
+  mkdir -p "$(dirname "${target}")"
+  UV_CACHE_DIR="${UV_CACHE_DIR}" "${UV_BIN}" venv \
+    --seed \
+    --allow-existing \
+    --python "${PYTHON_BIN}" \
+    "${target}"
+}
+
+install_requirements_component() {
+  local component="$1"
+  local python constraints
+  python="$(target_python "${component}")"
+  constraints="$(constraint_path "${component}")"
+  create_component_venv "${component}"
+  (
+    cd "${CHECKOUT}/${component}"
+    UV_CACHE_DIR="${UV_CACHE_DIR}" "${UV_BIN}" pip install \
+      --python "${python}" \
+      --constraints "${constraints}" \
+      -r requirements.txt \
+      'ray[default]==2.55.1' \
+      'openai==2.7.2'
+  )
+}
+
+install_vllm_proxy() {
+  local component="responses_api_models/vllm_model"
+  local python constraints
+  python="$(target_python "${component}")"
+  constraints="$(constraint_path "${component}")"
+  create_component_venv "${component}"
+  (
+    cd "${CHECKOUT}/${component}"
+    UV_CACHE_DIR="${UV_CACHE_DIR}" "${UV_BIN}" pip install \
+      --python "${python}" \
+      --constraints "${constraints}" \
+      -e . \
+      'ray[default]==2.55.1' \
+      'openai==2.7.2'
+  )
+}
+
+write_ready_marker() {
+  local tmp="${READY_MARKER}.tmp.$$"
+  {
+    echo "created_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "checkout_revision=$(git -C "${CHECKOUT}" rev-parse HEAD)"
+    echo "uv_version=$("${UV_BIN}" --version)"
+    echo "python_version=$("${PYTHON_BIN}" --version 2>&1)"
+    echo "venv_root=${VENV_ROOT}"
+    echo "uv_cache_dir=${UV_CACHE_DIR}"
+    sha256sum "${CONSTRAINTS_DIR}"/*.txt
+  } >"${tmp}"
+  chmod 600 "${tmp}"
+  mv "${tmp}" "${READY_MARKER}"
+}
+
+validate_runtime() {
+  [[ -f "${READY_MARKER}" ]] || { echo "ERROR: runtime marker not found: ${READY_MARKER}" >&2; return 1; }
+  local agent_python proxy_python judge_python resource_python
+  agent_python="$(target_python responses_api_agents/stirrup_agent)"
+  proxy_python="$(target_python responses_api_models/vllm_model)"
+  judge_python="$(target_python responses_api_models/openai_model)"
+  resource_python="$(target_python resources_servers/gdpval)"
+
+  "${agent_python}" -c 'import nemo_gym, ray, stirrup, transformers'
+  "${proxy_python}" -c 'import nemo_gym, openai, ray'
+  "${judge_python}" -c 'import nemo_gym, openai, ray'
+  "${resource_python}" -c 'import nemo_gym, openai, ray'
+  "${agent_python}" -c \
+    'import importlib.metadata as m; print("stirrup=" + m.version("stirrup")); print("transformers=" + m.version("transformers")); print("ray=" + m.version("ray")); print("openai=" + m.version("openai"))'
+  echo "Runtime validation passed: ${READY_MARKER}"
+}
+
+bootstrap() {
+  preflight
+  mkdir -p "${CONSTRAINTS_DIR}" "${VENV_ROOT}" "${UV_CACHE_DIR}"
+  export UV_PYTHON_DOWNLOADS=never
+  export UV_LINK_MODE=copy
+  snapshot_constraints
+  install_requirements_component responses_api_agents/stirrup_agent
+  install_vllm_proxy
+  install_requirements_component responses_api_models/openai_model
+  install_requirements_component resources_servers/gdpval
+  write_ready_marker
+  validate_runtime
+}
+
+case "${1:-validate}" in
+  bootstrap) bootstrap ;;
+  validate) preflight; validate_runtime ;;
+  -h|--help|help) usage ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/benchmarks/gdpval/slurm/cluster.env.example
+++ b/benchmarks/gdpval/slurm/cluster.env.example
@@ -1,0 +1,99 @@
+# GDPVal Slurm orchestration — site configuration.
+#
+#   cp cluster.env.example cluster.env    # cluster.env is gitignored
+#   $EDITOR cluster.env
+#   set -a; . ./cluster.env; set +a
+#
+# Nothing here has a site-specific default. A plausible-looking default would
+# silently point a run at the wrong model, image or account, and the failure
+# shows up hours later as bad numbers rather than as an error.
+
+# ---------------------------------------------------------------------------
+# Required
+# ---------------------------------------------------------------------------
+
+# Slurm account for GPU (server) jobs.
+GDPVAL_SLURM_ACCOUNT=
+
+# Model weights, readable from every compute node. Must match the model profile
+# you source from benchmarks/gdpval/models/.
+GDPVAL_MODEL_PATH=
+
+# vLLM container image (.sqsh for pyxis/enroot, or a squashfs Apptainer image).
+GDPVAL_VLLM_IMAGE=
+
+# Serving shape, parsers and context come from a model profile, not from here:
+#   set -a; . ./cluster.env; . ../models/glm-5.2-fp8.env; set +a
+# See benchmarks/gdpval/models/example.env to add your own.
+
+# ---------------------------------------------------------------------------
+# Paths — defaults are portable; override to put state on a shared filesystem
+# ---------------------------------------------------------------------------
+
+# Rollout state, logs and results. Must be shared across nodes.
+# Default: ${SCRATCH:-$HOME}/gdpval-rollouts
+#GDPVAL_SLURM_STAGING_ROOT=
+
+# Isolated checkout + bootstrapped runtime built by bootstrap_gdpval_runtime.sh.
+# Default: <staging root>/checkout and <staging root>/bootstrap
+#GDPVAL_SLURM_CHECKOUT=
+#GDPVAL_BOOT_ROOT=
+
+# Existing checkout to seed the bootstrap from, instead of a fresh clone.
+#GDPVAL_REFERENCE_CHECKOUT=
+
+# HF/pip/torch cache root. Default: ${SCRATCH:-$HOME}/gdpval-cache
+#CACHE_ROOT=
+
+# Shared filesystem mounted into the serving container. Default: /lustre
+#GDPVAL_SHARED_MOUNT=
+
+# ---------------------------------------------------------------------------
+# Slurm shape
+# ---------------------------------------------------------------------------
+
+#GDPVAL_SLURM_PARTITION=batch
+#GDPVAL_SLURM_QOS=normal
+#GDPVAL_SERVER_TIME_LIMIT=04:00:00
+
+# CPU-side client job. Leave unset to reuse the GPU account/partition.
+#GDPVAL_CLIENT_SLURM_ACCOUNT=
+#GDPVAL_CLIENT_SLURM_PARTITION=cpu
+#GDPVAL_CLIENT_SLURM_QOS=cpu-normal
+
+# Slurm reservation, if your site uses one. Unset means no --reservation flag.
+#GDPVAL_SLURM_RESERVATION=
+
+# ---------------------------------------------------------------------------
+# Apptainer path (only if you run the container-based worker)
+# ---------------------------------------------------------------------------
+
+#GDPVAL_APPTAINER_BIN=apptainer
+#GDPVAL_CONTAINER_PATH=
+
+# ---------------------------------------------------------------------------
+# Rollout client -> model endpoint
+#
+# These are read by slurm/run_gdpval_client.sbatch, slurm/submit_model_server.sh,
+# slurm/monitor_gdpval_pipeline.sh and run_gdpval_rollouts.sh, but had no entry
+# here. Keep secrets in the 0600 private env file the client sources, not in a
+# file that lives in the repo.
+# ---------------------------------------------------------------------------
+
+# Served model id, as it appears in the endpoint's /v1/models. This is NOT
+# GDPVAL_MODEL_PATH -- that selects the checkpoint and the agent tokenizer.
+#POLICY_MODEL_NAME=
+#POLICY_BASE_URL=
+#POLICY_API_KEY=
+
+# Tools. Set GDPVAL_ALLOW_NO_TAVILY=1 to run without web search rather than
+# failing preflight.
+#TAVILY_API_KEY=
+#GDPVAL_ALLOW_NO_TAVILY=
+
+# Interpreter used by the Slurm-side scripts. Default: the checkout's .venv.
+#PYTHON_BIN=
+
+# Where a run writes input/, results/ and deliverables/.
+# Default: ${GDPVAL_SLURM_STAGING_ROOT}/${GDPVAL_RUN_TAG}
+#GDPVAL_RUN_ROOT=

--- a/benchmarks/gdpval/slurm/monitor_gdpval_pipeline.sh
+++ b/benchmarks/gdpval/slurm/monitor_gdpval_pipeline.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wait for the staged model endpoint, then submit exactly one rollout client.
+# This runs on the Slurm login node; the client itself runs on cpu/cpu-normal.
+
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STAGING_ROOT="${GDPVAL_SLURM_STAGING_ROOT:-${SCRATCH:-$HOME}/gdpval-rollouts}"
+# The monitor drives `<wrapper> wait`, which validates /v1/models against the
+# dataset's expected model name, so it must see the dataset profile itself --
+# forwarding it to the client alone is not enough.
+if [[ -n "${GDPVAL_ENV_FILE:-}" ]]; then
+  if [[ ! -r "${GDPVAL_ENV_FILE}" ]]; then
+    echo "ERROR: GDPVAL_ENV_FILE is not readable: ${GDPVAL_ENV_FILE}" >&2
+    exit 2
+  fi
+  set -a
+  # shellcheck disable=SC1090
+  source "${GDPVAL_ENV_FILE}"
+  set +a
+fi
+PRIVATE_ENV="${GDPVAL_PRIVATE_ENV_FILE:-${STAGING_ROOT}/afterquery.private.env}"
+ENDPOINT_ENV="${GDPVAL_ENDPOINT_ENV_FILE:-${STAGING_ROOT}/endpoint.current.env}"
+CLIENT_SCRIPT="${SCRIPT_DIR}/run_gdpval_client.sbatch"
+SERVER_WRAPPER="${SCRIPT_DIR}/submit_model_server.sh"
+CLIENT_STATE="${GDPVAL_CLIENT_STATE_FILE:-${STAGING_ROOT}/client.current}"
+LOCK_DIR="${GDPVAL_PIPELINE_LOCK_DIR:-${STAGING_ROOT}/.monitor_gdpval_pipeline.lock}"
+ACTION="${GDPVAL_ACTION:-run}"
+TAVILY_WAIT_TIMEOUT="${GDPVAL_TAVILY_WAIT_TIMEOUT:-1800}"
+POLL_INTERVAL="${GDPVAL_PIPELINE_POLL_INTERVAL:-15}"
+LOCK_HELD=0
+SERVER_WAIT_PID=""
+
+cleanup() {
+  if [[ -n "${SERVER_WAIT_PID}" ]] && kill -0 "${SERVER_WAIT_PID}" 2>/dev/null; then
+    kill "${SERVER_WAIT_PID}" 2>/dev/null || true
+    wait "${SERVER_WAIT_PID}" 2>/dev/null || true
+  fi
+  if [[ "${LOCK_HELD}" == "1" ]]; then
+    rmdir "${LOCK_DIR}" 2>/dev/null || true
+  fi
+}
+
+handle_signal() {
+  local signal="$1"
+  cleanup
+  trap - EXIT
+  if [[ "${signal}" == "INT" ]]; then
+    exit 130
+  fi
+  exit 143
+}
+
+trap cleanup EXIT
+trap 'handle_signal INT' INT
+trap 'handle_signal TERM' TERM
+
+case "${ACTION}" in
+  run|full|resume) ;;
+  *) echo "ERROR: GDPVAL_ACTION must be run, full, or resume (got ${ACTION})" >&2; exit 2 ;;
+esac
+for value in "${TAVILY_WAIT_TIMEOUT}" "${POLL_INTERVAL}"; do
+  [[ "${value}" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: wait settings must be positive integers" >&2; exit 2; }
+done
+
+mkdir -p "${STAGING_ROOT}/client_logs"
+chmod 700 "${STAGING_ROOT}/client_logs"
+if ! mkdir "${LOCK_DIR}" 2>/dev/null; then
+  echo "ERROR: another pipeline monitor owns ${LOCK_DIR}" >&2
+  exit 2
+fi
+LOCK_HELD=1
+
+[[ -x "${SERVER_WRAPPER}" ]] || { echo "ERROR: missing server wrapper: ${SERVER_WRAPPER}" >&2; exit 1; }
+[[ -r "${CLIENT_SCRIPT}" ]] || { echo "ERROR: missing client script: ${CLIENT_SCRIPT}" >&2; exit 1; }
+[[ -f "${PRIVATE_ENV}" ]] || { echo "ERROR: missing private environment: ${PRIVATE_ENV}" >&2; exit 1; }
+
+"${SERVER_WRAPPER}" wait &
+SERVER_WAIT_PID=$!
+wait "${SERVER_WAIT_PID}"
+SERVER_WAIT_PID=""
+[[ -f "${ENDPOINT_ENV}" ]] || { echo "ERROR: endpoint wait returned without ${ENDPOINT_ENV}" >&2; exit 1; }
+
+deadline=$((SECONDS + TAVILY_WAIT_TIMEOUT))
+while true; do
+  if grep -q '^export GDPVAL_ALLOW_NO_TAVILY=1$' "${PRIVATE_ENV}"; then
+    echo "Private environment explicitly enables offline Tavily mode"
+    break
+  fi
+  if grep -Eq '^export TAVILY_API_KEY=.+$' "${PRIVATE_ENV}" \
+    && ! grep -q 'REPLACE_WITH_PRIVATE_TAVILY_KEY' "${PRIVATE_ENV}"; then
+    echo "Private Tavily configuration is present"
+    break
+  fi
+  if (( SECONDS >= deadline )); then
+    echo "ERROR: timed out waiting for Tavily configuration in ${PRIVATE_ENV}" >&2
+    exit 1
+  fi
+  echo "Endpoint is ready; waiting for private Tavily configuration"
+  sleep "${POLL_INTERVAL}"
+done
+
+if [[ -e "${CLIENT_STATE}" ]]; then
+  prior_job="$(grep '^job_id=' "${CLIENT_STATE}" | cut -d= -f2 || true)"
+  prior_state=""
+  if [[ "${prior_job}" =~ ^[0-9]+$ ]]; then
+    # squeue exits nonzero once a job leaves the queue ("Invalid job id
+    # specified"), which under `set -euo pipefail` aborted this monitor before
+    # it could archive a stale client state. Treat a purged job as "no live
+    # client", but still fail loudly when squeue itself is unusable: a
+    # controller outage must not be misread as "safe to submit another client".
+    if ! squeue_out="$(squeue -h -j "${prior_job}" -o '%T' 2>&1)"; then
+      if ! grep -qi 'invalid job id' <<<"${squeue_out}"; then
+        echo "ERROR: squeue failed for prior client job ${prior_job}: ${squeue_out}" >&2
+        exit 1
+      fi
+      squeue_out=""
+    fi
+    prior_state="$(head -1 <<<"${squeue_out}")"
+  fi
+  if [[ -n "${prior_state}" ]]; then
+    echo "ERROR: rollout client job ${prior_job} is already ${prior_state}" >&2
+    exit 1
+  fi
+  stale_state="${CLIENT_STATE}.stale.$(date -u +%Y%m%dT%H%M%SZ).$$"
+  mv "${CLIENT_STATE}" "${stale_state}"
+  chmod 600 "${stale_state}"
+fi
+
+# sbatch --export is an allowlist: GDPVAL_PRIVATE_ENV_FILE selects which private env
+# (and therefore which dataset profile) the client sources, so a Mercor run does
+# not silently inherit AfterQuery's.
+submission="$(
+  sbatch --parsable \
+    --export="USER=${USER},HOME=${HOME},LOGNAME=${LOGNAME:-${USER}},PATH=${PATH},LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-},SLURM_CONF=${SLURM_CONF:-},GDPVAL_ACTION=${ACTION},GDPVAL_PRIVATE_ENV_FILE=${PRIVATE_ENV},GDPVAL_ENV_FILE=${GDPVAL_ENV_FILE:-}" \
+    "${CLIENT_SCRIPT}"
+)"
+job_id="${submission%%;*}"
+if [[ ! "${job_id}" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: could not parse rollout client job ID from sbatch" >&2
+  exit 1
+fi
+
+tmp_state="${CLIENT_STATE}.tmp.$$"
+{
+  echo "job_id=${job_id}"
+  echo "action=${ACTION}"
+  echo "server_endpoint_env=${ENDPOINT_ENV}"
+  echo "submitted_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} >"${tmp_state}"
+chmod 600 "${tmp_state}"
+mv "${tmp_state}" "${CLIENT_STATE}"
+
+echo "Submitted rollout client job ${job_id} with action ${ACTION}"
+echo "Client state: ${CLIENT_STATE}"

--- a/benchmarks/gdpval/slurm/rpm2cpio_stdin.sh
+++ b/benchmarks/gdpval/slurm/rpm2cpio_stdin.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# BusyBox rpm2cpio does not accept '-' for stdin, while Apptainer's
+# unprivileged installer streams RPMs through that interface.
+
+if [[ "${1:-}" != "-" ]]; then
+  exec /usr/bin/busybox rpm2cpio "$@"
+fi
+
+temporary_rpm="$(mktemp "${TMPDIR:-/tmp}/rpm2cpio.XXXXXX.rpm")"
+trap 'rm -f "${temporary_rpm}"' EXIT INT TERM
+/bin/cat >"${temporary_rpm}"
+/usr/bin/busybox rpm2cpio "${temporary_rpm}"

--- a/benchmarks/gdpval/slurm/run_gdpval_client.sbatch
+++ b/benchmarks/gdpval/slurm/run_gdpval_client.sbatch
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=gdpval-rollout-client
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=64
+#SBATCH --mem=180G
+#SBATCH --time=03:45:00
+
+set -euo pipefail
+umask 077
+
+STAGING_ROOT="${GDPVAL_SLURM_STAGING_ROOT:-${SCRATCH:-$HOME}/gdpval-rollouts}"
+CHECKOUT="${GDPVAL_SLURM_CHECKOUT:-${STAGING_ROOT}/checkout}"
+PRIVATE_ENV="${GDPVAL_PRIVATE_ENV_FILE:-${STAGING_ROOT}/afterquery.private.env}"
+ENDPOINT_ENV="${GDPVAL_ENDPOINT_ENV_FILE:-${STAGING_ROOT}/endpoint.current.env}"
+BOOTSTRAP="${CHECKOUT}/benchmarks/gdpval/slurm/bootstrap_gdpval_runtime.sh"
+RUNNER="${CHECKOUT}/benchmarks/gdpval/run_gdpval_rollouts.sh"
+ACTION="${GDPVAL_ACTION:-run}"
+
+validate_action() {
+  case "$1" in
+    run|full|resume) ;;
+    *)
+      echo "ERROR: GDPVAL_ACTION must be run, full, or resume (got $1)" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Fail invalid sbatch --export values before touching private launch state.
+validate_action "${ACTION}"
+
+require_private_file() {
+  local path="$1"
+  if [[ ! -f "${path}" ]]; then
+    echo "ERROR: required private environment file not found: ${path}" >&2
+    return 1
+  fi
+  local mode
+  mode="$(stat -c '%a' "${path}")"
+  if [[ "${mode}" != "600" && "${mode}" != "400" ]]; then
+    echo "ERROR: private environment file must have mode 600 or 400: ${path} (${mode})" >&2
+    return 1
+  fi
+}
+
+require_private_file "${PRIVATE_ENV}"
+require_private_file "${ENDPOINT_ENV}"
+[[ -x "${BOOTSTRAP}" ]] || { echo "ERROR: bootstrap script not executable: ${BOOTSTRAP}" >&2; exit 1; }
+[[ -x "${RUNNER}" ]] || { echo "ERROR: rollout runner not executable: ${RUNNER}" >&2; exit 1; }
+
+set -a
+# The private file supplies Tavily and run settings. The validated endpoint file
+# is loaded second so stale placeholder endpoint values cannot win.
+# shellcheck disable=SC1090
+source "${PRIVATE_ENV}"
+# The dataset profile describes WHICH batch this run is, so it must beat the
+# private file's site defaults. Without this the profile arrives (the monitor
+# forwards GDPVAL_ENV_FILE through its --export allowlist) and is then dropped,
+# so every run silently validates against whatever batch the private file names.
+if [[ -n "${GDPVAL_ENV_FILE:-}" ]]; then
+  [[ -r "${GDPVAL_ENV_FILE}" ]] || { echo "ERROR: GDPVAL_ENV_FILE is not readable: ${GDPVAL_ENV_FILE}" >&2; exit 1; }
+  # shellcheck disable=SC1090
+  source "${GDPVAL_ENV_FILE}"
+fi
+# shellcheck disable=SC1090
+source "${ENDPOINT_ENV}"
+set +a
+# Already applied above; unset so the runner does not source it a second time.
+unset GDPVAL_ENV_FILE
+
+ACTION="${GDPVAL_ACTION:-run}"
+validate_action "${ACTION}"
+
+: "${POLICY_MODEL_NAME:?validated endpoint model is unset}"
+: "${POLICY_BASE_URL:?validated endpoint URL is unset}"
+: "${POLICY_API_KEY:?validated endpoint API key is unset}"
+: "${GDPVAL_SERVER_JOB_ID:?validated endpoint server job is unset}"
+: "${GDPVAL_SERVER_ROOT:?validated endpoint server root is unset}"
+: "${GDPVAL_ENDPOINT_CREATED_AT_UTC:?validated endpoint creation time is unset}"
+: "${GDPVAL_APPTAINER_BIN:?GDPVAL_APPTAINER_BIN must name the private Apptainer executable}"
+if [[ "${GDPVAL_ALLOW_NO_TAVILY:-0}" != "1" ]]; then
+  : "${TAVILY_API_KEY:?TAVILY_API_KEY must be set in the private environment file}"
+  if [[ "${TAVILY_API_KEY}" == REPLACE_WITH_* ]]; then
+    echo "ERROR: TAVILY_API_KEY still contains the template placeholder" >&2
+    exit 1
+  fi
+fi
+if [[ "${GDPVAL_APPTAINER_BIN}" != /* ]]; then
+  echo "ERROR: GDPVAL_APPTAINER_BIN must be absolute (got ${GDPVAL_APPTAINER_BIN})" >&2
+  exit 1
+fi
+if [[ ! -x "${GDPVAL_APPTAINER_BIN}" ]]; then
+  echo "ERROR: GDPVAL_APPTAINER_BIN is not executable: ${GDPVAL_APPTAINER_BIN}" >&2
+  exit 1
+fi
+if [[ ! "${GDPVAL_SERVER_JOB_ID}" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: validated endpoint has an invalid server job ID: ${GDPVAL_SERVER_JOB_ID}" >&2
+  exit 1
+fi
+case "${GDPVAL_SERVER_ROOT}" in
+  "${STAGING_ROOT}/model_servers/"*) ;;
+  *)
+    echo "ERROR: validated endpoint server root is outside the staging tree: ${GDPVAL_SERVER_ROOT}" >&2
+    exit 1
+    ;;
+esac
+if [[ ! -d "${GDPVAL_SERVER_ROOT}" ]]; then
+  echo "ERROR: validated endpoint server root does not exist: ${GDPVAL_SERVER_ROOT}" >&2
+  exit 1
+fi
+command -v squeue >/dev/null
+# squeue exits nonzero once the server job leaves the queue, which under
+# `set -euo pipefail` killed this script before the explicit check below could
+# report why. Failing closed here is correct: any unreadable state is treated as
+# "not RUNNING" so the clear error is printed instead of a silent bash abort.
+SERVER_STATE="$(squeue -h -j "${GDPVAL_SERVER_JOB_ID}" -o '%T' 2>/dev/null | head -1 || true)"
+if [[ "${SERVER_STATE}" != "RUNNING" ]]; then
+  echo "ERROR: endpoint server job ${GDPVAL_SERVER_JOB_ID} is not RUNNING (state ${SERVER_STATE:-UNKNOWN})" >&2
+  exit 1
+fi
+export PATH="$(dirname "${GDPVAL_APPTAINER_BIN}"):${PATH}"
+# Ray on a Lustre path is slow to start and can exceed the 107-byte AF_UNIX
+# socket path limit; /tmp is node-local.
+export RAY_TMPDIR="${RAY_TMPDIR:-/tmp}"
+
+cd "${CHECKOUT}"
+"${BOOTSTRAP}" validate
+"${RUNNER}" "${ACTION}"

--- a/benchmarks/gdpval/slurm/run_gdpval_continuation_gate.sbatch
+++ b/benchmarks/gdpval/slurm/run_gdpval_continuation_gate.sbatch
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=gdpval-cont-gate
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=4G
+#SBATCH --time=00:20:00
+
+set -euo pipefail
+umask 077
+
+STAGING_ROOT="${GDPVAL_SLURM_STAGING_ROOT:-${SCRATCH:-$HOME}/gdpval-rollouts}"
+CHECKOUT="${GDPVAL_SLURM_CHECKOUT:-${STAGING_ROOT}/checkout}"
+RUN_ROOT="${GDPVAL_RUN_ROOT:-${STAGING_ROOT}/${GDPVAL_RUN_TAG:-run}}"
+PARENT_SERVER_JOB_ID="${GDPVAL_PARENT_SERVER_JOB_ID:?GDPVAL_PARENT_SERVER_JOB_ID is required}"
+PARENT_CLIENT_JOB_ID="${GDPVAL_PARENT_CLIENT_JOB_ID:?GDPVAL_PARENT_CLIENT_JOB_ID is required}"
+CONTINUATION_STATE="${GDPVAL_CONTINUATION_STATE_FILE:-${STAGING_ROOT}/continuation.current}"
+SERVER_STATE="${GDPVAL_SERVER_STATE_FILE:-${STAGING_ROOT}/model_server.current}"
+CLIENT_STATE="${GDPVAL_CLIENT_STATE_FILE:-${STAGING_ROOT}/client.current}"
+SUBMITTER="${CHECKOUT}/benchmarks/gdpval/slurm/submit_model_server.sh"
+MONITOR_BATCH="${CHECKOUT}/benchmarks/gdpval/slurm/run_gdpval_continuation_monitor.sbatch"
+VALIDATOR="${CHECKOUT}/benchmarks/gdpval/validate_gdpval_batch.py"
+RESUME_VALIDATOR="${CHECKOUT}/benchmarks/gdpval/slurm/validate_gdpval_resume_state.py"
+PYTHON_BIN="${CHECKOUT}/.venv/bin/python"
+# Dataset profile (source a datasets/*.env). run_gdpval_rollouts.sh names the
+# launch copy after the source basename, so derive the same name here.
+SOURCE_INPUT="${GDPVAL_INPUT_JSONL-}"
+if [[ -n "${GDPVAL_LAUNCH_INPUT-}" ]]; then
+  LAUNCH_INPUT="${GDPVAL_LAUNCH_INPUT}"
+elif [[ -n "${SOURCE_INPUT}" ]]; then
+  LAUNCH_INPUT="${RUN_ROOT}/input/$(basename "${SOURCE_INPUT}" .jsonl).launch.jsonl"
+else
+  echo "ERROR: set GDPVAL_INPUT_JSONL (or GDPVAL_LAUNCH_INPUT) from your dataset profile" >&2
+  exit 1
+fi
+# Optional: batches with no prompt-backed reference repairs leave this unset.
+REFERENCE_OVERRIDES="${GDPVAL_REFERENCE_OVERRIDES-}"
+RESULTS_DIR="${RUN_ROOT}/results"
+FULL_OUTPUT="${RESULTS_DIR}/rollouts.jsonl"
+FULL_MATERIALIZED="${RESULTS_DIR}/rollouts_materialized_inputs.jsonl"
+FULL_FAILURES="${RESULTS_DIR}/rollouts_failures.jsonl"
+DELIVERABLES_DIR="${RUN_ROOT}/deliverables"
+SMOKE_TASK_ID="${GDPVAL_SMOKE_TASK_ID-}"
+SMOKE_OUTPUT="${RESULTS_DIR}/smoke_${SMOKE_TASK_ID}.jsonl"
+SMOKE_MATERIALIZED="${RESULTS_DIR}/smoke_${SMOKE_TASK_ID}_materialized_inputs.jsonl"
+SMOKE_FAILURES="${RESULTS_DIR}/smoke_${SMOKE_TASK_ID}_failures.jsonl"
+SMOKE_DELIVERABLES="${RUN_ROOT}/smoke_deliverables"
+EXPECTED_MODEL_NAME="${GDPVAL_EXPECTED_MODEL_NAME:-${GDPVAL_MODEL_BASE_NAME:-}-0}"
+EXPECTED_LAUNCH_SHA256="${GDPVAL_EXPECTED_LAUNCH_SHA256:-9e8d2d182a142e44f60fabb0dff1eaf9f7bd9f7e5c8d23fc2dc5879373d04bad}"
+LOCK_DIR="${GDPVAL_CONTINUATION_LOCK_DIR:-${STAGING_ROOT}/.gdpval_continuation_gate.lock}"
+LOCK_HELD=0
+
+cleanup() {
+  if [[ "${LOCK_HELD}" == "1" ]]; then
+    rmdir "${LOCK_DIR}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+require_file() {
+  local path="$1"
+  [[ -f "${path}" ]] || {
+    echo "ERROR: required file not found: ${path}" >&2
+    return 1
+  }
+}
+
+job_state() {
+  local job_id="$1"
+  local state
+  state="$(squeue -h -j "${job_id}" -o '%T' | head -1)"
+  if [[ -z "${state}" ]]; then
+    state="$(sacct -n -X -j "${job_id}" -o State | awk 'NF {print $1; exit}')"
+  fi
+  printf '%s' "${state:-UNKNOWN}"
+}
+
+require_terminal_job() {
+  local job_id="$1"
+  local label="$2"
+  local state
+  state="$(job_state "${job_id}")"
+  case "${state}" in
+    COMPLETED*|FAILED*|CANCELLED*|TIMEOUT*|NODE_FAIL*|OUT_OF_MEMORY*|PREEMPTED*|BOOT_FAIL*|DEADLINE*|REVOKED*)
+      echo "${label} job ${job_id} is terminal: ${state}"
+      ;;
+    *)
+      echo "ERROR: ${label} job ${job_id} is not terminal: ${state}" >&2
+      return 1
+      ;;
+  esac
+}
+
+state_value() {
+  local path="$1"
+  local wanted="$2"
+  awk -F= -v wanted="${wanted}" '$1 == wanted {sub(/^[^=]*=/, ""); print; exit}' "${path}"
+}
+
+write_continuation_state() {
+  local status="$1"
+  local action="${2:-}"
+  local new_server_job_id="${3:-}"
+  local monitor_job_id="${4:-}"
+  local tmp="${CONTINUATION_STATE}.tmp.$$"
+  {
+    echo "status=${status}"
+    echo "parent_server_job_id=${PARENT_SERVER_JOB_ID}"
+    echo "parent_client_job_id=${PARENT_CLIENT_JOB_ID}"
+    echo "gate_job_id=${SLURM_JOB_ID:-manual}"
+    [[ -n "${action}" ]] && echo "action=${action}"
+    [[ -n "${new_server_job_id}" ]] && echo "new_server_job_id=${new_server_job_id}"
+    [[ -n "${monitor_job_id}" ]] && echo "monitor_job_id=${monitor_job_id}"
+    echo "updated_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  } >"${tmp}"
+  chmod 600 "${tmp}"
+  mv "${tmp}" "${CONTINUATION_STATE}"
+}
+
+line_count() {
+  local path="$1"
+  if [[ -f "${path}" ]]; then
+    wc -l <"${path}" | tr -d ' '
+  else
+    printf '0'
+  fi
+}
+
+# Profile-driven validator arguments. Without --task-id-pattern and
+# --reference-mode the validator falls back to its own defaults, which is how a
+# gate silently rejects every row of a batch it was not written for.
+profile_validator_args() {
+  local -a args=(--input "${LAUNCH_INPUT}")
+  [[ -n "${GDPVAL_EXPECTED_COUNT-}" ]] && args+=(--expected-count "${GDPVAL_EXPECTED_COUNT}")
+  [[ -n "${EXPECTED_LAUNCH_SHA256-}" ]] && args+=(--expected-sha256 "${EXPECTED_LAUNCH_SHA256}")
+  [[ -n "${REFERENCE_OVERRIDES}" ]] && args+=(--reference-overrides "${REFERENCE_OVERRIDES}")
+  [[ -n "${GDPVAL_TASK_ID_PATTERN-}" ]] && args+=(--task-id-pattern "${GDPVAL_TASK_ID_PATTERN}")
+  [[ -n "${GDPVAL_REFERENCE_MODE-}" ]] && args+=(--reference-mode "${GDPVAL_REFERENCE_MODE}")
+  printf '%s\n' "${args[@]}"
+}
+
+validate_full() {
+  local -a args=()
+  args=()
+  while IFS= read -r _pa_line; do args+=("$_pa_line"); done < <(profile_validator_args)
+  "${PYTHON_BIN}" "${VALIDATOR}" "${args[@]}" \
+    --rollouts "${FULL_OUTPUT}" \
+    --deliverables-dir "${DELIVERABLES_DIR}" \
+    --expected-response-model "${EXPECTED_MODEL_NAME}"
+}
+
+validate_smoke() {
+  local -a args=()
+  args=()
+  while IFS= read -r _pa_line; do args+=("$_pa_line"); done < <(profile_validator_args)
+  [[ -n "${SMOKE_TASK_ID}" ]] && args+=(--smoke-task-id "${SMOKE_TASK_ID}")
+  "${PYTHON_BIN}" "${VALIDATOR}" "${args[@]}" \
+    --rollouts "${SMOKE_OUTPUT}" \
+    --deliverables-dir "${SMOKE_DELIVERABLES}" \
+    --require-deliverable \
+    --expected-response-model "${EXPECTED_MODEL_NAME}"
+}
+
+validate_partial_full_state() {
+  "${PYTHON_BIN}" "${RESUME_VALIDATOR}" \
+    --launch-input "${LAUNCH_INPUT}" \
+    --rollouts "${FULL_OUTPUT}" \
+    --materialized-inputs "${FULL_MATERIALIZED}" \
+    --failures "${FULL_FAILURES}" \
+    --run-config "${RUN_ROOT}/run_config.sha256" \
+    --expected-launch-sha256 "${EXPECTED_LAUNCH_SHA256}" \
+    --expected-model "${EXPECTED_MODEL_NAME}" \
+    --deliverables-dir "${DELIVERABLES_DIR}"
+}
+
+directory_has_entries() {
+  local path="$1"
+  [[ -d "${path}" && -n "$(find "${path}" -mindepth 1 -maxdepth 1 -print -quit)" ]]
+}
+
+archive_empty_lock() {
+  local path="$1"
+  local archive_dir="$2"
+  if [[ ! -e "${path}" ]]; then
+    return
+  fi
+  if [[ ! -d "${path}" ]] || directory_has_entries "${path}"; then
+    echo "ERROR: refusing to archive nonempty or non-directory lock: ${path}" >&2
+    return 1
+  fi
+  mv "${path}" "${archive_dir}/$(basename "${path}")"
+  echo "Archived stale lock: ${path}"
+}
+
+archive_unfinished_smoke() {
+  local timestamp archive_dir
+  timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  archive_dir="${RUN_ROOT}/continuation_archive/${timestamp}_after_${PARENT_SERVER_JOB_ID}"
+  mkdir -p "${archive_dir}/results" "${archive_dir}/logs"
+  chmod 700 "${RUN_ROOT}/continuation_archive" "${archive_dir}" "${archive_dir}/results" "${archive_dir}/logs"
+
+  local unexpected
+  unexpected="$(
+    find "${RESULTS_DIR}" -mindepth 1 -maxdepth 1 \
+      ! -name "smoke_${SMOKE_TASK_ID}.jsonl" \
+      ! -name "smoke_${SMOKE_TASK_ID}_materialized_inputs.jsonl" \
+      ! -name "smoke_${SMOKE_TASK_ID}_failures.jsonl" \
+      -print -quit
+  )"
+  if [[ -n "${unexpected}" ]]; then
+    echo "ERROR: unfinished smoke has unexpected result state: ${unexpected}" >&2
+    return 1
+  fi
+
+  local path
+  for path in "${SMOKE_OUTPUT}" "${SMOKE_MATERIALIZED}" "${SMOKE_FAILURES}"; do
+    if [[ -e "${path}" ]]; then
+      mv "${path}" "${archive_dir}/results/"
+    fi
+  done
+  if [[ -d "${SMOKE_DELIVERABLES}" ]]; then
+    mv "${SMOKE_DELIVERABLES}" "${archive_dir}/smoke_deliverables"
+  fi
+  mkdir -p "${SMOKE_DELIVERABLES}"
+  chmod 700 "${SMOKE_DELIVERABLES}"
+
+  if [[ -f "${RUN_ROOT}/logs/gym_env_start.log" ]]; then
+    mv "${RUN_ROOT}/logs/gym_env_start.log" "${archive_dir}/logs/"
+  fi
+  if [[ -f "${RUN_ROOT}/run_manifest.txt" ]]; then
+    mv "${RUN_ROOT}/run_manifest.txt" "${archive_dir}/"
+  fi
+  archive_empty_lock "${RUN_ROOT}/.launch.lock" "${archive_dir}"
+  echo "Archived unfinished smoke state: ${archive_dir}"
+}
+
+archive_server_state() {
+  require_file "${SERVER_STATE}"
+  local captured_job_id terminal_state
+  captured_job_id="$(state_value "${SERVER_STATE}" job_id)"
+  if [[ "${captured_job_id}" != "${PARENT_SERVER_JOB_ID}" ]]; then
+    echo "ERROR: current server state points to ${captured_job_id}, expected ${PARENT_SERVER_JOB_ID}" >&2
+    return 1
+  fi
+  terminal_state="$(job_state "${PARENT_SERVER_JOB_ID}")"
+  local archived="${SERVER_STATE}.terminal.${PARENT_SERVER_JOB_ID}.$(date -u +%Y%m%dT%H%M%SZ)"
+  mv "${SERVER_STATE}" "${archived}"
+  chmod 600 "${archived}"
+  echo "Archived terminal server state (${terminal_state}): ${archived}"
+}
+
+verify_captured_state_identity() {
+  require_file "${SERVER_STATE}"
+  require_file "${CLIENT_STATE}"
+  require_file "${CONTINUATION_STATE}"
+  local current_server current_client captured_gate captured_server captured_client
+  current_server="$(state_value "${SERVER_STATE}" job_id)"
+  current_client="$(state_value "${CLIENT_STATE}" job_id)"
+  captured_gate="$(state_value "${CONTINUATION_STATE}" gate_job_id)"
+  captured_server="$(state_value "${CONTINUATION_STATE}" parent_server_job_id)"
+  captured_client="$(state_value "${CONTINUATION_STATE}" parent_client_job_id)"
+  if [[ "${current_server}" != "${PARENT_SERVER_JOB_ID}" || "${captured_server}" != "${PARENT_SERVER_JOB_ID}" ]]; then
+    echo "ERROR: captured server identity changed; refusing continuation" >&2
+    return 1
+  fi
+  if [[ "${current_client}" != "${PARENT_CLIENT_JOB_ID}" || "${captured_client}" != "${PARENT_CLIENT_JOB_ID}" ]]; then
+    echo "ERROR: captured client identity changed; refusing continuation" >&2
+    return 1
+  fi
+  if [[ -n "${SLURM_JOB_ID:-}" && "${captured_gate}" != "${SLURM_JOB_ID}" ]]; then
+    echo "ERROR: continuation state belongs to gate ${captured_gate}, not ${SLURM_JOB_ID}" >&2
+    return 1
+  fi
+}
+
+for path in "${SUBMITTER}" "${MONITOR_BATCH}" "${VALIDATOR}" "${RESUME_VALIDATOR}" "${PYTHON_BIN}" "${LAUNCH_INPUT}"; do
+  require_file "${path}"
+done
+# Optional -- only required when the profile declares one.
+[[ -n "${REFERENCE_OVERRIDES}" ]] && require_file "${REFERENCE_OVERRIDES}"
+for command_name in sbatch squeue sacct awk sha256sum; do
+  command -v "${command_name}" >/dev/null
+done
+for job_id in "${PARENT_SERVER_JOB_ID}" "${PARENT_CLIENT_JOB_ID}"; do
+  [[ "${job_id}" =~ ^[0-9]+$ ]] || {
+    echo "ERROR: invalid parent job ID: ${job_id}" >&2
+    exit 2
+  }
+done
+
+mkdir -p "${STAGING_ROOT}/continuation_logs"
+chmod 700 "${STAGING_ROOT}/continuation_logs"
+if ! mkdir "${LOCK_DIR}" 2>/dev/null; then
+  echo "ERROR: another continuation gate owns ${LOCK_DIR}" >&2
+  exit 2
+fi
+LOCK_HELD=1
+
+require_terminal_job "${PARENT_SERVER_JOB_ID}" "server"
+require_terminal_job "${PARENT_CLIENT_JOB_ID}" "client"
+verify_captured_state_identity
+
+if [[ "$(line_count "${FULL_OUTPUT}")" == "100" ]] && validate_full; then
+  echo "All 100 rollouts are valid; no continuation allocation is needed"
+  write_continuation_state complete_no_continuation
+  exit 0
+fi
+
+ACTION=""
+if [[ -f "${FULL_OUTPUT}" || -f "${FULL_MATERIALIZED}" ]]; then
+  if [[ ! -f "${FULL_OUTPUT}" || ! -f "${FULL_MATERIALIZED}" ]]; then
+    echo "ERROR: full continuation requires both ${FULL_OUTPUT} and ${FULL_MATERIALIZED}" >&2
+    exit 1
+  fi
+  validate_partial_full_state
+  ACTION=resume
+  echo "Detected partial full collection: $(line_count "${FULL_OUTPUT}")/100 rows; scheduling resume"
+elif [[ "$(line_count "${SMOKE_OUTPUT}")" == "1" ]] && validate_smoke; then
+  ACTION=resume
+  echo "Smoke is valid and full collection has not started; scheduling full collection"
+else
+  if directory_has_entries "${DELIVERABLES_DIR}"; then
+    echo "ERROR: unfinished smoke has an unexpected nonempty full deliverables cache: ${DELIVERABLES_DIR}" >&2
+    exit 1
+  fi
+  archive_unfinished_smoke
+  ACTION=run
+  echo "Smoke did not finish; scheduling one clean smoke retry"
+fi
+
+mkdir -p "${RUN_ROOT}/continuation_archive"
+chmod 700 "${RUN_ROOT}/continuation_archive"
+archive_empty_lock "${RUN_ROOT}/.launch.lock" "${RUN_ROOT}/continuation_archive"
+archive_empty_lock "${STAGING_ROOT}/.monitor_gdpval_pipeline.lock" "${RUN_ROOT}/continuation_archive"
+archive_server_state
+
+GDPVAL_SLURM_STAGING_ROOT="${STAGING_ROOT}" "${SUBMITTER}" submit
+NEW_SERVER_JOB_ID="$(state_value "${SERVER_STATE}" job_id)"
+[[ "${NEW_SERVER_JOB_ID}" =~ ^[0-9]+$ ]] || {
+  echo "ERROR: submitter wrote an invalid new server job ID: ${NEW_SERVER_JOB_ID}" >&2
+  exit 1
+}
+write_continuation_state server_queued "${ACTION}" "${NEW_SERVER_JOB_ID}"
+
+MONITOR_SUBMISSION="$(
+  sbatch --parsable \
+    --dependency="after:${NEW_SERVER_JOB_ID}+1" \
+    --export="USER=${USER},HOME=${HOME},LOGNAME=${LOGNAME:-${USER}},PATH=${PATH},LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-},SLURM_CONF=${SLURM_CONF:-},GDPVAL_ACTION=${ACTION},GDPVAL_SLURM_STAGING_ROOT=${STAGING_ROOT}" \
+    "${MONITOR_BATCH}"
+)"
+MONITOR_JOB_ID="${MONITOR_SUBMISSION%%;*}"
+[[ "${MONITOR_JOB_ID}" =~ ^[0-9]+$ ]] || {
+  echo "ERROR: could not parse continuation monitor job ID" >&2
+  exit 1
+}
+
+write_continuation_state continuation_queued "${ACTION}" "${NEW_SERVER_JOB_ID}" "${MONITOR_JOB_ID}"
+echo "Queued continuation server ${NEW_SERVER_JOB_ID}"
+echo "Queued endpoint monitor ${MONITOR_JOB_ID} with action ${ACTION}"

--- a/benchmarks/gdpval/slurm/run_gdpval_continuation_monitor.sbatch
+++ b/benchmarks/gdpval/slurm/run_gdpval_continuation_monitor.sbatch
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=gdpval-cont-monitor
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=2G
+#SBATCH --time=01:00:00
+
+set -euo pipefail
+umask 077
+
+STAGING_ROOT="${GDPVAL_SLURM_STAGING_ROOT:-${SCRATCH:-$HOME}/gdpval-rollouts}"
+CHECKOUT="${GDPVAL_SLURM_CHECKOUT:-${STAGING_ROOT}/checkout}"
+MONITOR="${CHECKOUT}/benchmarks/gdpval/slurm/monitor_gdpval_pipeline.sh"
+ACTION="${GDPVAL_ACTION:-resume}"
+
+case "${ACTION}" in
+  run|full|resume) ;;
+  *)
+    echo "ERROR: GDPVAL_ACTION must be run, full, or resume (got ${ACTION})" >&2
+    exit 2
+    ;;
+esac
+
+[[ -x "${MONITOR}" ]] || {
+  echo "ERROR: pipeline monitor is not executable: ${MONITOR}" >&2
+  exit 1
+}
+
+mkdir -p "${STAGING_ROOT}/continuation_logs"
+chmod 700 "${STAGING_ROOT}/continuation_logs"
+
+export GDPVAL_ACTION="${ACTION}"
+export GDPVAL_SLURM_STAGING_ROOT="${STAGING_ROOT}"
+export GDPVAL_SERVER_READY_TIMEOUT="${GDPVAL_SERVER_READY_TIMEOUT:-3300}"
+exec "${MONITOR}"

--- a/benchmarks/gdpval/slurm/run_parallel_vllm.sh
+++ b/benchmarks/gdpval/slurm/run_parallel_vllm.sh
@@ -1,0 +1,472 @@
+#!/bin/bash
+#SBATCH --time=04:00:00
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:4
+#SBATCH --switches=1
+#SBATCH --output=%j_%x.out
+#SBATCH --error=%j_%x.err
+
+set -euo pipefail
+
+OUTPUT_DIR=""
+# Shared filesystem mounted into the container. Named for the site convention
+# it came from; override for a cluster that mounts its shared storage elsewhere.
+SHARED_MOUNT="${GDPVAL_SHARED_MOUNT:-/lustre}"
+
+# Keep the upstream flag names for compatibility with the existing launcher stack.
+VLLM_IMAGE="${VLLM_IMAGE:-}"
+MODEL_PATH="${MODEL_PATH:-}"
+MODEL_NAME="${MODEL_NAME:-}"
+NUM_INSTANCES=""
+INSTANCE_IDX=""
+
+# Serving shape. Every value below is model-specific, so it comes from a model
+# profile (benchmarks/gdpval/models/*.env) rather than being edited here.
+NUM_NODES="${GDPVAL_NUM_NODES:-2}"
+# Set GDPVAL_SLURM_ACCOUNT (or --account) to your Slurm account.
+# export QOS="${QOS-<your-qos>}"
+# export RESERVATION="${RESERVATION-<your-reservation>}"
+ACCOUNT="${GDPVAL_SLURM_ACCOUNT:-}"
+PARTITION="${GDPVAL_SLURM_PARTITION:-batch}"
+export QOS="${QOS-normal}"
+export RESERVATION="${RESERVATION-}"
+TIME_LIMIT="${GDPVAL_SERVER_TIME_LIMIT:-04:00:00}"
+
+BASE_RAY_PORT=6379
+BASE_VLLM_PORT=10240
+
+TENSOR_PARALLEL_SIZE="${GDPVAL_TENSOR_PARALLEL_SIZE:-8}"
+PIPELINE_PARALLEL_SIZE="${GDPVAL_PIPELINE_PARALLEL_SIZE:-1}"
+DATA_PARALLEL_SIZE="${GDPVAL_DATA_PARALLEL_SIZE:-1}"
+DATA_PARALLEL_SIZE_LOCAL="${GDPVAL_DATA_PARALLEL_SIZE_LOCAL:-1}"
+GPU_MEMORY_UTILIZATION="${GDPVAL_GPU_MEMORY_UTILIZATION:-0.90}"
+API_SERVER_COUNT="${GDPVAL_API_SERVER_COUNT:-1}"
+# Served context must cover the rollout token budget or long requests are
+# truncated or rejected. Do not simply set this to the model's native maximum:
+# context trades directly against per-replica concurrency via KV cache.
+MAX_MODEL_LEN="${GDPVAL_MAX_MODEL_LEN:-262144}"
+
+CACHE_ROOT="${CACHE_ROOT:-${SCRATCH:-$HOME}/gdpval-cache}"
+HF_HOME="${HF_HOME:-${CACHE_ROOT}/huggingface}"
+VLLM_CACHE_ROOT="${VLLM_CACHE_ROOT:-${CACHE_ROOT}/vllm}"
+
+usage() {
+    echo "Usage: $0 --num-instances <n> --output-dir <path> [OPTIONS]"
+    echo ""
+    echo "Required outside Slurm:"
+    echo "  --num-instances <n>        Number of endpoint instances to launch"
+    echo "  --output-dir <path>        Output directory for logs and server_info"
+    echo ""
+    echo "Optional overrides:"
+    echo "  --vllm-image <path>        vLLM Ray container image (default: ${VLLM_IMAGE})"
+    echo "  --model-path <path>        Model checkpoint path (default: ${MODEL_PATH})"
+    echo "  --model-name <name>        Base served model name (default: ${MODEL_NAME})"
+    echo "  --num-nodes <n>            Nodes per server job (default: ${NUM_NODES})"
+    echo "  --account <name>           Slurm account for self-submitted jobs (default: ${ACCOUNT})"
+    echo "  --partition <name>         Slurm partition for self-submitted jobs (default: ${PARTITION})"
+    echo "  --qos <name>               Slurm QoS for self-submitted jobs (default: ${QOS:-<none>})"
+    echo "  --reservation <name>       Slurm reservation for self-submitted jobs (default: ${RESERVATION:-<none>})"
+    echo "  --time-limit <time>        Slurm walltime for self-submitted jobs (default: ${TIME_LIMIT})"
+    echo "  --tp-size <n>              Tensor parallel size (default: ${TENSOR_PARALLEL_SIZE})"
+    echo "  --pp-size <n>              Pipeline parallel size (default: ${PIPELINE_PARALLEL_SIZE})"
+    echo "  --dp-size <n>              Data parallel size (default: ${DATA_PARALLEL_SIZE})"
+    echo "  --dp-size-local <n>        Local data parallel size per node (default: ${DATA_PARALLEL_SIZE_LOCAL})"
+    echo "  --gpu-memory-utilization <fraction>"
+    echo "                             GPU memory utilization (default: ${GPU_MEMORY_UTILIZATION})"
+    echo "  --api-server-count <n>     vLLM API server count (default: ${API_SERVER_COUNT})"
+    echo "  --max-model-len <n>        Served context length, prompt + output (default: ${MAX_MODEL_LEN})"
+    echo "  --cache-root <path>        Host-visible cache root (default: ${CACHE_ROOT})"
+    echo ""
+    echo "Notes:"
+    echo "  - The launcher writes one server_info/<model>-<idx>.env file per endpoint."
+    exit 1
+}
+
+require_positive_int() {
+    local name="$1"
+    local value="$2"
+    if ! [[ "${value}" =~ ^[0-9]+$ ]] || [[ "${value}" -lt 1 ]]; then
+        echo "ERROR: ${name} must be a positive integer; got '${value}'" >&2
+        exit 1
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --vllm-image)
+            VLLM_IMAGE="$2"
+            shift 2
+            ;;
+        --model-path)
+            MODEL_PATH="$2"
+            shift 2
+            ;;
+        --model-name)
+            MODEL_NAME="$2"
+            shift 2
+            ;;
+        --num-instances)
+            NUM_INSTANCES="$2"
+            shift 2
+            ;;
+        --instance-idx)
+            INSTANCE_IDX="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --num-nodes)
+            NUM_NODES="$2"
+            shift 2
+            ;;
+        --account)
+            ACCOUNT="$2"
+            shift 2
+            ;;
+        --partition)
+            PARTITION="$2"
+            shift 2
+            ;;
+        --qos)
+            QOS="$2"
+            export QOS
+            shift 2
+            ;;
+        --reservation)
+            RESERVATION="$2"
+            export RESERVATION
+            shift 2
+            ;;
+        --time-limit)
+            TIME_LIMIT="$2"
+            shift 2
+            ;;
+        --tp-size)
+            TENSOR_PARALLEL_SIZE="$2"
+            shift 2
+            ;;
+        --pp-size)
+            PIPELINE_PARALLEL_SIZE="$2"
+            shift 2
+            ;;
+        --dp-size)
+            DATA_PARALLEL_SIZE="$2"
+            shift 2
+            ;;
+        --dp-size-local)
+            DATA_PARALLEL_SIZE_LOCAL="$2"
+            shift 2
+            ;;
+        --gpu-memory-utilization)
+            GPU_MEMORY_UTILIZATION="$2"
+            shift 2
+            ;;
+        --api-server-count)
+            API_SERVER_COUNT="$2"
+            shift 2
+            ;;
+        --max-model-len)
+            MAX_MODEL_LEN="$2"
+            shift 2
+            ;;
+        --cache-root)
+            CACHE_ROOT="$2"
+            HF_HOME="${CACHE_ROOT}/huggingface"
+            VLLM_CACHE_ROOT="${CACHE_ROOT}/vllm"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            usage
+            ;;
+    esac
+done
+
+require_positive_int "--num-nodes" "${NUM_NODES}"
+require_positive_int "--tp-size" "${TENSOR_PARALLEL_SIZE}"
+require_positive_int "--pp-size" "${PIPELINE_PARALLEL_SIZE}"
+require_positive_int "--dp-size" "${DATA_PARALLEL_SIZE}"
+require_positive_int "--dp-size-local" "${DATA_PARALLEL_SIZE_LOCAL}"
+require_positive_int "--api-server-count" "${API_SERVER_COUNT}"
+require_positive_int "--max-model-len" "${MAX_MODEL_LEN}"
+
+if [[ $((DATA_PARALLEL_SIZE % DATA_PARALLEL_SIZE_LOCAL)) -ne 0 ]]; then
+    echo "ERROR: --dp-size must be divisible by --dp-size-local" >&2
+    exit 1
+fi
+
+if [[ -z "${SLURM_JOB_ID:-}" ]]; then
+    if [[ -z "${VLLM_IMAGE}" || -z "${MODEL_PATH}" || -z "${MODEL_NAME}" || -z "${NUM_INSTANCES}" || -z "${OUTPUT_DIR}" ]]; then
+        echo "ERROR: missing required arguments"
+        usage
+    fi
+
+    require_positive_int "--num-instances" "${NUM_INSTANCES}"
+
+    mkdir -p "${OUTPUT_DIR}/slurm_logs"
+    mkdir -p "${OUTPUT_DIR}/server_info"
+
+    for ((i=0; i<NUM_INSTANCES; i++)); do
+        INSTANCE_MODEL_NAME="${MODEL_NAME}-${i}"
+        SERVER_STDOUT_PATH="${OUTPUT_DIR}/slurm_logs/%j_%x.out"
+        SERVER_STDERR_PATH="${OUTPUT_DIR}/slurm_logs/%j_%x.err"
+        SBATCH_ARGS=(
+            -A "${ACCOUNT}"
+            -p "${PARTITION}"
+            --time "${TIME_LIMIT}"
+            --nodes "${NUM_NODES}"
+            --ntasks "${NUM_NODES}"
+            --ntasks-per-node 1
+            --gres gpu:4
+            --switches 1
+            -J "${INSTANCE_MODEL_NAME}"
+            --output "${SERVER_STDOUT_PATH}"
+            --error "${SERVER_STDERR_PATH}"
+        )
+
+        if [[ -n "${QOS}" ]]; then
+            SBATCH_ARGS+=(--qos "${QOS}")
+        fi
+
+        if [[ -n "${RESERVATION}" ]]; then
+            SBATCH_ARGS+=(--reservation "${RESERVATION}")
+        fi
+
+        sbatch \
+            "${SBATCH_ARGS[@]}" \
+            "$0" \
+            --vllm-image "${VLLM_IMAGE}" \
+            --model-path "${MODEL_PATH}" \
+            --model-name "${MODEL_NAME}" \
+            --num-instances "${NUM_INSTANCES}" \
+            --instance-idx "${i}" \
+            --output-dir "${OUTPUT_DIR}" \
+            --num-nodes "${NUM_NODES}" \
+            --time-limit "${TIME_LIMIT}" \
+            --tp-size "${TENSOR_PARALLEL_SIZE}" \
+            --pp-size "${PIPELINE_PARALLEL_SIZE}" \
+            --dp-size "${DATA_PARALLEL_SIZE}" \
+            --dp-size-local "${DATA_PARALLEL_SIZE_LOCAL}" \
+            --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
+            --api-server-count "${API_SERVER_COUNT}" \
+            --max-model-len "${MAX_MODEL_LEN}" \
+            --cache-root "${CACHE_ROOT}"
+    done
+    exit 0
+fi
+
+if [[ -z "${VLLM_IMAGE}" || -z "${MODEL_PATH}" || -z "${MODEL_NAME}" || -z "${NUM_INSTANCES}" || -z "${INSTANCE_IDX}" || -z "${OUTPUT_DIR}" ]]; then
+    echo "ERROR: missing required arguments inside Slurm job"
+    exit 1
+fi
+
+if ! [[ "${INSTANCE_IDX}" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: --instance-idx must be a non-negative integer"
+    exit 1
+fi
+
+INSTANCE_MODEL_NAME="${MODEL_NAME}-${INSTANCE_IDX}"
+RAY_PORT=$((BASE_RAY_PORT + INSTANCE_IDX))
+VLLM_PORT=$((BASE_VLLM_PORT + INSTANCE_IDX))
+LOG_FILE="${OUTPUT_DIR}/${INSTANCE_MODEL_NAME}_$(date +%Y%m%d_%H%M%S).log"
+touch "${LOG_FILE}"
+
+mkdir -p "${OUTPUT_DIR}" "${HF_HOME}" "${VLLM_CACHE_ROOT}"
+
+export WORK_DIR="${OUTPUT_DIR}"
+export OUTPUT_DIR SHARED_MOUNT VLLM_IMAGE MODEL_PATH INSTANCE_MODEL_NAME LOG_FILE
+export RAY_PORT VLLM_PORT NUM_NODES INSTANCE_IDX
+export TENSOR_PARALLEL_SIZE PIPELINE_PARALLEL_SIZE DATA_PARALLEL_SIZE DATA_PARALLEL_SIZE_LOCAL
+export GPU_MEMORY_UTILIZATION API_SERVER_COUNT
+export MAX_MODEL_LEN
+export CACHE_ROOT HF_HOME VLLM_CACHE_ROOT
+
+srun \
+    --kill-on-bad-exit=1 \
+    --no-container-mount-home \
+    --container-image="${VLLM_IMAGE}" \
+    --container-mounts="${OUTPUT_DIR}:/outputs,${SHARED_MOUNT}:${SHARED_MOUNT}" \
+    --export=ALL \
+    --mpi=pmix \
+    bash -lc '
+        set -euo pipefail
+        cd /outputs
+
+        export HF_HOME="${HF_HOME}"
+        export VLLM_CACHE_ROOT="${VLLM_CACHE_ROOT}"
+
+        export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
+        export VLLM_ENGINE_READY_TIMEOUT_S=3600
+        export RAY_CGRAPH_get_timeout=600
+        export RAY_raylet_start_wait_time_s=120
+        export VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm
+        export VLLM_ALLREDUCE_USE_SYMM_MEM=0
+        export VLLM_USE_DEEP_GEMM=0
+        export FLASHINFER_WORKSPACE_BASE=/tmp
+
+        HEAD_IP_FILE="/outputs/.ray_head_ip_${SLURM_JOB_ID}_${INSTANCE_IDX}"
+        RAY_FIXED_PORTS="--node-manager-port=8266 --object-manager-port=8267 --metrics-export-port=8269 --dashboard-agent-grpc-port=8270 --dashboard-agent-listen-port=8271 --runtime-env-agent-port=8272"
+
+        if [ "${SLURM_PROCID}" -eq 0 ]; then
+            rm -f "${HEAD_IP_FILE}"
+
+            HEAD_IP=$(hostname -I | awk "{print \$1}")
+            if [ -z "${HEAD_IP}" ]; then
+                HEAD_IP=$(getent hosts "$(hostname)" | awk "{print \$1; exit}")
+            fi
+
+            if [ -z "${HEAD_IP}" ]; then
+                echo "ERROR: could not determine head node IP"
+                exit 1
+            fi
+
+            echo "${HEAD_IP}" > "${HEAD_IP_FILE}"
+            echo "=== [rank0] Starting Ray head on ${HEAD_IP}:${RAY_PORT} ==="
+            ray start --head --node-ip-address="${HEAD_IP}" --port="${RAY_PORT}" ${RAY_FIXED_PORTS} --disable-usage-stats
+
+            export RAY_ADDRESS="${HEAD_IP}:${RAY_PORT}"
+            echo "=== [rank0] Waiting for ${NUM_NODES} Ray node(s) ==="
+            for _ in $(seq 1 360); do
+                if [ "$(ray status --address "${RAY_ADDRESS}" 2>/dev/null | grep -c "node_")" -ge "${NUM_NODES}" ]; then
+                    break
+                fi
+                sleep 5
+            done
+
+            if [ "$(ray status --address "${RAY_ADDRESS}" 2>/dev/null | grep -c "node_")" -lt "${NUM_NODES}" ]; then
+                echo "ERROR: timed out waiting for ${NUM_NODES} Ray nodes"
+                ray status --address "${RAY_ADDRESS}" || true
+                ray stop || true
+                rm -f "${HEAD_IP_FILE}"
+                exit 1
+            fi
+            ray status --address "${RAY_ADDRESS}" || true
+
+            echo "=== [rank0] Starting vLLM server for ${INSTANCE_MODEL_NAME} (TP=${TENSOR_PARALLEL_SIZE}, PP=${PIPELINE_PARALLEL_SIZE}, DP=${DATA_PARALLEL_SIZE}, DPL=${DATA_PARALLEL_SIZE_LOCAL}) ==="
+            SERVE_PORT="${VLLM_PORT}"
+            unset VLLM_PORT
+
+            # Model-specific flags come from the model profile. Anything vLLM
+            # accepts can be appended via GDPVAL_VLLM_EXTRA_ARGS without editing
+            # this launcher.
+            VLLM_ARGS=(
+                --trust-remote-code
+                --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}"
+                --pipeline-parallel-size "${PIPELINE_PARALLEL_SIZE}"
+                --distributed-executor-backend ray
+                --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}"
+                --port "${SERVE_PORT}"
+                --enable-prefix-caching
+                --enable-chunked-prefill
+                --api-server-count "${API_SERVER_COUNT}"
+                --chat-template-content-format string
+                --served-model-name "${INSTANCE_MODEL_NAME}"
+                --max-model-len "${MAX_MODEL_LEN}"
+                --compilation-config "{\"pass_config\": {\"fuse_allreduce_rms\": false}}"
+                --model-loader-extra-config "{\"enable_multithread_load\": true, \"num_threads\": 96}"
+            )
+            # Ray data parallelism only when the profile asks for more than one
+            # replica; passing DP=1 changes the vLLM execution path for no reason.
+            if [ "${DATA_PARALLEL_SIZE}" -gt 1 ]; then
+                VLLM_ARGS+=(--data-parallel-size "${DATA_PARALLEL_SIZE}"
+                            --data-parallel-backend ray
+                            --data-parallel-size-local "${DATA_PARALLEL_SIZE_LOCAL}")
+            fi
+            [ -n "${GDPVAL_TOOL_CALL_PARSER:-}" ] && \
+                VLLM_ARGS+=(--enable-auto-tool-choice --tool-call-parser "${GDPVAL_TOOL_CALL_PARSER}")
+            [ -n "${GDPVAL_REASONING_PARSER:-}" ] && \
+                VLLM_ARGS+=(--reasoning-parser "${GDPVAL_REASONING_PARSER}")
+            [ -n "${GDPVAL_KV_CACHE_DTYPE:-}" ] && \
+                VLLM_ARGS+=(--kv-cache-dtype "${GDPVAL_KV_CACHE_DTYPE}")
+            # Batch scheduling. Left unset these take whatever the containers vLLM
+            # defaults to, which then silently decides how much of the requested
+            # agent concurrency the engine will actually run at once -- and a DP run
+            # that is really capped here looks exactly like one that failed to scale.
+            [ -n "${GDPVAL_MAX_NUM_SEQS:-}" ] && \
+                VLLM_ARGS+=(--max-num-seqs "${GDPVAL_MAX_NUM_SEQS}")
+            [ -n "${GDPVAL_MAX_NUM_BATCHED_TOKENS:-}" ] && \
+                VLLM_ARGS+=(--max-num-batched-tokens "${GDPVAL_MAX_NUM_BATCHED_TOKENS}")
+            [ "${GDPVAL_EXPERT_PARALLEL:-1}" = "1" ] && VLLM_ARGS+=(--enable-expert-parallel)
+            # Some Blackwell/SM100 ranks fail Inductor autotuning at startup with a
+            # CUDA driver error; eager execution keeps every rank out of that path.
+            [ "${GDPVAL_ENFORCE_EAGER:-0}" = "1" ] && VLLM_ARGS+=(--enforce-eager)
+            # shellcheck disable=SC2206
+            [ -n "${GDPVAL_VLLM_EXTRA_ARGS:-}" ] && VLLM_ARGS+=(${GDPVAL_VLLM_EXTRA_ARGS})
+
+            vllm serve "${MODEL_PATH}" "${VLLM_ARGS[@]}" > "${LOG_FILE}" 2>&1 &
+
+            VLLM_PID=$!
+
+            echo "=== [rank0] Waiting for server readiness (tailing ${LOG_FILE}) ==="
+            tail -f "${LOG_FILE}" &
+            TAIL_PID=$!
+
+            while ! grep -Eq "Uvicorn running on|Application startup complete\\." "${LOG_FILE}" 2>/dev/null; do
+                if grep -Eq "Failed to run autotuning code block|Engine core initialization failed|EngineCore failed to start" "${LOG_FILE}" 2>/dev/null; then
+                    echo "ERROR: vLLM reported a fatal startup failure; inspect ${LOG_FILE}"
+                    kill "${VLLM_PID}" 2>/dev/null || true
+                    wait "${VLLM_PID}" 2>/dev/null || true
+                    kill "${TAIL_PID}" 2>/dev/null || true
+                    ray stop || true
+                    rm -f "${HEAD_IP_FILE}"
+                    exit 1
+                fi
+                if ! kill -0 "${VLLM_PID}" 2>/dev/null; then
+                    echo "ERROR: vLLM server process died"
+                    kill "${TAIL_PID}" 2>/dev/null || true
+                    ray stop || true
+                    rm -f "${HEAD_IP_FILE}"
+                    exit 1
+                fi
+                sleep 2
+            done
+
+            echo ""
+            echo "=== Server is ready on http://${HEAD_IP}:${SERVE_PORT}/v1 ==="
+            echo ""
+
+            RUNTIME_SERVER_INFO_DIR="/outputs/server_info"
+            RUNTIME_SERVER_INFO_FILE="${RUNTIME_SERVER_INFO_DIR}/${INSTANCE_MODEL_NAME}.env"
+            mkdir -p "${RUNTIME_SERVER_INFO_DIR}"
+
+            SERVER_URL="http://${HEAD_IP}:${SERVE_PORT}/v1"
+            {
+                echo "MODEL_NAME=${INSTANCE_MODEL_NAME}"
+                echo "INSTANCE_IDX=${INSTANCE_IDX}"
+                echo "HEAD_IP=${HEAD_IP}"
+                echo "VLLM_PORT=${SERVE_PORT}"
+                echo "SERVER_URL=${SERVER_URL}"
+            } > "${RUNTIME_SERVER_INFO_FILE}"
+
+            sync || true
+            echo "Wrote server info to ${RUNTIME_SERVER_INFO_FILE}"
+
+            wait "${VLLM_PID}"
+            kill "${TAIL_PID}" 2>/dev/null || true
+            ray stop || true
+            rm -f "${HEAD_IP_FILE}"
+        else
+            for _ in $(seq 1 180); do
+                [ -s "${HEAD_IP_FILE}" ] && break
+                sleep 1
+            done
+
+            if [ ! -s "${HEAD_IP_FILE}" ]; then
+                echo "ERROR: timed out waiting for Ray head IP file: ${HEAD_IP_FILE}"
+                exit 1
+            fi
+
+            HEAD_IP=$(cat "${HEAD_IP_FILE}")
+            export RAY_ADDRESS="${HEAD_IP}:${RAY_PORT}"
+
+            echo "=== [rank${SLURM_PROCID}] Starting Ray worker for ${RAY_ADDRESS} ==="
+            until ray start --address="${RAY_ADDRESS}" ${RAY_FIXED_PORTS} --disable-usage-stats; do
+                echo "Retrying Ray worker connection to ${RAY_ADDRESS}"
+                sleep 5
+            done
+
+            tail -f /dev/null
+        fi
+    '

--- a/benchmarks/gdpval/slurm/smoke_apptainer_worker.sh
+++ b/benchmarks/gdpval/slurm/smoke_apptainer_worker.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly apptainer_bin="${GDPVAL_APPTAINER_BIN:-apptainer}"
+readonly container_path="${GDPVAL_CONTAINER_PATH:-}"
+readonly smoke_dir="${GDPVAL_APPTAINER_SMOKE_DIR:-/tmp/gdpval-apptainer-smoke-${SLURM_JOB_ID:-manual}}"
+
+if [[ -z "${container_path}" ]]; then
+    echo "ERROR: GDPVAL_CONTAINER_PATH is required (path to the Apptainer image)." >&2
+    exit 2
+fi
+
+test -x "${apptainer_bin}"
+test -r "${container_path}"
+mkdir -p "${smoke_dir}"
+chmod 700 "${smoke_dir}"
+
+echo "worker=$(hostname) arch=$(uname -m) smoke_dir=${smoke_dir}"
+"${apptainer_bin}" version
+"${apptainer_bin}" inspect "${container_path}" >/dev/null
+echo "sif_inspect=ok"
+
+"${apptainer_bin}" exec \
+  --writable-tmpfs \
+  --cleanenv \
+  --pid \
+  --no-mount home,tmp,bind-paths \
+  --home /root \
+  --mount "type=bind,src=${smoke_dir},dst=/workspace_io" \
+  "${container_path}" \
+  /bin/bash -lc '
+    set -euo pipefail
+    python -c "import importlib; modules=(\"numpy\",\"pandas\",\"polars\",\"scipy\",\"matplotlib\",\"plotly\",\"sklearn\",\"docx\",\"pptx\",\"openpyxl\",\"fitz\",\"pdfplumber\",\"reportlab\",\"weasyprint\",\"PIL\",\"cv2\",\"playwright\"); [importlib.import_module(module) for module in modules]; print(\"python_imports=ok count=17\")"
+    for tool in libreoffice tesseract pandoc pdftotext gs ffmpeg dot convert pdflatex xelatex lualatex latexmk biber java gdalinfo jq unzip chromium timeout git; do
+      command -v "${tool}" >/dev/null
+    done
+    printf "%s\n" "apptainer_workspace_roundtrip=ok" > /workspace_io/roundtrip.txt
+    test "$(cat /workspace_io/roundtrip.txt)" = "apptainer_workspace_roundtrip=ok"
+    echo "system_tools=ok count=20"
+    echo "provider_style_exec=ok"
+  '
+
+test "$(cat "${smoke_dir}/roundtrip.txt")" = "apptainer_workspace_roundtrip=ok"
+echo "host_bind_roundtrip=ok"

--- a/benchmarks/gdpval/slurm/submit_gdpval_continuation.sh
+++ b/benchmarks/gdpval/slurm/submit_gdpval_continuation.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STAGING_ROOT="${GDPVAL_SLURM_STAGING_ROOT:-${SCRATCH:-$HOME}/gdpval-rollouts}"
+SERVER_STATE="${GDPVAL_SERVER_STATE_FILE:-${STAGING_ROOT}/model_server.current}"
+CLIENT_STATE="${GDPVAL_CLIENT_STATE_FILE:-${STAGING_ROOT}/client.current}"
+CONTINUATION_STATE="${GDPVAL_CONTINUATION_STATE_FILE:-${STAGING_ROOT}/continuation.current}"
+GATE_BATCH="${SCRIPT_DIR}/run_gdpval_continuation_gate.sbatch"
+LOG_DIR="${STAGING_ROOT}/continuation_logs"
+SUBMISSION_LOCK_DIR="${GDPVAL_CONTINUATION_SUBMISSION_LOCK_DIR:-${STAGING_ROOT}/.submit_gdpval_continuation.lock}"
+SUBMISSION_LOCK_HELD=0
+
+release_submission_lock() {
+  if [[ "${SUBMISSION_LOCK_HELD}" == "1" ]]; then
+    rmdir "${SUBMISSION_LOCK_DIR}" 2>/dev/null || true
+    SUBMISSION_LOCK_HELD=0
+  fi
+}
+
+usage() {
+  cat <<'EOF'
+Usage: submit_gdpval_continuation.sh ACTION [SERVER_JOB_ID CLIENT_JOB_ID]
+
+Actions:
+  preflight  Validate the current parent jobs and continuation scripts.
+  submit     Queue one conditional continuation gate after both parent jobs.
+  status     Show the gate and any continuation server/monitor/client jobs.
+
+The gate validates all 100 outputs before requesting more GPUs. If the current
+run is complete it exits without a new allocation. Otherwise it resumes a
+partial full collection, starts full collection after a valid smoke, or
+recoverably archives and retries an unfinished smoke.
+EOF
+}
+
+state_value() {
+  local path="$1"
+  local wanted="$2"
+  awk -F= -v wanted="${wanted}" '$1 == wanted {sub(/^[^=]*=/, ""); print; exit}' "${path}"
+}
+
+require_file() {
+  local path="$1"
+  [[ -f "${path}" ]] || {
+    echo "ERROR: required file not found: ${path}" >&2
+    return 1
+  }
+}
+
+job_state() {
+  local job_id="$1"
+  local state
+  state="$(squeue -h -j "${job_id}" -o '%T' | head -1)"
+  if [[ -z "${state}" ]]; then
+    state="$(sacct -n -X -j "${job_id}" -o State | awk 'NF {print $1; exit}')"
+  fi
+  printf '%s' "${state:-UNKNOWN}"
+}
+
+resolve_parent_jobs() {
+  PARENT_SERVER_JOB_ID="${2:-${GDPVAL_PARENT_SERVER_JOB_ID:-}}"
+  PARENT_CLIENT_JOB_ID="${3:-${GDPVAL_PARENT_CLIENT_JOB_ID:-}}"
+  if [[ -z "${PARENT_SERVER_JOB_ID}" ]]; then
+    require_file "${SERVER_STATE}"
+    PARENT_SERVER_JOB_ID="$(state_value "${SERVER_STATE}" job_id)"
+  fi
+  if [[ -z "${PARENT_CLIENT_JOB_ID}" ]]; then
+    require_file "${CLIENT_STATE}"
+    PARENT_CLIENT_JOB_ID="$(state_value "${CLIENT_STATE}" job_id)"
+  fi
+  for job_id in "${PARENT_SERVER_JOB_ID}" "${PARENT_CLIENT_JOB_ID}"; do
+    [[ "${job_id}" =~ ^[0-9]+$ ]] || {
+      echo "ERROR: invalid parent job ID: ${job_id}" >&2
+      return 1
+    }
+  done
+}
+
+preflight() {
+  resolve_parent_jobs "$@"
+  require_file "${GATE_BATCH}"
+  require_file "${SCRIPT_DIR}/run_gdpval_continuation_monitor.sbatch"
+  require_file "${SCRIPT_DIR}/submit_model_server.sh"
+  command -v sbatch >/dev/null
+  command -v scontrol >/dev/null
+  command -v squeue >/dev/null
+  command -v sacct >/dev/null
+  bash -n "${GATE_BATCH}"
+  bash -n "${SCRIPT_DIR}/run_gdpval_continuation_monitor.sbatch"
+
+  if [[ -e "${CONTINUATION_STATE}" ]]; then
+    local prior_gate prior_state
+    prior_gate="$(state_value "${CONTINUATION_STATE}" gate_job_id)"
+    prior_state=""
+    if [[ "${prior_gate}" =~ ^[0-9]+$ ]]; then
+      prior_state="$(job_state "${prior_gate}")"
+    fi
+    echo "ERROR: continuation state already exists (gate ${prior_gate:-unknown}, ${prior_state:-unknown}): ${CONTINUATION_STATE}" >&2
+    return 1
+  fi
+
+  echo "Continuation preflight passed"
+  echo "  parent server: ${PARENT_SERVER_JOB_ID} ($(job_state "${PARENT_SERVER_JOB_ID}"))"
+  echo "  parent client: ${PARENT_CLIENT_JOB_ID} ($(job_state "${PARENT_CLIENT_JOB_ID}"))"
+  echo "  dependency: afterany:${PARENT_SERVER_JOB_ID}:${PARENT_CLIENT_JOB_ID}"
+}
+
+submit_gate() {
+  if ! mkdir "${SUBMISSION_LOCK_DIR}" 2>/dev/null; then
+    echo "ERROR: another continuation submission owns ${SUBMISSION_LOCK_DIR}" >&2
+    return 1
+  fi
+  SUBMISSION_LOCK_HELD=1
+  trap release_submission_lock EXIT
+  preflight "$@"
+  mkdir -p "${LOG_DIR}"
+  chmod 700 "${LOG_DIR}"
+  local submission gate_job_id tmp_state
+  submission="$(
+    sbatch --parsable \
+      --hold \
+      --dependency="afterany:${PARENT_SERVER_JOB_ID}:${PARENT_CLIENT_JOB_ID}" \
+      --export="USER=${USER},HOME=${HOME},LOGNAME=${LOGNAME:-${USER}},PATH=${PATH},LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-},SLURM_CONF=${SLURM_CONF:-},GDPVAL_SLURM_STAGING_ROOT=${STAGING_ROOT},GDPVAL_PARENT_SERVER_JOB_ID=${PARENT_SERVER_JOB_ID},GDPVAL_PARENT_CLIENT_JOB_ID=${PARENT_CLIENT_JOB_ID},GDPVAL_CONTINUATION_STATE_FILE=${CONTINUATION_STATE}" \
+      "${GATE_BATCH}"
+  )"
+  gate_job_id="${submission%%;*}"
+  [[ "${gate_job_id}" =~ ^[0-9]+$ ]] || {
+    echo "ERROR: could not parse continuation gate job ID" >&2
+    return 1
+  }
+
+  tmp_state="${CONTINUATION_STATE}.tmp.$$"
+  {
+    echo "status=gate_queued"
+    echo "parent_server_job_id=${PARENT_SERVER_JOB_ID}"
+    echo "parent_client_job_id=${PARENT_CLIENT_JOB_ID}"
+    echo "gate_job_id=${gate_job_id}"
+    echo "dependency=afterany:${PARENT_SERVER_JOB_ID}:${PARENT_CLIENT_JOB_ID}"
+    echo "submitted_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  } >"${tmp_state}"
+  chmod 600 "${tmp_state}"
+  mv "${tmp_state}" "${CONTINUATION_STATE}"
+  scontrol release "${gate_job_id}"
+  release_submission_lock
+  trap - EXIT
+
+  echo "Queued conditional continuation gate ${gate_job_id}"
+  echo "  dependency: afterany:${PARENT_SERVER_JOB_ID}:${PARENT_CLIENT_JOB_ID}"
+  echo "  state: ${CONTINUATION_STATE}"
+}
+
+show_job() {
+  local label="$1"
+  local job_id="$2"
+  if [[ "${job_id}" =~ ^[0-9]+$ ]]; then
+    echo "${label} ${job_id}: $(job_state "${job_id}")"
+  fi
+}
+
+status() {
+  require_file "${CONTINUATION_STATE}"
+  local status_value parent_server parent_client gate new_server monitor
+  status_value="$(state_value "${CONTINUATION_STATE}" status)"
+  parent_server="$(state_value "${CONTINUATION_STATE}" parent_server_job_id)"
+  parent_client="$(state_value "${CONTINUATION_STATE}" parent_client_job_id)"
+  gate="$(state_value "${CONTINUATION_STATE}" gate_job_id)"
+  new_server="$(state_value "${CONTINUATION_STATE}" new_server_job_id)"
+  monitor="$(state_value "${CONTINUATION_STATE}" monitor_job_id)"
+  echo "Continuation status: ${status_value:-unknown}"
+  show_job "Parent server" "${parent_server}"
+  show_job "Parent client" "${parent_client}"
+  show_job "Gate" "${gate}"
+  show_job "New server" "${new_server}"
+  show_job "Endpoint monitor" "${monitor}"
+  if [[ -f "${CLIENT_STATE}" ]]; then
+    show_job "Current client" "$(state_value "${CLIENT_STATE}" job_id)"
+  fi
+}
+
+case "${1:-status}" in
+  preflight) preflight "$@" ;;
+  submit) submit_gate "$@" ;;
+  status) status ;;
+  -h|--help|help) usage ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/benchmarks/gdpval/slurm/submit_model_server.sh
+++ b/benchmarks/gdpval/slurm/submit_model_server.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Submit and validate the model server used by GDPVal rollout
+# batches. Dataset-specific values come from a profile in datasets/.
+
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+STAGING_ROOT="${GDPVAL_SLURM_STAGING_ROOT:-${SCRATCH:-$HOME}/gdpval-rollouts}"
+LAUNCHER="${GDPVAL_SERVER_LAUNCHER:-${SCRIPT_DIR}/run_parallel_vllm.sh}"
+EXPECTED_LAUNCHER_SHA256="${GDPVAL_EXPECTED_LAUNCHER_SHA256:-e2c74e61c9a8cf3556566699e1367df42d7442c098bb3acf99e431d4313f8b50}"
+MODEL_PATH="${GDPVAL_MODEL_PATH:-}"
+VLLM_IMAGE="${GDPVAL_VLLM_IMAGE:-}"
+MODEL_BASE_NAME="${GDPVAL_MODEL_BASE_NAME:-}"
+EXPECTED_MODEL_NAME="${MODEL_BASE_NAME}-0"
+ACCOUNT="${GDPVAL_SLURM_ACCOUNT:-}"
+PARTITION="${GDPVAL_SLURM_PARTITION:-batch}"
+QOS="${GDPVAL_SLURM_QOS:-normal}"
+TIME_LIMIT="${GDPVAL_SERVER_TIME_LIMIT:-04:00:00}"
+STATE_FILE="${GDPVAL_SERVER_STATE_FILE:-${STAGING_ROOT}/model_server.current}"
+CURRENT_ENDPOINT_ENV="${GDPVAL_CURRENT_ENDPOINT_ENV:-${STAGING_ROOT}/endpoint.current.env}"
+SUBMISSION_LOCK_DIR="${GDPVAL_SERVER_SUBMISSION_LOCK_DIR:-${STAGING_ROOT}/.submit_model_server.lock}"
+
+# Site-specific inputs have no default on purpose: a wrong-but-plausible default
+# silently points the run at somebody else's model, image or Slurm account.
+_missing=()
+[[ -n "${ACCOUNT}" ]]    || _missing+=("GDPVAL_SLURM_ACCOUNT")
+[[ -n "${MODEL_PATH}" ]] || _missing+=("GDPVAL_MODEL_PATH")
+[[ -n "${VLLM_IMAGE}" ]] || _missing+=("GDPVAL_VLLM_IMAGE")
+[[ -n "${MODEL_BASE_NAME}" ]] || _missing+=("GDPVAL_MODEL_BASE_NAME (set by the model profile)")
+if (( ${#_missing[@]} )); then
+    echo "ERROR: required setting(s) not set: ${_missing[*]}" >&2
+    echo "       Copy benchmarks/gdpval/slurm/cluster.env.example, fill it in, and source it." >&2
+    exit 2
+fi
+VALIDATOR="${REPO_ROOT}/benchmarks/gdpval/validate_gdpval_batch.py"
+# Dataset-scoped: a profile (benchmarks/gdpval/datasets/*.env) points these at
+# another GDPVal-format batch. Overrides may be empty when a dataset ships no
+# prompt-backed reference repairs.
+INPUT_JSONL="${GDPVAL_INPUT_JSONL:-${STAGING_ROOT}/input/afterquery_gdpval_subset_100_20260721.jsonl}"
+OVERRIDES_JSON="${GDPVAL_REFERENCE_OVERRIDES-${REPO_ROOT}/benchmarks/gdpval/data/afterquery_gdpval_subset_100_20260721.reference_overrides.json}"
+SOURCE_SHA256="${GDPVAL_EXPECTED_SOURCE_SHA256:-104e8c3bccc20420c7f225cd1b7f7822335764d018f665700042b341355c4f34}"
+EXPECTED_COUNT="${GDPVAL_EXPECTED_COUNT:-100}"
+REFERENCE_MODE="${GDPVAL_REFERENCE_MODE:-https}"
+TASK_ID_PATTERN="${GDPVAL_TASK_ID_PATTERN-}"
+if [[ -z "${TASK_ID_PATTERN}" ]]; then
+  TASK_ID_PATTERN='AQ-\d{5}$'
+fi
+
+usage() {
+  cat <<'EOF'
+Usage: submit_model_server.sh ACTION
+
+Actions:
+  preflight  Validate paths, hashes, account settings, and scheduler state.
+  submit     Submit one model server job, shaped by the active model profile.
+  status     Show the captured job state and server-info availability.
+  wait       Wait for readiness, validate /models, and write endpoint.env.
+
+By default, submit refuses to queue while no batch nodes are allocatable. Set
+GDPVAL_ALLOW_QUEUE_DURING_MAINTENANCE=1 only when intentionally queueing early.
+
+The wait action allows 24 hours in the scheduler queue by default, then starts
+a separate 4-hour readiness timeout once the job reaches RUNNING. Override the
+limits with GDPVAL_SERVER_QUEUE_TIMEOUT and GDPVAL_SERVER_READY_TIMEOUT (seconds).
+EOF
+}
+
+require_file() {
+  local path="$1"
+  if [[ ! -f "${path}" ]]; then
+    echo "ERROR: required file not found: ${path}" >&2
+    return 1
+  fi
+}
+
+file_sha256() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+preflight() {
+  require_file "${LAUNCHER}"
+  require_file "${VLLM_IMAGE}"
+  require_file "${INPUT_JSONL}"
+  if [[ -n "${OVERRIDES_JSON}" ]]; then
+    require_file "${OVERRIDES_JSON}"
+  fi
+  if [[ ! -e "${MODEL_PATH}" ]]; then
+    echo "ERROR: model path not found: ${MODEL_PATH}" >&2
+    return 1
+  fi
+  command -v sbatch >/dev/null
+  command -v squeue >/dev/null
+  command -v sinfo >/dev/null
+  command -v curl >/dev/null
+  command -v sha256sum >/dev/null
+
+  local launcher_sha input_sha
+  launcher_sha="$(file_sha256 "${LAUNCHER}")"
+  input_sha="$(file_sha256 "${INPUT_JSONL}")"
+  if [[ "${launcher_sha}" != "${EXPECTED_LAUNCHER_SHA256}" ]]; then
+    echo "ERROR: launcher hash mismatch (set GDPVAL_EXPECTED_LAUNCHER_SHA256 if you edited it): ${launcher_sha}" >&2
+    return 1
+  fi
+  if grep -q 'HF_TOKEN' "${LAUNCHER}"; then
+    echo "ERROR: launcher must not hardcode HF_TOKEN" >&2
+    return 1
+  fi
+  if [[ "${input_sha}" != "${SOURCE_SHA256}" ]]; then
+    echo "ERROR: input hash mismatch: ${input_sha}" >&2
+    return 1
+  fi
+  bash -n "${LAUNCHER}"
+
+  local allocatable_nodes
+  allocatable_nodes="$(sinfo -h -p "${PARTITION}" -t idle,alloc,mix -o '%D' | awk '{sum += $1} END {print sum + 0}')"
+  if (( allocatable_nodes == 0 )) && [[ "${GDPVAL_ALLOW_QUEUE_DURING_MAINTENANCE:-0}" != "1" ]]; then
+    echo "ERROR: partition ${PARTITION} has no allocatable nodes; maintenance is still active" >&2
+    return 1
+  fi
+
+  echo "Server preflight passed"
+  echo "  expected model: ${EXPECTED_MODEL_NAME}"
+  echo "  account/qos: ${ACCOUNT}/${QOS}"
+  echo "  partition nodes currently allocatable: ${allocatable_nodes}"
+  echo "  shape: 2 nodes, 8 GPUs, TP8, DP1 (fp8)"
+}
+
+write_state() {
+  local server_root="$1"
+  local job_id="$2"
+  local server_info="${server_root}/server_info/${EXPECTED_MODEL_NAME}.env"
+  local tmp_state="${STATE_FILE}.tmp.$$"
+  mkdir -p "$(dirname "${STATE_FILE}")"
+  {
+    echo "server_root=${server_root}"
+    echo "job_id=${job_id}"
+    echo "expected_model_name=${EXPECTED_MODEL_NAME}"
+    echo "server_info=${server_info}"
+    echo "submitted_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  } >"${tmp_state}"
+  chmod 600 "${tmp_state}"
+  mv "${tmp_state}" "${STATE_FILE}"
+}
+
+load_state() {
+  require_file "${STATE_FILE}"
+  SERVER_ROOT=""
+  JOB_ID=""
+  STATE_EXPECTED_MODEL=""
+  SERVER_INFO=""
+  STATE_SUBMITTED_AT_UTC=""
+  while IFS='=' read -r key value; do
+    case "${key}" in
+      server_root) SERVER_ROOT="${value}" ;;
+      job_id) JOB_ID="${value}" ;;
+      expected_model_name) STATE_EXPECTED_MODEL="${value}" ;;
+      server_info) SERVER_INFO="${value}" ;;
+      submitted_at_utc) STATE_SUBMITTED_AT_UTC="${value}" ;;
+    esac
+  done <"${STATE_FILE}"
+  if [[ -z "${SERVER_ROOT}" || ! "${JOB_ID}" =~ ^[0-9]+$ || -z "${SERVER_INFO}" || -z "${STATE_SUBMITTED_AT_UTC}" ]]; then
+    echo "ERROR: malformed server state: ${STATE_FILE}" >&2
+    return 1
+  fi
+  if [[ "${STATE_EXPECTED_MODEL}" != "${EXPECTED_MODEL_NAME}" ]]; then
+    echo "ERROR: state expects ${STATE_EXPECTED_MODEL}, launcher expects ${EXPECTED_MODEL_NAME}" >&2
+    return 1
+  fi
+}
+
+SUBMISSION_LOCK_HELD=0
+
+acquire_submission_lock() {
+  mkdir -p "$(dirname "${SUBMISSION_LOCK_DIR}")"
+  if ! mkdir "${SUBMISSION_LOCK_DIR}" 2>/dev/null; then
+    echo "ERROR: another server submission holds the lock: ${SUBMISSION_LOCK_DIR}" >&2
+    return 1
+  fi
+  SUBMISSION_LOCK_HELD=1
+}
+
+release_submission_lock() {
+  if [[ "${SUBMISSION_LOCK_HELD}" == "1" ]]; then
+    rmdir "${SUBMISSION_LOCK_DIR}" 2>/dev/null || true
+    SUBMISSION_LOCK_HELD=0
+  fi
+}
+
+invalidate_current_endpoint() {
+  if [[ -e "${CURRENT_ENDPOINT_ENV}" || -L "${CURRENT_ENDPOINT_ENV}" ]]; then
+    local stale_endpoint
+    stale_endpoint="${CURRENT_ENDPOINT_ENV}.stale.$(date -u +%Y%m%dT%H%M%SZ).$$"
+    mv "${CURRENT_ENDPOINT_ENV}" "${stale_endpoint}"
+    chmod 600 "${stale_endpoint}"
+    echo "Archived stale endpoint environment: ${stale_endpoint}"
+  fi
+}
+
+submit_server() {
+  acquire_submission_lock
+  trap release_submission_lock EXIT
+  preflight
+  if [[ -e "${STATE_FILE}" ]]; then
+    echo "ERROR: state file already exists; inspect it before another submission: ${STATE_FILE}" >&2
+    return 1
+  fi
+  invalidate_current_endpoint
+  local timestamp server_root submission_output submission_log job_id
+  timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  server_root="${STAGING_ROOT}/model_servers/${MODEL_BASE_NAME}_${timestamp}"
+  if [[ -e "${server_root}" ]]; then
+    echo "ERROR: server output path already exists: ${server_root}" >&2
+    return 1
+  fi
+  mkdir -p "${server_root}"
+
+  submission_log="${server_root}/submission.stdout"
+  submission_output="$(
+    env -i \
+      HOME="${HOME}" \
+      USER="${USER}" \
+      LOGNAME="${LOGNAME:-${USER}}" \
+      PATH="${PATH}" \
+      LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}" \
+      SLURM_CONF="${SLURM_CONF:-}" \
+      LANG="${LANG:-C.UTF-8}" \
+      bash "${LAUNCHER}" \
+      --vllm-image "${VLLM_IMAGE}" \
+      --model-path "${MODEL_PATH}" \
+      --model-name "${MODEL_BASE_NAME}" \
+      --num-instances 1 \
+      --output-dir "${server_root}" \
+      --num-nodes 2 \
+      --account "${ACCOUNT}" \
+      --partition "${PARTITION}" \
+      --qos "${QOS}" \
+      --time-limit "${TIME_LIMIT}" \
+      --tp-size 8 \
+      --pp-size 1 \
+      --dp-size 1 \
+      --dp-size-local 1 \
+      --gpu-memory-utilization 0.90 \
+      --max-model-len 262144
+  )"
+  printf '%s\n' "${submission_output}" >"${submission_log}"
+  chmod 600 "${submission_log}"
+  job_id="$(printf '%s\n' "${submission_output}" | awk '/Submitted batch job [0-9]+/{print $4}' | tail -1)"
+  if [[ ! "${job_id}" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: could not parse the submitted Slurm job ID; inspect ${submission_log}" >&2
+    return 1
+  fi
+  write_state "${server_root}" "${job_id}"
+  release_submission_lock
+  trap - EXIT
+  echo "Submitted ${MODEL_BASE_NAME} server job ${job_id}"
+  echo "  server root: ${server_root}"
+  echo "  state: ${STATE_FILE}"
+}
+
+job_state() {
+  local state
+  state="$(squeue -h -j "${JOB_ID}" -o '%T' 2>/dev/null | head -1 || true)"
+  if [[ -z "${state}" ]]; then
+    state="$(sacct -n -X -j "${JOB_ID}" -o State | awk 'NF {print $1; exit}')"
+  fi
+  printf '%s' "${state:-UNKNOWN}"
+}
+
+status_server() {
+  load_state
+  echo "Job ${JOB_ID}: $(job_state)"
+  echo "Expected model: ${EXPECTED_MODEL_NAME}"
+  if [[ -f "${SERVER_INFO}" ]]; then
+    echo "Server info: ready at ${SERVER_INFO}"
+  else
+    echo "Server info: not written yet"
+  fi
+}
+
+read_server_info() {
+  INFO_MODEL_NAME=""
+  INFO_SERVER_URL=""
+  while IFS='=' read -r key value; do
+    case "${key}" in
+      MODEL_NAME) INFO_MODEL_NAME="${value}" ;;
+      SERVER_URL) INFO_SERVER_URL="${value}" ;;
+    esac
+  done <"${SERVER_INFO}"
+  if [[ "${INFO_MODEL_NAME}" != "${EXPECTED_MODEL_NAME}" ]]; then
+    echo "ERROR: server-info model mismatch: ${INFO_MODEL_NAME}" >&2
+    return 1
+  fi
+  if [[ ! "${INFO_SERVER_URL}" =~ ^http://[A-Za-z0-9._:-]+/v1$ ]]; then
+    echo "ERROR: invalid server URL in ${SERVER_INFO}" >&2
+    return 1
+  fi
+}
+
+write_endpoint_env() {
+  local endpoint_env="${SERVER_ROOT}/endpoint.env"
+  local tmp_env="${endpoint_env}.tmp.$$"
+  local current_env="${CURRENT_ENDPOINT_ENV}"
+  local tmp_current="${current_env}.tmp.$$"
+  local created_at_utc
+  created_at_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  {
+    printf 'export POLICY_MODEL_NAME=%q\n' "${EXPECTED_MODEL_NAME}"
+    printf 'export POLICY_BASE_URL=%q\n' "${INFO_SERVER_URL}"
+    printf 'export POLICY_API_KEY=%q\n' "dummy"
+    printf 'export GDPVAL_SERVER_JOB_ID=%q\n' "${JOB_ID}"
+    printf 'export GDPVAL_SERVER_ROOT=%q\n' "${SERVER_ROOT}"
+    printf 'export GDPVAL_SERVER_SUBMITTED_AT_UTC=%q\n' "${STATE_SUBMITTED_AT_UTC}"
+    printf 'export GDPVAL_ENDPOINT_CREATED_AT_UTC=%q\n' "${created_at_utc}"
+  } >"${tmp_env}"
+  chmod 600 "${tmp_env}"
+  mv "${tmp_env}" "${endpoint_env}"
+  cp "${endpoint_env}" "${tmp_current}"
+  chmod 600 "${tmp_current}"
+  mv "${tmp_current}" "${current_env}"
+  echo "Validated endpoint environment: ${endpoint_env}"
+  echo "Current endpoint environment: ${current_env}"
+  echo "Endpoint provenance: job ${JOB_ID}, server root ${SERVER_ROOT}, created ${created_at_utc}"
+}
+
+wait_for_server() {
+  load_state
+  local queue_timeout="${GDPVAL_SERVER_QUEUE_TIMEOUT:-86400}"
+  local ready_timeout="${GDPVAL_SERVER_READY_TIMEOUT:-14400}"
+  local interval="${GDPVAL_SERVER_POLL_INTERVAL:-15}"
+  if [[ ! "${queue_timeout}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: GDPVAL_SERVER_QUEUE_TIMEOUT must be a positive integer: ${queue_timeout}" >&2
+    return 1
+  fi
+  if [[ ! "${ready_timeout}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: GDPVAL_SERVER_READY_TIMEOUT must be a positive integer: ${ready_timeout}" >&2
+    return 1
+  fi
+  if [[ ! "${interval}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "ERROR: GDPVAL_SERVER_POLL_INTERVAL must be a positive integer: ${interval}" >&2
+    return 1
+  fi
+  local queue_deadline=$((SECONDS + queue_timeout))
+  local ready_deadline=0
+  local wait_phase="queue"
+  while [[ ! -f "${SERVER_INFO}" ]]; do
+    local state
+    state="$(job_state)"
+    case "${state}" in
+      FAILED*|CANCELLED*|TIMEOUT*|NODE_FAIL*|OUT_OF_MEMORY*|PREEMPTED*|BOOT_FAIL*|DEADLINE*|REVOKED*|COMPLETED*|COMPLETING*)
+        echo "ERROR: server job ${JOB_ID} reached terminal state ${state}" >&2
+        return 1
+        ;;
+    esac
+    if [[ "${wait_phase}" == "queue" ]]; then
+      if [[ "${state}" == "RUNNING" ]]; then
+        wait_phase="readiness"
+        ready_deadline=$((SECONDS + ready_timeout))
+        echo "Server job ${JOB_ID} is RUNNING; starting ${ready_timeout}s readiness timeout"
+      elif (( SECONDS >= queue_deadline )); then
+        echo "ERROR: timed out after ${queue_timeout}s waiting for job ${JOB_ID} to start; job state ${state}" >&2
+        return 1
+      fi
+    elif (( SECONDS >= ready_deadline )); then
+      echo "ERROR: timed out after ${ready_timeout}s waiting for ${SERVER_INFO}; job state ${state}" >&2
+      return 1
+    fi
+    echo "Waiting for model server (${wait_phase}); job ${JOB_ID} is ${state}"
+    sleep "${interval}"
+  done
+
+  if [[ "$(job_state)" != "RUNNING" ]]; then
+    echo "ERROR: server-info exists but job ${JOB_ID} is not RUNNING" >&2
+    return 1
+  fi
+  read_server_info
+  # Dataset-scoped: an empty overrides path must be omitted entirely (argparse
+  # would turn "" into Path(".")), and the row count / id pattern / locator mode
+  # all come from the active profile rather than AfterQuery's values.
+  local endpoint_args=(
+    --input "${INPUT_JSONL}"
+    --expected-count "${EXPECTED_COUNT}"
+    --expected-sha256 "${SOURCE_SHA256}"
+    --task-id-pattern "${TASK_ID_PATTERN}"
+    --reference-mode "${REFERENCE_MODE}"
+    --check-model-endpoint
+    --model-base-url "${INFO_SERVER_URL}"
+    --model-name "${EXPECTED_MODEL_NAME}"
+  )
+  if [[ -n "${OVERRIDES_JSON}" ]]; then
+    endpoint_args+=(--reference-overrides "${OVERRIDES_JSON}")
+  fi
+  POLICY_API_KEY=dummy "${REPO_ROOT}/.venv/bin/python" "${VALIDATOR}" "${endpoint_args[@]}"
+  write_endpoint_env
+}
+
+case "${1:-preflight}" in
+  preflight) preflight ;;
+  submit) submit_server ;;
+  status) status_server ;;
+  wait) wait_for_server ;;
+  -h|--help|help) usage ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/benchmarks/gdpval/slurm/validate_gdpval_resume_state.py
+++ b/benchmarks/gdpval/slurm/validate_gdpval_resume_state.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate that a partial AfterQuery rollout can be resumed safely."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+class ResumeStateError(ValueError):
+    """Raised when cached rollout state is unsafe to resume."""
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                raise ResumeStateError(f"{path}: blank line {line_number}")
+            value = json.loads(line)
+            if not isinstance(value, dict):
+                raise ResumeStateError(f"{path}: row {line_number} is not an object")
+            rows.append(value)
+    return rows
+
+
+def _rollout_key(row: dict[str, Any], *, label: str) -> tuple[int, int]:
+    task_index = row.get("_ng_task_index")
+    rollout_index = row.get("_ng_rollout_index")
+    if (
+        isinstance(task_index, bool)
+        or not isinstance(task_index, int)
+        or isinstance(rollout_index, bool)
+        or not isinstance(rollout_index, int)
+    ):
+        raise ResumeStateError(f"{label}: invalid Gym task/rollout key")
+    if not 0 <= task_index < 100 or rollout_index != 0:
+        raise ResumeStateError(f"{label}: unexpected Gym key ({task_index}, {rollout_index})")
+    return task_index, rollout_index
+
+
+def validate_partial_resume_state(
+    *,
+    launch_input: Path,
+    rollouts: Path,
+    materialized_inputs: Path,
+    failures: Path | None,
+    run_config: Path,
+    expected_launch_sha256: str,
+    expected_model: str,
+    deliverables_dir: Path,
+) -> int:
+    actual_hash = hashlib.sha256(launch_input.read_bytes()).hexdigest()
+    if actual_hash != expected_launch_sha256:
+        raise ResumeStateError(f"launch hash mismatch: {actual_hash}")
+
+    expected_rows = _read_jsonl(launch_input)
+    expected_ids = [str(row.get("task_id")) for row in expected_rows]
+    if len(expected_ids) != 100 or len(set(expected_ids)) != 100:
+        raise ResumeStateError("launch input does not contain 100 unique task IDs")
+
+    materialized = _read_jsonl(materialized_inputs)
+    if len(materialized) != 100:
+        raise ResumeStateError("materialized input does not contain 100 rows")
+    materialized_by_key: dict[tuple[int, int], str] = {}
+    for row_number, row in enumerate(materialized, 1):
+        key = _rollout_key(row, label=f"materialized row {row_number}")
+        if key in materialized_by_key:
+            raise ResumeStateError(f"materialized inputs duplicate Gym key {key}")
+        task_id = str(row.get("task_id"))
+        if task_id != expected_ids[key[0]]:
+            raise ResumeStateError(f"materialized Gym key {key} maps to {task_id}, expected {expected_ids[key[0]]}")
+        agent_ref = row.get("agent_ref")
+        if not isinstance(agent_ref, dict) or agent_ref.get("name") != "gdpval_stirrup_agent":
+            raise ResumeStateError(f"{task_id}: materialized input has an unexpected agent")
+        materialized_by_key[key] = task_id
+    expected_keys = {(index, 0) for index in range(100)}
+    if set(materialized_by_key) != expected_keys:
+        raise ResumeStateError("materialized Gym keys do not cover the 100-task batch")
+
+    outputs = _read_jsonl(rollouts)
+    if len(outputs) > 100:
+        raise ResumeStateError("partial rollout output contains more than 100 rows")
+    output_keys: set[tuple[int, int]] = set()
+    for row_number, row in enumerate(outputs, 1):
+        key = _rollout_key(row, label=f"rollout row {row_number}")
+        if key in output_keys:
+            raise ResumeStateError(f"partial rollout output duplicates Gym key {key}")
+        output_keys.add(key)
+        task_id = str(row.get("task_id"))
+        if materialized_by_key.get(key) != task_id:
+            raise ResumeStateError(
+                f"rollout Gym key {key} maps to {task_id}, materialized input maps to {materialized_by_key.get(key)}"
+            )
+        if row.get("execute_only") is not True:
+            raise ResumeStateError(f"{task_id}: execute_only is not true")
+        if row.get("reward") is not None or row.get("judge_response") is not None:
+            raise ResumeStateError(f"{task_id}: judge fields are populated")
+        agent_ref = row.get("agent_ref")
+        if not isinstance(agent_ref, dict) or agent_ref.get("name") != "gdpval_stirrup_agent":
+            raise ResumeStateError(f"{task_id}: rollout has an unexpected agent")
+        response = row.get("response")
+        if not isinstance(response, dict) or response.get("error") is not None:
+            raise ResumeStateError(f"{task_id}: rollout has an invalid response")
+        if response.get("model") != expected_model:
+            raise ResumeStateError(f"{task_id}: response model mismatch")
+
+        expected_dir = (deliverables_dir / f"task_{task_id}" / "repeat_0").resolve()
+        reported_dir = row.get("deliverables_dir")
+        if not isinstance(reported_dir, str) or Path(reported_dir).resolve() != expected_dir:
+            raise ResumeStateError(f"{task_id}: deliverables directory mismatch")
+        finish_marker = expected_dir / "finish_params.json"
+        if not finish_marker.is_file():
+            raise ResumeStateError(f"{task_id}: cached rollout is missing {finish_marker}")
+        finish_value = json.loads(finish_marker.read_text(encoding="utf-8"))
+        if not isinstance(finish_value, dict):
+            raise ResumeStateError(f"{task_id}: finish marker is not an object")
+
+    if failures is not None and failures.is_file():
+        _read_jsonl(failures)
+
+    fingerprint = run_config.read_text(encoding="utf-8").strip()
+    if re.fullmatch(r"[0-9a-f]{64}", fingerprint) is None:
+        raise ResumeStateError("run_config.sha256 is missing or malformed")
+
+    return len(outputs)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--launch-input", type=Path, required=True)
+    parser.add_argument("--rollouts", type=Path, required=True)
+    parser.add_argument("--materialized-inputs", type=Path, required=True)
+    parser.add_argument("--failures", type=Path)
+    parser.add_argument("--run-config", type=Path, required=True)
+    parser.add_argument("--expected-launch-sha256", required=True)
+    parser.add_argument("--expected-model", required=True)
+    parser.add_argument("--deliverables-dir", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        completed = validate_partial_resume_state(
+            launch_input=args.launch_input,
+            rollouts=args.rollouts,
+            materialized_inputs=args.materialized_inputs,
+            failures=args.failures,
+            run_config=args.run_config,
+            expected_launch_sha256=args.expected_launch_sha256,
+            expected_model=args.expected_model,
+            deliverables_dir=args.deliverables_dir,
+        )
+    except (OSError, json.JSONDecodeError, ResumeStateError) as exc:
+        print(f"ERROR: partial rollout state is not resumable: {exc}")
+        return 1
+    print(f"Partial full state is resumable: {completed}/100 completed rows")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/gdpval/slurm/wait_for_slurm_account.sh
+++ b/benchmarks/gdpval/slurm/wait_for_slurm_account.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Poll Slurm for a specific user/account association and stop once it appears.
+# This monitor is intentionally passive: it never submits or cancels jobs.
+
+umask 077
+
+STAGING_ROOT="${GDPVAL_SLURM_STAGING_ROOT:-${SCRATCH:-$HOME}/gdpval-rollouts}"
+TARGET_USER="${GDPVAL_ACCOUNT_TARGET_USER:-${USER:-$(id -un)}}"
+TARGET_ACCOUNT="${GDPVAL_SLURM_ACCOUNT:-}"
+TARGET_CLUSTER="${GDPVAL_ACCOUNT_TARGET_CLUSTER:-}"
+REQUIRED_QOS="${GDPVAL_ACCOUNT_REQUIRED_QOS:-normal}"
+POLL_INTERVAL="${GDPVAL_ACCOUNT_POLL_INTERVAL:-600}"
+QUERY_TIMEOUT="${GDPVAL_ACCOUNT_QUERY_TIMEOUT:-30}"
+STATE_FILE="${GDPVAL_ACCOUNT_STATE_FILE:-${STAGING_ROOT}/slurm_account_onboarding.state}"
+LOCK_FILE="${GDPVAL_ACCOUNT_LOCK_FILE:-${STAGING_ROOT}/.monitor_n4_onboarding.lock}"
+PID_FILE="${GDPVAL_ACCOUNT_PID_FILE:-${STAGING_ROOT}/monitor_n4_onboarding.pid}"
+ACTION="${1:-monitor}"
+PID_WRITTEN=0
+
+usage() {
+  cat <<'EOF'
+Usage: monitor_n4_onboarding.sh [monitor|once]
+
+Actions:
+  monitor  Poll until the Slurm association appears (default).
+  once     Check once and exit 0 if approved or 3 if still pending.
+
+Environment:
+  GDPVAL_ACCOUNT_TARGET_USER      Slurm username (default: $USER)
+  GDPVAL_SLURM_ACCOUNT       Slurm account to wait for (required)
+  GDPVAL_ACCOUNT_TARGET_CLUSTER   Restrict to one Slurm cluster (default: any)
+  GDPVAL_ACCOUNT_REQUIRED_QOS     Required QOS token (default: normal)
+  GDPVAL_ACCOUNT_POLL_INTERVAL    Poll interval in seconds (default: 600)
+  GDPVAL_ACCOUNT_QUERY_TIMEOUT    sacctmgr timeout in seconds (default: 30)
+  GDPVAL_ACCOUNT_STATE_FILE       Atomic status marker path
+  GDPVAL_ACCOUNT_LOCK_FILE        Single-monitor flock path
+  GDPVAL_ACCOUNT_PID_FILE         Active monitor PID path
+EOF
+}
+
+cleanup() {
+  if [[ "${PID_WRITTEN}" == "1" ]]; then
+    rm -f "${PID_FILE}"
+  fi
+}
+
+handle_signal() {
+  cleanup
+  trap - EXIT
+  exit 143
+}
+
+write_state() {
+  local status="$1"
+  local checked_at_utc="$2"
+  local association="${3:-}"
+  local tmp_state="${STATE_FILE}.tmp.$$"
+
+  {
+    printf 'status=%s\n' "${status}"
+    printf 'checked_at_utc=%s\n' "${checked_at_utc}"
+    printf 'cluster=%s\n' "${TARGET_CLUSTER}"
+    printf 'user=%s\n' "${TARGET_USER}"
+    printf 'account=%s\n' "${TARGET_ACCOUNT}"
+    printf 'required_qos=%s\n' "${REQUIRED_QOS}"
+    if [[ -n "${association}" ]]; then
+      printf 'association=%s\n' "${association}"
+    fi
+  } >"${tmp_state}"
+  chmod 600 "${tmp_state}"
+  mv "${tmp_state}" "${STATE_FILE}"
+}
+
+find_association() {
+  local output rc
+  if output="$(
+    timeout "${QUERY_TIMEOUT}s" sacctmgr -r -nP show associations \
+      "Accounts=${TARGET_ACCOUNT}" \
+      "Clusters=${TARGET_CLUSTER}" \
+      "Users=${TARGET_USER}" \
+      Format=Cluster,Account,User,Partition,QOS 2>&1
+  )"; then
+    :
+  else
+    rc=$?
+    printf 'ERROR: sacctmgr association query failed (rc=%s): %s\n' \
+      "${rc}" "${output}" >&2
+    return "${rc}"
+  fi
+
+  printf '%s\n' "${output}" |
+    awk -F'|' \
+      -v target_cluster="${TARGET_CLUSTER}" \
+      -v target_account="${TARGET_ACCOUNT}" \
+      -v target_user="${TARGET_USER}" \
+      -v required_qos="${REQUIRED_QOS}" '
+      {
+        for (i = 1; i <= NF; i++) {
+          gsub(/^[[:space:]]+|[[:space:]]+$/, "", $i)
+        }
+        qos_ok = 0
+        qos_count = split($5, qos_tokens, ",")
+        for (i = 1; i <= qos_count; i++) {
+          if (qos_tokens[i] == required_qos) {
+            qos_ok = 1
+          }
+        }
+        if ($1 == target_cluster &&
+            $2 == target_account &&
+            $3 == target_user &&
+            ($4 == "" || $4 == "batch") &&
+            qos_ok) {
+          print
+          exit
+        }
+      }
+    '
+}
+
+case "${ACTION}" in
+  monitor|once) ;;
+  -h|--help|help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "ERROR: action must be monitor or once (got ${ACTION})" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+[[ "${TARGET_USER}" =~ ^[A-Za-z0-9_.-]+$ ]] ||
+  { echo "ERROR: invalid Slurm username: ${TARGET_USER}" >&2; exit 2; }
+[[ "${TARGET_ACCOUNT}" =~ ^[A-Za-z0-9_.-]+$ ]] ||
+  { echo "ERROR: invalid Slurm account: ${TARGET_ACCOUNT}" >&2; exit 2; }
+[[ "${TARGET_CLUSTER}" =~ ^[A-Za-z0-9_.-]+$ ]] ||
+  { echo "ERROR: invalid Slurm cluster: ${TARGET_CLUSTER}" >&2; exit 2; }
+[[ "${REQUIRED_QOS}" =~ ^[A-Za-z0-9_.-]+$ ]] ||
+  { echo "ERROR: invalid required QOS: ${REQUIRED_QOS}" >&2; exit 2; }
+[[ "${POLL_INTERVAL}" =~ ^[1-9][0-9]*$ ]] ||
+  { echo "ERROR: GDPVAL_ACCOUNT_POLL_INTERVAL must be a positive integer" >&2; exit 2; }
+[[ "${QUERY_TIMEOUT}" =~ ^[1-9][0-9]*$ ]] ||
+  { echo "ERROR: GDPVAL_ACCOUNT_QUERY_TIMEOUT must be a positive integer" >&2; exit 2; }
+
+command -v sacctmgr >/dev/null
+command -v timeout >/dev/null
+command -v flock >/dev/null
+mkdir -p "${STAGING_ROOT}" "$(dirname "${STATE_FILE}")"
+
+if [[ "${ACTION}" == "monitor" ]]; then
+  exec 9>>"${LOCK_FILE}"
+  chmod 600 "${LOCK_FILE}"
+  if ! flock -n 9; then
+    echo "Onboarding monitor is already running"
+    exit 0
+  fi
+  printf '%s\n' "$$" >"${PID_FILE}"
+  chmod 600 "${PID_FILE}"
+  PID_WRITTEN=1
+  trap cleanup EXIT
+  trap handle_signal INT TERM
+fi
+
+while true; do
+  checked_at_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if association="$(find_association)"; then
+    :
+  else
+    rc=$?
+    write_state error "${checked_at_utc}"
+    printf '%s status=error query_rc=%s user=%s account=%s; retrying\n' \
+      "${checked_at_utc}" "${rc}" "${TARGET_USER}" "${TARGET_ACCOUNT}"
+    if [[ "${ACTION}" == "once" ]]; then
+      exit 4
+    fi
+    sleep "${POLL_INTERVAL}"
+    continue
+  fi
+
+  if [[ -n "${association}" ]]; then
+    write_state approved "${checked_at_utc}" "${association}"
+    printf '%s status=approved user=%s account=%s\n' \
+      "${checked_at_utc}" "${TARGET_USER}" "${TARGET_ACCOUNT}"
+    exit 0
+  fi
+
+  write_state pending "${checked_at_utc}"
+  printf '%s status=pending user=%s account=%s\n' \
+    "${checked_at_utc}" "${TARGET_USER}" "${TARGET_ACCOUNT}"
+
+  if [[ "${ACTION}" == "once" ]]; then
+    exit 3
+  fi
+  sleep "${POLL_INTERVAL}"
+done

--- a/benchmarks/gdpval/tests/test_validate_gdpval_resume_state.py
+++ b/benchmarks/gdpval/tests/test_validate_gdpval_resume_state.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+GDPVAL_ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = GDPVAL_ROOT / "slurm" / "validate_gdpval_resume_state.py"
+MODEL_NAME = "my-model-0"
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _build_partial_state(tmp_path: Path) -> tuple[list[str], Path, Path]:
+    launch = tmp_path / "input" / "launch.jsonl"
+    rollouts = tmp_path / "results" / "rollouts.jsonl"
+    materialized = tmp_path / "results" / "rollouts_materialized_inputs.jsonl"
+    failures = tmp_path / "results" / "rollouts_failures.jsonl"
+    run_config = tmp_path / "run_config.sha256"
+    deliverables = tmp_path / "deliverables"
+
+    launch_rows = [{"task_id": f"AQ-{index:05d}"} for index in range(100)]
+    materialized_rows = [
+        {
+            "task_id": row["task_id"],
+            "_ng_task_index": index,
+            "_ng_rollout_index": 0,
+            "agent_ref": {"name": "gdpval_stirrup_agent"},
+        }
+        for index, row in enumerate(launch_rows)
+    ]
+    task_id = launch_rows[0]["task_id"]
+    task_dir = deliverables / f"task_{task_id}" / "repeat_0"
+    task_dir.mkdir(parents=True)
+    (task_dir / "finish_params.json").write_text('{"paths": []}\n', encoding="utf-8")
+    rollout_rows = [
+        {
+            "task_id": task_id,
+            "_ng_task_index": 0,
+            "_ng_rollout_index": 0,
+            "agent_ref": {"name": "gdpval_stirrup_agent"},
+            "execute_only": True,
+            "reward": None,
+            "judge_response": None,
+            "response": {"model": MODEL_NAME, "error": None},
+            "deliverables_dir": str(task_dir),
+        }
+    ]
+
+    _write_jsonl(launch, launch_rows)
+    _write_jsonl(materialized, materialized_rows)
+    _write_jsonl(rollouts, rollout_rows)
+    failures.write_text("", encoding="utf-8")
+    run_config.write_text("a" * 64 + "\n", encoding="utf-8")
+    launch_sha = hashlib.sha256(launch.read_bytes()).hexdigest()
+    args = [
+        sys.executable,
+        str(VALIDATOR),
+        "--launch-input",
+        str(launch),
+        "--rollouts",
+        str(rollouts),
+        "--materialized-inputs",
+        str(materialized),
+        "--failures",
+        str(failures),
+        "--run-config",
+        str(run_config),
+        "--expected-launch-sha256",
+        launch_sha,
+        "--expected-model",
+        MODEL_NAME,
+        "--deliverables-dir",
+        str(deliverables),
+    ]
+    return args, rollouts, task_dir
+
+
+def test_partial_resume_validator_accepts_matching_gym_keys_and_finish_marker(tmp_path):
+    args, _, _ = _build_partial_state(tmp_path)
+
+    result = subprocess.run(args, check=False, capture_output=True, text=True)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "1/100 completed rows" in result.stdout
+
+
+def test_partial_resume_validator_rejects_task_mapped_to_wrong_gym_key(tmp_path):
+    args, rollouts, _ = _build_partial_state(tmp_path)
+    row = json.loads(rollouts.read_text(encoding="utf-8"))
+    row["_ng_task_index"] = 1
+    _write_jsonl(rollouts, [row])
+
+    result = subprocess.run(args, check=False, capture_output=True, text=True)
+
+    assert result.returncode == 1
+    assert "materialized input maps to" in result.stdout
+
+
+def test_partial_resume_validator_requires_cached_finish_marker(tmp_path):
+    args, _, task_dir = _build_partial_state(tmp_path)
+    (task_dir / "finish_params.json").unlink()
+
+    result = subprocess.run(args, check=False, capture_output=True, text=True)
+
+    assert result.returncode == 1
+    assert "cached rollout is missing" in result.stdout


### PR DESCRIPTION
Stacked on #2162, which was reduced to the runner, validator and dataset prep that recent runs actually exercise.

This adds the rest of the cluster harness: `slurm/` bootstrap, model server submission, the continuation gate/monitor, resume-state validation, and the GLM model profiles.

None of it is exercised by the collocated rollout path used today, so it is separated for its own review. Two known issues to settle here rather than in #2162:

- `submit_model_server.sh` runs `env -i`, which strips every `GDPVAL_*` a model profile exports, then hardcodes `--num-nodes 2 --tp-size 8` — this makes `models/*.env` inert.
- `slurm/` is a non-collocated orchestration path that has not been run recently.

Merge after #2162.