### PR TITLE
fix(recipes): harden Lightning evaluation recipes

### DIFF
--- a/nemotron_recipes/lightning-3.5/base/README.md
+++ b/nemotron_recipes/lightning-3.5/base/README.md
@@ -11,7 +11,7 @@ on `nemo-evaluator-launcher` 0.2.6.
 There are two configs:
 
 - **Base suite** — [`base-suite.yaml`](./base-suite.yaml),
-  the 21 short-context tasks across knowledge, math, code, commonsense, reading
+  the 20 short-context tasks across knowledge, math, code, commonsense, reading
   comprehension and multilingual. Runs against an OpenAI-compatible endpoint **you
   provide** (`deployment: none`) — see
   [Running against an existing endpoint](#running-against-an-existing-endpoint). The
@@ -25,7 +25,7 @@ There are two configs:
 suite is LLM-graded. What you need is:
 
 - one OpenAI-compatible **`/v1/completions`** endpoint serving the base model, which
-  **must honour `echo` together with `logprobs`** (9 of the 21 tasks are scored by
+  **must honour `echo` together with `logprobs`** (9 of the 20 tasks are scored by
   log-likelihood).
 
 ### Reproducing the reference numbers
@@ -151,7 +151,7 @@ short-context suite this way.
 
 ### Base suite
 
-21 pretraining tasks against your endpoint:
+20 pretraining tasks against your endpoint:
 
 ```bash
 nel run --config base-suite.yaml --env-file .env
@@ -162,7 +162,7 @@ nel run --config base-suite.yaml --env-file .env -t adlr_mmlu # one benchmark
 | Category | Tasks |
 |---|---|
 | General knowledge | `adlr_mmlu`, `adlr_mmlu_pro_5_shot_base`, `adlr_agieval_en_cot`, `adlr_gpqa_diamond_cot_5_shot` |
-| Math | `adlr_gsm8k_cot_8_shot`, `adlr_minerva_math_nemo_4_shot`, `adlr_math_500_4_shot_sampled` |
+| Math | `adlr_gsm8k_cot_8_shot`, `adlr_math_500_4_shot_sampled` |
 | Code | `adlr_humaneval_greedy`, `adlr_humaneval_sampled`, `adlr_mbpp_sanitized_3_shot_greedy`, `adlr_mbpp_sanitized_3_shot_sampled` |
 | Commonsense | `adlr_commonsense_qa_7_shot`, `adlr_arc_challenge_llama_25_shot`, `hellaswag`, `openbookqa`, `piqa`, `social_iqa`, `adlr_winogrande_5_shot` |
 | Reading comprehension | `adlr_race` |
@@ -196,7 +196,7 @@ The nine log-likelihood tasks send:
 | | tasks |
 |---|---|
 | **Need `echo` + `logprobs`** | `adlr_arc_challenge_llama_25_shot`, `adlr_commonsense_qa_7_shot`, `adlr_global_mmlu_lite_5_shot`, `adlr_race`, `adlr_winogrande_5_shot`, `hellaswag`, `openbookqa`, `piqa`, `social_iqa` |
-| **Plain completions** | `adlr_agieval_en_cot`, `adlr_gpqa_diamond_cot_5_shot`, `adlr_gsm8k_cot_8_shot`, `adlr_humaneval_greedy`, `adlr_humaneval_sampled`, `adlr_math_500_4_shot_sampled`, `adlr_mbpp_sanitized_3_shot_greedy`, `adlr_mbpp_sanitized_3_shot_sampled`, `adlr_mgsm_native_cot_8_shot`, `adlr_minerva_math_nemo_4_shot`, `adlr_mmlu`, `adlr_mmlu_pro_5_shot_base` |
+| **Plain completions** | `adlr_agieval_en_cot`, `adlr_gpqa_diamond_cot_5_shot`, `adlr_gsm8k_cot_8_shot`, `adlr_humaneval_greedy`, `adlr_humaneval_sampled`, `adlr_math_500_4_shot_sampled`, `adlr_mbpp_sanitized_3_shot_greedy`, `adlr_mbpp_sanitized_3_shot_sampled`, `adlr_mgsm_native_cot_8_shot`, `adlr_mmlu`, `adlr_mmlu_pro_5_shot_base` |
 
 Some hosted services accept the request but silently ignore `echo`, which produces
 **wrong scores rather than an error** — check before trusting the multiple-choice

--- a/nemotron_recipes/lightning-3.5/base/base-suite.yaml
+++ b/nemotron_recipes/lightning-3.5/base/base-suite.yaml
@@ -17,9 +17,6 @@
 # Base (pretraining) suite for NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Base-BF16, run
 # against an EXISTING OpenAI-compatible endpoint. Nothing is deployed by this config.
 #
-# For the variant that deploys its own local vLLM, use
-# `base-suite.yaml` instead.
-#
 # How to use:
 #
 # 1. copy this file locally or clone the repository
@@ -40,7 +37,7 @@
 # endpoint is not a substitute: the base model has no chat template, and wrapping the
 # prompts in one changes what is being measured.
 #
-# 9 of the 21 tasks are multiple-choice and scored by log-likelihood. They send:
+# 9 of the 20 tasks are multiple-choice and scored by log-likelihood. They send:
 #
 #     {"prompt": ..., "max_tokens": 1, "logprobs": 1, "echo": true,
 #      "temperature": 0, "seed": 1234}
@@ -59,8 +56,8 @@
 #                            adlr_humaneval_sampled, adlr_math_500_4_shot_sampled,
 #                            adlr_mbpp_sanitized_3_shot_greedy,
 #                            adlr_mbpp_sanitized_3_shot_sampled,
-#                            adlr_mgsm_native_cot_8_shot, adlr_minerva_math_nemo_4_shot,
-#                            adlr_mmlu, adlr_mmlu_pro_5_shot_base
+#                            adlr_mgsm_native_cot_8_shot, adlr_mmlu,
+#                            adlr_mmlu_pro_5_shot_base
 #
 # If your endpoint cannot do echo+logprobs, run only the second group with `-t <task>`.
 #
@@ -121,6 +118,7 @@ target:
 evaluation:
   env_vars:
     HF_TOKEN: host:HF_TOKEN
+    POLICY_API_KEY: host:POLICY_API_KEY  # pragma: allowlist secret
     TRUST_REMOTE_CODE: lit:1
   nemo_evaluator_config:
     config:
@@ -149,10 +147,6 @@ evaluation:
       container: nvcr.io/nvidia/eval-factory/lm-evaluation-harness:26.03
     # Math
     - name: adlr_gsm8k_cot_8_shot
-      container: nvcr.io/nvidia/eval-factory/lm-evaluation-harness:26.03
-    # NOTE: adlr_minerva_math_nemo_4_shot currently fails on the 26.03 container —
-    #       see the "Known issue" section of the README.
-    - name: adlr_minerva_math_nemo_4_shot
       container: nvcr.io/nvidia/eval-factory/lm-evaluation-harness:26.03
     - name: adlr_math_500_4_shot_sampled
       container: nvcr.io/nvidia/eval-factory/lm-evaluation-harness:26.03

--- a/nemotron_recipes/lightning-3.5/instruct/README.md
+++ b/nemotron_recipes/lightning-3.5/instruct/README.md
@@ -23,9 +23,10 @@ Every recipe accepts `LIMIT` for a quick smoke, `OUT` for the output directory,
 `./results/<benchmark>`.
 
 Each recipe first rolls the repo back to the Gym commit its tech report number was
-produced with, leaving the recipes alone. It overwrites tracked files, so commit or stash
-your work first; `git restore .` puts everything back. Set `PIN_GYM=0` to run against
-your current checkout instead.
+produced with, leaving the recipes alone. Before doing so, it requires no uncommitted
+changes outside `nemotron_recipes` (ignored outputs are allowed), so it cannot overwrite
+your work. Set `PIN_GYM=0` to run
+against your current checkout instead.
 
 ## Prerequisites
 

--- a/nemotron_recipes/lightning-3.5/instruct/gym/.env.example
+++ b/nemotron_recipes/lightning-3.5/instruct/gym/.env.example
@@ -118,9 +118,9 @@ PINCHBENCH_TAVILY_API_KEY=???
 # Rollout retry budget, Gym's default is 3. Only PinchBench's published run raised it,
 # and its recipe sets that itself — override here only if you want a different budget.
 # NEMO_GYM_MAX_ROLLOUT_ATTEMPTS=
-# Recipes pin Gym to the commit their tech report number was produced with, which
-# rewrites tracked files (never the recipes) — commit or stash your own work first, and
-# run `git restore .` to undo. Set PIN_GYM=0 to run against your current checkout, or
-# GYM_PIN to a different commit.
+# Recipes pin Gym to the commit their tech report number was produced with. They refuse
+# to pin over uncommitted changes outside nemotron_recipes (ignored outputs are allowed),
+# protecting your work. Set
+# PIN_GYM=0 to run against your current checkout, or GYM_PIN to a different commit.
 # PIN_GYM=0
 # GYM_PIN=

--- a/nemotron_recipes/lightning-3.5/instruct/gym/aa-lcr.sh
+++ b/nemotron_recipes/lightning-3.5/instruct/gym/aa-lcr.sh
@@ -39,6 +39,12 @@ POLICY=policy_model.responses_api_models.vllm_model
 # `git restore .` from the repo root.
 GYM_PIN="${GYM_PIN:-e446e4f415b9cde0e95bb813c85e9e3e23f5d893}"   # 0.5.0rc0
 if [ "${PIN_GYM:-1}" != 0 ]; then
+  if ! git diff --quiet -- . ':(exclude)nemotron_recipes' ||
+    ! git diff --cached --quiet -- . ':(exclude)nemotron_recipes' ||
+    [ -n "$(git ls-files --others --exclude-standard -- . ':(exclude)nemotron_recipes')" ]; then
+    echo "refusing to pin over uncommitted changes outside nemotron_recipes; commit/stash them or set PIN_GYM=0" >&2
+    exit 1
+  fi
   git rev-parse --verify -q "$GYM_PIN^{commit}" >/dev/null 2>&1 || git fetch origin "$GYM_PIN"
   git restore --source="$GYM_PIN" -- . ':(exclude)nemotron_recipes' || exit 1
   echo "pinned Gym to $GYM_PIN (recipes untouched; PIN_GYM=0 to skip; git restore . to undo)"

--- a/nemotron_recipes/lightning-3.5/instruct/gym/browsecomp/browsecomp.sh
+++ b/nemotron_recipes/lightning-3.5/instruct/gym/browsecomp/browsecomp.sh
@@ -32,6 +32,7 @@ export BROWSECOMP_RUN_FULL=1
 # Used judge: GLM-5.1
 BROWSECOMP_JUDGE_MODEL="${BROWSECOMP_JUDGE_MODEL:?}"
 TAVILY_API_KEY="${TAVILY_API_KEY:?export TAVILY_API_KEY (one key, or [k1,k2] for several)}"
+export TAVILY_API_KEY
 
 # The domain list search skips. Which domains are on it changes search coverage,
 # so results shift if you swap in a different list.
@@ -52,6 +53,12 @@ POLICY=policy_model_no_interleaved_reasoning.responses_api_models.vllm_model
 # `git restore .` from the repo root.
 GYM_PIN="${GYM_PIN:-e446e4f415b9cde0e95bb813c85e9e3e23f5d893}"   # 0.5.0rc0
 if [ "${PIN_GYM:-1}" != 0 ]; then
+  if ! git diff --quiet -- . ':(exclude)nemotron_recipes' ||
+    ! git diff --cached --quiet -- . ':(exclude)nemotron_recipes' ||
+    [ -n "$(git ls-files --others --exclude-standard -- . ':(exclude)nemotron_recipes')" ]; then
+    echo "refusing to pin over uncommitted changes outside nemotron_recipes; commit/stash them or set PIN_GYM=0" >&2
+    exit 1
+  fi
   git rev-parse --verify -q "$GYM_PIN^{commit}" >/dev/null 2>&1 || git fetch origin "$GYM_PIN"
   git restore --source="$GYM_PIN" -- . ':(exclude)nemotron_recipes' || exit 1
   echo "pinned Gym to $GYM_PIN (recipes untouched; PIN_GYM=0 to skip; git restore . to undo)"
@@ -69,7 +76,6 @@ gym eval run \
   --max-output-tokens 32768 \
   "++$QWEN.model=$BROWSECOMP_JUDGE_MODEL" \
   "++$HARNESS.judge_model_server.name=Qwen3-235B-A22B-Instruct-2507-FP8" \
-  "++$HARNESS.tavily_api_key=$TAVILY_API_KEY" \
   "++$HARNESS.exclude_domains_file_path=$EXCLUDE_JSON" \
   "++$AGENT.save_model_call_using_vllm_tokenize_endpoint=false" \
   "++$POLICY.chat_template_kwargs={enable_thinking: true}" \

--- a/nemotron_recipes/lightning-3.5/instruct/gym/critpt.sh
+++ b/nemotron_recipes/lightning-3.5/instruct/gym/critpt.sh
@@ -36,6 +36,7 @@
 # holds its slot, so anything lower wedges the run until it times out.
 
 ARTIFICIAL_ANALYSIS_API_KEY="${ARTIFICIAL_ANALYSIS_API_KEY:?export ARTIFICIAL_ANALYSIS_API_KEY (one key, or [k1,k2] to fail over when a key is rate-limited)}"
+export ARTIFICIAL_ANALYSIS_API_KEY
 
 AGENT=critpt_benchmark_agent.responses_api_agents.critpt_agent
 CRITPT=critpt_resources_server.resources_servers.critpt
@@ -52,6 +53,12 @@ export CRITPT_CACHE_DIR="${CRITPT_CACHE_DIR:-$(realpath -m "${OUT:-./results/cri
 # `git restore .` from the repo root.
 GYM_PIN="${GYM_PIN:-e446e4f415b9cde0e95bb813c85e9e3e23f5d893}"   # 0.5.0rc0
 if [ "${PIN_GYM:-1}" != 0 ]; then
+  if ! git diff --quiet -- . ':(exclude)nemotron_recipes' ||
+    ! git diff --cached --quiet -- . ':(exclude)nemotron_recipes' ||
+    [ -n "$(git ls-files --others --exclude-standard -- . ':(exclude)nemotron_recipes')" ]; then
+    echo "refusing to pin over uncommitted changes outside nemotron_recipes; commit/stash them or set PIN_GYM=0" >&2
+    exit 1
+  fi
   git rev-parse --verify -q "$GYM_PIN^{commit}" >/dev/null 2>&1 || git fetch origin "$GYM_PIN"
   git restore --source="$GYM_PIN" -- . ':(exclude)nemotron_recipes' || exit 1
   echo "pinned Gym to $GYM_PIN (recipes untouched; PIN_GYM=0 to skip; git restore . to undo)"
@@ -66,7 +73,6 @@ gym eval run \
   ${RESUME:+--resume} \
   --output "${OUT:-./results/critpt}/evaluator_rollouts.jsonl" \
   "++$AGENT.datasets=[{name: critpt, type: benchmark, jsonl_fpath: benchmarks/critpt/data/critpt_benchmark.jsonl, prompt_config: benchmarks/critpt/prompts/turn1.yaml, prepare_script: benchmarks/critpt/prepare.py, num_repeats: ${CRITPT_REPEATS:-5}}]" \
-  "++artificial_analysis_api_key=$ARTIFICIAL_ANALYSIS_API_KEY" \
   "++$CRITPT.verify_timeout_seconds=21600" \
   "++$POLICY.chat_template_kwargs={enable_thinking: true}" \
   "++$POLICY.extra_body={skip_special_tokens: false}" \

--- a/nemotron_recipes/lightning-3.5/instruct/gym/env.yaml.example
+++ b/nemotron_recipes/lightning-3.5/instruct/gym/env.yaml.example
@@ -56,6 +56,8 @@ responses_create_params:
 # live on different providers, replace ${judge_url}/${judge_key} per block.
 judge_url: "<judge-base-url>"                 # e.g. https://api.openai.com/v1
 judge_key: ${oc.env:JUDGE_API_KEY,""}
+tavily_api_key: ${oc.env:TAVILY_API_KEY,""}
+artificial_analysis_api_key: ${oc.env:ARTIFICIAL_ANALYSIS_API_KEY,""}
 
 # ===================== WIRING (don't rename) =====================
 # These block names are Gym server ids fixed by the benchmark configs. Each pins the
@@ -107,3 +109,10 @@ gdpval_judge_model:
       openai_base_url: ${judge_url}
       openai_model: gemini-3.1-pro-preview
       openai_api_key: ${judge_key}
+
+# GDPval's pinned benchmark config does not declare this setting, so the user-owned
+# env overlay supplies it after the recipe restores the pinned Gym revision.
+gdpval_stirrup_agent:
+  responses_api_agents:
+    stirrup_agent:
+      tavily_api_key: ${oc.env:TAVILY_API_KEY,""}

--- a/nemotron_recipes/lightning-3.5/instruct/gym/gdpval/gdpval.sh
+++ b/nemotron_recipes/lightning-3.5/instruct/gym/gdpval/gdpval.sh
@@ -48,6 +48,7 @@ else
   [ -r "$GDPVAL_CONTAINER_PATH" ] || { echo "gdpval.sif not readable at $GDPVAL_CONTAINER_PATH" >&2; exit 1; }
   TAVILY_API_KEY="${TAVILY_API_KEY:?export TAVILY_API_KEY (one key, or [k1,k2] for several)}"
 fi
+export TAVILY_API_KEY
 
 STIR=gdpval_stirrup_agent.responses_api_agents.stirrup_agent
 GDR=gdpval_resources_server.resources_servers.gdpval
@@ -109,6 +110,12 @@ fi
 # `git restore .` from the repo root.
 GYM_PIN="${GYM_PIN:-57c15a22f8b82d3d859b71468fe3329f4e2093b4}"
 if [ "${PIN_GYM:-1}" != 0 ]; then
+  if ! git diff --quiet -- . ':(exclude)nemotron_recipes' ||
+    ! git diff --cached --quiet -- . ':(exclude)nemotron_recipes' ||
+    [ -n "$(git ls-files --others --exclude-standard -- . ':(exclude)nemotron_recipes')" ]; then
+    echo "refusing to pin over uncommitted changes outside nemotron_recipes; commit/stash them or set PIN_GYM=0" >&2
+    exit 1
+  fi
   git rev-parse --verify -q "$GYM_PIN^{commit}" >/dev/null 2>&1 || git fetch origin "$GYM_PIN"
   git restore --source="$GYM_PIN" -- . ':(exclude)nemotron_recipes' || exit 1
   echo "pinned Gym to $GYM_PIN (recipes untouched; PIN_GYM=0 to skip; git restore . to undo)"
@@ -122,7 +129,6 @@ gym eval run \
   --split benchmark \
   ${RESUME:+--resume} \
   --output "${OUT:-./results/gdpval}/evaluator_rollouts.jsonl" \
-  "++$STIR.tavily_api_key=$TAVILY_API_KEY" \
   "++$STIR.persist_deliverables_dir=$DELIVERABLES" \
   "++$GDR.judge_sampling_seed=${JUDGE_SAMPLING_SEED:-42}" \
   "++$GDR.persist_raw_judge_responses=true" \

--- a/nemotron_recipes/lightning-3.5/instruct/gym/gpqa.sh
+++ b/nemotron_recipes/lightning-3.5/instruct/gym/gpqa.sh
@@ -32,6 +32,12 @@
 # `git restore .` from the repo root.
 GYM_PIN="${GYM_PIN:-e446e4f415b9cde0e95bb813c85e9e3e23f5d893}"   # 0.5.0rc0
 if [ "${PIN_GYM:-1}" != 0 ]; then
+  if ! git diff --quiet -- . ':(exclude)nemotron_recipes' ||
+    ! git diff --cached --quiet -- . ':(exclude)nemotron_recipes' ||
+    [ -n "$(git ls-files --others --exclude-standard -- . ':(exclude)nemotron_recipes')" ]; then
+    echo "refusing to pin over uncommitted changes outside nemotron_recipes; commit/stash them or set PIN_GYM=0" >&2
+    exit 1
+  fi
   git rev-parse --verify -q "$GYM_PIN^{commit}" >/dev/null 2>&1 || git fetch origin "$GYM_PIN"
   git restore --source="$GYM_PIN" -- . ':(exclude)nemotron_recipes' || exit 1
   echo "pinned Gym to $GYM_PIN (recipes untouched; PIN_GYM=0 to skip; git restore . to undo)"

--- a/nemotron_recipes/lightning-3.5/instruct/gym/hle.sh
+++ b/nemotron_recipes/lightning-3.5/instruct/gym/hle.sh
@@ -43,6 +43,12 @@ POLICY=policy_model.responses_api_models.vllm_model
 # `git restore .` from the repo root.
 GYM_PIN="${GYM_PIN:-e446e4f415b9cde0e95bb813c85e9e3e23f5d893}"   # 0.5.0rc0
 if [ "${PIN_GYM:-1}" != 0 ]; then
+  if ! git diff --quiet -- . ':(exclude)nemotron_recipes' ||
+    ! git diff --cached --quiet -- . ':(exclude)nemotron_recipes' ||
+    [ -n "$(git ls-files --others --exclude-standard -- . ':(exclude)nemotron_recipes')" ]; then
+    echo "refusing to pin over uncommitted changes outside nemotron_recipes; commit/stash them or set PIN_GYM=0" >&2
+    exit 1
+  fi
   git rev-parse --verify -q "$GYM_PIN^{commit}" >/dev/null 2>&1 || git fetch origin "$GYM_PIN"
   git restore --source="$GYM_PIN" -- . ':(exclude)nemotron_recipes' || exit 1
   echo "pinned Gym to $GYM_PIN (recipes untouched; PIN_GYM=0 to skip; git restore . to undo)"

--- a/nemotron_recipes/lightning-3.5/instruct/gym/omniscience.sh
+++ b/nemotron_recipes/lightning-3.5/instruct/gym/omniscience.sh
@@ -37,6 +37,12 @@
 # `git restore .` from the repo root.
 GYM_PIN="${GYM_PIN:-e446e4f415b9cde0e95bb813c85e9e3e23f5d893}"   # 0.5.0rc0
 if [ "${PIN_GYM:-1}" != 0 ]; then
+  if ! git diff --quiet -- . ':(exclude)nemotron_recipes' ||
+    ! git diff --cached --quiet -- . ':(exclude)nemotron_recipes' ||
+    [ -n "$(git ls-files --others --exclude-standard -- . ':(exclude)nemotron_recipes')" ]; then
+    echo "refusing to pin over uncommitted changes outside nemotron_recipes; commit/stash them or set PIN_GYM=0" >&2
+    exit 1
+  fi
   git rev-parse --verify -q "$GYM_PIN^{commit}" >/dev/null 2>&1 || git fetch origin "$GYM_PIN"
   git restore --source="$GYM_PIN" -- . ':(exclude)nemotron_recipes' || exit 1
   echo "pinned Gym to $GYM_PIN (recipes untouched; PIN_GYM=0 to skip; git restore . to undo)"

--- a/nemotron_recipes/lightning-3.5/instruct/gym/pinchbench.sh
+++ b/nemotron_recipes/lightning-3.5/instruct/gym/pinchbench.sh
@@ -56,6 +56,9 @@ PINCHBENCH_MODEL_NAME="${PINCHBENCH_MODEL_NAME:?export PINCHBENCH_MODEL_NAME (na
 # One key only — this field is a plain string, so [k1,k2] is taken literally. Kept
 # separate from TAVILY_API_KEY for that reason: the other recipes accept a key list.
 PINCHBENCH_TAVILY_API_KEY="${PINCHBENCH_TAVILY_API_KEY:?export PINCHBENCH_TAVILY_API_KEY (one key)}"
+export PINCHBENCH_MODEL_BASE_URL PINCHBENCH_MODEL_API_KEY PINCHBENCH_MODEL_NAME
+export PINCHBENCH_JUDGE_MODEL PINCHBENCH_JUDGE_BASE_URL PINCHBENCH_JUDGE_API_KEY
+export PINCHBENCH_TAVILY_API_KEY
 
 # The published run raised Gym's rollout retry budget from its default of 3. An
 # exhausted rollout scores 0, so on a flaky endpoint this moves the result.
@@ -74,6 +77,12 @@ OUTDIR="$(realpath -m "${OUT:-./results/pinchbench}")"
 # `git restore .` from the repo root.
 GYM_PIN="${GYM_PIN:-86290ee8fdc191f2d27b48bd2e957a25dcbd7fd7}"
 if [ "${PIN_GYM:-1}" != 0 ]; then
+  if ! git diff --quiet -- . ':(exclude)nemotron_recipes' ||
+    ! git diff --cached --quiet -- . ':(exclude)nemotron_recipes' ||
+    [ -n "$(git ls-files --others --exclude-standard -- . ':(exclude)nemotron_recipes')" ]; then
+    echo "refusing to pin over uncommitted changes outside nemotron_recipes; commit/stash them or set PIN_GYM=0" >&2
+    exit 1
+  fi
   git rev-parse --verify -q "$GYM_PIN^{commit}" >/dev/null 2>&1 || git fetch origin "$GYM_PIN"
   git restore --source="$GYM_PIN" -- . ':(exclude)nemotron_recipes' || exit 1
   echo "pinned Gym to $GYM_PIN (recipes untouched; PIN_GYM=0 to skip; git restore . to undo)"
@@ -88,13 +97,6 @@ gym eval run \
   ${RESUME:+--resume} \
   --output "${OUT:-./results/pinchbench}/evaluator_rollouts.jsonl" \
   "+sandbox_image=$PINCHBENCH_SIF" \
-  "+model_base_url=$PINCHBENCH_MODEL_BASE_URL" \
-  "+model_api_key=$PINCHBENCH_MODEL_API_KEY" \
-  "+model_name=$PINCHBENCH_MODEL_NAME" \
-  "+judge_model=$PINCHBENCH_JUDGE_MODEL" \
-  "+judge_base_url=$PINCHBENCH_JUDGE_BASE_URL" \
-  "+judge_api_key=$PINCHBENCH_JUDGE_API_KEY" \
-  "+tavily_api_key=$PINCHBENCH_TAVILY_API_KEY" \
   "++$BENCH.datasets=[{name: pinchbench, type: benchmark, jsonl_fpath: benchmarks/pinchbench/data/pinchbench_benchmark.jsonl, prompt_config: null, prepare_script: benchmarks/pinchbench/prepare.py, num_repeats: 10, license: MIT}]" \
   "++$PB.web_search_provider=tavily" \
   "++$PB.sandbox_provider.apptainer.direct_exec=true" \

--- a/nemotron_recipes/lightning-3.5/instruct/gym/scicode.sh
+++ b/nemotron_recipes/lightning-3.5/instruct/gym/scicode.sh
@@ -39,6 +39,12 @@ TEST_DATA="${TEST_DATA:?export TEST_DATA (path to SciCode test_data.h5)}"
 # `git restore .` from the repo root.
 GYM_PIN="${GYM_PIN:-e446e4f415b9cde0e95bb813c85e9e3e23f5d893}"   # 0.5.0rc0
 if [ "${PIN_GYM:-1}" != 0 ]; then
+  if ! git diff --quiet -- . ':(exclude)nemotron_recipes' ||
+    ! git diff --cached --quiet -- . ':(exclude)nemotron_recipes' ||
+    [ -n "$(git ls-files --others --exclude-standard -- . ':(exclude)nemotron_recipes')" ]; then
+    echo "refusing to pin over uncommitted changes outside nemotron_recipes; commit/stash them or set PIN_GYM=0" >&2
+    exit 1
+  fi
   git rev-parse --verify -q "$GYM_PIN^{commit}" >/dev/null 2>&1 || git fetch origin "$GYM_PIN"
   git restore --source="$GYM_PIN" -- . ':(exclude)nemotron_recipes' || exit 1
   echo "pinned Gym to $GYM_PIN (recipes untouched; PIN_GYM=0 to skip; git restore . to undo)"

--- a/nemotron_recipes/lightning-3.5/instruct/gym/tau3.sh
+++ b/nemotron_recipes/lightning-3.5/instruct/gym/tau3.sh
@@ -45,6 +45,12 @@ TAU2_VENV="${TAU2_VENV:-$GYM_ROOT/responses_api_agents/tau2/.venv}"
 # `git restore .` from the repo root.
 GYM_PIN="${GYM_PIN:-e590c4fadd36a89ab4b826497a7414b4a9de281c}"   # 0.5.0rc0, first commit with `gym env prefetch`
 if [ "${PIN_GYM:-1}" != 0 ]; then
+  if ! git diff --quiet -- . ':(exclude)nemotron_recipes' ||
+    ! git diff --cached --quiet -- . ':(exclude)nemotron_recipes' ||
+    [ -n "$(git ls-files --others --exclude-standard -- . ':(exclude)nemotron_recipes')" ]; then
+    echo "refusing to pin over uncommitted changes outside nemotron_recipes; commit/stash them or set PIN_GYM=0" >&2
+    exit 1
+  fi
   git rev-parse --verify -q "$GYM_PIN^{commit}" >/dev/null 2>&1 || git fetch origin "$GYM_PIN"
   git restore --source="$GYM_PIN" -- . ':(exclude)nemotron_recipes' || exit 1
   echo "pinned Gym to $GYM_PIN (recipes untouched; PIN_GYM=0 to skip; git restore . to undo)"

--- a/nemotron_recipes/lightning-3.5/reproducibility.md
+++ b/nemotron_recipes/lightning-3.5/reproducibility.md
@@ -10,7 +10,7 @@ The recipes are split by model:
   suites are NeMo Evaluator configs in
   [`instruct/nemo-evaluator/`](./instruct/nemo-evaluator/).
 - **[`base/`](./base/README.md)** — the base (pretraining) model:
-  `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Base-BF16`, 21 short-context benchmarks
+  `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Base-BF16`, 20 short-context benchmarks
   plus RULER. These are `nemo-evaluator-launcher` configs rather than Gym recipes, and
   their prerequisites differ.
 
@@ -46,7 +46,7 @@ long context. Prerequisites differ from the instruct recipes — see
 | Group | Benchmarks |
 |---|---|
 | General knowledge | MMLU, MMLU-Pro, AGIEval, GPQA Diamond |
-| Math | GSM8K, Minerva Math, MATH-500 |
+| Math | GSM8K, MATH-500 |
 | Code | HumanEval (greedy + sampled), MBPP-sanitized (greedy + sampled) |
 | Commonsense | CommonsenseQA, ARC-Challenge, HellaSwag, OpenBookQA, PIQA, Social IQa, WinoGrande |
 | Reading comprehension | RACE |


### PR DESCRIPTION
### Summary
- Prevent pinned evaluation recipes from overwriting uncommitted work outside `nemotron_recipes`.
- Resolve recipe credentials through environment-backed configuration instead of command-line overrides.
- Correct the base suite credential wiring and remove its known-failing Minerva task.

### Why
- Recipe runs should preserve local work and avoid storing API keys in process arguments or invocation artifacts.

### Test plan
- [x] Shell syntax check for every recipe script
- [x] YAML and JSON parsing plus base-suite contract checks
- [x] Dirty-worktree guard and secret-argument checks with a mock `gym` command