### PR TITLE
feat(catalog): seed manifest-backed prototype data

### DIFF
--- a/benchmarks/financebench/manifest.yaml
+++ b/benchmarks/financebench/manifest.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+name: financebench
+version: 0.1.0
+kind: benchmark
+integration_profile: custom-gym-verifier
+domain: knowledge
+description: Open-book financial question answering over evidence from SEC filings.
+modality: text
+licensing: CC-BY-NC-4.0
+authors:
+  - NVIDIA NeMo Gym contributors
+reward:
+  range: [0, 1]
+  higher_is_better: true
+determinism: stochastic
+resources_server: equivalence_llm_judge
+agent_server: simple_agent
+model_server: policy_model
+datasets:
+  - name: financebench
+    type: benchmark
+    jsonl_fpath: benchmarks/financebench/data/financebench_benchmark.jsonl
+    prepare_script: benchmarks/financebench/prepare.py
+    prompt_config: benchmarks/financebench/prompts/default.yaml
+    num_repeats: 1
+canonical_split: train
+standard_prompt_config: benchmarks/financebench/prompts/default.yaml
+lifecycle: active

--- a/benchmarks/flores200/manifest.yaml
+++ b/benchmarks/flores200/manifest.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+name: flores200
+version: 0.1.0
+kind: benchmark
+integration_profile: custom-gym-verifier
+domain: translation
+description: English-to-many translation across FLORES+ devtest language pairs.
+modality: text
+licensing: CC-BY-SA-4.0
+authors:
+  - NVIDIA NeMo Gym contributors
+reward:
+  range: [0, 1]
+  higher_is_better: true
+determinism: seeded
+resources_server: wmt_translation
+agent_server: simple_agent
+model_server: policy_model
+datasets:
+  - name: flores200
+    type: benchmark
+    jsonl_fpath: benchmarks/flores200/data/flores200_devtest_benchmark.jsonl
+    prepare_script: benchmarks/flores200/prepare.py
+    prompt_config: benchmarks/flores200/prompts/default.yaml
+    num_repeats: 1
+canonical_split: devtest
+standard_prompt_config: benchmarks/flores200/prompts/default.yaml
+lifecycle: active

--- a/benchmarks/gpqa/manifest.yaml
+++ b/benchmarks/gpqa/manifest.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+name: gpqa
+version: 0.1.0
+kind: benchmark
+integration_profile: custom-gym-verifier
+domain: knowledge
+description: Graduate-level multiple-choice questions across physics, biology, and chemistry.
+modality: text
+licensing: unknown
+authors:
+  - NVIDIA NeMo Gym contributors
+reward:
+  range: [0, 1]
+  higher_is_better: true
+determinism: seeded
+resources_server: mcqa
+agent_server: simple_agent
+model_server: policy_model
+datasets:
+  - name: gpqa
+    type: benchmark
+    jsonl_fpath: benchmarks/gpqa/data/gpqa_diamond_benchmark.jsonl
+    prepare_script: benchmarks/gpqa/prepare.py
+    prompt_config: benchmarks/prompts/eval/aai/mcq-4choices.yaml
+    num_repeats: 8
+grading_mode: lenient_answer_colon_md
+canonical_split: train
+standard_prompt_config: benchmarks/prompts/eval/aai/mcq-4choices.yaml
+lifecycle: active

--- a/benchmarks/gsm8k/manifest.yaml
+++ b/benchmarks/gsm8k/manifest.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+name: gsm8k
+version: 0.1.0
+kind: benchmark
+integration_profile: custom-gym-verifier
+domain: math
+description: Grade-school math word problems from the GSM8K test split.
+modality: text
+licensing: MIT
+authors:
+  - NVIDIA NeMo Gym contributors
+reward:
+  range: [0, 1]
+  higher_is_better: true
+determinism: unknown
+resources_server: math_with_judge
+agent_server: simple_agent
+model_server: policy_model
+datasets:
+  - name: gsm8k
+    type: benchmark
+    jsonl_fpath: benchmarks/gsm8k/data/gsm8k_benchmark.jsonl
+    prepare_script: benchmarks/gsm8k/prepare.py
+    prompt_config: benchmarks/prompts/generic/math.yaml
+    num_repeats: 1
+canonical_split: test
+standard_prompt_config: benchmarks/prompts/generic/math.yaml
+lifecycle: active

--- a/benchmarks/human_eval/manifest.yaml
+++ b/benchmarks/human_eval/manifest.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+name: human_eval
+version: 0.1.0
+kind: benchmark
+integration_profile: custom-gym-verifier
+domain: coding
+description: Python function-completion tasks scored with EvalPlus base and plus tests.
+modality: text
+licensing: MIT
+authors:
+  - NVIDIA NeMo Gym contributors
+reward:
+  range: [0, 1]
+  higher_is_better: true
+determinism: seeded
+resources_server: evalplus
+agent_server: simple_agent
+model_server: policy_model
+datasets:
+  - name: human_eval
+    type: benchmark
+    jsonl_fpath: benchmarks/human_eval/data/human_eval_benchmark.jsonl
+    prepare_script: benchmarks/human_eval/prepare.py
+    prompt_config: benchmarks/prompts/generic/codegen.yaml
+    num_repeats: 1
+canonical_split: test
+standard_prompt_config: benchmarks/prompts/generic/codegen.yaml
+lifecycle: active

--- a/benchmarks/longbench_v2/manifest.yaml
+++ b/benchmarks/longbench_v2/manifest.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+name: longbench_v2
+version: 0.1.0
+kind: benchmark
+integration_profile: custom-gym-verifier
+domain: long_context
+description: Long-context multiple-choice evaluation spanning six reasoning domains.
+modality: text
+licensing: Apache-2.0
+authors:
+  - NVIDIA NeMo Gym contributors
+reward:
+  range: [0, 1]
+  higher_is_better: true
+determinism: seeded
+resources_server: mcqa
+agent_server: simple_agent
+model_server: policy_model
+datasets:
+  - name: longbench_v2
+    type: benchmark
+    jsonl_fpath: benchmarks/longbench_v2/data/longbench_v2_benchmark.jsonl
+    prepare_script: benchmarks/longbench_v2/prepare.py
+    prompt_config: benchmarks/longbench_v2/prompts/default.yaml
+    num_repeats: 1
+canonical_split: train
+standard_prompt_config: benchmarks/longbench_v2/prompts/default.yaml
+lifecycle: active

--- a/catalog-prototype/README.md
+++ b/catalog-prototype/README.md
@@ -1,0 +1,23 @@
+# NeMo Gym catalog prototype data
+
+This directory contains a snapshot of the unified NeMo Gym environment and benchmark catalog for UI prototyping.
+The snapshot intentionally includes both manifest-backed and legacy entries so a prototype can demonstrate the
+migration state.
+
+Refresh the snapshot from the repository root:
+
+```bash
+gym list environments --json --full | jq '.' > catalog-prototype/catalog.json
+```
+
+Use `metadata_complete` and `status` in the UI:
+
+- `metadata_complete: true` / `status: experimental` means a valid manifest supplied the full structured record.
+- `metadata_complete: false` / `status: no-manifest` means Gym discovered a legacy runnable config and some fields
+  are unavailable.
+
+The full payload includes repository-relative source paths, composition, datasets, authors, reward semantics,
+determinism, and benchmark protocol fields. Missing legacy metadata is represented with empty values rather than
+invented values.
+
+See `lovable-prompt.md` for a prompt that can be pasted into Lovable after importing or syncing this branch.

