### PR TITLE
fix: serialize Jest in nv-internal SWE

### DIFF
--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -673,6 +673,28 @@ EVAL_HARNESS_COMMIT={eval_harness_commit} \\
         )
 
 
+# A jest invocation:
+# runner-prefixed (npx/yarn), or bare `jest` in command position (line start or after &&/;/|),
+# but never inside words ("ts-jest", "config_jest"), quotes (grep '"jest"'), or assignments.
+_JEST_INVOCATION_RE = re.compile(r"((?:^|&&|;|\|)\s*|\b(?:npx|yarn)\s+)(jest\b)")
+
+
+def _serialize_nv_internal_jest(run_script: str) -> str:
+    """Force Jest in-band: large worker pools can wedge rootless Apptainer FUSE mid-eval."""
+    serialized_lines = []
+    for line in run_script.splitlines(keepends=True):
+        if _JEST_INVOCATION_RE.search(line):
+            flags = []
+            if "--runInBand" not in line and "--maxWorkers" not in line:
+                flags.append("--runInBand")
+            if "--forceExit" not in line:
+                flags.append("--forceExit")
+            if flags:
+                line = _JEST_INVOCATION_RE.sub(rf"\1\2 {' '.join(flags)}", line, count=1)
+        serialized_lines.append(line)
+    return "".join(serialized_lines)
+
+
 class NVInternalDatasetProcessor(BaseDatasetHarnessProcessor):
     def get_run_command(self) -> ExecuteContainerCommandArgs:
         instance_dict = json.loads(self.config.problem_info["instance_dict"])
@@ -715,7 +737,7 @@ class NVInternalDatasetProcessor(BaseDatasetHarnessProcessor):
         else:
             test_files = ",".join(test_files_str)
 
-        run_script = instance_dict["run_script.sh"]
+        run_script = _serialize_nv_internal_jest(instance_dict["run_script.sh"])
         parsing_script = instance_dict["parsing_script.py"]
         run_script_path = self.config.persistent_dir / "run_script.sh"
         parsing_script_path = self.config.persistent_dir / "parsing_script.py"

--- a/responses_api_agents/swe_agents/app.py
+++ b/responses_api_agents/swe_agents/app.py
@@ -698,6 +698,28 @@ EVAL_HARNESS_COMMIT={eval_harness_commit} \\
         )
 
 
+# A jest invocation:
+# runner-prefixed (npx/yarn), or bare `jest` in command position (line start or after &&/;/|),
+# but never inside words ("ts-jest", "config_jest"), quotes (grep '"jest"'), or assignments.
+_JEST_INVOCATION_RE = re.compile(r"((?:^|&&|;|\|)\s*|\b(?:npx|yarn)\s+)(jest\b)")
+
+
+def _serialize_nv_internal_jest(run_script: str) -> str:
+    """Force Jest in-band: large worker pools can wedge rootless Apptainer FUSE mid-eval."""
+    serialized_lines = []
+    for line in run_script.splitlines(keepends=True):
+        if _JEST_INVOCATION_RE.search(line):
+            flags = []
+            if "--runInBand" not in line and "--maxWorkers" not in line:
+                flags.append("--runInBand")
+            if "--forceExit" not in line:
+                flags.append("--forceExit")
+            if flags:
+                line = _JEST_INVOCATION_RE.sub(rf"\1\2 {' '.join(flags)}", line, count=1)
+        serialized_lines.append(line)
+    return "".join(serialized_lines)
+
+
 class NVInternalDatasetProcessor(BaseDatasetHarnessProcessor):
     def get_run_command(self) -> ExecuteContainerCommandArgs:
         instance_dict = orjson.loads(self.config.problem_info["instance_dict"])
@@ -740,7 +762,7 @@ class NVInternalDatasetProcessor(BaseDatasetHarnessProcessor):
         else:
             test_files = ",".join(test_files_str)
 
-        run_script = instance_dict["run_script.sh"]
+        run_script = _serialize_nv_internal_jest(instance_dict["run_script.sh"])
         parsing_script = instance_dict["parsing_script.py"]
         run_script_path = self.config.persistent_dir / "run_script.sh"
         parsing_script_path = self.config.persistent_dir / "parsing_script.py"

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -673,6 +673,36 @@ class TestNVInternalDatasetProcessor:
             result = processor.get_run_command()
             assert "test_x.py,test_y.py" in result.command
 
