### PR TITLE
docs(fern): remove NeMo Evaluator from Ecosystem page

### DIFF
--- a/fern/versions/latest/pages/about/ecosystem.mdx
+++ b/fern/versions/latest/pages/about/ecosystem.mdx
@@ -67,7 +67,6 @@ Depending on your workflow, you may also find these NeMo libraries useful across
 | Library | Purpose |
 |---------|---------|
 | **[NeMo Gym](https://github.com/NVIDIA-NeMo/Gym)** | Evaluate and improve models and agents using environments *(this project)* |
-| [NeMo Evaluator](https://github.com/NVIDIA-NeMo/Evaluator) | Model evaluation and benchmarking |
 | [NeMo RL](https://github.com/NVIDIA-NeMo/RL) | Scalable post-training with GRPO, DPO, and SFT |
 | [NeMo Megatron-Bridge](https://github.com/NVIDIA-NeMo/Megatron-Bridge) | Pretraining and fine-tuning with Megatron-Core |
 | [NeMo AutoModel](https://github.com/NVIDIA-NeMo/Automodel) | PyTorch native training for Hugging Face models |


### PR DESCRIPTION
## Summary
- Remove the NeMo Evaluator row from the Evaluation & Training table on About → Ecosystem

## Test plan
- [x] `make docs-check`
- [x] Confirm Fern preview on the PR
- [x] Verify Ecosystem page no longer lists NeMo Evaluator under Evaluation & Training