### PR TITLE
fix: preserve unknown response usage details in responses converters

### DIFF
--- a/nemo_gym/anthropic_converter.py
+++ b/nemo_gym/anthropic_converter.py
@@ -808,10 +808,8 @@ class AnthropicConverter:
         output_tokens = usage.get("output_tokens", 0)
         return NeMoGymResponseUsage(
             input_tokens=input_tokens,
-            input_tokens_details=NeMoGymResponseInputTokensDetails(
-                cached_tokens=usage.get("cache_read_input_tokens", 0)
-            ),
+            input_tokens_details=NeMoGymResponseInputTokensDetails(cached_tokens=usage.get("cache_read_input_tokens")),
             output_tokens=output_tokens,
-            output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=0),
+            output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=None),
             total_tokens=input_tokens + output_tokens,
         )

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -513,11 +513,11 @@ NeMoGymResponseOutputItem = Annotated[
 
 
 class NeMoGymResponseInputTokensDetails(ResponseInputTokensDetails):
-    pass
+    cached_tokens: Optional[int]
 
 
 class NeMoGymResponseOutputTokensDetails(ResponseOutputTokensDetails):
-    pass
+    reasoning_tokens: Optional[int]
 
 
 class NeMoGymResponseUsage(ResponseUsage):
@@ -535,12 +535,25 @@ class NeMoGymResponseUsage(ResponseUsage):
         )
         for usage in usages:
             final_usage.input_tokens += usage.input_tokens
-            final_usage.input_tokens_details.cached_tokens += usage.input_tokens_details.cached_tokens
+            final_usage.input_tokens_details.cached_tokens = _add_optional_token_counts(
+                final_usage.input_tokens_details.cached_tokens,
+                usage.input_tokens_details.cached_tokens,
+            )
             final_usage.output_tokens += usage.output_tokens
-            final_usage.output_tokens_details.reasoning_tokens += usage.output_tokens_details.reasoning_tokens
+            final_usage.output_tokens_details.reasoning_tokens = _add_optional_token_counts(
+                final_usage.output_tokens_details.reasoning_tokens,
+                usage.output_tokens_details.reasoning_tokens,
+            )
             final_usage.total_tokens += usage.total_tokens
 
         return final_usage
+
+
+def _add_optional_token_counts(left: Optional[int], right: Optional[int]) -> Optional[int]:
+    """Add reported token counts without turning an unknown count into a measurement."""
+    if left is None or right is None:
+        return None
+    return left + right
 
 
 def accumulate_response_usage(
@@ -557,9 +570,15 @@ def accumulate_response_usage(
     result.output_tokens += additional.output_tokens
     result.total_tokens += additional.total_tokens
     if result.input_tokens_details is not None and additional.input_tokens_details is not None:
-        result.input_tokens_details.cached_tokens += additional.input_tokens_details.cached_tokens
+        result.input_tokens_details.cached_tokens = _add_optional_token_counts(
+            result.input_tokens_details.cached_tokens,
+            additional.input_tokens_details.cached_tokens,
+        )
     if result.output_tokens_details is not None and additional.output_tokens_details is not None:
-        result.output_tokens_details.reasoning_tokens += additional.output_tokens_details.reasoning_tokens
+        result.output_tokens_details.reasoning_tokens = _add_optional_token_counts(
+            result.output_tokens_details.reasoning_tokens,
+            additional.output_tokens_details.reasoning_tokens,
+        )
     return result
 
 

--- a/nemo_gym/responses_converter.py
+++ b/nemo_gym/responses_converter.py
@@ -75,7 +75,7 @@ def _optional_token_count(value: Any) -> Optional[int]:
 
 def _usage_detail(usage: Any, detail_group: str, detail_name: str, *top_level_aliases: str) -> Optional[int]:
     """Read one canonical nested token detail, then named provider aliases."""
-    details = getattr(usage, detail_group, None)
+    details = usage.get(detail_group) if isinstance(usage, dict) else getattr(usage, detail_group, None)
     value = details.get(detail_name) if isinstance(details, dict) else getattr(details, detail_name, None)
     value = _optional_token_count(value)
     if value is not None:
@@ -600,12 +600,10 @@ class ResponsesConverter(BaseModel):
             usage = NeMoGymResponseUsage(
                 input_tokens=chat_completion.usage.prompt_tokens,
                 input_tokens_details=NeMoGymResponseInputTokensDetails(
-                    cached_tokens=cached_tokens if cached_tokens is not None else 0,
+                    cached_tokens=cached_tokens,
                 ),
                 output_tokens=chat_completion.usage.completion_tokens,
-                output_tokens_details=NeMoGymResponseOutputTokensDetails(
-                    reasoning_tokens=reasoning_tokens if reasoning_tokens is not None else 0
-                ),
+                output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=reasoning_tokens),
                 # Provider totals can use accounting that differs from prompt + completion.
                 total_tokens=chat_completion.usage.total_tokens,
             )

--- a/responses_api_models/inference_provider/tests/test_app.py
+++ b/responses_api_models/inference_provider/tests/test_app.py
@@ -487,6 +487,35 @@ class TestResponses:
         assert data["usage"]["input_tokens_details"]["cached_tokens"] == 4
         assert data["usage"]["output_tokens_details"]["reasoning_tokens"] == 2
 
+    async def test_responses_preserve_unknown_usage_details(self, monkeypatch: MonkeyPatch, tmp_path) -> None:
+        server = _make_server()
+        server.server_client.global_config_dict = {
+            "observability_enabled": True,
+            "model_call_capture_dir": str(tmp_path),
+        }
+        app = server.setup_webserver()
+        client = TestClient(app)
+
+        mock_data = _mock_chat_response(content="Hi!")
+        mock_data["usage"] = {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        }
+
+        server._client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        server._client.create_chat_completion = AsyncMock(return_value=mock_data)
+
+        response = client.post("/ng-rollout/0-0/v1/responses", json={"input": "hello"})
+        data = response.json()
+
+        assert data["usage"]["input_tokens_details"]["cached_tokens"] is None
+        assert data["usage"]["output_tokens_details"]["reasoning_tokens"] is None
+        [record] = read_model_call_records(CaptureStore(tmp_path), "0-0")
+        assert record.cache_hit is None
+        assert record.cached_tokens is None
+        assert record.tokens_reasoning is None
+
     async def test_responses_incomplete_max_tokens(self, monkeypatch: MonkeyPatch) -> None:
         server = _make_server()
         app = server.setup_webserver()

--- a/responses_api_models/litellm_model/app.py
+++ b/responses_api_models/litellm_model/app.py
@@ -26,7 +26,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
 )
