### PR TITLE
[Super 3.5 evals] Update Aug 15 2026

### DIFF
--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -213,10 +213,18 @@ trap cleanup_server EXIT INT TERM
 if (( $should_run_eval )); then
     # No need to wait for endpoint since Gym will wait for model endpoints to spin up before proceeding.
 
+    # @bxyu-nvidia: Put the Gym servers on a separate node than the PREFILL_HEAD which is also running the vllm-router
+    # This helps relieve so much network traffic on one node.
+    if [[ -v 'nodes[1]' ]]; then
+        EVAL_NODE=\${nodes[1]}
+    else
+        EVAL_NODE=\${nodes[0]}
+    fi
+
     # @bxyu-nvidia: We need --cpus-per-task=SLURM_CPUS_ON_NODE, otherwise we run into a lot of ServerDisconnectedError and ConnectionResetByPeer errors from Gym servers and vLLM. Not sure what the correlation is
     eval_status=0
     PREFILL_HEAD="\$PREFILL_HEAD" \
-    srun --overlap --exact --nodes=1 --ntasks=1 --cpus-per-task=\$SLURM_CPUS_ON_NODE --nodelist="\$PREFILL_HEAD" --gpus=0 \
+    srun --overlap --exact --nodes=1 --ntasks=1 --cpus-per-task=\$SLURM_CPUS_ON_NODE --nodelist="\$EVAL_NODE" --gpus=0 \
         --container-image=$CONTAINER \
         --container-name=eval-container-on-node \
         --container-mounts=$MOUNTS \

--- a/benchmarks/nemotron_3.5_super/vllm_configs/nemotron_3.5_super.sh
+++ b/benchmarks/nemotron_3.5_super/vllm_configs/nemotron_3.5_super.sh
@@ -22,7 +22,7 @@ VLLM_COMMON_ARGS=(
 VLLM_PREFILL_ARGS=(
     --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_load_failure_policy":"fail"}'
     --max-num-batched-tokens 33920
-    --max-num-seqs 512
+    --max-num-seqs 1024
     --data-parallel-size-local 1
     --tensor-parallel-size 4
 )
@@ -30,7 +30,7 @@ VLLM_DECODE_ARGS=(
     --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_load_failure_policy":"fail"}'
     --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
     --max-num-batched-tokens 33920
-    --max-num-seqs 512
+    --max-num-seqs 1024
     --data-parallel-size-local 1
     --tensor-parallel-size 4
 )

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -867,15 +867,15 @@ class RolloutCollectionHelper(BaseModel):
 
                 time_taken_s = time() - start_time
                 time_taken = timedelta(seconds=int(time_taken_s))
-                rollouts_per_min = len(results) / time_taken_s / 60
-                print_str = f"Finished {len(results)} rollouts ({int(current_pct)}%) in {time_taken} ({rollouts_per_min:.2f} rollouts/min). "
+                rollouts_per_min = len(results) / (time_taken_s / 60)
+                print_str = f"Finished {len(results)} / {len(input_rows)} rollouts ({int(current_pct)}%) in {time_taken} ({rollouts_per_min:.2f} rollouts/min). "
 
                 top_left = counts_left.most_common()
                 top_left_str = "\n".join(f"{i + 1}. {k}: {v}" for i, (k, v) in enumerate(top_left))
                 print_str += f"""Examples left:
 {top_left_str}
 """
-                for agent_name in agent_name_to_metrics:
+                for agent_name in sorted(agent_name_to_metrics):
                     metrics = agent_name_to_metrics[agent_name]
                     avg_metrics = {k: v / agent_name_to_counts[agent_name] for k, v in metrics.items()}
                     print_str += f"""Found {agent_name_to_counts[agent_name]} rollouts for `{agent_name}`.

--- a/resources_servers/swebench/analyze_golden_patch_logs.py
+++ b/resources_servers/swebench/analyze_golden_patch_logs.py
@@ -54,6 +54,11 @@ for path in glob("resources_servers/swebench/logs/run_evaluation/**/report.json"
     path = Path(path)
     report = json.loads(path.read_text())
     instance_id: str = list(report.keys())[0]
+
+    # Skip instances not part of this benchmark
+    if instance_id not in instance_id_to_row:
+        continue
+
     repo_name = instance_id.rsplit("-", maxsplit=1)[0].replace("__", "/")
     repo_ext = MAP_REPO_TO_EXT[repo_name]
 
@@ -77,8 +82,10 @@ for instance_id in instance_id_to_row:
         continue
 
     dirpaths = glob(f"resources_servers/swebench/logs/run_evaluation/**/{instance_id}", recursive=True)
-    assert len(dirpaths) == 1
-    report_path = Path(dirpaths[0]) / "report.json"
+    dirpaths: list[Path] = list(map(Path, dirpaths))
+    dirpaths.sort(key=lambda p: p.stat().st_birthtime, reverse=True)
+
+    report_path = dirpaths[0] / "report.json"
     copy_sample(report_path, instance_id)
 
     failed_instance_ids.append(instance_id)

--- a/resources_servers/swebench/configs/swebench.yaml
+++ b/resources_servers/swebench/configs/swebench.yaml
@@ -18,7 +18,7 @@ swebench_resources_server:          # instance name — how agents/CLI refer to 
         ready_timeout_s: 1200
         resources:
           cpu: 2
-          memory_mib: 8192
+          memory_mib: 16384
           # 30 GiB works on every provider: within Fargate's 21-200 GiB ephemeral range
           # (an explicit 20 is rejected there) and fine as an ephemeral request elsewhere.
           disk_gib: 30

--- a/responses_api_agents/opencode_sandboxed_agent/README.md
+++ b/responses_api_agents/opencode_sandboxed_agent/README.md
@@ -12,6 +12,8 @@ python responses_api_agents/opencode_sandboxed_agent/client.py \
     +benchmark_jsonl=benchmarks/swebench/data/swebench_verified_benchmark.jsonl
 ```
 
+For E2E functional testing, run as above and remove the actual opencode run command from the exec.
+
 ## Prefetch OpenCode binary and upload to S3
 ```bash
 curl -L https://opencode.ai/install -o opencode_install.sh

--- a/scripts/filter_by_agent.py
+++ b/scripts/filter_by_agent.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from argparse import ArgumentParser
+from pathlib import Path
+
+import orjson
+from tqdm.auto import tqdm
+
+
+parser = ArgumentParser()
+parser.add_argument("--input-jsonl", type=str, required=True)
+parser.add_argument("--output-jsonl", type=str, default="temp.jsonl")
+parser.add_argument("--agent", type=str, required=True)
+args = parser.parse_args()
+
+print(f"Writing results to `{Path(args.output_jsonl).absolute()}`")
+with open(args.input_jsonl) as f_in, open(args.output_jsonl, "w") as f_out:
+    for line in tqdm(f_in):
+        row = orjson.loads(line)
+        if row.get("agent_ref", dict()).get("name") != args.agent:
+            continue
+
+        f_out.write(line)


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

1. Run Gym on non-head node: benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
2. Bump up max-num-seqs for Super 3.5: benchmarks/nemotron_3.5_super/vllm_configs/nemotron_3.5_super.sh
3. Minor rollout collection intermediate printing fixes: nemo_gym/rollout_collection.py
4. Increase SWE Bench memory cap from 8GB to 16GB: resources_servers/swebench/configs/swebench.yaml
5. Misc fixes/changes/comments: resources_servers/swebench/analyze_golden_patch_logs.py, responses_api_agents/opencode_sandboxed_agent/README.md
6. Filter by agent script: scripts/filter_by_agent.py

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
