### PR TITLE
feat(sandbox): let providers renew a sandbox's lifetime

### DIFF
--- a/fern/versions/latest/pages/infrastructure/sandbox/adding-a-provider.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/adding-a-provider.mdx
@@ -69,6 +69,56 @@ Provider implementations should preserve the same lifecycle contract as the buil
 - Make `close()` safe to call from cleanup paths.
 - Use `aclose()` for provider-scoped resources such as SDK clients.
 
+## Optional Capabilities
+
+Beyond the required protocol, a provider can advertise extra abilities by implementing one of
+the `runtime_checkable` capability protocols in `nemo_gym.sandbox.providers.base`. Callers test
+for them with `isinstance()` and fall back when they are absent, so implementing one is
+additive — nothing breaks by leaving it out.
+
+### `RenewableProvider`
+
+Implement this when your backend can move a sandbox's expiry after creation. It lets callers
+give sandboxes a short lifetime and keep them alive through use, instead of granting a long
+lifetime up front and hoping something deletes it.
+
+```python
+class MySandboxProvider:
+    ...
+
+    async def renew(self, handle: SandboxHandle, ttl_s: float) -> None:
+        # Expire ttl_s seconds FROM NOW — not ttl_s added to the time remaining.
+        await handle.raw.set_expiry(seconds_from_now=ttl_s)
+```
+
+The contract callers rely on:
+
+- The new expiry is measured from *now*, so repeated calls hold a constant window rather than
+  extending without bound.
+- Renewing an already-expired or deleted sandbox should raise; callers treat renewal as best
+  effort and carry on with the original lifetime.
+- If your backend has no expiry concept at all, do not implement this — its absence is the
+  correct signal, and a no-op `renew()` would claim a guarantee you cannot keep.
+
+### `ConnectableProvider`
+
+Implement this when a sandbox is reachable by id from a different process — that is, when the
+state lives in an external control plane rather than in this process. It backs
+`AsyncSandbox.serialize()` / `AsyncSandbox.connect()`, so a sandbox created in one
+process can be operated from another.
+
+```python
+    async def serialize_handle(self, handle: SandboxHandle, *, scope: str | None = None) -> dict:
+        return {"sandbox_id": handle.sandbox_id}
+
+    async def connect(self, descriptor: Mapping[str, Any]) -> SandboxHandle:
+        raw = await my_runtime_attach(descriptor["sandbox_id"])
+        return SandboxHandle(sandbox_id=str(raw.id), provider_name=self.name, raw=raw)
+```
+
+A provider whose sandboxes only exist in-process should not implement this; callers surface a
+clear "cannot reattach" error rather than silently leaking a sandbox they can no longer reach.
+
 ## Provider Config
 
 Provider constructors receive the single provider-specific mapping from a named sandbox block:

