### PR TITLE
feat: swe_trace_converter change for the opencode backend

### DIFF
--- a/responses_api_agents/swe_agents/README.md
+++ b/responses_api_agents/swe_agents/README.md
@@ -180,10 +180,11 @@ gym _setup_params  ──▶  OpenCodeHarnessProcessor.get_run_command   (host s
 
 ### Key files (in the [nv-opencode fork](https://github.com/sdevare-nv/nv-opencode))
 
-- `packages/opencode/src/provider/sdk/nemo-gym/language-model.ts` — `LanguageModelV3` impl. Strips token-ID fields from older assistant messages on input (mirrors `nemo_gym_client.py:85-97`); captures `prompt_token_ids` / `generation_token_ids` / `generation_log_probs` from the response and threads them into `providerMetadata.nemo-gym`.
+- `packages/opencode/src/provider/sdk/nemo-gym/language-model.ts` — `LanguageModelV3` impl. Strips token-ID fields from older assistant messages on input (mirrors `nemo_gym_client.py:85-97`); captures `prompt_token_ids` / `generation_token_ids` / `generation_log_probs` from the response and threads them into `providerMetadata.nemo-gym`. It also records each model request's latency and completion timestamp.
 - `packages/opencode/src/provider/sdk/nemo-gym/index.ts` — `createNemoGym(opts)` factory.
 - `packages/opencode/src/provider/provider.ts` — registers `@opencode-ai/nemo-gym` in `BUNDLED_PROVIDERS` so opencode's normal config path picks it up.
-- `packages/opencode/src/bench/cli.ts` — per-instance bench driver. Writes a temporary `.opencode/opencode.jsonc` (registers the `nemo-gym` provider with the right `baseURL`, `completionsDir`, `instanceId`; defines a `swe-bench` agent with the SWE-bench tool subset; sets `compaction.auto: false`), then spawns `bun .../src/index.ts run "<task>" --agent swe-bench --model nemo-gym/<model> --format json` against the workspace dir. On exit it captures `git diff` and writes `output.jsonl` in the openhands-compatible shape.
+- `packages/opencode/src/bench/metrics.ts` — converts completion dumps and final tool events into response-latency, token-usage, and tool-execution records with absolute timestamps.
+- `packages/opencode/src/bench/cli.ts` — per-instance bench driver. Writes a temporary `.opencode/opencode.jsonc` (registers the `nemo-gym` provider with the right `baseURL`, `completionsDir`, `instanceId`; defines a `swe-bench` agent with the SWE-bench tool subset; sets `compaction.auto: false`), then spawns `bun .../src/index.ts run "<task>" --agent swe-bench --model nemo-gym/<model> --format json` against the workspace dir. On exit it captures `git diff`, consolidates the precise timing metrics, and writes `output.jsonl` in the openhands-compatible shape.
 - `evaluation/benchmarks/swe_bench/scripts/run_infer.sh` — in-SIF entry script invoked by the gym harness.
 
 ### Token-ID guarantees (RL contract)
@@ -209,7 +210,8 @@ Per-turn JSON files match the openhands shape exactly:
     "generation_log_probs": [...]
   },
   "kwargs":   { "tools": [...], "model": "...", ... },
-  "timestamp": 1715000000.0
+  "latency": 12.34,
+  "timestamp": 1715000000.0 // completion-received time
 }
 ```
 
@@ -220,12 +222,18 @@ Final `output.jsonl` matches what `RunOpenHandsAgent.process_single_datapoint` a
   "instance_id": "...",
   "test_result": { "git_patch": "diff --git ..." },
   "metadata":    { "llm_config": { "model": "..." } },
-  "metrics":     { "bench_run_time": 412.3, "opencode_exit_code": 0 },
+  "metrics": {
+    "bench_run_time": 412.3,
+    "opencode_exit_code": 0,
+    "response_latencies": [...],
+    "action_execution_latencies": [...],
+    "token_usages": [...]
+  },
   "error":       null
 }
 ```
 
