### PR TITLE
test(responses): check the item union and boundary sets against the installed openai SDK

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -338,9 +338,8 @@ class NeMoGymResponseCustomToolCall(ResponseCustomToolCall):
     """A client-executed custom tool call (OpenAI Responses ``custom_tool_call`` output item)."""
 
 
-# The results a client hands back for the calls above.
-# The SDK models them in response_input_item rather than exporting them at the package root.
-# They reach Gym as input items, and openai puts them in ResponseOutputItem from a later version.
+# These models represent client-supplied results for the calls above.
+# The installed SDK defines them in ``response_input_item``.
 class NeMoGymComputerCallOutput(ComputerCallOutput):
     """The client's result of a computer-use action (``computer_call_output`` item)."""
 

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -82,6 +82,12 @@ from openai.types.responses.response_create_params import (
 from openai.types.responses.response_function_call_output_item_list_param import (
     ResponseFunctionCallOutputItemListParam,
 )
+from openai.types.responses.response_input_item import (
+    ComputerCallOutput,
+    LocalShellCallOutput,
+    McpApprovalResponse,
+    ResponseCustomToolCallOutput,
+)
 from openai.types.responses.response_input_param import (
     ResponseInputMessageContentListParam,
 )
@@ -93,6 +99,9 @@ from openai.types.responses.response_output_item import (
     McpListTools,
 )
 from openai.types.responses.response_output_text_param import Annotation, Logprob
+from openai.types.responses.response_reasoning_item import (
+    Content as ReasoningContent,
+)
 from openai.types.responses.response_reasoning_item import (
     Summary,
 )
@@ -182,6 +191,7 @@ class NeMoGymResponseReasoningItem(BaseModel):
     summary: List[NeMoGymSummary]
     type: Literal["reasoning"] = "reasoning"
     encrypted_content: Optional[str] = None
+    content: Optional[List[ReasoningContent]] = None
 
     # As of Wed Sep 17, 2025, the OpenAI API with GPT-5 returns None for this status rather than a valid value here.
     # On subsequent calls to the OpenAI endpoints within a rollout, the status parameter is not accepted i.e. the OpenAI API returns a bad request when the status parameter is populated.
@@ -328,6 +338,25 @@ class NeMoGymResponseCustomToolCall(ResponseCustomToolCall):
     """A client-executed custom tool call (OpenAI Responses ``custom_tool_call`` output item)."""
 
 
+# The results a client hands back for the calls above.
+# The SDK models them in response_input_item rather than exporting them at the package root.
+# They reach Gym as input items, and openai puts them in ResponseOutputItem from a later version.
+class NeMoGymComputerCallOutput(ComputerCallOutput):
+    """The client's result of a computer-use action (``computer_call_output`` item)."""
+
+
+class NeMoGymResponseCustomToolCallOutput(ResponseCustomToolCallOutput):
+    """The client's result of a custom tool call (``custom_tool_call_output`` item)."""
+
+
+class NeMoGymLocalShellCallOutput(LocalShellCallOutput):
+    """The client's result of a local shell command (``local_shell_call_output`` item)."""
+
+
+class NeMoGymMcpApprovalResponse(McpApprovalResponse):
+    """The client's answer to a hosted-MCP approval request (``mcp_approval_response`` item)."""
+
+
 class NeMoGymResponseInputText(ResponseInputTextParam):
     pass
 
@@ -415,6 +444,10 @@ NeMoGymResponseInputItem = Annotated[
         NeMoGymResponseCodeInterpreterToolCall,
         NeMoGymLocalShellCall,
         NeMoGymResponseCustomToolCall,
+        NeMoGymComputerCallOutput,
+        NeMoGymResponseCustomToolCallOutput,
+        NeMoGymLocalShellCallOutput,
+        NeMoGymMcpApprovalResponse,
         # Training variants.
         NeMoGymEasyInputMessageForTraining,
         NeMoGymMessageForTraining,

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -648,14 +648,11 @@ _RESPONSE_OUTPUT_BOUNDARY_TYPES = frozenset(
     }
 )
 
-# Responses output-item types that are not model-generated.
-# These are tool results the client supplies, approvals it grants, and context-management bookkeeping.
-# They must stay out of the boundary set above.
-# Otherwise split_responses_input_output_items would treat a tool result as the start of the sampled segment.
+# These item types are not model-generated.
+# They include client-supplied tool results, approvals, and context-management data.
+# Excluding them from the boundary set prevents tool results from starting the sampled segment.
 #
-# The SDK does not distinguish the two groups, so the classification lives here.
-# These reach Gym as input items at the pinned version, and openai moves them into
-# ResponseOutputItem alongside generated items in a later release.
+# The SDK unions do not distinguish generated items from client-supplied items.
 _RESPONSE_NON_BOUNDARY_TYPES: frozenset[str] = frozenset(
     {
         "computer_call_output",

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -648,6 +648,24 @@ _RESPONSE_OUTPUT_BOUNDARY_TYPES = frozenset(
     }
 )
 
+# Responses output-item types that are not model-generated.
+# These are tool results the client supplies, approvals it grants, and context-management bookkeeping.
+# They must stay out of the boundary set above.
+# Otherwise split_responses_input_output_items would treat a tool result as the start of the sampled segment.
+#
+# The SDK does not distinguish the two groups, so the classification lives here.
+# These reach Gym as input items at the pinned version, and openai moves them into
+# ResponseOutputItem alongside generated items in a later release.
+_RESPONSE_NON_BOUNDARY_TYPES: frozenset[str] = frozenset(
+    {
+        "computer_call_output",
+        "custom_tool_call_output",
+        "function_call_output",
+        "local_shell_call_output",
+        "mcp_approval_response",
+    }
+)
+
 
 def split_responses_input_output_items(
     items: List[NeMoGymResponseOutputItem],

--- a/responses_api_agents/cvdp_agent/tests/test_app.py
+++ b/responses_api_agents/cvdp_agent/tests/test_app.py
@@ -465,6 +465,7 @@ class TestAgenticSandboxSpec:
             "output": [
                 {
                     "id": "msg_688babb17a7881998cc7a42d53c8e5790abdf302bcd600d3",
+                    "content": None,
                     "encrypted_content": None,
                     "summary": [
                         {

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -621,6 +621,7 @@ class TestApp:
             "output": [
                 {
                     "id": "msg_688babb17a7881998cc7a42d53c8e5790abdf302bcd600d3",
+                    "content": None,
                     "encrypted_content": None,
                     "summary": [
                         {
@@ -863,6 +864,7 @@ class TestApp:
             "output": [
                 {
                     "id": "msg_688babb17a7881998cc7a42d53c8e5790abdf302bcd600d3",
+                    "content": None,
                     "encrypted_content": None,
                     "summary": [
                         {

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -12,7 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Annotated, Any, Dict, List, Literal, get_args, get_origin
+from types import UnionType
+from typing import Annotated, Any, Dict, List, Literal, NotRequired, Required, Union, get_args, get_origin
 
 import openai
 import pytest
@@ -69,6 +70,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseMcpApprovalRequest,
     NeMoGymResponseMcpCall,
     NeMoGymResponseMcpListTools,
+    NeMoGymResponseOutputItem,
     NeMoGymResponseOutputMessage,
     NeMoGymResponseOutputTokensDetails,
     NeMoGymResponseReasoningItem,
@@ -538,26 +540,20 @@ def test_accumulate_response_usage_tolerates_missing_detail_objects() -> None:
     assert result.output_tokens_details.reasoning_tokens == 1
 
 
-# ===========================================================================
-# Responses item coverage against the installed openai SDK
+# Responses item coverage against the installed OpenAI SDK.
 #
-# Gym declares its own NeMoGym* item classes rather than using the SDK's.
-# It also keeps three hand-maintained lists derived from the same SDK union:
-#   NeMoGymResponseInputItem, which types Gym can represent
-#   _RESPONSE_OUTPUT_BOUNDARY_TYPES, which types start the model's generation
-#   RESPONSES_TO_TRAIN, which types can carry sampled token IDs
+# Gym defines its own item classes.
+# It also maintains three lists that correspond to SDK union members:
+# - ``NeMoGymResponseInputItem`` lists the item types Gym can represent.
+# - ``_RESPONSE_OUTPUT_BOUNDARY_TYPES`` lists model-generated item types.
+# - ``RESPONSES_TO_TRAIN`` maps item types that can carry sampled token IDs.
 #
-# ResponseOutputItem gains members with most openai releases.
-# None of the three lists is derived from it, so nothing else fails when they fall behind.
-# Drift shows up as a 500 on the non-streaming path.
-# On the streaming path it shows up as a silently truncated transcript.
-#
-# Run these against every version in the supported openai window, not only the pinned one.
-# ===========================================================================
+# An outdated list can cause non-streaming requests to fail.
+# It can also cause streaming requests to omit transcript items.
 
 
-# `message` is covered by split_responses_input_output_items' `role == "assistant"` check.
-# The type set does not carry it, so it is exempt from the boundary classification.
+# ``split_responses_input_output_items`` detects assistant messages by role.
+# The boundary type set therefore excludes ``message``.
 _BOUNDARY_EXEMPT = frozenset({"message"})
 
 
@@ -566,7 +562,8 @@ def _unwrap(annotation: Any) -> Any:
 
     ``ResponseOutputItem`` is ``Annotated[Union[...], PropertyInfo]``.
     Gym's output item is ``Annotated[Union[...], BeforeValidator]``.
-    Without unwrapping, ``get_args`` returns the two ``Annotated`` arguments instead of the union members.
+    Without unwrapping, ``get_args`` returns the ``Annotated`` arguments.
+    It does not return the union members.
     """
     while get_origin(annotation) is Annotated:
         annotation = get_args(annotation)[0]
@@ -579,52 +576,98 @@ def _union_members(annotation: Any) -> List[type]:
     return [_unwrap(arg) for arg in args] if args else [annotation]
 
 
+def _literal_domain(annotation: Any) -> frozenset[Any] | None:
+    """Return a finite top-level Literal domain after removing transparent wrappers.
+
+    Return ``None`` when the annotation is not bounded by Literals.
+    Do not descend into containers or nested models.
+    """
+    origin = get_origin(annotation)
+    if origin in (Annotated, Required, NotRequired):
+        return _literal_domain(get_args(annotation)[0])
+    if origin is Literal:
+        return frozenset(get_args(annotation))
+    if origin in (Union, UnionType):
+        domain: set[Any] = set()
+        for member in get_args(annotation):
+            if member is type(None):
+                continue
+            member_domain = _literal_domain(member)
+            if member_domain is None:
+                return None
+            domain.update(member_domain)
+        return frozenset(domain) if domain else None
+    return None
+
+
+def _field_annotations(model: type) -> Dict[str, Any]:
+    """Read fields from either an SDK/Gym Pydantic model or SDK TypedDict."""
+    model_fields = getattr(model, "model_fields", None)
+    if model_fields is not None:
+        return {name: field.annotation for name, field in model_fields.items()}
+    return dict(getattr(model, "__annotations__", {}))
+
+
 def _type_tags(model: type) -> List[str]:
     """The ``Literal`` values of a pydantic model's ``type`` field."""
-    field = getattr(model, "model_fields", {}).get("type")
-    if field is None:
+    annotation = _field_annotations(model).get("type")
+    if annotation is None:
         return []
-    annotation = field.annotation
-    if get_origin(annotation) is Literal:
-        return [str(value) for value in get_args(annotation)]
-    return [str(value) for arg in get_args(annotation) if get_origin(arg) is Literal for value in get_args(arg)]
+    domain = _literal_domain(annotation)
+    return [] if domain is None else [str(value) for value in domain]
 
 
-def _sdk_tags(union: Any) -> Dict[str, type]:
-    tags: Dict[str, type] = {}
-    for member in _union_members(union):
-        for tag in _type_tags(member):
-            tags.setdefault(tag, member)
-    return tags
-
-
-def _gym_tag_owners() -> Dict[str, List[type]]:
+def _tag_owners(union: Any) -> Dict[str, List[type]]:
     owners: Dict[str, List[type]] = {}
-    for member in _union_members(NeMoGymResponseInputItem):
+    for member in _union_members(union):
         for tag in _type_tags(member):
             owners.setdefault(tag, []).append(member)
     return owners
 
 
-# ResponseInputItem is the source of truth rather than ResponseOutputItem.
-# Gym has to carry every type a client can send, which is the wider set:
-# test_sdk_output_types_are_a_subset_of_input_types keeps that relationship honest.
-# An item type Gym cannot represent is a 500 on the non-streaming path either way.
-SDK_INPUT_TAGS = _sdk_tags(ResponseInputItem)
-SDK_OUTPUT_TAGS = _sdk_tags(ResponseOutputItem)
-GYM_TAG_OWNERS = _gym_tag_owners()
+def _literal_fields(owners: List[type]) -> Dict[str, frozenset[Any] | None]:
+    """Aggregate Literal domains accepted by all same-tag union alternatives.
+
+    A ``None`` value means at least one owner accepts an unbounded annotation.
+    Missing fields are omitted.
+    """
+    fields: Dict[str, frozenset[Any] | None] = {}
+    for owner in owners:
+        for field, annotation in _field_annotations(owner).items():
+            domain = _literal_domain(annotation)
+            if field not in fields:
+                fields[field] = domain
+            elif fields[field] is not None and domain is not None:
+                fields[field] = fields[field] | domain
+            else:
+                fields[field] = None
+    return fields
+
+
+# Input and output ownership must remain independent.
+# Some fields with the same type tag have different input and output ``Literal`` domains.
+SDK_INPUT_TAG_OWNERS = _tag_owners(ResponseInputItem)
+SDK_OUTPUT_TAG_OWNERS = _tag_owners(ResponseOutputItem)
+GYM_INPUT_TAG_OWNERS = _tag_owners(NeMoGymResponseInputItem)
+GYM_OUTPUT_TAG_OWNERS = _tag_owners(NeMoGymResponseOutputItem)
+SDK_INPUT_TAGS = frozenset(SDK_INPUT_TAG_OWNERS)
+SDK_OUTPUT_TAGS = frozenset(SDK_OUTPUT_TAG_OWNERS)
+
+# Gym accepts provider-specific MCP status strings.
+# Each exemption must identify a finite SDK ``Literal`` field.
+_UNBOUNDED_GYM_INPUT_LITERAL_FIELDS = {
+    ("mcp_call", "status"): "NVIDIA-hosted MCP endpoints may return statuses outside the SDK Literal.",
+}
 
 # Types Gym deliberately does not represent.
-# item_reference is a pointer to an item held server-side.
-# Gym replays transcripts in full and keeps no item store, so it cannot resolve one.
-# Rejecting the request is better than accepting a reference that resolves to nothing.
+# ``item_reference`` points to an item held by the server.
+# Gym keeps no item store.
+# It cannot resolve the reference while replaying a transcript.
 GYM_UNREPRESENTABLE_TYPES = frozenset({"item_reference"})
 
 
-# The SDK model each hand-written Gym model mirrors.
-# Only the pairing is declared here: which models are hand-written is derived from the union by
-# _derived_hand_written_models(), and test_hand_written_model_list_is_complete fails if this list
-# and that derivation disagree. Nothing here has to be remembered when a model is added.
+# Pair each manually defined Gym model with the SDK model it mirrors.
+# ``_derived_hand_written_models`` identifies which Gym models require a pairing.
 _HAND_WRITTEN_MODELS = [
     (NeMoGymEasyInputMessage, EasyInputMessage),
     (NeMoGymMessage, InputMessage),
@@ -634,35 +677,43 @@ _HAND_WRITTEN_MODELS = [
     (NeMoGymResponseReasoningItem, ResponseReasoningItem),
 ]
 
-# Fields left out of a hand-written model on purpose, with the reason.
-# `NeMoGymResponseReasoningItem.status` is commented out at its definition: the OpenAI API returns
-# None for it and then rejects the field when it is sent back on a later call in the same rollout.
+# Fields intentionally omitted from manually defined models.
+# The OpenAI API can return ``None`` for ``NeMoGymResponseReasoningItem.status``.
+# It rejects that field when Gym sends it in a later request.
 _DELIBERATE_FIELD_OMISSIONS = {("NeMoGymResponseReasoningItem", "status")}
 
 
-def _derived_hand_written_models() -> List[type]:
-    """Union members that copy an SDK model instead of subclassing one.
+def _deliberately_omitted_tag_fields() -> set[tuple[str, str]]:
+    models = {gym.__name__: gym for gym, _ in _HAND_WRITTEN_MODELS}
+    return {
+        (tag, field) for model_name, field in _DELIBERATE_FIELD_OMISSIONS for tag in _type_tags(models[model_name])
+    }
 
-    A member with an openai class in its MRO inherits new SDK fields, so it cannot fall behind.
-    A member that subclasses another Gym copy is covered by whatever that copy declares.
-    What is left declares its own fields against no SDK model, which is what can drift.
+
+def _derived_hand_written_models() -> List[type]:
+    """Return union members that define SDK fields without subclassing an SDK model.
+
+    A member with an OpenAI class in its MRO inherits SDK fields.
+    A member that subclasses another Gym model inherits that model's fields.
+    The remaining members define their own fields and require explicit parity checks.
     """
+    union_members = set(_union_members(NeMoGymResponseInputItem)) | set(_union_members(NeMoGymResponseOutputItem))
     copies = [
         member
-        for member in _union_members(NeMoGymResponseInputItem)
+        for member in union_members
         if not any(base.__module__.startswith("openai.") for base in member.__mro__[1:])
     ]
-    # A ForTraining variant subclasses the Gym model it adds token fields to, so it inherits
-    # whatever that model declares and is covered by checking the model it derives from.
+    # A training variant inherits the fields of its base Gym model.
+    # Checking the base model therefore covers the variant.
     return [model for model in copies if not any(other in model.__mro__[1:] for other in copies)]
 
 
 def test_hand_written_model_list_is_complete() -> None:
     """Every hand-written union member must be paired with the SDK model it mirrors.
 
-    _HAND_WRITTEN_MODELS is what the parity test iterates, so a hand-written model missing from it
-    is simply never checked. The membership half is derived rather than remembered; only the
-    pairing to an SDK model has to be written down, because nothing in the code records it.
+    The parity test iterates over ``_HAND_WRITTEN_MODELS``.
+    It derives the Gym model set independently.
+    Each SDK model pairing must be declared explicitly.
     """
     derived = {model.__name__ for model in _derived_hand_written_models()}
     declared = {gym.__name__ for gym, _ in _HAND_WRITTEN_MODELS}
@@ -685,9 +736,9 @@ def test_hand_written_model_list_is_complete() -> None:
 def test_hand_written_models_carry_every_sdk_field(gym_model: type, sdk_model: type) -> None:
     """A copied model must not fall behind the SDK model it copies.
 
-    The union tests above match on the `type` discriminator, so a Gym model keeps owning its tag
-    however far its fields drift. A field the SDK adds and Gym omits is dropped during validation
-    without an error: the request is accepted, and the value is gone from everything downstream.
+    Union membership depends on the ``type`` discriminator.
+    It does not verify field parity.
+    Validation drops SDK fields that the corresponding Gym model omits.
     """
     missing = sorted(
         field
@@ -703,8 +754,10 @@ def test_hand_written_models_carry_every_sdk_field(gym_model: type, sdk_model: t
 
 
 def test_deliberate_omissions_are_still_real_sdk_fields() -> None:
-    """An omission recorded for a field the SDK no longer has hides the next real one."""
+    """Require each deliberate omission to identify an existing SDK field."""
     by_name = {gym.__name__: sdk for gym, sdk in _HAND_WRITTEN_MODELS}
+    unknown_models = sorted(model for model, _ in _DELIBERATE_FIELD_OMISSIONS if model not in by_name)
+    assert not unknown_models, f"Deliberate omissions name unknown Gym models: {unknown_models}"
     stale = sorted(
         f"{model}.{field}"
         for model, field in _DELIBERATE_FIELD_OMISSIONS
@@ -714,10 +767,9 @@ def test_deliberate_omissions_are_still_real_sdk_fields() -> None:
 
 
 def test_sdk_union_is_introspectable() -> None:
-    """Guard the introspection itself.
+    """Verify that the SDK union introspection returns members.
 
-    If a future SDK restructures either union so the helpers above find no members, every other
-    test in this file would pass vacuously.
+    The other parity tests would pass vacuously if this introspection returned no members.
     """
     for name, tags in (("ResponseInputItem", SDK_INPUT_TAGS), ("ResponseOutputItem", SDK_OUTPUT_TAGS)):
         assert len(tags) >= 13, (
@@ -729,11 +781,164 @@ def test_sdk_union_is_introspectable() -> None:
         assert "function_call" in tags
 
 
-def test_sdk_output_types_are_a_subset_of_input_types() -> None:
-    """The input union is used as the source of truth, which relies on it being the wider set.
+def test_gym_unions_are_introspectable_independently() -> None:
+    """Verify input and output union introspection independently."""
+    for name, owners in (
+        ("NeMoGymResponseInputItem", GYM_INPUT_TAG_OWNERS),
+        ("NeMoGymResponseOutputItem", GYM_OUTPUT_TAG_OWNERS),
+    ):
+        assert len(owners) >= 12, (
+            f"Only found {len(owners)} tagged members in {name}. Its union shape probably changed "
+            f"and this file's introspection needs updating -- do not point both sides at one alias."
+        )
+        assert all(tag and tagged_owners for tag, tagged_owners in owners.items())
 
-    A type the provider can return but a client cannot send would go unchecked.
-    Gym would then 500 on replaying that item back as history, which is how issue #2436 happened.
+
+def test_sdk_literal_domains_are_introspectable() -> None:
+    """Verify that field introspection returns ``Literal`` domains."""
+    for name, owners in (
+        ("ResponseInputItem", SDK_INPUT_TAG_OWNERS),
+        ("ResponseOutputItem", SDK_OUTPUT_TAG_OWNERS),
+        ("NeMoGymResponseInputItem", GYM_INPUT_TAG_OWNERS),
+        ("NeMoGymResponseOutputItem", GYM_OUTPUT_TAG_OWNERS),
+    ):
+        literal_fields = {
+            (tag, field)
+            for tag, tag_owners in owners.items()
+            for field, domain in _literal_fields(tag_owners).items()
+            if domain is not None
+        }
+        assert len(literal_fields) >= 20, (
+            f"Only found {len(literal_fields)} top-level Literal fields in {name}; "
+            f"the structural parity checks would be mostly vacuous."
+        )
+        assert ("message", "role") in literal_fields
+        assert ("function_call", "type") in literal_fields
+
+
+def test_literal_domain_unwraps_transparent_typing_layers() -> None:
+    wrapped = Annotated[
+        Union[Required[Literal["first"]], NotRequired[Literal["second"]], None],
+        "metadata",
+    ]
+    assert _literal_domain(wrapped) == frozenset({"first", "second"})
+    assert _literal_domain(Union[Literal["bounded"], str]) is None
+
+
+@pytest.mark.parametrize("tag", sorted(SDK_OUTPUT_TAGS))
+def test_gym_output_accepts_every_sdk_output_literal(tag: str) -> None:
+    """Provider output Literal values must survive Gym response validation."""
+    sdk_fields = _literal_fields(SDK_OUTPUT_TAG_OWNERS[tag])
+    gym_fields = _literal_fields(GYM_OUTPUT_TAG_OWNERS.get(tag, []))
+    for field, sdk_domain in sdk_fields.items():
+        if sdk_domain is None:
+            continue
+        if (tag, field) in _deliberately_omitted_tag_fields():
+            continue
+        assert field in gym_fields, (
+            f"openai {openai.__version__} output {tag}.{field} has Literal domain "
+            f"{sorted(sdk_domain, key=repr)}, but no Gym output owner declares that field."
+        )
+        gym_domain = gym_fields[field]
+        if gym_domain is None:  # An unbounded annotation accepts every provider value.
+            continue
+        missing = sdk_domain - gym_domain
+        assert not missing, (
+            f"openai {openai.__version__} can output {tag}.{field} values "
+            f"{sorted(missing, key=repr)} that Gym rejects. SDK={sorted(sdk_domain, key=repr)}, "
+            f"Gym output={sorted(gym_domain, key=repr)}."
+        )
+
+
+@pytest.mark.parametrize("tag", sorted(SDK_INPUT_TAGS))
+def test_gym_input_literal_domains_match_sdk_input(tag: str) -> None:
+    """Gym must accept the SDK input domain without admitting unsendable Literals."""
+    if tag in GYM_UNREPRESENTABLE_TYPES:
+        return
+    sdk_fields = _literal_fields(SDK_INPUT_TAG_OWNERS[tag])
+    gym_fields = _literal_fields(GYM_INPUT_TAG_OWNERS.get(tag, []))
+    for field, sdk_domain in sdk_fields.items():
+        if sdk_domain is None:
+            continue
+        if (tag, field) in _deliberately_omitted_tag_fields():
+            continue
+        assert field in gym_fields, (
+            f"openai {openai.__version__} input {tag}.{field} has Literal domain "
+            f"{sorted(sdk_domain, key=repr)}, but no Gym input owner declares that field."
+        )
+        gym_domain = gym_fields[field]
+        if gym_domain is None:
+            assert (tag, field) in _UNBOUNDED_GYM_INPUT_LITERAL_FIELDS, (
+                f"Gym input {tag}.{field} is unbounded while the SDK domain is "
+                f"{sorted(sdk_domain, key=repr)}. Narrow it to the SDK domain or explicitly "
+                f"document the provider-tolerance widening."
+            )
+            continue
+        missing = sdk_domain - gym_domain
+        extra = gym_domain - sdk_domain
+        assert not missing, f"Gym rejects SDK-supported input values for {tag}.{field}: {sorted(missing, key=repr)}."
+        assert not extra, (
+            f"Gym input {tag}.{field} accepts {sorted(extra, key=repr)}, but openai "
+            f"{openai.__version__} input accepts only {sorted(sdk_domain, key=repr)}. "
+            f"This usually means one Gym class is shared with a wider SDK output model. "
+            f"Split the Gym input/output owners and normalize provider output before input validation."
+        )
+    gym_only_literals = {
+        field: domain for field, domain in gym_fields.items() if domain is not None and field not in sdk_fields
+    }
+    assert not gym_only_literals, (
+        f"Gym input {tag!r} declares Literal fields absent from the SDK input model: "
+        f"{gym_only_literals}. These are usually output-only fields leaking through a shared owner."
+    )
+
+
+def test_shared_gym_owners_do_not_hide_unreplayable_output_literals() -> None:
+    """A shared class cannot model output values that the SDK rejects as input."""
+    for tag in sorted(SDK_OUTPUT_TAGS & SDK_INPUT_TAGS):
+        output_fields = _literal_fields(SDK_OUTPUT_TAG_OWNERS[tag])
+        input_fields = _literal_fields(SDK_INPUT_TAG_OWNERS[tag])
+        shared_owners = set(GYM_OUTPUT_TAG_OWNERS.get(tag, [])) & set(GYM_INPUT_TAG_OWNERS.get(tag, []))
+        for field, output_domain in output_fields.items():
+            input_domain = input_fields.get(field, frozenset())
+            if output_domain is None or input_domain is None:
+                continue
+            unreplayable = output_domain - input_domain
+            if not unreplayable:
+                continue
+            unsafe_shared = [
+                owner.__name__
+                for owner in shared_owners
+                if (domain := _literal_domain(_field_annotations(owner).get(field))) is None
+                or bool(domain & unreplayable)
+            ]
+            assert not unsafe_shared, (
+                f"openai {openai.__version__} output {tag}.{field} adds "
+                f"{sorted(unreplayable, key=repr)}, which its input schema rejects, while Gym shares "
+                f"{unsafe_shared} between input and output. Split the Gym owners, then normalize "
+                f"provider output before validating replay input."
+            )
+
+
+def test_unbounded_input_literal_exemptions_are_live() -> None:
+    """Require each exemption to match bounded SDK and unbounded Gym fields."""
+    for tag, field in _UNBOUNDED_GYM_INPUT_LITERAL_FIELDS:
+        assert tag in SDK_INPUT_TAG_OWNERS and tag in GYM_INPUT_TAG_OWNERS, (
+            f"Unbounded input exemption {(tag, field)} names a tag absent from one input union."
+        )
+        sdk_domain = _literal_fields(SDK_INPUT_TAG_OWNERS[tag]).get(field)
+        gym_domain = _literal_fields(GYM_INPUT_TAG_OWNERS[tag]).get(field, frozenset())
+        assert sdk_domain is not None, (
+            f"Unbounded input exemption {(tag, field)} is dead: SDK has no finite Literal domain."
+        )
+        assert gym_domain is None, f"Unbounded input exemption {(tag, field)} is dead: Gym is no longer unbounded."
+
+
+def test_sdk_output_types_are_a_subset_of_input_types() -> None:
+    """Verify that the input union includes every output item type.
+
+    The tests use the input union as the source of item types.
+    An output-only type would otherwise go unchecked.
+    Gym could then fail when replaying that item as history.
     """
     emitted_but_not_sendable = sorted(set(SDK_OUTPUT_TAGS) - set(SDK_INPUT_TAGS))
     assert not emitted_but_not_sendable, (
@@ -745,19 +950,18 @@ def test_sdk_output_types_are_a_subset_of_input_types() -> None:
 
 @pytest.mark.parametrize("tag", sorted(SDK_INPUT_TAGS))
 def test_gym_union_represents_every_sdk_item_type(tag: str) -> None:
-    """Every type a client can send needs a Gym union member, or an explicit decision not to.
+    """Require a Gym union member or explicit exclusion for each SDK input type.
 
     Without one, ``NeMoGymResponse.model_validate`` returns a 500 on the non-streaming path.
-    On the streaming path, ``sanitize_streaming_responses_body`` drops the item from the replayed
-    transcript with a warning and returns 200.
+    ``sanitize_streaming_responses_body`` drops the item on the streaming path.
     """
     if tag in GYM_UNREPRESENTABLE_TYPES:
-        assert tag not in GYM_TAG_OWNERS, (
+        assert tag not in GYM_INPUT_TAG_OWNERS, (
             f"{tag!r} is listed in GYM_UNREPRESENTABLE_TYPES but NeMoGymResponseInputItem now has "
             f"a member for it. Remove it from that list."
         )
         return
-    assert tag in GYM_TAG_OWNERS, (
+    assert tag in GYM_INPUT_TAG_OWNERS, (
         f"openai {openai.__version__} accepts a {tag!r} item and "
         f"NeMoGymResponseInputItem has no member for it.\n"
         f"Fix: add a NeMoGym* wrapper in nemo_gym/openai_utils.py and list it in "
@@ -770,10 +974,10 @@ def test_gym_union_represents_every_sdk_item_type(tag: str) -> None:
 
 @pytest.mark.parametrize("tag", sorted(SDK_INPUT_TAGS))
 def test_every_sdk_item_type_is_classified(tag: str) -> None:
-    """Each type Gym can carry is either a generation boundary or explicitly not one.
+    """Classify each represented SDK item type by whether the model generated it.
 
     The classification cannot be read off the SDK.
-    Later versions put tool results in ``ResponseOutputItem`` alongside generated items.
+    ``ResponseOutputItem`` can contain tool results and generated items.
     An unclassified type falls to the "not a boundary" side by default.
     That labels sampled tokens as prompt.
     """
@@ -799,11 +1003,10 @@ def test_boundary_sets_are_disjoint() -> None:
 
 
 def test_message_is_not_in_the_boundary_set() -> None:
-    """A user or system message must not open the trained segment.
+    """Keep user and system messages out of the generated output segment.
 
     ``split_responses_input_output_items`` handles assistant messages through its ``role == "assistant"`` check.
-    Adding "message" to the type set would make the first prompt message a boundary.
-    That classifies the whole prompt as generation.
+    Adding ``message`` to the type set would classify prompt messages as generated output.
     """
     assert "message" not in _RESPONSE_OUTPUT_BOUNDARY_TYPES
 
@@ -818,18 +1021,10 @@ def test_message_is_not_in_the_boundary_set() -> None:
     ],
 )
 def test_no_dead_entries_in_any_type_list(set_name: str, tags: frozenset) -> None:
-    """Every tag named in any of these lists must be a Responses item type at the installed SDK.
+    """Require every listed tag to be an item type in the installed SDK.
 
-    A tag that is not one never matches anything.
-    It also makes the list look more complete than it is.
-    Naming a type the pinned SDK lacks has the same effect, since nothing exercises the entry, so a
-    type is added in the change that raises the pin far enough to introduce it.
-
-    Every list is checked, because each one goes stale silently and in its own way:
-    a dead entry in the classification sets leaves its intended type unclassified, and a dead entry
-    in an exemption list leaves its intended type checked when it was meant to be skipped, or the
-    reverse. In both cases the tests that would notice are parametrized over the SDK's tags, so they
-    never visit a tag the SDK does not have.
+    An unknown tag never matches an item.
+    The SDK-based parameterization also cannot exercise an unknown tag.
     """
     suspicious = tags - set(SDK_INPUT_TAGS)
     assert not suspicious, (
@@ -840,12 +1035,10 @@ def test_no_dead_entries_in_any_type_list(set_name: str, tags: frozenset) -> Non
 
 
 def _classes_the_converter_can_emit() -> List[str]:
-    """Every class that can end up in postprocess_assistant_message_dict's output list.
+    """Return classes that can enter the converter's response output list.
 
     ``training_variant_of`` has one production caller, which passes it ``response_output[-1].__class__``.
-    That list is local to the function.
-    The classes that can reach the lookup are exactly those appended to it, which the AST can enumerate.
-    This is derived rather than hard-coded, so adding a fourth ``append`` fails this test.
+    The AST identifies classes appended to that local list.
     """
     import ast
     import inspect
@@ -860,7 +1053,7 @@ def _classes_the_converter_can_emit() -> List[str]:
         and node.name == "postprocess_assistant_message_dict"
     )
 
-    # name -> class it is constructed from, for locals appended by reference
+    # Map each local variable to the class used to construct it.
     local_classes = {}
     for node in ast.walk(func):
         if isinstance(node, ast.Assign):
@@ -883,18 +1076,16 @@ def _classes_the_converter_can_emit() -> List[str]:
                 emitted.add(arg.func.id)
             elif isinstance(arg, ast.Name) and arg.id in local_classes:
                 emitted.add(local_classes[arg.id])
-            else:  # pragma: no cover - a shape this analysis does not model
+            else:  # pragma: no cover - an unsupported AST expression
                 emitted.add(f"<unresolved: {ast.dump(arg)[:60]}>")
     return sorted(emitted)
 
 
 def test_every_item_the_converter_can_emit_has_a_training_variant() -> None:
-    """Whatever can reach ``training_variant_of`` must be registered in RESPONSES_TO_TRAIN.
+    """Require a training variant for each class passed to ``training_variant_of``.
 
-    Note this is not "every model-emitted type has a variant".
-    Each variant is another member of the ``NeMoGymResponseInputItem`` smart union.
-    An unrecognised item reports every member's errors.
-    So a type gets a variant once a converter can emit it carrying sampled token IDs.
+    Each variant is a member of ``NeMoGymResponseInputItem``.
+    A type needs a variant when the converter can attach sampled token IDs to it.
     """
     emitted = _classes_the_converter_can_emit()
     unresolved = [name for name in emitted if name.startswith("<unresolved")]
@@ -916,7 +1107,7 @@ def test_every_item_the_converter_can_emit_has_a_training_variant() -> None:
 
 
 def test_training_variants_actually_carry_token_fields() -> None:
-    """A registered variant must really add the token payload, not just be a distinct class."""
+    """Require each registered variant to define the token payload fields."""
     for base, variant in RESPONSES_TO_TRAIN.items():
         assert issubclass(variant, base), f"{variant.__name__} must subclass {base.__name__}"
         assert issubclass(variant, TokenIDLogProbMixin), f"{variant.__name__} must mix in TokenIDLogProbMixin"
@@ -925,14 +1116,20 @@ def test_training_variants_actually_carry_token_fields() -> None:
 
 
 def test_training_variants_are_in_the_union() -> None:
-    """A variant absent from the union cannot round-trip: it serializes but fails to validate."""
+    """Require each training variant to belong to the input union.
+
+    A variant outside the union serializes but fails validation.
+    """
     union_members = set(_union_members(NeMoGymResponseInputItem))
     missing = sorted(v.__name__ for v in RESPONSES_TO_TRAIN.values() if v not in union_members)
     assert not missing, f"ForTraining variants missing from NeMoGymResponseInputItem: {missing}"
 
 
 def test_training_variant_lookup_fails_with_a_named_error() -> None:
-    """An unregistered class must not surface as a bare KeyError (a 500 with no explanation)."""
+    """Require a descriptive error for an unregistered class.
+
+    A bare ``KeyError`` would produce an unexplained server error.
+    """
 
     class _Unregistered:
         pass
@@ -942,13 +1139,12 @@ def test_training_variant_lookup_fails_with_a_named_error() -> None:
 
 
 def test_duplicate_type_tags_are_documented() -> None:
-    """Record which tags map to several union members.
+    """Require explicit coverage for tags that map to several union members.
 
-    These are why ``Field(discriminator="type")`` cannot be used.
-    They are also why one unrecognised item produces errors from every union member.
-    Pinning the expected set makes a new collision a deliberate change.
+    Duplicate tags prevent use of ``Field(discriminator="type")``.
+    They also make an unrecognized item report errors from every union member.
     """
-    duplicates = {tag for tag, owners in GYM_TAG_OWNERS.items() if len(owners) > 1}
+    duplicates = {tag for tag, owners in GYM_INPUT_TAG_OWNERS.items() if len(owners) > 1}
     assert duplicates == {"message", "function_call", "reasoning"}, (
         f"duplicate type tags changed: {sorted(duplicates)}. Each duplicate widens the error "
         f"report for an unrecognised item; update this test if the change is intended."

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -12,14 +12,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Annotated, Any, Dict, List, Literal, get_args, get_origin
+
+import openai
 import pytest
 from openai.types.responses import (
+    EasyInputMessage,
     ResponseCodeInterpreterToolCall,
     ResponseComputerToolCall,
     ResponseCustomToolCall,
     ResponseFileSearchToolCall,
+    ResponseFunctionToolCall,
     ResponseFunctionWebSearch,
+    ResponseOutputItem,
+    ResponseOutputMessage,
+    ResponseReasoningItem,
 )
+from openai.types.responses.response_input_item import (
+    FunctionCallOutput as InputFunctionCallOutput,
+)
+from openai.types.responses.response_input_item import (
+    Message as InputMessage,
+)
+from openai.types.responses.response_input_item import ResponseInputItem
 from openai.types.responses.response_output_item import (
     ImageGenerationCall,
     LocalShellCall,
@@ -30,29 +45,41 @@ from openai.types.responses.response_output_item import (
 from pydantic import ValidationError
 
 from nemo_gym.openai_utils import (
+    RESPONSES_TO_TRAIN,
     NeMoGymAsyncOpenAI,
     NeMoGymChatCompletion,
     NeMoGymChatCompletionCreateParamsNonStreaming,
     NeMoGymChatCompletionMessageCustomToolCall,
     NeMoGymChoice,
+    NeMoGymEasyInputMessage,
     NeMoGymFunctionCallOutput,
     NeMoGymImageGenerationCall,
     NeMoGymLocalShellCall,
+    NeMoGymMessage,
     NeMoGymResponse,
     NeMoGymResponseCodeInterpreterToolCall,
     NeMoGymResponseComputerToolCall,
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseCustomToolCall,
     NeMoGymResponseFileSearchToolCall,
+    NeMoGymResponseFunctionToolCall,
     NeMoGymResponseFunctionWebSearch,
+    NeMoGymResponseInputItem,
     NeMoGymResponseInputTokensDetails,
     NeMoGymResponseMcpApprovalRequest,
     NeMoGymResponseMcpCall,
     NeMoGymResponseMcpListTools,
+    NeMoGymResponseOutputMessage,
     NeMoGymResponseOutputTokensDetails,
+    NeMoGymResponseReasoningItem,
     NeMoGymResponseUsage,
     TokenIDLogProbMixin,
     accumulate_response_usage,
+    training_variant_of,
+)
+from nemo_gym.responses_converter import (
+    _RESPONSE_NON_BOUNDARY_TYPES,
+    _RESPONSE_OUTPUT_BOUNDARY_TYPES,
 )
 
 
@@ -509,3 +536,420 @@ def test_accumulate_response_usage_tolerates_missing_detail_objects() -> None:
     assert (result.input_tokens, result.output_tokens, result.total_tokens) == (20, 10, 30)
     assert result.input_tokens_details is None
     assert result.output_tokens_details.reasoning_tokens == 1
+
+
+# ===========================================================================
+# Responses item coverage against the installed openai SDK
+#
+# Gym declares its own NeMoGym* item classes rather than using the SDK's.
+# It also keeps three hand-maintained lists derived from the same SDK union:
+#   NeMoGymResponseInputItem, which types Gym can represent
+#   _RESPONSE_OUTPUT_BOUNDARY_TYPES, which types start the model's generation
+#   RESPONSES_TO_TRAIN, which types can carry sampled token IDs
+#
+# ResponseOutputItem gains members with most openai releases.
+# None of the three lists is derived from it, so nothing else fails when they fall behind.
+# Drift shows up as a 500 on the non-streaming path.
+# On the streaming path it shows up as a silently truncated transcript.
+#
+# Run these against every version in the supported openai window, not only the pinned one.
+# ===========================================================================
+
+
+# `message` is covered by split_responses_input_output_items' `role == "assistant"` check.
+# The type set does not carry it, so it is exempt from the boundary classification.
+_BOUNDARY_EXEMPT = frozenset({"message"})
+
+
+def _unwrap(annotation: Any) -> Any:
+    """Strip ``Annotated`` wrappers.
+
+    ``ResponseOutputItem`` is ``Annotated[Union[...], PropertyInfo]``.
+    Gym's output item is ``Annotated[Union[...], BeforeValidator]``.
+    Without unwrapping, ``get_args`` returns the two ``Annotated`` arguments instead of the union members.
+    """
+    while get_origin(annotation) is Annotated:
+        annotation = get_args(annotation)[0]
+    return annotation
+
+
+def _union_members(annotation: Any) -> List[type]:
+    annotation = _unwrap(annotation)
+    args = get_args(annotation)
+    return [_unwrap(arg) for arg in args] if args else [annotation]
+
+
+def _type_tags(model: type) -> List[str]:
+    """The ``Literal`` values of a pydantic model's ``type`` field."""
+    field = getattr(model, "model_fields", {}).get("type")
+    if field is None:
+        return []
+    annotation = field.annotation
+    if get_origin(annotation) is Literal:
+        return [str(value) for value in get_args(annotation)]
+    return [str(value) for arg in get_args(annotation) if get_origin(arg) is Literal for value in get_args(arg)]
+
+
+def _sdk_tags(union: Any) -> Dict[str, type]:
+    tags: Dict[str, type] = {}
+    for member in _union_members(union):
+        for tag in _type_tags(member):
+            tags.setdefault(tag, member)
+    return tags
+
+
+def _gym_tag_owners() -> Dict[str, List[type]]:
+    owners: Dict[str, List[type]] = {}
+    for member in _union_members(NeMoGymResponseInputItem):
+        for tag in _type_tags(member):
+            owners.setdefault(tag, []).append(member)
+    return owners
+
+
+# ResponseInputItem is the source of truth rather than ResponseOutputItem.
+# Gym has to carry every type a client can send, which is the wider set:
+# test_sdk_output_types_are_a_subset_of_input_types keeps that relationship honest.
+# An item type Gym cannot represent is a 500 on the non-streaming path either way.
+SDK_INPUT_TAGS = _sdk_tags(ResponseInputItem)
+SDK_OUTPUT_TAGS = _sdk_tags(ResponseOutputItem)
+GYM_TAG_OWNERS = _gym_tag_owners()
+
+# Types Gym deliberately does not represent.
+# item_reference is a pointer to an item held server-side.
+# Gym replays transcripts in full and keeps no item store, so it cannot resolve one.
+# Rejecting the request is better than accepting a reference that resolves to nothing.
+GYM_UNREPRESENTABLE_TYPES = frozenset({"item_reference"})
+
+
+# The SDK model each hand-written Gym model mirrors.
+# Only the pairing is declared here: which models are hand-written is derived from the union by
+# _derived_hand_written_models(), and test_hand_written_model_list_is_complete fails if this list
+# and that derivation disagree. Nothing here has to be remembered when a model is added.
+_HAND_WRITTEN_MODELS = [
+    (NeMoGymEasyInputMessage, EasyInputMessage),
+    (NeMoGymMessage, InputMessage),
+    (NeMoGymResponseOutputMessage, ResponseOutputMessage),
+    (NeMoGymResponseFunctionToolCall, ResponseFunctionToolCall),
+    (NeMoGymFunctionCallOutput, InputFunctionCallOutput),
+    (NeMoGymResponseReasoningItem, ResponseReasoningItem),
+]
+
+# Fields left out of a hand-written model on purpose, with the reason.
+# `NeMoGymResponseReasoningItem.status` is commented out at its definition: the OpenAI API returns
+# None for it and then rejects the field when it is sent back on a later call in the same rollout.
+_DELIBERATE_FIELD_OMISSIONS = {("NeMoGymResponseReasoningItem", "status")}
+
+
+def _derived_hand_written_models() -> List[type]:
+    """Union members that copy an SDK model instead of subclassing one.
+
+    A member with an openai class in its MRO inherits new SDK fields, so it cannot fall behind.
+    A member that subclasses another Gym copy is covered by whatever that copy declares.
+    What is left declares its own fields against no SDK model, which is what can drift.
+    """
+    copies = [
+        member
+        for member in _union_members(NeMoGymResponseInputItem)
+        if not any(base.__module__.startswith("openai.") for base in member.__mro__[1:])
+    ]
+    # A ForTraining variant subclasses the Gym model it adds token fields to, so it inherits
+    # whatever that model declares and is covered by checking the model it derives from.
+    return [model for model in copies if not any(other in model.__mro__[1:] for other in copies)]
+
+
+def test_hand_written_model_list_is_complete() -> None:
+    """Every hand-written union member must be paired with the SDK model it mirrors.
+
+    _HAND_WRITTEN_MODELS is what the parity test iterates, so a hand-written model missing from it
+    is simply never checked. The membership half is derived rather than remembered; only the
+    pairing to an SDK model has to be written down, because nothing in the code records it.
+    """
+    derived = {model.__name__ for model in _derived_hand_written_models()}
+    declared = {gym.__name__ for gym, _ in _HAND_WRITTEN_MODELS}
+
+    unpaired = sorted(derived - declared)
+    assert not unpaired, (
+        f"{unpaired} declare their own fields rather than subclassing an openai model, so they can "
+        f"fall behind the SDK, and nothing checks them.\n"
+        f"Fix: add each to _HAND_WRITTEN_MODELS with the SDK model it mirrors."
+    )
+
+    no_longer_hand_written = sorted(declared - derived)
+    assert not no_longer_hand_written, (
+        f"{no_longer_hand_written} are in _HAND_WRITTEN_MODELS but now subclass an openai model, "
+        f"so they inherit its fields. Remove them from that list."
+    )
+
+
+@pytest.mark.parametrize("gym_model, sdk_model", _HAND_WRITTEN_MODELS, ids=lambda m: getattr(m, "__name__", m))
+def test_hand_written_models_carry_every_sdk_field(gym_model: type, sdk_model: type) -> None:
+    """A copied model must not fall behind the SDK model it copies.
+
+    The union tests above match on the `type` discriminator, so a Gym model keeps owning its tag
+    however far its fields drift. A field the SDK adds and Gym omits is dropped during validation
+    without an error: the request is accepted, and the value is gone from everything downstream.
+    """
+    missing = sorted(
+        field
+        for field in sdk_model.model_fields
+        if field not in gym_model.model_fields and (gym_model.__name__, field) not in _DELIBERATE_FIELD_OMISSIONS
+    )
+    assert not missing, (
+        f"{sdk_model.__name__} at openai {openai.__version__} has {missing} and "
+        f"{gym_model.__name__} does not, so those fields are silently dropped.\n"
+        f"Fix: add the field with the SDK's type, or record it in _DELIBERATE_FIELD_OMISSIONS "
+        f"with the reason."
+    )
+
+
+def test_deliberate_omissions_are_still_real_sdk_fields() -> None:
+    """An omission recorded for a field the SDK no longer has hides the next real one."""
+    by_name = {gym.__name__: sdk for gym, sdk in _HAND_WRITTEN_MODELS}
+    stale = sorted(
+        f"{model}.{field}"
+        for model, field in _DELIBERATE_FIELD_OMISSIONS
+        if model in by_name and field not in by_name[model].model_fields
+    )
+    assert not stale, f"{stale} are recorded as deliberate omissions but the SDK no longer has them."
+
+
+def test_sdk_union_is_introspectable() -> None:
+    """Guard the introspection itself.
+
+    If a future SDK restructures either union so the helpers above find no members, every other
+    test in this file would pass vacuously.
+    """
+    for name, tags in (("ResponseInputItem", SDK_INPUT_TAGS), ("ResponseOutputItem", SDK_OUTPUT_TAGS)):
+        assert len(tags) >= 13, (
+            f"Only found {len(tags)} tagged members in {name} at openai {openai.__version__}. "
+            f"The union shape probably changed and this file's introspection needs updating -- "
+            f"do not relax this assertion."
+        )
+        assert "message" in tags
+        assert "function_call" in tags
+
+
+def test_sdk_output_types_are_a_subset_of_input_types() -> None:
+    """The input union is used as the source of truth, which relies on it being the wider set.
+
+    A type the provider can return but a client cannot send would go unchecked.
+    Gym would then 500 on replaying that item back as history, which is how issue #2436 happened.
+    """
+    emitted_but_not_sendable = sorted(set(SDK_OUTPUT_TAGS) - set(SDK_INPUT_TAGS))
+    assert not emitted_but_not_sendable, (
+        f"openai {openai.__version__} can return {emitted_but_not_sendable} but does not accept "
+        f"them as input items, so driving these tests off ResponseInputItem no longer covers "
+        f"everything. Check both unions here."
+    )
+
+
+@pytest.mark.parametrize("tag", sorted(SDK_INPUT_TAGS))
+def test_gym_union_represents_every_sdk_item_type(tag: str) -> None:
+    """Every type a client can send needs a Gym union member, or an explicit decision not to.
+
+    Without one, ``NeMoGymResponse.model_validate`` returns a 500 on the non-streaming path.
+    On the streaming path, ``sanitize_streaming_responses_body`` drops the item from the replayed
+    transcript with a warning and returns 200.
+    """
+    if tag in GYM_UNREPRESENTABLE_TYPES:
+        assert tag not in GYM_TAG_OWNERS, (
+            f"{tag!r} is listed in GYM_UNREPRESENTABLE_TYPES but NeMoGymResponseInputItem now has "
+            f"a member for it. Remove it from that list."
+        )
+        return
+    assert tag in GYM_TAG_OWNERS, (
+        f"openai {openai.__version__} accepts a {tag!r} item and "
+        f"NeMoGymResponseInputItem has no member for it.\n"
+        f"Fix: add a NeMoGym* wrapper in nemo_gym/openai_utils.py and list it in "
+        f"NeMoGymResponseInputItem. Then classify it in nemo_gym/responses_converter.py as "
+        f"either _RESPONSE_OUTPUT_BOUNDARY_TYPES (the model generated it) or "
+        f"_RESPONSE_NON_BOUNDARY_TYPES (a client-supplied result or bookkeeping).\n"
+        f"If Gym should not represent it, add it to GYM_UNREPRESENTABLE_TYPES with the reason."
+    )
+
+
+@pytest.mark.parametrize("tag", sorted(SDK_INPUT_TAGS))
+def test_every_sdk_item_type_is_classified(tag: str) -> None:
+    """Each type Gym can carry is either a generation boundary or explicitly not one.
+
+    The classification cannot be read off the SDK.
+    Later versions put tool results in ``ResponseOutputItem`` alongside generated items.
+    An unclassified type falls to the "not a boundary" side by default.
+    That labels sampled tokens as prompt.
+    """
+    if tag in _BOUNDARY_EXEMPT or tag in GYM_UNREPRESENTABLE_TYPES:
+        return
+    is_boundary = tag in _RESPONSE_OUTPUT_BOUNDARY_TYPES
+    is_not_boundary = tag in _RESPONSE_NON_BOUNDARY_TYPES
+    assert is_boundary or is_not_boundary, (
+        f"openai {openai.__version__} has an output item type {tag!r} that is in neither "
+        f"_RESPONSE_OUTPUT_BOUNDARY_TYPES nor _RESPONSE_NON_BOUNDARY_TYPES "
+        f"(nemo_gym/responses_converter.py).\n"
+        f"Decide: did the model generate this item (boundary), or did the client supply it as a "
+        f"tool result / approval / bookkeeping (not a boundary)? Defaulting is not safe."
+    )
+    assert not (is_boundary and is_not_boundary), (
+        f"{tag!r} is in both the boundary and non-boundary sets; they must stay disjoint."
+    )
+
+
+def test_boundary_sets_are_disjoint() -> None:
+    overlap = _RESPONSE_OUTPUT_BOUNDARY_TYPES & _RESPONSE_NON_BOUNDARY_TYPES
+    assert not overlap, f"a type cannot be both a boundary and not a boundary: {sorted(overlap)}"
+
+
+def test_message_is_not_in_the_boundary_set() -> None:
+    """A user or system message must not open the trained segment.
+
+    ``split_responses_input_output_items`` handles assistant messages through its ``role == "assistant"`` check.
+    Adding "message" to the type set would make the first prompt message a boundary.
+    That classifies the whole prompt as generation.
+    """
+    assert "message" not in _RESPONSE_OUTPUT_BOUNDARY_TYPES
+
+
+@pytest.mark.parametrize(
+    "set_name, tags",
+    [
+        ("_RESPONSE_OUTPUT_BOUNDARY_TYPES", _RESPONSE_OUTPUT_BOUNDARY_TYPES),
+        ("_RESPONSE_NON_BOUNDARY_TYPES", _RESPONSE_NON_BOUNDARY_TYPES),
+        ("GYM_UNREPRESENTABLE_TYPES", GYM_UNREPRESENTABLE_TYPES),
+        ("_BOUNDARY_EXEMPT", _BOUNDARY_EXEMPT),
+    ],
+)
+def test_no_dead_entries_in_any_type_list(set_name: str, tags: frozenset) -> None:
+    """Every tag named in any of these lists must be a Responses item type at the installed SDK.
+
+    A tag that is not one never matches anything.
+    It also makes the list look more complete than it is.
+    Naming a type the pinned SDK lacks has the same effect, since nothing exercises the entry, so a
+    type is added in the change that raises the pin far enough to introduce it.
+
+    Every list is checked, because each one goes stale silently and in its own way:
+    a dead entry in the classification sets leaves its intended type unclassified, and a dead entry
+    in an exemption list leaves its intended type checked when it was meant to be skipped, or the
+    reverse. In both cases the tests that would notice are parametrized over the SDK's tags, so they
+    never visit a tag the SDK does not have.
+    """
+    suspicious = tags - set(SDK_INPUT_TAGS)
+    assert not suspicious, (
+        f"{sorted(suspicious)} are in {set_name} but are not Responses item types at openai "
+        f"{openai.__version__}. Either the tag is a typo, or it belongs to a later SDK and should "
+        f"be added when the pin moves."
+    )
+
+
+def _classes_the_converter_can_emit() -> List[str]:
+    """Every class that can end up in postprocess_assistant_message_dict's output list.
+
+    ``training_variant_of`` has one production caller, which passes it ``response_output[-1].__class__``.
+    That list is local to the function.
+    The classes that can reach the lookup are exactly those appended to it, which the AST can enumerate.
+    This is derived rather than hard-coded, so adding a fourth ``append`` fails this test.
+    """
+    import ast
+    import inspect
+
+    from nemo_gym import responses_converter
+
+    tree = ast.parse(inspect.getsource(responses_converter))
+    func = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "postprocess_assistant_message_dict"
+    )
+
+    # name -> class it is constructed from, for locals appended by reference
+    local_classes = {}
+    for node in ast.walk(func):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and isinstance(node.value, ast.Call):
+                    if isinstance(node.value.func, ast.Name):
+                        local_classes[target.id] = node.value.func.id
+
+    emitted = set()
+    for node in ast.walk(func):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        base = node.func.value
+        if not (isinstance(base, ast.Name) and base.id == "response_output"):
+            continue
+        if node.func.attr not in ("append", "extend", "insert"):
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.Call) and isinstance(arg.func, ast.Name):
+                emitted.add(arg.func.id)
+            elif isinstance(arg, ast.Name) and arg.id in local_classes:
+                emitted.add(local_classes[arg.id])
+            else:  # pragma: no cover - a shape this analysis does not model
+                emitted.add(f"<unresolved: {ast.dump(arg)[:60]}>")
+    return sorted(emitted)
+
+
+def test_every_item_the_converter_can_emit_has_a_training_variant() -> None:
+    """Whatever can reach ``training_variant_of`` must be registered in RESPONSES_TO_TRAIN.
+
+    Note this is not "every model-emitted type has a variant".
+    Each variant is another member of the ``NeMoGymResponseInputItem`` smart union.
+    An unrecognised item reports every member's errors.
+    So a type gets a variant once a converter can emit it carrying sampled token IDs.
+    """
+    emitted = _classes_the_converter_can_emit()
+    unresolved = [name for name in emitted if name.startswith("<unresolved")]
+    assert not unresolved, (
+        f"this test's AST analysis could not resolve {unresolved} in "
+        f"postprocess_assistant_message_dict, so it cannot prove the invariant. Extend "
+        f"_classes_the_converter_can_emit rather than deleting the assertion."
+    )
+
+    registered = {cls.__name__ for cls in RESPONSES_TO_TRAIN}
+    missing = sorted(set(emitted) - registered)
+    assert not missing, (
+        f"ResponsesConverter.postprocess_assistant_message_dict can emit {missing}, and "
+        f"responses_converter.py hands response_output[-1] to training_variant_of(), so a "
+        f"rollout carrying token IDs would fail there.\n"
+        f"Fix: declare `class <Name>ForTraining(<Name>, TokenIDLogProbMixin)`, add it to "
+        f"NeMoGymResponseInputItem, and register the pair in RESPONSES_TO_TRAIN."
+    )
+
+
+def test_training_variants_actually_carry_token_fields() -> None:
+    """A registered variant must really add the token payload, not just be a distinct class."""
+    for base, variant in RESPONSES_TO_TRAIN.items():
+        assert issubclass(variant, base), f"{variant.__name__} must subclass {base.__name__}"
+        assert issubclass(variant, TokenIDLogProbMixin), f"{variant.__name__} must mix in TokenIDLogProbMixin"
+        for field in ("prompt_token_ids", "generation_token_ids", "generation_log_probs"):
+            assert field in variant.model_fields, f"{variant.__name__} is missing {field}"
+
+
+def test_training_variants_are_in_the_union() -> None:
+    """A variant absent from the union cannot round-trip: it serializes but fails to validate."""
+    union_members = set(_union_members(NeMoGymResponseInputItem))
+    missing = sorted(v.__name__ for v in RESPONSES_TO_TRAIN.values() if v not in union_members)
+    assert not missing, f"ForTraining variants missing from NeMoGymResponseInputItem: {missing}"
+
+
+def test_training_variant_lookup_fails_with_a_named_error() -> None:
+    """An unregistered class must not surface as a bare KeyError (a 500 with no explanation)."""
+
+    class _Unregistered:
+        pass
+
+    with pytest.raises(NotImplementedError, match="has no ForTraining variant"):
+        training_variant_of(_Unregistered)
+
+
+def test_duplicate_type_tags_are_documented() -> None:
+    """Record which tags map to several union members.
+
+    These are why ``Field(discriminator="type")`` cannot be used.
+    They are also why one unrecognised item produces errors from every union member.
+    Pinning the expected set makes a new collision a deliberate change.
+    """
+    duplicates = {tag for tag, owners in GYM_TAG_OWNERS.items() if len(owners) > 1}
+    assert duplicates == {"message", "function_call", "reasoning"}, (
+        f"duplicate type tags changed: {sorted(duplicates)}. Each duplicate widens the error "
+        f"report for an unrecognised item; update this test if the change is intended."
+    )

--- a/tests/unit_tests/test_responses_api_model_streaming.py
+++ b/tests/unit_tests/test_responses_api_model_streaming.py
@@ -91,9 +91,8 @@ def _function_call_item(name: str) -> dict:
     }
 
 
-# Minimal valid payloads, one per item type NeMoGymResponseInputItem accepts.
-# Keyed by the type tag, so a new union member without a fixture is reported by
-# test_every_union_tag_has_a_fixture rather than going untested.
+# Provide one minimal valid payload for each item type in ``NeMoGymResponseInputItem``.
+# Key payloads by type tag so the fixture coverage test can detect missing entries.
 ITEM_FIXTURES: dict[str, dict] = {
     "message": {
         "type": "message",
@@ -217,15 +216,11 @@ ITEM_FIXTURES: dict[str, dict] = {
 }
 
 
-# Item types Gym can carry in a Responses transcript but that Chat Completions cannot express.
-# ResponsesConverter.responses_to_chat_completion_create_params raises NotImplementedError for these.
-# A hosted web search or an MCP call has no chat-message representation.
+# These Responses item types have no Chat Completions representation.
+# ``ResponsesConverter.responses_to_chat_completion_create_params`` raises ``NotImplementedError`` for them.
 #
-# Union membership and chat-convertibility are therefore two separate things.
-# openai_model passes Responses through untouched and handles all of these.
-# Model servers that downconvert to a chat backend, vllm_model and inference_provider, cannot replay them.
-# They raise inside the converter rather than rejecting the request.
-# A type added to the union belongs in one list or the other.
+# ``openai_model`` passes Responses requests through without conversion.
+# ``vllm_model`` and ``inference_provider`` convert requests to Chat Completions.
 CHAT_INCONVERTIBLE_TYPES = frozenset(
     {
         "code_interpreter_call",
@@ -605,14 +600,13 @@ class TestResponsesDispatchRoute:
 
 
 class TestUnionItemTypesThroughDispatch:
-    """Both dispatch paths must agree about which item types are legal.
+    """Verify item handling on streaming and non-streaming dispatch paths.
 
     A plain JSON request validates strictly.
     A ``stream: true`` request goes through ``sanitize_streaming_responses_body`` first.
-    That validates each input item on its own, drops the ones that fail with a warning, and returns 200.
-    The drop is intended for unknown harness bookkeeping.
-    Losing one carrier item is preferable to a 422 that ends the rollout.
-    It also means an item type Gym cannot represent disappears from the transcript rather than raising.
+    The sanitizer validates each input item separately.
+    It drops invalid items with a warning.
+    This behavior allows unknown harness data without rejecting the entire request.
     """
 
     _ADAPTER = TypeAdapter(NeMoGymResponseInputItem)
@@ -638,7 +632,7 @@ class TestUnionItemTypesThroughDispatch:
         return tags
 
     def test_every_union_tag_has_a_fixture(self) -> None:
-        """A union member with no fixture is untested by everything below."""
+        """Require a fixture for every union member."""
         missing = sorted(self._union_tags() - set(ITEM_FIXTURES))
         assert not missing, (
             f"NeMoGymResponseInputItem accepts {missing} but ITEM_FIXTURES has no payload for "
@@ -647,7 +641,7 @@ class TestUnionItemTypesThroughDispatch:
 
     @pytest.mark.parametrize("tag", sorted(ITEM_FIXTURES))
     def test_fixture_is_a_valid_union_member(self, tag: str) -> None:
-        """Guard the fixtures themselves: an invalid payload would make the drop tests vacuous."""
+        """Require every fixture to validate as a union member."""
         try:
             self._ADAPTER.validate_python(ITEM_FIXTURES[tag])
         except ValidationError as exc:  # pragma: no cover - only on a bad fixture
@@ -655,12 +649,7 @@ class TestUnionItemTypesThroughDispatch:
 
     @pytest.mark.parametrize("tag", sorted(ITEM_FIXTURES))
     def test_streaming_does_not_drop_representable_items(self, tag: str) -> None:
-        """The transcript the backend sees matches what the client sent, item for item.
-
-        Regression guard for issue #2436.
-        Before the hosted-tool wrappers existed, a ``web_search_call`` echoed back as history was
-        dropped here, at HTTP 200 with only a log line.
-        """
+        """Preserve each representable item in the transcript sent to the backend."""
         client, server = _client(_EchoModel)
         history = [
             {"role": "user", "content": "first turn"},
@@ -693,12 +682,10 @@ class TestUnionItemTypesThroughDispatch:
         assert streaming.status_code == 200
 
     def test_unrepresentable_input_item_is_dropped_when_streaming_and_rejected_otherwise(self) -> None:
-        """Record the asymmetry so a change to it is deliberate.
+        """Verify the different handling of unrepresentable input items.
 
-        An item type with no union member is a 422 non-streaming and a silent drop streaming.
-        The drop is intentional.
-        Making the streaming path strict, or making the drop louder, comes with a failing test
-        pointing at it.
+        Non-streaming requests reject an item type with no union member.
+        Streaming requests drop the item.
         """
         client, server = _client(_EchoModel)
         unknown = {"type": "definitely_not_a_responses_item_type", "id": "x_1"}
@@ -712,14 +699,11 @@ class TestUnionItemTypesThroughDispatch:
 
     @pytest.mark.parametrize("tag", sorted(ITEM_FIXTURES))
     def test_union_type_is_chat_convertible_or_declared_inconvertible(self, tag: str) -> None:
-        """Every union type is either downconvertible to chat, or declared as not.
+        """Classify each union type by whether Chat Completions can represent it.
 
         The union says what Gym can carry.
-        The converter says what a chat backend can express, and that is a strict subset.
-        Nothing else states where the line falls, because
-        ``responses_to_chat_completion_create_params`` ends in ``case _: raise NotImplementedError``.
-        A type added to the union would otherwise first show up as a mid-rollout failure on
-        whichever model server downconverts.
+        The converter supports a subset of those item types.
+        Unsupported types raise ``NotImplementedError`` during conversion.
         """
         converter = ResponsesConverter(return_token_id_information=False)
         params = NeMoGymResponseCreateParamsNonStreaming(input=[ITEM_FIXTURES[tag]])
@@ -745,17 +729,11 @@ class TestUnionItemTypesThroughDispatch:
 
     @pytest.mark.parametrize("tag", sorted(ITEM_FIXTURES))
     def test_params_survive_a_dump_and_revalidate(self, tag: str) -> None:
-        """Anything the params model accepts, it must accept again after model_dump().
+        """Require accepted parameters to validate again after ``model_dump``.
 
         Servers forward a request by re-validating ``**body.model_dump()``.
-        A dump Gym cannot re-read breaks that hop.
-        The risk is an SDK model whose field accepts a value its matching ``*Param`` TypedDict does not.
-        Dumping emits the value, and re-validation rejects it.
-
-        Construction is the gate that keeps that from happening.
-        A tool carrying ``defer_loading: None`` is refused up front, rather than dumped into
-        something unreadable.
-        This test records that, per item type.
+        SDK models and their corresponding ``*Param`` types may accept different values.
+        Re-validation must accept every value emitted by the first validation.
         """
         params = NeMoGymResponseCreateParamsNonStreaming(
             input=[ITEM_FIXTURES[tag]],
@@ -770,6 +748,6 @@ class TestUnionItemTypesThroughDispatch:
             )
 
     def test_chat_inconvertible_list_has_no_stale_entries(self) -> None:
-        """A declared-inconvertible type that is not in the union is a stale entry."""
+        """Require each type unsupported by Chat Completions to belong to the input union."""
         stale = sorted(CHAT_INCONVERTIBLE_TYPES - self._union_tags())
         assert not stale, f"CHAT_INCONVERTIBLE_TYPES names types the union does not accept: {stale}"

--- a/tests/unit_tests/test_responses_api_model_streaming.py
+++ b/tests/unit_tests/test_responses_api_model_streaming.py
@@ -29,6 +29,7 @@ from uuid import uuid4
 import pytest
 from fastapi import Body, Request
 from fastapi.testclient import TestClient
+from pydantic import TypeAdapter, ValidationError
 
 from nemo_gym.base_responses_api_model import BaseResponsesAPIModelConfig, SimpleResponsesAPIModel
 from nemo_gym.openai_utils import (
@@ -36,7 +37,9 @@ from nemo_gym.openai_utils import (
     NeMoGymChatCompletionCreateParamsNonStreaming,
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseInputItem,
 )
+from nemo_gym.responses_converter import ResponsesConverter
 from nemo_gym.responses_streaming import (
     flatten_namespace_tools,
     sanitize_streaming_responses_body,
@@ -86,6 +89,161 @@ def _function_call_item(name: str) -> dict:
         "arguments": "{}",
         "status": "completed",
     }
+
+
+# Minimal valid payloads, one per item type NeMoGymResponseInputItem accepts.
+# Keyed by the type tag, so a new union member without a fixture is reported by
+# test_every_union_tag_has_a_fixture rather than going untested.
+ITEM_FIXTURES: dict[str, dict] = {
+    "message": {
+        "type": "message",
+        "id": "msg_1",
+        "role": "assistant",
+        "status": "completed",
+        "content": [{"type": "output_text", "text": "hello", "annotations": []}],
+    },
+    "function_call": {
+        "type": "function_call",
+        "id": "fc_1",
+        "call_id": "call_1",
+        "name": "get_weather",
+        "arguments": "{}",
+        "status": "completed",
+    },
+    "function_call_output": {
+        "type": "function_call_output",
+        "call_id": "call_1",
+        "output": "sunny",
+        "status": "completed",
+    },
+    "reasoning": {
+        "type": "reasoning",
+        "id": "rs_1",
+        "status": "completed",
+        "summary": [{"type": "summary_text", "text": "thinking"}],
+    },
+    "web_search_call": {
+        "type": "web_search_call",
+        "id": "ws_1",
+        "status": "completed",
+        "action": {"type": "search", "query": "weather"},
+    },
+    "file_search_call": {
+        "type": "file_search_call",
+        "id": "fs_1",
+        "status": "completed",
+        "queries": ["report"],
+    },
+    "computer_call": {
+        "type": "computer_call",
+        "id": "cu_1",
+        "call_id": "call_cu_1",
+        "status": "completed",
+        "action": {"type": "screenshot"},
+        "pending_safety_checks": [],
+    },
+    "custom_tool_call": {
+        "type": "custom_tool_call",
+        "id": "ct_1",
+        "call_id": "call_ct_1",
+        "name": "my_tool",
+        "input": "payload",
+    },
+    "local_shell_call": {
+        "type": "local_shell_call",
+        "id": "ls_1",
+        "call_id": "call_ls_1",
+        "status": "completed",
+        "action": {
+            "type": "exec",
+            "command": ["ls", "-la"],
+            "env": {},
+        },
+    },
+    "image_generation_call": {
+        "type": "image_generation_call",
+        "id": "ig_1",
+        "status": "completed",
+        "result": None,
+    },
+    "code_interpreter_call": {
+        "type": "code_interpreter_call",
+        "id": "ci_1",
+        "status": "completed",
+        "code": "print(1)",
+        "container_id": "cntr_1",
+        "outputs": None,
+    },
+    "mcp_call": {
+        "type": "mcp_call",
+        "id": "mcp_1",
+        "name": "search",
+        "arguments": "{}",
+        "server_label": "my_server",
+    },
+    "mcp_list_tools": {
+        "type": "mcp_list_tools",
+        "id": "mlt_1",
+        "server_label": "my_server",
+        "tools": [],
+    },
+    "mcp_approval_request": {
+        "type": "mcp_approval_request",
+        "id": "mar_1",
+        "name": "search",
+        "arguments": "{}",
+        "server_label": "my_server",
+    },
+    "computer_call_output": {
+        "type": "computer_call_output",
+        "call_id": "call_cu_1",
+        "output": {"type": "computer_screenshot", "image_url": "data:image/png;base64,x"},
+    },
+    "custom_tool_call_output": {
+        "type": "custom_tool_call_output",
+        "call_id": "call_ct_1",
+        "output": "tool result",
+    },
+    "local_shell_call_output": {
+        "type": "local_shell_call_output",
+        "id": "lso_1",
+        "output": "total 0",
+    },
+    "mcp_approval_response": {
+        "type": "mcp_approval_response",
+        "approval_request_id": "mar_1",
+        "approve": True,
+    },
+}
+
+
+# Item types Gym can carry in a Responses transcript but that Chat Completions cannot express.
+# ResponsesConverter.responses_to_chat_completion_create_params raises NotImplementedError for these.
+# A hosted web search or an MCP call has no chat-message representation.
+#
+# Union membership and chat-convertibility are therefore two separate things.
+# openai_model passes Responses through untouched and handles all of these.
+# Model servers that downconvert to a chat backend, vllm_model and inference_provider, cannot replay them.
+# They raise inside the converter rather than rejecting the request.
+# A type added to the union belongs in one list or the other.
+CHAT_INCONVERTIBLE_TYPES = frozenset(
+    {
+        "code_interpreter_call",
+        "computer_call",
+        "custom_tool_call",
+        "file_search_call",
+        "image_generation_call",
+        "local_shell_call",
+        "mcp_approval_request",
+        "mcp_call",
+        "mcp_list_tools",
+        "web_search_call",
+        "computer_call_output",
+        "custom_tool_call_output",
+        "local_shell_call_output",
+        "mcp_approval_response",
+    }
+)
 
 
 NAMESPACE_TOOL = {
@@ -444,3 +602,174 @@ class TestResponsesDispatchRoute:
         client, _ = _client(_FailingModel)
         with pytest.raises(RuntimeError, match="backend exploded"):
             client.post("/v1/responses", json={"input": [{"role": "user", "content": "hi"}]})
+
+
+class TestUnionItemTypesThroughDispatch:
+    """Both dispatch paths must agree about which item types are legal.
+
+    A plain JSON request validates strictly.
+    A ``stream: true`` request goes through ``sanitize_streaming_responses_body`` first.
+    That validates each input item on its own, drops the ones that fail with a warning, and returns 200.
+    The drop is intended for unknown harness bookkeeping.
+    Losing one carrier item is preferable to a 422 that ends the rollout.
+    It also means an item type Gym cannot represent disappears from the transcript rather than raising.
+    """
+
+    _ADAPTER = TypeAdapter(NeMoGymResponseInputItem)
+
+    @staticmethod
+    def _union_tags() -> set[str]:
+        """The ``type`` tags NeMoGymResponseInputItem accepts."""
+        from typing import Annotated, Literal, get_args, get_origin
+
+        def unwrap(annotation):
+            while get_origin(annotation) is Annotated:
+                annotation = get_args(annotation)[0]
+            return annotation
+
+        tags: set[str] = set()
+        for member in (unwrap(a) for a in get_args(unwrap(NeMoGymResponseInputItem))):
+            field = getattr(member, "model_fields", {}).get("type")
+            if field is None:
+                continue
+            annotation = field.annotation
+            if get_origin(annotation) is Literal:
+                tags.update(str(v) for v in get_args(annotation))
+        return tags
+
+    def test_every_union_tag_has_a_fixture(self) -> None:
+        """A union member with no fixture is untested by everything below."""
+        missing = sorted(self._union_tags() - set(ITEM_FIXTURES))
+        assert not missing, (
+            f"NeMoGymResponseInputItem accepts {missing} but ITEM_FIXTURES has no payload for "
+            f"them, so the tests below skip those types. Add a minimal valid payload."
+        )
+
+    @pytest.mark.parametrize("tag", sorted(ITEM_FIXTURES))
+    def test_fixture_is_a_valid_union_member(self, tag: str) -> None:
+        """Guard the fixtures themselves: an invalid payload would make the drop tests vacuous."""
+        try:
+            self._ADAPTER.validate_python(ITEM_FIXTURES[tag])
+        except ValidationError as exc:  # pragma: no cover - only on a bad fixture
+            pytest.fail(f"ITEM_FIXTURES[{tag!r}] does not validate against the union: {exc}")
+
+    @pytest.mark.parametrize("tag", sorted(ITEM_FIXTURES))
+    def test_streaming_does_not_drop_representable_items(self, tag: str) -> None:
+        """The transcript the backend sees matches what the client sent, item for item.
+
+        Regression guard for issue #2436.
+        Before the hosted-tool wrappers existed, a ``web_search_call`` echoed back as history was
+        dropped here, at HTTP 200 with only a log line.
+        """
+        client, server = _client(_EchoModel)
+        history = [
+            {"role": "user", "content": "first turn"},
+            ITEM_FIXTURES[tag],
+            {"role": "user", "content": "second turn"},
+        ]
+        response = client.post("/v1/responses", json={"input": history, "stream": True})
+        assert response.status_code == 200
+
+        seen = server.last_params.input
+        assert len(seen) == len(history), (
+            f"a {tag!r} item was dropped from the streaming transcript: sent {len(history)} input "
+            f"items, backend received {len(seen)}. Check the warning from "
+            f"sanitize_streaming_responses_body."
+        )
+        assert getattr(seen[1], "type", None) == tag
+
+    @pytest.mark.parametrize("tag", sorted(ITEM_FIXTURES))
+    def test_both_dispatch_paths_accept_representable_items(self, tag: str) -> None:
+        """Streamed and non-streamed agree for every type Gym can represent."""
+        client, _ = _client(_EchoModel)
+        body = {"input": [{"role": "user", "content": "hi"}, ITEM_FIXTURES[tag]]}
+
+        non_streaming = client.post("/v1/responses", json=body)
+        streaming = client.post("/v1/responses", json={**body, "stream": True})
+
+        assert non_streaming.status_code == 200, (
+            f"{tag!r} is in the union but the non-streaming path rejected it: {non_streaming.text[:400]}"
+        )
+        assert streaming.status_code == 200
+
+    def test_unrepresentable_input_item_is_dropped_when_streaming_and_rejected_otherwise(self) -> None:
+        """Record the asymmetry so a change to it is deliberate.
+
+        An item type with no union member is a 422 non-streaming and a silent drop streaming.
+        The drop is intentional.
+        Making the streaming path strict, or making the drop louder, comes with a failing test
+        pointing at it.
+        """
+        client, server = _client(_EchoModel)
+        unknown = {"type": "definitely_not_a_responses_item_type", "id": "x_1"}
+        body = {"input": [{"role": "user", "content": "hi"}, unknown]}
+
+        assert client.post("/v1/responses", json=body).status_code == 422
+
+        streaming = client.post("/v1/responses", json={**body, "stream": True})
+        assert streaming.status_code == 200
+        assert len(server.last_params.input) == 1, "the unknown item should have been dropped"
+
+    @pytest.mark.parametrize("tag", sorted(ITEM_FIXTURES))
+    def test_union_type_is_chat_convertible_or_declared_inconvertible(self, tag: str) -> None:
+        """Every union type is either downconvertible to chat, or declared as not.
+
+        The union says what Gym can carry.
+        The converter says what a chat backend can express, and that is a strict subset.
+        Nothing else states where the line falls, because
+        ``responses_to_chat_completion_create_params`` ends in ``case _: raise NotImplementedError``.
+        A type added to the union would otherwise first show up as a mid-rollout failure on
+        whichever model server downconverts.
+        """
+        converter = ResponsesConverter(return_token_id_information=False)
+        params = NeMoGymResponseCreateParamsNonStreaming(input=[ITEM_FIXTURES[tag]])
+        try:
+            converter.responses_to_chat_completion_create_params(params)
+            convertible = True
+        except NotImplementedError:
+            convertible = False
+
+        if tag in CHAT_INCONVERTIBLE_TYPES:
+            assert not convertible, (
+                f"{tag!r} is listed in CHAT_INCONVERTIBLE_TYPES but the chat converter now handles "
+                f"it. Remove it from that list."
+            )
+        else:
+            assert convertible, (
+                f"{tag!r} is in the Gym union but responses_to_chat_completion_create_params "
+                f"raises NotImplementedError for it, so a model server that downconverts to Chat "
+                f"Completions (vllm_model, inference_provider) fails mid-rollout on it.\n"
+                f"Fix: add a `case {tag!r}` to responses_to_chat_completion_create_params, or add "
+                f"{tag!r} to CHAT_INCONVERTIBLE_TYPES to declare it Responses-only."
+            )
+
+    @pytest.mark.parametrize("tag", sorted(ITEM_FIXTURES))
+    def test_params_survive_a_dump_and_revalidate(self, tag: str) -> None:
+        """Anything the params model accepts, it must accept again after model_dump().
+
+        Servers forward a request by re-validating ``**body.model_dump()``.
+        A dump Gym cannot re-read breaks that hop.
+        The risk is an SDK model whose field accepts a value its matching ``*Param`` TypedDict does not.
+        Dumping emits the value, and re-validation rejects it.
+
+        Construction is the gate that keeps that from happening.
+        A tool carrying ``defer_loading: None`` is refused up front, rather than dumped into
+        something unreadable.
+        This test records that, per item type.
+        """
+        params = NeMoGymResponseCreateParamsNonStreaming(
+            input=[ITEM_FIXTURES[tag]],
+            tools=[{"type": "function", "name": "f", "parameters": {}, "strict": None}],
+        )
+        dumped = params.model_dump()
+        try:
+            NeMoGymResponseCreateParamsNonStreaming(**dumped)
+        except ValidationError as exc:
+            pytest.fail(
+                f"a {tag!r} item survives validation but not a dump/re-validate round trip: {exc.errors()[:2]}"
+            )
+
+    def test_chat_inconvertible_list_has_no_stale_entries(self) -> None:
+        """A declared-inconvertible type that is not in the union is a stale entry."""
+        stale = sorted(CHAT_INCONVERTIBLE_TYPES - self._union_tags())
+        assert not stale, f"CHAT_INCONVERTIBLE_TYPES names types the union does not accept: {stale}"


### PR DESCRIPTION
Part of https://github.com/NVIDIA-NeMo/Gym/issues/2452

Gym mirrors OpenAI Responses item types in `NeMoGymResponseInputItem`, `NeMoGymResponseOutputItem`, the transcript boundary sets, and `RESPONSES_TO_TRAIN`. The OpenAI SDK changes these schemas independently. A missing or narrowed item can fail request validation, disappear from a streaming replay, or move the prompt/generation boundary used for training.

This change adds checks against the installed OpenAI SDK. Input and output ownership are inspected separately. The checks cover type tags, fields on hand-written models, top-level `Literal` domains, boundary classification, converter support, and training variants.

## Input and output parity

A shared type tag does not imply a shared schema. The SDK may accept one set of values in provider output and a narrower set when the item is replayed as input.

```mermaid
flowchart LR
    SDKO["SDK ResponseOutputItem"] --> GO["Gym output owners"]
    SDKI["SDK ResponseInputItem"] --> GI["Gym input owners"]
    SDKO --> LD["Compare top-level Literal domains"]
    SDKI --> LD
    GO --> LD
    GI --> LD
    LD --> OA["Provider output values remain accepted"]
    LD --> IA["Replay input stays valid"]
    LD --> SPLIT["Different domains require different owners"]
```

The output checks reject a Gym model that cannot accept every value the provider may emit. The input checks reject a Gym model that accepts values outside the SDK input domain. A shared Gym owner also fails when the SDK output domain contains values that the input domain rejects.

The checks unwrap `Annotated`, `Required`, `NotRequired`, `Union`, and PEP 604 unions before reading `Literal` values. Vacuity checks fail if SDK or Gym introspection stops finding the expected unions and fields. Every exemption is checked so stale entries cannot hide later drift.

## Item coverage and replay behavior

`ResponseInputItem` remains the source for client-supplied items. `ResponseOutputItem` is checked independently for provider output. This adds wrappers for `computer_call_output`, `custom_tool_call_output`, `local_shell_call_output`, and `mcp_approval_response`, which OpenAI 2.7.2 accepts as input but does not emit.

```mermaid
flowchart TD
    ITEM["Responses input item"] --> STREAM{"Streaming request?"}
    STREAM -->|"No"| STRICT["Validate the complete request"]
    STREAM -->|"Yes"| SANITIZE["Validate each replay item"]
    STRICT --> KNOWN{"Gym owns the type tag?"}
    SANITIZE --> KNOWN
    KNOWN -->|"Yes"| FORWARD["Forward the item"]
    KNOWN -->|"No, non-streaming"| REJECT["Reject the request"]
    KNOWN -->|"No, streaming"| DROP["Drop the item with a warning"]
```

`_RESPONSE_NON_BOUNDARY_TYPES` records client results and bookkeeping that do not begin model generation. `_RESPONSE_OUTPUT_BOUNDARY_TYPES` records model-generated calls. A type in neither set fails the checks instead of defaulting to prompt data.

`CHAT_INCONVERTIBLE_TYPES` records items that have no Chat Completions representation. This keeps Responses pass-through support separate from the capabilities of model servers that downconvert to Chat Completions.

`item_reference` remains intentionally unsupported. Gym replays complete transcripts and has no server-side item store that can resolve the reference.