### PR TITLE
feat: add OrcaRouter as a named inference provider

### DIFF
--- a/fern/versions/latest/pages/model-server/inference-providers.mdx
+++ b/fern/versions/latest/pages/model-server/inference-providers.mdx
@@ -30,6 +30,7 @@ All provider configs live in [`responses_api_models/inference_provider/configs/`
 | HF Inference | `hf_inference.yaml` | `https://router.huggingface.co/v1` |
 | Nebius | `nebius.yaml` | `https://api.tokenfactory.nebius.com/v1/` |
 | OpenRouter | `openrouter.yaml` | `https://openrouter.ai/api/v1` |
+| OrcaRouter | `orcarouter.yaml` | `https://api.orcarouter.ai/v1` |
 | Together.ai | `together.yaml` | `https://api.together.xyz/v1` |
 
 ## Set Your Credentials

--- a/responses_api_models/inference_provider/README.md
+++ b/responses_api_models/inference_provider/README.md
@@ -9,6 +9,7 @@ A model server for any inference provider that exposes an OpenAI-compatible `/v1
 | Fireworks | `configs/fireworks.yaml` |
 | Together.ai | `configs/together.yaml` |
 | OpenRouter | `configs/openrouter.yaml` |
+| OrcaRouter | `configs/orcarouter.yaml` |
 | DeepInfra | `configs/deepinfra.yaml` |
 | Nebius | `configs/nebius.yaml` |
 | Friendli | `configs/friendli.yaml` |

--- a/responses_api_models/inference_provider/configs/orcarouter.yaml
+++ b/responses_api_models/inference_provider/configs/orcarouter.yaml
@@ -1,0 +1,7 @@
+policy_model:
+  responses_api_models:
+    inference_provider:
+      entrypoint: app.py
+      base_url: https://api.orcarouter.ai/v1
+      api_key: ${policy_api_key}
+      model: ${policy_model_name}


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a named provider to the
`inference_provider` model server, wired exactly like the existing OpenRouter
entry: a ready-made `configs/orcarouter.yaml` plus rows in the README and Fern
docs provider tables.

I'm an engineer on the OrcaRouter team.

## What does this PR do?

- **`responses_api_models/inference_provider/configs/orcarouter.yaml`** (new):
  named config pointing at `https://api.orcarouter.ai/v1`, mirroring
  `openrouter.yaml`. Auto-discovered by `nemo_gym/model_registry.py`, so it's
  selectable via `--model-type inference_provider/orcarouter` with just
  `policy_api_key` and `policy_model_name` set in `env.yaml`.
- **`responses_api_models/inference_provider/README.md`**: adds OrcaRouter to
  the Supported Providers table.
- **`fern/versions/latest/pages/model-server/inference-providers.mdx`**: adds
  OrcaRouter (base URL + config) to the Supported Providers table.

OrcaRouter is an OpenAI-compatible routing gateway, so the server uses the same
`/v1/chat/completions` transport as the other `inference_provider` variants; no
application code changes. The generic `inference_provider.yaml` remains
available for any unlisted provider.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; no unrelated drive-by edits.
- [x] Tests N/A for this docs/config-only change (existing model-server tests
      and `tests/unit_tests/test_model_registry.py` cover discovery mechanics
      and are unaffected).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`): the
      YAML/README/mdx files added are outside the `.py`-only hooks; `ruff`,
      `end-of-file-fixer`, and `trailing-whitespace` report no findings.
- [x] Commit has DCO sign-off (`git commit -s`).

## Verification

- New config parses as valid YAML and resolves to the correct base URL.
- `nemo_gym/model_registry._discover_models_in_dir` walks
  `configs/*.yaml`, so `inference_provider/orcarouter` is discoverable with no
  registry changes.
- Live API (same OpenAI-compatible transport the server uses, against the real
  gateway): `GET /v1/models` returns 200 with 193 models (incl.
  `openai/gpt-5.5`); `POST /v1/chat/completions` with an OrcaRouter API key
  returns 200 and the expected completion.
- Because the provider is a base-URL config, any pipeline that uses it also
  inherits OrcaRouter's gateway-level, zero-trust security controls for AI
  agents, with no application code changes.
