### PR TITLE
chore: route PR reviews to owning teams via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,151 @@
-.github/ @nvidia-nemo/automation
-docker/ @nvidia-nemo/automation
-pyproject.toml @nvidia-nemo/automation
-uv.lock @nvidia-nemo/automation
+# NeMo Gym — code ownership
+#
+# Encodes the "NeMo Gym Code Component Ownership" map so GitHub auto-requests the
+# right reviewers on every PR.
+#
+# Teams (membership is the source of truth and is maintained by each team's
+# maintainers — do not list individuals here):
+#   @NVIDIA-NeMo/gym_env_benchmarks  Frontier Eval — EM Rita Neves,
+#                                    Eng PICs Michal Bien, Marta Stepniewska-Dziubinska
+#   @NVIDIA-NeMo/gym_core            Core-Arch + RL — EM Bernard Nguyen,
+#                                    Eng PIC Ananth Subramaniam
+#   @NVIDIA-NeMo/gym_architects      Advisors — backstop for anything unclaimed, and
+#                                    escalation path for cross-lane disputes
+#   @NVIDIA-NeMo/automation          CI, build, and release infrastructure
+#
+# The split follows one principle: Core owns the contracts and the substrate,
+# Frontier Eval owns the implementations and the evaluation outputs built on top of
+# them. So base_responses_api_agent.py (the interface) is Core while every harness
+# under responses_api_agents/ is Frontier Eval; rollout_collection.py (the engine) is
+# Core while reward_profile.py (what consumes rollouts to make decisions) is
+# Frontier Eval.
+#
+# Two rules this file cannot express, which still apply by policy:
+#   1. Breaking changes to shared contracts and user-facing CLI surfaces need
+#      sign-off from BOTH lanes, ideally agreed at the proposal stage.
+#   2. Well-isolated changes that do not touch core features may be reviewed by
+#      other frequent contributors without the code owner.
+#
+# GitHub applies the LAST matching pattern for a path, so rules run
+# general -> specific. Every team below has write access to this repo; a team
+# without write access is silently ignored by CODEOWNERS.
+
+# ── Global backstop ──────────────────────────────────────────────────────────
+# Anything not claimed by a more specific rule (data/, cache/, results/,
+# scripts/, top-level files) routes to the advisors. If a category of unclaimed
+# files starts generating recurring work, give it an explicit owner here rather
+# than leaning on the backstop.
+*                                       @NVIDIA-NeMo/gym_architects
+
+# ═════════════════════════════════════════════════════════════════════════════
+# FRONTIER EVAL
+# ═════════════════════════════════════════════════════════════════════════════
+
+# Agent servers — loop semantics, harness contract, turn policy, trajectory shape
+/responses_api_agents/                  @NVIDIA-NeMo/gym_env_benchmarks
+
+# Resource servers — verifiers, rewards, tool behavior, failure policy.
+# Servers such as code_gen and swerl_gen call the Core sandbox API, but the server
+# logic is a Frontier Eval implementation: bugs in the verifier or reward are
+# Frontier Eval, bugs in sandbox execution or isolation are Core.
+/resources_servers/                     @NVIDIA-NeMo/gym_env_benchmarks
+
+# Benchmarks & environments — environment definition, packaging, suites, onboarding
+/benchmarks/                            @NVIDIA-NeMo/gym_env_benchmarks
+/environments/                          @NVIDIA-NeMo/gym_env_benchmarks
+
+# CLI. gym env start/status/test also orchestrates environment lifecycle, which is
+# conceptually Core; it sits here because that is where the CLI lives. Loop in Core
+# when a change touches lifecycle or orchestration semantics rather than the
+# command surface.
+/nemo_gym/cli/                          @NVIDIA-NeMo/gym_env_benchmarks
+/nemo_gym/cli_setup_command.py          @NVIDIA-NeMo/gym_env_benchmarks
+
+# Data, datasets & decision-grade stats — reward profiling, benchmark packaging,
+# dataset registry contracts
+/nemo_gym/benchmarks.py                 @NVIDIA-NeMo/gym_env_benchmarks
+/nemo_gym/dataset_orchestrator.py       @NVIDIA-NeMo/gym_env_benchmarks
+/nemo_gym/gitlab_utils.py               @NVIDIA-NeMo/gym_env_benchmarks
+/nemo_gym/hf_utils.py                   @NVIDIA-NeMo/gym_env_benchmarks
+/nemo_gym/prompt.py                     @NVIDIA-NeMo/gym_env_benchmarks
+/nemo_gym/reward_profile.py             @NVIDIA-NeMo/gym_env_benchmarks
+
+# ═════════════════════════════════════════════════════════════════════════════
+# CORE-ARCH + RL
+# ═════════════════════════════════════════════════════════════════════════════
+
+# Model serving boundary — inference-side reliability, NeMo-RL/Dynamo alignment
+/responses_api_models/                  @NVIDIA-NeMo/gym_core
+
+# Serialization & networking — wire formats, transport, converters
+/nemo_gym/server_utils.py               @NVIDIA-NeMo/gym_core
+/nemo_gym/openai_utils.py               @NVIDIA-NeMo/gym_core
+/nemo_gym/anthropic_utils.py            @NVIDIA-NeMo/gym_core
+/nemo_gym/anthropic_converter.py        @NVIDIA-NeMo/gym_core
+/nemo_gym/responses_converter.py        @NVIDIA-NeMo/gym_core
+
+# Core runtime & contracts — base server interfaces, registries, rollout engine.
+# Breaking changes here also need Frontier Eval sign-off.
+/nemo_gym/base_resources_server.py      @NVIDIA-NeMo/gym_core
+/nemo_gym/base_responses_api_agent.py   @NVIDIA-NeMo/gym_core
+/nemo_gym/base_responses_api_model.py   @NVIDIA-NeMo/gym_core
+/nemo_gym/registry.py                   @NVIDIA-NeMo/gym_core
+/nemo_gym/agent_registry.py             @NVIDIA-NeMo/gym_core
+/nemo_gym/rollout_collection.py         @NVIDIA-NeMo/gym_core
+/nemo_gym/profiling.py                  @NVIDIA-NeMo/gym_core
+/nemo_gym/server_metadata.py            @NVIDIA-NeMo/gym_core
+/nemo_gym/server_status.py              @NVIDIA-NeMo/gym_core
+
+# NeMo-RL integration — training data substrate and shared contracts
+/nemo_gym/train_data_utils.py           @NVIDIA-NeMo/gym_core
+
+# Sandbox & execution — provider API, server hardening, isolation
+/nemo_gym/sandbox/                      @NVIDIA-NeMo/gym_core
+/nemo_gym/resources/                    @NVIDIA-NeMo/gym_core
+
+# ── Not in the ownership doc; mapped by analogy, confirm in review ────────────
+# Placed by the same contracts-vs-implementations principle used above.
+/nemo_gym/chat_streaming.py             @NVIDIA-NeMo/gym_core
+/nemo_gym/responses_streaming.py        @NVIDIA-NeMo/gym_core
+/nemo_gym/discovery.py                  @NVIDIA-NeMo/gym_core
+/nemo_gym/model_registry.py             @NVIDIA-NeMo/gym_core
+/nemo_gym/resources_server_registry.py  @NVIDIA-NeMo/gym_core
+/nemo_gym/mcp_auto_exposure.py          @NVIDIA-NeMo/gym_core
+/nemo_gym/orchestration/                @NVIDIA-NeMo/gym_core
+/nemo_gym/rollout_correlation.py        @NVIDIA-NeMo/gym_core
+/nemo_gym/rollout_observability.py      @NVIDIA-NeMo/gym_core
+/nemo_gym/decorators.py                 @NVIDIA-NeMo/gym_core
+/nemo_gym/path_utils.py                 @NVIDIA-NeMo/gym_core
+# Verification and rollout-time agent inputs sit on the evaluation side.
+/nemo_gym/judge.py                      @NVIDIA-NeMo/gym_env_benchmarks
+/nemo_gym/skills.py                     @NVIDIA-NeMo/gym_env_benchmarks
+/nemo_gym/rollout_reverification.py     @NVIDIA-NeMo/gym_env_benchmarks
+
+# ═════════════════════════════════════════════════════════════════════════════
+# CO-OWNED
+# ═════════════════════════════════════════════════════════════════════════════
+
+# Shared runtime contracts. Core owns the contract, Frontier Eval builds directly
+# against it, so both lanes are required reviewers.
+/nemo_gym/__init__.py                   @NVIDIA-NeMo/gym_core @NVIDIA-NeMo/gym_env_benchmarks
+/nemo_gym/config_types.py               @NVIDIA-NeMo/gym_core @NVIDIA-NeMo/gym_env_benchmarks
+/nemo_gym/global_config.py              @NVIDIA-NeMo/gym_core @NVIDIA-NeMo/gym_env_benchmarks
+/nemo_gym/package_info.py               @NVIDIA-NeMo/gym_core @NVIDIA-NeMo/gym_env_benchmarks
+
+# The verifiers harness is the framework side of the NeMo-RL integration: a
+# Frontier Eval harness against a Core-owned boundary.
+/responses_api_agents/verifiers_agent/  @NVIDIA-NeMo/gym_env_benchmarks @NVIDIA-NeMo/gym_core
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+# Core library tests encode integration-test expectations for the Core contract.
+# Per-server tests live under each server directory and inherit that server's owner.
+/tests/                                 @NVIDIA-NeMo/gym_core
+
+# ── CI & build ───────────────────────────────────────────────────────────────
+/.github/                               @NVIDIA-NeMo/automation
+/docker/                                @NVIDIA-NeMo/automation
+/Makefile                               @NVIDIA-NeMo/automation
+/pyproject.toml                         @NVIDIA-NeMo/automation
+/uv.lock                                @NVIDIA-NeMo/automation
+/codecov.yml                            @NVIDIA-NeMo/automation
+/.pre-commit-config.yaml                @NVIDIA-NeMo/automation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,9 +11,8 @@
 #                                    Eng PIC Ananth Subramaniam
 #   @NVIDIA-NeMo/gym_architects      Tech-lead advisors — escalation for cross-lane
 #                                    disputes and backstop for unclaimed paths
