### PR TITLE
fix(responses): preserve reasoning effort across conversions

### DIFF
--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -227,6 +227,10 @@ class ResponsesConverter(BaseModel):
         if max_output_tokens is not None:
             responses_create_params["max_tokens"] = max_output_tokens
 
+        reasoning = responses_create_params.pop("reasoning", None)
+        if reasoning is not None and reasoning.get("effort") is not None:
+            responses_create_params["reasoning_effort"] = reasoning["effort"]
+
         tools = responses_create_params.pop("tools", None)
         if tools:
             responses_create_params["tools"] = []
@@ -394,7 +398,9 @@ class ResponsesConverter(BaseModel):
             metadata=chat_completion_create_params.metadata,
             model=chat_completion_create_params.model,
             parallel_tool_calls=chat_completion_create_params.parallel_tool_calls,
-            reasoning=Reasoning(reasoning_effort=chat_completion_create_params.reasoning_effort),
+            reasoning=Reasoning(effort=chat_completion_create_params.reasoning_effort)
+            if chat_completion_create_params.reasoning_effort is not None
+            else None,
             service_tier=chat_completion_create_params.service_tier,
             store=chat_completion_create_params.store,
             temperature=chat_completion_create_params.temperature,

--- a/tests/unit_tests/test_responses_converter.py
+++ b/tests/unit_tests/test_responses_converter.py
@@ -21,6 +21,7 @@ from openai.types.completion_usage import CompletionTokensDetails, CompletionUsa
 
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
+    NeMoGymChatCompletionCreateParamsNonStreaming,
     NeMoGymChatCompletionMessage,
     NeMoGymChatCompletionMessageToolCall,
     NeMoGymChoice,
@@ -410,6 +411,22 @@ def test_responses_to_chat_completion_with_tools_keeps_tool_choice(converter: Re
 
 def test_chat_completion_to_responses_tools_accepts_none(converter: ResponsesConverter):
     assert converter._chat_completion_to_responses_tools(None) == []
+
+
+@pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high"])
+def test_reasoning_effort_round_trips_between_request_schemas(converter: ResponsesConverter, effort: str):
+    responses_params = converter.chat_completion_to_responses_create_params(
+        NeMoGymChatCompletionCreateParamsNonStreaming(
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_effort=effort,
+            tools=[],
+        )
+    )
+
+    assert responses_params.reasoning == {"effort": effort}
+
+    chat_params = converter.responses_to_chat_completion_create_params(responses_params)
+    assert chat_params.reasoning_effort == effort
 
 
 def test_responses_to_chat_completion_token_id_information_path():


### PR DESCRIPTION
## Summary

The [Chat Completions API](https://platform.openai.com/docs/api-reference/chat/create#chat_create-reasoning_effort) stores reasoning effort in the top-level `reasoning_effort` field. The [Responses API](https://platform.openai.com/docs/api-reference/responses/create#responses_create-reasoning) stores it in `reasoning.effort`. The converter currently drops the value in one direction and writes it to the wrong Responses field in the other direction.

Both conversion directions now map the fields explicitly. When Chat omits `reasoning_effort`, the converter leaves `reasoning` unset.

```mermaid
flowchart LR
    RESP["Responses request<br/>reasoning.effort"] --> TOCHAT["Responses to Chat"]
    TOCHAT --> CHAT["Chat request<br/>reasoning_effort"]
    CHAT --> TORESP["Chat to Responses"]
    TORESP --> RESP
```

## References

- [OpenAI Python 2.7.2 Chat request schema](https://github.com/openai/openai-python/blob/v2.7.2/src/openai/types/chat/completion_create_params.py)
- [OpenAI Python 2.7.2 `Reasoning` model](https://github.com/openai/openai-python/blob/v2.7.2/src/openai/types/shared/reasoning.py)