-This means gym's existing `get_openhands_trajectory_from_completions` and patch-extraction logic work without any changes when `agent_framework: opencode`.
+This means gym's existing `get_openhands_trajectory_from_completions` and patch-extraction logic work without any changes when `agent_framework: opencode`. Gym also copies the three per-turn arrays into `nemo_gym_metrics.json` under `per_turn_metrics`, so `swe_trace_converter.py` uses the same precise schema for OpenCode and OpenHands rollouts.
 
 ### Setup
 
@@ -579,7 +587,7 @@ jq -C . swebench-verified.openhands.qwen3-30b-coder.jsonl | less -R
 
 ## Output format
 
-Each `responses` call returns a `NeMoGymResponse` whose `output` is a Responses-API conversion of the OpenHands chat-completion trajectory, whose `tools` is the function-tool list the agent saw, and whose `metadata` carries `metrics` (a `SWEBenchMetrics` JSON) and the full `instance_config`. The same metrics are written incrementally to `<persistent_dir>/nemo_gym_metrics.json` for profiling and post-run inspection.
+Each `responses` call returns a `NeMoGymResponse` whose `output` is a Responses-API conversion of the selected agent's chat-completion trajectory, whose `tools` is the function-tool list the agent saw, and whose `metadata` carries `metrics` (a `SWEBenchMetrics` JSON) and the full `instance_config`. The same metrics are written incrementally to `<persistent_dir>/nemo_gym_metrics.json` for profiling and post-run inspection.
 
 `run` wraps that in `SWEBenchVerifyResponse`:
 

--- a/responses_api_agents/swe_agents/scripts/swe_trace_converter.py
+++ b/responses_api_agents/swe_agents/scripts/swe_trace_converter.py
@@ -25,6 +25,7 @@ execution timeline from absolute event timestamps. The timeline shows:
   - Evaluation (CPU work) - red
   - Framework Overhead (time between measured agent events) - red
   - Agent Startup (not instrumented) - gray
+  - Agent Finalization (not instrumented) - gray
   - Agent Init (sum of measured container/runtime startup phases) - yellow
 
 Multiple parallel agent rollouts are shown simultaneously, grouped by instance ID,
@@ -39,6 +40,7 @@ Usage:
 import argparse
 import json
 import os
+from bisect import bisect_left
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 
@@ -57,14 +59,94 @@ PER_TURN_METRICS = (
 )
 
 
-def parse_iso_timestamp(ts_str):
-    """Parse ISO timestamp string to epoch seconds (float).
-    Rollout timestamps are UTC; OpenHands action timestamps may omit the offset.
-    """
+def parse_iso_timestamp(ts_str, naive_offset_seconds=0):
+    """Parse an ISO timestamp, treating naive values as UTC plus an offset."""
+    if ts_str.endswith("Z"):
+        ts_str = f"{ts_str[:-1]}+00:00"
     dt = datetime.fromisoformat(ts_str)
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp() + naive_offset_seconds
     return dt.timestamp()
