### PR TITLE
refactor(sandbox): adopt Pydantic provider configs

### DIFF
--- a/fern/versions/latest/pages/infrastructure/sandbox/adding-a-provider.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/adding-a-provider.mdx
@@ -100,12 +100,14 @@ Use `SandboxSpec.provider_options` for per-sandbox options that do not belong in
 
 ```python
 from collections.abc import Mapping
-from dataclasses import dataclass
 from typing import Any
 
+from pydantic import BaseModel, ConfigDict
 
-@dataclass(frozen=True)
-class MyProviderOptions:
+
+class MyProviderOptions(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     snapshot_id: str | None = None
     labels: dict[str, str] | None = None
 
@@ -113,11 +115,9 @@ class MyProviderOptions:
     def from_mapping(cls, options: Mapping[str, Any] | None) -> "MyProviderOptions":
         if options is None:
             return cls()
-        allowed = set(cls.__dataclass_fields__)
-        unknown = set(options) - allowed
-        if unknown:
-            raise ValueError(f"Unknown provider option(s): {', '.join(sorted(unknown))}")
-        return cls(**dict(options))
+        if not isinstance(options, Mapping):
+            raise TypeError("provider_options must be a mapping")
+        return cls.model_validate(dict(options))
 ```
 
 Then resolve it inside `create()`:
@@ -128,7 +128,7 @@ async def create(self, spec: SandboxSpec) -> SandboxHandle:
     ...
 ```
 
-This keeps common fields such as `image`, `env`, `files`, `metadata`, and `resources` portable while still giving a provider room for runtime-specific behavior.
+This keeps common fields such as `image`, `env`, `files`, `metadata`, `resources`, and `resource_requests` portable while still giving a provider room for runtime-specific behavior. Pydantic rejects unknown provider-option keys and exposes `model_validate()` and `model_dump()` for typed configuration boundaries.
 
 ## Registry
 

--- a/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
@@ -60,8 +60,8 @@ The public API is part of `nemo-gym`. Runtime backends can have optional depende
 | --- | --- |
 | `AsyncSandbox` | Async facade for FastAPI servers, async agents, and rollout code. Use this inside async code. |
 | `Sandbox` | Sync facade for synchronous harnesses. It owns a private event loop and rejects calls from an already-running async loop. |
-| `SandboxSpec` | Provider-neutral sandbox creation request. Includes image, TTL, working directory, files, metadata, resources, entrypoint, and provider options. |
-| `SandboxResources` | Typed resource request with CPU, memory, disk, and GPU fields. |
+| `SandboxSpec` | Provider-neutral sandbox creation request. Includes image, TTL, working directory, files, metadata, resource limits and requests, entrypoint, and provider options. |
+| `SandboxResources` | Typed resource quantities with CPU, memory, disk, and GPU fields. |
 | `SandboxExecResult` | Command result with `stdout`, `stderr`, `return_code`, and optional `error_type`. |
 | `SandboxStatus` | Provider-neutral lifecycle status: `starting`, `running`, `stopped`, `error`, or `unknown`. |
 | `SandboxCreateError` | Base create-time failure for provider allocation and readiness errors. |
@@ -145,6 +145,8 @@ mini_swe_agent_2:
 
 Every provider config can bind the same name, such as `sandbox`, so swapping backends is swapping the provider config path passed to `gym env start`. If one run needs multiple sandboxes, give each block a distinct name and reference each one separately.
 
+Built-in provider configuration and option types are Pydantic models. Where a provider constructor exposes configuration sections, each section accepts its exported typed model or a plain Hydra mapping. `resolve_provider_config()` recursively normalizes typed models to plain configuration values while preserving explicitly supplied fields.
+
 `default_metadata` is merged into `SandboxSpec.metadata` before create. The agent's own `sandbox_spec.metadata` wins on key conflicts.
 
 The helpers used by agents are public:
@@ -212,7 +214,7 @@ Do not call `Sandbox` from FastAPI handlers, async resources servers, or async a
 
 ## SandboxSpec Fields
 
-`SandboxSpec` is intentionally provider-neutral. Providers map these fields onto their own runtime primitives.
+`SandboxSpec` is intentionally provider-neutral. Providers map these fields onto their own runtime primitives. `SandboxSpec` and `SandboxResources` are Pydantic models, so configuration mappings can be loaded with `model_validate()` and serialized with `model_dump()`.
 
 | Field | Description |
 | --- | --- |
@@ -223,7 +225,8 @@ Do not call `Sandbox` from FastAPI handlers, async resources servers, or async a
 | `env` | Environment variables injected into the sandbox. Forward only values required by the task. |
 | `files` | Text files to upload at startup, keyed by remote target path. |
 | `metadata` | String metadata for tracing, debugging, and backend labels. Providers may normalize values for their runtime. |
-| `resources` | `SandboxResources` or a mapping with `cpu`, `memory_mib`, `disk_gib`, `gpu`, and `gpu_type`. |
+| `resources` | Resource limits or requirements as `SandboxResources`, or a mapping with `cpu`, `memory_mib`, `disk_gib`, `gpu`, and `gpu_type`. |
+| `resource_requests` | Optional scheduling requests using the same fields as `resources`. Numeric requests cannot exceed corresponding limits. Providers without distinct request and limit semantics ignore this hint. |
 | `entrypoint` | Optional container entrypoint override. |
 | `provider_options` | Provider-specific options that do not fit the common schema. |
 
@@ -237,10 +240,15 @@ spec = SandboxSpec(
         "memory_mib": 8192,
         "disk_gib": 20,
     },
+    resource_requests={
+        "cpu": 0.5,
+        "memory_mib": 2048,
+        "disk_gib": 20,
+    },
 )
 ```
 