-#   @NVIDIA-NeMo/gym_leads           Leads (EM/PM/TPM) — docs surfaces, which leads
-#                                    edit often and which are not a tech-lead call
-#   @NVIDIA-NeMo/docs_team           TME — docs/ and fern/
+#   @NVIDIA-NeMo/gym_leads           Leads (EM/PM/TPM) — docs surfaces (docs/, fern/),
+#                                    which leads edit often and which are not a tech-lead call
 #   @NVIDIA-NeMo/automation          CI, build, and release infrastructure
 #
 # The split follows one principle: Core owns the contracts and the substrate,
@@ -147,12 +146,12 @@
 # DOCS
 # ═════════════════════════════════════════════════════════════════════════════
 
-# TME owns the docs surface, and leads edit it often enough to be standing
-# reviewers rather than an escalation. Docs changes that restate a shared runtime
-# contract still need both lanes, same as config_types.py — a policy rule this
-# file cannot express.
-/docs/                                  @NVIDIA-NeMo/docs_team @NVIDIA-NeMo/gym_leads
-/fern/                                  @NVIDIA-NeMo/docs_team @NVIDIA-NeMo/gym_leads
+# Docs are owned by leads (EM/PM/TPM), who edit them often; this keeps docs out
+# of the tech-lead backstop. Docs changes that restate a shared runtime contract
+# still need both lanes, same as config_types.py — a policy rule this file cannot
+# express.
+/docs/                                  @NVIDIA-NeMo/gym_leads
+/fern/                                  @NVIDIA-NeMo/gym_leads
 
 # ═════════════════════════════════════════════════════════════════════════════
 # CI & BUILD

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,9 +10,9 @@
 #   @NVIDIA-NeMo/gym_core            Core-Arch + RL — EM Bernard Nguyen,
 #                                    Eng PIC Ananth Subramaniam
 #   @NVIDIA-NeMo/gym_architects      Tech-lead advisors — escalation for cross-lane
