### PR TITLE
Fix global_config: Preserve sibling order when outer config_paths override inner ones

### DIFF
--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -303,14 +303,28 @@ class GlobalConfigDictParser(BaseModel):
 
     def load_extra_config_paths(self, config_paths: List[str]) -> Tuple[List[str], List[DictConfig]]:
         """
-        Returns the new total config_paths and the extra configs
+        Returns the new total config_paths and the extra configs, ordered for merging.
+
+        Two rules decide precedence, and they are independent:
+
+        - A config named in another config's ``config_paths`` is *inner*. The config
+          that pulled it in overrides it, however deep the nesting goes.
+        - Configs at the same level are siblings, in the order they were listed. A
+          later sibling overrides an earlier one.
+
+        The returned configs are ordered so that a left-to-right ``OmegaConf.merge``
+        produces both rules: deepest level first, and within a level, listed order.
         """
         config_paths = config_paths.copy()
+        # Nesting level per entry in config_paths, parallel to it: 0 for the entries
+        # the caller passed, +1 for each config pulled in by another config.
+        depths: List[int] = [0] * len(config_paths)
 
         extra_configs: List[DictConfig] = []
         duplicate_config_paths: List[str] = []
         # Just a careful note here that we explicitly mutate config_paths as it is being appended to
-        for config_path in config_paths:
+        for index, config_path in enumerate(config_paths):
+            depth = depths[index]
             original_entry = config_path
             config_path = Path(config_path)
             # Search NEMO_GYM_EXTRA_ROOTS, cwd, then the install root (see _resolve_under_cwd_or_install).
@@ -333,6 +347,7 @@ Check the path is spelled correctly and is relative to your working directory, a
             for new_config_path in extra_config.get(CONFIG_PATHS_KEY_NAME) or []:
                 if new_config_path not in config_paths:
                     config_paths.append(new_config_path)
+                    depths.append(depth + 1)
                 else:
                     duplicate_config_paths.append(new_config_path)
             extra_configs.append(extra_config)
@@ -343,6 +358,13 @@ Check the path is spelled correctly and is relative to your working directory, a
 In cases like these, you may want to consider using the `inherit_from` OmegaConf directive e.g. '++my_specific_server=${{inherit_from:generic_server}}' and then overriding config parameters in `my_specific_server`.
 Duplicate config paths:
 {duplicate_config_paths_str}""")
+
+        # Deepest level first, so an outer config merges after -- and therefore
+        # overrides -- anything it pulled in. The sort is stable, so configs at the
+        # same level keep the order they were listed in and a later sibling still
+        # overrides an earlier one.
+        merge_order = sorted(range(len(extra_configs)), key=lambda i: -depths[i])
+        extra_configs = [extra_configs[i] for i in merge_order]
 
         return config_paths, extra_configs
 
@@ -650,10 +672,9 @@ Pass each config with --config (it builds the list for you), e.g.:
   gym env start --config resources_servers/<env>/configs/<env>.yaml"""
             ) from e
 
+        # Returned in merge order: inner configs first, so the config that pulled them
+        # in overrides them; siblings in listed order, so a later one overrides earlier.
         config_paths, extra_configs = self.load_extra_config_paths(config_paths)
-
-        # Reverse here so the "inner" configs (appended to the list) are ovreridden by the outer configs.
-        extra_configs.reverse()
 
         # Dot env overrides previous configs
         extra_configs.append(dotenv_extra_config)

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -355,6 +355,143 @@ b: 2
             == global_config_dict
         )
 
