### PR TITLE
feat(cli): add `gym sandbox debug`

### DIFF
--- a/fern/versions/latest/pages/infrastructure/sandbox/debugging.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/debugging.mdx
@@ -110,7 +110,7 @@ sandbox   opensandbox
 task      django__django-10973  (index 0 of 1, from .../data/example.jsonl)
 image     docker.io/swebench/sweb.eval.x86_64.django_1776_django-10973:latest
           via spec_resolver (responses_api_agents.mini_swe_agent_2.sandbox_hooks:spec_for_row)
-spec      ttl_s=18000  ready_timeout_s=1200  cpu=2.0  memory_mib=8192  disk_gib=30  workdir=/testbed
+spec      ttl_s=900.0  ready_timeout_s=1200  cpu=2.0  memory_mib=8192  disk_gib=30  workdir=/testbed
 exec      activate_conda=True conda_env=testbed cwd=/testbed user=root
 wrapper   responses_api_agents.mini_swe_agent_2.sandbox_hooks:conda_activate_wrap
 ```
@@ -144,7 +144,7 @@ gym sandbox debug --config $AGENT --config $PROVIDER \
 ```
 
 ```
-✓ django__django-10973  reason=pass exit=0  61.4s (command 52.8s + overhead 1.5s, boot 7.1s)
+✓ django__django-10973  reason=pass exit=0  67.1s (command 21.0s + overhead 1.3s, boot 44.8s)
 ```
 
 `command` is measured by execd *inside* the sandbox; `overhead` is what the round trip added.
@@ -161,13 +161,14 @@ gym sandbox debug --config $AGENT --config $PROVIDER \
 ```
 
 ```json
-{"boot": 7.104, "setup": 0.0, "exec": 54.312, "command": 52.800, "overhead": 1.512, "total": 61.416}
+{"boot": 44.812, "setup": 0.0, "exec": 22.303, "command": 21.024, "overhead": 1.279, "total": 67.115}
 ```
 
 <Note>
-`pip install torch` pulls roughly 2.7 GB. Run it against a package cache if your cluster has
-one — a repeated install that stays at the same `command` time while `boot` moves is telling
-you the install is not what changed.
+Note *which* torch: this image's `testbed` env is Python 3.6, so pip resolves to torch 1.10.2 —
+the last release with `cp36` wheels — at about 880 MB, not a multi-GB modern build. Run it
+against a package cache if your cluster has one; a repeated install that holds the same
+`command` time while `boot` moves is telling you the install is not what changed.
 </Note>
 
 ### Pointing at a real OpenSandbox server
@@ -191,6 +192,22 @@ Reaching a cluster-internal server usually means a port-forward, in which case
 kubectl port-forward -n <namespace> svc/<opensandbox-service> 18080:80
 export OPENSANDBOX_DOMAIN=127.0.0.1:18080
 ```
+
+<Warning>
+If the sandbox's egress sidecar is intercepting TLS, a **conda-based image will not trust the
+proxy's CA** and `pip` fails with `CERTIFICATE_VERIFY_FAILED`. The CA is installed into the system
+trust store, but conda ships and consults its own at
+`/opt/miniconda3/envs/<env>/ssl/cert.pem`. Every SWE-bench image is conda-based, so this is the
+common case rather than an edge one. Point the standard variables at the CA that is already
+delivered to the container:
+
+```bash
+--env SSL_CERT_FILE=/opt/opensandbox/mitmproxy-ca-cert.pem \
+--env REQUESTS_CA_BUNDLE=/opt/opensandbox/mitmproxy-ca-cert.pem
+```
+
+Debian-style images (`python:3.12-slim`) read the system store and need none of this.
+</Warning>
 
 ### With and without the wrapper
 

--- a/fern/versions/latest/pages/infrastructure/sandbox/debugging.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/debugging.mdx
@@ -1,0 +1,431 @@
+---
+title: Debugging sandboxes
+description: Boot and inspect the sandbox a task runs in, without running a rollout.
+---
+
+Answering "what is actually inside this task's container?" normally means starting the whole
+stack — model server, Ray, agent, rollout — and hoping the failure reproduces. `gym sandbox
+debug` skips all of that: it boots the sandbox a server would create for a task, using the
+same provider, image, and `SandboxSpec` a rollout gets, and runs whatever you ask inside it.
+
+```bash
+# What would this task boot? (no sandbox created, no cluster needed)
+gym sandbox debug --config <config> --task <task-id> --dry-run
+
+# Actually boot it and look around
+gym sandbox debug --config <config> --task <task-id> --command "ls -la && python -V"
+```
+
+See [CLI commands](/reference/cli-commands) for the full flag list.
+
+## A worked example: SWE-bench with mini-swe-agent
+
+`mini_swe_agent_2` is the reference case, because its sandbox is the interesting kind: the
+image is derived per task rather than declared, and commands are wrapped so they run against
+the task's own Python. Its config already declares both hooks, so nothing extra is needed.
+
+First, find out which tasks exist. `--list-tasks` reads the dataset and nothing else — no
+provider config, no credentials, no cluster:
+
+```bash
+AGENT=responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+
+gym sandbox debug --config $AGENT --list-tasks
+```
+
+```
+5 task(s) in .../mini_swe_agent_2/data/example.jsonl
+  django__django-10973              repo=django/django  subset=verified  split=test  difficulty=15 min - 1 hour
+  pylint-dev__pylint-4551           repo=pylint-dev/pylint  subset=verified  split=test  difficulty=1-4 hours
+  sphinx-doc__sphinx-8595           repo=sphinx-doc/sphinx  subset=verified  split=test  difficulty=<15 min fix
+  sympy__sympy-20916                repo=sympy/sympy  subset=verified  split=test  difficulty=<15 min fix
+  scikit-learn__scikit-learn-14141  repo=scikit-learn/scikit-learn  subset=verified  split=test  difficulty=<15 min fix
+
+Run one with --task <id>
+```
+
+`--list-tasks` prints each row's id plus whichever of `repo`, `subset`, `split`, `difficulty`
+and `image_name` the row carries, which is usually enough to pick one. `--json` gives the same
+thing machine-readably:
+
+```bash
+gym sandbox debug --config $AGENT --list-tasks --json | jq -r '.[].id'
+```
+
+<Warning>
+With no `-i/--input` this lists the server's committed `data/example.jsonl`, which is a smoke
+fixture pinned at **five rows** — `gym env test` enforces that count. It is not the benchmark.
+</Warning>
+
+SWE-bench Verified itself is 500 instances and is not in the repo. Materialize it once, then
+point `-i` at the result:
+
+```bash
+python - <<'EOF'
+import json
+from datasets import load_dataset
+
+rows = load_dataset("princeton-nlp/SWE-bench_Verified", split="test")
+with open("swebench_verified.jsonl", "w") as f:
+    for row in rows:
+        record = dict(row)
+        # What mini_swe_agent_2's spec_resolver reads to derive the image, plus
+        # the Gym envelope every row needs.
+        record["subset"] = "verified"
+        record["split"] = "test"
+        record.setdefault("responses_create_params", {"input": []})
+        f.write(json.dumps(record) + "\n")
+EOF
+
+gym sandbox debug --config $AGENT -i swebench_verified.jsonl --list-tasks
+```
+
+A row only has to carry what the server's `spec_resolver` reads — for `mini_swe_agent_2` that
+is `instance_id` and `subset`, from which the image is derived. A row may also set
+`image_name` to name its image outright, which takes precedence.
+
+<Note>
+Every SWE-bench Verified task is Python. The 500 instances span 12 repositories — django (231),
+sympy (75), sphinx (44), matplotlib (34), scikit-learn (32), astropy (22), xarray (22), pytest
+(19), pylint (10), requests (8), seaborn (2), flask (1) — and their test patches touch `.py`
+files almost exclusively. There are no Go, Rust, C++, or Java tasks.
+
+The *containers* are not Python-only, though: `gcc` and `g++` are present, because several of
+those projects build C extensions. Each image ships a conda env named `testbed` holding the
+interpreter the task expects, which is why the wrapper activates it.
+</Note>
+
+Now inspect one. This creates nothing and needs no cluster:
+
+```bash
+PROVIDER=nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
+
+gym sandbox debug --config $AGENT --config $PROVIDER \
+    --task django__django-10973 --dry-run
+```
+
+```
+server    mini_swe_agent_2  (responses_api_agents)
+sandbox   opensandbox
+task      django__django-10973  (index 0 of 1, from .../data/example.jsonl)
+image     docker.io/swebench/sweb.eval.x86_64.django_1776_django-10973:latest
+          via spec_resolver (responses_api_agents.mini_swe_agent_2.sandbox_hooks:spec_for_row)
+spec      ttl_s=18000  ready_timeout_s=1200  cpu=2.0  memory_mib=8192  disk_gib=30  workdir=/testbed
+exec      activate_conda=True conda_env=testbed cwd=/testbed user=root
+wrapper   responses_api_agents.mini_swe_agent_2.sandbox_hooks:conda_activate_wrap
+```
+
+The image was derived from `instance_id` + `subset`; no row field carried it. Now run
+something in it:
+
+```bash
+gym sandbox debug --config $AGENT --config $PROVIDER \
+    --task django__django-10973 \
+    --command "python -c 'import django; print(django.__version__)'"
+```
+
+```
+3.0.dev20250910094507
+✓ django__django-10973  reason=pass exit=0  8.6s (command 1.4s + overhead 1.1s, boot 7.1s)
+```
+
+That is the testbed interpreter, not the system one — the wrapper did that.
+
+### Timing a long install
+
+Short commands hide the distinction between a slow command and a slow link. A large install
+does not, which makes it the clearest way to read the timing fields:
+
+```bash
+gym sandbox debug --config $AGENT --config $PROVIDER \
+    --task django__django-10973 \
+    --command "pip install torch" \
+    --timeout-total 900
+```
+
+```
+✓ django__django-10973  reason=pass exit=0  61.4s (command 52.8s + overhead 1.5s, boot 7.1s)
+```
+
+`command` is measured by execd *inside* the sandbox; `overhead` is what the round trip added.
+Only the first is a property of the task — so this is the number to watch when comparing
+images, package indexes, or clusters. Figures vary with cache state and cluster; treat the
+shape, not the values, as the point.
+
+Add `--json` for the full trace, or `-o` to persist it:
+
+```bash
+gym sandbox debug --config $AGENT --config $PROVIDER \
+    --task django__django-10973 --command "pip install torch" --json \
+  | jq '.timing'
+```
+
+```json
+{"boot": 7.104, "setup": 0.0, "exec": 54.312, "command": 52.800, "overhead": 1.512, "total": 61.416}
+```
+
+<Note>
+`pip install torch` pulls roughly 2.7 GB. Run it against a package cache if your cluster has
+one — a repeated install that stays at the same `command` time while `boot` moves is telling
+you the install is not what changed.
+</Note>
+
+### Pointing at a real OpenSandbox server
+
+The shipped `opensandbox.yaml` reads its endpoint and credential from the environment, so
+neither lands in a config file:
+
+```bash
+export OPENSANDBOX_DOMAIN=<your-opensandbox-host>:<port>
+export OPENSANDBOX_API_KEY=<your-api-key>
+```
+
+If the server runs with authentication disabled (`api_key = ""` server-side, with
+`OPENSANDBOX_INSECURE_SERVER=YES`), there is no key to obtain — but the variable must still be
+set to something, because the config interpolates it and Hydra fails on an unset reference.
+
+Reaching a cluster-internal server usually means a port-forward, in which case
+`OPENSANDBOX_DOMAIN` is the local end of the tunnel:
+
+```bash
+kubectl port-forward -n <namespace> svc/<opensandbox-service> 18080:80
+export OPENSANDBOX_DOMAIN=127.0.0.1:18080
+```
+
+### With and without the wrapper
+
+`--bare` runs the command exactly as typed, skipping the server's `exec_wrapper`. The
+difference is what the rollout actually sees versus what a plain shell would:
+
+```bash
+# wrapped (default) — conda activate testbed && ...
+gym sandbox debug --config $AGENT --config $PROVIDER --task django__django-10973 \
+    --command "python -c 'import sys; print(sys.executable)'"
+```
+
+```
+/opt/miniconda3/envs/testbed/bin/python
+✓ django__django-10973  reason=pass exit=0  8.359s (command 0.316s + overhead 1.079s, boot 6.964s)
+```
+
+```bash
+# --bare — the command as typed, no preamble
+gym sandbox debug --config $AGENT --config $PROVIDER --task django__django-10973 --bare \
+    --command "python -c 'import sys; print(sys.executable)'"
+```
+
+```
+/opt/miniconda3/bin/python
+✓ django__django-10973  reason=pass exit=0  8.051s (command 0.013s + overhead 1.088s, boot 6.95s)
+```
+
+Same command, different interpreter — and the wrapped run spends 0.316s of command time
+against 0.013s, which is what conda activation costs. Use `--bare` when the wrapper itself is what you are
+debugging; leave it off when you want to reproduce the rollout.
+
+`--dry-run` prints the fully wrapped command without running anything, which is the quickest
+way to see what the preamble expands to:
+
+```bash
+gym sandbox debug --config $AGENT --config $PROVIDER --task django__django-10973 \
+    --command "pytest -x" --dry-run
+```
+
+To poke at several tasks at once, select them by count instead of by id. `--concurrency`
+bounds how many sandboxes exist at the same time:
+
+```bash
+gym sandbox debug --config $AGENT --config $PROVIDER --limit 3 --concurrency 3 \
+    --command "git -C /testbed log --oneline -1"
+```
+
+And to stay in one sandbox across several commands:
+
+```bash
+gym sandbox debug --config $AGENT --config $PROVIDER --task django__django-10973 \
+    --command "true" --keep --ttl 1800
+# sandbox <id> left running (expires in 30m)
+
+gym sandbox exec --config $AGENT --config $PROVIDER --sandbox-id <id> \
+    --command "python -m pytest tests/dbshell -x"
+gym sandbox rm --config $AGENT --config $PROVIDER --sandbox-id <id>
+```
+
+## How a sandbox gets resolved
+
+Every sandbox-backed server declares `sandbox_provider`, and that is the only thing they all
+agree on — how each one arrives at a `SandboxSpec` varies. Resolution is therefore layered,
+and each layer is optional. Most environments never need more than the first two.
+
+### Layer 0 — the provider
+
+`gym sandbox` scans the merged config for any block declaring `sandbox_provider`. Agents and
+resources servers are treated identically; nothing keys off the server kind. Both accepted
+forms work — a name referencing a provider block elsewhere in the config, or an inline
+single-key mapping.
+
+When exactly one server declares a sandbox it is used automatically; otherwise pass
+`--server <name>`. `--sandbox <name>` swaps the provider that block points at, so the same
+task can run against a local provider and a cluster one without editing committed config.
+
+### Layer 1 — the declarative spec
+
+If the block has a `sandbox_spec` mapping, it becomes the base `SandboxSpec`: `image`,
+`ttl_s`, `ready_timeout_s`, `workdir`, `env`, `files`, `metadata`, `resources`, `entrypoint`,
+and `provider_options`, plus `image_rewrites` for deployments that serve a registry mirror.
+Unknown keys are rejected rather than ignored, since a typo'd spec key is otherwise invisible
+until the sandbox misbehaves.
+
+An environment whose sandbox is fully described in YAML is already debuggable at this point,
+with no code and no further config:
+
+```bash
+gym sandbox debug --config <config> --command "python -V"
+```
+
+### Layer 2 — `spec_resolver`, when the spec is computed
+
+Some environments build their spec in Python because it depends on the task row. Rather than
+have the CLI guess, such a server points at the function that already does it:
+
+```yaml
+      sandbox_task:
+        spec_resolver: my_env.sandbox_hooks:spec_for_row
+```
+
+The function takes `(row, server_config)` and returns a `SandboxSpec` (or a mapping). It is
+called with `row=None` when no task is selected, so it should fall back to the configured
+spec in that case.
+
+If the image is simply *on* the row, no code is needed — name the field instead:
+
+```yaml
+      sandbox_task:
+        image_from_row: image_name     # dotted paths work: verifier_metadata.image
+```
+
+### Layer 3 — `exec_wrapper`, when commands are prepared
+
+Environments routinely set up the shell before their real command: activating a conda
+environment, fixing `PATH`, relaxing apt's sandbox. Reproducing that is the difference
+between debugging the environment the rollout sees and debugging a different one, so the
+wrapper is applied by default:
+
+```yaml
+      sandbox_task:
+        exec_wrapper: my_env.sandbox_hooks:wrap_command
+```
+
+The function takes `(command, **exec_kwargs)` — where `exec_kwargs` is the server's
+`sandbox_environment_kwargs` merged with any CLI overrides — and returns the command to run.
+Pass `--bare` to skip it, which is what you want when the wrapper itself is the suspect.
+
+## Resolution precedence
+
+```
+image:    --image  >  spec_resolver / sandbox_spec  >  row[image_from_row]
+command:  --bare ? <as typed> : exec_wrapper(command, **exec_kwargs)
+exec:     --cwd / --user / --env  >  sandbox_environment_kwargs
+```
+
+<Note>
+Hook references are `"module.path:attribute"` and are imported by the CLI, not by the server.
+Point them at a dependency-light module rather than an `app.py` that imports Ray or a
+benchmark harness at module scope, or the import will fail.
+</Note>
+
+## Output
+
+Each run writes a directory you can come back to:
+
+```
+outputs/<server>--debug/<run-uuid>/
+├── config.yaml     # the resolved config — re-runnable via --config
+└── traces.jsonl    # one record per task
+```
+
+A trace record carries the resolved spec and image, the sandbox id, the exact command that
+ran (wrapped or not), the exit code and output, and per-stage timings. Outcomes are classified as `pass`, `nonzero_exit`, `timeout`, `cancelled`, `error`, or
+`not_run`, and the command exits non-zero if any task failed — so it works as a check, not
+just as something to read.
+
+### Where the time went
+
+Timing a sandbox command from the outside measures the round-trip as well as the work. When
+the provider can report how long the command itself ran, the trace separates the two:
+
+```json
+"timing": {"boot": 7.123, "setup": 0.0, "exec": 6.389,
+           "command": 5.307, "overhead": 1.082, "total": 13.512}
+```
+
+- `boot` — provisioning the sandbox
+- `command` — the command's own runtime, measured inside the sandbox
+- `overhead` — `exec` minus `command`: dispatch and transport
+- `total` — everything, including teardown
+
+So a ten-minute `pip install` reads as `command 580s + overhead 20s` rather than an
+undifferentiated ten minutes. Providers that cannot measure the command omit `command` and
+`overhead` rather than guessing.
+
+## Sandbox lifetime
+
+Every sandbox this command creates gets a short, bounded lifetime. A debugging session can be
+interrupted, killed, or simply forgotten, and a sandbox nobody is using still holds cluster
+capacity until it expires.
+
+- **Default: 15 minutes.** This is a *cap*, applied whether the server sets `ttl_s` or not.
+  Server configs size `ttl_s` for a whole rollout — mini-swe-agent asks for five hours — which
+  is the wrong order of magnitude for poking at a container. A server asking for *less* than
+  the cap keeps its shorter value.
+- **`--ttl <seconds>` opts out** for cases that genuinely need longer. Above an hour it warns,
+  since sandboxes held that long are usually forgotten rather than needed.
+- **Servers that set no `ttl_s` are covered too.** Providers read an absent lifetime as *never
+  auto-terminate* — safe for a rollout that always deletes its own sandbox, unsafe here.
+
+Providers impose their own floor as well (OpenSandbox requires at least 60 seconds).
+
+### Renewal keeps an in-use sandbox alive
+
+A short lifetime would be useless if it expired while you were still working, so
+`gym sandbox exec` pushes the expiry back before each command, on providers that advertise the
+`RenewableProvider` capability. Activity is what keeps a sandbox alive, rather than a long
+lifetime granted up front:
+
+```
+$ gym sandbox exec --config $AGENT --config $PROVIDER --sandbox-id <id> --command "echo hi"
+hi
+✓ <id>  exit=0  command 0.302s  expires in 15m
+```
+
+The renewal window is `max(--ttl, --timeout-total + 60s)`, so a command running longer than the
+TTL will not have the sandbox expire underneath it. On a provider that cannot renew, the
+sandbox keeps the lifetime it was created with.
+
+## Keeping a sandbox alive
+
+By default a sandbox is torn down as soon as the command finishes. `--keep` leaves it running
+and prints its id, so you can keep poking:
+
+```bash
+gym sandbox debug --config <config> --task <id> --command "ls" --keep
+#   sandbox <id> left running (expires in 15m)
+#   reattach: gym sandbox exec --sandbox-id <id> --command ...
+#   delete:   gym sandbox rm --sandbox-id <id>
+
+gym sandbox exec  --config <config> --sandbox-id <id> --command "git status"
+gym sandbox rm    --config <config> --sandbox-id <id>
+```
+
+This needs a provider that can reattach to a sandbox by id — one backed by an external
+control plane. `--keep` is refused up front on providers that cannot, since the sandbox would
+otherwise be left running with no way to reach or delete it.
+
+Interrupt handling is deliberate for the same reason: the first Ctrl-C tears down cleanly and
+subsequent ones are ignored while cleanup runs, so a second Ctrl-C cannot orphan a sandbox
+that is costing capacity.
+
+## Limitations
+
+- Output is captured and printed when the command finishes, not streamed as it runs.
+- The gold/setup checks that `verifiers` exposes as `validate` are not implemented yet.

