### PR TITLE
fix(swe_agents): forward max_output_tokens to the OpenHands llm config

### DIFF
--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -1585,12 +1585,17 @@ AGENT_FRAMEWORK_COMMIT={self.config.agent_framework_commit} \\
         # openai_model proxy force-overrides). tomlkit refuses to serialize None,
         # so coerce to an empty string here; the value is unused once the proxy
         # substitutes its configured backend.
-        config["llm"]["model"] |= {
+        llm_model_config = {
             "model": self.config.body.model or "",
             "base_url": "",  # May need to populate this
             "temperature": self.config.inference_params["temperature"],
             "top_p": self.config.inference_params["top_p"],
         }
+        max_output_tokens = self.config.inference_params.get("tokens_to_generate")
+        if max_output_tokens is not None:
+            llm_model_config["max_output_tokens"] = max_output_tokens
+
+        config["llm"]["model"] |= llm_model_config
 
         config_str = tomlkit.dumps(config)
 


### PR DESCRIPTION
The request body's `max_output_tokens` is already mapped into `inference_params` as `tokens_to_generate`, but `get_run_command` never writes it into the generated OpenHands `config.toml` — only `temperature` and `top_p` are forwarded. OpenHands therefore runs with its own default output limit, and a caller-requested cap (e.g. from a training harness that budgets generation lengths) is silently ignored.

Forward it as `llm.model.max_output_tokens` when present; behavior is unchanged for requests that don't set it.