### PR TITLE
cp: fix(ci): lazy-load optional gprof2dot dependency into r0.5.1 (#2499)

### DIFF
--- a/nemo_gym/profiling.py
+++ b/nemo_gym/profiling.py
@@ -12,15 +12,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections.abc import Callable
 from io import StringIO
 from pathlib import Path
 from subprocess import run
 from typing import Optional
 
 import yappi
-from gprof2dot import main as gprof2dot_main
 from pydantic import BaseModel
 from pydot import graph_from_dot_file
+
+
+def _require_gprof2dot() -> Callable[..., None]:
+    try:
+        from gprof2dot import main as gprof2dot_main
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "gprof2dot is required for CPU profiling. Install nemo-gym[dev] before enabling profiling."
+        ) from e
+
+    return gprof2dot_main
 
 
 class Profiler(BaseModel):
@@ -57,6 +68,8 @@ Please install dot using:
         self.dump()
 
     def dump(self) -> None:
+        gprof2dot_main = _require_gprof2dot()
+
         self.base_profile_dir.mkdir(parents=True, exist_ok=True)
         log_path = self.base_profile_dir / f"{self.name}.log"
         callgrind_path = self.base_profile_dir / f"{self.name}.callgrind"

--- a/tests/unit_tests/test_profiling.py
+++ b/tests/unit_tests/test_profiling.py
@@ -12,7 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import builtins
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 from pydantic import ValidationError
@@ -35,3 +37,25 @@ class TestProfiling:
     def test_profiler_errors_on_invalid_name(self, tmp_path: Path) -> None:
         with raises(ValidationError, match="Spaces are not allowed"):
             Profiler(name="test name", base_profile_dir=tmp_path / "profile")
+
+    def test_profiler_reports_missing_gprof2dot(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+        real_import = builtins.__import__
+
+        def fake_import(
+            name: str,
+            globals_: dict[str, Any] | None = None,
+            locals_: dict[str, Any] | None = None,
+            fromlist: tuple[str, ...] = (),
+            level: int = 0,
+        ) -> Any:
+            if name == "gprof2dot":
+                raise ModuleNotFoundError(name)
+            return real_import(name, globals_, locals_, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        profiler = Profiler(name="test_name", base_profile_dir=tmp_path / "profile")
+        with raises(ModuleNotFoundError, match=r"Install nemo-gym\[dev\]"):
+            profiler.dump()
+
+        assert not profiler.base_profile_dir.exists()


### PR DESCRIPTION
## Summary
- Cherry-pick of #2499 into `r0.5.1`
- Lazy-loads optional `gprof2dot` dependency to avoid import errors when not installed

## Test plan
- [ ] CI passes on `r0.5.1`