--- a/fern/versions/latest/pages/infrastructure/sandbox/debugging.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/debugging.mdx
@@ -209,6 +209,28 @@ delivered to the container:
 Debian-style images (`python:3.12-slim`) read the system store and need none of this.
 </Warning>
 
+### Overriding what the server resolved
+
+`--env`, `--metadata` and `--provider-option` are the top layer of the resolution chain: they apply
+on top of both the declarative `sandbox_spec` and whatever a `spec_resolver` returned. That matters
+for a server that computes its spec in Python, because the resolver's spec wins outright over
+config — without these flags there would be no way to add anything to it from the command line.
+
+`--provider-option` decodes its value as JSON when it decodes, since provider options are not all
+strings; anything that is not valid JSON stays a string, so ids and names need no quoting.
+
+Asking a sandbox for a transparently-intercepting egress sidecar needs one of each, which is what
+this looks like in practice:
+
+```bash
+gym sandbox debug --config $AGENT --config $PROVIDER --task django__django-10973 \
+    --command "pip install --no-input tabulate" \
+    --env OPENSANDBOX_EGRESS_MITMPROXY_TRANSPARENT=true \
+    --env SSL_CERT_FILE=/opt/opensandbox/mitmproxy-ca-cert.pem \
+    --metadata istio.io/dataplane-mode=none \
+    --provider-option 'network_policy={"defaultAction":"allow","egress":[]}'
+```
+
 ### With and without the wrapper
 
 `--bare` runs the command exactly as typed, skipping the server's `exec_wrapper`. The

--- a/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
@@ -190,6 +190,68 @@ async with AsyncSandbox(provider_config, spec) as sandbox:
     passed = result.return_code == 0
 ```
 
+## Sandbox Lifetime and Renewal
+
+A sandbox's lifetime is set by `SandboxSpec.ttl_s`, which providers map onto their own expiry
+mechanism. The sandbox self-deletes when it expires, whether or not anything is still using it.
+
+<Warning>
+Leaving `ttl_s` unset does **not** mean "a sensible default". Providers with a server-side
+expiry read it as *never auto-terminate*, so the sandbox survives until something explicitly
+deletes it. That is safe for a rollout whose `finally` always calls `stop()`, and a capacity
+leak for anything that can be interrupted, crash, or be forgotten. Set `ttl_s` unless you are
+certain a caller always deletes the sandbox.
+</Warning>
+
+Pick a lifetime from how long the work takes, not how long you might want the sandbox:
+
+```python
+spec = SandboxSpec(
+    image="ghcr.io/example/eval-image:py312",
+    ttl_s=1800,  # a backstop, not the expected duration
+)
+```
+
+The TTL is a backstop for the case where cleanup never runs. Normal teardown is still
+`stop()` — an expiry is what saves you when `stop()` never happens.
+
+### Renewal
+
+Some providers can push an expiry back after creation. That allows a pattern that is safer
+than a long TTL: give the sandbox a short lifetime, then extend it while it is genuinely in
+use. A sandbox that stops being used stops being renewed, and expires on its own.
+
+The capability is optional, so check for it before relying on it:
+
+```python
+from nemo_gym.sandbox import RenewableProvider, create_provider
+
+provider = create_provider(provider_config)
+
+if isinstance(provider, RenewableProvider):
+    # Expire 15 minutes from now, refreshed on each pass through the loop.
+    await provider.renew(handle, ttl_s=900)
+```
+
+`renew()` sets the expiry to `ttl_s` seconds **from now**; it does not add to the time
+remaining. Calling it with the same value repeatedly holds the sandbox at a constant window
+rather than extending it without bound.
+
+Two things to get right when renewing around work:
+
+- **Renew before, not after.** A command that outlives the current expiry dies partway
+  through. Renew with at least the command's own timeout plus some slack —
+  `max(ttl_s, timeout_s + 60)` is the rule `gym sandbox exec` uses.
+- **Treat failures as non-fatal.** A failed renewal means the sandbox keeps its existing
+  expiry, which is a shorter lifetime rather than a broken one. Failing the caller's work over
+  it trades a small problem for a larger one.
+
+Providers without the capability ignore renewal entirely; their sandboxes keep the lifetime
+they were created with. See each provider page for whether it supports renewal.
+
+For the CLI side of this — the 15-minute cap, `--ttl`, and per-command renewal — see
+[Debugging sandboxes](/infrastructure/sandbox/debugging).
+
 ## Sync vs. Async
 
 Use `AsyncSandbox` inside FastAPI handlers, async resources servers, async agents, and rollout collection code.
@@ -217,7 +279,7 @@ Do not call `Sandbox` from FastAPI handlers, async resources servers, or async a
 | Field | Description |
 | --- | --- |
 | `image` | Container image to create. |
-| `ttl_s` | Sandbox lifetime in seconds, when supported by the provider. |
+| `ttl_s` | Sandbox lifetime in seconds, when supported by the provider. Unset means *never auto-terminate* on providers with a server-side expiry — see [Sandbox Lifetime and Renewal](#sandbox-lifetime-and-renewal). |
 | `ready_timeout_s` | Time to wait for sandbox readiness. |
 | `workdir` | Default working directory for `exec()` calls. |
 | `env` | Environment variables injected into the sandbox. Forward only values required by the task. |

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
@@ -210,8 +210,23 @@ The provider creates one OpenSandbox sandbox per Gym sandbox:
 | Exec | `handle.raw.commands.run(...)` with command options derived from `exec()` arguments. |
 | Status | `handle.raw.get_info()` mapped onto `SandboxStatus`. |
 | Close | `handle.raw.kill()` followed by local SDK handle cleanup. |
+| Renew | `handle.raw.renew(...)` — moves the expiry to `ttl_s` seconds from now. |
+| Connect | `opensandbox.Sandbox.connect(...)` — reattaches to a sandbox by id from any process. |
 
 If `create.skip_health_check` is enabled, the provider reconnects to the sandbox before running the NeMo Gym readiness probe so follow-up operations use a fresh SDK handle.
+
+### Lifetime
+
+`SandboxSpec.ttl_s` becomes the sandbox's `timeout`, and the server expires the sandbox that
+long after creation. OpenSandbox requires **at least 60 seconds**, and rejects shorter values.
+
+Omitting `ttl_s` omits `timeout` entirely, which OpenSandbox treats as *never auto-terminate*:
+the sandbox lives until something deletes it. Set a TTL on any path that might not reach its
+cleanup.
+
+This provider implements both `RenewableProvider` and `ConnectableProvider`, so a short TTL
+plus renewal is the recommended pattern — see
+[Sandbox Lifetime and Renewal](/infrastructure/sandbox/index#sandbox-lifetime-and-renewal).
 
 ## File Transfer
 

--- a/fern/versions/latest/pages/reference/cli-commands.mdx
+++ b/fern/versions/latest/pages/reference/cli-commands.mdx
@@ -51,6 +51,11 @@ gym eval aggregate            # merge sharded rollout results
 gym eval profile              # compute a reward profile from rollouts
 gym eval reverify             # recompute rewards from existing rollouts without re-running inference
 
+# Sandboxes
+gym sandbox debug             # boot a task's sandbox and run a command in it
+gym sandbox exec              # run a command in an already-running sandbox
+gym sandbox rm                # delete a running sandbox
+
 # Contributor helpers
 gym dev test                  # run NeMo Gym's unit tests
 ```
