### PR TITLE
feat(pinchbench): per-rollout model-call capture and a configurable stalled-run abort threshold

### DIFF
--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -84,18 +84,12 @@ class PinchBenchAgentConfig(BaseResponsesAPIAgentConfig):
     max_tokens: int = 16384
     context_window: int = 131072
     openclaw_provider_timeout_seconds: Optional[int] = None
-    # No-progress age before OpenClaw abort-drains a stalled run (`diagnostics.stuckSessionAbortMs`).
-    # None keeps OpenClaw's default of at least 5 minutes and 3x the warn threshold; under a
-    # saturated endpoint that default cuts merely-slow sessions, which grades as a task failure
-    # rather than surfacing as a timeout.
+    # OpenClaw `diagnostics.stuckSessionAbortMs`. None keeps its default.
     openclaw_stuck_session_abort_seconds: Optional[int] = None
     work_root: str = "/tmp/pinchbench_gym"
     transcripts_dir: str = "/tmp/pinchbench_gym/transcripts"
     max_agent_id_length: int = 64
-    # Address the model server under `/ng-rollout/<rollout_id>` so model-call capture can
-    # attribute each call. The prefix is applied only when observability is enabled, which is
-    # also the only time it is needed; set this to False for a model_base_url that is not a
-    # Gym model server, since a direct endpoint has no such route and would 404.
+    # False when model_base_url is not a Gym model server: the prefix route would 404.
     rollout_scoped_model_url: bool = True
 
     @model_validator(mode="after")
@@ -188,13 +182,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         raise NotImplementedError("PinchBench is an external benchmark; use /run.")
 
     def _rollout_scoped_model_base_url(self, rollout_id: Optional[str]) -> str:
-        """Model URL for one rollout, optionally carrying the capture correlation prefix.
-
-        Model-call capture only records calls that arrive under ``/ng-rollout/<id>``; without it
-        the middleware forwards them unattributed, so an agent talking to a Gym model server on a
-        bare URL is invisible to observability. Only valid against a Gym model server -- any other
-        endpoint has no such route and would 404, hence ``rollout_scoped_model_url``.
-        """
+        """Model URL carrying the ``/ng-rollout/<id>`` prefix model-call capture keys on."""
         base = self.config.model_base_url.rstrip("/")
         if not self.config.rollout_scoped_model_url or not rollout_id:
             return base
@@ -720,11 +708,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
             raise ValueError("record is missing verifier_metadata.task_id")
 
         run_id = uuid.uuid4().hex
-        # The capture prefix must carry Gym's rollout id -- the task/rollout indices that key
-        # `<rollout_id>.capture.jsonl` and appear as `ng_model_call_capture.rollout_id` on the
-        # collected rollout. `run_id` is a fresh uuid naming this invocation's work and transcript
-        # directories; using it here would write capture files no rollout can be matched back to.
-        # Returns None when observability is off, which leaves the URL unprefixed.
+        # Gym's rollout id, not `run_id`: capture files are keyed on it. None when capture is off.
         rollout_id = self.rollout_id_from_run(body)
         out_dir = Path(self.config.work_root) / run_id
         out_dir.mkdir(parents=True, exist_ok=True)

--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -51,6 +51,7 @@ from nemo_gym.openai_utils import (
 )
 from nemo_gym.rollout_collection import NG_FAILURE_CLASS_KEY, NG_NO_PERSIST_KEY, NG_TERMINAL_KEY
 from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec, get_provider_class
+from nemo_gym.server_utils import apply_rollout_prefix
 
 
 _SEARCH_KEY_MAP: dict[str, str] = {"brave": "brave_api_key", "tavily": "tavily_api_key"}
@@ -91,6 +92,11 @@ class PinchBenchAgentConfig(BaseResponsesAPIAgentConfig):
     work_root: str = "/tmp/pinchbench_gym"
     transcripts_dir: str = "/tmp/pinchbench_gym/transcripts"
     max_agent_id_length: int = 64
