### PR TITLE
fix(opensandbox): make exec resilient to execd bind race and dead backends

### DIFF
--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -801,17 +801,13 @@ class OpenSandboxProvider:
                         f"{operation!r} (proxy 502: no TCP connection to execd); the sandbox "
                         f"is likely dead; sandbox_id={sandbox_id!r}"
                     ) from e
-                sleep_s = min(
-                    self._operations.retry_delay_s * (2 ** (attempt - 1)),
-                    self._operations.retry_max_delay_s,
-                )
+                # The execd bind window is short, so poll quickly with a small
+                # capped backoff rather than the per-operation delays (which are
+                # tuned for slow creates).
+                sleep_s = min(0.25 * 2 ** (attempt - 1), 2.0)
                 LOGGER.warning(
                     "Backend-connect 502 on %s; retrying submission %s/%s in %.1fs; sandbox_id=%s",
-                    operation,
-                    attempt,
-                    attempts,
-                    sleep_s,
-                    sandbox_id,
+                    operation, attempt, attempts, sleep_s, sandbox_id,
                 )
                 await asyncio.sleep(sleep_s)
 

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -807,7 +807,11 @@ class OpenSandboxProvider:
                 sleep_s = min(0.25 * 2 ** (attempt - 1), 2.0)
                 LOGGER.warning(
                     "Backend-connect 502 on %s; retrying submission %s/%s in %.1fs; sandbox_id=%s",
-                    operation, attempt, attempts, sleep_s, sandbox_id,
+                    operation,
+                    attempt,
+                    attempts,
+                    sleep_s,
+                    sandbox_id,
                 )
                 await asyncio.sleep(sleep_s)
 

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -775,14 +775,12 @@ class OpenSandboxProvider:
         timeout_s: float | None,
         retries: int,
     ) -> Any:
-        """Submit a command, absorbing backend-connect 502s the command retries skip.
+        """Retry backend-connect 502s that ``command_retries`` deliberately skips.
 