+
+
+def is_naive_iso_timestamp(ts_str):
+    """Return whether an ISO timestamp omits its UTC offset."""
+    if ts_str.endswith("Z"):
+        return False
+    return datetime.fromisoformat(ts_str).tzinfo is None
+
+
+def record_span(record, naive_offset_seconds=0):
+    """Return a record's absolute start and end timestamps."""
+    end = parse_iso_timestamp(record["timestamp"], naive_offset_seconds)
+    start = (
+        parse_iso_timestamp(record["start_timestamp"], naive_offset_seconds)
+        if record.get("start_timestamp")
+        else end - record["latency"]
+    )
+    return start, end, record
+
+
+def gaps_within(container_start, container_end, spans):
+    """Yield uncovered intervals inside a container span."""
+    previous_end = container_start
+    for start, end in sorted(spans):
+        start = max(start, container_start)
+        end = min(end, container_end)
+        if start >= container_end or end <= container_start:
+            continue
+        if start > previous_end:
+            yield previous_end, start
+        previous_end = max(previous_end, end)
+    if previous_end < container_end:
+        yield previous_end, container_end
+
+
+def infer_action_timestamp_offset(actions, response_spans, generation_start, generation_end):
+    """Infer a whole-hour UTC correction for legacy naive action timestamps.
+
+    OpenHands historically stamped events with the sandbox's local wall clock
+    and omitted the offset. Most SWE images use UTC, but an image with another
+    timezone can otherwise place its tool spans hours outside the rollout.
+    """
+    if not any(is_naive_iso_timestamp(action["timestamp"]) for action in actions):
+        return 0
+
+    response_ends = sorted(end for _, end, _ in response_spans)
+
+    def nearest_response_distance(timestamp):
+        index = bisect_left(response_ends, timestamp)
+        distances = []
+        if index < len(response_ends):
+            distances.append(abs(timestamp - response_ends[index]))
+        if index:
+            distances.append(abs(timestamp - response_ends[index - 1]))
+        return min(distances)
+
+    def candidate_score(offset_seconds):
+        action_spans = []
+        for action in actions:
+            end = parse_iso_timestamp(action["timestamp"], offset_seconds)
+            start = (
+                parse_iso_timestamp(action["start_timestamp"], offset_seconds)
+                if action.get("start_timestamp")
+                else end - action["latency"]
+            )
+            action_spans.append((start, end))
+
+        outside_seconds = sum(
+            max(generation_start - start, 0) + max(end - generation_end, 0) for start, end in action_spans
+        )
+        if response_ends:
+            nearest_response_seconds = sum(nearest_response_distance(start) for start, _ in action_spans) / len(
+                action_spans
+            )
+            return outside_seconds, nearest_response_seconds, abs(offset_seconds)
+        return outside_seconds, abs(offset_seconds)
+
+    candidates = (hours * 3600 for hours in range(-14, 15))
+    return min(candidates, key=candidate_score)
 
 
 def to_us(seconds):
@@ -115,6 +197,8 @@ def validate_precise_metrics(nm, dir_name):
     ptm = nm["per_turn_metrics"]
 
     for field in AGENT_INIT_METRICS:
+        if field not in nm:
+            continue
         duration = nm.get(field)
         if not isinstance(duration, (int, float)) or duration < 0:
             errors.append(f"{field} is invalid")
@@ -127,9 +211,15 @@ def validate_precise_metrics(nm, dir_name):
         for index, record in enumerate(records):
             if not record.get("timestamp"):
                 errors.append(f"{label} {index} timestamp is missing")
+            if "start_timestamp" in record and not record.get("start_timestamp"):
+                errors.append(f"{label} {index} start_timestamp is invalid")
             latency = record.get("latency")
             if not isinstance(latency, (int, float)) or latency < 0:
                 errors.append(f"{label} {index} latency is invalid")
+            elif record.get("start_timestamp") and record.get("timestamp"):
+                measured = parse_iso_timestamp(record["timestamp"]) - parse_iso_timestamp(record["start_timestamp"])
+                if abs(measured - latency) > 0.001:
+                    errors.append(f"{label} {index} timestamps and latency are inconsistent")
 
     response_ids = [record.get("response_id") for record in responses]
     token_ids = [record.get("response_id") for record in token_usages]
@@ -171,54 +261,134 @@ def reconstruct_rollout_events(nm):
     responses = ptm["response_latencies"]
     actions = ptm["action_execution_latencies"]
     token_by_rid = {usage["response_id"]: usage for usage in ptm["token_usages"]}
+    root_session_ids = {
+        response["session_id"]
+        for response in responses
+        if response.get("session_id") and response.get("parent_session_id") is None
+    }
+
+    response_spans = [record_span(response) for response in responses]
+    generation_end = gen_start + nm["openhands_run_time"]
+    action_timestamp_offset = infer_action_timestamp_offset(
+        actions,
+        response_spans,
+        gen_start,
+        generation_end,
+    )
+    action_spans = [record_span(action, action_timestamp_offset) for action in actions]
+
+    # Parallel OpenCode subagents can complete out of order. Number turns by
+    # their recorded request starts so the trace reflects launch order.
+    response_spans.sort(key=lambda span: (span[0], span[1], span[2]["response_id"]))
 
     llm_starts = []