-from nemo_gym.responses_converter import VLLMConverter
+from nemo_gym.responses_converter import VLLMConverter, _usage_detail
 from nemo_gym.server_utils import request
 from responses_api_models.openai_model.app import SimpleModelServer, SimpleModelServerConfig
 
@@ -72,6 +72,19 @@ def _normalize_to_response(data: Dict[str, Any]) -> Dict[str, Any]:
     input_tokens = usage.get("input_tokens", 0) or usage.get("prompt_tokens", 0)
     output_tokens = usage.get("output_tokens", 0) or usage.get("completion_tokens", 0)
     total_tokens = usage.get("total_tokens", 0) or (input_tokens + output_tokens)
+    cached_tokens = _usage_detail(
+        usage,
+        "prompt_tokens_details",
+        "cached_tokens",
+        "cached_input_tokens",
+        "cache_read_input_tokens",
+    )
+    reasoning_tokens = _usage_detail(
+        usage,
+        "completion_tokens_details",
+        "reasoning_tokens",
+        "reasoning_output_tokens",
+    )
 
     output = data.get("output")
     if not isinstance(output, list) or not output:
@@ -111,8 +124,8 @@ def _normalize_to_response(data: Dict[str, Any]) -> Dict[str, Any]:
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
             "total_tokens": total_tokens,
-            "input_tokens_details": {"cached_tokens": 0},
-            "output_tokens_details": {"reasoning_tokens": 0},
+            "input_tokens_details": {"cached_tokens": cached_tokens},
+            "output_tokens_details": {"reasoning_tokens": reasoning_tokens},
         },
     }
 

--- a/responses_api_models/litellm_model/tests/test_app.py
+++ b/responses_api_models/litellm_model/tests/test_app.py
@@ -159,6 +159,18 @@ class TestNormalizeToResponse:
         assert result["output"][0]["content"][0]["text"] == "Hi from Opus!"
         assert result["usage"]["input_tokens"] == 10
         assert result["usage"]["output_tokens"] == 5
+        assert result["usage"]["input_tokens_details"]["cached_tokens"] is None
+        assert result["usage"]["output_tokens_details"]["reasoning_tokens"] is None
+
+    def test_chat_completion_usage_details_preserved(self) -> None:
+        data = deepcopy(CHAT_COMPLETION_RESPONSE)
+        data["usage"]["prompt_tokens_details"] = {"cached_tokens": 4}
+        data["usage"]["completion_tokens_details"] = {"reasoning_tokens": 2}
+
+        result = _normalize_to_response(data)
+
+        assert result["usage"]["input_tokens_details"]["cached_tokens"] == 4
+        assert result["usage"]["output_tokens_details"]["reasoning_tokens"] == 2
 
     def test_hybrid_format_normalization(self) -> None:
         """chat.completion with output[] (LiteLLM hybrid) is normalized."""

--- a/tests/unit_tests/test_anthropic_converter_egress.py
+++ b/tests/unit_tests/test_anthropic_converter_egress.py
@@ -188,6 +188,25 @@ class TestAnthropicConverter:
         assert response.usage.total_tokens == 30
         assert response.usage.input_tokens_details.cached_tokens == 3
 
