### PR TITLE
fix(docs): remove absolute internal URL from 0.5.0 release notes

### DIFF
--- a/fern/versions/latest/pages/about/release-notes.mdx
+++ b/fern/versions/latest/pages/about/release-notes.mdx
@@ -48,6 +48,8 @@ Five new built-in providers: **Docker**, **Daytona**, **ECS Fargate**, **Enroot*
 
 OpenSandbox reliability at scale is significantly improved: keepalive-bounded transport eliminates silent rollout zeroing at concurrency 300–1500; image registry auth supports private container images; sandbox resources are automatically labeled with team, user, and workload identifiers.
 
+See [Available Sandbox Providers](/nemo-gym/nemo_gym/sandbox/providers) for the full list.
+
 ### Configure Agent Harnesses
 
 New harnesses join the existing set (Claude Code, Hermes, mini-SWE-Agent, OpenClaw, Pi, and more):

--- a/fern/versions/latest/pages/about/release-notes.mdx
+++ b/fern/versions/latest/pages/about/release-notes.mdx
@@ -48,8 +48,6 @@ Five new built-in providers: **Docker**, **Daytona**, **ECS Fargate**, **Enroot*
 
 OpenSandbox reliability at scale is significantly improved: keepalive-bounded transport eliminates silent rollout zeroing at concurrency 300–1500; image registry auth supports private container images; sandbox resources are automatically labeled with team, user, and workload identifiers.
 
-See [Available Sandbox Providers](https://docs.nvidia.com/nemo/gym/nemo-gym/nemo_gym/sandbox/providers/) for the full list.
-
 ### Configure Agent Harnesses
 
 New harnesses join the existing set (Claude Code, Hermes, mini-SWE-Agent, OpenClaw, Pi, and more):

--- a/fern/versions/v0.5.0/pages/about/release-notes.mdx
+++ b/fern/versions/v0.5.0/pages/about/release-notes.mdx
@@ -48,6 +48,8 @@ Five new built-in providers: **Docker**, **Daytona**, **ECS Fargate**, **Enroot*
 
 OpenSandbox reliability at scale is significantly improved: keepalive-bounded transport eliminates silent rollout zeroing at concurrency 300–1500; image registry auth supports private container images; sandbox resources are automatically labeled with team, user, and workload identifiers.
 
+See [Available Sandbox Providers](/nemo-gym/nemo_gym/sandbox/providers) for the full list.
+
 ### Configure Agent Harnesses
 
 New harnesses join the existing set (Claude Code, Hermes, mini-SWE-Agent, OpenClaw, Pi, and more):

--- a/fern/versions/v0.5.0/pages/about/release-notes.mdx
+++ b/fern/versions/v0.5.0/pages/about/release-notes.mdx
@@ -48,8 +48,6 @@ Five new built-in providers: **Docker**, **Daytona**, **ECS Fargate**, **Enroot*
 
 OpenSandbox reliability at scale is significantly improved: keepalive-bounded transport eliminates silent rollout zeroing at concurrency 300–1500; image registry auth supports private container images; sandbox resources are automatically labeled with team, user, and workload identifiers.
 
-See [Available Sandbox Providers](https://docs.nvidia.com/nemo/gym/nemo-gym/nemo_gym/sandbox/providers/) for the full list.
-
 ### Configure Agent Harnesses
 
 New harnesses join the existing set (Claude Code, Hermes, mini-SWE-Agent, OpenClaw, Pi, and more):


### PR DESCRIPTION
## Summary

Fixes the `test_internal_pages_are_linked_by_path_not_by_absolute_url` test failure introduced by #2389.

The v0.5.0 release notes sandboxing section contained a `docs.nvidia.com/nemo/gym/...` absolute link. The test requires all internal docs links in `latest/` to use relative paths (to keep readers within the version they're reading). Replaced with a relative path `/nemo-gym/nemo_gym/sandbox/providers` in both `latest/` and the `v0.5.0/` snapshot.

## Test plan

- [ ] `test_internal_pages_are_linked_by_path_not_by_absolute_url` passes
- [ ] Cherry-pick to `r0.5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)