@@ -741,6 +746,84 @@ gym eval reverify \
 ```
 
 See [Reverify Rollouts](/tutorials/evaluation-tutorials/reverify-rollouts) for a full walkthrough.
+
+---
+
+## Sandboxes
+
+Inspect and poke at the sandbox a task would run in, without starting the model server,
+Ray, and the agent. See [Debugging sandboxes](/infrastructure/sandbox/debugging) for how a
+server opts in.
+
+### `gym sandbox debug`
+
+Boot the sandbox a server would create — same provider, image, and spec a rollout gets — and
+run a command or an uploaded script inside it. With no `-i/--input` it boots the server's
+configured sandbox; with one it binds a dataset row first.
+
+| Option | Description |
+| --- | --- |
+| `--server` | Server whose sandbox to use. Inferred when only one is configured. |
+| `--sandbox` | Override the server's `sandbox_provider` reference. |
+| `-i`, `--input` | Task rows JSONL. Defaults to the server's committed `data/example.jsonl`, which is a small fixture rather than the full benchmark. |
+| `--task` | Select a row by task id; repeatable. |
+| `--limit`, `--shuffle` | Cap and shuffle (fixed seed) the selected rows. |
+| `--command` | Command to run inside the sandbox. |
+| `--script-path` | Local script to upload and run. |
+| `--dry-run` | Print the resolved sandbox and exit without provisioning. |
+| `--list-tasks` | List the task ids available to `--task` and exit. Reads only the dataset — no provider or credentials needed. |
+| `--image` | Override the resolved container image. |
+| `--bare` | Skip the server's `exec_wrapper` and run the command as typed. |
+| `--cwd`, `--user`, `--env` | Override the exec context. `--env` takes `KEY=VALUE`, repeatable. |
+| `--concurrency` | Maximum sandboxes in flight (default 4). |
+| `--timeout-setup`, `--timeout-total` | Seconds allowed for boot/upload and for the command. |
+| `--ttl` | Sandbox lifetime in seconds. Defaults to 15 minutes, capping whatever the server's `ttl_s` asks for. Warns above 1 hour. |
+| `--keep` | Leave sandboxes running and print their ids. |
+| `-o`, `--output-dir` | Where to write `config.yaml` and `traces.jsonl`. |
+| `--quiet` | Suppress command output; keep the summary line. |
+| `--exit-zero` | Always exit 0, even when the command failed. |
+
+```bash
+# Inspect a task without provisioning anything
+gym sandbox debug --config <agent-config> --config <provider-config> \
+    --task <task-id> --dry-run
+
+# Run a command in that task's sandbox
+gym sandbox debug --config <agent-config> --config <provider-config> \
+    --task <task-id> --command "python -m pytest -x"
+
+# Upload a script and leave the sandbox up afterwards
+gym sandbox debug --config <config> --script-path ./poke.sh --keep
+```
+
+Exits non-zero when any command failed, so it is usable as a check. Each run writes
+`outputs/<server>--debug/<uuid>/` containing `traces.jsonl` (one record per task: resolved
+spec, image, sandbox id, exit code, output, per-stage timings) and a `config.yaml` you can
+feed back via `--config` to reproduce the run.
+
+### `gym sandbox exec`
+
+Run a command in a sandbox left running by `--keep`. Requires a provider that can reattach
+by id.
+
+| Option | Description |
+| --- | --- |
+| `--sandbox-id` | Id of the running sandbox. |
+| `--command` | Command to run. |
+| `--bare`, `--cwd`, `--user` | As for `gym sandbox debug`. |
+| `--ttl` | Seconds to extend the sandbox's expiry by before running (default 15 minutes). |
+
+```bash
+gym sandbox exec --config <config> --sandbox-id <id> --command "git log -1"
+```
+
+### `gym sandbox rm`
+
+Delete a running sandbox.
+
+```bash
+gym sandbox rm --config <config> --sandbox-id <id>
+```
 
 ---
 

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -782,6 +782,13 @@ COMMANDS = {
             SANDBOX_CWD,
             SANDBOX_USER,
             _text_list_flag("env", "env", "Extra environment variable; repeatable.", metavar="KEY=VALUE"),
+            _text_list_flag("metadata", "metadata", "Extra sandbox metadata; repeatable.", metavar="KEY=VALUE"),
+            _text_list_flag(
+                "provider-option",
+                "provider_option",
+                "Extra provider option, value parsed as JSON when it parses; repeatable.",
+                metavar="KEY=VALUE",
+            ),
             _value_flag("concurrency", "concurrency", "Maximum sandboxes in flight."),
             _value_flag("timeout-setup", "timeout_setup", "Seconds allowed for boot and upload."),
             SANDBOX_TIMEOUT_TOTAL,

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -99,6 +99,60 @@ def _bool_flag(name: str, hydra_key: str, flag_help: str) -> Flag:
     )
 
 
+def hydra_quote(value: str) -> str:
+    """Quote a value so Hydra's override grammar takes it literally.
+
+    Free-text values (a shell command, a path with spaces) collide with that
+    grammar: `--command "python -c 'x'"` fails on the inner quotes, and commas
+    or brackets are read as sweep/list syntax.
+
+    Hydra unescapes `\\"` but leaves `\\\\` alone, so a backslash directly before a
+    quote cannot be encoded. Rather than guess, prefer a delimiter the value does
+    not contain and verify the result parses back to exactly what was typed —
+    running a *different* command than the one you asked for is a worse failure
+    than refusing.
+    """
+    from hydra.core.override_parser.overrides_parser import OverridesParser
+
+    text = str(value)
+    for delimiter in ('"', "'"):
+        if delimiter in text:
+            continue
+        candidate = f"{delimiter}{text}{delimiter}"
+        try:
+            if OverridesParser.create().parse_overrides([f"+_probe={candidate}"])[0].value() == text:
+                return candidate
+        except Exception:  # noqa: S110 - fall through to the next delimiter
+            pass
+
+    raise ValueError(
+        f"Cannot pass {text!r} through Hydra's override grammar because it contains both quote "
+        f"characters. Put it in a file and use --script-path instead."
+    )
+
+
+def _text_flag(name: str, hydra_key: str, flag_help: str, *, aliases: tuple[str, ...] = ()) -> Flag:
+    """A `--name VALUE` flag for free text, quoted so Hydra accepts any characters."""
+    dest = name.replace("-", "_")
+    return Flag(
+        register=lambda p: p.add_argument(f"--{name}", *aliases, dest=dest, help=flag_help),
+        translate_to_hydra=lambda args: (
+            [f"+{hydra_key}={hydra_quote(getattr(args, dest))}"] if getattr(args, dest) is not None else []
+        ),
+    )
+
+
+def _text_list_flag(name: str, hydra_key: str, flag_help: str, *, metavar: str) -> Flag:
+    """A repeatable `--name VALUE` flag collected into one Hydra list, each element quoted."""
+    dest = name.replace("-", "_")
+    return Flag(
+        register=lambda p: p.add_argument(f"--{name}", action="append", metavar=metavar, help=flag_help),
+        translate_to_hydra=lambda args: (
+            [f"+{hydra_key}=[{','.join(hydra_quote(v) for v in getattr(args, dest))}]"] if getattr(args, dest) else []
+        ),
+    )
+
+
 # Shared flag: load Gym config files. Reused by every command that reads server/benchmark configs.
 CONFIG = Flag(
     register=lambda p: p.add_argument(
@@ -293,6 +347,20 @@ ENVIRONMENT = _asset_selector("environment")
 RESOURCES_SERVER_CONFIG = _asset_selector("resources-server")
 MODEL_TYPE = _asset_selector("model-type")
 
+# Shared `gym sandbox` flags. `--server` names the config block whose sandbox to act on (an agent or a
+# resources server — both declare `sandbox_provider`); `--sandbox` swaps the provider that block points at,
+# so the same task can run against a local provider and a cluster one without editing committed config.
+SANDBOX_SERVER = _value_flag("server", "server_name", "Server whose sandbox to use; inferred when unambiguous.")
+SANDBOX_NAME = _value_flag("sandbox", "sandbox_name", "Override the server's sandbox_provider reference.")
+SANDBOX_ID = _text_flag("sandbox-id", "sandbox_id", "Id of a running sandbox.")
+SANDBOX_COMMAND = _text_flag("command", "command", "Command to run inside the sandbox.")
+SANDBOX_BARE = _bool_flag("bare", "bare", "Skip the server's exec_wrapper and run the command as typed.")
+SANDBOX_CWD = _text_flag("cwd", "cwd", "Working directory for the command.")
+SANDBOX_USER = _text_flag("user", "user", "User to run the command as.")
+SANDBOX_QUIET = _bool_flag("quiet", "quiet", "Suppress command stdout/stderr; keep the summary line.")
+SANDBOX_EXIT_ZERO = _bool_flag("exit-zero", "exit_zero", "Always exit 0, even when the command failed.")
+SANDBOX_TIMEOUT_TOTAL = _value_flag("timeout-total", "timeout_total", "Seconds allowed for the command itself.")
+
 # `--search-dir`: extra component-search roots. `main()` folds these into the `NEMO_GYM_EXTRA_ROOTS` env
 # var before dispatch (see there), so a single register-only flag suffices for every command — the roots
 # reach discovery, the `--<component> NAME` selectors, deep path resolution, and spawned servers alike.
@@ -368,6 +436,7 @@ GROUPS = {
     "dataset": "Manage datasets.",
     "env": "Develop and run environments.",
     "eval": "Run evaluations.",
+    "sandbox": "Inspect and poke at task sandboxes.",
     "dev": "Contributor helpers.",
 }
 
@@ -690,6 +759,64 @@ COMMANDS = {
                 ),
             ),
         ),
+    ),
+    "sandbox debug": Command(
+        target="nemo_gym.cli.sandbox:debug",
+        summary="Boot a task's sandbox and run a command or script inside it.",
+        flags=(
+            CONFIG,
+            SEARCH_DIR,
+            JSON,
+            SANDBOX_SERVER,
+            SANDBOX_NAME,
+            _text_flag("input", "input_jsonl_fpath", "Task rows JSONL file.", aliases=("-i",)),
+            _text_list_flag("task", "task_ids", "Select a row by task id; repeatable.", metavar="ID"),
+            _value_flag("limit", "limit", "Maximum number of tasks to run."),
+            _bool_flag("shuffle", "shuffle", "Shuffle rows (fixed seed) before applying --limit."),
+            SANDBOX_COMMAND,
+            _text_flag("script-path", "script_path", "Local script to upload and run."),
+            _bool_flag("dry-run", "dry_run", "Print the resolved sandbox and exit without provisioning."),
+            _bool_flag("list-tasks", "list_tasks", "List the task ids available to --task and exit."),
+            _text_flag("image", "image", "Override the resolved container image."),
+            SANDBOX_BARE,
+            SANDBOX_CWD,
+            SANDBOX_USER,
+            _text_list_flag("env", "env", "Extra environment variable; repeatable.", metavar="KEY=VALUE"),
+            _value_flag("concurrency", "concurrency", "Maximum sandboxes in flight."),
+            _value_flag("timeout-setup", "timeout_setup", "Seconds allowed for boot and upload."),
+            SANDBOX_TIMEOUT_TOTAL,
+            _value_flag("ttl", "ttl_s", "Sandbox lifetime in seconds before it self-deletes."),
+            _bool_flag("keep", "keep", "Leave sandboxes running and print their ids."),
+            _text_flag(
+                "output-dir", "output_dirpath", "Where to write config.yaml and traces.jsonl.", aliases=("-o",)
+            ),
+            SANDBOX_QUIET,
+            SANDBOX_EXIT_ZERO,
+        ),
+    ),
+    "sandbox exec": Command(
+        target="nemo_gym.cli.sandbox:exec_command",
+        summary="Run a command in an already-running sandbox.",
+        flags=(
+            CONFIG,
+            SEARCH_DIR,
+            SANDBOX_ID,
+            SANDBOX_SERVER,
+            SANDBOX_NAME,
+            SANDBOX_COMMAND,
+            SANDBOX_BARE,
+            SANDBOX_CWD,
+            SANDBOX_USER,
+            SANDBOX_TIMEOUT_TOTAL,
+            _value_flag("ttl", "ttl_s", "Seconds to extend the sandbox's expiry by before running."),
+            SANDBOX_QUIET,
+            SANDBOX_EXIT_ZERO,
+        ),
+    ),
+    "sandbox rm": Command(
+        target="nemo_gym.cli.sandbox:rm",
+        summary="Delete a running sandbox.",
+        flags=(CONFIG, SEARCH_DIR, SANDBOX_ID, SANDBOX_SERVER, SANDBOX_NAME),
     ),
     "dev test": Command(target="nemo_gym.cli.dev:dev_test", summary="Run NeMo Gym's unit tests."),
 }

--- a/nemo_gym/cli/sandbox.py
+++ b/nemo_gym/cli/sandbox.py
@@ -184,6 +184,11 @@ class SandboxDebugConfig(BaseNeMoGymCLIConfig):
     cwd: Optional[str] = Field(default=None, description="Working directory for the command.")
     user: Optional[str] = Field(default=None, description="User to run the command as.")
     env: List[str] = Field(default_factory=list, description="Extra environment variables as KEY=VALUE.")
+    metadata: List[str] = Field(default_factory=list, description="Extra sandbox metadata as KEY=VALUE; repeatable.")
+    provider_option: List[str] = Field(
+        default_factory=list,
+        description="Extra provider option as KEY=VALUE, value parsed as JSON when it parses; repeatable.",
+    )
 
     concurrency: int = Field(default=4, description="Maximum sandboxes in flight.")
     timeout_setup: Optional[float] = Field(default=None, description="Seconds allowed for boot and upload.")
@@ -388,14 +393,34 @@ def _exec_kwargs(server_config: Dict[str, Any], config: Any) -> Dict[str, Any]:
     return kwargs
 
 
-def _parse_env(pairs: List[str]) -> Dict[str, str]:
-    env: Dict[str, str] = {}
+def _parse_pairs(pairs: List[str], *, flag: str) -> Dict[str, str]:
+    parsed: Dict[str, str] = {}
     for pair in pairs:
         key, separator, value = pair.partition("=")
         if not separator or not key:
-            raise ConfigError(f"--env expects KEY=VALUE, got {pair!r}")
-        env[key] = value
-    return env
+            raise ConfigError(f"{flag} expects KEY=VALUE, got {pair!r}")
+        parsed[key] = value
+    return parsed
+
+
+def _parse_env(pairs: List[str]) -> Dict[str, str]:
+    return _parse_pairs(pairs, flag="--env")
+
+
+def _parse_provider_options(pairs: List[str]) -> Dict[str, Any]:
+    """Parse --provider-option KEY=VALUE, decoding VALUE as JSON when it decodes.
+
+    Provider options are not all strings: a network policy is a mapping, and
+    skip_health_check is a bool. Falling back to the raw string keeps the simple
+    cases (an id, a name) free of quoting ceremony.
+    """
+    options: Dict[str, Any] = {}
+    for key, value in _parse_pairs(pairs, flag="--provider-option").items():
+        try:
+            options[key] = json.loads(value)
+        except json.JSONDecodeError:
+            options[key] = value
+    return options
 
 
 ########################################
@@ -565,6 +590,12 @@ def build_plan(
     exec_kwargs = _exec_kwargs(server_config, config)
 
     env = {**spec.env, **_parse_env(config.env)}
+    # CLI flags are the top layer, above both the declarative sandbox_spec and a
+    # spec_resolver's output. Without this a resolver-based server could not be
+    # given a networkPolicy or an istio label from the command line at all, since
+    # the resolver's spec wins outright over config.
+    metadata.update(_parse_pairs(config.metadata, flag="--metadata"))
+    provider_options = {**spec.provider_options, **_parse_provider_options(config.provider_option)}
     # An explicit --ttl is taken at face value; otherwise cap at the debugging
     # default, whether the server asked for a rollout-sized lifetime or none at all
     # (which providers read as "never auto-terminate").
@@ -586,7 +617,7 @@ def build_plan(
         metadata=metadata,
         resources=spec.resources,
         entrypoint=list(spec.entrypoint) if spec.entrypoint else None,
-        provider_options=dict(spec.provider_options),
+        provider_options=provider_options,
     )
 
     raw_command = config.command

--- a/nemo_gym/cli/sandbox.py
+++ b/nemo_gym/cli/sandbox.py
@@ -1,0 +1,1220 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`gym sandbox` — boot, inspect, and poke at a server's task sandbox.
+
+Reproducing "what does this task's container actually look like?" normally means
+starting the whole stack: model server, Ray, agent, rollout. These commands cut
+straight to the sandbox, using the same provider, image, and spec a rollout would.
+"""
+
+import asyncio
+import atexit
+import json
+import logging
+import random
+import signal
+import time
+import uuid
+import weakref
+from collections.abc import Mapping
+from contextlib import suppress
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import rich
+from omegaconf import DictConfig, OmegaConf
+from pydantic import Field, model_validator
+from rich.markup import escape
+
+from nemo_gym import _resolve_under_cwd_or_install
+from nemo_gym.cli.utils import did_you_mean, exit_cleanly_on_config_error
+from nemo_gym.config_types import BaseNeMoGymCLIConfig, ConfigError, ConfigPathNotFoundError
+from nemo_gym.global_config import (
+    JSON_OUTPUT_KEY_NAME,
+    NEMO_GYM_RESERVED_TOP_LEVEL_KEYS,
+    VERBOSE_KEY_NAME,
+    GlobalConfigDictParser,
+    GlobalConfigDictParserConfig,
+    get_global_config_dict,
+)
+from nemo_gym.sandbox import (
+    AsyncSandbox,
+    ConnectableProvider,
+    RenewableProvider,
+    SandboxSpec,
+    create_provider,
+    resolve_provider_config,
+    resolve_provider_metadata,
+)
+from nemo_gym.sandbox.hooks import replace_image, resolve_spec, task_id_for_row, wrap_command
+
+
+# Outcome taxonomy for a debug action. `not_run` covers a sandbox that booted but
+# whose action never started (an earlier stage failed).
+REASON_PASS = "pass"
+REASON_NONZERO_EXIT = "nonzero_exit"
+REASON_TIMEOUT = "timeout"
+REASON_CANCELLED = "cancelled"
+REASON_ERROR = "error"
+REASON_NOT_RUN = "not_run"
+
+# Uploaded scripts land here rather than in the task workdir: the point of debug
+# is to observe the task's state, not to add to it.
+REMOTE_SCRIPT_DIR = "/tmp"
+
+# A provider-enforced timeout returns slightly under the requested budget once
+# round-trip time is subtracted, so allow a little slack before calling it one.
+_TIMEOUT_TOLERANCE = 0.9
+
+# Default ceiling on how long a debugging sandbox lives. Server configs size
+# `ttl_s` for a full rollout — mini-swe-agent asks for five hours — which is the
+# wrong order of magnitude for poking at a container, and several servers set no
+# ttl at all, which providers read as "never auto-terminate". Neither is safe for
+# a tool that can be Ctrl-C'd, killed, or simply forgotten after `--keep`, so both
+# are capped here. `--ttl` opts out for the cases that genuinely need longer.
+DEFAULT_TTL_S = 900.0
+
+# Above this, an explicit `--ttl` is worth questioning: sandboxes held this long
+# are usually forgotten rather than needed.
+TTL_WARN_THRESHOLD_S = 3600.0
+
+_DEFAULT_OUTPUT_ROOT = "outputs"
+
+# Sandboxes that must be torn down even if the loop dies under us. Weak so a
+# stopped sandbox can still be collected normally.
+_LIVE_SANDBOXES: "weakref.WeakSet[AsyncSandbox]" = weakref.WeakSet()
+_cleaning_up = False
+
+
+def _cleanup_at_exit() -> None:  # pragma: no cover - interpreter shutdown path
+    """Last-resort teardown for sandboxes still alive at interpreter exit.
+
+    By this point the event loop is usually gone, so a fresh one is spun up per
+    sandbox. Failures are swallowed: this runs during shutdown, where raising
+    would only mask whatever actually went wrong.
+    """
+    for sandbox in list(_LIVE_SANDBOXES):
+        with suppress(Exception):
+            asyncio.run(sandbox.stop())
+
+
+atexit.register(_cleanup_at_exit)
+
+
+def _install_interrupt_handler() -> None:  # pragma: no cover - signal path
+    """Make the first Ctrl-C unwind cleanly and ignore the ones after it.
+
+    A second Ctrl-C during teardown would orphan a running sandbox — which on a
+    cluster keeps burning capacity until its TTL expires. Swallowing repeats is
+    what makes "cleaning up, please wait" an honest message.
+    """
+
+    def handler(signum, frame):
+        global _cleaning_up
+        if _cleaning_up:
+            rich.print("[yellow]cleanup in progress — please wait (ctrl-c ignored)[/yellow]")
+            return
+        _cleaning_up = True
+        rich.print("[yellow]interrupted — cleaning up, please wait...[/yellow]")
+        raise KeyboardInterrupt
+
+    with suppress(ValueError):  # not on the main thread
+        signal.signal(signal.SIGINT, handler)
+        signal.signal(signal.SIGTERM, handler)
+
+
+########################################
+# Config models
+########################################
+
+
+class SandboxDebugConfig(BaseNeMoGymCLIConfig):
+    """
+    Boot the sandbox a server would create for a task and run a command inside it.
+
+    Resolves the provider and spec exactly as the server does, so what you poke at is
+    the environment the rollout sees. With no `-i/--input`, it boots the server's
+    configured sandbox; with one, it binds a dataset row first.
+
+    Examples:
+
+    ```bash
+    # Inspect without provisioning anything
+    gym sandbox debug --config <config> --task <id> --dry-run
+
+    # Run a command in one task's sandbox
+    gym sandbox debug --config <config> --task <id> --command "pytest -x"
+
+    # Upload and run a script, leaving the sandbox up afterwards
+    gym sandbox debug --config <config> --script-path ./poke.sh --keep
+    ```
+    """
+
+    server_name: Optional[str] = Field(
+        default=None, description="Server whose sandbox to boot. Inferred when only one is configured."
+    )
+    sandbox_name: Optional[str] = Field(default=None, description="Override the server's sandbox_provider reference.")
+    input_jsonl_fpath: Optional[str] = Field(
+        default=None, description="Task rows. Defaults to the server's example dataset when a task is selected."
+    )
+    task_ids: List[str] = Field(default_factory=list, description="Select rows by task id; repeatable.")
+    limit: Optional[int] = Field(default=None, description="Maximum number of tasks to run.")
+    shuffle: bool = Field(default=False, description="Shuffle rows (fixed seed) before applying --limit.")
+
+    command: Optional[str] = Field(default=None, description="Command to run inside the sandbox.")
+    script_path: Optional[str] = Field(default=None, description="Local script to upload and run.")
+    dry_run: bool = Field(default=False, description="Print the resolved sandbox and exit without provisioning.")
+    list_tasks: bool = Field(default=False, description="List the task ids in the dataset and exit.")
+
+    image: Optional[str] = Field(default=None, description="Override the resolved container image.")
+    bare: bool = Field(default=False, description="Skip the server's exec_wrapper and run the command as typed.")
+    cwd: Optional[str] = Field(default=None, description="Working directory for the command.")
+    user: Optional[str] = Field(default=None, description="User to run the command as.")
+    env: List[str] = Field(default_factory=list, description="Extra environment variables as KEY=VALUE.")
+
+    concurrency: int = Field(default=4, description="Maximum sandboxes in flight.")
+    timeout_setup: Optional[float] = Field(default=None, description="Seconds allowed for boot and upload.")
+    timeout_total: Optional[float] = Field(default=600.0, description="Seconds allowed for the command itself.")
+    ttl_s: Optional[float] = Field(
+        default=None,
+        description=f"Sandbox lifetime in seconds. Defaults to the server's ttl_s, or {DEFAULT_TTL_S:g}s if it sets none.",
+    )
+
+    keep: bool = Field(default=False, description="Leave sandboxes running and print their ids.")
+    output_dirpath: Optional[str] = Field(default=None, description="Where to write config.yaml and traces.jsonl.")
+    quiet: bool = Field(default=False, description="Suppress command stdout/stderr; keep the summary.")
+    exit_zero: bool = Field(default=False, description="Always exit 0, even when the command failed.")
+
+    @model_validator(mode="after")
+    def check_action(self) -> "SandboxDebugConfig":
+        if self.command and self.script_path:
+            raise ValueError("pass at most one of --command or --script-path")
+        # --dry-run is a modifier, not an action: passing a command with it shows
+        # how that command would be wrapped, which is half the point of inspecting.
+        if not (self.dry_run or self.list_tasks or self.command or self.script_path):
+            raise ValueError("pass --command, --script-path, --dry-run, or --list-tasks")
+        if self.script_path and not Path(self.script_path).is_file():
+            raise ValueError(f"--script-path is not a file: {self.script_path}")
+        if self.concurrency < 1:
+            raise ValueError("--concurrency must be >= 1")
+        if self.ttl_s is not None and self.ttl_s <= 0:
+            # Providers impose their own floor (OpenSandbox requires 60s); only the
+            # universally-wrong case is rejected here, so their message still shows.
+            raise ValueError("--ttl must be > 0")
+        return self
+
+
+class SandboxExecConfig(BaseNeMoGymCLIConfig):
+    """
+    Run a command in an already-running sandbox, or delete one.
+
+    Pairs with `gym sandbox debug --keep`, which prints the sandbox id. Requires a
+    provider that can reattach by id.
+
+    Examples:
+
+    ```bash
+    gym sandbox exec --config <config> --sandbox-id <id> --command "git log -1"
+    gym sandbox rm --config <config> --sandbox-id <id>
+    ```
+    """
+
+    sandbox_id: Optional[str] = Field(default=None, description="Id of the running sandbox.")
+    server_name: Optional[str] = Field(default=None, description="Server whose provider config to connect with.")
+    sandbox_name: Optional[str] = Field(default=None, description="Override the server's sandbox_provider reference.")
+    command: Optional[str] = Field(default=None, description="Command to run (not used by `rm`).")
+    bare: bool = Field(default=False, description="Skip the server's exec_wrapper.")
+    cwd: Optional[str] = Field(default=None, description="Working directory for the command.")
+    user: Optional[str] = Field(default=None, description="User to run the command as.")
+    timeout_total: Optional[float] = Field(default=600.0, description="Seconds allowed for the command.")
+    ttl_s: Optional[float] = Field(
+        default=None,
+        description=f"Seconds to extend the sandbox's expiry by before running (default {DEFAULT_TTL_S:g}s).",
+    )
+    quiet: bool = Field(default=False, description="Suppress stdout/stderr; keep the summary.")
+    exit_zero: bool = Field(default=False, description="Always exit 0, even when the command failed.")
+
+
+########################################
+# Server / provider / spec resolution
+########################################
+
+
+def _redacted_config_yaml(global_config_dict: Any) -> str:
+    """Serialize the resolved config with secrets masked.
+
+    This file is written to a run directory that gets shared and attached to bug
+    reports, so a resolved API key must not land in it. Values come from the
+    environment anyway, so re-running from this config needs the same env vars
+    set — which is the trade worth making.
+    """
+    redacted = deepcopy(global_config_dict)
+    GlobalConfigDictParser()._recursively_hide_secrets(redacted)
+    return OmegaConf.to_yaml(redacted, resolve=True)
+
+
+def _warn_on_long_ttl(ttl_s: Optional[float]) -> None:
+    """Flag a lifetime long enough that a forgotten sandbox becomes expensive."""
+    if ttl_s is not None and ttl_s > TTL_WARN_THRESHOLD_S:
+        rich.print(
+            f"[yellow]warning[/yellow] --ttl {_format_duration(ttl_s)} keeps a sandbox alive well past a "
+            f"normal debugging session; a forgotten one holds cluster capacity for that long. Delete it with "
+            f"`gym sandbox rm --sandbox-id <id>` when you are done."
+        )
+
+
+def _quiet_transport_logs(global_config_dict: Any) -> None:
+    """Silence per-request HTTP chatter unless `-v` was passed.
+
+    The sandbox SDK logs every proxied call at INFO, which buries the command
+    output this tool exists to show. Under `-v` the traffic is exactly what you
+    want, so it is only suppressed at the default level.
+    """
+    if global_config_dict.get(VERBOSE_KEY_NAME):
+        return
+    for name in ("httpx", "httpcore", "opensandbox"):
+        logging.getLogger(name).setLevel(logging.WARNING)
+
+
+def _plain(value: Any) -> Any:
+    """Return a plain Python container for an OmegaConf node."""
+    if isinstance(value, DictConfig):
+        return OmegaConf.to_container(value, resolve=True)
+    return value
+
+
+def discover_sandbox_servers(global_config_dict: Any) -> Dict[str, Dict[str, Any]]:
+    """Find every server block that declares a sandbox.
+
+    `sandbox_provider` is the one thing every sandbox-backed server agrees on, so
+    it is what identifies them — regardless of whether they are agents or
+    resources servers. The descent mirrors how `gym env start` locates servers.
+
+    Returns:
+        Mapping of server instance name to
+        ``{"top_level": str, "server_type": str, "config": dict}``.
+    """
+    servers: Dict[str, Dict[str, Any]] = {}
+    for top_level in global_config_dict:
+        if top_level in NEMO_GYM_RESERVED_TOP_LEVEL_KEYS:
+            continue
+        by_type = global_config_dict[top_level]
+        if not isinstance(by_type, DictConfig):
+            continue
+        for server_type in by_type:
+            by_name = by_type[server_type]
+            if not isinstance(by_name, DictConfig):
+                continue
+            for name in by_name:
+                block = by_name[name]
+                if not isinstance(block, DictConfig) or "sandbox_provider" not in block:
+                    continue
+                servers[str(name)] = {
+                    "name": str(name),
+                    "top_level": str(top_level),
+                    "server_type": str(server_type),
+                    "config": _plain(block),
+                }
+    return servers
+
+
+def select_server(servers: Dict[str, Dict[str, Any]], server_name: Optional[str]) -> Tuple[str, Dict[str, Any]]:
+    """Pick the server to debug, inferring it when the choice is unambiguous."""
+    if not servers:
+        raise ConfigError(
+            "No sandbox-backed server found in the merged config. A server opts in by declaring "
+            "`sandbox_provider`; pass its config with --config."
+        )
+    if server_name:
+        if server_name not in servers:
+            raise ConfigError(
+                f"Unknown server {server_name!r}. Configured sandbox servers: "
+                f"{', '.join(sorted(servers))}.{did_you_mean(server_name, servers)}"
+            )
+        return server_name, servers[server_name]
+    if len(servers) > 1:
+        raise ConfigError(
+            f"Several sandbox servers are configured ({', '.join(sorted(servers))}). Pick one with --server."
+        )
+    name = next(iter(servers))
+    return name, servers[name]
+
+
+def build_provider(server_config: Dict[str, Any], global_config_dict: Any, sandbox_name: Optional[str]) -> Any:
+    """Instantiate the provider a server would use.
+
+    `sandbox_provider` is either a name referencing a provider block elsewhere in
+    the config or an inline single-key mapping; `resolve_provider_config` accepts
+    both. `--sandbox` swaps the reference so the same task can run on a local
+    provider and a cluster one without editing committed config.
+    """
+    reference = sandbox_name or server_config.get("sandbox_provider")
+    if reference is None:
+        raise ConfigError("Server does not declare `sandbox_provider`.")
+    provider_config = resolve_provider_config(reference, global_config_dict)
+    return create_provider(provider_config), provider_config
+
+
+def provider_default_metadata(server_config: Dict[str, Any], global_config_dict: Any, sandbox_name: Optional[str]):
+    reference = sandbox_name or server_config.get("sandbox_provider")
+    return resolve_provider_metadata(reference, global_config_dict)
+
+
+def _exec_kwargs(server_config: Dict[str, Any], config: Any) -> Dict[str, Any]:
+    """Merge the server's exec defaults with CLI overrides.
+
+    `sandbox_environment_kwargs` is where servers keep the shell context their
+    commands assume (workdir, user, conda env), so it doubles as the argument set
+    for an `exec_wrapper`.
+    """
+    kwargs = dict(server_config.get("sandbox_environment_kwargs") or {})
+    if getattr(config, "cwd", None):
+        kwargs["cwd"] = config.cwd
+    if getattr(config, "user", None):
+        kwargs["user"] = config.user
+    return kwargs
+
+
+def _parse_env(pairs: List[str]) -> Dict[str, str]:
+    env: Dict[str, str] = {}
+    for pair in pairs:
+        key, separator, value = pair.partition("=")
+        if not separator or not key:
+            raise ConfigError(f"--env expects KEY=VALUE, got {pair!r}")
+        env[key] = value
+    return env
+
+
+########################################
+# Task rows
+########################################
+
+
+def _default_input_fpath(server_config: Dict[str, Any], entry: Dict[str, Any]) -> Optional[str]:
+    """Fall back to the server's example dataset when no input file is given.
+
+    A declared `example` dataset wins; otherwise fall back to the committed
+    `data/example.jsonl` every server is required to ship, which is what makes
+    `--task <id>` work with no `-i`.
+    """
+    for dataset in server_config.get("datasets") or []:
+        if isinstance(dataset, dict) and dataset.get("type") == "example" and dataset.get("jsonl_fpath"):
+            return str(dataset["jsonl_fpath"])
+
+    conventional = Path(entry["server_type"]) / entry["name"] / "data" / "example.jsonl"
+    with suppress(Exception):
+        if _resolve_under_cwd_or_install(conventional).exists():
+            return str(conventional)
+    return None
+
+
+def load_rows(
+    input_jsonl_fpath: Optional[str],
+    *,
+    entry: Dict[str, Any],
+    task_ids: List[str],
+    limit: Optional[int],
+    shuffle: bool,
+    id_from_row: Optional[str],
+    require_selection: bool = False,
+) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    """Load and select the dataset rows to debug.
+
+    Returns ``([], None)`` when nothing selects a row, which is the signal to boot
+    the server's configured sandbox unbound to any task. ``require_selection``
+    forces the dataset to be read anyway, for callers that want the whole thing.
+    """
+    if not require_selection and input_jsonl_fpath is None and not task_ids and limit is None:
+        return [], None
+
+    fpath = input_jsonl_fpath or _default_input_fpath(entry["config"], entry)
+    if fpath is None:
+        raise ConfigError(
+            "Selecting tasks needs a dataset. Pass -i/--input, or configure an `example` dataset on the server."
+        )
+
+    resolved = _resolve_under_cwd_or_install(Path(fpath))
+    if not resolved.exists():
+        raise ConfigPathNotFoundError(f"Input file not found: '{fpath}' (-i/--input).")
+
+    rows: List[Dict[str, Any]] = []
+    with open(resolved) as f:
+        for line_no, line in enumerate(f, 1):
+            if line.strip():
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    raise ConfigError(f"Malformed JSON in '{resolved}' at line {line_no}: {e}") from e
+
+    if task_ids:
+        wanted = set(task_ids)
+        selected = [r for r in rows if task_id_for_row(r, id_from_row=id_from_row) in wanted]
+        found = {task_id_for_row(r, id_from_row=id_from_row) for r in selected}
+        missing = wanted - found
+        if missing:
+            available = [task_id_for_row(r, id_from_row=id_from_row) or "<unnamed>" for r in rows]
+            raise ConfigError(
+                f"No row matched --task {', '.join(sorted(missing))} in '{resolved}'. "
+                f"Available ids: {', '.join(available[:20])}{' ...' if len(available) > 20 else ''}"
+            )
+        rows = selected
+
+    if shuffle:
+        random.Random(0).shuffle(rows)
+    if limit is not None:
+        rows = rows[:limit]
+    return rows, str(resolved)
+
+
+########################################
+# Planning
+########################################
+
+
+class TaskPlan:
+    """Everything needed to boot and use one sandbox, resolved ahead of time.
+
+    Built before any provisioning so `--dry-run` and a real run agree by
+    construction — a dry run that diverged from the real thing would be worse
+    than no dry run at all.
+    """
+
+    def __init__(
+        self,
+        *,
+        index: int,
+        task_id: Optional[str],
+        row: Optional[Dict[str, Any]],
+        spec: SandboxSpec,
+        spec_source: str,
+        image_source: str,
+        exec_kwargs: Dict[str, Any],
+        command: Optional[str],
+        wrapped: bool,
+        raw_command: Optional[str],
+        wrapper_label: str,
+    ) -> None:
+        self.wrapper_label = wrapper_label
+        self.index = index
+        self.task_id = task_id
+        self.row = row
+        self.spec = spec
+        self.spec_source = spec_source
+        self.image_source = image_source
+        self.exec_kwargs = exec_kwargs
+        self.command = command
+        self.wrapped = wrapped
+        self.raw_command = raw_command
+
+    @property
+    def name(self) -> str:
+        return self.task_id or f"task-{self.index}"
+
+
+def build_plan(
+    *,
+    index: int,
+    row: Optional[Dict[str, Any]],
+    server_config: Dict[str, Any],
+    sandbox_task: Dict[str, Any],
+    default_metadata: Dict[str, Any],
+    config: SandboxDebugConfig,
+) -> TaskPlan:
+    """Resolve one task into a concrete spec and command."""
+    spec, spec_source = resolve_spec(
+        sandbox_spec=server_config.get("sandbox_spec"),
+        sandbox_task=sandbox_task,
+        row=row,
+        server_config=server_config,
+    )
+
+    image_source = spec_source
+    if config.image:
+        spec = replace_image(spec, config.image)
+        image_source = "--image"
+    if spec.image is None:
+        raise ConfigError(
+            "Could not determine a container image. Pass --image, set `sandbox_spec.image`, or declare "
+            "`sandbox_task.image_from_row` / `sandbox_task.spec_resolver` on the server."
+        )
+
+    # Provider defaults sit underneath the server's own metadata, which sits
+    # underneath what identifies this run — most specific wins.
+    metadata = {**default_metadata, **spec.metadata}
+    metadata["nemo_gym_tool"] = "gym-sandbox-debug"
+    if row is not None:
+        task_id = task_id_for_row(row, id_from_row=sandbox_task.get("id_from_row"))
+        if task_id:
+            metadata["task_id"] = task_id[:63]
+    else:
+        task_id = None
+
+    exec_kwargs = _exec_kwargs(server_config, config)
+
+    env = {**spec.env, **_parse_env(config.env)}
+    # An explicit --ttl is taken at face value; otherwise cap at the debugging
+    # default, whether the server asked for a rollout-sized lifetime or none at all
+    # (which providers read as "never auto-terminate").
+    if config.ttl_s is not None:
+        ttl_s = config.ttl_s
+    elif spec.ttl_s is None:
+        ttl_s = DEFAULT_TTL_S
+    else:
+        ttl_s = min(float(spec.ttl_s), DEFAULT_TTL_S)
+    spec = SandboxSpec(
+        image=spec.image,
+        ttl_s=ttl_s,
+        ready_timeout_s=spec.ready_timeout_s,
+        # Servers that keep their workdir in `sandbox_environment_kwargs` rather
+        # than in the spec still expect the sandbox to land there.
+        workdir=config.cwd or spec.workdir or exec_kwargs.get("cwd"),
+        env=env,
+        files=dict(spec.files),
+        metadata=metadata,
+        resources=spec.resources,
+        entrypoint=list(spec.entrypoint) if spec.entrypoint else None,
+        provider_options=dict(spec.provider_options),
+    )
+
+    raw_command = config.command
+    if config.script_path:
+        remote = f"{REMOTE_SCRIPT_DIR}/ng-debug-{index}-{Path(config.script_path).name}"
+        raw_command = f"chmod +x {remote} && {remote}"
+
+    command, wrapped = (None, False)
+    if raw_command is not None:
+        command, wrapped = wrap_command(
+            raw_command, sandbox_task=sandbox_task, exec_kwargs=exec_kwargs, bare=config.bare
+        )
+
+    wrapper_ref = sandbox_task.get("exec_wrapper")
+    if config.bare:
+        wrapper_label = f"(skipped by --bare; server declares {wrapper_ref})" if wrapper_ref else "(none)"
+    else:
+        wrapper_label = str(wrapper_ref) if wrapper_ref else "(none)"
+
+    return TaskPlan(
+        index=index,
+        task_id=task_id,
+        row=row,
+        spec=spec,
+        spec_source=spec_source,
+        image_source=image_source,
+        exec_kwargs=exec_kwargs,
+        command=command,
+        wrapped=wrapped,
+        raw_command=raw_command,
+        wrapper_label=wrapper_label,
+    )
+
+
+def _spec_summary(spec: SandboxSpec) -> str:
+    resources = spec.resources
+    parts = [
+        f"{key}={value}" for key, value in (("ttl_s", spec.ttl_s), ("ready_timeout_s", spec.ready_timeout_s)) if value
+    ]
+    for key, value in (
+        ("cpu", resources.cpu),
+        ("memory_mib", resources.memory_mib),
+        ("disk_gib", resources.disk_gib),
+        ("gpu", resources.gpu),
+    ):
+        if value:
+            parts.append(f"{key}={value}")
+    if spec.workdir:
+        parts.append(f"workdir={spec.workdir}")
+    return "  ".join(parts) or "(defaults)"
+
+
+def render_dry_run(
+    *,
+    server_name: str,
+    server_type: str,
+    provider_config: Dict[str, Any],
+    plans: List[TaskPlan],
+    input_fpath: Optional[str],
+    total_rows: int,
+) -> None:
+    """Show what would be provisioned, without provisioning it."""
+    provider_name = next(iter(provider_config), "?")
+    for plan in plans:
+        rows: List[Tuple[str, str]] = [
+            ("server", f"{server_name}  ({server_type})"),
+            ("sandbox", provider_name),
+        ]
+        if plan.task_id:
+            location = f"index {plan.index} of {total_rows}"
+            if input_fpath:
+                location += f", from {input_fpath}"
+            rows.append(("task", f"{plan.task_id}  ({location})"))
+        else:
+            rows.append(("task", "(none — booting the server's configured sandbox)"))
+        rows.append(("image", f"{plan.spec.image}\nvia {plan.image_source}"))
+        rows.append(("spec", _spec_summary(plan.spec)))
+        if plan.spec.metadata:
+            rows.append(("metadata", " ".join(f"{k}={v}" for k, v in sorted(plan.spec.metadata.items()))))
+        if plan.spec.files:
+            rows.append(("files", " ".join(sorted(plan.spec.files))))
+        rows.append(("exec", " ".join(f"{k}={v}" for k, v in sorted(plan.exec_kwargs.items())) or "(defaults)"))
+        # Name the wrapper even with no command, since it is the main reason a
+        # command behaves differently here than it does typed into a shell.
+        rows.append(("wrapper", plan.wrapper_label))
+        if plan.command:
+            rows.append(("command", plan.command))
+
+        # A key/value list rather than a table: one very long cell (the wrapped
+        # command) would otherwise pad every other row out to its width.
+        width = max(len(label) for label, _ in rows)
+        for label, value in rows:
+            first, *rest = str(value).split("\n")
+            rich.print(f"[bold cyan]{label.ljust(width)}[/bold cyan]  {escape(first)}")
+            for line in rest:
+                rich.print(f"{' ' * width}  [dim]{escape(line)}[/dim]")
+        rich.print("")
+
+
+########################################
+# Execution
+########################################
+
+
+async def _sandbox_id(sandbox: AsyncSandbox) -> Optional[str]:
+    """Best-effort id for a running sandbox, for display and for `--keep`.
+
+    Connectable providers expose it through `serialize()`, which is also the
+    descriptor `gym sandbox exec` reattaches with. Others have no externally
+    meaningful id, so the trace simply records none.
+    """
+    with suppress(Exception):
+        descriptor = await sandbox.serialize()
+        if isinstance(descriptor, Mapping) and descriptor.get("sandbox_id"):
+            return str(descriptor["sandbox_id"])
+    handle = getattr(sandbox, "_handle", None)
+    return getattr(handle, "sandbox_id", None)
+
+
+async def run_plan(
+    plan: TaskPlan,
+    *,
+    provider_factory,
+    provider_name: str,
+    config: SandboxDebugConfig,
+    semaphore: asyncio.Semaphore,
+    write_trace,
+) -> Dict[str, Any]:
+    """Boot one sandbox, run the action in it, and return the trace record."""
+    trace: Dict[str, Any] = {
+        "task": {"index": plan.index, "id": plan.task_id},
+        "provider": provider_name,
+        "image": plan.spec.image,
+        "image_source": plan.image_source,
+        "ttl_s": plan.spec.ttl_s,
+        "spec_source": plan.spec_source,
+        "action": "script" if config.script_path else "command",
+        "command": plan.command,
+        "wrapped": plan.wrapped,
+        "sandbox_id": None,
+        "ok": False,
+        "reason": REASON_NOT_RUN,
+        "exit_code": None,
+        "stdout": None,
+        "stderr": None,
+        "kept": False,
+        "timing": {},
+    }
+
+    async with semaphore:
+        sandbox = AsyncSandbox(provider_factory(), plan.spec)
+        started = time.monotonic()
+        boot_started = started
+        # Which budget is in force right now, so a timeout can name the stage that
+        # blew it rather than reporting whichever number happens to be handy.
+        stage, budget = "boot", config.timeout_setup
+        try:
+            await asyncio.wait_for(sandbox.start(), timeout=config.timeout_setup)
+            _LIVE_SANDBOXES.add(sandbox)
+            trace["timing"]["boot"] = round(time.monotonic() - boot_started, 3)
+            trace["sandbox_id"] = await _sandbox_id(sandbox)
+
+            stage, budget = "setup", config.timeout_setup
+            setup_started = time.monotonic()
+            if config.script_path:
+                remote = f"{REMOTE_SCRIPT_DIR}/ng-debug-{plan.index}-{Path(config.script_path).name}"
+                await asyncio.wait_for(sandbox.upload(config.script_path, remote), timeout=config.timeout_setup)
+            trace["timing"]["setup"] = round(time.monotonic() - setup_started, 3)
+
+            stage, budget = "exec", config.timeout_total
+            exec_started = time.monotonic()
+            result = await sandbox.exec(
+                plan.command,
+                cwd=plan.exec_kwargs.get("cwd"),
+                user=plan.exec_kwargs.get("user"),
+                timeout_s=config.timeout_total,
+            )
+            elapsed = time.monotonic() - exec_started
+            trace["timing"]["exec"] = round(elapsed, 3)
+            # Split what the command spent from what the round-trip cost, so a slow
+            # run points at the right culprit. Providers that can't measure the
+            # command itself simply leave the breakdown out.
+            if result.duration_ms is not None:
+                command_s = result.duration_ms / 1000.0
+                trace["timing"]["command"] = round(command_s, 3)
+                trace["timing"]["overhead"] = round(max(elapsed - command_s, 0.0), 3)
+            trace["stdout"] = result.stdout
+            trace["stderr"] = result.stderr
+            trace["exit_code"] = result.return_code
+            trace["ok"] = result.return_code == 0
+            trace["reason"] = REASON_PASS if result.return_code == 0 else REASON_NONZERO_EXIT
+            if result.error_type:
+                trace["reason"] = REASON_ERROR
+                trace["ok"] = False
+                trace["error_type"] = result.error_type
+            elif result.return_code is not None and result.return_code < 0:
+                # Providers enforce the timeout themselves and report it as an
+                # abnormal (negative) code rather than raising, so a timeout would
+                # otherwise read as an ordinary non-zero exit. Real process exits
+                # are 0-255, so a negative code always means killed, not returned.
+                timed_out = budget is not None and elapsed >= budget * _TIMEOUT_TOLERANCE
+                trace["reason"] = REASON_TIMEOUT if timed_out else REASON_ERROR
+                trace["error"] = (
+                    f"command timed out after {budget}s"
+                    if timed_out
+                    else f"command terminated abnormally (code {result.return_code})"
+                )
+        except asyncio.TimeoutError:
+            trace["reason"] = REASON_TIMEOUT
+            trace["error"] = f"{stage} timed out after {budget}s"
+            if stage == "boot":
+                # A create that times out may already have produced a sandbox on
+                # the provider's side that we never got a handle for, so there is
+                # nothing to tear down here. Say so rather than leak quietly.
+                trace["may_have_orphaned_sandbox"] = True
+                rich.print(
+                    f"[yellow]warning[/yellow] {plan.name}: boot timed out; a sandbox may have been created "
+                    f"without returning a handle and cannot be cleaned up automatically. Check for orphans "
+                    f"with metadata nemo_gym_tool=gym-sandbox-debug."
+                )
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            trace["reason"] = REASON_CANCELLED
+            trace["error"] = "cancelled"
+            raise
+        except Exception as e:
+            trace["reason"] = REASON_ERROR
+            trace["error"] = str(e)
+            trace["error_type"] = type(e).__name__
+        finally:
+            trace["timing"]["total"] = round(time.monotonic() - started, 3)
+            if config.keep and trace["sandbox_id"]:
+                trace["kept"] = True
+                _LIVE_SANDBOXES.discard(sandbox)
+            else:
+                with suppress(Exception):
+                    await asyncio.shield(sandbox.stop())
+                _LIVE_SANDBOXES.discard(sandbox)
+            await write_trace(trace)
+
+    return trace
+
+
+def _print_result(trace: Dict[str, Any], *, quiet: bool) -> None:
+    name = trace["task"]["id"] or f"task-{trace['task']['index']}"
+    if not quiet:
+        for stream in ("stdout", "stderr"):
+            text = trace.get(stream)
+            if text:
+                rich.print(f"[dim]--- {stream} ({name}) ---[/dim]")
+                print(text)
+
+    mark = "[green]✓[/green]" if trace["ok"] else "[red]✗[/red]"
+    detail = f"reason={trace['reason']}"
+    if trace.get("exit_code") is not None:
+        detail += f" exit={trace['exit_code']}"
+    if trace.get("error"):
+        detail += f" error={trace['error']}"
+    timing = trace.get("timing", {})
+    duration = f"{timing.get('total', 0)}s"
+    if "command" in timing:
+        duration += (
+            f" (command {timing['command']}s + overhead {timing.get('overhead', 0)}s, boot {timing.get('boot', 0)}s)"
+        )
+    rich.print(f"{mark} {name}  {detail}  {duration}")
+    if trace.get("kept"):
+        # State the expiry, not just that it was kept: a sandbox you forget about
+        # holds cluster capacity until its TTL, so the deadline is the useful part.
+        ttl = trace.get("ttl_s")
+        expiry = f"expires in {_format_duration(ttl)}" if ttl else "no expiry set"
+        rich.print(
+            f"  [yellow]sandbox {trace['sandbox_id']} left running[/yellow] ({expiry})\n"
+            f"  reattach: gym sandbox exec --sandbox-id {trace['sandbox_id']} --command ...\n"
+            f"  delete:   gym sandbox rm --sandbox-id {trace['sandbox_id']}"
+        )
+
+
+def _format_duration(seconds: float) -> str:
+    """Render a TTL the way a person reads a deadline, not as a raw second count."""
+    seconds = int(seconds)
+    hours, remainder = divmod(seconds, 3600)
+    minutes = remainder // 60
+    if hours and minutes:
+        return f"{hours}h{minutes:02d}m"
+    if hours:
+        return f"{hours}h"
+    if minutes:
+        return f"{minutes}m"
+    return f"{seconds}s"
+
+
+########################################
+# Commands
+########################################
+
+
+def _resolve_server(config: Any, global_config_dict: Any):
+    """Pick the server and read its hooks, without touching the provider.
+
+    Kept separate so read-only work (listing a dataset) needs neither provider
+    credentials nor a provider config on the command line.
+    """
+    servers = discover_sandbox_servers(global_config_dict)
+    server_name, entry = select_server(servers, config.server_name)
+    sandbox_task = dict(entry["config"].get("sandbox_task") or {})
+    return server_name, entry, sandbox_task
+
+
+def _resolve_context(config: Any, global_config_dict: Any):
+    """Shared resolution: pick the server, build its provider, read its hooks."""
+    server_name, entry, sandbox_task = _resolve_server(config, global_config_dict)
+    server_config = entry["config"]
+    provider, provider_config = build_provider(server_config, global_config_dict, config.sandbox_name)
+    return server_name, entry, server_config, provider, provider_config, sandbox_task
+
+
+# Row fields worth showing next to an id, in preference order. Enough to tell two
+# tasks apart without dumping a problem statement into the terminal.
+_TASK_DETAIL_FIELDS = ("repo", "subset", "split", "difficulty", "image_name")
+
+
+def _list_tasks(config: Any, *, entry: Dict[str, Any], sandbox_task: Dict[str, Any], as_json: bool) -> None:
+    """Print the task ids available to `--task`.
+
+    Without this the only way to learn an id is to guess one and read it out of
+    the error, which is a poor way to start.
+    """
+    id_from_row = sandbox_task.get("id_from_row")
+    rows, source = load_rows(
+        config.input_jsonl_fpath,
+        entry=entry,
+        task_ids=[],
+        limit=config.limit,
+        shuffle=config.shuffle,
+        id_from_row=id_from_row,
+        # Listing is about the dataset, so an unfiltered read is the point.
+        require_selection=True,
+    )
+
+    listed = [
+        {
+            "index": index,
+            "id": task_id_for_row(row, id_from_row=id_from_row),
+            **{field: row[field] for field in _TASK_DETAIL_FIELDS if field in row},
+        }
+        for index, row in enumerate(rows)
+    ]
+
+    if as_json:
+        print(json.dumps(listed, indent=2))
+        return
+
+    if not listed:
+        rich.print(f"[yellow]No tasks found in {source}[/yellow]")
+        return
+
+    rich.print(f"[dim]{len(listed)} task(s) in {source}[/dim]")
+    width = max((len(str(item["id"])) for item in listed), default=0)
+    for item in listed:
+        detail = "  ".join(f"{k}={v}" for k, v in item.items() if k not in ("index", "id"))
+        rich.print(f"  [cyan]{str(item['id']).ljust(width)}[/cyan]  [dim]{escape(detail)}[/dim]")
+    rich.print("\n[dim]Run one with --task <id>[/dim]")
+
+
+@exit_cleanly_on_config_error
+def debug() -> None:
+    """Boot a task's sandbox and run a command or script inside it."""
+    global_config_dict = get_global_config_dict(
+        global_config_dict_parser_config=GlobalConfigDictParserConfig(
+            initial_global_config_dict=GlobalConfigDictParserConfig.NO_MODEL_GLOBAL_CONFIG_DICT,
+        ),
+    )
+    config = SandboxDebugConfig.model_validate(global_config_dict)
+    as_json = bool(global_config_dict.get(JSON_OUTPUT_KEY_NAME))
+    _quiet_transport_logs(global_config_dict)
+    _warn_on_long_ttl(config.ttl_s)
+
+    # Listing only reads the dataset, so resolve the server but not the provider:
+    # no provider config, no credentials, no cluster.
+    if config.list_tasks:
+        _, list_entry, list_hooks = _resolve_server(config, global_config_dict)
+        _list_tasks(config, entry=list_entry, sandbox_task=list_hooks, as_json=as_json)
+        return
+
+    server_name, entry, server_config, provider, provider_config, sandbox_task = _resolve_context(
+        config, global_config_dict
+    )
+
+    rows, input_fpath = load_rows(
+        config.input_jsonl_fpath,
+        entry=entry,
+        task_ids=config.task_ids,
+        limit=config.limit,
+        shuffle=config.shuffle,
+        id_from_row=sandbox_task.get("id_from_row"),
+    )
+    default_metadata = provider_default_metadata(server_config, global_config_dict, config.sandbox_name)
+
+    # No row selected means "boot what this server is configured to boot".
+    row_list: List[Optional[Dict[str, Any]]] = list(rows) if rows else [None]
+    plans = [
+        build_plan(
+            index=index,
+            row=row,
+            server_config=server_config,
+            sandbox_task=sandbox_task,
+            default_metadata=default_metadata,
+            config=config,
+        )
+        for index, row in enumerate(row_list)
+    ]
+
+    if config.dry_run:
+        if as_json:
+            print(
+                json.dumps(
+                    [
+                        {
+                            "server": server_name,
+                            "server_type": entry["server_type"],
+                            "provider": next(iter(provider_config), None),
+                            "task_id": plan.task_id,
+                            "image": plan.spec.image,
+                            "image_source": plan.image_source,
+                            "spec_source": plan.spec_source,
+                            "exec": plan.exec_kwargs,
+                            "command": plan.command,
+                        }
+                        for plan in plans
+                    ],
+                    indent=2,
+                )
+            )
+        else:
+            render_dry_run(
+                server_name=server_name,
+                server_type=entry["server_type"],
+                provider_config=provider_config,
+                plans=plans,
+                input_fpath=input_fpath,
+                total_rows=len(row_list),
+            )
+        return
+
+    # Refuse --keep up front on a provider we could not reattach to: the sandbox
+    # would sit there costing capacity with no way to reach or delete it.
+    if config.keep and not isinstance(provider, ConnectableProvider):
+        raise ConfigError(
+            f"--keep needs a provider that can reattach by id, and "
+            f"{getattr(provider, 'name', type(provider).__name__)!r} cannot. Without it the sandbox would "
+            f"be left running with no way to reach or delete it."
+        )
+
+    _install_interrupt_handler()
+    output_dir = Path(config.output_dirpath or Path(_DEFAULT_OUTPUT_ROOT) / f"{server_name}--debug" / uuid.uuid4().hex)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "config.yaml").write_text(_redacted_config_yaml(global_config_dict))
+    traces_path = output_dir / "traces.jsonl"
+    traces_path.write_text("")
+    rich.print(f"[dim]results: {output_dir}/[/dim]")
+
+    write_lock = asyncio.Lock()
+
+    async def write_trace(trace: Dict[str, Any]) -> None:
+        # Serialize whole lines and write off-loop so a cancellation cannot tear
+        # a record in half; a trace line is either complete or absent.
+        line = json.dumps(trace) + "\n"
+        async with write_lock:
+            await asyncio.shield(asyncio.to_thread(_append, traces_path, line))
+
+    provider_name = next(iter(provider_config), "?")
+
+    async def main() -> List[Dict[str, Any]]:
+        semaphore = asyncio.Semaphore(config.concurrency)
+        try:
+            return await asyncio.gather(
+                *(
+                    run_plan(
+                        plan,
+                        # One provider per sandbox: providers own SDK clients, and
+                        # AsyncSandbox.stop() closes the provider it was given.
+                        provider_factory=lambda: create_provider(provider_config),
+                        provider_name=provider_name,
+                        config=config,
+                        semaphore=semaphore,
+                        write_trace=write_trace,
+                    )
+                    for plan in plans
+                ),
+                return_exceptions=True,
+            )
+        finally:
+            # `provider` was built only to test the reattach capability; the run
+            # itself uses per-sandbox providers. Release its client either way.
+            with suppress(Exception):
+                await provider.aclose()
+
+    try:
+        results = asyncio.run(main())
+    except KeyboardInterrupt:  # pragma: no cover - signal path
+        rich.print("[yellow]interrupted[/yellow]")
+        raise SystemExit(130)
+
+    traces = [r for r in results if isinstance(r, dict)]
+    for trace in traces:
+        _print_result(trace, quiet=config.quiet)
+
+    failures = [t for t in traces if not t["ok"]] + [r for r in results if not isinstance(r, dict)]
+    if failures and not config.exit_zero:
+        raise SystemExit(1)
+
+
+def _append(path: Path, line: str) -> None:
+    with open(path, "a") as f:
+        f.write(line)
+
+
+async def _renew(provider, sandbox: AsyncSandbox, ttl_s: float) -> bool:
+    """Push the sandbox's expiry out, if the provider can. Best effort.
+
+    A provider without the capability simply keeps whatever lifetime it was
+    created with; failing the command over an expiry bump would be worse than
+    the shorter lifetime.
+    """
+    if not isinstance(provider, RenewableProvider):
+        return False
+    handle = getattr(sandbox, "_handle", None)
+    if handle is None:
+        return False
+    try:
+        await provider.renew(handle, ttl_s)
+        return True
+    except Exception as e:
+        rich.print(f"[yellow]warning[/yellow] could not extend the sandbox expiry: {e}")
+        return False
+
+
+async def _connect(provider, sandbox_id: str):
+    """Reattach to a running sandbox, or explain why the provider cannot.
+
+    Only providers backed by an external control plane can be reached by id from
+    a fresh process; a provider that keeps its sandboxes in-process has nothing
+    to reconnect to.
+    """
+    if not isinstance(provider, ConnectableProvider):
+        raise ConfigError(
+            f"Provider {getattr(provider, 'name', type(provider).__name__)!r} cannot reattach to an existing "
+            f"sandbox, so `gym sandbox exec` and `gym sandbox rm` are unavailable for it. Use "
+            f"`gym sandbox debug --command ...` instead, which creates its own sandbox."
+        )
+    return await AsyncSandbox.connect({"sandbox_id": sandbox_id}, provider=provider)
+
+
+@exit_cleanly_on_config_error
+def exec_command() -> None:
+    """Run a command in an already-running sandbox."""
+    global_config_dict = get_global_config_dict(
+        global_config_dict_parser_config=GlobalConfigDictParserConfig(
+            initial_global_config_dict=GlobalConfigDictParserConfig.NO_MODEL_GLOBAL_CONFIG_DICT,
+        ),
+    )
+    config = SandboxExecConfig.model_validate(global_config_dict)
+    _quiet_transport_logs(global_config_dict)
+    if not config.sandbox_id:
+        raise ConfigError("--sandbox-id is required.")
+    if not config.command:
+        raise ConfigError("--command is required.")
+
+    _, _, server_config, provider, _, sandbox_task = _resolve_context(config, global_config_dict)
+    exec_kwargs = _exec_kwargs(server_config, config)
+    command, _ = wrap_command(config.command, sandbox_task=sandbox_task, exec_kwargs=exec_kwargs, bare=config.bare)
+
+    # Bump the expiry before running rather than after, so the command has a full
+    # window and a sandbox stays alive for as long as it is being used — a short
+    # lifetime plus renewal beats a long lifetime nobody remembers to clean up.
+    ttl_s = config.ttl_s if config.ttl_s is not None else DEFAULT_TTL_S
+    renew_s = max(ttl_s, (config.timeout_total or 0) + 60)
+
+    async def main():
+        sandbox = await _connect(provider, config.sandbox_id)
+        renewed = await _renew(provider, sandbox, renew_s)
+        try:
+            return await sandbox.exec(
+                command,
+                cwd=exec_kwargs.get("cwd"),
+                user=exec_kwargs.get("user"),
+                timeout_s=config.timeout_total,
+            ), renewed
+        finally:
+            # Detach without killing: the sandbox outlives this command by design.
+            with suppress(Exception):
+                await provider.aclose()
+
+    result, renewed = asyncio.run(main())
+    if not config.quiet:
+        for text in (result.stdout, result.stderr):
+            if text:
+                print(text)
+
+    detail = f"exit={result.return_code}"
+    if result.duration_ms is not None:
+        detail += f"  command {round(result.duration_ms / 1000.0, 3)}s"
+    if renewed:
+        detail += f"  expires in {_format_duration(renew_s)}"
+    mark = "[green]✓[/green]" if result.return_code == 0 else "[red]✗[/red]"
+    rich.print(f"{mark} {config.sandbox_id}  {detail}")
+
+    if result.return_code != 0 and not config.exit_zero:
+        raise SystemExit(result.return_code or 1)
+
+
+@exit_cleanly_on_config_error
+def rm() -> None:
+    """Delete a running sandbox."""
+    global_config_dict = get_global_config_dict(
+        global_config_dict_parser_config=GlobalConfigDictParserConfig(
+            initial_global_config_dict=GlobalConfigDictParserConfig.NO_MODEL_GLOBAL_CONFIG_DICT,
+        ),
+    )
+    config = SandboxExecConfig.model_validate(global_config_dict)
+    _quiet_transport_logs(global_config_dict)
+    if not config.sandbox_id:
+        raise ConfigError("--sandbox-id is required.")
+
+    _, _, _, provider, _, _ = _resolve_context(config, global_config_dict)
+
+    async def main():
+        sandbox = await _connect(provider, config.sandbox_id)
+        await sandbox.stop()
+
+    asyncio.run(main())
+    rich.print(f"[green]✓[/green] deleted sandbox {config.sandbox_id}")

