### PR TITLE
feat(sandbox): report the command duration execd measures

### DIFF
--- a/nemo_gym/sandbox/providers/base.py
+++ b/nemo_gym/sandbox/providers/base.py
@@ -151,12 +151,19 @@ class SandboxExecResult:
     command. Providers may use a non-process sentinel with ``error_type`` set
     when the sandbox runtime reports an execution failure without a process
     exit code.
+
+    ``duration_ms`` is how long the command itself ran *inside* the sandbox, as
+    measured there. A caller timing the ``exec`` call also measures transport and
+    dispatch, which is the difference between "my build takes ten minutes" and
+    "my build takes eight and the round-trip takes two". Providers that cannot
+    report it leave it ``None``.
     """
 
     stdout: str | None
     stderr: str | None
     return_code: int
     error_type: str | None = None
+    duration_ms: float | None = None
 
 
 ExecResult = SandboxExecResult

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -333,6 +333,20 @@ def _to_image_spec(image: str, image_auth: Mapping[str, Any] | None) -> Any:
     return SandboxImageSpec(image, auth=SandboxImageAuth(**dict(image_auth)))
 
 
+def _duration_ms_between(started_at: Any, finished_at: Any) -> float | None:
+    """Milliseconds between two SDK timestamps, or None if they cannot be subtracted.
+
+    Deliberately forgiving: a timing number is a nice-to-have, and a renamed or
+    re-typed timestamp field must not turn a successful command into an exception.
+    """
+    if started_at is None or finished_at is None:
+        return None
+    try:
+        return (finished_at - started_at).total_seconds() * 1000.0
+    except (AttributeError, TypeError):
+        return None
+
+
 def _to_sandbox_status(state: Any) -> SandboxStatus:
     normalized = str(state or "").lower()
     if normalized in {"active", "ready", "running"}:
@@ -1082,7 +1096,19 @@ class OpenSandboxProvider:
             else:
                 return_code = 0
 
-            return SandboxExecResult(stdout=stdout, stderr=stderr, return_code=return_code, error_type=error_type)
+            # execd reports how long the command actually ran inside the sandbox.
+            # A caller timing its own exec() measures the command plus the round
+            # trip and cannot separate a slow command from a slow link.
+            completion = getattr(execution, "complete", None)
+            duration_ms = getattr(completion, "execution_time_in_millis", None) if completion is not None else None
+
+            return SandboxExecResult(
+                stdout=stdout,
+                stderr=stderr,
+                return_code=return_code,
+                error_type=error_type,
+                duration_ms=float(duration_ms) if duration_ms is not None else None,
+            )
 
         # Backstop for wedges the inner deadlines miss. Background exec polls, so
         # sdk_timeout_s bounds a single request rather than the command: without
@@ -1185,7 +1211,19 @@ class OpenSandboxProvider:
         else:
             return_code = 0
 
-        return SandboxExecResult(stdout=stdout, stderr=stderr, return_code=return_code, error_type=error_type)
+        # Same measurement as the foreground path, from the only fields this one
+        # has: the background status carries started_at/finished_at rather than a
+        # completion block. Reporting nothing here would make duration_ms depend on
+        # which path happened to run, which is worse than not reporting it at all.
+        duration_ms = _duration_ms_between(getattr(status, "started_at", None), getattr(status, "finished_at", None))
+
+        return SandboxExecResult(
+            stdout=stdout,
+            stderr=stderr,
+            return_code=return_code,
+            error_type=error_type,
+            duration_ms=float(duration_ms) if duration_ms is not None else None,
+        )
 
     async def exec(
         self,

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -1247,3 +1247,66 @@ async def test_connect_honours_skip_health_check_opt_out(fake_opensandbox_sdk: N
     await provider.connect({"sandbox_id": "sandbox-9"})
 
     assert FakeSandbox.connected_kwargs["skip_health_check"] is True
+
+
+async def test_exec_reports_the_duration_execd_measured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """execd already times the command; dropping that leaves callers guessing.
+
+    A client that only times its own ``exec`` call cannot tell a slow command
+    from a slow link. Surfacing execd's number gives it both halves.
+    """
+
+    class FakeRunCommandOpts:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    class FakeCommands:
+        def __init__(self, complete: Any) -> None:
+            self._complete = complete
+
+        async def run(self, command: str, *, opts: FakeRunCommandOpts) -> Any:
+            return SimpleNamespace(
+                logs=SimpleNamespace(stdout=[], stderr=[]),
+                error=None,
+                exit_code=0,
+                complete=self._complete,
+            )
+
+    monkeypatch.setattr(
+        opensandbox_provider,
+        "_require_opensandbox_sdk",
+        lambda: (object, object, FakeRunCommandOpts, object, object),
+    )
+    provider = opensandbox_provider.OpenSandboxProvider(connection={"request_timeout_s": 5})
+
+    def handle_reporting(complete: Any) -> opensandbox_provider.SandboxHandle:
+        return opensandbox_provider.SandboxHandle(
+            sandbox_id="sandbox-1",
+            provider_name="opensandbox",
+            raw=SimpleNamespace(commands=FakeCommands(complete)),
+        )
+
+    result = await provider.exec(handle_reporting(SimpleNamespace(execution_time_in_millis=3002)), "sleep 3")
+    assert result.duration_ms == 3002.0
+
+    # Older execd builds, and the error paths, report no completion block at all.
+    for complete in (None, SimpleNamespace()):
+        assert (await provider.exec(handle_reporting(complete), "true")).duration_ms is None
+
+
+def test_duration_ms_between_handles_missing_and_odd_timestamps() -> None:
+    """Timing is a nice-to-have; a renamed or re-typed field must not raise.
+
+    The background exec path has no completion block, so it derives the duration
+    from started_at/finished_at. If that ever stops subtracting cleanly the command
+    should still return its result, just without a number.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    started = datetime(2026, 8, 1, 12, 0, 0, tzinfo=timezone.utc)
+    assert opensandbox_provider._duration_ms_between(started, started + timedelta(seconds=3.002)) == 3002.0
+
+    assert opensandbox_provider._duration_ms_between(None, started) is None
+    assert opensandbox_provider._duration_ms_between(started, None) is None
+    # A string timestamp (a plausible SDK change) must degrade, not explode.
+    assert opensandbox_provider._duration_ms_between("2026-08-01T12:00:00Z", started) is None


### PR DESCRIPTION
**Bottom of a 4-PR stack** (#2400 → #2401 → #2402 → #2403) that adds `gym sandbox debug`. This one stands alone.

## Why

A caller that times its own `exec()` measures the command *plus* the round trip, so it cannot tell a slow command from a slow link. execd already times the command inside the sandbox; the provider was discarding it.

## What

Both exec paths now report `duration_ms`, from whichever field each has:

| path | source |
|---|---|
| foreground | `execution_time_in_millis` on the completion block |
| background | status `finished_at` − `started_at` (there is no completion block) |

Reporting on only one path would make `duration_ms` depend on which path happened to run — and the caller cannot tell which that was. An intermittently-absent number is worse than no number.

`_duration_ms_between` returns `None` rather than raising if the timestamps stop subtracting cleanly. A timing figure is a nice-to-have; a renamed or re-typed SDK field must not turn a successful command into an exception.

## Tests

Covers the foreground read, and for the helper: a normal delta, either timestamp missing, and a string timestamp (a plausible SDK change) degrading to `None` instead of raising.
