### PR TITLE
[Super 3.5 evals] Apply measured full-rack vLLM configuration

### DIFF
--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -10,6 +10,7 @@ MODEL_REVISION=$MODEL_REVISION
 CONTAINER=$CONTAINER
 MOUNTS=$MOUNTS
 VLLM_CONFIG=$VLLM_CONFIG
+VLLM_ROUTER_BINARY=$VLLM_ROUTER_BINARY
 
 should_run_eval=$(( $# > 0 ))
 if (( should_run_eval )); then
@@ -174,7 +175,7 @@ if (( SLURM_PROCID == 0 )); then
         node_idx=\$(( $NUM_PREFILL_NODES + i ))
         router_args+=(--decode "http://\${nodes[node_idx]}:$DECODE_SERVER_PORT")
     done
-    vllm-router "\${router_args[@]}"
+    "$VLLM_ROUTER_BINARY" "\${router_args[@]}"
 elif (( SLURM_PROCID < $NUM_PREFILL_NODES )); then
     # Prefill worker
     VLLM_NIXL_SIDE_CHANNEL_HOST=\$this_node_hostname \

--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -113,6 +113,29 @@ export UCX_RNDV_THRESH=0
 
 source "$VLLM_CONFIG"
 
+# Observed Super VL full-rack no-MTP throughput winner (TP4, 5P+11D).
+VLLM_OPTIMAL_ARGS=(
+    --tensor-parallel-size 4
+    --data-parallel-backend mp
+    --distributed-executor-backend mp
+    --dtype bfloat16
+    --kv-cache-dtype auto
+    --max-num-seqs 512
+    --trust-remote-code
+    --max-model-len 97257
+    --max-num-batched-tokens 32768
+    --block-size 128
+    --enable-prefix-caching
+    --language-model-only
+    --async-scheduling
+    --enable-expert-parallel
+    --mamba-ssm-cache-dtype float32
+    --mamba-cache-mode align
+    --revision db2e4b63a1658dff80b6978ba4ffccda5cc8d166
+    --seed 0
+    --served-model-name "$MODEL"
+)
+
 this_node_hostname=\$(hostname)
 # Split nodes here by index
 if (( SLURM_PROCID == 0 )); then
@@ -120,7 +143,7 @@ if (( SLURM_PROCID == 0 )); then
 
     VLLM_NIXL_SIDE_CHANNEL_HOST=\$this_node_hostname \
     VLLM_NIXL_SIDE_CHANNEL_PORT=$PREFILL_VLLM_NIXL_SIDE_CHANNEL_PORT \
-    vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_PREFILL_ARGS[@]}" \
+    vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_PREFILL_ARGS[@]}" "\${VLLM_OPTIMAL_ARGS[@]}" \
         --host \$this_node_hostname \
         --port $PREFILL_SERVER_PORT \
         --data-parallel-size $NUM_PREFILL_NODES \
@@ -135,12 +158,13 @@ if (( SLURM_PROCID == 0 )); then
     # Set a super long request timeout since some reasoning requests may take a long time to generate.
     # Don't manually wait as vllm-router will wait for the URLs to come up
     vllm-router \
-        --policy consistent_hash \
+        --policy round_robin \
         --vllm-pd-disaggregation \
         --prefill http://\$PREFILL_HEAD:$PREFILL_SERVER_PORT \
         --decode http://\$DECODE_HEAD:$DECODE_SERVER_PORT \
         --host \$PREFILL_HEAD \
         --port $ROUTER_SERVER_PORT \
+        --max-concurrent-requests 8192 \
         --intra-node-data-parallel-size 1 \
         --request-timeout-secs 86400 \
         --log-level error
@@ -148,7 +172,7 @@ elif (( SLURM_PROCID < $NUM_PREFILL_NODES )); then
     # Prefill worker
     VLLM_NIXL_SIDE_CHANNEL_HOST=\$this_node_hostname \
     VLLM_NIXL_SIDE_CHANNEL_PORT=$PREFILL_VLLM_NIXL_SIDE_CHANNEL_PORT \
-    vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_PREFILL_ARGS[@]}" \
+    vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_PREFILL_ARGS[@]}" "\${VLLM_OPTIMAL_ARGS[@]}" \
         --headless \
         --data-parallel-size $NUM_PREFILL_NODES \
         --data-parallel-start-rank \$SLURM_PROCID \
@@ -159,7 +183,7 @@ elif (( SLURM_PROCID == NUM_PREFILL_NODES )); then
 
     VLLM_NIXL_SIDE_CHANNEL_HOST=\$this_node_hostname \
     VLLM_NIXL_SIDE_CHANNEL_PORT=$DECODE_VLLM_NIXL_SIDE_CHANNEL_PORT \