-Unknown resource keys raise a `ValueError`, which catches config drift early.
+Unknown resource keys raise a `ValueError`, which catches config drift early. When `resource_requests` is omitted, providers retain their existing single-resource-map behavior.
 
 ## Startup Files and File Transfer
 

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
@@ -71,7 +71,7 @@ gym env start \
   --config responses_api_models/vllm_model/configs/vllm_model.yaml
 ```
 
-The provider constructor accepts four optional config sections:
+The provider constructor accepts five optional config sections:
 
 | Section | Purpose |
 | --- | --- |
@@ -79,6 +79,7 @@ The provider constructor accepts four optional config sections:
 | `create` | Sandbox create timeout, retry, image pull policy, and health-check behavior. |
 | `probe` | Post-create command probe used to verify command execution before the sandbox is returned. |
 | `operations` | Retry and timeout behavior for SDK operations after create, including command retries and close timeout. |
+| `attribution` | Default team, user, workload, and run metadata attached to every sandbox. |
 
 ## SandboxSpec Provider Options
 
@@ -121,7 +122,8 @@ Unknown provider option keys raise `ValueError`; values with the wrong type rais
 | `env` | Passed to OpenSandbox create and command execution. |
 | `files` | Seed files uploaded before the first command. |
 | `metadata` | Passed to OpenSandbox create after provider-specific normalization. |
-| `resources` | Mapped to OpenSandbox resource quantities. |
+| `resources` | Mapped to OpenSandbox resource limits. |
+| `resource_requests` | Mapped to separate OpenSandbox scheduling requests. When omitted, OpenSandbox applies the resource limits as requests too. |
 | `entrypoint` | Passed to OpenSandbox create when set. |
 | `provider_options` | Per-sandbox OpenSandbox options such as `image_auth`, `platform`, `snapshot_id`, `volumes`, `skip_health_check`, and `extensions`. |
 
@@ -136,6 +138,8 @@ Unknown provider option keys raise `ValueError`; values with the wrong type rais
 | `disk_gib` | `ephemeral-storage`, formatted as `<value>Gi` |
 | `gpu` | `gpu` |
 | `gpu_type` | `gpu_type` |
+
+Use `SandboxSpec.resources` for limits and `SandboxSpec.resource_requests` for lower scheduling requests when a workload needs burst headroom without reserving its full limit. Numeric request values must not exceed their corresponding limits.
 
 The provider also normalizes metadata values for backend labels by replacing unsupported characters and truncating values to the provider limit.
 

--- a/nemo_gym/sandbox/config.py
+++ b/nemo_gym/sandbox/config.py
@@ -42,6 +42,8 @@ the provider rather than the agent config::
 from collections.abc import Mapping
 from typing import Any
 
+from pydantic import BaseModel
+
 
 # Reserved keys inside a sandbox block that are not the provider config.
 SANDBOX_BLOCK_DEFAULT_METADATA_KEY = "default_metadata"
@@ -49,7 +51,7 @@ SANDBOX_BLOCK_RESERVED_KEYS = frozenset({SANDBOX_BLOCK_DEFAULT_METADATA_KEY})
 
 
 def _to_plain_dict(value: Any) -> Any:
-    """Return a plain ``dict`` for mappings, including OmegaConf ``DictConfig``."""
+    """Recursively normalize config containers and Pydantic models to plain values."""
     try:
         from omegaconf import DictConfig, OmegaConf
     except ImportError:  # pragma: no cover - omegaconf is a core dependency
@@ -57,9 +59,13 @@ def _to_plain_dict(value: Any) -> Any:
         OmegaConf = None  # type: ignore[assignment]
 
     if OmegaConf is not None and isinstance(value, DictConfig):
-        return OmegaConf.to_container(value, resolve=True)
+        return _to_plain_dict(OmegaConf.to_container(value, resolve=True))
+    if isinstance(value, BaseModel):
+        return _to_plain_dict(value.model_dump(mode="python", exclude_unset=True))
     if isinstance(value, Mapping):
-        return dict(value)
+        return {key: _to_plain_dict(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_plain_dict(item) for item in value]
     return value
 
 

--- a/nemo_gym/sandbox/providers/apptainer/provider.py
+++ b/nemo_gym/sandbox/providers/apptainer/provider.py
@@ -29,7 +29,9 @@ import uuid
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from nemo_gym.sandbox.providers.base import (
     SandboxCreateError,
@@ -78,42 +80,49 @@ def _require_apptainer() -> str:
     return path
 
 
-@dataclass(frozen=True)
-class ApptainerCreateConfig:
+class ApptainerCreateConfig(BaseModel):
     """Settings for creating an Apptainer sandbox instance."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     mount_point: str = DEFAULT_MOUNT_POINT
     start_timeout_s: float | None = 600
-    extra_start_args: list[str] = field(default_factory=list)
+    extra_start_args: list[str] = Field(default_factory=list)
     apply_resource_limits: bool = True
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.start_timeout_s is not None and self.start_timeout_s <= 0:
             raise ValueError("create.start_timeout_s must be > 0")
         if not self.mount_point.startswith("/"):
             raise ValueError("create.mount_point must be an absolute path")
+        return self
 
 
-@dataclass(frozen=True)
-class ApptainerExecConfig:
+class ApptainerExecConfig(BaseModel):
     """Settings for running commands inside an Apptainer sandbox."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     default_timeout_s: float | None = 180
     fakeroot_for_root: bool = True
-    default_binds: list[str] = field(default_factory=list)
-    extra_exec_args: list[str] = field(default_factory=list)
+    default_binds: list[str] = Field(default_factory=list)
+    extra_exec_args: list[str] = Field(default_factory=list)
     concurrency: int = 32
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.default_timeout_s is not None and self.default_timeout_s <= 0:
             raise ValueError("exec.default_timeout_s must be > 0")
         if self.concurrency < 1:
             raise ValueError("exec.concurrency must be >= 1")
+        return self
 
 
-@dataclass(frozen=True)
-class ApptainerProbeConfig:
+class ApptainerProbeConfig(BaseModel):
     """Post-create probe settings: a test command confirming the sandbox is usable."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     command: str | None = READY_PROBE_COMMAND
     expected_stdout: str | None = READY_PROBE_EXPECTED
@@ -122,7 +131,8 @@ class ApptainerProbeConfig:
     stable_count: int = 1
     stable_delay_s: float = 0.0
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.command is not None and self.timeout_s <= 0:
             raise ValueError("probe.timeout_s must be > 0")
         if self.deadline_s is not None and self.deadline_s <= 0:
@@ -131,6 +141,7 @@ class ApptainerProbeConfig:
             raise ValueError("probe.stable_count must be >= 1")
         if self.stable_delay_s < 0:
             raise ValueError("probe.stable_delay_s must be >= 0")
+        return self
 
 
 @dataclass

--- a/nemo_gym/sandbox/providers/base.py
+++ b/nemo_gym/sandbox/providers/base.py
@@ -18,8 +18,10 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, Self, runtime_checkable
 from urllib.parse import urlsplit
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class SandboxStatus(str, Enum):
@@ -61,58 +63,134 @@ class SandboxEndpoint:
         )
 
 
-@dataclass(frozen=True)
-class SandboxResources:
-    """Provider-neutral resource request."""
+_SANDBOX_RESOURCES_POSITIONAL_FIELDS = (
+    "cpu",
+    "memory_mib",
+    "disk_gib",
+    "gpu",
+    "gpu_type",
+)
 
-    cpu: float | None = None
+
+class SandboxResources(BaseModel):
+    """Provider-neutral resource quantities."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", allow_inf_nan=False)
+
+    cpu: int | float | None = None
     memory_mib: int | None = None
     disk_gib: int | None = None
     gpu: int | None = None
     gpu_type: str | None = None
 
+    def __init__(self, *args: Any, **data: Any) -> None:
+        if len(args) > len(_SANDBOX_RESOURCES_POSITIONAL_FIELDS):
+            raise TypeError(
+                f"SandboxResources() accepts at most {len(_SANDBOX_RESOURCES_POSITIONAL_FIELDS)} "
+                f"positional arguments, got {len(args)}"
+            )
+
+        positional_data = dict(zip(_SANDBOX_RESOURCES_POSITIONAL_FIELDS, args, strict=False))
+        for field_name in positional_data:
+            if field_name in data:
+                raise TypeError(f"SandboxResources() got multiple values for argument {field_name!r}")
+
+        super().__init__(**positional_data, **data)
+
+    @model_validator(mode="before")
     @classmethod
-    def from_mapping(cls, resources: Mapping[str, Any] | None) -> "SandboxResources":
+    def reject_unknown_fields(cls, resources: Any) -> Any:
+        if isinstance(resources, Mapping):
+            unknown_keys = set(resources) - set(cls.model_fields)
+            if unknown_keys:
+                unknown = ", ".join(sorted(unknown_keys))
+                allowed = ", ".join(sorted(cls.model_fields))
+                raise ValueError(f"Unknown sandbox resource keys: {unknown}. Expected keys: {allowed}")
+        return resources
+
+    @field_validator("cpu", mode="before")
+    @classmethod
+    def coerce_cpu(cls, cpu: Any) -> int | float | None:
+        if cpu is None or isinstance(cpu, int):
+            return cpu
+        return float(cpu)
+
+    @field_validator("memory_mib", "disk_gib", "gpu", mode="before")
+    @classmethod
+    def coerce_integer_resource(cls, value: Any) -> int | None:
+        return int(value) if value is not None else None
+
+    @field_validator("gpu_type", mode="before")
+    @classmethod
+    def coerce_gpu_type(cls, gpu_type: Any) -> str | None:
+        return str(gpu_type) if gpu_type is not None else None
+
+    @classmethod
+    def from_mapping(cls, resources: Mapping[str, Any] | Self | None) -> Self:
         if resources is None:
             return cls()
-        allowed_keys = set(cls.__dataclass_fields__)
-        unknown_keys = set(resources) - allowed_keys
-        if unknown_keys:
-            unknown = ", ".join(sorted(unknown_keys))
-            allowed = ", ".join(sorted(allowed_keys))
-            raise ValueError(f"Unknown sandbox resource keys: {unknown}. Expected keys: {allowed}")
-        return cls(
-            cpu=float(resources["cpu"]) if resources.get("cpu") is not None else None,
-            memory_mib=int(resources["memory_mib"]) if resources.get("memory_mib") is not None else None,
-            disk_gib=int(resources["disk_gib"]) if resources.get("disk_gib") is not None else None,
-            gpu=int(resources["gpu"]) if resources.get("gpu") is not None else None,
-            gpu_type=str(resources["gpu_type"]) if resources.get("gpu_type") is not None else None,
-        )
+        if isinstance(resources, cls):
+            return resources
+        values = dict(resources)
+        if values.get("cpu") is not None:
+            values["cpu"] = float(values["cpu"])
+        return cls.model_validate(values)
 
 
-@dataclass(frozen=True)
-class SandboxSpec:
+_SANDBOX_SPEC_POSITIONAL_FIELDS = (
+    "image",
+    "ttl_s",
+    "ready_timeout_s",
+    "workdir",
+    "env",
+    "files",
+    "metadata",
+    "resources",
+    "entrypoint",
+    "provider_options",
+    "ports",
+)
+
+
+class SandboxSpec(BaseModel):
     """Sandbox creation request."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     image: str | None = None
     ttl_s: int | float | None = None
     ready_timeout_s: int | float | None = None
     workdir: str | None = None
-    env: dict[str, str] = field(default_factory=dict)
-    files: dict[str, str] = field(default_factory=dict)
-    metadata: dict[str, str] = field(default_factory=dict)
-    resources: SandboxResources | Mapping[str, Any] = field(default_factory=SandboxResources)
+    env: dict[str, str] = Field(default_factory=dict)
+    files: dict[str, str] = Field(default_factory=dict)
+    metadata: dict[str, str] = Field(default_factory=dict)
+    resources: SandboxResources = Field(default_factory=SandboxResources)
+    resource_requests: SandboxResources | None = None
     entrypoint: list[str] | None = None
-    provider_options: dict[str, Any] = field(default_factory=dict)
-    ports: tuple[int, ...] | list[int] = field(default_factory=tuple)
+    provider_options: dict[str, Any] = Field(default_factory=dict)
+    ports: tuple[int, ...] = Field(default_factory=tuple)
 
-    def __post_init__(self) -> None:
-        if not isinstance(self.resources, SandboxResources):
-            object.__setattr__(self, "resources", SandboxResources.from_mapping(self.resources))
-        if not isinstance(self.ports, (list, tuple)):
+    def __init__(self, *args: Any, **data: Any) -> None:
+        if len(args) > len(_SANDBOX_SPEC_POSITIONAL_FIELDS):
+            raise TypeError(
+                f"SandboxSpec() accepts at most {len(_SANDBOX_SPEC_POSITIONAL_FIELDS)} "
+                f"positional arguments, got {len(args)}"
+            )
+
+        positional_data = dict(zip(_SANDBOX_SPEC_POSITIONAL_FIELDS, args, strict=False))
+        for field_name in positional_data:
+            if field_name in data:
+                raise TypeError(f"SandboxSpec() got multiple values for argument {field_name!r}")
+
+        super().__init__(**positional_data, **data)
+
+    @field_validator("ports", mode="before")
+    @classmethod
+    def normalize_ports(cls, ports: Any) -> tuple[int, ...]:
+        if not isinstance(ports, (list, tuple)):
             raise TypeError("Sandbox ports must be a list or tuple of TCP port numbers")
         normalized_ports: list[int] = []
-        for raw_port in self.ports:
+        for raw_port in ports:
             if isinstance(raw_port, bool):
                 raise ValueError(f"Invalid sandbox TCP port: {raw_port!r}")
             if not isinstance(raw_port, (int, str)):
@@ -126,7 +204,45 @@ class SandboxSpec:
             if port in normalized_ports:
                 raise ValueError(f"Duplicate sandbox TCP port: {port}")
             normalized_ports.append(port)
-        object.__setattr__(self, "ports", tuple(normalized_ports))
+        return tuple(normalized_ports)
+
+    @field_validator("resources", mode="before")
+    @classmethod
+    def default_resources(cls, resources: Any) -> Any:
+        """Keep accepting an explicit null resource block as an empty request."""
+        if resources is None or isinstance(resources, (Mapping, SandboxResources)):
+            return SandboxResources.from_mapping(resources)
+        return resources
+
+    @field_validator("resource_requests", mode="before")
+    @classmethod
+    def normalize_resource_requests(cls, resource_requests: Any) -> Any:
+        if isinstance(resource_requests, (Mapping, SandboxResources)):
+            return SandboxResources.from_mapping(resource_requests)
+        return resource_requests
+
+    @field_validator("provider_options", mode="before")
+    @classmethod
+    def normalize_provider_options(cls, provider_options: Any) -> Any:
+        if provider_options is None:
+            return {}
+        if isinstance(provider_options, BaseModel):
+            return provider_options.model_dump(mode="python")
+        return provider_options
+
+    @model_validator(mode="after")
+    def validate_resource_requests(self) -> Self:
+        if self.resource_requests is None:
+            return self
+
+        for field_name in ("cpu", "memory_mib", "disk_gib", "gpu"):
+            request = getattr(self.resource_requests, field_name)
+            limit = getattr(self.resources, field_name)
+            if request is not None and limit is not None and request > limit:
+                raise ValueError(
+                    f"resource_requests.{field_name} ({request}) cannot exceed resources.{field_name} ({limit})"
+                )
+        return self
 
 
 @dataclass

--- a/nemo_gym/sandbox/providers/daytona/provider.py
+++ b/nemo_gym/sandbox/providers/daytona/provider.py
@@ -20,9 +20,10 @@ import math
 import re
 import uuid
 from collections.abc import Mapping
-from dataclasses import dataclass, field, fields, replace
 from pathlib import Path
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from nemo_gym.sandbox.providers.base import (
     SandboxCreateError,
@@ -306,51 +307,65 @@ def _log_operation_retry(retry_state: Any) -> None:
     )
 
 
-class DaytonaConfigBase:
-    """Shared dataclass construction for Daytona provider config blocks."""
+class DaytonaConfigBase(BaseModel):
+    """Shared Pydantic construction for Daytona provider config blocks."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     @classmethod
-    def from_mapping(cls, value: Any) -> Any:
+    def from_mapping(cls, value: Any) -> Self:
         if value is None:
             return cls()
         if isinstance(value, cls):
             return value
         if not isinstance(value, Mapping):
             raise TypeError(f"{cls.__name__} must be a mapping or {cls.__name__} instance")
-        field_names = {field.name for field in fields(cls) if field.init}
+        field_names = set(cls.model_fields)
         unsupported_keys = sorted(str(key) for key in value if key not in field_names)
         if unsupported_keys:
             raise ValueError(f"Unsupported Daytona {cls.__name__} settings: {', '.join(unsupported_keys)}")
-        return cls(**{key: val for key, val in value.items() if key in field_names})
-
-
-def _supplied_config_keys(value: Any, config_cls: type[Any]) -> set[str]:
-    if not isinstance(value, Mapping):
-        return set()
-    field_names = {field.name for field in fields(config_cls) if field.init}
-    return {str(key) for key in value if key in field_names}
+        return cls.model_validate(dict(value))
 
 
 def _string_map(values: dict[str, Any]) -> dict[str, str]:
     return {str(key): str(value) for key, value in values.items()}
 
 
-@dataclass(frozen=True)
-class DaytonaProviderOptions:
+class DaytonaProviderOptions(BaseModel):
     """Recognized per-sandbox create options read from ``SandboxSpec.provider_options``."""
 
-    extensions: Mapping[str, str] = field(default_factory=dict)
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    extensions: dict[str, str] = Field(default_factory=dict)
     snapshot_id: str | None = None
-    volumes: tuple[Mapping[str, Any], ...] = ()
+    volumes: tuple[dict[str, Any], ...] = ()
+
+    @field_validator("extensions", mode="before")
+    @classmethod
+    def normalize_extensions(cls, extensions: Any) -> Any:
+        if isinstance(extensions, Mapping):
+            return _string_map(dict(extensions))
+        return extensions
+
+    @field_validator("volumes", mode="before")
+    @classmethod
+    def normalize_volumes(cls, volumes: Any) -> Any:
+        if volumes is None:
+            return ()
+        if isinstance(volumes, (list, tuple)):
+            return tuple(dict(volume) if isinstance(volume, Mapping) else volume for volume in volumes)
+        return volumes
 
     @classmethod
     def from_mapping(cls, options: Mapping[str, Any] | None) -> "DaytonaProviderOptions":
         if options is None:
             return cls()
+        if isinstance(options, cls):
+            return options
         if not isinstance(options, Mapping):
             raise TypeError("Daytona provider_options must be a mapping")
 
-        allowed = set(cls.__dataclass_fields__)
+        allowed = set(cls.model_fields)
         unknown = set(options) - allowed
         if unknown:
             raise ValueError(
@@ -370,10 +385,12 @@ class DaytonaProviderOptions:
         if not isinstance(volumes, (list, tuple)) or not all(isinstance(volume, Mapping) for volume in volumes):
             raise TypeError("Daytona provider option 'volumes' must be a list of mappings")
 
-        return cls(
-            extensions=_string_map(dict(extensions)),
-            snapshot_id=snapshot_id,
-            volumes=tuple(dict(volume) for volume in volumes),
+        return cls.model_validate(
+            {
+                "extensions": dict(extensions),
+                "snapshot_id": snapshot_id,
+                "volumes": volumes,
+            }
         )
 
 
@@ -383,11 +400,12 @@ def _provider_options(spec: SandboxSpec) -> DaytonaProviderOptions:
 
 def _normalize_spec(spec: SandboxSpec) -> SandboxSpec:
     _provider_options(spec)
-    return replace(
-        spec,
-        env=_string_map(spec.env),
-        metadata=_string_map(spec.metadata),
-        provider_options={} if spec.provider_options is None else dict(spec.provider_options),
+    return spec.model_copy(
+        update={
+            "env": _string_map(spec.env),
+            "metadata": _string_map(spec.metadata),
+            "provider_options": {} if spec.provider_options is None else dict(spec.provider_options),
+        }
     )
 
 
@@ -452,7 +470,7 @@ def _configured_or_extension(spec: SandboxSpec, key: str, configured: Any) -> An
 
 def _resources_requested(resources: SandboxResources | Mapping[str, Any]) -> bool:
     if isinstance(resources, SandboxResources):
-        return any(getattr(resources, field.name) is not None for field in fields(SandboxResources))
+        return bool(resources.model_dump(exclude_none=True))
     return bool(resources)
 
 
@@ -527,7 +545,6 @@ def _to_sandbox_status(value: Any) -> SandboxStatus:
     return SandboxStatus.UNKNOWN
 
 
-@dataclass(frozen=True)
 class DaytonaConnectionConfig(DaytonaConfigBase):
     """Daytona API client connection settings."""
 
@@ -540,12 +557,13 @@ class DaytonaConnectionConfig(DaytonaConfigBase):
     connection_pool_maxsize: int | None = None
     otel_enabled: bool | None = None
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_connection_pool_maxsize(self) -> Self:
         if self.connection_pool_maxsize is not None and self.connection_pool_maxsize <= 0:
             raise ValueError("connection.connection_pool_maxsize must be > 0")
+        return self
 
 
-@dataclass(frozen=True)
 class DaytonaCreateConfig(DaytonaConfigBase):
     """Daytona sandbox creation settings."""
 
@@ -563,7 +581,8 @@ class DaytonaCreateConfig(DaytonaConfigBase):
     network_block_all: bool | None = None
     network_allow_list: str | None = None
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_create_settings(self) -> Self:
         if self.timeout_s < 0:
             raise ValueError("create.timeout_s must be >= 0")
         if self.retries < 0:
@@ -572,9 +591,9 @@ class DaytonaCreateConfig(DaytonaConfigBase):
             raise ValueError("create.retry_delay_s must be >= 0")
         if self.retry_max_delay_s < 0:
             raise ValueError("create.retry_max_delay_s must be >= 0")
+        return self
 
 
-@dataclass(frozen=True)
 class DaytonaProbeConfig(DaytonaConfigBase):
     """Post-create probe settings."""
 
@@ -583,14 +602,15 @@ class DaytonaProbeConfig(DaytonaConfigBase):
     timeout_s: int = 30
     deadline_s: float | None = None
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_probe_settings(self) -> Self:
         if self.command is not None and self.timeout_s <= 0:
             raise ValueError("probe.timeout_s must be > 0")
         if self.deadline_s is not None and self.deadline_s <= 0:
             raise ValueError("probe.deadline_s must be > 0")
+        return self
 
 
-@dataclass(frozen=True)
 class DaytonaOperationConfig(DaytonaConfigBase):
     """Retry and timeout settings for Daytona operations after create."""
 
@@ -602,7 +622,8 @@ class DaytonaOperationConfig(DaytonaConfigBase):
     file_timeout_s: int | None = 30 * 60
     close_timeout_s: float | None = 60.0
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_operation_settings(self) -> Self:
         if self.retries < 0:
             raise ValueError("operations.retries must be >= 0")
         if self.retry_delay_s < 0:
@@ -617,17 +638,19 @@ class DaytonaOperationConfig(DaytonaConfigBase):
             raise ValueError("operations.file_timeout_s must be > 0")
         if self.close_timeout_s is not None and self.close_timeout_s <= 0:
             raise ValueError("operations.close_timeout_s must be > 0")
+        return self
 
 
-@dataclass(frozen=True)
 class DaytonaBatchConfig(DaytonaConfigBase):
     """Client-side batch fanout settings."""
 
     concurrency: int = 4
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_concurrency(self) -> Self:
         if self.concurrency < 1:
             raise ValueError("batch.concurrency must be >= 1")
+        return self
 
 
 class DaytonaProvider:
@@ -649,7 +672,7 @@ class DaytonaProvider:
         self._probe = DaytonaProbeConfig.from_mapping(probe)
         self._operations = DaytonaOperationConfig.from_mapping(operations)
         self._batch = DaytonaBatchConfig.from_mapping(batch)
-        self._connection_supplied_keys = _supplied_config_keys(connection, DaytonaConnectionConfig)
+        self._connection_supplied_keys = set(self._connection.model_fields_set)
         self._daytona: Any | None = None
 
     def _client(self) -> Any:
@@ -781,7 +804,7 @@ class DaytonaProvider:
         extensions = _spec_extensions(spec)
         extensions[f"{DAYTONA_EXTENSION_PREFIX}name"] = sandbox_id
         provider_options[PROVIDER_OPTION_EXTENSIONS] = extensions
-        return replace(spec, metadata=metadata, provider_options=provider_options)
+        return spec.model_copy(update={"metadata": metadata, "provider_options": provider_options})
 
     async def _verify_created_handle(self, handle: SandboxHandle) -> None:
         if self._probe.command is None:

--- a/nemo_gym/sandbox/providers/docker/provider.py
+++ b/nemo_gym/sandbox/providers/docker/provider.py
@@ -28,7 +28,9 @@ import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Self, TypeVar
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from nemo_gym.sandbox.providers.base import (
     SandboxCreateError,
@@ -43,6 +45,8 @@ from nemo_gym.sandbox.providers.base import (
 
 
 LOGGER = logging.getLogger(__name__)
+
+_ConfigT = TypeVar("_ConfigT", bound=BaseModel)
 
 CONTAINER_NAME_PREFIX = "nemo-gym-"
 SANDBOX_LABEL = "nemo-gym.sandbox"
@@ -79,13 +83,13 @@ def _require_docker() -> str:
     return path
 
 
-def _coerce_config(value: Any, config_cls: type[Any]) -> Any:
+def _coerce_config(value: Any, config_cls: type[_ConfigT]) -> _ConfigT:
     if value is None:
         return config_cls()
     if isinstance(value, config_cls):
         return value
     if isinstance(value, Mapping):
-        return config_cls(**value)
+        return config_cls.model_validate(value)
     raise TypeError(f"{config_cls.__name__} must be a mapping or {config_cls.__name__} instance")
 
 
@@ -112,22 +116,24 @@ def _redact_argv(argv: list[str]) -> list[str]:
     return out
 
 
-@dataclass(frozen=True)
-class DockerCreateConfig:
+class DockerCreateConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     keepalive_shell: str = DEFAULT_KEEPALIVE_SHELL
     keepalive_cmd: str = DEFAULT_KEEPALIVE_CMD
     start_timeout_s: float | None = 600
     use_init: bool = True
     network: str | None = None  # None: default bridge; "none": no network; else a named network.
     read_only: bool = False
-    cap_drop: list[str] = field(default_factory=list)
-    security_opt: list[str] = field(default_factory=list)
+    cap_drop: list[str] = Field(default_factory=list)
+    security_opt: list[str] = Field(default_factory=list)
     pids_limit: int | None = None
-    extra_run_args: list[str] = field(default_factory=list)
+    extra_run_args: list[str] = Field(default_factory=list)
     apply_resource_limits: bool = True
     publish_host: str = "127.0.0.1"
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.start_timeout_s is not None and self.start_timeout_s <= 0:
             raise ValueError("create.start_timeout_s must be > 0")
         if self.pids_limit is not None and self.pids_limit <= 0:
@@ -136,27 +142,32 @@ class DockerCreateConfig:
             ipaddress.ip_address(self.publish_host)
         except ValueError as exc:
             raise ValueError("create.publish_host must be an IPv4 or IPv6 address") from exc
+        return self
 
 
-@dataclass(frozen=True)
-class DockerExecConfig:
+class DockerExecConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     default_timeout_s: float | None = 180
-    extra_exec_args: list[str] = field(default_factory=list)
+    extra_exec_args: list[str] = Field(default_factory=list)
     concurrency: int = 32
     # `<shell> -c <cmd>`. None auto-detects bash (needed for conda `source`), else falls back to sh.
     exec_shell: str | None = None
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.default_timeout_s is not None and self.default_timeout_s <= 0:
             raise ValueError("exec.default_timeout_s must be > 0")
         if self.concurrency < 1:
             raise ValueError("exec.concurrency must be >= 1")
         if self.exec_shell is not None and not self.exec_shell:
             raise ValueError("exec.exec_shell must be null (auto) or a non-empty shell name/path")
+        return self
 
 
-@dataclass(frozen=True)
-class DockerProbeConfig:
+class DockerProbeConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     command: str | None = READY_PROBE_COMMAND
     expected_stdout: str | None = READY_PROBE_EXPECTED
     timeout_s: int = 30
@@ -164,7 +175,8 @@ class DockerProbeConfig:
     stable_count: int = 1
     stable_delay_s: float = 0.0
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.command is not None and self.timeout_s <= 0:
             raise ValueError("probe.timeout_s must be > 0")
         if self.deadline_s is not None and self.deadline_s <= 0:
@@ -173,6 +185,7 @@ class DockerProbeConfig:
             raise ValueError("probe.stable_count must be >= 1")
         if self.stable_delay_s < 0:
             raise ValueError("probe.stable_delay_s must be >= 0")
+        return self
 
 
 @dataclass

--- a/nemo_gym/sandbox/providers/ecs_fargate/__init__.py
+++ b/nemo_gym/sandbox/providers/ecs_fargate/__init__.py
@@ -16,7 +16,9 @@
 
 from nemo_gym.sandbox.providers.ecs_fargate.engine import (
     EcsFargateConfig,
+    OutsideEndpoint,
     SshSidecarConfig,
+    VolumeMount,
 )
 from nemo_gym.sandbox.providers.ecs_fargate.provider import (
     EcsFargateProvider,
@@ -27,6 +29,8 @@ from nemo_gym.sandbox.providers.ecs_fargate.provider import (
 __all__ = [
     "EcsFargateConfig",
     "EcsFargateProvider",
+    "OutsideEndpoint",
     "SshSidecarConfig",
+    "VolumeMount",
     "engine_config_from_mapping",
 ]

--- a/nemo_gym/sandbox/providers/ecs_fargate/engine.py
+++ b/nemo_gym/sandbox/providers/ecs_fargate/engine.py
@@ -41,12 +41,12 @@ import time
 import uuid
 import zipfile
 from dataclasses import dataclass, field
-from dataclasses import replace as _dc_replace
 from pathlib import Path
 from typing import Any, Callable, Self, TypeVar
 from urllib.parse import ParseResult, urlparse
 
 import aiohttp
+from pydantic import BaseModel, ConfigDict, Field
 
 
 # Matches the exec-server script's TB_EXEC_PORT fallback and the
@@ -66,8 +66,7 @@ class ExecResult:
     return_code: int
 
 
-@dataclass
-class OutsideEndpoint:
+class OutsideEndpoint(BaseModel):
     """A host-side URL that must be reachable from inside the sandbox.
 
     The sandbox rewrites *url* for its network topology and exposes the
@@ -75,13 +74,16 @@ class OutsideEndpoint:
     container.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     url: str
     env_var: str
 
 
-@dataclass
-class VolumeMount:
+class VolumeMount(BaseModel):
     """EFS mount (ECS Fargate). Host bind mounts are unused on Fargate."""
+
+    model_config = ConfigDict(extra="forbid")
 
     host_path: str = ""
     container_path: str = ""
@@ -97,16 +99,17 @@ class VolumeMount:
         return self.efs or self.efs_filesystem_id is not None
 
 
-@dataclass
-class SandboxSpec:
+class SandboxSpec(BaseModel):
     """Per-problem sandbox requirements."""
+
+    model_config = ConfigDict(extra="forbid")
 
     image: str
     workdir: str = "/workspace"
-    env: dict[str, str] = field(default_factory=dict)
-    files: dict[str, str] = field(default_factory=dict)
+    env: dict[str, str] = Field(default_factory=dict)
+    files: dict[str, str] = Field(default_factory=dict)
     entrypoint: str | None = None
-    volumes: list[VolumeMount] = field(default_factory=list)
+    volumes: list[VolumeMount] = Field(default_factory=list)
     environment_dir: str | None = None
 
 
@@ -187,7 +190,7 @@ def resolve_ecs_config_from_ssm(
     return config
 
 
-# ── Config dataclasses ───────────────────────────────────────────────
+# ── Config models ─────────────────────────────────────────────────────
 
 
 def _sanitize_id(value: str, max_len: int = 100) -> str:
@@ -208,13 +211,14 @@ def _is_ecr_image_ref(image: str) -> bool:
     return bool(_ECR_IMAGE_REF_RE.match(image))
 
 
-@dataclass(frozen=True)
-class SshSidecarConfig:
+class SshSidecarConfig(BaseModel):
     """SSH sidecar container configuration.
 
     exec_server_port set → exec-server mode (one-way tunnel).
     exec_server_port None → agent-server mode (two-way tunnel).
     """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     sshd_port: int = 2222
     ssh_ready_timeout_sec: float = 300.0
@@ -224,14 +228,15 @@ class SshSidecarConfig:
     exec_server_port: int | None = None
 
 
-@dataclass(frozen=True)
-class EcsFargateConfig:
+class EcsFargateConfig(BaseModel):
     """Configuration for the ECS Fargate sandbox."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     region: str | None = None
     cluster: str = ""
-    subnets: list[str] = field(default_factory=list)
-    security_groups: list[str] = field(default_factory=list)
+    subnets: list[str] = Field(default_factory=list)
+    security_groups: list[str] = Field(default_factory=list)
     assign_public_ip: bool = False
     task_definition: str | None = None
     task_definition_family_prefix: str = "ecs-sandbox"
@@ -1706,7 +1711,7 @@ class EcsFargateSandbox:
         built_image: str | None = None
         env_dir = cfg.environment_dir or self._spec.environment_dir
         if cfg.ecr_repository and env_dir:
-            per_task_cfg = _dc_replace(cfg, environment_dir=env_dir)
+            per_task_cfg = cfg.model_copy(update={"environment_dir": env_dir})
             built_image = ImageBuilder.ensure_image_built(
                 cfg=per_task_cfg, environment_name=_sanitize_id(self._spec.image or "sandbox")
             )

--- a/nemo_gym/sandbox/providers/ecs_fargate/provider.py
+++ b/nemo_gym/sandbox/providers/ecs_fargate/provider.py
@@ -22,7 +22,7 @@ to it. The model endpoint is reached directly from the sandbox, or via the SSH r
 
 from __future__ import annotations
 
-from dataclasses import replace
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -39,24 +39,12 @@ from nemo_gym.sandbox.providers.ecs_fargate import engine
 
 def _outside_endpoints(spec: SandboxSpec) -> list[engine.OutsideEndpoint]:
     raw = spec.provider_options.get("outside_endpoints") or []
-    endpoints = []
-    for item in raw:
-        if isinstance(item, engine.OutsideEndpoint):
-            endpoints.append(item)
-        else:
-            endpoints.append(engine.OutsideEndpoint(url=item["url"], env_var=item["env_var"]))
-    return endpoints
+    return [engine.OutsideEndpoint.model_validate(item) for item in raw]
 
 
 def _volumes(spec: SandboxSpec) -> list[engine.VolumeMount]:
     raw = spec.provider_options.get("volumes") or []
-    volumes = []
-    for item in raw:
-        if isinstance(item, engine.VolumeMount):
-            volumes.append(item)
-        else:
-            volumes.append(engine.VolumeMount(**item))
-    return volumes
+    return [engine.VolumeMount.model_validate(item) for item in raw]
 
 
 def _engine_spec(spec: SandboxSpec) -> engine.SandboxSpec:
@@ -96,7 +84,7 @@ def _apply_spec_overrides(cfg: engine.EcsFargateConfig, spec: SandboxSpec) -> en
         overrides["memory"] = str(int(resources.memory_mib))
     if resources.disk_gib is not None:
         overrides["ephemeral_storage_gib"] = int(resources.disk_gib)
-    return replace(cfg, **overrides) if overrides else cfg
+    return cfg.model_copy(update=overrides) if overrides else cfg
 
 
 class EcsFargateProvider:
@@ -187,65 +175,60 @@ def engine_config_from_mapping(config: dict[str, Any]) -> engine.EcsFargateConfi
 
     ssh_sidecar = _sidecar_config(config.get("ssh_sidecar"), ssm.get("ssh_sidecar", {}))
 
-    return engine.EcsFargateConfig(
-        region=region,
-        cluster=pick("cluster", ""),
-        subnets=config.get("subnets") or ssm.get("subnets", []),
-        security_groups=config.get("security_groups") or ssm.get("security_groups", []),
-        assign_public_ip=pick("assign_public_ip", True),
-        task_definition=config.get("task_definition"),
-        task_definition_family_prefix=config.get("task_definition_family_prefix", "ecs-sandbox"),
-        image_template=config.get("image_template"),
-        container_name=config.get("container_name", "main"),
-        container_port=config.get("container_port"),
-        cpu=str(config.get("cpu", "4096")),
-        memory=str(config.get("memory", "8192")),
-        ephemeral_storage_gib=config.get("ephemeral_storage_gib"),
-        platform_version=config.get("platform_version"),
-        execution_role_arn=pick("execution_role_arn"),
-        task_role_arn=pick("task_role_arn"),
-        extra_env=config.get("extra_env"),
-        log_group=pick("log_group"),
-        log_stream_prefix=config.get("log_stream_prefix"),
-        max_task_lifetime_sec=config.get("max_task_lifetime_sec") or 14400,
-        startup_timeout_sec=float(config.get("startup_timeout_sec", 300.0)),
-        ssh_sidecar=ssh_sidecar,
-        s3_bucket=pick("s3_bucket"),
-        s3_prefix=config.get("s3_prefix"),
-        ecr_repository=pick("ecr_repository"),
-        environment_dir=config.get("environment_dir"),
-        codebuild_project=config.get("codebuild_project"),
-        codebuild_service_role=pick("codebuild_service_role"),
-        codebuild_compute_type=config.get("codebuild_compute_type") or "BUILD_GENERAL1_MEDIUM",
-        codebuild_build_timeout=config.get("codebuild_build_timeout") or 60,
-        auto_mirror=config.get("auto_mirror", True),
-        dockerhub_secret_arn=pick("dockerhub_secret_arn"),
-        efs_filesystem_id=pick("efs_filesystem_id"),
-        efs_access_point_id=pick("efs_access_point_id"),
-        ssm_project=ssm_project,
-    )
+    resolved = {
+        **config,
+        "region": region,
+        "cluster": pick("cluster", ""),
+        "subnets": config.get("subnets") or ssm.get("subnets", []),
+        "security_groups": config.get("security_groups") or ssm.get("security_groups", []),
+        "assign_public_ip": pick("assign_public_ip", True),
+        "cpu": str(config.get("cpu", "4096")),
+        "memory": str(config.get("memory", "8192")),
+        "execution_role_arn": pick("execution_role_arn"),
+        "task_role_arn": pick("task_role_arn"),
+        "log_group": pick("log_group"),
+        "max_task_lifetime_sec": config.get("max_task_lifetime_sec") or 14400,
+        "startup_timeout_sec": float(config.get("startup_timeout_sec", 300.0)),
+        "ssh_sidecar": ssh_sidecar,
+        "s3_bucket": pick("s3_bucket"),
+        "ecr_repository": pick("ecr_repository"),
+        "codebuild_service_role": pick("codebuild_service_role"),
+        "codebuild_compute_type": config.get("codebuild_compute_type") or "BUILD_GENERAL1_MEDIUM",
+        "codebuild_build_timeout": config.get("codebuild_build_timeout") or 60,
+        "auto_mirror": config.get("auto_mirror", True),
+        "dockerhub_secret_arn": pick("dockerhub_secret_arn"),
+        "efs_filesystem_id": pick("efs_filesystem_id"),
+        "efs_access_point_id": pick("efs_access_point_id"),
+        "ssm_project": ssm_project,
+    }
+    return engine.EcsFargateConfig.model_validate(resolved)
 
 
-def _sidecar_config(yaml_sidecar: Any, ssm_ssh: dict[str, Any]) -> engine.SshSidecarConfig | None:
+def _sidecar_config(yaml_sidecar: Any, ssm_ssh: Mapping[str, Any]) -> engine.SshSidecarConfig | None:
     if yaml_sidecar is not None:
-        sc = dict(yaml_sidecar) if isinstance(yaml_sidecar, dict) else yaml_sidecar
-        if isinstance(sc, engine.SshSidecarConfig):
-            return sc
-        pub = sc.get("public_key_secret_arn") or ssm_ssh.get("public_key_secret_arn", "")
-        priv = sc.get("private_key_secret_arn") or ssm_ssh.get("private_key_secret_arn", "")
+        if isinstance(yaml_sidecar, engine.SshSidecarConfig):
+            return yaml_sidecar
+        if not isinstance(yaml_sidecar, Mapping):
+            raise TypeError("ssh_sidecar must be a mapping or SshSidecarConfig instance")
+
+        resolved = dict(yaml_sidecar)
+        pub = resolved.get("public_key_secret_arn") or ssm_ssh.get("public_key_secret_arn", "")
+        priv = resolved.get("private_key_secret_arn") or ssm_ssh.get("private_key_secret_arn", "")
         if not pub or not priv:
             raise ValueError(
                 "ssh_sidecar.public_key_secret_arn and ssh_sidecar.private_key_secret_arn "
                 "are required (set explicitly or auto-discovered from SSM)."
             )
-        return engine.SshSidecarConfig(
-            sshd_port=sc.get("sshd_port", engine.DEFAULT_SSHD_PORT),
-            ssh_ready_timeout_sec=sc.get("ssh_ready_timeout_sec", 300.0),
-            public_key_secret_arn=pub,
-            private_key_secret_arn=priv,
-            image=sc.get("image"),
-            exec_server_port=sc.get("exec_server_port", engine.DEFAULT_EXEC_SERVER_PORT),
+        resolved.update(
+            {
+                "sshd_port": resolved.get("sshd_port", engine.DEFAULT_SSHD_PORT),
+                "ssh_ready_timeout_sec": resolved.get("ssh_ready_timeout_sec", 300.0),
+                "public_key_secret_arn": pub,
+                "private_key_secret_arn": priv,
+                "exec_server_port": resolved.get("exec_server_port", engine.DEFAULT_EXEC_SERVER_PORT),
+            }
         )
+        return engine.SshSidecarConfig.model_validate(resolved)
     if ssm_ssh.get("public_key_secret_arn") and ssm_ssh.get("private_key_secret_arn"):
         return engine.SshSidecarConfig(
             sshd_port=ssm_ssh.get("sshd_port", engine.DEFAULT_SSHD_PORT),

--- a/nemo_gym/sandbox/providers/enroot/provider.py
+++ b/nemo_gym/sandbox/providers/enroot/provider.py
@@ -37,7 +37,9 @@ import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import IO, Any
+from typing import IO, Any, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from nemo_gym.sandbox.providers.base import (
     SandboxCreateError,
@@ -134,9 +136,10 @@ def _require_enroot() -> str:
     return path
 
 
-@dataclass(frozen=True)
-class EnrootCreateConfig:
+class EnrootCreateConfig(BaseModel):
     """Settings for creating an Enroot sandbox container."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     mount_point: str = DEFAULT_MOUNT_POINT
     # Provider-scoped enroot paths. When None they are resolved under a
@@ -161,11 +164,12 @@ class EnrootCreateConfig:
     create_timeout_s: float | None = 600
     start_timeout_s: float | None = 600
     start_poll_s: float = 0.5
-    extra_import_args: list[str] = field(default_factory=list)
-    extra_create_args: list[str] = field(default_factory=list)
-    extra_start_args: list[str] = field(default_factory=list)
+    extra_import_args: list[str] = Field(default_factory=list)
+    extra_create_args: list[str] = Field(default_factory=list)
+    extra_start_args: list[str] = Field(default_factory=list)
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         for attr in ("import_timeout_s", "create_timeout_s", "start_timeout_s"):
             value = getattr(self, attr)
             if value is not None and value <= 0:
@@ -174,28 +178,33 @@ class EnrootCreateConfig:
             raise ValueError("create.start_poll_s must be > 0")
         if not self.mount_point.startswith("/"):
             raise ValueError("create.mount_point must be an absolute path")
+        return self
 
 
-@dataclass(frozen=True)
-class EnrootExecConfig:
+class EnrootExecConfig(BaseModel):
     """Settings for running commands inside an Enroot sandbox."""
 
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     default_timeout_s: float | None = 180
-    default_mounts: list[str] = field(default_factory=list)
-    extra_exec_args: list[str] = field(default_factory=list)
+    default_mounts: list[str] = Field(default_factory=list)
+    extra_exec_args: list[str] = Field(default_factory=list)
     concurrency: int = 32
     exec_shell: str = "sh"
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.default_timeout_s is not None and self.default_timeout_s <= 0:
             raise ValueError("exec.default_timeout_s must be > 0")
         if self.concurrency < 1:
             raise ValueError("exec.concurrency must be >= 1")
+        return self
 
 
-@dataclass(frozen=True)
-class EnrootProbeConfig:
+class EnrootProbeConfig(BaseModel):
     """Post-create probe settings: a test command confirming the sandbox is usable."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     command: str | None = READY_PROBE_COMMAND
     expected_stdout: str | None = READY_PROBE_EXPECTED
@@ -204,7 +213,8 @@ class EnrootProbeConfig:
     stable_count: int = 1
     stable_delay_s: float = 0.0
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.command is not None and self.timeout_s <= 0:
             raise ValueError("probe.timeout_s must be > 0")
         if self.deadline_s is not None and self.deadline_s <= 0:
@@ -213,6 +223,7 @@ class EnrootProbeConfig:
             raise ValueError("probe.stable_count must be >= 1")
         if self.stable_delay_s < 0:
             raise ValueError("probe.stable_delay_s must be >= 0")
+        return self
 
 
 @dataclass

--- a/nemo_gym/sandbox/providers/opensandbox/__init__.py
+++ b/nemo_gym/sandbox/providers/opensandbox/__init__.py
@@ -24,6 +24,7 @@ from nemo_gym.sandbox.providers.opensandbox.provider import (
     OpenSandboxOperationConfig,
     OpenSandboxProbeConfig,
     OpenSandboxProvider,
+    OpenSandboxProviderOptions,
 )
 
 
@@ -37,4 +38,5 @@ __all__ = [
     "OpenSandboxOperationConfig",
     "OpenSandboxProbeConfig",
     "OpenSandboxProvider",
+    "OpenSandboxProviderOptions",
 ]

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -19,10 +19,11 @@ import logging
 import re
 import shlex
 from collections.abc import Mapping
-from dataclasses import dataclass, field, replace
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Awaitable, Callable
+from typing import Any, Awaitable, Callable, Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from nemo_gym.sandbox.attribution import RUN_KEY, log_attribution_once, resolve_attribution, resolve_run_id
 from nemo_gym.sandbox.providers.base import (
@@ -308,10 +309,11 @@ def _metadata_map(values: dict[str, Any]) -> dict[str, str]:
 
 
 def _normalize_spec(spec: SandboxSpec) -> SandboxSpec:
-    return replace(
-        spec,
-        env=_string_map(spec.env),
-        metadata=_metadata_map(spec.metadata),
+    return spec.model_copy(
+        update={
+            "env": _string_map(spec.env),
+            "metadata": _metadata_map(spec.metadata),
+        }
     )
 
 
@@ -346,8 +348,13 @@ def _to_sandbox_status(state: Any) -> SandboxStatus:
     return SandboxStatus.UNKNOWN
 
 
-@dataclass(frozen=True)
-class OpenSandboxConnectionConfig:
+class _OpenSandboxConfig(BaseModel):
+    """Shared validation and immutability for OpenSandbox configuration models."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class OpenSandboxConnectionConfig(_OpenSandboxConfig):
     """OpenSandbox server connection settings.
 
     ``keepalive_expiry_s`` must stay below the server's own keep-alive idle
@@ -375,8 +382,7 @@ class OpenSandboxConnectionConfig:
     transport_backend: str = "httpx"
 
 
-@dataclass(frozen=True)
-class OpenSandboxAttributionConfig:
+class OpenSandboxAttributionConfig(_OpenSandboxConfig):
     """Job attribution merged into every sandbox's metadata (Kubernetes labels on the sandbox).
 
     OpenSandbox propagates sandbox metadata as Kubernetes labels on the sandbox resources, so
@@ -402,22 +408,23 @@ class OpenSandboxAttributionConfig:
     run: str | None = None
     key_prefix: str = DEFAULT_ATTRIBUTION_KEY_PREFIX
 
-    def __post_init__(self) -> None:
-        normalized = self.key_prefix.strip()
+    @field_validator("key_prefix")
+    @classmethod
+    def normalize_key_prefix(cls, key_prefix: str) -> str:
+        normalized = key_prefix.strip()
         if normalized and not normalized.endswith("/"):
             normalized += "/"
         if normalized and not ATTRIBUTION_KEY_PREFIX_RE.fullmatch(normalized[:-1]):
             # Invalid prefixes would otherwise fail server-side at sandbox create with an
             # opaque error; values are sanitized by the provider but keys pass through.
             raise ValueError(
-                f"attribution key_prefix {self.key_prefix!r} must be a lowercase DNS subdomain "
+                f"attribution key_prefix {key_prefix!r} must be a lowercase DNS subdomain "
                 "(Kubernetes label-key prefix), e.g. 'nemo-gym.nvidia.com/', or '' for bare keys"
             )
-        object.__setattr__(self, "key_prefix", normalized)
+        return normalized
 
 
-@dataclass(frozen=True)
-class OpenSandboxCreateConfig:
+class OpenSandboxCreateConfig(_OpenSandboxConfig):
     """OpenSandbox create/reconnect retry settings."""
 
     request_timeout_s: int | None = None
@@ -430,7 +437,8 @@ class OpenSandboxCreateConfig:
     connect_attempt_timeout_s: float = 30.0
     connect_poll_s: float = 2.0
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.image_pull_policy is not None:
             validate_image_pull_policy(self.image_pull_policy)
         if self.timeout_s is not None and self.timeout_s <= 0:
@@ -445,10 +453,10 @@ class OpenSandboxCreateConfig:
             raise ValueError("create.connect_attempt_timeout_s must be > 0")
         if self.connect_poll_s <= 0:
             raise ValueError("create.connect_poll_s must be > 0")
+        return self
 
 
-@dataclass(frozen=True)
-class OpenSandboxProbeConfig:
+class OpenSandboxProbeConfig(_OpenSandboxConfig):
     """Post-create probe settings."""
 
     command: str | None = "printf nemo-gym-sandbox-ready"
@@ -458,7 +466,8 @@ class OpenSandboxProbeConfig:
     stable_count: int = 1
     stable_delay_s: float = 0.0
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.command is not None and self.timeout_s <= 0:
             raise ValueError("probe.timeout_s must be > 0")
         if self.deadline_s is not None and self.deadline_s <= 0:
@@ -467,10 +476,10 @@ class OpenSandboxProbeConfig:
             raise ValueError("probe.stable_count must be >= 1")
         if self.stable_delay_s < 0:
             raise ValueError("probe.stable_delay_s must be >= 0")
+        return self
 
 
-@dataclass(frozen=True)
-class OpenSandboxOperationConfig:
+class OpenSandboxOperationConfig(_OpenSandboxConfig):
     """Retry and timeout settings for SDK operations after create."""
 
     retries: int = 3
@@ -478,6 +487,7 @@ class OpenSandboxOperationConfig:
     retry_max_delay_s: float = 15.0
     command_retries: int = 0
     close_timeout_s: float | None = 30.0
+
     # Poll short status/log requests instead of holding one SSE stream open for
     # the whole command. Set this behind a load balancer that caps stream
     # duration, which would otherwise drop the stream and hang the client.
@@ -486,7 +496,8 @@ class OpenSandboxOperationConfig:
     background_poll_initial_s: float = 0.25
     background_poll_interval_s: float = 2.0
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.retries < 0:
             raise ValueError("operations.retries must be >= 0")
         if self.retry_delay_s < 0:
@@ -501,34 +512,49 @@ class OpenSandboxOperationConfig:
             raise ValueError("operations.background_poll_interval_s must be > 0")
         if self.background_poll_initial_s <= 0:
             raise ValueError("operations.background_poll_initial_s must be > 0")
+        return self
 
 
-@dataclass(frozen=True)
-class OpenSandboxProviderOptions:
+class OpenSandboxProviderOptions(_OpenSandboxConfig):
     """Recognized per-sandbox create options read from ``SandboxSpec.provider_options``.
 
     ``image_auth``, ``platform``, and ``volumes`` entries are passed through to the
     OpenSandbox SDK, so their inner fields are validated by the SDK rather than here.
     """
 
-    image_auth: Mapping[str, Any] | None = None
-    platform: Mapping[str, Any] | None = None
+    image_auth: dict[str, Any] | None = None
+    platform: dict[str, Any] | None = None
     snapshot_id: str | None = None
-    volumes: tuple[Mapping[str, Any], ...] = ()
+    volumes: tuple[dict[str, Any], ...] = ()
     skip_health_check: bool | None = None
-    extensions: Mapping[str, str] = field(default_factory=dict)
-    # Scheduling requests (same keys as SandboxSpec.resources, which become the
-    # limits). Unset, the server applies the single resources map as both.
-    resource_requests: Mapping[str, Any] | None = None
+    extensions: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("volumes", mode="before")
+    @classmethod
+    def normalize_volumes(cls, volumes: Any) -> Any:
+        if volumes is None:
+            return ()
+        if isinstance(volumes, (list, tuple)):
+            return tuple(dict(volume) if isinstance(volume, Mapping) else volume for volume in volumes)
+        return volumes
+
+    @field_validator("extensions", mode="before")
+    @classmethod
+    def normalize_extensions(cls, extensions: Any) -> Any:
+        if isinstance(extensions, Mapping):
+            return _string_map(extensions)
+        return extensions
 
     @classmethod
     def from_mapping(cls, options: Mapping[str, Any] | None) -> "OpenSandboxProviderOptions":
         if options is None:
             return cls()
+        if isinstance(options, cls):
+            return options
         if not isinstance(options, Mapping):
             raise TypeError("OpenSandbox provider_options must be a mapping")
 
-        allowed = set(cls.__dataclass_fields__)
+        allowed = set(cls.model_fields)
         unknown = set(options) - allowed
         if unknown:
             raise ValueError(
@@ -554,9 +580,6 @@ class OpenSandboxProviderOptions:
         extensions = options.get("extensions", {})
         if not isinstance(extensions, Mapping):
             raise TypeError("OpenSandbox provider option 'extensions' must be a mapping")
-        resource_requests = options.get("resource_requests")
-        if resource_requests is not None and not isinstance(resource_requests, Mapping):
-            raise TypeError("OpenSandbox provider option 'resource_requests' must be a mapping")
 
         return cls(
             image_auth=dict(image_auth) if image_auth is not None else None,
@@ -565,7 +588,6 @@ class OpenSandboxProviderOptions:
             volumes=tuple(dict(volume) for volume in volumes),
             skip_health_check=skip_health_check,
             extensions=_string_map(dict(extensions)),
-            resource_requests=dict(resource_requests) if resource_requests is not None else None,
         )
 
 
@@ -888,8 +910,8 @@ class OpenSandboxProvider:
             "extensions": self._resolve_extensions(options.extensions),
             "connection_config": self._connection_config(request_timeout_s=self._create.request_timeout_s),
         }
-        if options.resource_requests is not None:
-            kwargs["resource_requests"] = _resource_map(SandboxResources.from_mapping(options.resource_requests))
+        if spec.resource_requests is not None:
+            kwargs["resource_requests"] = _resource_map(spec.resource_requests)
         if spec.image is not None:
             kwargs["image"] = _to_image_spec(spec.image, options.image_auth)
         if options.snapshot_id is not None:
@@ -991,7 +1013,7 @@ class OpenSandboxProvider:
         Job attribution keys (``team`` / ``user`` / ``workload`` / ``run``) are merged into the
         spec's metadata (explicit spec keys win) so every sandbox is attributable via its labels.
         """
-        spec = replace(spec, metadata={**self._attribution_metadata(), **spec.metadata})
+        spec = spec.model_copy(update={"metadata": {**self._attribution_metadata(), **spec.metadata}})
         return await self._create_with_retries(_normalize_spec(spec))
 
     async def status(self, handle: SandboxHandle) -> SandboxStatus:

--- a/nemo_gym/sandbox/providers/openshell/README.md
+++ b/nemo_gym/sandbox/providers/openshell/README.md
@@ -55,6 +55,7 @@ When `spec.image` is unset, the gateway's configured default image is used
 | `workdir` | default `workdir` for every exec (no create-time equivalent) |
 | `resources.gpu` | `ResourceRequirements.gpu.count` |
 | `resources.cpu/memory_mib/disk_gib/gpu_type` | not mapped by this provider; OpenShell exposes driver-specific limits through `SandboxTemplate.resources` — pass `provider_options.template_resources` (a warning notes the redirection) |
+| `resource_requests` | scheduling hint ignored; OpenShell does not expose separate request/limit semantics through this provider |
 | `ttl_s` | not enforced (sandboxes live until `close()`); logs a warning |
 | `entrypoint` | unsupported; raises (the OpenShell supervisor owns the entrypoint) |
 | `provider_options.providers` | OpenShell credential-provider names attached to the sandbox |

--- a/nemo_gym/sandbox/providers/openshell/provider.py
+++ b/nemo_gym/sandbox/providers/openshell/provider.py
@@ -37,7 +37,9 @@ from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from nemo_gym.sandbox.providers.base import (
     SandboxCreateError,
@@ -179,9 +181,10 @@ def _is_retryable_create_error(exc: BaseException) -> bool:
     }
 
 
-@dataclass(frozen=True)
-class OpenShellConnectionConfig:
+class OpenShellConnectionConfig(BaseModel):
     """Gateway connection settings. Defaults target a local plaintext gateway (deploy/docker compose)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     endpoint: str = "localhost:8080"
     workspace: str = "default"
@@ -191,7 +194,8 @@ class OpenShellConnectionConfig:
     tls_key_path: str | None = None
     request_timeout_s: float = 30.0
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if not self.endpoint:
             raise ValueError("connection.endpoint must be a non-empty host:port")
         if not self.workspace:
@@ -200,17 +204,20 @@ class OpenShellConnectionConfig:
             raise ValueError("connection.request_timeout_s must be > 0")
         if bool(self.tls_cert_path) != bool(self.tls_key_path):
             raise ValueError("connection.tls_cert_path and connection.tls_key_path must be set together")
+        return self
 
 
-@dataclass(frozen=True)
-class OpenShellCreateConfig:
+class OpenShellCreateConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     ready_timeout_s: float = 300
     poll_interval_s: float = 1.0
     retries: int = 2
     retry_delay_s: float = 1.0
     retry_max_delay_s: float = 30.0
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.ready_timeout_s <= 0:
             raise ValueError("create.ready_timeout_s must be > 0")
         if self.poll_interval_s <= 0:
@@ -221,10 +228,12 @@ class OpenShellCreateConfig:
             raise ValueError("create.retry_delay_s must be >= 0")
         if self.retry_max_delay_s < 0:
             raise ValueError("create.retry_max_delay_s must be >= 0")
+        return self
 
 
-@dataclass(frozen=True)
-class OpenShellExecConfig:
+class OpenShellExecConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     default_timeout_s: float | None = 180
     # Bounds in-flight gateway RPCs across ALL operations sharing this connection config --
     # exec as well as control-plane calls (create/get/delete and probe polling). The pool
@@ -234,7 +243,8 @@ class OpenShellExecConfig:
     exec_shell: str = "/bin/sh"
     upload_chunk_bytes: int = DEFAULT_UPLOAD_CHUNK_BYTES
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.default_timeout_s is not None and self.default_timeout_s <= 0:
             raise ValueError("exec.default_timeout_s must be > 0")
         if self.concurrency < 1:
@@ -243,10 +253,12 @@ class OpenShellExecConfig:
             raise ValueError("exec.exec_shell must be a non-empty shell name/path")
         if self.upload_chunk_bytes < 1:
             raise ValueError("exec.upload_chunk_bytes must be >= 1")
+        return self
 
 
-@dataclass(frozen=True)
-class OpenShellProbeConfig:
+class OpenShellProbeConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     command: str | None = READY_PROBE_COMMAND
     expected_stdout: str | None = READY_PROBE_EXPECTED
     timeout_s: int = 30
@@ -256,7 +268,8 @@ class OpenShellProbeConfig:
     # hammer it for the full deadline when a sandbox is slow to become exec-ready.
     stable_delay_s: float = 1.0
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.command is not None and self.timeout_s <= 0:
             raise ValueError("probe.timeout_s must be > 0")
         if self.deadline_s is not None and self.deadline_s <= 0:
@@ -265,33 +278,42 @@ class OpenShellProbeConfig:
             raise ValueError("probe.stable_count must be >= 1")
         if self.stable_delay_s < 0:
             raise ValueError("probe.stable_delay_s must be >= 0")
+        return self
 
 
-@dataclass(frozen=True)
-class OpenShellOperationsConfig:
+class OpenShellOperationsConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     close_wait_deleted: bool = True
     close_timeout_s: float = 60
     poll_interval_s: float = 1.0
 
-    def __post_init__(self) -> None:
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
         if self.close_timeout_s <= 0:
             raise ValueError("operations.close_timeout_s must be > 0")
         if self.poll_interval_s <= 0:
             raise ValueError("operations.poll_interval_s must be > 0")
+        return self
 
 
-@dataclass(frozen=True)
-class OpenShellProviderOptions:
+class OpenShellProviderOptions(BaseModel):
     """Validated per-sandbox options carried in ``SandboxSpec.provider_options``."""
 
-    providers: list[str] = field(default_factory=list)
-    policy: Any | None = None
-    template_resources: dict[str, Any] = field(default_factory=dict)
-    driver_config: dict[str, Any] = field(default_factory=dict)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
+    providers: list[str] = Field(default_factory=list)
+    policy: Any | None = None
+    template_resources: dict[str, Any] = Field(default_factory=dict)
+    driver_config: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
     @classmethod
-    def from_mapping(cls, options: Mapping[str, Any]) -> "OpenShellProviderOptions":
-        allowed = set(cls.__dataclass_fields__)
+    def normalize_options(cls, options: Any) -> Any:
+        if not isinstance(options, Mapping):
+            return options
+
+        allowed = set(cls.model_fields)
         unknown = set(options) - allowed
         if unknown:
             raise ValueError(
@@ -315,12 +337,16 @@ class OpenShellProviderOptions:
         driver_config = options.get("driver_config") or {}
         if not isinstance(driver_config, Mapping):
             raise TypeError(f"provider_options['driver_config'] must be a mapping, got {type(driver_config).__name__}")
-        return cls(
-            providers=[str(p) for p in providers],
-            policy=policy,
-            template_resources=dict(template_resources),
-            driver_config=dict(driver_config),
-        )
+        return {
+            "providers": [str(p) for p in providers],
+            "policy": policy,
+            "template_resources": dict(template_resources),
+            "driver_config": dict(driver_config),
+        }
+
+    @classmethod
+    def from_mapping(cls, options: Mapping[str, Any]) -> "OpenShellProviderOptions":
+        return cls.model_validate(options)
 
 
 @dataclass
@@ -473,7 +499,7 @@ class OpenShellProvider:
         ]
         if ignored:
             LOGGER.warning(
-                "%s resource requests are not mapped by this provider; OpenShell exposes driver-specific "
+                "%s resource limits are not mapped by this provider; OpenShell exposes driver-specific "
                 "limits through SandboxTemplate.resources — pass provider_options.template_resources instead.",
                 ", ".join(ignored),
             )

--- a/nemo_gym/sandbox/providers/utils.py
+++ b/nemo_gym/sandbox/providers/utils.py
@@ -20,17 +20,22 @@ opensandbox providers. They live here so there is a single implementation.
 
 import posixpath
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
 
 
-def coerce_config(value: Any, config_cls: type[Any]) -> Any:
-    """Accept either a config dataclass instance or a plain mapping (Hydra YAML)."""
+_ConfigT = TypeVar("_ConfigT", bound=BaseModel)
+
+
+def coerce_config(value: Any, config_cls: type[_ConfigT]) -> _ConfigT:
+    """Accept either a config model instance or a plain mapping (Hydra YAML)."""
     if value is None:
         return config_cls()
     if isinstance(value, config_cls):
         return value
     if isinstance(value, Mapping):
-        return config_cls(**value)
+        return config_cls.model_validate(value)
     raise TypeError(f"{config_cls.__name__} must be a mapping or {config_cls.__name__} instance")
 
 

--- a/resources_servers/litmus_agent/app.py
+++ b/resources_servers/litmus_agent/app.py
@@ -681,6 +681,7 @@ class LitmusAgentResourcesServer(SimpleResourcesServer):
         spec = dict(self.config.sandbox_spec)
         files = dict(spec.pop("files", {}))
         files[_CODE_EXEC_DRIVER_PATH] = _CODE_EXEC_DRIVER
+        resource_requests = spec.pop("resource_requests", None)
 
         known = SandboxSpec(
             image=spec.pop("image", None),
@@ -691,8 +692,12 @@ class LitmusAgentResourcesServer(SimpleResourcesServer):
             files=files,
             metadata=dict(spec.pop("metadata", {})),
             resources=SandboxResources.from_mapping(spec.pop("resources", {})),
+            resource_requests=(
+                SandboxResources.from_mapping(resource_requests) if resource_requests is not None else None
+            ),
             entrypoint=spec.pop("entrypoint", None),
             provider_options=dict(spec.pop("provider_options", {})),
+            ports=spec.pop("ports", ()),
         )
         if spec:
             raise ValueError(f"Unknown sandbox_spec keys: {', '.join(sorted(spec))}")

--- a/resources_servers/litmus_agent/configs/litmus_agent_apptainer.yaml
+++ b/resources_servers/litmus_agent/configs/litmus_agent_apptainer.yaml
@@ -31,9 +31,8 @@ litmus_agent:
             mount_point: /sandbox
             start_timeout_s: 600
             # cgroups-v2 delegation is not guaranteed inside an enroot container;
-            # leave resource limits off unless the node supports it. Literal bool
-            # (not oc.env) because the apptainer sub-config is a plain dataclass
-            # with no string coercion -- "False" would be truthy.
+            # leave resource limits off unless the node supports it. Keep this a
+            # literal bool so the checked-in config is explicit and self-contained.
             apply_resource_limits: false
           probe:
             command: printf apptainer-sandbox-ready

--- a/resources_servers/litmus_agent/tests/test_app.py
+++ b/resources_servers/litmus_agent/tests/test_app.py
@@ -817,6 +817,23 @@ class TestSandboxSpecAndRouting:
         assert _CODE_EXEC_DRIVER_PATH in spec.files
         assert spec.image == "fake:latest"
 
+    def test_resource_requests_forwarded_as_public_spec_field(self):
+        server = _make_sandbox_server(
+            sandbox_spec={
+                "image": "fake:latest",
+                "resources": {"cpu": 2, "memory_mib": 4096},
+                "resource_requests": {"cpu": 0.5, "memory_mib": 1024},
+                "provider_options": {"network": "isolated"},
+                "ports": [8000, 9222],
+            }
+        )
+        spec = server._build_sandbox_spec()
+        assert spec.resource_requests is not None
+        assert spec.resource_requests.cpu == 0.5
+        assert spec.resource_requests.memory_mib == 1024
+        assert spec.provider_options == {"network": "isolated"}
+        assert spec.ports == (8000, 9222)
+
     def test_unknown_spec_key_raises(self):
         server = _make_sandbox_server(sandbox_spec={"image": "x", "bogus": 1})
         with pytest.raises(ValueError, match="Unknown sandbox_spec keys: bogus"):

--- a/resources_servers/swebench/app.py
+++ b/resources_servers/swebench/app.py
@@ -34,7 +34,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.global_config import get_global_config_dict
-from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
+from nemo_gym.sandbox import AsyncSandbox, SandboxSpec
 from nemo_gym.sandbox.config import resolve_provider_config, resolve_provider_metadata
 from nemo_gym.server_utils import SESSION_ID_KEY
 from resources_servers.swebench.swebench_patches import run_instance
@@ -172,14 +172,13 @@ fi
         await self._inner_container.stop()
 
 
-# TODO @bxyu-nvidia: Eventually once the sandbox server infra is ready, these seed_session types need to upgrade to pass a sandbox spec.
-# They can possibly even omitted once this graduates to core infra.
 class SWEBenchSeedSessionRequest(SWEBenchInstanceRequest, BaseSeedSessionRequest):
     sandbox_spec: Optional[Dict[str, Any]] = None
 
 
 class SWEBenchSeedSessionResponse(BaseSeedSessionResponse):
-    sandbox_handle: str  # @bxyu-nvidia: Just a plain string URI for now for OpenSandbox backend.
+    # A generic seed-session handle type can replace this provider-facing string once available.
+    sandbox_handle: str
 
 
 class SwebenchResourcesServer(SimpleResourcesServer):
@@ -190,28 +189,27 @@ class SwebenchResourcesServer(SimpleResourcesServer):
 
         self._session_id_to_sandbox: Dict[str, AsyncSandbox] = dict()
 
-    async def _create_sandbox(self, test_spec: TestSpec) -> AsyncSandbox:
-        # TODO @bxyu-nvidia: Refactor this after Hemil's swap from Python dataclass to Pydantic BaseModel
+    async def _create_sandbox(
+        self,
+        test_spec: TestSpec,
+        sandbox_spec: Optional[Dict[str, Any]] = None,
+    ) -> AsyncSandbox:
         global_config_dict = get_global_config_dict()
         resolved_sandbox_provider = resolve_provider_config(self.config.sandbox_provider, global_config_dict)
         provider_default_metadata = resolve_provider_metadata(self.config.sandbox_provider, global_config_dict)
-        eval_sandbox_spec = SandboxSpec(
-            image=test_spec.instance_image_key,
-            ttl_s=self.config.sandbox_config.get("ttl_s", None),
-            ready_timeout_s=self.config.sandbox_config.get("ready_timeout_s", None),
-            workdir=None,  # Default to container's WORKDIR
-            env=dict(),
-            files=dict(),
-            metadata=provider_default_metadata
+        request_spec = sandbox_spec or {}
+        merged_spec = self.config.sandbox_config | request_spec
+        merged_spec["image"] = test_spec.instance_image_key
+        merged_spec["metadata"] = (
+            provider_default_metadata
             | self.config.sandbox_config.get("metadata", {})
+            | request_spec.get("metadata", {})
             | {
                 "nemo_gym_agent": self.config.name,
                 "instance_id": test_spec.instance_id[:63],
-            },
-            resources=SandboxResources.from_mapping(self.config.sandbox_config.get("resources", {})),
-            entrypoint=None,
-            provider_options=self.config.sandbox_config.get("provider_options", {}),
+            }
         )
+        eval_sandbox_spec = SandboxSpec.model_validate(merged_spec)
         eval_sandbox = AsyncSandbox(resolved_sandbox_provider)
         await eval_sandbox.start(eval_sandbox_spec)
 
@@ -244,12 +242,12 @@ class SwebenchResourcesServer(SimpleResourcesServer):
 
     async def seed_session(self, request: Request, body: SWEBenchSeedSessionRequest) -> SWEBenchSeedSessionResponse:
         test_spec = self._make_test_spec(body)
-        eval_sandbox = await self._create_sandbox(test_spec)
+        eval_sandbox = await self._create_sandbox(test_spec, sandbox_spec=body.sandbox_spec)
         self._session_id_to_sandbox[request.session[SESSION_ID_KEY]] = eval_sandbox
 
-        # @bxyu-nvidia: Activate the necessary conda environments for SWE Bench Verified Python instances
+        # Activate the necessary conda environments for SWE Bench Verified Python instances.
         # This may be overfit and needs to be config'd or detected.
-        # TODO @bxyu-nvidia: This pattern is not yet supported because calls to sandbox.exec use separate processes
+        # This pattern is not yet supported because calls to sandbox.exec use separate processes.
         # For now, the activation is put on the harness side.
         # await eval_sandbox.exec("source /opt/miniconda3/bin/activate && conda activate testbed")
 

--- a/resources_servers/swebench/configs/swebench.yaml
+++ b/resources_servers/swebench/configs/swebench.yaml
@@ -20,12 +20,12 @@ swebench_resources_server:          # instance name — how agents/CLI refer to 
           # 30 GiB works on every provider: within Fargate's 21-200 GiB ephemeral range
           # (an explicit 20 is rejected there) and fine as an ephemeral request elsewhere.
           disk_gib: 30
-        provider_options:
-          # Scheduling requests, kept below the limits so sandboxes pack densely.
-          resource_requests:
-            cpu: 0.5
-            memory_mib: 512
-            disk_gib: 30
+        # Provider-neutral scheduling requests, kept below the limits so
+        # sandboxes pack densely on providers that support separate requests.
+        resource_requests:
+          cpu: 0.5
+          memory_mib: 512
+          disk_gib: 30
         metadata:
           benchmark: swebench-verified
           harness: mini-swe-agent

--- a/resources_servers/swebench/tests/test_app.py
+++ b/resources_servers/swebench/tests/test_app.py
@@ -17,11 +17,133 @@ from unittest.mock import AsyncMock, MagicMock
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 
-from nemo_gym.server_utils import ServerClient
+from nemo_gym.sandbox import SandboxResources
+from nemo_gym.server_utils import SESSION_ID_KEY, ServerClient
 from resources_servers.swebench.app import SwebenchResourcesServer, SwebenchResourcesServerConfig
 
 
 class TestApp:
+    async def test_create_sandbox_forwards_resource_requests(self, monkeypatch: MonkeyPatch) -> None:
+        config = SwebenchResourcesServerConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="swebench",
+            sandbox_provider="test",
+            sandbox_config={
+                "resources": {"cpu": 2, "memory_mib": 8192, "disk_gib": 30},
+                "resource_requests": {"cpu": 0.5, "memory_mib": 2048, "disk_gib": 10},
+                "ports": [3000, "8080"],
+            },
+        )
+        server = SwebenchResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+        provider = object()
+        sandbox = MagicMock()
+        sandbox.start = AsyncMock()
+        async_sandbox = MagicMock(return_value=sandbox)
+        monkeypatch.setattr("resources_servers.swebench.app.get_global_config_dict", lambda: {})
+        monkeypatch.setattr("resources_servers.swebench.app.resolve_provider_config", lambda *_args: provider)
+        monkeypatch.setattr("resources_servers.swebench.app.resolve_provider_metadata", lambda *_args: {})
+        monkeypatch.setattr("resources_servers.swebench.app.AsyncSandbox", async_sandbox)
+        test_spec = MagicMock(
+            instance_image_key="swebench/image:latest",
+            instance_id="owner__repo-1",
+            repo="owner/repo",
+        )
+
+        result = await server._create_sandbox(test_spec)
+
+        assert result is sandbox
+        async_sandbox.assert_called_once_with(provider)
+        sandbox.start.assert_awaited_once()
+        spec = sandbox.start.await_args.args[0]
+        assert spec.resources == SandboxResources(cpu=2, memory_mib=8192, disk_gib=30)
+        assert spec.resource_requests == SandboxResources(cpu=0.5, memory_mib=2048, disk_gib=10)
+        assert spec.ports == (3000, 8080)
+
+    async def test_seed_session_forwards_sandbox_spec_override(self) -> None:
+        config = SwebenchResourcesServerConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="swebench",
+            sandbox_provider="test",
+            sandbox_config={},
+        )
+        server = SwebenchResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+        request_spec = {
+            "resource_requests": {"cpu": 0.25, "memory_mib": 1024},
+            "ports": [9000],
+        }
+        body = MagicMock(sandbox_spec=request_spec)
+        test_spec = MagicMock()
+        sandbox = MagicMock(_handle=MagicMock(sandbox_id="sandbox-1"))
+        server._make_test_spec = MagicMock(return_value=test_spec)
+        server._create_sandbox = AsyncMock(return_value=sandbox)
+        request = MagicMock(session={SESSION_ID_KEY: "session-1"})
+
+        response = await server.seed_session(request, body)
+
+        server._create_sandbox.assert_awaited_once_with(test_spec, sandbox_spec=request_spec)
+        assert response.sandbox_handle == "sandbox-1"
+        assert server._session_id_to_sandbox["session-1"] is sandbox
+
+    async def test_request_sandbox_spec_overrides_config(self, monkeypatch: MonkeyPatch) -> None:
+        config = SwebenchResourcesServerConfig(
+            host="0.0.0.0",
+            port=8080,
+            entrypoint="",
+            name="swebench",
+            sandbox_provider="test",
+            sandbox_config={
+                "ttl_s": 300,
+                "resources": {"cpu": 2, "memory_mib": 8192},
+                "resource_requests": {"cpu": 0.5, "memory_mib": 2048},
+                "ports": [3000],
+                "metadata": {"configured": "true", "overridden": "config"},
+            },
+        )
+        server = SwebenchResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+        sandbox = MagicMock(start=AsyncMock())
+        monkeypatch.setattr("resources_servers.swebench.app.get_global_config_dict", lambda: {})
+        monkeypatch.setattr("resources_servers.swebench.app.resolve_provider_config", lambda *_args: object())
+        monkeypatch.setattr(
+            "resources_servers.swebench.app.resolve_provider_metadata",
+            lambda *_args: {"provider": "test"},
+        )
+        monkeypatch.setattr("resources_servers.swebench.app.AsyncSandbox", MagicMock(return_value=sandbox))
+        test_spec = MagicMock(
+            instance_image_key="swebench/image:latest",
+            instance_id="owner__repo-1",
+            repo="owner/repo",
+        )
+
+        await server._create_sandbox(
+            test_spec,
+            sandbox_spec={
+                "image": "request/image:ignored",
+                "ttl_s": 60,
+                "resource_requests": {"cpu": 0.25, "memory_mib": 1024},
+                "ports": [9000],
+                "metadata": {"request": "true", "overridden": "request"},
+            },
+        )
+
+        spec = sandbox.start.await_args.args[0]
+        assert spec.image == "swebench/image:latest"
+        assert spec.ttl_s == 60
+        assert spec.resources == SandboxResources(cpu=2, memory_mib=8192)
+        assert spec.resource_requests == SandboxResources(cpu=0.25, memory_mib=1024)
+        assert spec.ports == (9000,)
+        assert spec.metadata == {
+            "provider": "test",
+            "configured": "true",
+            "overridden": "request",
+            "request": "true",
+            "nemo_gym_agent": "swebench",
+            "instance_id": "owner__repo-1",
+        }
+
     def test_sanity(self, monkeypatch: MonkeyPatch) -> None:
         config = SwebenchResourcesServerConfig(
             host="0.0.0.0",

--- a/responses_api_agents/anyswe_agent/app.py
+++ b/responses_api_agents/anyswe_agent/app.py
@@ -313,6 +313,7 @@ class AnySweAgent(SimpleResponsesAPIAgent):
     ) -> SandboxSpec:
         config = dict(params.sandbox_spec)
         provider_options = dict(config.pop("provider_options", {}))
+        resource_requests = config.pop("resource_requests", None)
         metadata = {
             **params.sandbox_default_metadata,
             **config.pop("metadata", {}),
@@ -328,8 +329,12 @@ class AnySweAgent(SimpleResponsesAPIAgent):
             files=files or {},
             metadata=metadata,
             resources=SandboxResources.from_mapping(config.pop("resources", {})),
+            resource_requests=(
+                SandboxResources.from_mapping(resource_requests) if resource_requests is not None else None
+            ),
             entrypoint=config.pop("entrypoint", None),
             provider_options=provider_options,
+            ports=config.pop("ports", ()),
         )
 
     @staticmethod

--- a/responses_api_agents/anyswe_agent/tests/test_app.py
+++ b/responses_api_agents/anyswe_agent/tests/test_app.py
@@ -107,7 +107,9 @@ class TestSandboxAPI:
                 "ttl_s": 600,
                 "ready_timeout_s": 300,
                 "resources": {"cpu": 2, "memory_mib": 4096},
+                "resource_requests": {"cpu": 0.5, "memory_mib": 2048},
                 "provider_options": {"platform": {"arch": "amd64"}},
+                "ports": [8000, 9222],
             },
             sandbox_default_metadata={"sandbox-api": "opensandbox-sdk"},
             swebench_agent_timeout=100,
@@ -119,9 +121,13 @@ class TestSandboxAPI:
         assert spec.image == "image:tag"
         assert spec.ttl_s == 600
         assert spec.resources.cpu == 2
+        assert spec.resource_requests is not None
+        assert spec.resource_requests.cpu == 0.5
+        assert spec.resource_requests.memory_mib == 2048
         assert spec.metadata["sandbox-api"] == "opensandbox-sdk"
         assert spec.provider_options == {"platform": {"arch": "amd64"}}
         assert spec.files == {"/tmp/input": "data"}
+        assert spec.ports == (8000, 9222)
 
     def test_agent_config_is_forwarded_without_harness_specific_changes(self) -> None:
         params = SimpleNamespace(

--- a/responses_api_agents/harbor_agent/README.md
+++ b/responses_api_agents/harbor_agent/README.md
@@ -39,6 +39,16 @@ The default Harbor environments are not sufficient for HPC training, so this rep
 includes a custom Singularity environment implementation.
 It is designed around task-local setup, staged task files, and predictable runtime
 paths used by Harbor jobs.
+
+The package also includes a provider-neutral NeMo Gym sandbox environment for
+running Harbor tasks through any configured sandbox provider. Its
+`harbor_environment_kwargs.sandbox_resource_requests` mapping sets optional
+scheduling requests separately from the task or `override_*` resource limits;
+requests must not exceed those resolved limits. Reserve
+`sandbox_provider_options` for settings specific to the selected provider. See
+[`configs/harbor_agent_opensandbox.yaml`](configs/harbor_agent_opensandbox.yaml)
+for a complete example.
+
 For Singularity installation and image preparation (`docker_image` as `.sif` path vs.
 registry reference), see [Quick Start: 2) Set up dependencies and task images](#2-set-up-dependencies-and-task-images).
 

--- a/responses_api_agents/harbor_agent/configs/harbor_agent_opensandbox.yaml
+++ b/responses_api_agents/harbor_agent/configs/harbor_agent_opensandbox.yaml
@@ -75,6 +75,12 @@ harbor_agent:
         override_cpus: 8
         override_memory_mb: 16384
         override_storage_mb: 30720
+        # Provider-neutral scheduling requests, kept below the limits so
+        # providers with separate requests can pack sandboxes more densely.
+        sandbox_resource_requests:
+          cpu: 0.5
+          memory_mib: 2048
+          disk_gib: 30
         # Sandboxes see the host's full core count, so build tools fan out to
         # nproc workers and get CFS-throttled; pinning right-sizes that.
         # Fail-open: no taskset or too few cores leaves the command unpinned.

--- a/responses_api_agents/harbor_agent/custom_envs/nemo_gym_sandbox/environment.py
+++ b/responses_api_agents/harbor_agent/custom_envs/nemo_gym_sandbox/environment.py
@@ -41,6 +41,7 @@ from harbor.models.trial.paths import EnvironmentPaths
 
 from nemo_gym.sandbox import (
     AsyncSandbox,
+    SandboxResources,
     SandboxSpec,
     resolve_provider_config,
     resolve_provider_metadata,
@@ -80,9 +81,11 @@ class NemoGymSandboxEnvironment(BaseEnvironment):
             (optionally wrapped with a reserved ``default_metadata`` key, same
             shape as the shipped ``sandbox:`` config blocks).
         sandbox_metadata: Extra ``SandboxSpec.metadata`` entries.
-        sandbox_provider_options: ``SandboxSpec.provider_options`` passed through
-            to the provider, e.g. ``resource_requests`` to schedule sandboxes
-            below their resource limits.
+        sandbox_resource_requests: Provider-neutral scheduling resource requests.
+            Accepts ``SandboxResources`` fields and must not exceed the task's
+            resolved resource limits.
+        sandbox_provider_options: Provider-specific ``SandboxSpec.provider_options``
+            passed through unchanged.
         sandbox_env: Extra environment variables set in the sandbox.
         sandbox_ttl_s: Sandbox server-side TTL safety net (default 21600).
         sandbox_ready_timeout_s: Create/readiness timeout incl. image pull
@@ -119,6 +122,7 @@ class NemoGymSandboxEnvironment(BaseEnvironment):
         *args,
         sandbox_provider: Optional[Mapping[str, Any]] = None,
         sandbox_metadata: Optional[Mapping[str, Any]] = None,
+        sandbox_resource_requests: Optional[Mapping[str, Any]] = None,
         sandbox_provider_options: Optional[Mapping[str, Any]] = None,
         sandbox_env: Optional[Mapping[str, str]] = None,
         sandbox_ttl_s: Optional[float] = 21600,
@@ -135,6 +139,9 @@ class NemoGymSandboxEnvironment(BaseEnvironment):
         # _validate_* hooks, which read these.
         self._sandbox_provider = sandbox_provider
         self._sandbox_metadata = dict(sandbox_metadata or {})
+        self._sandbox_resource_requests = None
+        if sandbox_resource_requests is not None:
+            self._sandbox_resource_requests = SandboxResources.from_mapping(sandbox_resource_requests)
         self._sandbox_provider_options = dict(sandbox_provider_options or {})
         self._sandbox_env = {str(k): str(v) for k, v in dict(sandbox_env or {}).items()}
         self._sandbox_ttl_s = sandbox_ttl_s
@@ -221,6 +228,7 @@ class NemoGymSandboxEnvironment(BaseEnvironment):
             env=self._sandbox_env,
             metadata=metadata,
             resources=resources,
+            resource_requests=self._sandbox_resource_requests,
             provider_options=dict(self._sandbox_provider_options),
         )
 

--- a/responses_api_agents/harbor_agent/tests/test_environment.py
+++ b/responses_api_agents/harbor_agent/tests/test_environment.py
@@ -161,14 +161,24 @@ class TestStartStop:
         assert provider.exec_calls[0]["command"] == "mkdir -p /logs/agent /logs/verifier"
 
     @pytest.mark.asyncio
-    async def test_start_passes_provider_options_through(self, tmp_path):
+    async def test_start_passes_resource_requests_and_provider_options(self, tmp_path):
         env = _make_environment(
             tmp_path,
-            sandbox_provider_options={"resource_requests": {"cpu": 0.25, "memory_mib": 1024}},
+            sandbox_resource_requests={"cpu": 0.25, "memory_mib": 1024},
+            sandbox_provider_options={"runtime_class": "batch"},
         )
         await env.start(force_build=False)
         spec = _provider().created_specs[0]
-        assert spec.provider_options == {"resource_requests": {"cpu": 0.25, "memory_mib": 1024}}
+        assert spec.resource_requests is not None
+        assert spec.resource_requests.cpu == 0.25
+        assert spec.resource_requests.memory_mib == 1024
+        assert spec.provider_options == {"runtime_class": "batch"}
+
+    def test_resource_requests_cannot_exceed_task_limits(self, tmp_path):
+        env = _make_environment(tmp_path, sandbox_resource_requests={"cpu": 4.5})
+
+        with pytest.raises(ValueError, match=r"resource_requests\.cpu.*cannot exceed resources\.cpu"):
+            env._build_spec()
 
     @pytest.mark.asyncio
     async def test_start_honours_harbor_resource_overrides(self, tmp_path):

--- a/responses_api_agents/mini_swe_agent_2/README.md
+++ b/responses_api_agents/mini_swe_agent_2/README.md
@@ -173,14 +173,16 @@ mini_swe_agent_2:
       sandbox_spec:
         ttl_s: 18000
         ready_timeout_s: 1200
+        # Resource limits (burst ceiling).
         resources:
           cpu: 2
           memory_mib: 8192
-          disk_gib: 20
-        provider_options:
-          platform:
-            os: linux
-            arch: amd64
+          disk_gib: 30
+        # Provider-neutral scheduling requests.
+        resource_requests:
+          cpu: 0.5
+          memory_mib: 2048
+          disk_gib: 30
         metadata:
           benchmark: swebench-verified
           harness: mini-swe-agent
@@ -200,6 +202,12 @@ mini_swe_agent_2:
 sandbox block in the merged config, the recommended decoupled form) or an inline
 single-key provider mapping (`{provider_name: {...}}`) when you prefer to keep
 everything in one file.
+
+`sandbox_spec.resources` defines the resource limits, while the optional
+`sandbox_spec.resource_requests` field provides provider-neutral scheduling
+requests for providers that support separate requests and limits. Each numeric
+request must be less than or equal to its corresponding limit. Providers without
+separate request semantics may ignore this hint.
 
 ### Sandbox Provider Configuration
 
@@ -264,7 +272,10 @@ Optional `sandbox_resource_profiles` can be configured as a list of resource
 maps. When present, the agent hashes `instance_id` and deterministically merges
 one profile into `sandbox_spec.resources`. This is useful for spreading
 SWE-bench tasks across a small set of resource sizes without changing the input
-data.
+data. If a selected profile lowers a numeric resource limit below its configured
+request, the agent clamps that request to the profiled limit. It does not create
+requests when `sandbox_spec.resource_requests` is omitted; other request-over-limit
+configurations fail validation.
 
 ### Advanced: multiple sandboxes
 
@@ -656,6 +667,7 @@ environment:
       connection: ...
   spec:
     resources: ...
+    resource_requests: ...
     provider_options:
       platform: ...
     metadata: ...
@@ -667,7 +679,7 @@ environment:
 
 - Validates that a sandbox provider was configured.
 - Builds a `SandboxSpec` from the task image, environment variables, metadata,
-  resources, and provider-specific options.
+  resource limits, resource requests, and provider-specific options.
 - Adds standard metadata such as `nemo_gym_agent=mini_swe_agent_2` and
   `instance_id`.
 - Creates a `Sandbox` facade and calls `Sandbox.start(...)`.

--- a/responses_api_agents/mini_swe_agent_2/app.py
+++ b/responses_api_agents/mini_swe_agent_2/app.py
@@ -47,7 +47,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
 )
 from nemo_gym.reward_profile import compute_pass_majority_metrics, highest_k_metrics
-from nemo_gym.sandbox import resolve_provider_config, resolve_provider_metadata
+from nemo_gym.sandbox import SandboxResources, resolve_provider_config, resolve_provider_metadata
 from nemo_gym.server_utils import (
     ServerClient,
     get_first_server_config_dict,
@@ -73,7 +73,7 @@ class MiniSWEAgentConfig(BaseResponsesAPIAgentConfig):
     skip_if_exists: bool = False
     step_limit: int = 250
     tool_choice: Optional[str | dict[str, Any]] = None
-    sandbox_resource_profiles: Optional[list[dict[str, str]]] = None
+    sandbox_resource_profiles: Optional[list[dict[str, Any]]] = None
 
 
 class MiniSWEAgentRunRequest(BaseRunRequest):
@@ -214,10 +214,34 @@ def _sandbox_spec_for_instance(
         return instance_spec
 
     resources = dict(instance_spec.get("resources") or {})
+    base_resources = SandboxResources.from_mapping(resources)
     digest = hashlib.sha256(instance_id.encode("utf-8")).digest()
     profile = resource_profiles[int.from_bytes(digest[:4], "big") % len(resource_profiles)]
     resources.update(profile)
     instance_spec["resources"] = resources
+
+    # Profiles override resource limits. If one lowers a limit below a
+    # configured scheduling request, lower that request with it so the
+    # provider-neutral SandboxSpec remains valid. An omitted request block is
+    # intentionally left omitted, preserving each provider's default behavior.
+    if instance_spec.get("resource_requests") is not None:
+        resource_requests = dict(instance_spec["resource_requests"])
+        normalized_requests = SandboxResources.from_mapping(resource_requests)
+        profile_resources = SandboxResources.from_mapping(resources)
+        for field_name in ("cpu", "memory_mib", "disk_gib", "gpu"):
+            if field_name not in profile:
+                continue
+            request = getattr(normalized_requests, field_name)
+            limit = getattr(profile_resources, field_name)
+            base_limit = getattr(base_resources, field_name)
+            if (
+                request is not None
+                and limit is not None
+                and request > limit
+                and (base_limit is None or (request <= base_limit and limit < base_limit))
+            ):
+                resource_requests[field_name] = resources[field_name]
+        instance_spec["resource_requests"] = resource_requests
     return instance_spec
 
 

--- a/responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+++ b/responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
@@ -37,12 +37,12 @@ mini_swe_agent_2:
           # 30 GiB works on every provider: within Fargate's 21-200 GiB ephemeral range
           # (an explicit 20 is rejected there) and fine as an ephemeral request elsewhere.
           disk_gib: 30
-        provider_options:
-          # Scheduling requests, kept below the limits so sandboxes pack densely.
-          resource_requests:
-            cpu: 0.5
-            memory_mib: 2048
-            disk_gib: 30
+        # Provider-neutral scheduling requests, kept below the limits so
+        # sandboxes pack densely on providers that support separate requests.
+        resource_requests:
+          cpu: 0.5
+          memory_mib: 2048
+          disk_gib: 30
         metadata:
           benchmark: swebench-verified
           harness: mini-swe-agent

--- a/responses_api_agents/mini_swe_agent_2/sandbox_environment.py
+++ b/responses_api_agents/mini_swe_agent_2/sandbox_environment.py
@@ -80,6 +80,7 @@ class MiniSWESandboxEnvironment:
         image = spec_config.pop("image", None) or self.config.image
         image = rewrite_image(image, spec_config.pop("image_rewrites", []))
         provider_options = dict(spec_config.pop("provider_options", {}))
+        resource_requests_config = spec_config.pop("resource_requests", None)
 
         env = dict(spec_config.pop("env", {}))
         for key in self.config.forward_env:
@@ -102,8 +103,14 @@ class MiniSWESandboxEnvironment:
                     "instance_id": (self.config.instance_id or "unknown")[:63],
                 },
                 resources=SandboxResources.from_mapping(spec_config.pop("resources", {})),
+                resource_requests=(
+                    SandboxResources.from_mapping(resource_requests_config)
+                    if resource_requests_config is not None
+                    else None
+                ),
                 entrypoint=spec_config.pop("entrypoint", None),
                 provider_options=provider_options,
+                ports=spec_config.pop("ports", ()),
             )
         )
 

--- a/responses_api_agents/mini_swe_agent_2/tests/test_app.py
+++ b/responses_api_agents/mini_swe_agent_2/tests/test_app.py
@@ -29,6 +29,9 @@ from nemo_gym.openai_utils import (
     NeMoGymChatCompletionCreateParamsNonStreaming,
     NeMoGymResponseCreateParamsNonStreaming,
 )
+from nemo_gym.sandbox import SandboxResources, SandboxSpec
+from nemo_gym.sandbox.providers.daytona.provider import DaytonaProviderOptions
+from nemo_gym.sandbox.providers.openshell.provider import OpenShellProviderOptions
 from nemo_gym.server_utils import ServerClient
 
 
@@ -46,6 +49,7 @@ except ModuleNotFoundError as exc:
     sys.modules["minisweagent.config"] = minisweagent_config_module
 
 from responses_api_agents.mini_swe_agent_2 import app as mini_swe_app_module
+from responses_api_agents.mini_swe_agent_2 import sandbox_environment as mini_swe_sandbox_environment_module
 from responses_api_agents.mini_swe_agent_2.app import (
     OPENSANDBOX_API_KEY_ENV,
     MiniSWEAgent,
@@ -343,8 +347,12 @@ class TestApp:
             _json_dict_from_metadata("[]", field_name="extra_body")
 
     def test_sandbox_resource_profiles_override_static_resources(self) -> None:
+        base_spec = {
+            "resources": {"cpu": 2, "memory_mib": 8192, "disk_gib": 30},
+            "resource_requests": {"cpu": 0.5, "memory_mib": 2048, "disk_gib": 30},
+        }
         spec = _sandbox_spec_for_instance(
-            {"resources": {"cpu": 1, "memory_mib": 8192, "disk_gib": 20}},
+            base_spec,
             resource_profiles=[
                 {"cpu": 0.25, "memory_mib": 3072, "disk_gib": 1},
                 {"cpu": 0.5, "memory_mib": 4096, "disk_gib": 1},
@@ -356,7 +364,103 @@ class TestApp:
             {"cpu": 0.25, "memory_mib": 3072, "disk_gib": 1},
             {"cpu": 0.5, "memory_mib": 4096, "disk_gib": 1},
         )
+        assert spec["resource_requests"] in (
+            {"cpu": 0.25, "memory_mib": 2048, "disk_gib": 1},
+            {"cpu": 0.5, "memory_mib": 2048, "disk_gib": 1},
+        )
+        assert SandboxSpec.model_validate(spec).resource_requests is not None
+        assert base_spec["resource_requests"] == {"cpu": 0.5, "memory_mib": 2048, "disk_gib": 30}
+
+        without_requests = _sandbox_spec_for_instance(
+            {"resources": {"cpu": 2}},
+            resource_profiles=[{"cpu": 0.25}],
+            instance_id="task",
+        )
+        assert "resource_requests" not in without_requests
+        assert SandboxSpec.model_validate(without_requests).resource_requests is None
+
+        with pytest.raises(ValueError, match=r"resource_requests\.cpu .* cannot exceed resources\.cpu"):
+            SandboxSpec.model_validate(
+                _sandbox_spec_for_instance(
+                    {
+                        "resources": {"cpu": 0.25},
+                        "resource_requests": {"cpu": 1},
+                    },
+                    resource_profiles=[{"cpu": 0.5}],
+                    instance_id="task",
+                )
+            )
+
+        with pytest.raises(ValueError, match=r"resource_requests\.cpu .* cannot exceed resources\.cpu"):
+            SandboxSpec.model_validate(
+                _sandbox_spec_for_instance(
+                    {
+                        "resources": {"cpu": 0.5},
+                        "resource_requests": {"cpu": 1},
+                    },
+                    resource_profiles=[{"cpu": 0.25}],
+                    instance_id="task",
+                )
+            )
         assert _sandbox_spec_for_instance(None, resource_profiles=None, instance_id="task") == {}
+
+    def test_default_yaml_uses_provider_neutral_resource_requests(self) -> None:
+        config_path = Path(__file__).resolve().parents[1] / "configs" / "mini_swe_agent_2.yaml"
+        agent_config = yaml.safe_load(config_path.read_text(encoding="utf-8"))["mini_swe_agent_2"][
+            "responses_api_agents"
+        ]["mini_swe_agent_2"]
+        spec_config = agent_config["sandbox_spec"]
+
+        assert spec_config["resource_requests"] == {
+            "cpu": 0.5,
+            "memory_mib": 2048,
+            "disk_gib": 30,
+        }
+        assert "resource_requests" not in spec_config.get("provider_options", {})
+        spec = SandboxSpec.model_validate(spec_config)
+
+        assert spec.resource_requests == SandboxResources(
+            cpu=0.5,
+            memory_mib=2048,
+            disk_gib=30,
+        )
+        assert DaytonaProviderOptions.from_mapping(spec.provider_options) == DaytonaProviderOptions()
+        assert OpenShellProviderOptions.from_mapping(spec.provider_options) == OpenShellProviderOptions()
+
+    def test_sandbox_environment_passes_provider_neutral_resource_requests(self, monkeypatch) -> None:
+        captured: dict[str, Any] = {}
+
+        class FakeSandbox:
+            def __init__(self, provider: dict[str, Any]) -> None:
+                captured["provider"] = provider
+
+            def start(self, spec: SandboxSpec) -> "FakeSandbox":
+                captured["spec"] = spec
+                return self
+
+            def stop(self) -> None:
+                captured["stopped"] = True
+
+        monkeypatch.setattr(mini_swe_sandbox_environment_module, "Sandbox", FakeSandbox)
+        env = mini_swe_sandbox_environment_module.MiniSWESandboxEnvironment(
+            image="image:tag",
+            provider={"provider-neutral": {}},
+            spec={
+                "resources": {"cpu": 2, "memory_mib": 8192},
+                "resource_requests": {"cpu": 0.5, "memory_mib": 2048},
+                "ports": [8000, 9222],
+            },
+        )
+
+        try:
+            assert captured["provider"] == {"provider-neutral": {}}
+            assert captured["spec"].resource_requests == SandboxResources(cpu=0.5, memory_mib=2048)
+            assert captured["spec"].provider_options == {}
+            assert captured["spec"].ports == (8000, 9222)
+        finally:
+            env.cleanup()
+
+        assert captured["stopped"] is True
 
     def test_sandbox_provider_config_dump_strips_api_key(self) -> None:
         provider = {

--- a/responses_api_agents/opencode_sandboxed_agent/app.py
+++ b/responses_api_agents/opencode_sandboxed_agent/app.py
@@ -105,7 +105,7 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
         if self.config.debug:
             print("Creating new sandbox since one wasn't provided", file=sys.stderr)
 
-        # TODO @bxyu-nvidia: Refactor this after Hemil's swap from Python dataclass to Pydantic BaseModel
+        resource_requests = self.config.sandbox_config.get("resource_requests")
         sandbox_spec = SandboxSpec(
             image="swebench/sweb.eval.x86_64.astropy_1776_astropy-12907",  # This is just the first SWE Bench Verified image for now
             ttl_s=self.config.sandbox_config.get("ttl_s", None),
@@ -113,12 +113,16 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
             workdir=None,  # Default to container's WORKDIR
             env=dict(),
             files=dict(),
+            ports=self.config.sandbox_config.get("ports", []),
             metadata=provider_default_metadata
             | self.config.sandbox_config.get("metadata", {})
             | {
                 "nemo_gym_agent": self.config.name,
             },
             resources=SandboxResources.from_mapping(self.config.sandbox_config.get("resources", {})),
+            resource_requests=(
+                SandboxResources.from_mapping(resource_requests) if resource_requests is not None else None
+            ),
             entrypoint=None,
             provider_options=self.config.sandbox_config.get("provider_options", {}),
         )

--- a/responses_api_agents/opencode_sandboxed_agent/tests/test_app.py
+++ b/responses_api_agents/opencode_sandboxed_agent/tests/test_app.py
@@ -34,6 +34,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseUsage,
     NeMoGymSummary,
 )
+from nemo_gym.sandbox import SandboxResources
 from nemo_gym.server_utils import SESSION_ID_KEY, ServerClient
 from responses_api_agents.opencode_sandboxed_agent.app import OpenCodeSandboxedAgent, OpenCodeSandboxedAgentConfig
 
@@ -127,6 +128,46 @@ class TestOpenCodeSandboxedAgent:
         ]
 
         assert expected_usages == actual_usages
+
+    async def test_start_sandbox_forwards_resource_requests(self, monkeypatch: MonkeyPatch) -> None:
+        config = self._create_config().model_copy(
+            update={
+                "sandbox_provider": "opensandbox",
+                "sandbox_config": {
+                    "resources": {"cpu": 2, "memory_mib": 4096, "disk_gib": 30},
+                    "resource_requests": {"cpu": 0.5, "memory_mib": 2048, "disk_gib": 30},
+                    "ports": [8000, 9222],
+                },
+            }
+        )
+        server = OpenCodeSandboxedAgent(config=config, server_client=MagicMock(spec=ServerClient))
+        provider = MagicMock()
+        sandbox = MagicMock()
+        sandbox.start = AsyncMock()
+
+        monkeypatch.setattr("responses_api_agents.opencode_sandboxed_agent.app.get_global_config_dict", lambda: {})
+        monkeypatch.setattr(
+            "responses_api_agents.opencode_sandboxed_agent.app.resolve_provider_config",
+            lambda _provider_name, _global_config: {},
+        )
+        monkeypatch.setattr(
+            "responses_api_agents.opencode_sandboxed_agent.app.resolve_provider_metadata",
+            lambda _provider_name, _global_config: {},
+        )
+        monkeypatch.setattr(
+            "responses_api_agents.opencode_sandboxed_agent.app.create_provider", lambda _config: provider
+        )
+        sandbox_factory = MagicMock(return_value=sandbox)
+        monkeypatch.setattr("responses_api_agents.opencode_sandboxed_agent.app.AsyncSandbox", sandbox_factory)
+
+        assert await server._start_sandbox() is sandbox
+
+        sandbox_factory.assert_called_once_with(provider)
+        sandbox.start.assert_awaited_once()
+        spec = sandbox.start.await_args.args[0]
+        assert spec.resources == SandboxResources(cpu=2, memory_mib=4096, disk_gib=30)
+        assert spec.resource_requests == SandboxResources(cpu=0.5, memory_mib=2048, disk_gib=30)
+        assert spec.ports == (8000, 9222)
 
     async def test_responses_sanity(self, opencode_export_test_data: Dict[str, Any], monkeypatch: MonkeyPatch) -> None:
         config = self._create_config()

--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -221,13 +221,18 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
     # --- per-task sandbox (Gym Sandbox API; provider-neutral) ---------------
     def _build_spec(self, task_id: str) -> SandboxSpec:
         cfg = dict(self.config.sandbox_spec)
+        resource_requests = cfg.get("resource_requests")
         return SandboxSpec(
             image=cfg.get("image"),
             ttl_s=cfg.get("ttl_s"),
             ready_timeout_s=cfg.get("ready_timeout_s"),
             workdir=cfg.get("workdir"),
             resources=SandboxResources.from_mapping(cfg.get("resources", {})),
+            resource_requests=(
+                SandboxResources.from_mapping(resource_requests) if resource_requests is not None else None
+            ),
             provider_options=cfg.get("provider_options", {}),
+            ports=cfg.get("ports", ()),
             env=self._task_env(task_id),
             metadata={"task_id": task_id},
         )

--- a/responses_api_agents/pinchbench/tests/test_app.py
+++ b/responses_api_agents/pinchbench/tests/test_app.py
@@ -96,12 +96,19 @@ def test_build_spec_from_config():
             "image": "/sif/pinchbench.sif",
             "ready_timeout_s": 600,
             "resources": {"cpu": 4, "memory_mib": 8192},
+            "resource_requests": {"cpu": 1, "memory_mib": 2048},
+            "provider_options": {"network": "isolated"},
+            "ports": [8000, 9222],
         }
     )
     spec = agent._build_spec("task_x")
     assert spec.image == "/sif/pinchbench.sif"
     assert spec.ready_timeout_s == 600
     assert spec.resources.cpu == 4 and spec.resources.memory_mib == 8192
+    assert spec.resource_requests is not None
+    assert spec.resource_requests.cpu == 1 and spec.resource_requests.memory_mib == 2048
+    assert spec.provider_options == {"network": "isolated"}
+    assert spec.ports == (8000, 9222)
     assert spec.metadata == {"task_id": "task_x"}
     # the per-task env (incl the in-sandbox gateway token) is injected into the spec
     assert spec.env["TASK_ID"] == "task_x"

--- a/tests/unit_tests/test_apptainer_provider.py
+++ b/tests/unit_tests/test_apptainer_provider.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from nemo_gym.sandbox.providers.apptainer import provider as apptainer_provider
 from nemo_gym.sandbox.providers.base import (
@@ -116,6 +117,92 @@ def test_coerce_config() -> None:
     assert coerce({"concurrency": 7}, cls).concurrency == 7
     with pytest.raises(TypeError):
         coerce(123, cls)
+
+
+def test_config_models_validate_and_dump() -> None:
+    create = apptainer_provider.ApptainerCreateConfig.model_validate(
+        {
+            "mount_point": "/workspace",
+            "start_timeout_s": 15,
+            "extra_start_args": ["--cleanenv"],
+            "apply_resource_limits": False,
+        }
+    )
+    exec_config = apptainer_provider.ApptainerExecConfig.model_validate(
+        {
+            "default_timeout_s": 12,
+            "fakeroot_for_root": False,
+            "default_binds": ["/host:/container"],
+            "extra_exec_args": ["--contain"],
+            "concurrency": 4,
+        }
+    )
+    probe = apptainer_provider.ApptainerProbeConfig.model_validate(
+        {
+            "command": "true",
+            "expected_stdout": "",
+            "timeout_s": 5,
+            "deadline_s": 20,
+            "stable_count": 2,
+            "stable_delay_s": 0.5,
+        }
+    )
+
+    assert isinstance(create, BaseModel)
+    assert create.model_dump() == {
+        "mount_point": "/workspace",
+        "start_timeout_s": 15.0,
+        "extra_start_args": ["--cleanenv"],
+        "apply_resource_limits": False,
+    }
+    assert exec_config.model_dump() == {
+        "default_timeout_s": 12.0,
+        "fakeroot_for_root": False,
+        "default_binds": ["/host:/container"],
+        "extra_exec_args": ["--contain"],
+        "concurrency": 4,
+    }
+    assert probe.model_dump() == {
+        "command": "true",
+        "expected_stdout": "",
+        "timeout_s": 5,
+        "deadline_s": 20.0,
+        "stable_count": 2,
+        "stable_delay_s": 0.5,
+    }
+
+
+@pytest.mark.parametrize(
+    "config_cls",
+    [
+        apptainer_provider.ApptainerCreateConfig,
+        apptainer_provider.ApptainerExecConfig,
+        apptainer_provider.ApptainerProbeConfig,
+    ],
+)
+def test_config_models_are_frozen_and_forbid_extra(config_cls: type[BaseModel]) -> None:
+    config = config_cls()
+    field_name = next(iter(config_cls.model_fields))
+
+    with pytest.raises(ValidationError, match="Instance is frozen"):
+        setattr(config, field_name, None)
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        config_cls.model_validate({"unexpected": "value"})
+
+
+def test_config_list_defaults_are_isolated() -> None:
+    first_create = apptainer_provider.ApptainerCreateConfig()
+    second_create = apptainer_provider.ApptainerCreateConfig()
+    first_create.extra_start_args.append("--cleanenv")
+
+    first_exec = apptainer_provider.ApptainerExecConfig()
+    second_exec = apptainer_provider.ApptainerExecConfig()
+    first_exec.default_binds.append("/host:/container")
+    first_exec.extra_exec_args.append("--contain")
+
+    assert second_create.extra_start_args == []
+    assert second_exec.default_binds == []
+    assert second_exec.extra_exec_args == []
 
 
 def test_config_validation() -> None:

--- a/tests/unit_tests/test_daytona_provider.py
+++ b/tests/unit_tests/test_daytona_provider.py
@@ -23,6 +23,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from nemo_gym.sandbox.providers.base import SandboxHandle, SandboxSpec, SandboxStatus
 from nemo_gym.sandbox.providers.daytona import provider as daytona_provider
@@ -211,6 +212,61 @@ def test_config_unknown_keys_fail_fast() -> None:
         daytona_provider.DaytonaProvider(create={"typo": "value"})
 
 
+@pytest.mark.parametrize(
+    ("config_cls", "values"),
+    [
+        (daytona_provider.DaytonaConnectionConfig, {"api_url": "https://api.example"}),
+        (daytona_provider.DaytonaCreateConfig, {"timeout_s": 12.5}),
+        (daytona_provider.DaytonaProbeConfig, {"command": None, "timeout_s": 0}),
+        (daytona_provider.DaytonaOperationConfig, {"command_retries": 2}),
+        (daytona_provider.DaytonaBatchConfig, {"concurrency": 8}),
+    ],
+)
+def test_config_models_are_frozen_strict_and_round_trip(
+    config_cls: type[daytona_provider.DaytonaConfigBase],
+    values: dict[str, Any],
+) -> None:
+    assert issubclass(config_cls, BaseModel)
+
+    config = config_cls.from_mapping(values)
+    restored = config_cls.model_validate(config.model_dump(exclude_unset=True))
+    assert restored == config
+    assert restored.model_fields_set == config.model_fields_set
+    assert config_cls.from_mapping(config) is config
+
+    field_name = next(iter(values))
+    with pytest.raises(ValidationError, match="Instance is frozen"):
+        setattr(config, field_name, values[field_name])
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        config_cls.model_validate({**values, "typo": "value"})
+    with pytest.raises(TypeError, match="must be a mapping"):
+        config_cls.from_mapping(object())
+
+
+def test_provider_options_model_is_frozen_strict_and_serializable() -> None:
+    assert issubclass(daytona_provider.DaytonaProviderOptions, BaseModel)
+    raw_options = {
+        "extensions": {"daytona.name": 123},
+        "snapshot_id": "snapshot-1",
+        "volumes": [{"name": "workspace"}],
+    }
+    options = daytona_provider.DaytonaProviderOptions.from_mapping(raw_options)
+
+    assert options.extensions == {"daytona.name": "123"}
+    assert options.volumes == ({"name": "workspace"},)
+    assert daytona_provider.DaytonaProviderOptions.model_validate(raw_options) == options
+    assert daytona_provider.DaytonaProviderOptions.model_validate(options.model_dump()) == options
+    assert (
+        daytona_provider.DaytonaProviderOptions().extensions
+        is not daytona_provider.DaytonaProviderOptions().extensions
+    )
+
+    with pytest.raises(ValidationError, match="Instance is frozen"):
+        options.snapshot_id = "snapshot-2"
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        daytona_provider.DaytonaProviderOptions.model_validate({"platform": {"os": "linux"}})
+
+
 def test_conversion_helpers_and_config_validation(fake_daytona_sdk: None) -> None:
     create_config = daytona_provider.DaytonaCreateConfig(timeout_s=1)
     assert daytona_provider.DaytonaCreateConfig.from_mapping(create_config) is create_config
@@ -297,6 +353,10 @@ def test_conversion_helpers_and_config_validation(fake_daytona_sdk: None) -> Non
     with pytest.raises(ValueError, match="Unsupported Daytona DaytonaConnectionConfig settings: typo"):
         daytona_provider.DaytonaProvider(connection={"typo": True})
 
+    assert daytona_provider.DaytonaProbeConfig(command=None, timeout_s=0).timeout_s == 0
+    with pytest.raises(ValueError, match="probe.deadline_s must be > 0"):
+        daytona_provider.DaytonaProbeConfig(command=None, timeout_s=0, deadline_s=0)
+
 
 def test_snapshot_creation_rejects_ignored_resources(fake_daytona_sdk: None) -> None:
     provider = daytona_provider.DaytonaProvider(probe={"command": None})
@@ -311,13 +371,15 @@ def test_snapshot_creation_rejects_ignored_resources(fake_daytona_sdk: None) -> 
 
 def test_image_creation_keeps_resource_overrides(fake_daytona_sdk: None) -> None:
     provider = daytona_provider.DaytonaProvider(probe={"command": None})
-    params = provider._to_create_params(
-        SandboxSpec(
-            image="python:3.12",
-            resources={"cpu": 2, "memory_mib": 2048, "disk_gib": 9},
-        )
+    spec = SandboxSpec(
+        image="python:3.12",
+        resources={"cpu": 2, "memory_mib": 2048, "disk_gib": 9},
+        resource_requests={"cpu": 0.5, "memory_mib": 1024, "disk_gib": 1},
     )
+    options = daytona_provider._provider_options(spec)
+    params = provider._to_create_params(spec)
 
+    assert options == daytona_provider.DaytonaProviderOptions()
     assert isinstance(params, FakeImageParams)
     assert params.kwargs["resources"].kwargs == {"cpu": 2, "memory": 2, "disk": 9}
 
@@ -368,6 +430,27 @@ async def test_client_lifecycle_create_kwargs_and_status_fallbacks(fake_daytona_
     unlimited_client = unlimited_provider._client()
     assert unlimited_client.config.kwargs == {"connection_pool_maxsize": None}
     await unlimited_provider.aclose()
+
+    typed_connection = daytona_provider.DaytonaConnectionConfig(connection_pool_maxsize=None)
+    assert typed_connection.model_fields_set == {"connection_pool_maxsize"}
+    restored_typed_connection = daytona_provider.DaytonaConnectionConfig.model_validate(
+        typed_connection.model_dump(exclude_unset=True)
+    )
+    assert restored_typed_connection.model_fields_set == {"connection_pool_maxsize"}
+    typed_unlimited_provider = daytona_provider.DaytonaProvider(connection=restored_typed_connection)
+    typed_unlimited_client = typed_unlimited_provider._client()
+    assert typed_unlimited_client.config.kwargs == {"connection_pool_maxsize": None}
+    await typed_unlimited_provider.aclose()
+
+    default_connection = daytona_provider.DaytonaConnectionConfig()
+    restored_default_connection = daytona_provider.DaytonaConnectionConfig.model_validate(
+        default_connection.model_dump(exclude_unset=True)
+    )
+    assert restored_default_connection.model_fields_set == set()
+    default_connection_provider = daytona_provider.DaytonaProvider(connection=restored_default_connection)
+    default_connection_client = default_connection_provider._client()
+    assert default_connection_client.config is None
+    await default_connection_provider.aclose()
 
     kwargs = provider._base_create_kwargs(
         SandboxSpec(

--- a/tests/unit_tests/test_docker_provider.py
+++ b/tests/unit_tests/test_docker_provider.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from nemo_gym.sandbox.providers.base import (
     SandboxExecResult,
@@ -113,6 +114,67 @@ def test_coerce_config() -> None:
     assert coerce({"concurrency": 7}, cls).concurrency == 7
     with pytest.raises(TypeError):
         coerce(123, cls)
+
+
+@pytest.mark.parametrize(
+    ("config_cls", "values"),
+    [
+        (docker_provider.DockerCreateConfig, {"network": "none", "cap_drop": ["ALL"]}),
+        (docker_provider.DockerExecConfig, {"concurrency": 7, "exec_shell": "bash"}),
+        (docker_provider.DockerProbeConfig, {"stable_count": 2, "stable_delay_s": 0.5}),
+    ],
+)
+def test_config_pydantic_round_trip(config_cls: type[BaseModel], values: dict[str, Any]) -> None:
+    config = config_cls.model_validate(values)
+
+    assert isinstance(config, BaseModel)
+    assert config_cls.model_validate(config) is config
+    assert config_cls.model_validate(config.model_dump()) == config
+    for key, value in values.items():
+        assert config.model_dump()[key] == value
+
+
+@pytest.mark.parametrize(
+    "config_cls",
+    [
+        docker_provider.DockerCreateConfig,
+        docker_provider.DockerExecConfig,
+        docker_provider.DockerProbeConfig,
+    ],
+)
+def test_config_rejects_extra_fields(config_cls: type[BaseModel]) -> None:
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        config_cls.model_validate({"unknown_option": True})
+
+
+@pytest.mark.parametrize(
+    ("config", "field_name", "new_value"),
+    [
+        (docker_provider.DockerCreateConfig(), "network", "none"),
+        (docker_provider.DockerExecConfig(), "concurrency", 1),
+        (docker_provider.DockerProbeConfig(), "stable_count", 2),
+    ],
+)
+def test_config_is_frozen(config: BaseModel, field_name: str, new_value: Any) -> None:
+    with pytest.raises(ValidationError, match="frozen_instance"):
+        setattr(config, field_name, new_value)
+
+
+def test_config_list_defaults_are_isolated() -> None:
+    create_a = docker_provider.DockerCreateConfig()
+    create_b = docker_provider.DockerCreateConfig()
+    exec_a = docker_provider.DockerExecConfig()
+    exec_b = docker_provider.DockerExecConfig()
+
+    create_a.cap_drop.append("ALL")
+    create_a.security_opt.append("no-new-privileges")
+    create_a.extra_run_args.append("--pull=never")
+    exec_a.extra_exec_args.append("--privileged")
+
+    assert create_b.cap_drop == []
+    assert create_b.security_opt == []
+    assert create_b.extra_run_args == []
+    assert exec_b.extra_exec_args == []
 
 
 def test_config_validation() -> None:

--- a/tests/unit_tests/test_ecs_fargate_engine.py
+++ b/tests/unit_tests/test_ecs_fargate_engine.py
@@ -37,6 +37,7 @@ from urllib.parse import urlparse
 
 import aiohttp
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from nemo_gym.sandbox.providers.ecs_fargate import engine
 
@@ -248,6 +249,132 @@ def test_port_from_url_defaults():
 # ── _OutsideEndpointRoute / _OutsideEndpointRouting ───────────────────
 
 
+def test_ecs_config_types_are_frozen_pydantic_models_and_round_trip():
+    assert issubclass(engine.SshSidecarConfig, BaseModel)
+    assert issubclass(engine.EcsFargateConfig, BaseModel)
+
+    config = engine.EcsFargateConfig.model_validate(
+        {
+            "region": "us-west-2",
+            "cluster": "sandbox-cluster",
+            "subnets": ["subnet-a"],
+            "extra_env": {"MODEL_URL": "http://{task_ip}:8000"},
+            "ssh_sidecar": {
+                "sshd_port": 52222,
+                "public_key_secret_arn": "arn:pub",  # pragma: allowlist secret
+                "private_key_secret_arn": "arn:priv",  # pragma: allowlist secret
+                "exec_server_port": 19542,
+            },
+        }
+    )
+
+    assert config.ssh_sidecar == engine.SshSidecarConfig(
+        sshd_port=52222,
+        public_key_secret_arn="arn:pub",  # pragma: allowlist secret
+        private_key_secret_arn="arn:priv",  # pragma: allowlist secret
+        exec_server_port=19542,
+    )
+    assert engine.EcsFargateConfig.model_validate(config.model_dump()) == config
+
+    with pytest.raises(ValidationError, match="frozen_instance"):
+        config.region = "us-east-1"
+    with pytest.raises(ValidationError, match="frozen_instance"):
+        config.ssh_sidecar.sshd_port = 2222
+
+
+@pytest.mark.parametrize("model", [engine.SshSidecarConfig, engine.EcsFargateConfig])
+def test_ecs_config_types_forbid_extra_fields(model):
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        model.model_validate({"unexpected": True})
+
+
+def test_ecs_config_mutable_defaults_are_isolated():
+    first = engine.EcsFargateConfig()
+    second = engine.EcsFargateConfig()
+
+    first.subnets.append("subnet-a")
+    first.security_groups.append("sg-a")
+
+    assert second.subnets == []
+    assert second.security_groups == []
+
+
+def test_sandbox_spec_types_are_pydantic_models_and_validate_nested_mappings():
+    assert issubclass(engine.OutsideEndpoint, BaseModel)
+    assert issubclass(engine.VolumeMount, BaseModel)
+    assert issubclass(engine.SandboxSpec, BaseModel)
+
+    spec = engine.SandboxSpec.model_validate(
+        {
+            "image": "python:3.12",
+            "env": {"MODEL": "test"},
+            "volumes": [
+                {
+                    "container_path": "/mnt/data",
+                    "readonly": True,
+                    "efs_filesystem_id": "fs-123",
+                }
+            ],
+        }
+    )
+
+    assert spec.volumes == [engine.VolumeMount(container_path="/mnt/data", readonly=True, efs_filesystem_id="fs-123")]
+    assert spec.model_dump() == {
+        "image": "python:3.12",
+        "workdir": "/workspace",
+        "env": {"MODEL": "test"},
+        "files": {},
+        "entrypoint": None,
+        "volumes": [
+            {
+                "host_path": "",
+                "container_path": "/mnt/data",
+                "readonly": True,
+                "efs": False,
+                "efs_filesystem_id": "fs-123",
+                "efs_root_directory": None,
+                "efs_access_point_id": None,
+            }
+        ],
+        "environment_dir": None,
+    }
+    assert engine.SandboxSpec.model_validate(spec.model_dump()) == spec
+
+
+@pytest.mark.parametrize(
+    ("model", "values"),
+    [
+        (engine.OutsideEndpoint, {"url": "http://model:8000/v1", "env_var": "MODEL_URL"}),
+        (engine.VolumeMount, {"container_path": "/mnt/data"}),
+        (engine.SandboxSpec, {"image": "python:3.12"}),
+    ],
+)
+def test_sandbox_spec_types_forbid_extra_fields(model, values):
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        model.model_validate({**values, "unexpected": True})
+
+
+def test_sandbox_spec_types_preserve_mutability_default_isolation_and_efs_property():
+    first = engine.SandboxSpec(image="python:3.12")
+    second = engine.SandboxSpec(image="python:3.12")
+
+    first.workdir = "/app"
+    first.env["KEY"] = "value"
+    first.files["script.py"] = "print('hello')"
+    first.volumes.append(engine.VolumeMount(container_path="/mnt/default", efs=True))
+
+    assert first.workdir == "/app"
+    assert second.env == {}
+    assert second.files == {}
+    assert second.volumes == []
+    assert first.volumes[0].is_efs
+
+    mount = engine.VolumeMount(container_path="/mnt/explicit")
+    assert not mount.is_efs
+    mount.efs_filesystem_id = "fs-456"
+    assert mount.is_efs
+
+
 def test_route_for_endpoint_and_rewrite():
     ep = engine.OutsideEndpoint(url="https://api.host:9000/v1", env_var="MODEL_BASE_URL")
     route = engine._OutsideEndpointRoute.for_endpoint(ep, remote_port=20001)
@@ -290,13 +417,16 @@ def test_routing_for_exec_server_dedupes_and_allocates():
 def test_routing_for_agent_server_validation_and_target():
     with pytest.raises(ValueError, match="only one OutsideEndpoint"):
         engine._OutsideEndpointRouting.for_agent_server(
-            [engine.OutsideEndpoint("http://h:1/", "A"), engine.OutsideEndpoint("http://h:2/", "B")]
+            [
+                engine.OutsideEndpoint(url="http://h:1/", env_var="A"),
+                engine.OutsideEndpoint(url="http://h:2/", env_var="B"),
+            ]
         )
     with pytest.raises(ValueError, match="requires OutsideEndpoint"):
         engine._OutsideEndpointRouting.for_agent_server([])
 
     routing = engine._OutsideEndpointRouting.for_agent_server(
-        [engine.OutsideEndpoint("http://model.host:7000/v1", "MODEL")]
+        [engine.OutsideEndpoint(url="http://model.host:7000/v1", env_var="MODEL")]
     )
     assert routing.agent_tunnel_port == 7000
     assert routing.agent_tunnel_target() == ("model.host", 7000)
@@ -312,12 +442,14 @@ def test_routing_agent_tunnel_target_requires_endpoints():
 
 def test_routing_resolve_url_paths():
     # Reverse-tunnel match by netloc.
-    endpoints = [engine.OutsideEndpoint("http://10.0.0.1:4000/v1", "A")]
+    endpoints = [engine.OutsideEndpoint(url="http://10.0.0.1:4000/v1", env_var="A")]
     routing = engine._OutsideEndpointRouting.for_exec_server(endpoints, _exec_sidecar())
     assert routing.resolve_url("http://10.0.0.1:4000/chat").startswith("http://127.0.0.1:")
 
     # Agent-tunnel fallback rewrites netloc to the agent port.
-    agent = engine._OutsideEndpointRouting.for_agent_server([engine.OutsideEndpoint("http://m:7000/v1", "M")])
+    agent = engine._OutsideEndpointRouting.for_agent_server(
+        [engine.OutsideEndpoint(url="http://m:7000/v1", env_var="M")]
+    )
     assert agent.resolve_url("http://anything:1/path") == "http://127.0.0.1:7000/path"
 
     # No routes and no agent tunnel -> error.
@@ -1484,7 +1616,7 @@ def test_build_env_vars_merges_spec_extra_and_routing():
     sb = _make_sandbox(spec=spec, extra_env={"RENDERED": "ip={task_ip} img={image}"})
     sb._task_ip = "9.9.9.9"
     sb._outside_endpoint_routing = engine._OutsideEndpointRouting.for_exec_server(
-        [engine.OutsideEndpoint("http://10.0.0.1:4000/v1", "MODEL_BASE_URL")], _exec_sidecar()
+        [engine.OutsideEndpoint(url="http://10.0.0.1:4000/v1", env_var="MODEL_BASE_URL")], _exec_sidecar()
     )
     env = sb._build_env_vars()
     assert env["FROM_SPEC"] == "1"
@@ -1495,7 +1627,7 @@ def test_build_env_vars_merges_spec_extra_and_routing():
 def test_split_env_separates_runtime_keys():
     sb = _make_sandbox()
     sb._outside_endpoint_routing = engine._OutsideEndpointRouting.for_exec_server(
-        [engine.OutsideEndpoint("http://10.0.0.1:4000/v1", "MODEL_BASE_URL")], _exec_sidecar()
+        [engine.OutsideEndpoint(url="http://10.0.0.1:4000/v1", env_var="MODEL_BASE_URL")], _exec_sidecar()
     )
     env = {"STABLE": "a", "_NEL_EFS_SESSION": "sess", "MODEL_BASE_URL": "http://127.0.0.1:4000/v1"}
     stable, runtime = sb._split_env(env)
@@ -2177,7 +2309,7 @@ def test_open_tunnel_exec_server_mode():
     sb._task_ip = "1.2.3.4"
     sb._ssh_key_file = "/tmp/key"
     sb._outside_endpoint_routing = engine._OutsideEndpointRouting.for_exec_server(
-        [engine.OutsideEndpoint("http://10.0.0.1:4000/v1", "MODEL")], _exec_sidecar()
+        [engine.OutsideEndpoint(url="http://10.0.0.1:4000/v1", env_var="MODEL")], _exec_sidecar()
     )
     tunnel = MagicMock()
     with patch(f"{_ENG}.SshTunnel", return_value=tunnel) as ctor:
@@ -2195,7 +2327,7 @@ def test_open_tunnel_agent_server_mode():
     sb._ssh_key_file = "/tmp/key"
     sb._ssh_tunnel_port = 7000
     sb._outside_endpoint_routing = engine._OutsideEndpointRouting.for_agent_server(
-        [engine.OutsideEndpoint("http://10.0.0.2:9000/v1", "MODEL")]
+        [engine.OutsideEndpoint(url="http://10.0.0.2:9000/v1", env_var="MODEL")]
     )
     tunnel = MagicMock()
     with patch(f"{_ENG}.SshTunnel", return_value=tunnel) as ctor, patch(f"{_ENG}._free_port", return_value=15000):
@@ -2213,7 +2345,7 @@ def test_open_tunnel_agent_server_requires_container_port():
     sb._ssh_key_file = "/tmp/key"
     sb._ssh_tunnel_port = 7000
     sb._outside_endpoint_routing = engine._OutsideEndpointRouting.for_agent_server(
-        [engine.OutsideEndpoint("http://10.0.0.2:9000/v1", "MODEL")]
+        [engine.OutsideEndpoint(url="http://10.0.0.2:9000/v1", env_var="MODEL")]
     )
     with patch(f"{_ENG}._free_port", return_value=15000):
         with pytest.raises(ValueError, match="container_port is required"):
@@ -2415,7 +2547,7 @@ def test_local_port_property_paths():
 def test_resolved_endpoint_url_and_resolve_outside_endpoint():
     sb = _make_sandbox()
     sb._outside_endpoint_routing = engine._OutsideEndpointRouting.for_agent_server(
-        [engine.OutsideEndpoint("http://model:7000/v1", "MODEL")]
+        [engine.OutsideEndpoint(url="http://model:7000/v1", env_var="MODEL")]
     )
     assert sb.resolved_endpoint_url("MODEL") == "http://127.0.0.1:7000/v1"
     assert sb.resolve_outside_endpoint("http://anything/v1").startswith("http://127.0.0.1:7000")
@@ -2705,7 +2837,7 @@ def test_do_start_agent_server_full_path():
         ssh_sidecar=_agent_sidecar(),
         container_port=9000,
     )
-    sb._outside_endpoints = [engine.OutsideEndpoint("http://10.0.0.9:9000/v1", "MODEL")]
+    sb._outside_endpoints = [engine.OutsideEndpoint(url="http://10.0.0.9:9000/v1", env_var="MODEL")]
     with _do_start_seams() as (tunnel, _ec):
         sb._do_start()
     assert sb._ssh_tunnel is tunnel

--- a/tests/unit_tests/test_ecs_fargate_provider.py
+++ b/tests/unit_tests/test_ecs_fargate_provider.py
@@ -20,6 +20,7 @@ import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from nemo_gym.sandbox import AsyncSandbox
 from nemo_gym.sandbox.providers import (
@@ -139,6 +140,49 @@ def test_config_no_ssm_when_cluster_present():
     with patch(f"{_ENG}.resolve_ecs_config_from_ssm") as resolve:
         create_provider(_provider_config())
     resolve.assert_not_called()
+
+
+def test_config_preserves_an_existing_sidecar_model():
+    sidecar = engine.SshSidecarConfig(
+        public_key_secret_arn="arn:pub",  # pragma: allowlist secret
+        private_key_secret_arn="arn:priv",  # pragma: allowlist secret
+    )
+
+    cfg = engine_config_from_mapping({"cluster": "c", "ssh_sidecar": sidecar})
+
+    assert cfg.ssh_sidecar is sidecar
+
+
+def test_config_mapping_forwards_all_declared_fields():
+    cfg = engine_config_from_mapping(
+        {
+            "cluster": "c",
+            "poll_interval_sec": 0.25,
+            "run_task_max_retries": 7,
+            "build_parallelism": 11,
+        }
+    )
+
+    assert cfg.poll_interval_sec == 0.25
+    assert cfg.run_task_max_retries == 7
+    assert cfg.build_parallelism == 11
+
+
+def test_config_mapping_rejects_unknown_provider_and_sidecar_fields():
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        engine_config_from_mapping({"cluster": "c", "unknown": True})
+
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        engine_config_from_mapping(
+            {
+                "cluster": "c",
+                "ssh_sidecar": {
+                    "public_key_secret_arn": "arn:pub",  # pragma: allowlist secret
+                    "private_key_secret_arn": "arn:priv",  # pragma: allowlist secret
+                    "unknown": True,
+                },
+            }
+        )
 
 
 def test_sidecar_missing_key_arns_raises():
@@ -415,6 +459,8 @@ def test_apply_spec_overrides_maps_resources_and_ttl():
     assert out.cpu == "2048"  # vCPUs -> Fargate CPU units
     assert out.memory == "4096"
     assert out.ephemeral_storage_gib == 50
+    assert cfg.cpu == "256"
+    assert cfg.memory == "512"
     # no per-sandbox requests -> config returned unchanged (same object)
     assert _apply_spec_overrides(cfg, SandboxSpec(image="img")) is cfg
 

--- a/tests/unit_tests/test_enroot_provider.py
+++ b/tests/unit_tests/test_enroot_provider.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from nemo_gym.sandbox.providers.base import (
     SandboxExecResult,
@@ -166,6 +167,69 @@ def test_coerce_config() -> None:
     assert coerce({"concurrency": 7}, cls).concurrency == 7
     with pytest.raises(TypeError):
         coerce(123, cls)
+
+
+@pytest.mark.parametrize(
+    ("config_cls", "values"),
+    [
+        (
+            enroot_provider.EnrootCreateConfig,
+            {"mount_point": "/workspace", "extra_start_args": ["--conf", "foo"]},
+        ),
+        (
+            enroot_provider.EnrootExecConfig,
+            {"concurrency": 4, "default_mounts": ["/host:/container"]},
+        ),
+        (
+            enroot_provider.EnrootProbeConfig,
+            {"command": "true", "expected_stdout": None, "timeout_s": 5},
+        ),
+    ],
+)
+def test_config_pydantic_round_trip(config_cls: type[BaseModel], values: dict[str, Any]) -> None:
+    config = config_cls.model_validate(values)
+
+    assert isinstance(config, BaseModel)
+    for key, value in values.items():
+        assert getattr(config, key) == value
+    assert config_cls.model_validate(config.model_dump()) == config
+
+
+@pytest.mark.parametrize(
+    "config_cls",
+    [
+        enroot_provider.EnrootCreateConfig,
+        enroot_provider.EnrootExecConfig,
+        enroot_provider.EnrootProbeConfig,
+    ],
+)
+def test_config_is_frozen_and_rejects_extra_fields(config_cls: type[BaseModel]) -> None:
+    config = config_cls()
+    field_name = next(iter(config_cls.model_fields))
+
+    with pytest.raises(ValidationError, match="frozen"):
+        setattr(config, field_name, getattr(config, field_name))
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        config_cls.model_validate({"unknown": True})
+
+
+@pytest.mark.parametrize(
+    ("config_cls", "field_name"),
+    [
+        (enroot_provider.EnrootCreateConfig, "extra_import_args"),
+        (enroot_provider.EnrootCreateConfig, "extra_create_args"),
+        (enroot_provider.EnrootCreateConfig, "extra_start_args"),
+        (enroot_provider.EnrootExecConfig, "default_mounts"),
+        (enroot_provider.EnrootExecConfig, "extra_exec_args"),
+    ],
+)
+def test_config_list_defaults_are_isolated(config_cls: type[BaseModel], field_name: str) -> None:
+    first = config_cls()
+    second = config_cls()
+
+    getattr(first, field_name).append("value")
+
+    assert getattr(second, field_name) == []
 
 
 def test_config_validation() -> None:

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -16,7 +16,7 @@
 import asyncio
 import builtins
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, is_dataclass
 from datetime import timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -24,6 +24,7 @@ from typing import Any
 
 import httpx
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from nemo_gym.sandbox.providers.base import SandboxResources, SandboxSpec, SandboxStatus
 
@@ -169,6 +170,83 @@ async def test_provider_conversion_helpers(
     assert opensandbox_provider._to_volumes([{"name": "workspace"}]) == [FakeVolume(name="workspace")]
 
 
+@pytest.mark.parametrize(
+    ("config_cls", "values", "field_name", "expected"),
+    [
+        (
+            opensandbox_provider.OpenSandboxConnectionConfig,
+            {"domain": "sandbox.example"},
+            "domain",
+            "sandbox.example",
+        ),
+        (
+            opensandbox_provider.OpenSandboxAttributionConfig,
+            {"key_prefix": " acme.example.com "},
+            "key_prefix",
+            "acme.example.com/",
+        ),
+        (opensandbox_provider.OpenSandboxCreateConfig, {"retries": 4}, "retries", 4),
+        (
+            opensandbox_provider.OpenSandboxProbeConfig,
+            {"command": None, "timeout_s": 0},
+            "timeout_s",
+            0,
+        ),
+        (
+            opensandbox_provider.OpenSandboxOperationConfig,
+            {"command_retries": 2},
+            "command_retries",
+            2,
+        ),
+        (
+            opensandbox_provider.OpenSandboxProviderOptions,
+            {"volumes": [{"name": "workspace"}], "extensions": {"retry-count": 3}},
+            "volumes",
+            ({"name": "workspace"},),
+        ),
+    ],
+)
+def test_config_models_are_frozen_pydantic_models(
+    config_cls: type[BaseModel],
+    values: dict[str, Any],
+    field_name: str,
+    expected: Any,
+) -> None:
+    config = config_cls.model_validate(values)
+
+    assert isinstance(config, BaseModel)
+    assert not is_dataclass(config)
+    assert getattr(config, field_name) == expected
+    assert config_cls.model_validate(config.model_dump()) == config
+    with pytest.raises(ValidationError, match="Instance is frozen"):
+        setattr(config, field_name, expected)
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        config_cls.model_validate({"unknown_option": True})
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        opensandbox_provider.OpenSandboxConnectionConfig(),
+        opensandbox_provider.OpenSandboxAttributionConfig(),
+        opensandbox_provider.OpenSandboxCreateConfig(),
+        opensandbox_provider.OpenSandboxProbeConfig(),
+        opensandbox_provider.OpenSandboxOperationConfig(),
+    ],
+)
+def test_coerce_config_preserves_model_identity(config: BaseModel) -> None:
+    assert opensandbox_provider._coerce_config(config, type(config)) is config
+
+
+def test_provider_options_mutable_defaults_are_isolated() -> None:
+    first = opensandbox_provider.OpenSandboxProviderOptions()
+    second = opensandbox_provider.OpenSandboxProviderOptions()
+
+    first.extensions["custom"] = "value"
+
+    assert second.extensions == {}
+
+
 async def test_direct_create_passes_platform_to_sdk_create(
     fake_opensandbox_sdk: None,
 ) -> None:
@@ -200,7 +278,7 @@ async def test_direct_create_passes_resource_requests_to_sdk_create(
         SandboxSpec(
             image="mirror.gcr.io/astral/uv:python3.12-bookworm-slim",
             resources={"cpu": 1, "memory_mib": 8192, "disk_gib": 30},
-            provider_options={"resource_requests": {"cpu": 0.5, "memory_mib": 2048, "disk_gib": 30}},
+            resource_requests={"cpu": 0.5, "memory_mib": 2048, "disk_gib": 30},
         ),
     )
 
@@ -211,16 +289,20 @@ async def test_direct_create_passes_resource_requests_to_sdk_create(
         "ephemeral-storage": "30Gi",
     }
 
-    with pytest.raises(TypeError, match="'resource_requests' must be a mapping"):
-        opensandbox_provider.OpenSandboxProviderOptions.from_mapping({"resource_requests": "big"})
 
-    with pytest.raises(ValueError, match="Unknown sandbox resource keys"):
-        await provider.create(
-            SandboxSpec(
-                image="mirror.gcr.io/astral/uv:python3.12-bookworm-slim",
-                provider_options={"resource_requests": {"memory_gib": 2}},
-            ),
-        )
+async def test_direct_create_omits_resource_requests_when_unspecified(
+    fake_opensandbox_sdk: None,
+) -> None:
+    provider = opensandbox_provider.OpenSandboxProvider(probe={"command": None})
+
+    await provider.create(
+        SandboxSpec(
+            image="mirror.gcr.io/astral/uv:python3.12-bookworm-slim",
+            resources={"cpu": 1, "memory_mib": 8192, "disk_gib": 30},
+        ),
+    )
+
+    assert "resource_requests" not in FakeSandbox.created_kwargs
 
 
 async def test_direct_create_passes_image_auth_to_sdk_create(
@@ -308,7 +390,7 @@ def test_provider_options_from_mapping() -> None:
             "snapshot_id": "snap-1",
             "volumes": [{"name": "workspace"}],
             "skip_health_check": True,
-            "extensions": {"imagePullPolicy": "Never"},
+            "extensions": {"imagePullPolicy": "Never", "retry-count": 3},
         }
     )
     assert parsed.image_auth == {"username": "user", "password": TEST_REGISTRY_PASSWORD}
@@ -316,10 +398,21 @@ def test_provider_options_from_mapping() -> None:
     assert parsed.snapshot_id == "snap-1"
     assert parsed.volumes == ({"name": "workspace"},)
     assert parsed.skip_health_check is True
-    assert parsed.extensions == {"imagePullPolicy": "Never"}
+    assert parsed.extensions == {"imagePullPolicy": "Never", "retry-count": "3"}
+
+    model_validated = options_cls.model_validate(
+        {
+            "volumes": [{"name": "workspace"}],
+            "extensions": {"retry-count": 3},
+        }
+    )
+    assert model_validated.volumes == ({"name": "workspace"},)
+    assert model_validated.extensions == {"retry-count": "3"}
 
     with pytest.raises(ValueError, match="Unknown OpenSandbox provider option"):
         options_cls.from_mapping({"bogus": 1})
+    with pytest.raises(ValueError, match="Unknown OpenSandbox provider option"):
+        options_cls.from_mapping({"resource_requests": {"cpu": 0.5}})
     with pytest.raises(TypeError, match="provider_options must be a mapping"):
         options_cls.from_mapping(["not", "a", "mapping"])
     with pytest.raises(TypeError, match="'platform' must be a mapping"):
@@ -330,6 +423,10 @@ def test_provider_options_from_mapping() -> None:
         options_cls.from_mapping({"snapshot_id": 123})
     with pytest.raises(TypeError, match="'volumes' must be a list of mappings"):
         options_cls.from_mapping({"volumes": ["workspace"]})
+
+    first = options_cls.from_mapping({"volumes": None, "extensions": {}})
+    second = options_cls.from_mapping({"volumes": (), "extensions": {}})
+    assert first == second == options_cls()
 
 
 def test_connection_config_and_image_policy(fake_opensandbox_sdk: None) -> None:
@@ -887,6 +984,7 @@ async def test_create_once_and_connect_after_create_error_paths(
             "platform": {"os": "linux", "arch": "amd64"},
             "volumes": [{"name": "workspace"}],
             "skip_health_check": False,
+            "extensions": {"custom": 3},
         },
     )
     handle = await provider._create_once(spec)
@@ -905,6 +1003,11 @@ async def test_create_once_and_connect_after_create_error_paths(
     assert FakeSandbox.created_kwargs["platform"] == FakePlatformSpec(os="linux", arch="amd64")
     assert FakeSandbox.created_kwargs["volumes"] == [{"name": "workspace"}]
     assert FakeSandbox.created_kwargs["skip_health_check"] is True
+    assert FakeSandbox.created_kwargs["extensions"] == {
+        "custom": "3",
+        "imagePullPolicy": "IfNotPresent",
+        "opensandbox.extensions.image-pull-policy": "IfNotPresent",
+    }
 
     class FailingConnectSandbox(FakeSandbox):
         @classmethod

--- a/tests/unit_tests/test_openshell_provider.py
+++ b/tests/unit_tests/test_openshell_provider.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from nemo_gym.sandbox.providers.base import SandboxHandle, SandboxSpec, SandboxStatus
 from nemo_gym.sandbox.providers.registry import get_provider_class
@@ -235,6 +236,54 @@ def test_constructor_builds_real_client_and_config_coercion() -> None:
         openshell_provider._release_shared_client(provider._shared)
 
 
+def test_configs_are_frozen_pydantic_models_with_roundtrip_support() -> None:
+    configs = (
+        OpenShellConnectionConfig(endpoint="gateway:8080"),
+        OpenShellCreateConfig(retries=3),
+        OpenShellExecConfig(concurrency=4),
+        OpenShellProbeConfig(command=None, timeout_s=0),
+        OpenShellOperationsConfig(close_wait_deleted=False),
+        OpenShellProviderOptions.from_mapping({"providers": "nvidia"}),
+    )
+
+    for config in configs:
+        assert isinstance(config, BaseModel)
+        assert config.model_config["frozen"] is True
+        assert type(config).model_validate(config.model_dump()) == config
+
+    with pytest.raises(ValidationError, match="frozen"):
+        configs[0].endpoint = "other:8080"
+
+
+def test_connection_config_remains_hashable_for_shared_client_keys() -> None:
+    connection = OpenShellConnectionConfig(endpoint="gateway:8080", workspace="team-a")
+    equivalent = OpenShellConnectionConfig.model_validate(connection.model_dump())
+
+    assert {connection: "shared-client"}[equivalent] == "shared-client"
+
+
+def test_config_coercion_preserves_model_identity_and_normalizes_mappings() -> None:
+    config = OpenShellExecConfig(concurrency=4)
+
+    assert openshell_provider._coerce_config(config, OpenShellExecConfig) is config
+    assert openshell_provider._coerce_config({"concurrency": "4"}, OpenShellExecConfig) == config
+
+
+@pytest.mark.parametrize(
+    "config_cls",
+    [
+        OpenShellConnectionConfig,
+        OpenShellCreateConfig,
+        OpenShellExecConfig,
+        OpenShellProbeConfig,
+        OpenShellOperationsConfig,
+    ],
+)
+def test_config_models_reject_unknown_fields(config_cls: type[BaseModel]) -> None:
+    with pytest.raises(ValueError):
+        config_cls.model_validate({"unexpected": True})
+
+
 @pytest.mark.parametrize(
     ("group", "kwargs"),
     [
@@ -289,6 +338,14 @@ def test_provider_options_validation() -> None:
         OpenShellProviderOptions.from_mapping({"driver_config": ["not", "a", "mapping"]})
     options = OpenShellProviderOptions.from_mapping({"providers": "solo"})
     assert options.providers == ["solo"]
+    assert OpenShellProviderOptions.model_validate(
+        {"providers": ("first", 2), "template_resources": {"cpu": "2"}}
+    ).model_dump() == {
+        "providers": ["first", "2"],
+        "policy": None,
+        "template_resources": {"cpu": "2"},
+        "driver_config": {},
+    }
 
 
 async def test_create_success_maps_spec(make_provider, fake_client: FakeClient) -> None:
@@ -299,10 +356,13 @@ async def test_create_success_maps_spec(make_provider, fake_client: FakeClient) 
         metadata={"task": "demo", SANDBOX_LABEL: "user-override"},
         workdir="/workspace",
         resources={"gpu": 2},
+        resource_requests={"gpu": 1},
         provider_options={"providers": ["nvidia"]},
     )
     handle = await provider.create(spec)
 
+    assert spec.provider_options == {"providers": ["nvidia"]}
+    assert "resource_requests" not in spec.provider_options
     call = fake_client.create_calls[0]
     assert call["workspace"] == "default"
     assert call["name"].startswith(SANDBOX_NAME_PREFIX)

--- a/tests/unit_tests/test_sandbox.py
+++ b/tests/unit_tests/test_sandbox.py
@@ -22,6 +22,7 @@ from typing import Any
 from uuid import uuid4
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
 import nemo_gym.sandbox.providers.registry as provider_registry
 from nemo_gym.sandbox import (
@@ -383,8 +384,6 @@ def test_sandbox_resources_validation() -> None:
     assert spec.resources == SandboxResources(cpu=0.5, memory_mib=4096, disk_gib=8)
     assert spec.ports == (8000, 9222)
 
-    with pytest.raises(ValueError, match="Unknown sandbox resource keys"):
-        SandboxSpec(resources={"memory": "4Gi"})
     with pytest.raises(ValueError, match="Duplicate sandbox TCP port"):
         SandboxSpec(ports=[8000, 8000])
     with pytest.raises(ValueError, match="between 1 and 65535"):
@@ -395,28 +394,256 @@ def test_sandbox_resources_validation() -> None:
         SandboxEndpoint(endpoint="/relative/path")
 
 
+def test_sandbox_spec_models_validate_config_and_dump() -> None:
+    assert issubclass(SandboxResources, BaseModel)
+    assert issubclass(SandboxSpec, BaseModel)
+
+    spec = SandboxSpec.model_validate(
+        {
+            "image": "image:tag",
+            "env": {"MODE": "test"},
+            "resources": {
+                "cpu": "2",
+                "memory_mib": "4096",
+                "disk_gib": "8",
+                "gpu": "1",
+                "gpu_type": 100,
+            },
+            "resource_requests": {
+                "cpu": "0.5",
+                "memory_mib": "2048",
+                "disk_gib": "4",
+                "gpu": "1",
+            },
+        }
+    )
+
+    assert spec.resources == SandboxResources(cpu=2.0, memory_mib=4096, disk_gib=8, gpu=1, gpu_type="100")
+    assert spec.resource_requests == SandboxResources(cpu=0.5, memory_mib=2048, disk_gib=4, gpu=1)
+    assert spec.provider_options == {}
+    assert "resource_requests" not in spec.provider_options
+    assert spec.model_dump() == {
+        "image": "image:tag",
+        "ttl_s": None,
+        "ready_timeout_s": None,
+        "workdir": None,
+        "env": {"MODE": "test"},
+        "files": {},
+        "metadata": {},
+        "resources": {
+            "cpu": 2.0,
+            "memory_mib": 4096,
+            "disk_gib": 8,
+            "gpu": 1,
+            "gpu_type": "100",
+        },
+        "resource_requests": {
+            "cpu": 0.5,
+            "memory_mib": 2048,
+            "disk_gib": 4,
+            "gpu": 1,
+            "gpu_type": None,
+        },
+        "entrypoint": None,
+        "provider_options": {},
+        "ports": (),
+    }
+    assert SandboxSpec.model_validate(spec.model_dump()) == spec
+    empty_spec = SandboxSpec(resources=None)
+    assert empty_spec.resources == SandboxResources()
+    assert empty_spec.resource_requests is None
+    assert SandboxResources.from_mapping(spec.resources) is spec.resources
+
+
+def test_sandbox_spec_models_reject_unknown_fields() -> None:
+    with pytest.raises(ValidationError, match="Unknown sandbox resource keys: memory"):
+        SandboxSpec(resources={"memory": "4Gi"})
+
+    with pytest.raises(ValidationError, match="Unknown sandbox resource keys: memory"):
+        SandboxSpec(resource_requests={"memory": "2Gi"})
+
+    with pytest.raises(ValidationError) as spec_error:
+        SandboxSpec(image="image:tag", ready_timout_s=10)
+    assert spec_error.value.errors()[0]["loc"] == ("ready_timout_s",)
+    assert spec_error.value.errors()[0]["type"] == "extra_forbidden"
+
+
+def test_sandbox_resources_keeps_legacy_positional_field_order() -> None:
+    resources = SandboxResources(1.5, 4096, 8, 1, "H100")
+
+    assert resources == SandboxResources(
+        cpu=1.5,
+        memory_mib=4096,
+        disk_gib=8,
+        gpu=1,
+        gpu_type="H100",
+    )
+
+
+def test_sandbox_resources_rejects_invalid_positional_construction() -> None:
+    with pytest.raises(TypeError, match=r"accepts at most 5 positional arguments, got 6"):
+        SandboxResources(1, 4096, 8, 1, "H100", "extra")
+
+    with pytest.raises(TypeError, match=r"got multiple values for argument 'cpu'"):
+        SandboxResources(1, cpu=2)
+
+
 def test_sandbox_endpoint_is_an_optional_provider_capability() -> None:
     assert isinstance(FakeSandboxProvider(), SupportsSandboxEndpoint)
     assert not isinstance(PlainSandboxProvider(), SupportsSandboxEndpoint)
 
 
-def test_sandbox_spec_keeps_legacy_positional_provider_options() -> None:
-    provider_options = {"legacy": True}
+def test_sandbox_spec_keeps_legacy_positional_field_order() -> None:
     spec = SandboxSpec(
         "image:tag",
         60,
         30,
         "/workspace",
-        {},
-        {},
-        {},
-        SandboxResources(cpu=1),
-        ["/bin/sh"],
-        provider_options,
+        {"MODE": "test"},
+        {"/tmp/input": "contents"},
+        {"suite": "unit"},
+        {"cpu": 2},
+        ["/bin/sh", "-lc"],
+        {"legacy": True},
+        [8000, "9222"],
+        resource_requests={"cpu": 1},
     )
 
-    assert spec.provider_options == provider_options
-    assert spec.ports == ()
+    assert spec.image == "image:tag"
+    assert spec.ttl_s == 60
+    assert spec.ready_timeout_s == 30
+    assert spec.workdir == "/workspace"
+    assert spec.env == {"MODE": "test"}
+    assert spec.files == {"/tmp/input": "contents"}
+    assert spec.metadata == {"suite": "unit"}
+    assert spec.resources == SandboxResources(cpu=2)
+    assert spec.entrypoint == ["/bin/sh", "-lc"]
+    assert spec.provider_options == {"legacy": True}
+    assert spec.ports == (8000, 9222)
+    assert spec.resource_requests == SandboxResources(cpu=1)
+
+
+def test_sandbox_spec_rejects_invalid_positional_construction() -> None:
+    with pytest.raises(TypeError, match=r"accepts at most 11 positional arguments, got 12"):
+        SandboxSpec(*([None] * 12))
+
+    with pytest.raises(TypeError, match=r"got multiple values for argument 'image'"):
+        SandboxSpec("image:tag", image="other:tag")
+
+
+@pytest.mark.parametrize(
+    ("field", "limit", "requested"),
+    [
+        ("cpu", 1, 1.5),
+        ("memory_mib", 4096, 4097),
+        ("disk_gib", 8, 9),
+        ("gpu", 1, 2),
+    ],
+)
+def test_sandbox_spec_rejects_resource_requests_above_limits(
+    field: str,
+    limit: int | float,
+    requested: int | float,
+) -> None:
+    with pytest.raises(
+        ValidationError,
+        match=rf"resource_requests\.{field} .* cannot exceed resources\.{field}",
+    ):
+        SandboxSpec(resources={field: limit}, resource_requests={field: requested})
+
+
+def test_sandbox_spec_allows_resource_request_without_corresponding_limit() -> None:
+    spec = SandboxSpec(resource_requests={"cpu": "2"})
+
+    assert spec.resources.cpu is None
+    assert spec.resource_requests == SandboxResources(cpu=2.0)
+
+
+def test_sandbox_spec_does_not_compare_gpu_type_requests() -> None:
+    differing = SandboxSpec(
+        resources={"gpu_type": "H100"},
+        resource_requests={"gpu_type": "A100"},
+    )
+    request_only = SandboxSpec(resource_requests={"gpu_type": "H100"})
+
+    assert differing.resource_requests == SandboxResources(gpu_type="A100")
+    assert request_only.resource_requests == SandboxResources(gpu_type="H100")
+
+
+def test_sandbox_spec_allows_equal_numeric_resource_requests() -> None:
+    numeric_resources = {
+        "cpu": "1.5",
+        "memory_mib": "2048",
+        "disk_gib": "8",
+        "gpu": "1",
+    }
+
+    spec = SandboxSpec(resources=numeric_resources, resource_requests=numeric_resources)
+
+    assert spec.resource_requests == spec.resources
+
+
+def test_sandbox_spec_compares_resource_requests_after_coercion() -> None:
+    with pytest.raises(
+        ValidationError,
+        match=r"resource_requests\.cpu \(1\.5\) cannot exceed resources\.cpu \(1\.0\)",
+    ):
+        SandboxSpec(resources={"cpu": "1.0"}, resource_requests={"cpu": "1.5"})
+
+
+@pytest.mark.parametrize("cpu", ["nan", "inf", "-inf"])
+@pytest.mark.parametrize("field", ["resources", "resource_requests"])
+def test_sandbox_spec_rejects_non_finite_cpu_quantities(field: str, cpu: str) -> None:
+    with pytest.raises(ValidationError, match="Input should be a finite number"):
+        SandboxSpec.model_validate({field: {"cpu": cpu}})
+
+
+def test_sandbox_spec_distinguishes_empty_and_omitted_resource_requests() -> None:
+    explicit_empty = SandboxSpec(resource_requests={})
+
+    assert explicit_empty.resource_requests == SandboxResources()
+    assert explicit_empty.resource_requests is not None
+    assert SandboxSpec().resource_requests is None
+
+
+def test_sandbox_spec_accepts_typed_provider_options_models() -> None:
+    from nemo_gym.sandbox.providers.daytona import DaytonaProviderOptions
+    from nemo_gym.sandbox.providers.opensandbox import OpenSandboxProviderOptions
+    from nemo_gym.sandbox.providers.openshell import OpenShellProviderOptions
+
+    options_models = [
+        DaytonaProviderOptions(snapshot_id="snapshot-1"),
+        OpenSandboxProviderOptions(snapshot_id="snapshot-1"),
+        OpenShellProviderOptions(providers=["local"]),
+    ]
+
+    for options in options_models:
+        spec = SandboxSpec(provider_options=options)
+        assert spec.provider_options == options.model_dump(mode="python")
+        assert isinstance(spec.model_dump()["provider_options"], dict)
+        assert type(options).from_mapping(options) is options
+
+    assert SandboxSpec(provider_options=None).provider_options == {}
+
+
+def test_sandbox_spec_models_preserve_frozen_and_default_factory_behavior() -> None:
+    spec = SandboxSpec()
+    resources = SandboxResources()
+    with pytest.raises(ValidationError, match="Instance is frozen"):
+        spec.image = "other:tag"
+    with pytest.raises(ValidationError, match="Instance is frozen"):
+        resources.cpu = 1
+    assert spec.resource_requests is None
+
+    other_spec = SandboxSpec()
+    spec.env["MODE"] = "test"
+    spec.files["/tmp/input"] = "contents"
+    spec.metadata["suite"] = "unit"
+    spec.provider_options["platform"] = {"arch": "arm64"}
+    assert other_spec.env == {}
+    assert other_spec.files == {}
+    assert other_spec.metadata == {}
+    assert other_spec.provider_options == {}
 
 
 def test_provider_registry_validation_and_listing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -545,6 +772,35 @@ def test_resolve_provider_config_inline_mapping() -> None:
     assert resolve_provider_config(inline) == inline
     # The result is a fresh dict, not the same object.
     assert resolve_provider_config(inline) is not inline
+
+
+def test_resolve_provider_config_normalizes_typed_sections_without_losing_explicit_none() -> None:
+    from nemo_gym.sandbox.providers.daytona import DaytonaConnectionConfig
+    from nemo_gym.sandbox.providers.opensandbox import OpenSandboxConnectionConfig
+
+    default_connection = resolve_provider_config({"daytona": {"connection": DaytonaConnectionConfig()}})
+    explicit_none = resolve_provider_config({"daytona": {"connection": DaytonaConnectionConfig(api_url=None)}})
+    opensandbox = resolve_provider_config(
+        {
+            "opensandbox": {
+                "connection": OpenSandboxConnectionConfig(
+                    domain="sandbox.example",
+                    api_key="secret",
+                )
+            }
+        }
+    )
+
+    assert default_connection == {"daytona": {"connection": {}}}
+    assert explicit_none == {"daytona": {"connection": {"api_url": None}}}
+    assert opensandbox == {
+        "opensandbox": {
+            "connection": {
+                "domain": "sandbox.example",
+                "api_key": "secret",
+            }
+        }
+    }
 
 
 def test_resolve_provider_config_errors() -> None:


### PR DESCRIPTION
## Summary

- Convert provider-neutral sandbox specs/resources and every built-in provider configuration/options DTO to frozen Pydantic models with strict extra-field validation.
- Add provider-neutral `SandboxSpec.resource_requests`, validate numeric requests do not exceed limits, and map separate requests in OpenSandbox without leaking provider-specific options into shared config.
- Preserve legacy positional construction and latest-main behavior for ports, endpoints, Docker host publishing, OpenSandbox background execution, and connection health checks.
- Forward requests and ports through all config-backed sandbox builders, including MiniSWE, AnySWE, PinchBench, Litmus, SWE-bench, OpenCode, and Harbor.

## Why

Pydantic gives sandbox configuration a consistent validation, normalization, and serialization path. Making scheduling requests a first-class provider-neutral field also keeps agent configuration portable across providers.

## Compatibility and impact

- Existing mappings and typed model instances remain accepted.
- `resource_requests` is optional; omission preserves each provider's current behavior.
- Runtime handles, execution results, endpoints, and private provider state remain dataclasses because they are not configuration inputs.
- Existing pre-merge `provider_options.resource_requests` examples are migrated directly; no compatibility shim is needed.

## Validation

- Sandbox/provider unit suite: 705 passed, 4 skipped; the known macOS Enroot `/proc` case was deselected.
- Affected resource-server/agent suites: 143 passed, plus 19 MiniSWE tests passed separately.
- OSWorld sandbox-provider suite: 8 passed.
- Ruff lint and format checks passed for all changed Python files.
- Fern docs check: 0 errors; only the expected unauthenticated redirects warning.
- Harbor YAML, compilation, lint, and behavioral smoke checks passed. The optional Harbor and CVDP test modules were not collected because the workspace lacks their pinned Harbor and NLTK dependencies.