--- a/nemo_gym/sandbox/__init__.py
+++ b/nemo_gym/sandbox/__init__.py
@@ -19,6 +19,7 @@ from nemo_gym.sandbox.config import resolve_provider_config, resolve_provider_me
 from nemo_gym.sandbox.providers import (
     ConnectableProvider,
     ExecResult,
+    RenewableProvider,
     SandboxCreateError,
     SandboxCreateVerificationError,
     SandboxEndpoint,
@@ -41,6 +42,7 @@ __all__ = [
     "Sandbox",
     "AsyncSandbox",
     "ConnectableProvider",
+    "RenewableProvider",
     "ExecResult",
     "SandboxCreateError",
     "SandboxCreateVerificationError",

--- a/nemo_gym/sandbox/providers/__init__.py
+++ b/nemo_gym/sandbox/providers/__init__.py
@@ -17,6 +17,7 @@
 from nemo_gym.sandbox.providers.base import (
     ConnectableProvider,
     ExecResult,
+    RenewableProvider,
     SandboxCreateError,
     SandboxCreateVerificationError,
     SandboxEndpoint,
@@ -38,6 +39,7 @@ from nemo_gym.sandbox.providers.registry import (
 
 __all__ = [
     "ConnectableProvider",
+    "RenewableProvider",
     "ExecResult",
     "SandboxCreateError",
     "SandboxCreateVerificationError",

--- a/nemo_gym/sandbox/providers/base.py
+++ b/nemo_gym/sandbox/providers/base.py
@@ -255,3 +255,19 @@ class ConnectableProvider(Protocol):
     async def connect(self, descriptor: Mapping[str, Any]) -> SandboxHandle:
         """Rebuild a live handle in this process from a descriptor."""
         ...
+
+
+@runtime_checkable
+class RenewableProvider(Protocol):
+    """Optional capability: push back a sandbox's expiry.
+
+    Lets a caller hold a sandbox open across several operations without giving it
+    a long lifetime up front — the lifetime stays short, and activity is what
+    keeps it alive. Providers whose sandboxes have no server-side expiry do not
+    implement this. Membership is checked with ``isinstance`` because the
+    protocol is ``runtime_checkable``.
+    """
+
+    async def renew(self, handle: SandboxHandle, ttl_s: float) -> None:
+        """Set the sandbox to expire ``ttl_s`` seconds from now."""
+        ...

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -96,6 +96,10 @@ DEFAULT_ATTRIBUTION_KEY_PREFIX = "nemo-gym.nvidia.com/"
 # Kubernetes label-key prefixes must be DNS-1123 subdomains (max 253 chars).
 ATTRIBUTION_KEY_PREFIX_RE = re.compile(r"(?=.{1,253}$)[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*")
 DEFAULT_IMAGE_PULL_POLICY = "IfNotPresent"
+
+# Shortest sandbox lifetime the OpenSandbox API accepts; below it, create returns
+# an HTTP 422 that does not say which field was at fault.
+MIN_TTL_S = 60.0
 IMAGE_PULL_POLICY_EXTENSION_KEY = "imagePullPolicy"
 IMAGE_PULL_POLICY_ANNOTATION_EXTENSION_KEY = "opensandbox.extensions.image-pull-policy"
 VALID_IMAGE_PULL_POLICIES = {"Always", "IfNotPresent", "Never"}
@@ -691,6 +695,17 @@ class OpenSandboxProvider:
         """
         return {"sandbox_id": handle.sandbox_id}
 
+    async def renew(self, handle: SandboxHandle, ttl_s: float) -> None:
+        """Push the sandbox's expiry out to ``ttl_s`` seconds from now."""
+        await self._await_sdk_operation(
+            lambda: handle.raw.renew(timedelta(seconds=ttl_s)),
+            operation="renew",
+            sandbox_id=handle.sandbox_id,
+            timeout_s=float(self._connection.request_timeout_s)
+            if self._connection.request_timeout_s is not None
+            else None,
+        )
+
     async def connect(self, descriptor: Mapping[str, Any]) -> SandboxHandle:
         """Rebuild a live handle from an OpenSandbox sandbox id via the SDK.
 
@@ -909,6 +924,12 @@ class OpenSandboxProvider:
         if options.snapshot_id is not None:
             kwargs["snapshot_id"] = options.snapshot_id
         if spec.ttl_s is not None:
+            # The API rejects a shorter lifetime with a bare HTTP 422, which says
+            # nothing about which field was wrong. Name it here instead.
+            if spec.ttl_s < MIN_TTL_S:
+                raise ValueError(
+                    f"OpenSandbox requires a sandbox lifetime of at least {MIN_TTL_S:g}s; got ttl_s={spec.ttl_s:g}"
+                )
             kwargs["timeout"] = timedelta(seconds=spec.ttl_s)
         if spec.ready_timeout_s is not None:
             kwargs["ready_timeout"] = timedelta(seconds=spec.ready_timeout_s)

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -25,7 +25,7 @@ from typing import Any
 import httpx
 import pytest
 
-from nemo_gym.sandbox.providers.base import SandboxResources, SandboxSpec, SandboxStatus
+from nemo_gym.sandbox.providers.base import RenewableProvider, SandboxResources, SandboxSpec, SandboxStatus
 
 
 pytestmark = pytest.mark.sandbox
@@ -878,7 +878,7 @@ async def test_create_once_and_connect_after_create_error_paths(
     monkeypatch.setattr(opensandbox_provider, "_to_volumes", lambda volumes: volumes)
     spec = SandboxSpec(
         image="image:tag",
-        ttl_s=10,
+        ttl_s=600,
         ready_timeout_s=20,
         resources=SandboxResources(cpu=2, memory_mib=8192, disk_gib=20, gpu=1, gpu_type="H100"),
         entrypoint=["/bin/sh"],
@@ -892,7 +892,7 @@ async def test_create_once_and_connect_after_create_error_paths(
     handle = await provider._create_once(spec)
     assert handle.sandbox_id == "sandbox-1"
     assert FakeSandbox.created_kwargs["snapshot_id"] == "snapshot-1"
-    assert FakeSandbox.created_kwargs["timeout"] == timedelta(seconds=10)
+    assert FakeSandbox.created_kwargs["timeout"] == timedelta(seconds=600)
     assert FakeSandbox.created_kwargs["ready_timeout"] == timedelta(seconds=20)
     assert FakeSandbox.created_kwargs["resource"] == {
         "cpu": "2",
@@ -1310,3 +1310,37 @@ def test_duration_ms_between_handles_missing_and_odd_timestamps() -> None:
     assert opensandbox_provider._duration_ms_between(started, None) is None
     # A string timestamp (a plausible SDK change) must degrade, not explode.
     assert opensandbox_provider._duration_ms_between("2026-08-01T12:00:00Z", started) is None
+async def test_renew_pushes_the_expiry_out() -> None:
+    """Renewal is what lets a sandbox be short-lived *and* long-held.
+
+    Without it the only way to keep a box past its lifetime is to ask for a long
+    one up front, which is exactly the request that strands sandboxes when the
+    caller goes away.
+    """
+    renewals: list[timedelta] = []
+
+    class FakeRaw:
+        async def renew(self, delta: timedelta) -> None:
+            renewals.append(delta)
+
+    provider = opensandbox_provider.OpenSandboxProvider(connection={"request_timeout_s": 5})
+    handle = opensandbox_provider.SandboxHandle(sandbox_id="sandbox-1", provider_name="opensandbox", raw=FakeRaw())
+
+    await provider.renew(handle, 900.0)
+    assert renewals == [timedelta(seconds=900)]
+    assert isinstance(provider, RenewableProvider)
+
+
+def test_ttl_below_the_api_minimum_is_named_locally() -> None:
+    """A sub-minimum lifetime otherwise comes back as a bare HTTP 422.
+
+    The API's floor is provider knowledge, so the provider is where it can be
+    turned into a message that says which field was wrong.
+    """
+    import asyncio
+
+    from nemo_gym.sandbox.providers.opensandbox.provider import MIN_TTL_S, OpenSandboxProvider
+
+    provider = OpenSandboxProvider(connection={"domain": "example", "api_key": "k"})
+    with pytest.raises(ValueError, match=f"at least {MIN_TTL_S:g}s"):
+        asyncio.run(provider.create(SandboxSpec(image="img", ttl_s=30)))


### PR DESCRIPTION
**PR 2 of 4** in the `gym sandbox debug` stack (#2400 → **#2401** → #2402 → #2403).

## Why

Holding a sandbox open across several operations currently means asking for a long lifetime up front — and a long lifetime is exactly what strands sandboxes when the caller goes away. Renewal inverts that: the lifetime stays short, and *activity* is what keeps the sandbox alive.

That matters most for the debugger at the top of this stack, which holds a box open for as long as a command runs but must not leak one when you Ctrl-C.

## What

`RenewableProvider`, a `runtime_checkable` protocol next to the existing `ConnectableProvider`, implemented for OpenSandbox. Callers probe with `isinstance()` and fall back to the original lifetime, so implementing it is additive.

The contract is the part worth reviewing:

- The new expiry is measured **from now**, not added to the time remaining — so repeated calls hold a constant window rather than extending without bound.
- Renewing an expired or deleted sandbox raises; callers treat renewal as best-effort.
- A backend with no expiry concept should **not** implement this. Its absence is the signal callers test for, and a no-op `renew()` would claim a guarantee the provider cannot keep.

Includes docs for both optional capabilities in `adding-a-provider.mdx` — `ConnectableProvider` landed without them.
