### PR TITLE
feat: propagate backend's completion ids

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -137,6 +137,7 @@ class TokenIDLogProbMixin(BaseModel):
     generation_token_ids: List[int]
     generation_log_probs: List[float]
     routed_experts: Optional[RoutedExperts] = None
+    completion_id: Optional[str] = None
 
 
 class TokenIDLogProbTypedDictMixin(TypedDict):
@@ -144,6 +145,7 @@ class TokenIDLogProbTypedDictMixin(TypedDict):
     generation_token_ids: List[int]
     generation_log_probs: List[float]
     routed_experts: NotRequired[RoutedExperts]
+    completion_id: NotRequired[Optional[str]]
 
 
 REQUIRED_TOKEN_METADATA_FIELDS = frozenset(
@@ -153,7 +155,7 @@ REQUIRED_TOKEN_METADATA_FIELDS = frozenset(
         "generation_log_probs",
     }
 )
-TOKEN_METADATA_FIELDS = REQUIRED_TOKEN_METADATA_FIELDS | {"routed_experts"}
+TOKEN_METADATA_FIELDS = REQUIRED_TOKEN_METADATA_FIELDS | {"routed_experts", "completion_id"}
 
 
 def _validate_atomic_token_metadata(value: Any) -> Any:

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -167,6 +167,7 @@ class TokenIDLogProbMixin(BaseModel):
     generation_token_ids: List[int]
     generation_log_probs: List[float]
     routed_experts: Optional[RoutedExperts] = None
+    completion_id: Optional[str] = None
 
 
 class TokenIDLogProbTypedDictMixin(TypedDict):
@@ -174,6 +175,7 @@ class TokenIDLogProbTypedDictMixin(TypedDict):
     generation_token_ids: List[int]
     generation_log_probs: List[float]
     routed_experts: NotRequired[RoutedExperts]
+    completion_id: NotRequired[Optional[str]]
 
 
 REQUIRED_TOKEN_METADATA_FIELDS = frozenset(
@@ -183,7 +185,7 @@ REQUIRED_TOKEN_METADATA_FIELDS = frozenset(
         "generation_log_probs",
     }
 )
-TOKEN_METADATA_FIELDS = REQUIRED_TOKEN_METADATA_FIELDS | {"routed_experts"}
+TOKEN_METADATA_FIELDS = REQUIRED_TOKEN_METADATA_FIELDS | {"routed_experts", "completion_id"}
 
 
 def _validate_atomic_token_metadata(value: Any) -> Any:

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -486,10 +486,16 @@ class ResponsesConverter(BaseModel):
     # Chat Completion to Response
     # =======================================================
 
-    def postprocess_chat_response(self, choice: NeMoGymChoice) -> List[NeMoGymResponseOutputItem]:
-        return self.postprocess_assistant_message_dict(choice.message.model_dump(exclude_none=True))
+    def postprocess_chat_response(
+        self, choice: NeMoGymChoice, completion_id: Optional[str] = None
+    ) -> List[NeMoGymResponseOutputItem]:
+        return self.postprocess_assistant_message_dict(
+            choice.message.model_dump(exclude_none=True), completion_id=completion_id
+        )
 
-    def postprocess_assistant_message_dict(self, message_dict: Dict[str, Any]) -> List[NeMoGymResponseOutputItem]:
+    def postprocess_assistant_message_dict(
+        self, message_dict: Dict[str, Any], completion_id: Optional[str] = None
+    ) -> List[NeMoGymResponseOutputItem]:
         response_output = []
 
         content = message_dict.get("content") or ""
@@ -545,10 +551,13 @@ class ResponsesConverter(BaseModel):
         if token_information is not None:
             last_response_output_item = response_output[-1]
             train_cls = training_variant_of(last_response_output_item.__class__)
-            response_output[-1] = train_cls(
+            train_kwargs = {
                 **last_response_output_item.model_dump(),
                 **token_information.model_dump(exclude_none=True),
-            )
+            }
+            if completion_id:
+                train_kwargs.setdefault("completion_id", completion_id)
+            response_output[-1] = train_cls(**train_kwargs)
 
         return response_output
 
@@ -591,7 +600,7 @@ class ResponsesConverter(BaseModel):
     ) -> NeMoGymResponse:
         choice = chat_completion.choices[0]
 