-#                                    disputes and last-resort review of unclaimed paths
-#   @NVIDIA-NeMo/project_managers    Leads (EM/PM/TPM) — product/process surfaces that
-#                                    are not a tech-lead escalation (examples, scripts)
+#                                    disputes and backstop for unclaimed paths
+#   @NVIDIA-NeMo/gym_leads           Leads (EM/PM/TPM) — docs surfaces, which leads
+#                                    edit often and which are not a tech-lead call
 #   @NVIDIA-NeMo/docs_team           TME — docs/ and fern/
 #   @NVIDIA-NeMo/automation          CI, build, and release infrastructure
 #
@@ -35,11 +35,9 @@
 
 # ── Global backstop ──────────────────────────────────────────────────────────
 # Anything not claimed by a more specific rule (data/, cache/, results/,
-# top-level files) routes to the tech-lead advisors. Product/process paths that
-# leads (EM/PM/TPM) routinely own are claimed explicitly below rather than
-# falling through here. If a category of unclaimed files starts generating
-# recurring work, give it an explicit owner here rather than leaning on the
-# backstop.
+# examples/, scripts/, top-level files) routes to the tech-lead advisors. If a
+# category of unclaimed files starts generating recurring work, give it an
+# explicit owner here rather than leaning on the backstop.
 *                                       @NVIDIA-NeMo/gym_architects
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -146,18 +144,15 @@
 /responses_api_agents/verifiers_agent/  @NVIDIA-NeMo/gym_env_benchmarks @NVIDIA-NeMo/gym_core
 
 # ═════════════════════════════════════════════════════════════════════════════
