### PR TITLE
fix(pinchbench): address the model server per rollout so capture attributes calls

### DIFF
--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -125,9 +125,10 @@ class PinchBenchAgentConfig(BaseResponsesAPIAgentConfig):
     # fallback workspace it never reads back. Refuse the run instead.
     max_agent_id_length: int = 64
     # Address the model server under `/ng-rollout/<rollout_id>` so model-call capture can
-    # attribute each call. Only valid when `model_base_url` is a Gym model server; a direct
-    # vLLM endpoint has no such route and would 404.
-    rollout_scoped_model_url: bool = False
+    # attribute each call. The prefix is applied only when observability is enabled, which is
+    # also the only time it is needed; set this to False for a model_base_url that is not a
+    # Gym model server, since a direct vLLM endpoint has no such route and would 404.
+    rollout_scoped_model_url: bool = True
 
     @model_validator(mode="after")
     def _reject_unresolvable_agent_id(self) -> "PinchBenchAgentConfig":
@@ -712,6 +713,12 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
             raise ValueError("record is missing verifier_metadata.task_id")
 
         run_id = uuid.uuid4().hex
+        # The capture prefix must carry Gym's rollout id -- the task/rollout indices that key
+        # `<rollout_id>.capture.jsonl` and appear as `ng_model_call_capture.rollout_id` on the
+        # collected rollout. `run_id` is a fresh uuid that names this invocation's work and
+        # transcript directories; using it here would write capture files no rollout can be
+        # matched back to. Returns None when observability is off, which leaves the URL bare.
+        rollout_id = self.rollout_id_from_run(body)
         out_dir = Path(self.config.work_root) / run_id
         out_dir.mkdir(parents=True, exist_ok=True)
         result = {"reward": 0.0, "grading_type": "unknown", "breakdown": {}, "notes": "", "status": "error"}
@@ -721,7 +728,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         archive_path = ""
         try:
             async with self._sem:
-                await self._run_in_sandbox(task_id, out_dir, run_id)  # one sandbox per task
+                await self._run_in_sandbox(task_id, out_dir, rollout_id)  # one sandbox per task
             result = self._parse_result(task_id, out_dir)
             response = self._response_from_transcript(task_id, out_dir)
             transcript_events, archive_path = self._collect_transcript(task_id, out_dir, run_id)

--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -68,6 +68,7 @@ from nemo_gym.openai_utils import (
     NeMoGymSummary,
 )
 from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
+from nemo_gym.server_utils import apply_rollout_prefix
 
 
 class PinchBenchAgentConfig(BaseResponsesAPIAgentConfig):
@@ -123,6 +124,10 @@ class PinchBenchAgentConfig(BaseResponsesAPIAgentConfig):
     # output. Long ids do not match, and every task then silently runs against a
     # fallback workspace it never reads back. Refuse the run instead.
     max_agent_id_length: int = 64
+    # Address the model server under `/ng-rollout/<rollout_id>` so model-call capture can
+    # attribute each call. Only valid when `model_base_url` is a Gym model server; a direct
+    # vLLM endpoint has no such route and would 404.
+    rollout_scoped_model_url: bool = False
 
     @model_validator(mode="after")
     def _reject_unresolvable_agent_id(self) -> "PinchBenchAgentConfig":
@@ -189,12 +194,28 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
     ) -> NeMoGymResponse:
         raise NotImplementedError("PinchBench is an external benchmark; use /run.")
 
+    def _rollout_scoped_model_base_url(self, rollout_id: Optional[str]) -> str:
+        """Model URL for one rollout, optionally carrying the capture correlation prefix.
+
+        Model-call capture only records calls that arrive under ``/ng-rollout/<id>``; without
+        it the middleware forwards them unattributed, so an agent that talks to a Gym model
+        server on a bare URL is invisible to observability. Only valid when
+        ``model_base_url`` is a Gym model server -- a non-Gym endpoint would 404 on the prefix.
+        """
+        base = self.config.model_base_url.rstrip("/")
+        if not self.config.rollout_scoped_model_url or not rollout_id:
+            return base
+        root, sep, suffix = base.rpartition("/v1")
+        if not sep:
+            return apply_rollout_prefix(base, rollout_id)
+        return f"{apply_rollout_prefix(root, rollout_id)}/v1{suffix}"
+
     # --- task env ----------------------------------------------------------
