### PR TITLE
fix(responses): validate token metadata as a bundle

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -131,6 +131,34 @@ class TokenIDLogProbTypedDictMixin(TypedDict):
     routed_experts: NotRequired[RoutedExperts]
 
 
+_REQUIRED_TOKEN_METADATA_FIELDS = frozenset(
+    {
+        "prompt_token_ids",
+        "generation_token_ids",
+        "generation_log_probs",
+    }
+)
+_TOKEN_METADATA_FIELDS = _REQUIRED_TOKEN_METADATA_FIELDS | {"routed_experts"}
+
+
+def _validate_atomic_token_metadata(value: Any) -> Any:
+    """Require complete token metadata when any token field is present."""
+    if not isinstance(value, dict):
+        return value
+
+    present_fields = _TOKEN_METADATA_FIELDS.intersection(value)
+    if not present_fields:
+        return value
+
+    missing_fields = _REQUIRED_TOKEN_METADATA_FIELDS.difference(present_fields)
+    if missing_fields:
+        missing = ", ".join(sorted(missing_fields))
+        raise ValueError(f"Token metadata must include all required fields; missing: {missing}")
+
+    TokenIDLogProbMixin.model_validate({field: value[field] for field in present_fields})
+    return value
+
+
 ########################################
 # Responses API inputs
 ########################################
@@ -325,32 +353,34 @@ RESPONSES_TO_TRAIN = {
 }
 
 