-    for turn, response in enumerate(responses, start=1):
-        timestamp = response["timestamp"]
-        end = parse_iso_timestamp(timestamp)
+    for turn, (start, end, response) in enumerate(response_spans, start=1):
         latency = response["latency"]
-        start = end - latency
+        duration = end - start
         response_id = response["response_id"]
         token_usage = token_by_rid[response_id]
+        request_kind = response.get("request_kind", "agent")
         metadata = {
             "response_id": response_id,
             "recorded_latency": latency,
             "turn": turn,
         }
+        for field in ("session_id", "parent_session_id", "session_turn", "request_kind"):
+            if field in response:
+                metadata[field] = response[field]
+        if request_kind == "title":
+            metadata["_trace_name"] = "Session Title Generation (GPU)"
+        elif request_kind == "subagent":
+            metadata["_trace_name"] = "Subagent LLM Generation (GPU)"
         metadata["prompt_tokens"] = token_usage["prompt_tokens"]
         metadata["completion_tokens"] = token_usage["completion_tokens"]
-        events.append(("llm_generation", start, latency, metadata))
+        if "reasoning_tokens" in token_usage:
+            metadata["reasoning_tokens"] = token_usage["reasoning_tokens"]
+        events.append(("llm_generation", start, duration, metadata))
         llm_starts.append(start)
 
-    for action in actions:
-        timestamp = action["timestamp"]
-        end = parse_iso_timestamp(timestamp)
-        latency = action["latency"]
+    for start, end, action in action_spans:
+        metadata = {
+            "observation_type": action["observation_type"],
+            "observation_id": action["observation_id"],
+            "message": action["message"],
+        }
+        for field in ("session_id", "child_session_id", "input", "output"):
+            if field in action:
+                metadata[field] = action[field]
+        if action["observation_type"] == "task":
+            metadata["_trace_name"] = "Subagent Task"
+            metadata["_nested"] = True
+        elif action.get("session_id") and action["session_id"] not in root_session_ids:
+            metadata["_trace_name"] = "Subagent Tool Execution (CPU)"
         events.append(
             (
                 "tool_execution",
-                end - latency,
-                latency,
-                {
-                    "observation_type": action["observation_type"],
-                    "observation_id": action["observation_id"],
-                    "message": action["message"],
-                },
+                start,
+                end - start,
+                metadata,
             )
         )
+
+    # A Subagent Task is a parent tool span containing the child session's LLM
+    # and tool activity. The task record's child_session_id provides the exact
+    # relationship, including when sibling subagents overlap. Show the exact
+    # complement as nested Framework Overhead.
+    child_parent = {
+        response["session_id"]: response["parent_session_id"]
+        for _, _, response in response_spans
+        if response.get("session_id") and response.get("parent_session_id")
+    }
+    measured_by_session = defaultdict(list)
+    for start, end, response in response_spans:
+        session_id = response.get("session_id")
+        if session_id in child_parent:
+            measured_by_session[session_id].append((start, end))
+    for start, end, action in action_spans:
+        session_id = action.get("session_id")
+        if session_id in child_parent and action.get("observation_type") != "task":
+            measured_by_session[session_id].append((start, end))
+
+    for task_start, task_end, task in action_spans:
+        if task.get("observation_type") != "task":
+            continue
+        child_session_id = task.get("child_session_id")
+        if not child_session_id:
+            continue
+
+        measured = [
+            (start, end)
+            for start, end in measured_by_session.get(child_session_id, [])
+            if start < task_end and end > task_start
+        ]
+        if measured:
+            for gap_start, gap_end in gaps_within(task_start, task_end, measured):
+                events.append(
+                    (
+                        "framework_overhead",
+                        gap_start,
+                        gap_end - gap_start,
+                        {
+                            "scope": "subagent",
+                            "session_id": child_session_id,
+                            "parent_session_id": task.get("session_id"),
+                            "_nested": True,
+                        },
+                    )
+                )
 
     if ray_queue_time > 0:
         events.append(("queue_wait", gen_start - ray_queue_time, ray_queue_time, {}))
 