--- a/catalog-prototype/catalog.json
+++ b/catalog-prototype/catalog.json
@@ -1,0 +1,10718 @@
+[
+  {
+    "name": "aalcr",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/aalcr/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "aalcr"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "aalcr"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "abstention",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "rlhf",
+    "description": "Train models to abstain when unsure using three-tier reward on HotPotQA with LLM judge",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/abstention/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "abstention"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "hotpotqa_train"
+      },
+      {
+        "name": "hotpotqa_val"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "aime24",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/aime24/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "aime24"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "aime24-x",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/aime24-x/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "aime24-x"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "aime25",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/aime25/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "aime25"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "aime25-x",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/aime25-x/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "aime25-x"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "aime26",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/aime26/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "aime26"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "answer-judge",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/answer-judge/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_proof_judgement"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "answer-judge"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "apex_shortlist",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/apex_shortlist/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "apex_shortlist"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "arc_agi",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Abstract reasoning tasks from the ARC-AGI benchmark. See https://arcprize.org/arc-agi.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/arc_agi/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "arc_agi"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "training_1"
+      },
+      {
+        "name": "evaluation_1"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "arena_hard",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/arena_hard/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "arena_hard"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "arena_hard_v2",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/arena_hard_v2/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "arena_hard_v2"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "asr_leaderboard",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/asr_leaderboard/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "asr_with_pc"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "asr_leaderboard"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "bigcodebench",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/bigcodebench/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "bigcodebench"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "biomnibench_da",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Harbor agent for BiomniBench-DA (Docker bind-mount profile).",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/biomnibench_da/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "harbor_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "birdbench",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/birdbench/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "birdbench"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "blackjack",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "games",
+    "description": "Blackjack. Model hits or stands. Reward +1 win, 0 draw, -1 loss/bust.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/blackjack/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "blackjack"
+      ],
+      "agent_server": "gymnasium_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "browsecomp",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/browsecomp/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "browsecomp_advanced_harness"
+      ],
+      "agent_server": "browsecomp_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "browsecomp"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "bunsenbench_chemistry_mcq",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/bunsenbench_chemistry_mcq/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "bunsenbench_chemistry_mcq"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "calendar",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Multi-turn calendar scheduling dataset. User states events and constraints in natural language; model schedules events to satisfy all constraints.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/calendar/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "calendar"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "calendar_v2",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Multi-turn calendar scheduling dataset. User states events and constraints in natural language; model schedules events to satisfy all constraints.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/calendar_v2/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "calendar"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "circle_click",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "Click on circles in images",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/circle_click/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "circle_click"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "circle_count",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "Count circles of a given color in images",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/circle_count/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "circle_count"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "code_gen",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "coding",
+    "description": "Model must submit the right code to solve a problem",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/code_gen/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "code_gen"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "opencodereasoning_filtered_train"
+      },
+      {
+        "name": "livecodebench_v5_validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "critpt",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/critpt/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "critpt_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "critpt"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "ether0",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "ether0 chemistry benchmark verifiers",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/ether0/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "ether0"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "val"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "finance_agent_v2",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/finance_agent_v2/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "finance_agent_v2",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "finance_agent_v2"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "finance_sec_search/config_no_web_search",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/finance_sec_search/config_no_web_search.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "finance_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "finance_sec_search"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "finance_sec_search/config_web_search",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/finance_sec_search/config_web_search.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "finance_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "finance_sec_search_web_search"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "financebench",
+    "kind": "benchmark",
+    "status": "experimental",
+    "domain": "knowledge",
+    "description": "Open-book financial question answering over evidence from SEC filings.",
+    "version": "0.1.0",
+    "integration_profile": "custom-gym-verifier",
+    "modality": "text",
+    "licensing": "CC-BY-NC-4.0",
+    "lifecycle": "active",
+    "metadata_complete": true,
+    "source": {
+      "config": "benchmarks/financebench/config.yaml",
+      "manifest": "benchmarks/financebench/manifest.yaml"
+    },
+    "composition": {
+      "resources_servers": [
+        "equivalence_llm_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": "policy_model",
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [
+      "NVIDIA NeMo Gym contributors"
+    ],
+    "reward": {
+      "range": [
+        0.0,
+        1.0
+      ],
+      "higher_is_better": true
+    },
+    "determinism": "stochastic",
+    "datasets": [
+      {
+        "name": "financebench",
+        "type": "benchmark",
+        "jsonl_fpath": "benchmarks/financebench/data/financebench_benchmark.jsonl",
+        "prepare_script": "benchmarks/financebench/prepare.py",
+        "prompt_config": "benchmarks/financebench/prompts/default.yaml",
+        "num_repeats": 1
+      }
+    ],
+    "canonical_split": "train",
+    "standard_prompt_config": "benchmarks/financebench/prompts/default.yaml",
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "flores200",
+    "kind": "benchmark",
+    "status": "experimental",
+    "domain": "translation",
+    "description": "English-to-many translation across FLORES+ devtest language pairs.",
+    "version": "0.1.0",
+    "integration_profile": "custom-gym-verifier",
+    "modality": "text",
+    "licensing": "CC-BY-SA-4.0",
+    "lifecycle": "active",
+    "metadata_complete": true,
+    "source": {
+      "config": "benchmarks/flores200/config.yaml",
+      "manifest": "benchmarks/flores200/manifest.yaml"
+    },
+    "composition": {
+      "resources_servers": [
+        "wmt_translation"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": "policy_model",
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [
+      "NVIDIA NeMo Gym contributors"
+    ],
+    "reward": {
+      "range": [
+        0.0,
+        1.0
+      ],
+      "higher_is_better": true
+    },
+    "determinism": "seeded",
+    "datasets": [
+      {
+        "name": "flores200",
+        "type": "benchmark",
+        "jsonl_fpath": "benchmarks/flores200/data/flores200_devtest_benchmark.jsonl",
+        "prepare_script": "benchmarks/flores200/prepare.py",
+        "prompt_config": "benchmarks/flores200/prompts/default.yaml",
+        "num_repeats": 1
+      }
+    ],
+    "canonical_split": "devtest",
+    "standard_prompt_config": "benchmarks/flores200/prompts/default.yaml",
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "frontierscience_olympiad",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/frontierscience_olympiad/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "frontierscience_olympiad"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "frontierscience_research",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": "FrontierScience research rubric grading via single-pass LLM judge",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/frontierscience_research/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "frontierscience_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "frontierscience_research"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "gdpval",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/gdpval/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "gdpval"
+      ],
+      "agent_server": "stirrup_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "gdpval"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "global-piqa",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/global-piqa/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "mcqa"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "global-piqa"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "gpqa",
+    "kind": "benchmark",
+    "status": "experimental",
+    "domain": "knowledge",
+    "description": "Graduate-level multiple-choice questions across physics, biology, and chemistry.",
+    "version": "0.1.0",
+    "integration_profile": "custom-gym-verifier",
+    "modality": "text",
+    "licensing": "unknown",
+    "lifecycle": "active",
+    "metadata_complete": true,
+    "source": {
+      "config": "benchmarks/gpqa/config.yaml",
+      "manifest": "benchmarks/gpqa/manifest.yaml"
+    },
+    "composition": {
+      "resources_servers": [
+        "mcqa"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": "policy_model",
+      "rollout_driver": null,
+      "grading_mode": "lenient_answer_colon_md"
+    },
+    "authors": [
+      "NVIDIA NeMo Gym contributors"
+    ],
+    "reward": {
+      "range": [
+        0.0,
+        1.0
+      ],
+      "higher_is_better": true
+    },
+    "determinism": "seeded",
+    "datasets": [
+      {
+        "name": "gpqa",
+        "type": "benchmark",
+        "jsonl_fpath": "benchmarks/gpqa/data/gpqa_diamond_benchmark.jsonl",
+        "prepare_script": "benchmarks/gpqa/prepare.py",
+        "prompt_config": "benchmarks/prompts/eval/aai/mcq-4choices.yaml",
+        "num_repeats": 8
+      }
+    ],
+    "canonical_split": "train",
+    "standard_prompt_config": "benchmarks/prompts/eval/aai/mcq-4choices.yaml",
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "gpqa-x",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/gpqa-x/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "mcqa"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "gpqa-x"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "graphwalks",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/graphwalks/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "graphwalks"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "graphwalks/config_n3_1m",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/graphwalks/config_n3_1m.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "graphwalks_n3_1m"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "gsm8k",
+    "kind": "benchmark",
+    "status": "experimental",
+    "domain": "math",
+    "description": "Grade-school math word problems from the GSM8K test split.",
+    "version": "0.1.0",
+    "integration_profile": "custom-gym-verifier",
+    "modality": "text",
+    "licensing": "MIT",
+    "lifecycle": "active",
+    "metadata_complete": true,
+    "source": {
+      "config": "benchmarks/gsm8k/config.yaml",
+      "manifest": "benchmarks/gsm8k/manifest.yaml"
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": "policy_model",
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [
+      "NVIDIA NeMo Gym contributors"
+    ],
+    "reward": {
+      "range": [
+        0.0,
+        1.0
+      ],
+      "higher_is_better": true
+    },
+    "determinism": "unknown",
+    "datasets": [
+      {
+        "name": "gsm8k",
+        "type": "benchmark",
+        "jsonl_fpath": "benchmarks/gsm8k/data/gsm8k_benchmark.jsonl",
+        "prepare_script": "benchmarks/gsm8k/prepare.py",
+        "prompt_config": "benchmarks/prompts/generic/math.yaml",
+        "num_repeats": 1
+      }
+    ],
+    "canonical_split": "test",
+    "standard_prompt_config": "benchmarks/prompts/generic/math.yaml",
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "hendrycks_math",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/hendrycks_math/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "hendrycks_math"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "hle",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/hle/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "equivalence_llm_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "hle"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "hle/config_vision",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/hle/config_vision.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "equivalence_llm_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "hle_vision"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "hmmt_feb25",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/hmmt_feb25/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "hmmt_feb25"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "hmmt_nov25",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/hmmt_nov25/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "hmmt_nov25"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "hotpotqa_closedbook",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/hotpotqa_closedbook/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "hotpotqa_closedbook"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "human_eval",
+    "kind": "benchmark",
+    "status": "experimental",
+    "domain": "coding",
+    "description": "Python function-completion tasks scored with EvalPlus base and plus tests.",
+    "version": "0.1.0",
+    "integration_profile": "custom-gym-verifier",
+    "modality": "text",
+    "licensing": "MIT",
+    "lifecycle": "active",
+    "metadata_complete": true,
+    "source": {
+      "config": "benchmarks/human_eval/config.yaml",
+      "manifest": "benchmarks/human_eval/manifest.yaml"
+    },
+    "composition": {
+      "resources_servers": [
+        "evalplus"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": "policy_model",
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [
+      "NVIDIA NeMo Gym contributors"
+    ],
+    "reward": {
+      "range": [
+        0.0,
+        1.0
+      ],
+      "higher_is_better": true
+    },
+    "determinism": "seeded",
+    "datasets": [
+      {
+        "name": "human_eval",
+        "type": "benchmark",
+        "jsonl_fpath": "benchmarks/human_eval/data/human_eval_benchmark.jsonl",
+        "prepare_script": "benchmarks/human_eval/prepare.py",
+        "prompt_config": "benchmarks/prompts/generic/codegen.yaml",
+        "num_repeats": 1
+      }
+    ],
+    "canonical_split": "test",
+    "standard_prompt_config": "benchmarks/prompts/generic/codegen.yaml",
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "human_eval_infilling",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/human_eval_infilling/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "code_fim"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "human_eval_infilling_random_span"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "ifbench",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/ifbench/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "ifbench"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "ifeval",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/ifeval/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "ifeval"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "iheval",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/iheval/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "iheval"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "imo_answerbench",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/imo_answerbench/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "imo_answerbench"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "imo_gradingbench",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/imo_gradingbench/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "imo_gradingbench"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "imo_gradingbench"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "imo_proofbench",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/imo_proofbench/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "imo_proofbench"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "instruction_following",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "instruction_following",
+    "description": "Instruction following datasets targeting IFEval and IFBench style instruction following capabilities",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/instruction_following/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "instruction_following"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "ioi",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/ioi/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "competitive_coding_challenges"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "ioi"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "labbench2_vlm",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/labbench2_vlm/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "labbench2_vlm_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "labbench2_vlm"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "legal_agent_bench",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/legal_agent_bench/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "harbor_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "legal_agent_bench"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "librispeech_pc",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/librispeech_pc/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "librispeech_pc"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "litmus-bench",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/litmus-bench/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "litmus_agent"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "litmus-bench"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "livecodebench-x",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/livecodebench-x/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "livecodebench-x"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "livecodebench/v5_2408_2502/cascade",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/livecodebench/v5_2408_2502/cascade.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "livecodebench_v5_cascade"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "livecodebench/v5_2408_2502/config",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/livecodebench/v5_2408_2502/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "livecodebench_v5"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "livecodebench/v6_2408_2505/cascade",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/livecodebench/v6_2408_2505/cascade.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "livecodebench_v6_cascade"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "livecodebench/v6_2408_2505/config",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/livecodebench/v6_2408_2505/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "livecodebench_v6"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "longbench_v2",
+    "kind": "benchmark",
+    "status": "experimental",
+    "domain": "long_context",
+    "description": "Long-context multiple-choice evaluation spanning six reasoning domains.",
+    "version": "0.1.0",
+    "integration_profile": "custom-gym-verifier",
+    "modality": "text",
+    "licensing": "Apache-2.0",
+    "lifecycle": "active",
+    "metadata_complete": true,
+    "source": {
+      "config": "benchmarks/longbench_v2/config.yaml",
+      "manifest": "benchmarks/longbench_v2/manifest.yaml"
+    },
+    "composition": {
+      "resources_servers": [
+        "mcqa"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": "policy_model",
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [
+      "NVIDIA NeMo Gym contributors"
+    ],
+    "reward": {
+      "range": [
+        0.0,
+        1.0
+      ],
+      "higher_is_better": true
+    },
+    "determinism": "seeded",
+    "datasets": [
+      {
+        "name": "longbench_v2",
+        "type": "benchmark",
+        "jsonl_fpath": "benchmarks/longbench_v2/data/longbench_v2_benchmark.jsonl",
+        "prepare_script": "benchmarks/longbench_v2/prepare.py",
+        "prompt_config": "benchmarks/longbench_v2/prompts/default.yaml",
+        "num_repeats": 1
+      }
+    ],
+    "canonical_split": "train",
+    "standard_prompt_config": "benchmarks/longbench_v2/prompts/default.yaml",
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "longbench_v2/config_n3_1m",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/longbench_v2/config_n3_1m.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "longbench_v2_n3_1m"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "longcodebench",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/longcodebench/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "longcodebench"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "longcodebench/config_n3_1m",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/longcodebench/config_n3_1m.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "longcodebench_n3_1m"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "longmt_pg19",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/longmt_pg19/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "pg19_benchmark"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "longmt_wmt24pp",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/longmt_wmt24pp/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "wmt24pp_benchmark"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "m_arena_hard",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/m_arena_hard/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "arena_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "m_arena_hard"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "m_arena_hard_v2",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/m_arena_hard_v2/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "arena_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "m_arena_hard_v2"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "math-500",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/math-500/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "math-500"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "mbpp",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/mbpp/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "evalplus"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "mbpp"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "minif2f",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/minif2f/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "minif2f"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "mmlu",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/mmlu/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "mcqa"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "mmlu"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "mmlu-redux",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/mmlu-redux/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "mcqa"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "mmlu-redux"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "mmlu_pro",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/mmlu_pro/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "mcqa"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "mmlu_pro"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "mmlu_prox",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/mmlu_prox/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "mcqa"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "mmlu_prox"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "mmmlu",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/mmmlu/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "mcqa"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "mmmlu"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "mobench",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/mobench/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "mobench"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "mrcr",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/mrcr/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "mrcr"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "mrcr/config_n3_128k",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/mrcr/config_n3_128k.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "mrcr_n3_128k"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "mrcr/config_n3_1m",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/mrcr/config_n3_1m.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "mrcr_n3_1m"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "musan",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/musan/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "asr_with_pc"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "musan"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "numb3rs",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/numb3rs/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "asr_with_pc"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "numb3rs"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "omniscience",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/omniscience/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "omniscience"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "osworld",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/osworld/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "osworld_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      },
+      {
+        "name": "osworld"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "physics",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/physics/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "physics"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "pinchbench",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/pinchbench/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "pinchbench",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "pinchbench"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "polymath",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/polymath/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "polymath"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "polymath"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "proof-arena-judge",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/proof-arena-judge/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_proof_judgement"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "proof-arena-judge"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "proof_bench_judge",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/proof_bench_judge/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_proof_judgement"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "proof_bench_judge"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "proofnet",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/proofnet/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "proofnet"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "putnam_bench",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/putnam_bench/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "putnam_bench"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "reasoning_gym",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Over 100 tasks including algebra, arithmetic, computation, cognition, geometry, graph theory, logic, and many common games.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/reasoning_gym/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "reasoning_gym_claude_code",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Claude Code agent harness for reasoning gym tasks",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/reasoning_gym_claude_code/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "claude_code_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "reasoning_gym_hermes",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Hermes Agent with terminal, file, code_execution, skills, todo toolsets on reasoning_gym tasks",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/reasoning_gym_hermes/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "hermes_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "reasoning_gym_orchestrator",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "LangGraph orchestrator agent compatible with resource servers that do not use tools; enables diverse agent training data and test time scaling vs a simple agent, extensible to use tools or other agent architectures",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/reasoning_gym_orchestrator/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "langgraph_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "reasoning_gym_parallel_thinking",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "LangGraph parallel thinking agent compatible with resource servers that do not use tools; enables diverse agent training data and test time scaling vs a simple agent, extensible to use tools or other agent architectures",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/reasoning_gym_parallel_thinking/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "langgraph_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "reasoning_gym_reflection",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "LangGraph reflection agent compatible with resource servers that do not use tools; provides iterative reflection for diverse agent training data and test time scaling, extensible to use tools or other agent architectures",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/reasoning_gym_reflection/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "langgraph_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "reasoning_gym_rewoo",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "LangGraph ReWOO agent compatible with resource servers that do not use tools; enables diverse agent training data and test time scaling vs a simple agent, extensible to use tools or other agent architectures",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/reasoning_gym_rewoo/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "langgraph_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/aalcr",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/aalcr/configs/aalcr.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "aalcr"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/arena_judge",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "Arena Hard v2 pairwise LLM-judge server — ports arena-hard-auto's category-specific judging with side-swapped prompts",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/arena_judge/configs/arena_judge.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "arena_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/asr_with_pc",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "ASR with WER scoring (standard, case-sensitive, punctuation+capitalization)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/asr_with_pc/configs/asr_with_pc.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "asr_with_pc"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/aviary/gsm8k_aviary",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "GSM8k benchmark with calculator tool",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/aviary/configs/gsm8k_aviary.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "aviary"
+      ],
+      "agent_server": "aviary_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/aviary/hotpotqa_aviary",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Multi-hop question answering on the HotPotQA dataset with Wikipedia search",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/aviary/configs/hotpotqa_aviary.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "aviary"
+      ],
+      "agent_server": "aviary_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/bigcodebench",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "coding",
+    "description": "Verifies model-generated Python solutions against the BigCodeBench unittest suite.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/bigcodebench/configs/bigcodebench.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "bigcodebench"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/bird_sql",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "coding",
+    "description": "Text-to-SQL with execution-based evaluation on BIRD dev (1534 SQLite tasks). Binary reward from unordered result-set equality.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/bird_sql/configs/bird_sql.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "bird_sql"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/browsecomp_advanced_harness",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Model uses search tools to satisfy a user query.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/browsecomp_advanced_harness/configs/browsecomp_advanced_harness.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "browsecomp_advanced_harness"
+      ],
+      "agent_server": "browsecomp_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/bunsenbench_chemistry_mcq",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Public BunsenBench chemistry multiple-choice benchmark verifier",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/bunsenbench_chemistry_mcq/configs/bunsenbench_chemistry_mcq.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "bunsenbench_chemistry_mcq"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/code_fim",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "coding",
+    "description": "Code Fill-in-the-Middle judged by HumanEval-Infilling test suite (single_line, multi_line, random_span, random_span_light)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/code_fim/configs/code_fim.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "code_fim"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/competitive_coding_challenges",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "coding",
+    "description": "Execution of competitive programming competition questions",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/competitive_coding_challenges/configs/competitive_coding_challenges.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "competitive_coding_challenges"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/conversational_tool_use_simulation",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Conversational tool-use simulation environment.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/conversational_tool_use_simulation/configs/conversational_tool_use_simulation.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "conversational_tool_use_simulation"
+      ],
+      "agent_server": "conversational_tool_use/simulation",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/critpt",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "Research-level physics problems scored by the Artificial Analysis API",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/critpt/configs/critpt.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "critpt"
+      ],
+      "agent_server": "critpt_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/equivalence_llm_judge",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Short answer questions with LLM-as-a-judge",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/equivalence_llm_judge/configs/equivalence_llm_judge.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "equivalence_llm_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "example_openqa"
+      },
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/equivalence_llm_judge/nl2bash-equivalency",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Short bash command generation questions with LLM-as-a-judge",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/equivalence_llm_judge/configs/nl2bash-equivalency.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "equivalence_llm_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/equivalence_rule/lc",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Question - Answering with rule-based reward",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/equivalence_rule/configs/lc.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "equivalence_rule"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/evalplus",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "coding",
+    "description": "Function-completion code judged by EvalPlus base + plus tests (HumanEval+, MBPP+)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/evalplus/configs/evalplus.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "evalplus"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/example_mcp_weather",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Claude Code MCP smoke test — a plain HTTP weather tool route auto-exposed over MCP",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/example_mcp_weather/configs/example_mcp_weather.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "example_mcp_weather"
+      ],
+      "agent_server": "claude_code_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/example_multi_step",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "instruction_following",
+    "description": "Multi-step tool calling",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/example_multi_step/configs/example_multi_step.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "example_multi_step"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/example_multi_turn_gymnasium",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Example multi-turn environment using Gymnasium",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/example_multi_turn_gymnasium/configs/example_multi_turn_gymnasium.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "example_multi_turn_gymnasium"
+      ],
+      "agent_server": "gymnasium_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/example_session_state_mgmt",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Session state management (in-memory)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/example_session_state_mgmt/configs/example_session_state_mgmt.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "example_session_state_mgmt"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/example_single_tool_call",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Basic single-step tool calling",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/example_single_tool_call/configs/example_single_tool_call.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "example_single_tool_call"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/example_tool_call_multireward",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Single tool call scored on decoupled correctness / schema_valid / format rewards (multi-reward, for GDPO)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/example_tool_call_multireward/configs/example_tool_call_multireward.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "example_tool_call_multireward"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/finance_agent_v2",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Vals finance-agent-v2 tools (web/EDGAR/price/calculator) for financial research questions",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/finance_agent_v2/configs/finance_agent_v2.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "finance_agent_v2"
+      ],
+      "agent_server": "finance_agent_v2",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/finance_sec_search",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "SEC EDGAR filing search for financial analysis questions",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/finance_sec_search/configs/finance_sec_search.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "finance_sec_search"
+      ],
+      "agent_server": "finance_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/format_verification/citation_format",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "instruction_following",
+    "description": "Verify citation/reference markers in model responses via string matching",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/format_verification/configs/citation_format.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "format_verification"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/format_verification/freeform_formatting",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "instruction_following",
+    "description": "Verify freeform text formatting (bullets, headings, tables, etc.) via regex patterns",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/format_verification/configs/freeform_formatting.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "format_verification"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/frontierscience_judge",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "FrontierScience answer grading via single-pass LLM judge",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/frontierscience_judge/configs/frontierscience_judge.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "frontierscience_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/genrm_compare",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "rlhf",
+    "description": "GenRM pairwise comparison for RLHF training",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/genrm_compare/configs/genrm_compare.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "genrm_compare"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/google_search",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Multi-choice question answering problems with search tools integrated",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/google_search/configs/google_search.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "google_search"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/gpqa_diamond",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "GPQA Diamond multiple-choice question answering problems",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/gpqa_diamond/configs/gpqa_diamond.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "gpqa_diamond"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/graphwalks",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "Long-context graph-walks (BFS / parents) with F1-over-node-sets grading from openai/graphwalks",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/graphwalks/configs/graphwalks.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "graphwalks"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/grl_sokoban",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "games",
+    "description": "Single-box Sokoban in Gymnasium API style.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/grl_sokoban/configs/grl_sokoban.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "grl_sokoban"
+      ],
+      "agent_server": "gymnasium_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/grl_tetris",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "games",
+    "description": "Tetris in Gymnasium API style. Model emits one or more moves per turn.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/grl_tetris/configs/grl_tetris.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "grl_tetris"
+      ],
+      "agent_server": "gymnasium_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/gui_coordinate",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "GUI coordinate grounding verifier for visual pointing tasks",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/gui_coordinate/configs/gui_coordinate.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "gui_coordinate"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/gymnasium",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "Base class for Gymnasium-style servers. Not a standalone server.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/gymnasium/configs/gymnasium.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "gymnasium"
+      ],
+      "agent_server": "gymnasium_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/hotpotqa_qa",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Short-answer QA with deterministic SQuAD-style + alternative-aware substring verification (HotpotQA closed-book).",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/hotpotqa_qa/configs/hotpotqa_qa.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "hotpotqa_qa"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/ifbench",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "instruction_following",
+    "description": "IFBench instruction following evaluation using AllenAI's IFBench library (57 instruction types)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/ifbench/configs/ifbench.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "ifbench"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/iheval",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "instruction_following",
+    "description": "IHEval instruction-hierarchy benchmark (8 single-turn tasks — task execution, safety, tool use, rule following) scored with the upstream rule-based checkers.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/iheval/configs/iheval.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "iheval"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "test"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/imo_gradingbench",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Four-class grading of math proofs — the policy model reads a problem plus a candidate proof and emits one of correct / almost / partial / incorrect as the last word.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/imo_gradingbench/configs/imo_gradingbench.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "imo_gradingbench"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/imo_proofbench_judge",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "IMO ProofBench grader using a strong LLM judge with the IMO 0-7 rubric",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/imo_proofbench_judge/configs/imo_proofbench_judge.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "imo_proofbench_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/indirect_prompt_injection",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "safety",
+    "description": "Indirect prompt injection resistance for multi-domain tool-use agents",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/indirect_prompt_injection/configs/indirect_prompt_injection.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "indirect_prompt_injection"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/inverse_if",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Inverse IF instruction-following benchmark with per-task LLM judge",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/inverse_if/configs/inverse_if.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "inverse_if"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "inverse_if_example"
+      },
+      {
+        "name": "inverse_if_train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/jailbreak_detection/jailbreak_detection_nemotron_combined_reward_tp8",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "safety",
+    "description": "Jailbreak detection with Nemotron judge + combined reward",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/jailbreak_detection/configs/jailbreak_detection_nemotron_combined_reward_tp8.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "jailbreak_detection"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "jailbreak_engagement_with_disclaimer"
+      },
+      {
+        "name": "jailbreak_refusal_with_explanation"
+      },
+      {
+        "name": "jailbreak_hard_refusal_no_redirection"
+      },
+      {
+        "name": "jailbreak_hard_refusal_with_helplines"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/labbench2_vlm",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "labbench2 VLM benchmarks: scientific figure/table QA (figqa2, tableqa2), protocol troubleshooting (protocolqa2), LLM-as-judge",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/labbench2_vlm/configs/labbench2_vlm.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "labbench2_vlm"
+      ],
+      "agent_server": "labbench2_vlm_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "figqa2_img"
+      },
+      {
+        "name": "figqa2_pdf"
+      },
+      {
+        "name": "tableqa2_img"
+      },
+      {
+        "name": "tableqa2_pdf"
+      },
+      {
+        "name": "protocolqa2"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/lc_niah",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Answer-correctness reward gated by low reasoning/input overlap",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/lc_niah/configs/lc_niah.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "lc_niah"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/legal_agent_bench",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Harbor-native integration of <a href='https://github.com/harveyai/harvey-labs/tree/f46ef86e4788545622db25dcffa3aebb7a139929'>Legal Agent Benchmark (LAB)</a>",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/legal_agent_bench/configs/legal_agent_bench.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "legal_agent_bench"
+      ],
+      "agent_server": "harbor_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "legal_agent_bench"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/litmus_agent",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Domain-agnostic answer verifier: extracts a model's final answer with an answer_format regex and scores it against expected_answer per an answer_type taxonomy (float, bool, string). For tool-using rows it can also host a sandbox-backed stateful Python code-execution tool.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/litmus_agent/configs/litmus_agent.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "litmus_agent"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/litmus_agent/litmus_agent_apptainer",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Domain-agnostic answer verifier: extracts a model's final answer with an answer_format regex and scores it against expected_answer per an answer_type taxonomy (float, bool, string). For tool-using rows it can also host a sandbox-backed stateful Python code-execution tool. This variant backs the tool with the local Apptainer provider (no service or API key); swap to litmus_agent.yaml for the OpenSandbox provider.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/litmus_agent/configs/litmus_agent_apptainer.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "litmus_agent"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/longmt_eval",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "Document-level MT verifier using the SEGALE pipeline (ersatz segment → LASER2 embed → vecalign align → COMETKiwi score)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/longmt_eval/configs/longmt_eval.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "longmt_eval"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/longmt_eval/longmt_pg19",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "Document-level MT verifier for pg19 books using the SEGALE pipeline (ersatz segment → LASER2 embed → vecalign align → COMETKiwi score)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/longmt_eval/configs/longmt_pg19.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "longmt_eval"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/longmt_eval/longmt_wmt24pp",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "Document-level MT verifier for wmt24pp short docs using the SEGALE pipeline (ersatz segment → LASER2 embed → vecalign align → COMETKiwi score).",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/longmt_eval/configs/longmt_wmt24pp.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "longmt_eval"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_advanced_calculations",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "An instruction following math environment with counter-intuitive calculators",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_advanced_calculations/configs/math_advanced_calculations.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_advanced_calculations"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_formal_lean",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Lean4 formal proof verification environment",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_formal_lean/configs/math_formal_lean.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_formal_lean"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_formal_lean/math_formal_lean_multi_turn",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Lean4 formal proof verification environment with multi-turn self-correction",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_formal_lean/configs/math_formal_lean_multi_turn.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_formal_lean"
+      ],
+      "agent_server": "proof_refinement_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_formal_lean/nemotron_clean_easy",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Lean4 formal proof verification environment",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_formal_lean/configs/nemotron_clean_easy.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_formal_lean"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_formal_lean/nemotron_first_try_hard",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Lean4 formal proof verification environment",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_formal_lean/configs/nemotron_first_try_hard.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_formal_lean"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_formal_lean/nemotron_medium_500",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Lean4 formal proof verification environment",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_formal_lean/configs/nemotron_medium_500.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_formal_lean"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_formal_lean/nemotron_very_easy",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Lean4 formal proof verification environment",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_formal_lean/configs/nemotron_very_easy.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_formal_lean"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_proof_judgement",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Binary judgement of math proofs — the policy model reads a problem plus a candidate proof and outputs Judgement: Yes/No.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_proof_judgement/configs/math_proof_judgement.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_proof_judgement"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_with_autograder",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Math QA verified by a Skills-style autograder LLM judge with math-verify symbolic fallback",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_with_autograder/configs/math_with_autograder.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_autograder"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_with_code",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Model solves competitive math problems using simple calculator tools",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_with_code/configs/math_with_code.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_code"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_with_judge",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "OpenMathReasoning math dataset with math-verify and LLM-as-a-judge",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_with_judge/configs/math_with_judge.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_with_judge/dapo17k",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "DAPO17k math dataset with math-verify",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_with_judge/configs/dapo17k.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_with_judge/math_stack_overflow",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "MathStackOverflow math dataset with math-verify",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_with_judge/configs/math_stack_overflow.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_with_judge/math_with_judge_hermes_agent",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Hermes Agent with terminal, file, code_execution, skills, todo toolsets on OpenMathReasoning math dataset with math-verify and LLM-as-a-judge",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_with_judge/configs/math_with_judge_hermes_agent.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "hermes_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_with_judge/math_with_judge_kilocode_agent",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "KiloCode agent harness on OpenMathReasoning math dataset with math-verify",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_with_judge/configs/math_with_judge_kilocode_agent.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "kilocode_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_with_judge/math_with_judge_openclaw_agent",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "OpenClaw agent harness on OpenMathReasoning math dataset with math-verify",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_with_judge/configs/math_with_judge_openclaw_agent.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "openclaw_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_with_judge/math_with_judge_opencode_agent",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "OpenCode agent harness on OpenMathReasoning math dataset with math-verify",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_with_judge/configs/math_with_judge_opencode_agent.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "opencode_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/math_with_judge/math_with_judge_pi_agent",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "pi agent harness on OpenMathReasoning math dataset with math-verify",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/math_with_judge/configs/math_with_judge_pi_agent.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "math_with_judge"
+      ],
+      "agent_server": "pi_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/mcqa",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Multi-choice question answering problems",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/mcqa/configs/mcqa.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "mcqa"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      },
+      {
+        "name": "example_with_template_metadata"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/mrcr",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "Multi-round coreference resolution over multi-turn conversations with prefix-gated SequenceMatcher grading",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/mrcr/configs/mrcr.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "mrcr"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/multichallenge/multichallenge_nrl",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Targets inference memory, instruction retention, version editing, and self-coherence.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/multichallenge/configs/multichallenge_nrl.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "multichallenge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "multichallenge_example"
+      },
+      {
+        "name": "multichallenge_advanced"
+      },
+      {
+        "name": "multichallenge_vanilla"
+      },
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/newton_bench",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Scientific law discovery tasks through agentic experimentation across 12 physics domains",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/newton_bench/configs/newton_bench.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "newton_bench"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/ns_tools",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "NeMo Skills tool execution with math verification",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/ns_tools/configs/ns_tools.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "ns_tools"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/nvarc/inductive",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "ARC-AGI inductive mode: model outputs Python code with transform()",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/nvarc/configs/inductive.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "nvarc"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/nvarc/transductive",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "ARC-AGI transductive mode: model outputs grid directly",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/nvarc/configs/transductive.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "nvarc"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/omniscience",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Omniscience factual knowledge QA with LLM judge verification",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/omniscience/configs/omniscience.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "omniscience"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/openenv/openenv_coding",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "coding",
+    "description": "Python code execution environment via OpenEnv. Executes code and returns stdout/stderr.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/openenv/configs/openenv_coding.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "openenv"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/openenv/openenv_echo",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Echo environment via OpenEnv (MCP). Echoes messages back with length-based rewards.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/openenv/configs/openenv_echo.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "openenv"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/openenv/openenv_maze",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "games",
+    "description": "Maze navigation environment via OpenEnv. Agent navigates an 8x8 grid to find the exit.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/openenv/configs/openenv_maze.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "openenv"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/over_refusal_detection",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "safety",
+    "description": "Over-refusal detection based on XSTest - trains models to respond helpfully to safe prompts",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/over_refusal_detection/configs/over_refusal_detection.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "over_refusal_detection"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/physics_judge",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Physics QA verified by NeMo Skills' physics judge LLM with math-verify symbolic fallback",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/physics_judge/configs/physics_judge.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "physics_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/polymath",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "PolyMath multilingual math benchmark with weighted (difficulty) and per-language metrics",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/polymath/configs/polymath.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "polymath"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/proof_genselect",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Pairwise proof selection with binary correctness reward",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/proof_genselect/configs/proof_genselect.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "proof_genselect"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/proof_judge",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Theorem proving with verifier + meta-verifier judge (combined env)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/proof_judge/configs/proof_judge.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "proof_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/proof_verification",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "math",
+    "description": "Proof verification scored against ground truth and meta-verifier agreement",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/proof_verification/configs/proof_verification.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "proof_verification"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/ragtruth",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "RAGTruth case-level hallucination detection; reward = 1 when the model's binary \"any hallucination?\" verdict matches the gold label.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/ragtruth/configs/ragtruth.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "ragtruth"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "test_qa"
+      },
+      {
+        "name": "test_summary"
+      },
+      {
+        "name": "test_data2txt"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/reasoning_gym/orchestrator_agent",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "LangGraph orchestrator agent compatible with resource servers that do not use tools; enables diverse agent training data and test time scaling vs a simple agent, extensible to use tools or other agent architectures",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/reasoning_gym/configs/orchestrator_agent.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "langgraph_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/reasoning_gym/parallel_thinking_agent",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "LangGraph parallel thinking agent compatible with resource servers that do not use tools; enables diverse agent training data and test time scaling vs a simple agent, extensible to use tools or other agent architectures",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/reasoning_gym/configs/parallel_thinking_agent.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "langgraph_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/reasoning_gym/reasoning_gym_claude_code_agent",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Claude Code agent harness for reasoning gym tasks",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/reasoning_gym/configs/reasoning_gym_claude_code_agent.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "claude_code_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/reasoning_gym/reasoning_gym_claude_code_agent_model_server",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Claude Code agent harness for reasoning gym tasks, via a Gym model server's /v1/messages",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/reasoning_gym/configs/reasoning_gym_claude_code_agent_model_server.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "claude_code_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/reasoning_gym/reasoning_gym_codex_agent",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Codex agent harness for reasoning gym tasks",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/reasoning_gym/configs/reasoning_gym_codex_agent.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "codex_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/reasoning_gym/reasoning_gym_codex_agent_model_server",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Codex agent harness for reasoning gym tasks, via a Gym model server's /v1/responses",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/reasoning_gym/configs/reasoning_gym_codex_agent_model_server.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "codex_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/reasoning_gym/reflection_agent",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "LangGraph reflection agent compatible with resource servers that do not use tools; provides iterative reflection for diverse agent training data and test time scaling, extensible to use tools or other agent architectures",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/reasoning_gym/configs/reflection_agent.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "langgraph_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/reasoning_gym/rewoo_agent",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "LangGraph ReWOO agent compatible with resource servers that do not use tools; enables diverse agent training data and test time scaling vs a simple agent, extensible to use tools or other agent architectures",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/reasoning_gym/configs/rewoo_agent.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "reasoning_gym"
+      ],
+      "agent_server": "langgraph_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/rolemrc",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "instruction_following",
+    "description": "RoleMRC role-play MRC scored with reference metrics (ROUGE/BLEU/METEOR/BERTScore); ROUGE-L is the reward.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/rolemrc/configs/rolemrc.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "rolemrc"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "test"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/rolemrc/rolemrc_judge",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "rlhf",
+    "description": "RoleMRC role-play MRC scored by a 5-aspect LLM-as-judge (knowledge range, style, nested/multi-turn instruction, instruction priority).",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/rolemrc/configs/rolemrc_judge.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "rolemrc"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "test"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/ruler",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/ruler/configs/ruler.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "ruler"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/scicode",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "coding",
+    "description": "Multi-step scientific code generation; sub-step solutions executed against SciCode test cases",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/scicode/configs/scicode.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "scicode"
+      ],
+      "agent_server": "scicode_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/simpleqa",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "SimpleQA short-form factual QA with 3-tier LLM judge (CORRECT / INCORRECT / NOT_ATTEMPTED)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/simpleqa/configs/simpleqa.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "simpleqa"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/single_step_tool_use_with_argument_comparison",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Conversational tool-use RL from expert trajectories; behavior cloning per step across auth, lookup, and servicing domains.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/single_step_tool_use_with_argument_comparison/configs/single_step_tool_use_with_argument_comparison.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "single_step_tool_use_with_argument_comparison"
+      ],
+      "agent_server": "tool_simulation_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/single_step_tool_use_with_argument_comparison/droid_pivot_single_step_tool_use_with_argument_comparison",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Droid agent pivot dataset; behavior cloning per step from successful Droid rollouts.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/single_step_tool_use_with_argument_comparison/configs/droid_pivot_single_step_tool_use_with_argument_comparison.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "single_step_tool_use_with_argument_comparison"
+      ],
+      "agent_server": "tool_simulation_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/single_step_tool_use_with_argument_comparison/parallel_tool_calls_single_step_tool_use_with_argument_comparison",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Parallel tool-call verification; the model must emit the expected set of tool calls in a single turn, in any order.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/single_step_tool_use_with_argument_comparison/configs/parallel_tool_calls_single_step_tool_use_with_argument_comparison.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "single_step_tool_use_with_argument_comparison"
+      ],
+      "agent_server": "tool_simulation_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/single_step_tool_use_with_argument_comparison/search_pivot_single_step_tool_use_with_argument_comparison",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "The model must output the next correct call in a given trajectory involving search tools.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/single_step_tool_use_with_argument_comparison/configs/search_pivot_single_step_tool_use_with_argument_comparison.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "single_step_tool_use_with_argument_comparison"
+      ],
+      "agent_server": "tool_simulation_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/single_step_tool_use_with_argument_comparison/swe_pivot_single_step_tool_use_with_argument_comparison",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "GitHub-issue dataset for software-engineering agents; refactored from SWE-Gym and SWE-Bench-Verified for NeMo Gym.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/single_step_tool_use_with_argument_comparison/configs/swe_pivot_single_step_tool_use_with_argument_comparison.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "single_step_tool_use_with_argument_comparison"
+      ],
+      "agent_server": "tool_simulation_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/single_step_tool_use_with_argument_comparison/toolcall_schema_single_step_tool_use_with_argument_comparison",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "General function-calling RL dataset using expert trajectories; behavior cloning to match expert tool calls per step.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/single_step_tool_use_with_argument_comparison/configs/toolcall_schema_single_step_tool_use_with_argument_comparison.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "single_step_tool_use_with_argument_comparison"
+      ],
+      "agent_server": "tool_simulation_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/speed_bench",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "Speculative-decoding throughput benchmark. Reads vLLM `/metrics` Prometheus counters before/after generation to compute acceptance length and acceptance rate.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/speed_bench/configs/speed_bench.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "speed_bench"
+      ],
+      "agent_server": "speed_bench_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/spider2_lite",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "coding",
+    "description": "Text-to-SQL with execution-based evaluation on Spider 2.0-Lite (135 SQLite tasks). Binary reward based on result-set equivalence.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/spider2_lite/configs/spider2_lite.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "spider2_lite"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "spider2_lite_sqlite_validation"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/string_match",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "General-purpose string matching verifier for free-form text answers",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/string_match/configs/string_match.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "string_match"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/structeval/structeval_nonrenderable",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "instruction_following",
+    "description": "StructEval non-renderable format verification (JSON, YAML, CSV, TOML, XML)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/structeval/configs/structeval_nonrenderable.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "structeval"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/structured_outputs/structured_outputs_json",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "instruction_following",
+    "description": "Check if responses are following structured output requirements in prompts",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/structured_outputs/configs/structured_outputs_json.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "structured_outputs"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/structured_outputs/structured_outputs_json_yaml_xml_v1",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "instruction_following",
+    "description": "Check if responses are following structured output requirements in prompts",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/structured_outputs/configs/structured_outputs_json_yaml_xml_v1.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "structured_outputs"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/structured_outputs/structured_outputs_v3",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "instruction_following",
+    "description": "Check if responses follow structured output requirements (JSON, YAML, XML, TOML, CSV). Created 20260409.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/structured_outputs/configs/structured_outputs_v3.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "structured_outputs"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/structured_outputs/structured_outputs_v4",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "instruction_following",
+    "description": "Check if responses follow tool-call structured output schemas. Created 20260424.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/structured_outputs/configs/structured_outputs_v4.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "structured_outputs"
+      ],
+      "agent_server": "non_executing_simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/swe_pivot",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "SWE pivot verifier for PivotRL on coding agent trajectories",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/swe_pivot/configs/swe_pivot.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "swe_pivot"
+      ],
+      "agent_server": "tool_simulation_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/swerl_gen",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "coding",
+    "description": "Running sandboxed evaluation for SWE-style tasks (either patch generation or reproduction test generation)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/swerl_gen/configs/swerl_gen.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "swerl_gen"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/swerl_llm_judge",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "coding",
+    "description": "SWE-style multiple-choice LLM-judge tasks scored via <solution>...</solution> choice.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/swerl_llm_judge/configs/swerl_llm_judge.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "swerl_llm_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/tales",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "games",
+    "description": "TALES text-adventure games (textworld, textworld_express, alfworld, scienceworld, jericho) in Gymnasium API style.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/tales/configs/tales.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "tales"
+      ],
+      "agent_server": "gymnasium_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/tavily_search/tavily_search_judge_vllm_model",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Model uses search tools to satisfy a user query.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/tavily_search/configs/tavily_search_judge_vllm_model.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "tavily_search"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      },
+      {
+        "name": "benchmark_browsecomp"
+      },
+      {
+        "name": "simpleqa_benchmark"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/terminal_multi_harness/terminal_multi_harness_agent006",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Agent006 harness structured-action verifier for next-step pivot RL.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/terminal_multi_harness/configs/terminal_multi_harness_agent006.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "terminal_multi_harness"
+      ],
+      "agent_server": "tool_simulation_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/terminal_multi_harness/terminal_multi_harness_codex",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Codex harness structured-action verifier for next-step pivot RL.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/terminal_multi_harness/configs/terminal_multi_harness_codex.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "terminal_multi_harness"
+      ],
+      "agent_server": "tool_simulation_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/terminal_multi_harness/terminal_multi_harness_opencode",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "OpenCode harness structured-action verifier for next-step pivot RL.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/terminal_multi_harness/configs/terminal_multi_harness_opencode.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "terminal_multi_harness"
+      ],
+      "agent_server": "tool_simulation_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/terminal_multi_harness/terminal_multi_harness_stirrup",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Stirrup harness structured-action verifier for next-step pivot RL.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/terminal_multi_harness/configs/terminal_multi_harness_stirrup.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "terminal_multi_harness"
+      ],
+      "agent_server": "tool_simulation_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/terminus_judge",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "single-step terminal based task (rubrics v4 judge prompt)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/terminus_judge/configs/terminus_judge.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "terminus_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/terminus_judge/terminus_judge_simple",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "single-step terminal based task (simple judge prompt)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/terminus_judge/configs/terminus_judge_simple.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "terminus_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/terminus_judge/terminus_judge_string_only",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "single-step terminal based task (string similarity only)",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/terminus_judge/configs/terminus_judge_string_only.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "terminus_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/text_to_sql",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "coding",
+    "description": "Text-to-SQL generation with LLM-as-a-judge equivalence checking",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/text_to_sql/configs/text_to_sql.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "text_to_sql"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/toolsandbox",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "ToolSandbox multi-turn tool-use benchmark; reward is the milestone similarity in [0, 1] (0 if a minefield is hit).",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/toolsandbox/configs/toolsandbox.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "toolsandbox"
+      ],
+      "agent_server": "toolsandbox_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "test"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/ugphysics_judge",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "knowledge",
+    "description": "Undergraduate physics QA verified by a TRUE/FALSE LLM judge with math-verify symbolic fallback",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/ugphysics_judge/configs/ugphysics_judge.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "ugphysics_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/verifif",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "instruction_following",
+    "description": "VerifIF instruction following validators with rule-based and LLM judge support",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/verifif/configs/verifif.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "verifif"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/vlm_eval_kit",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "Run all supported VLMEvalKit benchmarks.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/vlm_eval_kit/configs/vlm_eval_kit.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "vlm_eval_kit"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "MMBench_DEV_EN_V11"
+      },
+      {
+        "name": "OCRBench"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/vlm_eval_kit/MMBench_DEV_EN_V11",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/vlm_eval_kit/configs/MMBench_DEV_EN_V11.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "vlm_eval_kit"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "MMBench_DEV_EN_V11"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/vlm_eval_kit/OCRBench",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/vlm_eval_kit/configs/OCRBench.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "vlm_eval_kit"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "OCRBench"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/wmt_translation",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "other",
+    "description": "Machine-translation verifier computing corpus-level spBLEU and ChrF per language pair plus optional xCOMET-XXL neural QE via a Ray GPU actor.",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/wmt_translation/configs/wmt_translation.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "wmt_translation"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/xlam_fc",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Salesforce xlam-function-calling-60k tool calling tasks",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/xlam_fc/configs/xlam_fc.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "xlam_fc"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      },
+      {
+        "name": "train"
+      },
+      {
+        "name": "valid"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "resources_servers/xstest",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "safety",
+    "description": "XSTest safety benchmark - exaggerated safety (over-refusal) evaluation",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "resources_servers/xstest/configs/xstest.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "xstest"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "ruler",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/ruler/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "ruler"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "ruler/config_pretrain",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/ruler/config_pretrain.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "ruler_pretrain"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "scicode",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/scicode/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "scicode"
+      ],
+      "agent_server": "scicode_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "scicode"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "secque",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/secque/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "equivalence_llm_judge"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "secque"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "simpleqa",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/simpleqa/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "simpleqa"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "speed-bench/config_qualitative",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/speed-bench/config_qualitative.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "speed_bench_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "speed_bench_qualitative"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "speed-bench/config_throughput_2k",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/speed-bench/config_throughput_2k.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "speed_bench_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "speed_bench_throughput_2k"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "spider2_lite",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/spider2_lite/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "spider2_lite"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "supergpqa",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/supergpqa/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "mcqa"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "supergpqa"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "swebench/multilingual/opencode",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/swebench/multilingual/opencode.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "opencode_sandboxed_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "swebench_multilingual"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "swebench/verified/opencode",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/swebench/verified/opencode.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "opencode_sandboxed_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "swebench_verified"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "tau2/configs/banking_alltools",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/tau2/configs/banking_alltools.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "tau2",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "tau2_banking_knowledge_alltools"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "tau2/configs/banking_bm25_grep_artificial_analysis",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/tau2/configs/banking_bm25_grep_artificial_analysis.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "tau2",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "tau2_banking_knowledge_bm25_grep_artificial_analysis"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "tau2/configs/banking_terminal_use",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/tau2/configs/banking_terminal_use.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "tau2",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "tau2_banking_knowledge_terminal_use"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "tau2/configs/tau2",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/tau2/configs/tau2.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "tau2",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "tau2"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "toolsandbox",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/toolsandbox/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "toolsandbox_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "toolsandbox"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "ugphysics",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/ugphysics/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "ugphysics"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "wmt24pp",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/wmt24pp/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "wmt_translation"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "wmt24pp"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "workplace_assistant",
+    "kind": "environment",
+    "status": "no-manifest",
+    "domain": "agent",
+    "description": "Workplace assistant multi-step tool-using environment",
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "environments/workplace_assistant/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [
+        "workplace_assistant"
+      ],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "train"
+      },
+      {
+        "name": "validation"
+      },
+      {
+        "name": "example"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  },
+  {
+    "name": "xstest",
+    "kind": "benchmark",
+    "status": "no-manifest",
+    "domain": null,
+    "description": null,
+    "version": null,
+    "integration_profile": null,
+    "modality": null,
+    "licensing": null,
+    "lifecycle": null,
+    "metadata_complete": false,
+    "source": {
+      "config": "benchmarks/xstest/config.yaml",
+      "manifest": null
+    },
+    "composition": {
+      "resources_servers": [],
+      "agent_server": "simple_agent",
+      "model_server": null,
+      "rollout_driver": null,
+      "grading_mode": null
+    },
+    "authors": [],
+    "reward": null,
+    "determinism": null,
+    "datasets": [
+      {
+        "name": "xstest"
+      }
+    ],
+    "canonical_split": null,
+    "standard_prompt_config": null,
+    "session_model": null,
+    "state": null,
+    "sandbox": null,
+    "adopted_from": null
+  }
+]

