### PR TITLE
fix(responses): preserve structured function outputs

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -79,6 +79,9 @@ from openai.types.responses.response_create_params import (
     ToolChoice,
     ToolParam,
 )
+from openai.types.responses.response_function_call_output_item_list_param import (
+    ResponseFunctionCallOutputItemListParam,
+)
 from openai.types.responses.response_input_param import (
     ResponseInputMessageContentListParam,
 )
@@ -231,7 +234,7 @@ class NeMoGymFunctionCallOutput(BaseModel):
     """
 
     call_id: str
-    output: str
+    output: Union[str, ResponseFunctionCallOutputItemListParam]
     type: Literal["function_call_output"] = "function_call_output"
     id: Optional[str] = None
     status: Optional[Literal["in_progress", "completed", "incomplete"]] = None

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -263,8 +263,29 @@ class ResponsesConverter(BaseModel):
         state.flush_assistant()
 
         assert "call_id" in m
+        output = m["output"]
+        if isinstance(output, str):
+            content = output
+        elif isinstance(output, list):
+            unsupported_types = sorted(
+                {part.get("type", "<missing>") for part in output if part.get("type") != "input_text"}
+            )
+            if unsupported_types:
+                raise NotImplementedError(
+                    "Cannot convert Responses function_call_output "
+                    f"for call {m['call_id']!r} to a Chat Completions tool message: "
+                    "Chat tool messages cannot represent content part type(s) "
+                    f"{', '.join(repr(part_type) for part_type in unsupported_types)}"
+                )
+            content = [{"type": "text", "text": part["text"]} for part in output]
+        else:  # pragma: no cover - guarded by NeMoGymFunctionCallOutput validation
+            raise TypeError(
+                "Responses function_call_output must be a string or a list of structured content parts, "
+                f"got {type(output).__name__}"
+            )
+
         converted = NeMoGymChatCompletionToolMessageParam(
-            content=m["output"],
+            content=content,
             role="tool",
             tool_call_id=m["call_id"],
         )
@@ -501,10 +522,13 @@ class ResponsesConverter(BaseModel):
             elif role == "assistant":
                 output_items.extend(self.postprocess_assistant_message_dict(message))
             elif role == "tool":
+                content = message["content"]
+                if isinstance(content, list):
+                    content = [{"type": "input_text", "text": part["text"]} for part in content]
                 output_items.append(
                     NeMoGymFunctionCallOutput(
                         call_id=message["tool_call_id"],
-                        output=message["content"],
+                        output=content,
                         status="completed",
                     )
                 )

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -35,6 +35,7 @@ from nemo_gym.openai_utils import (
     NeMoGymChatCompletionCreateParamsNonStreaming,
     NeMoGymChatCompletionMessageCustomToolCall,
     NeMoGymChoice,
+    NeMoGymFunctionCallOutput,
     NeMoGymImageGenerationCall,
     NeMoGymLocalShellCall,
     NeMoGymResponse,
@@ -223,6 +224,23 @@ class TestNeMoGymChatCompletionSchemas:
 
         assert round_tripped == completion
         assert isinstance(completion.choices[0].message.tool_calls[0], NeMoGymChatCompletionMessageCustomToolCall)
+
+
+class TestNeMoGymFunctionCallOutput:
+    @pytest.mark.parametrize(
+        "output",
+        [
+            "plain text",
+            [{"type": "input_text", "text": "structured text"}],
+            [{"type": "input_image", "image_url": "https://example.com/image.png", "detail": "high"}],
+            [{"type": "input_file", "file_id": "file_123", "filename": "result.txt"}],
+        ],
+        ids=["string", "text", "image", "file"],
+    )
+    def test_accepts_and_preserves_openai_2_7_2_payloads(self, output) -> None:
+        item = NeMoGymFunctionCallOutput(call_id="call_1", output=output)
+
+        assert item.model_dump()["output"] == output
 
 
 class TestNeMoGymResponseHostedMcpItems:

--- a/tests/unit_tests/test_responses_converter.py
+++ b/tests/unit_tests/test_responses_converter.py
@@ -299,6 +299,55 @@ def test_responses_to_chat_completion_function_call_and_output(converter: Respon
     assert tool_msg["content"] == "sunny"
 
 
+def test_responses_to_chat_completion_preserves_structured_function_output_text(converter: ResponsesConverter):
+    params = converter.responses_to_chat_completion_create_params(
+        NeMoGymResponseCreateParamsNonStreaming(
+            input=[
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": [
+                        {"type": "input_text", "text": "first"},
+                        {"type": "input_text", "text": "second"},
+                    ],
+                }
+            ]
+        )
+    )
+
+    assert params.messages == [
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": [
+                {"type": "text", "text": "first"},
+                {"type": "text", "text": "second"},
+            ],
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("output", "unsupported_type"),
+    [
+        ([{"type": "input_image", "file_id": "file_123"}], "input_image"),
+        ([{"type": "input_file", "file_id": "file_123"}], "input_file"),
+    ],
+)
+def test_responses_to_chat_completion_rejects_unrepresentable_function_output(
+    converter: ResponsesConverter, output: list[dict], unsupported_type: str
+):
+    responses_params = NeMoGymResponseCreateParamsNonStreaming(
+        input=[{"type": "function_call_output", "call_id": "call_1", "output": output}]
+    )
+
+    with pytest.raises(
+        NotImplementedError,
+        match=rf"Chat tool messages cannot represent content part type\(s\) '{unsupported_type}'",
+    ):
+        converter.responses_to_chat_completion_create_params(responses_params)
+
+
 def test_responses_to_chat_completion_reasoning_prepended(converter: ResponsesConverter):
     reasoning = NeMoGymResponseReasoningItem(
         id="rs_1",
@@ -653,6 +702,26 @@ def test_chat_messages_to_responses_items_all_roles(converter: ResponsesConverte
     # system, user (None -> ""), assistant message, tool output
     assert items[1].content == ""
     assert any(isinstance(item, NeMoGymFunctionCallOutput) for item in items)
+
+
+def test_chat_structured_tool_text_to_responses_preserves_parts(converter: ResponsesConverter):
+    items = converter.chat_completions_messages_to_responses_items(
+        [
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": [
+                    {"type": "text", "text": "first"},
+                    {"type": "text", "text": "second"},
+                ],
+            }
+        ]
+    )
+
+    assert items[0].model_dump()["output"] == [
+        {"type": "input_text", "text": "first"},
+        {"type": "input_text", "text": "second"},
+    ]
 
 
 def test_chat_messages_to_responses_items_unrecognized_role_raises(converter: ResponsesConverter):


### PR DESCRIPTION
## Summary

The OpenAI SDK allows `function_call_output.output` to be either a string or a list of text, image, or file parts. Gym narrows this field to `str`, so structured outputs fail validation before conversion.

Gym now accepts the SDK output type. Responses `input_text` parts map to Chat tool-message `text` parts and map back without losing their structure. Chat tool messages cannot represent image or file output parts, so Responses-to-Chat conversion raises `NotImplementedError` and identifies the unsupported part type instead of discarding it.

```mermaid
flowchart TD
    OUTPUT["Responses function_call_output"] --> KIND{"Output shape"}
    KIND -->|"String"| CHATSTR["Chat tool-message string"]
    KIND -->|"input_text list"| CHATTEXT["Chat text parts"]
    KIND -->|"input_image or input_file"| ERROR["NotImplementedError"]
    CHATTEXT --> ROUNDTRIP["Responses input_text parts"]
```