### PR TITLE
fix: rescue lingering finished SWE episodes and mask infra failures

### DIFF
--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -2763,11 +2763,6 @@ class RunOpenHandsAgent(BaseModel):
             self._apply_watchdog_stats(metrics, openhands_active_command, mode="agent")
             metrics.openhands_run_time += time.time()
             metrics.patch_exists = False
-            # An agent command that died without producing output is an infrastructure failure,
-            # not a model failure; allow for it to be masked out of the gradient.
-            metrics.mask_sample = True
-            metrics.failure_reason = "agent_command_failure"
-            metrics.agent_error_kind = "other"
             metrics.final_eval_apptainer_spinup_time = None
             # Detect wall-clock agent timeout: openhands_run_time (elapsed since start)
             # reached or exceeded the configured swebench_agent_timeout.
@@ -2775,6 +2770,16 @@ class RunOpenHandsAgent(BaseModel):
                 metrics.openhands_run_time is not None
                 and metrics.openhands_run_time >= self.config.swebench_agent_timeout
             )
+            # An agent command that died without producing output is an infrastructure failure,
+            # not a model failure; allow for it to be masked out of the gradient.
+            metrics.mask_sample = True
+            if metrics.agent_timed_out:
+                metrics.failure_reason = "agent_timeout"
+            elif metrics.oom_killed:
+                metrics.failure_reason = "agent_oom"
+            else:
+                metrics.failure_reason = "agent_command_failure"
+            metrics.agent_error_kind = metrics.agent_error_kind or "other"
             update_and_read_metrics(self.config.metrics_fpath, metrics.model_dump())
             if self.config.debug:
                 profiler.stop()

--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -276,6 +276,10 @@ class SWEBenchMetrics(BaseModel):
     patch_exists: Optional[bool] = None
     model_patch: Optional[str] = None
 
+    # Set by the worker when an episode failed due to infrastructure.
+    mask_sample: bool = False
+    failure_reason: Optional[str] = None
+
     # Failure-mode signals used to decide mask_sample downstream.
     agent_error_kind: Optional[str] = None
     agent_timed_out: Optional[bool] = None
@@ -2448,6 +2452,11 @@ class ActiveContainerCommand(BaseModel):
     watchdog_stats: Dict[str, Any] = Field(default_factory=dict)
 
 
+_CONTAINER_COMMAND_POLL_INTERVAL_S = 5.0
+_OPENHANDS_COMPLETION_MARKER = "Instances processed: 100%"
+_OPENHANDS_OUTPUT_GRACE_S = 60.0
+
+
 class RunOpenHandsAgent(BaseModel):
     config: SWEBenchWrapperInstanceConfig
 
@@ -2593,14 +2602,70 @@ class RunOpenHandsAgent(BaseModel):
             )
         return active_command
 
+    async def _terminate_lingering_process(self, active_command: ActiveContainerCommand) -> None:
+        """SIGKILL a container whose useful work is done but whose process lingers."""
+        if active_command.process.returncode is not None:
+            return
+        _kill_container_tree(active_command.process.pid)
+        try:
+            active_command.process.kill()
+        except ProcessLookupError:
+            pass
+        try:
+            await asyncio.wait_for(active_command.process.wait(), timeout=30)
+        except asyncio.TimeoutError:
+            pass
+
     async def _finish_container_command(
         self, active_command: ActiveContainerCommand, command: ExecuteContainerCommandArgs
     ) -> str:
         data_point = self.config.problem_info
+        terminated_after_completion = False
+        completion_marker_seen_at: Optional[float] = None
 
         try:
-            # Wait for completion with timeout
-            await asyncio.wait_for(active_command.process.communicate(), timeout=command.timeout)
+            # Wait for completion with timeout, polling so a finished-but-lingering
+            # agent can be rescued. This happens when a command is left running.
+            # Without the polling rescue, such episodes spend their full timeout
+            # and are reported as failures, despite having valid output files.
+            deadline = asyncio.get_running_loop().time() + command.timeout
+            while active_command.process.returncode is None:
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    raise asyncio.TimeoutError
+                try:
+                    await asyncio.wait_for(
+                        active_command.process.wait(),
+                        timeout=min(_CONTAINER_COMMAND_POLL_INTERVAL_S, remaining),
+                    )
+                except asyncio.TimeoutError:
+                    if command.mode != "agent":
+                        continue
+
+                    active_command.log_file.flush()
+                    log_text = active_command.log_file_path.read_text(errors="replace")
+                    if _OPENHANDS_COMPLETION_MARKER in log_text:
+                        now = asyncio.get_running_loop().time()
+                        if completion_marker_seen_at is None:
+                            completion_marker_seen_at = now
+                        pred_files = glob.glob(command.expected_file_pattern, recursive=True)
+                        complete_pred_files = []
+                        for pred_file in pred_files:
+                            try:
+                                json.loads(Path(pred_file).read_text().strip())
+                                complete_pred_files.append(pred_file)
+                            except (OSError, json.JSONDecodeError):
+                                continue
+                        if complete_pred_files:
+                            await self._terminate_lingering_process(active_command)
+                            terminated_after_completion = True
+                            break
+                        if now - completion_marker_seen_at >= _OPENHANDS_OUTPUT_GRACE_S:
+                            await self._terminate_lingering_process(active_command)
+                            raise RuntimeError(
+                                "OpenHands finished without output or with incomplete output; "
+                                "terminated its lingering container process group"
+                            )
         except asyncio.TimeoutError:
             if active_command.process.returncode is None:
                 _kill_container_tree(active_command.process.pid)
