### PR TITLE
feat(sandbox): add the sandbox_task hook mechanism

### DIFF
--- a/nemo_gym/config_types.py
+++ b/nemo_gym/config_types.py
@@ -564,6 +564,35 @@ class Domain(str, Enum):
     OTHER = "other"
 
 
+class SandboxTaskConfig(BaseModel):
+    """How tooling reconstructs the sandbox a sandbox-backed server would create.
+
+    Servers agree on `sandbox_provider` but not on how they reach a `SandboxSpec`:
+    some declare it entirely in `sandbox_spec`, others compute it from the task
+    row. This block lets a server that computes it hand the recipe to tooling —
+    notably `gym sandbox debug` — without that tooling importing the server.
+
+    Every field is optional; with none set, the spec comes from `sandbox_spec`
+    alone. Hook references are `"module.path:attribute"` and must be importable
+    from the environment running them, so point them at a dependency-light module
+    rather than an `app.py` that imports Ray or a benchmark harness at import time.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    image_from_row: Optional[str] = None
+    """Row field holding the container image. Dotted paths allowed."""
+
+    id_from_row: Optional[str] = None
+    """Row field naming the task. Defaults to instance_id/task_id/uuid/id."""
+
+    spec_resolver: Optional[str] = None
+    """`(row, server_config) -> SandboxSpec | Mapping`. Wins over `sandbox_spec`."""
+
+    exec_wrapper: Optional[str] = None
+    """`(command, **exec_kwargs) -> str`, applied so a command runs as the server runs it."""
+
+
 class BaseServerConfig(BaseModel):
     host: str
     port: int
@@ -577,6 +606,9 @@ class BaseRunServerConfig(BaseServerConfig):
 
 class BaseRunServerInstanceConfig(BaseRunServerConfig):
     name: str  # This name is unique at runtime.
+    # Read by tooling (`gym sandbox`), not by the server itself; see SandboxTaskConfig.
+    # Declared on the instance config so both agents and resources servers inherit it.
+    sandbox_task: Optional[SandboxTaskConfig] = None
 
 
 ########################################

--- a/nemo_gym/sandbox/__init__.py
+++ b/nemo_gym/sandbox/__init__.py
@@ -16,6 +16,14 @@
 
 from nemo_gym.sandbox.api import AsyncSandbox, Sandbox
 from nemo_gym.sandbox.config import resolve_provider_config, resolve_provider_metadata
+from nemo_gym.sandbox.hooks import (
+    SandboxHookError,
+    load_hook,
+    resolve_spec,
+    spec_from_mapping,
+    task_id_for_row,
+    wrap_command,
+)
 from nemo_gym.sandbox.providers import (
     ConnectableProvider,
     ExecResult,
@@ -49,6 +57,7 @@ __all__ = [
     "SandboxEndpoint",
     "SandboxExecResult",
     "SandboxHandle",
+    "SandboxHookError",
     "SandboxProvider",
     "SandboxResources",
     "SandboxSpec",
@@ -57,8 +66,13 @@ __all__ = [
     "create_provider",
     "get_provider_class",
     "list_providers",
+    "load_hook",
     "register_provider",
     "resolve_provider_config",
     "resolve_provider_metadata",
+    "resolve_spec",
     "rewrite_image",
+    "spec_from_mapping",
+    "task_id_for_row",
+    "wrap_command",
 ]

--- a/nemo_gym/sandbox/hooks.py
+++ b/nemo_gym/sandbox/hooks.py
@@ -1,0 +1,272 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Turn a server's config (and optionally one dataset row) into a runnable sandbox.
+
+Every sandbox-backed server declares ``sandbox_provider``; that part is uniform.
+How each one arrives at a :class:`~nemo_gym.sandbox.SandboxSpec` is not — some
+spell the whole spec out in YAML, others build it in Python because it depends
+on the task row. This module supplies the shared, declarative half and a pair of
+opt-in escape hatches for the rest, so tooling (notably ``gym sandbox debug``)
+can reconstruct a server's sandbox without importing the server itself.
+
+A server opts in through a ``sandbox_task`` block on its config::
+
+    sandbox_task:
+      image_from_row: image_name                     # row field holding the image
+      id_from_row: instance_id                       # row field naming the task
+      spec_resolver: my_pkg.hooks:spec_for_row       # (row, config) -> SandboxSpec
+      exec_wrapper:  my_pkg.hooks:wrap               # (command, **kwargs) -> str
+
+Every key is optional. With none of them set, the spec comes from the config's
+``sandbox_spec`` mapping alone, which already covers servers that keep their
+sandbox fully declarative.
+
+Hook targets must be importable from the CLI's environment, so point them at a
+dependency-light module rather than at a server ``app.py`` that imports Ray or a
+benchmark harness at module scope.
+"""
+
+import importlib
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from nemo_gym.sandbox.providers import SandboxResources, SandboxSpec
+from nemo_gym.sandbox.utils import rewrite_image
+
+
+# Row fields consulted, in order, when `sandbox_task.id_from_row` is unset.
+DEFAULT_ID_FIELDS = ("instance_id", "task_id", "uuid", "id")
+
+# Keys `spec_from_mapping` understands. `image_rewrites` is consumed rather than
+# forwarded: it rewrites `image` instead of being a SandboxSpec field.
+_SPEC_FIELDS = (
+    "image",
+    "ttl_s",
+    "ready_timeout_s",
+    "workdir",
+    "env",
+    "files",
+    "metadata",
+    "resources",
+    "entrypoint",
+    "provider_options",
+)
+
+
+class SandboxHookError(RuntimeError):
+    """Raised when a ``sandbox_task`` hook cannot be loaded or run."""
+
+
+def load_hook(reference: str) -> Callable[..., Any]:
+    """Import a ``"module.path:attribute"`` hook reference.
+
+    Args:
+        reference: Dotted module path and attribute separated by ``:``.
+
+    Returns:
+        The referenced callable.
+
+    Raises:
+        SandboxHookError: If the reference is malformed, the module or attribute
+            does not exist, or the attribute is not callable. Import failures
+            keep the original exception as ``__cause__``; the common cause is a
+            hook that lives in a module importing heavy server-only dependencies.
+    """
+    module_path, separator, attribute = reference.partition(":")
+    if not separator or not module_path or not attribute:
+        raise SandboxHookError(f"Sandbox hook {reference!r} must be of the form 'module.path:attribute'")
+
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as e:
+        raise SandboxHookError(
+            f"Sandbox hook {reference!r} could not be imported: {e}. Hooks must be importable from the "
+            f"environment running them, so point them at a dependency-light module rather than a server "
+            f"entrypoint that imports its harness at module scope."
+        ) from e
+
+    try:
+        hook = getattr(module, attribute)
+    except AttributeError as e:
+        raise SandboxHookError(f"Sandbox hook {reference!r} not found: {module_path} has no {attribute!r}") from e
+
+    if not callable(hook):
+        raise SandboxHookError(f"Sandbox hook {reference!r} is not callable (got {type(hook).__name__})")
+    return hook
+
+
+def spec_from_mapping(mapping: Mapping[str, Any] | None) -> SandboxSpec:
+    """Build a :class:`SandboxSpec` from a YAML ``sandbox_spec`` mapping.
+
+    Any ``image_rewrites`` entry is applied to ``image`` and then dropped, so a
+    deployment can point at a registry mirror without the caller knowing. Unknown
+    keys fail loudly instead of being silently ignored — a typo in a spec key is
+    otherwise invisible until the sandbox behaves unexpectedly.
+
+    Args:
+        mapping: The raw ``sandbox_spec`` mapping, or ``None`` for an empty spec.
+
+    Returns:
+        The equivalent ``SandboxSpec``.
+
+    Raises:
+        ValueError: If the mapping holds keys that are not spec fields.
+    """
+    remaining = dict(mapping or {})
+    image = rewrite_image(remaining.pop("image", None), list(remaining.pop("image_rewrites", []) or []))
+
+    spec = SandboxSpec(
+        image=image,
+        ttl_s=remaining.pop("ttl_s", None),
+        ready_timeout_s=remaining.pop("ready_timeout_s", None),
+        workdir=remaining.pop("workdir", None),
+        env=dict(remaining.pop("env", {}) or {}),
+        files=dict(remaining.pop("files", {}) or {}),
+        metadata=dict(remaining.pop("metadata", {}) or {}),
+        resources=SandboxResources.from_mapping(remaining.pop("resources", {}) or {}),
+        entrypoint=remaining.pop("entrypoint", None),
+        provider_options=dict(remaining.pop("provider_options", {}) or {}),
+    )
+    if remaining:
+        known = ", ".join(sorted((*_SPEC_FIELDS, "image_rewrites")))
+        raise ValueError(f"Unknown sandbox_spec keys: {', '.join(sorted(remaining))}. Known keys: {known}")
+    return spec
+
+
+def coerce_spec(value: Any) -> SandboxSpec:
+    """Accept either a ``SandboxSpec`` or a raw mapping from a ``spec_resolver``."""
+    if isinstance(value, SandboxSpec):
+        return value
+    if isinstance(value, Mapping):
+        return spec_from_mapping(value)
+    raise SandboxHookError(f"spec_resolver must return a SandboxSpec or a mapping, got {type(value).__name__}")
+
+
+def task_id_for_row(row: Mapping[str, Any], *, id_from_row: str | None = None) -> str | None:
+    """Return a row's task identifier.
+
+    Looks at ``id_from_row`` when the server names the field, otherwise tries the
+    conventional ones in :data:`DEFAULT_ID_FIELDS`. Nested lookups such as
+    ``verifier_metadata.task_id`` are supported with dotted paths.
+    """
+    fields = (id_from_row,) if id_from_row else DEFAULT_ID_FIELDS
+    for field in fields:
+        value = _lookup(row, field)
+        if value is not None and str(value):
+            return str(value)
+    return None
+
+
+def _lookup(row: Mapping[str, Any], field: str | None) -> Any:
+    """Read a possibly-dotted path out of a row, returning ``None`` if absent."""
+    if not field:
+        return None
+    current: Any = row
+    for part in field.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def resolve_spec(
+    *,
+    sandbox_spec: Mapping[str, Any] | None,
+    sandbox_task: Mapping[str, Any] | None,
+    row: Mapping[str, Any] | None,
+    server_config: Mapping[str, Any] | None = None,
+) -> tuple[SandboxSpec, str]:
+    """Resolve the spec a server would use, optionally bound to one dataset row.
+
+    A ``spec_resolver`` hook wins when the server declares one, since a server
+    that computes its spec in Python is the authority on it. Otherwise the
+    declarative ``sandbox_spec`` mapping is used, with ``image_from_row``
+    filling in an image the config does not carry.
+
+    Args:
+        sandbox_spec: The server's ``sandbox_spec`` mapping, if any.
+        sandbox_task: The server's ``sandbox_task`` hook block, if any.
+        row: The dataset row to bind, or ``None`` to resolve the server's
+            configured sandbox on its own.
+        server_config: The full server config block, passed through to the hook.
+
+    Returns:
+        ``(spec, source)`` where ``source`` names where the spec came from, for
+        display by ``--dry-run`` and for the persisted trace.
+    """
+    hooks = dict(sandbox_task or {})
+
+    resolver_ref = hooks.get("spec_resolver")
+    if resolver_ref:
+        resolver = load_hook(str(resolver_ref))
+        try:
+            resolved = resolver(row, dict(server_config or {}))
+        except Exception as e:
+            raise SandboxHookError(f"spec_resolver {resolver_ref!r} failed: {e}") from e
+        return coerce_spec(resolved), f"spec_resolver ({resolver_ref})"
+
+    spec = spec_from_mapping(sandbox_spec)
+    if spec.image is None and row is not None:
+        image = _lookup(row, hooks.get("image_from_row"))
+        if image:
+            rewrites = list((sandbox_spec or {}).get("image_rewrites", []) or [])
+            return replace_image(spec, rewrite_image(str(image), rewrites)), "row field"
+
+    return spec, "sandbox_spec"
+
+
+def replace_image(spec: SandboxSpec, image: str | None) -> SandboxSpec:
+    """Return ``spec`` with a different image (``SandboxSpec`` is frozen)."""
+    return SandboxSpec(
+        image=image,
+        ttl_s=spec.ttl_s,
+        ready_timeout_s=spec.ready_timeout_s,
+        workdir=spec.workdir,
+        env=dict(spec.env),
+        files=dict(spec.files),
+        metadata=dict(spec.metadata),
+        resources=spec.resources,
+        entrypoint=list(spec.entrypoint) if spec.entrypoint else None,
+        provider_options=dict(spec.provider_options),
+    )
+
+
+def wrap_command(
+    command: str,
+    *,
+    sandbox_task: Mapping[str, Any] | None,
+    exec_kwargs: Mapping[str, Any] | None = None,
+    bare: bool = False,
+) -> tuple[str, bool]:
+    """Apply a server's ``exec_wrapper`` so a command runs as the server runs it.
+
+    Servers routinely prepare the shell before their real command — activating a
+    conda env, relaxing apt's sandbox, fixing ``PATH``. Reproducing that is the
+    difference between debugging the environment the rollout sees and debugging a
+    different one. ``bare`` skips the wrapper, which is what you want when the
+    wrapper itself is the suspect.
+
+    Returns:
+        ``(command, wrapped)`` — ``wrapped`` is ``False`` when no wrapper applied.
+    """
+    wrapper_ref = (sandbox_task or {}).get("exec_wrapper")
+    if bare or not wrapper_ref:
+        return command, False
+
+    wrapper = load_hook(str(wrapper_ref))
+    try:
+        return str(wrapper(command, **dict(exec_kwargs or {}))), True
+    except Exception as e:
+        raise SandboxHookError(f"exec_wrapper {wrapper_ref!r} failed: {e}") from e

