### PR TITLE
fix(local_vllm_model): put the server venv's bin on the Ray actor's PATH

### DIFF
--- a/responses_api_models/local_vllm_model/app.py
+++ b/responses_api_models/local_vllm_model/app.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import sys
 from argparse import Namespace
 from pathlib import Path
@@ -162,6 +163,20 @@ Environment variables: {env_vars_to_print}""")
 
         return final_args, env_vars
 
+    def _ray_actor_path(self) -> str:
+        """PATH for the Ray actor running vLLM.
+
+        runtime_env.py_executable gives the actor this server's venv interpreter, but does not
+        put that venv's bin directory on its PATH, so console scripts installed next to the
+        interpreter are not resolvable in the actor or its child processes. vLLM declares ninja
+        as a runtime dependency and shells out to it when compiling kernels, which fails with
+        "No such file or directory: 'ninja'" even though ninja is installed in the venv.
+
+        Prepend the interpreter's directory, keeping the inherited PATH as a fallback.
+        """
+        venv_bin_dir = str(Path(self.config.ray_worker_py_executable).resolve().parent)
+        return os.pathsep.join(filter(None, [venv_bin_dir, os.environ.get("PATH", "")]))
+
     def _select_vllm_server_head_node(self, server_args: Namespace, env_vars: Dict[str, str]) -> PlacementGroup:
         """
         Our LocalVLLMModelActor Ray actor scheduling strategy is as follows:
