### PR TITLE
[SWE] Accept prebuilt OpenHands runtimes

### DIFF
--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -1548,8 +1548,8 @@ class OpenHandsHarnessProcessor(BaseDatasetHarnessProcessor):
             relative_path = output_dir.relative_to(resolved_setup_dir)
             if not output_dir.is_dir():
                 raise ValueError(f"OpenHands prebuilt setup is missing writable directory {relative_path}")
-            if not os.access(output_dir, os.W_OK):
-                raise ValueError(f"OpenHands prebuilt directory is not writable: {relative_path}")
+            if not os.access(output_dir, os.W_OK | os.X_OK):
+                raise ValueError(f"OpenHands prebuilt directory is not writable and searchable: {relative_path}")
 
         def _git(*args: str) -> str:
             result = subprocess_run(

--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -33,7 +33,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from shutil import rmtree
-from subprocess import Popen
+from subprocess import Popen, TimeoutExpired
 from subprocess import run as subprocess_run
 from traceback import format_exc
 from typing import Any, Dict, List, Literal, NamedTuple, Optional, Tuple, Union
@@ -1521,9 +1521,35 @@ class OpenHandsHarnessProcessor(BaseDatasetHarnessProcessor):
             resolved_setup_dir / "miniforge3/bin/python",
         )
         for required_file in required_files:
+            relative_path = required_file.relative_to(resolved_setup_dir)
             if not required_file.is_file():
-                relative_path = required_file.relative_to(resolved_setup_dir)
                 raise ValueError(f"OpenHands prebuilt setup is missing {relative_path}")