-    init_components = {field: nm[field] for field in AGENT_INIT_METRICS}
+    init_components = {field: nm[field] for field in AGENT_INIT_METRICS if field in nm}
     init_duration = sum(init_components.values())
     if init_duration > 0:
         events.append(("agent_init", gen_start, init_duration, init_components))
 
     # Agent Startup (not instrumented) is the exact interval after the measured
     # container/runtime init phases finish and before the first LLM request
-    # begins. OpenHands emits no finer-grained timestamps inside this interval,
-    # so keep it separate from both Agent Init and Framework Overhead.
+    # begins. The agent backends emit no finer-grained timestamps inside this
+    # interval, so keep it separate from both Agent Init and Framework Overhead.
     init_end = gen_start + init_duration
     if init_duration > 0 and llm_starts:
         first_llm_start = min(llm_starts)
@@ -260,17 +430,9 @@ def reconstruct_rollout_events(nm):
         )
     )
     if spans:
-        previous_end = gen_start
-        for next_start, next_end in spans:
-            gap = next_start - previous_end
-            if gap > 0:
-                events.append(("framework_overhead", previous_end, gap, {}))
-            previous_end = max(previous_end, next_end)
-
-        generation_end = eval_start if eval_start is not None else gen_start + nm["openhands_run_time"]
-        trailing_gap = generation_end - previous_end
-        if trailing_gap > 0:
-            events.append(("framework_overhead", previous_end, trailing_gap, {}))
+        for gap_start, gap_end in gaps_within(gen_start, generation_end, spans):
+            category = "agent_finalization_uninstrumented" if gap_end == generation_end else "framework_overhead"
+            events.append((category, gap_start, gap_end - gap_start, {}))
 
     return events
 
@@ -283,6 +445,7 @@ CATEGORY_COLORS = {
     "evaluation": "terrible",  # dark red
     "framework_overhead": "terrible",  # dark red
     "agent_startup_uninstrumented": "grey",  # neutral gray
+    "agent_finalization_uninstrumented": "grey",  # neutral gray
     "agent_init": "yellow",  # yellow
     "queue_wait": "thread_state_sleeping",  # light purple
 }
@@ -294,6 +457,7 @@ CATEGORY_DISPLAY = {
     "evaluation": "Evaluation (CPU)",
     "framework_overhead": "Framework Overhead",
     "agent_startup_uninstrumented": "Agent Startup (not instrumented)",
+    "agent_finalization_uninstrumented": "Agent Finalization (not instrumented)",
     "agent_init": "Agent Init",
     "queue_wait": "Ray Queue Wait",
 }
@@ -319,6 +483,7 @@ def build_chrome_trace(log_dir):
 
     # Collect all entry directories
     entries = []
+    entry_events = {}
     entry_start_times = {}
     skipped_entries = 0
     for name in sorted(os.listdir(log_dir)):
@@ -340,6 +505,7 @@ def build_chrome_trace(log_dir):
             skipped_entries += 1
             continue
         entries.append((name, data))
+        entry_events[name] = events
         entry_start_times[name] = min((event[1] for event in events), default=start_time)
 
     print(f"Processing {len(entries)} rollout entries...")