--- a/catalog-prototype/lovable-prompt.md
+++ b/catalog-prototype/lovable-prompt.md
@@ -1,0 +1,27 @@
+# Lovable build prompt
+
+Build a responsive NeMo Gym Environments Hub using `catalog-prototype/catalog.json` as the only data source.
+
+Create a dark, research-oriented interface inspired by an environment registry, while using original NeMo Gym
+visual styling rather than copying Prime Intellect branding or assets. The main page should include:
+
+- tabs for All, Benchmarks, and Environments;
+- full-text search over name, description, domain, and dataset names;
+- filters for domain, modality, integration profile, licensing, lifecycle, and catalog status;
+- featured cards for the six entries where `metadata_complete` is true;
+- a compact grid for the remaining entries;
+- visible `experimental` and `no-manifest` badges, with explanatory tooltips;
+- an explicit “Metadata pending” treatment for fields absent from legacy entries;
+- responsive layouts for desktop and mobile.
+
+Each entry should open a detail route. The detail page should show description, version, source paths, authors,
+composition, datasets, reward range and direction, determinism, canonical split, standard prompt configuration,
+licensing, and lifecycle. Hide sections that have no meaningful data. Include copy buttons for these commands:
+
+```bash
+gym env validate <name> --kind <kind> --json
+gym env start --<kind> <name> --model-type vllm_model
+```
+
+Add a client-side Star action backed by local storage. Do not add authentication, a database, hosted evaluations,
+or write operations in this prototype. Treat the JSON as immutable and show a helpful empty state for every filter.