+    def _mock_config_paths_env(self, monkeypatch: MonkeyPatch, config_paths: list[str]) -> None:
+        """Scaffolding shared by the sibling-ordering tests: stub .env.yaml, hydra and
+        the loader so only the config_paths merge order is under test."""
+        # Clear any lingering env vars.
+        monkeypatch.delenv(NEMO_GYM_CONFIG_DICT_ENV_VAR_NAME, raising=False)
+        monkeypatch.setattr(nemo_gym.global_config, "_GLOBAL_CONFIG_DICT", None)
+
+        # Explicitly handle any local .env.yaml files. Either read or don't read.
+        exists_mock = MagicMock()
+        exists_mock.return_value = True
+        monkeypatch.setattr(nemo_gym.global_config.Path, "exists", exists_mock)
+
+        # Override the hydra main wrapper call. At runtime, this will use sys.argv.
+        hydra_main_mock = MagicMock()
+
+        def hydra_main_wrapper(fn):
+            config_dict = DictConfig({"config_paths": config_paths})
+            return lambda: fn(config_dict)
+
+        hydra_main_mock.return_value = hydra_main_wrapper
+        monkeypatch.setattr(nemo_gym.global_config.hydra, "main", hydra_main_mock)
+
+        # Override OmegaConf.load to avoid file reads.
+        omegaconf_load_mock = MagicMock()
+        original_load = OmegaConf.load
+        omegaconf_load_mock.side_effect = lambda path: (DictConfig({}) if "env" in str(path) else original_load(path))
+        monkeypatch.setattr(nemo_gym.server_utils.OmegaConf, "load", omegaconf_load_mock)
+
+    def test_get_global_config_dict_config_paths_later_sibling_wins(
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Two configs passed by the caller, neither referencing the other: the later
+        entry overrides the earlier one, which is how an override config is layered on
+        top of a base config."""
+        self._mock_versions_for_testing(monkeypatch)
+
+        (tmp_path / "base.yaml").write_text("""a: base
+b: base
+        """)
+        (tmp_path / "override.yaml").write_text("""a: override
+        """)
+
+        self._mock_config_paths_env(monkeypatch, [f"{tmp_path}/base.yaml", f"{tmp_path}/override.yaml"])
+
+        global_config_dict = get_global_config_dict()
+        assert (
+            self._default_global_config_dict_values
+            | {
+                "config_paths": [f"{tmp_path}/base.yaml", f"{tmp_path}/override.yaml"],
+                "a": "override",
+                "b": "base",
+            }
+            == global_config_dict
+        )
+
+    def test_get_global_config_dict_config_paths_outer_beats_inner_across_siblings(
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Nesting and sibling order applied together. ``override.yaml`` is listed after
+        ``base.yaml`` so it wins on ``a``; ``base.yaml`` pulls in ``inner.yaml``, so it
+        wins on ``b`` despite ``inner.yaml`` being merged as part of the same list."""
+        self._mock_versions_for_testing(monkeypatch)
+
+        (tmp_path / "base.yaml").write_text(f"""\
+config_paths:
+- {tmp_path}/inner.yaml
+
+a: base
+b: base
+        """)
+        (tmp_path / "inner.yaml").write_text("""b: inner
+c: inner
+        """)
+        (tmp_path / "override.yaml").write_text("""a: override
+        """)
+
+        self._mock_config_paths_env(monkeypatch, [f"{tmp_path}/base.yaml", f"{tmp_path}/override.yaml"])
+
+        global_config_dict = get_global_config_dict()
+        assert (
+            self._default_global_config_dict_values
+            | {
+                "config_paths": [
+                    f"{tmp_path}/base.yaml",
+                    f"{tmp_path}/override.yaml",
+                    f"{tmp_path}/inner.yaml",
+                ],
+                "a": "override",
+                "b": "base",
+                "c": "inner",
+            }
+            == global_config_dict
+        )
+
+    def test_get_global_config_dict_config_paths_outer_beats_inner_two_levels_deep(
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Precedence follows nesting depth rather than position, at every level:
+        outer overrides middle, which overrides inner."""
+        self._mock_versions_for_testing(monkeypatch)
+
+        (tmp_path / "outer.yaml").write_text(f"""\
+config_paths:
+- {tmp_path}/middle.yaml
+
+a: outer
+        """)
+        (tmp_path / "middle.yaml").write_text(f"""\
+config_paths:
+- {tmp_path}/inner.yaml
+
+a: middle
+b: middle
+        """)
+        (tmp_path / "inner.yaml").write_text("""a: inner
+b: inner
+c: inner
+        """)
+
+        self._mock_config_paths_env(monkeypatch, [f"{tmp_path}/outer.yaml"])
+
+        global_config_dict = get_global_config_dict()
+        assert (
+            self._default_global_config_dict_values
+            | {
+                "config_paths": [
+                    f"{tmp_path}/outer.yaml",
+                    f"{tmp_path}/middle.yaml",
+                    f"{tmp_path}/inner.yaml",
+                ],
+                "a": "outer",
+                "b": "middle",
+                "c": "inner",
+            }
+            == global_config_dict
+        )
+
     def test_get_global_config_dict_server_host_port_defaults(self, monkeypatch: MonkeyPatch) -> None:
         self._mock_versions_for_testing(monkeypatch)
 


### PR DESCRIPTION
## What does this PR do?

Nesting depth and sibling order are two independent precedence axes in
`config_paths`, and a single list reversal cannot express both.

`load_extra_config_paths` walks `config_paths` breadth-first and appends nested
entries to the same flat list, so it ends up as
`[caller entries..., their children..., grandchildren...]`. Merging that
left-to-right let children override their parents, so #2478 (0051ad85) reversed
the whole list. That correctly made outer configs win, but it also reversed the
caller's own entries against each other, inverting sibling precedence: given
`--config base.yaml --config override.yaml`, `base.yaml` now wins.

The failure is silent. The override still loads, still resolves, and still
appears in the final `config_paths`; it just loses every key it sets. For an
eval config that means the run completes and reports plausible numbers scored
against the wrong judge prompt and reward mode.

This PR tracks each entry's nesting depth as it is discovered and orders the
configs deepest-first with a stable sort. Deepest-first keeps #2478's intent at
any depth: an outer config merges last and overrides anything it pulled in.
Stability restores sibling precedence, so same-level configs keep the order they
were listed in and a later one overrides an earlier one. The blanket
`extra_configs.reverse()` at the call site is no longer needed.

Nothing in `docs/` describes this precedence, so the added tests are the spec.

## Tests

Three additive cases in `TestGlobalConfig`; no existing assertion changed.

- `..._config_paths_later_sibling_wins` — two caller entries, neither referencing
  the other; the later one overrides the earlier.
- `..._config_paths_outer_beats_inner_across_siblings` — both axes at once: the
  later sibling wins its key while the parent still beats the config it pulled in.
- `..._config_paths_outer_beats_inner_two_levels_deep` — outer beats middle beats
  inner.

Negative control: with `global_config.py` reverted to `main`, the two sibling
tests fail with the production symptom (`a: base` where `a: override` is
expected) while the three-level nesting test passes either way, confirming the
property #2478 added is preserved rather than traded away.

Full unit suite: 2435 passed. One unrelated pre-existing failure
(`test_cli_utils.py::TestPrintRichTable::test_not_truncated_regardless_of_ambient_width`),
which fails identically on unmodified `main`.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes.
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`).
- [x] All commits have DCO sign-off (`git commit -s`).