@@ -216,6 +231,8 @@ Total Ray cluster resources: {cluster_resources()}""")
                 env_vars={
                     "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1",
                     "PYTHONPATH": pythonpath,
+                    # Listed before `env_vars` so a server config can still override PATH.
+                    "PATH": self._ray_actor_path(),
                     **env_vars,
                 },
             ),

--- a/responses_api_models/local_vllm_model/tests/test_app.py
+++ b/responses_api_models/local_vllm_model/tests/test_app.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 
 from vllm import platforms
@@ -82,6 +84,118 @@ class TestApp:
         assert cfg.use_completions_api is True
         assert cfg.render_chat_template is True
         assert cfg.tokenizer == "some-other-model"
+
+    @staticmethod
+    def _config_with_py_executable(py_executable: str) -> LocalVLLMModelConfig:
+        return LocalVLLMModelConfig(
+            host="",
+            port=0,
+            entrypoint="",
+            name="test name",
+            model="test model",
+            return_token_id_information=False,
+            uses_reasoning_parser=False,
+            vllm_serve_env_vars=dict(),
+            vllm_serve_kwargs=dict(),
+            ray_worker_py_executable=py_executable,
+        )
+
+    def test_ray_actor_path_leads_with_the_py_executable_directory(self, monkeypatch, tmp_path) -> None:
+        """The actor resolves console scripts from the same venv as its interpreter.
+
+        runtime_env.py_executable only sets the interpreter, so without this the binaries
+        installed beside it (vLLM's ninja) are not on the actor's PATH.
+        """
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        py_executable = venv_bin / "python"
+        py_executable.touch()
+
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        class DummyLocalVLLMModel:
+            config = self._config_with_py_executable(str(py_executable))
+
+        actor_path = LocalVLLMModel._ray_actor_path(DummyLocalVLLMModel())
+
+        # The venv's bin directory wins over anything inherited...
+        assert actor_path.split(os.pathsep)[0] == str(venv_bin)
+        # ...but the inherited PATH is preserved as a fallback.
+        assert actor_path == os.pathsep.join([str(venv_bin), "/usr/bin", "/bin"])
+
+    def test_ray_actor_path_without_an_inherited_path(self, monkeypatch, tmp_path) -> None:
+        """An unset/empty PATH must not produce a stray empty entry, which resolves to cwd."""
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        py_executable = venv_bin / "python"
+        py_executable.touch()
+
+        monkeypatch.delenv("PATH", raising=False)
+
+        class DummyLocalVLLMModel:
+            config = self._config_with_py_executable(str(py_executable))
+
+        actor_path = LocalVLLMModel._ray_actor_path(DummyLocalVLLMModel())
+
+        assert actor_path == str(venv_bin)
+        assert "" not in actor_path.split(os.pathsep)
+
+    def test_ray_actor_py_executable_defaults_to_the_running_interpreter(self) -> None:
+        """Gym activates the server venv before launching, so sys.executable is that venv's
+        python and the actor PATH follows it without any per-server configuration."""
+
+        class DummyLocalVLLMModel:
+            config = self._config_with_py_executable(sys.executable)
+
+        assert DummyLocalVLLMModel.config.ray_worker_py_executable == sys.executable
+        actor_path = LocalVLLMModel._ray_actor_path(DummyLocalVLLMModel())
+        assert actor_path.split(os.pathsep)[0] == str(Path(sys.executable).resolve().parent)
+
+    def test_start_vllm_server_passes_path_into_the_actor_runtime_env(self, monkeypatch, tmp_path) -> None:
+        """The computed PATH reaches the actor's runtime_env, and a server-supplied PATH wins."""
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        py_executable = venv_bin / "python"
+        py_executable.touch()
+
+        captured = {}
+
+        class FakeActorClass:
+            @staticmethod
+            def options(**kwargs):
+                captured.update(kwargs)
+                return MagicMock()
+
+        monkeypatch.setattr(responses_api_models.local_vllm_model.app, "LocalVLLMModelActor", FakeActorClass)
+        monkeypatch.setattr(responses_api_models.local_vllm_model.app.ray, "get", lambda _: "http://localhost:1234/v1")
+
+        def build_dummy(vllm_serve_env_vars):
+            config = self._config_with_py_executable(str(py_executable))
+            config.vllm_serve_env_vars = vllm_serve_env_vars
+            config.base_url = None
+
+            class DummyLocalVLLMModel:
+                pass
+
+            dummy = DummyLocalVLLMModel()
+            dummy.config = config
+            dummy._configure_vllm_serve = lambda: (MagicMock(), dict(vllm_serve_env_vars))
+            dummy._select_vllm_server_head_node = lambda *args, **kwargs: MagicMock()
+            dummy._ray_actor_path = lambda: LocalVLLMModel._ray_actor_path(dummy)
+            dummy._post_init = lambda: None
+            dummy.await_server_ready = lambda: None
+            return dummy
+
+        # Default: the venv's bin directory is on the actor's PATH.
+        LocalVLLMModel.start_vllm_server(build_dummy({}))
+        env_vars = captured["runtime_env"]["env_vars"]
+        assert env_vars["PATH"].split(os.pathsep)[0] == str(venv_bin)
+        assert captured["runtime_env"]["py_executable"] == str(py_executable)
+
+        # A server config can still override it.
+        captured.clear()
+        LocalVLLMModel.start_vllm_server(build_dummy({"PATH": "/custom/bin"}))
+        assert captured["runtime_env"]["env_vars"]["PATH"] == "/custom/bin"
 
     def test_sanity_start_vllm_server(self, monkeypatch) -> None:
         get_global_config_dict_mock = MagicMock()


### PR DESCRIPTION
`start_vllm_server` sets `runtime_env.py_executable` to `ray_worker_py_executable`, which gives the vLLM actor this server's venv interpreter. It does not put that venv's `bin` directory on the actor's PATH, so console scripts installed next to the interpreter are not resolvable in the actor or in the child processes it spawns.

vLLM declares `ninja` as a runtime dependency and shells out to it when compiling kernels, so spinup fails with `Worker failed with error '[Errno 2] No such file or directory: 'ninja''` even though ninja is installed in the server venv.

This only shows up where ninja is not already on the system PATH. The `vllm/vllm-openai` images have it at `/usr/local/bin`, so the gap was invisible there.

NeMo-RL containers have ninja only inside a venv, and `local_vllm_model` does not start there at all. I reproduced it on vllm 0.24.0 and 0.25.1, so it is not tied to a version bump.

## Change

`_ray_actor_path` derives the PATH from `ray_worker_py_executable`, and `start_vllm_server` passes it in `runtime_env.env_vars`. It is listed ahead of the server's own `env_vars` so a config can still override PATH.

Deriving it from `ray_worker_py_executable` rather than hardcoding a directory keeps it correct wherever the venv lands, and makes `py_executable` and PATH consistent instead of the actor getting the interpreter from one venv and its binaries from another. It also covers future vLLM shell-outs rather than ninja specifically.

## Testing

Three unit tests in `responses_api_models/local_vllm_model/tests/test_app.py` cover the helper (leading entry, inherited PATH preserved, no empty segment when PATH is unset), and one covers the wiring by capturing the actor's `runtime_env` — including that a server-supplied PATH still wins.

End to end in `nvcr.io/nvidian/nemo-rl:nightly`, serving `Qwen/Qwen3-0.6B` via `ng_run`: without this change spinup fails on ninja; with it the server reaches `All 1 / 1 servers ready!` and returns completions