--- a/fern/versions/latest/pages/reference/cli-commands.mdx
+++ b/fern/versions/latest/pages/reference/cli-commands.mdx
@@ -170,12 +170,14 @@ List the manifest-first catalog unioned with legacy environment and benchmark co
 | `--status experimental\|no-manifest` | Filter by manifest coverage status. |
 | `--lifecycle active\|deprecated` | Filter by lifecycle. |
 | `--json` | Output catalog entries as JSON. |
+| `--full` | With `--json`, include source paths, composition, datasets, reward semantics, and full manifest metadata. |
 
 ```bash
 gym list environments
 gym list environments calendar        # inspect one environment
 gym list environments --kind benchmark --domain math
 gym list environments --json | jq '.[].name'
+gym list environments --kind benchmark --json --full > catalog.json
 ```
 
 ### `gym list agents`

--- a/nemo_gym/cli/env.py
+++ b/nemo_gym/cli/env.py
@@ -48,7 +48,7 @@ from nemo_gym.cli.utils import (
     render_component_inspection,
 )
 from nemo_gym.config_types import BaseNeMoGymCLIConfig, ConfigError
-from nemo_gym.environment.manifest import EnvironmentKind, IntegrationProfile
+from nemo_gym.environment.manifest import EnvironmentKind, IntegrationProfile, load_manifest
 from nemo_gym.environment.onboarding import (
     EnvironmentOnboardingError,
     VerifierReport,
@@ -1414,8 +1414,15 @@ def _inspect_environment(
     )
 
 
-def _catalog_payload(entry: EnvironmentCatalogEntry) -> Dict[str, object]:
-    return {
+def _catalog_source_path(path: Path) -> str:
+    for index, part in enumerate(path.parts):
+        if part in {"benchmarks", "environments", "resources_servers"}:
+            return Path(*path.parts[index:]).as_posix()
+    return path.as_posix()
+
+
+def _catalog_payload(entry: EnvironmentCatalogEntry, *, full: bool = False) -> Dict[str, object]:
+    payload: Dict[str, object] = {
         "name": entry.name,
         "kind": entry.kind,
         "status": entry.status,
@@ -1427,6 +1434,61 @@ def _catalog_payload(entry: EnvironmentCatalogEntry) -> Dict[str, object]:
         "licensing": entry.licensing,
         "lifecycle": entry.lifecycle,
     }
+    if not full:
+        return payload
+
+    details = read_environment_details(entry.config_path)
+    payload["domain"] = entry.domain or details["domain"]
+    payload["description"] = entry.description or details["description"]
+    payload["metadata_complete"] = entry.manifest_path is not None
+    payload["source"] = {
+        "config": _catalog_source_path(entry.config_path),
+        "manifest": _catalog_source_path(entry.manifest_path) if entry.manifest_path is not None else None,
+    }
+
+    if entry.manifest_path is None:
+        payload.update(
+            composition={
+                "resources_servers": details["resources_servers"],
+                "agent_server": details["agent"],
+                "model_server": None,
+                "rollout_driver": None,
+                "grading_mode": None,
+            },
+            authors=[],
+            reward=None,
+            determinism=None,
+            datasets=[{"name": name} for name in details["datasets"]],
+            canonical_split=None,
+            standard_prompt_config=None,
+            session_model=None,
+            state=None,
+            sandbox=None,
+            adopted_from=None,
+        )
+        return payload
+
+    manifest = load_manifest(entry.manifest_path)
+    payload.update(
+        composition={
+            "resources_servers": [manifest.resources_server],
+            "agent_server": manifest.agent_server,
+            "model_server": manifest.model_server,
+            "rollout_driver": manifest.rollout_driver,
+            "grading_mode": manifest.grading_mode,
+        },
+        authors=list(manifest.authors),
+        reward=manifest.reward.model_dump(mode="json"),
+        determinism=manifest.determinism.value,
+        datasets=[dataset.model_dump(mode="json", exclude_none=True) for dataset in manifest.datasets],
+        canonical_split=manifest.canonical_split,
+        standard_prompt_config=manifest.standard_prompt_config,
+        session_model=manifest.session_model.value if manifest.session_model is not None else None,
+        state=manifest.state.value if manifest.state is not None else None,
+        sandbox=manifest.sandbox,
+        adopted_from=(manifest.adopted_from.model_dump(mode="json") if manifest.adopted_from is not None else None),
+    )
+    return payload
 
 
 @exit_cleanly_on_config_error
@@ -1464,7 +1526,8 @@ def list_environments() -> None:
         entries = [entry for entry in entries if getattr(entry, attribute) == expected]
 
     if global_config_dict.get(JSON_OUTPUT_KEY_NAME, False):
-        print(json.dumps([_catalog_payload(entry) for entry in entries]))
+        full = global_config_dict.get("catalog_full", False)
+        print(json.dumps([_catalog_payload(entry, full=full) for entry in entries]))
         return
 
     if not entries:

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -151,6 +151,11 @@ RESOURCES_SERVER = Flag(
 # env status). Each command reads the reserved `json` config key ad hoc via
 # global_config_dict.get(JSON_OUTPUT_KEY_NAME) (see general.py, eval.py, env.py).
 JSON = _bool_flag("json", "json", "Output as machine-readable JSON.")
+CATALOG_FULL = _bool_flag(
+    "full",
+    "catalog_full",
+    "Include source, composition, and full manifest metadata in catalog JSON output.",
+)
 
 # `gym list <type> [<name>]`: an optional component name. When given, the listing command inspects that one
 # component (surfaced as the reserved `component_name` config key) instead of listing all.
@@ -541,6 +546,7 @@ COMMANDS = {
             ),
             _value_flag("lifecycle", "lifecycle", "Filter by lifecycle.", choices=("active", "deprecated")),
             JSON,
+            CATALOG_FULL,
             SEARCH_DIR,
         ),
     ),

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -55,6 +55,7 @@ from nemo_gym.cli.env import (
 )
 from nemo_gym.cli.utils import exit_cleanly_on_config_error
 from nemo_gym.config_types import ConfigError, NoServerInstancesError, ResourcesServerInstanceConfig
+from nemo_gym.environment.manifest import dump_manifest
 from nemo_gym.environment.scaffold import ScaffoldError
 from nemo_gym.registry import EnvironmentCatalogEntry
 
@@ -819,6 +820,113 @@ class TestListEnvironments:
                 "modality": "text",
                 "licensing": "Apache-2.0",
                 "lifecycle": "active",
+            }
+        ]
+
+    def test_full_json_output_includes_manifest_and_composition_metadata(
+        self,
+        monkeypatch: MonkeyPatch,
+        capsys,
+        tmp_path: Path,
+    ) -> None:
+        benchmark_dir = tmp_path / "benchmarks" / "alpha"
+        benchmark_dir.mkdir(parents=True)
+        manifest_path = benchmark_dir / "manifest.yaml"
+        config_path = benchmark_dir / "config.yaml"
+        manifest_path.write_text(
+            dump_manifest(
+                {
+                    "name": "alpha",
+                    "version": "1.2.3",
+                    "kind": "benchmark",
+                    "integration_profile": "custom-gym-verifier",
+                    "domain": "math",
+                    "description": "Alpha benchmark",
+                    "modality": "text",
+                    "licensing": "Apache-2.0",
+                    "authors": ["NVIDIA NeMo Gym contributors"],
+                    "reward": {"range": [0, 1], "higher_is_better": True},
+                    "determinism": "seeded",
+                    "resources_server": "alpha_resources",
+                    "agent_server": "simple_agent",
+                    "model_server": "policy_model",
+                    "datasets": [
+                        {
+                            "name": "test",
+                            "type": "benchmark",
+                            "jsonl_fpath": "benchmarks/alpha/data/test.jsonl",
+                            "prepare_script": "benchmarks/alpha/prepare.py",
+                            "prompt_config": "benchmarks/alpha/prompts/default.yaml",
+                        }
+                    ],
+                    "canonical_split": "test",
+                    "standard_prompt_config": "benchmarks/alpha/prompts/default.yaml",
+                }
+            ),
+            encoding="utf-8",
+        )
+        config_path.write_text("{}\n", encoding="utf-8")
+        entry = EnvironmentCatalogEntry(
+            name="alpha",
+            config_path=config_path,
+            path=benchmark_dir,
+            description="Alpha benchmark",
+            domain="math",
+            kind="benchmark",
+            status="experimental",
+            manifest_path=manifest_path,
+            version="1.2.3",
+            integration_profile="custom-gym-verifier",
+            modality="text",
+            licensing="Apache-2.0",
+            lifecycle="active",
+        )
+        self._mock_catalog(
+            monkeypatch,
+            overrides={"json": True, "catalog_full": True},
+            entries=(entry,),
+        )
+        monkeypatch.setattr(
+            nemo_gym.cli.env,
+            "read_environment_details",
+            lambda _path: {
+                "domain": "math",
+                "description": "Alpha benchmark",
+                "value": None,
+                "resources_servers": ["alpha_resources"],
+                "agent": "simple_agent",
+                "datasets": ["test"],
+            },
+        )
+
+        list_environments()
+
+        payload = json.loads(capsys.readouterr().out)[0]
+        assert payload["metadata_complete"] is True
+        assert payload["source"] == {
+            "config": "benchmarks/alpha/config.yaml",
+            "manifest": "benchmarks/alpha/manifest.yaml",
+        }
+        assert payload["composition"] == {
+            "resources_servers": ["alpha_resources"],
+            "agent_server": "simple_agent",
+            "model_server": "policy_model",
+            "rollout_driver": None,
+            "grading_mode": None,
+        }
+        assert payload["authors"] == ["NVIDIA NeMo Gym contributors"]
+        assert payload["reward"] == {"range": [0.0, 1.0], "higher_is_better": True}
+        assert payload["determinism"] == "seeded"
+        assert payload["canonical_split"] == "test"
+        assert payload["standard_prompt_config"] == "benchmarks/alpha/prompts/default.yaml"
+        assert payload["datasets"] == [
+            {
+                "name": "test",
+                "type": "benchmark",
+                "jsonl_fpath": "benchmarks/alpha/data/test.jsonl",
+                "prepare_script": "benchmarks/alpha/prepare.py",
+                "prompt_config": "benchmarks/alpha/prompts/default.yaml",
+                "num_repeats": 1,
             }
         ]
 

