### PR TITLE
cp: security: remove dependencies flagged in legal review (#2492) into r0.5.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,6 @@ apt-get install -y --no-install-recommends \
     jq \
     curl \
     git \
-    rsync \
     wget \
     less \
     vim

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,11 +221,7 @@ dependencies = [
     # License: BSD 2-Clause https://pyasn1.readthedocs.io/en/latest/license.html
     "pyasn1>=0.6.4",
 
-    # gprof2dot and pydot: Used for outputting dot graphs for profiling.
-    # Updated: Wed Feb 25, 2026 with gprof2dot==2025.4.14 and pydot==4.0.1
-    # gprof2dot License: GNU Lesser General Public License v3.0 https://github.com/jamielennox/requests-mock/blob/9742d02a8cad17276dbeba7b300b6d27ae1b6fb1/LICENSE
     # pydot License: MIT https://github.com/pydot/pydot/blob/a2bee1e770698867332516fb2878fac262b4ffc5/LICENSES/MIT.txt
-    "gprof2dot",
     "pydot",
 ]
 
@@ -277,6 +273,11 @@ sandbox = [
 
 # We include dev dependencies as an extra since technically each server module is a consumer (which means we cannot use dependency groups, which are intended to be within a project).
 dev = [
+    # gprof2dot: Used for outputting dot graphs for profiling.
+    # Updated: Wed Feb 25, 2026 with gprof2dot==2025.4.14
+    # License: LGPLv3+ https://github.com/jrfonseca/gprof2dot/blob/master/COPYING.LESSER
+    "gprof2dot",
+
     # Pre-commit: Used for pre-commit hooks.
     # Updated: Thu Sep 04, 2025 with pre-commit==4.3.0
     # License: MIT https://github.com/pre-commit/pre-commit/blob/e70b313c8017b2b6d7844e91795c9d41b9ceb9fb/LICENSE
@@ -354,6 +355,7 @@ override-dependencies = [
     "opencv-python-headless; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "torchaudio; sys_platform == 'never'",
+    "pycountry; sys_platform == 'never'",
 ]
 # NOTE: server venvs install nemo-gym editably and inherit this list, so anything
 # here is also silently dropped from them (uv >=0.11.24). Servers that need a

--- a/resources_servers/toolsandbox/overrides.txt
+++ b/resources_servers/toolsandbox/overrides.txt
@@ -1,0 +1,1 @@
+pycountry

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ resolution-markers = [
 constraints = [{ name = "grpcio", specifier = ">=1.81.0rc1" }]
 overrides = [
     { name = "opencv-python-headless", marker = "sys_platform == 'never'" },
+    { name = "pycountry", marker = "sys_platform == 'never'" },
     { name = "spacy", specifier = ">=3.8.13" },
     { name = "torchaudio", marker = "sys_platform == 'never'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
@@ -2535,7 +2536,6 @@ dependencies = [
     { name = "fastapi" },
     { name = "fonttools" },
     { name = "gitpython" },
-    { name = "gprof2dot" },
     { name = "hydra-core" },
     { name = "itsdangerous" },
     { name = "mcp" },
@@ -2566,6 +2566,7 @@ all = [
     { name = "boto3" },
     { name = "coverage" },
     { name = "daytona" },
+    { name = "gprof2dot" },
     { name = "mypy" },
     { name = "opensandbox" },
     { name = "openshell" },
@@ -2580,6 +2581,7 @@ all = [
 ]
 dev = [
     { name = "coverage" },
+    { name = "gprof2dot" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -2621,7 +2623,7 @@ requires-dist = [
     { name = "flashinfer-python", marker = "extra == 'vllm'", specifier = "==0.6.12" },
     { name = "fonttools", specifier = ">=4.60.2" },
     { name = "gitpython", specifier = ">=3.1.57" },
-    { name = "gprof2dot" },
+    { name = "gprof2dot", marker = "extra == 'dev'" },
     { name = "hydra-core" },
     { name = "itsdangerous" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
@@ -3292,7 +3294,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/1d/99/76b7c80252aa83c1a
 
 [[package]]
 name = "opensandbox"
-version = "0.1.9"
+version = "0.1.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3300,9 +3302,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/2a/ab3cc141e041f71a373c97fcda8749dba9328f1b9bf80401378c0611556f/opensandbox-0.1.9.tar.gz", hash = "sha256:670fbf292c498f8467963d21e91ade9ea8b8f63f4ef18d18fff9581e0952ec03", size = 160034, upload-time = "2026-05-12T12:27:20.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/21/654a3d69815b09690e926d553f3f4a178640d1206000a1b49f5e22c8eb68/opensandbox-0.1.15.tar.gz", hash = "sha256:017abc9b399b88da51bf077d6fb94ee89b1783e601495e85ba85fed478fed1b0", size = 228729, upload-time = "2026-07-24T09:36:29.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/9b/553f8d7a30eddb12785711b2a1c682386878e2bb95450acd806f9fa62930/opensandbox-0.1.9-py3-none-any.whl", hash = "sha256:17faed35b60a982fee5a643fed8e4e12f041e5432d5ea0665d2828d1f2082759", size = 360945, upload-time = "2026-05-12T12:27:19.465Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5c/ab87ea696531210790feb8f575471036fccba29dedaff201736f15bbb3a7/opensandbox-0.1.15-py3-none-any.whl", hash = "sha256:992b01490551f4d8e3f99caa25e34cb9d1690f0c5027eeebab912738291957d1", size = 538522, upload-time = "2026-07-24T09:36:28.277Z" },
 ]
 
 [[package]]
@@ -4102,7 +4104,7 @@ wheels = [
 
 [package.optional-dependencies]
 pycountry = [
-    { name = "pycountry" },
+    { name = "pycountry", marker = "sys_platform == 'never'" },
 ]
 
 [[package]]


### PR DESCRIPTION
Cherry-pick of #2492 into `r0.5.1`.