+    def test_anthropic_to_responses_preserves_unknown_usage_details(self) -> None:
+        response = AnthropicConverter().anthropic_to_responses(
+            anthropic_response={
+                "id": "msg_123",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-20250514",
+                "content": [{"type": "text", "text": "Hello."}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 10, "output_tokens": 2},
+            },
+            request_body=NeMoGymResponseCreateParamsNonStreaming(input="hello"),
+            model="claude-sonnet-4-20250514",
+        )
+
+        assert response.usage is not None
+        assert response.usage.input_tokens_details.cached_tokens is None
+        assert response.usage.output_tokens_details.reasoning_tokens is None
+
     def test_anthropic_to_responses_maps_stop_reasons_to_incomplete_details(self) -> None:
         converter = AnthropicConverter()
         request_body = NeMoGymResponseCreateParamsNonStreaming(input="hello")

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -505,7 +505,7 @@ class TestRoutedExpertsWireFormats:
             TokenIDLogProbMixin.model_validate({**self._BASE, "routed_experts": 42})
 
 
-def _usage(*, cached_tokens: int, reasoning_tokens: int) -> NeMoGymResponseUsage:
+def _usage(*, cached_tokens: int | None, reasoning_tokens: int | None) -> NeMoGymResponseUsage:
     return NeMoGymResponseUsage(
         input_tokens=10,
         input_tokens_details=NeMoGymResponseInputTokensDetails(cached_tokens=cached_tokens),
@@ -526,6 +526,21 @@ def test_accumulate_response_usage_preserves_all_counts_and_missing_values() -> 
     assert (result.input_tokens_details.cached_tokens, result.output_tokens_details.reasoning_tokens) == (7, 5)
     assert first.input_tokens_details.cached_tokens == 0
     assert accumulate_response_usage(result, None) == result
+
+
+def test_accumulate_response_usage_keeps_unknown_details_unknown() -> None:
+    known = _usage(cached_tokens=7, reasoning_tokens=4)
+    unknown = _usage(cached_tokens=None, reasoning_tokens=None)
+
+    forward = accumulate_response_usage(known, unknown)
+    reverse = accumulate_response_usage(unknown, known)
+
+    assert forward is not None
+    assert reverse is not None
+    assert forward.input_tokens_details.cached_tokens is None
+    assert forward.output_tokens_details.reasoning_tokens is None
+    assert reverse.input_tokens_details.cached_tokens is None
+    assert reverse.output_tokens_details.reasoning_tokens is None
 
 
 def test_accumulate_response_usage_tolerates_missing_detail_objects() -> None:

--- a/tests/unit_tests/test_responses_converter.py
+++ b/tests/unit_tests/test_responses_converter.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 import pytest
 from openai.types.completion_usage import CompletionTokensDetails, CompletionUsage, PromptTokensDetails
 
+from nemo_gym.base_responses_api_model import _cache_signal
 from nemo_gym.openai_utils import (
     NeMoGymChatCompletion,
     NeMoGymChatCompletionCreateParamsNonStreaming,
@@ -83,6 +84,15 @@ def test_usage_detail_ignores_ambiguous_top_level_names():
     usage = {"cached_tokens": 99, "cached_input_tokens": 7, "reasoning_tokens": 88, "reasoning_output_tokens": 3}
     assert _usage_detail(usage, "prompt_tokens_details", "cached_tokens", "cached_input_tokens") == 7
     assert _usage_detail(usage, "completion_tokens_details", "reasoning_tokens", "reasoning_output_tokens") == 3
+
+
+def test_usage_detail_prefers_nested_details_in_mappings():
+    usage = {
+        "prompt_tokens_details": {"cached_tokens": 5},
+        "cached_input_tokens": 7,
+    }
+
+    assert _usage_detail(usage, "prompt_tokens_details", "cached_tokens", "cached_input_tokens") == 5
 
 
 # ===========================================================================
@@ -864,6 +874,31 @@ def test_chat_completion_to_response_sanity(converter: ResponsesConverter, finis
     )
 
     assert expected_response == actual_response
+
+
+def test_chat_completion_to_response_preserves_unknown_usage_details(converter: ResponsesConverter):
+    response = converter.chat_completion_to_response(
+        responses_create_params=NeMoGymResponseCreateParamsNonStreaming(model="", input="hello"),
+        chat_completion=NeMoGymChatCompletion(
+            id="",
+            created=0,
+            model="",
+            object="chat.completion",
+            choices=[
+                NeMoGymChoice(
+                    index=0,
+                    finish_reason="stop",
+                    message=NeMoGymChatCompletionMessage(role="assistant", content="hi"),
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=11, completion_tokens=5, total_tokens=16),
+        ),
+    )
+
+    assert response.usage is not None
+    assert response.usage.input_tokens_details.cached_tokens is None
+    assert response.usage.output_tokens_details.reasoning_tokens is None
+    assert _cache_signal(response.usage.model_dump()) == (None, None)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Preserve absent cache and reasoning token details as `null` instead of converting them to measured zeroes.
- Propagate provider-reported usage details through Chat Completions conversion, Anthropic conversion, and LiteLLM normalization.
- Keep aggregated detail counts unknown when any contributing count is unknown, preventing observability from reporting fabricated cache misses.