--- a/tests/unit_tests/test_environment_manifest.py
+++ b/tests/unit_tests/test_environment_manifest.py
@@ -16,9 +16,19 @@ from nemo_gym.environment.manifest import (
     load_manifest,
     manifest_json_schema,
 )
+from nemo_gym.environment.validation import _mirror_differences, _resolve_manifest_composition
 
 
 REPO_ROOT = Path(__file__).parents[2]
+
+SEEDED_CATALOG_BENCHMARKS = (
+    "financebench",
+    "flores200",
+    "gpqa",
+    "gsm8k",
+    "human_eval",
+    "longbench_v2",
+)
 
 
 def _manifest(*, profile: str = "custom-gym-verifier", kind: str = "environment") -> dict:
@@ -67,6 +77,17 @@ def test_environment_manifest_parses_and_uses_declared_defaults() -> None:
     assert manifest.determinism.value == "unknown"
     assert manifest.lifecycle.value == "active"
     assert manifest.session_model is None
+
+
+@pytest.mark.parametrize("name", SEEDED_CATALOG_BENCHMARKS)
+def test_seeded_catalog_benchmark_manifest_matches_authoritative_config(name: str) -> None:
+    benchmark_dir = REPO_ROOT / "benchmarks" / name
+    manifest = load_manifest(benchmark_dir / "manifest.yaml")
+    composition = _resolve_manifest_composition(benchmark_dir / "config.yaml")
+
+    assert manifest.name == name
+    assert manifest.kind.value == "benchmark"
+    assert _mirror_differences(manifest, composition) == {}
 
 
 def test_integration_profiles_are_closed_string_values() -> None:


### PR DESCRIPTION
## Summary

Adds a manifest-backed catalog data foundation for the NeMo Gym Environments Hub prototype.

- Adds manifests for six representative benchmarks: FinanceBench, FLORES-200, GPQA, GSM8K, HumanEval, and LongBench v2.
- Adds `gym list environments --json --full` for a UI-consumable catalog payload with source paths, composition, datasets, reward semantics, and manifest metadata.
- Adds a checked-in catalog snapshot plus a Lovable-ready prototype brief.
- Documents the new CLI export and covers it with unit tests.

## Why

The existing unified catalog discovers runnable legacy configurations, but UI discovery needs structured metadata and a clear distinction between complete manifest-backed records and legacy entries whose metadata is pending.

## Validation

- `.venv/bin/pytest tests/unit_tests/test_cli.py tests/unit_tests/test_cli_main.py tests/unit_tests/test_environment_manifest.py tests/unit_tests/test_registry.py -q --tb=short -k "not test_valid_config_passes"` (306 passed, 1 deselected)
- `.venv/bin/pre-commit run --files ...`

The excluded validation test is blocked locally by an unrelated port-11000 allocation conflict.