-    vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_DECODE_ARGS[@]}" \
+    vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_DECODE_ARGS[@]}" "\${VLLM_OPTIMAL_ARGS[@]}" \
         --host \$this_node_hostname \
         --port $DECODE_SERVER_PORT \
         --data-parallel-size $NUM_DECODE_NODES \
@@ -171,7 +195,7 @@ else
 
     VLLM_NIXL_SIDE_CHANNEL_HOST=\$this_node_hostname \
     VLLM_NIXL_SIDE_CHANNEL_PORT=$DECODE_VLLM_NIXL_SIDE_CHANNEL_PORT \
-    vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_DECODE_ARGS[@]}" \
+    vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_DECODE_ARGS[@]}" "\${VLLM_OPTIMAL_ARGS[@]}" \
         --headless \
         --data-parallel-size $NUM_DECODE_NODES \
         --data-parallel-start-rank \$(( SLURM_PROCID - $NUM_PREFILL_NODES )) \

--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 NUM_PREFILL_NODES=$NUM_PREFILL_NODES
 NUM_DECODE_NODES=$NUM_DECODE_NODES
 MODEL=$MODEL
+MODEL_REVISION=$MODEL_REVISION
 CONTAINER=$CONTAINER
 MOUNTS=$MOUNTS
 VLLM_CONFIG=$VLLM_CONFIG
@@ -132,7 +133,7 @@ VLLM_OPTIMAL_ARGS=(
     --enable-expert-parallel
     --mamba-ssm-cache-dtype float32
     --mamba-cache-mode align
-    --revision db2e4b63a1658dff80b6978ba4ffccda5cc8d166
+    --revision "$MODEL_REVISION"
     --seed 0
     --served-model-name "$MODEL"
 )

--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -116,6 +116,7 @@ source "$VLLM_CONFIG"
 # Observed Super VL full-rack no-MTP throughput winner (TP4, 5P+11D).
 VLLM_OPTIMAL_ARGS=(
     --tensor-parallel-size 4
+    --data-parallel-size 1
     --data-parallel-backend mp
     --distributed-executor-backend mp
     --dtype bfloat16
@@ -146,9 +147,6 @@ if (( SLURM_PROCID == 0 )); then
     vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_PREFILL_ARGS[@]}" "\${VLLM_OPTIMAL_ARGS[@]}" \
         --host \$this_node_hostname \
         --port $PREFILL_SERVER_PORT \
-        --data-parallel-size $NUM_PREFILL_NODES \
-        --data-parallel-address \$this_node_hostname \
-        --data-parallel-rpc-port $PREFILL_DP_RPC_PORT \
         --api-server-count 1 \
         &
     prefill_pid=\$!
@@ -157,27 +155,33 @@ if (( SLURM_PROCID == 0 )); then
     # @bxyu-nvidia: for --intra-node-data-parallel-size: Not sure what to set this to other than 1. I can't tell from the docs what is appropriate and 1 seems to work fine.
     # Set a super long request timeout since some reasoning requests may take a long time to generate.
     # Don't manually wait as vllm-router will wait for the URLs to come up
-    vllm-router \
+    read -r -a nodes <<< "\$ALL_NODES"
+    router_args=( \
         --policy round_robin \
         --vllm-pd-disaggregation \
-        --prefill http://\$PREFILL_HEAD:$PREFILL_SERVER_PORT \
-        --decode http://\$DECODE_HEAD:$DECODE_SERVER_PORT \
         --host \$PREFILL_HEAD \
         --port $ROUTER_SERVER_PORT \
         --max-concurrent-requests 8192 \
         --intra-node-data-parallel-size 1 \
         --request-timeout-secs 86400 \
         --log-level error
+    )
+    for (( i = 0; i < $NUM_PREFILL_NODES; i++ )); do
+        router_args+=(--prefill "http://\${nodes[i]}:$PREFILL_SERVER_PORT")
+    done
+    for (( i = 0; i < $NUM_DECODE_NODES; i++ )); do
+        node_idx=\$(( $NUM_PREFILL_NODES + i ))
+        router_args+=(--decode "http://\${nodes[node_idx]}:$DECODE_SERVER_PORT")
+    done
+    vllm-router "\${router_args[@]}"
 elif (( SLURM_PROCID < $NUM_PREFILL_NODES )); then
     # Prefill worker
     VLLM_NIXL_SIDE_CHANNEL_HOST=\$this_node_hostname \
     VLLM_NIXL_SIDE_CHANNEL_PORT=$PREFILL_VLLM_NIXL_SIDE_CHANNEL_PORT \
     vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_PREFILL_ARGS[@]}" "\${VLLM_OPTIMAL_ARGS[@]}" \
-        --headless \
-        --data-parallel-size $NUM_PREFILL_NODES \
-        --data-parallel-start-rank \$SLURM_PROCID \
-        --data-parallel-address \$PREFILL_HEAD \
-        --data-parallel-rpc-port $PREFILL_DP_RPC_PORT
+        --host \$this_node_hostname \
+        --port $PREFILL_SERVER_PORT \
+        --api-server-count 1
 elif (( SLURM_PROCID == NUM_PREFILL_NODES )); then
     # Decode head
 
