### PR TITLE
bump: version 0.5.0 → 0.5.1 on main

### DIFF
--- a/nemo_gym/package_info.py
+++ b/nemo_gym/package_info.py
@@ -16,7 +16,7 @@
 
 MAJOR = 0
 MINOR = 5
-PATCH = 0
+PATCH = 1
 PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)


### PR DESCRIPTION
## Summary

- Bumps `PATCH` from `0` to `1` in `nemo_gym/package_info.py` (cherry-pick of `0f9c375a1` from `r0.5.0`)
