### PR TITLE
fix(swe_agents): run the R2E eval through the /r2egym_setup bind

### DIFF
--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -550,6 +550,21 @@ EVAL_HARNESS_COMMIT={eval_harness_commit} \\
             return setup_dir
 
     def get_run_command(self) -> ExecuteContainerCommandArgs:
+        # Invoke the venv through the /r2egym_setup bind: _build_apptainer_command always
+        # creates that one, while its second bind of the setup dir at the original host
+        # path needs overlay/underlay support for deep destination paths inside read-only
+        # SIFs and can fail to establish. Put both path variants of the venv
+        # site-packages and src tree on PYTHONPATH — the editable install's .pth file
+        # references the original host path, and Python silently skips entries that do
+        # not resolve — so imports work whichever binds succeeded.
+        python_path = ":".join(
+            [
+                "/r2egym_setup/R2E-Gym/venv/lib/python3.12/site-packages",
+                f"{self.config.r2e_gym_setup_dir}/R2E-Gym/venv/lib/python3.12/site-packages",
+                "/r2egym_setup/R2E-Gym/src",
+                f"{self.config.r2e_gym_setup_dir}/R2E-Gym/src",
+            ]
+        )
         r2e_gym_cmd = (
             f'date +"%s.%N" > {self.config.final_eval_apptainer_spinup_timestamp_mounted_fpath} && '
             f"{self._get_command_sleep_until_predictions_file()} && "
@@ -559,9 +574,9 @@ EVAL_HARNESS_COMMIT={eval_harness_commit} \\
             f'export UV_INSTALL_DIR="{self.config.r2e_gym_setup_dir}/uv" && '
             f'export UV_PYTHON_INSTALL_DIR="{self.config.r2e_gym_setup_dir}/python" && '
             f'export PATH="{self.config.r2e_gym_setup_dir}/uv/bin:$PATH" && '
+            f'export PYTHONPATH="{python_path}:$PYTHONPATH" && '
             # Run with clean environment to avoid venv contamination
-            # Use the pre-built venv directly with its absolute path
-            f"env -u VIRTUAL_ENV {self.config.r2e_gym_setup_dir}/R2E-Gym/venv/bin/python src/r2egym/agenthub/run/run_local_evaluation.py "
+            "env -u VIRTUAL_ENV /r2egym_setup/R2E-Gym/venv/bin/python -m r2egym.agenthub.run.run_local_evaluation "
             f"    --predictions_path {self.config.output_for_eval_mounted_path} "
             f"    --instance_id {self.config.instance_id} "
             f"    --timeout {self.config.swebench_tests_timeout} "

--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -549,8 +549,27 @@ EVAL_HARNESS_COMMIT={eval_harness_commit} \\
 
             return setup_dir
 
+    def _mounted_eval_python(self) -> str:
+        """Resolve the eval interpreter to a path that exists under the /r2egym_setup bind.
+
+        uv creates venv/bin/python (and the versionless python install dir) as
+        symlinks to absolute host paths, so invoking the venv wrapper through
+        /r2egym_setup still dereferences to the host path — dangling when the
+        same-path bind did not establish. Resolve the symlink chain on the host
+        and re-anchor the real interpreter under /r2egym_setup: the standalone
+        CPython locates its stdlib relative to the executable, and the venv
+        site-packages arrive via PYTHONPATH.
+        """
+        setup_dir = os.path.realpath(str(self.config.r2e_gym_setup_dir))
+        resolved = os.path.realpath(f"{setup_dir}/R2E-Gym/venv/bin/python")
+        if resolved.startswith(f"{setup_dir}/"):
+            return f"/r2egym_setup{resolved[len(setup_dir):]}"
+        # Interpreter resolves outside the setup dir (non-standard setup); keep
+        # the venv wrapper via the fixed bind as the best effort.
+        return "/r2egym_setup/R2E-Gym/venv/bin/python"
+
     def get_run_command(self) -> ExecuteContainerCommandArgs:
-        # Invoke the venv through the /r2egym_setup bind: _build_apptainer_command always
+        # Run the eval through the /r2egym_setup bind: _build_apptainer_command always
         # creates that one, while its second bind of the setup dir at the original host
         # path needs overlay/underlay support for deep destination paths inside read-only
         # SIFs and can fail to establish. Put both path variants of the venv
@@ -576,7 +595,7 @@ EVAL_HARNESS_COMMIT={eval_harness_commit} \\
             f'export PATH="{self.config.r2e_gym_setup_dir}/uv/bin:$PATH" && '
             f'export PYTHONPATH="{python_path}:$PYTHONPATH" && '
             # Run with clean environment to avoid venv contamination
-            "env -u VIRTUAL_ENV /r2egym_setup/R2E-Gym/venv/bin/python -m r2egym.agenthub.run.run_local_evaluation "
+            f"env -u VIRTUAL_ENV {self._mounted_eval_python()} -m r2egym.agenthub.run.run_local_evaluation "
             f"    --predictions_path {self.config.output_for_eval_mounted_path} "
             f"    --instance_id {self.config.instance_id} "
             f"    --timeout {self.config.swebench_tests_timeout} "

--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -563,7 +563,7 @@ EVAL_HARNESS_COMMIT={eval_harness_commit} \\
         setup_dir = os.path.realpath(str(self.config.r2e_gym_setup_dir))
         resolved = os.path.realpath(f"{setup_dir}/R2E-Gym/venv/bin/python")
         if resolved.startswith(f"{setup_dir}/"):
-            return f"/r2egym_setup{resolved[len(setup_dir):]}"
+            return f"/r2egym_setup{resolved[len(setup_dir) :]}"
         # Interpreter resolves outside the setup dir (non-standard setup); keep
         # the venv wrapper via the fixed bind as the best effort.
         return "/r2egym_setup/R2E-Gym/venv/bin/python"

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -821,7 +821,8 @@ class TestR2EGymDatasetProcessor:
             processor = R2EGymDatasetProcessor(config=config)
             result = processor.get_run_command()
             assert isinstance(result, ExecuteContainerCommandArgs)
-            assert "run_local_evaluation.py" in result.command
+            assert "/r2egym_setup/R2E-Gym/venv/bin/python" in result.command
+            assert "-m r2egym.agenthub.run.run_local_evaluation" in result.command
             assert result.mode == "eval"
 
 

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -848,10 +848,7 @@ class TestR2EGymDatasetProcessor:
             processor = R2EGymDatasetProcessor(config=config)
             result = processor.get_run_command()
 
-            assert (
-                "/r2egym_setup/python/cpython-3.12.13-linux-x86_64-gnu/bin/python3.12"
-                in result.command
-            )
+            assert "/r2egym_setup/python/cpython-3.12.13-linux-x86_64-gnu/bin/python3.12" in result.command
             assert f"{setup_dir}/R2E-Gym/venv/bin/python" not in result.command
 
 

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -825,6 +825,35 @@ class TestR2EGymDatasetProcessor:
             assert "-m r2egym.agenthub.run.run_local_evaluation" in result.command
             assert result.mode == "eval"
 
+    def test_get_run_command_remaps_symlinked_interpreter(self) -> None:
+        """The eval interpreter must not dereference to a host-absolute path.
+
+        Mirrors uv's real layout: venv/bin/python -> versionless install dir
+        (itself a symlink) -> versioned interpreter, all via absolute host
+        paths that only resolve in-container when the same-path bind worked.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = _make_instance_config(tmpdir)
+            setup_dir = Path(config.r2e_gym_setup_dir)
+            real_dir = setup_dir / "python/cpython-3.12.13-linux-x86_64-gnu"
+            real_python = real_dir / "bin/python3.12"
+            real_python.parent.mkdir(parents=True)
+            real_python.touch()
+            versionless_dir = setup_dir / "python/cpython-3.12-linux-x86_64-gnu"
+            versionless_dir.symlink_to(real_dir)
+            venv_bin = setup_dir / "R2E-Gym/venv/bin"
+            venv_bin.mkdir(parents=True)
+            (venv_bin / "python").symlink_to(versionless_dir / "bin/python3.12")
+
+            processor = R2EGymDatasetProcessor(config=config)
+            result = processor.get_run_command()
+
+            assert (
+                "/r2egym_setup/python/cpython-3.12.13-linux-x86_64-gnu/bin/python3.12"
+                in result.command
+            )
+            assert f"{setup_dir}/R2E-Gym/venv/bin/python" not in result.command
+
 
 ########################################
 # OpenHandsHarnessProcessor tests


### PR DESCRIPTION
`_build_apptainer_command` mounts the R2E setup directory **twice** for eval containers — at `/r2egym_setup` and at its original host path (the code comments note the second bind exists because "uv venv has hardcoded absolute paths in its wrappers"):

```python
mount_args.append(f"--mount type=bind,src={params.r2e_gym_setup_dir},dst=/r2egym_setup")
mount_args.append(f"--mount type=bind,src={params.r2e_gym_setup_dir},dst={params.r2e_gym_setup_dir}")
```

The eval command is currently inconsistent about which one it uses: it `cd`s into `/r2egym_setup/R2E-Gym` (the mount) but invokes the venv python via the original host path. The same-path bind only establishes when apptainer can create deep destination paths inside the read-only testbed SIFs (overlay/underlay support); on hosts where it can't, the interpreter path simply doesn't exist inside the container and **every R2E evaluation fails**.

This PR makes the command use the bind that is always created:

- Invoke the venv python via `/r2egym_setup/...` and run the eval as a module (`-m r2egym.agenthub.run.run_local_evaluation`).
- Put both path variants of the venv `site-packages` and the `src` tree on `PYTHONPATH`. This is needed because the venv installs R2E-Gym in **editable** mode, so its `.pth` file references the original host `src` path — resolvable only under the same-path bind. Python silently skips `PYTHONPATH` entries that don't resolve, so imports work whichever binds succeeded.

Deployments where the same-path bind works are unaffected (it is still mounted and still on `PYTHONPATH`). We have been running exactly this invocation in production multinode RL training, where the read-only instance SIFs cannot host the deep same-path bind.

---

**Update — interpreter re-anchoring.** `venv/bin/python` (and uv's versionless `python/cpython-3.12-*` dir) are symlinks to absolute host paths, so invoking the venv wrapper through `/r2egym_setup` still dereferenced to the host path and remained dependent on the same-path bind. `get_run_command` now resolves the symlink chain on the host (`os.path.realpath`) and embeds the real interpreter re-anchored under `/r2egym_setup`. The standalone CPython locates its stdlib relative to the executable, and the venv site-packages arrive via `PYTHONPATH`, so no venv activation is needed. Setups whose interpreter resolves outside the setup dir fall back to the venv wrapper path (previous behavior). Covered by a new unit test that mirrors uv's two-layer symlink layout.

---

**Evidence update (2026-08-11).** We probed this directly on our production clusters (apptainer 1.5.3 inside the training container, real testbed SIF, the exact two `--mount` args above): with `enable underlay = yes` (apptainer's default) the same-path deep bind **does establish** and the current host-path invocation works. We could not reproduce a failure in our environments, and a 64-node training run using the unmodified invocation converged normally.

So this PR should be read as **portability hardening**, not a fix for a reproducible breakage: it removes the eval's dependency on the underlay/overlay-dependent same-path bind (a host `apptainer.conf` setting outside Gym's control) by routing everything through the `/r2egym_setup` bind that `_build_apptainer_command` always creates. On hosts with underlay disabled, the current invocation would dangle; with this change it does not. Happy to close instead if the maintainers consider the current dual-bind contract acceptable.