### PR TITLE
fix(opensandbox): send the API key on proxied execd routes

### DIFF
--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -640,6 +640,14 @@ class OpenSandboxProvider:
             kwargs["request_timeout"] = timedelta(seconds=request_timeout_s)
         if self._connection.use_server_proxy:
             kwargs["use_server_proxy"] = True
+            # The SDK's execd-facing clients (health ping, commands, files)
+            # send only ConnectionConfig.headers — api_key alone never reaches
+            # proxied /proxy/* routes, so servers that enforce auth there 401
+            # every health ping and create times out at ready_timeout. Inject
+            # the key only in proxy mode: a direct sandbox endpoint runs
+            # untrusted code and must never see it.
+            if self._connection.api_key is not None:
+                kwargs["headers"] = {"OPEN-SANDBOX-API-KEY": self._connection.api_key}
         if self._connection.keepalive_expiry_s is not None or self._connection.disable_connection_pooling:
             kwargs["transport"] = self._get_transport()
         return ConnectionConfig(**kwargs)

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -352,9 +352,20 @@ def test_connection_config_and_image_policy(fake_opensandbox_sdk: None) -> None:
         "protocol": "https",
         "request_timeout": timedelta(seconds=10),
         "use_server_proxy": True,
+        # The API key must also travel as a header: the SDK's execd clients
+        # (health ping, commands, files) send only ConnectionConfig.headers,
+        # and proxied /proxy/* routes may enforce auth.
+        "headers": {"OPEN-SANDBOX-API-KEY": "key"},  # pragma: allowlist secret
     }
     short_timeout_config = provider._connection_config(request_timeout_s=3)
     assert short_timeout_config.kwargs["request_timeout"] == timedelta(seconds=3)
+
+    # Direct-endpoint mode must NOT carry the key: the sandbox runs untrusted
+    # code and would be able to read it.
+    direct = opensandbox_provider.OpenSandboxProvider(
+        connection={"domain": "sandbox.example", "api_key": "key"}  # pragma: allowlist secret
+    )
+    assert "headers" not in direct._connection_config().kwargs
 
 
 def test_connection_transport_backends(fake_opensandbox_sdk: None, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

On OpenSandbox deployments that enforce API-key auth on the server's `/proxy/*` routes, every proxied execd request fails with `401 {"code":"MISSING_API_KEY"}` **even though `api_key` is configured** — because the SDK wires the key only into the lifecycle-API clients. The execd-facing clients (health ping, commands, filesystem) send only `ConnectionConfig.headers`, which the provider never populated.

The visible symptom is nasty: `Sandbox.create` returns `202`, endpoint lookups return `200`, but the SDK's internal health wait pings `/proxy/44772/ping` keyless, gets `401` forever, and creation spins until `ready_timeout` before failing with `SandboxReadyTimeoutException`. Exec and file operations through the proxy fail the same way.

## Change

In `_connection_config`, when `use_server_proxy` is enabled and an `api_key` is configured, also pass the key as the `OPEN-SANDBOX-API-KEY` header via `ConnectionConfig.headers` — the SDK merges those headers into every execd client, so proxied pings/execs authenticate.

Scoped deliberately:
- **Proxy mode only.** In direct-endpoint mode the request terminates at the sandbox itself, which runs untrusted code and must never see the key.
- Harmless on servers that don't enforce proxy auth (verified: the header is accepted either way).

## Testing

Unit: extended `test_connection_config_and_image_policy` — proxy mode + api_key → `headers={"OPEN-SANDBOX-API-KEY": ...}` present; direct mode → no `headers` injected.

End-to-end A/B against a live enforcing deployment (provider → SDK 0.1.15 → server proxy), same script, only the provider tree differing:

| Arm | Result |
|---|---|
| provider **without** this change | `SandboxReadyTimeoutException` — health check false continuously (keyless pings 401), create fails after every retry |
| provider **with** this change | create ready in 19s, `exec("echo e2e-ok")` → rc=0 `stdout='e2e-ok'`, clean close |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