-# DOCS / PRODUCT SURFACES
+# DOCS
 # ═════════════════════════════════════════════════════════════════════════════
 
-# Docs — TME owns the surface; both lanes review because docs encode the same
-# shared contracts as config_types / global_config (per ownership callouts).
-/docs/                                  @NVIDIA-NeMo/docs_team @NVIDIA-NeMo/gym_core @NVIDIA-NeMo/gym_env_benchmarks
-/fern/                                  @NVIDIA-NeMo/docs_team @NVIDIA-NeMo/gym_core @NVIDIA-NeMo/gym_env_benchmarks
-
-# Examples and scripts are frequently owned by leads (EM/PM/TPM), not tech-lead
-# advisors. Keep architects as a secondary reviewer for escalation only.
-/examples/                              @NVIDIA-NeMo/project_managers @NVIDIA-NeMo/gym_architects
-/scripts/                               @NVIDIA-NeMo/project_managers @NVIDIA-NeMo/gym_architects
+# TME owns the docs surface, and leads edit it often enough to be standing
+# reviewers rather than an escalation. Docs changes that restate a shared runtime
+# contract still need both lanes, same as config_types.py — a policy rule this
+# file cannot express.
+/docs/                                  @NVIDIA-NeMo/docs_team @NVIDIA-NeMo/gym_leads
+/fern/                                  @NVIDIA-NeMo/docs_team @NVIDIA-NeMo/gym_leads
 
 # ═════════════════════════════════════════════════════════════════════════════
 # CI & BUILD

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,8 +9,11 @@
 #                                    Eng PICs Michal Bien, Marta Stepniewska-Dziubinska
 #   @NVIDIA-NeMo/gym_core            Core-Arch + RL — EM Bernard Nguyen,
 #                                    Eng PIC Ananth Subramaniam
-#   @NVIDIA-NeMo/gym_architects      Advisors — backstop for anything unclaimed, and
-#                                    escalation path for cross-lane disputes
+#   @NVIDIA-NeMo/gym_architects      Tech-lead advisors — escalation for cross-lane
+#                                    disputes and last-resort review of unclaimed paths
+#   @NVIDIA-NeMo/project_managers    Leads (EM/PM/TPM) — product/process surfaces that
+#                                    are not a tech-lead escalation (examples, scripts)
+#   @NVIDIA-NeMo/docs_team           TME — docs/ and fern/
 #   @NVIDIA-NeMo/automation          CI, build, and release infrastructure
 #
 # The split follows one principle: Core owns the contracts and the substrate,
@@ -32,9 +35,11 @@
 
 # ── Global backstop ──────────────────────────────────────────────────────────
 # Anything not claimed by a more specific rule (data/, cache/, results/,
-# scripts/, top-level files) routes to the advisors. If a category of unclaimed
-# files starts generating recurring work, give it an explicit owner here rather
-# than leaning on the backstop.
+# top-level files) routes to the tech-lead advisors. Product/process paths that
+# leads (EM/PM/TPM) routinely own are claimed explicitly below rather than
+# falling through here. If a category of unclaimed files starts generating
+# recurring work, give it an explicit owner here rather than leaning on the
+# backstop.
 *                                       @NVIDIA-NeMo/gym_architects
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -121,6 +126,10 @@
 /nemo_gym/skills.py                     @NVIDIA-NeMo/gym_env_benchmarks
 /nemo_gym/rollout_reverification.py     @NVIDIA-NeMo/gym_env_benchmarks
 
+# Core library tests encode integration-test expectations for the Core contract.
+# Per-server tests live under each server directory and inherit that server's owner.
+/tests/                                 @NVIDIA-NeMo/gym_core
+
 # ═════════════════════════════════════════════════════════════════════════════
 # CO-OWNED
 # ═════════════════════════════════════════════════════════════════════════════
@@ -136,12 +145,24 @@
 # Frontier Eval harness against a Core-owned boundary.
 /responses_api_agents/verifiers_agent/  @NVIDIA-NeMo/gym_env_benchmarks @NVIDIA-NeMo/gym_core
 
-# ── Tests ────────────────────────────────────────────────────────────────────
-# Core library tests encode integration-test expectations for the Core contract.
-# Per-server tests live under each server directory and inherit that server's owner.
-/tests/                                 @NVIDIA-NeMo/gym_core
+# ═════════════════════════════════════════════════════════════════════════════
+# DOCS / PRODUCT SURFACES
+# ═════════════════════════════════════════════════════════════════════════════
 
