### PR TITLE
fix(swe_agents): fix exit-code capture and final-failure exit in openhands.sh make-build retry

### DIFF
--- a/responses_api_agents/swe_agents/setup_scripts/openhands.sh
+++ b/responses_api_agents/swe_agents/setup_scripts/openhands.sh
@@ -104,9 +104,10 @@ export PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '\.venv' | tr '\n' ':' | sed 
 # Configure poetry to create virtualenv in the project directory (so it's mounted in container)
 export POETRY_VIRTUALENVS_IN_PROJECT=true
 
-# Retry `make build` with a timeout guard on the first attempt
+# Retry `make build` with a timeout guard on the first attempt.
+# The timeout is env-overridable for hosts where a healthy build takes longer.
 MAX_MAKE_BUILD_ATTEMPTS=2
-MAKE_BUILD_TIMEOUT_SECONDS=$((2 * 60))
+MAKE_BUILD_TIMEOUT_SECONDS="${MAKE_BUILD_TIMEOUT_SECONDS:-$((2 * 60))}"
 MAKE_BUILD_TIMEOUT_MINUTES=$((MAKE_BUILD_TIMEOUT_SECONDS / 60))
 
 attempt=1
@@ -117,9 +118,10 @@ while [ "$attempt" -le "$MAX_MAKE_BUILD_ATTEMPTS" ]; do
         if timeout "$MAKE_BUILD_TIMEOUT_SECONDS" make build; then
             echo "make build completed successfully."
             break
+        else
+            exit_code=$?
         fi
 
-        exit_code=$?
         if [ "$exit_code" -eq 124 ]; then
             echo "make build timed out after $MAKE_BUILD_TIMEOUT_MINUTES minutes."
         else
@@ -128,6 +130,7 @@ while [ "$attempt" -le "$MAX_MAKE_BUILD_ATTEMPTS" ]; do
 
         echo "Retrying make build after cleanup..."
         make clean || true
+        rm -rf .venv
         attempt=$((attempt + 1))
         continue
     fi
@@ -135,10 +138,12 @@ while [ "$attempt" -le "$MAX_MAKE_BUILD_ATTEMPTS" ]; do
     if make build; then
         echo "make build completed successfully."
         break
+    else
+        exit_code=$?
     fi
 
-    exit_code=$?
     echo "make build failed on the final attempt with exit code $exit_code."
+    exit "$exit_code"
 done
 
 # Install Python dependencies with poetry


### PR DESCRIPTION
The retry loop around `make build` in `setup_scripts/openhands.sh` has three bugs:

1. **Wrong exit code captured.** `exit_code=$?` runs after the `if` statement has completed, so it captures the if-statement's status (always 0), not make's. Timeouts are reported as "failed with exit code 0" and exit 124 is never detected.
2. **Infinite loop on final failure.** On the final attempt, a failure neither increments `attempt` nor exits, so the loop re-runs `make build` forever instead of failing the setup. In a Docker build this hangs until the CI job times out; worse, if a late retry "succeeds" against a half-broken tree, the failure is deferred to runtime.
3. **Stale `.venv` between retries.** A first-attempt timeout leaves a partially-built in-project `.venv` behind (`POETRY_VIRTUALENVS_IN_PROJECT=true` is set just above); `make clean` does not remove it. The script has already `cd`'d into `$openhands_dir` at this point, so the removal only targets the OpenHands checkout.

This PR captures the exit code in an `else` branch (while it is still make's), `exit`s with it on the final failure, and removes `.venv` before retrying.

It also makes the first-attempt timeout env-overridable (`MAKE_BUILD_TIMEOUT_SECONDS`, default unchanged at 2 minutes), so hosts where a healthy `make build` legitimately takes longer can raise it without editing the script — on such hosts the 2-minute guard otherwise kills every healthy first attempt and forces the fallback path above.