### PR TITLE
fix(opensandbox): authenticate proxied operations

### DIFF
--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -612,6 +612,9 @@ class OpenSandboxProvider:
             kwargs["request_timeout"] = timedelta(seconds=request_timeout_s)
         if self._connection.use_server_proxy:
             kwargs["use_server_proxy"] = True
+            if self._connection.api_key is not None:
+                # SDK 0.1.15 does not copy api_key into proxied exec/file requests.
+                kwargs["headers"] = {"OPEN-SANDBOX-API-KEY": self._connection.api_key}
         if self._connection.keepalive_expiry_s is not None:
             kwargs["transport"] = self._get_transport()
         return ConnectionConfig(**kwargs)

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -352,6 +352,7 @@ def test_connection_config_and_image_policy(fake_opensandbox_sdk: None) -> None:
         "protocol": "https",
         "request_timeout": timedelta(seconds=10),
         "use_server_proxy": True,
+        "headers": {"OPEN-SANDBOX-API-KEY": "key"},  # pragma: allowlist secret
     }
     short_timeout_config = provider._connection_config(request_timeout_s=3)
     assert short_timeout_config.kwargs["request_timeout"] == timedelta(seconds=3)


### PR DESCRIPTION
## Summary

- forward the configured OpenSandbox API key as `OPEN-SANDBOX-API-KEY` for server-proxied exec and file requests
- add regression coverage for the generated SDK connection configuration

## Motivation

With OpenSandbox Python SDK 0.1.15, sandbox lifecycle creation authenticates through `api_key`, but proxied exec/file adapters forward `ConnectionConfig.headers`. Against an authenticated server proxy this makes creation succeed while subsequent operations fail with `401 MISSING_API_KEY`. The header is added only when both `use_server_proxy` and `api_key` are configured.

## Test plan

- `resources_servers/litmus_agent/.venv/bin/pytest tests/unit_tests/test_opensandbox_provider.py -q` (27 passed, 1 skipped)
- scoped pre-commit hooks passed