### PR TITLE
Fix global_config: keep sibling subtrees contiguous when flattening config_paths

### DIFF
--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -305,26 +305,28 @@ class GlobalConfigDictParser(BaseModel):
         """
         Returns the new total config_paths and the extra configs, ordered for merging.
 
-        Two rules decide precedence, and they are independent:
+        Two rules decide precedence:
 
         - A config named in another config's ``config_paths`` is *inner*. The config
           that pulled it in overrides it, however deep the nesting goes.
-        - Configs at the same level are siblings, in the order they were listed. A
-          later sibling overrides an earlier one.
+        - Configs listed together are siblings, in the order they were listed. A later
+          sibling overrides an earlier one, and so does everything it pulled in.
 
         The returned configs are ordered so that a left-to-right ``OmegaConf.merge``
-        produces both rules: deepest level first, and within a level, listed order.
+        produces both rules: the include tree flattened so that a config follows
+        everything it pulled in, with each subtree kept contiguous.
         """
         config_paths = config_paths.copy()
-        # Nesting level per entry in config_paths, parallel to it: 0 for the entries
-        # the caller passed, +1 for each config pulled in by another config.
-        depths: List[int] = [0] * len(config_paths)
+        # The entries the caller passed; everything appended below was pulled in by one
+        # of them, directly or transitively.
+        root_count = len(config_paths)
+        # Entries pulled in by each entry, parallel to config_paths, in listed order.
+        children: List[List[int]] = [[] for _ in config_paths]
 
         extra_configs: List[DictConfig] = []
         duplicate_config_paths: List[str] = []
         # Just a careful note here that we explicitly mutate config_paths as it is being appended to
         for index, config_path in enumerate(config_paths):
-            depth = depths[index]
             original_entry = config_path
             config_path = Path(config_path)
             # Search NEMO_GYM_EXTRA_ROOTS, cwd, then the install root (see _resolve_under_cwd_or_install).
@@ -347,7 +349,8 @@ Check the path is spelled correctly and is relative to your working directory, a
             for new_config_path in extra_config.get(CONFIG_PATHS_KEY_NAME) or []:
                 if new_config_path not in config_paths:
                     config_paths.append(new_config_path)
-                    depths.append(depth + 1)
+                    children.append([])
+                    children[index].append(len(config_paths) - 1)
                 else:
                     duplicate_config_paths.append(new_config_path)
             extra_configs.append(extra_config)
@@ -359,11 +362,19 @@ In cases like these, you may want to consider using the `inherit_from` OmegaConf
 Duplicate config paths:
 {duplicate_config_paths_str}""")
 
-        # Deepest level first, so an outer config merges after -- and therefore
-        # overrides -- anything it pulled in. The sort is stable, so configs at the
-        # same level keep the order they were listed in and a later sibling still
-        # overrides an earlier one.
-        merge_order = sorted(range(len(extra_configs)), key=lambda i: -depths[i])
+        # Flatten the include tree so that every config merges after -- and therefore
+        # overrides -- the ones it pulled in, and each subtree stays contiguous in
+        # listed order, so a later sibling and its own includes override an earlier
+        # sibling's. Iterative post-order, since include chains can nest arbitrarily.
+        merge_order: List[int] = []
+        pending: List[Tuple[int, bool]] = [(root, False) for root in reversed(range(root_count))]
+        while pending:
+            index, children_visited = pending.pop()
+            if children_visited:
+                merge_order.append(index)
+                continue
+            pending.append((index, True))
+            pending.extend((child, False) for child in reversed(children[index]))
         extra_configs = [extra_configs[i] for i in merge_order]
 
         return config_paths, extra_configs
@@ -672,8 +683,8 @@ Pass each config with --config (it builds the list for you), e.g.:
   gym env start --config resources_servers/<env>/configs/<env>.yaml"""
             ) from e
 
-        # Returned in merge order: inner configs first, so the config that pulled them
-        # in overrides them; siblings in listed order, so a later one overrides earlier.
+        # Returned in merge order: a config follows everything it pulled in, so it
+        # overrides them; siblings in listed order, so a later one overrides earlier.
         config_paths, extra_configs = self.load_extra_config_paths(config_paths)
 
         # Dot env overrides previous configs

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -492,6 +492,59 @@ c: inner
             == global_config_dict
         )
 
