### PR TITLE
fix(responses): remove `reasoning_item` from the boundary set, and name the training-variant error

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -360,6 +360,40 @@ RESPONSES_TO_TRAIN = {
     NeMoGymResponseReasoningItem: NeMoGymResponseReasoningItemForTraining,
 }
 
+# The hosted-tool and client-executed call types have no variant here:
+#   web_search_call, file_search_call, code_interpreter_call, image_generation_call,
+#   mcp_call, computer_call, custom_tool_call, local_shell_call.
+#
+# training_variant_of() is reached only from ResponsesConverter.postprocess_assistant_message_dict,
+# which passes response_output[-1].
+# That list is local to the function.
+# It holds only NeMoGymResponseReasoningItem, NeMoGymResponseOutputMessage
+# or NeMoGymResponseFunctionToolCall, all registered above.
+#
+# Each variant is also another member of NeMoGymResponseInputItem.
+# That union is validated in smart mode, so an unrecognised item reports the errors of every member.
+# Variants that nothing can emit only make those errors harder to read.
+#
+# The upstream models permit extra fields.
+# An item carrying token IDs without a declared variant still round-trips through its base class.
+# Add a variant when a converter emits that type with sampled token IDs.
+
+
+def training_variant_of(item_cls: type) -> type:
+    """Return the ForTraining subclass that carries token IDs for ``item_cls``.
+
+    Raises NotImplementedError rather than KeyError, so the message can name the class and the fix.
+    Either register the pair in RESPONSES_TO_TRAIN, or stop attaching token IDs to that item.
+    """
+    try:
+        return RESPONSES_TO_TRAIN[item_cls]
+    except KeyError:
+        raise NotImplementedError(
+            f"{item_cls.__name__} has no ForTraining variant, so token IDs and logprobs cannot be "
+            f"attached to it. Add it to RESPONSES_TO_TRAIN in nemo_gym/openai_utils.py if the policy "
+            f"samples this item's tokens; provider-executed hosted calls should not reach this path."
+        ) from None
+
 
 NeMoGymResponseInputItem = Annotated[
     Union[

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -507,14 +507,7 @@ class ResponsesConverter(BaseModel):
         token_information = _token_information_from_mapping(message_dict) if self.return_token_id_information else None
         if token_information is not None:
             last_response_output_item = response_output[-1]
-<<<<<<< HEAD
-            train_cls = RESPONSES_TO_TRAIN[last_response_output_item.__class__]
-=======
             train_cls = training_variant_of(last_response_output_item.__class__)
-            extra_training_fields = {}
-            if "routed_experts" in message_dict and message_dict["routed_experts"] is not None:
-                extra_training_fields["routed_experts"] = message_dict["routed_experts"]
->>>>>>> 6bd05e3a (fix(responses): remove reasoning_item from the boundary set, and name the training-variant error)
             response_output[-1] = train_cls(
                 **last_response_output_item.model_dump(),
                 **token_information.model_dump(exclude_none=True),

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -26,7 +26,6 @@ from uuid import uuid4
 from pydantic import BaseModel, Field
 
 from nemo_gym.openai_utils import (
-    RESPONSES_TO_TRAIN,
     NeMoGymChatCompletion,
     NeMoGymChatCompletionAssistantMessageForTrainingParam,
     NeMoGymChatCompletionAssistantMessageParam,
@@ -58,6 +57,7 @@ from nemo_gym.openai_utils import (
     Reasoning,
     TokenIDLogProbMixin,
     _validate_atomic_token_metadata,
+    training_variant_of,
 )
 
 
@@ -193,8 +193,18 @@ class ResponsesConverter(BaseModel):
                     self._format_function_call(m, state)
                 case "function_call_output":
                     self._format_function_call_output(m, state)
-                case _:  # pragma: no cover
-                    raise NotImplementedError(f"Unsupported message type: {m}")
+                case _:
+                    # This fires mid-rollout, on whichever model server downconverts.
+                    # Most types that reach it are Responses-only by design.
+                    # They are not an omission here.
+                    # The item itself is left out of the message.
+                    # A compaction record carries an opaque blob, and the tag is what identifies the problem.
+                    raise NotImplementedError(
+                        f"{m['type']!r} has no Chat Completions representation, so this rollout "
+                        f"cannot be downconverted. Route it to a model server that passes "
+                        f"Responses through (nemo_gym serves these unconverted), or add a "
+                        f"`case {m['type']!r}` here if the type does have a chat equivalent."
+                    )
 
             if self.return_token_id_information:
                 token_information = _token_information_from_mapping(m)
@@ -497,7 +507,14 @@ class ResponsesConverter(BaseModel):
         token_information = _token_information_from_mapping(message_dict) if self.return_token_id_information else None
         if token_information is not None:
             last_response_output_item = response_output[-1]
+<<<<<<< HEAD
             train_cls = RESPONSES_TO_TRAIN[last_response_output_item.__class__]
+=======
+            train_cls = training_variant_of(last_response_output_item.__class__)
+            extra_training_fields = {}
+            if "routed_experts" in message_dict and message_dict["routed_experts"] is not None:
+                extra_training_fields["routed_experts"] = message_dict["routed_experts"]
+>>>>>>> 6bd05e3a (fix(responses): remove reasoning_item from the boundary set, and name the training-variant error)
             response_output[-1] = train_cls(
                 **last_response_output_item.model_dump(),
                 **token_information.model_dump(exclude_none=True),
@@ -614,6 +631,13 @@ class ResponsesConverter(BaseModel):
         )
 
 
+# Responses output-item types that mark the start of the model's own generation.
+# split_responses_input_output_items cuts at the first item of one of these types.
+# Everything before it is replayed prompt.
+# Everything after is the segment carrying sampled tokens.
+#
+# "message" is absent because the role == "assistant" check below already covers an assistant message.
+# A user, system or developer message must not open the segment.
 _RESPONSE_OUTPUT_BOUNDARY_TYPES = frozenset(
     {
         "code_interpreter_call",
@@ -627,7 +651,6 @@ _RESPONSE_OUTPUT_BOUNDARY_TYPES = frozenset(
         "mcp_call",
         "mcp_list_tools",
         "reasoning",
-        "reasoning_item",
         "web_search_call",
     }
 )
@@ -641,10 +664,15 @@ def split_responses_input_output_items(
 
     split_at = len(items)
     for i, item in enumerate(items):
-        if (
-            getattr(item, "role", None) == "assistant"
-            or getattr(item, "type", None) in _RESPONSE_OUTPUT_BOUNDARY_TYPES
-        ):
+        # The role shortcut is for assistant messages only.
+        # Applied to any item carrying a role, it outranks the type set below and decides the split
+        # on its own, so a non-message item that happens to have role == "assistant" would open the
+        # trained segment however it is classified.
+        # Every item type with a role is a message at the pinned SDK, so this is the same behaviour
+        # here, stated in a way later versions cannot subvert.
+        item_type = getattr(item, "type", None)
+        is_assistant_message = item_type == "message" and getattr(item, "role", None) == "assistant"
+        if is_assistant_message or item_type in _RESPONSE_OUTPUT_BOUNDARY_TYPES:
             split_at = i
             break
 

--- a/tests/unit_tests/test_responses_converter.py
+++ b/tests/unit_tests/test_responses_converter.py
@@ -40,6 +40,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseReasoningItem,
     NeMoGymResponseUsage,
     NeMoGymSummary,
+    training_variant_of,
 )
 from nemo_gym.responses_converter import (
     ResponsesConverter,
@@ -833,6 +834,28 @@ def test_split_on_assistant_message():
     assert outputs == [assistant]
 
 
+def test_a_non_message_item_with_an_assistant_role_is_not_a_boundary():
+    """The role shortcut must not decide the split for items that are not messages.
+
+    An item type outside the boundary set stays on the prompt side however its role reads.
+    No item type at the pinned SDK carries a role without being a message, so this is a guard
+    against a later version adding one rather than a fix for something reachable today.
+    A non-message item that opened the trained segment would label replayed prompt as generation.
+    """
+
+    class _RoledNonMessage:
+        type = "not_a_boundary_type"
+        role = "assistant"
+
+    user = NeMoGymEasyInputMessage(role="user", content="hi", type="message")
+    carrier = _RoledNonMessage()
+
+    inputs, outputs = split_responses_input_output_items([user, carrier])
+
+    assert inputs == [user, carrier], "a non-message item must not open the trained segment"
+    assert outputs == []
+
+
 def test_split_on_function_call():
     user = NeMoGymEasyInputMessage(role="user", content="hi", type="message")
     fc = NeMoGymResponseFunctionToolCall(
@@ -870,7 +893,6 @@ def test_split_on_reasoning():
         "mcp_call",
         "mcp_list_tools",
         "reasoning",
-        "reasoning_item",
         "web_search_call",
     ],
 )
@@ -915,3 +937,63 @@ def test_round_trip_with_tool_calls(converter: ResponsesConverter):
     assert assistant_msg["role"] == "assistant"
     assert assistant_msg["content"] == "<think>thinking</think>chatting"
     assert assistant_msg["tool_calls"][0]["function"]["name"] == "get_weather"
+
+
+# ===========================================================================
+# training_variant_of
+# ===========================================================================
+
+
+def test_training_variant_of_returns_the_registered_variant():
+    assert training_variant_of(NeMoGymResponseOutputMessage) is NeMoGymResponseOutputMessageForTraining
+
+
+def test_training_variant_of_covers_everything_postprocess_can_emit():
+    """postprocess_assistant_message_dict passes response_output[-1] to training_variant_of, so
+    every class it appends must be registered."""
+    for cls in (
+        NeMoGymResponseReasoningItem,
+        NeMoGymResponseOutputMessage,
+        NeMoGymResponseFunctionToolCall,
+    ):
+        assert training_variant_of(cls) is not None
+
+
+def test_downconverting_an_unsupported_type_names_it_and_the_way_out():
+    """A Responses-only item reaching a chat backend must say which type and what to do.
+
+    This is the sibling of the training-variant error.
+    It fires mid-rollout, on whichever model server downconverts.
+    The message names the type rather than dumping the item, because an item can carry an opaque blob.
+    """
+    converter = ResponsesConverter(return_token_id_information=False)
+    params = NeMoGymResponseCreateParamsNonStreaming(
+        input=[
+            {
+                "type": "file_search_call",
+                "id": "fs_1",
+                "queries": ["a-query-that-should-not-reach-the-error"],
+                "status": "completed",
+            }
+        ]
+    )
+
+    with pytest.raises(NotImplementedError) as excinfo:
+        converter.responses_to_chat_completion_create_params(params)
+
+    message = str(excinfo.value)
+    assert "'file_search_call'" in message, "the error must name the offending type"
+    assert "Responses through" in message, "the error must point at the way out"
+    assert "a-query-that-should-not-reach-the-error" not in message, (
+        "the item payload must not be interpolated into the error"
+    )
+
+
+def test_training_variant_of_raises_a_named_error_for_an_unregistered_class():
+    """An unregistered class raises NotImplementedError, not KeyError."""
+
+    class _NotAnItem:
+        pass
+
+    with pytest.raises(NotImplementedError, match="has no ForTraining variant"):
+        training_variant_of(_NotAnItem)


### PR DESCRIPTION
Part of https://github.com/NVIDIA-NeMo/Gym/issues/2452

Two corrections to the Responses item plumbing. Neither changes behaviour at the current openai pin.

1. `_RESPONSE_OUTPUT_BOUNDARY_TYPES` listed `"reasoning_item"`, which is not a Responses output item type at any openai version. 

The class is `ResponseReasoningItem`. Its `type` tag is `"reasoning"`: https://github.com/openai/openai-python/blob/650be393dedf2a4550092817c2b82c1d04d6e9dc/src/openai/types/responses/response_reasoning_item.py#L34

which is what the responses converter emits: https://github.com/NVIDIA-NeMo/Gym/blob/abc21ebb3f46bba160ab50d1707eaff1f0b494b0/nemo_gym/responses_converter.py#L412-L418

2. `RESPONSES_TO_TRAIN[item_cls]` directly looks up the dict in the responses converter. It was a bare dict access, so an unregistered class raised `KeyError` and reached the client as a 500 with no explanation. `training_variant_of()` raises `NotImplementedError` naming the class and what to add.

Nothing reaches that path today. The lookup is passed `response_output[-1]` from `postprocess_assistant_message_dict`, whose local list can only hold `NeMoGymResponseReasoningItem`, `NeMoGymResponseOutputMessage` or `NeMoGymResponseFunctionToolCall`, and all three are registered. The point is that the next converter to emit a new item type gets a message telling it what to add rather than a stack trace.

3. `responses_to_chat_completion_create_params` matches on each item's `type` and has a case for four of them. Everything else falls to `case _`, which raised `Unsupported message type: {the whole item}`: https://github.com/NVIDIA-NeMo/Gym/blob/a62c30035519f738e583b6c1f08254cde70ced1b/nemo_gym/responses_converter.py#L174-L184

That message reads as a gap in the converter. It usually is not. Most types that reach it have no Chat Completions representation at all, so the transcript needs a model server that passes Responses through rather than a new case here. `openai_model` does; `vllm_model` and `inference_provider` downconvert and cannot.

The message now names the type and says which of those two situations it is. It no longer prints the item, because the payload can be large or opaque, and the `type` tag is the part that identifies the problem.