-        response_output = self.postprocess_chat_response(choice)
+        response_output = self.postprocess_chat_response(choice, completion_id=chat_completion.id)
         response_output_dicts = [item.model_dump() for item in response_output]
 
         usage = None
@@ -628,7 +637,7 @@ class ResponsesConverter(BaseModel):
 
         # Chat Completion -> Response
         return NeMoGymResponse(
-            id=f"resp_{uuid4().hex}",
+            id=chat_completion.id or f"resp_{uuid4().hex}",
             created_at=chat_completion.created,
             model=responses_create_params.model,
             object="response",

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -640,10 +640,16 @@ class ResponsesConverter(BaseModel):
     # Chat Completion to Response
     # =======================================================
 
-    def postprocess_chat_response(self, choice: NeMoGymChoice) -> List[NeMoGymResponseOutputItem]:
-        return self.postprocess_assistant_message_dict(choice.message.model_dump(exclude_none=True))
+    def postprocess_chat_response(
+        self, choice: NeMoGymChoice, completion_id: Optional[str] = None
+    ) -> List[NeMoGymResponseOutputItem]:
+        return self.postprocess_assistant_message_dict(
+            choice.message.model_dump(exclude_none=True), completion_id=completion_id
+        )
 
-    def postprocess_assistant_message_dict(self, message_dict: Dict[str, Any]) -> List[NeMoGymResponseOutputItem]:
+    def postprocess_assistant_message_dict(
+        self, message_dict: Dict[str, Any], completion_id: Optional[str] = None
+    ) -> List[NeMoGymResponseOutputItem]:
         response_output = []
 
         content = message_dict.get("content") or ""
@@ -699,10 +705,13 @@ class ResponsesConverter(BaseModel):
         if token_information is not None:
             last_response_output_item = response_output[-1]
             train_cls = training_variant_of(last_response_output_item.__class__)
-            response_output[-1] = train_cls(
+            train_kwargs = {
                 **last_response_output_item.model_dump(),
                 **token_information.model_dump(exclude_none=True),
-            )
+            }
+            if completion_id:
+                train_kwargs.setdefault("completion_id", completion_id)
+            response_output[-1] = train_cls(**train_kwargs)
 
         return response_output
 
@@ -745,7 +754,7 @@ class ResponsesConverter(BaseModel):
     ) -> NeMoGymResponse:
         choice = chat_completion.choices[0]
 
-        response_output = self.postprocess_chat_response(choice)
+        response_output = self.postprocess_chat_response(choice, completion_id=chat_completion.id)
         response_output_dicts = [item.model_dump() for item in response_output]
 
         usage = None
