### PR TITLE
fix(deps): isolate OpenShell SDK from sandbox extra

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -59,7 +59,7 @@ jobs:
           curl -LsSf "$UV_INSTALL_URL" | sh
           uv venv
           source .venv/bin/activate
-          uv sync --extra dev --extra sandbox
+          uv sync --extra dev --extra sandbox --extra openshell
 
       - name: Test
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -154,7 +154,7 @@ jobs:
         if: needs.detect.outputs.run_full == 'true'
         run: |
           source ./scripts/ci/setup_dev.sh
-          uv sync --extra dev --extra sandbox
+          uv sync --extra dev --extra sandbox --extra openshell
 
       # Sandbox is public-GitHub-only and is intentionally outside scripts/ci contract v3.
       - name: Sandbox unit tests

--- a/nemo_gym/sandbox/providers/openshell/README.md
+++ b/nemo_gym/sandbox/providers/openshell/README.md
@@ -6,7 +6,7 @@ container/MicroVM sandboxes through a compute driver (Docker, Podman, Kubernetes
 enforces policy-based egress on every outbound connection.
 
 The provider talks to the gateway's gRPC control plane through the synchronous
-[`openshell`](https://pypi.org/project/openshell/) SDK (installed with the `nemo-gym[sandbox]`
+[`openshell`](https://pypi.org/project/openshell/) SDK (installed with the `nemo-gym[openshell]`
 extra). Blocking SDK calls run on a thread pool bounded by `exec.concurrency`; providers built
 from identical connection configs share one gRPC channel and one pool, so per-sandbox provider
 instances (the `AsyncSandbox` pattern) do not multiply threads or channels. Sandboxes live in

--- a/nemo_gym/sandbox/providers/openshell/provider.py
+++ b/nemo_gym/sandbox/providers/openshell/provider.py
@@ -76,7 +76,7 @@ def _require_openshell() -> None:
     except ModuleNotFoundError as e:
         raise ModuleNotFoundError(
             "The openshell SDK is required for the openshell sandbox provider. Install "
-            "nemo-gym[sandbox] in the runtime image before using env.sandbox.provider.name=openshell."
+            "nemo-gym[openshell] in the runtime image before using env.sandbox.provider.name=openshell."
         ) from e
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,15 +265,6 @@ sandbox = [
     # License: BSD 3-Clause https://github.com/karpetrosyan/httpx-aiohttp/blob/master/LICENSE
     "httpx-aiohttp>=0.2.0",
 
-    # OpenShell SDK: used by the OpenShell sandbox provider for gateway create/exec/delete over gRPC.
-    # Lower bound 0.0.92: the version that made `workspace` a required argument on sandbox
-    # lifecycle calls. Upper bound <0.1: the SDK is alpha 0.0.x and the provider also relies on
-    # its generated protos (openshell._proto), so minor bumps can break call shapes; the
-    # SDK-conformance unit test guards the raise of this ceiling.
-    # Updated: Tue Jul 14, 2026 with openshell>=0.0.92,<0.1
-    # License: Apache 2.0 https://github.com/NVIDIA/OpenShell/blob/main/LICENSE
-    "openshell>=0.0.92,<0.1",
-
     # Daytona SDK: used by the Daytona sandbox provider for create/exec/delete and file operations.
     # License: Apache 2.0 https://pypi.org/project/daytona/
     "daytona>=0.179.0",
@@ -283,6 +274,18 @@ sandbox = [
     # Updated: Tue Jun 03, 2026 with boto3>=1.34
     # License: Apache 2.0 https://github.com/boto/boto3/blob/develop/LICENSE
     "boto3>=1.34",
+]
+
+# Keep OpenShell opt-in so its platform-specific SDK wheel cannot block installs for other providers.
+openshell = [
+    # OpenShell SDK: used by the OpenShell sandbox provider for gateway create/exec/delete over gRPC.
+    # Lower bound 0.0.92: the version that made `workspace` a required argument on sandbox
+    # lifecycle calls. Upper bound <0.1: the SDK is alpha 0.0.x and the provider also relies on
+    # its generated protos (openshell._proto), so minor bumps can break call shapes; the
+    # SDK-conformance unit test guards the raise of this ceiling.
+    # Updated: Tue Jul 14, 2026 with openshell>=0.0.92,<0.1
+    # License: Apache 2.0 https://github.com/NVIDIA/OpenShell/blob/main/LICENSE
+    "openshell>=0.0.92,<0.1",
 ]
 
 # We include dev dependencies as an extra since technically each server module is a consumer (which means we cannot use dependency groups, which are intended to be within a project).

--- a/tests/unit_tests/test_openshell_provider.py
+++ b/tests/unit_tests/test_openshell_provider.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import base64
+import builtins
 import inspect
 from pathlib import Path
 from types import SimpleNamespace
@@ -28,7 +29,7 @@ from nemo_gym.sandbox.providers.registry import get_provider_class
 pytestmark = pytest.mark.sandbox
 
 
-pytest.importorskip("openshell", reason="openshell optional sandbox dependency is not installed")
+pytest.importorskip("openshell", reason="openshell optional dependency is not installed")
 
 import grpc  # noqa: E402  (grpcio ships with the openshell SDK)
 from openshell import SandboxError, SandboxRef, SandboxStatusRef  # noqa: E402
@@ -207,6 +208,26 @@ def _make_handle(
 
 def test_registry_resolves_openshell() -> None:
     assert get_provider_class("openshell") is OpenShellProvider
+
+
+def test_missing_openshell_dependency_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals_: dict[str, Any] | None = None,
+        locals_: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        if name == "openshell" or name.startswith("openshell."):
+            raise ModuleNotFoundError(name)
+        return real_import(name, globals_, locals_, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ModuleNotFoundError, match=r"nemo-gym\[openshell\]"):
+        openshell_provider._require_openshell()
 
 
 def test_provider_call_shapes_bind_against_installed_sdk() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2594,7 +2594,6 @@ all = [
     { name = "httpx-aiohttp" },
     { name = "mypy" },
     { name = "opensandbox" },
-    { name = "openshell" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -2617,12 +2616,14 @@ dev = [
     { name = "requests-mock" },
     { name = "ruff" },
 ]
+openshell = [
+    { name = "openshell" },
+]
 sandbox = [
     { name = "boto3" },
     { name = "daytona" },
     { name = "httpx-aiohttp" },
     { name = "opensandbox" },
-    { name = "openshell" },
     { name = "tenacity" },
 ]
 vllm = [
@@ -2663,7 +2664,7 @@ requires-dist = [
     { name = "omegaconf" },
     { name = "openai", specifier = "<=2.7.2" },
     { name = "opensandbox", marker = "extra == 'sandbox'", specifier = ">=0.1.15" },
-    { name = "openshell", marker = "extra == 'sandbox'", specifier = ">=0.0.92,<0.1" },
+    { name = "openshell", marker = "extra == 'openshell'", specifier = ">=0.0.92,<0.1" },
     { name = "orjson" },
     { name = "packaging", specifier = ">=24.2" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.6.0" },
@@ -2691,7 +2692,7 @@ requires-dist = [
     { name = "wandb" },
     { name = "yappi" },
 ]
-provides-extras = ["all", "vllm", "sandbox", "dev"]
+provides-extras = ["all", "vllm", "sandbox", "openshell", "dev"]
 
 [package.metadata.requires-dev]
 codec = [


### PR DESCRIPTION
## Summary

- Move the OpenShell SDK into a dedicated `openshell` optional extra.
- Keep the shared `sandbox` and portable `all` extras installable on hosts that cannot use the OpenShell wheel.
- Update OpenShell installation guidance and preserve SDK-backed provider coverage in CI.
- Add coverage for the missing-SDK installation hint.

## Root cause

OpenShell 0.0.92 is distributed only as platform-specific wheels, and its Linux wheels require the `manylinux_2_39` baseline. Including it in the shared `sandbox` extra makes dependency resolution fail on older-glibc hosts even when users select a different sandbox provider.

## Impact

Users of OpenSandbox, Apptainer, Docker, and other providers can continue installing `nemo-gym[sandbox]` without resolving OpenShell. OpenShell users opt in explicitly with `nemo-gym[openshell]`.

## Validation

- `uv lock --check`
- Dependency exports confirm `sandbox` and `all` exclude OpenShell while `openshell` resolves `openshell==0.0.92`
- Fresh sandbox-only environment confirms lazy OpenShell provider discovery still works without the SDK
- `pytest -q tests/unit_tests/test_openshell_provider.py` (`82 passed`)
- Repository pre-commit hooks on all changed files
- Full sandbox unit selection: `365 passed`, `4 skipped`; one unrelated macOS-only Enroot test fails because `/proc` is unavailable
