### PR TITLE
cp: feat(docker): install enroot and declare bash in Gym container (#2392) into r0.5.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,12 +24,14 @@ FROM ${BASE_IMAGE} AS base
 ENV NEMO_GYM_CONTAINER=1
 USER root
 
+ARG ENROOT_VERSION=3.5.0
 RUN <<"EOF" bash -exu -o pipefail
 export DEBIAN_FRONTEND=noninteractive
 export TZ=America/Los_Angeles
 
 apt-get update
 apt-get install -y --no-install-recommends \
+    bash \
     jq \
     curl \
     git \
@@ -37,6 +39,14 @@ apt-get install -y --no-install-recommends \
     wget \
     less \
     vim
+
+# Install enroot for the EnrootProvider sandbox backend.
+# GitHub releases provide signed .debs for amd64 and arm64.
+arch=$(dpkg --print-architecture)
+curl -fSsL -o /tmp/enroot.deb \
+    "https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_VERSION}-1_${arch}.deb"
+apt-get install -y /tmp/enroot.deb
+rm /tmp/enroot.deb
 
 apt-get clean
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Cherry-pick of #2392 into `r0.5.1`.