@@ -386,22 +552,25 @@ def build_chrome_trace(log_dir):
     # --- Process each entry ---
     rollout_count = 0
     stats = {
-        "total_agent_rollout_time": 0.0,
+        "total_fallback_rollout_time": 0.0,
         "total_llm_time": 0.0,
         "total_tool_time": 0.0,
         "total_eval_time": 0.0,
         "total_init_time": 0.0,
         "total_startup_time": 0.0,
+        "total_finalization_time": 0.0,
         "total_framework_overhead_time": 0.0,
         "resolved_count": 0,
         "total_count": 0,
+        "detailed_count": 0,
+        "fallback_count": 0,
     }
 
     for dir_name, data in entries:
         iid = extract_instance_id(dir_name)
         pid = instance_to_pid[iid]
-        # tid = rollout index within this instance (1-based)
-        tid = instance_groups[iid].index(dir_name) + 1
+        rollout_number = instance_groups[iid].index(dir_name) + 1
+        tid = rollout_number
 
         # Thread metadata
         hash_suffix = dir_name.rsplit("_", 2)[-1][:8]
@@ -411,10 +580,15 @@ def build_chrome_trace(log_dir):
         eval_time = data["final_eval_time"] if data.get("evaluation_start_timestamp") else 0
 
         # Reconstruct events first to compute per-rollout sums
-        events = reconstruct_rollout_events(data)
+        events = entry_events[dir_name]
+        is_detailed = has_per_turn_metrics(data)
 
         rollout_llm_time = sum(dur for cat, _, dur, _ in events if cat == "llm_generation")
-        rollout_tool_time = sum(dur for cat, _, dur, _ in events if cat == "tool_execution")
+        rollout_tool_time = sum(
+            duration
+            for category, _, duration, metadata in events
+            if category == "tool_execution" and not metadata.get("_nested")
+        )
 
         trace_events.append(
             {
@@ -423,25 +597,35 @@ def build_chrome_trace(log_dir):
                 "pid": pid,
                 "tid": tid,
                 "args": {
-                    "name": f"R{tid} [{status}] gen={gen_time:.0f}s eval={eval_time:.0f}s llm={rollout_llm_time:.0f}s tool={rollout_tool_time:.0f}s ({hash_suffix})"
+                    "name": f"R{rollout_number} [{status}] gen={gen_time:.0f}s eval={eval_time:.0f}s llm={rollout_llm_time:.0f}s tool={rollout_tool_time:.0f}s ({hash_suffix})"
                 },
             }
         )
-
+        trace_events.append(
+            {
+                "name": "thread_sort_index",
+                "ph": "M",
+                "pid": pid,
+                "tid": tid,
+                "args": {"sort_index": tid},
+            }
+        )
         for cat, start_s, dur_s, meta in events:
             ts_us = to_us(start_s)
             end_us = to_us(start_s + dur_s)
             dur_us = max(0, end_us - ts_us)
-
+            event_args = dict(meta)
+            event_name = event_args.pop("_trace_name", CATEGORY_DISPLAY[cat])
+            nested = event_args.pop("_nested", False)
             event = {
-                "name": CATEGORY_DISPLAY[cat] + PERFETTO_NAME_SUFFIX.get(cat, ""),
+                "name": event_name + PERFETTO_NAME_SUFFIX.get(cat, ""),
                 "cat": cat,
                 "ph": "X",
                 "ts": ts_us,
                 "dur": dur_us,
                 "pid": pid,
                 "tid": tid,
-                "args": meta,
+                "args": event_args,
             }
             event["cname"] = CATEGORY_COLORS[cat]
 
@@ -449,10 +633,12 @@ def build_chrome_trace(log_dir):
 
             # Accumulate stats
             if cat == "agent_rollout":
-                stats["total_agent_rollout_time"] += dur_s
+                stats["total_fallback_rollout_time"] += dur_s
+            elif not is_detailed:
+                continue
             elif cat == "llm_generation":
                 stats["total_llm_time"] += dur_s
-            elif cat == "tool_execution":
+            elif cat == "tool_execution" and not nested:
                 stats["total_tool_time"] += dur_s
             elif cat == "evaluation":
                 stats["total_eval_time"] += dur_s