--- a/responses_api_agents/mini_swe_agent_2/app.py
+++ b/responses_api_agents/mini_swe_agent_2/app.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import hashlib
 import json
 import os
@@ -51,6 +52,10 @@ from nemo_gym.sandbox import resolve_provider_config, resolve_provider_metadata
 from nemo_gym.server_utils import (
     ServerClient,
     get_first_server_config_dict,
+)
+from responses_api_agents.mini_swe_agent_2.sandbox_hooks import (
+    resource_profile_for_instance,
+    swebench_image_for_row,
 )
 
 
@@ -213,11 +218,9 @@ def _sandbox_spec_for_instance(
     if not resource_profiles:
         return instance_spec
 
-    resources = dict(instance_spec.get("resources") or {})
-    digest = hashlib.sha256(instance_id.encode("utf-8")).digest()
-    profile = resource_profiles[int.from_bytes(digest[:4], "big") % len(resource_profiles)]
-    resources.update(profile)
-    instance_spec["resources"] = resources
+    instance_spec["resources"] = resource_profile_for_instance(
+        instance_spec.get("resources"), resource_profiles, instance_id
+    )
     return instance_spec
 
 
@@ -232,17 +235,9 @@ def _swebench_config_path() -> Path:
 
 
 def _swebench_image_name(instance: dict[str, Any], subset: str) -> str:
-    image_name = instance.get("image_name")
-    if image_name:
-        return str(image_name)
-
-    instance_id = instance["instance_id"]
-    if subset == "verified":
-        docker_compatible_id = instance_id.replace("__", "_1776_")
-        return f"docker.io/swebench/sweb.eval.x86_64.{docker_compatible_id}:latest".lower()
-
-    docker_compatible_id = instance_id.replace("__", "_s_")
-    return f"docker.io/xingyaoww/sweb.eval.x86_64.{docker_compatible_id}:latest".lower()
+    # `subset` is passed explicitly here but lives on the row for the shared hook,
+    # which `gym sandbox debug` also calls; keep the two in agreement.
+    return swebench_image_for_row({**instance, "subset": subset})
 
 
 def _message_content_to_text(content: Any) -> str:

--- a/responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+++ b/responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
@@ -51,6 +51,18 @@ mini_swe_agent_2:
         conda_env: testbed
         activate_conda: true
         user: root
+      # How `gym sandbox debug` reconstructs a task's sandbox without running the
+      # agent. The image is derived from the row rather than declared, so a
+      # resolver is needed; the wrapper makes a debugged command run against the
+      # testbed Python, exactly as a rollout's does (`--bare` opts out).
+      #
+      #   gym sandbox debug --config <this file> --config <provider config> \
+      #       --task django__django-10973 --command "python -m pytest -x"
+      sandbox_task:
+        id_from_row: instance_id
+        image_from_row: image_name
+        spec_resolver: responses_api_agents.mini_swe_agent_2.sandbox_hooks:spec_for_row
+        exec_wrapper: responses_api_agents.mini_swe_agent_2.sandbox_hooks:conda_activate_wrap
       run_golden: false
       step_timeout: 600
       eval_timeout: 1800

--- a/responses_api_agents/mini_swe_agent_2/sandbox_environment.py
+++ b/responses_api_agents/mini_swe_agent_2/sandbox_environment.py
@@ -15,7 +15,6 @@
 """mini-swe-agent environment adapter backed by the Gym sandbox API."""
 
 import os
-import shlex
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -34,6 +33,7 @@ except ModuleNotFoundError:
 
 from nemo_gym.sandbox import Sandbox, SandboxResources, SandboxSpec
 from nemo_gym.sandbox.utils import rewrite_image
+from responses_api_agents.mini_swe_agent_2.sandbox_hooks import conda_activate_wrap
 
 
 @dataclass
@@ -121,20 +121,12 @@ class MiniSWESandboxEnvironment:
         }
 
     def _command(self, command: str) -> str:
