### PR TITLE
[Stirrup] Flag fragmentary web fetches and make tool call ids unique

### DIFF
--- a/responses_api_agents/stirrup_agent/stirrup_utils.py
+++ b/responses_api_agents/stirrup_agent/stirrup_utils.py
@@ -92,6 +92,20 @@ def convert_stirrup_history_to_output_items(
     input_items: list = []
     output_items: list = []
 
+    # Some serving layers mint tool_call_id per turn (e.g. "code_exec:0"), so the same id
+    # recurs every turn and a trajectory ends up with many function_call / function_call_output
+    # pairs sharing one call_id. Anything that later pairs them by id -- replay, training,
+    # trajectory analysis -- then silently attributes the wrong output to a call. Disambiguate
+    # by occurrence: the nth call and the nth output for a given raw id get the same suffix, so
+    # pairing is preserved while ids become unique within the response. The first occurrence
+    # keeps the raw id, so a trajectory that never repeats one is unchanged.
+    call_seq: dict[str, int] = {}
+    output_seq: dict[str, int] = {}
+
+    def _disambiguate(raw: str, seen: dict[str, int]) -> str:
+        seen[raw] = seen.get(raw, 0) + 1
+        return raw if seen[raw] == 1 else f"{raw}#{seen[raw]}"
+
     for turn in history:
         for msg in turn:
             if isinstance(msg, SystemMessage):
@@ -106,7 +120,7 @@ def convert_stirrup_history_to_output_items(
                 content = msg.content if isinstance(msg.content, str) else str(msg.content)
                 output_items.append(
                     NeMoGymFunctionCallOutput(
-                        call_id=msg.tool_call_id,
+                        call_id=_disambiguate(msg.tool_call_id, output_seq),
                         output=content,
                         type="function_call_output",
                     )
@@ -153,7 +167,7 @@ def convert_stirrup_history_to_output_items(
                             NeMoGymResponseFunctionToolCall(
                                 id=f"fc-{uuid.uuid4().hex[:8]}",
                                 arguments=tc.arguments if isinstance(tc.arguments, str) else json.dumps(tc.arguments),
-                                call_id=call_id,
+                                call_id=_disambiguate(call_id, call_seq),
                                 name=tc.name,
                                 type="function_call",
                                 status="completed",
@@ -165,7 +179,7 @@ def convert_stirrup_history_to_output_items(
                 content = msg.content if isinstance(msg.content, str) else str(msg.content)
                 output_items.append(
                     NeMoGymFunctionCallOutput(
-                        call_id=call_id,
+                        call_id=_disambiguate(call_id, output_seq),
                         output=content,
                         type="function_call_output",
                     )

--- a/responses_api_agents/stirrup_agent/tavily_search.py
+++ b/responses_api_agents/stirrup_agent/tavily_search.py
@@ -148,6 +148,27 @@ class _FetchParams(BaseModel):
     url: Annotated[str, Field(description="Full HTTP or HTTPS URL of the web page to fetch.")]
 
 
+# A markdown extraction this much smaller than the page it came from is usually a fragment,
+# not a short page. Observed on a real run: 313 characters returned for a 141 KB page (0.2%),
+# which the model consumed as if it were the whole page.
+_SUSPICIOUS_EXTRACTION_RATIO = 0.01
+_MIN_HTML_FOR_RATIO_CHECK = 20_000
+
+
+def _extract_page_text(html: str) -> str:
+    """Extract readable text from *html* as markdown, falling back to a bare pass.
+
+    The fallback matters because ``extract`` returning ``None`` is otherwise indistinguishable
+    from a genuinely empty page.
+    """
+    import trafilatura
+
+    extracted = trafilatura.extract(html, output_format="markdown")
+    if extracted and extracted.strip():
+        return extracted.strip()
+    return (trafilatura.extract(html, include_comments=True) or "").strip()
+
+
 async def _fetch_executor(
     params: _FetchParams,
     *,
@@ -163,9 +184,30 @@ async def _fetch_executor(
         )
         resp.raise_for_status()
 
-        import trafilatura
-
-        body_md = trafilatura.extract(resp.text, output_format="markdown") or ""
+        body_md = _extract_page_text(resp.text)
+        if not body_md:
+            # An empty <body> with no error reads to the model as "this page is blank",
+            # and it will happily reason on from nothing. Say what happened instead.
+            return ToolResult(
+                content=(
+                    f"<web_fetch><url>{params.url}</url>"
+                    f"<error>fetched {len(resp.text)} bytes but no readable text could be extracted; "
+                    f"the page is likely script-rendered. Try fetching a different URL, or retrieve it "
+                    f"inside code_exec if you need the raw markup.</error></web_fetch>"
+                ),
+                success=False,
+                metadata=ToolUseCountMetadata(),
+            )
+        if len(resp.text) >= _MIN_HTML_FOR_RATIO_CHECK and (
+            len(body_md) < _SUSPICIOUS_EXTRACTION_RATIO * len(resp.text)
+        ):
+            # Extraction succeeded but returned a sliver. Without saying so, the model treats
+            # the sliver as the whole page; with it, it can re-fetch the raw markup itself.
+            body_md = (
+                f"[extracted only {len(body_md)} characters of readable text from a "
+                f"{len(resp.text)}-byte page; this is likely a fragment, so re-fetch the raw "
+                f"markup inside code_exec if you need the rest]\n\n{body_md}"
+            )
         return ToolResult(
             content=f"<web_fetch><url>{params.url}</url><body>{truncate_msg(body_md, MAX_LENGTH)}</body></web_fetch>",
             metadata=ToolUseCountMetadata(),

--- a/responses_api_agents/stirrup_agent/tests/test_tool_call_id_uniqueness.py
+++ b/responses_api_agents/stirrup_agent/tests/test_tool_call_id_uniqueness.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A call_id must identify one call, or downstream pairing attributes the wrong output.
+
+Some serving layers mint ``tool_call_id`` per turn ("code_exec:0"), so a long trajectory
+repeats the same id dozens of times. Real runs carry 268-300 duplicate ids each. Replay,
+training and analysis code that pairs ``function_call`` to ``function_call_output`` by id
+then silently matches a call to some other turn's output.
+"""
+
+from stirrup.core.models import AssistantMessage, ToolCall, ToolMessage
+
+from responses_api_agents.stirrup_agent.stirrup_utils import convert_stirrup_history_to_output_items
+
+
+def _turn(call_id: str, args: str, output: str) -> list:
+    """One assistant tool call plus the tool result that answers it."""
+    return [
+        AssistantMessage(content="", tool_calls=[ToolCall(tool_call_id=call_id, name="code_exec", arguments=args)]),
+        ToolMessage(content=output, name="code_exec", tool_call_id=call_id),
+    ]
+
+
+def _calls_and_outputs(items):
+    calls = [i for i in items if getattr(i, "type", None) == "function_call"]
+    outputs = [i for i in items if getattr(i, "type", None) == "function_call_output"]
+    return calls, outputs
+
+
+def test_repeated_ids_across_turns_become_unique():
+    history = [_turn("code_exec:0", f"arg{i}", f"out{i}") for i in range(4)]
+
+    _, items = convert_stirrup_history_to_output_items(history)
+    calls, _ = _calls_and_outputs(items)
+
+    ids = [c.call_id for c in calls]
+    assert len(set(ids)) == len(ids) == 4, f"call ids are not unique: {ids}"
+
+
+def test_each_call_still_pairs_with_its_own_output():
+    """Uniqueness is worthless if it breaks the pairing it exists to protect."""
+    history = [_turn("code_exec:0", f"arg{i}", f"out{i}") for i in range(4)]
+
+    _, items = convert_stirrup_history_to_output_items(history)
+    calls, outputs = _calls_and_outputs(items)
+
+    by_id = {o.call_id: o.output for o in outputs}
+    for i, call in enumerate(calls):
+        assert call.arguments == f"arg{i}"
+        assert by_id[call.call_id] == f"out{i}", (
+            f"call with arguments {call.arguments!r} resolved to output {by_id[call.call_id]!r}"
+        )
+
+
+def test_distinct_ids_are_left_alone():
+    history = [_turn(f"code_exec:{i}", f"arg{i}", f"out{i}") for i in range(3)]
+
+    _, items = convert_stirrup_history_to_output_items(history)
+    calls, outputs = _calls_and_outputs(items)
+
+    assert [c.call_id for c in calls] == ["code_exec:0", "code_exec:1", "code_exec:2"]
+    assert [o.call_id for o in outputs] == ["code_exec:0", "code_exec:1", "code_exec:2"]
+
+
+def test_interleaved_tools_pair_independently():
+    """Two tools each reusing their own id must not cross-contaminate."""
+    history = [
+        _turn("code_exec:0", "code-a", "code-out-a"),
+        _turn("web_search:0", "search-a", "search-out-a"),
+        _turn("code_exec:0", "code-b", "code-out-b"),
+        _turn("web_search:0", "search-b", "search-out-b"),
+    ]
+
+    _, items = convert_stirrup_history_to_output_items(history)
+    calls, outputs = _calls_and_outputs(items)
+
+    by_id = {o.call_id: o.output for o in outputs}
+    resolved = {c.arguments: by_id[c.call_id] for c in calls}
+    assert resolved == {
+        "code-a": "code-out-a",
+        "code-b": "code-out-b",
+        "search-a": "search-out-a",
+        "search-b": "search-out-b",
+    }

--- a/responses_api_agents/stirrup_agent/tests/test_web_fetch_extraction.py
+++ b/responses_api_agents/stirrup_agent/tests/test_web_fetch_extraction.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A fetch that returns a fragment, or nothing, must not look like a successful read.
+
+trafilatura defaults to precision over recall and drops link text, so a heavily templated
+page can extract to a few hundred characters. Observed on a real run: 313 characters
+returned for a 141 KB page, with no error - the model reasoned on the fragment and only
+recovered because it happened to notice and re-fetch with curl. A total extraction failure
+was worse: an empty ``<body>`` with ``success=True``, indistinguishable from a blank page.
+"""
+
+import asyncio
+
+from responses_api_agents.stirrup_agent.tavily_search import _fetch_executor, _FetchParams
+
+
+_LINK_HEAVY = """<html><body>
+<nav><a href="/a">Home</a></nav>
+<main>
+  <h1>Service tiers</h1>
+  <ul>
+    <li><a href="/bronze">Bronze tier covers same-day courier dispatch</a></li>
+    <li><a href="/silver">Silver tier adds pharmacy coordination windows</a></li>
+    <li><a href="/gold">Gold tier guarantees a two-hour infusion slot</a></li>
+  </ul>
+  <table>
+    <tr><th>Tier</th><th>Price</th></tr>
+    <tr><td>Bronze</td><td>1200</td></tr>
+    <tr><td>Gold</td><td>4800</td></tr>
+  </table>
+</main></body></html>"""
+
+_NO_TEXT = "<html><head><title>t</title></head><body><script>var a=1;</script></body></html>"
+
+
+class _Resp:
+    def __init__(self, text: str):
+        self.text = text
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _Client:
+    def __init__(self, text: str):
+        self._text = text
+
+    async def get(self, url, headers=None):  # noqa: ARG002 - signature mirrors httpx
+        return _Resp(self._text)
+
+
+def _fetch(html: str):
+    return asyncio.run(_fetch_executor(_FetchParams(url="https://example.test/p"), client=_Client(html)))
+
+
+def test_a_sliver_of_a_large_page_is_flagged_as_a_fragment():
+    """The real failure: 313 characters returned for a 141 KB page, consumed as the whole page."""
+    html = (
+        "<html><body><main><p>One short sentence of real content.</p></main>"
+        "<script>" + "var padding = 1;" * 4000 + "</script></body></html>"
+    )
+    assert len(html) > 20_000
+
+    text = _fetch(html).content
+
+    assert "likely a fragment" in text, "the model was handed a sliver with no indication of it"
+    assert "One short sentence of real content." in text, "the extracted text itself must survive"
+
+
+def test_a_short_page_is_not_flagged():
+    """A genuinely short page is not a fragment; crying wolf would teach the model to ignore it."""
+    text = _fetch(_LINK_HEAVY).content
+
+    assert "likely a fragment" not in text
+    assert "Service tiers" in text
+
+
+def test_unextractable_page_is_an_error_not_an_empty_body():
+    result = _fetch(_NO_TEXT)
+
+    assert result.success is False
+    assert "<body></body>" not in result.content, "an empty body reads to the model as a blank page"
+    assert "no readable text" in result.content
+
+
+def test_unextractable_page_reports_what_was_fetched():
+    """The model needs to know bytes arrived, so it retries rather than concluding 'empty'."""
+    result = _fetch(_NO_TEXT)
+
+    assert str(len(_NO_TEXT)) in result.content
+
+
+def test_normal_page_still_returns_a_body():
+    result = _fetch(_LINK_HEAVY)
+
+    assert result.success is True
+    assert "<body>" in result.content
+    assert "Service tiers" in result.content


### PR DESCRIPTION
Two pre-existing bugs found while comparing rollout trajectories. Independent of the GDPVal upstreaming PRs; neither file is touched by them.

**`fetch_web_page` reports success on a fragment or on nothing.** `trafilatura.extract(...) or ""` means a total extraction failure returns an empty `<body>` with `success=True`, which the model reads as a blank page. A partial extraction is worse: a real run returned 313 characters for a 141 KB page and the model reasoned on the fragment, recovering only because it happened to notice and re-fetch with curl. Now an unextractable page is an error that says how many bytes arrived, and an extraction under 1% of a >=20 KB page is prefixed with its own size so the model can re-fetch the raw markup.

Deliberately not changed: `favor_recall`/`include_links` made no measurable difference on the fixtures tested, so the extraction parameters are left alone.

**`call_id` is not unique within a trajectory.** Some serving layers mint `tool_call_id` per turn (`code_exec:0`), so it recurs every turn — real runs carry 268-300 duplicates each. Replay, training and analysis code pairing `function_call` to `function_call_output` by id silently attributes the wrong output to a call; a test without the fix resolves the call carrying `arg0` to the output `out3`. Disambiguated by occurrence, so the nth call and nth output for a raw id share a suffix and pairing is preserved. The first occurrence keeps the raw id, so trajectories that never repeat one are unchanged.

9 new tests; 3 of the fetch tests and all 4 id tests fail without the corresponding fix. 385 passed / 3 skipped across the stirrup and gdpval suites.