@@ -460,10 +646,16 @@ def build_chrome_trace(log_dir):
                 stats["total_init_time"] += dur_s
             elif cat == "agent_startup_uninstrumented":
                 stats["total_startup_time"] += dur_s
-            elif cat == "framework_overhead":
+            elif cat == "agent_finalization_uninstrumented":
+                stats["total_finalization_time"] += dur_s
+            elif cat == "framework_overhead" and not nested:
                 stats["total_framework_overhead_time"] += dur_s
 
         stats["total_count"] += 1
+        if is_detailed:
+            stats["detailed_count"] += 1
+        else:
+            stats["fallback_count"] += 1
         if resolved:
             stats["resolved_count"] += 1
 
@@ -483,66 +675,86 @@ def build_chrome_trace(log_dir):
     print("      runtime connection, and runtime initialization durations")
     print("Agent Startup (not instrumented): Uninstrumented interval from the end")
     print("      of measured Agent Init to the first LLM generation")
+    print("Agent Finalization (not instrumented): Uninstrumented interval from the")
+    print("      final measured agent event to generation process completion")
     print("Framework Overhead: Time between measured agent events that is not")
     print("      LLM generation or tool execution")
 
     # Print summary statistics
     print("\n--- Summary Statistics (aggregated across all rollouts) ---")
     print(f"  Total rollouts: {stats['total_count']}")
+    print(f"  Detailed rollouts: {stats['detailed_count']}")
+    print(f"  Fallback-only rollouts: {stats['fallback_count']}")
     print(
         f"  Resolved: {stats['resolved_count']}/{stats['total_count']} "
         f"({100 * stats['resolved_count'] / max(stats['total_count'], 1):.1f}%)"
     )
