### PR TITLE
chore(deps): pin openai to 2.44.0

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -59,6 +59,9 @@ from openai.types.chat.completion_create_params import (
     ResponseFormat,
     WebSearchOptions,
 )
+from openai.types.chat.completion_create_params import (
+    Moderation as ChatCompletionModeration,
+)
 from openai.types.responses import (
     FunctionToolParam,
     Response,
@@ -67,10 +70,13 @@ from openai.types.responses import (
     ResponseCodeInterpreterToolCall,
     ResponseCompactionItem,
     ResponseComputerToolCall,
+    ResponseComputerToolCallOutputItem,
     ResponseCustomToolCall,
+    ResponseCustomToolCallOutputItem,
     ResponseFileSearchToolCall,
     ResponseFunctionShellToolCall,
     ResponseFunctionShellToolCallOutput,
+    ResponseFunctionToolCallOutputItem,
     ResponseFunctionWebSearch,
     ResponseInputTextParam,
     ResponseToolSearchCall,
@@ -95,6 +101,9 @@ from openai.types.responses.response_function_call_output_item_list_param import
 )
 from openai.types.responses.response_input_content_param import ResponseInputContentParam
 from openai.types.responses.response_input_item import (
+    AdditionalTools as InputAdditionalTools,
+)
+from openai.types.responses.response_input_item import (
     CompactionTrigger,
     ComputerCallOutput,
     LocalShellCallOutput,
@@ -102,12 +111,20 @@ from openai.types.responses.response_input_item import (
     ResponseCustomToolCallOutput,
 )
 from openai.types.responses.response_output_item import (
-    AdditionalTools,
+    AdditionalTools as OutputAdditionalTools,
+)
+from openai.types.responses.response_output_item import (
     ImageGenerationCall,
     LocalShellCall,
     McpApprovalRequest,
     McpCall,
     McpListTools,
+)
+from openai.types.responses.response_output_item import (
+    LocalShellCallOutput as OutputLocalShellCallOutput,
+)
+from openai.types.responses.response_output_item import (
+    McpApprovalResponse as OutputMcpApprovalResponse,
 )
 from openai.types.responses.response_output_text_param import Annotation, Logprob
 from openai.types.responses.response_reasoning_item import (
@@ -121,7 +138,7 @@ from openai.types.responses.response_usage import OutputTokensDetails as Respons
 from openai.types.responses.response_usage import ResponseUsage
 from openai.types.shared.chat_model import ChatModel
 from openai.types.shared_params import FunctionDefinition
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_validator
 from typing_extensions import TypedDict
 
 from nemo_gym.server_utils import (
@@ -233,7 +250,7 @@ class NeMoGymResponseOutputMessage(BaseModel):
     role: Literal["assistant"] = "assistant"
     status: Literal["in_progress", "completed", "incomplete"] = "completed"
     type: Literal["message"] = "message"
-    # Codex models send this back on follow-up requests, so dropping it changes what they see.
+    # Preserve the response phase when replaying the item.
     phase: Optional[Literal["commentary", "final_answer"]] = None
 
 
@@ -273,7 +290,7 @@ class NeMoGymEasyInputMessage(BaseModel):
     content: Union[str, NeMoGymResponseInputContentList]
     role: Literal["user", "assistant", "system", "developer"]
     type: Literal["message"] = "message"
-    # Codex models send this back on follow-up requests, so dropping it changes what they see.
+    # Preserve the response phase when replaying the item.
     phase: Optional[Literal["commentary", "final_answer"]] = None
 
 
@@ -304,7 +321,7 @@ class NeMoGymResponseFunctionToolCall(BaseModel):
     type: Literal["function_call"] = "function_call"
     id: Optional[str] = None
     status: Optional[Literal["in_progress", "completed", "incomplete"]] = None
-    # The namespace a tool was exposed under. Dropping it loses which tool the call refers to.
+    # The namespace identifies the tool when names overlap.
     namespace: Optional[str] = None
 
 
@@ -390,33 +407,40 @@ class NeMoGymResponseCustomToolCall(ResponseCustomToolCall):
 # These models represent client-supplied results for the calls above.
 # The installed SDK defines them in ``response_input_item``.
 class NeMoGymComputerCallOutput(ComputerCallOutput):
-    """The client's result of a computer-use action (``computer_call_output`` item).
+    """A computer-use result accepted in request input (``computer_call_output`` item)."""
 
-    ``status`` is widened past the input model's literal.
-    A provider reports a failed computer action with ``status="failed"``, which the SDK's output
-    model accepts and its input model does not, so inheriting the input literal unchanged would
-    make a failed action a 500 on the non-streaming path.
-    """
 
-    status: Optional[Literal["in_progress", "completed", "incomplete", "failed"]] = None
+class NeMoGymResponseComputerCallOutput(ResponseComputerToolCallOutputItem):
+    """Provider output for a computer-use action, including ``status="failed"``."""
 
 
 class NeMoGymResponseCustomToolCallOutput(ResponseCustomToolCallOutput):
     """The client's result of a custom tool call (``custom_tool_call_output`` item)."""
 
 
+class NeMoGymResponseCustomToolCallOutputItem(ResponseCustomToolCallOutputItem):
+    """Provider output for a custom tool call."""
+
+
 class NeMoGymLocalShellCallOutput(LocalShellCallOutput):
     """The client's result of a local shell command (``local_shell_call_output`` item)."""
+
+
+class NeMoGymResponseLocalShellCallOutput(OutputLocalShellCallOutput):
+    """Provider output for a local shell command."""
 
 
 class NeMoGymMcpApprovalResponse(McpApprovalResponse):
     """The client's answer to a hosted-MCP approval request (``mcp_approval_response`` item)."""
 
 
-# The Codex tool family and the context-management item, which ResponseOutputItem gained at the pinned SDK.
-# Gym has to represent each one.
-# An item it cannot represent is a 500 on the non-streaming path.
-# On the streaming path it is a silent drop from the replayed transcript.
+class NeMoGymResponseMcpApprovalResponse(OutputMcpApprovalResponse):
+    """Provider output carrying an answer to a hosted-MCP approval request."""
+
+
+# These output items must remain representable in Gym transcripts.
+# Unsupported items cause non-streaming validation errors.
+# The streaming path would otherwise omit them from replayed transcripts.
 
 
 class NeMoGymResponseApplyPatchToolCall(ResponseApplyPatchToolCall):
@@ -448,24 +472,19 @@ class NeMoGymResponseToolSearchOutputItem(ResponseToolSearchOutputItem):
 
 
 class NeMoGymCompactionTrigger(CompactionTrigger):
-    """A client's request that the provider compact the context (``compaction_trigger`` item).
+    """A request for the provider to compact the context (``compaction_trigger`` item).
 
-    The client-side counterpart to the ``compaction`` record.
-    Gym carries it so a Codex harness can ask for compaction without losing the item.
+    Gym preserves this input item when replaying the transcript.
     """
 
 
-# The tool carrier Codex code mode sends.
-class NeMoGymAdditionalTools(AdditionalTools):
-    """Tools carried inside an input item rather than the tools param (``additional_tools``).
+# Additional tool definitions sent with an input transcript.
+class NeMoGymAdditionalTools(InputAdditionalTools):
+    """Additional tool definitions accepted in request input."""
 
-    ``role`` is narrowed to the input model's literal.
-    The SDK's output model accepts eight roles and its input model accepts only ``developer``, so
-    an item validated against the wider set cannot always be replayed as input, which is the one
-    thing this type exists to do.
-    """
 
-    role: Literal["developer"] = "developer"
+class NeMoGymResponseAdditionalTools(OutputAdditionalTools):
+    """Additional tool definitions returned by the provider."""
 
 
 class NeMoGymResponseInputText(ResponseInputTextParam):
@@ -581,6 +600,23 @@ NeMoGymResponseInputItem = Annotated[
 NeMoGymResponseInput: TypeAlias = List[NeMoGymResponseInputItem]
 
 
+def _normalize_response_item_for_input(item: Any) -> Any:
+    """Convert a provider output item to the request input schema."""
+    if isinstance(item, BaseModel):
+        item = item.model_dump(exclude_unset=True)
+    if not isinstance(item, dict):
+        return item
+
+    item_type = item.get("type")
+    if item_type == "additional_tools" and item.get("role") != "developer":
+        item = item.copy()
+        item["role"] = "developer"
+    elif item_type == "computer_call_output" and item.get("status") == "failed":
+        item = item.copy()
+        item.pop("status")
+    return item
+
+
 class NeMoGymResponseCreateParamsNonStreaming(BaseModel):
     """
     This class is a copy of openai.types.responses.response_create_params.ResponseCreateParamsNonStreaming
@@ -589,6 +625,16 @@ class NeMoGymResponseCreateParamsNonStreaming(BaseModel):
     """
 
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_output_items_for_replay(cls, value: Any) -> Any:
+        """Normalize fields whose OpenAI output and input schemas differ."""
+        if not isinstance(value, dict) or not isinstance(value.get("input"), list):
+            return value
+        value = value.copy()
+        value["input"] = [_normalize_response_item_for_input(item) for item in value["input"]]
+        return value
 
     background: Optional[bool] = None
     include: Optional[List[ResponseIncludable]] = None
@@ -604,10 +650,9 @@ class NeMoGymResponseCreateParamsNonStreaming(BaseModel):
     reasoning: Optional[Reasoning] = None
     service_tier: Optional[Literal["auto", "default", "flex", "scale", "priority"]] = None
     store: Optional[bool] = None
-    # Mirrored from the pinned SDK's request schema.
-    # The model forbids extras, so a field the SDK has and this does not is a 422 on the
-    # non-streaming path, and sanitize_streaming_responses_body filters it out on the streaming
-    # one, which loses it without saying so.
+    # These fields mirror the SDK request schema.
+    # Missing fields cause non-streaming validation errors.
+    # The streaming sanitizer would otherwise remove them.
     context_management: Optional[List[ContextManagement]] = None
     conversation: Union[str, ResponseConversationParamParam, None] = None
     moderation: Optional[Moderation] = None
@@ -639,8 +684,45 @@ def _require_response_output_item_type(value: Any) -> Any:
     return value
 
 
+class NeMoGymResponseFunctionCallOutput(ResponseFunctionToolCallOutputItem):
+    """Provider output for a function call result."""
+
+
 NeMoGymResponseOutputItem = Annotated[
-    NeMoGymResponseInputItem,
+    Union[
+        NeMoGymResponseOutputMessage,
+        NeMoGymResponseFunctionToolCall,
+        NeMoGymResponseFunctionCallOutput,
+        NeMoGymResponseReasoningItem,
+        NeMoGymResponseMcpCall,
+        NeMoGymResponseMcpListTools,
+        NeMoGymResponseMcpApprovalRequest,
+        NeMoGymResponseFileSearchToolCall,
+        NeMoGymResponseFunctionWebSearch,
+        NeMoGymResponseComputerToolCall,
+        NeMoGymImageGenerationCall,
+        NeMoGymResponseCodeInterpreterToolCall,
+        NeMoGymLocalShellCall,
+        NeMoGymResponseCustomToolCall,
+        NeMoGymResponseComputerCallOutput,
+        NeMoGymResponseCustomToolCallOutputItem,
+        NeMoGymResponseLocalShellCallOutput,
+        NeMoGymResponseMcpApprovalResponse,
+        NeMoGymResponseApplyPatchToolCall,
+        NeMoGymResponseApplyPatchToolCallOutput,
+        NeMoGymResponseCompactionItem,
+        NeMoGymResponseFunctionShellToolCall,
+        NeMoGymResponseFunctionShellToolCallOutput,
+        NeMoGymResponseToolSearchCall,
+        NeMoGymResponseToolSearchOutputItem,
+        NeMoGymResponseAdditionalTools,
+        # Local agents use the request input model for function results.
+        # Accept it alongside the SDK output model.
+        NeMoGymFunctionCallOutput,
+        NeMoGymResponseOutputMessageForTraining,
+        NeMoGymResponseFunctionToolCallForTraining,
+        NeMoGymResponseReasoningItemForTraining,
+    ],
     BeforeValidator(_require_response_output_item_type),
 ]
 
@@ -900,6 +982,8 @@ NeMoGymChatCompletionMessageParam: TypeAlias = Annotated[
 
 
 class NeMoGymChatCompletionCreateParamsNonStreaming(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     messages: List[NeMoGymChatCompletionMessageParam]
     model: Optional[Union[str, ChatModel]] = None
     audio: Optional[ChatCompletionAudioParam] = None
@@ -909,14 +993,18 @@ class NeMoGymChatCompletionCreateParamsNonStreaming(BaseModel):
     max_completion_tokens: Optional[int] = None
     max_tokens: Optional[int] = None
     metadata: Optional[Metadata] = None
+    moderation: Optional[ChatCompletionModeration] = None
     modalities: Optional[List[Literal["text", "audio"]]] = None
     n: Optional[int] = None
     parallel_tool_calls: bool = True  # OpenAI default
     prediction: Optional[ChatCompletionPredictionContentParam] = None
     presence_penalty: Optional[float] = None
+    prompt_cache_key: Optional[str] = None
+    prompt_cache_retention: Optional[Literal["in_memory", "24h"]] = None
     reasoning_effort: Optional[ReasoningEffort] = None
     response_format: Optional[ResponseFormat] = None
     seed: Optional[int] = None
+    safety_identifier: Optional[str] = None
     service_tier: Optional[Literal["auto", "default", "flex", "scale", "priority"]] = None
     stop: Union[Optional[str], List[str], None] = None
     store: Optional[bool] = None
@@ -927,6 +1015,7 @@ class NeMoGymChatCompletionCreateParamsNonStreaming(BaseModel):
     top_logprobs: Optional[int] = None
     top_p: Optional[float] = None
     user: Optional[str] = None
+    verbosity: Optional[Literal["low", "medium", "high"]] = None
     web_search_options: Optional[WebSearchOptions] = None
     stream: Optional[Literal[False]] = None
 

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -62,20 +62,31 @@ from openai.types.chat.completion_create_params import (
 from openai.types.responses import (
     FunctionToolParam,
     Response,
+    ResponseApplyPatchToolCall,
+    ResponseApplyPatchToolCallOutput,
     ResponseCodeInterpreterToolCall,
+    ResponseCompactionItem,
     ResponseComputerToolCall,
     ResponseCustomToolCall,
     ResponseFileSearchToolCall,
+    ResponseFunctionShellToolCall,
+    ResponseFunctionShellToolCallOutput,
     ResponseFunctionWebSearch,
     ResponseInputTextParam,
+    ResponseToolSearchCall,
+    ResponseToolSearchOutputItem,
 )
+from openai.types.responses.response_conversation_param_param import ResponseConversationParamParam
 from openai.types.responses.response_create_params import (
+    ContextManagement,
     Metadata,
+    Moderation,
     Reasoning,
     ResponseIncludable,
     ResponsePromptParam,
     ResponsesModel,
     ResponseTextConfigParam,
+    StreamOptions,
     ToolChoice,
     ToolParam,
 )
@@ -84,12 +95,14 @@ from openai.types.responses.response_function_call_output_item_list_param import
 )
 from openai.types.responses.response_input_content_param import ResponseInputContentParam
 from openai.types.responses.response_input_item import (
+    CompactionTrigger,
     ComputerCallOutput,
     LocalShellCallOutput,
     McpApprovalResponse,
     ResponseCustomToolCallOutput,
 )
 from openai.types.responses.response_output_item import (
+    AdditionalTools,
     ImageGenerationCall,
     LocalShellCall,
     McpApprovalRequest,
@@ -220,6 +233,8 @@ class NeMoGymResponseOutputMessage(BaseModel):
     role: Literal["assistant"] = "assistant"
     status: Literal["in_progress", "completed", "incomplete"] = "completed"
     type: Literal["message"] = "message"
+    # Codex models send this back on follow-up requests, so dropping it changes what they see.
+    phase: Optional[Literal["commentary", "final_answer"]] = None
 
 
 class NeMoGymInputVideoPart(TypedDict, total=False):
@@ -258,6 +273,8 @@ class NeMoGymEasyInputMessage(BaseModel):
     content: Union[str, NeMoGymResponseInputContentList]
     role: Literal["user", "assistant", "system", "developer"]
     type: Literal["message"] = "message"
+    # Codex models send this back on follow-up requests, so dropping it changes what they see.
+    phase: Optional[Literal["commentary", "final_answer"]] = None
 
 
 class NeMoGymMessage(BaseModel):
@@ -287,6 +304,8 @@ class NeMoGymResponseFunctionToolCall(BaseModel):
     type: Literal["function_call"] = "function_call"
     id: Optional[str] = None
     status: Optional[Literal["in_progress", "completed", "incomplete"]] = None
+    # The namespace a tool was exposed under. Dropping it loses which tool the call refers to.
+    namespace: Optional[str] = None
 
 
 class NeMoGymResponseMcpCall(McpCall):
@@ -371,7 +390,15 @@ class NeMoGymResponseCustomToolCall(ResponseCustomToolCall):
 # These models represent client-supplied results for the calls above.
 # The installed SDK defines them in ``response_input_item``.
 class NeMoGymComputerCallOutput(ComputerCallOutput):
-    """The client's result of a computer-use action (``computer_call_output`` item)."""
+    """The client's result of a computer-use action (``computer_call_output`` item).
+
+    ``status`` is widened past the input model's literal.
+    A provider reports a failed computer action with ``status="failed"``, which the SDK's output
+    model accepts and its input model does not, so inheriting the input literal unchanged would
+    make a failed action a 500 on the non-streaming path.
+    """
+
+    status: Optional[Literal["in_progress", "completed", "incomplete", "failed"]] = None
 
 
 class NeMoGymResponseCustomToolCallOutput(ResponseCustomToolCallOutput):
@@ -384,6 +411,61 @@ class NeMoGymLocalShellCallOutput(LocalShellCallOutput):
 
 class NeMoGymMcpApprovalResponse(McpApprovalResponse):
     """The client's answer to a hosted-MCP approval request (``mcp_approval_response`` item)."""
+
+
+# The Codex tool family and the context-management item, which ResponseOutputItem gained at the pinned SDK.
+# Gym has to represent each one.
+# An item it cannot represent is a 500 on the non-streaming path.
+# On the streaming path it is a silent drop from the replayed transcript.
+
+
+class NeMoGymResponseApplyPatchToolCall(ResponseApplyPatchToolCall):
+    """A patch the model wants applied (``apply_patch_call`` output item)."""
+
+
+class NeMoGymResponseApplyPatchToolCallOutput(ResponseApplyPatchToolCallOutput):
+    """The client's result of applying a patch (``apply_patch_call_output`` item)."""
+
+
+class NeMoGymResponseCompactionItem(ResponseCompactionItem):
+    """An opaque context-compaction record the provider emits (``compaction`` item)."""
+
+
+class NeMoGymResponseFunctionShellToolCall(ResponseFunctionShellToolCall):
+    """A shell command the model wants run (``shell_call`` output item)."""
+
+
+class NeMoGymResponseFunctionShellToolCallOutput(ResponseFunctionShellToolCallOutput):
+    """The client's result of running a shell command (``shell_call_output`` item)."""
+
+
+class NeMoGymResponseToolSearchCall(ResponseToolSearchCall):
+    """A tool-search call (``tool_search_call`` output item)."""
+
+
+class NeMoGymResponseToolSearchOutputItem(ResponseToolSearchOutputItem):
+    """The result of a tool search (``tool_search_output`` item)."""
+
+
+class NeMoGymCompactionTrigger(CompactionTrigger):
+    """A client's request that the provider compact the context (``compaction_trigger`` item).
+
+    The client-side counterpart to the ``compaction`` record.
+    Gym carries it so a Codex harness can ask for compaction without losing the item.
+    """
+
+
+# The tool carrier Codex code mode sends.
+class NeMoGymAdditionalTools(AdditionalTools):
+    """Tools carried inside an input item rather than the tools param (``additional_tools``).
+
+    ``role`` is narrowed to the input model's literal.
+    The SDK's output model accepts eight roles and its input model accepts only ``developer``, so
+    an item validated against the wider set cannot always be replayed as input, which is the one
+    thing this type exists to do.
+    """
+
+    role: Literal["developer"] = "developer"
 
 
 class NeMoGymResponseInputText(ResponseInputTextParam):
@@ -477,6 +559,16 @@ NeMoGymResponseInputItem = Annotated[
         NeMoGymResponseCustomToolCallOutput,
         NeMoGymLocalShellCallOutput,
         NeMoGymMcpApprovalResponse,
+        # Codex tool family and context management.
+        NeMoGymResponseApplyPatchToolCall,
+        NeMoGymResponseApplyPatchToolCallOutput,
+        NeMoGymResponseCompactionItem,
+        NeMoGymResponseFunctionShellToolCall,
+        NeMoGymResponseFunctionShellToolCallOutput,
+        NeMoGymResponseToolSearchCall,
+        NeMoGymResponseToolSearchOutputItem,
+        NeMoGymCompactionTrigger,
+        NeMoGymAdditionalTools,
         # Training variants.
         NeMoGymEasyInputMessageForTraining,
         NeMoGymMessageForTraining,
@@ -512,6 +604,17 @@ class NeMoGymResponseCreateParamsNonStreaming(BaseModel):
     reasoning: Optional[Reasoning] = None
     service_tier: Optional[Literal["auto", "default", "flex", "scale", "priority"]] = None
     store: Optional[bool] = None
+    # Mirrored from the pinned SDK's request schema.
+    # The model forbids extras, so a field the SDK has and this does not is a 422 on the
+    # non-streaming path, and sanitize_streaming_responses_body filters it out on the streaming
+    # one, which loses it without saying so.
+    context_management: Optional[List[ContextManagement]] = None
+    conversation: Union[str, ResponseConversationParamParam, None] = None
+    moderation: Optional[Moderation] = None
+    prompt_cache_key: Optional[str] = None
+    prompt_cache_retention: Optional[Literal["in_memory", "24h"]] = None
+    safety_identifier: Optional[str] = None
+    stream_options: Optional[StreamOptions] = None
     temperature: Optional[float] = None
     text: Optional[ResponseTextConfigParam] = None
     tool_choice: ToolChoice = "auto"  # OpenAI default

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -716,9 +716,13 @@ NeMoGymResponseOutputItem = Annotated[
         NeMoGymResponseToolSearchCall,
         NeMoGymResponseToolSearchOutputItem,
         NeMoGymResponseAdditionalTools,
-        # Local agents use the request input model for function results.
-        # Accept it alongside the SDK output model.
+        # Local agents include prompt messages and function results in returned trajectories.
+        # Accept their request models alongside the SDK output models.
+        NeMoGymEasyInputMessage,
+        NeMoGymMessage,
         NeMoGymFunctionCallOutput,
+        NeMoGymEasyInputMessageForTraining,
+        NeMoGymMessageForTraining,
         NeMoGymResponseOutputMessageForTraining,
         NeMoGymResponseFunctionToolCallForTraining,
         NeMoGymResponseReasoningItemForTraining,

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -173,8 +173,6 @@ class ResponsesConverter(BaseModel):
                 "max_tool_calls",
                 "previous_response_id",
                 "prompt",
-                "reasoning",
-                "text",
                 "truncation",
             }
             & responses_create_params.keys()
@@ -262,16 +260,41 @@ class ResponsesConverter(BaseModel):
             responses_create_params["max_tokens"] = max_output_tokens
 
         reasoning = responses_create_params.pop("reasoning", None)
-        if reasoning is not None and reasoning.get("effort") is not None:
-            responses_create_params["reasoning_effort"] = reasoning["effort"]
+        if reasoning is not None:
+            unsupported_reasoning_fields = sorted(
+                field for field, value in reasoning.items() if field != "effort" and value is not None
+            )
+            if unsupported_reasoning_fields:
+                raise NotImplementedError(
+                    "Responses reasoning field(s) "
+                    f"{unsupported_reasoning_fields} have no Chat Completions representation."
+                )
+            if reasoning.get("effort") is not None:
+                responses_create_params["reasoning_effort"] = reasoning["effort"]
+
+        text = responses_create_params.pop("text", None)
+        if text is not None:
+            if text.get("format") is not None:
+                raise NotImplementedError("Responses text format has no implemented Chat Completions conversion.")
+            if text.get("verbosity") is not None:
+                responses_create_params["verbosity"] = text["verbosity"]
 
         tools = responses_create_params.pop("tools", None)
         if tools:
             responses_create_params["tools"] = []
             for tool_dict in tools:
+                tool_type = tool_dict.get("type")
+                if tool_type != "function":
+                    raise NotImplementedError(
+                        f"Responses tool type {tool_type!r} has no implemented Chat Completions conversion."
+                    )
+                if tool_dict.get("defer_loading"):
+                    raise NotImplementedError(
+                        "Responses function tools with defer_loading enabled have no Chat Completions representation."
+                    )
                 tool_dict = tool_dict.copy()
                 tool_dict.pop("type", None)
-                tool_dict.pop("strict", None)
+                tool_dict.pop("defer_loading", None)
                 responses_create_params["tools"].append(
                     NeMoGymChatCompletionToolParam(type="function", function=NeMoGymFunctionDefinition(**tool_dict))
                 )
@@ -332,6 +355,8 @@ class ResponsesConverter(BaseModel):
     ) -> None:
         # Tool-call-only assistant turns may omit `content` entirely, not just null it.
         content = m.get("content")
+        if m.get("phase") is not None:
+            raise NotImplementedError("Responses message phase has no Chat Completions representation.")
 
         if isinstance(content, list) and m["role"] != "assistant":
             converted_parts = []
@@ -340,12 +365,20 @@ class ResponsesConverter(BaseModel):
                     case "input_text":
                         converted_parts.append({"type": "text", "text": part_param["text"]})
                     case "input_image":
-                        image_url = part_param.get("image_url", "")
+                        image_url = part_param.get("image_url")
+                        if image_url is None:
+                            raise NotImplementedError(
+                                "Responses input images referenced by file_id have no Chat Completions representation."
+                            )
                         if isinstance(image_url, dict):
                             image_url = image_url.get("url", "")
                         if not image_url:
                             raise ValueError(f"{part_param['type']} requires a non-empty image_url")
                         detail = part_param.get("detail", "auto")
+                        if detail == "original":
+                            raise NotImplementedError(
+                                "Responses input image detail 'original' has no Chat Completions representation."
+                            )
                         converted_parts.append(
                             {"type": "image_url", "image_url": {"url": image_url, "detail": detail}}
                         )
@@ -457,6 +490,8 @@ class ResponsesConverter(BaseModel):
     ) -> None:
         state.assistant_item_buffered = True
         assert "call_id" in m
+        if m.get("namespace") is not None:
+            raise NotImplementedError("Responses function call namespace has no Chat Completions representation.")
         tool_call = NeMoGymChatCompletionMessageToolCallParam(
             id=m["call_id"],
             function=NeMoGymChatCompletionMessageToolCallFunctionParam(
@@ -487,13 +522,20 @@ class ResponsesConverter(BaseModel):
             max_output_tokens=chat_completion_create_params.max_completion_tokens,
             metadata=chat_completion_create_params.metadata,
             model=chat_completion_create_params.model,
+            moderation=chat_completion_create_params.moderation,
             parallel_tool_calls=chat_completion_create_params.parallel_tool_calls,
+            prompt_cache_key=chat_completion_create_params.prompt_cache_key,
+            prompt_cache_retention=chat_completion_create_params.prompt_cache_retention,
             reasoning=Reasoning(effort=chat_completion_create_params.reasoning_effort)
             if chat_completion_create_params.reasoning_effort is not None
             else None,
+            safety_identifier=chat_completion_create_params.safety_identifier,
             service_tier=chat_completion_create_params.service_tier,
             store=chat_completion_create_params.store,
             temperature=chat_completion_create_params.temperature,
+            text={"verbosity": chat_completion_create_params.verbosity}
+            if chat_completion_create_params.verbosity is not None
+            else None,
             tool_choice=chat_completion_create_params.tool_choice
             if chat_completion_create_params.tool_choice is not None
             else "auto",

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -163,7 +163,7 @@ class ResponsesConverter(BaseModel):
         self,
         responses_create_params: NeMoGymResponseCreateParamsNonStreaming,
     ) -> NeMoGymChatCompletionCreateParamsNonStreaming:
-        responses_create_params = responses_create_params.model_dump(exclude_unset=True)
+        responses_create_params = responses_create_params.model_dump(exclude_none=True, exclude_unset=True)
 
         unsupported_fields = sorted(
             {

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -164,9 +164,31 @@ class ResponsesConverter(BaseModel):
     ) -> NeMoGymChatCompletionCreateParamsNonStreaming:
         responses_create_params = responses_create_params.model_dump(exclude_unset=True)
 
+        unsupported_fields = sorted(
+            {
+                "background",
+                "context_management",
+                "conversation",
+                "include",
+                "max_tool_calls",
+                "previous_response_id",
+                "prompt",
+                "reasoning",
+                "text",
+                "truncation",
+            }
+            & responses_create_params.keys()
+        )
+        if unsupported_fields:
+            raise NotImplementedError(
+                f"Responses request field(s) {unsupported_fields} have no Chat Completions "
+                "representation, so this request cannot be downconverted. Route it to a model "
+                "server that passes Responses through."
+            )
+
         state = ResponsesConverterState(return_token_id_information=self.return_token_id_information)
 
-        response_input = responses_create_params["input"]
+        response_input = responses_create_params.pop("input")
         if isinstance(response_input, str):
             wrapped_input = {
                 "content": [
@@ -180,7 +202,7 @@ class ResponsesConverter(BaseModel):
             }
             input_messages = [wrapped_input]
         else:
-            input_messages = responses_create_params.pop("input", [])
+            input_messages = response_input
 
         for m in input_messages:
             if not m.get("type") and m.get("role"):

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -23,6 +23,7 @@ import re
 from typing import Any, ClassVar, Dict, List, Optional, Tuple
 from uuid import uuid4
 
+from openai.types.responses.response_create_params import ToolParam
 from pydantic import BaseModel, Field
 
 from nemo_gym.openai_utils import (
@@ -37,12 +38,12 @@ from nemo_gym.openai_utils import (
     NeMoGymChatCompletionSystemMessageParam,
     NeMoGymChatCompletionToolMessageParam,
     NeMoGymChatCompletionToolParam,
+    NeMoGymChatCompletionToolUnionParam,
     NeMoGymChatCompletionUserMessageParam,
     NeMoGymChoice,
     NeMoGymEasyInputMessage,
     NeMoGymFunctionCallOutput,
     NeMoGymFunctionDefinition,
-    NeMoGymFunctionToolParam,
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCall,
@@ -279,30 +280,42 @@ class ResponsesConverter(BaseModel):
             if text.get("verbosity") is not None:
                 responses_create_params["verbosity"] = text["verbosity"]
 
+        tool_choice = self._responses_to_chat_tool_choice(responses_create_params.pop("tool_choice", None))
         tools = responses_create_params.pop("tools", None)
         if tools:
             responses_create_params["tools"] = []
             for tool_dict in tools:
                 tool_type = tool_dict.get("type")
-                if tool_type != "function":
+                if tool_type not in {"function", "custom"}:
                     raise NotImplementedError(
                         f"Responses tool type {tool_type!r} has no implemented Chat Completions conversion."
                     )
                 if tool_dict.get("defer_loading"):
                     raise NotImplementedError(
-                        "Responses function tools with defer_loading enabled have no Chat Completions representation."
+                        f"Responses {tool_type} tools with defer_loading enabled "
+                        "have no Chat Completions representation."
                     )
                 tool_dict = tool_dict.copy()
                 tool_dict.pop("type", None)
                 tool_dict.pop("defer_loading", None)
-                responses_create_params["tools"].append(
-                    NeMoGymChatCompletionToolParam(type="function", function=NeMoGymFunctionDefinition(**tool_dict))
-                )
+                if tool_type == "function":
+                    tool_dict = {key: value for key, value in tool_dict.items() if value is not None}
+                    converted_tool = NeMoGymChatCompletionToolParam(
+                        type="function",
+                        function=NeMoGymFunctionDefinition(**tool_dict),
+                    )
+                else:
+                    converted_tool = {
+                        "type": "custom",
+                        "custom": self._responses_custom_tool_to_chat(tool_dict),
+                    }
+                responses_create_params["tools"].append(converted_tool)
+            if tool_choice is not None:
+                responses_create_params["tool_choice"] = tool_choice
         else:
-            if responses_create_params.get("tool_choice") == "required":
-                raise ValueError("tool_choice='required' requires at least one tool")
+            if tool_choice not in (None, "auto", "none"):
+                raise ValueError(f"tool_choice={tool_choice!r} requires at least one tool")
 
-            responses_create_params.pop("tool_choice", None)
             responses_create_params.pop("parallel_tool_calls", None)
 
         chat_completion_create_params = NeMoGymChatCompletionCreateParamsNonStreaming(
@@ -506,12 +519,89 @@ class ResponsesConverter(BaseModel):
     # Chat Completion create params to Response create params
     # =======================================================
 
+    @staticmethod
+    def _tool_reference_to_responses(tool: dict) -> dict:
+        tool_type = tool.get("type")
+        if tool_type not in {"function", "custom"}:
+            raise NotImplementedError(f"Chat tool reference type {tool_type!r} has no Responses representation.")
+        return {"type": tool_type, **tool[tool_type]}
+
+    @staticmethod
+    def _tool_reference_to_chat(tool: dict) -> dict:
+        tool_type = tool.get("type")
+        if tool_type not in {"function", "custom"}:
+            raise NotImplementedError(f"Responses tool reference type {tool_type!r} has no Chat representation.")
+        return {"type": tool_type, tool_type: {key: value for key, value in tool.items() if key != "type"}}
+
+    @staticmethod
+    def _chat_custom_tool_to_responses(tool: dict) -> dict:
+        converted = dict(tool)
+        tool_format = converted.get("format")
+        if tool_format is not None and tool_format["type"] == "grammar":
+            converted["format"] = {"type": "grammar", **tool_format["grammar"]}
+        return converted
+
+    @staticmethod
+    def _responses_custom_tool_to_chat(tool: dict) -> dict:
+        converted = dict(tool)
+        tool_format = converted.get("format")
+        if tool_format is not None and tool_format["type"] == "grammar":
+            converted["format"] = {
+                "type": "grammar",
+                "grammar": {key: value for key, value in tool_format.items() if key != "type"},
+            }
+        return converted
+
+    def _chat_to_responses_tool_choice(self, tool_choice: Any) -> Any:
+        if tool_choice is None or isinstance(tool_choice, str):
+            return tool_choice
+
+        tool_type = tool_choice.get("type")
+        if tool_type in {"function", "custom"}:
+            return self._tool_reference_to_responses(tool_choice)
+        if tool_type == "allowed_tools":
+            allowed_tools = tool_choice["allowed_tools"]
+            return {
+                "type": "allowed_tools",
+                "mode": allowed_tools["mode"],
+                "tools": [self._tool_reference_to_responses(tool) for tool in allowed_tools["tools"]],
+            }
+        raise NotImplementedError(f"Chat tool choice type {tool_type!r} has no Responses representation.")
+
+    def _responses_to_chat_tool_choice(self, tool_choice: Any) -> Any:
+        if tool_choice is None or isinstance(tool_choice, str):
+            return tool_choice
+
+        tool_type = tool_choice.get("type")
+        if tool_type in {"function", "custom"}:
+            return self._tool_reference_to_chat(tool_choice)
+        if tool_type == "allowed_tools":
+            return {
+                "type": "allowed_tools",
+                "allowed_tools": {
+                    "mode": tool_choice["mode"],
+                    "tools": [self._tool_reference_to_chat(tool) for tool in tool_choice["tools"]],
+                },
+            }
+        raise NotImplementedError(f"Responses tool choice type {tool_type!r} has no Chat representation.")
+
     def _chat_completion_to_responses_tools(
-        self, chat_completions_tools: Optional[List[NeMoGymChatCompletionToolParam]]
-    ) -> List[NeMoGymFunctionToolParam]:
+        self, chat_completions_tools: Optional[List[NeMoGymChatCompletionToolUnionParam]]
+    ) -> List[ToolParam]:
         if chat_completions_tools is None:
             return []
-        return [tool["function"] | {"type": "function"} for tool in chat_completions_tools]
+
+        converted_tools = []
+        for tool in chat_completions_tools:
+            tool_type = tool["type"]
+            tool_definition = dict(tool[tool_type])
+            if tool_type == "function":
+                tool_definition.setdefault("parameters", None)
+                tool_definition.setdefault("strict", None)
+            else:
+                tool_definition = self._chat_custom_tool_to_responses(tool_definition)
+            converted_tools.append({"type": tool_type, **tool_definition})
+        return converted_tools
 
     def chat_completion_to_responses_create_params(
         self,
@@ -536,7 +626,7 @@ class ResponsesConverter(BaseModel):
             text={"verbosity": chat_completion_create_params.verbosity}
             if chat_completion_create_params.verbosity is not None
             else None,
-            tool_choice=chat_completion_create_params.tool_choice
+            tool_choice=self._chat_to_responses_tool_choice(chat_completion_create_params.tool_choice)
             if chat_completion_create_params.tool_choice is not None
             else "auto",
             tools=self._chat_completion_to_responses_tools(chat_completion_create_params.tools),

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -680,6 +680,9 @@ _RESPONSE_OUTPUT_BOUNDARY_TYPES = frozenset(
         "mcp_list_tools",
         "reasoning",
         "web_search_call",
+        "apply_patch_call",
+        "shell_call",
+        "tool_search_call",
     }
 )
 
@@ -690,11 +693,17 @@ _RESPONSE_OUTPUT_BOUNDARY_TYPES = frozenset(
 # The SDK unions do not distinguish generated items from client-supplied items.
 _RESPONSE_NON_BOUNDARY_TYPES: frozenset[str] = frozenset(
     {
+        "additional_tools",
+        "apply_patch_call_output",
+        "compaction",
+        "compaction_trigger",
         "computer_call_output",
         "custom_tool_call_output",
         "function_call_output",
         "local_shell_call_output",
         "mcp_approval_response",
+        "shell_call_output",
+        "tool_search_output",
     }
 )
 

--- a/nemo_gym/responses_streaming.py
+++ b/nemo_gym/responses_streaming.py
@@ -118,8 +118,8 @@ def sanitize_streaming_responses_body(body: dict[str, Any]) -> tuple[dict[str, A
     # The params model only admits `stream: false` (Gym responses are non-streaming internally);
     # the streaming envelope is synthesized by the caller, so the flag is dropped here.
     body.pop("stream", None)
-    # stream_options only means anything alongside `stream: true`, so it goes with the flag.
-    # Left in place it would travel on a request that is now non-streaming.
+    # `stream_options` applies only when `stream` is true.
+    # Remove it from the internal non-streaming request.
     body.pop("stream_options", None)
 
     ns_map: NamespaceMap = {}

--- a/nemo_gym/responses_streaming.py
+++ b/nemo_gym/responses_streaming.py
@@ -118,6 +118,9 @@ def sanitize_streaming_responses_body(body: dict[str, Any]) -> tuple[dict[str, A
     # The params model only admits `stream: false` (Gym responses are non-streaming internally);
     # the streaming envelope is synthesized by the caller, so the flag is dropped here.
     body.pop("stream", None)
+    # stream_options only means anything alongside `stream: true`, so it goes with the flag.
+    # Left in place it would travel on a request that is now non-streaming.
+    body.pop("stream_options", None)
 
     ns_map: NamespaceMap = {}
     if "tools" in body:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,9 +84,14 @@ dependencies = [
 
     # OpenAI: We leverage OpenAI Responses, Chat Completions, and Completions schemas for Nemo Gym abstractions. It may also be used to directly query endpoints.
     # We specifically upper bound this OpenAI dependency since the version bumps so frequently.
-    # Updated Wed Feb 17, 2026 with openai<=2.7.2
-    # License: Apache 2.0 https://github.com/openai/openai-python/blob/a8258744cbecf51321587fc870e8920bd2c07809/LICENSE
-    "openai<=2.7.2",
+    # Pinned to a single version, not a range.
+    # Gym subclasses the SDK's pydantic models and mirrors its Responses item union by hand.
+    # Each version needs its own audit, so a range would claim support for versions nobody tested.
+    # 2.45.0 makes InputTokensDetails.cache_write_tokens required, which NeMoGymResponseInputTokensDetails cannot satisfy.
+    # Moving this pin means re-running tests/unit_tests/test_openai_utils.py, which names each item type Gym cannot represent.
+    # Updated Tue Aug 11, 2026 with openai==2.44.0
+    # License: Apache 2.0 https://github.com/openai/openai-python/blob/v2.44.0/LICENSE
+    "openai==2.44.0",
 
     # Anthropic: We leverage the Anthropic Messages schemas (request/response Python types) for the
     # /v1/messages <-> Responses mapping in nemo_gym/anthropic_converter.py. Types only — we never

--- a/resources_servers/cvdp/requirements.txt
+++ b/resources_servers/cvdp/requirements.txt
@@ -9,5 +9,4 @@ tabulate==0.9.0
 numpy==2.2.3
 colorama==0.4.6
 ruamel.yaml==0.18.15
-openai==2.7.2
 tiktoken==0.9.0

--- a/resources_servers/finance_agent_v2/overrides.txt
+++ b/resources_servers/finance_agent_v2/overrides.txt
@@ -1,9 +1,0 @@
-# model-library declares openai[aiohttp]>=2.28.0, but nemo-gym pins openai to a
-# vLLM-compatible version, so the two cannot resolve together. The upstream code
-# runs fine on the older client; only the declared floor conflicts.
-#
-# uv --override replaces every declared constraint on openai, including nemo-gym's,
-# so this mirrors the cap in the root pyproject.toml instead of merely dropping the
-# floor: `openai<3.0` here would silently install a far newer client. Bump this
-# together with nemo-gym's pin; tests/test_app.py asserts the two stay in sync.
-openai[aiohttp]<=2.7.2

--- a/resources_servers/finance_agent_v2/requirements.txt
+++ b/resources_servers/finance_agent_v2/requirements.txt
@@ -5,11 +5,9 @@
 # exact so the benchmark is reproducible (bump deliberately).
 -e nemo-gym[dev] @ ../../
 
-# Vals model-library (provides model_library.agent.Tool / ToolOutput / base.LLM).
-# finance-agent pins `model-library==0.1.25`. Its metadata declares
-# openai[aiohttp]>=2.28.0, which cannot resolve against the vLLM-compatible openai
-# nemo-gym pins; `overrides.txt` drops that floor. The code runs on the older
-# client — only the declared floor conflicts.
+# Vals model-library provides model_library.agent.Tool, ToolOutput, and base.LLM.
+# finance-agent pins `model-library==0.1.25`.
+# Its OpenAI floor is compatible with nemo-gym's exact pin.
 model-library==0.1.25
 
 # Vals finance-agent-v2 (provides finance_agent.tools.* and finance_agent.prompt).

--- a/resources_servers/finance_agent_v2/tests/test_upstream_parity.py
+++ b/resources_servers/finance_agent_v2/tests/test_upstream_parity.py
@@ -26,7 +26,6 @@ package is installed into.
 
 import ast
 import inspect
-import re
 from pathlib import Path
 
 import finance_agent.get_agent as upstream_get_agent
@@ -118,18 +117,3 @@ class TestUpstreamParity:
             "tools",
             "llm_config",
         }
-
-    def test_openai_override_matches_the_nemo_gym_pin(self) -> None:
-        """``overrides.txt`` exists only to drop model-library's openai floor.
-
-        uv applies an override to every declared constraint on the package, so a
-        looser bound here would replace nemo-gym's cap too and silently install a
-        newer client than the one Gym is tested against. Bump both together.
-        """
-        gym_pin = re.search(r'"openai(<=|==)([\d.]+)"', (_REPO_ROOT / "pyproject.toml").read_text())
-        assert gym_pin, "nemo-gym no longer pins openai; revisit this override"
-
-        overrides = (_REPO_ROOT / "resources_servers" / "finance_agent_v2" / "overrides.txt").read_text()
-        assert f"openai[aiohttp]<={gym_pin.group(2)}" in overrides, (
-            "resources_servers/finance_agent_v2/overrides.txt is out of sync with nemo-gym's openai pin"
-        )

--- a/resources_servers/genrm_compare/utils.py
+++ b/resources_servers/genrm_compare/utils.py
@@ -77,7 +77,7 @@ class GenRMOutputParseError(ValueError):
 def _to_jsonable_data(value: Any) -> Any:
     """Recursively convert request payloads into JSON-serializable data."""
     if isinstance(value, BaseModel):
-        return value.model_dump(mode="json")
+        return value.model_dump(mode="json", exclude_none=True)
     if isinstance(value, dict):
         return {str(k): _to_jsonable_data(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):

--- a/resources_servers/single_step_tool_use_with_argument_comparison/tests/test_app.py
+++ b/resources_servers/single_step_tool_use_with_argument_comparison/tests/test_app.py
@@ -100,10 +100,10 @@ class TestApp:
         assert verify_response.category == expected_reward_category
 
     async def test_verify(self, resources_server: SingleStepToolUseArgumentComparisonResourcesServer) -> None:
-        # Built as a FunctionToolParam rather than dumped from the FunctionTool model.
-        # The SDK's model and its param TypedDict disagree about optionality.
-        # FunctionTool.defer_loading is Optional[bool] = None, while FunctionToolParam declares it a plain bool.
-        # So FunctionTool(...).model_dump() emits defer_loading=None, which the params model rejects.
+        # Build the request type directly because the SDK types differ in optionality.
+        # `FunctionTool.defer_loading` defaults to `None`.
+        # `FunctionToolParam` requires a boolean when the field is present.
+        # Dumping the model includes `None`, which the request model rejects.
         tool: FunctionToolParam = {
             "type": "function",
             "name": "set_metric_count",

--- a/resources_servers/single_step_tool_use_with_argument_comparison/tests/test_app.py
+++ b/resources_servers/single_step_tool_use_with_argument_comparison/tests/test_app.py
@@ -256,11 +256,12 @@ class TestApp:
             StepRewardCategory.NO_EXPECTED_CHAT_MESSAGE,
         )
 
-    def _search_tool(self) -> FunctionTool:
-        return FunctionTool(
-            type="function",
-            name="search",
-            parameters={
+    def _search_tool(self) -> FunctionToolParam:
+        return {
+            "type": "function",
+            "name": "search",
+            "strict": None,
+            "parameters": {
                 "type": "object",
                 "properties": {
                     "query": {
@@ -271,10 +272,10 @@ class TestApp:
                     "query",
                 ],
             },
-        )
+        }
 
     def _parallel_verify_request(
-        self, tool: FunctionTool, actual_queries: list[str], expected_queries: list[str]
+        self, tool: FunctionToolParam, actual_queries: list[str], expected_queries: list[str]
     ) -> SingleStepToolUseArgumentComparisonVerifyRequest:
         responses_create_params = NeMoGymResponseCreateParamsNonStreaming(
             input=[
@@ -284,7 +285,7 @@ class TestApp:
                 )
             ],
             parallel_tool_calls=True,
-            tools=[tool.model_dump()],
+            tools=[tool],
         )
         response = NeMoGymResponse(
             id="parallel_tool_calls",

--- a/resources_servers/single_step_tool_use_with_argument_comparison/tests/test_app.py
+++ b/resources_servers/single_step_tool_use_with_argument_comparison/tests/test_app.py
@@ -15,7 +15,7 @@
 import json
 from unittest.mock import MagicMock
 
-from openai.types.responses import FunctionTool
+from openai.types.responses import FunctionToolParam
 from pytest import approx, fixture
 
 from nemo_gym.openai_utils import (
@@ -70,7 +70,7 @@ class TestApp:
         self,
         resources_server: SingleStepToolUseArgumentComparisonResourcesServer,
         responses_create_params: NeMoGymResponseCreateParamsNonStreaming,
-        tool: FunctionTool,
+        tool: FunctionToolParam,
         expected_action: ExpectedAction,
         response_id: str,
         output_item: NeMoGymResponseOutputItem,
@@ -100,10 +100,15 @@ class TestApp:
         assert verify_response.category == expected_reward_category
 
     async def test_verify(self, resources_server: SingleStepToolUseArgumentComparisonResourcesServer) -> None:
-        tool = FunctionTool(
-            type="function",
-            name="set_metric_count",
-            parameters={
+        # Built as a FunctionToolParam rather than dumped from the FunctionTool model.
+        # The SDK's model and its param TypedDict disagree about optionality.
+        # FunctionTool.defer_loading is Optional[bool] = None, while FunctionToolParam declares it a plain bool.
+        # So FunctionTool(...).model_dump() emits defer_loading=None, which the params model rejects.
+        tool: FunctionToolParam = {
+            "type": "function",
+            "name": "set_metric_count",
+            "strict": None,
+            "parameters": {
                 "type": "object",
                 "properties": {
                     "metric_name": {
@@ -118,8 +123,7 @@ class TestApp:
                     "metric_count",
                 ],
             },
-        )
-        tool_param = tool.model_dump()
+        }
         tool_call_responses_create_params = NeMoGymResponseCreateParamsNonStreaming(
             input=[
                 NeMoGymEasyInputMessage(
@@ -127,7 +131,7 @@ class TestApp:
                     content="Set the views metric count to 75.",
                 )
             ],
-            tools=[tool_param],
+            tools=[tool],
         )
 
         expected_arguments = {
@@ -224,7 +228,7 @@ class TestApp:
                     content="This is a greeting.",
                 )
             ],
-            tools=[tool_param],
+            tools=[tool],
         )
         expected_message = MessageAction(
             type="message",

--- a/responses_api_agents/aviary_agent/tests/test_app.py
+++ b/responses_api_agents/aviary_agent/tests/test_app.py
@@ -619,6 +619,7 @@ class TestApp:
                                 "type": "function_call",
                                 "id": None,
                                 "status": None,
+                                "namespace": None,
                             }
                         ],
                         "env_id": env_id,

--- a/responses_api_agents/cvdp_agent/tests/test_app.py
+++ b/responses_api_agents/cvdp_agent/tests/test_app.py
@@ -39,14 +39,11 @@ from responses_api_agents.cvdp_agent.app import (
 
 
 def _drop_nulls(value):
-    """Recursively remove keys whose value is None.
+    """Remove dictionary entries with a value of ``None`` recursively.
 
-    NeMoGymResponse and the item models under it inherit the SDK's, so each openai release can add
-    optional fields at any depth. They arrive as None and break a literal comparison.
-    Comparing only the top-level keys this test asserts does not reach a field added inside
-    `output`, where the item models live.
-    A field this fixture expects to hold a value still fails if it arrives as None.
-    tests/unit_tests/test_openai_utils.py is what notices the field set moving.
+    SDK releases can add optional response fields at any depth.
+    Exact comparisons should ignore these unset fields.
+    Expected non-null values remain part of the comparison.
     """
     if isinstance(value, dict):
         return {k: _drop_nulls(v) for k, v in value.items() if v is not None}

--- a/responses_api_agents/cvdp_agent/tests/test_app.py
+++ b/responses_api_agents/cvdp_agent/tests/test_app.py
@@ -38,6 +38,23 @@ from responses_api_agents.cvdp_agent.app import (
 )
 
 
+def _drop_nulls(value):
+    """Recursively remove keys whose value is None.
+
+    NeMoGymResponse and the item models under it inherit the SDK's, so each openai release can add
+    optional fields at any depth. They arrive as None and break a literal comparison.
+    Comparing only the top-level keys this test asserts does not reach a field added inside
+    `output`, where the item models live.
+    A field this fixture expects to hold a value still fails if it arrives as None.
+    tests/unit_tests/test_openai_utils.py is what notices the field set moving.
+    """
+    if isinstance(value, dict):
+        return {k: _drop_nulls(v) for k, v in value.items() if v is not None}
+    if isinstance(value, list):
+        return [_drop_nulls(v) for v in value]
+    return value
+
+
 class TestApp:
     def test_sanity(self) -> None:
         config = CVDPAgentConfig(
@@ -167,7 +184,7 @@ class TestApp:
             "prompt_cache_key": None,
             "safety_identifier": None,
         }
-        assert expected_responses_dict == actual_responses_dict
+        assert _drop_nulls(expected_responses_dict) == _drop_nulls(actual_responses_dict)
 
 
 class TestAgenticSandboxSpec:
@@ -512,4 +529,4 @@ class TestAgenticSandboxSpec:
             "prompt_cache_key": None,
             "safety_identifier": None,
         }
-        assert expected_responses_dict == actual_responses_dict
+        assert _drop_nulls(expected_responses_dict) == _drop_nulls(actual_responses_dict)

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -43,14 +43,11 @@ from responses_api_agents.simple_agent.app import (
 
 
 def _drop_nulls(value):
-    """Recursively remove keys whose value is None.
+    """Remove dictionary entries with a value of ``None`` recursively.
 
-    NeMoGymResponse and the item models under it inherit the SDK's, so each openai release can add
-    optional fields at any depth. They arrive as None and break a literal comparison.
-    Comparing only the top-level keys this test asserts does not reach a field added inside
-    `output`, where the item models live.
-    A field this fixture expects to hold a value still fails if it arrives as None.
-    tests/unit_tests/test_openai_utils.py is what notices the field set moving.
+    SDK releases can add optional response fields at any depth.
+    Exact comparisons should ignore these unset fields.
+    Expected non-null values remain part of the comparison.
     """
     if isinstance(value, dict):
         return {k: _drop_nulls(v) for k, v in value.items() if v is not None}

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -42,6 +42,23 @@ from responses_api_agents.simple_agent.app import (
 )
 
 
+def _drop_nulls(value):
+    """Recursively remove keys whose value is None.
+
+    NeMoGymResponse and the item models under it inherit the SDK's, so each openai release can add
+    optional fields at any depth. They arrive as None and break a literal comparison.
+    Comparing only the top-level keys this test asserts does not reach a field added inside
+    `output`, where the item models live.
+    A field this fixture expects to hold a value still fails if it arrives as None.
+    tests/unit_tests/test_openai_utils.py is what notices the field set moving.
+    """
+    if isinstance(value, dict):
+        return {k: _drop_nulls(v) for k, v in value.items() if v is not None}
+    if isinstance(value, list):
+        return [_drop_nulls(v) for v in value]
+    return value
+
+
 def _make_agent(
     observability_enabled: bool, agent_type: type[SimpleAgent] = SimpleAgent
 ) -> tuple[SimpleAgent, MagicMock]:
@@ -193,7 +210,7 @@ class TestApp:
             "prompt_cache_key": None,
             "safety_identifier": None,
         }
-        assert expected_responses_dict == actual_responses_dict
+        assert _drop_nulls(expected_responses_dict) == _drop_nulls(actual_responses_dict)
 
         prefixed_response = client.post(
             "/ng-rollout/0-0/v1/responses", json={"input": [{"role": "user", "content": "hello"}]}
@@ -322,7 +339,7 @@ class TestApp:
         ]
         assert all(turn.timestamp > 0 for turn in turns)
         assert [turn.model_calls[0].response_id for turn in turns] == ["resp-tool", "resp-final"]
-        assert turns[0].model_dump(mode="json")["question"] == [
+        assert _drop_nulls(turns[0].model_dump(mode="json")["question"]) == [
             {"role": "user", "content": "question", "type": "message"}
         ]
         assert [item["type"] for item in turns[1].model_dump(mode="json")["question"]] == [
@@ -668,7 +685,7 @@ class TestApp:
             "prompt_cache_key": None,
             "safety_identifier": None,
         }
-        assert expected_responses_dict == actual_responses_dict
+        assert _drop_nulls(expected_responses_dict) == _drop_nulls(actual_responses_dict)
 
     async def test_usage_sanity(self, monkeypatch: MonkeyPatch) -> None:
         config = SimpleAgentConfig(
@@ -897,7 +914,7 @@ class TestApp:
             "prompt_cache_key": None,
             "safety_identifier": None,
         }
-        assert expected_responses_dict == actual_responses_dict
+        assert _drop_nulls(expected_responses_dict) == _drop_nulls(actual_responses_dict)
 
     async def test_run_skip_verification_uses_configured_reward(self) -> None:
         config = SimpleAgentConfig(

--- a/responses_api_agents/simple_agent_with_compaction/tests/test_app.py
+++ b/responses_api_agents/simple_agent_with_compaction/tests/test_app.py
@@ -74,6 +74,15 @@ def _mock_response(payload=None, *, status=200, content="", cookies=None) -> Mag
     return response
 
 
+def _drop_nulls(value):
+    """Recursively remove fields whose value is None."""
+    if isinstance(value, dict):
+        return {key: _drop_nulls(item) for key, item in value.items() if item is not None}
+    if isinstance(value, (list, tuple)):
+        return [_drop_nulls(item) for item in value]
+    return value
+
+
 class _ImageObservationAgent(SimpleAgentWithCompaction):
     """Test-only adapter that turns resource JSON into a multimodal observation."""
 
@@ -222,7 +231,7 @@ class TestApp:
             "prompt_cache_key": None,
             "safety_identifier": None,
         }
-        assert expected_responses_dict == actual_responses_dict
+        assert _drop_nulls(expected_responses_dict) == _drop_nulls(actual_responses_dict)
 
         prefixed_response = client.post(
             "/ng-rollout/0-0/v1/responses", json={"input": [{"role": "user", "content": "hello"}]}
@@ -456,11 +465,11 @@ class TestApp:
             function_call,
             tool_response,
         ]
-        assert normalize_semantic_items(model_calls[1].kwargs["json"].input) == normalize_semantic_items(
-            expected_complete_history
+        assert _drop_nulls(normalize_semantic_items(model_calls[1].kwargs["json"].input)) == _drop_nulls(
+            normalize_semantic_items(expected_complete_history)
         )
-        assert normalize_semantic_items(response.json()["output"]) == normalize_semantic_items(
-            [function_call, tool_response, final_message]
+        assert _drop_nulls(normalize_semantic_items(response.json()["output"])) == _drop_nulls(
+            normalize_semantic_items([function_call, tool_response, final_message])
         )
 
     async def test_active_recency_rewrites_only_at_chunk_boundaries(self) -> None:
@@ -845,7 +854,7 @@ class TestApp:
         ]
         assert all(turn.timestamp > 0 for turn in turns)
         assert [turn.model_calls[0].response_id for turn in turns] == ["resp-tool", "resp-final"]
-        assert turns[0].model_dump(mode="json")["question"] == [
+        assert _drop_nulls(turns[0].model_dump(mode="json")["question"]) == [
             {"role": "user", "content": "question", "type": "message"}
         ]
         assert [item["type"] for item in turns[1].model_dump(mode="json")["question"]] == [
@@ -1195,7 +1204,7 @@ class TestApp:
             "prompt_cache_key": None,
             "safety_identifier": None,
         }
-        assert expected_responses_dict == actual_responses_dict
+        assert _drop_nulls(expected_responses_dict) == _drop_nulls(actual_responses_dict)
 
     async def test_usage_sanity(self, monkeypatch: MonkeyPatch) -> None:
         config = SimpleAgentWithCompactionConfig(
@@ -1424,7 +1433,7 @@ class TestApp:
             "prompt_cache_key": None,
             "safety_identifier": None,
         }
-        assert expected_responses_dict == actual_responses_dict
+        assert _drop_nulls(expected_responses_dict) == _drop_nulls(actual_responses_dict)
 
     async def test_run_skip_verification_uses_configured_reward(self) -> None:
         config = SimpleAgentWithCompactionConfig(

--- a/responses_api_agents/simple_strands_agent/overrides.txt
+++ b/responses_api_agents/simple_strands_agent/overrides.txt
@@ -1,3 +1,3 @@
 numpy==2.3.2
-openai==2.21.0
+openai==2.44.0
 pyarrow==25.0.0

--- a/responses_api_agents/tau2/tests/test_app.py
+++ b/responses_api_agents/tau2/tests/test_app.py
@@ -367,11 +367,9 @@ class TestApp:
 
             d["duration"] = 0.0
 
-            # NeMoGymResponse inherits the SDK's Response, so each openai release can add optional fields.
-            # They arrive here as None.
-            # Dropping nulls ignores that, while a field this fixture expects to hold a value
-            # still fails if it arrives as None.
-            # tests/unit_tests/test_openai_utils.py owns the full field set.
+            # SDK releases can add optional response fields.
+            # Ignore these fields when their values are `None`.
+            # Expected non-null values remain part of the comparison.
             return _drop_nulls(d)
 
         assert _clean(expected_response_dict) == _clean(actual_response_dict)

--- a/responses_api_agents/tau2/tests/test_app.py
+++ b/responses_api_agents/tau2/tests/test_app.py
@@ -43,6 +43,17 @@ from responses_api_agents.tau2.app import (
 from tau2.data_model.message import AssistantMessage, UserMessage
 from tau2.data_model.simulation import RewardInfo, SimulationRun, TerminationReason
 from tau2.utils import llm_utils as tau2_llm_utils
+
+
+def _drop_nulls(value):
+    """Recursively remove keys whose value is None."""
+    if isinstance(value, dict):
+        return {k: _drop_nulls(v) for k, v in value.items() if v is not None}
+    if isinstance(value, list):
+        return [_drop_nulls(v) for v in value]
+    return value
+
+
 # isort: on
 
 
@@ -356,7 +367,12 @@ class TestApp:
 
             d["duration"] = 0.0
 
-            return d
+            # NeMoGymResponse inherits the SDK's Response, so each openai release can add optional fields.
+            # They arrive here as None.
+            # Dropping nulls ignores that, while a field this fixture expects to hold a value
+            # still fails if it arrives as None.
+            # tests/unit_tests/test_openai_utils.py owns the full field set.
+            return _drop_nulls(d)
 
         assert _clean(expected_response_dict) == _clean(actual_response_dict)
 

--- a/responses_api_agents/tool_simulation_agent/tests/test_app.py
+++ b/responses_api_agents/tool_simulation_agent/tests/test_app.py
@@ -27,14 +27,11 @@ from responses_api_agents.tool_simulation_agent.app import ToolSimulationAgent, 
 
 
 def _drop_nulls(value):
-    """Recursively remove keys whose value is None.
+    """Remove dictionary entries with a value of ``None`` recursively.
 
-    These tests assert the exact payload sent downstream, and that payload contains a NeMoGymResponse dump.
-    NeMoGymResponse inherits the SDK's Response, so each openai release can add optional fields.
-    They arrive here as None and break a literal comparison.
-    Dropping nulls on both sides ignores that class of change.
-    A field the fixture expects to hold a value still fails if it arrives as None.
-    tests/unit_tests/test_openai_utils.py is what notices the field set moving.
+    SDK releases can add optional response fields.
+    Exact payload comparisons should ignore these unset fields.
+    Expected non-null values remain part of the comparison.
     """
     if isinstance(value, dict):
         return {k: _drop_nulls(v) for k, v in value.items() if v is not None}

--- a/responses_api_agents/tool_simulation_agent/tests/test_app.py
+++ b/responses_api_agents/tool_simulation_agent/tests/test_app.py
@@ -26,6 +26,27 @@ from nemo_gym.server_utils import ServerClient
 from responses_api_agents.tool_simulation_agent.app import ToolSimulationAgent, ToolSimulationAgentConfig
 
 
+def _drop_nulls(value):
+    """Recursively remove keys whose value is None.
+
+    These tests assert the exact payload sent downstream, and that payload contains a NeMoGymResponse dump.
+    NeMoGymResponse inherits the SDK's Response, so each openai release can add optional fields.
+    They arrive here as None and break a literal comparison.
+    Dropping nulls on both sides ignores that class of change.
+    A field the fixture expects to hold a value still fails if it arrives as None.
+    tests/unit_tests/test_openai_utils.py is what notices the field set moving.
+    """
+    if isinstance(value, dict):
+        return {k: _drop_nulls(v) for k, v in value.items() if v is not None}
+    if isinstance(value, list):
+        return [_drop_nulls(v) for v in value]
+    return value
+
+
+def _calls_without_nulls(calls):
+    return [(c.args, _drop_nulls(c.kwargs)) for c in calls]
+
+
 class TestApp:
     @fixture
     def agent_config(self) -> ToolSimulationAgentConfig:
@@ -187,7 +208,7 @@ class TestApp:
             "usage": None,
             "user": None,
         }
-        assert chat_response.json() == expected_chat_response_json
+        assert _drop_nulls(expected_chat_response_json) == _drop_nulls(chat_response.json())
         server_client_post_mock.assert_called_once_with(
             server_name="model_server",
             url_path="/v1/responses",
@@ -376,7 +397,9 @@ class TestApp:
                 },
             ),
         ]
-        assert server_client_post_mock.call_args_list == expected_invalid_verify_response_calls
+        assert _calls_without_nulls(server_client_post_mock.call_args_list) == _calls_without_nulls(
+            expected_invalid_verify_response_calls
+        )
 
         valid_verify_response_object = {
             "responses_create_params": {
@@ -446,8 +469,10 @@ class TestApp:
             "reward": 1,
             "failure_reason": None,
         }
-        assert valid_verify_response.json() == expected_valid_verify_response_json
-        assert server_client_post_mock.call_args_list == expected_invalid_verify_response_calls
+        assert _drop_nulls(expected_valid_verify_response_json) == _drop_nulls(valid_verify_response.json())
+        assert _calls_without_nulls(server_client_post_mock.call_args_list) == _calls_without_nulls(
+            expected_invalid_verify_response_calls
+        )
 
     async def test_run_skip_verification_uses_configured_reward(self, agent_config: ToolSimulationAgentConfig) -> None:
         server_client_post_mock = AsyncMock()

--- a/responses_api_models/openai_model/tests/test_app.py
+++ b/responses_api_models/openai_model/tests/test_app.py
@@ -137,6 +137,21 @@ class TestApp:
             messages=[{"role": "user", "content": "hi"}],
             model="dummy_model",
         )
+
+        chat_244_fields = {
+            "moderation": {"model": "omni-moderation-latest"},
+            "prompt_cache_key": "cache-key",
+            "prompt_cache_retention": "24h",
+            "safety_identifier": "safe-user",
+            "verbosity": "high",
+        }
+        forwarded = client.post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}], **chat_244_fields},
+        )
+        assert forwarded.status_code == 200
+        assert {field: called_args_chat[field] for field in chat_244_fields} == chat_244_fields
+
         calls = read_model_call_records(CaptureStore(tmp_path), "chat-test")
         assert len(calls) == 1 and calls[0].dialect == "chat"
 

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -949,6 +949,7 @@ class TestApp:
                     "required": ["order_id"],
                 },
                 "description": "Get the current status for a given order",
+                "strict": True,
             },
             {
                 "name": "get_delivery_date",
@@ -963,6 +964,7 @@ class TestApp:
                     "required": ["order_id"],
                 },
                 "description": "Get the estimated delivery date for a given order",
+                "strict": True,
             },
         ]
         assert expected_sent_tools == actual_sent_tools
@@ -1419,6 +1421,7 @@ class TestApp:
                     },
                     "required": ["order_id", "date"],
                 },
+                "strict": True,
             }
         ]
         assert expected_sent_tools == actual_sent_tools

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -129,6 +129,13 @@ COMMON_RESPONSE_PARAMS = dict(
     status="completed",
     tool_choice="auto",
 )
+OPENAI_2_44_OPTIONAL_CHAT_FIELDS = {
+    "moderation",
+    "prompt_cache_key",
+    "prompt_cache_retention",
+    "safety_identifier",
+    "verbosity",
+}
 
 PARAMETERIZE_DATA = [
     # ----- EasyInputMessageParam: content as a list, id: "ez_list" -----
@@ -2679,7 +2686,8 @@ class TestVLLMConverter:
         )
 
         expected_chat_completion_create_params = NeMoGymChatCompletionCreateParamsNonStreaming(
-            **COMMON_RESPONSE_PARAMS,
+            parallel_tool_calls=COMMON_RESPONSE_PARAMS["parallel_tool_calls"],
+            tool_choice=COMMON_RESPONSE_PARAMS["tool_choice"],
             messages=[
                 {
                     "role": "user",
@@ -2958,7 +2966,7 @@ class TestVLLMConverter:
         )
 
         expected_output = test_data["expected_output"]
-        assert expected_output == chat_completion_create_params.model_dump()
+        assert expected_output == chat_completion_create_params.model_dump(exclude=OPENAI_2_44_OPTIONAL_CHAT_FIELDS)
 
     def test_round_trip_chat_completions_return_token_id_information(self) -> None:
         converter = VLLMConverter(return_token_id_information=True)
@@ -3064,7 +3072,7 @@ class TestVLLMConverter:
         )
 
         expected_output = test_data["expected_output_return_token_id_information"]
-        assert expected_output == chat_completion_create_params.model_dump()
+        assert expected_output == chat_completion_create_params.model_dump(exclude=OPENAI_2_44_OPTIONAL_CHAT_FIELDS)
 
     def test_whitespace_round_trip_chat_completions(self, monkeypatch: MonkeyPatch) -> None:
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -13,7 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from types import UnionType
-from typing import Annotated, Any, Dict, List, Literal, NotRequired, Required, Union, get_args, get_origin, get_type_hints
+from typing import (
+    Annotated,
+    Any,
+    Dict,
+    List,
+    Literal,
+    NotRequired,
+    Required,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 import openai
 import pytest

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -17,6 +17,7 @@ from typing import Annotated, Any, Dict, List, Literal, NotRequired, Required, U
 
 import openai
 import pytest
+from openai.types.chat.completion_create_params import CompletionCreateParamsNonStreaming
 from openai.types.responses import (
     EasyInputMessage,
     ResponseCodeInterpreterToolCall,
@@ -30,6 +31,12 @@ from openai.types.responses import (
     ResponseReasoningItem,
 )
 from openai.types.responses.response_create_params import ResponseCreateParamsBase
+from openai.types.responses.response_input_item import (
+    AdditionalTools as InputAdditionalTools,
+)
+from openai.types.responses.response_input_item import (
+    ComputerCallOutput as InputComputerCallOutput,
+)
 from openai.types.responses.response_input_item import (
     FunctionCallOutput as InputFunctionCallOutput,
 )
@@ -59,7 +66,9 @@ from nemo_gym.openai_utils import (
     NeMoGymLocalShellCall,
     NeMoGymMessage,
     NeMoGymResponse,
+    NeMoGymResponseAdditionalTools,
     NeMoGymResponseCodeInterpreterToolCall,
+    NeMoGymResponseComputerCallOutput,
     NeMoGymResponseComputerToolCall,
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseCustomToolCall,
@@ -118,6 +127,49 @@ class TestNeMoGymResponseCreateParamsNonStreaming:
     def test_unknown_field_still_forbidden(self) -> None:
         with pytest.raises(ValidationError):
             NeMoGymResponseCreateParamsNonStreaming(input="hello", not_a_real_field=1)
+
+    @pytest.mark.parametrize(
+        "role",
+        ["unknown", "user", "assistant", "system", "critic", "discriminator", "developer", "tool"],
+    )
+    def test_additional_tools_output_preserved_then_normalized_for_replay(self, role: str) -> None:
+        payload = {"type": "additional_tools", "id": "at_1", "role": role, "tools": []}
+
+        response = NeMoGymResponse.model_validate(_response_with_output([payload]))
+        assert isinstance(response.output[0], NeMoGymResponseAdditionalTools)
+        assert response.output[0].role == role
+        output_dump = response.model_dump(mode="json")["output"][0]
+        assert output_dump["role"] == role
+
+        replay = NeMoGymResponseCreateParamsNonStreaming(input=[output_dump])
+        replay_dump = replay.model_dump(mode="json", exclude_unset=True)["input"][0]
+        assert replay_dump["role"] == "developer"
+        assert (
+            InputAdditionalTools.model_validate(replay_dump).model_dump(mode="json", exclude_unset=True) == replay_dump
+        )
+
+    def test_failed_computer_output_preserved_then_status_removed_for_replay(self) -> None:
+        payload = {
+            "type": "computer_call_output",
+            "id": "cco_1",
+            "call_id": "call_1",
+            "output": {"type": "computer_screenshot", "image_url": "data:image/png;base64,x"},
+            "status": "failed",
+        }
+
+        response = NeMoGymResponse.model_validate(_response_with_output([payload]))
+        assert isinstance(response.output[0], NeMoGymResponseComputerCallOutput)
+        assert response.output[0].status == "failed"
+        output_dump = response.model_dump(mode="json")["output"][0]
+        assert output_dump["status"] == "failed"
+
+        replay = NeMoGymResponseCreateParamsNonStreaming(input=[output_dump])
+        replay_dump = replay.model_dump(mode="json", exclude_unset=True)["input"][0]
+        assert "status" not in replay_dump
+        assert (
+            InputComputerCallOutput.model_validate(replay_dump).model_dump(mode="json", exclude_unset=True)
+            == replay_dump
+        )
 
 
 class TestTokenMetadataValidation:
@@ -964,6 +1016,15 @@ def test_sdk_output_types_are_a_subset_of_input_types() -> None:
     )
 
 
+def test_gym_output_union_represents_every_sdk_output_type() -> None:
+    missing = sorted(set(SDK_OUTPUT_TAGS) - set(GYM_OUTPUT_TAG_OWNERS))
+    unexpected = sorted(set(GYM_OUTPUT_TAG_OWNERS) - set(SDK_OUTPUT_TAGS))
+    assert not (missing or unexpected), (
+        f"NeMoGymResponseOutputItem differs from openai {openai.__version__} ResponseOutputItem: "
+        f"missing={missing} unexpected={unexpected}"
+    )
+
+
 @pytest.mark.parametrize("tag", sorted(SDK_INPUT_TAGS))
 def test_gym_union_represents_every_sdk_item_type(tag: str) -> None:
     """Require a Gym union member or explicit exclusion for each SDK input type.
@@ -1168,12 +1229,10 @@ def test_duplicate_type_tags_are_documented() -> None:
 
 
 def test_request_model_carries_every_sdk_request_field() -> None:
-    """The strict request copy must not fall behind the SDK's request schema.
+    """Keep the strict request model aligned with the SDK request schema.
 
-    NeMoGymResponseCreateParamsNonStreaming forbids extras, so a field the SDK accepts and this
-    model does not is a 422 on the non-streaming path. On the streaming path
-    sanitize_streaming_responses_body filters against this model's fields, so the same request
-    succeeds with the field silently removed.
+    Missing fields cause non-streaming validation errors.
+    The streaming sanitizer would otherwise remove them.
     """
     sdk_fields = set(get_type_hints(ResponseCreateParamsBase, include_extras=True))
     missing = sorted(sdk_fields - set(NeMoGymResponseCreateParamsNonStreaming.model_fields))
@@ -1185,14 +1244,29 @@ def test_request_model_carries_every_sdk_request_field() -> None:
     )
 
 
+def test_chat_request_field_set_matches_sdk_without_deprecated_fields() -> None:
+    """Keep the strict Chat request model aligned with the supported SDK fields.
+
+    Deprecated fields remain disabled.
+    """
+    sdk_fields = set(get_type_hints(CompletionCreateParamsNonStreaming, include_extras=True))
+    expected = sdk_fields - {"function_call", "functions"}
+    actual = set(NeMoGymChatCompletionCreateParamsNonStreaming.model_fields)
+    assert actual == expected, (
+        f"openai {openai.__version__} Chat request fields changed: "
+        f"missing={sorted(expected - actual)} extra={sorted(actual - expected)}"
+    )
+
+    with pytest.raises(ValidationError):
+        NeMoGymChatCompletionCreateParamsNonStreaming(messages=[], not_a_real_field=True)
+
+
 def test_response_field_set_is_pinned() -> None:
-    """One place notices when the SDK adds a field to Response.
+    """Detect changes to the SDK ``Response`` fields.
 
-    NeMoGymResponse inherits openai's Response, so a new SDK field appears in every model_dump() Gym produces.
-    Server tests compare only the keys they assert, which keeps them from breaking on each release.
-    This test is what makes that safe, by failing once, here, when the field set moves.
-
-    On failure, decide whether Gym should forward, default or drop the new field, then update this list.
+    ``NeMoGymResponse`` inherits the SDK ``Response`` model.
+    New SDK fields therefore appear in Gym model dumps.
+    Update the expected set after deciding how Gym handles each changed field.
     """
     expected = {
         "background",

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -433,6 +433,13 @@ class TestNeMoGymResponseToolCallItems:
         assert call.type == "web_search_call"
         assert call.status == "completed"
 
+    def test_local_prompt_message_in_response_output_validates(self) -> None:
+        response = NeMoGymResponse.model_validate(
+            _response_with_output([{"type": "message", "role": "user", "content": "environment observation"}])
+        )
+
+        assert isinstance(response.output[0], NeMoGymEasyInputMessage)
+
     def test_remaining_output_call_items_validate(self) -> None:
         response = NeMoGymResponse.model_validate(
             _response_with_output(

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from types import UnionType
-from typing import Annotated, Any, Dict, List, Literal, NotRequired, Required, Union, get_args, get_origin
+from typing import Annotated, Any, Dict, List, Literal, NotRequired, Required, Union, get_args, get_origin, get_type_hints
 
 import openai
 import pytest
@@ -29,6 +29,7 @@ from openai.types.responses import (
     ResponseOutputMessage,
     ResponseReasoningItem,
 )
+from openai.types.responses.response_create_params import ResponseCreateParamsBase
 from openai.types.responses.response_input_item import (
     FunctionCallOutput as InputFunctionCallOutput,
 )
@@ -1163,4 +1164,75 @@ def test_duplicate_type_tags_are_documented() -> None:
     assert duplicates == {"message", "function_call", "reasoning"}, (
         f"duplicate type tags changed: {sorted(duplicates)}. Each duplicate widens the error "
         f"report for an unrecognised item; update this test if the change is intended."
+    )
+
+
+def test_request_model_carries_every_sdk_request_field() -> None:
+    """The strict request copy must not fall behind the SDK's request schema.
+
+    NeMoGymResponseCreateParamsNonStreaming forbids extras, so a field the SDK accepts and this
+    model does not is a 422 on the non-streaming path. On the streaming path
+    sanitize_streaming_responses_body filters against this model's fields, so the same request
+    succeeds with the field silently removed.
+    """
+    sdk_fields = set(get_type_hints(ResponseCreateParamsBase, include_extras=True))
+    missing = sorted(sdk_fields - set(NeMoGymResponseCreateParamsNonStreaming.model_fields))
+    assert not missing, (
+        f"openai {openai.__version__} accepts {missing} on a Responses request and "
+        f"NeMoGymResponseCreateParamsNonStreaming does not, so those are rejected when sent "
+        f"plainly and dropped when streaming.\n"
+        f"Fix: mirror each field with the SDK's type."
+    )
+
+
+def test_response_field_set_is_pinned() -> None:
+    """One place notices when the SDK adds a field to Response.
+
+    NeMoGymResponse inherits openai's Response, so a new SDK field appears in every model_dump() Gym produces.
+    Server tests compare only the keys they assert, which keeps them from breaking on each release.
+    This test is what makes that safe, by failing once, here, when the field set moves.
+
+    On failure, decide whether Gym should forward, default or drop the new field, then update this list.
+    """
+    expected = {
+        "background",
+        "completed_at",
+        "conversation",
+        "created_at",
+        "error",
+        "id",
+        "incomplete_details",
+        "instructions",
+        "max_output_tokens",
+        "max_tool_calls",
+        "metadata",
+        "model",
+        "moderation",
+        "object",
+        "output",
+        "parallel_tool_calls",
+        "previous_response_id",
+        "prompt",
+        "prompt_cache_key",
+        "prompt_cache_retention",
+        "reasoning",
+        "safety_identifier",
+        "service_tier",
+        "status",
+        "temperature",
+        "text",
+        "tool_choice",
+        "tools",
+        "top_logprobs",
+        "top_p",
+        "truncation",
+        "usage",
+        "user",
+    }
+    actual = set(NeMoGymResponse.model_fields)
+    added = sorted(actual - expected)
+    removed = sorted(expected - actual)
+    assert not (added or removed), (
+        f"openai {openai.__version__} changed Response's field set: added={added} removed={removed}.\n"
+        f"Decide what Gym does with each, then update this list."
     )

--- a/tests/unit_tests/test_responses_api_model_streaming.py
+++ b/tests/unit_tests/test_responses_api_model_streaming.py
@@ -94,12 +94,19 @@ def _function_call_item(name: str) -> dict:
 # Provide one minimal valid payload for each item type in ``NeMoGymResponseInputItem``.
 # Key payloads by type tag so the fixture coverage test can detect missing entries.
 ITEM_FIXTURES: dict[str, dict] = {
+    # Items the model generates.
     "message": {
         "type": "message",
         "id": "msg_1",
         "role": "assistant",
         "status": "completed",
         "content": [{"type": "output_text", "text": "hello", "annotations": []}],
+    },
+    "reasoning": {
+        "type": "reasoning",
+        "id": "rs_1",
+        "status": "completed",
+        "summary": [{"type": "summary_text", "text": "thinking"}],
     },
     "function_call": {
         "type": "function_call",
@@ -108,18 +115,6 @@ ITEM_FIXTURES: dict[str, dict] = {
         "name": "get_weather",
         "arguments": "{}",
         "status": "completed",
-    },
-    "function_call_output": {
-        "type": "function_call_output",
-        "call_id": "call_1",
-        "output": "sunny",
-        "status": "completed",
-    },
-    "reasoning": {
-        "type": "reasoning",
-        "id": "rs_1",
-        "status": "completed",
-        "summary": [{"type": "summary_text", "text": "thinking"}],
     },
     "web_search_call": {
         "type": "web_search_call",
@@ -193,6 +188,34 @@ ITEM_FIXTURES: dict[str, dict] = {
         "arguments": "{}",
         "server_label": "my_server",
     },
+    "shell_call": {
+        "type": "shell_call",
+        "id": "sh_1",
+        "call_id": "call_sh_1",
+        "status": "completed",
+        "action": {"type": "exec", "commands": ["ls -la"], "timeout_ms": 5000},
+    },
+    "apply_patch_call": {
+        "type": "apply_patch_call",
+        "id": "ap_1",
+        "call_id": "call_ap_1",
+        "status": "completed",
+        "operation": {"type": "create_file", "path": "a.py", "diff": "+print(1)"},
+    },
+    "tool_search_call": {
+        "type": "tool_search_call",
+        "id": "ts_1",
+        "arguments": {},
+        "execution": "server",
+        "status": "completed",
+    },
+    # Results a client hands back, and the approval it grants.
+    "function_call_output": {
+        "type": "function_call_output",
+        "call_id": "call_1",
+        "output": "sunny",
+        "status": "completed",
+    },
     "computer_call_output": {
         "type": "computer_call_output",
         "call_id": "call_cu_1",
@@ -212,6 +235,41 @@ ITEM_FIXTURES: dict[str, dict] = {
         "type": "mcp_approval_response",
         "approval_request_id": "mar_1",
         "approve": True,
+    },
+    "shell_call_output": {
+        "type": "shell_call_output",
+        "id": "sho_1",
+        "call_id": "call_sh_1",
+        "status": "completed",
+        "output": [],
+    },
+    "apply_patch_call_output": {
+        "type": "apply_patch_call_output",
+        "id": "apo_1",
+        "call_id": "call_ap_1",
+        "status": "completed",
+    },
+    "tool_search_output": {
+        "type": "tool_search_output",
+        "id": "tso_1",
+        "execution": "server",
+        "status": "completed",
+        "tools": [],
+    },
+    "compaction_trigger": {
+        "type": "compaction_trigger",
+    },
+    "additional_tools": {
+        "type": "additional_tools",
+        "id": "at_1",
+        "role": "developer",
+        "tools": [],
+    },
+    # Context-management bookkeeping and the tool carrier Codex code mode sends.
+    "compaction": {
+        "type": "compaction",
+        "id": "cmp_1",
+        "encrypted_content": "opaque",
     },
 }
 
@@ -233,10 +291,22 @@ CHAT_INCONVERTIBLE_TYPES = frozenset(
         "mcp_call",
         "mcp_list_tools",
         "web_search_call",
+        # Codex tool family and context management (openai >= 2.25). A shell command, a patch, a
+        # tool search and an opaque compaction record have no chat-message form either.
+        "apply_patch_call",
+        "apply_patch_call_output",
+        "compaction",
+        "shell_call",
+        "shell_call_output",
+        "tool_search_call",
+        "tool_search_output",
+        # Client-supplied results, approvals and tool carriers have no chat-message form.
         "computer_call_output",
         "custom_tool_call_output",
         "local_shell_call_output",
         "mcp_approval_response",
+        "compaction_trigger",
+        "additional_tools",
     }
 )
 
@@ -262,7 +332,8 @@ class TestSanitizeStreamingBody:
         cleaned, _ = sanitize_streaming_responses_body(
             {"input": [], "stream": True, "client_metadata": {"x": 1}, "prompt_cache_key": "abc", "store": False}
         )
-        assert set(cleaned) == {"input", "store"}
+        # prompt_cache_key is part of the pinned request schema, so it survives; client_metadata is not.
+        assert set(cleaned) == {"input", "store", "prompt_cache_key"}
         # the cleaned body validates against the strict params model
         NeMoGymResponseCreateParamsNonStreaming.model_validate(cleaned)
 
@@ -425,11 +496,23 @@ class TestSanitizeStreamingBody:
 
 class TestValidateStreamingParams:
     def test_prunes_nested_extra_fields(self) -> None:
-        # Codex sends `reasoning.context`, which the pinned SDK's Reasoning model forbids.
+        # A nested field the SDK's Reasoning model does not know is dropped so the rest of the
+        # request still validates. Uses an invented field name rather than a real one: a field
+        # the SDK later adopts stops being pruned, which is what happened to `reasoning.context`
+        # (Codex sent it, the pinned SDK forbade it, and openai 2.44 added it).
+        params = validate_streaming_responses_params(
+            {"input": [], "reasoning": {"effort": "medium", "not_a_real_reasoning_field": "x"}}
+        )
+        assert params.reasoning == {"effort": "medium"}
+
+    def test_reasoning_context_is_forwarded_now_that_the_sdk_models_it(self) -> None:
+        # Codex sends `reasoning.context`. The pinned SDK models it, so it is passed through
+        # rather than pruned. If a later SDK drops the field this fails, which is the signal to
+        # check whether Codex requests still round-trip.
         params = validate_streaming_responses_params(
             {"input": [], "reasoning": {"effort": "medium", "context": "all_turns"}}
         )
-        assert params.reasoning == {"effort": "medium"}
+        assert params.reasoning == {"effort": "medium", "context": "all_turns"}
 
     def test_unfixable_errors_still_raise(self) -> None:
         import pydantic
@@ -474,7 +557,9 @@ class TestSynthesizeSSE:
         response = _build_response([_function_call_item("exec_command")]).model_dump(mode="json")
         events = self._events("".join(synthesize_responses_sse(response, {"other__tool": ("other", "tool")})))
         assert events[1]["item"]["name"] == "exec_command"
-        assert "namespace" not in events[1]["item"]
+        # namespace is a field on the call model now, so an unmapped call carries it unset
+        # rather than not carrying it at all.
+        assert events[1]["item"]["namespace"] is None
 
     def test_failure_stream_is_terminal_response_failed(self) -> None:
         events = self._events("".join(synthesize_responses_failure_sse("boom", code="server_error")))
@@ -483,6 +568,26 @@ class TestSynthesizeSSE:
         assert failed["status"] == "failed"
         assert failed["error"] == {"code": "server_error", "message": "boom"}
         assert failed["output"] == []
+
+
+# Item types the streaming sanitizer removes from the input on purpose, so the no-drop check
+# below must not apply to them. `additional_tools` is a Codex code-mode carrier: the sanitizer
+# hoists the function tools it contains into the `tools` param and discards the item itself.
+STREAMING_CONSUMED_TYPES = frozenset({"additional_tools"})
+
+
+def test_no_dead_entries_in_streaming_consumed_types() -> None:
+    """Every consumed type must be one the union still accepts.
+
+    The test that reads this list is parametrized over ITEM_FIXTURES, so it never visits a tag that
+    is not in it. A dead entry is then invisible: the type it was meant to name is checked as if it
+    survived the sanitizer, and the type that actually is consumed goes unchecked.
+    """
+    suspicious = sorted(STREAMING_CONSUMED_TYPES - set(ITEM_FIXTURES))
+    assert not suspicious, (
+        f"{suspicious} are in STREAMING_CONSUMED_TYPES but have no fixture, so nothing checks that "
+        f"the sanitizer consumes them. Either the tag is a typo, or the type left the union."
+    )
 
 
 class _EchoModel(SimpleResponsesAPIModel):
@@ -660,6 +765,12 @@ class TestUnionItemTypesThroughDispatch:
         assert response.status_code == 200
 
         seen = server.last_params.input
+        if tag in STREAMING_CONSUMED_TYPES:
+            assert len(seen) == len(history) - 1, (
+                f"{tag!r} is declared as consumed by the sanitizer, but it survived the streaming "
+                f"path. Remove it from STREAMING_CONSUMED_TYPES."
+            )
+            return
         assert len(seen) == len(history), (
             f"a {tag!r} item was dropped from the streaming transcript: sent {len(history)} input "
             f"items, backend received {len(seen)}. Check the warning from "

--- a/tests/unit_tests/test_responses_api_model_streaming.py
+++ b/tests/unit_tests/test_responses_api_model_streaming.py
@@ -209,7 +209,7 @@ ITEM_FIXTURES: dict[str, dict] = {
         "execution": "server",
         "status": "completed",
     },
-    # Results a client hands back, and the approval it grants.
+    # Client-supplied tool results and approvals.
     "function_call_output": {
         "type": "function_call_output",
         "call_id": "call_1",
@@ -265,7 +265,7 @@ ITEM_FIXTURES: dict[str, dict] = {
         "role": "developer",
         "tools": [],
     },
-    # Context-management bookkeeping and the tool carrier Codex code mode sends.
+    # Context-compaction records.
     "compaction": {
         "type": "compaction",
         "id": "cmp_1",
@@ -291,8 +291,7 @@ CHAT_INCONVERTIBLE_TYPES = frozenset(
         "mcp_call",
         "mcp_list_tools",
         "web_search_call",
-        # Codex tool family and context management (openai >= 2.25). A shell command, a patch, a
-        # tool search and an opaque compaction record have no chat-message form either.
+        # Tool calls, tool results, and compaction records have no chat-message form.
         "apply_patch_call",
         "apply_patch_call_output",
         "compaction",
@@ -300,7 +299,7 @@ CHAT_INCONVERTIBLE_TYPES = frozenset(
         "shell_call_output",
         "tool_search_call",
         "tool_search_output",
-        # Client-supplied results, approvals and tool carriers have no chat-message form.
+        # Client-supplied results, approvals, and tool definitions have no chat-message form.
         "computer_call_output",
         "custom_tool_call_output",
         "local_shell_call_output",
@@ -332,7 +331,8 @@ class TestSanitizeStreamingBody:
         cleaned, _ = sanitize_streaming_responses_body(
             {"input": [], "stream": True, "client_metadata": {"x": 1}, "prompt_cache_key": "abc", "store": False}
         )
-        # prompt_cache_key is part of the pinned request schema, so it survives; client_metadata is not.
+        # `prompt_cache_key` is part of the request schema and survives.
+        # `client_metadata` is not part of the schema and is removed.
         assert set(cleaned) == {"input", "store", "prompt_cache_key"}
         # the cleaned body validates against the strict params model
         NeMoGymResponseCreateParamsNonStreaming.model_validate(cleaned)
@@ -496,19 +496,15 @@ class TestSanitizeStreamingBody:
 
 class TestValidateStreamingParams:
     def test_prunes_nested_extra_fields(self) -> None:
-        # A nested field the SDK's Reasoning model does not know is dropped so the rest of the
-        # request still validates. Uses an invented field name rather than a real one: a field
-        # the SDK later adopts stops being pruned, which is what happened to `reasoning.context`
-        # (Codex sent it, the pinned SDK forbade it, and openai 2.44 added it).
+        # Drop unknown nested fields so the remaining request can validate.
+        # Use an unsupported field name so schema additions do not change the test.
         params = validate_streaming_responses_params(
             {"input": [], "reasoning": {"effort": "medium", "not_a_real_reasoning_field": "x"}}
         )
         assert params.reasoning == {"effort": "medium"}
 
     def test_reasoning_context_is_forwarded_now_that_the_sdk_models_it(self) -> None:
-        # Codex sends `reasoning.context`. The pinned SDK models it, so it is passed through
-        # rather than pruned. If a later SDK drops the field this fails, which is the signal to
-        # check whether Codex requests still round-trip.
+        # The SDK models `reasoning.context`, so the sanitizer preserves it.
         params = validate_streaming_responses_params(
             {"input": [], "reasoning": {"effort": "medium", "context": "all_turns"}}
         )
@@ -557,8 +553,7 @@ class TestSynthesizeSSE:
         response = _build_response([_function_call_item("exec_command")]).model_dump(mode="json")
         events = self._events("".join(synthesize_responses_sse(response, {"other__tool": ("other", "tool")})))
         assert events[1]["item"]["name"] == "exec_command"
-        # namespace is a field on the call model now, so an unmapped call carries it unset
-        # rather than not carrying it at all.
+        # Unmapped calls retain an unset `namespace` field.
         assert events[1]["item"]["namespace"] is None
 
     def test_failure_stream_is_terminal_response_failed(self) -> None:
@@ -570,18 +565,17 @@ class TestSynthesizeSSE:
         assert failed["output"] == []
 
 
-# Item types the streaming sanitizer removes from the input on purpose, so the no-drop check
-# below must not apply to them. `additional_tools` is a Codex code-mode carrier: the sanitizer
-# hoists the function tools it contains into the `tools` param and discards the item itself.
+# The streaming sanitizer intentionally removes these input item types.
+# The transcript preservation check excludes them.
+# For `additional_tools`, the sanitizer moves function definitions into `tools`.
 STREAMING_CONSUMED_TYPES = frozenset({"additional_tools"})
 
 
 def test_no_dead_entries_in_streaming_consumed_types() -> None:
-    """Every consumed type must be one the union still accepts.
+    """Require a fixture for every consumed item type.
 
-    The test that reads this list is parametrized over ITEM_FIXTURES, so it never visits a tag that
-    is not in it. A dead entry is then invisible: the type it was meant to name is checked as if it
-    survived the sanitizer, and the type that actually is consumed goes unchecked.
+    The transcript test is parametrized over ``ITEM_FIXTURES``.
+    An entry without a fixture would not be tested.
     """
     suspicious = sorted(STREAMING_CONSUMED_TYPES - set(ITEM_FIXTURES))
     assert not suspicious, (

--- a/tests/unit_tests/test_responses_converter.py
+++ b/tests/unit_tests/test_responses_converter.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Unit tests for the shared Responses API <-> Chat Completions converter."""
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -625,7 +626,6 @@ def test_responses_to_chat_completion_model_and_max_tokens_and_tools(converter: 
 @pytest.mark.parametrize(
     "tool",
     [
-        {"type": "custom", "name": "shell"},
         {
             "type": "function",
             "name": "get_weather",
@@ -633,13 +633,188 @@ def test_responses_to_chat_completion_model_and_max_tokens_and_tools(converter: 
             "strict": True,
             "defer_loading": True,
         },
+        {
+            "type": "custom",
+            "name": "shell",
+            "defer_loading": True,
+        },
     ],
-    ids=["custom", "deferred_function"],
+    ids=["function", "custom"],
 )
-def test_responses_to_chat_completion_rejects_unimplemented_tool_conversion(converter: ResponsesConverter, tool: dict):
+def test_responses_to_chat_completion_rejects_deferred_tool(converter: ResponsesConverter, tool: dict):
     params = NeMoGymResponseCreateParamsNonStreaming(input="hi", tools=[tool])
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match="defer_loading"):
+        converter.responses_to_chat_completion_create_params(params)
+
+
+@pytest.mark.parametrize(
+    ("chat_tool", "responses_tool"),
+    [
+        (
+            {"type": "function", "function": {"name": "get_weather"}},
+            {"type": "function", "name": "get_weather", "parameters": None, "strict": None},
+        ),
+        (
+            {"type": "custom", "custom": {"name": "shell", "description": "Run a command"}},
+            {"type": "custom", "name": "shell", "description": "Run a command"},
+        ),
+        (
+            {
+                "type": "custom",
+                "custom": {
+                    "name": "parser",
+                    "format": {
+                        "type": "grammar",
+                        "grammar": {
+                            "definition": "start: WORD",
+                            "syntax": "lark",
+                        },
+                    },
+                },
+            },
+            {
+                "type": "custom",
+                "name": "parser",
+                "format": {
+                    "type": "grammar",
+                    "definition": "start: WORD",
+                    "syntax": "lark",
+                },
+            },
+        ),
+    ],
+    ids=["minimal_function", "custom", "custom_grammar"],
+)
+def test_tool_definitions_round_trip(
+    converter: ResponsesConverter,
+    chat_tool: dict,
+    responses_tool: dict,
+):
+    responses_params = converter.chat_completion_to_responses_create_params(
+        NeMoGymChatCompletionCreateParamsNonStreaming(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[chat_tool],
+        )
+    )
+    assert responses_params.tools == [responses_tool]
+
+    chat_params = converter.responses_to_chat_completion_create_params(responses_params)
+    assert chat_params.tools[0]["type"] == chat_tool["type"]
+    tool_type = chat_tool["type"]
+    assert chat_params.tools[0][tool_type]["name"] == chat_tool[tool_type]["name"]
+    if tool_type == "function":
+        assert chat_params.tools[0]["function"].get("parameters") is None
+        assert chat_params.tools[0]["function"].get("strict") is None
+    else:
+        assert chat_params.tools == [chat_tool]
+
+
+@pytest.mark.parametrize(
+    ("chat_choice", "responses_choice"),
+    [
+        (
+            {"type": "function", "function": {"name": "get_weather"}},
+            {"type": "function", "name": "get_weather"},
+        ),
+        (
+            {"type": "custom", "custom": {"name": "shell"}},
+            {"type": "custom", "name": "shell"},
+        ),
+        (
+            {
+                "type": "allowed_tools",
+                "allowed_tools": {
+                    "mode": "required",
+                    "tools": [
+                        {"type": "function", "function": {"name": "get_weather"}},
+                        {"type": "custom", "custom": {"name": "shell"}},
+                    ],
+                },
+            },
+            {
+                "type": "allowed_tools",
+                "mode": "required",
+                "tools": [
+                    {"type": "function", "name": "get_weather"},
+                    {"type": "custom", "name": "shell"},
+                ],
+            },
+        ),
+    ],
+    ids=["named_function", "named_custom", "allowed_tools"],
+)
+def test_tool_choices_round_trip(
+    converter: ResponsesConverter,
+    chat_choice: dict,
+    responses_choice: dict,
+):
+    assert converter._chat_to_responses_tool_choice(chat_choice) == responses_choice
+    assert converter._responses_to_chat_tool_choice(responses_choice) == chat_choice
+
+    chat_params = NeMoGymChatCompletionCreateParamsNonStreaming(
+        messages=[{"role": "user", "content": "hi"}],
+        tool_choice=chat_choice,
+        tools=[{"type": "function", "function": {"name": "get_weather"}}],
+    )
+
+    responses_params = converter.chat_completion_to_responses_create_params(chat_params)
+    round_tripped = converter.responses_to_chat_completion_create_params(responses_params)
+    assert json.loads(round_tripped.model_dump_json())["tool_choice"] == chat_choice
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        {"type": "apply_patch"},
+        {"type": "shell"},
+        {"type": "mcp", "server_label": "server"},
+        {"type": "file_search"},
+    ],
+    ids=["apply_patch", "shell", "mcp", "hosted"],
+)
+def test_responses_to_chat_completion_rejects_responses_only_tool_choices(
+    converter: ResponsesConverter,
+    tool_choice: dict,
+):
+    params = NeMoGymResponseCreateParamsNonStreaming(
+        input="hi",
+        tool_choice=tool_choice,
+        tools=[
+            {
+                "type": "function",
+                "name": "get_weather",
+                "parameters": None,
+                "strict": None,
+            }
+        ],
+    )
+
+    with pytest.raises(NotImplementedError, match="tool choice"):
+        converter.responses_to_chat_completion_create_params(params)
+
+
+def test_responses_to_chat_completion_rejects_responses_only_allowed_tool_reference(
+    converter: ResponsesConverter,
+):
+    params = NeMoGymResponseCreateParamsNonStreaming(
+        input="hi",
+        tool_choice={
+            "type": "allowed_tools",
+            "mode": "auto",
+            "tools": [{"type": "mcp", "server_label": "server"}],
+        },
+        tools=[
+            {
+                "type": "function",
+                "name": "get_weather",
+                "parameters": None,
+                "strict": None,
+            }
+        ],
+    )
+
+    with pytest.raises(NotImplementedError, match="tool reference"):
         converter.responses_to_chat_completion_create_params(params)
 
 
@@ -673,6 +848,31 @@ def test_responses_to_chat_completion_no_tools_rejects_required_tool_choice(
                 model="my-model",
                 tool_choice="required",
                 **tools_kwargs,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        {"type": "function", "name": "get_weather"},
+        {
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": "function", "name": "get_weather"}],
+        },
+    ],
+    ids=["named", "allowed"],
+)
+def test_responses_to_chat_completion_no_tools_rejects_structured_tool_choice(
+    converter: ResponsesConverter,
+    tool_choice: dict,
+):
+    with pytest.raises(ValueError, match="requires at least one tool"):
+        converter.responses_to_chat_completion_create_params(
+            NeMoGymResponseCreateParamsNonStreaming(
+                input="hi",
+                tool_choice=tool_choice,
             )
         )
 

--- a/tests/unit_tests/test_responses_converter.py
+++ b/tests/unit_tests/test_responses_converter.py
@@ -1536,6 +1536,24 @@ def test_downconverting_present_responses_only_fields_fails_explicitly(
         converter.responses_to_chat_completion_create_params(params)
 
 
+def test_downconverting_null_responses_only_fields_treats_them_as_absent(converter: ResponsesConverter):
+    params = NeMoGymResponseCreateParamsNonStreaming(
+        input="hi",
+        background=None,
+        context_management=None,
+        conversation=None,
+        include=None,
+        max_tool_calls=None,
+        previous_response_id=None,
+        prompt=None,
+        truncation=None,
+    )
+
+    converted = converter.responses_to_chat_completion_create_params(params)
+
+    assert converted.messages == [{"content": [{"text": "hi", "type": "text"}], "role": "user"}]
+
+
 def test_downconverting_text_format_fails_explicitly(converter: ResponsesConverter):
     params = NeMoGymResponseCreateParamsNonStreaming(input="hi", text={"format": {"type": "json_object"}})
 

--- a/tests/unit_tests/test_responses_converter.py
+++ b/tests/unit_tests/test_responses_converter.py
@@ -1216,6 +1216,30 @@ def test_downconverting_an_unsupported_type_names_it_and_the_way_out():
     )
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("background", True),
+        ("context_management", []),
+        ("conversation", "conv_1"),
+        ("include", ["reasoning.encrypted_content"]),
+        ("max_tool_calls", 2),
+        ("previous_response_id", "resp_1"),
+        ("prompt", {"id": "pmpt_1"}),
+        ("reasoning", {"effort": "high"}),
+        ("text", {"verbosity": "high"}),
+        ("truncation", "auto"),
+    ],
+)
+def test_downconverting_present_responses_only_fields_fails_explicitly(
+    converter: ResponsesConverter, field: str, value
+):
+    params = NeMoGymResponseCreateParamsNonStreaming(input="hi", **{field: value})
+
+    with pytest.raises(NotImplementedError, match=field):
+        converter.responses_to_chat_completion_create_params(params)
+
+
 def test_training_variant_of_raises_a_named_error_for_an_unregistered_class():
     """An unregistered class raises NotImplementedError, not KeyError."""
 

--- a/tests/unit_tests/test_responses_converter.py
+++ b/tests/unit_tests/test_responses_converter.py
@@ -401,6 +401,21 @@ def test_chat_schema_accepts_only_canonical_video_url():
         )
 
 
+@pytest.mark.parametrize(
+    "part",
+    [
+        {"type": "input_image", "file_id": "file_123", "detail": "high"},
+        {"type": "input_image", "image_url": "http://img", "detail": "original"},
+    ],
+    ids=["file_id", "original_detail"],
+)
+def test_responses_to_chat_completion_rejects_unrepresentable_input_images(converter: ResponsesConverter, part: dict):
+    params = NeMoGymResponseCreateParamsNonStreaming(input=[{"role": "user", "type": "message", "content": [part]}])
+
+    with pytest.raises(NotImplementedError):
+        converter.responses_to_chat_completion_create_params(params)
+
+
 def test_responses_to_chat_completion_unsupported_part_raises(converter: ResponsesConverter):
     # Exercise the converter directly with an unsupported content part type. A raw
     # ResponseCreateParams would reject this at schema-validation time, so we call the
@@ -604,6 +619,28 @@ def test_responses_to_chat_completion_model_and_max_tokens_and_tools(converter: 
     assert params.max_tokens == 128
     assert params.tools[0]["type"] == "function"
     assert params.tools[0]["function"]["name"] == "get_weather"
+    assert params.tools[0]["function"]["strict"] is True
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        {"type": "custom", "name": "shell"},
+        {
+            "type": "function",
+            "name": "get_weather",
+            "parameters": {},
+            "strict": True,
+            "defer_loading": True,
+        },
+    ],
+    ids=["custom", "deferred_function"],
+)
+def test_responses_to_chat_completion_rejects_unimplemented_tool_conversion(converter: ResponsesConverter, tool: dict):
+    params = NeMoGymResponseCreateParamsNonStreaming(input="hi", tools=[tool])
+
+    with pytest.raises(NotImplementedError):
+        converter.responses_to_chat_completion_create_params(params)
 
 
 @pytest.mark.parametrize("tools_kwargs", [{}, {"tools": []}], ids=["tools_absent", "tools_empty"])
@@ -666,7 +703,7 @@ def test_chat_completion_to_responses_tools_accepts_none(converter: ResponsesCon
     assert converter._chat_completion_to_responses_tools(None) == []
 
 
-@pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high"])
+@pytest.mark.parametrize("effort", ["none", "minimal", "low", "medium", "high", "xhigh"])
 def test_reasoning_effort_round_trips_between_request_schemas(converter: ResponsesConverter, effort: str):
     responses_params = converter.chat_completion_to_responses_create_params(
         NeMoGymChatCompletionCreateParamsNonStreaming(
@@ -680,6 +717,67 @@ def test_reasoning_effort_round_trips_between_request_schemas(converter: Respons
 
     chat_params = converter.responses_to_chat_completion_create_params(responses_params)
     assert chat_params.reasoning_effort == effort
+
+
+def test_shared_openai_request_fields_round_trip(converter: ResponsesConverter):
+    chat_params = NeMoGymChatCompletionCreateParamsNonStreaming(
+        messages=[{"role": "user", "content": "hi"}],
+        moderation={"model": "omni-moderation-latest"},
+        prompt_cache_key="cache-key",
+        prompt_cache_retention="24h",
+        safety_identifier="safe-user",
+        verbosity="high",
+        tools=[],
+    )
+
+    responses_params = converter.chat_completion_to_responses_create_params(chat_params)
+    assert responses_params.moderation == {"model": "omni-moderation-latest"}
+    assert responses_params.prompt_cache_key == "cache-key"
+    assert responses_params.prompt_cache_retention == "24h"
+    assert responses_params.safety_identifier == "safe-user"
+    assert responses_params.text == {"verbosity": "high"}
+
+    round_tripped = converter.responses_to_chat_completion_create_params(responses_params)
+    assert round_tripped.moderation == chat_params.moderation
+    assert round_tripped.prompt_cache_key == chat_params.prompt_cache_key
+    assert round_tripped.prompt_cache_retention == chat_params.prompt_cache_retention
+    assert round_tripped.safety_identifier == chat_params.safety_identifier
+    assert round_tripped.verbosity == chat_params.verbosity
+
+
+def test_responses_to_chat_completion_rejects_message_phase(converter: ResponsesConverter):
+    params = NeMoGymResponseCreateParamsNonStreaming(
+        input=[
+            {
+                "type": "message",
+                "id": "msg_1",
+                "role": "assistant",
+                "status": "completed",
+                "phase": "commentary",
+                "content": [{"type": "output_text", "text": "working", "annotations": []}],
+            }
+        ]
+    )
+
+    with pytest.raises(NotImplementedError, match="phase"):
+        converter.responses_to_chat_completion_create_params(params)
+
+
+def test_responses_to_chat_completion_rejects_function_namespace(converter: ResponsesConverter):
+    params = NeMoGymResponseCreateParamsNonStreaming(
+        input=[
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "run",
+                "namespace": "tools",
+                "arguments": "{}",
+            }
+        ]
+    )
+
+    with pytest.raises(NotImplementedError, match="namespace"):
+        converter.responses_to_chat_completion_create_params(params)
 
 
 def test_responses_to_chat_completion_token_id_information_path():
@@ -1226,8 +1324,6 @@ def test_downconverting_an_unsupported_type_names_it_and_the_way_out():
         ("max_tool_calls", 2),
         ("previous_response_id", "resp_1"),
         ("prompt", {"id": "pmpt_1"}),
-        ("reasoning", {"effort": "high"}),
-        ("text", {"verbosity": "high"}),
         ("truncation", "auto"),
     ],
 )
@@ -1235,6 +1331,21 @@ def test_downconverting_present_responses_only_fields_fails_explicitly(
     converter: ResponsesConverter, field: str, value
 ):
     params = NeMoGymResponseCreateParamsNonStreaming(input="hi", **{field: value})
+
+    with pytest.raises(NotImplementedError, match=field):
+        converter.responses_to_chat_completion_create_params(params)
+
+
+def test_downconverting_text_format_fails_explicitly(converter: ResponsesConverter):
+    params = NeMoGymResponseCreateParamsNonStreaming(input="hi", text={"format": {"type": "json_object"}})
+
+    with pytest.raises(NotImplementedError, match="text format"):
+        converter.responses_to_chat_completion_create_params(params)
+
+
+@pytest.mark.parametrize("field", ["context", "generate_summary", "summary"])
+def test_downconverting_responses_only_reasoning_fields_fails_explicitly(converter: ResponsesConverter, field: str):
+    params = NeMoGymResponseCreateParamsNonStreaming(input="hi", reasoning={field: "auto"})
 
     with pytest.raises(NotImplementedError, match=field):
         converter.responses_to_chat_completion_create_params(params)

--- a/uv.lock
+++ b/uv.lock
@@ -2662,7 +2662,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "nemo-gym", extras = ["dev", "sandbox"], marker = "extra == 'all'" },
     { name = "omegaconf" },
-    { name = "openai", specifier = "<=2.7.2" },
+    { name = "openai", specifier = "==2.44.0" },
     { name = "opensandbox", marker = "extra == 'sandbox'", specifier = ">=0.1.15" },
     { name = "openshell", marker = "extra == 'openshell'", specifier = ">=0.0.92,<0.1" },
     { name = "orjson" },
@@ -3251,7 +3251,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.7.2"
+version = "2.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3263,9 +3263,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/e3/cec27fa28ef36c4ccea71e9e8c20be9b8539618732989a82027575aab9d4/openai-2.7.2.tar.gz", hash = "sha256:082ef61163074d8efad0035dd08934cf5e3afd37254f70fc9165dd6a8c67dcbd", size = 595732, upload-time = "2025-11-10T16:42:31.108Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/f5/7c7cb955305cb41f7f3c5fd7e0e38bf6bbf2658468863d4b7b868a5cb8df/openai-2.44.0.tar.gz", hash = "sha256:68a5a5ffad82b8ff7d451c437529fb64f7c3b8123aaf0c021966a882d9e3947d", size = 988753, upload-time = "2026-06-24T20:56:02.293Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/66/22cfe4b695b5fd042931b32c67d685e867bfd169ebf46036b95b57314c33/openai-2.7.2-py3-none-any.whl", hash = "sha256:116f522f4427f8a0a59b51655a356da85ce092f3ed6abeca65f03c8be6e073d9", size = 1008375, upload-time = "2025-11-10T16:42:28.574Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f4/561ed79fd94876160018a5e75254cfcb9b0e62d4dded9dcb20072e86d623/openai-2.44.0-py3-none-any.whl", hash = "sha256:0a2a3ab2e29aeda368700f662ff9ba0f9df17ba4c54577a64e08b8115a3cc0ad", size = 1366216, upload-time = "2026-06-24T20:55:58.882Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes https://github.com/NVIDIA-NeMo/Gym/issues/2452

This change pins `openai==2.44.0` and updates the Responses and Chat schemas used by Gym.

Gym subclasses OpenAI SDK models and copies several request schemas into Pydantic models. The dependency is pinned to one audited version because a version range would allow schema changes that Gym has not handled. OpenAI 2.44.0 is the latest usable release in this update; 2.45.0 makes `InputTokensDetails.cache_write_tokens` required and breaks `NeMoGymResponseInputTokensDetails` construction.

## Responses items

OpenAI 2.44.0 adds the Codex tool family and context-management items:

- `shell_call` and `shell_call_output`
- `apply_patch_call` and `apply_patch_call_output`
- `tool_search_call` and `tool_search_output`
- `compaction` and `compaction_trigger`
- `additional_tools`

The model-generated calls are generation boundaries. Client results, approvals, tool carriers, and compaction records are non-boundaries. Types without a Chat Completions representation remain explicitly inconvertible.

## Output and replay input

OpenAI 2.44.0 gives some same-tag output and input models different value domains. `NeMoGymResponseOutputItem` and `NeMoGymResponseInputItem` use separate owners for those items.

```mermaid
flowchart LR
    PROVIDER["Provider response"] --> OUTPUT["NeMoGymResponseOutputItem"]
    OUTPUT --> PRESERVE["Preserve provider fields"]
    PRESERVE --> REPLAY["Next request input"]
    REPLAY --> NORMALIZE["Normalize output-only values"]
    NORMALIZE --> INPUT["NeMoGymResponseInputItem"]
    INPUT --> API["OpenAI 2.44 input schema"]
```

`additional_tools.role` is preserved on provider output. Replay changes non-`developer` roles to `developer`, which is the only value accepted by the SDK input model.

`computer_call_output.status="failed"` is preserved on provider output. Replay omits that optional status because the SDK input model does not accept `failed`.

Local agents may construct a response with the replay-input `function_call_output` model. The output union continues to accept that model alongside the SDK provider-output model.

## Request schemas

The Responses request model includes the fields added through OpenAI 2.44.0, including context management, conversation, moderation, cache controls, and safety identifiers. Native Responses model servers forward these fields.

The Chat Completions request model includes `moderation`, `prompt_cache_key`, `prompt_cache_retention`, `safety_identifier`, and `verbosity`. Unknown fields are rejected instead of being silently removed. Deprecated `function_call` and `functions` remain disabled.

Shared request fields round-trip through the converter. `text.verbosity` maps to Chat `verbosity`. `reasoning.effort` maps to Chat `reasoning_effort`, including the 2.44 values `none` and `xhigh`. See the [Responses reasoning configuration](https://platform.openai.com/docs/api-reference/responses/create#responses-create-reasoning) and [Chat reasoning effort](https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort) references.

Nested reasoning controls without a Chat equivalent are rejected. `text.format` is also rejected until its different Chat and Responses object shapes have an explicit conversion.

Function tools preserve `strict`. Deferred loading and tool types without an implemented conversion raise `NotImplementedError` instead of being partially converted. See the [Responses tools](https://platform.openai.com/docs/api-reference/responses/create#responses-create-tools) reference.

```mermaid
flowchart TD
    REQUEST["Responses request"] --> ROUTE{"Model server API"}
    ROUTE -->|"Responses"| PASS["Forward supported Responses fields"]
    ROUTE -->|"Chat Completions"| CHECK{"Lossless Chat conversion?"}
    CHECK -->|"Yes"| CONVERT["Map shared fields"]
    CHECK -->|"No"| ERROR["Raise NotImplementedError"]
```

## Replay safeguards

OpenAI 2.44.0 adds values that Chat Completions cannot represent. Downconversion now rejects them before information is lost:

- `message.phase`
- function-call `namespace`
- function-tool `defer_loading=true`
- input images referenced by `file_id`
- input-image detail `original`

Other Responses-only items and fields retain the same explicit rejection path.

## Streaming and component compatibility

The streaming sanitizer removes `stream_options` when it removes `stream`, because the option is only valid for streaming requests. It consumes `additional_tools` after hoisting supported function tools into the top-level `tools` field.

Response comparisons in affected agent tests remove null values recursively. This accounts for optional fields added inside nested output items. Duplicate item fixtures were removed so each type tag has one payload.

The `resources_servers/cvdp` OpenAI pin was removed. The package-level pin is the source used when server environments are created.