### PR TITLE
feat(sandbox): support network_policy in the OpenSandbox provider

### DIFF
--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -349,6 +349,21 @@ def _duration_ms_between(started_at: Any, finished_at: Any) -> float | None:
         return (finished_at - started_at).total_seconds() * 1000.0
     except (AttributeError, TypeError):
         return None
+def _to_network_policy(policy: Mapping[str, Any]) -> Any:
+    """Build the SDK NetworkPolicy model from a plain mapping.
+
+    Imported here rather than through ``_require_opensandbox_sdk`` so that helper's
+    return arity stays fixed -- every existing call site unpacks it positionally.
+    The guard call preserves the friendly missing-SDK message.
+
+    ``model_validate`` rather than ``NetworkPolicy(**policy)``: the model field is
+    ``default_action`` while the API spells it ``defaultAction``, and callers copy the
+    API spelling. Validating by alias accepts both.
+    """
+    _require_opensandbox_sdk()
+    from opensandbox.models.sandboxes import NetworkPolicy
+
+    return NetworkPolicy.model_validate(dict(policy))
 
 
 def _to_sandbox_status(state: Any) -> SandboxStatus:
@@ -538,6 +553,12 @@ class OpenSandboxProviderOptions:
     # Scheduling requests (same keys as SandboxSpec.resources, which become the
     # limits). Unset, the server applies the single resources map as both.
     resource_requests: Mapping[str, Any] | None = None
+    # Passing a policy is what makes the server attach the egress sidecar at all
+    # (apply_egress_to_spec returns early without one), so this gates every egress
+    # feature -- filtering, the credential proxy, transparent MITM -- not just
+    # blocking traffic. {"defaultAction": "allow", "egress": []} attaches the
+    # sidecar while allowing everything through.
+    network_policy: Mapping[str, Any] | None = None
 
     @classmethod
     def from_mapping(cls, options: Mapping[str, Any] | None) -> "OpenSandboxProviderOptions":
@@ -575,6 +596,9 @@ class OpenSandboxProviderOptions:
         resource_requests = options.get("resource_requests")
         if resource_requests is not None and not isinstance(resource_requests, Mapping):
             raise TypeError("OpenSandbox provider option 'resource_requests' must be a mapping")
+        network_policy = options.get("network_policy")
+        if network_policy is not None and not isinstance(network_policy, Mapping):
+            raise TypeError("OpenSandbox provider option 'network_policy' must be a mapping")
 
         return cls(
             image_auth=dict(image_auth) if image_auth is not None else None,
@@ -584,6 +608,7 @@ class OpenSandboxProviderOptions:
             skip_health_check=skip_health_check,
             extensions=_string_map(dict(extensions)),
             resource_requests=dict(resource_requests) if resource_requests is not None else None,
+            network_policy=dict(network_policy) if network_policy is not None else None,
         )
 
 
@@ -937,6 +962,8 @@ class OpenSandboxProvider:
             kwargs["entrypoint"] = spec.entrypoint
         if options.platform is not None:
             kwargs["platform"] = _to_platform_spec(options.platform)
+        if options.network_policy is not None:
+            kwargs["network_policy"] = _to_network_policy(options.network_policy)
         if options.volumes:
             kwargs["volumes"] = _to_volumes(list(options.volumes))
         if self._create.skip_health_check:

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -1344,3 +1344,43 @@ def test_ttl_below_the_api_minimum_is_named_locally() -> None:
     provider = OpenSandboxProvider(connection={"domain": "example", "api_key": "k"})
     with pytest.raises(ValueError, match=f"at least {MIN_TTL_S:g}s"):
         asyncio.run(provider.create(SandboxSpec(image="img", ttl_s=30)))
+async def test_direct_create_passes_network_policy_to_sdk_create(
+    fake_opensandbox_sdk: None,
+) -> None:
+    """A networkPolicy is what makes the server attach the egress sidecar at all.
+
+    Server-side, ``apply_egress_to_spec`` returns early without one, so omitting it
+    silently disables every egress feature -- filtering, the credential proxy and
+    transparent MITM alike -- while the sandbox itself still works.
+    """
+    provider = opensandbox_provider.OpenSandboxProvider(
+        connection={"request_timeout_s": 10},
+        probe={"command": None},
+    )
+
+    await provider.create(
+        SandboxSpec(
+            image="image:tag",
+            provider_options={"network_policy": {"defaultAction": "allow", "egress": []}},
+        ),
+    )
+
+    sent = FakeSandbox.created_kwargs["network_policy"]
+    # Validated by alias: callers write the API's defaultAction, not default_action.
+    assert sent.model_dump(by_alias=True, exclude_none=True) == {"defaultAction": "allow", "egress": []}
+
+
+async def test_direct_create_omits_network_policy_when_unset(fake_opensandbox_sdk: None) -> None:
+    provider = opensandbox_provider.OpenSandboxProvider(
+        connection={"request_timeout_s": 10},
+        probe={"command": None},
+    )
+
+    await provider.create(SandboxSpec(image="image:tag"))
+
+    assert "network_policy" not in FakeSandbox.created_kwargs
+
+
+def test_network_policy_option_must_be_a_mapping() -> None:
+    with pytest.raises(TypeError, match="network_policy"):
+        opensandbox_provider.OpenSandboxProviderOptions.from_mapping({"network_policy": "allow-all"})


### PR DESCRIPTION
**PR 4 of 5** in the `gym sandbox debug` stack (#2400 → #2401 → #2402 → **#2407** → #2403).

## Why

The provider had no way to send a `networkPolicy`, and `provider_options` rejects unknown keys, so this was not something a caller could work around.

That matters more than "one unsupported field" suggests. Server-side, `apply_egress_to_spec` **returns early when no policy is present**, so the egress sidecar is never attached at all. In practice *no* egress feature was reachable from Gym — not filtering, not the credential proxy, not transparent MITM.

```python
SandboxSpec(
    image=...,
    provider_options={"network_policy": {"defaultAction": "allow", "egress": []}},
)
```

Allow-all is the useful default: it attaches the sidecar while leaving every destination reachable.

## Why it is in this stack

It sits directly below #2403 because that PR's flagship example needs it. `--provider-option` hands the value to the provider; without this the provider rejects it and the example fails with `Unknown OpenSandbox provider option(s): network_policy`. Shipping the CLI flags without this would mean shipping a documented command that cannot run.

It is otherwise independent of the three layers below and could be reviewed on its own.

## Two implementation notes

**`NetworkPolicy` is imported inside `_to_network_policy`**, not added to `_require_opensandbox_sdk`'s return tuple. Widening that tuple touches all eight positional call sites plus every test fake — an earlier attempt produced five conflicts on a single upstream rebase. A local import costs nothing and keeps this independent of that helper's shape.

**Conversion uses `model_validate`**, not `NetworkPolicy(**policy)`. The model field is `default_action` while the API spells it `defaultAction`; callers copy the API spelling, and validating by alias accepts both.

## Validated

Used to drive a sandbox whose egress sidecar transparently redirects PyPI to an in-cluster cache. A bare `pip install` inside the container was served by nginx (`cache=MISS` first run, `HIT` on repeat) with nothing in the container configured to use it. That path is unreachable without this field.

Also verified through configuration alone — putting `network_policy` in a server's `sandbox_spec.provider_options` intercepts every sandbox that server creates, which is how an eval or RL run would use it, with no CLI involved.

## Tests

Policy reaches the SDK and round-trips by alias; omitted when unset; non-mapping raises `TypeError`.
