### PR TITLE
chore(deps): widen the openai window to >=2.25.0,<2.45.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,9 +84,14 @@ dependencies = [
 
     # OpenAI: We leverage OpenAI Responses, Chat Completions, and Completions schemas for Nemo Gym abstractions. It may also be used to directly query endpoints.
     # We specifically upper bound this OpenAI dependency since the version bumps so frequently.
-    # Updated Wed Feb 17, 2026 with openai<=2.7.2
+    # Floor 2.25.0: vllm>=0.25.0 imports NamespaceTool from openai.types.responses, which does not
+    # exist below 2.25.0. vllm only declares openai>=2.0.0, so a lower pin resolves cleanly and then
+    # fails at import time in vllm.entrypoints.openai.api_server.
+    # Ceiling <2.45.0: InputTokensDetails.cache_write_tokens becomes a required field there, and
+    # NeMoGymResponseInputTokensDetails subclasses it.
+    # Updated Fri Aug 07, 2026 with openai>=2.25.0,<2.45.0
     # License: Apache 2.0 https://github.com/openai/openai-python/blob/a8258744cbecf51321587fc870e8920bd2c07809/LICENSE
-    "openai<=2.7.2",
+    "openai>=2.25.0,<2.45.0",
 
     # Anthropic: We leverage the Anthropic Messages schemas (request/response Python types) for the
     # /v1/messages <-> Responses mapping in nemo_gym/anthropic_converter.py. Types only — we never

--- a/tests/unit_tests/test_responses_api_model_streaming.py
+++ b/tests/unit_tests/test_responses_api_model_streaming.py
@@ -272,9 +272,12 @@ class TestSanitizeStreamingBody:
 
 class TestValidateStreamingParams:
     def test_prunes_nested_extra_fields(self) -> None:
-        # Codex sends `reasoning.context`, which the pinned SDK's Reasoning model forbids.
+        # Nested fields the pinned SDK's Reasoning model does not define are dropped rather than
+        # raising. This used to send `reasoning.context`, which Codex sets, but openai 2.42.0 added
+        # that field to Reasoning: it is pruned below 2.42.0 and forwarded at or above it, so using
+        # a real field makes the assertion depend on where openai resolves in the supported range.
         params = validate_streaming_responses_params(
-            {"input": [], "reasoning": {"effort": "medium", "context": "all_turns"}}
+            {"input": [], "reasoning": {"effort": "medium", "not_a_reasoning_field": "all_turns"}}
         )
         assert params.reasoning == {"effort": "medium"}
 

--- a/uv.lock
+++ b/uv.lock
@@ -2618,7 +2618,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "nemo-gym", extras = ["dev", "sandbox"], marker = "extra == 'all'" },
     { name = "omegaconf" },
-    { name = "openai", specifier = "<=2.7.2" },
+    { name = "openai", specifier = ">=2.25.0,<2.45.0" },
     { name = "opensandbox", marker = "extra == 'sandbox'", specifier = ">=0.1.15" },
     { name = "openshell", marker = "extra == 'sandbox'", specifier = ">=0.0.92,<0.1" },
     { name = "orjson" },
