### PR TITLE
fix(sandbox): silence OpenSandbox SDK info logs

### DIFF
--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -42,6 +42,7 @@ from nemo_gym.sandbox.providers.utils import coerce_config as _coerce_config
 
 
 LOGGER = logging.getLogger(__name__)
+logging.getLogger("opensandbox").setLevel(logging.WARNING)
 
 
 class OpenSandboxCreateError(SandboxCreateError):

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import builtins
+import logging
 import sys
 from dataclasses import dataclass
 from datetime import timedelta
@@ -81,6 +82,17 @@ def fake_opensandbox_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
         return FakeSandbox, FakeConnectionConfig, object, FakePlatformSpec, object
 
     monkeypatch.setattr(opensandbox_provider, "_require_opensandbox_sdk", require_sdk)
+
+
+def test_sdk_info_logs_are_silenced(caplog: pytest.LogCaptureFixture) -> None:
+    sdk_logger = logging.getLogger("opensandbox.sandbox")
+
+    with caplog.at_level(logging.INFO):
+        sdk_logger.info("SDK info")
+        sdk_logger.warning("SDK warning")
+
+    sdk_messages = [record.message for record in caplog.records if record.name == sdk_logger.name]
+    assert sdk_messages == ["SDK warning"]
 
 
 def test_sdk_import_helpers_and_retry_classification() -> None:


### PR DESCRIPTION
## Summary

- suppress routine OpenSandbox SDK INFO messages
- preserve SDK warnings, errors, and NeMo Gym provider logs
- add regression coverage for the logging threshold

## Test plan

- [x] `.venv/bin/pytest tests/unit_tests/test_opensandbox_provider.py -x`
- [x] `.venv/bin/pre-commit run --files nemo_gym/sandbox/providers/opensandbox/provider.py tests/unit_tests/test_opensandbox_provider.py`
- [x] live OpenSandbox create, command execution, and cleanup smoke test with Python 3.13.14 and SDK 0.1.15; captured zero `opensandbox.*` INFO records while NeMo Gym provider INFO remained visible

Generated with [Codex](https://openai.com/codex/).