-        The proxy's 502 is a TCP-connect failure — the command never reached
-        execd — so retrying cannot run it twice even when ``command_retries``
-        is 0. This covers the ~2s execd bind window after a pod first reports
-        Running. A backend that stays unreachable through the budget is dead
-        (sandbox containers never restart), so fail fast and typed rather
-        than retrying for hours.
+        A proxy 502 is a TCP-connect failure: the command never reached execd, so
+        retrying under ``operations.retries`` cannot double-run it (unlike a real
+        command failure). When that budget is exhausted the backend is dead, so
+        raise a typed error and fail fast instead of retrying for hours.
         """
         attempts = self._operations.retries + 1
         for attempt in range(1, attempts + 1):

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -52,6 +52,15 @@ class OpenSandboxCreateVerificationError(SandboxCreateVerificationError):
     """Raised when a newly-created sandbox cannot execute a probe command."""
 
 
+class SandboxBackendUnreachableError(RuntimeError):
+    """Raised when the server proxy cannot open a TCP connection to a sandbox's exec daemon.
+
+    The proxy's 502 is a connect failure, so the submitted command never
+    started. Persistent 502s mean the backend is gone (e.g. the container was
+    OOM-killed and sandbox pods never restart); retrying cannot revive it.
+    """
+
+
 RETRYABLE_HTTP_STATUS_CODES = {408, 409, 425, 429, 500, 502, 503, 504}
 RETRYABLE_ERROR_MARKERS = (
     "all connection attempts failed",
@@ -261,13 +270,17 @@ def _log_create_retry(retry_state: Any) -> None:
     )
 
 
-def _log_operation_retry(retry_state: Any) -> None:
+def _log_operation_retry(retry_state: Any, *, operation: str = "?", sandbox_id: str = "?") -> None:
+    # operation + sandbox_id make an absorbed create-probe retry distinguishable
+    # from a failing agent exec; without them every 502 retry looks identical.
     exception = retry_state.outcome.exception() if retry_state.outcome else None
     sleep_s = retry_state.next_action.sleep if retry_state.next_action else None
     LOGGER.warning(
-        "Retrying OpenSandbox SDK operation after attempt %s; next_sleep_s=%s; error=%r",
+        "Retrying OpenSandbox SDK operation after attempt %s; next_sleep_s=%s; operation=%s; sandbox_id=%s; error=%r",
         retry_state.attempt_number,
         sleep_s,
+        operation,
+        sandbox_id,
         exception,
     )
 
@@ -730,7 +743,7 @@ class OpenSandboxProvider:
         max_attempts = retry_count + 1
 
         def _before_sleep(retry_state: Any) -> None:
-            _log_operation_retry(retry_state)
+            _log_operation_retry(retry_state, operation=operation, sandbox_id=sandbox_id)
 
         retry_policy = AsyncRetrying(
             retry=retry_if_exception(_is_retryable_sdk_operation_error),
@@ -752,6 +765,59 @@ class OpenSandboxProvider:
                 )
 
         raise RuntimeError("OpenSandbox SDK operation retry loop did not run")
+
+    async def _submit_command(
+        self,
+        operation_factory: Callable[[], Awaitable[Any]],
+        *,
+        operation: str,
+        sandbox_id: str,
+        timeout_s: float | None,
+        retries: int,
+    ) -> Any:
+        """Submit a command, absorbing backend-connect 502s the command retries skip.
+
+        The proxy's 502 is a TCP-connect failure — the command never reached
+        execd — so retrying cannot run it twice even when ``command_retries``
+        is 0. This covers the ~2s execd bind window after a pod first reports
+        Running. A backend that stays unreachable through the budget is dead
+        (sandbox containers never restart), so fail fast and typed rather
+        than retrying for hours.
+        """
+        attempts = self._operations.retries + 1
+        for attempt in range(1, attempts + 1):
+            try:
+                return await self._await_sdk_operation(
+                    operation_factory,
+                    operation=operation,
+                    sandbox_id=sandbox_id,
+                    timeout_s=timeout_s,
+                    retries=retries,
+                )
+            except Exception as e:
+                if _exception_status_code(e) != 502:
+                    raise
+                if attempt == attempts:
+                    raise SandboxBackendUnreachableError(
+                        f"Sandbox backend unreachable through {attempts} submissions of "
+                        f"{operation!r} (proxy 502: no TCP connection to execd); the sandbox "
+                        f"is likely dead; sandbox_id={sandbox_id!r}"
+                    ) from e
+                sleep_s = min(
+                    self._operations.retry_delay_s * (2 ** (attempt - 1)),
+                    self._operations.retry_max_delay_s,
+                )
+                LOGGER.warning(
+                    "Backend-connect 502 on %s; retrying submission %s/%s in %.1fs; sandbox_id=%s",
+                    operation,
+                    attempt,
+                    attempts,
+                    sleep_s,
+                    sandbox_id,
+                )
+                await asyncio.sleep(sleep_s)
+
+        raise RuntimeError("OpenSandbox command submission retry loop did not run")
 
     async def _verify_created_handle(self, handle: SandboxHandle) -> None:
         if self._probe.command is None:
@@ -1061,7 +1127,7 @@ class OpenSandboxProvider:
                     retries=effective_retries,
                 )
 
-            execution = await self._await_sdk_operation(
+            execution = await self._submit_command(
                 lambda: handle.raw.commands.run(effective_command, opts=RunCommandOpts(**opts_kwargs)),
                 operation="command run",
                 sandbox_id=handle.sandbox_id,
@@ -1118,7 +1184,7 @@ class OpenSandboxProvider:
         background_opts = dict(opts_kwargs)
         background_opts["background"] = True
 
-        execution = await self._await_sdk_operation(
+        execution = await self._submit_command(
             lambda: handle.raw.commands.run(command, opts=RunCommandOpts(**background_opts)),
             operation="command run (background submit)",
             sandbox_id=handle.sandbox_id,

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -1280,10 +1280,11 @@ async def test_exec_retries_backend_connect_502_despite_zero_command_retries(
         "_require_opensandbox_sdk",
         lambda: (object, object, FakeRunCommandOpts, object, object),
     )
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
     provider = opensandbox_provider.OpenSandboxProvider(
         connection={"request_timeout_s": 5},
         probe={"command": None},
-        operations={"retries": 3, "retry_delay_s": 0.001, "retry_max_delay_s": 0.002},
+        operations={"retries": 3},
     )
     handle = opensandbox_provider.SandboxHandle(sandbox_id="sb-flap", provider_name="opensandbox", raw=FakeRaw())
 
@@ -1322,10 +1323,11 @@ async def test_exec_persistent_502_raises_typed_backend_unreachable(
         "_require_opensandbox_sdk",
         lambda: (object, object, FakeRunCommandOpts, object, object),
     )
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
     provider = opensandbox_provider.OpenSandboxProvider(
         connection={"request_timeout_s": 5},
         probe={"command": None},
-        operations={"retries": 2, "retry_delay_s": 0.001, "retry_max_delay_s": 0.002},
+        operations={"retries": 2},
     )
     handle = opensandbox_provider.SandboxHandle(sandbox_id="sb-dead", provider_name="opensandbox", raw=FakeRaw())
 

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -1247,3 +1247,89 @@ async def test_connect_honours_skip_health_check_opt_out(fake_opensandbox_sdk: N
     await provider.connect({"sandbox_id": "sandbox-9"})
 
     assert FakeSandbox.connected_kwargs["skip_health_check"] is True
+
+
+@pytest.mark.asyncio
+async def test_exec_retries_backend_connect_502_despite_zero_command_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A proxy 502 means the command never started; it retries even with command_retries=0."""
+
+    class FakeRunCommandOpts:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    class Backend502Error(Exception):
+        status_code = 502
+
+    calls = {"n": 0}
+
+    class FakeCommands:
+        async def run(self, command: str, *, opts: FakeRunCommandOpts) -> Any:
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise Backend502Error("Failed to run command. Status code: 502")
+            return SimpleNamespace(logs=SimpleNamespace(stdout=[], stderr=[]), error=None, exit_code=0)
+
+    class FakeRaw:
+        def __init__(self) -> None:
+            self.commands = FakeCommands()
+
+    monkeypatch.setattr(
+        opensandbox_provider,
+        "_require_opensandbox_sdk",
+        lambda: (object, object, FakeRunCommandOpts, object, object),
+    )
+    provider = opensandbox_provider.OpenSandboxProvider(
+        connection={"request_timeout_s": 5},
+        probe={"command": None},
+        operations={"retries": 3, "retry_delay_s": 0.001, "retry_max_delay_s": 0.002},
+    )
+    handle = opensandbox_provider.SandboxHandle(sandbox_id="sb-flap", provider_name="opensandbox", raw=FakeRaw())
+
+    result = await provider.exec(handle, "echo ok", timeout_s=30)
+
+    assert result.return_code == 0
+    assert calls["n"] == 3  # two 502s absorbed, command never double-ran
+
+
+@pytest.mark.asyncio
+async def test_exec_persistent_502_raises_typed_backend_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """502s that outlive the budget mean a dead backend: fail fast and typed."""
+
+    class FakeRunCommandOpts:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    class Backend502Error(Exception):
+        status_code = 502
+
+    calls = {"n": 0}
+
+    class FakeCommands:
+        async def run(self, command: str, *, opts: FakeRunCommandOpts) -> Any:
+            calls["n"] += 1
+            raise Backend502Error("Failed to run command. Status code: 502")
+
+    class FakeRaw:
+        def __init__(self) -> None:
+            self.commands = FakeCommands()
+
+    monkeypatch.setattr(
+        opensandbox_provider,
+        "_require_opensandbox_sdk",
+        lambda: (object, object, FakeRunCommandOpts, object, object),
+    )
+    provider = opensandbox_provider.OpenSandboxProvider(
+        connection={"request_timeout_s": 5},
+        probe={"command": None},
+        operations={"retries": 2, "retry_delay_s": 0.001, "retry_max_delay_s": 0.002},
+    )
+    handle = opensandbox_provider.SandboxHandle(sandbox_id="sb-dead", provider_name="opensandbox", raw=FakeRaw())
+
+    with pytest.raises(opensandbox_provider.SandboxBackendUnreachableError, match="likely dead"):
+        await provider.exec(handle, "echo ok", timeout_s=30)
+
+    assert calls["n"] == 3  # operations.retries + 1 submissions, then typed failure