@@ -3199,7 +3199,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.7.2"
+version = "2.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3211,9 +3211,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/e3/cec27fa28ef36c4ccea71e9e8c20be9b8539618732989a82027575aab9d4/openai-2.7.2.tar.gz", hash = "sha256:082ef61163074d8efad0035dd08934cf5e3afd37254f70fc9165dd6a8c67dcbd", size = 595732, upload-time = "2025-11-10T16:42:31.108Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/f5/7c7cb955305cb41f7f3c5fd7e0e38bf6bbf2658468863d4b7b868a5cb8df/openai-2.44.0.tar.gz", hash = "sha256:68a5a5ffad82b8ff7d451c437529fb64f7c3b8123aaf0c021966a882d9e3947d", size = 988753, upload-time = "2026-06-24T20:56:02.293Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/66/22cfe4b695b5fd042931b32c67d685e867bfd169ebf46036b95b57314c33/openai-2.7.2-py3-none-any.whl", hash = "sha256:116f522f4427f8a0a59b51655a356da85ce092f3ed6abeca65f03c8be6e073d9", size = 1008375, upload-time = "2025-11-10T16:42:28.574Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f4/561ed79fd94876160018a5e75254cfcb9b0e62d4dded9dcb20072e86d623/openai-2.44.0-py3-none-any.whl", hash = "sha256:0a2a3ab2e29aeda368700f662ff9ba0f9df17ba4c54577a64e08b8115a3cc0ad", size = 1366216, upload-time = "2026-06-24T20:55:58.882Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
vllm 0.25.0 and later import `NamespaceTool` from `openai.types.responses` in `vllm/tool_parsers/utils.py`. That symbol does not exist below openai 2.25.0, and vllm only declares `openai>=2.0.0`, so the old `openai<=2.7.2` pin resolved cleanly and then failed at import time in `vllm.entrypoints.openai.api_server`. `local_vllm_model/app.py` imports from that module directly, so it could not start against vllm 0.25.x at all.

The ceiling is 2.45.0 because `InputTokensDetails.cache_write_tokens` becomes a required field there, and `NeMoGymResponseInputTokensDetails` in `nemo_gym/openai_utils.py` subclasses it, so every construction site would raise. Raising the ceiling past that also changes what Gym emits in serialized usage, so it belongs in its own change.

## Test change

`test_prunes_nested_extra_fields` sent `reasoning.context`, which Codex sets. openai 2.42.0 added `context` to the `Reasoning` TypedDict, so that field is pruned below 2.42.0 and forwarded at or above it — both inside the supported range. The test now uses a field the SDK does not define at any version in the range, so it still exercises pruning without depending on where openai resolves.

This is worth knowing beyond the test: Gym prunes request fields the pinned SDK does not recognize, so widening the window changes which fields reach backends. `reasoning.context` now passes through where it used to be dropped. Nothing errors; the forwarding contract just widens.

## Testing

Checked every openai symbol Gym imports (63 across 29 files) against 2.25.0 and 2.53.0 — none are missing. Diffed the pydantic schemas of the types Gym uses across that range; `cache_write_tokens` is the only breaking change.

Ran the unit suite at both ends of the window, 2.25.0 and 2.44.0: 1761 passed at each, with the same 11 pre-existing docs-link and tavily failures that main already has. Also ran `test_responses_api_model_streaming.py` at 2.25.0, 2.41.1, 2.42.0 and 2.44.0 to confirm the updated test is stable across the 2.42.0 boundary.

Separately confirmed the point of the change: with openai 2.44.0 installed against vllm 0.25.1, `vllm serve --help` goes from `exit=1` (ImportError on `NamespaceTool`) to `exit=0`.

## End-to-end sanity checks

Run against `local_vllm_model` serving `Qwen/Qwen3-0.6B` in `nvcr.io/nvidian/nemo-rl:nightly`, driving requests through Gym's model server so the Gym parser is exercised rather than the inner vLLM endpoint. Run at both ends of the window, since the lock only governs Gym's own dev environment — library consumers such as NeMo-RL resolve openai themselves and can land anywhere in the range.

| Check | openai 2.25.0 (floor) | openai 2.44.0 (lock) |
|---|---|---|
| streaming chat completion | 4 chunks, `[DONE]`, `finish_reason: length` | same |
| token-ID capture with `return_token_id_information: true` | `prompt_token_ids` len 13, `generation_token_ids` len 6, matches `usage.completion_tokens` | same, byte-identical IDs |

Also confirmed `ChatCompletion.model_config` and `Response.model_config` keep `extra="allow"` across 2.7.2, 2.25.0 and 2.44.0, and that vLLM's non-standard fields (`prompt_token_ids`, `token_ids`) survive validation at the top level, per choice, and on the message. That is the path that would otherwise drop token IDs silently and corrupt training data.

Not covered: live round trips against real OpenAI/Azure endpoints through `AsyncOpenAI`/`AsyncAzureOpenAI` (`openai_model`, `azure_openai_model`, `inference_provider`), and the NeMo-RL integration itself.