-        if not self.config.activate_conda or not self.config.conda_env:
-            return command
-        quoted_env = shlex.quote(self.config.conda_env)
-        # Resolve conda from common install roots before activating. The sandbox exec
-        # shell is non-login (apptainer/docker/ECS alike), so `conda` may not be on PATH
-        # and `conda info --base` can't be relied on. The grouped loop (not an `&&` chain)
-        # keeps a missing root from aborting the command; cwd is handled by exec(cwd=...),
-        # so we don't `cd` here.
-        return (
-            '{ for __base in /opt/miniconda3 /opt/conda "$HOME/miniconda3" '
-            '"$(command -v conda >/dev/null 2>&1 && conda info --base 2>/dev/null)"; do '
-            '[ -n "$__base" ] && [ -f "$__base/etc/profile.d/conda.sh" ] && '
-            '. "$__base/etc/profile.d/conda.sh" && break; done; } && '
-            f"conda activate {quoted_env} && {command}"
+        # Shared with `gym sandbox debug` so a debugged command runs in the same
+        # shell context as a real rollout's.
+        return conda_activate_wrap(
+            command,
+            conda_env=self.config.conda_env,
+            activate_conda=self.config.activate_conda,
         )
 
     def execute(

--- a/responses_api_agents/mini_swe_agent_2/sandbox_hooks.py
+++ b/responses_api_agents/mini_swe_agent_2/sandbox_hooks.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sandbox recipe for mini-swe-agent 2, shared by the agent and by tooling.
+
+`app.py` and `sandbox_environment.py` import these so there is one definition of
+how a SWE-bench row becomes a sandbox. They also live here, apart from `app.py`,
+so `gym sandbox debug` can import them: `app.py` pulls in Ray, mini-swe-agent,
+and the SWE-bench harness at module scope, none of which the CLI has.
+
+Keep this module's imports limited to the standard library and `nemo_gym`.
+"""
+
+import hashlib
+import shlex
+from collections.abc import Mapping
+from typing import Any
+
+from nemo_gym.sandbox import SandboxSpec
+from nemo_gym.sandbox.hooks import replace_image, spec_from_mapping
+
+
+def swebench_image_for_row(row: Mapping[str, Any] | None) -> str | None:
+    """Return the SWE-bench evaluation image for a task row.
+
+    A row may name its image directly; otherwise it is derived from the instance
+    id. The `__` substitutions are not cosmetic — they are what the published
+    image tags actually use, since Docker tags disallow the original separator.
+
+    Returns:
+        The image reference, or ``None`` when the row cannot name one.
+    """
+    if not row:
+        return None
+
+    image_name = row.get("image_name")
+    if image_name:
+        return str(image_name)
+
+    instance_id = row.get("instance_id")
+    if not instance_id:
+        return None
+
+    if str(row.get("subset", "")) == "verified":
+        return f"docker.io/swebench/sweb.eval.x86_64.{str(instance_id).replace('__', '_1776_')}:latest".lower()
+    return f"docker.io/xingyaoww/sweb.eval.x86_64.{str(instance_id).replace('__', '_s_')}:latest".lower()
+
+
+def resource_profile_for_instance(
+    resources: Mapping[str, Any] | None,
+    profiles: list[dict[str, Any]] | None,
+    instance_id: str,
+) -> dict[str, Any]:
+    """Pick this instance's resource profile.
+
+    Selection is a hash of the instance id rather than a random draw so a given
+    instance always lands on the same profile — otherwise a debug run and the
+    rollout it is meant to reproduce could get different resources.
+    """
+    merged = dict(resources or {})
+    if not profiles:
+        return merged
+    digest = hashlib.sha256(instance_id.encode("utf-8")).digest()
+    merged.update(profiles[int.from_bytes(digest[:4], "big") % len(profiles)])
+    return merged
+
+
+def spec_for_row(row: Mapping[str, Any] | None, server_config: Mapping[str, Any]) -> SandboxSpec:
+    """Build the sandbox spec this agent would create for a row.
+
+    Wired in as `sandbox_task.spec_resolver`. With no row, it falls back to the
+    declared `sandbox_spec` so tooling can still boot the configured sandbox.
+    """
+    raw_spec = dict(server_config.get("sandbox_spec") or {})
+    instance_id = str((row or {}).get("instance_id") or "")
+
+    if instance_id:
+        raw_spec["resources"] = resource_profile_for_instance(
+            raw_spec.get("resources"),
+            server_config.get("sandbox_resource_profiles"),
+            instance_id,
+        )
+
+    spec = spec_from_mapping(raw_spec)
+
+    image = swebench_image_for_row(row)
+    if image is not None:
+        # spec_from_mapping already applied image_rewrites to any configured
+        # image; a derived one has to go through the same rewrites to reach a
+        # mirrored registry.
+        from nemo_gym.sandbox import rewrite_image
+
+        spec = replace_image(spec, rewrite_image(image, list(raw_spec.get("image_rewrites", []) or [])))
+
+    if instance_id:
+        # 63 chars is the Kubernetes label-value ceiling the provider sanitizes to.
+        spec.metadata.update({"nemo_gym_agent": "mini_swe_agent_2", "instance_id": instance_id[:63]})
+    return spec
+
+
+def conda_activate_wrap(
+    command: str,
+    *,
+    conda_env: str | None = None,
+    activate_conda: bool = False,
+    **_: Any,
+) -> str:
+    """Prefix a command with conda activation so it runs against the task's Python.
+
+    Wired in as `sandbox_task.exec_wrapper`. Without this, `python` in a SWE-bench
+    image is the system interpreter rather than the testbed one, and results do
+    not match what the agent sees.
+    """
+    if not activate_conda or not conda_env:
+        return command
+
+    quoted_env = shlex.quote(conda_env)
+    # Resolve conda from common install roots before activating. The sandbox exec
+    # shell is non-login (apptainer/docker/ECS alike), so `conda` may not be on PATH
+    # and `conda info --base` can't be relied on. The grouped loop (not an `&&` chain)
+    # keeps a missing root from aborting the command; cwd is handled by exec(cwd=...),
+    # so we don't `cd` here.
+    return (
+        '{ for __base in /opt/miniconda3 /opt/conda "$HOME/miniconda3" '
+        '"$(command -v conda >/dev/null 2>&1 && conda info --base 2>/dev/null)"; do '
+        '[ -n "$__base" ] && [ -f "$__base/etc/profile.d/conda.sh" ] && '
+        '. "$__base/etc/profile.d/conda.sh" && break; done; } && '
+        f"conda activate {quoted_env} && {command}"
+    )

--- a/tests/unit_tests/test_sandbox_hooks.py
+++ b/tests/unit_tests/test_sandbox_hooks.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Tests for the sandbox_task hook mechanism (spec_resolver / exec_wrapper).
+
+These cover `nemo_gym.sandbox.hooks` on its own, without the CLI that consumes it.
+"""
+
+import json
+from typing import Any
+
+import pytest
+
+from nemo_gym.sandbox import SandboxSpec
+from nemo_gym.sandbox.hooks import (
+    SandboxHookError,
+    load_hook,
+    resolve_spec,
+    spec_from_mapping,
+    task_id_for_row,
+    wrap_command,
+)
+
+
+def test_load_hook_imports_callable() -> None:
+    assert load_hook("json:dumps") is json.dumps
+
+
+@pytest.mark.parametrize(
+    "reference, match",
+    [
+        ("json.dumps", "must be of the form"),
+        ("nemo_gym_missing_module_xyz:thing", "could not be imported"),
+        ("json:not_a_real_attribute", "not found"),
+        ("json:__doc__", "not callable"),
+    ],
+)
+def test_load_hook_rejects_bad_references(reference: str, match: str) -> None:
+    with pytest.raises(SandboxHookError, match=match):
+        load_hook(reference)
+
+
+########################################
+# hooks: id + spec resolution
+########################################
+
+
+def test_task_id_falls_back_through_conventional_fields() -> None:
+    assert task_id_for_row({"instance_id": "a"}) == "a"
+    assert task_id_for_row({"task_id": "b"}) == "b"
+    assert task_id_for_row({"uuid": "c"}) == "c"
+    assert task_id_for_row({"nope": "d"}) is None
+
+
+def test_task_id_supports_nested_field() -> None:
+    """Several servers keep the id under verifier_metadata."""
+    row = {"verifier_metadata": {"task_id": "nested"}}
+    assert task_id_for_row(row, id_from_row="verifier_metadata.task_id") == "nested"
+
+
+def test_resolve_spec_prefers_resolver_over_config() -> None:
+    """A server that computes its spec in Python is the authority on it."""
+    spec, source = resolve_spec(
+        sandbox_spec={"image": "from-config"},
+        sandbox_task={"spec_resolver": "tests.unit_tests.test_sandbox_hooks:_resolver"},
+        row={"instance_id": "x"},
+        server_config={},
+    )
+    assert spec.image == "resolved-x"
+    assert "spec_resolver" in source
+
+
+def _resolver(row, server_config):
+    return SandboxSpec(image=f"resolved-{(row or {}).get('instance_id', 'none')}")
+
+
+def test_resolve_spec_uses_row_image_when_config_has_none() -> None:
+    spec, source = resolve_spec(
+        sandbox_spec={"ttl_s": 5},
+        sandbox_task={"image_from_row": "image_name"},
+        row={"image_name": "from-row"},
+        server_config={},
+    )
+    assert spec.image == "from-row" and source == "row field"
+
+
+def test_resolve_spec_row_image_goes_through_rewrites() -> None:
+    """A derived image must reach the mirror too, not just a configured one."""
+    spec, _ = resolve_spec(
+        sandbox_spec={"image_rewrites": [{"from": "docker.io/", "to": "mirror/"}]},
+        sandbox_task={"image_from_row": "image_name"},
+        row={"image_name": "docker.io/x:1"},
+        server_config={},
+    )
+    assert spec.image == "mirror/x:1"
+
+
+def test_resolve_spec_surfaces_hook_failures() -> None:
+    with pytest.raises(SandboxHookError, match="spec_resolver .* failed"):
+        resolve_spec(
+            sandbox_spec=None,
+            sandbox_task={"spec_resolver": "tests.unit_tests.test_sandbox_hooks:_boom"},
+            row={},
+            server_config={},
+        )
+
+
+def _boom(row, server_config):
+    raise ValueError("nope")
+
+
+########################################
+# hooks: command wrapping
+########################################
+
+
+def _upper_wrapper(command, **kwargs):
+    return f"WRAPPED({command})"
+
+
+def test_wrap_command_applies_and_reports() -> None:
+    command, wrapped = wrap_command("ls", sandbox_task={"exec_wrapper": f"{__name__}:_upper_wrapper"})
+    assert command == "WRAPPED(ls)" and wrapped is True
+
+
+def test_wrap_command_bare_skips_wrapper() -> None:
+    """--bare exists so you can debug around a wrapper that is itself suspect."""
+    command, wrapped = wrap_command("ls", sandbox_task={"exec_wrapper": f"{__name__}:_upper_wrapper"}, bare=True)
+    assert command == "ls" and wrapped is False
+
+
+def test_wrap_command_without_wrapper_is_identity() -> None:
+    assert wrap_command("ls", sandbox_task={}) == ("ls", False)
+
+
+########################################
+# Server discovery
+########################################
+
+


### PR DESCRIPTION
**PR 3 of 4** in the `gym sandbox debug` stack (#2400 → #2401 → **#2402** → #2403).

## Why

Four of the six `nemo_gym.sandbox` consumers build their `SandboxSpec` in Python, because it depends on the task row — there is nothing declarative to read. So anything outside the owning server (a debugger, a validator) cannot answer *"what image would this row get?"* without importing that server's entire dependency tree. For `mini_swe_agent_2` that means `ray`, `minisweagent` and `swebench`.

## What

An optional `sandbox_task` block on `BaseRunServerInstanceConfig`:

```yaml
sandbox_task:
  spec_resolver: <module>:<fn>    # (row, config) -> SandboxSpec
  exec_wrapper:  <module>:<fn>    # (command, **kwargs) -> str
  image_from_row: <field>         # for the no-Python case
  id_from_row:    <field>
```

Servers that declare nothing are unaffected, and servers ignore the block at runtime.

`nemo_gym.sandbox.hooks` deliberately imports nothing from the CLI — the whole point is that a resolver is reachable from a process that has not imported the agent.

## And its first user

`mini_swe_agent_2` adopts it in the same PR, because a mechanism with no users is not reviewable. Image derivation moved out of `app.py` and the conda preamble out of `sandbox_environment.py`, into a **stdlib-only** `sandbox_hooks.py` that both the agent and an outside process can import. `app.py` and `sandbox_environment.py` now delegate to it — one source of truth, no behaviour change.