### PR DESCRIPTION
## Summary

Makes OpenSandbox `exec` resilient to two failure modes that both surface as proxy `502`s.

1. **execd bind race.** Sandbox pods have no readiness probe, so the server can mark a sandbox `Running` and proxy exec requests before its exec daemon (`execd`) has bound its port. The proxy then returns `502 "could not connect to the backend"` for a short window after a pod first reports `Running` (worse on cold images). The command never reached `execd`, so retrying it is safe **even when `command_retries=0`** — the default, since agent commands are usually mutating and must not double-run.
2. **Dead backend.** A container that OOM-kills mid-run leaves a live server record whose every request `502`s forever, because sandbox pods never restart.

With `command_retries=0`, either mode currently fails the exec outright.

## Changes

- Add `_submit_command`, which retries **only** connect-class `502`s under `operations.retries` (independent of `command_retries`) to cover the bind window.
- Once that budget is exhausted, raise a typed `SandboxBackendUnreachableError` so a dead backend **fails fast** instead of retrying for hours.
- Retry logging now carries `operation` + `sandbox_id`, so an absorbed create-probe retry is distinguishable from a failing agent exec.

No config change: `command_retries` stays `0`, and the `502`-retry lives in a separate budget so mutating commands are never double-run.

## Testing

Two unit tests in `tests/unit_tests/test_opensandbox_provider.py`:
- transient `502`s are retried with `command_retries=0` without the command double-running;
- persistent `502`s raise the typed backend-unreachable error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