+    def test_get_run_command_serializes_jest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            processor = self._make_processor(
+                tmpdir,
+                {
+                    "run_script.sh": (
+                        "#!/bin/bash\n"
+                        "npx jest tests/\n"
+                        "yarn jest --maxWorkers=2 suite/\n"
+                        ". /root/.nvm/nvm.sh && jest --config verbose_jest.config.json\n"
+                        "elif grep -q '\"jest\"' package.json; then\n"
+                        '"preset": "ts-jest",\n'
+                        "config_jest\n"
+                        "echo done"
+                    )
+                },
+            )
+            processor.get_run_command()
+            script = (processor.config.persistent_dir / "run_script.sh").read_text()
+            assert "npx jest --runInBand --forceExit tests/" in script
+            # An explicit worker count is respected; only --forceExit is added.
+            assert "yarn jest --forceExit --maxWorkers=2 suite/" in script
+            # Bare command-position jest (on PATH after nvm sourcing) is rewritten too.
+            assert "&& jest --runInBand --forceExit --config verbose_jest.config.json" in script
+            # Mentions that are not invocations stay untouched.
+            assert "elif grep -q '\"jest\"' package.json; then" in script
+            assert '"preset": "ts-jest",' in script
+            assert "config_jest\n" in script
+            assert "echo done" in script
+
     def test_get_run_command_no_repo_cmd(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             processor = self._make_processor(

--- a/responses_api_agents/swe_agents/tests/test_app.py
+++ b/responses_api_agents/swe_agents/tests/test_app.py
@@ -711,6 +711,36 @@ class TestNVInternalDatasetProcessor:
             result = processor.get_run_command()
             assert "test_x.py,test_y.py" in result.command
 
+    def test_get_run_command_serializes_jest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            processor = self._make_processor(
+                tmpdir,
+                {
+                    "run_script.sh": (
+                        "#!/bin/bash\n"
+                        "npx jest tests/\n"
+                        "yarn jest --maxWorkers=2 suite/\n"
+                        ". /root/.nvm/nvm.sh && jest --config verbose_jest.config.json\n"
+                        "elif grep -q '\"jest\"' package.json; then\n"
+                        '"preset": "ts-jest",\n'
+                        "config_jest\n"
+                        "echo done"
+                    )
+                },
+            )
+            processor.get_run_command()
+            script = (processor.config.persistent_dir / "run_script.sh").read_text()
+            assert "npx jest --runInBand --forceExit tests/" in script
+            # An explicit worker count is respected; only --forceExit is added.
+            assert "yarn jest --forceExit --maxWorkers=2 suite/" in script
+            # Bare command-position jest (on PATH after nvm sourcing) is rewritten too.
+            assert "&& jest --runInBand --forceExit --config verbose_jest.config.json" in script
+            # Mentions that are not invocations stay untouched.
+            assert "elif grep -q '\"jest\"' package.json; then" in script
+            assert '"preset": "ts-jest",' in script
+            assert "config_jest\n" in script
+            assert "echo done" in script
+
     def test_get_run_command_no_repo_cmd(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             processor = self._make_processor(


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

Forces Jest invocations in nv-internal eval scripts to run in-band: each jest line in an instance's run_script.sh gains --runInBand (skipped when the row already sets --maxWorkers) and --forceExit.

This has already been done for part of the dataset manually (90 rows), but the rest of the dataset still errors out due to Jest issues, so a comprehensive fix is useful.

Jest sizes its default worker pool from os.cpus(). The eval container gets a memory cgroup but no cpuset, so a single episode on a large node spawns a core-count fleet of Node workers.    
The episode runs under rootless Apptainer with a squashfuse rootfs: every node_modules read funnels through one user-space FUSE daemon per container, inside a fixed memory budget, on nodes running many concurrent episodes. Under load the worker fleet starves the FUSE daemon (D-state pileup) or exhausts the cgroup; separately, suites that leak open handles keep the jest process alive after all tests have passed.

Thus we reach the full `swebench_tests_timeout`, produce no output, and score 0, corrupting reward.

<!-- Briefly describe the change and the motivation. Link any related issue, e.g. "Closes #123". -->

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