-NeMoGymResponseInputItem = Union[
-    NeMoGymEasyInputMessage,
-    NeMoGymMessage,
-    NeMoGymResponseOutputMessage,
-    NeMoGymResponseFunctionToolCall,
-    NeMoGymFunctionCallOutput,
-    NeMoGymResponseReasoningItem,
-    NeMoGymResponseMcpCall,
-    NeMoGymResponseMcpListTools,
-    NeMoGymResponseMcpApprovalRequest,
-    # Responses API output-call items. The upstream SDK includes these in both
-    # ResponseOutputItem and ResponseInputItemParam (outputs are echoed back as
-    # input on subsequent turns), so they belong in this shared union:
-    NeMoGymResponseFileSearchToolCall,
-    NeMoGymResponseFunctionWebSearch,
-    NeMoGymResponseComputerToolCall,
-    NeMoGymImageGenerationCall,
-    NeMoGymResponseCodeInterpreterToolCall,
-    NeMoGymLocalShellCall,
-    NeMoGymResponseCustomToolCall,
-    # For training:
-    NeMoGymEasyInputMessageForTraining,
-    NeMoGymMessageForTraining,
-    NeMoGymResponseOutputMessageForTraining,
-    NeMoGymResponseFunctionToolCallForTraining,
-    NeMoGymResponseReasoningItemForTraining,
+NeMoGymResponseInputItem = Annotated[
+    Union[
+        NeMoGymEasyInputMessage,
+        NeMoGymMessage,
+        NeMoGymResponseOutputMessage,
+        NeMoGymResponseFunctionToolCall,
+        NeMoGymFunctionCallOutput,
+        NeMoGymResponseReasoningItem,
+        NeMoGymResponseMcpCall,
+        NeMoGymResponseMcpListTools,
+        NeMoGymResponseMcpApprovalRequest,
+        # The SDK includes these items in both response output and request input.
+        # Outputs are replayed as input on subsequent turns.
+        NeMoGymResponseFileSearchToolCall,
+        NeMoGymResponseFunctionWebSearch,
+        NeMoGymResponseComputerToolCall,
+        NeMoGymImageGenerationCall,
+        NeMoGymResponseCodeInterpreterToolCall,
+        NeMoGymLocalShellCall,
+        NeMoGymResponseCustomToolCall,
+        # Training variants.
+        NeMoGymEasyInputMessageForTraining,
+        NeMoGymMessageForTraining,
+        NeMoGymResponseOutputMessageForTraining,
+        NeMoGymResponseFunctionToolCallForTraining,
+        NeMoGymResponseReasoningItemForTraining,
+    ],
+    BeforeValidator(_validate_atomic_token_metadata),
 ]
 NeMoGymResponseInput: TypeAlias = List[NeMoGymResponseInputItem]
 
@@ -486,8 +516,14 @@ class NeMoGymChatCompletionMessageForTraining(NeMoGymChatCompletionMessage, Toke
     pass
 
 
+NeMoGymChatCompletionOutputMessage: TypeAlias = Annotated[
+    Union[NeMoGymChatCompletionMessage, NeMoGymChatCompletionMessageForTraining],
+    BeforeValidator(_validate_atomic_token_metadata),
+]
+
+
 class NeMoGymChoice(Choice):
-    message: Union[NeMoGymChatCompletionMessage, NeMoGymChatCompletionMessageForTraining]
+    message: NeMoGymChatCompletionOutputMessage
 
 
 class NeMoGymChatCompletion(ChatCompletion):
@@ -566,16 +602,19 @@ class NeMoGymFunctionToolParam(FunctionToolParam):
     pass
 
 
-NeMoGymChatCompletionMessageParam: TypeAlias = Union[
-    NeMoGymChatCompletionDeveloperMessageParam,
-    NeMoGymChatCompletionSystemMessageParam,
-    NeMoGymChatCompletionUserMessageParam,
-    NeMoGymChatCompletionAssistantMessageParam,
-    NeMoGymChatCompletionToolMessageParam,
-    # Don't add deprecated.
-    # NeMoGymChatCompletionFunctionMessageParam,
-    # Training:
-    NeMoGymChatCompletionAssistantMessageForTrainingParam,
+NeMoGymChatCompletionMessageParam: TypeAlias = Annotated[
+    Union[
+        NeMoGymChatCompletionDeveloperMessageParam,
+        NeMoGymChatCompletionSystemMessageParam,
+        NeMoGymChatCompletionUserMessageParam,
+        NeMoGymChatCompletionAssistantMessageParam,
+        NeMoGymChatCompletionToolMessageParam,
+        # Keep deprecated function messages out of this union.
+        # NeMoGymChatCompletionFunctionMessageParam,
+        # Training variants.
+        NeMoGymChatCompletionAssistantMessageForTrainingParam,
+    ],
+    BeforeValidator(_validate_atomic_token_metadata),
 ]
 
 

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -57,6 +57,7 @@ from nemo_gym.openai_utils import (
     NeMoGymSummary,
     Reasoning,
     TokenIDLogProbMixin,
+    _validate_atomic_token_metadata,
 )
 
 
@@ -94,11 +95,13 @@ class ResponsesConverterState(BaseModel):
 
     content_buffer: str = ""
     tool_calls_buffer: List[NeMoGymChatCompletionMessageToolCallParam] = Field(default_factory=list)
+    assistant_item_buffered: bool = False
 
     token_information: Optional[TokenIDLogProbMixin] = None
 
     def flush_assistant(self) -> None:
-        if not (self.content_buffer or self.tool_calls_buffer):
+        if not (self.assistant_item_buffered or self.content_buffer or self.tool_calls_buffer):
+            self.token_information = None
             return
 
         shared_params = dict(
@@ -107,7 +110,7 @@ class ResponsesConverterState(BaseModel):
             tool_calls=self.tool_calls_buffer,
         )
 
-        if self.return_token_id_information and self.token_information:
+        if self.return_token_id_information and self.token_information is not None:
             message = NeMoGymChatCompletionAssistantMessageForTrainingParam(
                 **shared_params,
                 **self.token_information.model_dump(exclude_none=True),
@@ -119,6 +122,16 @@ class ResponsesConverterState(BaseModel):
 
         self.content_buffer = ""
         self.tool_calls_buffer = []
+        self.assistant_item_buffered = False
+        self.token_information = None
+
+
+def _token_information_from_mapping(value: Dict[str, Any]) -> Optional[TokenIDLogProbMixin]:
+    """Return validated token metadata when the mapping contains it."""
+    _validate_atomic_token_metadata(value)
+    if "prompt_token_ids" not in value:
+        return None
+    return TokenIDLogProbMixin.model_validate(value)
 
 
 class ResponsesConverter(BaseModel):
@@ -183,13 +196,10 @@ class ResponsesConverter(BaseModel):
                 case _:  # pragma: no cover
                     raise NotImplementedError(f"Unsupported message type: {m}")
 
-            if self.return_token_id_information and m.get("prompt_token_ids"):
-                state.token_information = TokenIDLogProbMixin(
-                    prompt_token_ids=m["prompt_token_ids"],
-                    generation_token_ids=m["generation_token_ids"],
-                    generation_log_probs=m["generation_log_probs"],
-                    routed_experts=m.get("routed_experts"),
-                )
+            if self.return_token_id_information:
+                token_information = _token_information_from_mapping(m)
+                if token_information is not None:
+                    state.token_information = token_information
 
         state.flush_assistant()
 
@@ -282,6 +292,7 @@ class ResponsesConverter(BaseModel):
 
         match m["role"]:
             case "assistant":
+                state.assistant_item_buffered = True
                 final_content = ""
                 if m["content"] is None:
                     # Tool-call only turns have "None" according to the official API spec.
@@ -340,6 +351,7 @@ class ResponsesConverter(BaseModel):
         See: https://docs.nvidia.com/nemo/gym/main/infrastructure/engineering-notes/responses-api-evolution
         for background on reasoning in the Responses API.
         """
+        state.assistant_item_buffered = True
         if "summary" in m and m["summary"]:
             texts = [s["text"] for s in m["summary"]]
             state.content_buffer += self._wrap_reasoning_in_think_tags(texts)
@@ -349,6 +361,7 @@ class ResponsesConverter(BaseModel):
         m: dict,
         state: ResponsesConverterState,
     ) -> None:
+        state.assistant_item_buffered = True
         assert "call_id" in m
         tool_call = NeMoGymChatCompletionMessageToolCallParam(
             id=m["call_id"],
@@ -454,18 +467,13 @@ class ResponsesConverter(BaseModel):
                 )
             )
 
-        if self.return_token_id_information and "prompt_token_ids" in message_dict:
+        token_information = _token_information_from_mapping(message_dict) if self.return_token_id_information else None
+        if token_information is not None:
             last_response_output_item = response_output[-1]
             train_cls = RESPONSES_TO_TRAIN[last_response_output_item.__class__]
-            extra_training_fields = {}
-            if "routed_experts" in message_dict and message_dict["routed_experts"] is not None:
-                extra_training_fields["routed_experts"] = message_dict["routed_experts"]
             response_output[-1] = train_cls(
                 **last_response_output_item.model_dump(),
-                prompt_token_ids=message_dict["prompt_token_ids"],
-                generation_token_ids=message_dict["generation_token_ids"],
-                generation_log_probs=message_dict["generation_log_probs"],
-                **extra_training_fields,
+                **token_information.model_dump(exclude_none=True),
             )
 
         return response_output

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -31,6 +31,8 @@ from pydantic import ValidationError
 
 from nemo_gym.openai_utils import (
     NeMoGymAsyncOpenAI,
+    NeMoGymChatCompletionCreateParamsNonStreaming,
+    NeMoGymChoice,
     NeMoGymImageGenerationCall,
     NeMoGymLocalShellCall,
     NeMoGymResponse,
@@ -83,6 +85,44 @@ class TestNeMoGymResponseCreateParamsNonStreaming:
     def test_unknown_field_still_forbidden(self) -> None:
         with pytest.raises(ValidationError):
             NeMoGymResponseCreateParamsNonStreaming(input="hello", not_a_real_field=1)
+
+
+class TestTokenMetadataValidation:
+    @pytest.mark.parametrize(
+        "token_metadata",
+        [
+            {"generation_token_ids": [2], "generation_log_probs": [-0.1]},
+            {
+                "prompt_token_ids": [1],
+                "generation_token_ids": {"invalid": "shape"},
+                "generation_log_probs": [-0.1],
+            },
+        ],
+        ids=["partial", "malformed"],
+    )
+    def test_chat_request_rejects_invalid_metadata_instead_of_falling_back(self, token_metadata: dict) -> None:
+        with pytest.raises(ValidationError):
+            NeMoGymChatCompletionCreateParamsNonStreaming(
+                messages=[
+                    {
+                        "role": "assistant",
+                        "content": "answer",
+                        **token_metadata,
+                    }
+                ]
+            )
+
+    def test_chat_response_rejects_partial_metadata_instead_of_falling_back(self) -> None:
+        with pytest.raises(ValidationError):
+            NeMoGymChoice(
+                index=0,
+                finish_reason="stop",
+                message={
+                    "role": "assistant",
+                    "content": "answer",
+                    "prompt_token_ids": [1],
+                },
+            )
 
 
 class TestNeMoGymResponseHostedMcpItems:

--- a/tests/unit_tests/test_responses_converter.py
+++ b/tests/unit_tests/test_responses_converter.py
@@ -141,6 +141,23 @@ def test_flush_assistant_emits_training_message_when_token_info_present():
     state.flush_assistant()
     assert state.messages[0]["prompt_token_ids"] == [1, 2]
     assert state.messages[0]["generation_token_ids"] == [3]
+    assert state.token_information is None
+
+
+def test_flush_assistant_clears_token_info_when_no_assistant_is_buffered():
+    state = ResponsesConverterState(
+        return_token_id_information=True,
+        token_information={
+            "prompt_token_ids": [1],
+            "generation_token_ids": [2],
+            "generation_log_probs": [-0.1],
+        },
+    )
+
+    state.flush_assistant()
+
+    assert state.messages == []
+    assert state.token_information is None
 
 
 # ===========================================================================
@@ -416,6 +433,108 @@ def test_responses_to_chat_completion_token_id_information_path():
     assert msg["generation_token_ids"] == [4, 5]
 
 
+def test_responses_to_chat_completion_preserves_empty_prompt_token_ids():
+    converter = ResponsesConverter(return_token_id_information=True)
+    params = converter.responses_to_chat_completion_create_params(
+        NeMoGymResponseCreateParamsNonStreaming(
+            input=[
+                {
+                    "role": "assistant",
+                    "type": "message",
+                    "content": "trained answer",
+                    "prompt_token_ids": [],
+                    "generation_token_ids": [4],
+                    "generation_log_probs": [-0.1],
+                }
+            ]
+        )
+    )
+
+    assert params.messages[0]["prompt_token_ids"] == []
+    assert params.messages[0]["generation_token_ids"] == [4]
+
+
+def test_responses_to_chat_completion_does_not_leak_token_info_between_turns():
+    converter = ResponsesConverter(return_token_id_information=True)
+    params = converter.responses_to_chat_completion_create_params(
+        NeMoGymResponseCreateParamsNonStreaming(
+            input=[
+                {
+                    "role": "assistant",
+                    "type": "message",
+                    "content": "trained answer",
+                    "prompt_token_ids": [1],
+                    "generation_token_ids": [2],
+                    "generation_log_probs": [-0.1],
+                },
+                {"role": "user", "type": "message", "content": "next"},
+                {"role": "assistant", "type": "message", "content": "plain answer"},
+            ]
+        )
+    )
+
+    first_assistant, _, second_assistant = params.messages
+    assert first_assistant["prompt_token_ids"] == [1]
+    assert "prompt_token_ids" not in second_assistant
+    assert "generation_token_ids" not in second_assistant
+    assert "generation_log_probs" not in second_assistant
+
+
+def test_responses_to_chat_completion_preserves_empty_training_assistant():
+    converter = ResponsesConverter(return_token_id_information=True)
+    params = converter.responses_to_chat_completion_create_params(
+        NeMoGymResponseCreateParamsNonStreaming(
+            input=[
+                {
+                    "role": "assistant",
+                    "type": "message",
+                    "content": "",
+                    "prompt_token_ids": [],
+                    "generation_token_ids": [],
+                    "generation_log_probs": [],
+                }
+            ]
+        )
+    )
+
+    assert params.messages == [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [],
+            "prompt_token_ids": [],
+            "generation_token_ids": [],
+            "generation_log_probs": [],
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "token_metadata",
+    [
+        {"prompt_token_ids": [1]},
+        {
+            "prompt_token_ids": [1],
+            "generation_token_ids": "not-a-list",
+            "generation_log_probs": [-0.1],
+        },
+    ],
+    ids=["partial", "malformed"],
+)
+def test_response_input_rejects_invalid_token_metadata_atomically(token_metadata: dict):
+    with pytest.raises(ValueError, match="token|Token"):
+        NeMoGymResponseCreateParamsNonStreaming(
+            input=[
+                {
+                    "role": "assistant",
+                    "type": "message",
+                    "content": "answer",
+                    **token_metadata,
+                }
+            ]
+        )
+
+
 # ===========================================================================
 # postprocess_assistant_message_dict / postprocess_chat_response
 # ===========================================================================
@@ -486,6 +605,18 @@ def test_postprocess_token_id_information_wraps_last_item():
     )
     assert isinstance(output[-1], NeMoGymResponseOutputMessageForTraining)
     assert output[-1].prompt_token_ids == [1, 2]
+
+
+def test_postprocess_rejects_partial_token_metadata():
+    converter = ResponsesConverter(return_token_id_information=True)
+    with pytest.raises(ValueError, match="missing"):
+        converter.postprocess_assistant_message_dict(
+            {
+                "role": "assistant",
+                "content": "answer",
+                "prompt_token_ids": [1, 2],
+            }
+        )
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Responses training metadata consists of `prompt_token_ids`, `generation_token_ids`, and `generation_log_probs`. Partial payloads can currently match a plain union member. Empty `prompt_token_ids` are also mistaken for missing metadata.

The schema now validates these fields as one bundle. Empty arrays remain valid, while partial or malformed bundles fail validation. `ResponsesConverterState.flush_assistant()` clears the bundle after every assistant turn so metadata cannot leak into the next turn. `routed_experts` remains optional.

```mermaid
flowchart LR
    ITEM["Assistant item"] --> CHECK{"Any token field present?"}
    CHECK -->|"No"| PLAIN["Plain assistant message"]
    CHECK -->|"Yes"| COMPLETE{"Required bundle complete?"}
    COMPLETE -->|"No"| ERROR["Reject payload"]
    COMPLETE -->|"Yes"| TRAIN["Training assistant message"]
    PLAIN --> FLUSH["Flush assistant turn"]
    TRAIN --> FLUSH
    FLUSH --> RESET["Clear token metadata"]
```