-    total_time = (
-        stats["total_agent_rollout_time"]
-        + stats["total_llm_time"]
+    if stats["fallback_count"] > 0:
+        print(f"  Avg fallback duration:  {stats['total_fallback_rollout_time'] / stats['fallback_count']:>10.1f}s")
+
+    detailed_total_time = (
+        stats["total_llm_time"]
         + stats["total_tool_time"]
         + stats["total_eval_time"]
         + stats["total_init_time"]
         + stats["total_startup_time"]
+        + stats["total_finalization_time"]
         + stats["total_framework_overhead_time"]
     )
 
-    n = max(stats["total_count"], 1)
-    if total_time > 0:
-        avg_time = total_time / n
-        print(f"  Avg per rollout:        {avg_time:>10.1f}s")
-        if stats["total_agent_rollout_time"] > 0:
-            print(
-                f"  Agent Rollout:          {stats['total_agent_rollout_time'] / n:>10.1f}s  "
-                f"({100 * stats['total_agent_rollout_time'] / total_time:.1f}%)"
-            )
+    n = max(stats["detailed_count"], 1)
+    if detailed_total_time > 0:
+        avg_time = detailed_total_time / n
+        print("  Detailed timing (fallback-only rollouts excluded):")
+        print(f"  Avg per detailed rollout:{avg_time:>9.1f}s")
         print(
             f"  LLM Generation (GPU):   {stats['total_llm_time'] / n:>10.1f}s  "
-            f"({100 * stats['total_llm_time'] / total_time:.1f}%)"
+            f"({100 * stats['total_llm_time'] / detailed_total_time:.1f}%)"
         )
         print(
             f"  Tool Execution (CPU):   {stats['total_tool_time'] / n:>10.1f}s  "
-            f"({100 * stats['total_tool_time'] / total_time:.1f}%)"
+            f"({100 * stats['total_tool_time'] / detailed_total_time:.1f}%)"
         )
         print(
             f"  Evaluation (CPU):       {stats['total_eval_time'] / n:>10.1f}s  "
-            f"({100 * stats['total_eval_time'] / total_time:.1f}%)"
+            f"({100 * stats['total_eval_time'] / detailed_total_time:.1f}%)"
         )
         print(
             f"  Agent Init:             {stats['total_init_time'] / n:>10.1f}s  "
-            f"({100 * stats['total_init_time'] / total_time:.1f}%)"
+            f"({100 * stats['total_init_time'] / detailed_total_time:.1f}%)"
         )
         print(
             f"  Agent Startup:          {stats['total_startup_time'] / n:>10.1f}s  "
-            f"({100 * stats['total_startup_time'] / total_time:.1f}%)"
+            f"({100 * stats['total_startup_time'] / detailed_total_time:.1f}%)"
+        )
+        print(
+            f"  Agent Finalization:     {stats['total_finalization_time'] / n:>10.1f}s  "
+            f"({100 * stats['total_finalization_time'] / detailed_total_time:.1f}%)"
         )
         print(
             f"  Framework Overhead:     "
             f"{stats['total_framework_overhead_time'] / n:>10.1f}s  "
-            f"({100 * stats['total_framework_overhead_time'] / total_time:.1f}%)"
+            f"({100 * stats['total_framework_overhead_time'] / detailed_total_time:.1f}%)"
         )
-        cpu_time = stats["total_tool_time"] + stats["total_eval_time"]
+        cpu_core_work_time = stats["total_tool_time"] + stats["total_eval_time"]
+        framework_inefficiency_time = (
+            stats["total_init_time"]
+            + stats["total_startup_time"]
+            + stats["total_finalization_time"]
+            + stats["total_framework_overhead_time"]
+        )
         print("  ---")
-        print(f"  Total CPU overhead:     {cpu_time / n:>10.1f}s  ({100 * cpu_time / total_time:.1f}%)")
+        print(
+            f"  Total CPU core work (Tool call + Eval): {cpu_core_work_time / n:>10.1f}s  "
+            f"({100 * cpu_core_work_time / detailed_total_time:.1f}%)"
+        )
+        print(
+            f"  Total Framework inefficiency: {framework_inefficiency_time / n:>10.1f}s  "
+            f"({100 * framework_inefficiency_time / detailed_total_time:.1f}%)"
+        )
         print(
             f"  Total GPU (LLM) time:   {stats['total_llm_time'] / n:>10.1f}s  "
-            f"({100 * stats['total_llm_time'] / total_time:.1f}%)"
+            f"({100 * stats['total_llm_time'] / detailed_total_time:.1f}%)"
         )
 
     return {"traceEvents": trace_events}


### PR DESCRIPTION
This PR updates the `swe_trace_converter.py` script and the `README.md` file for the Opencode trace visualization.
The changes in the PR depend on this [nv-Opencode PR#3](https://github.com/sdevare-nv/nv-opencode/pull/3), so it should be merged after the above PR.

## PR details

There were no additional nemo-gym logic changes for this. All the required things from nemo-gym were already included in the [previous PR](https://github.com/NVIDIA-NeMo/Gym/pull/1825).
The depending [nv-Opencode PR#3](https://github.com/sdevare-nv/nv-opencode/pull/3) exports the per-turn detailed info in `nemo_gym_metrics.json::{..., metrics:{"HERE"}}` as the same as the OpenHands backend. 
The `swe_trace_converter.py` was modified to understand OpenCode specific (subagent, session title generation, etc.) notations.

## Example traces

### Small scale example
https://drive.google.com/file/d/1TvoKOp1c9e8L3m-VTK9dDRSLHSnb-jgg/view?usp=sharing
<img width="1418" height="804" alt="image" src="https://github.com/user-attachments/assets/4ecbbcf9-3e88-422c-b035-2a129b8e0ed1" />

### Larger scale run
https://drive.google.com/file/d/1eFLoJQnjtc9W2vNHgtuelfR00r1eXlNy/view?usp=sharing
<img width="1193" height="863" alt="image" src="https://github.com/user-attachments/assets/36b5e460-2ef1-4c00-a5e8-06d8fbb7e47f" />
<img width="1212" height="732" alt="image" src="https://github.com/user-attachments/assets/54b617c4-08db-4405-9e22-15bca46766d6" />