+    # Address the model server under `/ng-rollout/<rollout_id>` so model-call capture can
+    # attribute each call. The prefix is applied only when observability is enabled, which is
+    # also the only time it is needed; set this to False for a model_base_url that is not a
+    # Gym model server, since a direct endpoint has no such route and would 404.
+    rollout_scoped_model_url: bool = True
 
     @model_validator(mode="after")
     def _reject_unresolvable_agent_id(self) -> "PinchBenchAgentConfig":
@@ -181,11 +187,27 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
     ) -> NeMoGymResponse:
         raise NotImplementedError("PinchBench is an external benchmark; use /run.")
 
-    def _task_env(self, task_id: str) -> dict:
+    def _rollout_scoped_model_base_url(self, rollout_id: Optional[str]) -> str:
+        """Model URL for one rollout, optionally carrying the capture correlation prefix.
+
+        Model-call capture only records calls that arrive under ``/ng-rollout/<id>``; without it
+        the middleware forwards them unattributed, so an agent talking to a Gym model server on a
+        bare URL is invisible to observability. Only valid against a Gym model server -- any other
+        endpoint has no such route and would 404, hence ``rollout_scoped_model_url``.
+        """
+        base = self.config.model_base_url.rstrip("/")
+        if not self.config.rollout_scoped_model_url or not rollout_id:
+            return base
+        root, sep, suffix = base.rpartition("/v1")
+        if not sep:
+            return apply_rollout_prefix(base, rollout_id)
+        return f"{apply_rollout_prefix(root, rollout_id)}/v1{suffix}"
+
+    def _task_env(self, task_id: str, rollout_id: Optional[str] = None) -> dict:
         env = {
             "TASK_ID": task_id,
             "MODEL_NAME": self.config.model_name,
-            "MODEL_BASE_URL": self.config.model_base_url,
+            "MODEL_BASE_URL": self._rollout_scoped_model_base_url(rollout_id),
             "MODEL_API_KEY": self.config.model_api_key,
             "JUDGE_MODEL": self.config.judge_model,
             "JUDGE_BASE_URL": self.config.judge_base_url,
@@ -208,7 +230,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
             env["TAVILY_API_KEY"] = self.config.tavily_api_key
         return env
 
-    def _build_spec(self, task_id: str) -> SandboxSpec:
+    def _build_spec(self, task_id: str, rollout_id: Optional[str] = None) -> SandboxSpec:
         cfg = dict(self.config.sandbox_spec)
         return SandboxSpec(
             image=cfg.get("image"),
@@ -217,11 +239,11 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
             workdir=cfg.get("workdir"),
             resources=SandboxResources.from_mapping(cfg.get("resources", {})),
             provider_options=cfg.get("provider_options", {}),
-            env=self._task_env(task_id),
+            env=self._task_env(task_id, rollout_id),
             metadata={"task_id": task_id},
         )
 
-    async def _run_in_sandbox(self, task_id: str, out_dir: Path) -> int | None:
+    async def _run_in_sandbox(self, task_id: str, out_dir: Path, rollout_id: Optional[str] = None) -> int | None:
         """Run one PinchBench task and pull its /out archive back.
 
         Returns the apptainer exit code when the direct_exec path exits non-zero but
@@ -230,14 +252,14 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         provider = self.config.sandbox_provider or {}
         apptainer_cfg = provider.get("apptainer") if isinstance(provider, dict) else None
         if isinstance(apptainer_cfg, dict) and apptainer_cfg.get("direct_exec"):
-            return await self._run_in_apptainer_direct(task_id, out_dir, apptainer_cfg)
+            return await self._run_in_apptainer_direct(task_id, out_dir, apptainer_cfg, rollout_id)
 
         if not self.config.sandbox_provider:
             raise ValueError("pinchbench requires sandbox_provider (see configs/pinchbench.yaml)")
         archive = f"{self.config.sandbox_work_base.rstrip('/')}/out/out.tgz"
         sb = AsyncSandbox(self.config.sandbox_provider)
         try:
-            await sb.start(self._build_spec(task_id))
+            await sb.start(self._build_spec(task_id, rollout_id))
             await sb.exec("bash /opt/run_task.sh", timeout_s=self.config.task_timeout_s)
             await sb.download(archive, out_dir / "out.tgz")
         finally:
@@ -362,7 +384,9 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         wrapper_path.chmod(0o755)
         return wrapper_path
 
-    async def _run_in_apptainer_direct(self, task_id: str, out_dir: Path, apptainer_cfg: dict[str, Any]) -> int | None:
+    async def _run_in_apptainer_direct(
+        self, task_id: str, out_dir: Path, apptainer_cfg: dict[str, Any], rollout_id: Optional[str] = None
+    ) -> int | None:
         image = self.config.sandbox_spec.get("image")
         if not image:
             raise ValueError("pinchbench sandbox_spec.image is required for direct Apptainer exec")
@@ -379,7 +403,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         elif isinstance(direct_args, str):
             direct_args = direct_args.split()
 
-        task_env = self._task_env(task_id)
+        task_env = self._task_env(task_id, rollout_id)
         argv = ["apptainer", "exec", *[str(arg) for arg in direct_args]]
         argv += ["--bind", f"{staging_dir}:{work_base}"]
         for key, value in task_env.items():
@@ -696,6 +720,12 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
             raise ValueError("record is missing verifier_metadata.task_id")
 
         run_id = uuid.uuid4().hex
+        # The capture prefix must carry Gym's rollout id -- the task/rollout indices that key
+        # `<rollout_id>.capture.jsonl` and appear as `ng_model_call_capture.rollout_id` on the
+        # collected rollout. `run_id` is a fresh uuid naming this invocation's work and transcript
+        # directories; using it here would write capture files no rollout can be matched back to.
+        # Returns None when observability is off, which leaves the URL unprefixed.
+        rollout_id = self.rollout_id_from_run(body)
         out_dir = Path(self.config.work_root) / run_id
         out_dir.mkdir(parents=True, exist_ok=True)
         result = {"reward": 0.0, "grading_type": "unknown", "breakdown": {}, "notes": "", "status": "error"}
@@ -706,7 +736,7 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         non_clean_exit_rc: int | None = None
         try:
             async with self._sem:
-                non_clean_exit_rc = await self._run_in_sandbox(task_id, out_dir)
+                non_clean_exit_rc = await self._run_in_sandbox(task_id, out_dir, rollout_id)
             result = self._parse_result(task_id, out_dir)
             response = self._response_from_transcript(task_id, out_dir)
             transcript_events, archive_path = self._collect_transcript(task_id, out_dir, run_id)

--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -83,6 +83,11 @@ class PinchBenchAgentConfig(BaseResponsesAPIAgentConfig):
     max_tokens: int = 16384
     context_window: int = 131072
     openclaw_provider_timeout_seconds: Optional[int] = None
+    # No-progress age before OpenClaw abort-drains a stalled run (`diagnostics.stuckSessionAbortMs`).
+    # None keeps OpenClaw's default of at least 5 minutes and 3x the warn threshold; under a
+    # saturated endpoint that default cuts merely-slow sessions, which grades as a task failure
+    # rather than surfacing as a timeout.
+    openclaw_stuck_session_abort_seconds: Optional[int] = None
     work_root: str = "/tmp/pinchbench_gym"
     transcripts_dir: str = "/tmp/pinchbench_gym/transcripts"
     max_agent_id_length: int = 64
@@ -195,6 +200,8 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
         }
         if self.config.openclaw_provider_timeout_seconds:
             env["PINCHBENCH_PROVIDER_TIMEOUT_SECONDS"] = str(self.config.openclaw_provider_timeout_seconds)
+        if self.config.openclaw_stuck_session_abort_seconds:
+            env["PINCHBENCH_STUCK_SESSION_ABORT_SECONDS"] = str(self.config.openclaw_stuck_session_abort_seconds)
         if self.config.brave_api_key:
             env["BRAVE_API_KEY"] = self.config.brave_api_key
         if self.config.tavily_api_key:
@@ -269,6 +276,11 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
             max_tokens = int(os.environ.get("PINCHBENCH_MAX_TOKENS", "65536"))
             context_window = int(os.environ.get("PINCHBENCH_CONTEXT_WINDOW", "131072"))
             provider_timeout_s = int(os.environ["PINCHBENCH_PROVIDER_TIMEOUT_SECONDS"]) if os.environ.get("PINCHBENCH_PROVIDER_TIMEOUT_SECONDS") else None
+            stuck_abort_s = (
+                int(os.environ["PINCHBENCH_STUCK_SESSION_ABORT_SECONDS"])
+                if os.environ.get("PINCHBENCH_STUCK_SESSION_ABORT_SECONDS")
+                else None
+            )
             runtime_params = {
                 "temperature": 1,
                 "top_p": 0.95,
@@ -317,6 +329,8 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
                 for agent in agents.get("list", []):
                     if isinstance(agent, dict):
                         agent["timeoutSeconds"] = provider_timeout_s
+            if stuck_abort_s is not None:
+                cfg.setdefault("diagnostics", {})["stuckSessionAbortMs"] = stuck_abort_s * 1000
             cfg_path.write_text(json.dumps(cfg, indent=2, ensure_ascii=False), "utf-8")
             PYCFG
 

--- a/responses_api_agents/pinchbench/tests/test_app.py
+++ b/responses_api_agents/pinchbench/tests/test_app.py
@@ -244,7 +244,7 @@ async def test_run_returns_zero_on_failure_never_raises(tmp_path, monkeypatch):
     otherwise ng_collect_rollouts (fail-fast) aborts the whole collection."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def boom(task_id, out_dir):
+    async def boom(task_id, out_dir, rollout_id=None):
         raise RuntimeError("sandbox exploded")
 
     monkeypatch.setattr(agent, "_run_in_sandbox", boom)
@@ -282,7 +282,7 @@ def _run_body(task_id="task_x"):
 async def test_failure_routing_sentinels(exc, expected_class, no_persist, terminal, tmp_path, monkeypatch):
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def fail(task_id, out_dir):
+    async def fail(task_id, out_dir, rollout_id=None):
         raise exc
 
     monkeypatch.setattr(agent, "_run_in_sandbox", fail)
@@ -297,7 +297,7 @@ async def test_successful_task_carries_no_routing_sentinels(tmp_path, monkeypatc
     """Scored rollouts must keep landing in the main jsonl (no sentinel keys)."""
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def ok(task_id, out_dir):
+    async def ok(task_id, out_dir, rollout_id=None):
         return None
 
     monkeypatch.setattr(agent, "_run_in_sandbox", ok)
@@ -378,7 +378,7 @@ async def test_run_raises_on_missing_task_id(tmp_path):
 async def test_non_clean_exit_rc_present_in_raw_rollout(tmp_path, monkeypatch):
     agent = make_agent(work_root=str(tmp_path / "work"), transcripts_dir=str(tmp_path / "arch"))
 
-    async def non_clean(task_id, out_dir):
+    async def non_clean(task_id, out_dir, rollout_id=None):
         return 1
 
     monkeypatch.setattr(agent, "_run_in_sandbox", non_clean)

--- a/responses_api_agents/pinchbench/tests/test_rollout_scoped_model_url.py
+++ b/responses_api_agents/pinchbench/tests/test_rollout_scoped_model_url.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Addressing the model server per rollout so model-call capture can attribute calls.
+
+Capture only records calls arriving under ``/ng-rollout/<rollout_id>``; on a bare URL the
+middleware forwards them unattributed and the run ends with an empty capture directory.
+"""
+
+from nemo_gym.global_config import (
+    OBSERVABILITY_ENABLED_KEY_NAME,
+    ROLLOUT_INDEX_KEY_NAME,
+    TASK_INDEX_KEY_NAME,
+)
+from responses_api_agents.pinchbench.tests.test_app import make_agent
+
+
+ROLLOUT = "abc123"
+
+
+def _observable(agent, enabled=True):
+    """Give the agent a global config; capture gating is read from there, not the agent config."""
+    agent.server_client.global_config_dict = {OBSERVABILITY_ENABLED_KEY_NAME: enabled}
+    return agent
+
+
+def test_prefix_is_inserted_ahead_of_the_api_version():
+    agent = make_agent(model_base_url="http://host:8000/v1")
+
+    assert agent._task_env("task_x", ROLLOUT)["MODEL_BASE_URL"] == f"http://host:8000/ng-rollout/{ROLLOUT}/v1"
+
+
+def test_opting_out_leaves_the_url_bare():
+    agent = make_agent(model_base_url="http://host:8000/v1", rollout_scoped_model_url=False)
+
+    assert agent._task_env("task_x", ROLLOUT)["MODEL_BASE_URL"] == "http://host:8000/v1"
+
+
+def test_without_a_rollout_id_the_url_is_unchanged():
+    agent = make_agent(model_base_url="http://host:8000/v1")
+
+    assert agent._task_env("task_x")["MODEL_BASE_URL"] == "http://host:8000/v1"
+
+
+def test_a_url_with_no_api_version_still_gets_the_prefix():
+    agent = make_agent(model_base_url="http://host:8000")
+
+    assert agent._task_env("task_x", ROLLOUT)["MODEL_BASE_URL"] == f"http://host:8000/ng-rollout/{ROLLOUT}"
+
+
+def test_a_trailing_slash_does_not_produce_a_double_slash():
+    agent = make_agent(model_base_url="http://host:8000/v1/")
+
+    assert agent._task_env("task_x", ROLLOUT)["MODEL_BASE_URL"] == f"http://host:8000/ng-rollout/{ROLLOUT}/v1"
+
+
+def test_the_sandbox_spec_carries_the_scoped_url():
+    agent = make_agent(model_base_url="http://host:8000/v1")
+
+    assert agent._build_spec("task_x", ROLLOUT).env["MODEL_BASE_URL"].endswith(f"/ng-rollout/{ROLLOUT}/v1")
+
+
+def test_the_id_is_gyms_rollout_id_not_a_fresh_uuid():
+    """The prefix must key capture files to the collected rollout.
+
+    ``run()`` also mints a uuid to name its work and transcript directories; prefixing with
+    that instead writes ``<uuid>.capture.jsonl`` files that no rollout can be matched back to.
+    """
+    agent = _observable(make_agent(model_base_url="http://host:8000/v1"))
+    body = {TASK_INDEX_KEY_NAME: 12, ROLLOUT_INDEX_KEY_NAME: 0}
+
+    assert agent.rollout_id_from_run(body) == "12-0"
+    assert agent._task_env("task_x", "12-0")["MODEL_BASE_URL"] == "http://host:8000/ng-rollout/12-0/v1"
+
+
+def test_capture_disabled_yields_no_rollout_id():
+    """Gating lives in ``rollout_id_from_run``, so the default-on prefix costs nothing when off."""
+    agent = _observable(make_agent(model_base_url="http://host:8000/v1"), enabled=False)
+    body = {TASK_INDEX_KEY_NAME: 12, ROLLOUT_INDEX_KEY_NAME: 0}
+
+    assert agent.rollout_id_from_run(body) is None
+    assert agent._task_env("task_x", None)["MODEL_BASE_URL"] == "http://host:8000/v1"

--- a/responses_api_agents/pinchbench/tests/test_stuck_session_abort.py
+++ b/responses_api_agents/pinchbench/tests/test_stuck_session_abort.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OpenClaw's stalled-run abort threshold (``diagnostics.stuckSessionAbortMs``).
+
+Left unset, OpenClaw abort-drains a stalled run after at least 5 minutes and 3x
+the warn threshold. A saturated model endpoint makes ordinary generations exceed
+that, so sessions are cut mid-task and the partial work grades as a failure
+rather than surfacing as a timeout.
+"""
+
+from responses_api_agents.pinchbench.tests.test_app import make_agent
+
+
+def test_threshold_is_not_sent_when_unset():
+    env = make_agent()._task_env("task_x")
+
+    assert "PINCHBENCH_STUCK_SESSION_ABORT_SECONDS" not in env
+
+
+def test_threshold_reaches_the_sandbox_in_seconds():
+    env = make_agent(openclaw_stuck_session_abort_seconds=3600)._task_env("task_x")
+
+    assert env["PINCHBENCH_STUCK_SESSION_ABORT_SECONDS"] == "3600"
+
+
+def test_threshold_is_independent_of_the_provider_timeout():
+    env = make_agent(openclaw_provider_timeout_seconds=14400)._task_env("task_x")
+
+    assert env["PINCHBENCH_PROVIDER_TIMEOUT_SECONDS"] == "14400"
+    assert "PINCHBENCH_STUCK_SESSION_ABORT_SECONDS" not in env
+
+
+def test_the_sandbox_writes_it_to_openclaw_config_as_milliseconds(tmp_path):
+    wrapper = make_agent()._write_direct_exec_wrapper(tmp_path).read_text()
+
+    assert "PINCHBENCH_STUCK_SESSION_ABORT_SECONDS" in wrapper
+    assert 'cfg.setdefault("diagnostics", {})["stuckSessionAbortMs"] = stuck_abort_s * 1000' in wrapper


### PR DESCRIPTION
Two independent fixes for running PinchBench against a saturated endpoint, one commit each. Both were validated on full 147-task runs before this PR; supersedes #2412 and #2307, rebuilt on current `main`.

## 1. Configurable stalled-run abort threshold

OpenClaw abort-drains a stalled run after `diagnostics.stuckSessionAbortMs`, defaulting to at least 5 minutes and 3x the warn threshold. Under a saturated model endpoint, ordinary generations exceed that window, so OpenClaw cuts the session mid-task — and nothing surfaces as a timeout. The endpoint still answers 200, the rollout records as a success, and the partial work grades as a low score.

Measured on a concurrency scan with model and config fixed: reward fell monotonically as rollout concurrency rose, and zero-reward rollouts became the *shortest* ones rather than the longest — the signature of sessions being cut rather than tasks being hard.

The agent already writes provider and agent timeouts into the OpenClaw config; this adds the diagnostics threshold alongside them. Default stays unset, so runs that don't opt in keep OpenClaw's behaviour.

## 2. Per-rollout model URL so capture attributes calls

Capture only records calls arriving under `/ng-rollout/<rollout_id>`; anything else is forwarded unattributed. The agent hands its sandbox a bare `model_base_url`, so a run against a Gym model server with `observability_enabled: true` produces **no request/response record at all** — capture creates its directory and leaves it empty.

That gap matters more here than for most agents: the harness rewrites the transcript before persisting it, scrubbing tool calls that name an unregistered tool while keeping their error results. The transcript therefore can't show what the model actually asked for, and the raw response is the only place that evidence survives.

Two details worth review:

**The id is `rollout_id_from_run(body)`, not the run's uuid.** `run()` mints a uuid to name its work and transcript directories. Prefixing with that writes `<uuid>.capture.jsonl` files no rollout can be matched back to — the collected rollout records its task/rollout indices under `ng_model_call_capture.rollout_id`, so the two never join and `calls` comes back empty with a `model_call_capture_no_records` gap. Observed on a full run before the fix: 147 capture files on disk, none attributable to a task. After: files named `0-0.capture.jsonl` with populated `calls`, correct token counts and latencies.

**`rollout_scoped_model_url` defaults to true.** `rollout_id_from_run` returns `None` whenever observability is disabled, so the prefix is inert unless capture is actually on — and when it is on, capture already requires a Gym model server, the only place the prefix is routable. Defaulting it off meant a user could set `observability_enabled` and still collect nothing, with an empty directory as the only symptom. Set it to false for a `model_base_url` that is not a Gym model server, since a direct endpoint has no such route and would 404.

## Tests

Written before the implementation and confirmed failing against `main` (9 failed / 3 passed, the 3 being absence-assertions that hold vacuously), then passing after.

- `test_stuck_session_abort.py` — threshold absent when unset, reaches the sandbox in seconds, independent of the provider timeout, written to the OpenClaw config as milliseconds
- `test_rollout_scoped_model_url.py` — prefix placement ahead of the API version, URLs with no version suffix, trailing-slash handling, opting out, propagation into the sandbox spec, the id being Gym's rollout id rather than a uuid, and capture-disabled yielding no prefix

`responses_api_agents/pinchbench/tests/`: **76 passed**. Ruff check and format clean.

Four `_run_in_sandbox` mocks in `test_app.py` gained the new `rollout_id` parameter.

Full `tests/` suite: 22 failed / 1757 passed — identical counts on unmodified `main` (macOS-only failures, e.g. `/proc` absent), so no regression from this branch.