+    def test_get_global_config_dict_config_paths_later_sibling_subtree_wins_at_uneven_depth(
+        self, monkeypatch: MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Sibling order covers everything a sibling pulled in, whatever depth it sits
+        at. ``first.yaml`` nests one level and ``second.yaml`` two, and the key both of
+        their innermost configs set resolves to the later sibling's."""
+        self._mock_versions_for_testing(monkeypatch)
+
+        (tmp_path / "first.yaml").write_text(f"""\
+config_paths:
+- {tmp_path}/first_inner.yaml
+
+first: first
+        """)
+        (tmp_path / "first_inner.yaml").write_text("""first: first_inner
+contested: first_inner
+        """)
+        (tmp_path / "second.yaml").write_text(f"""\
+config_paths:
+- {tmp_path}/second_middle.yaml
+
+second: second
+        """)
+        (tmp_path / "second_middle.yaml").write_text(f"""\
+config_paths:
+- {tmp_path}/second_inner.yaml
+
+second: second_middle
+        """)
+        (tmp_path / "second_inner.yaml").write_text("""second: second_inner
+contested: second_inner
+        """)
+
+        self._mock_config_paths_env(monkeypatch, [f"{tmp_path}/first.yaml", f"{tmp_path}/second.yaml"])
+
+        global_config_dict = get_global_config_dict()
+        assert (
+            self._default_global_config_dict_values
+            | {
+                "config_paths": [
+                    f"{tmp_path}/first.yaml",
+                    f"{tmp_path}/second.yaml",
+                    f"{tmp_path}/first_inner.yaml",
+                    f"{tmp_path}/second_middle.yaml",
+                    f"{tmp_path}/second_inner.yaml",
+                ],
+                "first": "first",
+                "second": "second",
+                "contested": "second_inner",
+            }
+            == global_config_dict
+        )
+
     def test_get_global_config_dict_server_host_port_defaults(self, monkeypatch: MonkeyPatch) -> None:
         self._mock_versions_for_testing(monkeypatch)
 


### PR DESCRIPTION
Follow-up to #2572, addressing review feedback from @cmunley1 that arrived after the merge.

## Problem

#2572 restored sibling precedence by sorting all configs globally on nesting depth. That interleaves independent subtrees. For `config_paths: [A, B]` where `A -> A1` and `B -> B1 -> B2`, the depths are `A=0, B=0, A1=1, B1=1, B2=2`, so the merge order is `[B2, A1, B1, A, B]` and `A1` overrides `B2` even though `B` is the later sibling.

It also makes precedence a function of absolute nesting depth, which is not a local property: wrapping one extra include layer inside `B` — a refactor entirely within `B`'s subtree — silently changes how that subtree ranks against `A`'s.

## Fix

Flatten the include tree with an iterative post-order walk instead of sorting: children before parent, siblings in listed order, each subtree contiguous. The example above now merges as `[A1, A, B2, B1, B]`. This matches how Hydra's defaults list behaves, which is the closest analog users will have in mind.

The traversal is iterative so deep include chains cannot exhaust the stack. Termination is structural rather than relying on a visited set: an edge is only recorded when a path is appended for the first time, so a child always has a higher index than its parent and every node has at most one parent, making the edge set a forest even when configs reference each other cyclically.

Two behaviors are deliberately unchanged: the returned `config_paths` list keeps its existing discovery order (only merge order moves), and a config pulled in by two different parents still attaches at its first reference.

## Testing

- New `test_get_global_config_dict_config_paths_later_sibling_subtree_wins_at_uneven_depth` builds the reported shape (one sibling nesting one level, the other two) and pins the key both innermost configs set. It fails against #2572 with `contested: 'first_inner'` and passes here with `second_inner`.
- The three ordering tests from #2572 pass both before and after, confirming the new test is the one carrying this case.
- Full unit suite: 2462 passed, 41 skipped. One unrelated pre-existing failure in `test_cli_utils.py::test_not_truncated_regardless_of_ambient_width`, which also fails on a clean tree.