### PR TITLE
fix(responses): handle omitted Chat tools

### DIFF
--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -365,8 +365,10 @@ class ResponsesConverter(BaseModel):
     # =======================================================
 
     def _chat_completion_to_responses_tools(
-        self, chat_completions_tools: List[NeMoGymChatCompletionToolParam]
+        self, chat_completions_tools: Optional[List[NeMoGymChatCompletionToolParam]]
     ) -> List[NeMoGymFunctionToolParam]:
+        if chat_completions_tools is None:
+            return []
         return [tool["function"] | {"type": "function"} for tool in chat_completions_tools]
 
     def chat_completion_to_responses_create_params(

--- a/tests/unit_tests/test_responses_converter.py
+++ b/tests/unit_tests/test_responses_converter.py
@@ -391,6 +391,10 @@ def test_responses_to_chat_completion_with_tools_keeps_tool_choice(converter: Re
     assert len(params.tools) == 1
 
 
+def test_chat_completion_to_responses_tools_accepts_none(converter: ResponsesConverter):
+    assert converter._chat_completion_to_responses_tools(None) == []
+
+
 def test_responses_to_chat_completion_token_id_information_path():
     converter = ResponsesConverter(return_token_id_information=True)
     params = converter.responses_to_chat_completion_create_params(


### PR DESCRIPTION
## Summary

The [Chat Completions API](https://platform.openai.com/docs/api-reference/chat/create#chat_create-tools) defines `tools` as an optional array. Gym represents an omitted Chat field as `None`, but `_chat_completion_to_responses_tools()` currently requires a list and iterates over it. Converting a Chat request that omits tools therefore raises `TypeError`.

The [Responses API](https://platform.openai.com/docs/api-reference/responses/create#responses_create-tools) also defines `tools` as an array rather than a nullable value. The helper now accepts Gym's in-memory `None` and maps it to the empty list used by `NeMoGymResponseCreateParamsNonStreaming.tools`. Tool conversion is unchanged when definitions are present.

```mermaid
flowchart LR
    CHAT["Chat request"] --> CHECK{"tools present?"}
    CHECK -->|"No"| EMPTY["Responses tools: []"]
    CHECK -->|"Yes"| CONVERT["Convert function tools"]
    EMPTY --> RESP["Responses request"]
    CONVERT --> RESP
```

## References

- [OpenAI Python 2.7.2 Chat request schema](https://github.com/openai/openai-python/blob/v2.7.2/src/openai/types/chat/completion_create_params.py)
- [OpenAI Python 2.7.2 Responses request schema](https://github.com/openai/openai-python/blob/v2.7.2/src/openai/types/responses/response_create_params.py)