--- a/tests/unit_tests/test_cli_main.py
+++ b/tests/unit_tests/test_cli_main.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import importlib
 import logging
 import os
 import sys
@@ -1276,3 +1277,114 @@ class TestListEnvironmentsRouting:
         target, overrides = _dispatch_for(monkeypatch, ["list", "environments", "calendar"])
         assert target == "nemo_gym.cli.env:list_environments"
         assert overrides == ["+component_name=calendar"]
+
+
+class TestSandboxFlags:
+    """`gym sandbox` routing: argparse flags -> Hydra overrides."""
+
+    def test_debug_routes_with_config_and_task(self, monkeypatch: MonkeyPatch) -> None:
+        target, overrides = _dispatch_for(
+            monkeypatch,
+            ["sandbox", "debug", "--config", "a.yaml", "--task", "t1", "--command", "ls"],
+        )
+        assert target == "nemo_gym.cli.sandbox:debug"
+        paths, others = _split_overrides(overrides)
+        assert paths == {"a.yaml"}
+        assert others == {'+task_ids=["t1"]', '+command="ls"'}
+
+    def test_repeated_task_becomes_one_list(self, monkeypatch: MonkeyPatch) -> None:
+        _, overrides = _dispatch_for(monkeypatch, ["sandbox", "debug", "--task", "t1", "--task", "t2", "--dry-run"])
+        _, others = _split_overrides(overrides)
+        assert '+task_ids=["t1","t2"]' in others
+
+    def test_repeated_env_becomes_one_list(self, monkeypatch: MonkeyPatch) -> None:
+        _, overrides = _dispatch_for(
+            monkeypatch, ["sandbox", "debug", "--env", "A=1", "--env", "B=2", "--command", "ls"]
+        )
+        _, others = _split_overrides(overrides)
+        assert '+env=["A=1","B=2"]' in others
+
+    def test_bool_flags_translate(self, monkeypatch: MonkeyPatch) -> None:
+        _, overrides = _dispatch_for(monkeypatch, ["sandbox", "debug", "--dry-run", "--bare", "--keep", "--shuffle"])
+        _, others = _split_overrides(overrides)
+        assert others == {"+dry_run=true", "+bare=true", "+keep=true", "+shuffle=true"}
+
+    def test_unset_flags_contribute_nothing(self, monkeypatch: MonkeyPatch) -> None:
+        _, overrides = _dispatch_for(monkeypatch, ["sandbox", "debug", "--dry-run"])
+        assert overrides == ["+dry_run=true"]
+
+    def test_server_and_sandbox_selectors(self, monkeypatch: MonkeyPatch) -> None:
+        _, overrides = _dispatch_for(
+            monkeypatch, ["sandbox", "debug", "--server", "s1", "--sandbox", "sbx", "--dry-run"]
+        )
+        _, others = _split_overrides(overrides)
+        assert "+server_name=s1" in others
+        assert "+sandbox_name=sbx" in others
+
+    def test_input_alias(self, monkeypatch: MonkeyPatch) -> None:
+        _, overrides = _dispatch_for(monkeypatch, ["sandbox", "debug", "-i", "rows.jsonl", "--dry-run"])
+        _, others = _split_overrides(overrides)
+        assert '+input_jsonl_fpath="rows.jsonl"' in others
+
+    def test_output_dir_alias(self, monkeypatch: MonkeyPatch) -> None:
+        _, overrides = _dispatch_for(monkeypatch, ["sandbox", "debug", "-o", "out/", "--command", "ls"])
+        _, others = _split_overrides(overrides)
+        assert '+output_dirpath="out/"' in others
+
+    def test_exec_routes(self, monkeypatch: MonkeyPatch) -> None:
+        target, overrides = _dispatch_for(monkeypatch, ["sandbox", "exec", "--sandbox-id", "abc", "--command", "ls"])
+        assert target == "nemo_gym.cli.sandbox:exec_command"
+        _, others = _split_overrides(overrides)
+        assert others == {'+sandbox_id="abc"', '+command="ls"'}
+
+    def test_rm_routes(self, monkeypatch: MonkeyPatch) -> None:
+        target, overrides = _dispatch_for(monkeypatch, ["sandbox", "rm", "--sandbox-id", "abc"])
+        assert target == "nemo_gym.cli.sandbox:rm"
+        assert overrides == ['+sandbox_id="abc"']
+
+    def test_rm_rejects_command_flag(self, monkeypatch: MonkeyPatch) -> None:
+        # `sandbox rm` does not take --command; the router must reject it rather than leak it downstream.
+        monkeypatch.setattr(cli_main, "dispatch", lambda target, overrides: None)
+        monkeypatch.setattr(sys, "argv", ["gym", "sandbox", "rm", "--sandbox-id", "a", "--command", "ls"])
+        with pytest.raises(SystemExit):
+            main()
+
+    def test_targets_are_importable(self) -> None:
+        # A typo'd target string only surfaces at dispatch time, which is too late.
+        for name in ("sandbox debug", "sandbox exec", "sandbox rm"):
+            module_path, func_name = cli_main.COMMANDS[name].target.split(":")
+            assert callable(getattr(importlib.import_module(module_path), func_name))
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "python -c 'import django; print(django.__version__)'",
+            'python -c "print(1)"',
+            "pytest -k 'a or b' --tb=short",
+            "ls [abc]",
+            "echo a,b",
+            "grep -r 'x' . | wc -l",
+            r"printf 'a\\tb'",
+            "echo $HOME && ls",
+            "sed -i 's/a/b/g' f.txt",
+            'python -c "print(1)"',
+        ],
+    )
+    def test_command_with_shell_syntax_is_hydra_safe(self, monkeypatch: MonkeyPatch, command) -> None:
+        # A debug command is arbitrary shell, so it collides with Hydra's override grammar: quotes,
+        # brackets and commas are all syntax there. The emitted override must parse AND round-trip
+        # back to exactly what was typed, or the sandbox runs a different command than you asked for.
+        _, overrides = _dispatch_for(monkeypatch, ["sandbox", "debug", "--command", command])
+        parsed = OverridesParser.create().parse_overrides(overrides)[0]
+        assert parsed.value() == command
+
+    def test_task_ids_with_special_chars_round_trip(self, monkeypatch: MonkeyPatch) -> None:
+        _, overrides = _dispatch_for(monkeypatch, ["sandbox", "debug", "--task", "a,b", "--dry-run"])
+        token = next(o for o in overrides if o.startswith("+task_ids="))
+        assert OverridesParser.create().parse_overrides([token])[0].value() == ["a,b"]
+
+    def test_command_that_cannot_be_encoded_is_refused_not_mangled(self, monkeypatch: MonkeyPatch) -> None:
+        # A value containing both quote characters with a backslash before one of them cannot be
+        # encoded (Hydra unescapes \" but not \\). Refusing beats silently running something else.
+        with pytest.raises(SystemExit):
+            _dispatch_for(monkeypatch, ["sandbox", "debug", "--command", 'echo "a\\"b" \'c\''])