-# ── CI & build ───────────────────────────────────────────────────────────────
+# Docs — TME owns the surface; both lanes review because docs encode the same
+# shared contracts as config_types / global_config (per ownership callouts).
+/docs/                                  @NVIDIA-NeMo/docs_team @NVIDIA-NeMo/gym_core @NVIDIA-NeMo/gym_env_benchmarks
+/fern/                                  @NVIDIA-NeMo/docs_team @NVIDIA-NeMo/gym_core @NVIDIA-NeMo/gym_env_benchmarks
+
+# Examples and scripts are frequently owned by leads (EM/PM/TPM), not tech-lead
+# advisors. Keep architects as a secondary reviewer for escalation only.
+/examples/                              @NVIDIA-NeMo/project_managers @NVIDIA-NeMo/gym_architects
+/scripts/                               @NVIDIA-NeMo/project_managers @NVIDIA-NeMo/gym_architects
+
+# ═════════════════════════════════════════════════════════════════════════════
+# CI & BUILD
+# ═════════════════════════════════════════════════════════════════════════════
+
 /.github/                               @NVIDIA-NeMo/automation
 /docker/                                @NVIDIA-NeMo/automation
 /Makefile                               @NVIDIA-NeMo/automation


### PR DESCRIPTION
## Summary

Encodes the NeMo Gym Code Component Ownership map in `.github/CODEOWNERS` so GitHub auto-requests the owning team on every PR, instead of leaving review assignment to whoever happens to notice. Today the file only covers CI paths, so everything else lands with no owner.

The split follows the doc's principle: **Core owns the contracts and the substrate, Frontier Eval owns the implementations and the evaluation outputs built on top of them.** `base_responses_api_agent.py` (the interface) is Core while every harness under `responses_api_agents/` is Frontier Eval; `rollout_collection.py` (the engine) is Core while `reward_profile.py` (what consumes rollouts to make decisions) is Frontier Eval.

Teams used, all confirmed to exist with write access to this repo (a team without write access is silently ignored by CODEOWNERS):

| Team | Lane |
|---|---|
| `@NVIDIA-NeMo/gym_env_benchmarks` | Frontier Eval |
| `@NVIDIA-NeMo/gym_core` | Core-Arch + RL |
| `@NVIDIA-NeMo/gym_architects` | Advisors, backstop and escalation |
| `@NVIDIA-NeMo/automation` | CI, build, release (unchanged) |

Member lists are deliberately not duplicated into the file — GitHub team membership is the source of truth, maintained by each team's maintainers.

## Open questions for reviewers

- **`docs/` and `fern/` are intentionally left unassigned** in this PR, so they fall to the `gym_architects` backstop. The ownership table assigns docs to TME, but the callouts say both lanes should review. There is a `docs_team` in the org with write access if we want to route there. This is the main thing to settle before this leaves draft.
- **Files not in the ownership doc are mapped by analogy** and grouped under a clearly marked section. Roughly 14 `nemo_gym` modules postdate the doc: streaming dialects, the discovery/registry modules, `orchestration/`, and the rollout observability helpers went to Core as substrate; `judge.py`, `skills.py`, and `rollout_reverification.py` went to Frontier Eval as verification and evaluation-output surfaces. `rollout_reverification.py` is the least obvious call — it is a `rollout_*` sibling of the Core engine but it consumes rollouts to recompute rewards, which is the Frontier Eval side of the line.
- **`tests/` goes to Core**, since the core library tests encode integration expectations for the Core contract. Per-server tests live under each server directory and already inherit that server's owner.
- **Two policies in the doc cannot be expressed in CODEOWNERS** and are recorded as comments instead: breaking changes to shared contracts and user-facing CLI need sign-off from both lanes, and well-isolated changes may be reviewed by frequent contributors without the code owner.

`example_environments/` from the doc is omitted because that directory does not exist in the repo.

## Test plan

- [x] All 58 path patterns resolve to files or directories that exist in the repo, and every rule is syntactically valid.
- [x] Every team handle verified via the GitHub API to exist and hold write access on this repo.
- [x] Simulated GitHub's last-match-wins resolution against a spread of real paths. Spot checks: `responses_api_agents/simple_agent/app.py` to Frontier Eval, `nemo_gym/sandbox/api.py` to Core, `nemo_gym/config_types.py` to both lanes, `responses_api_agents/verifiers_agent/app.py` to both lanes, `.github/workflows/unit-tests.yml` to automation, `README.md` to the architects backstop.
- [x] GitHub's own CODEOWNERS validation API reports zero errors on this branch, confirming no rule or team handle is being silently dropped.

Note that reviewer routing on this PR itself is governed by the CODEOWNERS on `main`, not the version in this branch, so the new rules only take effect after merge.