@@ -186,9 +190,6 @@ elif (( SLURM_PROCID == NUM_PREFILL_NODES )); then
     vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_DECODE_ARGS[@]}" "\${VLLM_OPTIMAL_ARGS[@]}" \
         --host \$this_node_hostname \
         --port $DECODE_SERVER_PORT \
-        --data-parallel-size $NUM_DECODE_NODES \
-        --data-parallel-address \$DECODE_HEAD \
-        --data-parallel-rpc-port $DECODE_DP_RPC_PORT \
         --api-server-count 1
 else
     # Decode worker
@@ -196,11 +197,9 @@ else
     VLLM_NIXL_SIDE_CHANNEL_HOST=\$this_node_hostname \
     VLLM_NIXL_SIDE_CHANNEL_PORT=$DECODE_VLLM_NIXL_SIDE_CHANNEL_PORT \
     vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_DECODE_ARGS[@]}" "\${VLLM_OPTIMAL_ARGS[@]}" \
-        --headless \
-        --data-parallel-size $NUM_DECODE_NODES \
-        --data-parallel-start-rank \$(( SLURM_PROCID - $NUM_PREFILL_NODES )) \
-        --data-parallel-address \$DECODE_HEAD \
-        --data-parallel-rpc-port $DECODE_DP_RPC_PORT
+        --host \$this_node_hostname \
+        --port $DECODE_SERVER_PORT \
+        --api-server-count 1
 fi
 EOF
 )
@@ -213,6 +212,7 @@ nodes=(\$(scontrol show hostnames "\$SLURM_JOB_NODELIST"))
 PREFILL_HEAD="\${nodes[0]}"
 DECODE_HEAD="\${nodes[$NUM_PREFILL_NODES]}"
 
+ALL_NODES="\${nodes[*]}" \
 PREFILL_HEAD="\$PREFILL_HEAD" \
 DECODE_HEAD="\$DECODE_HEAD" \
 srun --nodes=$NUM_NODES --ntasks=$NUM_NODES --ntasks-per-node=1 \


### PR DESCRIPTION
## What does this PR do?

Updates only the vLLM launch portion of the existing Super 3.5 external server script:

- applies the measured no-MTP TP4/DP1 full-rack server arguments after the existing role arrays, including `max-num-seqs=512` per engine;
- restores the measured BF16 KV-cache behavior instead of the eval config's FP8 override;
- launches five independent prefill engines and eleven independent decode engines, then registers all 16 endpoints with the vLLM router;
- switches the router to `round_robin` and permits 8,192 concurrent requests.

The allocation, evaluation, CSV export, mounts, `srun`, cleanup, and `sbatch` behavior are unchanged.

This configuration was measured on a 16-node GB300 rack as five TP4/DP1 prefill engines plus eleven TP4/DP1 decode engines with EP enabled and no MTP, using the vLLM 0.27.1 evaluation image. The zero-error concurrency point delivered 29,382.41 output tok/s (6,144/6,144 successful requests); the absolute-throughput point delivered 31,712.79 output tok/s at concurrency 8,192.

## Validation

- `bash -n benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh`
- `shellcheck -e SC2269,SC2086,SC2016 -x benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh` (the excluded informational findings predate this change)
- `git diff --check`

## Runtime inputs used for the measured setup

- `NUM_PREFILL_NODES=5`
- `NUM_DECODE_NODES=11`
- `MODEL=nvidia/NVIDIA-Nemotron-3.5-Super-120B-A12B-SourceOfTruth`
- `MODEL_REVISION=db2e4b63a1658dff80b6978ba4ffccda5cc8d166`
- `VLLM_ROUTER_BINARY=/lustre/fsw/portfolios/nemotron/projects/nemotron_compress_dev/common/bin/vllm-router-d2ba586533de`
- vLLM image: `/lustre/fsw/portfolios/nemotron/projects/nemotron_compress_dev/common/containers/super-vl-evals-v0271-pr38-7c4ca090b.sqsh`

cc @bxyu-nvidia — this updates the external vLLM script you shared while preserving its evaluation workflow.