--- a/tests/unit_tests/test_cli_sandbox.py
+++ b/tests/unit_tests/test_cli_sandbox.py
@@ -1,0 +1,1165 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `gym sandbox`.
+
+Everything runs against an in-process fake provider, so the suite exercises the
+real resolution and runner code without a container runtime. Both server kinds
+are covered: the design's whole claim is that an agent and a resources server
+are treated alike, so that is asserted rather than assumed.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from omegaconf import OmegaConf
+
+import nemo_gym.cli.sandbox as cli_sandbox
+from nemo_gym.config_types import ConfigError
+from nemo_gym.sandbox import SandboxSpec, register_provider
+from nemo_gym.sandbox.hooks import (
+    spec_from_mapping,
+)
+from nemo_gym.sandbox.providers.base import SandboxExecResult, SandboxHandle, SandboxStatus
+
+
+########################################
+# Fake provider
+########################################
+
+
+class RecordingProvider:
+    """Provider that records what it was asked to do and never leaves the process."""
+
+    name = "recording"
+    instances: list["RecordingProvider"] = []
+
+    def __init__(self, exit_code: int = 0, fail_create: bool = False, connectable: bool = True, **_: Any) -> None:
+        # Real providers are constructed from their YAML config block, so accept
+        # and ignore arbitrary provider settings the way they do.
+        self.exit_code = exit_code
+        self.fail_create = fail_create
+        self.connectable = connectable
+        self.created_specs: list[SandboxSpec] = []
+        self.exec_calls: list[dict[str, Any]] = []
+        self.uploads: list[tuple[Path, str]] = []
+        self.closed: list[str] = []
+        RecordingProvider.instances.append(self)
+
+    async def create(self, spec: SandboxSpec) -> SandboxHandle:
+        if self.fail_create:
+            raise RuntimeError("image pull failed")
+        self.created_specs.append(spec)
+        return SandboxHandle(sandbox_id="sbx-1", provider_name=self.name, raw={})
+
+    async def exec(self, handle, command, *, cwd=None, env=None, timeout_s=None, user=None) -> SandboxExecResult:
+        self.exec_calls.append({"command": command, "cwd": cwd, "user": user, "timeout_s": timeout_s})
+        return SandboxExecResult(stdout="hello", stderr=None, return_code=self.exit_code)
+
+    async def upload_file(self, handle, source_path: Path, target_path: str) -> None:
+        self.uploads.append((source_path, target_path))
+
+    async def download_file(self, handle, source_path: str, target_path: Path) -> None:
+        target_path.write_bytes(b"")
+
+    async def status(self, handle) -> SandboxStatus:
+        return SandboxStatus.RUNNING
+
+    async def close(self, handle) -> None:
+        self.closed.append(handle.sandbox_id)
+
+    async def aclose(self) -> None:
+        return None
+
+    # Connect capability, so --keep / exec / rm are exercisable.
+    async def serialize_handle(self, handle, *, scope=None) -> dict[str, Any]:
+        if not self.connectable:
+            raise RuntimeError("not connectable")
+        return {"sandbox_id": handle.sandbox_id}
+
+    async def connect(self, descriptor) -> SandboxHandle:
+        return SandboxHandle(sandbox_id=str(descriptor["sandbox_id"]), provider_name=self.name, raw={})
+
+
+class UnconnectableProvider(RecordingProvider):
+    """A provider with no way back to a sandbox once this process exits."""
+
+    name = "unconnectable"
+
+    serialize_handle = None  # type: ignore[assignment]
+    connect = None  # type: ignore[assignment]
+
+
+@pytest.fixture(autouse=True)
+def _register_fakes():
+    RecordingProvider.instances.clear()
+    for name, cls in (("recording", RecordingProvider), ("unconnectable", UnconnectableProvider)):
+        register_provider(name, cls, override=True)
+    yield
+    RecordingProvider.instances.clear()
+
+
+########################################
+# Config fixtures
+########################################
+
+AGENT_CONFIG = {
+    "swe_like": {
+        "responses_api_agents": {
+            "swe_like": {
+                "entrypoint": "app.py",
+                "host": "127.0.0.1",
+                "port": 10001,
+                "sandbox_provider": {"recording": {}},
+                "sandbox_spec": {
+                    "ttl_s": 900,
+                    "resources": {"cpu": 2, "memory_mib": 4096},
+                    "metadata": {"benchmark": "demo"},
+                },
+                "sandbox_environment_kwargs": {"cwd": "/testbed", "user": "root", "conda_env": "testbed"},
+                "sandbox_task": {
+                    "id_from_row": "instance_id",
+                    "image_from_row": "image_name",
+                },
+            }
+        }
+    }
+}
+
+RESOURCES_SERVER_CONFIG = {
+    "tool_host": {
+        "resources_servers": {
+            "tool_host": {
+                "entrypoint": "app.py",
+                "domain": "knowledge",
+                "host": "127.0.0.1",
+                "port": 10002,
+                "sandbox_provider": {"recording": {}},
+                # Fully declarative: no hooks, no row — the Layer-0/1 path.
+                "sandbox_spec": {"image": "docker.io/library/python:3.12-slim", "workdir": "/tmp"},
+            }
+        }
+    }
+}
+
+
+def _config(*blocks: dict, **overrides: Any):
+    merged: dict[str, Any] = {}
+    for block in blocks:
+        merged.update(block)
+    merged.update(overrides)
+    return OmegaConf.create(merged)
+
+
+def _rows(tmp_path: Path, rows: list[dict]) -> str:
+    fpath = tmp_path / "tasks.jsonl"
+    fpath.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return str(fpath)
+
+
+def _run_debug(monkeypatch, config, **cli):
+    """Drive `gym sandbox debug` with a merged config, as the router would."""
+    merged = _config(config, **cli) if isinstance(config, dict) else config
+    for key, value in cli.items():
+        merged[key] = value
+    monkeypatch.setattr(cli_sandbox, "get_global_config_dict", lambda **k: merged)
+    return cli_sandbox.debug()
+
+
+def _expect_error(capsys, fragment: str, fn, *args, **kwargs) -> None:
+    """Assert a command exits non-zero having printed `fragment`.
+
+    The CLI entrypoints wrap `ConfigError` into a rendered message plus
+    `SystemExit(1)`, so asserting on the message is both what the caller
+    actually sees and the thing worth pinning. Rich hard-wraps its output, so
+    whitespace is collapsed before matching.
+    """
+    with pytest.raises(SystemExit) as excinfo:
+        fn(*args, **kwargs)
+    assert excinfo.value.code == 1
+    printed = " ".join(capsys.readouterr().out.split())
+    assert fragment in printed, printed
+
+
+########################################
+# hooks: spec_from_mapping
+########################################
+
+
+def test_spec_from_mapping_reads_every_field() -> None:
+    spec = spec_from_mapping(
+        {
+            "image": "img:1",
+            "ttl_s": 60,
+            "ready_timeout_s": 30,
+            "workdir": "/w",
+            "env": {"A": "1"},
+            "files": {"/f": "x"},
+            "metadata": {"m": "v"},
+            "resources": {"cpu": 2, "memory_mib": 512},
+            "entrypoint": ["sleep", "1"],
+            "provider_options": {"p": 1},
+        }
+    )
+    assert spec.image == "img:1"
+    assert spec.ttl_s == 60 and spec.ready_timeout_s == 30 and spec.workdir == "/w"
+    assert spec.env == {"A": "1"} and spec.files == {"/f": "x"} and spec.metadata == {"m": "v"}
+    assert spec.resources.cpu == 2 and spec.resources.memory_mib == 512
+    assert spec.entrypoint == ["sleep", "1"] and spec.provider_options == {"p": 1}
+
+
+def test_spec_from_mapping_applies_image_rewrites() -> None:
+    """A mirrored registry should be transparent to whoever named the image."""
+    spec = spec_from_mapping(
+        {"image": "docker.io/library/python:3.12", "image_rewrites": [{"from": "docker.io/", "to": "mirror/"}]}
+    )
+    assert spec.image == "mirror/library/python:3.12"
+
+
+def test_spec_from_mapping_rejects_unknown_keys() -> None:
+    """A typo'd spec key is otherwise invisible until the sandbox misbehaves."""
+    with pytest.raises(ValueError, match="Unknown sandbox_spec keys: workdirr"):
+        spec_from_mapping({"image": "img", "workdirr": "/w"})
+
+
+def test_spec_from_mapping_handles_empty() -> None:
+    assert spec_from_mapping(None).image is None
+
+
+########################################
+# hooks: load_hook
+########################################
+
+
+@pytest.mark.parametrize(
+    "reference, match",
+    [
+        ("json.dumps", "must be of the form"),
+        ("nemo_gym_missing_module_xyz:thing", "could not be imported"),
+        ("json:not_a_real_attribute", "not found"),
+        ("json:__doc__", "not callable"),
+    ],
+)
+########################################
+# hooks: id + spec resolution
+########################################
+
+
+def _resolver(row, server_config):
+    return SandboxSpec(image=f"resolved-{(row or {}).get('instance_id', 'none')}")
+
+
+def _boom(row, server_config):
+    raise ValueError("nope")
+
+
+########################################
+# hooks: command wrapping
+########################################
+
+
+def _upper_wrapper(command, **kwargs):
+    return f"WRAPPED({command})"
+
+
+########################################
+# Server discovery
+########################################
+
+
+def test_discovers_agents_and_resources_servers_alike() -> None:
+    """`sandbox_provider` is the marker, not the server kind."""
+    servers = cli_sandbox.discover_sandbox_servers(_config(AGENT_CONFIG, RESOURCES_SERVER_CONFIG))
+    assert set(servers) == {"swe_like", "tool_host"}
+    assert servers["swe_like"]["server_type"] == "responses_api_agents"
+    assert servers["tool_host"]["server_type"] == "resources_servers"
+
+
+def test_ignores_blocks_without_a_sandbox() -> None:
+    config = _config({"plain": {"responses_api_models": {"plain": {"entrypoint": "app.py"}}}})
+    assert cli_sandbox.discover_sandbox_servers(config) == {}
+
+
+def test_select_server_infers_when_unambiguous() -> None:
+    servers = cli_sandbox.discover_sandbox_servers(_config(AGENT_CONFIG))
+    assert cli_sandbox.select_server(servers, None)[0] == "swe_like"
+
+
+def test_select_server_requires_a_choice_when_ambiguous() -> None:
+    servers = cli_sandbox.discover_sandbox_servers(_config(AGENT_CONFIG, RESOURCES_SERVER_CONFIG))
+    with pytest.raises(ConfigError, match="Pick one with --server"):
+        cli_sandbox.select_server(servers, None)
+
+
+def test_select_server_reports_unknown_name() -> None:
+    servers = cli_sandbox.discover_sandbox_servers(_config(AGENT_CONFIG))
+    with pytest.raises(ConfigError, match="Unknown server"):
+        cli_sandbox.select_server(servers, "nope")
+
+
+def test_no_sandbox_server_is_actionable() -> None:
+    with pytest.raises(ConfigError, match="declaring `sandbox_provider`"):
+        cli_sandbox.select_server({}, None)
+
+
+########################################
+# debug: dry run
+########################################
+
+
+def test_dry_run_resolves_without_creating_a_sandbox(monkeypatch, tmp_path, capsys) -> None:
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    _run_debug(monkeypatch, AGENT_CONFIG, input_jsonl_fpath=rows, dry_run=True)
+    out = capsys.readouterr().out
+    assert "img:a" in out and "task-a" in out
+    assert not RecordingProvider.instances or not RecordingProvider.instances[0].created_specs
+
+
+def test_dry_run_json_output(monkeypatch, tmp_path, capsys) -> None:
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    _run_debug(monkeypatch, AGENT_CONFIG, input_jsonl_fpath=rows, dry_run=True, json=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["image"] == "img:a"
+    assert payload[0]["task_id"] == "task-a"
+    assert payload[0]["server_type"] == "responses_api_agents"
+
+
+def test_resources_server_needs_no_row_or_hooks(monkeypatch, capsys) -> None:
+    """The Layer-0/1 path: a resources server with a declarative spec and no dataset."""
+    _run_debug(monkeypatch, RESOURCES_SERVER_CONFIG, dry_run=True, command="python -V")
+    out = capsys.readouterr().out
+    assert "docker.io/library/python:3.12-slim" in out
+    assert "booting the server's configured sandbox" in out
+
+
+########################################
+# debug: execution
+########################################
+
+
+def test_runs_command_and_writes_a_trace(monkeypatch, tmp_path) -> None:
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    out_dir = tmp_path / "out"
+    _run_debug(
+        monkeypatch,
+        AGENT_CONFIG,
+        input_jsonl_fpath=rows,
+        command="echo hi",
+        output_dirpath=str(out_dir),
+    )
+
+    provider = RecordingProvider.instances[-1]
+    assert provider.exec_calls[0]["command"] == "echo hi"
+    # Exec defaults come from sandbox_environment_kwargs.
+    assert provider.exec_calls[0]["cwd"] == "/testbed"
+    assert provider.exec_calls[0]["user"] == "root"
+    # The sandbox is torn down even on the happy path.
+    assert provider.closed == ["sbx-1"]
+
+    traces = [json.loads(line) for line in (out_dir / "traces.jsonl").read_text().splitlines()]
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace["ok"] is True and trace["reason"] == "pass" and trace["exit_code"] == 0
+    assert trace["image"] == "img:a" and trace["sandbox_id"] == "sbx-1"
+    assert trace["stdout"] == "hello"
+    assert set(trace["timing"]) >= {"boot", "setup", "exec", "total"}
+    # The resolved config is re-runnable via --config.
+    assert (out_dir / "config.yaml").exists()
+
+
+def test_nonzero_exit_is_classified_and_propagates(monkeypatch, tmp_path) -> None:
+    """A failing command must fail the process — this is what makes it CI-usable."""
+    register_provider("recording", lambda **k: RecordingProvider(exit_code=3), override=True)
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    with pytest.raises(SystemExit) as excinfo:
+        _run_debug(
+            monkeypatch,
+            AGENT_CONFIG,
+            input_jsonl_fpath=rows,
+            command="false",
+            output_dirpath=str(tmp_path / "out"),
+        )
+    assert excinfo.value.code == 1
+    trace = json.loads((tmp_path / "out" / "traces.jsonl").read_text().splitlines()[0])
+    assert trace["reason"] == "nonzero_exit" and trace["exit_code"] == 3 and trace["ok"] is False
+
+
+def test_exit_zero_suppresses_failure_exit(monkeypatch, tmp_path) -> None:
+    register_provider("recording", lambda **k: RecordingProvider(exit_code=3), override=True)
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    _run_debug(
+        monkeypatch,
+        AGENT_CONFIG,
+        input_jsonl_fpath=rows,
+        command="false",
+        output_dirpath=str(tmp_path / "out"),
+        exit_zero=True,
+    )
+
+
+def test_create_failure_is_recorded_not_raised(monkeypatch, tmp_path) -> None:
+    """A boot failure should read as a result, not a traceback."""
+    register_provider("recording", lambda **k: RecordingProvider(fail_create=True), override=True)
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    with pytest.raises(SystemExit):
+        _run_debug(
+            monkeypatch,
+            AGENT_CONFIG,
+            input_jsonl_fpath=rows,
+            command="echo hi",
+            output_dirpath=str(tmp_path / "out"),
+        )
+    trace = json.loads((tmp_path / "out" / "traces.jsonl").read_text().splitlines()[0])
+    assert trace["reason"] == "error" and "image pull failed" in trace["error"]
+    assert trace["sandbox_id"] is None
+
+
+def test_script_path_is_uploaded_outside_the_workdir(monkeypatch, tmp_path) -> None:
+    """The script must not land in the state being inspected."""
+    script = tmp_path / "poke.sh"
+    script.write_text("#!/bin/sh\necho poked\n")
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    _run_debug(
+        monkeypatch,
+        AGENT_CONFIG,
+        input_jsonl_fpath=rows,
+        script_path=str(script),
+        output_dirpath=str(tmp_path / "out"),
+    )
+    provider = RecordingProvider.instances[-1]
+    (_, remote) = provider.uploads[0]
+    assert remote.startswith("/tmp/") and remote.endswith("poke.sh")
+    assert remote in provider.exec_calls[0]["command"]
+    assert "chmod +x" in provider.exec_calls[0]["command"]
+
+
+def test_image_flag_overrides_everything(monkeypatch, tmp_path) -> None:
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    _run_debug(
+        monkeypatch,
+        AGENT_CONFIG,
+        input_jsonl_fpath=rows,
+        command="echo hi",
+        image="override:1",
+        output_dirpath=str(tmp_path / "out"),
+    )
+    assert RecordingProvider.instances[-1].created_specs[0].image == "override:1"
+
+
+def test_missing_image_is_actionable(monkeypatch, tmp_path, capsys) -> None:
+    rows = _rows(tmp_path, [{"instance_id": "task-a"}])
+    _expect_error(
+        capsys,
+        "Could not determine a container image",
+        _run_debug,
+        monkeypatch,
+        AGENT_CONFIG,
+        input_jsonl_fpath=rows,
+        command="echo hi",
+    )
+
+
+def test_env_flag_merges_into_spec(monkeypatch, tmp_path) -> None:
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    _run_debug(
+        monkeypatch,
+        AGENT_CONFIG,
+        input_jsonl_fpath=rows,
+        command="echo hi",
+        env=["FOO=bar"],
+        output_dirpath=str(tmp_path / "out"),
+    )
+    assert RecordingProvider.instances[-1].created_specs[0].env["FOO"] == "bar"
+
+
+def test_malformed_env_flag_is_rejected(monkeypatch, tmp_path, capsys) -> None:
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    _expect_error(
+        capsys,
+        "--env expects KEY=VALUE",
+        _run_debug,
+        monkeypatch,
+        AGENT_CONFIG,
+        input_jsonl_fpath=rows,
+        command="echo hi",
+        env=["FOO"],
+    )
+
+
+########################################
+# debug: row selection
+########################################
+
+
+def test_task_selection_filters_rows(monkeypatch, tmp_path, capsys) -> None:
+    rows = _rows(
+        tmp_path,
+        [
+            {"instance_id": "task-a", "image_name": "img:a"},
+            {"instance_id": "task-b", "image_name": "img:b"},
+        ],
+    )
+    _run_debug(monkeypatch, AGENT_CONFIG, input_jsonl_fpath=rows, task_ids=["task-b"], dry_run=True)
+    out = capsys.readouterr().out
+    assert "task-b" in out and "task-a" not in out
+
+
+def test_unknown_task_lists_what_is_available(monkeypatch, tmp_path, capsys) -> None:
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    _expect_error(
+        capsys,
+        "Available ids: task-a",
+        _run_debug,
+        monkeypatch,
+        AGENT_CONFIG,
+        input_jsonl_fpath=rows,
+        task_ids=["nope"],
+        dry_run=True,
+    )
+
+
+def test_limit_caps_the_number_of_tasks(monkeypatch, tmp_path) -> None:
+    rows = _rows(tmp_path, [{"instance_id": f"t{i}", "image_name": f"img:{i}"} for i in range(5)])
+    _run_debug(
+        monkeypatch,
+        AGENT_CONFIG,
+        input_jsonl_fpath=rows,
+        command="echo hi",
+        limit=2,
+        output_dirpath=str(tmp_path / "out"),
+    )
+    traces = (tmp_path / "out" / "traces.jsonl").read_text().splitlines()
+    assert len(traces) == 2
+
+
+def test_missing_input_file_is_actionable(monkeypatch, tmp_path, capsys) -> None:
+    _expect_error(
+        capsys,
+        "Input file not found",
+        _run_debug,
+        monkeypatch,
+        AGENT_CONFIG,
+        input_jsonl_fpath=str(tmp_path / "nope.jsonl"),
+        dry_run=True,
+    )
+
+
+def test_malformed_jsonl_names_the_line(monkeypatch, tmp_path, capsys) -> None:
+    fpath = tmp_path / "bad.jsonl"
+    fpath.write_text('{"instance_id": "a"}\nnot json\n')
+    _expect_error(
+        capsys,
+        "at line 2",
+        _run_debug,
+        monkeypatch,
+        AGENT_CONFIG,
+        input_jsonl_fpath=str(fpath),
+        dry_run=True,
+    )
+
+
+########################################
+# debug: --keep
+########################################
+
+
+def test_keep_leaves_the_sandbox_running(monkeypatch, tmp_path) -> None:
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    _run_debug(
+        monkeypatch,
+        AGENT_CONFIG,
+        input_jsonl_fpath=rows,
+        command="echo hi",
+        keep=True,
+        output_dirpath=str(tmp_path / "out"),
+    )
+    provider = RecordingProvider.instances[-1]
+    assert provider.closed == []
+    trace = json.loads((tmp_path / "out" / "traces.jsonl").read_text().splitlines()[0])
+    assert trace["kept"] is True and trace["sandbox_id"] == "sbx-1"
+
+
+def test_keep_is_refused_when_the_sandbox_could_not_be_reached_again(monkeypatch, tmp_path, capsys) -> None:
+    """Keeping a sandbox you cannot reattach to just leaks capacity."""
+    config = json.loads(json.dumps(AGENT_CONFIG))
+    config["swe_like"]["responses_api_agents"]["swe_like"]["sandbox_provider"] = {"unconnectable": {}}
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    _expect_error(
+        capsys,
+        "--keep needs a provider that can reattach",
+        _run_debug,
+        monkeypatch,
+        config,
+        input_jsonl_fpath=rows,
+        command="echo hi",
+        keep=True,
+    )
+
+
+########################################
+# exec / rm
+########################################
+
+
+def test_exec_reattaches_and_runs(monkeypatch, capsys) -> None:
+    merged = _config(AGENT_CONFIG, sandbox_id="sbx-9", command="git log -1")
+    monkeypatch.setattr(cli_sandbox, "get_global_config_dict", lambda **k: merged)
+    cli_sandbox.exec_command()
+    provider = RecordingProvider.instances[-1]
+    assert provider.exec_calls[0]["command"] == "git log -1"
+    assert "hello" in capsys.readouterr().out
+
+
+def test_exec_requires_a_sandbox_id(monkeypatch, capsys) -> None:
+    merged = _config(AGENT_CONFIG, command="ls")
+    monkeypatch.setattr(cli_sandbox, "get_global_config_dict", lambda **k: merged)
+    _expect_error(capsys, "--sandbox-id is required", cli_sandbox.exec_command)
+
+
+def test_exec_explains_providers_that_cannot_reattach(monkeypatch, capsys) -> None:
+    config = json.loads(json.dumps(AGENT_CONFIG))
+    config["swe_like"]["responses_api_agents"]["swe_like"]["sandbox_provider"] = {"unconnectable": {}}
+    merged = _config(config, sandbox_id="sbx-9", command="ls")
+    monkeypatch.setattr(cli_sandbox, "get_global_config_dict", lambda **k: merged)
+    _expect_error(capsys, "cannot reattach", cli_sandbox.exec_command)
+
+
+def test_rm_deletes_the_sandbox(monkeypatch, capsys) -> None:
+    merged = _config(AGENT_CONFIG, sandbox_id="sbx-9")
+    monkeypatch.setattr(cli_sandbox, "get_global_config_dict", lambda **k: merged)
+    cli_sandbox.rm()
+    assert RecordingProvider.instances[-1].closed == ["sbx-9"]
+    assert "deleted sandbox sbx-9" in capsys.readouterr().out
+
+
+def test_rm_requires_a_sandbox_id(monkeypatch, capsys) -> None:
+    merged = _config(AGENT_CONFIG)
+    monkeypatch.setattr(cli_sandbox, "get_global_config_dict", lambda **k: merged)
+    _expect_error(capsys, "--sandbox-id is required", cli_sandbox.rm)
+
+
+########################################
+# Config validation
+########################################
+
+
+def test_requires_an_action() -> None:
+    with pytest.raises(ValueError, match=r"pass --command, --script-path, --dry-run, or --list-tasks"):
+        cli_sandbox.SandboxDebugConfig.model_validate({})
+
+
+def test_rejects_two_actions() -> None:
+    with pytest.raises(ValueError, match="at most one of --command or --script-path"):
+        cli_sandbox.SandboxDebugConfig.model_validate({"command": "ls", "script_path": "x"})
+
+
+def test_dry_run_allows_a_command() -> None:
+    """--dry-run is a modifier: showing how a command would be wrapped is the point."""
+    config = cli_sandbox.SandboxDebugConfig.model_validate({"dry_run": True, "command": "ls"})
+    assert config.command == "ls"
+
+
+def test_rejects_missing_script(tmp_path) -> None:
+    with pytest.raises(ValueError, match="--script-path is not a file"):
+        cli_sandbox.SandboxDebugConfig.model_validate({"script_path": str(tmp_path / "nope.sh")})
+
+
+def test_rejects_bad_concurrency() -> None:
+    with pytest.raises(ValueError, match="--concurrency must be >= 1"):
+        cli_sandbox.SandboxDebugConfig.model_validate({"command": "ls", "concurrency": 0})
+
+
+########################################
+# Timeout classification
+########################################
+
+
+class TimingOutProvider(RecordingProvider):
+    """Provider that enforces its own timeout, reporting it as a negative code.
+
+    This is what OpenSandbox actually does: `exec` returns rather than raising,
+    with a code no real process could produce.
+    """
+
+    name = "timing_out"
+
+    async def exec(self, handle, command, *, cwd=None, env=None, timeout_s=None, user=None) -> SandboxExecResult:
+        self.exec_calls.append({"command": command, "cwd": cwd, "user": user, "timeout_s": timeout_s})
+        if timeout_s:
+            await asyncio.sleep(timeout_s)
+        return SandboxExecResult(stdout=None, stderr="CommandExecError: -1", return_code=-1)
+
+
+def _timing_out_config() -> dict:
+    config = json.loads(json.dumps(AGENT_CONFIG))
+    config["swe_like"]["responses_api_agents"]["swe_like"]["sandbox_provider"] = {"timing_out": {}}
+    return config
+
+
+def test_provider_enforced_timeout_is_not_reported_as_a_plain_failure(monkeypatch, tmp_path) -> None:
+    """A negative code after the budget elapsed is a timeout, not a non-zero exit.
+
+    Providers enforce the timeout themselves and return instead of raising, so
+    without this the run reads as "your command failed" when it never finished.
+    """
+    register_provider("timing_out", TimingOutProvider, override=True)
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    with pytest.raises(SystemExit):
+        _run_debug(
+            monkeypatch,
+            _timing_out_config(),
+            input_jsonl_fpath=rows,
+            command="sleep 60",
+            timeout_total=0.05,
+            output_dirpath=str(tmp_path / "out"),
+        )
+    trace = json.loads((tmp_path / "out" / "traces.jsonl").read_text().splitlines()[0])
+    assert trace["reason"] == "timeout"
+    assert "timed out after 0.05s" in trace["error"]
+
+
+class AbnormalExitProvider(RecordingProvider):
+    """Returns a negative code immediately — killed, but not by our timeout."""
+
+    name = "abnormal"
+
+    async def exec(self, handle, command, *, cwd=None, env=None, timeout_s=None, user=None) -> SandboxExecResult:
+        self.exec_calls.append({"command": command})
+        return SandboxExecResult(stdout=None, stderr=None, return_code=-9)
+
+
+def test_negative_code_well_inside_the_budget_is_an_error_not_a_timeout(monkeypatch, tmp_path) -> None:
+    register_provider("abnormal", AbnormalExitProvider, override=True)
+    config = json.loads(json.dumps(AGENT_CONFIG))
+    config["swe_like"]["responses_api_agents"]["swe_like"]["sandbox_provider"] = {"abnormal": {}}
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    with pytest.raises(SystemExit):
+        _run_debug(
+            monkeypatch,
+            config,
+            input_jsonl_fpath=rows,
+            command="boom",
+            timeout_total=600.0,
+            output_dirpath=str(tmp_path / "out"),
+        )
+    trace = json.loads((tmp_path / "out" / "traces.jsonl").read_text().splitlines()[0])
+    assert trace["reason"] == "error"
+    assert "terminated abnormally" in trace["error"]
+
+
+class SlowBootProvider(RecordingProvider):
+    """Provider whose create never finishes in time — e.g. an image that won't pull."""
+
+    name = "slow_boot"
+
+    async def create(self, spec: SandboxSpec) -> SandboxHandle:
+        await asyncio.sleep(10)
+        raise AssertionError("should have timed out")
+
+
+def test_boot_timeout_names_the_stage_and_its_own_budget(monkeypatch, tmp_path) -> None:
+    """A failed image pull must not be reported against the command's budget.
+
+    Getting this wrong sends you looking at your command when the sandbox never
+    started.
+    """
+    register_provider("slow_boot", SlowBootProvider, override=True)
+    config = json.loads(json.dumps(AGENT_CONFIG))
+    config["swe_like"]["responses_api_agents"]["swe_like"]["sandbox_provider"] = {"slow_boot": {}}
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    with pytest.raises(SystemExit):
+        _run_debug(
+            monkeypatch,
+            config,
+            input_jsonl_fpath=rows,
+            command="true",
+            timeout_setup=0.05,
+            timeout_total=600.0,
+            output_dirpath=str(tmp_path / "out"),
+        )
+    trace = json.loads((tmp_path / "out" / "traces.jsonl").read_text().splitlines()[0])
+    assert trace["reason"] == "timeout"
+    assert trace["error"] == "boot timed out after 0.05s"
+    assert trace["sandbox_id"] is None
+    # A cancelled create can leave a sandbox the provider never handed back a
+    # handle for. We cannot clean that up, so the trace has to admit it.
+    assert trace["may_have_orphaned_sandbox"] is True
+
+
+########################################
+# Persisted config
+########################################
+
+
+def test_written_config_redacts_secrets(monkeypatch, tmp_path) -> None:
+    """The run dir gets shared and attached to bug reports; keys must not be in it."""
+    config = json.loads(json.dumps(AGENT_CONFIG))
+    config["swe_like"]["responses_api_agents"]["swe_like"]["sandbox_provider"] = {
+        "recording": {"connection": {"api_key": "super-secret-value"}}
+    }
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    _run_debug(
+        monkeypatch,
+        config,
+        input_jsonl_fpath=rows,
+        command="echo hi",
+        output_dirpath=str(tmp_path / "out"),
+    )
+    written = (tmp_path / "out" / "config.yaml").read_text()
+    assert "super-secret-value" not in written
+    assert "****" in written
+
+
+########################################
+# Sandbox lifetime
+########################################
+
+# A server that leaves ttl_s unset — providers read that as "never auto-terminate".
+NO_TTL_CONFIG = {
+    "no_ttl": {
+        "responses_api_agents": {
+            "no_ttl": {
+                "entrypoint": "app.py",
+                "host": "127.0.0.1",
+                "port": 10003,
+                "sandbox_provider": {"recording": {}},
+                "sandbox_spec": {"image": "img:x"},
+            }
+        }
+    }
+}
+
+
+def test_sandbox_never_gets_an_unbounded_lifetime(monkeypatch, tmp_path) -> None:
+    """A server with no ttl_s must not yield a sandbox that never expires.
+
+    Providers treat a null lifetime as "delete me explicitly" — a promise this
+    tool cannot keep if it is killed or the user forgets a --keep.
+    """
+    _run_debug(
+        monkeypatch,
+        NO_TTL_CONFIG,
+        command="echo hi",
+        output_dirpath=str(tmp_path / "out"),
+    )
+    assert RecordingProvider.instances[-1].created_specs[0].ttl_s == cli_sandbox.DEFAULT_TTL_S
+
+
+def test_rollout_sized_server_ttl_is_capped_for_debugging(monkeypatch, tmp_path) -> None:
+    """A server's ttl_s is sized for a whole rollout; a debug poke shouldn't inherit it.
+
+    mini-swe-agent asks for five hours. Holding a debugging sandbox that long is
+    how a cluster fills up with boxes nobody is using.
+    """
+    config = json.loads(json.dumps(AGENT_CONFIG))
+    config["swe_like"]["responses_api_agents"]["swe_like"]["sandbox_spec"]["ttl_s"] = 18000
+    _run_debug(
+        monkeypatch,
+        config,
+        command="echo hi",
+        image="img:a",
+        output_dirpath=str(tmp_path / "out"),
+    )
+    assert RecordingProvider.instances[-1].created_specs[0].ttl_s == cli_sandbox.DEFAULT_TTL_S
+
+
+def test_server_ttl_shorter_than_the_cap_is_kept(monkeypatch, tmp_path) -> None:
+    """Capping is a ceiling, not a floor — a server asking for less still gets less."""
+    config = json.loads(json.dumps(AGENT_CONFIG))
+    config["swe_like"]["responses_api_agents"]["swe_like"]["sandbox_spec"]["ttl_s"] = 120
+    _run_debug(
+        monkeypatch,
+        config,
+        command="echo hi",
+        image="img:a",
+        output_dirpath=str(tmp_path / "out"),
+    )
+    assert RecordingProvider.instances[-1].created_specs[0].ttl_s == 120
+
+
+def test_explicit_ttl_is_not_capped(monkeypatch, tmp_path) -> None:
+    """The cap protects the default; someone who asks for longer means it."""
+    _run_debug(
+        monkeypatch,
+        AGENT_CONFIG,
+        command="echo hi",
+        image="img:a",
+        ttl_s=7200,
+        output_dirpath=str(tmp_path / "out"),
+    )
+    assert RecordingProvider.instances[-1].created_specs[0].ttl_s == 7200
+
+
+def test_long_ttl_warns_about_wasted_capacity(monkeypatch, tmp_path, capsys) -> None:
+    _run_debug(
+        monkeypatch,
+        AGENT_CONFIG,
+        command="echo hi",
+        image="img:a",
+        ttl_s=7200,
+        output_dirpath=str(tmp_path / "out"),
+    )
+    printed = " ".join(capsys.readouterr().out.split())
+    assert "--ttl 2h keeps a sandbox alive well past a normal debugging session" in printed
+
+
+def test_short_ttl_does_not_warn(monkeypatch, tmp_path, capsys) -> None:
+    _run_debug(
+        monkeypatch,
+        AGENT_CONFIG,
+        command="echo hi",
+        image="img:a",
+        ttl_s=600,
+        output_dirpath=str(tmp_path / "out"),
+    )
+    assert "keeps a sandbox alive" not in capsys.readouterr().out
+
+
+def test_ttl_flag_overrides_the_server(monkeypatch, tmp_path) -> None:
+    _run_debug(
+        monkeypatch,
+        AGENT_CONFIG,
+        command="echo hi",
+        image="img:a",
+        ttl_s=120,
+        output_dirpath=str(tmp_path / "out"),
+    )
+    assert RecordingProvider.instances[-1].created_specs[0].ttl_s == 120
+
+
+def test_ttl_flag_overrides_even_an_unset_server_ttl(monkeypatch, tmp_path) -> None:
+    _run_debug(
+        monkeypatch,
+        NO_TTL_CONFIG,
+        command="echo hi",
+        ttl_s=60,
+        output_dirpath=str(tmp_path / "out"),
+    )
+    assert RecordingProvider.instances[-1].created_specs[0].ttl_s == 60
+
+
+def test_kept_sandbox_reports_its_expiry(monkeypatch, tmp_path, capsys) -> None:
+    """A kept sandbox holds capacity until its TTL, so the deadline is the point."""
+    _run_debug(
+        monkeypatch,
+        AGENT_CONFIG,
+        command="echo hi",
+        image="img:a",
+        keep=True,
+        ttl_s=5400,
+        output_dirpath=str(tmp_path / "out"),
+    )
+    printed = " ".join(capsys.readouterr().out.split())
+    assert "expires in 1h30m" in printed
+    assert "gym sandbox rm --sandbox-id sbx-1" in printed
+    trace = json.loads((tmp_path / "out" / "traces.jsonl").read_text().splitlines()[0])
+    assert trace["ttl_s"] == 5400
+
+
+@pytest.mark.parametrize(
+    "seconds, expected",
+    [(45, "45s"), (600, "10m"), (3600, "1h"), (5400, "1h30m"), (18000, "5h")],
+)
+def test_duration_formatting(seconds, expected) -> None:
+    assert cli_sandbox._format_duration(seconds) == expected
+
+
+def test_rejects_nonpositive_ttl() -> None:
+    with pytest.raises(ValueError, match="--ttl must be > 0"):
+        cli_sandbox.SandboxDebugConfig.model_validate({"command": "ls", "ttl_s": 0})
+
+
+########################################
+# Execution timing
+########################################
+
+
+class TimedProvider(RecordingProvider):
+    """Provider that spends time on transport and reports only the command's share.
+
+    Sleeps longer than the duration it reports, mimicking a real round-trip: the
+    caller observes ~0.15s while the sandbox says the command itself took 0.05s.
+    """
+
+    name = "timed"
+    reported_ms = 50.0
+
+    async def exec(self, handle, command, *, cwd=None, env=None, timeout_s=None, user=None) -> SandboxExecResult:
+        self.exec_calls.append({"command": command})
+        await asyncio.sleep(0.15)
+        return SandboxExecResult(stdout="ok", stderr=None, return_code=0, duration_ms=self.reported_ms)
+
+
+def _timed_config(provider: str = "timed") -> dict:
+    config = json.loads(json.dumps(AGENT_CONFIG))
+    config["swe_like"]["responses_api_agents"]["swe_like"]["sandbox_provider"] = {provider: {}}
+    return config
+
+
+def test_timing_separates_command_from_transport(monkeypatch, tmp_path, capsys) -> None:
+    """ "Why did this take ten minutes?" needs command time apart from round-trip time."""
+    register_provider("timed", TimedProvider, override=True)
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    _run_debug(
+        monkeypatch,
+        _timed_config(),
+        input_jsonl_fpath=rows,
+        command="pip install torch",
+        output_dirpath=str(tmp_path / "out"),
+    )
+
+    timing = json.loads((tmp_path / "out" / "traces.jsonl").read_text().splitlines()[0])["timing"]
+    assert timing["command"] == 0.05
+    # exec covers command + transport, so overhead is what exec added on top.
+    assert timing["overhead"] == pytest.approx(timing["exec"] - 0.05, abs=0.01)
+    assert timing["overhead"] > 0
+    assert "command 0.05s" in " ".join(capsys.readouterr().out.split())
+
+
+class OverreportingProvider(TimedProvider):
+    """Claims more command time than the caller observed — clock skew, or a lying provider."""
+
+    name = "overreporting"
+    reported_ms = 60_000.0
+
+
+def test_overhead_never_goes_negative(monkeypatch, tmp_path) -> None:
+    """A provider reporting more time than we observed must not yield negative overhead."""
+    register_provider("overreporting", OverreportingProvider, override=True)
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    _run_debug(
+        monkeypatch,
+        _timed_config("overreporting"),
+        input_jsonl_fpath=rows,
+        command="true",
+        output_dirpath=str(tmp_path / "out"),
+    )
+    timing = json.loads((tmp_path / "out" / "traces.jsonl").read_text().splitlines()[0])["timing"]
+    assert timing["overhead"] == 0.0
+
+
+def test_timing_breakdown_omitted_when_the_provider_cannot_measure(monkeypatch, tmp_path) -> None:
+    """Most providers report no duration; don't invent one."""
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "image_name": "img:a"}])
+    _run_debug(
+        monkeypatch, AGENT_CONFIG, input_jsonl_fpath=rows, command="echo hi", output_dirpath=str(tmp_path / "out")
+    )
+    trace = json.loads((tmp_path / "out" / "traces.jsonl").read_text().splitlines()[0])
+    assert "command" not in trace["timing"]
+    assert "overhead" not in trace["timing"]
+
+
+########################################
+# Renewal on reattach
+########################################
+
+
+def test_exec_extends_the_expiry_before_running(monkeypatch, capsys) -> None:
+    """Each command bumps the clock, so an in-use sandbox stays alive on a short TTL."""
+    renewals: list[float] = []
+
+    class RenewingProvider(RecordingProvider):
+        name = "renewing"
+
+        async def renew(self, handle, ttl_s: float) -> None:
+            renewals.append(ttl_s)
+
+    register_provider("renewing", RenewingProvider, override=True)
+    config = json.loads(json.dumps(AGENT_CONFIG))
+    config["swe_like"]["responses_api_agents"]["swe_like"]["sandbox_provider"] = {"renewing": {}}
+    merged = _config(config, sandbox_id="sbx-9", command="ls", ttl_s=900, timeout_total=60)
+    monkeypatch.setattr(cli_sandbox, "get_global_config_dict", lambda **k: merged)
+    cli_sandbox.exec_command()
+
+    assert renewals == [900]
+    assert "expires in 15m" in " ".join(capsys.readouterr().out.split())
+
+
+def test_exec_renewal_covers_a_command_longer_than_the_ttl(monkeypatch) -> None:
+    """A 30-minute command on a 15-minute TTL must not have the sandbox die under it."""
+    renewals: list[float] = []
+
+    class RenewingProvider(RecordingProvider):
+        name = "renewing"
+
+        async def renew(self, handle, ttl_s: float) -> None:
+            renewals.append(ttl_s)
+
+    register_provider("renewing", RenewingProvider, override=True)
+    config = json.loads(json.dumps(AGENT_CONFIG))
+    config["swe_like"]["responses_api_agents"]["swe_like"]["sandbox_provider"] = {"renewing": {}}
+    merged = _config(config, sandbox_id="sbx-9", command="sleep 1800", ttl_s=900, timeout_total=1800)
+    monkeypatch.setattr(cli_sandbox, "get_global_config_dict", lambda **k: merged)
+    cli_sandbox.exec_command()
+
+    assert renewals == [1860]  # command budget plus a minute of slack
+
+
+def test_exec_still_works_when_the_provider_cannot_renew(monkeypatch, capsys) -> None:
+    """Renewal is best effort; a provider without it keeps its original lifetime."""
+    merged = _config(AGENT_CONFIG, sandbox_id="sbx-9", command="ls")
+    monkeypatch.setattr(cli_sandbox, "get_global_config_dict", lambda **k: merged)
+    cli_sandbox.exec_command()
+    printed = capsys.readouterr().out
+    assert "hello" in printed
+    assert "expires in" not in printed
+
+
+########################################
+# Task discovery
+########################################
+
+
+def test_list_tasks_shows_ids_and_context(monkeypatch, tmp_path, capsys) -> None:
+    """Guessing an id and reading it out of the error is a poor way to start."""
+    rows = _rows(
+        tmp_path,
+        [
+            {"instance_id": "task-a", "image_name": "img:a", "repo": "org/one"},
+            {"instance_id": "task-b", "image_name": "img:b", "repo": "org/two"},
+        ],
+    )
+    _run_debug(monkeypatch, AGENT_CONFIG, input_jsonl_fpath=rows, list_tasks=True)
+    printed = " ".join(capsys.readouterr().out.split())
+    assert "task-a" in printed and "task-b" in printed
+    assert "repo=org/one" in printed
+    assert "2 task(s)" in printed
+
+
+def test_list_tasks_needs_no_provider(monkeypatch, tmp_path, capsys) -> None:
+    """Listing reads a file; it should not need provider credentials or a cluster.
+
+    The provider block here is deliberately unresolvable — listing must still work.
+    """
+    config = json.loads(json.dumps(AGENT_CONFIG))
+    config["swe_like"]["responses_api_agents"]["swe_like"]["sandbox_provider"] = "not_a_real_reference"
+    rows = _rows(tmp_path, [{"instance_id": "task-a"}])
+    _run_debug(monkeypatch, config, input_jsonl_fpath=rows, list_tasks=True)
+    assert "task-a" in capsys.readouterr().out
+
+
+def test_list_tasks_json(monkeypatch, tmp_path, capsys) -> None:
+    rows = _rows(tmp_path, [{"instance_id": "task-a", "repo": "org/one"}])
+    _run_debug(monkeypatch, AGENT_CONFIG, input_jsonl_fpath=rows, list_tasks=True, json=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == [{"index": 0, "id": "task-a", "repo": "org/one"}]
+
+
+def test_list_tasks_is_a_standalone_action() -> None:
+    """It needs no --command; asking what exists precedes running anything."""
+    config = cli_sandbox.SandboxDebugConfig.model_validate({"list_tasks": True})
+    assert config.list_tasks is True

--- a/tests/unit_tests/test_cli_sandbox.py
+++ b/tests/unit_tests/test_cli_sandbox.py
@@ -1163,3 +1163,29 @@ def test_list_tasks_is_a_standalone_action() -> None:
     """It needs no --command; asking what exists precedes running anything."""
     config = cli_sandbox.SandboxDebugConfig.model_validate({"list_tasks": True})
     assert config.list_tasks is True
+
+
+def test_provider_options_parse_json_and_fall_back_to_strings() -> None:
+    """Provider options are not all strings.
+
+    A network policy is a mapping and skip_health_check is a bool, so values are
+    decoded as JSON; anything that is not valid JSON (an id, a name) is kept as the
+    raw string rather than rejected.
+    """
+    parsed = cli_sandbox._parse_provider_options(
+        [
+            'network_policy={"defaultAction": "allow", "egress": []}',
+            "skip_health_check=true",
+            "snapshot_id=snap-123",
+        ]
+    )
+    assert parsed["network_policy"] == {"defaultAction": "allow", "egress": []}
+    assert parsed["skip_health_check"] is True
+    assert parsed["snapshot_id"] == "snap-123"
+
+
+def test_pair_flags_name_themselves_when_malformed() -> None:
+    with pytest.raises(ConfigError, match="--provider-option expects KEY=VALUE"):
+        cli_sandbox._parse_provider_options(["no-equals-sign"])
+    with pytest.raises(ConfigError, match="--env expects KEY=VALUE"):
+        cli_sandbox._parse_env(["no-equals-sign"])

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -1310,6 +1310,8 @@ def test_duration_ms_between_handles_missing_and_odd_timestamps() -> None:
     assert opensandbox_provider._duration_ms_between(started, None) is None
     # A string timestamp (a plausible SDK change) must degrade, not explode.
     assert opensandbox_provider._duration_ms_between("2026-08-01T12:00:00Z", started) is None
+
+
 async def test_renew_pushes_the_expiry_out() -> None:
     """Renewal is what lets a sandbox be short-lived *and* long-held.
 

--- a/tests/unit_tests/test_sandbox_hooks.py
+++ b/tests/unit_tests/test_sandbox_hooks.py
@@ -19,7 +19,6 @@ These cover `nemo_gym.sandbox.hooks` on its own, without the CLI that consumes i
 """
 
 import json
-from typing import Any
 
 import pytest
 
@@ -28,7 +27,6 @@ from nemo_gym.sandbox.hooks import (
     SandboxHookError,
     load_hook,
     resolve_spec,
-    spec_from_mapping,
     task_id_for_row,
     wrap_command,
 )
@@ -148,5 +146,3 @@ def test_wrap_command_without_wrapper_is_identity() -> None:
 ########################################
 # Server discovery
 ########################################
-
-


### PR DESCRIPTION
**Top of a 5-PR stack** (#2400 → #2401 → #2402 → #2407 → **#2403**). Review the three below first; this one is the consumer that makes them worth having.

## Why

Poking at a sandbox-backed task currently means standing up the whole stack — model server, Ray, agent, rollout — and hoping the failure reproduces. There is no way to ask "what is actually inside that container?" without writing a harness.

## What

`gym sandbox debug` boots the sandbox a server *would* create for a task — same provider, same image, same `SandboxSpec` a rollout uses — runs a command or uploaded script inside it, and writes a re-runnable trace. Plus `gym sandbox exec` / `rm` for reattaching to a kept sandbox.

Two things need no cluster and no credentials: `--list-tasks` reads only the dataset, and `--dry-run` resolves the image and command wrapping offline in milliseconds.

## Worked example: a mini-swe-agent-2 container running `pip install torch`

Point at a server (nothing lands in a config file):

```bash
export OPENSANDBOX_DOMAIN=<your-opensandbox-host>:<port>
export OPENSANDBOX_API_KEY=<your-api-key>
```

If the server runs with auth disabled (`api_key = ""` plus `OPENSANDBOX_INSECURE_SERVER=YES`) there is no key to obtain — but the variable must still be set to something, because the config interpolates it and Hydra fails on an unset reference. For a cluster-internal server, port-forward and point `OPENSANDBOX_DOMAIN` at the local end.

First, what would this task even get? No cluster needed:

```bash
AGENT=responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
PROVIDER=nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml

gym sandbox debug --config $AGENT --config $PROVIDER --task django__django-10973 --dry-run
```

```
image     docker.io/swebench/sweb.eval.x86_64.django_1776_django-10973:latest
          via spec_resolver (responses_api_agents.mini_swe_agent_2.sandbox_hooks:spec_for_row)
spec      ttl_s=900.0  ready_timeout_s=1200  cpu=2.0  memory_mib=8192  disk_gib=30  workdir=/testbed
exec      activate_conda=True conda_env=testbed cwd=/testbed user=root
wrapper   responses_api_agents.mini_swe_agent_2.sandbox_hooks:conda_activate_wrap
```

The image was *derived* from `instance_id` + `subset` — no row field carried it. That answer comes from #2402's hooks; before them it was unreachable without importing ray.

Now actually run the install and time it:

```bash
gym sandbox debug --config $AGENT --config $PROVIDER \
    --task django__django-10973 --command "pip install torch" --timeout-total 900
```

```
✓ django__django-10973  reason=pass exit=0  67.1s (command 21.0s + overhead 1.3s, boot 44.8s)
```

```bash
gym sandbox debug ... --command "pip install torch" --json | jq '.timing'
```

```json
{"boot": 44.812, "setup": 0.0, "exec": 22.303, "command": 21.024, "overhead": 1.279, "total": 67.115}
```

`command` is execd's measurement from **inside** the sandbox (#2400); `overhead` is what the round trip added. Only the first is a property of the task, so it is the number to compare across images, package indexes, or clusters — and here it is a third of the total, with boot dominating because SWE-bench images are large.

Note *which* torch: this image's `testbed` env is Python 3.6, so pip resolves to **torch 1.10.2** — the last release with `cp36` wheels — at about 880 MB, not a multi-GB modern build. Measured against a warm in-cluster package cache the same install runs 21s cold / 13s warm, which is what makes it a useful probe for whether a cache is actually being used.

<details>
<summary>If the sandbox's egress sidecar is intercepting TLS</summary>

A conda-based image will **not** trust the proxy's CA and `pip` fails with `CERTIFICATE_VERIFY_FAILED`. The CA is installed into the system trust store, but conda ships and consults its own at `/opt/miniconda3/envs/<env>/ssl/cert.pem` — both hold 151 CAs, only the system one has the proxy's. Every SWE-bench image is conda-based, so this is the common case:

```bash
--env SSL_CERT_FILE=/opt/opensandbox/mitmproxy-ca-cert.pem \
--env REQUESTS_CA_BUNDLE=/opt/opensandbox/mitmproxy-ca-cert.pem
```

Debian-style images (`python:3.12-slim`) read the system store and need none of this. Documented in `debugging.mdx`.
</details>

## Not leaking sandboxes

The failure mode of getting this wrong is a leaked, paid-for sandbox, so it is handled deliberately rather than incidentally:

- sandboxes get a **short** lifetime that renewal (#2401) extends while the command runs, instead of a long one nobody remembers to clean up;
- the first SIGINT logs and re-raises so every `finally` unwinds, and later signals are **swallowed** — a second Ctrl-C must not orphan what the first was cleaning up;
- an `atexit` backstop over a `WeakSet` catches the case where the loop is already gone.

## Known limitations

**No live streaming.** `SandboxProvider.exec` returns a completed result, so incremental output needs new provider surface. execd does stream over SSE, so this is a follow-up rather than a dead end.

**Requesting an egress sidecar.** `--metadata` and `--provider-option` (added here) are the top layer of the resolution chain, so a `spec_resolver`'s spec can now be extended from the command line — previously only `--env` could, which left `networkPolicy` and the istio label unreachable. The provider side is #2407, directly below this PR, so the whole thing works as one command:

```bash
gym sandbox debug --config $AGENT --config $PROVIDER --task django__django-10973 \
    --command "pip install --no-input tabulate" \
    --env OPENSANDBOX_EGRESS_MITMPROXY_TRANSPARENT=true \
    --env SSL_CERT_FILE=/opt/opensandbox/mitmproxy-ca-cert.pem \
    --metadata istio.io/dataplane-mode=none \
    --provider-option 'network_policy={"defaultAction":"allow","egress":[]}'
```

Verified against a live cell: the wheel was served by the in-cluster cache (`cache=MISS` on the first run, `HIT` on the second) with nothing in the container configured to use it.

## Tests

260 tests across `test_cli_sandbox.py`, `test_cli_main.py` and `test_sandbox_hooks.py` — resolution at each layer, the precedence chain, `--bare`, `--dry-run`, trace shape, classification, cleanup on failure and interrupt, and a **resources-server** case alongside an agent case so generality is enforced rather than asserted.