-    def _task_env(self, task_id: str) -> dict:
+    def _task_env(self, task_id: str, rollout_id: Optional[str] = None) -> dict:
         env = {
             "TASK_ID": task_id,
             "MODEL_NAME": self.config.model_name,
-            "MODEL_BASE_URL": self.config.model_base_url,
+            "MODEL_BASE_URL": self._rollout_scoped_model_base_url(rollout_id),
             "MODEL_API_KEY": self.config.model_api_key,
             "JUDGE_MODEL": self.config.judge_model,
             "JUDGE_BASE_URL": self.config.judge_base_url,
@@ -219,7 +240,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         return env
 
     # --- per-task sandbox (Gym Sandbox API; provider-neutral) ---------------
-    def _build_spec(self, task_id: str) -> SandboxSpec:
+    def _build_spec(self, task_id: str, rollout_id: Optional[str] = None) -> SandboxSpec:
         cfg = dict(self.config.sandbox_spec)
         return SandboxSpec(
             image=cfg.get("image"),
@@ -228,16 +249,16 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
             workdir=cfg.get("workdir"),
             resources=SandboxResources.from_mapping(cfg.get("resources", {})),
             provider_options=cfg.get("provider_options", {}),
-            env=self._task_env(task_id),
+            env=self._task_env(task_id, rollout_id),
             metadata={"task_id": task_id},
         )
 
-    async def _run_in_sandbox(self, task_id: str, out_dir: Path) -> None:
+    async def _run_in_sandbox(self, task_id: str, out_dir: Path, rollout_id: Optional[str] = None) -> None:
         """Run one PinchBench task and pull its /out archive back."""
         provider = self.config.sandbox_provider or {}
         apptainer_cfg = provider.get("apptainer") if isinstance(provider, dict) else None
         if isinstance(apptainer_cfg, dict) and apptainer_cfg.get("direct_exec"):
-            await self._run_in_apptainer_direct(task_id, out_dir, apptainer_cfg)
+            await self._run_in_apptainer_direct(task_id, out_dir, apptainer_cfg, rollout_id)
             return
 
         if not self.config.sandbox_provider:
@@ -245,7 +266,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         archive = f"{self.config.sandbox_work_base.rstrip('/')}/out/out.tgz"
         sb = AsyncSandbox(self.config.sandbox_provider)
         try:
-            await sb.start(self._build_spec(task_id))
+            await sb.start(self._build_spec(task_id, rollout_id))
             await sb.exec("bash /opt/run_task.sh", timeout_s=self.config.task_timeout_s)
             await sb.download(archive, out_dir / "out.tgz")
         finally:
@@ -362,7 +383,9 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         wrapper_path.chmod(0o755)
         return wrapper_path
 
-    async def _run_in_apptainer_direct(self, task_id: str, out_dir: Path, apptainer_cfg: dict[str, Any]) -> None:
+    async def _run_in_apptainer_direct(
+        self, task_id: str, out_dir: Path, apptainer_cfg: dict[str, Any], rollout_id: Optional[str] = None
+    ) -> None:
         image = self.config.sandbox_spec.get("image")
         if not image:
             raise ValueError("pinchbench sandbox_spec.image is required for direct Apptainer exec")
@@ -382,7 +405,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         elif isinstance(direct_args, str):
             direct_args = direct_args.split()
 
-        task_env = self._task_env(task_id)
+        task_env = self._task_env(task_id, rollout_id)
         argv = ["apptainer", "exec", *[str(arg) for arg in direct_args]]
         argv += ["--bind", f"{staging_dir}:{work_base}"]
         for key, value in task_env.items():
@@ -698,7 +721,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         archive_path = ""
         try:
             async with self._sem:
-                await self._run_in_sandbox(task_id, out_dir)  # one sandbox per task
+                await self._run_in_sandbox(task_id, out_dir, run_id)  # one sandbox per task
             result = self._parse_result(task_id, out_dir)
             response = self._response_from_transcript(task_id, out_dir)
             transcript_events, archive_path = self._collect_transcript(task_id, out_dir, run_id)

--- a/responses_api_agents/pinchbench/tests/test_app.py
+++ b/responses_api_agents/pinchbench/tests/test_app.py
@@ -242,7 +242,7 @@ async def test_run_returns_zero_on_failure_never_raises(tmp_path, monkeypatch):
     otherwise ng_collect_rollouts (fail-fast) aborts the whole collection."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def boom(task_id, out_dir):
+    async def boom(task_id, out_dir, rollout_id=None):
         raise RuntimeError("sandbox exploded")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", boom)
@@ -277,7 +277,7 @@ async def test_generic_failure_routes_to_sidecar_not_main(tmp_path, monkeypatch)
     """A failed task must carry a failure class so it never lands in the main jsonl."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def boom(task_id, out_dir):
+    async def boom(task_id, out_dir, rollout_id=None):
         raise RuntimeError("sandbox exploded")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", boom)
@@ -293,7 +293,7 @@ async def test_signal_killed_sandbox_is_kill_shaped_and_unpersisted(tmp_path, mo
     """Walltime SIGTERM shape: no row anywhere; resume's set-difference re-dispatches."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def killed(task_id, out_dir):
+    async def killed(task_id, out_dir, rollout_id=None):
         raise SandboxKilledError("direct apptainer exec killed (rc=-15) for task task_x")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", killed)
@@ -308,7 +308,7 @@ async def test_task_timeout_is_terminal_sidecar(tmp_path, monkeypatch):
     """Per-task timeout consumed its budget: one sidecar row, never retried."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def slow(task_id, out_dir):
+    async def slow(task_id, out_dir, rollout_id=None):
         raise TimeoutError("direct apptainer exec timed out for task task_x")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", slow)
@@ -324,7 +324,7 @@ async def test_successful_task_carries_no_routing_sentinels(tmp_path, monkeypatc
     """Scored rollouts must keep landing in the main jsonl (no sentinel keys)."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def ok(task_id, out_dir):
+    async def ok(task_id, out_dir, rollout_id=None):
         return None
 
     monkeypatch.setattr(agent, "_run_in_sandbox", ok)

--- a/responses_api_agents/pinchbench/tests/test_rollout_scoped_model_url.py
+++ b/responses_api_agents/pinchbench/tests/test_rollout_scoped_model_url.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Addressing the model server per rollout so model-call capture can attribute calls.
+
+Capture only records calls arriving under ``/ng-rollout/<rollout_id>``; on a bare URL the
+middleware forwards them unattributed and the run has no request/response record at all.
+"""
+
+from responses_api_agents.pinchbench.tests.test_app import make_agent
+
+
+ROLLOUT = "abc123"
+
+
+def test_bare_url_by_default():
+    env = make_agent(model_base_url="http://host:8000/v1")._task_env("task_x", ROLLOUT)
+
+    assert env["MODEL_BASE_URL"] == "http://host:8000/v1"
+
+
+def test_prefix_is_inserted_ahead_of_the_api_version():
+    agent = make_agent(model_base_url="http://host:8000/v1", rollout_scoped_model_url=True)
+
+    assert agent._task_env("task_x", ROLLOUT)["MODEL_BASE_URL"] == f"http://host:8000/ng-rollout/{ROLLOUT}/v1"
+
+
+def test_without_a_rollout_id_the_url_is_unchanged():
+    agent = make_agent(model_base_url="http://host:8000/v1", rollout_scoped_model_url=True)
+
+    assert agent._task_env("task_x")["MODEL_BASE_URL"] == "http://host:8000/v1"
+
+
+def test_a_url_with_no_api_version_still_gets_the_prefix():
+    agent = make_agent(model_base_url="http://host:8000", rollout_scoped_model_url=True)
+
+    assert agent._task_env("task_x", ROLLOUT)["MODEL_BASE_URL"] == f"http://host:8000/ng-rollout/{ROLLOUT}"
+
+
+def test_the_sandbox_spec_carries_the_scoped_url():
+    agent = make_agent(model_base_url="http://host:8000/v1", rollout_scoped_model_url=True)
+
+    assert agent._build_spec("task_x", ROLLOUT).env["MODEL_BASE_URL"].endswith(f"/ng-rollout/{ROLLOUT}/v1")

--- a/responses_api_agents/pinchbench/tests/test_rollout_scoped_model_url.py
+++ b/responses_api_agents/pinchbench/tests/test_rollout_scoped_model_url.py
@@ -17,37 +17,70 @@ Capture only records calls arriving under ``/ng-rollout/<rollout_id>``; on a bar
 middleware forwards them unattributed and the run has no request/response record at all.
 """
 
+from nemo_gym.global_config import (
+    OBSERVABILITY_ENABLED_KEY_NAME,
+    ROLLOUT_INDEX_KEY_NAME,
+    TASK_INDEX_KEY_NAME,
+)
 from responses_api_agents.pinchbench.tests.test_app import make_agent
 
 
 ROLLOUT = "abc123"
 
 
-def test_bare_url_by_default():
-    env = make_agent(model_base_url="http://host:8000/v1")._task_env("task_x", ROLLOUT)
-
-    assert env["MODEL_BASE_URL"] == "http://host:8000/v1"
+def _observable(agent, enabled=True):
+    """Give the agent a global config, the only place capture gating is read from."""
+    agent.server_client.global_config_dict = {OBSERVABILITY_ENABLED_KEY_NAME: enabled}
+    return agent
 
 
 def test_prefix_is_inserted_ahead_of_the_api_version():
-    agent = make_agent(model_base_url="http://host:8000/v1", rollout_scoped_model_url=True)
+    agent = make_agent(model_base_url="http://host:8000/v1")
 
     assert agent._task_env("task_x", ROLLOUT)["MODEL_BASE_URL"] == f"http://host:8000/ng-rollout/{ROLLOUT}/v1"
 
 
+def test_opting_out_leaves_the_url_bare():
+    agent = make_agent(model_base_url="http://host:8000/v1", rollout_scoped_model_url=False)
+
+    assert agent._task_env("task_x", ROLLOUT)["MODEL_BASE_URL"] == "http://host:8000/v1"
+
+
 def test_without_a_rollout_id_the_url_is_unchanged():
-    agent = make_agent(model_base_url="http://host:8000/v1", rollout_scoped_model_url=True)
+    agent = make_agent(model_base_url="http://host:8000/v1")
 
     assert agent._task_env("task_x")["MODEL_BASE_URL"] == "http://host:8000/v1"
 
 
 def test_a_url_with_no_api_version_still_gets_the_prefix():
-    agent = make_agent(model_base_url="http://host:8000", rollout_scoped_model_url=True)
+    agent = make_agent(model_base_url="http://host:8000")
 
     assert agent._task_env("task_x", ROLLOUT)["MODEL_BASE_URL"] == f"http://host:8000/ng-rollout/{ROLLOUT}"
 
 
 def test_the_sandbox_spec_carries_the_scoped_url():
-    agent = make_agent(model_base_url="http://host:8000/v1", rollout_scoped_model_url=True)
+    agent = make_agent(model_base_url="http://host:8000/v1")
 
     assert agent._build_spec("task_x", ROLLOUT).env["MODEL_BASE_URL"].endswith(f"/ng-rollout/{ROLLOUT}/v1")
+
+
+def test_the_id_is_gym_s_rollout_id_not_a_fresh_uuid():
+    """The prefix must key capture files to the collected rollout.
+
+    `run()` also mints a uuid to name its work and transcript directories; prefixing with that
+    instead would write `<uuid>.capture.jsonl` that no rollout can be matched back to.
+    """
+    agent = _observable(make_agent(model_base_url="http://host:8000/v1"))
+    body = {TASK_INDEX_KEY_NAME: 12, ROLLOUT_INDEX_KEY_NAME: 0}
+
+    assert agent.rollout_id_from_run(body) == "12-0"
+    assert agent._task_env("task_x", "12-0")["MODEL_BASE_URL"] == "http://host:8000/ng-rollout/12-0/v1"
+
+
+def test_capture_disabled_yields_no_rollout_id():
+    """Gating lives in `rollout_id_from_run`, so the default-on prefix costs nothing when off."""
+    agent = _observable(make_agent(model_base_url="http://host:8000/v1"), enabled=False)
+    body = {TASK_INDEX_KEY_NAME: 12, ROLLOUT_INDEX_KEY_NAME: 0}
+
+    assert agent.rollout_id_from_run(body) is None
+    assert agent._task_env("task_x", None)["MODEL_BASE_URL"] == "http://host:8000/v1"


### PR DESCRIPTION
## Problem

Model-call capture records only calls that arrive under `/ng-rollout/<rollout_id>`; anything else the middleware forwards unattributed. The PinchBench agent hands its sandbox a bare `model_base_url`, so a run against a Gym model server with `observability_enabled: true` produces no request/response record at all — capture creates its directory and leaves it empty.

That gap matters here more than for most agents, because the harness rewrites the transcript before persisting it: a tool call naming an unregistered tool is scrubbed while its error result is kept, so the transcript cannot show what the model actually asked for. The raw response is the only place that evidence survives.

## Change

Thread the rollout id from `run()` through the sandbox spec and the direct apptainer path, and prefix the model URL the sandbox receives.

Two details worth review:

**The id is `rollout_id_from_run(body)`, not the run's uuid.** `run()` mints a uuid to name its work and transcript directories. Prefixing with that instead writes `<uuid>.capture.jsonl` files that no rollout can be matched back to — the collected rollout records its task/rollout indices under `ng_model_call_capture.rollout_id`, so the two never join, and `calls` comes back empty with a `model_call_capture_no_records` gap. Observed on a full run before the fix: 147 capture files on disk, none attributable to a task.

**`rollout_scoped_model_url` defaults to true.** `rollout_id_from_run` returns `None` whenever observability is disabled, so the prefix is inert unless capture is actually on — and when it is on, capture already requires a Gym model server, which is the only place the prefix is routable. Defaulting it off meant a user could set `observability_enabled` and still collect nothing, with an empty directory as the only symptom. Set it to false for a `model_base_url` that is not a Gym model server, since a direct vLLM endpoint has no such route and would 404.

## Tests

`responses_api_agents/pinchbench/tests/test_rollout_scoped_model_url.py` covers prefix placement ahead of the API version, URLs with no version suffix, opting out, propagation into the sandbox spec, that the id is Gym's rollout id rather than a uuid, and that capture-disabled yields no prefix.

24 passed in `responses_api_agents/pinchbench/tests/`.
