### PR TITLE
Add back Super 3.5 evals args to CLI rather than config

### DIFF
--- a/benchmarks/nemotron_3.5_super/eval_container_config.yaml
+++ b/benchmarks/nemotron_3.5_super/eval_container_config.yaml
@@ -54,18 +54,6 @@ policy_base_url: dummy
 policy_api_key: dummy  # pragma: allowlist secret
 policy_model_name: dummy
 
-# Tau2 and Tau3 servers may take a long time to spin up since we import the Tau repo which has hefty dependencies.
-uvicorn_timeout_worker_healthcheck: 600  # 10 mins
-upload_rollouts_to_wandb: false  # Rollouts file is massive. We leave on the cluster.
-global_aiohttp_connector_limit_per_host: 16384  # 16k concurrent requests should be enough. We can raise further if our inference is efficient enough to support.
-port_range_low: 63000  # Move into ephemeral ports
-port_range_high: 64000
-overwrite_metrics_conflicts: true
-split: benchmark
-use_absolute_ip: true  # Necessary for communication between harness in sandbox and Gym model servers
-reuse_existing_data_preparation: true
-skip_venv_if_present: true  # Reuse the venvs baked into the container if possible.
-
 # Used in Tau3 Banking
 gpt-5_4-mini-2026-03-17:
   responses_api_models:

--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -44,15 +44,33 @@ gym eval prepare $@ +use_cached_prepared_benchmarks=true
 
 experiment_name=$EXPERIMENT_NAME/slurm_jobs_id_\$SLURM_JOB_ID/date_\$(date +%Y%m%d_%H%M%S)
 # +uv_venv_dir=/opt/uv_venvs is from the container.
+# +skip_venv_if_present=true will reuse the venvs baked into the container if possible.
+# ++use_absolute_ip=true: Necessary for communication between harness in sandbox and Gym model servers
+# ++upload_rollouts_to_wandb=false: Rollouts file is massive. We leave on the cluster.
+# global_aiohttp_connector_limit_per_host: 16k concurrent requests should be enough. We can raise further if our inference is efficient enough to support.
+# port_range_low, port_range_high: Move into ephemeral ports
+# ++uvicorn_timeout_worker_healthcheck=600: Tau2 and Tau3 servers may take a long time to spin up since we import the Tau repo which has hefty dependencies.
 gym eval run \
     $@ \
     +wandb_project=$USER-gym-eval \
     +wandb_name=\$experiment_name \
     +uv_venv_dir=/opt/uv_venvs \
     +nemo_gym_log_dir=results/\$experiment_name/logs \
+    +skip_venv_if_present=true \
     ++output_jsonl_fpath=results/\$experiment_name.jsonl \
+    ++overwrite_metrics_conflicts=true \
+    ++split=benchmark \
+    ++use_absolute_ip=true \
+    ++reuse_existing_data_preparation=true \
     ++policy_base_url=http://\$(getent hosts "\$PREFILL_HEAD" | awk 'NR == 1 {print \$1}'):$ROUTER_SERVER_PORT/v1 \
-    ++policy_model_name=$MODEL
+    ++policy_api_key=dummy_api_key \
+    ++policy_model_name=$MODEL \
+    ++upload_rollouts_to_wandb=false \
+    ++global_aiohttp_connector_limit_per_host=16384 \
+    ++port_range_low=63000 \
+    ++port_range_high=64000 \
+    ++uvicorn_timeout_worker_healthcheck=600
+
 
 if (( $EXPORT_TO_CSV )); then
     python benchmarks/nemotron_3.5_super/export_to_csv.py \
@@ -114,9 +132,15 @@ if (( SLURM_PROCID == 0 )); then
     prefill_pid=\$!
     trap 'kill "\$prefill_pid" 2>/dev/null || true' EXIT
 
+    until curl -fs "http://\$PREFILL_HEAD:$PREFILL_SERVER_PORT/health" >/dev/null; do
+        sleep 5
+    done
+    until curl -fs "http://\$DECODE_HEAD:$DECODE_SERVER_PORT/health" >/dev/null; do
+        sleep 5
+    done
+
     # --intra-node-data-parallel-size must match the data-parallel-size-local above.
     # Set a super long request timeout since some reasoning requests may take a long time to generate.
-    # Don't manually wait as vllm-router will wait for the URLs to come up
     vllm-router \
         --policy consistent_hash \
         --vllm-pd-disaggregation \
@@ -126,9 +150,7 @@ if (( SLURM_PROCID == 0 )); then
         --port $ROUTER_SERVER_PORT \
         --intra-node-data-parallel-size 1 \
         --request-timeout-secs 86400 \
-        --prometheus-host 0.0.0.0 \
-        --prometheus-port 9000 \
-        --log-level info
+        --log-level error
 elif (( SLURM_PROCID < $NUM_PREFILL_NODES )); then
     # Prefill worker
     VLLM_NIXL_SIDE_CHANNEL_HOST=\$this_node_hostname \
@@ -204,7 +226,12 @@ cleanup_server() {
 trap cleanup_server EXIT INT TERM
 
 if (( $should_run_eval )); then
-    # No need to wait for endpoint since Gym will wait for model endpoints to spin up before proceeding.
+    until curl -fs "http://\$PREFILL_HEAD:$ROUTER_SERVER_PORT/health" >/dev/null; do
+        if ! kill -0 "\$server_step" 2>/dev/null; then
+            wait "\$server_step"
+        fi
+        sleep 5
+    done
 
     eval_status=0
     PREFILL_HEAD="\$PREFILL_HEAD" \


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

<!-- Briefly describe the change and the motivation. Link any related issue, e.g. "Closes #123". -->

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