@@ -782,7 +791,7 @@ class ResponsesConverter(BaseModel):
 
         # Chat Completion -> Response
         return NeMoGymResponse(
-            id=f"resp_{uuid4().hex}",
+            id=chat_completion.id or f"resp_{uuid4().hex}",
             created_at=chat_completion.created,
             model=responses_create_params.model,
             object="response",

--- a/responses_api_agents/harbor_agent/custom_agents/llms/nemo_gym_llm.py
+++ b/responses_api_agents/harbor_agent/custom_agents/llms/nemo_gym_llm.py
@@ -146,11 +146,12 @@ class NemoGymLLM(BaseLLM):
 
         # Detect silently-swallowed context-length errors from the Gym proxy.
         # When vLLM returns 400 "maximum context length", the proxy catches it
-        # and returns a fake 200 with id="chtcmpl-123" and content=None.
-        if response_dict.get("id") == "chtcmpl-123":
+        # and returns a fake 200 with content=None and an id prefixed "chtcmpl-123".
+        response_id = response_dict.get("id") or ""
+        if response_id.startswith("chtcmpl-123"):
             self.context_length_exceeded = True
             raise ContextLengthExceededError(
-                f"Model {self._model_name} context length exceeded (detected fake response id='chtcmpl-123')"
+                f"Model {self._model_name} context length exceeded (detected fake response id={response_id!r})"
             )
 
         choices = response_dict.get("choices", [])

--- a/responses_api_agents/harbor_agent/custom_agents/llms/test_nemo_gym_llm.py
+++ b/responses_api_agents/harbor_agent/custom_agents/llms/test_nemo_gym_llm.py
@@ -255,11 +255,12 @@ async def test_context_length_error_from_http_400():
 
 
 @pytest.mark.asyncio
-async def test_fake_response_id_raises_context_length_error():
-    """Gym proxy returns fake 200 with id='chtcmpl-123' for context-length overflow."""
+@pytest.mark.parametrize("fake_id", ["chtcmpl-123", "chtcmpl-123-0a1b2c3d4e5f"])
+async def test_fake_response_id_raises_context_length_error(fake_id):
+    """Gym proxy returns fake 200 with a 'chtcmpl-123'-prefixed id for context-length overflow."""
     llm = _make_llm()
     with pytest.raises(ContextLengthExceededError, match="chtcmpl-123"):
-        await _call(llm, _mock_response(content=None, id="chtcmpl-123"), prompt="hello")
+        await _call(llm, _mock_response(content=None, id=fake_id), prompt="hello")
 
 
 @pytest.mark.asyncio

--- a/responses_api_models/inference_provider/tests/test_app.py
+++ b/responses_api_models/inference_provider/tests/test_app.py
@@ -285,7 +285,7 @@ class TestResponses:
         assert response.status_code == 200
         data = response.json()
 
-        assert data["id"] == f"resp_{FIXED_UUID}"
+        assert data["id"] == "chatcmpl-test"
         assert data["model"] == "test-model"
         assert data["object"] == "response"
         assert data["status"] == "completed"

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -21,6 +21,7 @@ import os
 from copy import deepcopy
 from time import time, time_ns
 from typing import Any, ClassVar, Dict, List, Optional, Union
+from uuid import uuid4
 
 from aiohttp.client_exceptions import ClientResponseError
 from fastapi import Request
@@ -1233,7 +1234,7 @@ class VLLMModel(SimpleResponsesAPIModel):
             )
 
         chat_completion_dict = {
-            "id": completion_dict.get("id", "chatcmpl-completions"),
+            "id": completion_dict.get("id") or f"chatcmpl-{uuid4().hex}",
             "object": "chat.completion",
             "created": completion_dict.get("created", int(time())),
             "model": completion_dict.get("model", self.config.model),
@@ -1253,7 +1254,8 @@ class VLLMModel(SimpleResponsesAPIModel):
 
     def _create_empty_chat_completion(self) -> NeMoGymChatCompletion:
         return NeMoGymChatCompletion(
-            id="chtcmpl-123",
+            # harbor_agent's nemo_gym_llm.py detects fabricated responses by this prefix.
+            id=f"chtcmpl-123-{uuid4().hex}",
             object="chat.completion",
             created=int(time()),
             model=self.config.model,

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -22,6 +22,7 @@ from copy import deepcopy
 from threading import Lock
 from time import monotonic, time, time_ns
 from typing import Any, ClassVar, Dict, List, Optional, Union
+from uuid import uuid4
 
 from aiohttp.client_exceptions import ClientResponseError
 from fastapi import Request
@@ -1388,7 +1389,7 @@ class VLLMModel(SimpleResponsesAPIModel):
             )
 
         chat_completion_dict = {
-            "id": completion_dict.get("id", "chatcmpl-completions"),
+            "id": completion_dict.get("id") or f"chatcmpl-{uuid4().hex}",
             "object": "chat.completion",
             "created": completion_dict.get("created", int(time())),
             "model": completion_dict.get("model", self.config.model),
@@ -1408,7 +1409,8 @@ class VLLMModel(SimpleResponsesAPIModel):
 
     def _create_empty_chat_completion(self) -> NeMoGymChatCompletion:
         return NeMoGymChatCompletion(
-            id="chtcmpl-123",
+            # harbor_agent's nemo_gym_llm.py detects fabricated responses by this prefix.
+            id=f"chtcmpl-123-{uuid4().hex}",
             object="chat.completion",
             created=int(time()),
             model=self.config.model,

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -52,6 +52,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseReasoningItem,
     NeMoGymSummary,
 )
+from nemo_gym.responses_converter import ResponsesConverter
 from nemo_gym.server_utils import SESSION_ID_KEY, ServerClient
 from responses_api_models.vllm_model.app import (
     VLLMConverter,
@@ -168,7 +169,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -222,7 +223,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -275,7 +276,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -335,7 +336,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -415,7 +416,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -481,7 +482,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -544,7 +545,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -606,7 +607,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -686,7 +687,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -847,7 +848,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -1021,7 +1022,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=[],
             created_at=FIXED_TIME,
@@ -1252,7 +1253,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -1772,7 +1773,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -1917,7 +1918,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -2028,7 +2029,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -2223,7 +2224,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -2368,7 +2369,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -2479,7 +2480,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -2577,7 +2578,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **(COMMON_RESPONSE_PARAMS | {"status": "incomplete"}),
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=[],
             created_at=FIXED_TIME,
@@ -5104,3 +5105,47 @@ class TestSamplingOverrides:
         server = self._server({"temperature": 1.0}, is_responses_native=True)
         body = {"model": "dummy_model", "temperature": 0.2}
         assert server._apply_sampling_overrides(body)["temperature"] == 1.0
+
+
+class TestCompletionIdPropagation:
+    """The backend completion id must survive conversion: it becomes the Response
+    id (minted `resp_` only when the backend provides none) and is stamped as
+    `completion_id` on the promoted *ForTraining output item, so trainers can
+    join per-turn items back to the model call that produced them."""
+
+    def _convert(self, completion_id: str, monkeypatch):
+        monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
+        converter = ResponsesConverter(return_token_id_information=True, uses_reasoning_parser=False)
+        completion = NeMoGymChatCompletion(
+            id=completion_id,
+            choices=[
+                NeMoGymChoice(
+                    index=0,
+                    finish_reason="stop",
+                    message=NeMoGymChatCompletionMessageForTraining(
+                        role="assistant",
+                        content="hi",
+                        prompt_token_ids=[1, 2],
+                        generation_token_ids=[3],
+                        generation_log_probs=[-0.1],
+                    ),
+                )
+            ],
+            created=FIXED_TIME,
+            model="dummy_model",
+            object="chat.completion",
+        )
+        params = NeMoGymResponseCreateParamsNonStreaming(input="hello", model="dummy_model")
+        return converter.chat_completion_to_response(params, completion)
+
+    def test_backend_id_propagates(self, monkeypatch):
+        response = self._convert("chtcmpl-join-key", monkeypatch)
+        assert response.id == "chtcmpl-join-key"
+        (item,) = response.output
+        assert item.completion_id == "chtcmpl-join-key"
+
+    def test_missing_backend_id_falls_back_to_minted(self, monkeypatch):
+        response = self._convert("", monkeypatch)
+        assert response.id == f"resp_{FIXED_UUID}"
+        (item,) = response.output
+        assert item.completion_id is None

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -2578,7 +2578,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **(COMMON_RESPONSE_PARAMS | {"status": "incomplete"}),
-            id="chtcmpl-123",
+            id=f"chtcmpl-123-{FIXED_UUID}",
             object="response",
             tools=[],
             created_at=FIXED_TIME,
@@ -2608,6 +2608,7 @@ class TestApp:
         )
 
         monkeypatch.setattr("responses_api_models.vllm_model.app.time", lambda: FIXED_TIME)
+        monkeypatch.setattr("responses_api_models.vllm_model.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         response = client.post(
@@ -4048,17 +4049,30 @@ class TestCompletionsBackendResponseTranslation:
         assert msg.generation_log_probs == [-0.1, -0.2]
         assert msg.prompt_token_ids == [6, 7, 8]
 
-    def test_default_id_uses_chat_completion_prefix(self) -> None:
+    @mark.parametrize(
+        "fabricate, id_prefix",
+        [
+            (
+                lambda model: model._completion_dict_to_chat_completion(
+                    {
+                        "object": "text_completion",
+                        "created": 123,
+                        "model": "base-model",
+                        "choices": [{"index": 0, "text": "ok", "finish_reason": "stop"}],
+                    }
+                ),
+                "chatcmpl-",
+            ),
+            (lambda model: model._create_empty_chat_completion(), "chtcmpl-123-"),
+        ],
+        ids=["missing_backend_id", "empty_chat_completion"],
+    )
+    def test_fabricated_ids_minted_unique(self, fabricate, id_prefix) -> None:
         model = _make_completions_backend_model()
-        chat_completion = model._completion_dict_to_chat_completion(
-            {
-                "object": "text_completion",
-                "created": 123,
-                "model": "base-model",
-                "choices": [{"index": 0, "text": "ok", "finish_reason": "stop"}],
-            }
-        )
-        assert chat_completion.id == "chatcmpl-completions"
+        first, second = fabricate(model), fabricate(model)
+        assert first.id.startswith(id_prefix)
+        assert second.id.startswith(id_prefix)
+        assert first.id != second.id
 
     def test_missing_logprobs_raises(self) -> None:
         model = _make_completions_backend_model(return_token_id_information=True)
@@ -5138,14 +5152,16 @@ class TestCompletionIdPropagation:
         params = NeMoGymResponseCreateParamsNonStreaming(input="hello", model="dummy_model")
         return converter.chat_completion_to_response(params, completion)
 
-    def test_backend_id_propagates(self, monkeypatch):
-        response = self._convert("chtcmpl-join-key", monkeypatch)
-        assert response.id == "chtcmpl-join-key"
+    @mark.parametrize(
+        "backend_id, expected_response_id, expected_completion_id",
+        [
+            ("chtcmpl-join-key", "chtcmpl-join-key", "chtcmpl-join-key"),
+            ("", f"resp_{FIXED_UUID}", None),
+        ],
+        ids=["backend_id_propagates", "missing_id_falls_back_to_minted"],
+    )
+    def test_completion_id_propagation(self, backend_id, expected_response_id, expected_completion_id, monkeypatch):
+        response = self._convert(backend_id, monkeypatch)
+        assert response.id == expected_response_id
         (item,) = response.output
-        assert item.completion_id == "chtcmpl-join-key"
-
-    def test_missing_backend_id_falls_back_to_minted(self, monkeypatch):
-        response = self._convert("", monkeypatch)
-        assert response.id == f"resp_{FIXED_UUID}"
-        (item,) = response.output
-        assert item.completion_id is None
+        assert item.completion_id == expected_completion_id

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -2630,7 +2630,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **(COMMON_RESPONSE_PARAMS | {"status": "incomplete"}),
-            id="chtcmpl-123",
+            id=f"chtcmpl-123-{FIXED_UUID}",
             object="response",
             tools=[],
             created_at=FIXED_TIME,
@@ -2660,6 +2660,7 @@ class TestApp:
         )
 
         monkeypatch.setattr("responses_api_models.vllm_model.app.time", lambda: FIXED_TIME)
+        monkeypatch.setattr("responses_api_models.vllm_model.app.uuid4", lambda: FakeUUID())
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
 
         response = client.post(
@@ -4101,17 +4102,30 @@ class TestCompletionsBackendResponseTranslation:
         assert msg.generation_log_probs == [-0.1, -0.2]
         assert msg.prompt_token_ids == [6, 7, 8]
 
-    def test_default_id_uses_chat_completion_prefix(self) -> None:
+    @mark.parametrize(
+        "fabricate, id_prefix",
+        [
+            (
+                lambda model: model._completion_dict_to_chat_completion(
+                    {
+                        "object": "text_completion",
+                        "created": 123,
+                        "model": "base-model",
+                        "choices": [{"index": 0, "text": "ok", "finish_reason": "stop"}],
+                    }
+                ),
+                "chatcmpl-",
+            ),
+            (lambda model: model._create_empty_chat_completion(), "chtcmpl-123-"),
+        ],
+        ids=["missing_backend_id", "empty_chat_completion"],
+    )
+    def test_fabricated_ids_minted_unique(self, fabricate, id_prefix) -> None:
         model = _make_completions_backend_model()
-        chat_completion = model._completion_dict_to_chat_completion(
-            {
-                "object": "text_completion",
-                "created": 123,
-                "model": "base-model",
-                "choices": [{"index": 0, "text": "ok", "finish_reason": "stop"}],
-            }
-        )
-        assert chat_completion.id == "chatcmpl-completions"
+        first, second = fabricate(model), fabricate(model)
+        assert first.id.startswith(id_prefix)
+        assert second.id.startswith(id_prefix)
+        assert first.id != second.id
 
     def test_missing_logprobs_raises(self) -> None:
         model = _make_completions_backend_model(return_token_id_information=True)
@@ -5895,14 +5909,16 @@ class TestCompletionIdPropagation:
         params = NeMoGymResponseCreateParamsNonStreaming(input="hello", model="dummy_model")
         return converter.chat_completion_to_response(params, completion)
 
-    def test_backend_id_propagates(self, monkeypatch):
-        response = self._convert("chtcmpl-join-key", monkeypatch)
-        assert response.id == "chtcmpl-join-key"
+    @mark.parametrize(
+        "backend_id, expected_response_id, expected_completion_id",
+        [
+            ("chtcmpl-join-key", "chtcmpl-join-key", "chtcmpl-join-key"),
+            ("", f"resp_{FIXED_UUID}", None),
+        ],
+        ids=["backend_id_propagates", "missing_id_falls_back_to_minted"],
+    )
+    def test_completion_id_propagation(self, backend_id, expected_response_id, expected_completion_id, monkeypatch):
+        response = self._convert(backend_id, monkeypatch)
+        assert response.id == expected_response_id
         (item,) = response.output
-        assert item.completion_id == "chtcmpl-join-key"
-
-    def test_missing_backend_id_falls_back_to_minted(self, monkeypatch):
-        response = self._convert("", monkeypatch)
-        assert response.id == f"resp_{FIXED_UUID}"
-        (item,) = response.output
-        assert item.completion_id is None
+        assert item.completion_id == expected_completion_id

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -54,6 +54,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseReasoningItem,
     NeMoGymSummary,
 )
+from nemo_gym.responses_converter import ResponsesConverter
 from nemo_gym.server_utils import SESSION_ID_KEY, ServerClient
 from nemo_gym.token_id_capture import (
     CaptureContext,
@@ -217,7 +218,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -271,7 +272,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -324,7 +325,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -384,7 +385,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -464,7 +465,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -530,7 +531,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -593,7 +594,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -655,7 +656,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -735,7 +736,7 @@ PARAMETERIZE_DATA = [
         ),
         NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             created_at=FIXED_TIME,
             model="dummy_model",
             tools=[],
@@ -896,7 +897,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -1072,7 +1073,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=[],
             created_at=FIXED_TIME,
@@ -1303,7 +1304,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -1824,7 +1825,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -1969,7 +1970,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -2080,7 +2081,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -2275,7 +2276,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -2420,7 +2421,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -2531,7 +2532,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **COMMON_RESPONSE_PARAMS,
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=input_tools,
             created_at=FIXED_TIME,
@@ -2629,7 +2630,7 @@ class TestApp:
 
         expected_response = NeMoGymResponse(
             **(COMMON_RESPONSE_PARAMS | {"status": "incomplete"}),
-            id="resp_123",
+            id="chtcmpl-123",
             object="response",
             tools=[],
             created_at=FIXED_TIME,
@@ -5861,3 +5862,47 @@ class TestPrefixSupplyRejectsResponsesNative:
                 supply_prefix_token_ids=True,
                 is_responses_native=True,
             )
+
+
+class TestCompletionIdPropagation:
+    """The backend completion id must survive conversion: it becomes the Response
+    id (minted `resp_` only when the backend provides none) and is stamped as
+    `completion_id` on the promoted *ForTraining output item, so trainers can
+    join per-turn items back to the model call that produced them."""
+
+    def _convert(self, completion_id: str, monkeypatch):
+        monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
+        converter = ResponsesConverter(return_token_id_information=True, uses_reasoning_parser=False)
+        completion = NeMoGymChatCompletion(
+            id=completion_id,
+            choices=[
+                NeMoGymChoice(
+                    index=0,
+                    finish_reason="stop",
+                    message=NeMoGymChatCompletionMessageForTraining(
+                        role="assistant",
+                        content="hi",
+                        prompt_token_ids=[1, 2],
+                        generation_token_ids=[3],
+                        generation_log_probs=[-0.1],
+                    ),
+                )
+            ],
+            created=FIXED_TIME,
+            model="dummy_model",
+            object="chat.completion",
+        )
+        params = NeMoGymResponseCreateParamsNonStreaming(input="hello", model="dummy_model")
+        return converter.chat_completion_to_response(params, completion)
+
+    def test_backend_id_propagates(self, monkeypatch):
+        response = self._convert("chtcmpl-join-key", monkeypatch)
+        assert response.id == "chtcmpl-join-key"
+        (item,) = response.output
+        assert item.completion_id == "chtcmpl-join-key"
+
+    def test_missing_backend_id_falls_back_to_minted(self, monkeypatch):
+        response = self._convert("", monkeypatch)
+        assert response.id == f"resp_{FIXED_UUID}"
+        (item,) = response.output
+        assert item.completion_id is None


### PR DESCRIPTION
Right now, in Gym, the chat-completion -> response conversion creates fresh completion IDs.

This prevents us from matching rollouts in Gym with rollouts in the engine.    
Such matches are useful, and in the case of Megatron RL vital as of NVIDIA/Megatron-LM#6125.

This PR re-uses the engine's ID if it is provided.