### PR TITLE
test: add model-server end-to-end coverage

### DIFF
--- a/.github/workflows/cpu-e2e.yml
+++ b/.github/workflows/cpu-e2e.yml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: CPU end-to-end test
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  UV_INSTALL_URL: "https://astral.sh/uv/0.11.29/install.sh"
+
+jobs:
+  tool-use:
+    name: CPU tool-use end to end
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      E2E_DIR: ${{ runner.temp }}/nemo-gym-cpu-e2e
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Install uv
+        run: |
+          curl -LsSf "$UV_INSTALL_URL" | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run CPU end-to-end test
+        run: bash tests/e2e/run_cpu_tool_e2e.sh
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cpu-tool-use-e2e-${{ github.run_id }}
+          if-no-files-found: warn
+          path: ${{ runner.temp }}/nemo-gym-cpu-e2e/results/

--- a/tests/e2e/gpu_smoke.jsonl
+++ b/tests/e2e/gpu_smoke.jsonl
@@ -1,0 +1,1 @@
+{"responses_create_params":{"input":[{"role":"user","content":"Reply with a short greeting."}]},"verifier_metadata":{}}

--- a/tests/e2e/run_cpu_tool_e2e.sh
+++ b/tests/e2e/run_cpu_tool_e2e.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+E2E_DIR="${E2E_DIR:-${RUNNER_TEMP:-/tmp}/nemo-gym-cpu-e2e}"
+PROVIDER_PORT="${PROVIDER_PORT:-19999}"
+INDEX_PORT="${INDEX_PORT:-18888}"
+HEAD_PORT="${HEAD_PORT:-11000}"
+MODEL_API_KEY="${MODEL_API_KEY:-not-a-real-key}" # pragma: allowlist secret
+RESULTS_DIR="$E2E_DIR/results"
+VENV_DIR="$E2E_DIR/venv"
+PROVIDER_PID=""
+INDEX_PID=""
+GYM_PID=""
+
+cleanup() {
+  if [[ -n "$GYM_PID" ]]; then
+    kill "$GYM_PID" 2>/dev/null || true
+    wait "$GYM_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$PROVIDER_PID" ]]; then
+    kill "$PROVIDER_PID" 2>/dev/null || true
+    wait "$PROVIDER_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$INDEX_PID" ]]; then
+    kill "$INDEX_PID" 2>/dev/null || true
+    wait "$INDEX_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ "$E2E_DIR" == "/" ]]; then
+  echo "E2E_DIR cannot be the filesystem root." >&2
+  exit 1
+fi
+rm -rf -- "$E2E_DIR"
+mkdir -p "$RESULTS_DIR" "$E2E_DIR/dist" "$E2E_DIR/index/nemo-gym" "$E2E_DIR/workspace"
+
+uv build "$ROOT_DIR" --wheel --out-dir "$E2E_DIR/dist"
+cp "$E2E_DIR"/dist/*.whl "$E2E_DIR/index/nemo-gym/"
+for wheel in "$E2E_DIR"/index/nemo-gym/*.whl; do
+  wheel_name="$(basename "$wheel")"
+  printf '<a href="%s">%s</a>\n' "$wheel_name" "$wheel_name"
+done > "$E2E_DIR/index/nemo-gym/index.html"
+printf '<a href="nemo-gym/">nemo-gym</a>\n' > "$E2E_DIR/index/index.html"
+
+python3 -m http.server "$INDEX_PORT" --bind 127.0.0.1 --directory "$E2E_DIR/index" \
+  > "$RESULTS_DIR/package-index.log" 2>&1 &
+INDEX_PID=$!
+for _ in $(seq 1 10); do
+  if curl --fail --silent "http://127.0.0.1:${INDEX_PORT}/nemo-gym/" >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+curl --fail --silent "http://127.0.0.1:${INDEX_PORT}/nemo-gym/" >/dev/null
+
+uv venv "$VENV_DIR"
+uv pip install --python "$VENV_DIR/bin/python" "$E2E_DIR"/dist/*.whl
+export NEMO_GYM_ALLOW_PRERELEASE=true
+export UV_INDEX_URL="http://127.0.0.1:${INDEX_PORT}/"
+export UV_EXTRA_INDEX_URL="https://pypi.org/simple/"
+
+"$VENV_DIR/bin/python" "$ROOT_DIR/tests/e2e/scripted_provider.py" \
+  --port "$PROVIDER_PORT" \
+  --events "$RESULTS_DIR/provider-events.jsonl" \
+  > "$RESULTS_DIR/provider.log" 2>&1 &
+PROVIDER_PID=$!
+
+for _ in $(seq 1 30); do
+  if curl --fail --silent "http://127.0.0.1:${PROVIDER_PORT}/healthz" >/dev/null; then
+    break
+  fi
+  if ! kill -0 "$PROVIDER_PID" 2>/dev/null; then
+    echo "Scripted provider exited before becoming ready." >&2
+    exit 1
+  fi
+  sleep 1
+done
+curl --fail --silent "http://127.0.0.1:${PROVIDER_PORT}/healthz" >/dev/null
+
+cd "$E2E_DIR/workspace"
+"$VENV_DIR/bin/gym" env start \
+  --config "$ROOT_DIR/resources_servers/example_single_tool_call/configs/example_single_tool_call.yaml" \
+  --config "$ROOT_DIR/responses_api_models/vllm_model/configs/vllm_model.yaml" \
+  --model-url "http://127.0.0.1:${PROVIDER_PORT}/v1" \
+  --model-api-key "$MODEL_API_KEY" \
+  --model scripted-model \
+  > "$RESULTS_DIR/gym.log" 2>&1 &
+GYM_PID=$!
+"$ROOT_DIR/scripts/wait_for_servers.sh" "$GYM_PID" "$HEAD_PORT" 180
+
+"$VENV_DIR/bin/gym" eval run \
+  --no-serve \
+  --agent example_single_tool_call_simple_agent \
+  --input "$ROOT_DIR/resources_servers/example_single_tool_call/data/example.jsonl" \
+  --output "$RESULTS_DIR/rollouts.jsonl" \
+  --limit 1
+
+"$VENV_DIR/bin/python" "$ROOT_DIR/tests/e2e/verify_tool_rollout.py" \
+  --rollouts "$RESULTS_DIR/rollouts.jsonl" \
+  --provider-events "$RESULTS_DIR/provider-events.jsonl"

--- a/tests/e2e/run_external_vllm_gpu_e2e.sh
+++ b/tests/e2e/run_external_vllm_gpu_e2e.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+E2E_DIR="${E2E_DIR:-${RUNNER_TEMP:-/tmp}/nemo-gym-gpu-e2e}"
+VLLM_IMAGE="${VLLM_IMAGE:?Set VLLM_IMAGE to a pinned vLLM OpenAI image.}"
+MODEL="${MODEL:-Qwen/Qwen2.5-0.5B-Instruct}"
+GPU_DEVICE="${GPU_DEVICE:-0}"
+HF_CACHE_DIR="${HF_CACHE_DIR:-${HF_HOME:-$HOME/.cache/huggingface}}"
+VLLM_PORT="${VLLM_PORT:-18000}"
+INDEX_PORT="${INDEX_PORT:-28888}"
+HEAD_PORT="${HEAD_PORT:-11000}"
+MODEL_API_KEY="${MODEL_API_KEY:-not-a-real-key}" # pragma: allowlist secret
+VLLM_CONTAINER="${VLLM_CONTAINER:-nemo-gym-vllm-${GITHUB_RUN_ID:-$$}}"
+RESULTS_DIR="$E2E_DIR/results"
+VENV_DIR="$E2E_DIR/venv"
+INDEX_PID=""
+GYM_PID=""
+
+cleanup() {
+  if [[ -n "$GYM_PID" ]]; then
+    kill "$GYM_PID" 2>/dev/null || true
+    wait "$GYM_PID" 2>/dev/null || true
+  fi
+  docker logs "$VLLM_CONTAINER" > "$RESULTS_DIR/vllm.log" 2>&1 || true
+  docker rm --force "$VLLM_CONTAINER" >/dev/null 2>&1 || true
+  if [[ -n "$INDEX_PID" ]]; then
+    kill "$INDEX_PID" 2>/dev/null || true
+    wait "$INDEX_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ "$E2E_DIR" == "/" ]]; then
+  echo "E2E_DIR cannot be the filesystem root." >&2
+  exit 1
+fi
+rm -rf -- "$E2E_DIR"
+mkdir -p "$RESULTS_DIR" "$E2E_DIR/dist" "$E2E_DIR/index/nemo-gym" "$E2E_DIR/workspace" "$HF_CACHE_DIR"
+
+uv build "$ROOT_DIR" --wheel --out-dir "$E2E_DIR/dist"
+cp "$E2E_DIR"/dist/*.whl "$E2E_DIR/index/nemo-gym/"
+for wheel in "$E2E_DIR"/index/nemo-gym/*.whl; do
+  wheel_name="$(basename "$wheel")"
+  printf '<a href="%s">%s</a>\n' "$wheel_name" "$wheel_name"
+done > "$E2E_DIR/index/nemo-gym/index.html"
+printf '<a href="nemo-gym/">nemo-gym</a>\n' > "$E2E_DIR/index/index.html"
+
+python3 -m http.server "$INDEX_PORT" --bind 127.0.0.1 --directory "$E2E_DIR/index" \
+  > "$RESULTS_DIR/package-index.log" 2>&1 &
+INDEX_PID=$!
+for _ in $(seq 1 10); do
+  if curl --fail --silent "http://127.0.0.1:${INDEX_PORT}/nemo-gym/" >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+curl --fail --silent "http://127.0.0.1:${INDEX_PORT}/nemo-gym/" >/dev/null
+
+uv venv "$VENV_DIR"
+uv pip install --python "$VENV_DIR/bin/python" "$E2E_DIR"/dist/*.whl
+export NEMO_GYM_ALLOW_PRERELEASE=true
+export UV_INDEX_URL="http://127.0.0.1:${INDEX_PORT}/"
+export UV_EXTRA_INDEX_URL="https://pypi.org/simple/"
+
+docker run --detach --rm \
+  --name "$VLLM_CONTAINER" \
+  --gpus "device=${GPU_DEVICE}" \
+  --ipc host \
+  --publish "127.0.0.1:${VLLM_PORT}:8000" \
+  --volume "$HF_CACHE_DIR:/root/.cache/huggingface" \
+  "$VLLM_IMAGE" \
+  "$MODEL" \
+  --served-model-name "$MODEL" \
+  --dtype half \
+  --enforce-eager \
+  --gpu-memory-utilization 0.5 \
+  --max-model-len 2048 \
+  > "$RESULTS_DIR/vllm-container-id.txt"
+
+for _ in $(seq 1 300); do
+  if curl --fail --silent "http://127.0.0.1:${VLLM_PORT}/v1/models" >/dev/null; then
+    break
+  fi
+  if [[ "$(docker inspect "$VLLM_CONTAINER" --format '{{.State.Running}}' 2>/dev/null || true)" != "true" ]]; then
+    docker logs "$VLLM_CONTAINER" > "$RESULTS_DIR/vllm.log" 2>&1 || true
+    echo "vLLM exited before becoming ready." >&2
+    exit 1
+  fi
+  sleep 1
+done
+curl --fail --silent "http://127.0.0.1:${VLLM_PORT}/v1/models" > "$RESULTS_DIR/vllm-models.json"
+
+cd "$E2E_DIR/workspace"
+"$VENV_DIR/bin/gym" env start \
+  --config "$ROOT_DIR/resources_servers/example_single_tool_call/configs/example_single_tool_call.yaml" \
+  --config "$ROOT_DIR/responses_api_models/vllm_model/configs/vllm_model.yaml" \
+  --model-url "http://127.0.0.1:${VLLM_PORT}/v1" \
+  --model-api-key "$MODEL_API_KEY" \
+  --model "$MODEL" \
+  > "$RESULTS_DIR/gym.log" 2>&1 &
+GYM_PID=$!
+"$ROOT_DIR/scripts/wait_for_servers.sh" "$GYM_PID" "$HEAD_PORT" 180
+
+"$VENV_DIR/bin/gym" eval run \
+  --no-serve \
+  --agent example_single_tool_call_simple_agent \
+  --input "$ROOT_DIR/tests/e2e/gpu_smoke.jsonl" \
+  --output "$RESULTS_DIR/rollouts.jsonl" \
+  --limit 1 \
+  --max-output-tokens 32
+
+"$VENV_DIR/bin/python" "$ROOT_DIR/tests/e2e/verify_gpu_rollout.py" \
+  --rollouts "$RESULTS_DIR/rollouts.jsonl"
+
+docker logs "$VLLM_CONTAINER" > "$RESULTS_DIR/vllm.log" 2>&1

--- a/tests/e2e/scripted_provider.py
+++ b/tests/e2e/scripted_provider.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import threading
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+class ProviderState:
+    def __init__(self, events_path: Path) -> None:
+        self.events_path = events_path
+        self.lock = threading.Lock()
+
+    def record(self, body: dict[str, Any]) -> None:
+        with self.lock:
+            with self.events_path.open("a", encoding="utf-8") as events_file:
+                events_file.write(json.dumps(body) + "\n")
+
+
+class ProviderServer(ThreadingHTTPServer):
+    def __init__(self, address: tuple[str, int], state: ProviderState) -> None:
+        super().__init__(address, Handler)
+        self.state = state
+
+
+class Handler(BaseHTTPRequestHandler):
+    server: ProviderServer
+
+    def _write_json(self, status: int, body: dict[str, Any]) -> None:
+        payload = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self) -> None:
+        if self.path == "/healthz":
+            self._write_json(200, {"status": "ok"})
+            return
+        if self.path == "/v1/models":
+            self._write_json(
+                200,
+                {
+                    "object": "list",
+                    "data": [{"id": "scripted-model", "object": "model"}],
+                },
+            )
+            return
+        self._write_json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        if self.path != "/v1/chat/completions":
+            self._write_json(404, {"error": "not found"})
+            return
+
+        content_length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(content_length))
+        self.server.state.record(body)
+
+        messages = body.get("messages", [])
+        if any(message.get("role") == "tool" for message in messages):
+            message = {
+                "role": "assistant",
+                "content": "The weather in San Francisco is cold.",
+            }
+            finish_reason = "stop"
+            completion_tokens = 9
+        else:
+            advertised_tools = {tool.get("function", {}).get("name") for tool in body.get("tools", [])}
+            if "get_weather" not in advertised_tools:
+                self._write_json(400, {"error": "Gym did not forward the get_weather tool"})
+                return
+            message = {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_weather",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": json.dumps({"city": "San Francisco"}),
+                        },
+                    }
+                ],
+            }
+            finish_reason = "tool_calls"
+            completion_tokens = 7
+
+        self._write_json(
+            200,
+            {
+                "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": body.get("model", "scripted-model"),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": message,
+                        "finish_reason": finish_reason,
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": 10 + completion_tokens,
+                },
+            },
+        )
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--events", type=Path, required=True)
+    args = parser.parse_args()
+
+    args.events.parent.mkdir(parents=True, exist_ok=True)
+    args.events.unlink(missing_ok=True)
+    ProviderServer((args.host, args.port), ProviderState(args.events)).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/verify_gpu_rollout.py
+++ b/tests/e2e/verify_gpu_rollout.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rollouts", type=Path, required=True)
+    args = parser.parse_args()
+
+    with args.rollouts.open(encoding="utf-8") as rollouts_file:
+        rollouts = [json.loads(line) for line in rollouts_file if line.strip()]
+
+    assert len(rollouts) == 1, f"expected one rollout, found {len(rollouts)}"
+    rollout = rollouts[0]
+    response = rollout["response"]
+    assert response["status"] == "completed"
+    assert response["model"]
+    assert response["usage"]["input_tokens"] > 0
+    assert response["usage"]["output_tokens"] > 0
+
+    messages = [item for item in response["output"] if item["type"] == "message"]
+    assert len(messages) == 1
+    output_text = [content["text"] for content in messages[0]["content"] if content["type"] == "output_text"]
+    assert output_text and output_text[0].strip()
+    assert isinstance(rollout["reward"], float)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/verify_tool_rollout.py
+++ b/tests/e2e/verify_tool_rollout.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    with path.open(encoding="utf-8") as input_file:
+        return [json.loads(line) for line in input_file if line.strip()]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rollouts", type=Path, required=True)
+    parser.add_argument("--provider-events", type=Path, required=True)
+    args = parser.parse_args()
+
+    rollouts = read_jsonl(args.rollouts)
+    assert len(rollouts) == 1, f"expected one rollout, found {len(rollouts)}"
+
+    rollout = rollouts[0]
+    assert rollout["reward"] == 1.0
+    output = rollout["response"]["output"]
+    output_types = [item["type"] for item in output]
+    assert output_types == [
+        "function_call",
+        "function_call_output",
+        "message",
+    ], output_types
+
+    function_call = output[0]
+    assert function_call["name"] == "get_weather"
+    assert json.loads(function_call["arguments"]) == {"city": "San Francisco"}
+
+    tool_output = json.loads(output[1]["output"])
+    assert tool_output == {
+        "city": "San Francisco",
+        "weather_description": "The weather in San Francisco is cold.",
+    }
+
+    final_text = output[2]["content"][0]["text"]
+    assert final_text == "The weather in San Francisco is cold."
+
+    provider_events = read_jsonl(args.provider_events)
+    assert len(provider_events) == 2, f"expected two model requests, found {len(provider_events)}"
+    tool_messages = [message for message in provider_events[1]["messages"] if message.get("role") == "tool"]
+    assert len(tool_messages) == 1
+    assert "weather_description" in tool_messages[0]["content"]
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a pre-merge CPU workflow that builds the Gym wheel, installs it in a clean environment, and serves it to the isolated component environments created by `gym env start`.
- Exercise a deterministic two-request tool loop across the head server, `vllm_model`, `simple_agent`, resources server, verifier, and rollout collector.
- Add a runner-agnostic GPU script that starts external vLLM, loads a real model, runs inference through Gym, and checks the resulting token usage and output artifacts. CI can supply its pinned vLLM image, GPU device, and shared model cache without moving orchestration into workflow YAML.