+            if not os.access(required_file, os.X_OK):
+                raise ValueError(f"OpenHands prebuilt interpreter is not executable: {relative_path}")
+            try:
+                interpreter_check = subprocess_run(
+                    [str(required_file), "--version"],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+            except (OSError, TimeoutExpired) as error:
+                raise ValueError(f"OpenHands prebuilt interpreter could not run: {relative_path}") from error
+            if interpreter_check.returncode != 0:
+                raise ValueError(f"OpenHands prebuilt interpreter could not run: {relative_path}")
+
+        required_output_dirs = (
+            openhands_dir / ".eval_sessions",
+            openhands_dir / "logs",
+            openhands_dir / "evaluation/oh",
+        )
+        for output_dir in required_output_dirs:
+            relative_path = output_dir.relative_to(resolved_setup_dir)
+            if not output_dir.is_dir():
+                raise ValueError(f"OpenHands prebuilt setup is missing writable directory {relative_path}")
+            if not os.access(output_dir, os.W_OK):
+                raise ValueError(f"OpenHands prebuilt directory is not writable: {relative_path}")
 
         def _git(*args: str) -> str:
             result = subprocess_run(
@@ -3357,7 +3383,7 @@ class SWEBenchWrapper(SimpleResponsesAPIAgent):
         container_script_path = f"/container_scripts/{command.mode}_script.sh"
         mount_args.append(f"--mount type=bind,src={script_path},dst={container_script_path},ro")
 
-        mount_str = " ".join(mount_args)
+        mount_str = " ".join(f"--mount {shlex.quote(mount_arg.removeprefix('--mount '))}" for mount_arg in mount_args)
 
         # _JAVA_OPTIONS bundles JVM-wide settings that benefit Maven, Gradle,
         # and Robolectric-using tests:

--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -117,6 +117,13 @@ class SWEBenchWrapperConfig(BaseResponsesAPIAgentConfig):
     agent_framework_commit: str = Field(
         default="HEAD", description="Which commit to use when cloning the SWE-agent/OpenHands repo"
     )
+    openhands_prebuilt_setup_dir: Optional[Path] = Field(
+        default=None,
+        description=(
+            "Absolute path to a prebuilt OpenHands runtime. When set, Gym validates and uses it "
+            "without cloning, updating, or copying the runtime."
+        ),
+    )
     # Container configuration
     container_formatter: str | list[str] = Field(
         default="docker://swebench/sweb.eval.x86_64.{instance_id}", description="Container path template"
@@ -1498,6 +1505,60 @@ fi
 
 
 class OpenHandsHarnessProcessor(BaseDatasetHarnessProcessor):
+    def _validate_prebuilt_setup(self, setup_dir: Path) -> Path:
+        if not setup_dir.is_absolute():
+            raise ValueError("openhands_prebuilt_setup_dir must be an absolute path")
+        try:
+            resolved_setup_dir = setup_dir.resolve(strict=True)
+        except OSError as error:
+            raise ValueError(f"OpenHands prebuilt setup does not exist: {setup_dir}") from error
+        if not resolved_setup_dir.is_dir():
+            raise ValueError(f"OpenHands prebuilt setup is not a directory: {resolved_setup_dir}")
+
+        openhands_dir = resolved_setup_dir / "OpenHands"
+        required_files = (
+            openhands_dir / ".venv/bin/python",
+            resolved_setup_dir / "miniforge3/bin/python",
+        )
+        for required_file in required_files:
+            if not required_file.is_file():
+                relative_path = required_file.relative_to(resolved_setup_dir)
+                raise ValueError(f"OpenHands prebuilt setup is missing {relative_path}")
+
+        def _git(*args: str) -> str:
+            result = subprocess_run(
+                ["git", "-C", str(openhands_dir), *args],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                detail = result.stderr.strip() or result.stdout.strip()
+                raise ValueError(f"Invalid prebuilt OpenHands Git worktree: {detail}")
+            return result.stdout.strip()
+
+        git_root = Path(_git("rev-parse", "--show-toplevel"))
+        try:
+            is_openhands_root = os.path.samefile(git_root, openhands_dir)
+        except OSError:
+            is_openhands_root = False
+        if not is_openhands_root:
+            raise ValueError(f"Prebuilt OpenHands path is not a Git worktree root: {openhands_dir}")
+
+        target = self.config.agent_framework_commit
+        try:
+            resolved_target = _git("rev-parse", "--verify", f"{target}^{{commit}}")
+        except ValueError as error:
+            raise ValueError(f"Prebuilt OpenHands could not resolve configured commit {target!r}") from error
+        current_commit = _git("rev-parse", "HEAD")
+        if current_commit != resolved_target:
+            raise ValueError(
+                "Prebuilt OpenHands commit mismatch: "
+                f"runtime={current_commit}, configured={resolved_target} ({target})"
+            )
+
+        return resolved_setup_dir
+
     def _sync_openhands_to_config_commit(self, openhands_dir: Path) -> None:
         """Ensure OpenHands checkout matches config.agent_framework_commit.
 
@@ -1544,6 +1605,9 @@ class OpenHandsHarnessProcessor(BaseDatasetHarnessProcessor):
         print(f"OpenHands now at commit {new_commit[:12]} (target={target})", flush=True)
 
     def setup(self) -> Path:
+        if self.config.openhands_prebuilt_setup_dir is not None:
+            return self._validate_prebuilt_setup(self.config.openhands_prebuilt_setup_dir)
+
         setup_dir = self.parent_dir / "swe_openhands_setup"
 
         with file_lock(setup_dir, "OpenHands setup"):

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import os
 import shutil
+import subprocess
 import tempfile
 import time
 from pathlib import Path
@@ -227,6 +228,19 @@ class TestSWEBenchWrapperConfig:
         assert config.debug is False
         assert config.agent_framework_repo is None
         assert config.agent_framework_commit == "HEAD"
+        assert config.openhands_prebuilt_setup_dir is None
+
+    def test_prebuilt_openhands_setup_dir(self) -> None:
+        config = SWEBenchWrapperConfig(
+            host="localhost",
+            port=9003,
+            name="test_agent",
+            entrypoint="responses_api_agents/swe_agents",
+            model_server=ModelServerRef(type="responses_api_models", name="test"),
+            openhands_prebuilt_setup_dir=Path("/opt/openhands-runtime"),
+        )
+
+        assert config.openhands_prebuilt_setup_dir == Path("/opt/openhands-runtime")
 
     def test_custom_values(self) -> None:
         config = SWEBenchWrapperConfig(
@@ -831,6 +845,85 @@ class TestR2EGymDatasetProcessor:
 
 
 class TestOpenHandsHarnessProcessor:
+    @staticmethod
+    def _make_prebuilt_runtime(tmp_path: Path) -> Path:
+        setup_dir = tmp_path / "runtime"
+        openhands_dir = setup_dir / "OpenHands"
+        openhands_dir.mkdir(parents=True)
+        subprocess.run(["git", "init", "-q"], cwd=openhands_dir, check=True)
+        subprocess.run(["git", "config", "user.name", "test"], cwd=openhands_dir, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=openhands_dir, check=True)
+        (openhands_dir / "README.md").write_text("runtime\n")
+        subprocess.run(["git", "add", "README.md"], cwd=openhands_dir, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "runtime"], cwd=openhands_dir, check=True)
+        (openhands_dir / ".venv/bin").mkdir(parents=True)
+        (openhands_dir / ".venv/bin/python").touch()
+        (setup_dir / "miniforge3/bin").mkdir(parents=True)
+        (setup_dir / "miniforge3/bin/python").touch()
+        return setup_dir
+
+    def test_setup_uses_valid_prebuilt_runtime_without_mutation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        setup_dir = self._make_prebuilt_runtime(tmp_path)
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=setup_dir / "OpenHands",
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        config = _minimal_server_config().model_copy(
+            update={
+                "agent_framework_commit": head,
+                "openhands_prebuilt_setup_dir": setup_dir,
+            }
+        )
+        processor = OpenHandsHarnessProcessor(config=config)
+        monkeypatch.setattr(processor, "_run_setup_command", MagicMock())
+        monkeypatch.setattr(processor, "_sync_openhands_to_config_commit", MagicMock())
+
+        assert processor.setup() == setup_dir
+        processor._run_setup_command.assert_not_called()
+        processor._sync_openhands_to_config_commit.assert_not_called()
+
+    def test_setup_rejects_relative_prebuilt_runtime(self, tmp_path: Path) -> None:
+        config = _minimal_server_config().model_copy(update={"openhands_prebuilt_setup_dir": Path("relative/runtime")})
+
+        with pytest.raises(ValueError, match="absolute"):
+            OpenHandsHarnessProcessor(config=config).setup()
+
+    def test_setup_rejects_incomplete_prebuilt_runtime(self, tmp_path: Path) -> None:
+        setup_dir = self._make_prebuilt_runtime(tmp_path)
+        (setup_dir / "miniforge3/bin/python").unlink()
+        config = _minimal_server_config().model_copy(update={"openhands_prebuilt_setup_dir": setup_dir})
+
+        with pytest.raises(ValueError, match="miniforge3/bin/python"):
+            OpenHandsHarnessProcessor(config=config).setup()
+
+    def test_setup_rejects_prebuilt_runtime_commit_mismatch(self, tmp_path: Path) -> None:
+        setup_dir = self._make_prebuilt_runtime(tmp_path)
+        openhands_dir = setup_dir / "OpenHands"
+        configured_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=openhands_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        (openhands_dir / "second.txt").write_text("new runtime\n")
+        subprocess.run(["git", "add", "second.txt"], cwd=openhands_dir, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "new runtime"], cwd=openhands_dir, check=True)
+        config = _minimal_server_config().model_copy(
+            update={
+                "agent_framework_commit": configured_commit,
+                "openhands_prebuilt_setup_dir": setup_dir,
+            }
+        )
+
+        with pytest.raises(ValueError, match="commit mismatch"):
+            OpenHandsHarnessProcessor(config=config).setup()
+
     def test_get_run_command(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             config = _make_instance_config(tmpdir)

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -15,6 +15,7 @@
 import asyncio
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -857,9 +858,15 @@ class TestOpenHandsHarnessProcessor:
         subprocess.run(["git", "add", "README.md"], cwd=openhands_dir, check=True)
         subprocess.run(["git", "commit", "-q", "-m", "runtime"], cwd=openhands_dir, check=True)
         (openhands_dir / ".venv/bin").mkdir(parents=True)
-        (openhands_dir / ".venv/bin/python").touch()
+        openhands_python = openhands_dir / ".venv/bin/python"
+        openhands_python.write_text("#!/bin/sh\nexit 0\n")
+        openhands_python.chmod(0o755)
         (setup_dir / "miniforge3/bin").mkdir(parents=True)
-        (setup_dir / "miniforge3/bin/python").touch()
+        miniforge_python = setup_dir / "miniforge3/bin/python"
+        miniforge_python.write_text("#!/bin/sh\nexit 0\n")
+        miniforge_python.chmod(0o755)
+        for output_dir in (".eval_sessions", "logs", "evaluation/oh"):
+            (openhands_dir / output_dir).mkdir(parents=True)
         return setup_dir
 
     def test_setup_uses_valid_prebuilt_runtime_without_mutation(
@@ -899,6 +906,22 @@ class TestOpenHandsHarnessProcessor:
         config = _minimal_server_config().model_copy(update={"openhands_prebuilt_setup_dir": setup_dir})
 
         with pytest.raises(ValueError, match="miniforge3/bin/python"):
+            OpenHandsHarnessProcessor(config=config).setup()
+
+    def test_setup_rejects_nonexecutable_prebuilt_interpreter(self, tmp_path: Path) -> None:
+        setup_dir = self._make_prebuilt_runtime(tmp_path)
+        (setup_dir / "miniforge3/bin/python").chmod(0o644)
+        config = _minimal_server_config().model_copy(update={"openhands_prebuilt_setup_dir": setup_dir})
+
+        with pytest.raises(ValueError, match="not executable"):
+            OpenHandsHarnessProcessor(config=config).setup()
+
+    def test_setup_rejects_missing_prebuilt_output_directory(self, tmp_path: Path) -> None:
+        setup_dir = self._make_prebuilt_runtime(tmp_path)
+        (setup_dir / "OpenHands/logs").rmdir()
+        config = _minimal_server_config().model_copy(update={"openhands_prebuilt_setup_dir": setup_dir})
+
+        with pytest.raises(ValueError, match="OpenHands/logs"):
             OpenHandsHarnessProcessor(config=config).setup()
 
     def test_setup_rejects_prebuilt_runtime_commit_mismatch(self, tmp_path: Path) -> None:
@@ -1969,6 +1992,34 @@ class TestSWEBenchWrapperBuildApptainerCommand:
             assert "apptainer exec" in result
             assert "--writable-tmpfs" in result
             assert params.container in result
+
+    def test_openhands_mounts_preserve_paths_with_spaces(self, monkeypatch) -> None:
+        wrapper = _create_wrapper(monkeypatch)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            params = _make_instance_config(tmpdir)
+            params.persistent_dir.mkdir(parents=True, exist_ok=True)
+            params.openhands_setup_dir = Path(tmpdir) / "runtime with space"
+            openhands_dir = params.openhands_setup_dir / "OpenHands"
+            for subdir in [".eval_sessions", "logs", "evaluation/oh"]:
+                (openhands_dir / subdir).mkdir(parents=True, exist_ok=True)
+            (params.openhands_setup_dir / "miniforge3").mkdir(parents=True, exist_ok=True)
+
+            result = wrapper._build_apptainer_command(
+                params,
+                ExecuteContainerCommandArgs(
+                    command="echo hello",
+                    expected_file_pattern="/tmp/*.json",
+                    mode="agent",
+                    timeout=300,
+                ),
+            )
+            tokens = shlex.split(result)
+            mount_specs = [tokens[index + 1] for index, token in enumerate(tokens) if token == "--mount"]
+
+            assert any(
+                f"type=bind,src={openhands_dir},dst=/openhands_setup/OpenHands,ro" == mount_spec
+                for mount_spec in mount_specs
+            )
 
     def test_eval_mode_swebench_mounts(self, monkeypatch) -> None:
         wrapper = _create_wrapper(monkeypatch)

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -924,6 +924,14 @@ class TestOpenHandsHarnessProcessor:
         with pytest.raises(ValueError, match="OpenHands/logs"):
             OpenHandsHarnessProcessor(config=config).setup()
 
+    def test_setup_rejects_nonsearchable_prebuilt_output_directory(self, tmp_path: Path) -> None:
+        setup_dir = self._make_prebuilt_runtime(tmp_path)
+        (setup_dir / "OpenHands/logs").chmod(0o200)
+        config = _minimal_server_config().model_copy(update={"openhands_prebuilt_setup_dir": setup_dir})
+
+        with pytest.raises(ValueError, match="not writable and searchable"):
+            OpenHandsHarnessProcessor(config=config).setup()
+
     def test_setup_rejects_prebuilt_runtime_commit_mismatch(self, tmp_path: Path) -> None:
         setup_dir = self._make_prebuilt_runtime(tmp_path)
         openhands_dir = setup_dir / "OpenHands"


### PR DESCRIPTION
## Problem

A SWE rollout worker may spend part of its startup time preparing OpenHands before it can generate any tokens. Repeating this setup on every worker delays useful rollout work.

## High-level change

This PR lets a deployment prepare OpenHands once and give Gym the path to that ready-to-use runtime.

When the optional path is provided, Gym:

1. checks that the runtime is complete and matches the requested OpenHands commit;
2. uses it directly for the rollout; and
3. skips its normal OpenHands clone and installation path.

When the option is not provided, Gym behaves exactly as it does today.

```text
Current:  start worker -> build OpenHands -> start rollout
New:      start worker -> validate ready runtime -> start rollout
```

## Expected impact

The goal is to move repeated OpenHands setup out of the rollout critical path. This should reduce startup overhead in deployments that can distribute a prebuilt runtime.

This PR does not claim a measured speedup yet. We will add cold and warm setup-inclusive A/B results before marking it ready for review.

A previous prototype copied the runtime recursively at worker startup. It moved more than 183k files and took about 610 seconds in our canary, so that approach is intentionally not included here.

## Safety

Gym rejects a prebuilt runtime when:

- its OpenHands commit does not match the configured commit;
- its Python environments are missing or cannot run; or
- its required output directories cannot be used.

Apptainer mount paths are also shell-quoted. These checks prevent Gym from starting with a partial or mismatched runtime.

## Validation

- GitHub lint, unit, server, copyright, secret, and DCO checks passed
- 16 focused runtime and mount tests passed locally
- full local SWE agent test file: 149 passed; 2 existing Linux `/proc` tests cannot run on macOS
- independent code review found no remaining actionable issues

## Before marking ready for review

- run a live smoke test on a Linux rollout node;
- compare cold and warm startup with 24 samples per arm; and
- verify rollout output and accuracy remain unchanged.