@@ -2621,7 +2686,7 @@ class RunOpenHandsAgent(BaseModel):
                 f"Peak tree RSS: {active_command.watchdog_stats.get('agent_peak_rss_mb')}MB."
             )
 
-        if active_command.process.returncode != 0:
+        if active_command.process.returncode != 0 and not terminated_after_completion:
             raise RuntimeError(
                 f"Command failed with return code {active_command.process.returncode}. "
                 f"Logs:\n{active_command.log_file_path.read_text(errors='replace')}"
@@ -2698,6 +2763,11 @@ class RunOpenHandsAgent(BaseModel):
             self._apply_watchdog_stats(metrics, openhands_active_command, mode="agent")
             metrics.openhands_run_time += time.time()
             metrics.patch_exists = False
+            # An agent command that died without producing output is an infrastructure failure,
+            # not a model failure; allow for it to be masked out of the gradient.
+            metrics.mask_sample = True
+            metrics.failure_reason = "agent_command_failure"
+            metrics.agent_error_kind = "other"
             metrics.final_eval_apptainer_spinup_time = None
             # Detect wall-clock agent timeout: openhands_run_time (elapsed since start)
             # reached or exceeded the configured swebench_agent_timeout.
@@ -3713,14 +3783,30 @@ class SWEBenchWrapper(SimpleResponsesAPIAgent):
         agent_timed_out = bool(persisted_metrics.agent_timed_out)
         oom_killed = bool(persisted_metrics.oom_killed)
         eval_oom_killed = bool(persisted_metrics.eval_oom_killed)
+        failure_reason = persisted_metrics.failure_reason
         if (
-            (resolved_now and agent_error_kind in ("max_iteration", "context_window"))
+            persisted_metrics.mask_sample
+            or (resolved_now and agent_error_kind in ("max_iteration", "context_window"))
             or eval_timed_out
             or agent_timed_out
             or oom_killed
             or eval_oom_killed
         ):
             params.mask_sample = True
+            if not failure_reason:
+                if agent_timed_out:
+                    failure_reason = "agent_timeout"
+                elif eval_timed_out:
+                    failure_reason = "eval_timeout"
+                elif oom_killed:
+                    failure_reason = "agent_oom"
+                elif eval_oom_killed:
+                    failure_reason = "eval_oom"
+                else:
+                    failure_reason = f"agent_{agent_error_kind}"
+        # Persist the decision + reason next to the other metrics.
+        metrics_to_update["mask_sample"] = params.mask_sample
+        metrics_to_update["failure_reason"] = failure_reason
 
         trajectories_dir = params.persistent_dir / "trajectories"
         chat_completions_trajectory, chat_completions_tools, prefix_msg_count = (

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -1590,6 +1590,50 @@ class TestRunOpenHandsAgent:
         config = _make_instance_config(tmpdir, **overrides)
         return RunOpenHandsAgent(config=config)
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "agent_timeout_s, oom, expected_reason, expected_kind",
+        [
+            (0, False, "agent_timeout", "other"),
+            (900, True, "agent_oom", "oom"),
+            (900, False, "agent_command_failure", "other"),
+        ],
+        ids=["timeout", "oom", "other"],
+    )
+    async def test_worker_classifies_agent_failure_reason(
+        self, monkeypatch, agent_timeout_s, oom, expected_reason, expected_kind
+    ) -> None:
+        """The agent-failure path stamps the specific reason at the worker —
+        responses() never refines an already-set failure_reason — and keeps the
+        watchdog's oom error kind instead of clobbering it to "other". The raised
+        exception is deliberately generic: classification must come from the
+        timeout/OOM signals, not the exception type."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            agent = self._make_agent(tmpdir, swebench_agent_timeout=agent_timeout_s)
+
+            async def fake_start(_self, _command, _cmd_str):
+                process = await asyncio.create_subprocess_shell("true")
+                await process.wait()
+                return ActiveContainerCommand(
+                    process=process,
+                    log_file=MagicMock(),
+                    log_file_path=Path(tmpdir) / "log.txt",
+                    watchdog_stats={"oom_killed": True} if oom else {},
+                )
+
+            monkeypatch.setattr(RunOpenHandsAgent, "_start_container_command", fake_start)
+            monkeypatch.setattr(
+                RunOpenHandsAgent, "_finish_container_command", AsyncMock(side_effect=RuntimeError("boom"))
+            )
+            monkeypatch.setattr(RunOpenHandsAgent, "_kill_active_command", AsyncMock())
+
+            assert await agent.process_single_datapoint() is None
+
+            persisted = json.loads(agent.config.metrics_fpath.read_text())
+            assert persisted["mask_sample"] is True
+            assert persisted["failure_reason"] == expected_reason
+            assert persisted["agent_error_kind"] == expected_kind
+
     def test_openhands_dir_copy_from_host_no_output(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             agent = self._make_agent(tmpdir)

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -1740,6 +1740,64 @@ class TestRunOpenHandsAgent:
                 await agent._finish_container_command(active, cmd)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("output_state", "grace_s", "expect"),
+        [
+            # run_infer completed but produced NO output: after the grace the
+            # lingering container is killed and the episode fails loudly
+            # instead of burning the full timeout.
+            ("missing", 0.1, "raises"),
+            # Complete output exists but a command the model left running
+            # holds the container open: the episode is the success it is.
+            ("complete", 60.0, "returns"),
+            # Output exists but is still being written (not yet valid JSON):
+            # the grace window lets the writer finish rather than killing the
+            # container mid-flush.
+            ("late", 1.0, "returns"),
+        ],
+    )
+    async def test_finish_agent_rescues_or_fails_lingering_containers(
+        self, monkeypatch, output_state: str, grace_s: float, expect: str
+    ) -> None:
+        monkeypatch.setattr(swe_app, "_CONTAINER_COMMAND_POLL_INTERVAL_S", 0.05)
+        monkeypatch.setattr(swe_app, "_OPENHANDS_OUTPUT_GRACE_S", grace_s)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            agent = self._make_agent(tmpdir)
+            agent.config.persistent_dir.mkdir(parents=True, exist_ok=True)
+            expected_file = Path(tmpdir) / "output.jsonl"
+            writer = None
+            if output_state == "complete":
+                expected_file.write_text("{}")
+            elif output_state == "late":
+                expected_file.touch()
+
+                async def finish_write() -> None:
+                    await asyncio.sleep(0.15)
+                    expected_file.write_text("{}")
+
+                writer = asyncio.create_task(finish_write())
+
+            cmd = ExecuteContainerCommandArgs(
+                command="agent",
+                expected_file_pattern=str(expected_file),
+                mode="agent",
+                timeout=10,
+            )
+            active = await agent._start_container_command(
+                cmd,
+                "printf 'Instances processed: 100%%\\n'; sleep 100",
+            )
+            if expect == "raises":
+                with pytest.raises(RuntimeError, match="finished without output"):
+                    await agent._finish_container_command(active, cmd)
+            else:
+                result = await agent._finish_container_command(active, cmd)
+                assert result == str(expected_file)
+            if writer:
+                await writer
+            assert active.process.returncode is not None
+
+    @pytest.mark.asyncio
     async def test_finish_container_command_nonzero_exit(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             agent = self._make_agent(tmpdir)
@@ -2575,7 +2633,14 @@ class TestSWEBenchWrapperRun:
             tools=[],
             metadata={
                 "input": "[]",
-                "metrics": json.dumps({"resolved": False, "patch_exists": True}),
+                "metrics": json.dumps(
+                    {
+                        "resolved": False,
+                        "patch_exists": True,
+                        "mask_sample": True,
+                        "failure_reason": "agent_timeout",
+                    }
+                ),
                 "instance_config": _make_instance_config(tempfile.mkdtemp()).model_dump_json(),
             },
         )
@@ -2601,6 +2666,8 @@ class TestSWEBenchWrapperRun:
             result = await wrapper.run(body)
             assert isinstance(result, SWEBenchVerifyResponse)
             assert result.reward == 0.0
+            assert result.mask_sample is True
+            assert result.failure_reason == "agent_timeout"
 
 
 ########################################


### PR DESCRIPTION
This PR contains two fixes.

For the first, the harness will commonly be left running despite the model having finished the episode. This usually happens due to lingering commands. Currently this leads to a long timeout and failure. Rescuing these episodes from the harness allows them to complete early and retrieve rewards for what would otherwise be marked as a failure.

For the second, infra failures are now tagged so that the training backend can choose to mask out their gradients instead of training with them as 0 reward.