### PR TITLE
[GDPVal] Harden production rollout and judging paths

### DIFF
--- a/benchmarks/gdpval/README.md
+++ b/benchmarks/gdpval/README.md
@@ -284,6 +284,15 @@ model ids with the `JUDGE_GPT_MODEL`, `JUDGE_GEMINI_MODEL`, and
   eval-perspective win/loss/tie/trial counts per member), and each matchup's
   `trial_judges`.
 
+For final/reportable ELO runs, enable `strict_comparison_trials`. The resources
+server then rejects a comparison row unless every planned reference matchup
+returns exactly `num_comparison_trials` valid votes, with no skipped matchup or
+invalid verdict. The option defaults to `false` for backward compatibility; set
+it with
+`++gdpval_resources_server.resources_servers.gdpval.strict_comparison_trials=true`.
+Rejected rows remain retryable with the normal `--resume` workflow instead of
+silently contributing fewer votes to the ELO fit.
+
 ### Reproducibility
 
 Judge selection is seeded from a stable identity so a rerun of the same task

--- a/benchmarks/gdpval/README.md
+++ b/benchmarks/gdpval/README.md
@@ -69,12 +69,13 @@ the deliverable files (the same layout the Stirrup agent persists).
 Multi-stage ELO estimates the eval model's rating in a sequence of *stages*
 instead of judging every task against every reference. Each stage samples `T`
 tasks (`T` is configurable per stage and **defaults to the full task set** — all
-220 GDPVal tasks) and assigns **each task a single reference model** drawn
-uniformly at random (every included reference weighted equally) from the stage's
-adaptively-chosen set of references. It then fits an anchored Bradley-Terry MLE
-ELO — pooling each reference's win/loss/tie counts over the tasks assigned to it
-— and uses that estimate to pick the references for the next stage (typically
-narrowing to fewer references closest to the estimate, and growing `T`, so each
+220 GDPVal tasks) and assigns **each task a single reference model** from the
+stage's adaptively-chosen set. The default is an independent uniform draw;
+partial-completion stages use a seeded balanced assignment so every selected
+reference gets nearly the same number of planned tasks. It then fits an anchored
+Bradley-Terry MLE ELO — pooling each reference's win/loss/tie counts over the
+tasks assigned to it — and uses that estimate to pick the references for the
+next stage (typically narrowing to fewer references closest to the estimate, and growing `T`, so each
 reference gets a larger share of tasks as the estimate sharpens). Within each
 judged comparison a panel judge is still sampled per trial with equal
 probability. It runs through the **same** `gym eval run` pipeline and emits the
@@ -136,6 +137,35 @@ the full task budget on those instead of distant references like
 `num_tasks` is optional per stage; omit it to judge the full task distribution
 (the default). Every task is still compared against a single sampled reference.
 
+### Accepting partial calibration after timeouts
+
+Calibration stages retry incomplete work by default. To advance after a bounded
+number of persisted task timeouts, opt in on that non-final stage and set both
+overall and per-reference evidence floors:
+
+```bash
+++multistage.stages='[{num_tasks: 45, partial_completion: {min_success_fraction: 0.9, min_per_reference_success_fraction: 0.5, min_successful_rows_per_reference: 1}}, {num_tasks: 220, num_models: 4}]'
+```
+
+This example requires at least 90% of all planned calibration rows, at least 50%
+of each selected reference's assigned rows, and at least one judged row for every
+selected reference. The ELO fit must be finite and include every selected
+reference. Only a latest persisted `timeout_exceeded` failure can waive a row
+that would otherwise be retried; an undispatched, drained/no-persist, or other
+retryable row keeps the stage open. Terminal and max-attempt omissions still
+count against every coverage floor.
+
+For a freshly planned policy-enabled stage, task-to-reference assignments are
+balanced before dispatch. When the policy is added while resuming an existing
+strict run, the recorded assignment remains authoritative so the successful
+rows are reused exactly as collected.
+
+Partial completion is deliberately unavailable on the final stage. Its accepted
+row set and omitted keys are frozen in the stage journal, so resume cannot absorb
+late rows and silently change downstream reference selection. Enabling this
+policy while resuming an incomplete stage reuses its successful rollout evidence
+instead of invalidating the rollout cache.
+
 ### Fresh vs. cached deliverables
 
 - **Fresh** (generate deliverables): nothing extra. The agent persists each
@@ -178,7 +208,7 @@ full run:
 
 | Key | Default | Meaning |
 |-----|---------|---------|
-| `stages` | *(required)* | List of `{num_tasks?, num_models?, seed?}` (or `"[num_tasks]:[num_models]:seed"` strings). `num_tasks` omitted ⇒ full task set; `num_models` omitted ⇒ all references. |
+| `stages` | *(required)* | List of `{num_tasks?, num_models?, seed?, partial_completion?}` (or `"[num_tasks]:[num_models]:seed"` strings). `num_tasks` omitted ⇒ full task set; `num_models` omitted ⇒ all references. `partial_completion` is an opt-in non-final calibration policy with overall/per-reference success floors. |
 | `column` | `[occupation]` | Dataset column(s) the task sample is drawn proportionally over. |
 | `distribution_path` | *(auto)* | Reuse/write the task-distribution JSON here; built from the dataset when absent. |
 | `dataset_path` | *(prepared dataset)* | Dataset the distribution is built from. |
@@ -188,18 +218,35 @@ full run:
 
 ### Resuming an interrupted multi-stage run
 
-Set `RERUN_INCOMPLETE=true` (with the same `PERSIST_DELIVERABLES_DIR` as the
-original run) to resume a staged run that was cut short. A task whose deliverable
-already **finished** on disk (marked by `finish_params.json`) skips the policy
-rollout and is judged from cache; a task that never finished is re-rolled. On top
-of that, `rerun_incomplete` reuses **cached judgements**: the verify cache is keyed
-by each task's assigned reference, so a resumed stage that reassigns the same
-reference to a task returns its cached judgement instead of re-judging. Each
-stage's sampled tasks and per-task reference assignment are recorded in the stage
-journal (and re-derived deterministically from the stage seed when a recorded
-plan predates them), so they replay identically on resume; use the same
-`multistage.seed` so a fresh re-plan of any not-yet-started stage draws the same
-tasks and assignment. See
+Use the same output path and original run arguments and pass `--resume` to reuse
+the rollout file, failure sidecar, and multi-stage journal. Add the
+`partial_completion` policy shown below when recovering a strict calibration
+stage that ended with bounded timeouts:
+
+```bash
+gym eval run \
+    --resume \
+    --model-type vllm_model --benchmark gdpval --split benchmark \
+    --output results/gdpval_multistage.jsonl \
+    ++gdpval_resources_server.resources_servers.gdpval.reward_mode=comparison \
+    ++multistage.enabled=true \
+    ++multistage.stages='[{num_tasks: 45, partial_completion: {min_success_fraction: 0.9, min_per_reference_success_fraction: 0.5, min_successful_rows_per_reference: 1}}, {num_tasks: 220, num_models: 4}]'
+```
+
+Add `RERUN_INCOMPLETE=true` with the same `PERSIST_DELIVERABLES_DIR` when an
+unfinished task must resume or reuse its policy deliverable. A task whose
+deliverable already **finished** on disk (marked by `finish_params.json`) skips
+the policy rollout and is judged from cache; a task that never finished is
+re-rolled. `rerun_incomplete` also reuses **cached judgements** keyed by the
+task's assigned reference. Each stage's sampled tasks and per-task reference
+assignment are recorded in the stage journal (and re-derived deterministically
+from the stage seed for older plans), so they replay identically on resume. Use
+the same `multistage.seed` so an unplanned stage draws the same tasks.
+
+After a stage has been accepted as partial, its policy, included evidence, and
+omitted keys are frozen. Changing or removing that policy on `--resume` fails
+closed; start a fresh output path if you intentionally want a different
+calibration decision. See
 [Task Re-run Mode](../../responses_api_agents/stirrup_agent/README.md#task-re-run-mode)
 for the full semantics.
 

--- a/nemo_gym/deliverables.py
+++ b/nemo_gym/deliverables.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared classification for agent-produced deliverable artifacts."""
+
+from pathlib import Path
+
+
+# Run state may live beside the agent's output, but must never be graded or
+# treated as a reusable deliverable.
+IGNORE_FILES = frozenset(
+    {
+        "finish_params.json",
+        "history.json",
+        "history.pkl",
+        "inprogress_history.json",
+        "metadata.json",
+        "log.txt",
+        "reference_files",
+    }
+)
+
+
+def is_deliverable(path: Path) -> bool:
+    """Return whether *path* is an agent-produced output artifact."""
+    return path.is_file() and path.name not in IGNORE_FILES

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -270,6 +270,12 @@ def _is_terminal_failure(record: Dict[str, Any]) -> bool:
     failure_class = record.get(NG_FAILURE_CLASS_KEY)
     if failure_class == "timeout_exceeded":
         return False
+    if failure_class in ("reference_missing", "eval_missing", "transport_ineligible"):
+        # Environment faults: the deliverable tree can be repaired after the
+        # run (remounted reference view, restored eval dir). Terminal within a
+        # run, but re-validated on resume; the /verify recheck is cheap and the
+        # normal max-attempt cap still bounds re-dispatch.
+        return False
     if failure_class == "skipped":
         return True
     return bool(record.get(NG_TERMINAL_KEY))

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -282,8 +282,9 @@ def _migrate_invalid_judge_main_rows(output_fpath: Path) -> int:
 
     Old builds persisted ``invalid_judge_response=True`` as a zero-reward main
     success, which both contaminated aggregation and gated resume. Sidecar-first
-    migration is idempotent via a marker keyed by stage/task/rollout; the main
-    file is then atomically rewritten so a crash cannot lose retry state.
+    migration is idempotent via a marker keyed by
+    stage/task/rollout/attempt; the main file is then atomically rewritten so
+    a crash cannot lose retry state.
     """
     if not output_fpath.exists():
         return 0
@@ -299,16 +300,22 @@ def _migrate_invalid_judge_main_rows(output_fpath: Path) -> int:
     if not invalid_count:
         return 0
 
-    def migration_key(row: Mapping[str, Any]) -> Tuple[Any, Any, Any]:
+    def migration_key(row: Mapping[str, Any]) -> Tuple[Any, Any, Any, Any]:
         return (
             int(row.get("stage_index", 0) or 0),
             row.get(TASK_INDEX_KEY_NAME),
             row.get(ROLLOUT_INDEX_KEY_NAME),
+            int(row.get(ATTEMPT_INDEX_KEY_NAME, 0) or 0),
         )
+
+    # Keep this dependency local to the legacy GDPVal migration path. Importing
+    # a responses API agent from the core rollout module at import time creates
+    # an unnecessary core/agent dependency for every Gym command.
+    from responses_api_agents.stirrup_agent.file_reader import is_deliverable
 
     failures_fpath = failures_path_for(output_fpath)
     failures_fpath.parent.mkdir(parents=True, exist_ok=True)
-    already_migrated: set[Tuple[Any, Any, Any]] = set()
+    already_migrated: set[Tuple[Any, Any, Any, Any]] = set()
     if failures_fpath.exists():
         with failures_fpath.open("rb") as handle:
             for line in handle:
@@ -348,7 +355,9 @@ def _migrate_invalid_judge_main_rows(output_fpath: Path) -> int:
                 deliverables_dir = migrated.get("deliverables_dir")
                 try:
                     has_cached_deliverable = bool(
-                        deliverables_dir and Path(deliverables_dir).is_dir() and any(Path(deliverables_dir).iterdir())
+                        deliverables_dir
+                        and Path(deliverables_dir).is_dir()
+                        and any(is_deliverable(path) for path in Path(deliverables_dir).iterdir())
                     )
                 except (OSError, TypeError):
                     has_cached_deliverable = False

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -16,6 +16,7 @@ import asyncio
 import glob as glob_module
 import json
 import os
+import tempfile
 import time
 import warnings
 from asyncio import Future, Semaphore
@@ -24,7 +25,7 @@ from contextlib import nullcontext
 from copy import deepcopy
 from itertools import repeat
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Literal, Mapping, Optional, Tuple, Union
 
 import orjson
 from omegaconf import OmegaConf
@@ -122,7 +123,9 @@ def _get_max_rollout_attempts() -> int:
 class SharedRolloutCollectionConfig(BaseNeMoGymCLIConfig):
     output_jsonl_fpath: str = Field(description="The output data jsonl file path.")
     num_samples_in_parallel: Optional[int] = Field(
-        default=None, description="Limit the number of concurrent samples running at once."
+        default=None,
+        gt=0,
+        description="Limit the number of concurrent samples running at once. Must be positive when set.",
     )
     responses_create_params: Dict[str, Any] = Field(
         default_factory=dict,
@@ -220,16 +223,17 @@ class DispatchLatencyTracker:
 
     def summary(self) -> str:
         if not self._durations:
-            return "No completed rollouts to report latency for."
-        total = sum(self._durations)
-        lines = [
-            f"Per-task latency over {len(self._durations)} completed rollout(s): "
-            f"median {self.quantile(0.5) / 60:.1f} min, "
-            f"p90 {self.quantile(0.9) / 60:.1f} min, "
-            f"p99 {self.quantile(0.99) / 60:.1f} min, "
-            f"max {max(self._durations) / 60:.1f} min",
-            f"Task-time delivered: {total / 3600:.1f} task-hours",
-        ]
+            lines = ["No completed rollouts to report latency for."]
+        else:
+            total = sum(self._durations)
+            lines = [
+                f"Per-task latency over {len(self._durations)} completed rollout(s): "
+                f"median {self.quantile(0.5) / 60:.1f} min, "
+                f"p90 {self.quantile(0.9) / 60:.1f} min, "
+                f"p99 {self.quantile(0.99) / 60:.1f} min, "
+                f"max {max(self._durations) / 60:.1f} min",
+                f"Task-time delivered: {total / 3600:.1f} task-hours",
+            ]
         if self._drained:
             lines.append(
                 f"Drained (not dispatched, no time left in the budget): {self._drained}. "
@@ -252,6 +256,123 @@ def _observed_elapsed(record: Dict[str, Any]) -> Optional[float]:
         except (TypeError, ValueError):
             continue
     return None
+
+
+def _is_terminal_failure(record: Dict[str, Any]) -> bool:
+    """Whether a persisted failure must be gated on resume.
+
+    Older agent builds incorrectly stamped per-attempt timeouts terminal. A
+    timeout reflects the load/remaining walltime of that attempt, so it remains
+    retryable (up to the normal max-attempt cap). A skipped sample is unusable
+    regardless of which agent version wrote the sidecar and stays terminal.
+    """
+    failure_class = record.get(NG_FAILURE_CLASS_KEY)
+    if failure_class == "timeout_exceeded":
+        return False
+    if failure_class == "skipped":
+        return True
+    return bool(record.get(NG_TERMINAL_KEY))
+
+
+_MIGRATED_INVALID_JUDGE_KEY = "_ng_migrated_invalid_judge_response"
+
+
+def _migrate_invalid_judge_main_rows(output_fpath: Path) -> int:
+    """Move legacy invalid-judge rows from the main JSONL into the sidecar.
+
+    Old builds persisted ``invalid_judge_response=True`` as a zero-reward main
+    success, which both contaminated aggregation and gated resume. Sidecar-first
+    migration is idempotent via a marker keyed by stage/task/rollout; the main
+    file is then atomically rewritten so a crash cannot lose retry state.
+    """
+    if not output_fpath.exists():
+        return 0
+
+    invalid_count = 0
+    with output_fpath.open("rb") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if orjson.loads(stripped).get("invalid_judge_response"):
+                invalid_count += 1
+    if not invalid_count:
+        return 0
+
+    def migration_key(row: Mapping[str, Any]) -> Tuple[Any, Any, Any]:
+        return (
+            int(row.get("stage_index", 0) or 0),
+            row.get(TASK_INDEX_KEY_NAME),
+            row.get(ROLLOUT_INDEX_KEY_NAME),
+        )
+
+    failures_fpath = failures_path_for(output_fpath)
+    failures_fpath.parent.mkdir(parents=True, exist_ok=True)
+    already_migrated: set[Tuple[Any, Any, Any]] = set()
+    if failures_fpath.exists():
+        with failures_fpath.open("rb") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                row = orjson.loads(stripped)
+                if row.get(_MIGRATED_INVALID_JUDGE_KEY):
+                    already_migrated.add(migration_key(row))
+
+    mode = output_fpath.stat().st_mode & 0o7777
+    temp_path: Optional[Path] = None
+    try:
+        with (
+            tempfile.NamedTemporaryFile(
+                mode="wb", dir=output_fpath.parent, prefix=f".{output_fpath.name}.migrate-", delete=False
+            ) as output_handle,
+            output_fpath.open("rb") as source,
+            failures_fpath.open("ab") as failures_handle,
+        ):
+            temp_path = Path(output_handle.name)
+            for line in source:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                legacy = orjson.loads(stripped)
+                if not legacy.get("invalid_judge_response"):
+                    output_handle.write(stripped + b"\n")
+                    continue
+
+                key = migration_key(legacy)
+                if key in already_migrated:
+                    continue
+                migrated = dict(legacy)
+                migrated[NG_FAILURE_CLASS_KEY] = migrated.get(NG_FAILURE_CLASS_KEY) or "judge_invalid"
+                migrated.pop(NG_TERMINAL_KEY, None)
+                deliverables_dir = migrated.get("deliverables_dir")
+                try:
+                    has_cached_deliverable = bool(
+                        deliverables_dir and Path(deliverables_dir).is_dir() and any(Path(deliverables_dir).iterdir())
+                    )
+                except (OSError, TypeError):
+                    has_cached_deliverable = False
+                if has_cached_deliverable:
+                    migrated["reuse_cached_deliverable"] = True
+                else:
+                    migrated.pop("reuse_cached_deliverable", None)
+                migrated[_MIGRATED_INVALID_JUDGE_KEY] = True
+                failures_handle.write(orjson.dumps(migrated) + b"\n")
+                already_migrated.add(key)
+
+            # Make every retry record durable before removing the corresponding
+            # legacy success from the main file.
+            failures_handle.flush()
+            os.fsync(failures_handle.fileno())
+            output_handle.flush()
+            os.fsync(output_handle.fileno())
+        os.chmod(temp_path, mode)
+        os.replace(temp_path, output_fpath)
+        temp_path = None
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+    return invalid_count
 
 
 def _get_max_rollout_attempts() -> int:
@@ -348,6 +469,15 @@ class RolloutCollectionConfig(SharedRolloutCollectionConfig):
             bad = {name: n for name, n in nr.items() if n < 1}
             if bad:
                 raise ValueError(f"num_repeats dict values must be >= 1, got {bad}")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_dispatch_concurrency(self) -> "RolloutCollectionConfig":
+        if self.dispatch_budget_s is not None and self.num_samples_in_parallel is None:
+            raise ValueError(
+                "dispatch_budget_s requires a finite positive num_samples_in_parallel; "
+                "unbounded dispatch can POST the entire queue before the budget is re-checked"
+            )
         return self
 
     @property
@@ -556,6 +686,7 @@ class RolloutCollectionHelper(BaseModel):
     def _load_from_cache(
         self, config: RolloutCollectionConfig
     ) -> Tuple[List[Dict], List[Dict], List[Dict], List[List[str]]]:
+        _migrate_invalid_judge_main_rows(Path(config.output_jsonl_fpath))
         with config.materialized_jsonl_fpath.open() as f:
             original_input_rows = list(map(orjson.loads, f))
         with Path(config.output_jsonl_fpath).open("rb") as f:
@@ -574,6 +705,7 @@ class RolloutCollectionHelper(BaseModel):
         attempts_by_key: Counter = Counter()
         terminal_keys: set = set()
         elapsed_by_key: Dict[Tuple, float] = {}
+        reuse_cached_keys: set[Tuple[Any, Any]] = set()
         if failures_fpath.exists():
             with failures_fpath.open("rb") as f:
                 for line in f:
@@ -585,8 +717,10 @@ class RolloutCollectionHelper(BaseModel):
                         continue
                     k = (fr[TASK_INDEX_KEY_NAME], fr[ROLLOUT_INDEX_KEY_NAME])
                     attempts_by_key[k] += 1
-                    if fr.get(NG_TERMINAL_KEY):
+                    if _is_terminal_failure(fr):
                         terminal_keys.add(k)
+                    if fr.get("reuse_cached_deliverable"):
+                        reuse_cached_keys.add(k)
                     # A failed attempt still tells us how long this task runs -
                     # the only duration signal available for a task that has not
                     # succeeded yet. Keep the longest attempt seen.
@@ -604,9 +738,15 @@ class RolloutCollectionHelper(BaseModel):
         # captured model calls are keyed separately from the prior attempt's (see
         # maybe_rollout_id_from_run_body). The first attempt (0) is left unstamped -> bare rollout id.
         for row in input_rows:
-            attempt = attempts_by_key.get(get_key(row), 0)
+            key = get_key(row)
+            attempt = attempts_by_key.get(key, 0)
             if attempt > 0:
                 row[ATTEMPT_INDEX_KEY_NAME] = attempt
+            if key in reuse_cached_keys:
+                # A failed judging attempt can still have a valid persisted
+                # policy deliverable. Preserve the sidecar's signal so resume
+                # rejudges that artifact instead of rerunning the policy.
+                row["reuse_cached_deliverable"] = True
 
         # Longest-first: known-long tasks go to the front so they get a whole
         # allocation to finish in rather than being cut off at its boundary.
@@ -632,7 +772,7 @@ class RolloutCollectionHelper(BaseModel):
 - {len(original_input_rows)} original input rows
 - {len(rows)} rows already done (in main jsonl)
 - {sum(attempts_by_key.values())} prior failure attempts ({len(attempts_by_key)} unique tasks) in sidecar
-- {len(terminal_keys)} sidecar-terminal (timeout_exceeded / skipped) → not retried
+- {len(terminal_keys)} sidecar-terminal (for example skipped) → not retried
 - {len(maxed_out)} hit max_attempts={max_attempts} → not retried
 - {len(input_rows)} rows that still need to be run"""
         )
@@ -676,6 +816,12 @@ class RolloutCollectionHelper(BaseModel):
                     f.write(orjson.dumps(row) + b"\n")
 
             output_fpath.unlink(missing_ok=True)
+            # A fresh run must not inherit retry attempts or published metrics
+            # from an older run that used the same output path.
+            failures_path_for(output_fpath).unlink(missing_ok=True)
+            output_fpath.with_stem(output_fpath.stem + "_aggregate_metrics").with_suffix(".json").unlink(
+                missing_ok=True
+            )
 
         semaphore = nullcontext()
         if config.num_samples_in_parallel:

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -41,6 +41,7 @@ from nemo_gym.base_responses_api_model import (
     model_call_capture_dirs_from_config,
 )
 from nemo_gym.config_types import BaseNeMoGymCLIConfig, BaseServerConfig, ConfigError, ConfigPathNotFoundError
+from nemo_gym.deliverables import is_deliverable
 from nemo_gym.global_config import (
     AGENT_REF_KEY_NAME,
     ATTEMPT_INDEX_KEY_NAME,
@@ -307,11 +308,6 @@ def _migrate_invalid_judge_main_rows(output_fpath: Path) -> int:
             row.get(ROLLOUT_INDEX_KEY_NAME),
             int(row.get(ATTEMPT_INDEX_KEY_NAME, 0) or 0),
         )
-
-    # Keep this dependency local to the legacy GDPVal migration path. Importing
-    # a responses API agent from the core rollout module at import time creates
-    # an unnecessary core/agent dependency for every Gym command.
-    from responses_api_agents.stirrup_agent.file_reader import is_deliverable
 
     failures_fpath = failures_path_for(output_fpath)
     failures_fpath.parent.mkdir(parents=True, exist_ok=True)

--- a/nemo_gym/rollout_reverification.py
+++ b/nemo_gym/rollout_reverification.py
@@ -41,8 +41,12 @@ from nemo_gym.path_utils import failures_path_for
 from nemo_gym.rollout_collection import (
     NG_FAILURE_CLASS_KEY,
     NG_NO_PERSIST_KEY,
-    NG_TERMINAL_KEY,
     _get_max_rollout_attempts,
+    _is_terminal_failure,
+    _migrate_invalid_judge_main_rows,
+)
+from nemo_gym.rollout_collection import (
+    NG_TERMINAL_KEY as NG_TERMINAL_KEY,
 )
 from nemo_gym.server_utils import (
     ServerClient,
@@ -55,6 +59,8 @@ from nemo_gym.server_utils import (
 
 # Todo after merging branch `edobrowolska/judge_failures_v2`: replace this by importing from judge.py
 JUDGE_FAILED_FAILURE_CLASS = "judge_failed"
+JUDGE_INVALID_FAILURE_CLASS = "judge_invalid"
+_JUDGE_FAILURE_CLASSES = {JUDGE_FAILED_FAILURE_CLASS, JUDGE_INVALID_FAILURE_CLASS}
 
 # Printed at the start of a `--judge-failed-only` run.
 _RECOVERY_TWO_SOURCES_WARNING = (
@@ -280,7 +286,7 @@ def _load_cache_keys_by_status(output_fpaths: OutputPaths) -> CacheKeysByStatus:
                     continue
                 k = (fr[TASK_INDEX_KEY_NAME], fr[ROLLOUT_INDEX_KEY_NAME])
                 attempts_by_key[k] += 1
-                if fr.get(NG_TERMINAL_KEY):
+                if _is_terminal_failure(fr):
                     terminal_keys.add(k)
 
     max_attempts = _get_max_rollout_attempts()
@@ -309,7 +315,7 @@ def summarize_cache_usage(cache: CacheKeysByStatus, all_payloads: List[Dict], fi
         f"""Resumed from cache. Found:
 - {len(all_payloads)} total rows to be re-verified
 - {len(cache.successful_keys)} rows already done (in main jsonl)
-- {len(cache.terminal_keys)} sidecar-terminal (timeout_exceeded / skipped) → not retried
+- {len(cache.terminal_keys)} sidecar-terminal (for example skipped) → not retried
 - {len(cache.maxed_out_keys)} hit max_attempts → not retried
 - {len(filtered_payloads)} rows that still need to be run"""
     )
@@ -325,7 +331,18 @@ def summarize_cache_usage(cache: CacheKeysByStatus, all_payloads: List[Dict], fi
 
 def _is_judge_failure(row: Dict[str, Any]) -> bool:
     """Whether a failures-sidecar row is a judge failure (the only recoverable class)."""
-    return row.get(NG_FAILURE_CLASS_KEY) == JUDGE_FAILED_FAILURE_CLASS
+    return row.get(NG_FAILURE_CLASS_KEY) in _JUDGE_FAILURE_CLASSES
+
+
+def _normalize_invalid_judge_result(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Route a verifier's invalid judge response through the failure sidecar."""
+    if not result.get("invalid_judge_response") or result.get(NG_FAILURE_CLASS_KEY) is not None:
+        return result
+    retryable = result.get("invalid_judge_retryable") is not False
+    result[NG_FAILURE_CLASS_KEY] = JUDGE_INVALID_FAILURE_CLASS if retryable else "permanent"
+    if not retryable:
+        result[NG_TERMINAL_KEY] = True
+    return result
 
 
 def _recovery_rollout_predicate(
@@ -343,6 +360,11 @@ def _recovery_rollout_predicate(
     seen: set[tuple[Any, Any]] = set()
 
     def predicate(row: Dict[str, Any]) -> bool:
+        if "stage_index" in row:
+            raise ConfigError(
+                "--judge-failed-only does not support multi-stage rows; "
+                "resume the multi-stage rollout collection so stage identity and adaptive references are preserved"
+            )
         if not _is_judge_failure(row):
             return False
         key = (row.get(TASK_INDEX_KEY_NAME), row.get(ROLLOUT_INDEX_KEY_NAME))
@@ -414,7 +436,14 @@ def _yield_inputs_and_rollouts_paired(
 
 
 def _build_verify_payload(pair: InputRolloutPair) -> Dict:
-    return pair.input | {"response": pair.rollout["response"]}
+    payload = pair.input | {"response": pair.rollout["response"]}
+    # File-backed verifiers need the artifact path produced by the rollout, and
+    # adaptive comparison needs the exact reference subset used for that row.
+    # Preserve only verifier inputs, not rewards or failure bookkeeping.
+    for key in ("deliverables_dir", "reference_ids"):
+        if key in pair.rollout:
+            payload[key] = pair.rollout[key]
+    return payload
 
 
 def _prepare_payloads(
@@ -698,6 +727,10 @@ class RolloutReverificationHelper(BaseModel):
 
         if config.judge_failed_only:
             print(_RECOVERY_TWO_SOURCES_WARNING)
+            # Older Gym builds persisted invalid judge responses as apparent
+            # successes. Move them sidecar-first before seeding, otherwise their
+            # keys are copied into the recovery output and skipped forever.
+            _migrate_invalid_judge_main_rows(rollouts_jsonl_fpath)
             reverify_source_fpath = failures_path_for(rollouts_jsonl_fpath)
             # Seed the successes and dedup so the re-verification doesn't judge successes again.
             skip_keys = _seed_output_with_successes(rollouts_jsonl_fpath, output_fpaths.output)
@@ -725,6 +758,8 @@ class RolloutReverificationHelper(BaseModel):
         try:
             for future in _run_verification_payloads(payloads_to_reverify, semaphore=semaphore):
                 row, result = await future
+
+                _normalize_invalid_judge_result(result)
 
                 result[TASK_INDEX_KEY_NAME] = row[TASK_INDEX_KEY_NAME]
                 result[ROLLOUT_INDEX_KEY_NAME] = row[ROLLOUT_INDEX_KEY_NAME]

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -41,7 +41,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -50,6 +50,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.config_types import AggregateMetrics, AggregateMetricsRequest, ModelServerRef
+from nemo_gym.rollout_collection import NG_FAILURE_CLASS_KEY, NG_TERMINAL_KEY
 from nemo_gym.server_utils import get_server_url
 from resources_servers.gdpval.judge_panel import (
     ResolvedJudge,
@@ -310,7 +311,20 @@ class GDPValVerifyRequest(BaseVerifyRequest):
     reference_ids: Optional[List[str]] = None
 
 
+# The reference model has no deliverable for this task, so no battle can be
+# scored. An infrastructure gap, not a model outcome. Kept here rather than in
+# nemo_gym: the harness only needs the generic terminal flag, and the class name
+# is GDPVal vocabulary.
+REFERENCE_MISSING_FAILURE_CLASS = "reference_missing"
+
+
 class GDPValVerifyResponse(GDPValVerifyRequest, BaseVerifyResponse):
+    # Underscore-prefixed harness keys (``_ng_failure_class``,
+    # ``_ng_failure_terminal``) cannot be declared as pydantic fields, and the
+    # default ``extra="ignore"`` drops them silently -- a verify response that
+    # tried to stamp a failure class was serialised without it.
+    model_config = ConfigDict(extra="allow")
+
     verify_mode: Literal["rubric", "comparison"] = "rubric"
     judge_response: Optional[Dict[str, Any]] = None
     invalid_judge_response: Optional[bool] = None
@@ -667,11 +681,24 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         if not ref_dirs_by_id:
             print(f"[gdpval] no reference deliverable for task {body.task_id}", flush=True)
+            # Not a model outcome: no reference deliverable exists, so no battle
+            # can be scored. Stamped as a terminal failure rather than returned
+            # as a zero-reward success -- a success row carrying no battle
+            # evidence is rejected outright by the non-final-stage coverage gate
+            # (_partial_stage_outcome), which no partial_completion setting can
+            # relax, so one missing reference file used to kill the whole run.
+            # Terminal because retrying cannot make the file appear; as an
+            # omission it is then governed by the stage's partial_completion
+            # fractions like any other unusable row.
             return GDPValVerifyResponse(
                 **body.model_dump(),
                 reward=0.0,
                 verify_mode="comparison",
                 judge_response={"error": "reference_missing"},
+                **{
+                    NG_FAILURE_CLASS_KEY: REFERENCE_MISSING_FAILURE_CLASS,
+                    NG_TERMINAL_KEY: True,
+                },
             )
 
         if eval_task_dir is None or not task_attempted(str(eval_task_dir)):

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -176,6 +176,26 @@ class JudgePanelMember(BaseModel):
     handles_video: bool = False
 
 
+def _strict_comparison_trial_failure(
+    *,
+    attempted_matchups: int,
+    num_trials: int,
+    total_judged: int,
+    total_invalid: int,
+    ref_errors: Dict[str, List[str]],
+) -> Optional[str]:
+    """Describe an incomplete strict comparison result, or return ``None``."""
+
+    expected_judged = num_trials * attempted_matchups
+    if attempted_matchups <= 0 or ref_errors or total_invalid != 0 or total_judged != expected_judged:
+        return (
+            f"matchups={attempted_matchups} judged={total_judged}/{expected_judged} "
+            f"invalid={total_invalid} "
+            f"reference_errors={sum(len(errors) for errors in ref_errors.values())}"
+        )
+    return None
+
+
 class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     reward_mode: Literal["rubric", "comparison"] = "rubric"
 
@@ -201,6 +221,12 @@ class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     # Pairwise judge trials per task. 4 is the historical default; alternates
     # swap/no-swap to debias position effects.
     num_comparison_trials: int = 4
+
+    # Fail the whole verify request unless every planned comparison trial
+    # produced a valid vote. This keeps incomplete panel responses out of
+    # Stirrup's resume cache and prevents a later multistage plan from being
+    # selected from fewer votes than the configured scientific contract.
+    strict_comparison_trials: bool = False
 
     # ELO assigned to the (legacy single) reference model in pairwise mode.
     # Ignored when ``reference_models`` is set (each carries its own ``elo``).
@@ -681,6 +707,10 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         if not ref_dirs_by_id:
             print(f"[gdpval] no reference deliverable for task {body.task_id}", flush=True)
+            if self.config.strict_comparison_trials:
+                raise RuntimeError(
+                    f"strict comparison trial contract failed for task {body.task_id}: reference_missing"
+                )
             # Not a model outcome: no reference deliverable exists, so no battle
             # can be scored. Stamped as a terminal failure rather than returned
             # as a zero-reward success -- a success row carrying no battle
@@ -703,6 +733,8 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         if eval_task_dir is None or not task_attempted(str(eval_task_dir)):
             print(f"[gdpval] eval deliverable missing for task {body.task_id}", flush=True)
+            if self.config.strict_comparison_trials:
+                raise RuntimeError(f"strict comparison trial contract failed for task {body.task_id}: eval_missing")
             return GDPValVerifyResponse(
                 **body.model_dump(),
                 reward=0.0,
@@ -893,6 +925,15 @@ class GDPValResourcesServer(SimpleResourcesServer):
             )
 
         total_judged = total_wins + total_losses + total_ties
+        strict_failure = _strict_comparison_trial_failure(
+            attempted_matchups=attempted_matchups,
+            num_trials=self.config.num_comparison_trials,
+            total_judged=total_judged,
+            total_invalid=total_invalid,
+            ref_errors=ref_errors,
+        )
+        if self.config.strict_comparison_trials and strict_failure is not None:
+            raise RuntimeError(f"strict comparison trial contract failed for task {body.task_id}: {strict_failure}")
         if total_wins > total_losses:
             reward = 1.0
         elif total_losses > total_wins:

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -41,7 +41,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -174,6 +174,20 @@ class JudgePanelMember(BaseModel):
     # with a warning (video/images/text are still graded).
     handles_audio: bool = False
     handles_video: bool = False
+    # Representation and request limits are provider-specific. Keeping them on
+    # the panel member prevents one global knob from breaking a different API.
+    media_mode: Optional[Literal["native_pdf", "images_and_text", "native_pdf_overflow_images"]] = None
+    max_native_pdf_pages: Optional[int] = None
+    max_native_pdf_documents: Optional[int] = None
+    max_native_pdf_bytes: Optional[int] = None
+    # Provider limit for one native PDF document. Unlike the aggregate
+    # max_native_pdf_bytes eligibility ceiling, overflow mode rasterizes only
+    # documents above this lossless representation threshold.
+    max_native_pdf_bytes_per_document: Optional[int] = None
+    # Tried in order for images_and_text. The first lossless projection below
+    # max_serialized_request_bytes wins; otherwise this member is excluded.
+    raster_dpi_tiers: Tuple[int, ...] = ()
+    max_serialized_request_bytes: Optional[int] = None
 
 
 def _strict_comparison_trial_failure(
@@ -253,6 +267,8 @@ class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     judge_pdf_max_pages: int = 50
     # Attach the extracted text copy alongside the page images. Off → images only.
     judge_pdf_include_text: bool = True
+    # Exact request-wide image cap for raster and PDF-overflow transports.
+    judge_max_images_per_request: int = 450
     # Whether the (single) local judge natively reads audio / video, tracked
     # SEPARATELY because MiniMax-M3 — the reference self-hosted judge — reads video
     # but NOT audio (its config has an image + video tower but no audio config). So
@@ -321,6 +337,8 @@ class GDPValResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class GDPValVerifyRequest(BaseVerifyRequest):
+    model_config = ConfigDict(populate_by_name=True)
+
     task_id: str
     sector: Optional[str] = None
     occupation: Optional[str] = None
@@ -335,6 +353,15 @@ class GDPValVerifyRequest(BaseVerifyRequest):
     # reference. Used by the multi-stage ELO driver to select a different set of
     # reference models per judgementstage without reconfiguring the server.
     reference_ids: Optional[List[str]] = None
+    # Preserve multistage identity through /verify so Stirrup's namespace-keyed
+    # cache and the incrementally tagged output remain auditable.
+    verify_cache_namespace: Optional[str] = None
+    stage_index: Optional[int] = None
+    expected_final_stage_index: Optional[int] = None
+    expected_stage_row_count: Optional[int] = None
+    ng_task_index: Optional[int] = Field(default=None, alias="_ng_task_index")
+    ng_rollout_index: Optional[int] = Field(default=None, alias="_ng_rollout_index")
+    ng_attempt_index: Optional[int] = Field(default=None, alias="_ng_attempt_index")
 
 
 # The reference model has no deliverable for this task, so no battle can be
@@ -463,6 +490,13 @@ class GDPValResourcesServer(SimpleResourcesServer):
                     weight=member.weight,
                     handles_audio=member.handles_audio,
                     handles_video=member.handles_video,
+                    media_mode=member.media_mode or self.config.judge_media_mode,
+                    max_native_pdf_pages=member.max_native_pdf_pages,
+                    max_native_pdf_documents=member.max_native_pdf_documents,
+                    max_native_pdf_bytes=member.max_native_pdf_bytes,
+                    max_native_pdf_bytes_per_document=member.max_native_pdf_bytes_per_document,
+                    raster_dpi_tiers=tuple(member.raster_dpi_tiers),
+                    max_serialized_request_bytes=member.max_serialized_request_bytes,
                 )
             )
         return judges
@@ -680,8 +714,13 @@ class GDPValResourcesServer(SimpleResourcesServer):
         from resources_servers.gdpval.comparison import (
             JUDGE_REQUEST_TIMEOUT_SECONDS,
             Judge,
+            apply_native_pdf_overflow,
             build_file_section,
             clean_up_paths,
+            filter_media_eligible_judges,
+            plan_native_pdf_overflow,
+            preflight_judge_transport,
+            preview_trial_judges,
             run_trials,
             task_attempted,
         )
@@ -778,6 +817,13 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 weight=rj.weight,
                 handles_audio=rj.handles_audio,
                 handles_video=rj.handles_video,
+                media_mode=rj.media_mode,
+                max_native_pdf_pages=rj.max_native_pdf_pages,
+                max_native_pdf_documents=rj.max_native_pdf_documents,
+                max_native_pdf_bytes=rj.max_native_pdf_bytes,
+                max_native_pdf_bytes_per_document=rj.max_native_pdf_bytes_per_document,
+                raster_dpi_tiers=rj.raster_dpi_tiers,
+                max_serialized_request_bytes=rj.max_serialized_request_bytes,
             )
             for rj in resolved_judges
         ]
@@ -815,27 +861,56 @@ class GDPValResourcesServer(SimpleResourcesServer):
         ref_errors: Dict[str, List[str]] = {}
         attempted_matchups = 0
         last_error: Optional[Exception] = None
-        # Present PDFs/Office docs either as native PDF data URLs (frontier
-        # judges) or rasterized page images + text (image-only local VLM judges
-        # like a gym-spawned Kimi K2.6) — see ``judge_media_mode``.
-        media_kwargs: Dict[str, Any] = {
-            "media_mode": self.config.judge_media_mode,
-            "render_dpi": self.config.judge_pdf_render_dpi,
-            "max_pages": self.config.judge_pdf_max_pages,
-            "include_text": self.config.judge_pdf_include_text,
-            # Forward each AV modality only when a (routed) judge can read it.
-            "audio_capable": audio_capable,
-            "video_capable": video_capable,
-        }
-        try:
-            # ``build_file_section`` rasterizes pages (PyMuPDF) and extracts text
-            # (pdfminer) in images_and_text mode — CPU-bound work that must not
-            # run on the event loop, same reasoning as the ``run_trials`` dispatch
-            # below.
-            eval_submission = await asyncio.to_thread(
-                build_file_section, str(eval_task_dir), clean_up_list, **media_kwargs
+        # Cache each semantic side independently by representation and DPI.
+        # Native sections are also the exact source for provider-cap preflight.
+        section_cache: Dict[Tuple[str, str, int], List[dict]] = {}
+
+        async def _section(path: Optional[Path], mode: str, render_dpi: int) -> List[dict]:
+            key = (str(path) if path is not None else "<none>", mode, render_dpi)
+            if key not in section_cache:
+                section_cache[key] = await asyncio.to_thread(
+                    build_file_section,
+                    str(path) if path is not None else None,
+                    clean_up_list,
+                    media_mode=mode,
+                    render_dpi=render_dpi,
+                    max_pages=self.config.judge_pdf_max_pages,
+                    include_text=self.config.judge_pdf_include_text,
+                    audio_capable=audio_capable,
+                    video_capable=video_capable,
+                )
+            return section_cache[key]
+
+        def _image_count(*sections: List[dict]) -> int:
+            return sum(
+                1
+                for section in sections
+                for block in section
+                if block.get("type") == "image_url"
+                and str((block.get("image_url") or {}).get("url", "")).startswith("data:image/")
             )
 
+        def _native_pdf_stats(*sections: List[dict]) -> Dict[str, int]:
+            import base64
+
+            from resources_servers.gdpval.media_conversion import pdf_page_count
+
+            pages = documents = byte_count = 0
+            prefix = "data:application/pdf;base64,"
+            for section in sections:
+                for block in section:
+                    if block.get("type") != "image_url":
+                        continue
+                    url = str((block.get("image_url") or {}).get("url", ""))
+                    if not url.startswith(prefix):
+                        continue
+                    payload = base64.b64decode(url[len(prefix) :], validate=True)
+                    documents += 1
+                    byte_count += len(payload)
+                    pages += pdf_page_count(payload)
+            return {"pages": pages, "documents": documents, "bytes": byte_count}
+
+        try:
             # Judge the eval submission against every reference model, and within
             # each model against every available reference repeat. Raw vote
             # counts (not just per-matchup majority) are summed so the win rate
@@ -845,32 +920,193 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 ref_judged_repeats = 0
                 for ref_dir in dirs:
                     refs_subdir = ref_dir / "reference_files"
-                    refs = await asyncio.to_thread(
-                        build_file_section,
-                        str(refs_subdir) if refs_subdir.is_dir() else None,
-                        clean_up_list,
-                        **media_kwargs,
-                    )
-                    ref_submission = await asyncio.to_thread(
-                        build_file_section, str(ref_dir), clean_up_list, **media_kwargs
-                    )
                     attempted_matchups += 1
                     # Seed per (task, ref_id, ref_repeat) so judge sampling is
                     # reproducible and each reference subset draws independently —
                     # this makes multi-stage ELO reruns replayable per stage.
                     rng = make_rng(self.config.judge_sampling_seed, body.task_id, ref_id, ref_dir.name)
                     try:
+                        matchup_judges = list(judges)
+                        media_exclusions: List[Dict[str, Any]] = []
+                        render_dpi = self.config.judge_pdf_render_dpi
+                        native = {
+                            "refs": await _section(
+                                refs_subdir if refs_subdir.is_dir() else None,
+                                "native_pdf",
+                                render_dpi,
+                            ),
+                            "submission_a": await _section(ref_dir, "native_pdf", render_dpi),
+                            "submission_b": await _section(eval_task_dir, "native_pdf", render_dpi),
+                        }
+                        native_stats = _native_pdf_stats(*native.values())
+                        estimated_images = native_stats["pages"] + _image_count(*native.values())
+                        overflow_judges = [
+                            judge for judge in matchup_judges if judge.media_mode == "native_pdf_overflow_images"
+                        ]
+                        overflow_plan: Optional[Dict[str, Any]] = None
+                        if overflow_judges:
+                            caps = {
+                                judge.max_native_pdf_pages
+                                for judge in overflow_judges
+                                if judge.max_native_pdf_pages is not None
+                            }
+                            if len(caps) != 1:
+                                raise ValueError(f"overflow judges require one explicit native page cap, got {caps}")
+                            byte_caps = {
+                                judge.max_native_pdf_bytes_per_document
+                                for judge in overflow_judges
+                                if judge.max_native_pdf_bytes_per_document is not None
+                            }
+                            if len(byte_caps) != 1:
+                                raise ValueError(
+                                    f"overflow judges require one explicit native PDF byte cap, got {byte_caps}"
+                                )
+                            overflow_plan = plan_native_pdf_overflow(
+                                native,
+                                native_page_cap=caps.pop(),
+                                native_pdf_bytes_per_document=byte_caps.pop(),
+                                image_cap=self.config.judge_max_images_per_request,
+                                render_page_cap=self.config.judge_pdf_max_pages,
+                            )
+                        matchup_judges, media_exclusions = filter_media_eligible_judges(
+                            matchup_judges,
+                            native_stats=native_stats,
+                            estimated_images=estimated_images,
+                            image_cap=self.config.judge_max_images_per_request,
+                            overflow_plan=overflow_plan,
+                        )
+                        if not matchup_judges:
+                            raise ValueError("media routing excluded every judge")
+
+                        sections_by_judge: Dict[str, Dict[str, List[dict]]] = {}
+                        transport_receipts: Dict[str, Dict[str, Any]] = {}
+                        failed_names: Set[str] = set()
+                        # Sampling is replayed from the untouched RNG after any
+                        # pre-dispatch exclusion. Only modes that can actually be
+                        # sampled are materialized, avoiding needless raster work.
+                        while True:
+                            active = [judge for judge in matchup_judges if judge.name not in failed_names]
+                            if not active:
+                                raise ValueError("transport preflight excluded every judge")
+                            schedule = preview_trial_judges(active, self.config.num_comparison_trials, rng)
+                            needed = {judge.name: judge for judge in schedule}
+                            new_failure = False
+                            for judge_name, judge in needed.items():
+                                if judge_name in sections_by_judge or judge_name in failed_names:
+                                    continue
+                                candidates: List[Tuple[Optional[int], Dict[str, List[dict]]]] = []
+                                attempted_preflights: List[Dict[str, Any]] = []
+                                if judge.media_mode == "native_pdf":
+                                    candidates.append((None, native))
+                                elif judge.media_mode == "native_pdf_overflow_images":
+                                    if overflow_plan is None:
+                                        raise ValueError("overflow mode selected without a plan")
+                                    transformed = native
+                                    if overflow_plan.get("selected"):
+                                        transformed = await asyncio.to_thread(
+                                            apply_native_pdf_overflow,
+                                            native,
+                                            overflow_plan,
+                                            render_dpi=render_dpi,
+                                            max_pages=self.config.judge_pdf_max_pages,
+                                            include_text=self.config.judge_pdf_include_text,
+                                        )
+                                    candidates.append((render_dpi, transformed))
+                                elif judge.media_mode == "images_and_text":
+                                    tiers = judge.raster_dpi_tiers or (render_dpi,)
+                                    if any(dpi < 36 or dpi > 600 for dpi in tiers):
+                                        raise ValueError(f"invalid raster DPI tiers for {judge.name}: {tiers}")
+                                    # Build and preflight one tier at a time. A
+                                    # 300-page task can allocate tens of MiB per
+                                    # tier, so eagerly materializing every tier
+                                    # defeats the purpose of adaptive routing.
+                                    for dpi in tiers:
+                                        candidate_sections = {
+                                            "refs": await _section(
+                                                refs_subdir if refs_subdir.is_dir() else None,
+                                                "images_and_text",
+                                                dpi,
+                                            ),
+                                            "submission_a": await _section(ref_dir, "images_and_text", dpi),
+                                            "submission_b": await _section(eval_task_dir, "images_and_text", dpi),
+                                        }
+                                        receipt = await asyncio.to_thread(
+                                            preflight_judge_transport,
+                                            judge,
+                                            body.prompt or "",
+                                            candidate_sections,
+                                        )
+                                        receipt["render_dpi"] = dpi
+                                        attempted_preflights.append(receipt)
+                                        if receipt["eligible"]:
+                                            sections_by_judge[judge_name] = candidate_sections
+                                            transport_receipts[judge_name] = receipt
+                                            break
+                                        # Do not retain rejected raster payloads;
+                                        # only the small receipt survives.
+                                        for path in (
+                                            refs_subdir if refs_subdir.is_dir() else None,
+                                            ref_dir,
+                                            eval_task_dir,
+                                        ):
+                                            section_cache.pop(
+                                                (
+                                                    str(path) if path is not None else "<none>",
+                                                    "images_and_text",
+                                                    dpi,
+                                                ),
+                                                None,
+                                            )
+                                else:
+                                    raise ValueError(f"unknown judge media mode: {judge.media_mode}")
+
+                                if judge_name in sections_by_judge:
+                                    continue
+                                for dpi, candidate_sections in candidates:
+                                    receipt = await asyncio.to_thread(
+                                        preflight_judge_transport,
+                                        judge,
+                                        body.prompt or "",
+                                        candidate_sections,
+                                    )
+                                    receipt["render_dpi"] = dpi
+                                    attempted_preflights.append(receipt)
+                                    if receipt["eligible"]:
+                                        sections_by_judge[judge_name] = candidate_sections
+                                        transport_receipts[judge_name] = receipt
+                                        break
+                                if judge_name not in sections_by_judge:
+                                    failed_names.add(judge_name)
+                                    new_failure = True
+                                    media_exclusions.append(
+                                        {
+                                            "mode": judge.media_mode,
+                                            "judges": [judge.name],
+                                            "reason": "transport_preflight",
+                                            "attempts": attempted_preflights,
+                                        }
+                                    )
+                            if not new_failure:
+                                matchup_judges = active
+                                break
+
                         result = await asyncio.to_thread(
                             run_trials,
-                            judges=judges,
+                            judges=matchup_judges,
                             task_prompt=body.prompt or "",
-                            refs=refs,
-                            submission_a=ref_submission,
-                            submission_b=eval_submission,
+                            refs=native["refs"],
+                            submission_a=native["submission_a"],
+                            submission_b=native["submission_b"],
+                            sections_by_judge=sections_by_judge,
                             num_trials=self.config.num_comparison_trials,
                             return_raw_responses=self.config.persist_raw_judge_responses,
                             rng=rng,
                         )
+                        result["transport_by_judge"] = transport_receipts
+                        if media_exclusions:
+                            result["media_routing_exclusions"] = media_exclusions
+                        if overflow_plan and overflow_plan.get("selected"):
+                            result["native_pdf_overflow"] = overflow_plan
                     except Exception as e:  # noqa: BLE001 — isolate per-matchup judge failures
                         last_error = e
                         ref_errors.setdefault(ref_id, []).append(f"{ref_dir.name}: {e!r}")

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -369,6 +369,12 @@ class GDPValVerifyRequest(BaseVerifyRequest):
 # nemo_gym: the harness only needs the generic terminal flag, and the class name
 # is GDPVal vocabulary.
 REFERENCE_MISSING_FAILURE_CLASS = "reference_missing"
+EVAL_MISSING_FAILURE_CLASS = "eval_missing"
+TRANSPORT_INELIGIBLE_FAILURE_CLASS = "transport_ineligible"
+
+
+class TransportIneligibleError(ValueError):
+    """Every judge was excluded by deterministic media/transport eligibility."""
 
 
 class GDPValVerifyResponse(GDPValVerifyRequest, BaseVerifyResponse):
@@ -498,6 +504,17 @@ class GDPValResourcesServer(SimpleResourcesServer):
                     raster_dpi_tiers=tuple(member.raster_dpi_tiers),
                     max_serialized_request_bytes=member.max_serialized_request_bytes,
                 )
+            )
+        # Transport routing (needed/sections_by_judge, per-judge receipts, and
+        # vote pooling) all key on the resolved name. Two members collapsing to
+        # one name would silently send one judge the other's payload
+        # representation and merge their votes.
+        names = [judge.name for judge in judges]
+        duplicates = sorted({name for name in names if names.count(name) > 1})
+        if duplicates:
+            raise ValueError(
+                "judge panel members must resolve to unique names (set an explicit "
+                f"'name' on members sharing a model): duplicates={duplicates}"
             )
         return judges
 
@@ -774,12 +791,19 @@ class GDPValResourcesServer(SimpleResourcesServer):
             print(f"[gdpval] eval deliverable missing for task {body.task_id}", flush=True)
             if self.config.strict_comparison_trials:
                 raise RuntimeError(f"strict comparison trial contract failed for task {body.task_id}: eval_missing")
+            # Terminal for the same reason as reference_missing above: a
+            # zero-reward success row carries no battle evidence, is rejected by
+            # the coverage gate, and permanently gates the key on resume. A
+            # classified terminal failure is instead re-validated on resume.
             return GDPValVerifyResponse(
                 **body.model_dump(),
                 reward=0.0,
                 verify_mode="comparison",
                 judge_response={"error": "eval_missing"},
-                loss=True,
+                **{
+                    NG_FAILURE_CLASS_KEY: EVAL_MISSING_FAILURE_CLASS,
+                    NG_TERMINAL_KEY: True,
+                },
             )
 
         if self.config.preconvert_office_to_pdf:
@@ -860,6 +884,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
         # every reference that judged successfully.
         ref_errors: Dict[str, List[str]] = {}
         attempted_matchups = 0
+        transport_ineligible_matchups = 0
         last_error: Optional[Exception] = None
         # Cache each semantic side independently by representation and DPI.
         # Native sections are also the exact source for provider-cap preflight.
@@ -868,13 +893,21 @@ class GDPValResourcesServer(SimpleResourcesServer):
         async def _section(path: Optional[Path], mode: str, render_dpi: int) -> List[dict]:
             key = (str(path) if path is not None else "<none>", mode, render_dpi)
             if key not in section_cache:
+                # In raster mode a PDF longer than judge_pdf_max_pages would
+                # otherwise carry a DPI-independent truncation marker that
+                # excludes the judge at every tier. Render up to the request
+                # image budget; genuinely over-budget documents still truncate
+                # and are excluded on real caps.
+                page_cap = self.config.judge_pdf_max_pages
+                if mode == "images_and_text":
+                    page_cap = max(page_cap, self.config.judge_max_images_per_request)
                 section_cache[key] = await asyncio.to_thread(
                     build_file_section,
                     str(path) if path is not None else None,
                     clean_up_list,
                     media_mode=mode,
                     render_dpi=render_dpi,
-                    max_pages=self.config.judge_pdf_max_pages,
+                    max_pages=page_cap,
                     include_text=self.config.judge_pdf_include_text,
                     audio_capable=audio_capable,
                     video_capable=video_capable,
@@ -938,7 +971,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                             "submission_a": await _section(ref_dir, "native_pdf", render_dpi),
                             "submission_b": await _section(eval_task_dir, "native_pdf", render_dpi),
                         }
-                        native_stats = _native_pdf_stats(*native.values())
+                        native_stats = await asyncio.to_thread(_native_pdf_stats, *native.values())
                         estimated_images = native_stats["pages"] + _image_count(*native.values())
                         overflow_judges = [
                             judge for judge in matchup_judges if judge.media_mode == "native_pdf_overflow_images"
@@ -961,7 +994,8 @@ class GDPValResourcesServer(SimpleResourcesServer):
                                 raise ValueError(
                                     f"overflow judges require one explicit native PDF byte cap, got {byte_caps}"
                                 )
-                            overflow_plan = plan_native_pdf_overflow(
+                            overflow_plan = await asyncio.to_thread(
+                                plan_native_pdf_overflow,
                                 native,
                                 native_page_cap=caps.pop(),
                                 native_pdf_bytes_per_document=byte_caps.pop(),
@@ -976,7 +1010,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                             overflow_plan=overflow_plan,
                         )
                         if not matchup_judges:
-                            raise ValueError("media routing excluded every judge")
+                            raise TransportIneligibleError("media routing excluded every judge")
 
                         sections_by_judge: Dict[str, Dict[str, List[dict]]] = {}
                         transport_receipts: Dict[str, Dict[str, Any]] = {}
@@ -987,7 +1021,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                         while True:
                             active = [judge for judge in matchup_judges if judge.name not in failed_names]
                             if not active:
-                                raise ValueError("transport preflight excluded every judge")
+                                raise TransportIneligibleError("transport preflight excluded every judge")
                             schedule = preview_trial_judges(active, self.config.num_comparison_trials, rng)
                             needed = {judge.name: judge for judge in schedule}
                             new_failure = False
@@ -1109,12 +1143,22 @@ class GDPValResourcesServer(SimpleResourcesServer):
                             result["native_pdf_overflow"] = overflow_plan
                     except Exception as e:  # noqa: BLE001 — isolate per-matchup judge failures
                         last_error = e
+                        if isinstance(e, TransportIneligibleError):
+                            transport_ineligible_matchups += 1
                         ref_errors.setdefault(ref_id, []).append(f"{ref_dir.name}: {e!r}")
                         print(
                             f"[gdpval] judge failed for task {body.task_id} ref {ref_id}/{ref_dir.name}: {e!r}",
                             flush=True,
                         )
                         continue
+                    finally:
+                        # Reference-side payloads are matchup-local; only the
+                        # eval side repeats across matchups. Evicting the rest
+                        # bounds cache residency to one matchup plus the eval
+                        # sections instead of every reference x repeat.
+                        eval_key_prefix = str(eval_task_dir)
+                        for cache_key in [k for k in section_cache if k[0] != eval_key_prefix]:
+                            section_cache.pop(cache_key, None)
                     # ``run_trials`` casts submission_a=ref, submission_b=eval, so
                     # ``win_count_b`` is eval wins.
                     ref_wins += result["win_count_b"]
@@ -1156,6 +1200,22 @@ class GDPValResourcesServer(SimpleResourcesServer):
         # it as a failure (matches pre-resilience behavior) rather than emitting
         # a fake neutral reward that would pollute the metrics.
         if attempted_matchups > 0 and not per_reference:
+            if transport_ineligible_matchups == attempted_matchups:
+                # Deterministic eligibility exclusion of every judge on every
+                # matchup: retrying the same payload cannot succeed, so a
+                # generic 500 would only burn attempts and silently drop the
+                # task. Terminal within the run; re-validated on resume (caps,
+                # renderers, or panel config may change between runs).
+                return GDPValVerifyResponse(
+                    **body.model_dump(),
+                    reward=0.0,
+                    verify_mode="comparison",
+                    judge_response={"error": "transport_ineligible", "ref_errors": ref_errors},
+                    **{
+                        NG_FAILURE_CLASS_KEY: TRANSPORT_INELIGIBLE_FAILURE_CLASS,
+                        NG_TERMINAL_KEY: True,
+                    },
+                )
             raise RuntimeError(
                 f"all {attempted_matchups} judge matchup(s) failed for task {body.task_id}; last error: {last_error!r}"
             )

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -314,6 +314,7 @@ class GDPValVerifyResponse(GDPValVerifyRequest, BaseVerifyResponse):
     verify_mode: Literal["rubric", "comparison"] = "rubric"
     judge_response: Optional[Dict[str, Any]] = None
     invalid_judge_response: Optional[bool] = None
+    invalid_judge_retryable: Optional[bool] = None
     # Majority-decision flags across all (ref_repeat × trial) judge votes —
     # kept for back-compat with older verify responses (still bool-valued).
     win: Optional[bool] = None
@@ -516,7 +517,9 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 **body.model_dump(),
                 reward=0.0,
                 verify_mode="rubric",
+                judge_response={"scoring_error": "missing_rubric"},
                 invalid_judge_response=True,
+                invalid_judge_retryable=False,
             )
 
         judges = self._resolve_judges()
@@ -701,6 +704,9 @@ class GDPValResourcesServer(SimpleResourcesServer):
                     base_url=judge.base_url,
                     api_key=judge.api_key,
                     timeout=JUDGE_REQUEST_TIMEOUT_SECONDS,
+                    # comparison.send_judge_request owns the retry policy; the
+                    # SDK default would multiply every explicit attempt by 3.
+                    max_retries=0,
                 )
             return client_cache[key]
 
@@ -904,7 +910,33 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
     async def aggregate_metrics(self, body: AggregateMetricsRequest) -> AggregateMetrics:
         if self.config.reward_mode != "comparison":
-            return await super().aggregate_metrics(body)
+            # A scorer-side failure still carries reward=0.0 for schema
+            # compatibility. Do not let those sentinel zeros lower the model's
+            # reward: profile only rows backed by a usable judge response and
+            # expose coverage explicitly so an all-invalid run cannot resemble
+            # a genuinely low-scoring run.
+            valid_responses = [vr for vr in body.verify_responses if not bool(vr.get("invalid_judge_response"))]
+            valid_count = len(valid_responses)
+            invalid_count = len(body.verify_responses) - valid_count
+            total_count = len(body.verify_responses)
+            if valid_responses:
+                base = await super().aggregate_metrics(AggregateMetricsRequest(verify_responses=valid_responses))
+            else:
+                base = AggregateMetrics()
+            # These describe only the rows supplied to aggregation. Runtime
+            # judge failures live in the collection sidecar and are intentionally
+            # not presented as run-level coverage here.
+            coverage: Dict[str, Any] = {
+                "rubric/aggregate_rows_total": total_count,
+                "rubric/aggregate_rows_included": valid_count,
+                "rubric/legacy_invalid_rows_excluded": invalid_count,
+                "rubric/aggregate_rows_included_fraction": valid_count / total_count if total_count else 0.0,
+            }
+            return AggregateMetrics(
+                group_level_metrics=base.group_level_metrics,
+                agent_metrics={**base.agent_metrics, **coverage},
+                key_metrics={**base.key_metrics, **coverage},
+            )
 
         from resources_servers.gdpval.comparison import (
             calculate_elo,
@@ -970,29 +1002,54 @@ class GDPValResourcesServer(SimpleResourcesServer):
         # reference subset each time), so the same ``(task_index, rollout_index)``
         # appears once per stage — distinguished only by ``stage_index``.
         staged: Dict[int, List[Dict[str, Any]]] = {}
+        expected_stage_row_counts: Dict[int, Set[int]] = {}
+        expected_final_stage_values: Set[int] = set()
+        expected_final_stage_rows = 0
         for vr in body.verify_responses:
             stage_index = vr.get("stage_index")
             if stage_index is not None:
-                staged.setdefault(int(stage_index), []).append(vr)
+                normalized_stage_index = int(stage_index)
+                staged.setdefault(normalized_stage_index, []).append(vr)
+                expected_stage_row_count = vr.get("expected_stage_row_count")
+                if expected_stage_row_count is not None:
+                    expected_stage_row_counts.setdefault(normalized_stage_index, set()).add(
+                        int(expected_stage_row_count)
+                    )
+            expected_final_stage_index = vr.get("expected_final_stage_index")
+            if expected_final_stage_index is not None:
+                expected_final_stage_values.add(int(expected_final_stage_index))
+                expected_final_stage_rows += 1
+
+        expected_stage_declared = bool(expected_final_stage_values)
+        expected_stage_consistent = len(expected_final_stage_values) <= 1
+        expected_final_stage_index = (
+            next(iter(expected_final_stage_values)) if len(expected_final_stage_values) == 1 else None
+        )
 
         # RewardProfiler (the base aggregation) keys rollouts by
         # ``(task_index, rollout_index)`` and rejects duplicates. Multi-stage
         # rollouts collide on that key by design, so feed the base profiler the
-        # LAST stage alone — the headline stage, whose keys are unique — instead
-        # of the pooled set. Single-stage / untagged runs use the full body.
+        # selected headline stage alone, whose keys are unique, instead of the
+        # pooled set. New orchestrators declare ``expected_final_stage_index``;
+        # old artifacts retain max-observed-stage behavior for compatibility.
+        # If a declared stage is absent, max-observed is used only for the base
+        # diagnostic profile — it is never promoted to the comparison headline.
         base_body = body
         if staged:
-            base_body = AggregateMetricsRequest(verify_responses=staged[max(staged)])
+            base_stage_index = (
+                expected_final_stage_index
+                if expected_stage_consistent and expected_final_stage_index in staged
+                else max(staged)
+            )
+            base_body = AggregateMetricsRequest(verify_responses=staged[base_stage_index])
 
         # Pooled (across every stage / reference) win stats — always emitted as
         # descriptive metrics regardless of staging.
         wins, losses, ties, per_ref_totals = _accumulate(list(body.verify_responses))
 
         judged = wins + losses + ties
-        if judged == 0:
+        if judged == 0 and not staged:
             return await super().aggregate_metrics(base_body)
-
-        win_rate = (wins + 0.5 * ties) / judged
 
         base = await super().aggregate_metrics(base_body)
         # Total win stats (always emitted).
@@ -1001,8 +1058,9 @@ class GDPValResourcesServer(SimpleResourcesServer):
             "comparison/losses": losses,
             "comparison/ties": ties,
             "comparison/judged": judged,
-            "comparison/win_rate": win_rate,
         }
+        if judged:
+            extra["comparison/win_rate"] = (wins + 0.5 * ties) / judged
 
         # Per-reference win stats (always emitted when present).
         for ref_id, (rw, rl, rt, ref_elo) in per_ref_totals.items():
@@ -1018,37 +1076,79 @@ class GDPValResourcesServer(SimpleResourcesServer):
             if ref_elo is not None:
                 extra[f"comparison/ref/{ref_id}/reference_elo"] = ref_elo
 
-        # When stages are present, fit each stage's ELO independently and report
-        # the LAST stage's fit as the headline ``comparison/eval_elo`` (the
-        # multi-stage design refines on a larger task set vs nearby references in
-        # later stages), while exposing every stage's estimate as a
-        # ``comparison/stage_<k>/*`` extra for visibility. Untagged runs keep the
-        # original single-pass behavior below.
+        # When stages are present, fit each stage independently. New runs name
+        # the required headline stage explicitly; a missing/unfit required stage
+        # is degraded and deliberately emits no ``comparison/eval_elo`` rather
+        # than silently substituting an earlier or pooled fit. Old artifacts
+        # without the expectation field retain max-observed-stage behavior.
         if staged:
             extra["comparison/num_stages"] = len(staged)
-            headline: Optional[tuple[Optional[float], Optional[float], int]] = None
-            last_index = max(staged)
+            stage_fits: Dict[int, tuple[Optional[float], Optional[float], int]] = {}
             for stage_index in sorted(staged):
                 stage_responses = staged[stage_index]
                 _, _, _, stage_ref_totals = _accumulate(stage_responses)
                 stage_elo, stage_norm, stage_nref = _fit_mle(stage_ref_totals)
+                stage_fits[stage_index] = (stage_elo, stage_norm, stage_nref)
                 prefix = f"comparison/stage_{stage_index}"
                 if stage_elo is not None:
                     extra[f"{prefix}/eval_elo"] = stage_elo
                     extra[f"{prefix}/normalized_elo"] = stage_norm
                 extra[f"{prefix}/num_references"] = stage_nref
                 extra[f"{prefix}/num_tasks"] = len({vr.get("task_id") for vr in stage_responses})
-                if stage_index == last_index:
-                    headline = (stage_elo, stage_norm, stage_nref)
 
-            # Headline = last stage's fit. Fall back to the pooled MLE only if
-            # the last stage failed to produce a rating, so the run still
-            # surfaces a number.
+            headline_stage_index: Optional[int] = None
+            headline: Optional[tuple[Optional[float], Optional[float], int]] = None
+            if expected_stage_declared:
+                extra["comparison/expected_final_stage_declared_rows"] = expected_final_stage_rows
+                extra["comparison/expected_final_stage_consistent"] = int(expected_stage_consistent)
+                if expected_final_stage_index is not None:
+                    extra["comparison/expected_final_stage_index"] = expected_final_stage_index
+
+                final_stage_present = expected_stage_consistent and expected_final_stage_index in staged
+                final_stage_rows = staged.get(expected_final_stage_index, [])
+                observed_final_stage_count = len(
+                    {
+                        (
+                            vr.get("_ng_task_index", vr.get("task_id")),
+                            vr.get("_ng_rollout_index", 0),
+                        )
+                        for vr in final_stage_rows
+                    }
+                )
+                expected_count_values = expected_stage_row_counts.get(expected_final_stage_index, set())
+                expected_count_consistent = len(expected_count_values) == 1
+                expected_final_stage_count = next(iter(expected_count_values)) if expected_count_consistent else None
+                final_stage_complete = (
+                    final_stage_present
+                    and expected_final_stage_count is not None
+                    and observed_final_stage_count == expected_final_stage_count
+                )
+                candidate = stage_fits.get(expected_final_stage_index)
+                final_stage_fit = candidate is not None and candidate[0] is not None
+                if final_stage_complete and final_stage_fit:
+                    headline_stage_index = expected_final_stage_index
+                    headline = candidate
+                extra["comparison/final_stage_present"] = int(final_stage_present)
+                extra["comparison/final_stage_complete"] = int(final_stage_complete)
+                extra["comparison/final_stage_fit"] = int(final_stage_fit)
+                extra["comparison/final_stage_degraded"] = int(not (final_stage_complete and final_stage_fit))
+                extra["comparison/observed_final_stage_row_count"] = observed_final_stage_count
+                extra["comparison/expected_final_stage_row_count_consistent"] = int(expected_count_consistent)
+                if expected_final_stage_count is not None:
+                    extra["comparison/expected_final_stage_row_count"] = expected_final_stage_count
+            else:
+                # Backward compatibility for artifacts generated before the
+                # expected-stage field was introduced.
+                headline_stage_index = max(staged)
+                headline = stage_fits[headline_stage_index]
+                if headline[0] is None:
+                    headline = _fit_mle(per_ref_totals)
+                    headline_stage_index = None
+
             if headline is not None and headline[0] is not None:
                 eval_elo, normalized_elo, num_references = headline
-            else:
-                eval_elo, normalized_elo, num_references = _fit_mle(per_ref_totals)
-            if eval_elo is not None:
+                if headline_stage_index is not None:
+                    extra["comparison/headline_stage_index"] = headline_stage_index
                 extra["comparison/eval_elo"] = eval_elo
                 extra["comparison/normalized_elo"] = normalized_elo
                 extra["comparison/num_references"] = num_references
@@ -1078,7 +1178,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                             eval_elo, float(ref_elo)
                         )
             else:
-                eval_elo, normalized_elo = calculate_elo(win_rate, self.config.reference_elo)
+                eval_elo, normalized_elo = calculate_elo((wins + 0.5 * ties) / judged, self.config.reference_elo)
                 extra["comparison/eval_elo"] = eval_elo
                 extra["comparison/normalized_elo"] = normalized_elo
                 extra["comparison/reference_elo"] = self.config.reference_elo

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -800,6 +800,12 @@ def build_file_section(
             return
         if remaining <= 0:
             text_omitted = True
+            if _is_lossy_transport_marker(value):
+                # Loss markers are what preflight_judge_transport scans for; a
+                # marker swallowed by the text budget would let a request that
+                # silently lost an attachment pass as eligible.
+                section.append(dict(block))
+                text_used += len(value)
             return
         shown = _bounded_text(value, remaining, text_marker)
         if len(shown) < len(value):
@@ -889,8 +895,18 @@ def build_file_section(
         info = FILE_TYPE_MAP.get(full_path.suffix.lower().lstrip(".")) or {}
         av_identity: tuple[int, str] | None = None
         if info.get("type") in {"AUDIO", "VIDEO"}:
-            av_identity = _av_identity(full_path)
-            retained_as = retained_av_payloads.get(av_identity)
+            try:
+                # Identity exists only to deduplicate retained payloads; never
+                # hash a file the per-file cap already excludes from attachment.
+                if full_path.stat().st_size <= MAX_FILE_BYTES_FOR_JUDGE:
+                    av_identity = _av_identity(full_path)
+            except OSError as exc:
+                _append_block(
+                    {"type": "text", "text": f"[attachment unavailable for {file_name}: {exc.__class__.__name__}]"}
+                )
+                no_files = False
+                return
+            retained_as = retained_av_payloads.get(av_identity) if av_identity is not None else None
             if retained_as is not None:
                 _append_block(
                     {
@@ -1769,9 +1785,18 @@ def apply_native_pdf_overflow(
 
 _LOSSY_TRANSPORT_PREFIXES = (
     "[attachment omitted",
+    "[attachment unavailable",
     "[oversize:",
     "[truncated: rendered",
 )
+
+
+def _is_lossy_transport_marker(text: str) -> bool:
+    """Whether a text block records lost attachment content."""
+    if text.startswith(_LOSSY_TRANSPORT_PREFIXES):
+        return True
+    first_line = text.splitlines()[0] if text else ""
+    return first_line.startswith("[page ") and " omitted" in first_line
 
 
 def preflight_judge_transport(
@@ -1790,7 +1815,7 @@ def preflight_judge_transport(
     for message in messages:
         for block in message.get("content") or []:
             text = str(block.get("text", ""))
-            if text.startswith(_LOSSY_TRANSPORT_PREFIXES):
+            if _is_lossy_transport_marker(text):
                 markers.append(text.splitlines()[0][:240])
     create_kwargs = merge_create_kwargs(
         {

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
 import logging
 import math
 import os
@@ -70,6 +71,10 @@ JUDGE_PROMPT = (
     "better completed the task. "
     "Explain your reasoning then answer BOXED[A], BOXED[B], or BOXED[TIE].\n"
 )
+FINAL_VERDICT_REMINDER = (
+    "End your response with exactly one verdict token on its own final line: "
+    "BOXED[A], BOXED[B], or BOXED[TIE]. A response without one is invalid.\n"
+)
 
 A_WIN_RESPONSE = "BOXED[A]"
 B_WIN_RESPONSE = "BOXED[B]"
@@ -98,30 +103,50 @@ REQUEST_MAX_BACKOFF_SECONDS = 60.0
 # (below) so a genuinely dead upstream still bounds wall-clock rather than
 # retrying N x timeout.
 JUDGE_REQUEST_TIMEOUT_SECONDS = float(os.environ.get("GDPVAL_JUDGE_REQUEST_TIMEOUT_SECONDS", "300"))
+
+
+def _byte_limit(name: str, default: int) -> int:
+    """Read a positive byte limit while retaining the hardened default."""
+    value = int(os.environ.get(name, str(default)))
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value}")
+    return value
+
+
 # Per-file size cap on multimodal content blocks. Above this the file is
 # replaced with a one-line text marker so the judge still knows what was
 # claimed without us pushing 100s of MB of base64 through the proxy.
 # Set high enough (250 MB) that normal multi-stem audio and reference
 # videos in the GDPVal task set still go through; only catches the truly
 # pathological cases (e.g. ``task_a941b6d8`` 657 MB overlay clip).
-MAX_FILE_BYTES_FOR_JUDGE = 250 * 1024 * 1024
+MAX_FILE_BYTES_FOR_JUDGE = _byte_limit("GDPVAL_MAX_FILE_BYTES_FOR_JUDGE", 250 * 1024 * 1024)
 # Aggregate encoded payload is what the HTTP server sees. Keeping it below
 # 400 MiB leaves roughly 80 MB even if the model server's advertised 500 MB
 # ceiling is decimal, for JSON, prompts, spreadsheet text, and framing. The raw
 # ceiling separately prevents pathological media accumulation before base64.
-MAX_TOTAL_RAW_ATTACHMENT_BYTES_FOR_JUDGE = 300 * 1024 * 1024
-MAX_TOTAL_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE = 400 * 1024 * 1024
+MAX_TOTAL_RAW_ATTACHMENT_BYTES_FOR_JUDGE = _byte_limit(
+    "GDPVAL_MAX_TOTAL_RAW_ATTACHMENT_BYTES_FOR_JUDGE", 300 * 1024 * 1024
+)
+MAX_TOTAL_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE = _byte_limit(
+    "GDPVAL_MAX_TOTAL_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE", 400 * 1024 * 1024
+)
 # Each directory is built independently. Keeping every section below an equal,
 # conservative share means references can never consume the bytes needed to
 # show both submissions, and limits peak memory before message assembly.
-MAX_SECTION_RAW_ATTACHMENT_BYTES_FOR_JUDGE = 96 * 1024 * 1024
-MAX_SECTION_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE = 128 * 1024 * 1024
+MAX_SECTION_RAW_ATTACHMENT_BYTES_FOR_JUDGE = _byte_limit(
+    "GDPVAL_MAX_SECTION_RAW_ATTACHMENT_BYTES_FOR_JUDGE", 96 * 1024 * 1024
+)
+MAX_SECTION_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE = _byte_limit(
+    "GDPVAL_MAX_SECTION_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE", 128 * 1024 * 1024
+)
 MAX_TEXT_FILE_CHARS_FOR_JUDGE = 200_000
 MAX_SECTION_TEXT_CHARS_FOR_JUDGE = 1_000_000
 MAX_XLSX_TEXT_CHARS_FOR_JUDGE = 120_000
 # Includes base64, all text, data-URL prefixes, and conservative JSON framing.
 # This stays below endpoints configured with a 500 MB request-body ceiling.
-MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE = 420 * 1024 * 1024
+MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE = _byte_limit(
+    "GDPVAL_MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE", 420 * 1024 * 1024
+)
 MAX_TASK_PROMPT_CHARS_FOR_JUDGE = 1_000_000
 # Archives expand before their members enter the normal payload builders, so
 # bound that work independently. Extracting more than one section's raw budget
@@ -754,6 +779,15 @@ def build_file_section(
     text_used = 0
     text_omitted = False
     text_marker = "\n[...additional text omitted: section judge text budget exhausted]"
+    retained_av_payloads: dict[tuple[int, str], str] = {}
+
+    def _av_identity(path: Path) -> tuple[int, str]:
+        digest = hashlib.sha256()
+        size = path.stat().st_size
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return size, digest.hexdigest()
 
     def _append_block(block: dict) -> None:
         nonlocal text_used, text_omitted
@@ -852,6 +886,21 @@ def build_file_section(
         if full_path in provenance.suppressed_pdfs or full_path in fallback_suppressed_by_dir[parent]:
             return
         _append_block({"type": "text", "text": f"\n{file_name}:\n"})
+        info = FILE_TYPE_MAP.get(full_path.suffix.lower().lstrip(".")) or {}
+        av_identity: tuple[int, str] | None = None
+        if info.get("type") in {"AUDIO", "VIDEO"}:
+            av_identity = _av_identity(full_path)
+            retained_as = retained_av_payloads.get(av_identity)
+            if retained_as is not None:
+                _append_block(
+                    {
+                        "type": "text",
+                        "text": f"[byte-identical duplicate attachment; content retained once as "
+                        f"{retained_as}; sha256={av_identity[1]}]",
+                    }
+                )
+                no_files = False
+                return
         cached_office_pdf = provenance.office_pdfs.get(full_path) or fallback_pdfs_by_dir[parent].get(full_path)
         remaining_text = max(0, MAX_SECTION_TEXT_CHARS_FOR_JUDGE - text_used)
         if media_mode == "images_and_text":
@@ -870,6 +919,8 @@ def build_file_section(
             )
             if blocks:
                 _append_blocks(blocks)
+                if av_identity is not None and any(_attachment_payload(block)[0] for block in blocks):
+                    retained_av_payloads[av_identity] = file_name
                 no_files = False
             sheet_text = _structured_xlsx_text(full_path)
             if sheet_text:
@@ -891,6 +942,8 @@ def build_file_section(
         )
         if block is not None:
             _append_block(block)
+            if av_identity is not None and _attachment_payload(block)[0]:
+                retained_av_payloads[av_identity] = file_name
             no_files = False
         sheet_text = _structured_xlsx_text(full_path)
         if sheet_text:
@@ -1206,9 +1259,13 @@ def construct_judge_messages(
     submission_b: list[dict],
 ) -> list[dict]:
     """Assemble OpenAI messages for the judge: prompt + task + refs + submissions."""
+    verdict_reminder_block = {"type": "text", "text": FINAL_VERDICT_REMINDER}
     # Text can require up to twelve JSON bytes per Unicode code point. Give the
-    # task and three sections equal worst-case shares after reserving framing.
-    available_text_chars = max(0, MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE - 16 * 1024) // 12
+    # task and three sections equal worst-case shares after reserving framing,
+    # including the trailing verdict reminder, so the final serialized bound
+    # cannot exceed the request cap once every share is fully used.
+    framing_reserve = 16 * 1024 + _block_serialized_upper_bound(verdict_reminder_block)
+    available_text_chars = max(0, MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE - framing_reserve) // 12
     fair_text_cap = available_text_chars // 4
     section_text_cap = min(MAX_SECTION_TEXT_CHARS_FOR_JUDGE, fair_text_cap)
     refs = _bound_section_text(refs, section_text_cap)
@@ -1224,6 +1281,7 @@ def construct_judge_messages(
         {"type": "text", "text": SUBMISSION_A_CLOSE},
         {"type": "text", "text": SUBMISSION_B_OPEN},
         {"type": "text", "text": SUBMISSION_B_CLOSE},
+        verdict_reminder_block,
     ]
     sections = [refs, submission_a, submission_b]
     fixed_blocks = framing + [block for section in sections for block in section if _attachment_cost(block)[1] == 0]
@@ -1253,6 +1311,7 @@ def construct_judge_messages(
     content.append({"type": "text", "text": SUBMISSION_B_OPEN})
     content.extend(submission_b)
     content.append({"type": "text", "text": SUBMISSION_B_CLOSE})
+    content.append(verdict_reminder_block)
 
     serialized_bound = _content_serialized_upper_bound(content)
     if serialized_bound > MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE:
@@ -1404,6 +1463,360 @@ class Judge:
     # video but not audio.
     handles_audio: bool = False
     handles_video: bool = False
+    media_mode: str = "native_pdf"
+    max_native_pdf_pages: Optional[int] = None
+    max_native_pdf_documents: Optional[int] = None
+    max_native_pdf_bytes: Optional[int] = None
+    max_native_pdf_bytes_per_document: Optional[int] = None
+    raster_dpi_tiers: tuple[int, ...] = ()
+    max_serialized_request_bytes: Optional[int] = None
+
+
+def preview_trial_judges(judges: list[Judge], num_trials: int, rng: random.Random) -> list[Judge]:
+    """Preview the seeded schedule without consuming *rng*."""
+    if not judges:
+        raise ValueError("preview_trial_judges requires a non-empty judge panel")
+    clone = random.Random()
+    clone.setstate(rng.getstate())
+    return [sample_judge(judges, clone) for _ in range(num_trials)]
+
+
+def filter_media_eligible_judges(
+    judges: list[Judge],
+    *,
+    native_stats: dict[str, int],
+    estimated_images: int,
+    image_cap: int,
+    overflow_plan: Optional[dict] = None,
+) -> tuple[list[Judge], list[dict]]:
+    """Capability-gate the complete panel before seeded trial sampling."""
+    eligible: list[Judge] = []
+    exclusions: list[dict] = []
+    for judge in judges:
+        if judge.media_mode == "native_pdf_overflow_images":
+            if overflow_plan is None or not overflow_plan.get("eligible", False):
+                exclusions.append(
+                    {
+                        "mode": judge.media_mode,
+                        "judges": [judge.name],
+                        "overflow_plan": overflow_plan,
+                        "reason": "native_pdf_overflow_unavailable",
+                    }
+                )
+                continue
+            documents_after = overflow_plan.get("native_documents_after")
+            bytes_after = overflow_plan.get("native_bytes_after_bound")
+            over_aggregate = (
+                judge.max_native_pdf_documents is not None
+                and documents_after is not None
+                and documents_after > judge.max_native_pdf_documents
+            ) or (
+                judge.max_native_pdf_bytes is not None
+                and bytes_after is not None
+                and bytes_after > judge.max_native_pdf_bytes
+            )
+            if over_aggregate:
+                exclusions.append(
+                    {
+                        "mode": judge.media_mode,
+                        "judges": [judge.name],
+                        "pdf_stats": dict(native_stats),
+                        "native_documents_after": documents_after,
+                        "native_bytes_after_bound": bytes_after,
+                        "reason": "native_pdf_cap_after_overflow",
+                    }
+                )
+                continue
+            eligible.append(judge)
+            continue
+        if judge.media_mode == "images_and_text" and estimated_images > image_cap:
+            exclusions.append(
+                {
+                    "mode": judge.media_mode,
+                    "judges": [judge.name],
+                    "estimated_image_count": estimated_images,
+                    "pdf_stats": dict(native_stats),
+                    "cap": image_cap,
+                    "reason": "request_image_cap_preflight",
+                }
+            )
+            continue
+        if judge.media_mode == "native_pdf":
+            over = (
+                (judge.max_native_pdf_pages is not None and native_stats["pages"] > judge.max_native_pdf_pages)
+                or (
+                    judge.max_native_pdf_documents is not None
+                    and native_stats["documents"] > judge.max_native_pdf_documents
+                )
+                or (judge.max_native_pdf_bytes is not None and native_stats["bytes"] > judge.max_native_pdf_bytes)
+            )
+            if over:
+                exclusions.append(
+                    {
+                        "mode": judge.media_mode,
+                        "judges": [judge.name],
+                        "pdf_stats": dict(native_stats),
+                        "reason": "native_pdf_cap",
+                    }
+                )
+                continue
+        eligible.append(judge)
+    return eligible, exclusions
+
+
+def plan_native_pdf_overflow(
+    sections: dict[str, list[dict]],
+    *,
+    native_page_cap: int,
+    native_pdf_bytes_per_document: int,
+    image_cap: int,
+    render_page_cap: Optional[int] = None,
+) -> dict:
+    """Rasterize oversize PDFs and exactly enough pages for the page cap.
+
+    Any PDF above the provider's per-file limit is fully rasterized. For an
+    additional page-count overflow, whole small PDFs are rasterized first and
+    only the required prefix of the final document is rasterized. Every source
+    page remains represented while avoiding unnecessary image expansion.
+    """
+    from resources_servers.gdpval.media_conversion import pdf_page_count
+
+    prefix = "data:application/pdf;base64,"
+    documents: list[dict] = []
+    existing_images = 0
+    for section_name, blocks in sections.items():
+        for block_index, block in enumerate(blocks):
+            if block.get("type") != "image_url":
+                continue
+            url = str((block.get("image_url") or {}).get("url", ""))
+            if not url.startswith(prefix):
+                if url.startswith("data:image/"):
+                    existing_images += 1
+                continue
+            payload = base64.b64decode(url[len(prefix) :], validate=True)
+            pages = pdf_page_count(payload)
+            if pages <= 0:
+                raise ValueError(f"native PDF has no pages: {section_name}/{block_index}")
+            documents.append(
+                {
+                    "section": section_name,
+                    "block_index": block_index,
+                    "pages": pages,
+                    "bytes": len(payload),
+                    "sha256": hashlib.sha256(payload).hexdigest(),
+                }
+            )
+    total_pages = sum(item["pages"] for item in documents)
+    excess = max(0, total_pages - native_page_cap)
+    forced = {index for index, item in enumerate(documents) if item["bytes"] > native_pdf_bytes_per_document}
+    selected: list[dict] = [
+        {
+            **documents[index],
+            "raster_page_start": 0,
+            "raster_page_count": int(documents[index]["pages"]),
+            "native_page_count": 0,
+            "reason": "native_pdf_bytes_per_document",
+        }
+        for index in sorted(forced)
+    ]
+    forced_pages = sum(int(documents[index]["pages"]) for index in forced)
+    remaining = max(0, excess - forced_pages)
+    fully_rasterized: set[int] = set(forced)
+    for index in sorted(range(len(documents)), key=lambda value: (documents[value]["pages"], value)):
+        if index in forced:
+            continue
+        if remaining <= 0:
+            break
+        document = documents[index]
+        raster_page_count = min(int(document["pages"]), remaining)
+        selected.append(
+            {
+                **document,
+                "raster_page_start": 0,
+                "raster_page_count": raster_page_count,
+                "native_page_count": int(document["pages"]) - raster_page_count,
+                "reason": "native_pdf_page_cap",
+            }
+        )
+        if raster_page_count == int(document["pages"]):
+            fully_rasterized.add(index)
+        remaining -= raster_page_count
+    raster_pages = sum(int(item["raster_page_count"]) for item in selected)
+    native_pages = total_pages - raster_pages
+    total_images_after = existing_images + raster_pages
+    # A fully rasterized document leaves the native payload entirely; a prefix
+    # split keeps a native suffix whose size is bounded by the original bytes.
+    native_documents_after = sum(1 for index in range(len(documents)) if index not in fully_rasterized)
+    native_bytes_after_bound = sum(
+        int(documents[index]["bytes"]) for index in range(len(documents)) if index not in fully_rasterized
+    )
+    render_ok = render_page_cap is None or all(int(item["raster_page_count"]) <= render_page_cap for item in selected)
+    return {
+        "eligible": (
+            remaining == 0 and native_pages <= native_page_cap and total_images_after <= image_cap and render_ok
+        ),
+        "total_pdf_pages": total_pages,
+        "native_page_cap": native_page_cap,
+        "native_pdf_bytes_per_document": native_pdf_bytes_per_document,
+        "native_pages_after": native_pages,
+        "native_documents_after": native_documents_after,
+        "native_bytes_after_bound": native_bytes_after_bound,
+        "render_page_cap": render_page_cap,
+        "raster_pages": raster_pages,
+        "image_cap": image_cap,
+        "existing_images": existing_images,
+        "total_images_after": total_images_after,
+        "selected": selected,
+    }
+
+
+def _split_pdf_prefix(pdf_bytes: bytes, raster_page_count: int) -> tuple[bytes, bytes]:
+    """Return PDF byte streams for a non-empty prefix and suffix."""
+    try:
+        import fitz  # PyMuPDF
+    except ImportError as exc:
+        raise RuntimeError("PyMuPDF is required for native-PDF overflow splitting") from exc
+
+    source = fitz.open(stream=pdf_bytes, filetype="pdf")
+    prefix = fitz.open()
+    suffix = fitz.open()
+    try:
+        pages = int(source.page_count)
+        if not 0 < raster_page_count < pages:
+            raise ValueError(f"invalid PDF prefix split: {raster_page_count}/{pages}")
+        prefix.insert_pdf(source, from_page=0, to_page=raster_page_count - 1, links=True, annots=True)
+        suffix.insert_pdf(source, from_page=raster_page_count, to_page=pages - 1, links=True, annots=True)
+        return prefix.tobytes(garbage=0, deflate=False), suffix.tobytes(garbage=0, deflate=False)
+    finally:
+        suffix.close()
+        prefix.close()
+        source.close()
+
+
+def apply_native_pdf_overflow(
+    sections: dict[str, list[dict]],
+    plan: dict,
+    *,
+    render_dpi: int,
+    max_pages: int,
+    include_text: bool,
+) -> dict[str, list[dict]]:
+    """Apply a preflighted overflow plan while retaining every PDF page."""
+    from resources_servers.gdpval.media_conversion import pdf_bytes_to_blocks, pdf_page_count
+
+    selected = {(x["section"], int(x["block_index"])): x for x in plan.get("selected", [])}
+    if len(selected) != len(plan.get("selected", [])):
+        raise ValueError("overflow plan selects a PDF block more than once")
+    prefix = "data:application/pdf;base64,"
+    output: dict[str, list[dict]] = {}
+    for section_name, blocks in sections.items():
+        converted: list[dict] = []
+        for block_index, block in enumerate(blocks):
+            item = selected.get((section_name, block_index))
+            if item is None:
+                converted.append(block)
+                continue
+            url = str((block.get("image_url") or {}).get("url", ""))
+            if not url.startswith(prefix):
+                raise ValueError(f"overflow plan block drift: {section_name}/{block_index}")
+            payload = base64.b64decode(url[len(prefix) :], validate=True)
+            if hashlib.sha256(payload).hexdigest() != item["sha256"]:
+                raise ValueError(f"overflow plan hash drift: {section_name}/{block_index}")
+            pages = pdf_page_count(payload)
+            if pages != int(item["pages"]):
+                raise ValueError(f"overflow plan page-count drift: {section_name}/{block_index}")
+            raster_page_start = int(item.get("raster_page_start", 0))
+            raster_page_count = int(item.get("raster_page_count", pages))
+            native_page_count = int(item.get("native_page_count", pages - raster_page_count))
+            if raster_page_start != 0 or raster_page_count <= 0 or raster_page_count > pages:
+                raise ValueError(f"invalid overflow page range: {section_name}/{block_index}")
+            if native_page_count != pages - raster_page_count:
+                raise ValueError(f"overflow plan page partition drift: {section_name}/{block_index}")
+            if native_page_count:
+                raster_payload, native_payload = _split_pdf_prefix(payload, raster_page_count)
+                if pdf_page_count(raster_payload) != raster_page_count:
+                    raise ValueError(f"overflow prefix page-count drift: {section_name}/{block_index}")
+                if pdf_page_count(native_payload) != native_page_count:
+                    raise ValueError(f"overflow suffix page-count drift: {section_name}/{block_index}")
+            else:
+                raster_payload = payload
+                native_payload = b""
+            rendered = pdf_bytes_to_blocks(
+                raster_payload,
+                dpi=render_dpi,
+                max_pages=max_pages,
+                include_text=include_text,
+            )
+            image_count = sum(1 for x in rendered if x.get("type") == "image_url")
+            if image_count != raster_page_count or any(
+                str(x.get("text", "")).startswith("[truncated: rendered") for x in rendered
+            ):
+                raise ValueError(
+                    f"overflow render mismatch {section_name}/{block_index}: "
+                    f"images={image_count} pages={raster_page_count}"
+                )
+            converted.extend(rendered)
+            if native_payload:
+                converted.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": prefix + base64.b64encode(native_payload).decode("ascii")},
+                    }
+                )
+        output[section_name] = converted
+    return output
+
+
+_LOSSY_TRANSPORT_PREFIXES = (
+    "[attachment omitted",
+    "[oversize:",
+    "[truncated: rendered",
+)
+
+
+def preflight_judge_transport(
+    judge: Judge,
+    task_prompt: str,
+    sections: dict[str, list[dict]],
+) -> dict[str, Any]:
+    """Project one provider request and reject lossy or oversized transport."""
+    messages = construct_judge_messages(
+        task_prompt=task_prompt,
+        refs=sections["refs"],
+        submission_a=sections["submission_a"],
+        submission_b=sections["submission_b"],
+    )
+    markers: list[str] = []
+    for message in messages:
+        for block in message.get("content") or []:
+            text = str(block.get("text", ""))
+            if text.startswith(_LOSSY_TRANSPORT_PREFIXES):
+                markers.append(text.splitlines()[0][:240])
+    create_kwargs = merge_create_kwargs(
+        {
+            "model": judge.model,
+            "messages": messages,
+            "max_tokens": 65535,
+            "temperature": 1.0,
+        },
+        judge.create_overrides,
+    )
+    serialized_bytes = len(json.dumps(create_kwargs, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+    cap = judge.max_serialized_request_bytes
+    reasons: list[str] = []
+    if markers:
+        reasons.append("lossy_attachment_omission")
+    if cap is not None and serialized_bytes >= cap:
+        reasons.append("provider_wire_cap")
+    return {
+        "eligible": not reasons,
+        "judge": judge.name,
+        "media_mode": judge.media_mode,
+        "serialized_request_bytes": serialized_bytes,
+        "max_serialized_request_bytes": cap,
+        "loss_markers": markers,
+        "reasons": reasons,
+    }
 
 
 def run_trials(
@@ -1412,6 +1825,7 @@ def run_trials(
     refs: list[dict],
     submission_a: list[dict],
     submission_b: list[dict],
+    sections_by_judge: Optional[dict[str, dict[str, list[dict]]]] = None,
     num_trials: int = 4,
     max_output_tokens: int = 65535,
     return_raw_responses: bool = False,
@@ -1455,6 +1869,13 @@ def run_trials(
     for i in range(num_trials):
         judge = sample_judge(judges, rng)
         trial_judges.append(judge.name)
+        if sections_by_judge is not None:
+            if judge.name not in sections_by_judge:
+                raise ValueError(f"missing sections for judge {judge.name!r}")
+            judge_sections = sections_by_judge[judge.name]
+            refs = judge_sections["refs"]
+            submission_a = judge_sections["submission_a"]
+            submission_b = judge_sections["submission_b"]
         swapped = i % 2 != 0
         current_a = submission_b if swapped else submission_a
         current_b = submission_a if swapped else submission_b

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -21,22 +21,32 @@ between the eval model and a reference model's deliverables) and
 from __future__ import annotations
 
 import base64
+import hashlib
 import logging
 import math
 import os
 import random
 import re
 import shutil
+import stat
 import tempfile
 import time
 import zipfile
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Optional
 
 from openai import APITimeoutError
 
 from resources_servers.gdpval.judge_panel import AUDIO_EXTS, VIDEO_EXTS, merge_create_kwargs, sample_judge
+from resources_servers.gdpval.preconvert import (
+    OFFICE_EXTENSIONS,
+    AttachmentBudget,
+    extract_xlsx_structured_text,
+    resolve_pdf_provenance,
+    sidecar_pdf,
+)
+from resources_servers.gdpval.scoring import is_permanent_judge_error
 
 
 LOGGER = logging.getLogger(__name__)
@@ -95,6 +105,32 @@ JUDGE_REQUEST_TIMEOUT_SECONDS = float(os.environ.get("GDPVAL_JUDGE_REQUEST_TIMEO
 # videos in the GDPVal task set still go through; only catches the truly
 # pathological cases (e.g. ``task_a941b6d8`` 657 MB overlay clip).
 MAX_FILE_BYTES_FOR_JUDGE = 250 * 1024 * 1024
+# Aggregate encoded payload is what the HTTP server sees. Keeping it below
+# 400 MiB leaves roughly 80 MB even if the model server's advertised 500 MB
+# ceiling is decimal, for JSON, prompts, spreadsheet text, and framing. The raw
+# ceiling separately prevents pathological media accumulation before base64.
+MAX_TOTAL_RAW_ATTACHMENT_BYTES_FOR_JUDGE = 300 * 1024 * 1024
+MAX_TOTAL_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE = 400 * 1024 * 1024
+# Each directory is built independently. Keeping every section below an equal,
+# conservative share means references can never consume the bytes needed to
+# show both submissions, and limits peak memory before message assembly.
+MAX_SECTION_RAW_ATTACHMENT_BYTES_FOR_JUDGE = 96 * 1024 * 1024
+MAX_SECTION_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE = 128 * 1024 * 1024
+MAX_TEXT_FILE_CHARS_FOR_JUDGE = 200_000
+MAX_SECTION_TEXT_CHARS_FOR_JUDGE = 1_000_000
+MAX_XLSX_TEXT_CHARS_FOR_JUDGE = 120_000
+# Includes base64, all text, data-URL prefixes, and conservative JSON framing.
+# This stays below endpoints configured with a 500 MB request-body ceiling.
+MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE = 420 * 1024 * 1024
+MAX_TASK_PROMPT_CHARS_FOR_JUDGE = 1_000_000
+# Archives expand before their members enter the normal payload builders, so
+# bound that work independently. Extracting more than one section's raw budget
+# cannot make more binary evidence visible to the judge.
+MAX_ZIP_ARCHIVE_BYTES_FOR_JUDGE = MAX_FILE_BYTES_FOR_JUDGE
+MAX_ZIP_MEMBERS_FOR_JUDGE = 1_000
+MAX_ZIP_MEMBER_BYTES_FOR_JUDGE = MAX_SECTION_RAW_ATTACHMENT_BYTES_FOR_JUDGE
+MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES_FOR_JUDGE = MAX_SECTION_RAW_ATTACHMENT_BYTES_FOR_JUDGE
+ZIP_COPY_CHUNK_BYTES = 1024 * 1024
 RETRYABLE_ERROR_MARKERS = (
     "429",
     "502",
@@ -113,7 +149,6 @@ RETRYABLE_ERROR_MARKERS = (
     "temporarily unavailable",
     "connection error",
 )
-
 # ---------------------------------------------------------------------------
 # File handling
 # ---------------------------------------------------------------------------
@@ -124,9 +159,24 @@ def _data_url(mime_type: str, data: bytes) -> str:
     return f"data:{mime_type};base64,{b64}"
 
 
-def _load_raw_text(path: str | Path) -> str:
+def _bounded_text(text: str, cap: int, marker: str = "\n[...truncated]") -> str:
+    if cap <= 0:
+        return ""
+    if len(text) <= cap:
+        return text
+    if cap <= len(marker):
+        return marker[-cap:]
+    return text[: cap - len(marker)] + marker
+
+
+def _load_raw_text(path: str | Path, max_chars: int = MAX_TEXT_FILE_CHARS_FOR_JUDGE) -> str:
+    """Read only the prefix that can be emitted to the judge."""
+
+    if max_chars <= 0:
+        return ""
     with open(path, "r", encoding="utf-8") as f:
-        return f.read()
+        text = f.read(max_chars + 1)
+    return _bounded_text(text, max_chars)
 
 
 def _load_media(path: str | Path) -> bytes:
@@ -134,33 +184,160 @@ def _load_media(path: str | Path) -> bytes:
         return f.read()
 
 
-def _convert_to_pdf(path: str | Path) -> bytes | None:
-    """Load a pre-converted PDF (same name, .pdf extension). Returns None if missing."""
+def _resolve_office_pdf_path(
+    path: str | Path,
+    *,
+    cached_pdf_path: Path | None = None,
+    provenance_resolved: bool = False,
+) -> Path | None:
+    """Return a provenance-safe Office render without rereading known listings."""
+
     input_path = Path(path).resolve()
-    output_path = input_path.with_suffix(".pdf")
-    if output_path.exists():
-        return _load_media(output_path)
-    return None
+    if provenance_resolved:
+        return cached_pdf_path.resolve() if cached_pdf_path is not None else None
+    try:
+        entries = [entry.resolve() for entry in input_path.parent.iterdir() if entry.is_file()]
+    except OSError:
+        return None
+    output_path = resolve_pdf_provenance(entries).office_pdfs.get(input_path)
+    if output_path is None and input_path.suffix.lower() not in OFFICE_EXTENSIONS:
+        # Preserve the historical fallback for less-common document formats
+        # that are not preconverted by GDPVal but may already have a render.
+        injective = sidecar_pdf(input_path)
+        plain = input_path.with_suffix(".pdf")
+        output_path = injective if injective.is_file() else plain if plain.is_file() else None
+    return output_path
+
+
+def _convert_to_pdf(path: str | Path) -> bytes | None:
+    """Load the provenance-safe pre-converted PDF for an Office source."""
+
+    output_path = _resolve_office_pdf_path(path)
+    return _load_media(output_path) if output_path is not None else None
+
+
+def _attachment_omission(file_name: str, size_bytes: int, reason: str) -> dict[str, str]:
+    return {
+        "type": "text",
+        "text": f"[attachment omitted for {file_name}: {_human_attachment_size(size_bytes)} raw; {reason}]",
+    }
+
+
+def _reserve_attachment_path(
+    path: Path,
+    file_name: str,
+    budget: AttachmentBudget | None,
+) -> tuple[int, dict[str, str] | None]:
+    """Stat and reserve an attachment before any read or base64 allocation."""
+
+    try:
+        size_bytes = path.stat().st_size
+    except OSError:
+        return 0, {"type": "text", "text": f"[attachment unavailable for {file_name}]"}
+    if size_bytes > MAX_FILE_BYTES_FOR_JUDGE:
+        return size_bytes, _attachment_omission(file_name, size_bytes, "per-file judge payload limit")
+    if budget is not None and not budget.reserve(size_bytes):
+        return size_bytes, _attachment_omission(file_name, size_bytes, "section judge payload budget")
+    return size_bytes, None
 
 
 def _maybe_unzip(path: str | Path) -> tuple[Path | None, list[Path]]:
-    """Extract a zip into a per-call tempdir; never write into ``path.parent``.
+    """Extract a bounded zip into a per-call tempdir.
 
     The reference deliverables tree is mounted read-only in production, so the
     previous behaviour of ``extractall(path.parent)`` raised ``PermissionError``
-    and failed /verify outright. Returns ``(extract_dir, member_paths)`` —
-    callers are responsible for ``shutil.rmtree(extract_dir)`` after they're
-    done reading the members.
+    and failed /verify outright. Member count, individual expanded size, and
+    total expanded size are checked before opening a member; the streaming copy
+    enforces the declared size as a second line of defence. Absolute, parent-
+    traversing, duplicate, and symlink entries are ignored.
+
+    Returns ``(extract_dir, member_paths)``. Callers are responsible for
+    ``shutil.rmtree(extract_dir)`` after reading the members.
     """
     path = Path(path)
+    extract_dir: Path | None = None
     try:
+        if path.stat().st_size > MAX_ZIP_ARCHIVE_BYTES_FOR_JUDGE:
+            LOGGER.warning("zip %s exceeds the compressed archive limit; ignoring it", path)
+            return None, []
         with zipfile.ZipFile(path, "r") as zip_ref:
             extract_dir = Path(tempfile.mkdtemp(prefix="gdpval_unzip_"))
-            zip_ref.extractall(extract_dir)
-            members = zip_ref.namelist()
-            extracted_paths = [extract_dir / Path(member) for member in members if member]
+            extract_root = extract_dir.resolve()
+            extracted_paths: list[Path] = []
+            extracted_targets: set[Path] = set()
+            total_uncompressed = 0
+            examined_files = 0
+
+            for info in zip_ref.infolist():
+                if info.is_dir():
+                    continue
+                examined_files += 1
+                if examined_files > MAX_ZIP_MEMBERS_FOR_JUDGE:
+                    LOGGER.warning(
+                        "zip %s exceeds the %d-member extraction limit; ignoring remaining members",
+                        path,
+                        MAX_ZIP_MEMBERS_FOR_JUDGE,
+                    )
+                    break
+
+                # ZIP member names are POSIX paths regardless of host OS. Treat
+                # backslashes as separators too so a Windows consumer cannot turn
+                # a benign-looking name into traversal later.
+                member_path = PurePosixPath(info.filename.replace("\\", "/"))
+                parts = member_path.parts
+                mode = info.external_attr >> 16
+                if (
+                    member_path.is_absolute()
+                    or not parts
+                    or any(part in {"", ".", ".."} for part in parts)
+                    or re.match(r"^[A-Za-z]:", parts[0])
+                    or stat.S_ISLNK(mode)
+                ):
+                    LOGGER.warning("ignoring unsafe zip member %r in %s", info.filename, path)
+                    continue
+
+                member_size = max(0, info.file_size)
+                if member_size > MAX_ZIP_MEMBER_BYTES_FOR_JUDGE:
+                    LOGGER.warning("ignoring oversize zip member %r in %s", info.filename, path)
+                    continue
+                if total_uncompressed + member_size > MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES_FOR_JUDGE:
+                    LOGGER.warning("ignoring zip member %r after aggregate expansion limit", info.filename)
+                    continue
+
+                target = (extract_root / Path(*parts)).resolve()
+                if not target.is_relative_to(extract_root) or target in extracted_targets or target.exists():
+                    LOGGER.warning("ignoring duplicate or escaping zip member %r in %s", info.filename, path)
+                    continue
+
+                try:
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                except OSError:
+                    LOGGER.warning("ignoring conflicting zip member %r in %s", info.filename, path)
+                    continue
+                written = 0
+                try:
+                    with zip_ref.open(info, "r") as source, target.open("xb") as destination:
+                        while written < member_size:
+                            chunk = source.read(min(ZIP_COPY_CHUNK_BYTES, member_size - written))
+                            if not chunk:
+                                break
+                            destination.write(chunk)
+                            written += len(chunk)
+                        if written != member_size or source.read(1):
+                            raise ValueError("expanded size does not match ZIP metadata")
+                except (OSError, RuntimeError, ValueError, zipfile.BadZipFile):
+                    if target.is_file() or target.is_symlink():
+                        target.unlink(missing_ok=True)
+                    LOGGER.warning("failed bounded extraction of zip member %r in %s", info.filename, path)
+                    continue
+
+                total_uncompressed += written
+                extracted_targets.add(target)
+                extracted_paths.append(target)
         return extract_dir, extracted_paths
     except (zipfile.BadZipFile, zipfile.LargeZipFile, FileNotFoundError, OSError):
+        if extract_dir is not None:
+            shutil.rmtree(extract_dir, ignore_errors=True)
         return None, []
 
 
@@ -243,23 +420,29 @@ FILE_TYPE_MAP: dict[str, dict[str, Any]] = {
 }
 
 
-def get_file_content_block(file_dir: str, file_name: str) -> dict | None:
+def get_file_content_block(
+    file_dir: str,
+    file_name: str,
+    *,
+    attachment_budget: AttachmentBudget | None = None,
+    cached_office_pdf: Path | None = None,
+    provenance_resolved: bool = False,
+    max_text_chars: int = MAX_TEXT_FILE_CHARS_FOR_JUDGE,
+) -> dict | None:
     """Return a single OpenAI content block (dict) for a file, or ``None``."""
     file_extension = file_name.rsplit(".", 1)[-1].lower() if "." in file_name else ""
 
     if file_extension not in FILE_TYPE_MAP:
         file_type = "DOC"
-        file_converter = _convert_to_pdf
         file_mime_type = "application/pdf"
     else:
         file_type = FILE_TYPE_MAP[file_extension]["type"]
-        file_converter = FILE_TYPE_MAP[file_extension]["converter"]
         file_mime_type = FILE_TYPE_MAP[file_extension]["mime_type"]
 
-    full_path = os.path.join(file_dir, file_name)
+    full_path = Path(file_dir) / file_name
 
     try:
-        size_bytes = os.path.getsize(full_path)
+        size_bytes = full_path.stat().st_size
     except OSError:
         return None
     if size_bytes > MAX_FILE_BYTES_FOR_JUDGE:
@@ -271,27 +454,129 @@ def get_file_content_block(file_dir: str, file_name: str) -> dict | None:
 
     try:
         if file_type == "TXT":
-            raw_text = file_converter(full_path)
+            raw_text = _load_raw_text(full_path, max_text_chars)
             return {"type": "text", "text": raw_text}
 
         if file_type == "DOC":
-            doc_bytes = file_converter(full_path)
-            if doc_bytes is None:
+            pdf_path = _resolve_office_pdf_path(
+                full_path,
+                cached_pdf_path=cached_office_pdf,
+                provenance_resolved=provenance_resolved,
+            )
+            if pdf_path is None:
                 return None
-            return {"type": "image_url", "image_url": {"url": _data_url(file_mime_type, doc_bytes)}}
+            _size, omitted = _reserve_attachment_path(pdf_path, file_name, attachment_budget)
+            if omitted is not None:
+                return omitted
+            data = _load_media(pdf_path)
+            return {"type": "image_url", "image_url": {"url": _data_url(file_mime_type, data)}}
 
         if file_type == "PDF":
-            data = Path(full_path).read_bytes()
+            _size, omitted = _reserve_attachment_path(full_path, file_name, attachment_budget)
+            if omitted is not None:
+                return omitted
+            data = _load_media(full_path)
             return {"type": "image_url", "image_url": {"url": _data_url(file_mime_type, data)}}
 
         if file_type in ("IMG", "AUDIO", "VIDEO"):
-            media_bytes = file_converter(full_path)
+            _size, omitted = _reserve_attachment_path(full_path, file_name, attachment_budget)
+            if omitted is not None:
+                return omitted
+            media_bytes = _load_media(full_path)
             return {"type": "image_url", "image_url": {"url": _data_url(file_mime_type, media_bytes)}}
 
     except Exception as e:
         raise RuntimeError(f"Error getting file: {file_name} in directory: {file_dir}: {e}") from e
 
     return None
+
+
+MAX_RASTER_PAGE_PIXELS_FOR_JUDGE = 40_000_000
+
+
+def _pdf_path_to_image_text_blocks(
+    pdf_path: Path,
+    *,
+    render_dpi: int,
+    max_pages: int,
+    include_text: bool,
+    attachment_budget: AttachmentBudget,
+    max_text_chars: int,
+    file_name: str,
+) -> list[dict]:
+    """Render one PDF page at a time, reserving PNG bytes before base64."""
+
+    try:
+        import fitz
+    except ImportError:
+        LOGGER.warning("PyMuPDF (fitz) not installed; cannot rasterize PDF for image-only judge")
+        return []
+
+    try:
+        document = fitz.open(str(pdf_path))
+    except Exception as exc:
+        LOGGER.warning("failed to open PDF %s for rasterization: %r", file_name, exc)
+        return []
+
+    images: list[dict] = []
+    text_parts: list[str] = []
+    text_remaining = max(0, max_text_chars)
+    text_truncated = False
+    try:
+        total_pages = document.page_count
+        page_limit = min(total_pages, max(0, max_pages))
+        zoom = render_dpi / 72.0
+        matrix = fitz.Matrix(zoom, zoom)
+        for page_index in range(page_limit):
+            try:
+                page = document.load_page(page_index)
+                if include_text and text_remaining > 0:
+                    page_text = (page.get_text("text") or "").strip()
+                    if page_text:
+                        separator = 2 if text_parts else 0
+                        if separator < text_remaining:
+                            take = min(len(page_text), text_remaining - separator)
+                            text_parts.append(page_text[:take])
+                            text_remaining -= separator + take
+                            if take < len(page_text):
+                                text_truncated = True
+                elif include_text and text_parts:
+                    text_truncated = True
+
+                rect = page.rect
+                width = math.ceil(rect.width * zoom)
+                height = math.ceil(rect.height * zoom)
+                if width * height > MAX_RASTER_PAGE_PIXELS_FOR_JUDGE:
+                    images.append(
+                        {
+                            "type": "text",
+                            "text": f"[page {page_index + 1} omitted for {file_name}: raster dimensions too large]",
+                        }
+                    )
+                    continue
+                pixmap = page.get_pixmap(matrix=matrix, alpha=False)
+                png = pixmap.tobytes("png")
+            except Exception as exc:
+                LOGGER.warning("failed to render PDF page %d for %s: %r", page_index, file_name, exc)
+                continue
+            if not attachment_budget.reserve(len(png)):
+                images.append(_attachment_omission(file_name, len(png), "section judge payload budget"))
+                break
+            images.append({"type": "image_url", "image_url": {"url": _data_url("image/png", png)}})
+
+        if total_pages > page_limit:
+            images.append({"type": "text", "text": f"[truncated: rendered {page_limit} of {total_pages} pages]"})
+    finally:
+        document.close()
+
+    blocks: list[dict] = []
+    if text_parts:
+        extracted = "\n\n".join(text_parts)
+        if text_truncated:
+            extracted = _bounded_text(extracted + "x", max_text_chars, "\n[...text truncated]")
+        blocks.append({"type": "text", "text": f"[extracted text]\n{extracted}"})
+    blocks.extend(images)
+    return blocks
 
 
 def get_file_image_text_blocks(
@@ -303,6 +588,10 @@ def get_file_image_text_blocks(
     include_text: bool,
     audio_capable: bool = False,
     video_capable: bool = False,
+    attachment_budget: AttachmentBudget | None = None,
+    cached_office_pdf: Path | None = None,
+    provenance_resolved: bool = False,
+    max_text_chars: int = MAX_TEXT_FILE_CHARS_FOR_JUDGE,
 ) -> list[dict]:
     """``images_and_text`` variant of :func:`get_file_content_block`.
 
@@ -320,15 +609,19 @@ def get_file_image_text_blocks(
     judges, which vLLM won't route to the video/audio tower). An unreadable
     modality is replaced with a one-line marker. Returns a list of 0+ blocks.
     """
-    from resources_servers.gdpval.media_conversion import audio_video_block, pdf_bytes_to_blocks
+    from resources_servers.gdpval.media_conversion import audio_video_block
 
     file_extension = file_name.rsplit(".", 1)[-1].lower() if "." in file_name else ""
     info = FILE_TYPE_MAP.get(file_extension)
     file_type = info["type"] if info else "DOC"
-    full_path = os.path.join(file_dir, file_name)
+    full_path = Path(file_dir) / file_name
+    budget = attachment_budget or AttachmentBudget(
+        raw_limit=MAX_SECTION_RAW_ATTACHMENT_BYTES_FOR_JUDGE,
+        encoded_limit=MAX_SECTION_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE,
+    )
 
     try:
-        size_bytes = os.path.getsize(full_path)
+        size_bytes = full_path.stat().st_size
     except OSError:
         return []
     if size_bytes > MAX_FILE_BYTES_FOR_JUDGE:
@@ -338,10 +631,14 @@ def get_file_image_text_blocks(
     try:
         # PDFs and Office docs (preconverted to a sibling .pdf) → page images + text.
         if file_type == "PDF":
-            pdf_bytes: bytes | None = Path(full_path).read_bytes()
+            pdf_path: Path | None = full_path
         elif file_type == "DOC":
-            pdf_bytes = _convert_to_pdf(full_path)
-            if pdf_bytes is None:
+            pdf_path = _resolve_office_pdf_path(
+                full_path,
+                cached_pdf_path=cached_office_pdf,
+                provenance_resolved=provenance_resolved,
+            )
+            if pdf_path is None:
                 # No sibling .pdf render exists, so this Office deliverable's content
                 # is invisible to an image-only judge (only the filename is shown).
                 # Warn so an incomplete-preconvert reference cache surfaces instead of
@@ -352,14 +649,28 @@ def get_file_image_text_blocks(
                     file_name,
                 )
         else:
-            pdf_bytes = None
+            pdf_path = None
 
-        if pdf_bytes is not None:
-            blocks = pdf_bytes_to_blocks(
-                pdf_bytes,
-                dpi=render_dpi,
+        if pdf_path is not None:
+            try:
+                pdf_size = pdf_path.stat().st_size
+            except OSError:
+                return [{"type": "text", "text": f"[attachment unavailable for {file_name}]"}]
+            if pdf_size > MAX_FILE_BYTES_FOR_JUDGE:
+                return [_attachment_omission(file_name, pdf_size, "per-file judge payload limit")]
+            # The PDF is only an input to rasterization; it is not part of the
+            # request. Its compressed source size says nothing about whether a
+            # rendered PNG page fits the remaining attachment-output budget.
+            if not budget.can_fit(1):
+                return [_attachment_omission(file_name, pdf_size, "section judge payload budget")]
+            blocks = _pdf_path_to_image_text_blocks(
+                pdf_path,
+                render_dpi=render_dpi,
                 max_pages=max_pages,
                 include_text=include_text,
+                attachment_budget=budget,
+                max_text_chars=max_text_chars,
+                file_name=file_name,
             )
             if blocks:
                 return blocks
@@ -384,11 +695,21 @@ def get_file_image_text_blocks(
                 ]
             info = FILE_TYPE_MAP.get(file_extension) or {}
             mime = info.get("mime_type") or "application/octet-stream"
+            _size, omitted = _reserve_attachment_path(full_path, file_name, budget)
+            if omitted is not None:
+                return [omitted]
             data = _load_media(full_path)
             return [audio_video_block(mime, data, ext=file_extension, file_type=file_type, openai_native=True)]
 
         # Text and native images pass through exactly as in native mode.
-        block = get_file_content_block(file_dir, file_name)
+        block = get_file_content_block(
+            file_dir,
+            file_name,
+            attachment_budget=budget,
+            cached_office_pdf=cached_office_pdf,
+            provenance_resolved=provenance_resolved,
+            max_text_chars=max_text_chars,
+        )
         return [block] if block is not None else []
     except Exception as e:
         raise RuntimeError(f"Error getting file: {file_name} in directory: {file_dir}: {e}") from e
@@ -426,6 +747,37 @@ def build_file_section(
 
     section: list[dict] = []
     no_files = True
+    attachment_budget = AttachmentBudget(
+        raw_limit=MAX_SECTION_RAW_ATTACHMENT_BYTES_FOR_JUDGE,
+        encoded_limit=MAX_SECTION_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE,
+    )
+    text_used = 0
+    text_omitted = False
+    text_marker = "\n[...additional text omitted: section judge text budget exhausted]"
+
+    def _append_block(block: dict) -> None:
+        nonlocal text_used, text_omitted
+        if block.get("type") != "text":
+            section.append(block)
+            return
+        value = str(block.get("text", ""))
+        remaining = max(0, MAX_SECTION_TEXT_CHARS_FOR_JUDGE - text_used)
+        if not value:
+            return
+        if remaining <= 0:
+            text_omitted = True
+            return
+        shown = _bounded_text(value, remaining, text_marker)
+        if len(shown) < len(value):
+            text_omitted = True
+        copied = dict(block)
+        copied["text"] = shown
+        section.append(copied)
+        text_used += len(shown)
+
+    def _append_blocks(blocks: list[dict]) -> None:
+        for block in blocks:
+            _append_block(block)
 
     extracted_dirs: list[Path] = []
     if file_dir is not None and os.path.exists(file_dir):
@@ -437,12 +789,71 @@ def build_file_section(
                     extracted_dirs.append(extract_dir)
 
     ignore_files = _ignore_files()
+    provenance_by_dir: dict[Path, Any] = {}
+    fallback_pdfs_by_dir: dict[Path, dict[Path, Path]] = {}
+    fallback_suppressed_by_dir: dict[Path, frozenset[Path]] = {}
+
+    def _provenance(directory: str):
+        parent = Path(directory)
+        if parent not in provenance_by_dir:
+            entries = [entry for entry in parent.iterdir() if entry.is_file() and entry.name not in ignore_files]
+            provenance_by_dir[parent] = resolve_pdf_provenance(entries)
+            entry_set = set(entries)
+            fallback_sources = [
+                entry
+                for entry in entries
+                if entry.suffix.lower() != ".zip" and (entry.suffix.lower().lstrip(".") not in FILE_TYPE_MAP)
+            ]
+            stem_counts: dict[str, int] = {}
+            for source in fallback_sources:
+                stem_counts[source.stem] = stem_counts.get(source.stem, 0) + 1
+            fallback_pdfs: dict[Path, Path] = {}
+            fallback_suppressed: set[Path] = set()
+            for source in fallback_sources:
+                injective = sidecar_pdf(source)
+                plain = source.with_suffix(".pdf")
+                if injective in entry_set:
+                    fallback_pdfs[source] = injective
+                    fallback_suppressed.add(injective)
+                elif plain in entry_set and stem_counts[source.stem] == 1:
+                    fallback_pdfs[source] = plain
+                    fallback_suppressed.add(plain)
+                elif plain in entry_set:
+                    # Same ambiguity rule as recognized Office sources: never
+                    # emit a stale collided render as independent evidence.
+                    fallback_suppressed.add(plain)
+            fallback_pdfs_by_dir[parent] = fallback_pdfs
+            fallback_suppressed_by_dir[parent] = frozenset(fallback_suppressed)
+        return provenance_by_dir[parent]
+
+    def _structured_xlsx_text(full_path: Path) -> str | None:
+        if full_path.suffix.lower() != ".xlsx":
+            return None
+        try:
+            if full_path.stat().st_size > MAX_FILE_BYTES_FOR_JUDGE:
+                return None
+            remaining = max(0, MAX_SECTION_TEXT_CHARS_FOR_JUDGE - text_used)
+            if remaining <= 0:
+                return None
+            return extract_xlsx_structured_text(
+                full_path,
+                max_chars=min(MAX_XLSX_TEXT_CHARS_FOR_JUDGE, remaining),
+            )
+        except Exception as exc:
+            return f"[structured spreadsheet extraction failed: {exc}]"
 
     def _emit(directory: str, file_name: str) -> None:
         nonlocal no_files
         if file_name in ignore_files:
             return
-        section.append({"type": "text", "text": f"\n{file_name}:\n"})
+        full_path = Path(directory) / file_name
+        provenance = _provenance(directory)
+        parent = Path(directory)
+        if full_path in provenance.suppressed_pdfs or full_path in fallback_suppressed_by_dir[parent]:
+            return
+        _append_block({"type": "text", "text": f"\n{file_name}:\n"})
+        cached_office_pdf = provenance.office_pdfs.get(full_path) or fallback_pdfs_by_dir[parent].get(full_path)
+        remaining_text = max(0, MAX_SECTION_TEXT_CHARS_FOR_JUDGE - text_used)
         if media_mode == "images_and_text":
             blocks = get_file_image_text_blocks(
                 directory,
@@ -452,14 +863,38 @@ def build_file_section(
                 include_text=include_text,
                 audio_capable=audio_capable,
                 video_capable=video_capable,
+                attachment_budget=attachment_budget,
+                cached_office_pdf=cached_office_pdf,
+                provenance_resolved=True,
+                max_text_chars=min(MAX_TEXT_FILE_CHARS_FOR_JUDGE, remaining_text),
             )
             if blocks:
-                section.extend(blocks)
+                _append_blocks(blocks)
+                no_files = False
+            sheet_text = _structured_xlsx_text(full_path)
+            if sheet_text:
+                _append_block(
+                    {
+                        "type": "text",
+                        "text": f"\n{file_name} (structured spreadsheet cells):\n{sheet_text}",
+                    }
+                )
                 no_files = False
             return
-        block = get_file_content_block(directory, file_name)
+        block = get_file_content_block(
+            directory,
+            file_name,
+            attachment_budget=attachment_budget,
+            cached_office_pdf=cached_office_pdf,
+            provenance_resolved=True,
+            max_text_chars=min(MAX_TEXT_FILE_CHARS_FOR_JUDGE, remaining_text),
+        )
         if block is not None:
-            section.append(block)
+            _append_block(block)
+            no_files = False
+        sheet_text = _structured_xlsx_text(full_path)
+        if sheet_text:
+            _append_block({"type": "text", "text": f"\n{file_name} (structured spreadsheet cells):\n{sheet_text}"})
             no_files = False
 
     if file_dir is not None and os.path.exists(file_dir):
@@ -476,7 +911,16 @@ def build_file_section(
             _emit(str(member.parent), member.name)
 
     if no_files:
-        section.append({"type": "text", "text": "None"})
+        _append_block({"type": "text", "text": "None"})
+
+    if text_omitted and text_marker not in "".join(
+        str(block.get("text", "")) for block in section if block.get("type") == "text"
+    ):
+        for block in reversed(section):
+            if block.get("type") == "text":
+                previous = str(block.get("text", ""))
+                block["text"] = _bounded_text(previous + "x", len(previous), text_marker)
+                break
 
     return section
 
@@ -486,6 +930,275 @@ def build_file_section(
 # ---------------------------------------------------------------------------
 
 
+def _attachment_payload(block: dict) -> tuple[str, int]:
+    """Return the backing string and base64 start offset without copying it."""
+
+    block_type = block.get("type")
+    if block_type in {"image_url", "video_url"}:
+        value = block.get(block_type, {})
+        url = value.get("url", "") if isinstance(value, dict) else ""
+        if isinstance(url, str) and url.startswith("data:"):
+            comma = url.find(",")
+            if comma >= 0:
+                return url, comma + 1
+    elif block_type == "input_audio":
+        value = block.get("input_audio", {})
+        data = value.get("data", "") if isinstance(value, dict) else ""
+        if isinstance(data, str):
+            return data, 0
+    return "", 0
+
+
+def _attachment_cost(block: dict) -> tuple[int, int]:
+    """Return estimated raw bytes and encoded characters for a data attachment."""
+
+    payload, start = _attachment_payload(block)
+    encoded_chars = len(payload) - start
+    if encoded_chars <= 0:
+        return 0, 0
+
+    padding = 0
+    if payload[-1] == "=":
+        padding = 1
+        if encoded_chars > 1 and payload[-2] == "=":
+            padding = 2
+    raw_bytes = (encoded_chars // 4) * 3 - padding
+    return max(0, raw_bytes), encoded_chars
+
+
+def _attachment_fingerprint(block: dict) -> str:
+    """Hash the complete payload in bounded chunks for A/B-stable tie breaks."""
+
+    payload, start = _attachment_payload(block)
+    digest = hashlib.sha256()
+    chunk_size = 1024 * 1024
+    for offset in range(start, len(payload), chunk_size):
+        digest.update(payload[offset : offset + chunk_size].encode("ascii", errors="ignore"))
+    return digest.hexdigest()
+
+
+def _block_serialized_upper_bound(block: dict) -> int:
+    """Conservative JSON byte bound without copying large base64 strings."""
+
+    _raw_bytes, encoded_chars = _attachment_cost(block)
+    if encoded_chars:
+        payload, start = _attachment_payload(block)
+        # Base64 is JSON-safe ASCII. Account exactly for the data URL prefix and
+        # generously for keys, quotes, optional audio format, and punctuation.
+        return encoded_chars + start + 512
+    if block.get("type") == "text":
+        # Six bytes per character covers JSON escaping (including ensure_ascii)
+        # for BMP text; non-BMP can require two \uXXXX escapes, hence twelve.
+        value = str(block.get("text", ""))
+        non_bmp = sum(ord(character) > 0xFFFF for character in value)
+        return len(value) * 6 + non_bmp * 6 + 256
+    return 4096
+
+
+def _content_serialized_upper_bound(content: list[dict]) -> int:
+    """Conservative serialized request size including outer JSON framing."""
+
+    return 4096 + sum(_block_serialized_upper_bound(block) for block in content)
+
+
+def _bound_section_text(section: list[dict], cap: int) -> list[dict]:
+    result: list[dict] = []
+    remaining = max(0, cap)
+    marker = "\n[...additional text omitted: section judge text budget exhausted]"
+    omitted = False
+    last_text: int | None = None
+    for block in section:
+        if block.get("type") != "text":
+            result.append(block)
+            continue
+        value = str(block.get("text", ""))
+        if remaining <= 0:
+            omitted = omitted or bool(value)
+            continue
+        shown = _bounded_text(value, remaining, marker)
+        omitted = omitted or len(shown) < len(value)
+        copied = dict(block)
+        copied["text"] = shown
+        result.append(copied)
+        last_text = len(result) - 1
+        remaining -= len(shown)
+    if omitted and last_text is not None and marker not in str(result[last_text].get("text", "")):
+        previous = str(result[last_text].get("text", ""))
+        result[last_text]["text"] = _bounded_text(previous + "x", len(previous), marker)
+    return result
+
+
+def _enforce_attachment_budget(
+    sections: list[list[dict]],
+    *,
+    raw_limit: int,
+    encoded_limit: int,
+    serialized_limit: int | None = None,
+) -> list[list[dict]]:
+    """Keep the request's aggregate binary payload below both hard ceilings.
+
+    Attachments are selected smallest-first, maximizing the number of visible
+    artifacts and preventing one huge reference from starving both submissions.
+    Complete payload hashes break equal-size ties independently of A/B position,
+    so swapping the trial does not change which underlying artifact is kept.
+    Omitted blocks are replaced by explicit text evidence.
+    """
+
+    candidates: list[dict[str, Any]] = []
+    costs: dict[tuple[int, int], tuple[int, int]] = {}
+    for section_index, section in enumerate(sections):
+        for block_index, block in enumerate(section):
+            raw_bytes, encoded_chars = _attachment_cost(block)
+            if encoded_chars == 0:
+                continue
+            key = (section_index, block_index)
+            costs[key] = (raw_bytes, encoded_chars)
+            candidates.append(
+                {
+                    "raw": raw_bytes,
+                    "encoded": encoded_chars,
+                    "serialized": _block_serialized_upper_bound(block),
+                    "section": section_index,
+                    "block": block_index,
+                }
+            )
+
+    serialized_ceiling = encoded_limit + 1024 * len(candidates) if serialized_limit is None else serialized_limit
+    if (
+        sum(int(candidate["raw"]) for candidate in candidates) <= raw_limit
+        and sum(int(candidate["encoded"]) for candidate in candidates) <= encoded_limit
+        and sum(int(candidate["serialized"]) for candidate in candidates) <= serialized_ceiling
+    ):
+        # Normal requests are already bounded per section and fit the aggregate
+        # ceilings. Avoid hashing hundreds of MiB of base64 on every repeated
+        # judge trial when no selection decision is required.
+        return [list(section) for section in sections]
+
+    for candidate in candidates:
+        section_index = int(candidate["section"])
+        block_index = int(candidate["block"])
+        candidate["fingerprint"] = _attachment_fingerprint(sections[section_index][block_index])
+
+    def _sort_key(candidate: dict[str, Any]) -> tuple[int, int, int, str]:
+        return (
+            int(candidate["serialized"]),
+            int(candidate["encoded"]),
+            int(candidate["raw"]),
+            str(candidate["fingerprint"]),
+        )
+
+    selected: set[tuple[int, int]] = set()
+    used_raw = 0
+    used_encoded = 0
+    used_serialized = 0
+
+    def _select(candidate: dict[str, Any], local: AttachmentBudget | None = None, local_serialized: int = 0) -> bool:
+        nonlocal used_raw, used_encoded, used_serialized
+        key = (int(candidate["section"]), int(candidate["block"]))
+        if key in selected:
+            return True
+        raw_bytes = int(candidate["raw"])
+        encoded_chars = int(candidate["encoded"])
+        serialized_bytes = int(candidate["serialized"])
+        if (
+            used_raw + raw_bytes > raw_limit
+            or used_encoded + encoded_chars > encoded_limit
+            or used_serialized + serialized_bytes > serialized_ceiling
+        ):
+            return False
+        if local is not None:
+            if local_serialized + serialized_bytes > serialized_ceiling // max(1, len(sections)):
+                return False
+            if not local.reserve(raw_bytes, encoded_chars):
+                return False
+        selected.add(key)
+        used_raw += raw_bytes
+        used_encoded += encoded_chars
+        used_serialized += serialized_bytes
+        return True
+
+    # Reserve equal shares for A and B before references. Both passes use the
+    # same limits and payload-derived ordering, so swapping A/B is invariant.
+    section_raw = raw_limit // max(1, len(sections))
+    section_encoded = encoded_limit // max(1, len(sections))
+    local_budgets = [AttachmentBudget(section_raw, section_encoded) for _ in sections]
+    local_serialized_used = [0 for _ in sections]
+    section_order = list(range(1, len(sections))) + ([0] if sections else [])
+    for section_index in section_order:
+        for candidate in sorted(
+            (item for item in candidates if item["section"] == section_index),
+            key=_sort_key,
+        ):
+            before = used_serialized
+            if _select(candidate, local_budgets[section_index], local_serialized_used[section_index]):
+                local_serialized_used[section_index] += used_serialized - before
+
+    # If an attachment was larger than its equal share, give each nonempty
+    # submission one deterministic chance before references use spare capacity.
+    submission_seeds: list[dict[str, Any]] = []
+    for section_index in range(1, len(sections)):
+        if any(key[0] == section_index for key in selected):
+            continue
+        choices = [item for item in candidates if item["section"] == section_index]
+        if choices:
+            submission_seeds.append(min(choices, key=_sort_key))
+    for candidate in sorted(submission_seeds, key=_sort_key):
+        _select(candidate)
+
+    # Redistribute every unused byte globally, with complete-payload hashes as
+    # the final tie-break rather than section position.
+    for candidate in sorted(candidates, key=_sort_key):
+        _select(candidate)
+
+    bounded: list[list[dict]] = []
+    for section_index, section in enumerate(sections):
+        output: list[dict] = []
+        last_header = "attachment"
+        omitted_count = 0
+        omitted_raw = 0
+        omitted_encoded = 0
+        omitted_names: list[str] = []
+        for block_index, block in enumerate(section):
+            if block.get("type") == "text":
+                candidate_header = str(block.get("text", "")).strip().splitlines()
+                if candidate_header:
+                    last_header = candidate_header[0].rstrip(":")
+            raw_bytes, encoded_chars = costs.get((section_index, block_index), (0, 0))
+            if encoded_chars and (section_index, block_index) not in selected:
+                omitted_count += 1
+                omitted_raw += raw_bytes
+                omitted_encoded += encoded_chars
+                if len(omitted_names) < 10:
+                    omitted_names.append(last_header)
+            else:
+                output.append(block)
+        if omitted_count:
+            names = ", ".join(omitted_names)
+            if omitted_count > len(omitted_names):
+                names += f", and {omitted_count - len(omitted_names)} more"
+            output.append(
+                {
+                    "type": "text",
+                    "text": (
+                        f"[attachment omitted: {omitted_count} file(s) ({names}), "
+                        f"{_human_attachment_size(omitted_raw)} raw, "
+                        f"{_human_attachment_size(omitted_encoded)} base64; aggregate judge payload budget]"
+                    ),
+                }
+            )
+        bounded.append(output)
+    return bounded
+
+
+def _human_attachment_size(size: int) -> str:
+    value = float(size)
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if value < 1024 or unit == "GiB":
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} GiB"
+
+
 def construct_judge_messages(
     task_prompt: str,
     refs: list[dict],
@@ -493,8 +1206,44 @@ def construct_judge_messages(
     submission_b: list[dict],
 ) -> list[dict]:
     """Assemble OpenAI messages for the judge: prompt + task + refs + submissions."""
+    # Text can require up to twelve JSON bytes per Unicode code point. Give the
+    # task and three sections equal worst-case shares after reserving framing.
+    available_text_chars = max(0, MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE - 16 * 1024) // 12
+    fair_text_cap = available_text_chars // 4
+    section_text_cap = min(MAX_SECTION_TEXT_CHARS_FOR_JUDGE, fair_text_cap)
+    refs = _bound_section_text(refs, section_text_cap)
+    submission_a = _bound_section_text(submission_a, section_text_cap)
+    submission_b = _bound_section_text(submission_b, section_text_cap)
+    bounded_task = _bounded_text(task_prompt, min(MAX_TASK_PROMPT_CHARS_FOR_JUDGE, fair_text_cap))
+    prompt_block = {"type": "text", "text": JUDGE_PROMPT + TASK_TEMPLATE.format(task=bounded_task)}
+    framing = [
+        prompt_block,
+        {"type": "text", "text": REFERENCES_OPEN},
+        {"type": "text", "text": REFERENCES_CLOSE},
+        {"type": "text", "text": SUBMISSION_A_OPEN},
+        {"type": "text", "text": SUBMISSION_A_CLOSE},
+        {"type": "text", "text": SUBMISSION_B_OPEN},
+        {"type": "text", "text": SUBMISSION_B_CLOSE},
+    ]
+    sections = [refs, submission_a, submission_b]
+    fixed_blocks = framing + [block for section in sections for block in section if _attachment_cost(block)[1] == 0]
+    # Reserve one small aggregate omission notice per section. Everything else
+    # is bounded conservatively at the JSON-string level, including escaped text.
+    fixed_serialized = (
+        4096 + 4096 * len(sections) + sum(_block_serialized_upper_bound(block) for block in fixed_blocks)
+    )
+    attachment_serialized_limit = max(
+        0,
+        MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE - fixed_serialized,
+    )
+    refs, submission_a, submission_b = _enforce_attachment_budget(
+        sections,
+        raw_limit=MAX_TOTAL_RAW_ATTACHMENT_BYTES_FOR_JUDGE,
+        encoded_limit=MAX_TOTAL_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE,
+        serialized_limit=attachment_serialized_limit,
+    )
     content: list[dict] = []
-    content.append({"type": "text", "text": JUDGE_PROMPT + TASK_TEMPLATE.format(task=task_prompt)})
+    content.append(prompt_block)
     content.append({"type": "text", "text": REFERENCES_OPEN})
     content.extend(refs)
     content.append({"type": "text", "text": REFERENCES_CLOSE})
@@ -504,6 +1253,13 @@ def construct_judge_messages(
     content.append({"type": "text", "text": SUBMISSION_B_OPEN})
     content.extend(submission_b)
     content.append({"type": "text", "text": SUBMISSION_B_CLOSE})
+
+    serialized_bound = _content_serialized_upper_bound(content)
+    if serialized_bound > MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE:
+        raise ValueError(
+            "GDPVal judge request size budget exhausted before dispatch: "
+            f"{serialized_bound} > {MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE} bytes"
+        )
 
     return [{"role": "user", "content": content}]
 
@@ -518,6 +1274,8 @@ def _is_retryable(error: Exception) -> bool:
     # large for the judge endpoint to digest in time, and retrying just burns
     # another full timeout window per attempt. Fail the trial fast instead.
     if isinstance(error, APITimeoutError):
+        return False
+    if is_permanent_judge_error(error):
         return False
     error_text = str(error).lower()
     return any(marker in error_text for marker in RETRYABLE_ERROR_MARKERS)

--- a/resources_servers/gdpval/judge_panel.py
+++ b/resources_servers/gdpval/judge_panel.py
@@ -70,6 +70,17 @@ class ResolvedJudge:
     # server's routing).
     handles_audio: bool = False
     handles_video: bool = False
+    # The transport is selected per provider. Hosted GPT uses rasterized pages,
+    # while Gemini and Claude can consume native PDFs.
+    media_mode: str = "native_pdf"
+    max_native_pdf_pages: Optional[int] = None
+    max_native_pdf_documents: Optional[int] = None
+    max_native_pdf_bytes: Optional[int] = None
+    max_native_pdf_bytes_per_document: Optional[int] = None
+    # Raster tiers are tried in order. The first complete request below the
+    # provider wire cap is used; otherwise that judge is excluded pre-dispatch.
+    raster_dpi_tiers: tuple[int, ...] = ()
+    max_serialized_request_bytes: Optional[int] = None
 
 
 class _HasWeight(Protocol):

--- a/resources_servers/gdpval/media_conversion.py
+++ b/resources_servers/gdpval/media_conversion.py
@@ -172,6 +172,22 @@ def pdf_bytes_to_image_blocks(
     return blocks
 
 
+def pdf_page_count(pdf_bytes: bytes) -> int:
+    """Return the exact page count for an in-memory PDF, failing closed."""
+    try:
+        import fitz  # PyMuPDF
+    except ImportError as exc:
+        raise RuntimeError("PyMuPDF is required for native-PDF request gating") from exc
+    try:
+        doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+    except Exception as exc:
+        raise RuntimeError(f"cannot count PDF pages: {exc!r}") from exc
+    try:
+        return int(doc.page_count)
+    finally:
+        doc.close()
+
+
 def pdf_bytes_to_text(pdf_bytes: bytes, *, max_chars: int = DEFAULT_MAX_TEXT_CHARS) -> str:
     """Extract text from a PDF (as bytes), truncated to *max_chars*.
 

--- a/resources_servers/gdpval/multistage_elo.py
+++ b/resources_servers/gdpval/multistage_elo.py
@@ -20,8 +20,9 @@ tasks, multi-stage ELO runs a sequence of *stages*. Each stage:
    ``responses_api_agents.stirrup_agent.task_distribution``); ``T`` is
    configurable per stage and **defaults to the full task set**,
 2. Includes a set of ``M`` reference models and assigns **each task a single
-   reference** drawn uniformly (equal weight) from that set — so a task is
-   judged against one reference, not all ``M``,
+   reference** from that set — an independent uniform draw by default, with an
+   opt-in seeded balanced assignment — so a task is judged against one reference,
+   not all ``M``,
 3. Fits an anchored Bradley-Terry MLE ELO from that stage's win/loss/tie
    battles pooled per reference (reusing ``comparison.calculate_mle_elo``), and
 4. Uses that estimate to choose the ``M`` references for the next stage.
@@ -59,6 +60,25 @@ PerReferenceTotals = Dict[str, Dict[str, float]]
 
 
 @dataclass
+class PartialStagePolicy:
+    """Opt-in policy for accepting incomplete non-final calibration stages.
+
+    ``min_success_fraction`` gates successful rollout coverage across the whole
+    stage. ``min_per_reference_success_fraction`` and
+    ``min_successful_rows_per_reference`` apply independently to every selected
+    reference model, so an anchor cannot disappear entirely from a partial fit.
+    Only persisted task timeouts may be newly waived. Rows already resolved by
+    the standard terminal/max-attempt rules remain eligible, but every omission
+    still counts against the configured coverage floors. Drained/no-persist and
+    missing rows keep the stage open.
+    """
+
+    min_success_fraction: float = 1.0
+    min_per_reference_success_fraction: float = 1.0
+    min_successful_rows_per_reference: int = 1
+
+
+@dataclass
 class StageSpec:
     """Configuration for a single stage.
 
@@ -69,12 +89,15 @@ class StageSpec:
     available references" (used for the first, broad stage). Each task is judged
     against **one** reference sampled uniformly from the included set. ``seed``
     makes this stage's task sampling and per-task reference assignment
-    reproducible.
+    reproducible. ``partial_completion`` is an explicit, non-final-stage-only
+    escape hatch for accepting a calibrated ELO with bounded missing evidence;
+    it is disabled by default.
     """
 
     num_tasks: Optional[int] = None
     num_models: Optional[int] = None
     seed: Optional[int] = None
+    partial_completion: Optional[PartialStagePolicy] = None
 
 
 # ---------------------------------------------------------------------------
@@ -146,13 +169,16 @@ def assign_task_references(
     reference_ids: Sequence[str],
     *,
     rng: random.Random,
+    balanced: bool = False,
 ) -> Dict[str, str]:
-    """Assign each task a single reference model, sampled with equal probability.
+    """Assign each task a single reference model.
 
     Rather than judging every task against every included reference, each task is
-    compared against **one** reference drawn uniformly (each included reference
-    weighted equally) from ``reference_ids``. Returns a ``{task_id: ref_id}`` map;
-    empty when no references are included.
+    compared against **one** reference from ``reference_ids``. By default each
+    assignment is an independent uniform draw. With ``balanced=True``, assignment
+    slots are shuffled while ensuring per-reference task counts differ by at most
+    one. Returns a ``{task_id: ref_id}`` map; empty when no references are
+    included.
 
     Deterministic given *rng*, so a stage's assignment replays identically on
     resume (it is also recorded in the stage journal).
@@ -160,7 +186,16 @@ def assign_task_references(
     refs = list(reference_ids)
     if not refs:
         return {}
-    return {str(tid): rng.choice(refs) for tid in task_ids}
+    if not balanced:
+        return {str(tid): rng.choice(refs) for tid in task_ids}
+
+    tasks = [str(tid) for tid in task_ids]
+    full_cycles, remainder = divmod(len(tasks), len(refs))
+    slots = refs * full_cycles
+    if remainder:
+        slots.extend(rng.sample(refs, remainder))
+    rng.shuffle(slots)
+    return dict(zip(tasks, slots))
 
 
 # ---------------------------------------------------------------------------

--- a/resources_servers/gdpval/multistage_elo.py
+++ b/resources_servers/gdpval/multistage_elo.py
@@ -48,7 +48,7 @@ import json
 import random
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from resources_servers.gdpval.comparison import calculate_mle_elo
 
@@ -67,15 +67,17 @@ class PartialStagePolicy:
     stage. ``min_per_reference_success_fraction`` and
     ``min_successful_rows_per_reference`` apply independently to every selected
     reference model, so an anchor cannot disappear entirely from a partial fit.
-    Only persisted task timeouts may be newly waived. Rows already resolved by
-    the standard terminal/max-attempt rules remain eligible, but every omission
-    still counts against the configured coverage floors. Drained/no-persist and
-    missing rows keep the stage open.
+    ``waivable_failure_classes`` lists the persisted failure classes that may be
+    newly waived; it defaults to task timeouts only, preserving the original
+    behaviour. Rows already resolved by the standard terminal/max-attempt rules
+    remain eligible, but every omission still counts against the configured
+    coverage floors. Drained/no-persist and missing rows keep the stage open.
     """
 
     min_success_fraction: float = 1.0
     min_per_reference_success_fraction: float = 1.0
     min_successful_rows_per_reference: int = 1
+    waivable_failure_classes: Tuple[str, ...] = ("timeout_exceeded",)
 
 
 @dataclass

--- a/resources_servers/gdpval/multistage_orchestrator.py
+++ b/resources_servers/gdpval/multistage_orchestrator.py
@@ -285,7 +285,11 @@ def _partial_stage_outcome(
     for reference_id in reference_ids:
         planned = planned_per_reference[reference_id]
         if planned <= 0:
-            return None
+            # Balanced assignment gives a reference zero tasks whenever
+            # num_tasks < num_models. A reference with nothing planned has no
+            # coverage floor to violate; it contributes no evidence.
+            per_reference_success_fractions[reference_id] = 1.0
+            continue
         success_fraction_for_reference = judged_per_reference[reference_id] / planned
         per_reference_success_fractions[reference_id] = success_fraction_for_reference
         if (
@@ -429,8 +433,17 @@ def compute_fingerprint(
 
     component_types = {"responses_api_agents", "responses_api_models", "resources_servers"}
 
+    # Connection endpoints and credentials change across allocations (head-node
+    # IPs, rotated keys) without affecting any judgment, and secrets should not
+    # be hashed into persisted state at all. Only fields at the top level of a
+    # server config are stripped; nested config remains fingerprint-relevant.
+    connection_fields = {"host", "port"}
+
+    def is_connection_field(name: str) -> bool:
+        return name in connection_fields or name.endswith("_api_key") or name.endswith("_base_url")
+
     def jsonable_runtime_block(block: Mapping[str, Any]) -> Dict[str, Any]:
-        """Serialize a component block without process-local bind addresses."""
+        """Serialize a component block without endpoints or credentials."""
         result: Dict[str, Any] = {}
         for key, value in block.items():
             key = str(key)
@@ -448,7 +461,7 @@ def compute_fingerprint(
                     {
                         str(field): field_value
                         for field, field_value in server_config.items()
-                        if str(field) not in {"host", "port"}
+                        if not is_connection_field(str(field))
                     }
                     if isinstance(server_config, Mapping)
                     else server_config
@@ -1564,14 +1577,34 @@ def _atomic_filter_jsonl(path: Path, keep: Callable[[Mapping[str, Any]], bool]) 
 
 
 def _prune_downstream_files(output_fpath: str | Path, restart_stage: int) -> None:
-    """Remove persisted main/sidecar rows after ``restart_stage`` atomically."""
+    """Move persisted main/sidecar rows after ``restart_stage`` to a quarantine file.
+
+    Pruned rows are completed provider evidence; a restart decision must never
+    destroy them. Each prune appends the dropped rows to a timestamped
+    ``.pruned.<ns>`` sibling before atomically rewriting the source.
+    """
     output_fpath = Path(output_fpath)
 
     def keep(record: Mapping[str, Any]) -> bool:
         return int(record.get("stage_index", 0) or 0) <= restart_stage
 
-    _atomic_filter_jsonl(output_fpath, keep)
-    _atomic_filter_jsonl(failures_path_for(output_fpath), keep)
+    stale_suffix = f".pruned.{time.time_ns()}"
+    for path in (output_fpath, failures_path_for(output_fpath)):
+        if not path.exists():
+            continue
+        dropped: list[bytes] = []
+        with path.open("rb") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if stripped and not keep(orjson.loads(stripped)):
+                    dropped.append(stripped)
+        if dropped:
+            quarantine = path.with_name(path.name + stale_suffix)
+            with quarantine.open("wb") as out:
+                out.write(b"\n".join(dropped) + b"\n")
+                out.flush()
+                os.fsync(out.fileno())
+        _atomic_filter_jsonl(path, keep)
 
 
 def load_persisted_rows(output_fpath: str | Path) -> Dict[int, List[Dict[str, Any]]]:
@@ -2107,10 +2140,19 @@ def _prepare_resume(
 
     if reason is not None:
         print(f"[multistage-elo] starting fresh: {reason}", file=sys.stderr, flush=True)
-        output_fpath.unlink(missing_ok=True)
-        failures_path_for(output_fpath).unlink(missing_ok=True)
-        journal_fpath.unlink(missing_ok=True)
-        aggregate_metrics_path_for(output_fpath).unlink(missing_ok=True)
+        # Completed judged rollouts are expensive provider evidence. A stale
+        # fingerprint must never destroy them: set them aside recoverably.
+        stale_suffix = f".stale.{time.time_ns()}"
+        for stale in (
+            output_fpath,
+            failures_path_for(output_fpath),
+            journal_fpath,
+            aggregate_metrics_path_for(output_fpath),
+        ):
+            if stale.exists():
+                quarantined = stale.with_name(stale.name + stale_suffix)
+                stale.replace(quarantined)
+                print(f"[multistage-elo] quarantined stale state: {quarantined}", file=sys.stderr, flush=True)
     else:
         print("[multistage-elo] resuming multi-stage run from cache (fingerprint match)", file=sys.stderr, flush=True)
     return build_file_resume(output_fpath, journal_fpath, fingerprint)

--- a/resources_servers/gdpval/multistage_orchestrator.py
+++ b/resources_servers/gdpval/multistage_orchestrator.py
@@ -206,6 +206,7 @@ def _partial_policy_record(policy: PartialStagePolicy) -> Dict[str, Any]:
         "min_success_fraction": policy.min_success_fraction,
         "min_per_reference_success_fraction": policy.min_per_reference_success_fraction,
         "min_successful_rows_per_reference": policy.min_successful_rows_per_reference,
+        "newly_waivable_failure_classes": sorted(policy.waivable_failure_classes),
     }
 
 
@@ -297,7 +298,11 @@ def _partial_stage_outcome(
     result_by_key = {_stage_key(result): result for result in new_results}
     for key in unresolved_keys:
         result = result_by_key.get(key)
-        if result is None or result.get(NG_NO_PERSIST_KEY) or result.get(NG_FAILURE_CLASS_KEY) != "timeout_exceeded":
+        if (
+            result is None
+            or result.get(NG_NO_PERSIST_KEY)
+            or result.get(NG_FAILURE_CLASS_KEY) not in policy.waivable_failure_classes
+        ):
             return None
 
     per_reference = {
@@ -319,7 +324,7 @@ def _partial_stage_outcome(
         "success_fraction": success_fraction,
         "persisted_success_fraction": len(successful_by_key) / len(planned_by_key),
         "per_reference": per_reference,
-        "policy": {**_partial_policy_record(policy), "newly_waivable_failure_classes": ["timeout_exceeded"]},
+        "policy": _partial_policy_record(policy),
     }
 
 
@@ -346,17 +351,23 @@ def _cached_partial_snapshot_is_valid(
         "min_success_fraction",
         "min_per_reference_success_fraction",
         "min_successful_rows_per_reference",
+        "newly_waivable_failure_classes",
     }
     if (
         expected_policy is None
         or not isinstance(policy_record, Mapping)
         or not required_policy_fields <= set(policy_record)
-        or policy_record.get("newly_waivable_failure_classes") != ["timeout_exceeded"]
         or {field: policy_record[field] for field in required_policy_fields} != _partial_policy_record(expected_policy)
     ):
         return False
+    # The durable record spells the waiver set `newly_waivable_failure_classes`;
+    # the config field is `waivable_failure_classes`. Map it back before parsing.
+    replayed_policy_fields = {
+        field: policy_record[field] for field in required_policy_fields if field != "newly_waivable_failure_classes"
+    }
+    replayed_policy_fields["waivable_failure_classes"] = policy_record["newly_waivable_failure_classes"]
     try:
-        policy = _parse_partial_stage_policy({field: policy_record[field] for field in required_policy_fields})
+        policy = _parse_partial_stage_policy(replayed_policy_fields)
     except (TypeError, ValueError):
         return False
     if policy is None:
@@ -525,6 +536,13 @@ class MultiStageRunConfig:
     reuse_cached_deliverables: bool = True
 
 
+# Failure classes a partial-calibration policy may newly waive. A waived row is
+# omitted from the fit and still counts against every coverage floor, so this is
+# a bound on which *causes* are acceptable, not on how much may be missing.
+# `skipped` is excluded: an unusable sample is not evidence of anything.
+_WAIVABLE_FAILURE_CLASSES = frozenset({"timeout_exceeded", "transient"})
+
+
 def _validate_partial_stage_policy(policy: PartialStagePolicy) -> None:
     """Validate parsed and directly constructed partial policies."""
     for name in ("min_success_fraction", "min_per_reference_success_fraction"):
@@ -534,6 +552,15 @@ def _validate_partial_stage_policy(policy: PartialStagePolicy) -> None:
     minimum_rows = policy.min_successful_rows_per_reference
     if isinstance(minimum_rows, bool) or not isinstance(minimum_rows, int) or minimum_rows <= 0:
         raise ValueError("partial_completion.min_successful_rows_per_reference must be a positive integer")
+    waivable = policy.waivable_failure_classes
+    if isinstance(waivable, (str, bytes)) or not isinstance(waivable, Sequence) or not waivable:
+        raise ValueError("partial_completion.waivable_failure_classes must be a non-empty sequence of strings")
+    unknown_classes = sorted(set(map(str, waivable)) - _WAIVABLE_FAILURE_CLASSES)
+    if unknown_classes:
+        raise ValueError(
+            "partial_completion.waivable_failure_classes may only contain "
+            f"{sorted(_WAIVABLE_FAILURE_CLASSES)}; got {unknown_classes}"
+        )
 
 
 def _parse_partial_stage_policy(raw: Any) -> Optional[PartialStagePolicy]:
@@ -547,13 +574,20 @@ def _parse_partial_stage_policy(raw: Any) -> Optional[PartialStagePolicy]:
         "min_success_fraction",
         "min_per_reference_success_fraction",
         "min_successful_rows_per_reference",
+        "waivable_failure_classes",
     }
     unknown_fields = sorted(set(raw) - allowed_fields)
     if unknown_fields:
         raise ValueError(f"unknown partial_completion field(s): {', '.join(map(str, unknown_fields))}")
 
-    if any(isinstance(raw.get(field), bool) for field in allowed_fields if field in raw):
+    numeric_fields = allowed_fields - {"waivable_failure_classes"}
+    if any(isinstance(raw.get(field), bool) for field in numeric_fields if field in raw):
         raise ValueError("partial_completion thresholds must be numeric, not boolean")
+
+    raw_waivable = raw.get("waivable_failure_classes", ("timeout_exceeded",))
+    if isinstance(raw_waivable, (str, bytes)) or not isinstance(raw_waivable, Sequence):
+        raise ValueError("partial_completion.waivable_failure_classes must be a sequence of strings")
+    waivable = tuple(str(value) for value in raw_waivable)
 
     try:
         raw_minimum_rows = raw.get("min_successful_rows_per_reference", 1)
@@ -562,6 +596,7 @@ def _parse_partial_stage_policy(raw: Any) -> Optional[PartialStagePolicy]:
             min_success_fraction=float(raw.get("min_success_fraction", 1.0)),
             min_per_reference_success_fraction=float(raw.get("min_per_reference_success_fraction", 1.0)),
             min_successful_rows_per_reference=minimum_rows,
+            waivable_failure_classes=waivable,
         )
     except (TypeError, ValueError) as exc:
         raise ValueError("partial_completion thresholds must be numeric") from exc

--- a/resources_servers/gdpval/multistage_orchestrator.py
+++ b/resources_servers/gdpval/multistage_orchestrator.py
@@ -169,6 +169,36 @@ def compute_fingerprint(
             return value
         return repr(value)
 
+    component_types = {"responses_api_agents", "responses_api_models", "resources_servers"}
+
+    def jsonable_runtime_block(block: Mapping[str, Any]) -> Dict[str, Any]:
+        """Serialize a component block without process-local bind addresses."""
+        result: Dict[str, Any] = {}
+        for key, value in block.items():
+            key = str(key)
+            if key not in component_types:
+                result[key] = jsonable(value)
+                continue
+
+            servers = jsonable(value)
+            if not isinstance(servers, Mapping):
+                result[key] = servers
+                continue
+
+            result[key] = {
+                str(server_name): (
+                    {
+                        str(field): field_value
+                        for field, field_value in server_config.items()
+                        if str(field) not in {"host", "port"}
+                    }
+                    if isinstance(server_config, Mapping)
+                    else server_config
+                )
+                for server_name, server_config in servers.items()
+            }
+        return result
+
     payload = {
         "stages": [(s.num_tasks, s.num_models, s.seed) for s in multistage_config.stages],
         "seed": multistage_config.seed,
@@ -212,9 +242,8 @@ def compute_fingerprint(
 
         payload["rollout_collection_config"] = {name: jsonable(config_value(name)) for name in result_affecting_fields}
     if resolved_global_config is not None:
-        component_types = {"responses_api_agents", "responses_api_models", "resources_servers"}
         payload["runtime_components"] = {
-            str(name): jsonable(block)
+            str(name): jsonable_runtime_block(block)
             for name, block in resolved_global_config.items()
             if isinstance(block, Mapping) and component_types.intersection(block)
         }

--- a/resources_servers/gdpval/multistage_orchestrator.py
+++ b/resources_servers/gdpval/multistage_orchestrator.py
@@ -103,6 +103,10 @@ from resources_servers.gdpval.multistage_elo import (
 # return ``(row, result)`` pairs (result == the agent's /run response, i.e. the
 # GDPVal verify response). Injected so tests can avoid real servers.
 RolloutRunner = Callable[[List[Dict[str, Any]]], Awaitable[List[Tuple[Dict[str, Any], Dict[str, Any]]]]]
+AssignmentRepair = Callable[
+    [int, Sequence[str], Mapping[str, str]],
+    Tuple[Dict[str, str], Dict[str, Any]],
+]
 
 
 @dataclass
@@ -506,6 +510,12 @@ def compute_fingerprint(
             for name, block in resolved_global_config.items()
             if isinstance(block, Mapping) and component_types.intersection(block)
         }
+        # Transport-assignment repair rewrites which reference each task is
+        # judged against, so its settings must invalidate journals like any
+        # other planner input. Absent config hashes exactly as before.
+        transport_repair = (resolved_global_config.get("multistage") or {}).get("transport_assignment_repair")
+        if transport_repair is not None:
+            payload["transport_assignment_repair"] = jsonable(transport_repair)
     encoded = orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)
     return hashlib.sha256(encoded).hexdigest()
 
@@ -771,6 +781,8 @@ def tag_results(
         out[AGENT_REF_KEY_NAME] = row[AGENT_REF_KEY_NAME]
         if ATTEMPT_INDEX_KEY_NAME in row:
             out[ATTEMPT_INDEX_KEY_NAME] = row[ATTEMPT_INDEX_KEY_NAME]
+        if "verify_cache_namespace" in row:
+            out["verify_cache_namespace"] = row["verify_cache_namespace"]
         out["stage_index"] = stage_index
         if expected_final_stage_index is not None:
             out["expected_final_stage_index"] = expected_final_stage_index
@@ -800,6 +812,7 @@ async def run_multistage_stages(
     on_event: Optional[Callable[[str, dict], None]] = None,
     resume: Optional[StageResume] = None,
     dispatch_longest_first: bool = False,
+    assignment_repair: Optional[AssignmentRepair] = None,
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Run every stage and return ``(all_result_rows, stage_summaries)``.
 
@@ -960,7 +973,14 @@ async def run_multistage_stages(
             }
 
         reference_ids, task_ids, task_reference_ids, replayed = _plan_stage(
-            index, stage, reference_elos, eval_elo, stage_task_sets, multistage_config, resume
+            index,
+            stage,
+            reference_elos,
+            eval_elo,
+            stage_task_sets,
+            multistage_config,
+            resume,
+            assignment_repair,
         )
 
         stage_rows = build_stage_rows(
@@ -1222,6 +1242,7 @@ def _plan_stage(
     stage_task_sets: Sequence[Sequence[str]],
     multistage_config: MultiStageRunConfig,
     resume: Optional[StageResume],
+    assignment_repair: Optional[AssignmentRepair] = None,
 ) -> Tuple[List[str], List[str], Dict[str, str], bool]:
     """Return ``(reference_ids, task_ids, task_reference_ids, replayed)`` for a stage.
 
@@ -1258,19 +1279,30 @@ def _plan_stage(
         rng=rng,
         balanced=stage.partial_completion is not None,
     )
-    if resume is not None:
-        resume.on_plan(
+    repair_receipt: Optional[Dict[str, Any]] = None
+    if assignment_repair is not None:
+        task_reference_ids, repair_receipt = assignment_repair(
             index,
-            {
-                "stage_index": index,
-                "status": "planned",
-                "reference_ids": list(reference_ids),
-                "task_ids": list(task_ids),
-                "task_reference_ids": task_reference_ids,
-                "seed": stage.seed,
-                "prior_eval_elo": eval_elo,
-            },
+            reference_ids,
+            task_reference_ids,
         )
+        if set(task_reference_ids) != set(task_ids):
+            raise ValueError("transport assignment repair changed the stage task set")
+        if any(reference_id not in reference_ids for reference_id in task_reference_ids.values()):
+            raise ValueError("transport assignment repair selected a reference outside the stage")
+    if resume is not None:
+        plan = {
+            "stage_index": index,
+            "status": "planned",
+            "reference_ids": list(reference_ids),
+            "task_ids": list(task_ids),
+            "task_reference_ids": task_reference_ids,
+            "seed": stage.seed,
+            "prior_eval_elo": eval_elo,
+        }
+        if repair_receipt is not None:
+            plan["transport_assignment_repair"] = repair_receipt
+        resume.on_plan(index, plan)
     return list(reference_ids), task_ids, task_reference_ids, False
 
 
@@ -2016,6 +2048,13 @@ async def run_e2e_multistage(
         row["verify_cache_namespace"] = fingerprint
     resume = _prepare_resume(rollout_collection_config, output_fpath, journal_fpath, fingerprint)
 
+    assignment_repair = None
+    transport_config = (global_config_dict.get("multistage") or {}).get("transport_assignment_repair")
+    if isinstance(transport_config, Mapping) and transport_config.get("enabled"):
+        from resources_servers.gdpval.transport_assignment import make_assignment_repair
+
+        assignment_repair = make_assignment_repair(global_config_dict, transport_config)
+
     all_results, stage_summaries = await run_multistage_stages(
         multistage_config,
         reference_elos,
@@ -2025,6 +2064,7 @@ async def run_e2e_multistage(
         on_event=_log_event,
         resume=resume,
         dispatch_longest_first=bool(getattr(rollout_collection_config, "dispatch_longest_first", False)),
+        assignment_repair=assignment_repair,
     )
 
     print(latency_tracker.summary())

--- a/resources_servers/gdpval/multistage_orchestrator.py
+++ b/resources_servers/gdpval/multistage_orchestrator.py
@@ -26,10 +26,11 @@ How adaptivity maps onto the single-pass flow:
 * Each stage is one pass of the standard rollout collection over the stage's
   sampled ``T`` tasks (``T`` is configurable per stage and defaults to the full
   task distribution). The stage includes a set of reference models (chosen
-  adaptively — see below) and assigns **each task a single reference** sampled
-  uniformly (equal weight) from that set; the task's row is tagged with that one
-  ``reference_ids=[ref]`` (honored by the GDPVal verifier's per-request reference
-  filter) and a ``stage_index``.
+  adaptively — see below) and assigns **each task a single reference** from that
+  set; the default is an independent uniform sample, while partial-completion
+  stages use a seeded balanced assignment. The task's row is tagged with that
+  one ``reference_ids=[ref]`` (honored by the GDPVal verifier's per-request
+  reference filter) and a ``stage_index``.
 * Between stages we fit the stage's anchored Bradley-Terry MLE ELO (the same
   math the server's ``aggregate_metrics`` uses) — pooling each reference's
   win/loss/tie counts over the tasks assigned to it — to pick the next stage's
@@ -54,11 +55,13 @@ orchestration is unit-testable without any servers.
 from __future__ import annotations
 
 import hashlib
+import math
 import os
 import random
 import secrets
 import tempfile
 import time
+from collections import Counter
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -83,6 +86,7 @@ from nemo_gym.rollout_collection import (
     _observed_elapsed,
 )
 from resources_servers.gdpval.multistage_elo import (
+    PartialStagePolicy,
     PerReferenceTotals,
     StageSpec,
     assign_task_references,
@@ -111,6 +115,8 @@ class StageResume:
     ``(task_index, rollout_index)`` not to re-dispatch (success, terminal, or
     max-attempt). ``on_plan``/``on_outcome``/``on_rows`` persist newly produced
     state (``on_rows`` routes success/failure/kill_shaped like ``run_from_config``).
+    ``restart_from(i)`` invokes ``on_restart`` and preserves stage ``i``'s plan
+    and evidence while invalidating its outcome and every dependent later stage.
     """
 
     plans: Mapping[int, dict]
@@ -120,6 +126,7 @@ class StageResume:
     on_plan: Callable[[int, dict], None]
     on_outcome: Callable[[int, dict], None]
     on_rows: Callable[[int, List[Dict[str, Any]]], None]
+    on_restart: Callable[[int], None] = field(default=lambda _index: None, repr=False)
     # Longest observed failed-attempt duration, keyed by stage then
     # (task_index, rollout_index). This is the stage-aware equivalent of the
     # single-pass dispatcher's resume timing map.
@@ -129,6 +136,31 @@ class StageResume:
     reuse_cached_keys: Mapping[int, AbstractSet[Tuple[Any, Any]]] = field(default_factory=dict)
     # Number of sidecar attempts already consumed, keyed stage/task/rollout.
     attempts_by_stage: Mapping[int, Mapping[Tuple[Any, Any], int]] = field(default_factory=dict)
+    # Latest persisted failure per stage/task/rollout.  An explicit partial-stage
+    # policy may accept an already-recorded timeout without dispatching it again.
+    latest_failures_by_stage: Mapping[int, Mapping[Tuple[Any, Any], Dict[str, Any]]] = field(default_factory=dict)
+    # Latest attempt disposition written by this orchestrator, including
+    # drained/no-persist attempts that deliberately never enter the sidecar.
+    latest_attempt_dispositions_by_stage: Mapping[int, Mapping[Tuple[Any, Any], Dict[str, Any]]] = field(
+        default_factory=dict
+    )
+
+    def restart_from(self, index: int) -> None:
+        """Durably invalidate a stale outcome and every dependent later stage."""
+        self.on_restart(index)
+        self.plans = {stage: value for stage, value in self.plans.items() if stage <= index}
+        self.outcomes = {stage: value for stage, value in self.outcomes.items() if stage < index}
+        for name in (
+            "rows_by_stage",
+            "gated_keys",
+            "elapsed_by_stage",
+            "reuse_cached_keys",
+            "attempts_by_stage",
+            "latest_failures_by_stage",
+            "latest_attempt_dispositions_by_stage",
+        ):
+            values = getattr(self, name)
+            setattr(self, name, {stage: value for stage, value in values.items() if stage <= index})
 
 
 def _is_success_row(row: Mapping[str, Any]) -> bool:
@@ -137,6 +169,217 @@ def _is_success_row(row: Mapping[str, Any]) -> bool:
         row.get(NG_FAILURE_CLASS_KEY) is None
         and not row.get(NG_NO_PERSIST_KEY)
         and not row.get("invalid_judge_response")
+    )
+
+
+def _stage_key(row: Mapping[str, Any]) -> Tuple[Any, Any]:
+    return (row.get(TASK_INDEX_KEY_NAME), row.get(ROLLOUT_INDEX_KEY_NAME))
+
+
+def _fit_eligible_stage_keys(
+    stage_rows: Sequence[Mapping[str, Any]], successful_rows: Sequence[Mapping[str, Any]]
+) -> set[Tuple[Any, Any]]:
+    """Keys whose persisted success contains a usable assigned-reference battle."""
+    planned_by_key = {_stage_key(row): row for row in stage_rows}
+    successful_by_key = {_stage_key(row): row for row in successful_rows if _stage_key(row) in planned_by_key}
+    fit_eligible: set[Tuple[Any, Any]] = set()
+    for key, success in successful_by_key.items():
+        refs = list(planned_by_key[key].get("reference_ids") or [])
+        if not refs:
+            continue
+        counts = (success.get("per_reference") or {}).get(str(refs[0])) or {}
+        if sum(float(counts.get(name, 0) or 0) for name in ("wins", "losses", "ties")) > 0:
+            fit_eligible.add(key)
+    return fit_eligible
+
+
+def _recorded_key_set(record: Mapping[str, Any], field_name: str) -> set[Tuple[Any, Any]]:
+    keys: set[Tuple[Any, Any]] = set()
+    for value in record.get(field_name, []) or []:
+        if isinstance(value, (list, tuple)) and len(value) == 2:
+            keys.add((value[0], value[1]))
+    return keys
+
+
+def _partial_policy_record(policy: PartialStagePolicy) -> Dict[str, Any]:
+    return {
+        "min_success_fraction": policy.min_success_fraction,
+        "min_per_reference_success_fraction": policy.min_per_reference_success_fraction,
+        "min_successful_rows_per_reference": policy.min_successful_rows_per_reference,
+    }
+
+
+def _elo_evidence_sha256(rows: Sequence[Mapping[str, Any]]) -> str:
+    """Hash exactly the pooled battle evidence that determines a stage ELO."""
+    pooled = pool_per_reference(rows)
+    normalized = {
+        str(reference_id): {
+            "wins": int(counts.get("wins", 0) or 0),
+            "losses": int(counts.get("losses", 0) or 0),
+            "ties": int(counts.get("ties", 0) or 0),
+            "reference_elo": counts.get("reference_elo"),
+        }
+        for reference_id, counts in pooled.items()
+    }
+    return hashlib.sha256(orjson.dumps(normalized, option=orjson.OPT_SORT_KEYS)).hexdigest()
+
+
+def _partial_stage_outcome(
+    policy: PartialStagePolicy,
+    stage_rows: Sequence[Mapping[str, Any]],
+    successful_rows: Sequence[Mapping[str, Any]],
+    new_results: Sequence[Mapping[str, Any]],
+    unresolved_keys: AbstractSet[Tuple[Any, Any]],
+    reference_ids: Sequence[str],
+    stage_elo: Optional[float],
+    num_references: int,
+) -> Optional[Dict[str, Any]]:
+    """Return a durable partial outcome when every configured gate passes."""
+    if (
+        stage_elo is None
+        or not math.isfinite(stage_elo)
+        or not stage_rows
+        or not reference_ids
+        or num_references != len(reference_ids)
+    ):
+        return None
+
+    planned_by_key = {_stage_key(row): row for row in stage_rows}
+    if len(planned_by_key) != len(stage_rows):
+        return None
+    successful_by_key = {_stage_key(row): row for row in successful_rows if _stage_key(row) in planned_by_key}
+
+    planned_per_reference: Counter[str] = Counter()
+    successful_per_reference: Counter[str] = Counter()
+    judged_per_reference: Counter[str] = Counter()
+    fit_eligible_keys: set[Tuple[Any, Any]] = set()
+    for key, row in planned_by_key.items():
+        refs = list(row.get("reference_ids") or [])
+        if refs:
+            planned_per_reference[str(refs[0])] += 1
+        success = successful_by_key.get(key)
+        if success is None or not refs:
+            continue
+        reference_id = str(refs[0])
+        successful_per_reference[reference_id] += 1
+        counts = (success.get("per_reference") or {}).get(reference_id) or {}
+        if sum(float(counts.get(name, 0) or 0) for name in ("wins", "losses", "ties")) > 0:
+            judged_per_reference[reference_id] += 1
+            fit_eligible_keys.add(key)
+
+    # A main-file row without a usable battle is not calibration evidence.  Do
+    # not let it masquerade as a success or become part of the frozen snapshot.
+    if set(successful_by_key) - fit_eligible_keys:
+        return None
+
+    success_fraction = len(fit_eligible_keys) / len(planned_by_key)
+    if success_fraction < policy.min_success_fraction:
+        return None
+
+    per_reference_success_fractions: Dict[str, float] = {}
+    for reference_id in reference_ids:
+        planned = planned_per_reference[reference_id]
+        if planned <= 0:
+            return None
+        success_fraction_for_reference = judged_per_reference[reference_id] / planned
+        per_reference_success_fractions[reference_id] = success_fraction_for_reference
+        if (
+            judged_per_reference[reference_id] < policy.min_successful_rows_per_reference
+            or success_fraction_for_reference < policy.min_per_reference_success_fraction
+        ):
+            return None
+
+    planned_keys = list(planned_by_key)
+    included_keys = [key for key in planned_keys if key in fit_eligible_keys]
+    omitted_keys = [key for key in planned_keys if key not in fit_eligible_keys]
+    included_rows = [successful_by_key[key] for key in included_keys]
+    already_resolved_omitted_keys = set(omitted_keys) - set(unresolved_keys)
+    result_by_key = {_stage_key(result): result for result in new_results}
+    for key in unresolved_keys:
+        result = result_by_key.get(key)
+        if result is None or result.get(NG_NO_PERSIST_KEY) or result.get(NG_FAILURE_CLASS_KEY) != "timeout_exceeded":
+            return None
+
+    per_reference = {
+        reference_id: {
+            "planned": planned_per_reference[reference_id],
+            "successful": successful_per_reference[reference_id],
+            "judged": judged_per_reference[reference_id],
+            "success_fraction": per_reference_success_fractions[reference_id],
+        }
+        for reference_id in reference_ids
+    }
+    return {
+        "status": "partial_complete",
+        "included_keys": [list(key) for key in included_keys],
+        "omitted_keys": [list(key) for key in omitted_keys],
+        "accepted_unresolved_keys": [list(key) for key in planned_keys if key in unresolved_keys],
+        "already_resolved_omitted_keys": [list(key) for key in planned_keys if key in already_resolved_omitted_keys],
+        "evidence_sha256": _elo_evidence_sha256(included_rows),
+        "success_fraction": success_fraction,
+        "persisted_success_fraction": len(successful_by_key) / len(planned_by_key),
+        "per_reference": per_reference,
+        "policy": {**_partial_policy_record(policy), "newly_waivable_failure_classes": ["timeout_exceeded"]},
+    }
+
+
+def _cached_partial_snapshot_is_valid(
+    outcome: Mapping[str, Any],
+    expected_policy: Optional[PartialStagePolicy],
+    stage_rows: Sequence[Mapping[str, Any]],
+    persisted_rows: Sequence[Mapping[str, Any]],
+    reference_ids: Sequence[str],
+    reference_elos: Mapping[str, float],
+) -> bool:
+    """Revalidate a frozen partial outcome from its included evidence."""
+    omitted_keys = _recorded_key_set(outcome, "omitted_keys")
+    accepted_unresolved_keys = _recorded_key_set(outcome, "accepted_unresolved_keys")
+    already_resolved_omitted_keys = _recorded_key_set(outcome, "already_resolved_omitted_keys")
+    if (
+        accepted_unresolved_keys & already_resolved_omitted_keys
+        or accepted_unresolved_keys | already_resolved_omitted_keys != omitted_keys
+    ):
+        return False
+
+    policy_record = outcome.get("policy")
+    required_policy_fields = {
+        "min_success_fraction",
+        "min_per_reference_success_fraction",
+        "min_successful_rows_per_reference",
+    }
+    if (
+        expected_policy is None
+        or not isinstance(policy_record, Mapping)
+        or not required_policy_fields <= set(policy_record)
+        or policy_record.get("newly_waivable_failure_classes") != ["timeout_exceeded"]
+        or {field: policy_record[field] for field in required_policy_fields} != _partial_policy_record(expected_policy)
+    ):
+        return False
+    try:
+        policy = _parse_partial_stage_policy({field: policy_record[field] for field in required_policy_fields})
+    except (TypeError, ValueError):
+        return False
+    if policy is None:
+        return False
+
+    included_keys = _recorded_key_set(outcome, "included_keys")
+    frozen_rows = [row for row in persisted_rows if _stage_key(row) in included_keys and _is_success_row(row)]
+    stage_elo, _, num_references = fit_stage_elo(pool_per_reference(frozen_rows), reference_elos)
+    candidate = _partial_stage_outcome(
+        policy,
+        stage_rows,
+        frozen_rows,
+        [],
+        set(),
+        reference_ids,
+        stage_elo,
+        num_references,
+    )
+    return bool(
+        candidate is not None
+        and _recorded_key_set(candidate, "included_keys") == included_keys
+        and _recorded_key_set(candidate, "omitted_keys") == omitted_keys
+        and candidate.get("evidence_sha256") == outcome.get("evidence_sha256")
     )
 
 
@@ -214,6 +457,11 @@ def compute_fingerprint(
             for grp in sorted(distribution)
         },
     }
+    # Keep partial completion out of the rollout-cache fingerprint so an
+    # interrupted strict run can opt in without discarding successful rows. Its
+    # recorded plan remains authoritative; only a fresh policy-enabled plan uses
+    # balanced assignment. A persisted partial outcome records the exact policy
+    # and is revalidated on every resume.
     if materialized_rows is not None:
         materialized_hasher = hashlib.sha256()
         for row in materialized_rows:
@@ -277,10 +525,57 @@ class MultiStageRunConfig:
     reuse_cached_deliverables: bool = True
 
 
+def _validate_partial_stage_policy(policy: PartialStagePolicy) -> None:
+    """Validate parsed and directly constructed partial policies."""
+    for name in ("min_success_fraction", "min_per_reference_success_fraction"):
+        value = getattr(policy, name)
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not 0 < value <= 1:
+            raise ValueError(f"partial_completion.{name} must be in (0, 1]")
+    minimum_rows = policy.min_successful_rows_per_reference
+    if isinstance(minimum_rows, bool) or not isinstance(minimum_rows, int) or minimum_rows <= 0:
+        raise ValueError("partial_completion.min_successful_rows_per_reference must be a positive integer")
+
+
+def _parse_partial_stage_policy(raw: Any) -> Optional[PartialStagePolicy]:
+    """Parse and validate an opt-in partial-completion mapping."""
+    if raw is None:
+        return None
+    if not isinstance(raw, Mapping):
+        raise ValueError("stage partial_completion must be a mapping")
+
+    allowed_fields = {
+        "min_success_fraction",
+        "min_per_reference_success_fraction",
+        "min_successful_rows_per_reference",
+    }
+    unknown_fields = sorted(set(raw) - allowed_fields)
+    if unknown_fields:
+        raise ValueError(f"unknown partial_completion field(s): {', '.join(map(str, unknown_fields))}")
+
+    if any(isinstance(raw.get(field), bool) for field in allowed_fields if field in raw):
+        raise ValueError("partial_completion thresholds must be numeric, not boolean")
+
+    try:
+        raw_minimum_rows = raw.get("min_successful_rows_per_reference", 1)
+        minimum_rows = int(raw_minimum_rows)
+        policy = PartialStagePolicy(
+            min_success_fraction=float(raw.get("min_success_fraction", 1.0)),
+            min_per_reference_success_fraction=float(raw.get("min_per_reference_success_fraction", 1.0)),
+            min_successful_rows_per_reference=minimum_rows,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("partial_completion thresholds must be numeric") from exc
+    if minimum_rows != raw_minimum_rows:
+        raise ValueError("partial_completion.min_successful_rows_per_reference must be a positive integer")
+    _validate_partial_stage_policy(policy)
+    return policy
+
+
 def parse_multistage_config(raw: Mapping[str, Any]) -> MultiStageRunConfig:
     """Build a :class:`MultiStageRunConfig` from a raw config mapping.
 
-    Accepts stages as a list of mappings (``{num_tasks?, num_models?, seed?}``)
+    Accepts stages as a list of mappings (``{num_tasks?, num_models?, seed?,
+    partial_completion?}``)
     or as a list of ``"[num_tasks][:num_models[:seed]]"`` strings (handy for CLI
     overrides). ``num_tasks`` is the per-stage task count and defaults to the full
     task set when omitted (empty leading field in the string form). Raises
@@ -298,6 +593,7 @@ def parse_multistage_config(raw: Mapping[str, Any]) -> MultiStageRunConfig:
                     num_models=int(num_models) if num_models is not None else None,
                     seed=int(seed) if seed is not None else None,
                     num_tasks=int(num_tasks) if num_tasks is not None else None,
+                    partial_completion=_parse_partial_stage_policy(entry.get("partial_completion")),
                 )
             )
         else:
@@ -312,6 +608,8 @@ def parse_multistage_config(raw: Mapping[str, Any]) -> MultiStageRunConfig:
             "multistage.enabled=true but no stages were configured. Set "
             "multistage.stages, e.g. ++multistage.stages='[{num_tasks: 110, num_models: 12}, {num_models: 4}]'."
         )
+    if stages[-1].partial_completion is not None:
+        raise ValueError("partial_completion is allowed only on non-final calibration stages")
 
     column = raw.get("column") or raw.get("columns") or ["occupation"]
     if isinstance(column, str):
@@ -472,12 +770,14 @@ async def run_multistage_stages(
 
     For each stage: sample the stage's ``T`` tasks (``T`` defaults to the full
     task set), select the included references (closest known ELO to the running
-    estimate), assign each sampled task one of them uniformly at random, build the
-    stage's rollout rows, execute them via ``run_rollouts``, tag the results, pool
-    the per-reference votes, and fit the stage ELO (threaded into the next stage's
-    selection). ``all_result_rows`` is the concatenation of every stage's tagged
-    results (ready to write as the standard rollouts file); ``stage_summaries`` is
-    one dict per stage for logging.
+    estimate), assign each sampled task one reference, build the stage's rollout
+    rows, execute them via ``run_rollouts``, tag the results, pool the
+    per-reference votes, and fit the stage ELO (threaded into the next stage's
+    selection). Fresh partial-completion stages balance assignments across the
+    selected references; other fresh stages use independent uniform draws.
+    ``all_result_rows`` is the concatenation of every stage's tagged results
+    (ready to write as the standard rollouts file); ``stage_summaries`` is one
+    dict per stage for logging.
 
     ``rng`` seeds task sampling (defaults to ``multistage_config.seed``); per-task
     reference assignment is seeded independently per stage via
@@ -506,6 +806,11 @@ async def run_multistage_stages(
         nested=multistage_config.nested_tasks,
     )
     total_stages = len(multistage_config.stages)
+    for stage in multistage_config.stages:
+        if stage.partial_completion is not None:
+            _validate_partial_stage_policy(stage.partial_completion)
+    if total_stages and multistage_config.stages[-1].partial_completion is not None:
+        raise ValueError("partial_completion is allowed only on non-final calibration stages")
 
     def _emit(name: str, **data: object) -> None:
         if on_event is not None:
@@ -539,11 +844,56 @@ async def run_multistage_stages(
         # is terminal/max-attempt gated and therefore never enters the main file.
         produced.update(sidecar_produced_by_stage.get(index, set()))
         if resume is not None and index in resume.outcomes:
+            outcome = resume.outcomes[index]
             plan = resume.plans.get(index, {})
             expected_rows = [row for task_id in plan.get("task_ids", []) for row in rows_by_task.get(str(task_id), [])]
             expected_keys = {(row.get(TASK_INDEX_KEY_NAME), row.get(ROLLOUT_INDEX_KEY_NAME)) for row in expected_rows}
             resolved_keys = set(resume.gated_keys.get(index, set()))
             completion_is_covered = len(expected_keys) == len(expected_rows) and expected_keys <= resolved_keys
+            task_reference_ids = {
+                str(key): str(value) for key, value in (plan.get("task_reference_ids") or {}).items()
+            }
+            if not task_reference_ids and plan.get("reference_ids"):
+                assignment_rng = stage_assignment_rng(multistage_config.seed, plan.get("seed"), index)
+                task_reference_ids = assign_task_references(
+                    plan.get("task_ids", []),
+                    plan.get("reference_ids", []),
+                    rng=assignment_rng,
+                )
+            planned_stage_rows = build_stage_rows(rows_by_task, task_reference_ids, index)
+            if outcome.get("status") == "partial_complete":
+                included_keys = _recorded_key_set(outcome, "included_keys")
+                omitted_keys = _recorded_key_set(outcome, "omitted_keys")
+                persisted_success_keys = {_stage_key(row) for row in resume.rows_by_stage.get(index, [])}
+                completion_is_covered = (
+                    completion_is_covered
+                    and not (included_keys & omitted_keys)
+                    and included_keys | omitted_keys == expected_keys
+                    and included_keys <= persisted_success_keys
+                    and _cached_partial_snapshot_is_valid(
+                        outcome,
+                        stage.partial_completion,
+                        planned_stage_rows,
+                        resume.rows_by_stage.get(index, []),
+                        plan.get("reference_ids", []),
+                        reference_elos,
+                    )
+                )
+                if not completion_is_covered:
+                    raise RuntimeError(
+                        f"cached partial stage {index} snapshot is invalid; refusing to recompute "
+                        "adaptive downstream stages from changed evidence"
+                    )
+            elif index < total_stages - 1:
+                # Older runs used "complete" to mean terminal/max-attempt
+                # resolved.  Such an outcome is not safe to reuse for adaptive
+                # reference selection unless every planned row has usable
+                # persisted battle evidence.
+                persisted_rows = resume.rows_by_stage.get(index, [])
+                completion_is_covered = completion_is_covered and (
+                    _fit_eligible_stage_keys(planned_stage_rows, persisted_rows) == expected_keys
+                    and len(planned_stage_rows) == len(expected_rows)
+                )
             if completion_is_covered:
                 resumed_elo = _resume_complete_stage(
                     index,
@@ -569,6 +919,10 @@ async def run_multistage_stages(
                 expected_rows=len(expected_rows),
                 resolved_rows=len(expected_keys & resolved_keys),
             )
+            resume.restart_from(index)
+            sidecar_produced_by_stage = {
+                stage_index: keys for stage_index, keys in sidecar_produced_by_stage.items() if stage_index <= index
+            }
 
         reference_ids, task_ids, task_reference_ids, replayed = _plan_stage(
             index, stage, reference_elos, eval_elo, stage_task_sets, multistage_config, resume
@@ -616,6 +970,41 @@ async def run_multistage_stages(
                 )
                 pending_rows = known + unknown
 
+        # A run may opt into partial calibration after an allocation ended with
+        # persisted timeouts.  Evaluate that frozen evidence before dispatch so
+        # the already-timed-out rows are not forced through another long attempt.
+        pre_dispatch_partial_outcome: Optional[Dict[str, Any]] = None
+        if resume is not None and index < total_stages - 1 and stage.partial_completion is not None and pending_rows:
+            pending_keys_for_policy = {(row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME]) for row in pending_rows}
+            latest_failures = resume.latest_failures_by_stage.get(index, {})
+            latest_dispositions = resume.latest_attempt_dispositions_by_stage.get(index, {})
+            # Persisted failures are fsynced before their journal disposition,
+            # while no-persist tombstones are journaled first. A tombstone must
+            # therefore override an older sidecar; otherwise the sidecar is at
+            # least as new as the journal. If a later persisted attempt crashed
+            # before journaling, preferring its sidecar fails closed correctly.
+            latest_attempts = {
+                key: latest_dispositions[key]
+                if latest_dispositions.get(key, {}).get(NG_NO_PERSIST_KEY)
+                else latest_failures[key]
+                for key in pending_keys_for_policy
+                if latest_dispositions.get(key, {}).get(NG_NO_PERSIST_KEY) or key in latest_failures
+            }
+            persisted_failures = [latest_attempts[key] for key in pending_keys_for_policy if key in latest_attempts]
+            cached_elo, _, cached_num_references = fit_stage_elo(pool_per_reference(cached_rows), reference_elos)
+            candidate = _partial_stage_outcome(
+                stage.partial_completion,
+                stage_rows,
+                cached_rows,
+                persisted_failures,
+                pending_keys_for_policy,
+                reference_ids,
+                cached_elo,
+                cached_num_references,
+            )
+            if candidate is not None:
+                pre_dispatch_partial_outcome = {"stage_index": index, **candidate}
+
         num_reused = sum(1 for r in stage_rows if r.get("reuse_cached_deliverable"))
         _emit(
             "stage_start",
@@ -630,7 +1019,7 @@ async def run_multistage_stages(
             replayed=replayed,
         )
 
-        pairs = await run_rollouts(pending_rows)
+        pairs = [] if pre_dispatch_partial_outcome is not None else await run_rollouts(pending_rows)
         expected_stage_row_count = len(stage_rows)
         new_tagged = tag_results(
             pairs,
@@ -672,9 +1061,9 @@ async def run_multistage_stages(
         if stage_elo is not None:
             eval_elo = stage_elo
 
-        # Completion marker only; eval_elo is re-fit from rows on resume. A
-        # retryable failure or drained row deliberately leaves the stage open,
-        # even if an older implementation had already written "complete".
+        # Outcomes contain no authoritative ELO; it is re-fit from rows on
+        # resume. A retryable failure or drained row leaves the stage open unless
+        # an explicit non-final partial-completion policy accepts its evidence.
         returned_keys: set[Tuple[Any, Any]] = set()
         prior_attempts = resume.attempts_by_stage.get(index, {}) if resume is not None else {}
         for result in new_tagged:
@@ -690,9 +1079,55 @@ async def run_multistage_stages(
             if resolved:
                 returned_keys.add(key)
         pending_keys = {(r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME]) for r in pending_rows}
-        stage_complete = pending_keys <= returned_keys
+        unresolved_keys = pending_keys - returned_keys
+        stage_complete = not unresolved_keys
+        partial_outcome = pre_dispatch_partial_outcome
+        coverage_rejected = False
+        successful_keys = {_stage_key(row) for row in tagged}
+        planned_keys = {_stage_key(row) for row in stage_rows}
+        missing_success_keys = planned_keys - successful_keys
+        if index < total_stages - 1:
+            if stage.partial_completion is not None:
+                coverage_outcome = partial_outcome or _partial_stage_outcome(
+                    stage.partial_completion,
+                    stage_rows,
+                    tagged,
+                    new_tagged,
+                    unresolved_keys,
+                    reference_ids,
+                    stage_elo,
+                    num_references,
+                )
+                if missing_success_keys:
+                    partial_outcome = coverage_outcome
+                    if partial_outcome is not None:
+                        if "stage_index" not in partial_outcome:
+                            partial_outcome = {"stage_index": index, **partial_outcome}
+                        stage_complete = True
+                    else:
+                        stage_complete = False
+                        coverage_rejected = not unresolved_keys
+                elif coverage_outcome is None:
+                    # Even a persisted "success" must contain usable battle
+                    # evidence for every configured coverage gate.
+                    stage_complete = False
+                    coverage_rejected = True
+            else:
+                # Terminal/max-attempt means "do not retry", not "safe adaptive
+                # calibration".  Without an explicit partial policy every
+                # planned non-final row must contribute usable battle evidence.
+                if (
+                    stage_elo is None
+                    or not math.isfinite(stage_elo)
+                    or _fit_eligible_stage_keys(stage_rows, tagged) != planned_keys
+                ):
+                    stage_complete = False
+                    coverage_rejected = not unresolved_keys
         if resume is not None and stage_complete:
-            resume.on_outcome(index, {"stage_index": index, "status": "complete"})
+            resume.on_outcome(
+                index,
+                partial_outcome or {"stage_index": index, "status": "complete"},
+            )
 
         _emit(
             "stage_end",
@@ -702,28 +1137,43 @@ async def run_multistage_stages(
             normalized_elo=normalized,
             num_references=num_references,
         )
-        stage_summaries.append(
-            {
-                "stage_index": index,
-                "num_tasks": len(task_ids),
-                "num_rollouts": len(stage_rows),
-                "num_reused": num_reused,
-                "reference_ids": list(reference_ids),
-                "eval_elo": stage_elo,
-                "normalized_elo": normalized,
-                "num_references": num_references,
-            }
-        )
+        summary = {
+            "stage_index": index,
+            "num_tasks": len(task_ids),
+            "num_rollouts": len(stage_rows),
+            "num_reused": num_reused,
+            "reference_ids": list(reference_ids),
+            "eval_elo": stage_elo,
+            "normalized_elo": normalized,
+            "num_references": num_references,
+        }
+        if partial_outcome is not None:
+            summary.update(
+                partial=True,
+                success_fraction=partial_outcome["success_fraction"],
+                num_successful=len(partial_outcome["included_keys"]),
+                num_omitted=len(partial_outcome["omitted_keys"]),
+            )
+            _emit(
+                "stage_partial_complete",
+                index=index,
+                total_stages=total_stages,
+                success_fraction=partial_outcome["success_fraction"],
+                num_omitted=len(partial_outcome["omitted_keys"]),
+            )
+        stage_summaries.append(summary)
         if not stage_complete:
             _emit(
                 "stage_incomplete",
                 index=index,
                 total_stages=total_stages,
-                num_pending=len(pending_keys - returned_keys),
+                num_pending=len(unresolved_keys),
+                num_omitted=len(missing_success_keys),
+                coverage_blocked=coverage_rejected,
             )
-            # Later reference selection depends on this stage's complete ELO.
-            # Stop here and let resume replay the missing rows instead of
-            # creating downstream plans from a partial estimate.
+            # Later reference selection depends on an accepted ELO. Stop before
+            # creating downstream plans; retryable rows can resume, while a
+            # coverage-only rejection requires an explicit policy/data change.
             break
 
     return all_results, stage_summaries
@@ -744,7 +1194,8 @@ def _plan_stage(
     the ``num_models`` closest to the running ELO estimate). ``task_ids`` is the
     stage's sampled ``T`` tasks (the full task set when ``num_tasks`` is unset).
     ``task_reference_ids`` maps each task to the single reference it is judged
-    against, sampled uniformly (equal weight) from ``reference_ids``.
+    against. Fresh partial-completion stages use a seeded balanced assignment;
+    other fresh stages use independent uniform draws.
 
     ``replayed`` is True when the recorded plan was returned from
     ``resume.plans[index]`` (deterministic replay, even with ``seed=None``), False
@@ -766,7 +1217,12 @@ def _plan_stage(
     reference_ids = select_references(reference_elos, eval_elo, stage.num_models)
     task_ids = list(stage_task_sets[index])
     rng = stage_assignment_rng(multistage_config.seed, stage.seed, index)
-    task_reference_ids = assign_task_references(task_ids, reference_ids, rng=rng)
+    task_reference_ids = assign_task_references(
+        task_ids,
+        reference_ids,
+        rng=rng,
+        balanced=stage.partial_completion is not None,
+    )
     if resume is not None:
         resume.on_plan(
             index,
@@ -800,6 +1256,9 @@ def _resume_complete_stage(
     truth) rather than trusting the recorded ``eval_elo`` field, so the value
     threaded to later stages is always consistent with the persisted rows.
     """
+    outcome = resume.outcomes.get(index, {})
+    partial = outcome.get("status") == "partial_complete"
+    included_keys = _recorded_key_set(outcome, "included_keys") if partial else None
     cached_rows = [
         dict(
             r,
@@ -807,6 +1266,7 @@ def _resume_complete_stage(
             expected_stage_row_count=expected_stage_row_count,
         )
         for r in resume.rows_by_stage.get(index, [])
+        if included_keys is None or _stage_key(r) in included_keys
     ]
     plan = resume.plans.get(index, {})
     reference_ids = list(plan.get("reference_ids", []))
@@ -829,20 +1289,28 @@ def _resume_complete_stage(
         normalized_elo=normalized,
         num_references=num_references,
         num_rollouts=len(cached_rows),
+        partial=partial,
     )
-    stage_summaries.append(
-        {
-            "stage_index": index,
-            "num_tasks": len(task_ids),
-            "num_rollouts": len(cached_rows),
-            "num_reused": 0,
-            "reference_ids": reference_ids,
-            "eval_elo": stage_elo,
-            "normalized_elo": normalized,
-            "num_references": num_references,
-            "cached": True,
-        }
-    )
+    summary = {
+        "stage_index": index,
+        "num_tasks": len(task_ids),
+        "num_rollouts": len(cached_rows),
+        "num_reused": 0,
+        "reference_ids": reference_ids,
+        "eval_elo": stage_elo,
+        "normalized_elo": normalized,
+        "num_references": num_references,
+        "cached": True,
+    }
+    if partial:
+        summary.update(
+            partial=True,
+            num_rollouts=expected_stage_row_count,
+            num_successful=len(cached_rows),
+            success_fraction=outcome.get("success_fraction"),
+            num_omitted=len(_recorded_key_set(outcome, "omitted_keys")),
+        )
+    stage_summaries.append(summary)
     return stage_elo
 
 
@@ -946,9 +1414,40 @@ def read_journal(journal_fpath: str | Path) -> Tuple[Dict[int, dict], Dict[int, 
                 outcomes = {i: outcome for i, outcome in outcomes.items() if i < restart_stage}
             elif status == "planned":
                 plans[int(index)] = record
-            elif status == "complete":
+            elif status in {"complete", "partial_complete"}:
                 outcomes[int(index)] = record
     return plans, outcomes, fingerprint
+
+
+def load_latest_attempt_dispositions(
+    journal_fpath: str | Path,
+) -> Dict[int, Dict[Tuple[Any, Any], Dict[str, Any]]]:
+    """Load latest failure/no-persist attempt state recorded in the journal."""
+    latest: Dict[int, Dict[Tuple[Any, Any], Dict[str, Any]]] = {}
+    path = Path(journal_fpath)
+    if not path.exists():
+        return latest
+    with path.open("rb") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            record = orjson.loads(line)
+            status = record.get("status")
+            if status == "restart_from_stage":
+                restart_stage = int(record["stage_index"])
+                latest = {index: rows for index, rows in latest.items() if index <= restart_stage}
+                continue
+            if status != "attempt_dispositions":
+                continue
+            stage_index = int(record["stage_index"])
+            stage_latest = latest.setdefault(stage_index, {})
+            for disposition in record.get("attempts", []) or []:
+                if TASK_INDEX_KEY_NAME not in disposition or ROLLOUT_INDEX_KEY_NAME not in disposition:
+                    continue
+                key = (disposition[TASK_INDEX_KEY_NAME], disposition[ROLLOUT_INDEX_KEY_NAME])
+                stage_latest[key] = disposition
+    return latest
 
 
 def _pending_restart_stage(journal_fpath: str | Path) -> Optional[int]:
@@ -1121,6 +1620,27 @@ def load_failure_attempts(output_fpath: str | Path) -> Dict[int, Dict[Tuple[Any,
     return attempts_by_stage
 
 
+def load_latest_failures(output_fpath: str | Path) -> Dict[int, Dict[Tuple[Any, Any], Dict[str, Any]]]:
+    """Load the newest persisted sidecar failure for each stage-row key."""
+    latest_by_stage: Dict[int, Dict[Tuple[Any, Any], Dict[str, Any]]] = {}
+    failures_fpath = failures_path_for(Path(output_fpath))
+    if not failures_fpath.exists():
+        return latest_by_stage
+
+    with failures_fpath.open("rb") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            row = orjson.loads(line)
+            if TASK_INDEX_KEY_NAME not in row or ROLLOUT_INDEX_KEY_NAME not in row:
+                continue
+            stage_index = int(row.get("stage_index", 0) or 0)
+            key = (row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME])
+            latest_by_stage.setdefault(stage_index, {})[key] = row
+    return latest_by_stage
+
+
 def load_retryable_failure_stages(
     output_fpath: str | Path,
     gated_keys: Mapping[int, AbstractSet[Tuple[Any, Any]]],
@@ -1209,6 +1729,20 @@ def route_stage_rows(output_fpath: str | Path, rows: Sequence[Mapping[str, Any]]
                 fail_handle.write(orjson.dumps(row) + b"\n")
             else:
                 main_handle.write(orjson.dumps(row) + b"\n")
+        main_handle.flush()
+        fail_handle.flush()
+        os.fsync(main_handle.fileno())
+        os.fsync(fail_handle.fileno())
+
+
+def _gate_partial_outcome_omissions(
+    outcomes: Mapping[int, Mapping[str, Any]],
+    gated_keys: Dict[int, set[Tuple[Any, Any]]],
+) -> None:
+    """Keep journaled partial omissions closed on deterministic resume."""
+    for stage_index, outcome in outcomes.items():
+        if outcome.get("status") == "partial_complete":
+            gated_keys.setdefault(stage_index, set()).update(_recorded_key_set(outcome, "omitted_keys"))
 
 
 def build_file_resume(output_fpath: str | Path, journal_fpath: str | Path, fingerprint: str) -> StageResume:
@@ -1231,9 +1765,12 @@ def build_file_resume(output_fpath: str | Path, journal_fpath: str | Path, finge
     plans, outcomes, _ = read_journal(journal_fpath)
     rows_by_stage = load_persisted_rows(output_fpath)
     gated_keys = load_gated_keys(output_fpath, rows_by_stage)
+    _gate_partial_outcome_omissions(outcomes, gated_keys)
     elapsed_by_stage = load_failure_timings(output_fpath)
     reuse_cached_keys = load_reuse_cached_keys(output_fpath)
     attempts_by_stage = load_failure_attempts(output_fpath)
+    latest_failures_by_stage = load_latest_failures(output_fpath)
+    latest_attempt_dispositions_by_stage = load_latest_attempt_dispositions(journal_fpath)
     # Older multistage runs wrote a completion marker even when a retryable
     # sidecar failure remained. The sidecar is authoritative for retry state;
     # discard only those stale outcomes so the recorded plan is replayed.
@@ -1258,9 +1795,12 @@ def build_file_resume(output_fpath: str | Path, journal_fpath: str | Path, finge
         plans, outcomes, _ = read_journal(journal_fpath)
         rows_by_stage = load_persisted_rows(output_fpath)
         gated_keys = load_gated_keys(output_fpath, rows_by_stage)
+        _gate_partial_outcome_omissions(outcomes, gated_keys)
         elapsed_by_stage = load_failure_timings(output_fpath)
         reuse_cached_keys = load_reuse_cached_keys(output_fpath)
         attempts_by_stage = load_failure_attempts(output_fpath)
+        latest_failures_by_stage = load_latest_failures(output_fpath)
+        latest_attempt_dispositions_by_stage = load_latest_attempt_dispositions(journal_fpath)
 
     def on_plan(index: int, plan: dict) -> None:
         append_journal_record(journal_fpath, plan, fingerprint)
@@ -1269,7 +1809,56 @@ def build_file_resume(output_fpath: str | Path, journal_fpath: str | Path, finge
         append_journal_record(journal_fpath, outcome, fingerprint)
 
     def on_rows(index: int, rows: List[Dict[str, Any]]) -> None:
+        dispositions = [
+            {
+                TASK_INDEX_KEY_NAME: row[TASK_INDEX_KEY_NAME],
+                ROLLOUT_INDEX_KEY_NAME: row[ROLLOUT_INDEX_KEY_NAME],
+                NG_FAILURE_CLASS_KEY: row.get(NG_FAILURE_CLASS_KEY),
+                NG_NO_PERSIST_KEY: bool(row.get(NG_NO_PERSIST_KEY)),
+            }
+            for row in rows
+            if not _is_success_row(row) and TASK_INDEX_KEY_NAME in row and ROLLOUT_INDEX_KEY_NAME in row
+        ]
+        no_persist_dispositions = [row for row in dispositions if row[NG_NO_PERSIST_KEY]]
+        persisted_dispositions = [row for row in dispositions if not row[NG_NO_PERSIST_KEY]]
+        # A no-persist attempt is a tombstone for any older timeout sidecar.
+        # Journal it before routing so a crash can only cause a conservative
+        # retry, never acceptance based on the stale timeout.
+        if no_persist_dispositions:
+            append_journal_record(
+                journal_fpath,
+                {
+                    "stage_index": index,
+                    "status": "attempt_dispositions",
+                    "attempts": no_persist_dispositions,
+                },
+                fingerprint,
+            )
         route_stage_rows(output_fpath, rows)
+        if persisted_dispositions:
+            append_journal_record(
+                journal_fpath,
+                {
+                    "stage_index": index,
+                    "status": "attempt_dispositions",
+                    "attempts": persisted_dispositions,
+                },
+                fingerprint,
+            )
+
+    def on_restart(index: int) -> None:
+        append_journal_record(
+            journal_fpath,
+            {"stage_index": index, "status": "restart_from_stage"},
+            fingerprint,
+        )
+        aggregate_metrics_path_for(output_fpath).unlink(missing_ok=True)
+        _prune_downstream_files(output_fpath, index)
+        append_journal_record(
+            journal_fpath,
+            {"stage_index": index, "status": "restart_cleanup_complete"},
+            fingerprint,
+        )
 
     return StageResume(
         plans=plans,
@@ -1279,9 +1868,12 @@ def build_file_resume(output_fpath: str | Path, journal_fpath: str | Path, finge
         on_plan=on_plan,
         on_outcome=on_outcome,
         on_rows=on_rows,
+        on_restart=on_restart,
         elapsed_by_stage=elapsed_by_stage,
         reuse_cached_keys=reuse_cached_keys,
         attempts_by_stage=attempts_by_stage,
+        latest_failures_by_stage=latest_failures_by_stage,
+        latest_attempt_dispositions_by_stage=latest_attempt_dispositions_by_stage,
     )
 
 
@@ -1484,16 +2076,30 @@ def _log_event(name: str, data: dict) -> None:  # pragma: no cover
     elif name == "stage_cached":
         elo = data.get("eval_elo")
         elo_str = f"{elo:.1f}" if isinstance(elo, (int, float)) else "unset (no games)"
+        cache_kind = "partial result" if data.get("partial") else "complete result"
         print(
-            f"[multistage-elo] stage {data['index'] + 1}/{data['total_stages']} reused from cache: "
+            f"[multistage-elo] stage {data['index'] + 1}/{data['total_stages']} reused {cache_kind} from cache: "
             f"eval ELO = {elo_str} ({data.get('num_rollouts')} cached rollout(s))",
             file=sys.stderr,
             flush=True,
         )
+    elif name == "stage_partial_complete":
+        print(
+            f"[multistage-elo] stage {data['index'] + 1}/{data['total_stages']} accepted partial calibration: "
+            f"success coverage {data.get('success_fraction', 0):.1%}, omitted "
+            f"{data.get('num_omitted')} rollout(s)",
+            file=sys.stderr,
+            flush=True,
+        )
     elif name == "stage_incomplete":
+        detail = (
+            f"coverage policy rejected {data.get('num_omitted')} resolved omission(s)"
+            if data.get("coverage_blocked")
+            else f"{data.get('num_pending')} rollout(s) retryable or undispatched"
+        )
         print(
             f"[multistage-elo] stage {data['index'] + 1}/{data['total_stages']} remains incomplete "
-            f"({data.get('num_pending')} rollout(s) retryable or undispatched); stopping before downstream stages",
+            f"({detail}); stopping before downstream stages",
             file=sys.stderr,
             flush=True,
         )

--- a/resources_servers/gdpval/multistage_orchestrator.py
+++ b/resources_servers/gdpval/multistage_orchestrator.py
@@ -54,7 +54,11 @@ orchestration is unit-testable without any servers.
 from __future__ import annotations
 
 import hashlib
+import os
 import random
+import secrets
+import tempfile
+import time
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -62,13 +66,21 @@ from typing import AbstractSet, Any, Awaitable, Callable, Dict, List, Mapping, O
 
 import orjson
 
-from nemo_gym.global_config import AGENT_REF_KEY_NAME, ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
+from nemo_gym.global_config import (
+    AGENT_REF_KEY_NAME,
+    ATTEMPT_INDEX_KEY_NAME,
+    ROLLOUT_INDEX_KEY_NAME,
+    TASK_INDEX_KEY_NAME,
+)
 from nemo_gym.path_utils import failures_path_for
 from nemo_gym.rollout_collection import (
     NG_FAILURE_CLASS_KEY,
     NG_NO_PERSIST_KEY,
-    NG_TERMINAL_KEY,
+    DispatchLatencyTracker,
     _get_max_rollout_attempts,
+    _is_terminal_failure,
+    _migrate_invalid_judge_main_rows,
+    _observed_elapsed,
 )
 from resources_servers.gdpval.multistage_elo import (
     PerReferenceTotals,
@@ -108,17 +120,34 @@ class StageResume:
     on_plan: Callable[[int, dict], None]
     on_outcome: Callable[[int, dict], None]
     on_rows: Callable[[int, List[Dict[str, Any]]], None]
+    # Longest observed failed-attempt duration, keyed by stage then
+    # (task_index, rollout_index). This is the stage-aware equivalent of the
+    # single-pass dispatcher's resume timing map.
+    elapsed_by_stage: Mapping[int, Mapping[Tuple[Any, Any], float]] = field(default_factory=dict)
+    # Failed judging attempts whose persisted policy artifact should be reused
+    # on retry, keyed by stage then (task_index, rollout_index).
+    reuse_cached_keys: Mapping[int, AbstractSet[Tuple[Any, Any]]] = field(default_factory=dict)
+    # Number of sidecar attempts already consumed, keyed stage/task/rollout.
+    attempts_by_stage: Mapping[int, Mapping[Tuple[Any, Any], int]] = field(default_factory=dict)
 
 
 def _is_success_row(row: Mapping[str, Any]) -> bool:
     """A row is a success iff it carries neither a failure class nor no-persist."""
-    return row.get(NG_FAILURE_CLASS_KEY) is None and not row.get(NG_NO_PERSIST_KEY)
+    return (
+        row.get(NG_FAILURE_CLASS_KEY) is None
+        and not row.get(NG_NO_PERSIST_KEY)
+        and not row.get("invalid_judge_response")
+    )
 
 
 def compute_fingerprint(
     multistage_config: MultiStageRunConfig,
     reference_elos: Mapping[str, float],
     distribution: Mapping[str, Mapping[str, object]],
+    *,
+    materialized_rows: Optional[Sequence[Mapping[str, Any]]] = None,
+    rollout_collection_config: Optional[Any] = None,
+    resolved_global_config: Optional[Mapping[str, Any]] = None,
 ) -> str:
     """Stable hash of everything that affects stage planning.
 
@@ -126,6 +155,20 @@ def compute_fingerprint(
     journal stale: the plans/outcomes it records were produced under a different
     configuration or task distribution and cannot be safely replayed.
     """
+
+    def jsonable(value: Any) -> Any:
+        if hasattr(value, "model_dump"):
+            return value.model_dump(mode="json")
+        if isinstance(value, Mapping):
+            return {str(key): jsonable(item) for key, item in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [jsonable(item) for item in value]
+        if isinstance(value, Path):
+            return str(value)
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+        return repr(value)
+
     payload = {
         "stages": [(s.num_tasks, s.num_models, s.seed) for s in multistage_config.stages],
         "seed": multistage_config.seed,
@@ -141,6 +184,40 @@ def compute_fingerprint(
             for grp in sorted(distribution)
         },
     }
+    if materialized_rows is not None:
+        materialized_hasher = hashlib.sha256()
+        for row in materialized_rows:
+            materialized_hasher.update(orjson.dumps(row, option=orjson.OPT_SORT_KEYS))
+            materialized_hasher.update(b"\n")
+        payload["materialized_rows"] = {
+            "count": len(materialized_rows),
+            "sha256": materialized_hasher.hexdigest(),
+        }
+    if rollout_collection_config is not None:
+        result_affecting_fields = (
+            "agent_name",
+            "input_jsonl_fpath",
+            "limit",
+            "num_repeats",
+            "num_repeats_add_seed",
+            "responses_create_params",
+            "prompt_config",
+            "skills",
+        )
+
+        def config_value(name: str) -> Any:
+            if isinstance(rollout_collection_config, Mapping):
+                return rollout_collection_config.get(name)
+            return getattr(rollout_collection_config, name, None)
+
+        payload["rollout_collection_config"] = {name: jsonable(config_value(name)) for name in result_affecting_fields}
+    if resolved_global_config is not None:
+        component_types = {"responses_api_agents", "responses_api_models", "resources_servers"}
+        payload["runtime_components"] = {
+            str(name): jsonable(block)
+            for name, block in resolved_global_config.items()
+            if isinstance(block, Mapping) and component_types.intersection(block)
+        }
     encoded = orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)
     return hashlib.sha256(encoded).hexdigest()
 
@@ -311,6 +388,8 @@ def build_stage_rows(
 def tag_results(
     pairs: Sequence[Tuple[Mapping[str, Any], Mapping[str, Any]]],
     stage_index: int,
+    expected_final_stage_index: Optional[int] = None,
+    expected_stage_row_count: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """Attach rollout identity + ``stage_index`` to each stage result row.
 
@@ -318,6 +397,9 @@ def tag_results(
     result (task/rollout indices, agent ref) so the merged rollouts file and the
     standard ``_call_aggregate_metrics`` see well-formed rows, and stamps
     ``stage_index``/``task_id`` so the stage-aware aggregation can group by stage.
+    Multi-stage callers also provide ``expected_final_stage_index`` and
+    ``expected_stage_row_count`` so aggregation can distinguish a complete run
+    from a missing or partially drained final stage.
     """
     tagged: List[Dict[str, Any]] = []
     for row, result in pairs:
@@ -325,7 +407,13 @@ def tag_results(
         out[TASK_INDEX_KEY_NAME] = row[TASK_INDEX_KEY_NAME]
         out[ROLLOUT_INDEX_KEY_NAME] = row[ROLLOUT_INDEX_KEY_NAME]
         out[AGENT_REF_KEY_NAME] = row[AGENT_REF_KEY_NAME]
+        if ATTEMPT_INDEX_KEY_NAME in row:
+            out[ATTEMPT_INDEX_KEY_NAME] = row[ATTEMPT_INDEX_KEY_NAME]
         out["stage_index"] = stage_index
+        if expected_final_stage_index is not None:
+            out["expected_final_stage_index"] = expected_final_stage_index
+        if expected_stage_row_count is not None:
+            out["expected_stage_row_count"] = expected_stage_row_count
         if out.get("task_id") is None:
             tid = row_task_id(row)
             if tid is not None:
@@ -349,6 +437,7 @@ async def run_multistage_stages(
     rng: Optional[random.Random] = None,
     on_event: Optional[Callable[[str, dict], None]] = None,
     resume: Optional[StageResume] = None,
+    dispatch_longest_first: bool = False,
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Run every stage and return ``(all_result_rows, stage_summaries)``.
 
@@ -370,8 +459,8 @@ async def run_multistage_stages(
     interrupted stages re-dispatch only the ``(task, rollout)`` rows without a
     persisted success, and recorded plans (including each stage's per-task
     reference assignment) are replayed so selection is identical even when
-    ``multistage.seed`` is ``None``. ``resume=None`` is byte-for-byte the
-    pre-resume behavior.
+    ``multistage.seed`` is ``None``. ``resume=None`` preserves the same execution
+    semantics without file-backed persistence.
     """
     base_rng = rng or (
         random.Random(multistage_config.seed) if multistage_config.seed is not None else random.Random()
@@ -401,19 +490,56 @@ async def run_multistage_stages(
     # (task_id, rollout_index) deliverables already produced by earlier stages.
     # Later stages reuse these instead of re-running the policy.
     produced: set[Tuple[str, int]] = set()
+    sidecar_produced_by_stage: Dict[int, set[Tuple[str, int]]] = {}
+    if resume is not None and resume.reuse_cached_keys:
+        task_id_by_key: Dict[Tuple[Any, Any], str] = {}
+        for row in materialized_rows:
+            task_id = row_task_id(row)
+            if task_id is not None:
+                task_id_by_key[(row.get(TASK_INDEX_KEY_NAME), row.get(ROLLOUT_INDEX_KEY_NAME))] = task_id
+        for stage_index, keys in resume.reuse_cached_keys.items():
+            for key in keys:
+                task_id = task_id_by_key.get(key)
+                if task_id is not None:
+                    sidecar_produced_by_stage.setdefault(stage_index, set()).add((task_id, int(key[1] or 0)))
+
+    max_attempts = _get_max_rollout_attempts()
     for index, stage in enumerate(multistage_config.stages):
+        # A sidecar reuse flag is emitted only after the policy artifact exists.
+        # Treat it as produced from this stage onward even when the judging row
+        # is terminal/max-attempt gated and therefore never enters the main file.
+        produced.update(sidecar_produced_by_stage.get(index, set()))
         if resume is not None and index in resume.outcomes:
-            eval_elo = _resume_complete_stage(
-                index,
-                total_stages,
-                resume,
-                reference_elos,
-                produced,
-                all_results,
-                stage_summaries,
-                _emit,
+            plan = resume.plans.get(index, {})
+            expected_rows = [row for task_id in plan.get("task_ids", []) for row in rows_by_task.get(str(task_id), [])]
+            expected_keys = {(row.get(TASK_INDEX_KEY_NAME), row.get(ROLLOUT_INDEX_KEY_NAME)) for row in expected_rows}
+            resolved_keys = set(resume.gated_keys.get(index, set()))
+            completion_is_covered = len(expected_keys) == len(expected_rows) and expected_keys <= resolved_keys
+            if completion_is_covered:
+                resumed_elo = _resume_complete_stage(
+                    index,
+                    total_stages,
+                    len(expected_rows),
+                    resume,
+                    reference_elos,
+                    produced,
+                    all_results,
+                    stage_summaries,
+                    _emit,
+                )
+                # Match uninterrupted execution: a completed stage with no
+                # usable battles does not erase the last fitted ELO. Later
+                # adaptive stages continue from the most recent valid fit.
+                if resumed_elo is not None:
+                    eval_elo = resumed_elo
+                continue
+            _emit(
+                "stage_completion_stale",
+                index=index,
+                total_stages=total_stages,
+                expected_rows=len(expected_rows),
+                resolved_rows=len(expected_keys & resolved_keys),
             )
-            continue
 
         reference_ids, task_ids, task_reference_ids, replayed = _plan_stage(
             index, stage, reference_elos, eval_elo, stage_task_sets, multistage_config, resume
@@ -431,6 +557,35 @@ async def run_multistage_stages(
         # failures from the sidecar (mirrors ``_load_from_cache``, stage-keyed).
         gated_keys = set(resume.gated_keys.get(index, set())) if resume is not None else set()
         pending_rows = [r for r in stage_rows if (r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME]) not in gated_keys]
+        if resume is not None:
+            reuse_cached_keys = resume.reuse_cached_keys.get(index, set())
+            attempts_by_key = resume.attempts_by_stage.get(index, {})
+            for row in pending_rows:
+                key = (row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME])
+                if key in reuse_cached_keys:
+                    row["reuse_cached_deliverable"] = True
+                prior_attempts = attempts_by_key.get(key, 0)
+                if prior_attempts > 0:
+                    row[ATTEMPT_INDEX_KEY_NAME] = prior_attempts
+
+        if dispatch_longest_first and resume is not None:
+            elapsed_by_key = resume.elapsed_by_stage.get(index, {})
+            if elapsed_by_key:
+                known = [
+                    row
+                    for row in pending_rows
+                    if (row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME]) in elapsed_by_key
+                ]
+                unknown = [
+                    row
+                    for row in pending_rows
+                    if (row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME]) not in elapsed_by_key
+                ]
+                known.sort(
+                    key=lambda row: elapsed_by_key[(row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME])],
+                    reverse=True,
+                )
+                pending_rows = known + unknown
 
         num_reused = sum(1 for r in stage_rows if r.get("reuse_cached_deliverable"))
         _emit(
@@ -447,16 +602,38 @@ async def run_multistage_stages(
         )
 
         pairs = await run_rollouts(pending_rows)
-        new_tagged = tag_results(pairs, index)
+        expected_stage_row_count = len(stage_rows)
+        new_tagged = tag_results(
+            pairs,
+            index,
+            expected_final_stage_index=total_stages - 1,
+            expected_stage_row_count=expected_stage_row_count,
+        )
         if resume is not None:
             resume.on_rows(index, new_tagged)
+        # A verify-side failure can still carry a complete, reusable policy
+        # artifact. Make it available immediately to later stages in this same
+        # process; startup-only sidecar loading covers only resumed runs.
+        for row in new_tagged:
+            if not row.get("reuse_cached_deliverable"):
+                continue
+            tid = row_task_id(row)
+            if tid is not None:
+                produced.add((tid, int(row.get(ROLLOUT_INDEX_KEY_NAME, 0) or 0)))
         # Only successful rows feed pooling / aggregate.
         new_successes = [r for r in new_tagged if _is_success_row(r)]
-        tagged = list(cached_rows) + new_successes
+        tagged = [
+            dict(
+                r,
+                expected_final_stage_index=total_stages - 1,
+                expected_stage_row_count=expected_stage_row_count,
+            )
+            for r in cached_rows
+        ] + new_successes
         all_results.extend(tagged)
 
         # Record this stage's deliverables so later stages can reuse them.
-        for row in stage_rows:
+        for row in tagged:
             tid = row_task_id(row)
             if tid is not None:
                 produced.add((tid, int(row.get(ROLLOUT_INDEX_KEY_NAME, 0) or 0)))
@@ -466,8 +643,26 @@ async def run_multistage_stages(
         if stage_elo is not None:
             eval_elo = stage_elo
 
-        # Completion marker only; eval_elo is re-fit from rows on resume.
-        if resume is not None:
+        # Completion marker only; eval_elo is re-fit from rows on resume. A
+        # retryable failure or drained row deliberately leaves the stage open,
+        # even if an older implementation had already written "complete".
+        returned_keys: set[Tuple[Any, Any]] = set()
+        prior_attempts = resume.attempts_by_stage.get(index, {}) if resume is not None else {}
+        for result in new_tagged:
+            key = (result[TASK_INDEX_KEY_NAME], result[ROLLOUT_INDEX_KEY_NAME])
+            resolved = _is_success_row(result) or _is_terminal_failure(result)
+            if (
+                not resolved
+                and result.get(NG_FAILURE_CLASS_KEY) is not None
+                and not result.get(NG_NO_PERSIST_KEY)
+                and prior_attempts.get(key, 0) + 1 >= max_attempts
+            ):
+                resolved = True
+            if resolved:
+                returned_keys.add(key)
+        pending_keys = {(r[TASK_INDEX_KEY_NAME], r[ROLLOUT_INDEX_KEY_NAME]) for r in pending_rows}
+        stage_complete = pending_keys <= returned_keys
+        if resume is not None and stage_complete:
             resume.on_outcome(index, {"stage_index": index, "status": "complete"})
 
         _emit(
@@ -490,6 +685,17 @@ async def run_multistage_stages(
                 "num_references": num_references,
             }
         )
+        if not stage_complete:
+            _emit(
+                "stage_incomplete",
+                index=index,
+                total_stages=total_stages,
+                num_pending=len(pending_keys - returned_keys),
+            )
+            # Later reference selection depends on this stage's complete ELO.
+            # Stop here and let resume replay the missing rows instead of
+            # creating downstream plans from a partial estimate.
+            break
 
     return all_results, stage_summaries
 
@@ -551,6 +757,7 @@ def _plan_stage(
 def _resume_complete_stage(
     index: int,
     total_stages: int,
+    expected_stage_row_count: int,
     resume: StageResume,
     reference_elos: Mapping[str, float],
     produced: set[Tuple[str, int]],
@@ -564,7 +771,14 @@ def _resume_complete_stage(
     truth) rather than trusting the recorded ``eval_elo`` field, so the value
     threaded to later stages is always consistent with the persisted rows.
     """
-    cached_rows = list(resume.rows_by_stage.get(index, []))
+    cached_rows = [
+        dict(
+            r,
+            expected_final_stage_index=total_stages - 1,
+            expected_stage_row_count=expected_stage_row_count,
+        )
+        for r in resume.rows_by_stage.get(index, [])
+    ]
     plan = resume.plans.get(index, {})
     reference_ids = list(plan.get("reference_ids", []))
     task_ids = list(plan.get("task_ids", []))
@@ -621,9 +835,35 @@ def write_rollouts(all_results: Sequence[Mapping[str, Any]], output_fpath: str |
         deduped.values(),
         key=lambda r: (r.get("stage_index", 0), r.get(TASK_INDEX_KEY_NAME, 0), r.get(ROLLOUT_INDEX_KEY_NAME, 0)),
     )
-    with output_fpath.open("wb") as handle:
-        for row in ordered:
-            handle.write(orjson.dumps(row) + b"\n")
+    prior_mode = output_fpath.stat().st_mode & 0o7777 if output_fpath.exists() else None
+    temp_path: Optional[Path] = None
+    try:
+        # NamedTemporaryFile forces 0600, which would silently make a fresh
+        # shared rollout file owner-only. Create the staging file with the same
+        # 0666+umask semantics as a normal ``open(..., 'wb')`` instead.
+        for _ in range(100):
+            candidate = output_fpath.parent / f".{output_fpath.name}.merge-{secrets.token_hex(8)}"
+            try:
+                fd = os.open(candidate, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)
+            except FileExistsError:
+                continue
+            temp_path = candidate
+            break
+        else:  # pragma: no cover - cryptographically-random collisions
+            raise FileExistsError(f"could not allocate staging file beside {output_fpath}")
+
+        with os.fdopen(fd, "wb") as handle:
+            for row in ordered:
+                handle.write(orjson.dumps(row) + b"\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        if prior_mode is not None:
+            os.chmod(temp_path, prior_mode)
+        os.replace(temp_path, output_fpath)
+        temp_path = None
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
     return output_fpath
 
 
@@ -636,6 +876,12 @@ def journal_path_for(output_fpath: str | Path) -> Path:
     """``<output_stem>_multistage_state.jsonl`` sibling of the rollouts file."""
     output_fpath = Path(output_fpath)
     return output_fpath.with_name(f"{output_fpath.stem}_multistage_state.jsonl")
+
+
+def aggregate_metrics_path_for(output_fpath: str | Path) -> Path:
+    """Standard aggregate-metrics path associated with a rollout JSONL."""
+    output_fpath = Path(output_fpath)
+    return output_fpath.with_stem(output_fpath.stem + "_aggregate_metrics").with_suffix(".json")
 
 
 def read_journal(journal_fpath: str | Path) -> Tuple[Dict[int, dict], Dict[int, dict], Optional[str]]:
@@ -660,11 +906,77 @@ def read_journal(journal_fpath: str | Path) -> Tuple[Dict[int, dict], Dict[int, 
             index = record.get("stage_index")
             if index is None:
                 continue
-            if record.get("status") == "planned":
+            status = record.get("status")
+            if status == "restart_from_stage":
+                restart_stage = int(index)
+                # The marker is durable before downstream files are pruned. It
+                # therefore invalidates old journal state immediately even if
+                # the process dies during cleanup; newer records later in the
+                # journal can repopulate the recomputed stages.
+                plans = {i: plan for i, plan in plans.items() if i <= restart_stage}
+                outcomes = {i: outcome for i, outcome in outcomes.items() if i < restart_stage}
+            elif status == "planned":
                 plans[int(index)] = record
-            elif record.get("status") == "complete":
+            elif status == "complete":
                 outcomes[int(index)] = record
     return plans, outcomes, fingerprint
+
+
+def _pending_restart_stage(journal_fpath: str | Path) -> Optional[int]:
+    """Return a restart marker whose downstream file cleanup was not acknowledged."""
+    pending: Optional[int] = None
+    path = Path(journal_fpath)
+    if not path.exists():
+        return None
+    with path.open("rb") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            record = orjson.loads(line)
+            status = record.get("status")
+            if status == "restart_from_stage":
+                pending = int(record["stage_index"])
+            elif status == "restart_cleanup_complete" and pending == int(record["stage_index"]):
+                pending = None
+    return pending
+
+
+def _atomic_filter_jsonl(path: Path, keep: Callable[[Mapping[str, Any]], bool]) -> None:
+    """Atomically rewrite ``path`` with only records accepted by ``keep``."""
+    if not path.exists():
+        return
+    mode = path.stat().st_mode & 0o7777
+    temp_path: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", dir=path.parent, prefix=f".{path.name}.prune-", delete=False
+        ) as out:
+            temp_path = Path(out.name)
+            with path.open("rb") as source:
+                for line in source:
+                    stripped = line.strip()
+                    if stripped and keep(orjson.loads(stripped)):
+                        out.write(stripped + b"\n")
+            out.flush()
+            os.fsync(out.fileno())
+        os.chmod(temp_path, mode)
+        os.replace(temp_path, path)
+        temp_path = None
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+
+
+def _prune_downstream_files(output_fpath: str | Path, restart_stage: int) -> None:
+    """Remove persisted main/sidecar rows after ``restart_stage`` atomically."""
+    output_fpath = Path(output_fpath)
+
+    def keep(record: Mapping[str, Any]) -> bool:
+        return int(record.get("stage_index", 0) or 0) <= restart_stage
+
+    _atomic_filter_jsonl(output_fpath, keep)
+    _atomic_filter_jsonl(failures_path_for(output_fpath), keep)
 
 
 def load_persisted_rows(output_fpath: str | Path) -> Dict[int, List[Dict[str, Any]]]:
@@ -723,7 +1035,7 @@ def load_gated_keys(
                 continue
             key = (int(fr.get("stage_index", 0) or 0), fr[TASK_INDEX_KEY_NAME], fr[ROLLOUT_INDEX_KEY_NAME])
             attempts[key] = attempts.get(key, 0) + 1
-            if fr.get(NG_TERMINAL_KEY):
+            if _is_terminal_failure(fr):
                 terminal.add(key)
 
     for key in attempts:
@@ -731,6 +1043,109 @@ def load_gated_keys(
         if key in terminal or attempts[key] >= max_attempts:
             gated.setdefault(stage_index, set()).add((task_index, rollout_index))
     return gated
+
+
+def load_failure_timings(output_fpath: str | Path) -> Dict[int, Dict[Tuple[Any, Any], float]]:
+    """Load longest failed-attempt duration per stage/task/rollout key."""
+    elapsed_by_stage: Dict[int, Dict[Tuple[Any, Any], float]] = {}
+    failures_fpath = failures_path_for(Path(output_fpath))
+    if not failures_fpath.exists():
+        return elapsed_by_stage
+
+    with failures_fpath.open("rb") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            row = orjson.loads(line)
+            if TASK_INDEX_KEY_NAME not in row or ROLLOUT_INDEX_KEY_NAME not in row:
+                continue
+            elapsed = _observed_elapsed(row)
+            if elapsed is None:
+                continue
+            stage_index = int(row.get("stage_index", 0) or 0)
+            key = (row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME])
+            stage_timings = elapsed_by_stage.setdefault(stage_index, {})
+            stage_timings[key] = max(stage_timings.get(key, 0.0), elapsed)
+    return elapsed_by_stage
+
+
+def load_failure_attempts(output_fpath: str | Path) -> Dict[int, Dict[Tuple[Any, Any], int]]:
+    """Load prior sidecar attempt counts per stage/task/rollout key."""
+    attempts_by_stage: Dict[int, Dict[Tuple[Any, Any], int]] = {}
+    failures_fpath = failures_path_for(Path(output_fpath))
+    if not failures_fpath.exists():
+        return attempts_by_stage
+
+    with failures_fpath.open("rb") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            row = orjson.loads(line)
+            if TASK_INDEX_KEY_NAME not in row or ROLLOUT_INDEX_KEY_NAME not in row:
+                continue
+            stage_index = int(row.get("stage_index", 0) or 0)
+            key = (row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME])
+            stage_attempts = attempts_by_stage.setdefault(stage_index, {})
+            stage_attempts[key] = stage_attempts.get(key, 0) + 1
+    return attempts_by_stage
+
+
+def load_retryable_failure_stages(
+    output_fpath: str | Path,
+    gated_keys: Mapping[int, AbstractSet[Tuple[Any, Any]]],
+    rows_by_stage: Mapping[int, Sequence[Mapping[str, Any]]],
+) -> set[int]:
+    """Stages with a persisted failure that still needs another attempt."""
+    retryable: set[int] = set()
+    failures_fpath = failures_path_for(Path(output_fpath))
+    if not failures_fpath.exists():
+        return retryable
+
+    completed_keys = {
+        stage_index: {(row.get(TASK_INDEX_KEY_NAME), row.get(ROLLOUT_INDEX_KEY_NAME)) for row in rows}
+        for stage_index, rows in rows_by_stage.items()
+    }
+
+    with failures_fpath.open("rb") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            row = orjson.loads(line)
+            if TASK_INDEX_KEY_NAME not in row or ROLLOUT_INDEX_KEY_NAME not in row:
+                continue
+            stage_index = int(row.get("stage_index", 0) or 0)
+            key = (row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME])
+            # Historical failures remain in the append-only sidecar after a
+            # later attempt succeeds. Such a key is resolved, not retryable.
+            if key not in completed_keys.get(stage_index, set()) and key not in gated_keys.get(stage_index, set()):
+                retryable.add(stage_index)
+    return retryable
+
+
+def load_reuse_cached_keys(output_fpath: str | Path) -> Dict[int, set[Tuple[Any, Any]]]:
+    """Load stage-aware retry keys that should reuse a persisted deliverable."""
+    reuse_cached_keys: Dict[int, set[Tuple[Any, Any]]] = {}
+    failures_fpath = failures_path_for(Path(output_fpath))
+    if not failures_fpath.exists():
+        return reuse_cached_keys
+
+    with failures_fpath.open("rb") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            row = orjson.loads(line)
+            if not row.get("reuse_cached_deliverable"):
+                continue
+            if TASK_INDEX_KEY_NAME not in row or ROLLOUT_INDEX_KEY_NAME not in row:
+                continue
+            stage_index = int(row.get("stage_index", 0) or 0)
+            key = (row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME])
+            reuse_cached_keys.setdefault(stage_index, set()).add(key)
+    return reuse_cached_keys
 
 
 def append_journal_record(journal_fpath: str | Path, record: Mapping[str, Any], fingerprint: str) -> None:
@@ -741,6 +1156,8 @@ def append_journal_record(journal_fpath: str | Path, record: Mapping[str, Any], 
     out["fingerprint"] = fingerprint
     with path.open("ab") as handle:
         handle.write(orjson.dumps(out) + b"\n")
+        handle.flush()
+        os.fsync(handle.fileno())
 
 
 def route_stage_rows(output_fpath: str | Path, rows: Sequence[Mapping[str, Any]]) -> None:
@@ -767,9 +1184,54 @@ def route_stage_rows(output_fpath: str | Path, rows: Sequence[Mapping[str, Any]]
 
 def build_file_resume(output_fpath: str | Path, journal_fpath: str | Path, fingerprint: str) -> StageResume:
     """Build a file-backed :class:`StageResume` from the journal + rollout files."""
+    output_fpath = Path(output_fpath)
+    journal_fpath = Path(journal_fpath)
+    _migrate_invalid_judge_main_rows(output_fpath)
+
+    # Finish an interrupted cleanup before reading any reusable stage state.
+    recovered_restart = _pending_restart_stage(journal_fpath)
+    if recovered_restart is not None:
+        aggregate_metrics_path_for(output_fpath).unlink(missing_ok=True)
+        _prune_downstream_files(output_fpath, recovered_restart)
+        append_journal_record(
+            journal_fpath,
+            {"stage_index": recovered_restart, "status": "restart_cleanup_complete"},
+            fingerprint,
+        )
+
     plans, outcomes, _ = read_journal(journal_fpath)
     rows_by_stage = load_persisted_rows(output_fpath)
     gated_keys = load_gated_keys(output_fpath, rows_by_stage)
+    elapsed_by_stage = load_failure_timings(output_fpath)
+    reuse_cached_keys = load_reuse_cached_keys(output_fpath)
+    attempts_by_stage = load_failure_attempts(output_fpath)
+    # Older multistage runs wrote a completion marker even when a retryable
+    # sidecar failure remained. The sidecar is authoritative for retry state;
+    # discard only those stale outcomes so the recorded plan is replayed.
+    retryable_failure_stages = load_retryable_failure_stages(output_fpath, gated_keys, rows_by_stage)
+    if retryable_failure_stages and recovered_restart is None:
+        restart_stage = min(retryable_failure_stages)
+        # Persist the logical invalidation first. If cleanup is interrupted, the
+        # next process sees this marker, refuses stale downstream journal state,
+        # and idempotently finishes pruning the data files.
+        append_journal_record(
+            journal_fpath,
+            {"stage_index": restart_stage, "status": "restart_from_stage"},
+            fingerprint,
+        )
+        aggregate_metrics_path_for(output_fpath).unlink(missing_ok=True)
+        _prune_downstream_files(output_fpath, restart_stage)
+        append_journal_record(
+            journal_fpath,
+            {"stage_index": restart_stage, "status": "restart_cleanup_complete"},
+            fingerprint,
+        )
+        plans, outcomes, _ = read_journal(journal_fpath)
+        rows_by_stage = load_persisted_rows(output_fpath)
+        gated_keys = load_gated_keys(output_fpath, rows_by_stage)
+        elapsed_by_stage = load_failure_timings(output_fpath)
+        reuse_cached_keys = load_reuse_cached_keys(output_fpath)
+        attempts_by_stage = load_failure_attempts(output_fpath)
 
     def on_plan(index: int, plan: dict) -> None:
         append_journal_record(journal_fpath, plan, fingerprint)
@@ -788,6 +1250,9 @@ def build_file_resume(output_fpath: str | Path, journal_fpath: str | Path, finge
         on_plan=on_plan,
         on_outcome=on_outcome,
         on_rows=on_rows,
+        elapsed_by_stage=elapsed_by_stage,
+        reuse_cached_keys=reuse_cached_keys,
+        attempts_by_stage=attempts_by_stage,
     )
 
 
@@ -849,6 +1314,16 @@ async def run_e2e_multistage(
     )
 
     semaphore_size = getattr(rollout_collection_config, "num_samples_in_parallel", None)
+    dispatch_budget_s = getattr(rollout_collection_config, "dispatch_budget_s", None)
+    drain_margin_s = getattr(rollout_collection_config, "drain_margin_s", None)
+    if dispatch_budget_s is not None and (semaphore_size is None or semaphore_size <= 0):
+        raise ValueError(
+            "dispatch_budget_s requires a finite positive num_samples_in_parallel; "
+            "unbounded dispatch can POST the entire queue before the budget is re-checked"
+        )
+
+    latency_tracker = DispatchLatencyTracker()
+    dispatch_started_at = time.monotonic()
 
     async def run_rollouts(rows: List[Dict[str, Any]]) -> List[Tuple[Dict[str, Any], Dict[str, Any]]]:
         semaphore = None
@@ -857,14 +1332,32 @@ async def run_e2e_multistage(
 
             semaphore = Semaphore(semaphore_size)
         results: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
-        for future in helper.run_examples(rows, semaphore=semaphore or nullcontext()):
+        remaining_budget_s = None
+        if dispatch_budget_s is not None:
+            remaining_budget_s = max(0.0, dispatch_budget_s - (time.monotonic() - dispatch_started_at))
+        for future in helper.run_examples(
+            rows,
+            semaphore=semaphore or nullcontext(),
+            dispatch_budget_s=remaining_budget_s,
+            drain_margin_s=drain_margin_s,
+            latency_tracker=latency_tracker,
+        ):
             row, result = await future
             results.append((row, result))
         return results
 
     output_fpath = Path(rollout_collection_config.output_jsonl_fpath)
     journal_fpath = journal_path_for(output_fpath)
-    fingerprint = compute_fingerprint(multistage_config, reference_elos, distribution)
+    fingerprint = compute_fingerprint(
+        multistage_config,
+        reference_elos,
+        distribution,
+        materialized_rows=materialized_rows,
+        rollout_collection_config=rollout_collection_config,
+        resolved_global_config=global_config_dict,
+    )
+    for row in materialized_rows:
+        row["verify_cache_namespace"] = fingerprint
     resume = _prepare_resume(rollout_collection_config, output_fpath, journal_fpath, fingerprint)
 
     all_results, stage_summaries = await run_multistage_stages(
@@ -875,7 +1368,10 @@ async def run_e2e_multistage(
         run_rollouts,
         on_event=_log_event,
         resume=resume,
+        dispatch_longest_first=bool(getattr(rollout_collection_config, "dispatch_longest_first", False)),
     )
+
+    print(latency_tracker.summary())
 
     write_rollouts(all_results, output_fpath)
 
@@ -918,6 +1414,7 @@ def _prepare_resume(
         output_fpath.unlink(missing_ok=True)
         failures_path_for(output_fpath).unlink(missing_ok=True)
         journal_fpath.unlink(missing_ok=True)
+        aggregate_metrics_path_for(output_fpath).unlink(missing_ok=True)
     else:
         print("[multistage-elo] resuming multi-stage run from cache (fingerprint match)", file=sys.stderr, flush=True)
     return build_file_resume(output_fpath, journal_fpath, fingerprint)
@@ -961,6 +1458,13 @@ def _log_event(name: str, data: dict) -> None:  # pragma: no cover
         print(
             f"[multistage-elo] stage {data['index'] + 1}/{data['total_stages']} reused from cache: "
             f"eval ELO = {elo_str} ({data.get('num_rollouts')} cached rollout(s))",
+            file=sys.stderr,
+            flush=True,
+        )
+    elif name == "stage_incomplete":
+        print(
+            f"[multistage-elo] stage {data['index'] + 1}/{data['total_stages']} remains incomplete "
+            f"({data.get('num_pending')} rollout(s) retryable or undispatched); stopping before downstream stages",
             file=sys.stderr,
             flush=True,
         )

--- a/resources_servers/gdpval/preconvert.py
+++ b/resources_servers/gdpval/preconvert.py
@@ -48,7 +48,9 @@ import subprocess
 import tempfile
 import zipfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Iterable
 
 
 LOGGER = logging.getLogger(__name__)
@@ -104,11 +106,335 @@ def sidecar_pdf(path: Path) -> Path:
     return path.with_name(path.name + ".pdf")
 
 
+@dataclass(frozen=True)
+class PdfProvenance:
+    """Existing Office renders and PDFs that must not be emitted standalone.
+
+    A plain ``Plan.pdf`` cannot identify which source it renders when both
+    ``Plan.docx`` and ``Plan.pptx`` exist.  In that case it is quarantined as
+    ambiguous and only injective ``Plan.docx.pdf`` / ``Plan.pptx.pdf`` sidecars
+    are trusted.  PDFs whose stem does not collide with an Office source are
+    never included in :attr:`suppressed_pdfs` and remain independent artifacts.
+    """
+
+    office_pdfs: dict[Path, Path]
+    suppressed_pdfs: frozenset[Path]
+    ambiguous_pdfs: frozenset[Path]
+
+
+def base64_encoded_size(raw_bytes: int) -> int:
+    """Exact base64 payload length for *raw_bytes* without encoding the data."""
+
+    return 4 * ((max(0, raw_bytes) + 2) // 3)
+
+
+@dataclass
+class AttachmentBudget:
+    """Mutable raw/encoded byte budget used before loading judge attachments."""
+
+    raw_limit: int
+    encoded_limit: int
+    raw_used: int = 0
+    encoded_used: int = 0
+
+    def can_fit(self, raw_bytes: int, encoded_chars: int | None = None) -> bool:
+        raw = max(0, raw_bytes)
+        encoded = base64_encoded_size(raw) if encoded_chars is None else max(0, encoded_chars)
+        return self.raw_used + raw <= self.raw_limit and self.encoded_used + encoded <= self.encoded_limit
+
+    def reserve(self, raw_bytes: int, encoded_chars: int | None = None) -> bool:
+        raw = max(0, raw_bytes)
+        encoded = base64_encoded_size(raw) if encoded_chars is None else max(0, encoded_chars)
+        if not self.can_fit(raw, encoded):
+            return False
+        self.raw_used += raw
+        self.encoded_used += encoded
+        return True
+
+
+def resolve_pdf_provenance(paths: Iterable[Path]) -> PdfProvenance:
+    """Resolve sidecar PDFs for a directory listing without guessing provenance.
+
+    The injective ``source.ext.pdf`` spelling always wins.  The historical
+    ``source.pdf`` spelling is accepted only when exactly one Office source in
+    the same directory has that stem.  Any PDF selected as an Office render is
+    consumed, and an ambiguous historical sibling is suppressed so stale cache
+    artifacts cannot be judged a second (or third) time.
+    """
+
+    entries = [Path(path) for path in paths]
+    entry_set = set(entries)
+    groups: dict[tuple[Path, str], list[Path]] = {}
+    for path in entries:
+        if path.suffix.lower() in OFFICE_EXTENSIONS:
+            groups.setdefault((path.parent, path.stem), []).append(path)
+
+    office_pdfs: dict[Path, Path] = {}
+    suppressed: set[Path] = set()
+    ambiguous: set[Path] = set()
+    for (parent, stem), sources in groups.items():
+        plain_pdf = parent / f"{stem}.pdf"
+        plain_exists = plain_pdf in entry_set and plain_pdf.is_file()
+        is_ambiguous = len(sources) > 1
+
+        if plain_exists:
+            suppressed.add(plain_pdf)
+            if is_ambiguous:
+                ambiguous.add(plain_pdf)
+
+        for source in sources:
+            injective = sidecar_pdf(source)
+            if injective in entry_set and injective.is_file():
+                office_pdfs[source] = injective
+                suppressed.add(injective)
+            elif plain_exists and not is_ambiguous:
+                office_pdfs[source] = plain_pdf
+
+    return PdfProvenance(
+        office_pdfs=office_pdfs,
+        suppressed_pdfs=frozenset(suppressed),
+        ambiguous_pdfs=frozenset(ambiguous),
+    )
+
+
+def roundtrip_ooxml_copy(src: Path, dst: Path) -> None:
+    """Open and re-save an OOXML package to *dst*, leaving *src* unchanged.
+
+    This is deliberately a retry repair rather than a pre-pass: most Office
+    documents convert directly, while a small class of valid OPC packages is
+    rejected by LibreOffice until the format-specific library rewrites it.
+    """
+
+    extension = src.suffix.lower()
+    if extension == ".docx":
+        from docx import Document
+
+        Document(str(src)).save(str(dst))
+    elif extension == ".pptx":
+        from pptx import Presentation
+
+        Presentation(str(src)).save(str(dst))
+    elif extension == ".xlsx":
+        from openpyxl import load_workbook
+
+        workbook = load_workbook(str(src))
+        try:
+            workbook.save(str(dst))
+        finally:
+            workbook.close()
+    else:
+        raise ValueError(f"OOXML round-trip is unsupported for {src.suffix or '<no extension>'}")
+
+
+def extract_xlsx_structured_text(path: Path, *, max_chars: int = 120_000) -> str:
+    """Return bounded cell-level XLSX evidence including formulas and values.
+
+    Sheet XML is streamed directly rather than iterating openpyxl's rectangular
+    cell range. That matters for sparse workbooks whose used range says e.g.
+    ``XFD1048576``: visiting every empty coordinate would take effectively
+    forever. OOXML stores formulas and cached values together, so this also
+    preserves both when the producer wrote a cache.
+    """
+
+    import posixpath
+    import xml.etree.ElementTree as element_tree
+
+    spreadsheet_ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+    document_rel_ns = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    package_rel_ns = "http://schemas.openxmlformats.org/package/2006/relationships"
+    cell_tag = f"{{{spreadsheet_ns}}}c"
+    row_tag = f"{{{spreadsheet_ns}}}row"
+    formula_tag = f"{{{spreadsheet_ns}}}f"
+    value_tag = f"{{{spreadsheet_ns}}}v"
+    inline_string_tag = f"{{{spreadsheet_ns}}}is"
+    text_tag = f"{{{spreadsheet_ns}}}t"
+
+    # Records are bounded before shared-string resolution, so even a workbook
+    # with millions of populated cells cannot grow this function's output-side
+    # memory without limit.
+    records: list[tuple[str, str, str | None, str | None, str | None]] = []
+    shared_indices: set[int] = set()
+    estimated_chars = 0
+    truncated = False
+
+    def _record_cell(sheet_name: str, cell: element_tree.Element) -> None:
+        nonlocal estimated_chars, truncated
+        coordinate = cell.attrib.get("r", "?")
+        cell_type = cell.attrib.get("t", "")
+        formula_node = cell.find(formula_tag)
+        value_node = cell.find(value_tag)
+        inline_node = cell.find(inline_string_tag)
+        formula = formula_node.text if formula_node is not None else None
+        value = value_node.text if value_node is not None else None
+        inline = "".join(node.text or "" for node in inline_node.iter(text_tag)) if inline_node is not None else None
+        if formula is None and value is None and not inline:
+            return
+
+        # Cap stored raw strings too; a single cell can contain far more text
+        # than the whole judge budget.
+        room = max(0, max_chars - estimated_chars)
+        formula = formula[:room] if formula is not None else None
+        value = value[:room] if value is not None else None
+        inline = inline[:room] if inline is not None else None
+        records.append((sheet_name, coordinate, cell_type, formula, inline if inline is not None else value))
+        estimated_chars += min(
+            room,
+            len(coordinate) + len(formula or "") + len(inline or value or "") + 20,
+        )
+        if cell_type == "s" and value is not None:
+            try:
+                shared_indices.add(int(value))
+            except ValueError:
+                pass
+        if estimated_chars >= max_chars:
+            truncated = True
+
+    with zipfile.ZipFile(path) as archive:
+        workbook = element_tree.fromstring(archive.read("xl/workbook.xml"))
+        relationships = element_tree.fromstring(archive.read("xl/_rels/workbook.xml.rels"))
+        targets = {
+            relation.attrib["Id"]: relation.attrib["Target"]
+            for relation in relationships.findall(f"{{{package_rel_ns}}}Relationship")
+        }
+
+        sheets: list[tuple[str, str]] = []
+        for sheet in workbook.findall(f".//{{{spreadsheet_ns}}}sheet"):
+            relationship_id = sheet.attrib.get(f"{{{document_rel_ns}}}id")
+            target = targets.get(relationship_id or "")
+            if not target:
+                continue
+            part = target.lstrip("/") if target.startswith("/") else posixpath.normpath(f"xl/{target}")
+            sheets.append((sheet.attrib.get("name", "unnamed"), part))
+
+        for sheet_name, part in sheets:
+            header_cost = len(sheet_name) + 9
+            if estimated_chars + header_cost > max_chars:
+                truncated = True
+                break
+            estimated_chars += header_cost
+            try:
+                stream = archive.open(part)
+            except KeyError:
+                continue
+            with stream:
+                stack: list[element_tree.Element] = []
+                for event, node in element_tree.iterparse(stream, events=("start", "end")):
+                    if event == "start":
+                        stack.append(node)
+                        continue
+                    parent = stack[-2] if len(stack) > 1 else None
+                    if node.tag == cell_tag:
+                        _record_cell(sheet_name, node)
+                        node.clear()
+                    elif node.tag == row_tag:
+                        # Clearing cells alone leaves one empty element per cell
+                        # attached to its row. Remove the completed row from
+                        # sheetData as well so memory stays bounded by one row.
+                        node.clear()
+                        if parent is not None:
+                            parent.remove(node)
+                    stack.pop()
+                    if truncated:
+                        break
+            if truncated:
+                break
+
+        shared_strings: dict[int, str] = {}
+        if shared_indices and "xl/sharedStrings.xml" in archive.namelist():
+            wanted = set(shared_indices)
+            shared_index = -1
+            shared_chars_remaining = max_chars
+            with archive.open("xl/sharedStrings.xml") as stream:
+                stack = []
+                for event, node in element_tree.iterparse(stream, events=("start", "end")):
+                    if event == "start":
+                        stack.append(node)
+                        continue
+                    parent = stack[-2] if len(stack) > 1 else None
+                    done = False
+                    if node.tag == f"{{{spreadsheet_ns}}}si":
+                        shared_index += 1
+                        if shared_index in wanted:
+                            pieces: list[str] = []
+                            remaining = shared_chars_remaining
+                            for text_node in node.iter(text_tag):
+                                piece = text_node.text or ""
+                                pieces.append(piece[:remaining])
+                                remaining -= min(len(piece), remaining)
+                                if remaining <= 0:
+                                    break
+                            shared_strings[shared_index] = "".join(pieces)
+                            shared_chars_remaining -= len(shared_strings[shared_index])
+                            wanted.remove(shared_index)
+                            done = not wanted or shared_chars_remaining <= 0
+                        node.clear()
+                        if parent is not None:
+                            parent.remove(node)
+                    stack.pop()
+                    if done:
+                        break
+
+    lines: list[str] = []
+    used = 0
+    current_sheet: str | None = None
+
+    def _append(line: str, *, blank_before: bool = False) -> bool:
+        nonlocal used, truncated
+        separator = 2 if lines and blank_before else (1 if lines else 0)
+        if used + separator + len(line) > max_chars:
+            truncated = True
+            available = max(0, max_chars - used - separator)
+            if available > 0:
+                if lines and blank_before:
+                    lines.append("")
+                lines.append(line[:available])
+                used += separator + available
+            return False
+        if lines and blank_before:
+            lines.append("")
+        lines.append(line)
+        used += separator + len(line)
+        return True
+
+    for sheet_name, coordinate, cell_type, formula, raw_value in records:
+        if sheet_name != current_sheet:
+            if not _append(f"Sheet: {sheet_name}", blank_before=True):
+                break
+            current_sheet = sheet_name
+
+        value = raw_value
+        if cell_type == "s" and raw_value is not None:
+            try:
+                value = shared_strings.get(int(raw_value), f"[shared string #{raw_value}]")
+            except ValueError:
+                pass
+        elif cell_type == "b" and raw_value is not None:
+            value = "TRUE" if raw_value == "1" else "FALSE"
+
+        if formula is not None:
+            rendered = f"{coordinate}: formula: ={formula.lstrip('=')}"
+            if value not in (None, ""):
+                rendered += f"; cached/display value: {value}"
+        else:
+            rendered = f"{coordinate}: value={value}"
+        if not _append(rendered):
+            break
+
+    marker = "[...spreadsheet text truncated]"
+    text = "\n".join(lines)
+    if truncated:
+        keep = max(0, max_chars - len(marker) - 1)
+        text = text[:keep].rstrip() + "\n" + marker
+    return text[:max_chars]
+
+
 def needs_conversion(path: Path, *, ambiguous: bool = False) -> bool:
     if path.suffix.lower() not in OFFICE_EXTENSIONS:
         return False
+    if sidecar_pdf(path).exists():
+        return False
     if ambiguous:
-        return not sidecar_pdf(path).exists()
+        return True
     return not path.with_suffix(".pdf").exists()
 
 
@@ -132,6 +458,8 @@ def convert_to_pdf(path: Path, output_pdf: Path | None = None) -> tuple[Path, bo
     """
     profile_dir = Path(tempfile.mkdtemp(prefix="lo-profile-"))
     stage_dir: Path | None = None
+    retry_dir: Path | None = None
+    retry_profile_dir: Path | None = None
     input_path = path
     normalized = False
     needs_ns0_normalization = _ooxml_has_ns0_prefix(path)
@@ -152,25 +480,28 @@ def convert_to_pdf(path: Path, output_pdf: Path | None = None) -> tuple[Path, bo
         else:
             lo_outdir = str(path.parent)
 
-        result = subprocess.run(
-            [
-                "libreoffice",
-                "--headless",
-                "--nologo",
-                "--nolockcheck",
-                "--nodefault",
-                "--norestore",
-                f"-env:UserInstallation=file://{profile_dir.as_posix()}",
-                "--convert-to",
-                "pdf",
-                "--outdir",
-                lo_outdir,
-                str(input_path),
-            ],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
+        def _run_libreoffice(source: Path, outdir: str, profile: Path) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                [
+                    "libreoffice",
+                    "--headless",
+                    "--nologo",
+                    "--nolockcheck",
+                    "--nodefault",
+                    "--norestore",
+                    f"-env:UserInstallation=file://{profile.as_posix()}",
+                    "--convert-to",
+                    "pdf",
+                    "--outdir",
+                    outdir,
+                    str(source),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+
+        result = _run_libreoffice(input_path, lo_outdir, profile_dir)
         final_pdf = output_pdf if output_pdf is not None else path.with_suffix(".pdf")
         if needs_stage:
             staged_pdf = Path(lo_outdir) / (input_path.stem + ".pdf")
@@ -179,10 +510,33 @@ def convert_to_pdf(path: Path, output_pdf: Path | None = None) -> tuple[Path, bo
         if final_pdf.exists():
             suffix = " (after ns0 normalization)" if normalized else ""
             return path, True, f"converted {path.name}{suffix}"
+
+        # LibreOffice sometimes returns rc=0 while rejecting a valid OOXML OPC
+        # package. Re-saving through its format library rewrites the package in
+        # a canonical shape. Retry exactly once from that temp copy; the source
+        # deliverable is never opened for writing.
+        retry_error: str | None = None
+        if path.suffix.lower() in OOXML_EXTENSIONS:
+            retry_dir = Path(tempfile.mkdtemp(prefix="gdpval-roundtrip-"))
+            retry_profile_dir = Path(tempfile.mkdtemp(prefix="lo-profile-retry-"))
+            retry_input = retry_dir / _safe_basename(path.name)
+            try:
+                roundtrip_ooxml_copy(path, retry_input)
+                retry_result = _run_libreoffice(retry_input, str(retry_dir), retry_profile_dir)
+                retry_pdf = retry_dir / (retry_input.stem + ".pdf")
+                if retry_pdf.exists():
+                    shutil.move(str(retry_pdf), str(final_pdf))
+                    return path, True, f"converted {path.name} (after OOXML round-trip retry)"
+                retry_error = f"round-trip retry rc={retry_result.returncode}: {retry_result.stderr.strip()[:300]}"
+            except Exception as exc:
+                retry_error = f"round-trip retry failed: {exc!r}"
+
+        retry_suffix = f"; {retry_error}" if retry_error else ""
         return (
             path,
             False,
-            f"libreoffice rc={result.returncode} did not produce {final_pdf.name}: {result.stderr.strip()[:300]}",
+            f"libreoffice rc={result.returncode} did not produce {final_pdf.name}: "
+            f"{result.stderr.strip()[:300]}{retry_suffix}",
         )
     except subprocess.TimeoutExpired:
         return path, False, f"timeout converting {path.name}"
@@ -194,6 +548,10 @@ def convert_to_pdf(path: Path, output_pdf: Path | None = None) -> tuple[Path, bo
         shutil.rmtree(profile_dir, ignore_errors=True)
         if stage_dir is not None:
             shutil.rmtree(stage_dir, ignore_errors=True)
+        if retry_dir is not None:
+            shutil.rmtree(retry_dir, ignore_errors=True)
+        if retry_profile_dir is not None:
+            shutil.rmtree(retry_profile_dir, ignore_errors=True)
 
 
 def find_convertible_files(root_dir: str | os.PathLike) -> list[tuple[Path, Path | None]]:

--- a/resources_servers/gdpval/scoring.py
+++ b/resources_servers/gdpval/scoring.py
@@ -67,6 +67,21 @@ PERMANENT_JUDGE_ERROR_MARKERS = (
     "too many tokens",
 )
 
+# Throttle signals veto a permanent classification: provider 429 bodies often
+# contain permanent-sounding phrases ("you have sent too many tokens this
+# minute") yet succeed on retry. Misclassifying a throttle as permanent stamps
+# the trial terminal and silently drops the task from the benchmark.
+THROTTLE_ERROR_MARKERS = (
+    "http 429",
+    "error code: 429",
+    "status code: 429",
+    "too many requests",
+    "rate limit",
+    "rate-limit",
+    "retry-after",
+    "retry after",
+)
+
 JUDGE_REQUEST_TIMEOUT_SECONDS = float(os.environ.get("GDPVAL_JUDGE_REQUEST_TIMEOUT_SECONDS", "1800"))
 
 
@@ -74,7 +89,10 @@ def is_permanent_judge_error(error: BaseException | str) -> bool:
     """Whether retrying the same judge request is guaranteed to fail again."""
 
     if isinstance(error, str):
-        return any(marker in error.lower() for marker in PERMANENT_JUDGE_ERROR_MARKERS)
+        lowered = error.lower()
+        if any(marker in lowered for marker in THROTTLE_ERROR_MARKERS):
+            return False
+        return any(marker in lowered for marker in PERMANENT_JUDGE_ERROR_MARKERS)
 
     parts: list[str] = []
     seen: set[int] = set()
@@ -85,7 +103,10 @@ def is_permanent_judge_error(error: BaseException | str) -> bool:
             continue
         seen.add(id(current))
         parts.append(str(current))
-        if getattr(current, "status", None) == 413 or getattr(current, "status_code", None) == 413:
+        statuses = {getattr(current, "status", None), getattr(current, "status_code", None)}
+        if 429 in statuses:
+            return False
+        if 413 in statuses:
             return True
         for attr in ("response_content", "body"):
             value = getattr(current, attr, None)
@@ -99,6 +120,8 @@ def is_permanent_judge_error(error: BaseException | str) -> bool:
             pending.append(current.__context__)
 
     text = "\n".join(parts).lower()
+    if any(marker in text for marker in THROTTLE_ERROR_MARKERS):
+        return False
     return any(marker in text for marker in PERMANENT_JUDGE_ERROR_MARKERS)
 
 

--- a/resources_servers/gdpval/scoring.py
+++ b/resources_servers/gdpval/scoring.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import os
 import random
 import re
@@ -44,7 +45,61 @@ from resources_servers.gdpval.judge_panel import ResolvedJudge, merge_create_kwa
 # own parsed JSON, and a judge that emits its own "error" must not be discarded.
 SCORING_ERROR_KEY = "scoring_error"
 
+# Errors that cannot succeed when the same judge request is retried unchanged.
+# This is shared by rubric and comparison scoring so inner retry policy and the
+# outer rollout failure router cannot disagree about deterministic payload or
+# context failures.
+PERMANENT_JUDGE_ERROR_MARKERS = (
+    "request size is too large",
+    "request size budget exhausted",
+    "request body is too large",
+    "request entity too large",
+    "payload too large",
+    "content length limit exceeded",
+    "http 413",
+    "error code: 413",
+    "status code: 413",
+    "contextwindowexceeded",
+    "context window exceeded",
+    "maximum context length",
+    "maximum number of tokens allowed",
+    "input is too long",
+    "too many tokens",
+)
+
 JUDGE_REQUEST_TIMEOUT_SECONDS = float(os.environ.get("GDPVAL_JUDGE_REQUEST_TIMEOUT_SECONDS", "1800"))
+
+
+def is_permanent_judge_error(error: BaseException | str) -> bool:
+    """Whether retrying the same judge request is guaranteed to fail again."""
+
+    if isinstance(error, str):
+        return any(marker in error.lower() for marker in PERMANENT_JUDGE_ERROR_MARKERS)
+
+    parts: list[str] = []
+    seen: set[int] = set()
+    pending: list[BaseException] = [error]
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        parts.append(str(current))
+        if getattr(current, "status", None) == 413 or getattr(current, "status_code", None) == 413:
+            return True
+        for attr in ("response_content", "body"):
+            value = getattr(current, attr, None)
+            if isinstance(value, bytes):
+                parts.append(value.decode("utf-8", errors="replace"))
+            elif value is not None:
+                parts.append(str(value))
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+
+    text = "\n".join(parts).lower()
+    return any(marker in text for marker in PERMANENT_JUDGE_ERROR_MARKERS)
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +152,61 @@ def _score_from_truncated_json(text: str) -> float:
     if not scores:
         return 0.0
     return max(0.0, min(1.0, sum(scores) / len(scores)))
+
+
+_BINARY_SCORE_KEYS = ("overall_score", "total_score", "score", "average_score", "final_score")
+
+
+def _coerce_usable_score(value: Any) -> float | None:
+    """Return a finite numeric judge score, or ``None`` for unusable values."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return None
+    return score if math.isfinite(score) else None
+
+
+def _extract_binary_score(result: Any) -> tuple[float | None, str | None, list[float]]:
+    """Extract a binary-rubric score without inventing zeros for missing fields."""
+    if not isinstance(result, dict):
+        return None, None, []
+
+    for key in _BINARY_SCORE_KEYS:
+        score = _coerce_usable_score(result.get(key))
+        if score is not None:
+            return score, key, []
+
+    criteria_scores = result.get("criteria_scores")
+    if not isinstance(criteria_scores, list):
+        return None, None, []
+    scores = [
+        score
+        for criterion in criteria_scores
+        if isinstance(criterion, dict)
+        for score in [_coerce_usable_score(criterion.get("score"))]
+        if score is not None
+    ]
+    if not scores:
+        return None, None, []
+    return sum(scores) / len(scores), "criteria_scores", scores
+
+
+def _no_score_metadata(
+    result: Any,
+    *,
+    judge_name: str,
+    raw_response_text: str,
+    include_raw_responses: bool,
+) -> dict:
+    """Preserve a parsed reply while tagging it as lacking a usable score."""
+    metadata = dict(result) if isinstance(result, dict) else {"parsed_response": result}
+    metadata[SCORING_ERROR_KEY] = "no_score_in_response"
+    metadata["judge_name"] = judge_name
+    if include_raw_responses:
+        metadata["raw_responses"] = [raw_response_text]
+    return metadata
 
 
 async def score_with_rubric(
@@ -165,6 +275,8 @@ async def score_with_rubric(
                 response = await client.chat.completions.create(**create_kwargs)
                 break
             except Exception as retry_err:
+                if is_permanent_judge_error(retry_err):
+                    raise
                 err_str = str(retry_err)
                 is_retryable = "429" in err_str or "503" in err_str or "504" in err_str or "rate" in err_str.lower()
                 if is_retryable and attempt < max_retries:
@@ -210,28 +322,26 @@ async def score_with_rubric(
             # can flag the row instead of averaging it in as a real score.
             return score, {SCORING_ERROR_KEY: "truncated_json", "partial_score": score}
 
-        print(f"Rubric judge parsed keys: {list(result.keys())}", flush=True)
-        if "criteria_scores" in result:
-            scores = [c.get("score", 0) for c in result["criteria_scores"] if isinstance(c, dict)]
-            print(f"Criteria scores: {scores}", flush=True)
-            print(f"Criteria count: {len(scores)}, mean: {sum(scores) / len(scores) if scores else 0}", flush=True)
-
-        score = None
-        for key in ["overall_score", "total_score", "score", "average_score", "final_score"]:
-            if key in result:
-                score = float(result[key])
-                print(f"Found score under key '{key}': {score}", flush=True)
-                break
-
-        if score is None and "criteria_scores" in result:
-            scores = [float(c.get("score", 0)) for c in result["criteria_scores"] if isinstance(c, dict)]
-            if scores:
-                score = sum(scores) / len(scores)
-                print(f"No overall_score key found, computed mean of criteria: {score}", flush=True)
+        print(
+            f"Rubric judge parsed keys: {list(result.keys()) if isinstance(result, dict) else '<non-object JSON>'}",
+            flush=True,
+        )
+        score, score_source, criteria_scores = _extract_binary_score(result)
+        if criteria_scores:
+            print(f"Criteria scores: {criteria_scores}", flush=True)
+        if score_source in _BINARY_SCORE_KEYS:
+            print(f"Found score under key '{score_source}': {score}", flush=True)
+        elif score_source == "criteria_scores":
+            print(f"No overall score key found, computed mean of criteria: {score}", flush=True)
 
         if score is None:
             print(f"Could not extract score. Full result: {json.dumps(result)[:1000]}", flush=True)
-            score = 0.0
+            return 0.0, _no_score_metadata(
+                result,
+                judge_name=judge.name,
+                raw_response_text=raw_response_text,
+                include_raw_responses=include_raw_responses,
+            )
 
         print(f"Rubric final score: {score} (judge: {judge.name})", flush=True)
         if isinstance(result, dict):
@@ -245,6 +355,8 @@ async def score_with_rubric(
 
         print(f"Rubric scoring failed: {e}", flush=True)
         traceback.print_exc()
+        if is_permanent_judge_error(e):
+            raise
         return 0.0, None
 
 
@@ -321,6 +433,8 @@ async def score_with_rubric_visual(
                 response = await client.chat.completions.create(**create_kwargs)
                 break
             except Exception as retry_err:
+                if is_permanent_judge_error(retry_err):
+                    raise
                 err_str = str(retry_err)
                 is_retryable = "429" in err_str or "503" in err_str or "504" in err_str or "rate" in err_str.lower()
                 if is_retryable and attempt < max_retries:
@@ -357,27 +471,26 @@ async def score_with_rubric_visual(
             # can flag the row instead of averaging it in as a real score.
             return score, {SCORING_ERROR_KEY: "truncated_json", "partial_score": score}
 
-        print(f"Visual judge parsed keys: {list(result.keys())}", flush=True)
-        if "criteria_scores" in result:
-            scores = [c.get("score", 0) for c in result["criteria_scores"] if isinstance(c, dict)]
-            print(f"Criteria scores: {scores}", flush=True)
-
-        score = None
-        for key in ["overall_score", "total_score", "score", "average_score", "final_score"]:
-            if key in result:
-                score = float(result[key])
-                print(f"Found score under key '{key}': {score}", flush=True)
-                break
-
-        if score is None and "criteria_scores" in result:
-            scores = [float(c.get("score", 0)) for c in result["criteria_scores"] if isinstance(c, dict)]
-            if scores:
-                score = sum(scores) / len(scores)
-                print(f"No overall_score key found, computed mean of criteria: {score}", flush=True)
+        print(
+            f"Visual judge parsed keys: {list(result.keys()) if isinstance(result, dict) else '<non-object JSON>'}",
+            flush=True,
+        )
+        score, score_source, criteria_scores = _extract_binary_score(result)
+        if criteria_scores:
+            print(f"Criteria scores: {criteria_scores}", flush=True)
+        if score_source in _BINARY_SCORE_KEYS:
+            print(f"Found score under key '{score_source}': {score}", flush=True)
+        elif score_source == "criteria_scores":
+            print(f"No overall score key found, computed mean of criteria: {score}", flush=True)
 
         if score is None:
             print(f"Could not extract score. Full result: {json.dumps(result)[:1000]}", flush=True)
-            score = 0.0
+            return 0.0, _no_score_metadata(
+                result,
+                judge_name=judge.name,
+                raw_response_text=raw_response_text,
+                include_raw_responses=include_raw_responses,
+            )
 
         print(f"Visual judge final score: {score} (judge: {judge.name})", flush=True)
         if isinstance(result, dict):
@@ -391,6 +504,8 @@ async def score_with_rubric_visual(
 
         print(f"Visual rubric scoring failed: {e}", flush=True)
         traceback.print_exc()
+        if is_permanent_judge_error(e):
+            raise
         return 0.0, None
 
 
@@ -507,6 +622,8 @@ async def score_with_rubric_structured(
                 response = await client.chat.completions.create(**create_kwargs)
                 resp_text = (response.choices[0].message.content or "").strip()
             except Exception as e:
+                if is_permanent_judge_error(e):
+                    raise
                 err_str = str(e).lower()
                 is_retryable = any(m in err_str for m in ("429", "503", "504", "rate", "timeout"))
                 if is_retryable and retry < formatting_retries - 1:

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -146,6 +146,8 @@ class TestApp:
         assert resp.reward == 0.0
         assert resp.verify_mode == "rubric"
         assert resp.invalid_judge_response is True
+        assert resp.invalid_judge_retryable is False
+        assert resp.judge_response == {"scoring_error": "missing_rubric"}
 
     @pytest.mark.asyncio
     async def test_verify_rubric_with_canned_judge(self) -> None:
@@ -455,7 +457,7 @@ class TestApp:
             patch("resources_servers.gdpval.comparison.run_trials", side_effect=fake_run_trials),
             patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
             patch("resources_servers.gdpval.comparison.build_file_section", return_value=[]),
-            patch("resources_servers.gdpval.app.OpenAI" if False else "openai.OpenAI", return_value=MagicMock()),
+            patch("openai.OpenAI", return_value=MagicMock()) as openai_ctor,
         ):
             resp = await server.verify(body)
 
@@ -469,6 +471,7 @@ class TestApp:
         assert resp.win is True
         assert resp.judge_response["ref_repeat_count"] == 3
         assert len(resp.judge_response["per_ref_repeat"]) == 3
+        assert openai_ctor.call_args.kwargs["max_retries"] == 0
 
     @pytest.mark.asyncio
     async def test_verify_comparison_flat_layout_back_compat(self, tmp_path) -> None:
@@ -736,6 +739,67 @@ class TestApp:
 
         assert captured_kwargs["include_raw_responses"] is True
         assert resp.judge_response["raw_responses"] == ["FINAL_SCORE[7]\nMAX_POSSIBLE_SCORE[10]"]
+
+    def test_rubric_aggregate_excludes_invalid_judge_rows(self) -> None:
+        """Judge-failure sentinel zeros must not reduce aggregate reward."""
+        import asyncio as _asyncio
+
+        from nemo_gym.config_types import AggregateMetricsRequest
+
+        server = _server(reward_mode="rubric")
+        responses = [
+            {
+                "_ng_task_index": 0,
+                "_ng_rollout_index": 0,
+                "reward": 0.8,
+                "invalid_judge_response": False,
+                "response": {},
+            },
+            {
+                "_ng_task_index": 1,
+                "_ng_rollout_index": 0,
+                "reward": 0.0,
+                "invalid_judge_response": True,
+                "response": {},
+            },
+        ]
+
+        result = _asyncio.run(server.aggregate_metrics(AggregateMetricsRequest(verify_responses=responses)))
+
+        assert result.agent_metrics["mean/reward"] == 0.8
+        assert result.agent_metrics["rubric/aggregate_rows_total"] == 2
+        assert result.agent_metrics["rubric/aggregate_rows_included"] == 1
+        assert result.agent_metrics["rubric/legacy_invalid_rows_excluded"] == 1
+        assert result.agent_metrics["rubric/aggregate_rows_included_fraction"] == 0.5
+        assert [group["_ng_task_index"] for group in result.group_level_metrics] == [0]
+
+    def test_rubric_aggregate_all_invalid_has_no_reward_headline(self) -> None:
+        """An all-invalid judge run reports coverage instead of mean reward zero."""
+        import asyncio as _asyncio
+
+        from nemo_gym.config_types import AggregateMetricsRequest
+
+        server = _server(reward_mode="rubric")
+        responses = [
+            {
+                "_ng_task_index": task_index,
+                "_ng_rollout_index": 0,
+                "reward": 0.0,
+                "invalid_judge_response": True,
+                "response": {},
+            }
+            for task_index in range(2)
+        ]
+
+        result = _asyncio.run(server.aggregate_metrics(AggregateMetricsRequest(verify_responses=responses)))
+
+        assert "mean/reward" not in result.agent_metrics
+        assert "mean/reward" not in result.key_metrics
+        assert result.group_level_metrics == []
+        assert result.key_metrics["rubric/aggregate_rows_total"] == 2
+        assert result.key_metrics["rubric/aggregate_rows_included"] == 0
+        assert result.key_metrics["rubric/legacy_invalid_rows_excluded"] == 2
+        assert result.key_metrics["rubric/aggregate_rows_included_fraction"] == 0.0
 
     def test_aggregate_metrics_comparison_elo(self) -> None:
         from nemo_gym.config_types import AggregateMetricsRequest
@@ -1179,9 +1243,8 @@ class TestMultiReference:
         # Untagged run carries no stage_* keys at all.
         assert not any(k.startswith("comparison/stage_") for k in unstaged)
 
-    def test_aggregate_metrics_stage_aware_headline_is_last_stage(self) -> None:
-        """When rollouts are tagged with ``stage_index`` the headline eval_elo is
-        the LAST stage's fit, and every stage's estimate is emitted as an extra."""
+    def test_aggregate_metrics_stage_aware_headline_is_expected_final_stage(self) -> None:
+        """The declared final stage supplies the headline when its fit is usable."""
         from nemo_gym.config_types import AggregateMetricsRequest
 
         server = _server(
@@ -1201,6 +1264,8 @@ class TestMultiReference:
                 "_ng_task_index": 0,
                 "_ng_rollout_index": 0,
                 "stage_index": 0,
+                "expected_final_stage_index": 1,
+                "expected_stage_row_count": 1,
                 "task_id": "t0",
                 "reward": 0.5,
                 "total_wins": 5,
@@ -1216,6 +1281,8 @@ class TestMultiReference:
                 "_ng_task_index": 1,
                 "_ng_rollout_index": 0,
                 "stage_index": 1,
+                "expected_final_stage_index": 1,
+                "expected_stage_row_count": 1,
                 "task_id": "t1",
                 "reward": 1.0,
                 "total_wins": 8,
@@ -1244,10 +1311,176 @@ class TestMultiReference:
         # Headline == last stage's fit, not the pooled midpoint.
         assert m["comparison/eval_elo"] == m["comparison/stage_1/eval_elo"]
         assert m["comparison/num_references"] == 1
+        assert m["comparison/expected_final_stage_index"] == 1
+        assert m["comparison/headline_stage_index"] == 1
+        assert m["comparison/final_stage_present"] == 1
+        assert m["comparison/final_stage_complete"] == 1
+        assert m["comparison/final_stage_fit"] == 1
+        assert m["comparison/final_stage_degraded"] == 0
+        assert m["comparison/observed_final_stage_row_count"] == 1
+        assert m["comparison/expected_final_stage_row_count"] == 1
         # Pooled descriptive win stats still cover every stage.
         assert m["comparison/wins"] == 13
         assert m["comparison/judged"] == 20
         assert all(isinstance(v, (int, float)) for v in m.values())
+
+    def test_expected_final_stage_missing_does_not_promote_observed_stage(self) -> None:
+        """An incomplete run exposes stage metrics but no misleading headline."""
+        import asyncio as _asyncio
+
+        from nemo_gym.config_types import AggregateMetricsRequest
+
+        server = _server(
+            reward_mode="comparison",
+            reference_models={"low": {"deliverables_dir": "/tmp/low", "elo": 1000.0}},
+        )
+        responses = [
+            {
+                "_ng_task_index": 0,
+                "_ng_rollout_index": 0,
+                "stage_index": 0,
+                "expected_final_stage_index": 1,
+                "expected_stage_row_count": 1,
+                "task_id": "t0",
+                "reward": 1.0,
+                "total_wins": 8,
+                "total_losses": 2,
+                "total_ties": 0,
+                "per_reference": {
+                    "low": {"wins": 8, "losses": 2, "ties": 0, "reference_elo": 1000.0},
+                },
+                "response": {},
+            }
+        ]
+
+        metrics = _asyncio.run(
+            server.aggregate_metrics(AggregateMetricsRequest(verify_responses=responses))
+        ).agent_metrics
+
+        assert "comparison/stage_0/eval_elo" in metrics
+        assert "comparison/eval_elo" not in metrics
+        assert "comparison/headline_stage_index" not in metrics
+        assert metrics["comparison/expected_final_stage_index"] == 1
+        assert metrics["comparison/final_stage_present"] == 0
+        assert metrics["comparison/final_stage_complete"] == 0
+        assert metrics["comparison/final_stage_fit"] == 0
+        assert metrics["comparison/final_stage_degraded"] == 1
+
+    def test_expected_final_stage_unfit_does_not_fall_back_to_pooled_fit(self) -> None:
+        """A present final stage with no judged games cannot borrow an earlier ELO."""
+        import asyncio as _asyncio
+
+        from nemo_gym.config_types import AggregateMetricsRequest
+
+        server = _server(
+            reward_mode="comparison",
+            reference_models={"low": {"deliverables_dir": "/tmp/low", "elo": 1000.0}},
+        )
+        responses = [
+            {
+                "_ng_task_index": 0,
+                "_ng_rollout_index": 0,
+                "stage_index": 0,
+                "expected_final_stage_index": 1,
+                "expected_stage_row_count": 1,
+                "task_id": "t0",
+                "reward": 1.0,
+                "total_wins": 8,
+                "total_losses": 2,
+                "total_ties": 0,
+                "per_reference": {
+                    "low": {"wins": 8, "losses": 2, "ties": 0, "reference_elo": 1000.0},
+                },
+                "response": {},
+            },
+            {
+                "_ng_task_index": 1,
+                "_ng_rollout_index": 0,
+                "stage_index": 1,
+                "expected_final_stage_index": 1,
+                "expected_stage_row_count": 1,
+                "task_id": "t1",
+                "reward": 0.0,
+                "total_wins": 0,
+                "total_losses": 0,
+                "total_ties": 0,
+                "per_reference": {
+                    "low": {"wins": 0, "losses": 0, "ties": 0, "reference_elo": 1000.0},
+                },
+                "response": {},
+            },
+        ]
+
+        metrics = _asyncio.run(
+            server.aggregate_metrics(AggregateMetricsRequest(verify_responses=responses))
+        ).agent_metrics
+
+        assert "comparison/stage_0/eval_elo" in metrics
+        assert "comparison/stage_1/eval_elo" not in metrics
+        assert "comparison/eval_elo" not in metrics
+        assert metrics["comparison/final_stage_present"] == 1
+        assert metrics["comparison/final_stage_complete"] == 1
+        assert metrics["comparison/final_stage_fit"] == 0
+        assert metrics["comparison/final_stage_degraded"] == 1
+
+    def test_partial_expected_final_stage_does_not_emit_headline(self) -> None:
+        """A drained final stage cannot publish an ELO from its surviving subset."""
+        import asyncio as _asyncio
+
+        from nemo_gym.config_types import AggregateMetricsRequest
+
+        server = _server(
+            reward_mode="comparison",
+            reference_models={"low": {"deliverables_dir": "/tmp/low", "elo": 1000.0}},
+        )
+        responses = [
+            {
+                "_ng_task_index": 0,
+                "_ng_rollout_index": 0,
+                "stage_index": 0,
+                "expected_final_stage_index": 1,
+                "expected_stage_row_count": 1,
+                "task_id": "t0",
+                "reward": 0.5,
+                "total_wins": 5,
+                "total_losses": 5,
+                "total_ties": 0,
+                "per_reference": {
+                    "low": {"wins": 5, "losses": 5, "ties": 0, "reference_elo": 1000.0},
+                },
+                "response": {},
+            },
+            {
+                "_ng_task_index": 1,
+                "_ng_rollout_index": 0,
+                "stage_index": 1,
+                "expected_final_stage_index": 1,
+                "expected_stage_row_count": 2,
+                "task_id": "t1",
+                "reward": 1.0,
+                "total_wins": 8,
+                "total_losses": 2,
+                "total_ties": 0,
+                "per_reference": {
+                    "low": {"wins": 8, "losses": 2, "ties": 0, "reference_elo": 1000.0},
+                },
+                "response": {},
+            },
+        ]
+
+        metrics = _asyncio.run(
+            server.aggregate_metrics(AggregateMetricsRequest(verify_responses=responses))
+        ).agent_metrics
+
+        assert "comparison/stage_1/eval_elo" in metrics
+        assert "comparison/eval_elo" not in metrics
+        assert "comparison/headline_stage_index" not in metrics
+        assert metrics["comparison/final_stage_present"] == 1
+        assert metrics["comparison/final_stage_complete"] == 0
+        assert metrics["comparison/final_stage_fit"] == 1
+        assert metrics["comparison/final_stage_degraded"] == 1
+        assert metrics["comparison/observed_final_stage_row_count"] == 1
+        assert metrics["comparison/expected_final_stage_row_count"] == 2
 
     def test_aggregate_metrics_handles_repeated_task_across_stages(self) -> None:
         """The same ``(task_index, rollout_index)`` may recur across stages (one

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -28,6 +28,7 @@ from resources_servers.gdpval.app import (
     GDPValResourcesServerConfig,
     GDPValVerifyRequest,
     _iter_ref_repeat_dirs,
+    _strict_comparison_trial_failure,
 )
 
 
@@ -78,6 +79,210 @@ def _verify_request(**fields) -> GDPValVerifyRequest:
         rubric_pretty=fields.pop("rubric_pretty", ""),
         **fields,
     )
+
+
+class TestStrictComparisonTrials:
+    @staticmethod
+    def _comparison_server_and_body(tmp_path, *, strict: bool | None, num_references: int = 1):
+        eval_dir = tmp_path / "eval" / "task_task-1" / "repeat_0"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "finish_params.json").write_text("{}")
+
+        reference_models = {}
+        for index in range(num_references):
+            ref_id = f"ref-{index}"
+            ref_root = tmp_path / ref_id
+            ref_dir = ref_root / "task_task-1" / "repeat_0"
+            ref_dir.mkdir(parents=True)
+            (ref_dir / "finish_params.json").write_text("{}")
+            reference_models[ref_id] = {"deliverables_dir": str(ref_root), "elo": 1200.0}
+
+        extra = {}
+        if strict is not None:
+            extra["strict_comparison_trials"] = strict
+        server = _server(
+            reward_mode="comparison",
+            reference_models=reference_models,
+            preconvert_office_to_pdf=False,
+            num_comparison_trials=4,
+            **extra,
+        )
+        return server, _verify_request(deliverables_dir=str(eval_dir))
+
+    @staticmethod
+    def _missing_artifact_server_and_body(tmp_path, *, missing: str, strict: bool | None):
+        eval_dir = tmp_path / "eval" / "task_task-1" / "repeat_0"
+        ref_root = tmp_path / "ref"
+        ref_dir = ref_root / "task_task-1" / "repeat_0"
+        if missing != "eval":
+            eval_dir.mkdir(parents=True)
+            (eval_dir / "finish_params.json").write_text("{}")
+        if missing != "reference":
+            ref_dir.mkdir(parents=True)
+            (ref_dir / "finish_params.json").write_text("{}")
+
+        extra = {}
+        if strict is not None:
+            extra["strict_comparison_trials"] = strict
+        server = _server(
+            reward_mode="comparison",
+            reference_deliverables_dir=str(ref_root),
+            **extra,
+        )
+        return server, _verify_request(deliverables_dir=str(eval_dir))
+
+    @staticmethod
+    async def _verify_with_trials(server, body, side_effect):
+        run_trials = MagicMock()
+        if isinstance(side_effect, dict):
+            run_trials.return_value = side_effect
+        else:
+            run_trials.side_effect = side_effect
+        with (
+            patch("resources_servers.gdpval.comparison.run_trials", new=run_trials),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+            patch("resources_servers.gdpval.comparison.build_file_section", return_value=[]),
+            patch("openai.OpenAI", return_value=MagicMock()),
+        ):
+            return await server.verify(body)
+
+    @pytest.mark.asyncio
+    async def test_complete_contract_passes_when_enabled(self, tmp_path) -> None:
+        server, body = self._comparison_server_and_body(tmp_path, strict=True)
+        complete = {
+            "winner": "[[B]]",
+            "win_count_a": 0,
+            "win_count_b": 4,
+            "tie_count": 0,
+            "task_count": 4,
+            "invalid_count": 0,
+        }
+
+        response = await self._verify_with_trials(server, body, complete)
+
+        assert response.total_wins == 4
+        assert response.judge_response["total_judged"] == 4
+        assert response.judge_response["total_invalid"] == 0
+
+    @pytest.mark.parametrize(
+        ("result", "expected"),
+        [
+            (
+                {
+                    "winner": "[[B]]",
+                    "win_count_a": 0,
+                    "win_count_b": 3,
+                    "tie_count": 0,
+                    "task_count": 3,
+                    "invalid_count": 0,
+                },
+                "matchups=1 judged=3/4 invalid=0 reference_errors=0",
+            ),
+            (
+                {
+                    "winner": "[[B]]",
+                    "win_count_a": 0,
+                    "win_count_b": 3,
+                    "tie_count": 0,
+                    "task_count": 3,
+                    "invalid_count": 1,
+                },
+                "matchups=1 judged=3/4 invalid=1 reference_errors=0",
+            ),
+        ],
+        ids=["incomplete-judged", "invalid-trial"],
+    )
+    @pytest.mark.asyncio
+    async def test_incomplete_contract_fails_when_enabled(self, tmp_path, result, expected) -> None:
+        server, body = self._comparison_server_and_body(tmp_path, strict=True)
+
+        with pytest.raises(RuntimeError, match=expected):
+            await self._verify_with_trials(server, body, result)
+
+    @pytest.mark.asyncio
+    async def test_reference_error_fails_when_enabled(self, tmp_path) -> None:
+        server, body = self._comparison_server_and_body(tmp_path, strict=True, num_references=2)
+        complete = {
+            "winner": "[[B]]",
+            "win_count_a": 0,
+            "win_count_b": 4,
+            "tie_count": 0,
+            "task_count": 4,
+            "invalid_count": 0,
+        }
+
+        with pytest.raises(
+            RuntimeError,
+            match="matchups=2 judged=4/8 invalid=0 reference_errors=1",
+        ):
+            await self._verify_with_trials(server, body, [RuntimeError("judge timeout"), complete])
+
+    def test_zero_matchups_is_incomplete(self) -> None:
+        assert (
+            _strict_comparison_trial_failure(
+                attempted_matchups=0,
+                num_trials=4,
+                total_judged=0,
+                total_invalid=0,
+                ref_errors={},
+            )
+            == "matchups=0 judged=0/0 invalid=0 reference_errors=0"
+        )
+
+    @pytest.mark.parametrize("missing", ["reference", "eval"])
+    @pytest.mark.asyncio
+    async def test_missing_artifact_fails_when_enabled(self, tmp_path, missing) -> None:
+        server, body = self._missing_artifact_server_and_body(tmp_path, missing=missing, strict=True)
+
+        with pytest.raises(
+            RuntimeError,
+            match=rf"strict comparison trial contract failed for task task-1: {missing}_missing",
+        ):
+            await server.verify(body)
+
+    @pytest.mark.parametrize("missing", ["reference", "eval"])
+    @pytest.mark.asyncio
+    async def test_missing_artifact_keeps_legacy_response_by_default(self, tmp_path, missing) -> None:
+        server, body = self._missing_artifact_server_and_body(tmp_path, missing=missing, strict=None)
+
+        response = await server.verify(body)
+
+        assert server.config.strict_comparison_trials is False
+        assert response.reward == 0.0
+        assert response.judge_response == {"error": f"{missing}_missing"}
+
+    @pytest.mark.parametrize("strict", [True, False])
+    @pytest.mark.asyncio
+    async def test_missing_reference_strictness_contract(self, tmp_path, strict) -> None:
+        server, body = self._missing_artifact_server_and_body(tmp_path, missing="reference", strict=strict)
+
+        if strict:
+            with pytest.raises(RuntimeError, match="reference_missing"):
+                await server.verify(body)
+            return
+
+        response = await server.verify(body)
+        dumped = response.model_dump()
+        assert dumped["_ng_failure_class"] == "reference_missing"
+        assert dumped["_ng_failure_terminal"] is True
+
+    @pytest.mark.asyncio
+    async def test_default_is_non_strict_for_backward_compatibility(self, tmp_path) -> None:
+        server, body = self._comparison_server_and_body(tmp_path, strict=None)
+        incomplete = {
+            "winner": "[[B]]",
+            "win_count_a": 0,
+            "win_count_b": 3,
+            "tie_count": 0,
+            "task_count": 3,
+            "invalid_count": 1,
+        }
+
+        response = await self._verify_with_trials(server, body, incomplete)
+
+        assert server.config.strict_comparison_trials is False
+        assert response.judge_response["total_judged"] == 3
+        assert response.judge_response["total_invalid"] == 1
 
 
 class TestIterRefRepeatDirs:

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -413,6 +413,12 @@ class TestApp:
         assert resp.reward == 0.0
         assert resp.verify_mode == "comparison"
         assert resp.judge_response == {"error": "reference_missing"}
+        # Stamped as a terminal failure, not returned as a zero-reward success:
+        # a success row carrying no battle evidence is rejected outright by the
+        # non-final-stage coverage gate, which no policy setting can relax.
+        dumped = resp.model_dump()
+        assert dumped["_ng_failure_class"] == "reference_missing"
+        assert dumped["_ng_failure_terminal"] is True
 
     @pytest.mark.asyncio
     async def test_verify_comparison_iterates_all_ref_repeats(self, tmp_path) -> None:
@@ -1065,6 +1071,9 @@ class TestMultiReference:
 
         assert resp.reward == 0.0
         assert resp.judge_response == {"error": "reference_missing"}
+        dumped = resp.model_dump()
+        assert dumped["_ng_failure_class"] == "reference_missing"
+        assert dumped["_ng_failure_terminal"] is True
 
     @staticmethod
     def _two_ref_server_and_body(tmp_path):

--- a/resources_servers/gdpval/tests/test_comparison_file_handling.py
+++ b/resources_servers/gdpval/tests/test_comparison_file_handling.py
@@ -1,0 +1,331 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for GDPVal comparison file provenance and payload bounds."""
+
+from __future__ import annotations
+
+import base64
+import shutil
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from resources_servers.gdpval import comparison
+
+
+def _attachments(blocks: list[dict]) -> list[bytes]:
+    payloads: list[bytes] = []
+    for block in blocks:
+        if block.get("type") != "image_url":
+            continue
+        url = block["image_url"]["url"]
+        payloads.append(base64.b64decode(url.split(",", 1)[1]))
+    return payloads
+
+
+def _text(blocks: list[dict]) -> str:
+    return "\n".join(block.get("text", "") for block in blocks if block.get("type") == "text")
+
+
+def test_same_stem_sidecars_are_used_once_and_stale_plain_pdf_is_suppressed(tmp_path: Path) -> None:
+    (tmp_path / "Plan.docx").write_bytes(b"docx source")
+    (tmp_path / "Plan.pptx").write_bytes(b"pptx source")
+    (tmp_path / "Plan.docx.pdf").write_bytes(b"DOCX RENDER")
+    (tmp_path / "Plan.pptx.pdf").write_bytes(b"PPTX RENDER")
+    (tmp_path / "Plan.pdf").write_bytes(b"STALE COLLIDED RENDER")
+    (tmp_path / "Appendix.pdf").write_bytes(b"INDEPENDENT PDF")
+
+    blocks = comparison.build_file_section(str(tmp_path))
+
+    assert _attachments(blocks) == [b"INDEPENDENT PDF", b"DOCX RENDER", b"PPTX RENDER"]
+    text = _text(blocks)
+    assert "Plan.docx:" in text
+    assert "Plan.pptx:" in text
+    assert "Plan.pdf:" not in text
+    assert "Plan.docx.pdf:" not in text
+    assert "Plan.pptx.pdf:" not in text
+
+
+def test_ambiguous_plain_pdf_is_never_guessed_as_either_office_render(tmp_path: Path) -> None:
+    (tmp_path / "Plan.docx").write_bytes(b"docx source")
+    (tmp_path / "Plan.pptx").write_bytes(b"pptx source")
+    (tmp_path / "Plan.pdf").write_bytes(b"STALE COLLIDED RENDER")
+
+    blocks = comparison.build_file_section(str(tmp_path))
+
+    assert _attachments(blocks) == []
+    assert "Plan.pdf:" not in _text(blocks)
+
+
+def test_xlsx_emits_formula_cell_text_alongside_pdf(tmp_path: Path) -> None:
+    openpyxl = pytest.importorskip("openpyxl")
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.title = "Forecast"
+    sheet["A1"] = 4
+    sheet["A2"] = 8
+    sheet["A3"] = "=SUM(A1:A2)"
+    xlsx = tmp_path / "Budget.xlsx"
+    workbook.save(xlsx)
+    workbook.close()
+    (tmp_path / "Budget.xlsx.pdf").write_bytes(b"PDF RENDER")
+
+    blocks = comparison.build_file_section(str(tmp_path))
+
+    assert b"PDF RENDER" in _attachments(blocks)
+    text = _text(blocks)
+    assert "structured spreadsheet cells" in text
+    assert "Sheet: Forecast" in text
+    assert "A3: formula: =SUM(A1:A2)" in text
+    assert len(text) < comparison.MAX_XLSX_TEXT_CHARS_FOR_JUDGE + 500
+
+
+def test_oversize_xlsx_does_not_attempt_structured_extraction(tmp_path: Path, monkeypatch) -> None:
+    xlsx = tmp_path / "huge.xlsx"
+    xlsx.touch()
+    xlsx.write_bytes(b"x")
+    with xlsx.open("r+b") as stream:
+        stream.truncate(comparison.MAX_FILE_BYTES_FOR_JUDGE + 1)
+
+    def _unexpected(*args, **kwargs):
+        raise AssertionError("oversize XLSX must not be parsed")
+
+    monkeypatch.setattr(comparison, "extract_xlsx_structured_text", _unexpected)
+
+    blocks = comparison.build_file_section(str(tmp_path))
+
+    assert "oversize" in _text(blocks)
+
+
+def _data_block(payload: bytes) -> dict:
+    encoded = base64.b64encode(payload).decode("ascii")
+    return {"type": "image_url", "image_url": {"url": f"data:application/pdf;base64,{encoded}"}}
+
+
+def test_all_fit_attachments_do_not_require_payload_fingerprints(monkeypatch) -> None:
+    def _unexpected_fingerprint(_block):
+        raise AssertionError("all-fit payloads must not be hashed")
+
+    monkeypatch.setattr(comparison, "_attachment_fingerprint", _unexpected_fingerprint)
+
+    messages = comparison.construct_judge_messages(
+        "task",
+        [_data_block(b"reference")],
+        [_data_block(b"submission-a")],
+        [_data_block(b"submission-b")],
+    )
+
+    assert _attachments(messages[0]["content"]) == [b"reference", b"submission-a", b"submission-b"]
+
+
+def test_pdf_source_size_does_not_consume_rendered_page_budget(tmp_path: Path, monkeypatch) -> None:
+    pdf = tmp_path / "compressed.pdf"
+    pdf.write_bytes(b"source-is-larger-than-output-budget")
+    budget = comparison.AttachmentBudget(raw_limit=4, encoded_limit=8)
+
+    def _render(_path, *, attachment_budget, **_kwargs):
+        assert attachment_budget.reserve(1)
+        return [_data_block(b"P")]
+
+    monkeypatch.setattr(comparison, "_pdf_path_to_image_text_blocks", _render)
+
+    blocks = comparison.get_file_image_text_blocks(
+        str(tmp_path),
+        pdf.name,
+        render_dpi=72,
+        max_pages=1,
+        include_text=True,
+        attachment_budget=budget,
+    )
+
+    assert _attachments(blocks) == [b"P"]
+
+
+def test_zip_extraction_rejects_unsafe_and_oversize_members_before_open(tmp_path: Path, monkeypatch) -> None:
+    archive_path = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("safe.txt", "OK")
+        archive.writestr("oversize.txt", "TOO LARGE")
+        archive.writestr("../escape.txt", "ESCAPE")
+
+    monkeypatch.setattr(comparison, "MAX_ZIP_MEMBER_BYTES_FOR_JUDGE", 4)
+    monkeypatch.setattr(comparison, "MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES_FOR_JUDGE", 4)
+    real_open = zipfile.ZipFile.open
+    opened: list[str] = []
+
+    def _guarded_open(self, member, *args, **kwargs):
+        name = member.filename if isinstance(member, zipfile.ZipInfo) else str(member)
+        if name in {"oversize.txt", "../escape.txt"}:
+            raise AssertionError(f"rejected member was opened: {name}")
+        opened.append(name)
+        return real_open(self, member, *args, **kwargs)
+
+    monkeypatch.setattr(zipfile.ZipFile, "open", _guarded_open)
+    cleanup: list[Path] = []
+    try:
+        blocks = comparison.build_file_section(str(tmp_path), cleanup)
+    finally:
+        for directory in cleanup:
+            shutil.rmtree(directory, ignore_errors=True)
+
+    assert opened == ["safe.txt"]
+    text = _text(blocks)
+    assert "OK" in text
+    assert "TOO LARGE" not in text
+    assert "ESCAPE" not in text
+
+
+def test_zip_aggregate_limit_rejects_member_before_open(tmp_path: Path, monkeypatch) -> None:
+    archive_path = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("first.txt", "ONE")
+        archive.writestr("second.txt", "TWO")
+
+    monkeypatch.setattr(comparison, "MAX_ZIP_MEMBER_BYTES_FOR_JUDGE", 10)
+    monkeypatch.setattr(comparison, "MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES_FOR_JUDGE", 3)
+    real_open = zipfile.ZipFile.open
+    opened: list[str] = []
+
+    def _guarded_open(self, member, *args, **kwargs):
+        name = member.filename if isinstance(member, zipfile.ZipInfo) else str(member)
+        if name == "second.txt":
+            raise AssertionError("aggregate-budget rejection happened after opening the member")
+        opened.append(name)
+        return real_open(self, member, *args, **kwargs)
+
+    monkeypatch.setattr(zipfile.ZipFile, "open", _guarded_open)
+    extract_dir, paths = comparison._maybe_unzip(archive_path)
+    try:
+        assert opened == ["first.txt"]
+        assert [path.name for path in paths] == ["first.txt"]
+        assert paths[0].read_text() == "ONE"
+    finally:
+        if extract_dir is not None:
+            shutil.rmtree(extract_dir, ignore_errors=True)
+
+
+def test_zip_compressed_size_limit_rejects_before_parsing(tmp_path: Path, monkeypatch) -> None:
+    archive_path = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("file.txt", "content")
+
+    monkeypatch.setattr(comparison, "MAX_ZIP_ARCHIVE_BYTES_FOR_JUDGE", 1)
+
+    def _unexpected_parse(*_args, **_kwargs):
+        raise AssertionError("oversize archive must be rejected before ZipFile parses it")
+
+    monkeypatch.setattr(zipfile, "ZipFile", _unexpected_parse)
+
+    assert comparison._maybe_unzip(archive_path) == (None, [])
+
+
+def test_construct_messages_enforces_one_attachment_budget_across_all_sections(monkeypatch) -> None:
+    monkeypatch.setattr(comparison, "MAX_TOTAL_RAW_ATTACHMENT_BYTES_FOR_JUDGE", 12)
+    monkeypatch.setattr(comparison, "MAX_TOTAL_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE", 16)
+    refs = [{"type": "text", "text": "reference.pdf:"}, _data_block(b"ABCDEF")]
+    submission_a = [{"type": "text", "text": "a.pdf:"}, _data_block(b"GHIJKL")]
+    submission_b = [{"type": "text", "text": "b.pdf:"}, _data_block(b"MNOPQR")]
+
+    messages = comparison.construct_judge_messages("task", refs, submission_a, submission_b)
+    content = messages[0]["content"]
+    costs = [comparison._attachment_cost(block) for block in content]
+
+    assert sum(raw for raw, _encoded in costs) <= 12
+    assert sum(encoded for _raw, encoded in costs) <= 16
+    assert sum(1 for _raw, encoded in costs if encoded) == 2
+    assert _attachments(content) == [b"GHIJKL", b"MNOPQR"]
+    assert "attachment omitted" in _text(content)
+
+
+def test_office_sidecar_is_budgeted_before_reading(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "Plan.docx").write_bytes(b"source")
+    (tmp_path / "Plan.docx.pdf").write_bytes(b"render-too-large")
+    monkeypatch.setattr(comparison, "MAX_SECTION_RAW_ATTACHMENT_BYTES_FOR_JUDGE", 4)
+    monkeypatch.setattr(comparison, "MAX_SECTION_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE", 8)
+
+    def _unexpected_read(_path):
+        raise AssertionError("rejected sidecar must not be read")
+
+    monkeypatch.setattr(comparison, "_load_media", _unexpected_read)
+
+    blocks = comparison.build_file_section(str(tmp_path))
+
+    assert "attachment omitted" in _text(blocks)
+
+
+def test_cached_provenance_avoids_one_rescan_per_office_file(tmp_path: Path, monkeypatch) -> None:
+    for index in range(5):
+        (tmp_path / f"Plan{index}.docx").write_bytes(b"source")
+        (tmp_path / f"Plan{index}.docx.pdf").write_bytes(f"render-{index}".encode())
+
+    real_resolver = comparison.resolve_pdf_provenance
+    calls = 0
+
+    def _counted(paths):
+        nonlocal calls
+        calls += 1
+        return real_resolver(paths)
+
+    monkeypatch.setattr(comparison, "resolve_pdf_provenance", _counted)
+
+    comparison.build_file_section(str(tmp_path))
+
+    assert calls == 1
+
+
+def test_unsupported_document_keeps_direct_sidecar_fallback(tmp_path: Path) -> None:
+    (tmp_path / "Notes.odt").write_bytes(b"source")
+    (tmp_path / "Notes.odt.pdf").write_bytes(b"render")
+
+    blocks = comparison.build_file_section(str(tmp_path))
+
+    assert b"render" in _attachments(blocks)
+
+
+def test_full_payload_fingerprint_makes_a_b_swap_selection_invariant(monkeypatch) -> None:
+    left = b"A" * 1024 + b"L" * 1024 + b"Z" * 1024
+    right = b"A" * 1024 + b"R" * 1024 + b"Z" * 1024
+    monkeypatch.setattr(comparison, "MAX_TOTAL_RAW_ATTACHMENT_BYTES_FOR_JUDGE", len(left))
+    monkeypatch.setattr(
+        comparison,
+        "MAX_TOTAL_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE",
+        len(base64.b64encode(left)),
+    )
+
+    first = comparison.construct_judge_messages("task", [], [_data_block(left)], [_data_block(right)])
+    second = comparison.construct_judge_messages("task", [], [_data_block(right)], [_data_block(left)])
+
+    assert _attachments(first[0]["content"]) == _attachments(second[0]["content"])
+    assert len(_attachments(first[0]["content"])) == 1
+
+
+def test_total_serialized_bound_includes_task_and_section_text(monkeypatch) -> None:
+    monkeypatch.setattr(comparison, "MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE", 100_000)
+    huge_text = {"type": "text", "text": "x" * 100_000}
+
+    messages = comparison.construct_judge_messages(
+        "task" * 100_000,
+        [huge_text, _data_block(b"r" * 20_000)],
+        [huge_text, _data_block(b"a" * 20_000)],
+        [huge_text, _data_block(b"b" * 20_000)],
+    )
+
+    assert comparison._content_serialized_upper_bound(messages[0]["content"]) <= 100_000
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Request size is too large. Max size is 500 MB",
+        "litellm.ContextWindowExceededError: maximum number of tokens allowed 1048576",
+        "HTTP 413: request entity too large",
+        "503 upstream error: context window exceeded",
+    ],
+)
+def test_deterministic_payload_errors_are_not_retryable(message: str) -> None:
+    assert comparison._is_retryable(RuntimeError(message)) is False
+
+
+def test_transient_upstream_error_remains_retryable() -> None:
+    assert comparison._is_retryable(RuntimeError("503 service unavailable")) is True

--- a/resources_servers/gdpval/tests/test_hardening_fixes.py
+++ b/resources_servers/gdpval/tests/test_hardening_fixes.py
@@ -1,0 +1,304 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Resume safety, failure classification, and transport-repair hardening."""
+
+import json
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import orjson
+import pytest
+
+from resources_servers.gdpval.comparison import (
+    _is_lossy_transport_marker,
+    build_file_section,
+)
+from resources_servers.gdpval.multistage_orchestrator import (
+    MultiStageRunConfig,
+    _prepare_resume,
+    _prune_downstream_files,
+    compute_fingerprint,
+    failures_path_for,
+    parse_multistage_config,
+)
+from resources_servers.gdpval.scoring import is_permanent_judge_error
+from resources_servers.gdpval.transport_assignment import PairCost, _footprint, _pair_cost
+
+
+REF_ELOS = {"ref_a": 1000.0}
+DIST = {"grp": {"task_ids": ["t0"], "percentage": 100.0}}
+
+
+def _cfg() -> MultiStageRunConfig:
+    return MultiStageRunConfig(
+        enabled=True,
+        stages=parse_multistage_config({"enabled": True, "stages": [{"num_tasks": 1}]}).stages,
+        seed=0,
+    )
+
+
+class TestFingerprintConnectionFields:
+    def test_endpoint_and_credential_changes_do_not_invalidate(self) -> None:
+        def runtime(base_url: str, api_key: str) -> dict:
+            return {
+                "judge": {
+                    "responses_api_models": {
+                        "minimax": {
+                            "openai_base_url": base_url,
+                            "openai_api_key": api_key,
+                            "openai_model": "minimax-m3",
+                        }
+                    }
+                }
+            }
+
+        cfg = _cfg()
+        baseline = compute_fingerprint(
+            cfg, REF_ELOS, DIST, resolved_global_config=runtime("http://10.0.0.1:8000/v1", "sk-a")
+        )
+        rotated = compute_fingerprint(
+            cfg, REF_ELOS, DIST, resolved_global_config=runtime("http://10.0.9.9:8000/v1", "sk-b")
+        )
+        assert rotated == baseline
+
+        changed_model = dict(runtime("http://10.0.0.1:8000/v1", "sk-a"))
+        changed_model["judge"]["responses_api_models"]["minimax"]["openai_model"] = "other-model"
+        assert compute_fingerprint(cfg, REF_ELOS, DIST, resolved_global_config=changed_model) != baseline
+
+
+class TestStaleResumeQuarantine:
+    def test_stale_state_is_quarantined_not_deleted(self, tmp_path: Path) -> None:
+        output = tmp_path / "rollouts.jsonl"
+        journal = tmp_path / "rollouts_multistage_state.jsonl"
+        payload = b'{"stage_index": 0, "reward": 1.0}\n'
+        output.write_bytes(payload)
+        journal.write_bytes(b'{"stage_index": 0, "status": "planned", "fingerprint": "OLD"}\n')
+
+        config = SimpleNamespace(resume_from_cache=True)
+        _prepare_resume(config, output, journal, "NEW")
+
+        assert not journal.exists()
+        quarantined = sorted(tmp_path.glob("rollouts.jsonl.stale.*"))
+        assert quarantined and quarantined[0].read_bytes() == payload
+
+
+class TestPruneQuarantine:
+    def test_pruned_rows_are_preserved(self, tmp_path: Path) -> None:
+        output = tmp_path / "rollouts.jsonl"
+        rows = [
+            {"stage_index": 0, "task_id": "keep"},
+            {"stage_index": 1, "task_id": "pruned"},
+        ]
+        output.write_bytes(b"".join(orjson.dumps(row) + b"\n" for row in rows))
+        failures_path_for(output).write_bytes(orjson.dumps({"stage_index": 2, "task_id": "pruned_failure"}) + b"\n")
+
+        _prune_downstream_files(output, restart_stage=0)
+
+        assert orjson.loads(output.read_bytes())["task_id"] == "keep"
+        main_quarantine = sorted(tmp_path.glob("rollouts.jsonl.pruned.*"))
+        assert main_quarantine and orjson.loads(main_quarantine[0].read_bytes())["task_id"] == "pruned"
+        sidecar_quarantine = sorted(tmp_path.glob("*failures*.pruned.*"))
+        assert sidecar_quarantine
+
+
+class TestThrottleVeto:
+    def test_429_body_with_permanent_phrase_is_not_permanent(self) -> None:
+        assert is_permanent_judge_error("Error code: 429 - you have sent too many tokens this minute") is False
+        error = RuntimeError("upstream failure")
+        error.status = 429
+        error.body = "too many tokens"
+        assert is_permanent_judge_error(error) is False
+
+    def test_413_and_context_overflow_remain_permanent(self) -> None:
+        assert is_permanent_judge_error("HTTP 413: request entity too large") is True
+        error = RuntimeError("bad request")
+        error.status_code = 413
+        assert is_permanent_judge_error(error) is True
+        assert is_permanent_judge_error("maximum context length exceeded: input is too long") is True
+
+
+class TestVerifyCacheScreening:
+    def test_failure_classed_results_are_neither_written_nor_reused(self, tmp_path: Path) -> None:
+        from responses_api_agents.stirrup_agent.app import (
+            NG_FAILURE_CLASS_KEY,
+            StirrupAgentWrapper,
+            _verify_cache_path,
+        )
+
+        deliverables = tmp_path / "repeat_0"
+        deliverables.mkdir()
+        failure_result = {"reward": 0.0, NG_FAILURE_CLASS_KEY: "reference_missing"}
+
+        StirrupAgentWrapper._write_cached_verify(None, str(deliverables), failure_result)
+        cache_path = _verify_cache_path(str(deliverables))
+        assert cache_path is not None and not cache_path.exists()
+
+        # A legacy cache written before the fix must read as a miss.
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(failure_result))
+        assert StirrupAgentWrapper._read_cached_verify(None, str(deliverables)) is None
+
+        success_result = {"reward": 1.0, "judge_response": {}}
+        cache_path.write_text(json.dumps(success_result))
+        assert StirrupAgentWrapper._read_cached_verify(None, str(deliverables)) == success_result
+
+
+class TestLossMarkers:
+    def test_new_marker_forms_are_detected(self) -> None:
+        assert _is_lossy_transport_marker("[attachment unavailable for clip.mp4]")
+        assert _is_lossy_transport_marker("[page 3 omitted for deck.pdf: raster dimensions too large]")
+        assert not _is_lossy_transport_marker("[page 3] ordinary document text")
+        assert not _is_lossy_transport_marker("regular text")
+
+    def test_loss_marker_survives_exhausted_text_budget(self, tmp_path: Path, monkeypatch) -> None:
+        import resources_servers.gdpval.comparison as comparison
+
+        monkeypatch.setattr(comparison, "MAX_SECTION_TEXT_CHARS_FOR_JUDGE", 10)
+        (tmp_path / "a_filler.txt").write_text("x" * 100)
+        (tmp_path / "b_huge.mp4").write_bytes(b"0" * 64)
+        monkeypatch.setattr(comparison, "MAX_FILE_BYTES_FOR_JUDGE", 8)
+
+        clean_up: list = []
+        section = build_file_section(
+            str(tmp_path),
+            clean_up,
+            media_mode="native_pdf",
+            render_dpi=144,
+            max_pages=50,
+            include_text=True,
+            audio_capable=False,
+            video_capable=False,
+        )
+        texts = [str(block.get("text", "")) for block in section if block.get("type") == "text"]
+        assert any(_is_lossy_transport_marker(text) for text in texts)
+
+
+class TestAvIdentityGuard:
+    def test_oversize_av_is_not_hashed_and_fs_fault_degrades_to_marker(self, tmp_path: Path, monkeypatch) -> None:
+        import resources_servers.gdpval.comparison as comparison
+
+        monkeypatch.setattr(comparison, "MAX_FILE_BYTES_FOR_JUDGE", 4)
+        clip = tmp_path / "clip.mp4"
+        clip.write_bytes(b"0" * 64)
+
+        hashed: list = []
+        real_sha = comparison.hashlib.sha256
+
+        class _Spy:
+            def __init__(self) -> None:
+                hashed.append(1)
+                self._inner = real_sha()
+
+            def update(self, chunk) -> None:
+                self._inner.update(chunk)
+
+            def hexdigest(self) -> str:
+                return self._inner.hexdigest()
+
+        monkeypatch.setattr(comparison.hashlib, "sha256", _Spy)
+        section = build_file_section(
+            str(tmp_path),
+            [],
+            media_mode="native_pdf",
+            render_dpi=144,
+            max_pages=50,
+            include_text=True,
+            audio_capable=True,
+            video_capable=True,
+        )
+        assert not hashed, "over-cap AV must not be hashed"
+        assert section is not None
+
+
+class TestTransportRepairHardening:
+    def _cost(self, candidate: object, reference: object) -> PairCost:
+        return _pair_cost(
+            candidate,
+            reference,
+            max_file_bytes=250 * 1024 * 1024,
+            max_raw_bytes=300 * 1024 * 1024,
+            max_wire_bytes=420 * 1024 * 1024,
+            max_section_raw_bytes=96 * 1024 * 1024,
+            framing_reserve_bytes=4 * 1024 * 1024,
+        )
+
+    def test_corrupt_zip_is_costed_incompatible_not_fatal(self, tmp_path: Path) -> None:
+        (tmp_path / "broken.zip").write_bytes(b"this is not a zip archive")
+        footprint = _footprint(tmp_path)
+        assert footprint.defective is True
+
+        from resources_servers.gdpval.transport_assignment import Footprint
+
+        clean = Footprint(raw_bytes=1, max_file_bytes=1, has_av=False, file_count=1)
+        cost = self._cost(footprint, clean)
+        assert cost.compatible is False and "corrupt_archive" in cost.reasons
+
+    def test_valid_zip_members_still_enumerated(self, tmp_path: Path) -> None:
+        with zipfile.ZipFile(tmp_path / "ok.zip", "w") as archive:
+            archive.writestr("page.pdf", b"%PDF-fake")
+        footprint = _footprint(tmp_path)
+        assert footprint.defective is False and footprint.file_count == 1
+
+    def test_section_budget_marks_pair_incompatible(self) -> None:
+        from resources_servers.gdpval.transport_assignment import Footprint
+
+        big_section = Footprint(
+            raw_bytes=150 * 1024 * 1024, max_file_bytes=150 * 1024 * 1024, has_av=False, file_count=1
+        )
+        small = Footprint(raw_bytes=1, max_file_bytes=1, has_av=False, file_count=1)
+        cost = self._cost(big_section, small)
+        assert cost.compatible is False and "section_raw_over_cap" in cost.reasons
+
+    def test_new_av_extensions_are_recognized(self, tmp_path: Path) -> None:
+        (tmp_path / "voice.opus").write_bytes(b"0" * 10)
+        footprint = _footprint(tmp_path)
+        assert footprint.has_av is True and footprint.file_count == 1
+
+
+class TestJudgeNameCollision:
+    def test_duplicate_resolved_names_raise(self, monkeypatch) -> None:
+        from resources_servers.gdpval import app as gdpval_app
+
+        monkeypatch.setattr(gdpval_app, "get_server_url", lambda name: "http://judge")
+
+        def member(media_mode: str) -> SimpleNamespace:
+            return SimpleNamespace(
+                name=None,
+                model="gemini-2.5-pro",
+                create_params_overrides=None,
+                weight=1.0,
+                handles_audio=False,
+                handles_video=False,
+                media_mode=media_mode,
+                max_native_pdf_pages=None,
+                max_native_pdf_documents=None,
+                max_native_pdf_bytes=None,
+                max_native_pdf_bytes_per_document=None,
+                raster_dpi_tiers=[],
+                max_serialized_request_bytes=None,
+                model_server=SimpleNamespace(name="judge_server"),
+            )
+
+        fake_server = SimpleNamespace(
+            config=SimpleNamespace(
+                judge_responses_create_params_overrides=None,
+                judge_model_server=None,
+                judge_media_mode="native_pdf",
+            ),
+            _effective_panel=lambda: [member("native_pdf"), member("images_and_text")],
+        )
+        with pytest.raises(ValueError, match="unique names"):
+            gdpval_app.GDPValResourcesServer._resolve_judges(fake_server)

--- a/resources_servers/gdpval/tests/test_multistage_elo.py
+++ b/resources_servers/gdpval/tests/test_multistage_elo.py
@@ -110,6 +110,38 @@ class TestAssignTaskReferences:
     def test_empty_reference_set_yields_no_assignment(self) -> None:
         assert assign_task_references(["t0", "t1"], [], rng=random.Random(0)) == {}
 
+    def test_default_preserves_independent_uniform_draws(self) -> None:
+        task_ids = [f"t{i}" for i in range(20)]
+        refs = ["a", "b", "c"]
+        expected_rng = random.Random(11)
+        expected = {task_id: expected_rng.choice(refs) for task_id in task_ids}
+
+        assert assign_task_references(task_ids, refs, rng=random.Random(11)) == expected
+
+    def test_balanced_counts_differ_by_at_most_one(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        refs = ["a", "b", "c"]
+        assignment = assign_task_references(task_ids, refs, rng=random.Random(7), balanced=True)
+        counts = {ref: list(assignment.values()).count(ref) for ref in refs}
+
+        assert set(assignment) == set(task_ids)
+        assert max(counts.values()) - min(counts.values()) <= 1
+
+    def test_balanced_assignment_is_seeded_and_randomized(self) -> None:
+        task_ids = [f"t{i}" for i in range(20)]
+        refs = ["a", "b", "c"]
+        first = assign_task_references(task_ids, refs, rng=random.Random(3), balanced=True)
+        replay = assign_task_references(task_ids, refs, rng=random.Random(3), balanced=True)
+        other = assign_task_references(task_ids, refs, rng=random.Random(4), balanced=True)
+
+        assert first == replay
+        assert first != other
+
+    def test_balanced_with_fewer_tasks_than_references(self) -> None:
+        assignment = assign_task_references(["t0", "t1"], ["a", "b", "c", "d"], rng=random.Random(5), balanced=True)
+
+        assert len(set(assignment.values())) == 2
+
 
 class TestStageAssignmentRng:
     def test_distinct_streams_per_stage_and_seed(self) -> None:

--- a/resources_servers/gdpval/tests/test_multistage_orchestrator.py
+++ b/resources_servers/gdpval/tests/test_multistage_orchestrator.py
@@ -19,7 +19,7 @@ import json
 from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import pytest
 
@@ -1276,6 +1276,7 @@ class TestPartialStageCompletion:
         min_success_fraction: float = 0.6,
         min_per_reference_success_fraction: float = 0.6,
         min_successful_rows_per_reference: int = 1,
+        waivable_failure_classes: Optional[Sequence[str]] = None,
     ) -> MultiStageRunConfig:
         first_stage: Dict[str, Any] = {"num_tasks": 10}
         if enabled:
@@ -1284,6 +1285,8 @@ class TestPartialStageCompletion:
                 "min_per_reference_success_fraction": min_per_reference_success_fraction,
                 "min_successful_rows_per_reference": min_successful_rows_per_reference,
             }
+            if waivable_failure_classes is not None:
+                first_stage["partial_completion"]["waivable_failure_classes"] = list(waivable_failure_classes)
         return MultiStageRunConfig(
             enabled=True,
             stages=parse_multistage_config(
@@ -1747,6 +1750,62 @@ class TestPartialStageCompletion:
         assert set(dispatched_stages) == {0}
         assert len(summaries) == 1
         assert resume.completed == []
+
+    async def test_transient_omission_advances_when_explicitly_waivable(self) -> None:
+        """A judge-failure `transient` row is waivable only when the policy says so.
+
+        This is the `dc6c776f3af506df` case: one unresolved `transient` rollout
+        (an empty-PDF 400 from the judge panel) held the whole run at stage 1
+        under the timeout-only default, costing 176 of 220 tasks.
+        """
+        task_ids = [f"t{i}" for i in range(10)]
+        resume = self._balanced_resume(task_ids)
+        dispatched_stages: List[int] = []
+
+        _, summaries = await run_multistage_stages(
+            self._config(enabled=True, waivable_failure_classes=["timeout_exceeded", "transient"]),
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            self._runner(
+                {0, 1, 2, 3},
+                failure_class="transient",
+                dispatched_stages=dispatched_stages,
+            ),
+            resume=resume,
+        )
+
+        assert set(dispatched_stages) == {0, 1}
+        assert len(summaries) == 2
+        assert summaries[0]["partial"] is True
+        assert summaries[0]["num_omitted"] == 4
+        outcome = resume.completed[0][1]
+        assert outcome["status"] == "partial_complete"
+        assert outcome["policy"]["newly_waivable_failure_classes"] == ["timeout_exceeded", "transient"]
+
+    async def test_unknown_waivable_failure_class_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="waivable_failure_classes"):
+            parse_multistage_config(
+                {
+                    "enabled": True,
+                    "stages": [
+                        {"num_tasks": 10, "partial_completion": {"waivable_failure_classes": ["skipped"]}},
+                        {"num_tasks": 10},
+                    ],
+                }
+            )
+
+    async def test_empty_waivable_failure_classes_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="waivable_failure_classes"):
+            parse_multistage_config(
+                {
+                    "enabled": True,
+                    "stages": [
+                        {"num_tasks": 10, "partial_completion": {"waivable_failure_classes": []}},
+                        {"num_tasks": 10},
+                    ],
+                }
+            )
 
     async def test_policy_rejects_missing_elo_fit(self) -> None:
         task_ids = [f"t{i}" for i in range(10)]

--- a/resources_servers/gdpval/tests/test_multistage_orchestrator.py
+++ b/resources_servers/gdpval/tests/test_multistage_orchestrator.py
@@ -16,13 +16,21 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List, Tuple
 
 import pytest
 
-from nemo_gym.global_config import AGENT_REF_KEY_NAME, ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
+import nemo_gym.rollout_collection as rollout_collection_module
+import resources_servers.gdpval.multistage_orchestrator as multistage_module
+from nemo_gym.global_config import (
+    AGENT_REF_KEY_NAME,
+    ATTEMPT_INDEX_KEY_NAME,
+    ROLLOUT_INDEX_KEY_NAME,
+    TASK_INDEX_KEY_NAME,
+)
 from nemo_gym.path_utils import failures_path_for
 from nemo_gym.rollout_collection import (
     NG_FAILURE_CLASS_KEY,
@@ -39,12 +47,16 @@ from resources_servers.gdpval.multistage_orchestrator import (
     find_gdpval_reference_elos,
     index_rows_by_task,
     journal_path_for,
+    load_failure_attempts,
+    load_failure_timings,
     load_gated_keys,
     load_persisted_rows,
+    load_reuse_cached_keys,
     parse_multistage_config,
     read_journal,
     route_stage_rows,
     row_task_id,
+    run_e2e_multistage,
     run_multistage_stages,
     tag_results,
     write_rollouts,
@@ -195,10 +207,17 @@ class TestRowHelpers:
             "task_id": "t3",
         }
         result = {"per_reference": {}, "reward": 1.0}
-        tagged = tag_results([(row, result)], stage_index=1)
+        tagged = tag_results(
+            [(row, result)],
+            stage_index=1,
+            expected_final_stage_index=2,
+            expected_stage_row_count=17,
+        )
         assert tagged[0][TASK_INDEX_KEY_NAME] == 3
         assert tagged[0][ROLLOUT_INDEX_KEY_NAME] == 7
         assert tagged[0]["stage_index"] == 1
+        assert tagged[0]["expected_final_stage_index"] == 2
+        assert tagged[0]["expected_stage_row_count"] == 17
         assert tagged[0]["task_id"] == "t3"
 
 
@@ -255,6 +274,9 @@ class TestRunStages:
             rows,
             _fake_run_rollouts_factory(),
         )
+
+        assert all(row["expected_final_stage_index"] == 1 for row in all_results)
+        assert all(row["expected_stage_row_count"] == 20 for row in all_results)
 
         # Stage 0 uses all references; stage 1 shrinks to the 2 closest to the
         # stage-0 estimate (~1300 ⇒ b=1200, c=1400).
@@ -412,6 +434,17 @@ class TestWriteRollouts:
         lines = [json.loads(line) for line in out.read_text().splitlines()]
         assert [line["task_id"] for line in lines] == ["t0", "t1"]
 
+    def test_fresh_file_uses_normal_umask_permissions(self, tmp_path: Path) -> None:
+        control = tmp_path / "normal.jsonl"
+        control.write_bytes(b"normal\n")
+
+        out = write_rollouts(
+            [{TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0}],
+            tmp_path / "rollouts.jsonl",
+        )
+
+        assert out.stat().st_mode & 0o777 == control.stat().st_mode & 0o777
+
     def test_dedupes_by_stage_task_rollout(self, tmp_path: Path) -> None:
         results = [
             {"stage_index": 0, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "old"},
@@ -422,6 +455,32 @@ class TestWriteRollouts:
         lines = [json.loads(line) for line in out.read_text().splitlines()]
         # Dedup keeps the last write per (stage, task, rollout); stage 1 is distinct.
         assert [line["task_id"] for line in lines] == ["new", "other"]
+
+    def test_failed_rewrite_preserves_previous_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        out = tmp_path / "rollouts.jsonl"
+        original = b'{"previous":true}\n'
+        out.write_bytes(original)
+        real_dumps = multistage_module.orjson.dumps
+        calls = 0
+
+        def fail_on_second_row(value, *args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise RuntimeError("injected serialization failure")
+            return real_dumps(value, *args, **kwargs)
+
+        monkeypatch.setattr(multistage_module.orjson, "dumps", fail_on_second_row)
+        rows = [
+            {"stage_index": 0, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0},
+            {"stage_index": 0, TASK_INDEX_KEY_NAME: 1, ROLLOUT_INDEX_KEY_NAME: 0},
+        ]
+
+        with pytest.raises(RuntimeError, match="injected serialization failure"):
+            write_rollouts(rows, out)
+
+        assert out.read_bytes() == original
+        assert list(tmp_path.glob(".rollouts.jsonl.merge-*")) == []
 
 
 # ---------------------------------------------------------------------------
@@ -436,7 +495,16 @@ class RecordingResume(StageResume):
     explicitly to model terminal / max-attempt gating from the sidecar.
     """
 
-    def __init__(self, plans=None, outcomes=None, rows_by_stage=None, gated_keys=None) -> None:
+    def __init__(
+        self,
+        plans=None,
+        outcomes=None,
+        rows_by_stage=None,
+        gated_keys=None,
+        elapsed_by_stage=None,
+        reuse_cached_keys=None,
+        attempts_by_stage=None,
+    ) -> None:
         self.planned: List[Tuple[int, dict]] = []
         self.completed: List[Tuple[int, dict]] = []
         self.appended: Dict[int, List[Dict[str, Any]]] = {}
@@ -454,6 +522,9 @@ class RecordingResume(StageResume):
             on_plan=lambda i, p: self.planned.append((i, p)),
             on_outcome=lambda i, o: self.completed.append((i, o)),
             on_rows=lambda i, r: self.appended.setdefault(i, []).extend(r),
+            elapsed_by_stage=dict(elapsed_by_stage or {}),
+            reuse_cached_keys=dict(reuse_cached_keys or {}),
+            attempts_by_stage=dict(attempts_by_stage or {}),
         )
 
 
@@ -492,7 +563,7 @@ class TestResumeSeam:
         stage0_plan = {
             "stage_index": 0,
             "reference_ids": base_summaries[0]["reference_ids"],
-            "task_ids": [f"t{i}" for i in range(3)],
+            "task_ids": list(dict.fromkeys(row["task_id"] for row in stage0_rows)),
         }
         resume = RecordingResume(
             plans={0: stage0_plan},
@@ -562,6 +633,147 @@ class TestResumeSeam:
         # Final stage-0 result count equals the full run (cached + re-dispatched).
         assert summaries[0]["num_rollouts"] == base_summaries[0]["num_rollouts"]
 
+    async def test_completed_cached_stage_stamps_full_expected_row_count(self) -> None:
+        task_ids = ["t0", "t1"]
+        rows = _materialized_rows(task_ids, repeats=2)
+        cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["2"]}).stages,
+            seed=0,
+        )
+        full_results, summaries = await run_multistage_stages(
+            cfg, REF_ELOS, _distribution(task_ids), rows, _fake_run_rollouts_factory()
+        )
+        # Model a completed stage with one persisted success and the other rows
+        # accounted for by terminal/max-attempt sidecars. The success must still
+        # declare the full planned cardinality, not the cached success count.
+        resume = RecordingResume(
+            plans={
+                0: {
+                    "stage_index": 0,
+                    "reference_ids": summaries[0]["reference_ids"],
+                    "task_ids": task_ids,
+                }
+            },
+            outcomes={0: {"stage_index": 0, "status": "complete"}},
+            rows_by_stage={0: [full_results[0]]},
+            gated_keys={0: {(row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME]) for row in full_results}},
+        )
+
+        async def no_dispatch(rows_in: List[Dict[str, Any]]):
+            raise AssertionError("completed cached stage must not dispatch")
+
+        cached_results, _ = await run_multistage_stages(
+            cfg, REF_ELOS, _distribution(task_ids), rows, no_dispatch, resume=resume
+        )
+
+        assert len(cached_results) == 1
+        assert cached_results[0]["expected_stage_row_count"] == 4
+        assert cached_results[0]["expected_final_stage_index"] == 0
+
+    async def test_completed_stage_with_missing_cached_key_is_reopened(self) -> None:
+        task_ids = ["t0", "t1"]
+        rows = _materialized_rows(task_ids)
+        cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["2"]}).stages,
+            seed=0,
+        )
+        full_run = _fake_run_rollouts_factory()
+        full_results, summaries = await run_multistage_stages(cfg, REF_ELOS, _distribution(task_ids), rows, full_run)
+        missing = full_results[-1]
+        missing_key = (missing[TASK_INDEX_KEY_NAME], missing[ROLLOUT_INDEX_KEY_NAME])
+        cached = full_results[:-1]
+        resume = RecordingResume(
+            plans={
+                0: {
+                    "stage_index": 0,
+                    "reference_ids": summaries[0]["reference_ids"],
+                    "task_ids": task_ids,
+                }
+            },
+            outcomes={0: {"stage_index": 0, "status": "complete"}},
+            rows_by_stage={0: cached},
+        )
+        dispatched: List[Tuple[int, int]] = []
+
+        async def capture(rows_in: List[Dict[str, Any]]):
+            dispatched.extend((row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME]) for row in rows_in)
+            return await full_run(rows_in)
+
+        results, result_summaries = await run_multistage_stages(
+            cfg, REF_ELOS, _distribution(task_ids), rows, capture, resume=resume
+        )
+
+        assert dispatched == [missing_key]
+        assert len(results) == len(full_results)
+        assert result_summaries[0].get("cached") is not True
+
+    async def test_resumed_empty_fit_preserves_prior_elo_for_next_stage(self) -> None:
+        task_ids = [f"t{i}" for i in range(6)]
+        rows = _materialized_rows(task_ids)
+        cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["2:4", "2:2", "2:1"]}).stages,
+            seed=0,
+            reuse_cached_deliverables=False,
+        )
+        baseline_resume = RecordingResume()
+        successful_run = _fake_run_rollouts_factory()
+
+        async def terminal_middle_stage(rows_in: List[Dict[str, Any]]):
+            if rows_in and rows_in[0]["stage_index"] == 1:
+                return [
+                    (
+                        row,
+                        {
+                            NG_FAILURE_CLASS_KEY: "skipped",
+                            NG_TERMINAL_KEY: True,
+                        },
+                    )
+                    for row in rows_in
+                ]
+            return await successful_run(rows_in)
+
+        baseline_results, baseline_summaries = await run_multistage_stages(
+            cfg,
+            REF_ELOS,
+            _distribution(task_ids),
+            rows,
+            terminal_middle_stage,
+            resume=baseline_resume,
+        )
+        assert baseline_summaries[0]["eval_elo"] is not None
+        assert baseline_summaries[1]["eval_elo"] is None
+
+        stage0_rows = [row for row in baseline_results if row["stage_index"] == 0]
+        stage0_keys = {(row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME]) for row in stage0_rows}
+        stage1_keys = {(row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME]) for row in baseline_resume.appended[1]}
+        resumed = RecordingResume(
+            plans=dict(baseline_resume.planned[:2]),
+            outcomes=dict(baseline_resume.completed[:2]),
+            rows_by_stage={0: stage0_rows},
+            gated_keys={0: stage0_keys, 1: stage1_keys},
+        )
+
+        dispatched_stages: List[int] = []
+
+        async def capture_stage(rows_in: List[Dict[str, Any]]):
+            dispatched_stages.extend(row["stage_index"] for row in rows_in)
+            return await successful_run(rows_in)
+
+        _, resumed_summaries = await run_multistage_stages(
+            cfg,
+            REF_ELOS,
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            capture_stage,
+            resume=resumed,
+        )
+
+        assert set(dispatched_stages) == {2}
+        assert resumed_summaries[2]["reference_ids"] == baseline_summaries[2]["reference_ids"]
+
     async def test_plan_replay_is_deterministic_without_seed(self) -> None:
         task_ids = [f"t{i}" for i in range(10)]
         rows = _materialized_rows(task_ids)
@@ -630,6 +842,217 @@ class TestResumeSeam:
         await run_multistage_stages(cfg, REF_ELOS, _distribution(task_ids), rows, capturing_run, resume=resume)
         assert dispatched_keys == [failed_key]
 
+    async def test_resume_longest_first_uses_stage_aware_failure_timings(self) -> None:
+        task_ids = [f"t{i}" for i in range(4)]
+        rows = _materialized_rows(task_ids)
+        cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["4"]}).stages,
+            seed=0,
+        )
+        resume = RecordingResume(
+            plans={
+                0: {
+                    "stage_index": 0,
+                    "reference_ids": ["a"],
+                    "task_ids": task_ids,
+                    "task_reference_ids": {task_id: "a" for task_id in task_ids},
+                }
+            },
+            elapsed_by_stage={0: {(0, 0): 60.0, (2, 0): 9000.0}},
+        )
+        dispatched: List[int] = []
+        run = _fake_run_rollouts_factory()
+
+        async def capturing_run(rows_in: List[Dict[str, Any]]):
+            dispatched.extend(row[TASK_INDEX_KEY_NAME] for row in rows_in)
+            return await run(rows_in)
+
+        await run_multistage_stages(
+            cfg,
+            REF_ELOS,
+            _distribution(task_ids),
+            rows,
+            capturing_run,
+            resume=resume,
+            dispatch_longest_first=True,
+        )
+
+        assert dispatched == [2, 0, 1, 3]
+
+    async def test_resume_reuses_failed_judge_deliverable_for_matching_stage_only(self) -> None:
+        task_ids = ["t0"]
+        rows = _materialized_rows(task_ids)
+        cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["1", "1"]}).stages,
+            seed=0,
+            # Isolate sidecar propagation from normal cross-stage reuse.
+            reuse_cached_deliverables=False,
+        )
+        resume = RecordingResume(reuse_cached_keys={1: {(0, 0)}})
+        seen: List[Tuple[int, bool]] = []
+        run = _fake_run_rollouts_factory()
+
+        async def capturing_run(rows_in: List[Dict[str, Any]]):
+            seen.extend((row["stage_index"], bool(row.get("reuse_cached_deliverable"))) for row in rows_in)
+            return await run(rows_in)
+
+        await run_multistage_stages(cfg, REF_ELOS, _distribution(task_ids), rows, capturing_run, resume=resume)
+
+        assert seen == [(0, False), (1, True)]
+
+    async def test_gated_sidecar_artifact_is_produced_for_later_stages(self) -> None:
+        task_ids = ["t0"]
+        rows = _materialized_rows(task_ids)
+        cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["1", "1"]}).stages,
+            seed=0,
+        )
+        # Stage 0's judge-invalid row exhausted its attempts, but its sidecar
+        # flag proves that the reference-independent policy artifact exists.
+        resume = RecordingResume(
+            gated_keys={0: {(0, 0)}},
+            reuse_cached_keys={0: {(0, 0)}},
+            attempts_by_stage={0: {(0, 0): 3}},
+        )
+        seen: List[Tuple[int, bool]] = []
+        run = _fake_run_rollouts_factory()
+
+        async def capturing_run(rows_in: List[Dict[str, Any]]):
+            seen.extend((row["stage_index"], bool(row.get("reuse_cached_deliverable"))) for row in rows_in)
+            return await run(rows_in)
+
+        await run_multistage_stages(cfg, REF_ELOS, _distribution(task_ids), rows, capturing_run, resume=resume)
+
+        assert seen == [(1, True)]
+
+    async def test_new_terminal_judge_failure_reuses_artifact_in_next_stage(self) -> None:
+        task_ids = ["t0"]
+        rows = _materialized_rows(task_ids)
+        cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["1", "1"]}).stages,
+            seed=0,
+        )
+        seen: List[Tuple[int, bool]] = []
+        success_run = _fake_run_rollouts_factory()
+
+        async def terminal_then_success(rows_in: List[Dict[str, Any]]):
+            seen.extend((row["stage_index"], bool(row.get("reuse_cached_deliverable"))) for row in rows_in)
+            if rows_in and rows_in[0]["stage_index"] == 0:
+                return [
+                    (
+                        row,
+                        {
+                            NG_FAILURE_CLASS_KEY: "permanent",
+                            NG_TERMINAL_KEY: True,
+                            "reuse_cached_deliverable": True,
+                            "deliverables_dir": "/cached/task_t0/repeat_0",
+                        },
+                    )
+                    for row in rows_in
+                ]
+            return await success_run(rows_in)
+
+        await run_multistage_stages(
+            cfg,
+            REF_ELOS,
+            _distribution(task_ids),
+            rows,
+            terminal_then_success,
+        )
+
+        assert seen == [(0, False), (1, True)]
+
+    async def test_third_failure_is_resolved_without_fourth_invocation(self) -> None:
+        task_ids = ["t0"]
+        rows = _materialized_rows(task_ids)
+        cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["1", "1"]}).stages,
+            seed=0,
+            reuse_cached_deliverables=False,
+        )
+        resume = RecordingResume(attempts_by_stage={0: {(0, 0): 2}})
+        seen_attempts: List[Tuple[int, Any]] = []
+        run = _fake_run_rollouts_factory()
+
+        async def fail_third_then_succeed(rows_in: List[Dict[str, Any]]):
+            stage_index = rows_in[0]["stage_index"]
+            seen_attempts.append((stage_index, rows_in[0].get(ATTEMPT_INDEX_KEY_NAME)))
+            if stage_index == 0:
+                return [(rows_in[0], {NG_FAILURE_CLASS_KEY: "judge_invalid"})]
+            return await run(rows_in)
+
+        await run_multistage_stages(
+            cfg, REF_ELOS, _distribution(task_ids), rows, fail_third_then_succeed, resume=resume
+        )
+
+        assert seen_attempts == [(0, 2), (1, None)]
+        assert [index for index, _ in resume.completed] == [0, 1]
+        assert resume.appended[0][0][ATTEMPT_INDEX_KEY_NAME] == 2
+
+    async def test_drained_stage_is_not_marked_complete(self) -> None:
+        task_ids = ["t0"]
+        rows = _materialized_rows(task_ids)
+        cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["1", "1"]}).stages,
+            seed=0,
+        )
+        resume = RecordingResume()
+        dispatches = 0
+
+        async def drain(rows_in: List[Dict[str, Any]]):
+            nonlocal dispatches
+            dispatches += 1
+            return [
+                (
+                    row,
+                    {NG_FAILURE_CLASS_KEY: "kill_shaped", NG_NO_PERSIST_KEY: True},
+                )
+                for row in rows_in
+            ]
+
+        results, _ = await run_multistage_stages(cfg, REF_ELOS, _distribution(task_ids), rows, drain, resume=resume)
+
+        assert results == []
+        assert resume.completed == []
+        assert dispatches == 1
+
+    async def test_partial_final_stage_declares_full_expected_row_count(self) -> None:
+        task_ids = ["t0", "t1"]
+        rows = _materialized_rows(task_ids)
+        cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["2", "2"]}).stages,
+            seed=0,
+        )
+        resume = RecordingResume()
+        base_run = _fake_run_rollouts_factory()
+        calls = 0
+
+        async def partial_final(rows_in: List[Dict[str, Any]]):
+            nonlocal calls
+            calls += 1
+            pairs = await base_run(rows_in)
+            if calls == 2:
+                row, _ = pairs[-1]
+                pairs[-1] = (row, {NG_FAILURE_CLASS_KEY: "kill_shaped", NG_NO_PERSIST_KEY: True})
+            return pairs
+
+        results, _ = await run_multistage_stages(
+            cfg, REF_ELOS, _distribution(task_ids), rows, partial_final, resume=resume
+        )
+
+        final_rows = [row for row in results if row["stage_index"] == 1]
+        assert len(final_rows) == 1
+        assert final_rows[0]["expected_final_stage_index"] == 1
+        assert final_rows[0]["expected_stage_row_count"] == 2
+        assert [index for index, _ in resume.completed] == [0]
+
 
 class TestFingerprint:
     def test_stable_and_config_sensitive(self) -> None:
@@ -665,6 +1088,127 @@ class TestFingerprint:
             "g1": {"percentage": 0.1, "task_ids": ["t2", "t3"]},
         }
         assert compute_fingerprint(cfg, REF_ELOS, dist_a) != compute_fingerprint(cfg, REF_ELOS, dist_b)
+
+    def test_materialized_rows_and_result_affecting_run_config_invalidate(self) -> None:
+        cfg = _two_stage_cfg()
+        dist = _distribution(["t0"])
+        rows = _materialized_rows(["t0"])
+        run_config = SimpleNamespace(
+            agent_name="gdpval_stirrup_agent",
+            input_jsonl_fpath="tasks.jsonl",
+            limit=None,
+            num_repeats=1,
+            num_repeats_add_seed=False,
+            responses_create_params={"temperature": 0.6},
+            prompt_config="prompt.yaml",
+            skills=None,
+        )
+        baseline = compute_fingerprint(
+            cfg,
+            REF_ELOS,
+            dist,
+            materialized_rows=rows,
+            rollout_collection_config=run_config,
+        )
+
+        changed_prompt_row = [dict(rows[0], responses_create_params={"input": [{"role": "user", "content": "new"}]})]
+        assert (
+            compute_fingerprint(
+                cfg,
+                REF_ELOS,
+                dist,
+                materialized_rows=changed_prompt_row,
+                rollout_collection_config=run_config,
+            )
+            != baseline
+        )
+
+        changed_repeats = SimpleNamespace(**vars(run_config))
+        changed_repeats.num_repeats = 2
+        assert (
+            compute_fingerprint(
+                cfg,
+                REF_ELOS,
+                dist,
+                materialized_rows=rows,
+                rollout_collection_config=changed_repeats,
+            )
+            != baseline
+        )
+
+        remapped = [dict(rows[0], **{TASK_INDEX_KEY_NAME: 99})]
+        assert (
+            compute_fingerprint(
+                cfg,
+                REF_ELOS,
+                dist,
+                materialized_rows=remapped,
+                rollout_collection_config=run_config,
+            )
+            != baseline
+        )
+
+    def test_fixed_policy_and_judge_config_invalidate_fingerprint(self) -> None:
+        cfg = _two_stage_cfg()
+        dist = _distribution(["t0"])
+        rows = _materialized_rows(["t0"])
+        runtime = {
+            "policy_model": {"responses_api_models": {"vllm": {"model": "/checkpoints/policy-a"}}},
+            "gdpval_resources_server": {
+                "resources_servers": {
+                    "gdpval": {
+                        "num_comparison_trials": 2,
+                        "judge_responses_create_params_overrides": {"model": "judge-a"},
+                    }
+                }
+            },
+            "operational_logging": {"level": "INFO"},
+        }
+        baseline = compute_fingerprint(
+            cfg,
+            REF_ELOS,
+            dist,
+            materialized_rows=rows,
+            resolved_global_config=runtime,
+        )
+
+        changed_policy = deepcopy(runtime)
+        changed_policy["policy_model"]["responses_api_models"]["vllm"]["model"] = "/checkpoints/policy-b"
+        changed_judge = deepcopy(runtime)
+        changed_judge["gdpval_resources_server"]["resources_servers"]["gdpval"]["num_comparison_trials"] = 4
+        changed_logging = deepcopy(runtime)
+        changed_logging["operational_logging"]["level"] = "DEBUG"
+
+        assert (
+            compute_fingerprint(
+                cfg,
+                REF_ELOS,
+                dist,
+                materialized_rows=rows,
+                resolved_global_config=changed_policy,
+            )
+            != baseline
+        )
+        assert (
+            compute_fingerprint(
+                cfg,
+                REF_ELOS,
+                dist,
+                materialized_rows=rows,
+                resolved_global_config=changed_judge,
+            )
+            != baseline
+        )
+        assert (
+            compute_fingerprint(
+                cfg,
+                REF_ELOS,
+                dist,
+                materialized_rows=rows,
+                resolved_global_config=changed_logging,
+            )
+            == baseline
+        )
 
 
 class TestJournalIO:
@@ -813,6 +1357,209 @@ class TestFailureRouting:
         assert (2, 0) in gated[0]
         assert (3, 0) not in gated[0]
 
+    def test_reopening_stage_prunes_all_downstream_persisted_state(self, tmp_path: Path) -> None:
+        out = tmp_path / "rollouts.jsonl"
+        journal = journal_path_for(out)
+        from resources_servers.gdpval.multistage_orchestrator import append_journal_record
+
+        main_rows = [
+            {"stage_index": 0, TASK_INDEX_KEY_NAME: 9, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "keep"},
+            {"stage_index": 1, TASK_INDEX_KEY_NAME: 1, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "stale-1"},
+            {"stage_index": 2, TASK_INDEX_KEY_NAME: 2, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "stale-2"},
+        ]
+        out.write_text("".join(json.dumps(row) + "\n" for row in main_rows))
+        failures = [
+            {
+                "stage_index": 0,
+                TASK_INDEX_KEY_NAME: 0,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                NG_FAILURE_CLASS_KEY: "judge_invalid",
+                "elapsed_seconds": 10,
+                "reuse_cached_deliverable": True,
+            },
+            {
+                "stage_index": 1,
+                TASK_INDEX_KEY_NAME: 1,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                NG_FAILURE_CLASS_KEY: "judge_invalid",
+                "elapsed_seconds": 20,
+                "reuse_cached_deliverable": True,
+            },
+        ]
+        failures_path_for(out).write_text("".join(json.dumps(row) + "\n" for row in failures))
+        for stage_index in range(3):
+            append_journal_record(
+                journal,
+                {
+                    "stage_index": stage_index,
+                    "status": "planned",
+                    "reference_ids": ["a"],
+                    "task_ids": [f"t{stage_index}"],
+                },
+                "FP",
+            )
+            append_journal_record(journal, {"stage_index": stage_index, "status": "complete"}, "FP")
+
+        resume = build_file_resume(out, journal, "FP")
+
+        assert set(resume.plans) == {0}
+        assert resume.outcomes == {}
+        assert set(resume.rows_by_stage) == {0}
+        assert set(resume.gated_keys) <= {0}
+        assert set(resume.elapsed_by_stage) == {0}
+        assert set(resume.reuse_cached_keys) == {0}
+        assert set(resume.attempts_by_stage) == {0}
+        assert {json.loads(line)["stage_index"] for line in out.read_text().splitlines()} == {0}
+        assert {json.loads(line)["stage_index"] for line in failures_path_for(out).read_text().splitlines()} == {0}
+        journal_records = [json.loads(line) for line in journal.read_text().splitlines()]
+        assert any(row.get("status") == "restart_from_stage" and row["stage_index"] == 0 for row in journal_records)
+        assert journal_records[-1]["status"] == "restart_cleanup_complete"
+
+    def test_historical_failure_does_not_reopen_stage_after_later_success(self, tmp_path: Path) -> None:
+        out = tmp_path / "rollouts.jsonl"
+        journal = journal_path_for(out)
+        from resources_servers.gdpval.multistage_orchestrator import append_journal_record
+
+        main_rows = [
+            {"stage_index": 0, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "resolved"},
+            {"stage_index": 1, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "task_id": "downstream"},
+        ]
+        out.write_text("".join(json.dumps(row) + "\n" for row in main_rows))
+        failures_path_for(out).write_text(
+            json.dumps(
+                {
+                    "stage_index": 0,
+                    TASK_INDEX_KEY_NAME: 0,
+                    ROLLOUT_INDEX_KEY_NAME: 0,
+                    NG_FAILURE_CLASS_KEY: "judge_invalid",
+                }
+            )
+            + "\n"
+        )
+        for stage_index in range(2):
+            append_journal_record(
+                journal,
+                {"stage_index": stage_index, "status": "planned", "reference_ids": ["a"], "task_ids": ["t0"]},
+                "FP",
+            )
+            append_journal_record(journal, {"stage_index": stage_index, "status": "complete"}, "FP")
+
+        resume = build_file_resume(out, journal, "FP")
+
+        assert set(resume.outcomes) == {0, 1}
+        assert set(resume.rows_by_stage) == {0, 1}
+        assert not any(
+            json.loads(line).get("status") == "restart_from_stage" for line in journal.read_text().splitlines()
+        )
+
+    def test_legacy_terminal_timeout_reopens_stage_and_preserves_timing(self, tmp_path: Path) -> None:
+        out = tmp_path / "rollouts.jsonl"
+        out.write_bytes(b"")
+        journal = journal_path_for(out)
+        from resources_servers.gdpval.multistage_orchestrator import append_journal_record
+
+        append_journal_record(
+            journal,
+            {
+                "stage_index": 1,
+                "status": "planned",
+                "reference_ids": ["a"],
+                "task_ids": ["t0"],
+            },
+            "FP",
+        )
+        append_journal_record(journal, {"stage_index": 1, "status": "complete"}, "FP")
+        failures_path_for(out).write_text(
+            json.dumps(
+                {
+                    "stage_index": 1,
+                    TASK_INDEX_KEY_NAME: 7,
+                    ROLLOUT_INDEX_KEY_NAME: 0,
+                    NG_FAILURE_CLASS_KEY: "timeout_exceeded",
+                    NG_TERMINAL_KEY: True,
+                    "elapsed_seconds": 123.0,
+                    "reuse_cached_deliverable": True,
+                }
+            )
+            + "\n"
+        )
+
+        resume = build_file_resume(out, journal, "FP")
+
+        assert 1 not in resume.outcomes
+        assert (7, 0) not in resume.gated_keys.get(1, set())
+        assert load_failure_timings(out)[1][(7, 0)] == 123.0
+        assert load_failure_attempts(out)[1][(7, 0)] == 1
+        assert load_reuse_cached_keys(out)[1] == {(7, 0)}
+        assert resume.reuse_cached_keys[1] == {(7, 0)}
+        assert resume.attempts_by_stage[1][(7, 0)] == 1
+
+    def test_legacy_invalid_judge_main_row_migrates_before_resume(self, tmp_path: Path) -> None:
+        out = tmp_path / "rollouts.jsonl"
+        deliverables_dir = tmp_path / "deliverables" / "task-4"
+        deliverables_dir.mkdir(parents=True)
+        (deliverables_dir / "answer.txt").write_text("answer")
+        out.write_text(
+            json.dumps(
+                {
+                    "stage_index": 0,
+                    TASK_INDEX_KEY_NAME: 4,
+                    ROLLOUT_INDEX_KEY_NAME: 0,
+                    "task_id": "t4",
+                    "invalid_judge_response": True,
+                    "reward": 0.0,
+                    "deliverables_dir": str(deliverables_dir),
+                }
+            )
+            + "\n"
+        )
+        journal = journal_path_for(out)
+        from resources_servers.gdpval.multistage_orchestrator import append_journal_record
+
+        append_journal_record(
+            journal,
+            {"stage_index": 0, "status": "planned", "reference_ids": ["a"], "task_ids": ["t4"]},
+            "FP",
+        )
+        append_journal_record(journal, {"stage_index": 0, "status": "complete"}, "FP")
+
+        resume = build_file_resume(out, journal, "FP")
+
+        assert out.read_bytes() == b""
+        assert resume.rows_by_stage == {}
+        assert resume.outcomes == {}
+        assert resume.reuse_cached_keys[0] == {(4, 0)}
+        assert resume.attempts_by_stage[0][(4, 0)] == 1
+        migrated = [json.loads(line) for line in failures_path_for(out).read_text().splitlines()]
+        assert len(migrated) == 1
+        assert migrated[0][NG_FAILURE_CLASS_KEY] == "judge_invalid"
+        assert migrated[0]["reuse_cached_deliverable"] is True
+
+    def test_skipped_failure_keeps_stage_complete(self, tmp_path: Path) -> None:
+        out = tmp_path / "rollouts.jsonl"
+        out.write_bytes(b"")
+        journal = journal_path_for(out)
+        from resources_servers.gdpval.multistage_orchestrator import append_journal_record
+
+        append_journal_record(journal, {"stage_index": 0, "status": "complete"}, "FP")
+        failures_path_for(out).write_text(
+            json.dumps(
+                {
+                    "stage_index": 0,
+                    TASK_INDEX_KEY_NAME: 7,
+                    ROLLOUT_INDEX_KEY_NAME: 0,
+                    NG_FAILURE_CLASS_KEY: "skipped",
+                    NG_TERMINAL_KEY: True,
+                }
+            )
+            + "\n"
+        )
+
+        resume = build_file_resume(out, journal, "FP")
+
+        assert 0 in resume.outcomes
+        assert (7, 0) in resume.gated_keys[0]
+
     async def test_failure_row_redispatched_but_terminal_not(self) -> None:
         # A failed (non-terminal, below max) row is re-dispatched; a terminal one is not.
         task_ids = [f"t{i}" for i in range(10)]
@@ -939,12 +1686,14 @@ class TestPrepareResume:
     def test_resume_disabled_clears_existing_and_empties_state(self, tmp_path: Path) -> None:
         out = tmp_path / "rollouts.jsonl"
         journal = journal_path_for(out)
+        metrics = tmp_path / "rollouts_aggregate_metrics.json"
         out.write_text('{"x": 1}\n')
         journal.write_text('{"stage_index": 0, "status": "complete"}\n')
+        metrics.write_text('{"stale": true}\n')
         fp = compute_fingerprint(_two_stage_cfg(), REF_ELOS, _distribution(["t0"]))
         resume = _prepare_resume(self._cfg(False), out, journal, fp)
         assert isinstance(resume, StageResume)
-        assert not out.exists() and not journal.exists()
+        assert not out.exists() and not journal.exists() and not metrics.exists()
         assert resume.outcomes == {}
 
     def test_stale_fingerprint_clears_and_starts_fresh(self, tmp_path: Path) -> None:
@@ -988,3 +1737,73 @@ class TestPrepareResume:
         assert all(s["cached"] for s in again)
         assert [s["reference_ids"] for s in again] == [s["reference_ids"] for s in base]
         assert [s["eval_elo"] for s in again] == [s["eval_elo"] for s in base]
+
+
+class TestIntegrationWiring:
+    async def test_multistage_forwards_one_budget_and_shared_tracker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: List[Dict[str, Any]] = []
+        cache_namespaces: List[str] = []
+
+        class FakeHelper:
+            def _preprocess_rows_from_config(self, config):
+                return _materialized_rows(["t0"])
+
+            def run_examples(self, rows, **kwargs):
+                calls.append(kwargs)
+                cache_namespaces.extend(row["verify_cache_namespace"] for row in rows)
+
+                async def done(row):
+                    reference_id = row["reference_ids"][0]
+                    return row, {
+                        "task_id": row["task_id"],
+                        "per_reference": {
+                            reference_id: {
+                                "wins": 1,
+                                "losses": 0,
+                                "ties": 0,
+                                "reference_elo": REF_ELOS[reference_id],
+                            }
+                        },
+                    }
+
+                return [done(row) for row in rows]
+
+            async def _call_aggregate_metrics(self, results, rows, output_fpath):
+                return tmp_path / "aggregate.json"
+
+        monkeypatch.setattr(rollout_collection_module, "RolloutCollectionHelper", FakeHelper)
+        monkeypatch.setattr(
+            "resources_servers.gdpval.multistage_orchestrator.ensure_distribution",
+            lambda *args, **kwargs: (_distribution(["t0"]), None),
+        )
+        config = SimpleNamespace(
+            input_jsonl_fpath=str(tmp_path / "input.jsonl"),
+            output_jsonl_fpath=str(tmp_path / "rollouts.jsonl"),
+            num_samples_in_parallel=2,
+            dispatch_budget_s=120.0,
+            drain_margin_s=15.0,
+            dispatch_longest_first=True,
+            resume_from_cache=False,
+        )
+        global_config = {
+            "multistage": {"enabled": True, "stages": ["1", "1"], "seed": 0},
+            "gdpval": {
+                "resources_servers": {
+                    "gdpval": {"reference_models": {key: {"elo": elo} for key, elo in REF_ELOS.items()}}
+                }
+            },
+        }
+
+        await run_e2e_multistage(config, global_config)
+
+        assert len(calls) == 2
+        assert calls[0]["latency_tracker"] is calls[1]["latency_tracker"]
+        assert 0 <= calls[1]["dispatch_budget_s"] <= calls[0]["dispatch_budget_s"] <= 120.0
+        assert [call["drain_margin_s"] for call in calls] == [15.0, 15.0]
+        persisted = [json.loads(line) for line in (tmp_path / "rollouts.jsonl").read_text().splitlines()]
+        assert {row["expected_final_stage_index"] for row in persisted} == {1}
+        assert {row["expected_stage_row_count"] for row in persisted} == {1}
+        assert len(set(cache_namespaces)) == 1
+        assert len(cache_namespaces[0]) == 64

--- a/resources_servers/gdpval/tests/test_multistage_orchestrator.py
+++ b/resources_servers/gdpval/tests/test_multistage_orchestrator.py
@@ -19,7 +19,7 @@ import json
 from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
@@ -41,6 +41,8 @@ from resources_servers.gdpval.multistage_orchestrator import (
     MultiStageRunConfig,
     StageResume,
     _prepare_resume,
+    aggregate_metrics_path_for,
+    append_journal_record,
     build_file_resume,
     build_stage_rows,
     compute_fingerprint,
@@ -50,6 +52,8 @@ from resources_servers.gdpval.multistage_orchestrator import (
     load_failure_attempts,
     load_failure_timings,
     load_gated_keys,
+    load_latest_attempt_dispositions,
+    load_latest_failures,
     load_persisted_rows,
     load_reuse_cached_keys,
     parse_multistage_config,
@@ -136,6 +140,66 @@ class TestParseConfig:
     def test_empty_stages_raises(self) -> None:
         with pytest.raises(ValueError):
             parse_multistage_config({"enabled": True, "stages": []})
+
+    def test_parses_partial_completion_policy(self) -> None:
+        cfg = parse_multistage_config(
+            {
+                "enabled": True,
+                "stages": [
+                    {
+                        "num_tasks": 45,
+                        "partial_completion": {
+                            "min_success_fraction": 0.9,
+                            "min_per_reference_success_fraction": 0.5,
+                            "min_successful_rows_per_reference": 1,
+                        },
+                    },
+                    {"num_tasks": 220, "num_models": 4},
+                ],
+            }
+        )
+
+        policy = cfg.stages[0].partial_completion
+        assert policy is not None
+        assert policy.min_success_fraction == 0.9
+        assert policy.min_per_reference_success_fraction == 0.5
+        assert policy.min_successful_rows_per_reference == 1
+        assert cfg.stages[1].partial_completion is None
+
+    @pytest.mark.parametrize(
+        "partial_completion",
+        [
+            {"min_success_fraction": 0},
+            {"min_success_fraction": True},
+            {"min_per_reference_success_fraction": 1.1},
+            {"min_successful_rows_per_reference": 0},
+            {"min_successful_rows_per_reference": True},
+            {"allowed_failure_classes": ["transient"]},
+        ],
+    )
+    def test_rejects_unsafe_partial_completion_policy(self, partial_completion: Dict[str, Any]) -> None:
+        with pytest.raises(ValueError):
+            parse_multistage_config(
+                {
+                    "enabled": True,
+                    "stages": [
+                        {"num_tasks": 5, "partial_completion": partial_completion},
+                        {"num_tasks": 10, "num_models": 2},
+                    ],
+                }
+            )
+
+    def test_rejects_partial_completion_on_final_stage(self) -> None:
+        with pytest.raises(ValueError, match="non-final calibration stages"):
+            parse_multistage_config(
+                {
+                    "enabled": True,
+                    "stages": [
+                        {"num_tasks": 5},
+                        {"num_tasks": 10, "partial_completion": {"min_success_fraction": 0.9}},
+                    ],
+                }
+            )
 
 
 class TestFindReferenceElos:
@@ -537,10 +601,13 @@ class RecordingResume(StageResume):
         elapsed_by_stage=None,
         reuse_cached_keys=None,
         attempts_by_stage=None,
+        latest_failures_by_stage=None,
+        latest_attempt_dispositions_by_stage=None,
     ) -> None:
         self.planned: List[Tuple[int, dict]] = []
         self.completed: List[Tuple[int, dict]] = []
         self.appended: Dict[int, List[Dict[str, Any]]] = {}
+        self.restarted: List[int] = []
         rows_by_stage = dict(rows_by_stage or {})
         if gated_keys is None:
             gated_keys = {
@@ -555,9 +622,12 @@ class RecordingResume(StageResume):
             on_plan=lambda i, p: self.planned.append((i, p)),
             on_outcome=lambda i, o: self.completed.append((i, o)),
             on_rows=lambda i, r: self.appended.setdefault(i, []).extend(r),
+            on_restart=self.restarted.append,
             elapsed_by_stage=dict(elapsed_by_stage or {}),
             reuse_cached_keys=dict(reuse_cached_keys or {}),
             attempts_by_stage=dict(attempts_by_stage or {}),
+            latest_failures_by_stage=dict(latest_failures_by_stage or {}),
+            latest_attempt_dispositions_by_stage=dict(latest_attempt_dispositions_by_stage or {}),
         )
 
 
@@ -742,7 +812,61 @@ class TestResumeSeam:
         assert len(results) == len(full_results)
         assert result_summaries[0].get("cached") is not True
 
-    async def test_resumed_empty_fit_preserves_prior_elo_for_next_stage(self) -> None:
+    async def test_reopened_calibration_invalidates_dependent_stage(self) -> None:
+        task_ids = ["t0", "t1", "t2"]
+        rows = _materialized_rows(task_ids)
+        cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["3", "3:2"]}).stages,
+            seed=0,
+        )
+        baseline_resume = RecordingResume()
+        successful_run = _fake_run_rollouts_factory()
+        baseline_results, _ = await run_multistage_stages(
+            cfg,
+            REF_ELOS,
+            _distribution(task_ids),
+            rows,
+            successful_run,
+            resume=baseline_resume,
+        )
+        rows_by_stage = {
+            stage_index: [row for row in baseline_results if row["stage_index"] == stage_index]
+            for stage_index in (0, 1)
+        }
+        missing = rows_by_stage[0].pop()
+        missing_key = (missing[TASK_INDEX_KEY_NAME], missing[ROLLOUT_INDEX_KEY_NAME])
+        resumed = RecordingResume(
+            plans=dict(baseline_resume.planned),
+            outcomes=dict(baseline_resume.completed),
+            rows_by_stage=rows_by_stage,
+        )
+        dispatched: List[Tuple[int, Tuple[int, int]]] = []
+
+        async def capture(rows_in: List[Dict[str, Any]]):
+            dispatched.extend(
+                (
+                    row["stage_index"],
+                    (row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME]),
+                )
+                for row in rows_in
+            )
+            return await successful_run(rows_in)
+
+        await run_multistage_stages(
+            cfg,
+            REF_ELOS,
+            _distribution(task_ids),
+            rows,
+            capture,
+            resume=resumed,
+        )
+
+        assert resumed.restarted == [0]
+        assert [key for stage, key in dispatched if stage == 0] == [missing_key]
+        assert len([key for stage, key in dispatched if stage == 1]) == 3
+
+    async def test_resumed_empty_fit_blocks_adaptive_next_stage(self) -> None:
         task_ids = [f"t{i}" for i in range(6)]
         rows = _materialized_rows(task_ids)
         cfg = MultiStageRunConfig(
@@ -804,8 +928,10 @@ class TestResumeSeam:
             resume=resumed,
         )
 
-        assert set(dispatched_stages) == {2}
-        assert resumed_summaries[2]["reference_ids"] == baseline_summaries[2]["reference_ids"]
+        assert dispatched_stages == []
+        assert len(resumed_summaries) == 2
+        assert resumed_summaries[0]["cached"] is True
+        assert resumed_summaries[1]["eval_elo"] is None
 
     async def test_plan_replay_is_deterministic_without_seed(self) -> None:
         task_ids = [f"t{i}" for i in range(10)]
@@ -936,70 +1062,125 @@ class TestResumeSeam:
         assert seen == [(0, False), (1, True)]
 
     async def test_gated_sidecar_artifact_is_produced_for_later_stages(self) -> None:
-        task_ids = ["t0"]
+        task_ids = ["t0", "t1"]
         rows = _materialized_rows(task_ids)
         cfg = MultiStageRunConfig(
             enabled=True,
-            stages=parse_multistage_config({"enabled": True, "stages": ["1", "1"]}).stages,
+            stages=parse_multistage_config(
+                {
+                    "enabled": True,
+                    "stages": [
+                        {
+                            "num_tasks": 2,
+                            "partial_completion": {
+                                "min_success_fraction": 0.5,
+                                "min_per_reference_success_fraction": 0.5,
+                            },
+                        },
+                        {"num_tasks": 2},
+                    ],
+                }
+            ).stages,
             seed=0,
         )
+        cached_success = {
+            **rows[1],
+            "stage_index": 0,
+            "reference_ids": ["a"],
+            "per_reference": {"a": {"wins": 1, "losses": 0, "ties": 0, "reference_elo": REF_ELOS["a"]}},
+        }
         # Stage 0's judge-invalid row exhausted its attempts, but its sidecar
         # flag proves that the reference-independent policy artifact exists.
         resume = RecordingResume(
-            gated_keys={0: {(0, 0)}},
+            plans={
+                0: {
+                    "stage_index": 0,
+                    "status": "planned",
+                    "reference_ids": ["a"],
+                    "task_ids": task_ids,
+                    "task_reference_ids": {task_id: "a" for task_id in task_ids},
+                }
+            },
+            rows_by_stage={0: [cached_success]},
+            gated_keys={0: {(0, 0), (1, 0)}},
             reuse_cached_keys={0: {(0, 0)}},
             attempts_by_stage={0: {(0, 0): 3}},
         )
-        seen: List[Tuple[int, bool]] = []
+        seen: List[Tuple[int, int, bool]] = []
         run = _fake_run_rollouts_factory()
 
         async def capturing_run(rows_in: List[Dict[str, Any]]):
-            seen.extend((row["stage_index"], bool(row.get("reuse_cached_deliverable"))) for row in rows_in)
+            seen.extend(
+                (row["stage_index"], row[TASK_INDEX_KEY_NAME], bool(row.get("reuse_cached_deliverable")))
+                for row in rows_in
+            )
             return await run(rows_in)
 
         await run_multistage_stages(cfg, REF_ELOS, _distribution(task_ids), rows, capturing_run, resume=resume)
 
-        assert seen == [(1, True)]
+        assert sorted(seen) == [(1, 0, True), (1, 1, True)]
 
     async def test_new_terminal_judge_failure_reuses_artifact_in_next_stage(self) -> None:
-        task_ids = ["t0"]
+        task_ids = ["t0", "t1"]
         rows = _materialized_rows(task_ids)
         cfg = MultiStageRunConfig(
             enabled=True,
-            stages=parse_multistage_config({"enabled": True, "stages": ["1", "1"]}).stages,
+            stages=parse_multistage_config(
+                {
+                    "enabled": True,
+                    "stages": [
+                        {
+                            "num_tasks": 2,
+                            "partial_completion": {
+                                "min_success_fraction": 0.5,
+                                "min_per_reference_success_fraction": 0.5,
+                            },
+                        },
+                        {"num_tasks": 2},
+                    ],
+                }
+            ).stages,
             seed=0,
         )
-        seen: List[Tuple[int, bool]] = []
+        seen: List[Tuple[int, int, bool]] = []
         success_run = _fake_run_rollouts_factory()
 
         async def terminal_then_success(rows_in: List[Dict[str, Any]]):
-            seen.extend((row["stage_index"], bool(row.get("reuse_cached_deliverable"))) for row in rows_in)
+            seen.extend(
+                (row["stage_index"], row[TASK_INDEX_KEY_NAME], bool(row.get("reuse_cached_deliverable")))
+                for row in rows_in
+            )
             if rows_in and rows_in[0]["stage_index"] == 0:
-                return [
-                    (
-                        row,
-                        {
-                            NG_FAILURE_CLASS_KEY: "permanent",
-                            NG_TERMINAL_KEY: True,
-                            "reuse_cached_deliverable": True,
-                            "deliverables_dir": "/cached/task_t0/repeat_0",
-                        },
-                    )
-                    for row in rows_in
-                ]
+                pairs = await success_run(rows_in)
+                row, _ = pairs[0]
+                pairs[0] = (
+                    row,
+                    {
+                        NG_FAILURE_CLASS_KEY: "permanent",
+                        NG_TERMINAL_KEY: True,
+                        "reuse_cached_deliverable": True,
+                        "deliverables_dir": "/cached/task_t0/repeat_0",
+                    },
+                )
+                return pairs
             return await success_run(rows_in)
 
         await run_multistage_stages(
             cfg,
-            REF_ELOS,
+            {"a": REF_ELOS["a"]},
             _distribution(task_ids),
             rows,
             terminal_then_success,
         )
 
-        assert seen == [(0, False), (1, True)]
+        assert sorted(seen) == [
+            (0, 0, False),
+            (0, 1, False),
+            (1, 0, True),
+            (1, 1, True),
+        ]
 
-    async def test_third_failure_is_resolved_without_fourth_invocation(self) -> None:
+    async def test_third_failure_stops_adaptive_stage_without_fourth_invocation(self) -> None:
         task_ids = ["t0"]
         rows = _materialized_rows(task_ids)
         cfg = MultiStageRunConfig(
@@ -1023,8 +1204,8 @@ class TestResumeSeam:
             cfg, REF_ELOS, _distribution(task_ids), rows, fail_third_then_succeed, resume=resume
         )
 
-        assert seen_attempts == [(0, 2), (1, None)]
-        assert [index for index, _ in resume.completed] == [0, 1]
+        assert seen_attempts == [(0, 2)]
+        assert resume.completed == []
         assert resume.appended[0][0][ATTEMPT_INDEX_KEY_NAME] == 2
 
     async def test_drained_stage_is_not_marked_complete(self) -> None:
@@ -1087,6 +1268,901 @@ class TestResumeSeam:
         assert [index for index, _ in resume.completed] == [0]
 
 
+class TestPartialStageCompletion:
+    @staticmethod
+    def _config(
+        *,
+        enabled: bool,
+        min_success_fraction: float = 0.6,
+        min_per_reference_success_fraction: float = 0.6,
+        min_successful_rows_per_reference: int = 1,
+    ) -> MultiStageRunConfig:
+        first_stage: Dict[str, Any] = {"num_tasks": 10}
+        if enabled:
+            first_stage["partial_completion"] = {
+                "min_success_fraction": min_success_fraction,
+                "min_per_reference_success_fraction": min_per_reference_success_fraction,
+                "min_successful_rows_per_reference": min_successful_rows_per_reference,
+            }
+        return MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config(
+                {
+                    "enabled": True,
+                    "stages": [first_stage, {"num_tasks": 10, "num_models": 1}],
+                }
+            ).stages,
+            seed=0,
+        )
+
+    @staticmethod
+    def _balanced_resume(task_ids: List[str]) -> RecordingResume:
+        return RecordingResume(
+            plans={
+                0: {
+                    "stage_index": 0,
+                    "status": "planned",
+                    "reference_ids": ["a", "b"],
+                    "task_ids": task_ids,
+                    "task_reference_ids": {
+                        task_id: ("a" if index % 2 == 0 else "b") for index, task_id in enumerate(task_ids)
+                    },
+                    "seed": None,
+                    "prior_eval_elo": None,
+                }
+            }
+        )
+
+    @staticmethod
+    def _runner(
+        failed_indices: set[int],
+        *,
+        failure_class: str = "timeout_exceeded",
+        no_persist: bool = False,
+        terminal: bool = False,
+        empty_successes: bool = False,
+        dispatched_stages: Optional[List[int]] = None,
+    ):
+        successful_run = _fake_run_rollouts_factory(target_elo=1100.0)
+
+        async def run(rows_in: List[Dict[str, Any]]) -> List[Tuple[Dict[str, Any], Dict[str, Any]]]:
+            if dispatched_stages is not None:
+                dispatched_stages.extend(row["stage_index"] for row in rows_in)
+            pairs = await successful_run(rows_in)
+            if not rows_in or rows_in[0]["stage_index"] != 0:
+                return pairs
+
+            rewritten: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+            for row, result in pairs:
+                if row[TASK_INDEX_KEY_NAME] in failed_indices:
+                    failure = {NG_FAILURE_CLASS_KEY: failure_class}
+                    if no_persist:
+                        failure[NG_NO_PERSIST_KEY] = True
+                    if terminal:
+                        failure[NG_TERMINAL_KEY] = True
+                    rewritten.append((row, failure))
+                elif empty_successes:
+                    rewritten.append((row, {"task_id": row["task_id"], "per_reference": {}}))
+                else:
+                    rewritten.append((row, result))
+            return rewritten
+
+        return run
+
+    async def test_four_retryable_timeouts_keep_default_retry_stage_open(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        resume = self._balanced_resume(task_ids)
+        dispatched_stages: List[int] = []
+
+        results, summaries = await run_multistage_stages(
+            self._config(enabled=False),
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            self._runner({0, 1, 2, 3}, dispatched_stages=dispatched_stages),
+            resume=resume,
+        )
+
+        assert set(dispatched_stages) == {0}
+        assert len([row for row in results if row["stage_index"] == 0]) == 6
+        assert len(summaries) == 1
+        assert resume.completed == []
+
+    async def test_existing_41_of_45_timeout_stage_advances_without_redispatch(self, tmp_path: Path) -> None:
+        task_ids = [f"t{i}" for i in range(45)]
+        rows = _materialized_rows(task_ids)
+        reference_elos = {f"ref_{index}": 600.0 + 100.0 * index for index in range(9)}
+        reference_ids = list(reference_elos)
+        strict_cfg = parse_multistage_config(
+            {
+                "enabled": True,
+                "stages": [{"num_tasks": 45}, {"num_tasks": 45, "num_models": 4}],
+                "seed": 0,
+            }
+        )
+        partial_cfg = parse_multistage_config(
+            {
+                "enabled": True,
+                "stages": [
+                    {
+                        "num_tasks": 45,
+                        "partial_completion": {
+                            "min_success_fraction": 0.9,
+                            "min_per_reference_success_fraction": 0.8,
+                            "min_successful_rows_per_reference": 1,
+                        },
+                    },
+                    {"num_tasks": 45, "num_models": 4},
+                ],
+                "seed": 0,
+            }
+        )
+        distribution = _distribution(task_ids)
+        strict_fingerprint = compute_fingerprint(strict_cfg, reference_elos, distribution)
+        partial_fingerprint = compute_fingerprint(partial_cfg, reference_elos, distribution)
+        assert partial_fingerprint == strict_fingerprint
+
+        output = tmp_path / "rollouts.jsonl"
+        output.write_bytes(b"")
+        journal = journal_path_for(output)
+        task_reference_ids = {task_id: reference_ids[index // 5] for index, task_id in enumerate(task_ids)}
+        append_journal_record(
+            journal,
+            {
+                "stage_index": 0,
+                "status": "planned",
+                "reference_ids": reference_ids,
+                "task_ids": task_ids,
+                "task_reference_ids": task_reference_ids,
+                "seed": None,
+                "prior_eval_elo": None,
+            },
+            strict_fingerprint,
+        )
+
+        async def successful(rows_in: List[Dict[str, Any]]):
+            pairs = []
+            for row in rows_in:
+                reference_id = row["reference_ids"][0]
+                reference_elo = reference_elos[reference_id]
+                wins = 6 if reference_elo < 1000 else 4
+                pairs.append(
+                    (
+                        row,
+                        {
+                            "task_id": row["task_id"],
+                            "per_reference": {
+                                reference_id: {
+                                    "wins": wins,
+                                    "losses": 10 - wins,
+                                    "ties": 0,
+                                    "reference_elo": reference_elo,
+                                }
+                            },
+                        },
+                    )
+                )
+            return pairs
+
+        timeout_indices = {0, 5, 10, 15}
+
+        async def first_allocation(rows_in: List[Dict[str, Any]]):
+            assert {row["stage_index"] for row in rows_in} == {0}
+            pairs = await successful(rows_in)
+            return [
+                (row, {NG_FAILURE_CLASS_KEY: "timeout_exceeded"})
+                if row[TASK_INDEX_KEY_NAME] in timeout_indices
+                else (row, result)
+                for row, result in pairs
+            ]
+
+        first_results, first_summaries = await run_multistage_stages(
+            strict_cfg,
+            reference_elos,
+            distribution,
+            rows,
+            first_allocation,
+            resume=build_file_resume(output, journal, strict_fingerprint),
+        )
+        assert len(first_results) == 41
+        assert len(first_summaries) == 1
+        assert read_journal(journal)[1] == {}
+        assert set(load_latest_failures(output)[0]) == {(index, 0) for index in timeout_indices}
+
+        dispatched_stages: List[int] = []
+
+        async def resumed_allocation(rows_in: List[Dict[str, Any]]):
+            dispatched_stages.extend(row["stage_index"] for row in rows_in)
+            if any(row["stage_index"] == 0 for row in rows_in):
+                pytest.fail("persisted Stage-0 timeouts were unexpectedly redispatched")
+            pairs = await successful(rows_in)
+            row, _ = pairs[-1]
+            pairs[-1] = (row, {NG_FAILURE_CLASS_KEY: "kill_shaped", NG_NO_PERSIST_KEY: True})
+            return pairs
+
+        resumed_results, resumed_summaries = await run_multistage_stages(
+            partial_cfg,
+            reference_elos,
+            distribution,
+            rows,
+            resumed_allocation,
+            resume=build_file_resume(output, journal, partial_fingerprint),
+        )
+
+        assert set(dispatched_stages) == {1}
+        assert len([row for row in resumed_results if row["stage_index"] == 0]) == 41
+        assert len([row for row in resumed_results if row["stage_index"] == 1]) == 44
+        assert resumed_summaries[0]["partial"] is True
+        assert resumed_summaries[0]["success_fraction"] == pytest.approx(41 / 45)
+        plans, outcomes, fingerprint = read_journal(journal)
+        assert fingerprint == partial_fingerprint
+        assert 1 in plans
+        assert outcomes[0]["status"] == "partial_complete"
+        assert len(outcomes[0]["omitted_keys"]) == 4
+        assert 1 not in outcomes
+        assert all(record["success_fraction"] >= 0.8 for record in outcomes[0]["per_reference"].values())
+
+        final_dispatches: List[Tuple[int, int]] = []
+
+        async def finish_final_stage(rows_in: List[Dict[str, Any]]):
+            final_dispatches.extend((row["stage_index"], row[TASK_INDEX_KEY_NAME]) for row in rows_in)
+            return await successful(rows_in)
+
+        final_results, final_summaries = await run_multistage_stages(
+            partial_cfg,
+            reference_elos,
+            distribution,
+            rows,
+            finish_final_stage,
+            resume=build_file_resume(output, journal, partial_fingerprint),
+        )
+
+        assert len(final_dispatches) == 1
+        assert final_dispatches[0][0] == 1
+        assert len([row for row in final_results if row["stage_index"] == 0]) == 41
+        assert len([row for row in final_results if row["stage_index"] == 1]) == 45
+        assert len(final_summaries) == 2
+        assert read_journal(journal)[1][1]["status"] == "complete"
+
+    async def test_no_persist_retry_overrides_older_timeout_on_resume(self, tmp_path: Path) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        rows = _materialized_rows(task_ids)
+        cfg = parse_multistage_config(
+            {
+                "enabled": True,
+                "stages": [
+                    {
+                        "num_tasks": 10,
+                        "partial_completion": {
+                            "min_success_fraction": 0.8,
+                            "min_per_reference_success_fraction": 0.8,
+                        },
+                    },
+                    {"num_tasks": 10, "num_models": 1},
+                ],
+                "seed": 0,
+            }
+        )
+        reference_elos = {"a": 1000.0}
+        distribution = _distribution(task_ids)
+        output = tmp_path / "rollouts.jsonl"
+        journal = journal_path_for(output)
+        fingerprint = compute_fingerprint(cfg, reference_elos, distribution)
+        successful_run = _fake_run_rollouts_factory(target_elo=1100.0)
+
+        async def first_attempt(rows_in: List[Dict[str, Any]]):
+            pairs = await successful_run(rows_in)
+            return [
+                (row, {NG_FAILURE_CLASS_KEY: "timeout_exceeded"})
+                if row["stage_index"] == 0 and row[TASK_INDEX_KEY_NAME] >= 6
+                else (row, result)
+                for row, result in pairs
+            ]
+
+        _, first_summaries = await run_multistage_stages(
+            cfg,
+            reference_elos,
+            distribution,
+            rows,
+            first_attempt,
+            resume=build_file_resume(output, journal, fingerprint),
+        )
+        assert len(first_summaries) == 1
+
+        async def drained_retry(rows_in: List[Dict[str, Any]]):
+            pairs = await successful_run(rows_in)
+            return [
+                (
+                    row,
+                    {NG_FAILURE_CLASS_KEY: "kill_shaped", NG_NO_PERSIST_KEY: True},
+                )
+                if row[TASK_INDEX_KEY_NAME] >= 8
+                else (row, result)
+                for row, result in pairs
+            ]
+
+        _, second_summaries = await run_multistage_stages(
+            cfg,
+            reference_elos,
+            distribution,
+            rows,
+            drained_retry,
+            resume=build_file_resume(output, journal, fingerprint),
+        )
+        assert len(second_summaries) == 1
+        dispositions = load_latest_attempt_dispositions(journal)[0]
+        assert dispositions[(8, 0)][NG_NO_PERSIST_KEY] is True
+        assert dispositions[(9, 0)][NG_NO_PERSIST_KEY] is True
+
+        dispatched: List[Tuple[int, int]] = []
+
+        async def final_retry(rows_in: List[Dict[str, Any]]):
+            dispatched.extend((row["stage_index"], row[TASK_INDEX_KEY_NAME]) for row in rows_in)
+            return await successful_run(rows_in)
+
+        _, final_summaries = await run_multistage_stages(
+            cfg,
+            reference_elos,
+            distribution,
+            rows,
+            final_retry,
+            resume=build_file_resume(output, journal, fingerprint),
+        )
+
+        assert sorted(index for stage, index in dispatched if stage == 0) == [8, 9]
+        assert {stage for stage, _ in dispatched} == {0, 1}
+        assert len(final_summaries) == 2
+
+    async def test_newer_sidecar_failure_overrides_older_timeout_disposition(self, tmp_path: Path) -> None:
+        task_ids = [f"t{i}" for i in range(5)]
+        rows = _materialized_rows(task_ids)
+        strict_cfg = parse_multistage_config(
+            {
+                "enabled": True,
+                "stages": [{"num_tasks": 5}, {"num_tasks": 5, "num_models": 1}],
+                "seed": 0,
+            }
+        )
+        partial_cfg = parse_multistage_config(
+            {
+                "enabled": True,
+                "stages": [
+                    {
+                        "num_tasks": 5,
+                        "partial_completion": {
+                            "min_success_fraction": 0.8,
+                            "min_per_reference_success_fraction": 0.8,
+                        },
+                    },
+                    {"num_tasks": 5, "num_models": 1},
+                ],
+                "seed": 0,
+            }
+        )
+        reference_elos = {"a": 1000.0}
+        distribution = _distribution(task_ids)
+        output = tmp_path / "rollouts.jsonl"
+        journal = journal_path_for(output)
+        fingerprint = compute_fingerprint(strict_cfg, reference_elos, distribution)
+        assert compute_fingerprint(partial_cfg, reference_elos, distribution) == fingerprint
+        successful_run = _fake_run_rollouts_factory(target_elo=1100.0)
+
+        async def initial_timeout(rows_in: List[Dict[str, Any]]):
+            pairs = await successful_run(rows_in)
+            return [
+                (row, {NG_FAILURE_CLASS_KEY: "timeout_exceeded"}) if row[TASK_INDEX_KEY_NAME] == 4 else (row, result)
+                for row, result in pairs
+            ]
+
+        _, first_summaries = await run_multistage_stages(
+            strict_cfg,
+            reference_elos,
+            distribution,
+            rows,
+            initial_timeout,
+            resume=build_file_resume(output, journal, fingerprint),
+        )
+        assert len(first_summaries) == 1
+        timeout = load_latest_failures(output)[0][(4, 0)]
+        assert load_latest_attempt_dispositions(journal)[0][(4, 0)][NG_FAILURE_CLASS_KEY] == "timeout_exceeded"
+
+        # Simulate a crash after the newer sidecar row is fsynced but before its
+        # disposition is appended to the journal.
+        route_stage_rows(output, [{**timeout, NG_FAILURE_CLASS_KEY: "transient"}])
+        assert load_latest_failures(output)[0][(4, 0)][NG_FAILURE_CLASS_KEY] == "transient"
+        assert load_latest_attempt_dispositions(journal)[0][(4, 0)][NG_FAILURE_CLASS_KEY] == "timeout_exceeded"
+
+        dispatched: List[Tuple[int, int]] = []
+
+        async def capture(rows_in: List[Dict[str, Any]]):
+            dispatched.extend((row["stage_index"], row[TASK_INDEX_KEY_NAME]) for row in rows_in)
+            return await successful_run(rows_in)
+
+        _, summaries = await run_multistage_stages(
+            partial_cfg,
+            reference_elos,
+            distribution,
+            rows,
+            capture,
+            resume=build_file_resume(output, journal, fingerprint),
+        )
+
+        assert [task_index for stage, task_index in dispatched if stage == 0] == [4]
+        assert {stage for stage, _ in dispatched} == {0, 1}
+        assert len(summaries) == 2
+
+    async def test_explicit_timeout_only_policy_advances_with_balanced_coverage(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        resume = self._balanced_resume(task_ids)
+        dispatched_stages: List[int] = []
+
+        results, summaries = await run_multistage_stages(
+            self._config(enabled=True),
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            self._runner({0, 1, 2, 3}, dispatched_stages=dispatched_stages),
+            resume=resume,
+        )
+
+        assert set(dispatched_stages) == {0, 1}
+        assert len(summaries) == 2
+        assert summaries[0]["partial"] is True
+        assert summaries[0]["success_fraction"] == pytest.approx(0.6)
+        assert summaries[0]["num_omitted"] == 4
+        assert len([row for row in results if row["stage_index"] == 1]) == 10
+        assert [index for index, _ in resume.completed] == [0, 1]
+        outcome = resume.completed[0][1]
+        assert outcome["status"] == "partial_complete"
+        assert len(outcome["included_keys"]) == 6
+        assert len(outcome["omitted_keys"]) == 4
+        assert outcome["per_reference"]["a"]["success_fraction"] == pytest.approx(0.6)
+        assert outcome["per_reference"]["b"]["success_fraction"] == pytest.approx(0.6)
+
+    @pytest.mark.parametrize(
+        ("failure_class", "no_persist"),
+        [("transient", False), ("timeout_exceeded", True)],
+    )
+    async def test_policy_rejects_non_timeout_or_unpersisted_omissions(
+        self, failure_class: str, no_persist: bool
+    ) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        resume = self._balanced_resume(task_ids)
+        dispatched_stages: List[int] = []
+
+        _, summaries = await run_multistage_stages(
+            self._config(enabled=True),
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            self._runner(
+                {0, 1, 2, 3},
+                failure_class=failure_class,
+                no_persist=no_persist,
+                dispatched_stages=dispatched_stages,
+            ),
+            resume=resume,
+        )
+
+        assert set(dispatched_stages) == {0}
+        assert len(summaries) == 1
+        assert resume.completed == []
+
+    async def test_policy_rejects_missing_elo_fit(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        resume = self._balanced_resume(task_ids)
+
+        _, summaries = await run_multistage_stages(
+            self._config(enabled=True),
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            self._runner({0, 1, 2, 3}, empty_successes=True),
+            resume=resume,
+        )
+
+        assert summaries[0]["eval_elo"] is None
+        assert len(summaries) == 1
+        assert resume.completed == []
+
+    async def test_policy_rejects_one_success_row_without_battle_evidence(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        resume = self._balanced_resume(task_ids)
+        successful_run = _fake_run_rollouts_factory(target_elo=1100.0)
+
+        async def one_empty_battle(rows_in: List[Dict[str, Any]]):
+            pairs = await successful_run(rows_in)
+            if rows_in and rows_in[0]["stage_index"] == 0:
+                row, result = pairs[0]
+                pairs[0] = (row, {**result, "per_reference": {}})
+            return pairs
+
+        _, summaries = await run_multistage_stages(
+            self._config(enabled=True, min_success_fraction=0.8),
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            one_empty_battle,
+            resume=resume,
+        )
+
+        assert len(summaries) == 1
+        assert resume.completed == []
+
+    async def test_policy_requires_evidence_for_every_selected_reference(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        resume = RecordingResume(
+            plans={
+                0: {
+                    "stage_index": 0,
+                    "status": "planned",
+                    "reference_ids": ["a", "b"],
+                    "task_ids": task_ids,
+                    "task_reference_ids": {task_id: "a" for task_id in task_ids},
+                    "seed": None,
+                    "prior_eval_elo": None,
+                }
+            }
+        )
+
+        _, summaries = await run_multistage_stages(
+            self._config(enabled=True),
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            _fake_run_rollouts_factory(target_elo=1100.0),
+            resume=resume,
+        )
+
+        assert len(summaries) == 1
+        assert resume.completed == []
+
+    async def test_policy_rejects_inadequate_per_reference_coverage(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        resume = self._balanced_resume(task_ids)
+
+        _, summaries = await run_multistage_stages(
+            self._config(enabled=True),
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            self._runner({0, 2, 4, 6}),
+            resume=resume,
+        )
+
+        assert summaries[0]["eval_elo"] is not None
+        assert len(summaries) == 1
+        assert resume.completed == []
+
+    @pytest.mark.parametrize(
+        ("min_success_fraction", "min_per_reference_success_fraction", "min_successful_rows_per_reference"),
+        [
+            (0.8, 0.5, 1),
+            (0.6, 0.5, 4),
+        ],
+        ids=["overall-fraction", "minimum-rows-per-reference"],
+    )
+    async def test_policy_enforces_independent_coverage_floors(
+        self,
+        min_success_fraction: float,
+        min_per_reference_success_fraction: float,
+        min_successful_rows_per_reference: int,
+    ) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        resume = self._balanced_resume(task_ids)
+        cfg = self._config(
+            enabled=True,
+            min_success_fraction=min_success_fraction,
+            min_per_reference_success_fraction=min_per_reference_success_fraction,
+            min_successful_rows_per_reference=min_successful_rows_per_reference,
+        )
+
+        _, summaries = await run_multistage_stages(
+            cfg,
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            self._runner({0, 1, 2, 3}),
+            resume=resume,
+        )
+
+        assert len(summaries) == 1
+        assert resume.completed == []
+
+    async def test_policy_separates_existing_terminal_and_new_timeout_omissions(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        resume = self._balanced_resume(task_ids)
+        successful_run = _fake_run_rollouts_factory(target_elo=1100.0)
+
+        async def mixed_failures(rows_in: List[Dict[str, Any]]):
+            pairs = await successful_run(rows_in)
+            if not rows_in or rows_in[0]["stage_index"] != 0:
+                return pairs
+            rewritten = []
+            for row, result in pairs:
+                task_index = row[TASK_INDEX_KEY_NAME]
+                if task_index == 0:
+                    rewritten.append((row, {NG_FAILURE_CLASS_KEY: "skipped", NG_TERMINAL_KEY: True}))
+                elif task_index in {1, 2, 3}:
+                    rewritten.append((row, {NG_FAILURE_CLASS_KEY: "timeout_exceeded"}))
+                else:
+                    rewritten.append((row, result))
+            return rewritten
+
+        _, summaries = await run_multistage_stages(
+            self._config(enabled=True),
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            mixed_failures,
+            resume=resume,
+        )
+
+        assert len(summaries) == 2
+        outcome = resume.completed[0][1]
+        assert outcome["status"] == "partial_complete"
+        assert outcome["accepted_unresolved_keys"] == [[1, 0], [2, 0], [3, 0]]
+        assert outcome["already_resolved_omitted_keys"] == [[0, 0]]
+
+    async def test_enabled_policy_is_a_coverage_floor_for_terminal_omissions(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        resume = self._balanced_resume(task_ids)
+
+        _, summaries = await run_multistage_stages(
+            self._config(
+                enabled=True,
+                min_success_fraction=0.9,
+                min_per_reference_success_fraction=0.5,
+            ),
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            self._runner({0, 1}, failure_class="skipped", terminal=True),
+            resume=resume,
+        )
+
+        assert len(summaries) == 1
+        assert resume.completed == []
+
+    async def test_policy_rejects_undispatched_row(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        resume = self._balanced_resume(task_ids)
+        successful_run = _fake_run_rollouts_factory(target_elo=1100.0)
+
+        async def omit_one_result(rows_in: List[Dict[str, Any]]):
+            pairs = await successful_run(rows_in)
+            if rows_in and rows_in[0]["stage_index"] == 0:
+                return pairs[:-1]
+            return pairs
+
+        _, summaries = await run_multistage_stages(
+            self._config(enabled=True),
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            omit_one_result,
+            resume=resume,
+        )
+
+        assert len(summaries) == 1
+        assert resume.completed == []
+
+    async def test_direct_final_stage_policy_is_rejected(self) -> None:
+        task_ids = ["t0"]
+        cfg = self._config(enabled=True)
+        cfg.stages[-1].partial_completion = cfg.stages[0].partial_completion
+
+        with pytest.raises(ValueError, match="non-final calibration stages"):
+            await run_multistage_stages(
+                cfg,
+                {"a": 1000.0},
+                _distribution(task_ids),
+                _materialized_rows(task_ids),
+                _fake_run_rollouts_factory(),
+            )
+
+    async def test_invalid_directly_constructed_policy_is_rejected(self) -> None:
+        task_ids = ["t0"]
+        cfg = self._config(enabled=True)
+        assert cfg.stages[0].partial_completion is not None
+        cfg.stages[0].partial_completion.min_success_fraction = 1.1
+
+        with pytest.raises(ValueError, match="min_success_fraction"):
+            await run_multistage_stages(
+                cfg,
+                {"a": 1000.0},
+                _distribution(task_ids),
+                _materialized_rows(task_ids),
+                _fake_run_rollouts_factory(),
+            )
+
+    async def test_cached_partial_snapshot_with_invalid_evidence_is_not_reused(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        cfg = self._config(enabled=True)
+        initial_resume = self._balanced_resume(task_ids)
+        results, _ = await run_multistage_stages(
+            cfg,
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            self._runner({0, 1, 2, 3}),
+            resume=initial_resume,
+        )
+        stage0_rows = [row for row in results if row["stage_index"] == 0]
+        corrupted_rows = [dict(row, per_reference={}) for row in stage0_rows]
+        outcome = initial_resume.completed[0][1]
+        all_stage0_keys = {(index, 0) for index in range(10)}
+        resumed = RecordingResume(
+            plans={0: initial_resume.plans[0]},
+            outcomes={0: outcome},
+            rows_by_stage={0: corrupted_rows},
+            gated_keys={0: all_stage0_keys},
+        )
+        dispatched_stages: List[int] = []
+
+        with pytest.raises(RuntimeError, match="cached partial stage 0 snapshot is invalid"):
+            await run_multistage_stages(
+                cfg,
+                {"a": 1000.0, "b": 1200.0},
+                _distribution(task_ids),
+                _materialized_rows(task_ids),
+                self._runner(set(), dispatched_stages=dispatched_stages),
+                resume=resumed,
+            )
+
+        assert dispatched_stages == []
+        assert resumed.completed == []
+
+    async def test_cached_partial_snapshot_rejects_changed_valid_evidence(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        cfg = self._config(enabled=True)
+        initial_resume = self._balanced_resume(task_ids)
+        results, _ = await run_multistage_stages(
+            cfg,
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            self._runner({0, 1, 2, 3}),
+            resume=initial_resume,
+        )
+        stage0_rows = [deepcopy(row) for row in results if row["stage_index"] == 0]
+        reference_id = next(iter(stage0_rows[0]["per_reference"]))
+        counts = stage0_rows[0]["per_reference"][reference_id]
+        counts["wins"] += 1
+        resumed = RecordingResume(
+            plans={0: initial_resume.plans[0]},
+            outcomes={0: initial_resume.completed[0][1]},
+            rows_by_stage={0: stage0_rows},
+            gated_keys={0: {(index, 0) for index in range(10)}},
+        )
+        dispatched_stages: List[int] = []
+
+        with pytest.raises(RuntimeError, match="cached partial stage 0 snapshot is invalid"):
+            await run_multistage_stages(
+                cfg,
+                {"a": 1000.0, "b": 1200.0},
+                _distribution(task_ids),
+                _materialized_rows(task_ids),
+                self._runner(set(), dispatched_stages=dispatched_stages),
+                resume=resumed,
+            )
+
+        assert dispatched_stages == []
+
+    async def test_changed_policy_does_not_reuse_frozen_partial_outcome(self) -> None:
+        task_ids = [f"t{i}" for i in range(10)]
+        initial_cfg = self._config(enabled=True)
+        initial_resume = self._balanced_resume(task_ids)
+        results, _ = await run_multistage_stages(
+            initial_cfg,
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            self._runner({0, 1, 2, 3}),
+            resume=initial_resume,
+        )
+        outcome = initial_resume.completed[0][1]
+        stage0_rows = [row for row in results if row["stage_index"] == 0]
+        resumed = RecordingResume(
+            plans={0: initial_resume.plans[0]},
+            outcomes={0: outcome},
+            rows_by_stage={0: stage0_rows},
+            gated_keys={0: {(index, 0) for index in range(10)}},
+        )
+
+        with pytest.raises(RuntimeError, match="cached partial stage 0 snapshot is invalid"):
+            await run_multistage_stages(
+                self._config(enabled=True, min_success_fraction=0.5),
+                {"a": 1000.0, "b": 1200.0},
+                _distribution(task_ids),
+                _materialized_rows(task_ids),
+                self._runner(set()),
+                resume=resumed,
+            )
+
+    async def test_file_resume_freezes_partial_rows_and_ignores_late_success(self, tmp_path: Path) -> None:
+        task_ids = [f"t{i}" for i in range(5)]
+        rows = _materialized_rows(task_ids)
+        cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config(
+                {
+                    "enabled": True,
+                    "stages": [
+                        {
+                            "num_tasks": 5,
+                            "partial_completion": {
+                                "min_success_fraction": 0.8,
+                                "min_per_reference_success_fraction": 0.8,
+                            },
+                        },
+                        {"num_tasks": 5, "num_models": 1},
+                    ],
+                }
+            ).stages,
+            seed=0,
+        )
+        reference_elos = {"a": 1000.0}
+        distribution = _distribution(task_ids)
+        output = tmp_path / "rollouts.jsonl"
+        journal = journal_path_for(output)
+        fingerprint = compute_fingerprint(cfg, reference_elos, distribution)
+
+        first_resume = build_file_resume(output, journal, fingerprint)
+        _, first_summaries = await run_multistage_stages(
+            cfg,
+            reference_elos,
+            distribution,
+            rows,
+            self._runner({4}),
+            resume=first_resume,
+        )
+        plans, outcomes, _ = read_journal(journal)
+        assert outcomes[0]["status"] == "partial_complete"
+        assert first_summaries[0]["num_omitted"] == 1
+        original_stage0_elo = first_summaries[0]["eval_elo"]
+        original_stage1_plan = deepcopy(plans[1])
+
+        omitted_key = tuple(outcomes[0]["omitted_keys"][0])
+        late_base = next(row for row in rows if (row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME]) == omitted_key)
+        route_stage_rows(
+            output,
+            [
+                {
+                    TASK_INDEX_KEY_NAME: omitted_key[0],
+                    ROLLOUT_INDEX_KEY_NAME: omitted_key[1],
+                    AGENT_REF_KEY_NAME: late_base[AGENT_REF_KEY_NAME],
+                    "stage_index": 0,
+                    "task_id": late_base["task_id"],
+                    "per_reference": {"a": {"wins": 1, "losses": 0, "ties": 0, "reference_elo": 1000.0}},
+                }
+            ],
+        )
+
+        resumed = build_file_resume(output, journal, fingerprint)
+
+        async def no_dispatch(rows_in: List[Dict[str, Any]]):
+            pytest.fail(f"completed partial run unexpectedly dispatched {len(rows_in)} row(s)")
+
+        resumed_results, resumed_summaries = await run_multistage_stages(
+            cfg,
+            reference_elos,
+            distribution,
+            rows,
+            no_dispatch,
+            resume=resumed,
+        )
+
+        resumed_stage0 = [row for row in resumed_results if row["stage_index"] == 0]
+        assert len(resumed_stage0) == 4
+        assert omitted_key not in {(row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME]) for row in resumed_stage0}
+        assert resumed_summaries[0]["partial"] is True
+        assert resumed_summaries[0]["num_rollouts"] == 5
+        assert resumed_summaries[0]["num_successful"] == 4
+        assert resumed_summaries[0]["eval_elo"] == pytest.approx(original_stage0_elo)
+        assert resumed.plans[1] == original_stage1_plan
+
+
 class TestFingerprint:
     def test_stable_and_config_sensitive(self) -> None:
         dist = _distribution(["t0", "t1", "t2"])
@@ -1121,6 +2197,35 @@ class TestFingerprint:
             "g1": {"percentage": 0.1, "task_ids": ["t2", "t3"]},
         }
         assert compute_fingerprint(cfg, REF_ELOS, dist_a) != compute_fingerprint(cfg, REF_ELOS, dist_b)
+
+    def test_partial_completion_policy_preserves_rollout_cache_fingerprint(self) -> None:
+        dist = _distribution(["t0", "t1"])
+        strict = parse_multistage_config(
+            {"enabled": True, "stages": [{"num_tasks": 1}, {"num_tasks": 2, "num_models": 1}]}
+        )
+        partial = parse_multistage_config(
+            {
+                "enabled": True,
+                "stages": [
+                    {
+                        "num_tasks": 1,
+                        "partial_completion": {
+                            "min_success_fraction": 0.9,
+                            "min_per_reference_success_fraction": 0.5,
+                        },
+                    },
+                    {"num_tasks": 2, "num_models": 1},
+                ],
+            }
+        )
+        changed_threshold = deepcopy(partial)
+        assert changed_threshold.stages[0].partial_completion is not None
+        changed_threshold.stages[0].partial_completion.min_success_fraction = 0.8
+
+        strict_fingerprint = compute_fingerprint(strict, REF_ELOS, dist)
+        partial_fingerprint = compute_fingerprint(partial, REF_ELOS, dist)
+        assert partial_fingerprint == strict_fingerprint
+        assert compute_fingerprint(changed_threshold, REF_ELOS, dist) == partial_fingerprint
 
     def test_materialized_rows_and_result_affecting_run_config_invalidate(self) -> None:
         cfg = _two_stage_cfg()
@@ -1676,6 +2781,77 @@ class TestFailureRouting:
         all_results, _ = await run_multistage_stages(cfg, REF_ELOS, _distribution(task_ids), rows, mixed_run)
         assert all(NG_FAILURE_CLASS_KEY not in r for r in all_results)
         assert all(not r.get(NG_NO_PERSIST_KEY) for r in all_results)
+
+    async def test_runtime_stale_stage_prunes_file_backed_downstream(self, tmp_path: Path) -> None:
+        task_ids = ["t0", "t1", "t2"]
+        rows = _materialized_rows(task_ids)
+        cfg = MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": ["3", "3:2"]}).stages,
+            seed=0,
+        )
+        distribution = _distribution(task_ids)
+        output = tmp_path / "rollouts.jsonl"
+        journal = journal_path_for(output)
+        fingerprint = compute_fingerprint(cfg, REF_ELOS, distribution)
+        successful_run = _fake_run_rollouts_factory()
+
+        await run_multistage_stages(
+            cfg,
+            REF_ELOS,
+            distribution,
+            rows,
+            successful_run,
+            resume=build_file_resume(output, journal, fingerprint),
+        )
+        persisted = [json.loads(line) for line in output.read_text().splitlines()]
+        missing = next(row for row in persisted if row["stage_index"] == 0)
+        missing_key = (missing[TASK_INDEX_KEY_NAME], missing[ROLLOUT_INDEX_KEY_NAME])
+        output.write_text(
+            "".join(
+                json.dumps(row) + "\n"
+                for row in persisted
+                if (row["stage_index"], row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME]) != (0, *missing_key)
+            )
+        )
+        aggregate_path = aggregate_metrics_path_for(output)
+        aggregate_path.write_text("stale")
+
+        resume = build_file_resume(output, journal, fingerprint)
+        assert set(resume.outcomes) == {0, 1}
+        dispatched: List[Tuple[int, Tuple[int, int]]] = []
+
+        async def fresh_retry(rows_in: List[Dict[str, Any]]):
+            dispatched.extend(
+                (
+                    row["stage_index"],
+                    (row[TASK_INDEX_KEY_NAME], row[ROLLOUT_INDEX_KEY_NAME]),
+                )
+                for row in rows_in
+            )
+            pairs = await successful_run(rows_in)
+            return [(row, {**result, "fresh_retry": True}) for row, result in pairs]
+
+        await run_multistage_stages(
+            cfg,
+            REF_ELOS,
+            distribution,
+            rows,
+            fresh_retry,
+            resume=resume,
+        )
+
+        assert [key for stage, key in dispatched if stage == 0] == [missing_key]
+        assert len([key for stage, key in dispatched if stage == 1]) == 3
+        assert not aggregate_path.exists()
+        final_rows = [json.loads(line) for line in output.read_text().splitlines()]
+        assert len([row for row in final_rows if row["stage_index"] == 1]) == 3
+        assert all(row["fresh_retry"] is True for row in final_rows if row["stage_index"] == 1)
+        assert any(
+            json.loads(line).get("status") == "restart_from_stage" and json.loads(line)["stage_index"] == 0
+            for line in journal.read_text().splitlines()
+        )
+        assert set(read_journal(journal)[1]) == {0, 1}
 
     async def test_file_backed_resume_end_to_end(self, tmp_path: Path) -> None:
         task_ids = [f"t{i}" for i in range(10)]

--- a/resources_servers/gdpval/tests/test_multistage_orchestrator.py
+++ b/resources_servers/gdpval/tests/test_multistage_orchestrator.py
@@ -3124,3 +3124,111 @@ class TestIntegrationWiring:
         assert {row["expected_stage_row_count"] for row in persisted} == {1}
         assert len(set(cache_namespaces)) == 1
         assert len(cache_namespaces[0]) == 64
+
+
+class TestReferenceMissingCoverage:
+    """A terminal ``reference_missing`` row is an omission, not a stage-killer.
+
+    Pins the behaviour the failure-class change relies on: because the row is
+    terminal it is "already resolved", so it never reaches the unresolved-key
+    loop that consults ``waivable_failure_classes``. It is simply an omission
+    governed by the coverage floors -- which is why no leaf policy needs to list
+    ``reference_missing`` as waivable.
+    """
+
+    @staticmethod
+    def _rows(n: int, ref: str):
+        return [{TASK_INDEX_KEY_NAME: i, ROLLOUT_INDEX_KEY_NAME: 0, "reference_ids": [ref]} for i in range(n)]
+
+    def _outcome(self, *, judged: int, planned: int, ref: str = "r1"):
+        from resources_servers.gdpval.multistage_elo import PartialStagePolicy
+        from resources_servers.gdpval.multistage_orchestrator import _partial_stage_outcome
+
+        stage_rows = self._rows(planned, ref)
+        successful = []
+        for i in range(judged):
+            row = dict(stage_rows[i])
+            row["per_reference"] = {ref: {"wins": 4, "losses": 0, "ties": 0}}
+            successful.append(row)
+        policy = PartialStagePolicy(
+            min_success_fraction=0.9,
+            min_per_reference_success_fraction=0.5,
+            min_successful_rows_per_reference=1,
+            waivable_failure_classes=("timeout_exceeded", "transient"),
+        )
+        return _partial_stage_outcome(policy, stage_rows, successful, [], set(), [ref], 1200.0, 1)
+
+    def test_terminal_omission_is_accepted_without_being_waivable(self) -> None:
+        # 19 of 20 judged: the missing one is the reference_missing row. It is
+        # NOT in successful_rows and NOT in unresolved_keys (terminal).
+        outcome = self._outcome(judged=19, planned=20)
+        assert outcome is not None
+        assert outcome["success_fraction"] == pytest.approx(0.95)
+        assert len(outcome["omitted_keys"]) == 1
+
+    def test_still_rejected_when_coverage_floor_is_breached(self) -> None:
+        # Forgiveness is bounded: 17/20 = 0.85 is below min_success_fraction 0.9.
+        assert self._outcome(judged=17, planned=20) is None
+
+    def test_evidence_less_success_row_still_hard_rejects(self) -> None:
+        """The gate this change routes around is intentionally left intact: a
+        row that IS in the success set while carrying no battle stays fatal."""
+        from resources_servers.gdpval.multistage_elo import PartialStagePolicy
+        from resources_servers.gdpval.multistage_orchestrator import _partial_stage_outcome
+
+        ref = "r1"
+        stage_rows = self._rows(20, ref)
+        successful = []
+        for i, row in enumerate(stage_rows):
+            r = dict(row)
+            r["per_reference"] = {} if i == 0 else {ref: {"wins": 4, "losses": 0, "ties": 0}}
+            successful.append(r)
+        policy = PartialStagePolicy(
+            min_success_fraction=0.9,
+            min_per_reference_success_fraction=0.5,
+            min_successful_rows_per_reference=1,
+        )
+        assert _partial_stage_outcome(policy, stage_rows, successful, [], set(), [ref], 1200.0, 1) is None
+
+
+class TestReferenceMissingIsTerminal:
+    """A missing reference deliverable can never be fixed by retrying.
+
+    The verify response stamps the generic ``_ng_failure_terminal`` flag rather
+    than teaching ``_is_terminal_failure`` a GDPVal-specific class name -- the
+    harness already honours that flag, so no change to nemo_gym is needed.
+    """
+
+    def test_generic_terminal_flag_is_honoured(self) -> None:
+        from nemo_gym.rollout_collection import (
+            NG_FAILURE_CLASS_KEY,
+            NG_TERMINAL_KEY,
+            _is_terminal_failure,
+        )
+        from resources_servers.gdpval.app import REFERENCE_MISSING_FAILURE_CLASS
+
+        row = {
+            NG_FAILURE_CLASS_KEY: REFERENCE_MISSING_FAILURE_CLASS,
+            NG_TERMINAL_KEY: True,
+        }
+        assert _is_terminal_failure(row) is True
+
+    def test_timeout_stays_retryable(self) -> None:
+        from nemo_gym.rollout_collection import NG_FAILURE_CLASS_KEY, _is_terminal_failure
+
+        assert _is_terminal_failure({NG_FAILURE_CLASS_KEY: "timeout_exceeded"}) is False
+
+    def test_reference_missing_row_is_not_a_success(self) -> None:
+        """The point of the change: it must not reach the success set, where the
+        non-final-stage coverage gate would reject it before any threshold."""
+        from nemo_gym.rollout_collection import NG_FAILURE_CLASS_KEY
+        from resources_servers.gdpval.app import REFERENCE_MISSING_FAILURE_CLASS
+        from resources_servers.gdpval.multistage_orchestrator import _is_success_row
+
+        row = {
+            "task_id": "t1",
+            "reward": 0.0,
+            "judge_response": {"error": "reference_missing"},
+            NG_FAILURE_CLASS_KEY: REFERENCE_MISSING_FAILURE_CLASS,
+        }
+        assert _is_success_row(row) is False

--- a/resources_servers/gdpval/tests/test_multistage_orchestrator.py
+++ b/resources_servers/gdpval/tests/test_multistage_orchestrator.py
@@ -66,6 +66,39 @@ from resources_servers.gdpval.multistage_orchestrator import (
 REF_ELOS = {"a": 1000.0, "b": 1200.0, "c": 1400.0, "d": 1600.0}
 
 
+def _runtime_components_with_bind_addresses(host_prefix: str, port_offset: int) -> Dict[str, Any]:
+    return {
+        "agent": {
+            "responses_api_agents": {
+                "stirrup": {
+                    "host": f"{host_prefix}-agent",
+                    "port": 8001 + port_offset,
+                    "task": "gdpval",
+                    "worker_target": {"host": "sandbox.internal", "port": 9000},
+                }
+            }
+        },
+        "policy": {
+            "responses_api_models": {
+                "vllm": {
+                    "host": f"{host_prefix}-policy",
+                    "port": 8002 + port_offset,
+                    "model": "/checkpoints/policy-a",
+                }
+            }
+        },
+        "resources": {
+            "resources_servers": {
+                "gdpval": {
+                    "host": f"{host_prefix}-resources",
+                    "port": 8003 + port_offset,
+                    "num_comparison_trials": 2,
+                }
+            }
+        },
+    }
+
+
 # ---------------------------------------------------------------------------
 # Config parsing
 # ---------------------------------------------------------------------------
@@ -1210,6 +1243,29 @@ class TestFingerprint:
             == baseline
         )
 
+    def test_runtime_bind_addresses_do_not_invalidate_fingerprint(self) -> None:
+        cfg = _two_stage_cfg()
+        dist = _distribution(["t0"])
+        runtime = _runtime_components_with_bind_addresses("node-a", 0)
+        rebound_runtime = _runtime_components_with_bind_addresses("node-b", 100)
+
+        baseline = compute_fingerprint(cfg, REF_ELOS, dist, resolved_global_config=runtime)
+        assert compute_fingerprint(cfg, REF_ELOS, dist, resolved_global_config=rebound_runtime) == baseline
+
+        changed_nested_host = deepcopy(rebound_runtime)
+        changed_nested_host["agent"]["responses_api_agents"]["stirrup"]["worker_target"]["host"] = (
+            "other-sandbox.internal"
+        )
+        assert compute_fingerprint(cfg, REF_ELOS, dist, resolved_global_config=changed_nested_host) != baseline
+
+        changed_nested_port = deepcopy(rebound_runtime)
+        changed_nested_port["agent"]["responses_api_agents"]["stirrup"]["worker_target"]["port"] = 9001
+        assert compute_fingerprint(cfg, REF_ELOS, dist, resolved_global_config=changed_nested_port) != baseline
+
+        changed_model = deepcopy(rebound_runtime)
+        changed_model["policy"]["responses_api_models"]["vllm"]["model"] = "/checkpoints/policy-b"
+        assert compute_fingerprint(cfg, REF_ELOS, dist, resolved_global_config=changed_model) != baseline
+
 
 class TestJournalIO:
     def test_journal_round_trip_latest_wins(self, tmp_path: Path) -> None:
@@ -1708,6 +1764,32 @@ class TestPrepareResume:
         resume = _prepare_resume(self._cfg(True), out, journal, fp)
         assert not out.exists() and not journal.exists()
         assert resume.outcomes == {}
+
+    def test_runtime_bind_address_change_preserves_resume_state(self, tmp_path: Path) -> None:
+        from resources_servers.gdpval.multistage_orchestrator import append_journal_record
+
+        out = tmp_path / "rollouts.jsonl"
+        journal = journal_path_for(out)
+        out.write_text("")
+        dist = _distribution(["t0"])
+        old_fingerprint = compute_fingerprint(
+            _two_stage_cfg(),
+            REF_ELOS,
+            dist,
+            resolved_global_config=_runtime_components_with_bind_addresses("node-a", 0),
+        )
+        append_journal_record(journal, {"stage_index": 0, "status": "complete"}, old_fingerprint)
+        rebound_fingerprint = compute_fingerprint(
+            _two_stage_cfg(),
+            REF_ELOS,
+            dist,
+            resolved_global_config=_runtime_components_with_bind_addresses("node-b", 100),
+        )
+
+        resume = _prepare_resume(self._cfg(True), out, journal, rebound_fingerprint)
+
+        assert out.exists() and journal.exists()
+        assert set(resume.outcomes) == {0}
 
     async def test_fresh_run_persists_journal_then_resume_reuses_all(self, tmp_path: Path) -> None:
         # Regression: a fresh run through _prepare_resume must write the journal +

--- a/resources_servers/gdpval/tests/test_multistage_orchestrator.py
+++ b/resources_servers/gdpval/tests/test_multistage_orchestrator.py
@@ -3214,18 +3214,27 @@ class TestReferenceMissingIsTerminal:
     """
 
     def test_generic_terminal_flag_is_honoured(self) -> None:
+        from nemo_gym.rollout_collection import NG_TERMINAL_KEY, _is_terminal_failure
+
+        assert _is_terminal_failure({NG_TERMINAL_KEY: True}) is True
+
+    def test_environment_faults_are_revalidated_on_resume(self) -> None:
+        # reference_missing/eval_missing are terminal within a run (retrying
+        # cannot make the file appear) but the tree can be repaired between
+        # runs, so resume re-dispatches them for a cheap /verify recheck.
         from nemo_gym.rollout_collection import (
             NG_FAILURE_CLASS_KEY,
             NG_TERMINAL_KEY,
             _is_terminal_failure,
         )
-        from resources_servers.gdpval.app import REFERENCE_MISSING_FAILURE_CLASS
+        from resources_servers.gdpval.app import (
+            EVAL_MISSING_FAILURE_CLASS,
+            REFERENCE_MISSING_FAILURE_CLASS,
+        )
 
-        row = {
-            NG_FAILURE_CLASS_KEY: REFERENCE_MISSING_FAILURE_CLASS,
-            NG_TERMINAL_KEY: True,
-        }
-        assert _is_terminal_failure(row) is True
+        for failure_class in (REFERENCE_MISSING_FAILURE_CLASS, EVAL_MISSING_FAILURE_CLASS):
+            row = {NG_FAILURE_CLASS_KEY: failure_class, NG_TERMINAL_KEY: True}
+            assert _is_terminal_failure(row) is False
 
     def test_timeout_stays_retryable(self) -> None:
         from nemo_gym.rollout_collection import NG_FAILURE_CLASS_KEY, _is_terminal_failure

--- a/resources_servers/gdpval/tests/test_multistage_orchestrator.py
+++ b/resources_servers/gdpval/tests/test_multistage_orchestrator.py
@@ -2373,6 +2373,10 @@ class TestFingerprint:
         changed_policy["policy_model"]["responses_api_models"]["vllm"]["model"] = "/checkpoints/policy-b"
         changed_judge = deepcopy(runtime)
         changed_judge["gdpval_resources_server"]["resources_servers"]["gdpval"]["num_comparison_trials"] = 4
+        changed_strict_trials = deepcopy(runtime)
+        changed_strict_trials["gdpval_resources_server"]["resources_servers"]["gdpval"]["strict_comparison_trials"] = (
+            True
+        )
         changed_logging = deepcopy(runtime)
         changed_logging["operational_logging"]["level"] = "DEBUG"
 
@@ -2383,6 +2387,16 @@ class TestFingerprint:
                 dist,
                 materialized_rows=rows,
                 resolved_global_config=changed_policy,
+            )
+            != baseline
+        )
+        assert (
+            compute_fingerprint(
+                cfg,
+                REF_ELOS,
+                dist,
+                materialized_rows=rows,
+                resolved_global_config=changed_strict_trials,
             )
             != baseline
         )

--- a/resources_servers/gdpval/tests/test_preconvert.py
+++ b/resources_servers/gdpval/tests/test_preconvert.py
@@ -95,6 +95,44 @@ class TestConvertToPdfErrors:
         # The path should be a unique tempdir (one per call); just sanity-check it points to a path.
         assert "/lo-profile-" in env_flags[0]
 
+    def test_failed_conversion_retries_roundtripped_copy_without_mutating_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        source = tmp_path / "report.docx"
+        original = b"original OOXML package"
+        source.write_bytes(original)
+        calls: list[Path] = []
+
+        class _Completed:
+            returncode = 0
+            stdout = ""
+            stderr = "Error: source file could not be loaded"
+
+        def _roundtrip(src: Path, dst: Path) -> None:
+            assert src == source
+            dst.write_bytes(b"roundtripped package")
+
+        def _run(command, *_args, **_kwargs):
+            input_path = Path(command[-1])
+            calls.append(input_path)
+            if len(calls) == 2:
+                outdir = Path(command[command.index("--outdir") + 1])
+                (outdir / f"{input_path.stem}.pdf").write_bytes(b"%PDF retry")
+            return _Completed()
+
+        monkeypatch.setattr(pcv, "roundtrip_ooxml_copy", _roundtrip)
+        monkeypatch.setattr(subprocess, "run", _run)
+
+        _path, ok, message = pcv.convert_to_pdf(source)
+
+        assert ok is True
+        assert "round-trip retry" in message
+        assert len(calls) == 2
+        assert calls[0] == source
+        assert "gdpval-roundtrip-" in str(calls[1])
+        assert source.read_bytes() == original
+        assert source.with_suffix(".pdf").read_bytes() == b"%PDF retry"
+
 
 class TestPreconvertDirSurfacesFailures:
     def test_returns_error_messages(self, tmp_path: Path, monkeypatch) -> None:
@@ -126,6 +164,138 @@ class TestPreconvertDirSurfacesFailures:
 
         ok, fail, errors = pcv.preconvert_dir(str(tmp_path))
         assert (ok, fail, errors) == (1, 0, [])
+
+
+class TestStructuredXlsxText:
+    def test_sparse_extreme_coordinate_does_not_scan_empty_rectangle(self, tmp_path: Path) -> None:
+        openpyxl = pytest.importorskip("openpyxl")
+        workbook = openpyxl.Workbook()
+        sheet = workbook.active
+        sheet.title = "Sparse"
+        sheet["A1"] = "start"
+        sheet["XFD1048576"] = "far corner"
+        path = tmp_path / "sparse.xlsx"
+        workbook.save(path)
+        workbook.close()
+
+        text = pcv.extract_xlsx_structured_text(path, max_chars=500)
+
+        assert "A1: value=start" in text
+        assert "XFD1048576: value=far corner" in text
+        assert len(text) <= 500
+
+    def test_formula_and_truncation_marker_fit_within_bound(self, tmp_path: Path) -> None:
+        openpyxl = pytest.importorskip("openpyxl")
+        workbook = openpyxl.Workbook()
+        sheet = workbook.active
+        sheet["A1"] = 2
+        sheet["A2"] = 3
+        sheet["A3"] = "=SUM(A1:A2)"
+        sheet["A4"] = "X" * 500
+        path = tmp_path / "bounded.xlsx"
+        workbook.save(path)
+        workbook.close()
+
+        text = pcv.extract_xlsx_structured_text(path, max_chars=100)
+
+        assert "A3: formula: =SUM(A1:A2)" in text
+        assert text.endswith("[...spreadsheet text truncated]")
+        assert len(text) <= 100
+
+    def test_formula_includes_cached_value_when_package_provides_one(self, tmp_path: Path) -> None:
+        import zipfile
+
+        openpyxl = pytest.importorskip("openpyxl")
+        workbook = openpyxl.Workbook()
+        sheet = workbook.active
+        sheet["A1"] = 2
+        sheet["A2"] = 3
+        sheet["A3"] = "=SUM(A1:A2)"
+        original = tmp_path / "formula.xlsx"
+        cached = tmp_path / "formula_cached.xlsx"
+        workbook.save(original)
+        workbook.close()
+
+        replaced = False
+        with zipfile.ZipFile(original) as source, zipfile.ZipFile(cached, "w", zipfile.ZIP_DEFLATED) as target:
+            for item in source.infolist():
+                data = source.read(item.filename)
+                if item.filename == "xl/worksheets/sheet1.xml":
+                    updated = data.replace(
+                        b"<f>SUM(A1:A2)</f><v></v>",
+                        b"<f>SUM(A1:A2)</f><v>5</v>",
+                    )
+                    replaced = updated != data
+                    data = updated
+                target.writestr(item, data)
+        assert replaced, "test fixture did not install a formula cache"
+
+        text = pcv.extract_xlsx_structured_text(cached)
+
+        assert "A3: formula: =SUM(A1:A2); cached/display value: 5" in text
+
+    def test_first_oversize_shared_string_keeps_cell_evidence(self, tmp_path: Path) -> None:
+        import zipfile
+
+        openpyxl = pytest.importorskip("openpyxl")
+        workbook = openpyxl.Workbook()
+        workbook.active["A1"] = "seed"
+        original = tmp_path / "inline.xlsx"
+        shared = tmp_path / "shared.xlsx"
+        workbook.save(original)
+        workbook.close()
+
+        spreadsheet_ns = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+        sheet_xml = (
+            f'<worksheet xmlns="{spreadsheet_ns}"><sheetData><row r="1">'
+            '<c r="A1" t="s"><v>0</v></c></row></sheetData></worksheet>'
+        ).encode()
+        shared_xml = (
+            f'<sst xmlns="{spreadsheet_ns}" count="1" uniqueCount="1"><si><t>' + "X" * 10_000 + "</t></si></sst>"
+        ).encode()
+        with zipfile.ZipFile(original) as source, zipfile.ZipFile(shared, "w", zipfile.ZIP_DEFLATED) as target:
+            for item in source.infolist():
+                data = source.read(item.filename)
+                if item.filename == "xl/worksheets/sheet1.xml":
+                    data = sheet_xml
+                target.writestr(item, data)
+            target.writestr("xl/sharedStrings.xml", shared_xml)
+
+        text = pcv.extract_xlsx_structured_text(shared, max_chars=100)
+
+        assert "A1: value=" in text
+        assert text.endswith("[...spreadsheet text truncated]")
+        assert len(text) <= 100
+
+
+@pytest.mark.parametrize("extension", [".docx", ".pptx", ".xlsx"])
+def test_roundtrip_ooxml_copy_uses_format_library_and_preserves_source(tmp_path: Path, extension: str) -> None:
+    source = tmp_path / f"source{extension}"
+    destination = tmp_path / f"roundtripped{extension}"
+
+    if extension == ".docx":
+        docx = pytest.importorskip("docx")
+        document = docx.Document()
+        document.add_paragraph("GDPVal document")
+        document.save(source)
+    elif extension == ".pptx":
+        pptx = pytest.importorskip("pptx")
+        presentation = pptx.Presentation()
+        presentation.slides.add_slide(presentation.slide_layouts[6])
+        presentation.save(source)
+    else:
+        openpyxl = pytest.importorskip("openpyxl")
+        workbook = openpyxl.Workbook()
+        workbook.active["A1"] = "GDPVal workbook"
+        workbook.save(source)
+        workbook.close()
+
+    original = source.read_bytes()
+    pcv.roundtrip_ooxml_copy(source, destination)
+
+    assert source.read_bytes() == original
+    assert destination.is_file()
+    assert destination.read_bytes().startswith(b"PK")
 
 
 @pytest.mark.asyncio

--- a/resources_servers/gdpval/tests/test_preconvert_samestem.py
+++ b/resources_servers/gdpval/tests/test_preconvert_samestem.py
@@ -9,6 +9,7 @@ from resources_servers.gdpval.preconvert import (
     OFFICE_EXTENSIONS,
     find_convertible_files,
     needs_conversion,
+    resolve_pdf_provenance,
     sidecar_pdf,
 )
 
@@ -45,6 +46,14 @@ def test_existing_sidecar_means_no_reconversion(tmp_path: Path):
     assert "Plan.xlsx" in srcs
 
 
+def test_existing_sidecar_remains_valid_if_stem_becomes_unambiguous(tmp_path: Path):
+    source = tmp_path / "Plan.pptx"
+    source.write_bytes(b"PK\x03\x04")
+    sidecar_pdf(source).write_bytes(b"%PDF-1.4")
+
+    assert find_convertible_files(tmp_path) == []
+
+
 def test_ambiguous_conversion_checks_the_sidecar_not_the_sibling(tmp_path: Path):
     p = tmp_path / "Plan.pptx"
     p.write_bytes(b"PK\x03\x04")
@@ -58,3 +67,39 @@ def test_legacy_office_is_converted_too():
     assert LEGACY_OFFICE_EXTENSIONS <= OFFICE_EXTENSIONS
     for ext in (".doc", ".ppt", ".xls"):
         assert ext in OFFICE_EXTENSIONS
+
+
+def test_ambiguous_plain_pdf_is_quarantined_but_independent_pdf_survives(tmp_path: Path):
+    docx = tmp_path / "Plan.docx"
+    pptx = tmp_path / "Plan.pptx"
+    stale = tmp_path / "Plan.pdf"
+    independent = tmp_path / "Appendix.pdf"
+    for path in (docx, pptx):
+        path.write_bytes(b"PK\x03\x04")
+    stale.write_bytes(b"stale")
+    independent.write_bytes(b"independent")
+
+    provenance = resolve_pdf_provenance(tmp_path.iterdir())
+
+    assert provenance.office_pdfs == {}
+    assert stale in provenance.ambiguous_pdfs
+    assert stale in provenance.suppressed_pdfs
+    assert independent not in provenance.suppressed_pdfs
+
+
+def test_injective_sidecars_win_and_every_derived_pdf_is_consumed(tmp_path: Path):
+    docx = tmp_path / "Plan.docx"
+    pptx = tmp_path / "Plan.pptx"
+    stale = tmp_path / "Plan.pdf"
+    docx_sidecar = sidecar_pdf(docx)
+    pptx_sidecar = sidecar_pdf(pptx)
+    for path in (docx, pptx):
+        path.write_bytes(b"PK\x03\x04")
+    stale.write_bytes(b"stale")
+    docx_sidecar.write_bytes(b"docx render")
+    pptx_sidecar.write_bytes(b"pptx render")
+
+    provenance = resolve_pdf_provenance(tmp_path.iterdir())
+
+    assert provenance.office_pdfs == {docx: docx_sidecar, pptx: pptx_sidecar}
+    assert provenance.suppressed_pdfs == frozenset({stale, docx_sidecar, pptx_sidecar})

--- a/resources_servers/gdpval/tests/test_scoring.py
+++ b/resources_servers/gdpval/tests/test_scoring.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from resources_servers.gdpval.judge_panel import ResolvedJudge
+from resources_servers.gdpval.scoring import (
+    SCORING_ERROR_KEY,
+    is_permanent_judge_error,
+    score_with_rubric,
+    score_with_rubric_structured,
+    score_with_rubric_visual,
+)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "GDPVal judge request size budget exhausted before dispatch",
+        "upstream Error code: 413",
+    ],
+)
+def test_internal_payload_errors_are_permanent(message: str) -> None:
+    assert is_permanent_judge_error(message)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("visual", [False, True], ids=["text", "visual"])
+async def test_binary_rubric_valid_json_without_usable_score_is_tagged(visual: bool) -> None:
+    """A parsed reply with no numeric score is a judge failure, not a real zero."""
+    parsed_response = {
+        "criteria_scores": [{"criterion": "clarity", "explanation": "Looks good"}],
+        "summary": "No numeric grade was emitted.",
+    }
+    response = MagicMock()
+    response.choices = [
+        MagicMock(
+            finish_reason="stop",
+            message=MagicMock(content=json.dumps(parsed_response), tool_calls=None),
+        )
+    ]
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=response)
+
+    common = {
+        "rubric_json": [{"criterion": "clarity", "score": 1}],
+        "rubric_pretty": "",
+        "task_prompt": "Write a report.",
+        "judge_prompt_template": "unused-in-test.j2",
+        "judges": [ResolvedJudge(name="test-judge", base_url="http://judge/v1", model="judge")],
+        "include_raw_responses": True,
+    }
+
+    with (
+        patch("openai.AsyncOpenAI", return_value=client),
+        patch("resources_servers.gdpval.scoring._render_template", return_value="judge prompt"),
+    ):
+        if visual:
+            score, metadata = await score_with_rubric_visual(
+                deliverable_content_blocks=[{"type": "text", "text": "deliverable"}],
+                **common,
+            )
+        else:
+            score, metadata = await score_with_rubric(deliverable_text="deliverable", **common)
+
+    assert score == 0.0
+    assert metadata is not None
+    assert metadata[SCORING_ERROR_KEY] == "no_score_in_response"
+    assert metadata["criteria_scores"] == parsed_response["criteria_scores"]
+    assert metadata["judge_name"] == "test-judge"
+    assert metadata["raw_responses"] == [json.dumps(parsed_response)]
+
+
+@pytest.mark.asyncio
+async def test_binary_rubric_zero_is_a_usable_score() -> None:
+    """An explicit numeric zero remains distinguishable from a missing score."""
+    response = MagicMock()
+    response.choices = [
+        MagicMock(
+            finish_reason="stop",
+            message=MagicMock(content='{"overall_score": 0}', tool_calls=None),
+        )
+    ]
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=response)
+
+    with (
+        patch("openai.AsyncOpenAI", return_value=client),
+        patch("resources_servers.gdpval.scoring._render_template", return_value="judge prompt"),
+    ):
+        score, metadata = await score_with_rubric(
+            deliverable_text="deliverable",
+            rubric_json=[],
+            rubric_pretty="",
+            task_prompt="Write a report.",
+            judge_prompt_template="unused-in-test.j2",
+            judges=[ResolvedJudge(name="test-judge", base_url="http://judge/v1", model="judge")],
+        )
+
+    assert score == 0.0
+    assert metadata is not None
+    assert SCORING_ERROR_KEY not in metadata
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("visual", [False, True], ids=["text", "visual"])
+async def test_binary_rubric_permanent_judge_error_is_not_swallowed(visual: bool) -> None:
+    """Payload/context failures must reach the outer terminal-failure router."""
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(
+        side_effect=RuntimeError("503 upstream: Request size is too large. Max size is 500 MB")
+    )
+    common = {
+        "rubric_json": [{"criterion": "clarity", "score": 1}],
+        "rubric_pretty": "",
+        "task_prompt": "Write a report.",
+        "judge_prompt_template": "unused-in-test.j2",
+        "judges": [ResolvedJudge(name="test-judge", base_url="http://judge/v1", model="judge")],
+    }
+
+    with (
+        patch("openai.AsyncOpenAI", return_value=client),
+        patch("resources_servers.gdpval.scoring._render_template", return_value="judge prompt"),
+    ):
+        with pytest.raises(RuntimeError, match="Request size is too large"):
+            if visual:
+                await score_with_rubric_visual(
+                    deliverable_content_blocks=[{"type": "text", "text": "deliverable"}],
+                    **common,
+                )
+            else:
+                await score_with_rubric(deliverable_text="deliverable", **common)
+
+    assert client.chat.completions.create.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_structured_rubric_permanent_error_wins_over_retryable_status() -> None:
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(
+        side_effect=RuntimeError("503 upstream: maximum number of tokens allowed is 1048576")
+    )
+
+    with patch("openai.AsyncOpenAI", return_value=client):
+        with pytest.raises(RuntimeError, match="maximum number of tokens"):
+            await score_with_rubric_structured(
+                deliverable_text="deliverable",
+                rubric_json=[{"criterion": "clarity", "score": 1}],
+                rubric_pretty="",
+                task_prompt="Write a report.",
+                judges=[ResolvedJudge(name="test-judge", base_url="http://judge/v1", model="judge")],
+                num_trials=1,
+                formatting_retries=3,
+            )
+
+    assert client.chat.completions.create.await_count == 1

--- a/resources_servers/gdpval/tests/test_transport_modes.py
+++ b/resources_servers/gdpval/tests/test_transport_modes.py
@@ -1,0 +1,377 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Per-provider judge transport: overflow planning, eligibility, seeded replay."""
+
+import base64
+import random
+
+import fitz
+import pytest
+
+from resources_servers.gdpval.comparison import (
+    Judge,
+    apply_native_pdf_overflow,
+    filter_media_eligible_judges,
+    plan_native_pdf_overflow,
+    preview_trial_judges,
+)
+from resources_servers.gdpval.judge_panel import sample_judge
+from resources_servers.gdpval.media_conversion import pdf_page_count
+from resources_servers.gdpval.multistage_orchestrator import (
+    MultiStageRunConfig,
+    compute_fingerprint,
+    parse_multistage_config,
+)
+from resources_servers.gdpval.transport_assignment import PairCost, _solve_capacity_assignment
+
+
+PDF_PREFIX = "data:application/pdf;base64,"
+
+
+def _pdf_bytes(pages: int) -> bytes:
+    document = fitz.open()
+    for index in range(pages):
+        page = document.new_page(width=200, height=200)
+        page.insert_text((20, 40), f"page {index}")
+    payload = document.tobytes()
+    document.close()
+    return payload
+
+
+def _pdf_block(payload: bytes) -> dict:
+    return {"type": "image_url", "image_url": {"url": PDF_PREFIX + base64.b64encode(payload).decode()}}
+
+
+def _judge(name: str, **kwargs) -> Judge:
+    return Judge(name=name, client=None, model="judge-model", **kwargs)
+
+
+class TestPlanNativePdfOverflow:
+    def test_forces_full_rasterization_above_per_document_byte_cap(self) -> None:
+        small = _pdf_bytes(1)
+        big = _pdf_bytes(2)
+        sections = {"refs": [_pdf_block(small)], "submission_a": [_pdf_block(big)]}
+
+        plan = plan_native_pdf_overflow(
+            sections,
+            native_page_cap=100,
+            native_pdf_bytes_per_document=len(big) - 1,
+            image_cap=50,
+        )
+
+        assert plan["eligible"] is True
+        (selected,) = plan["selected"]
+        assert selected["section"] == "submission_a"
+        assert selected["reason"] == "native_pdf_bytes_per_document"
+        assert selected["raster_page_count"] == 2
+        assert selected["native_page_count"] == 0
+        # Every source page stays represented, natively or as images.
+        assert plan["native_pages_after"] + plan["raster_pages"] == plan["total_pdf_pages"] == 3
+
+    def test_prefix_only_rasterization_for_page_cap_overflow(self) -> None:
+        short = _pdf_bytes(3)
+        long = _pdf_bytes(5)
+        sections = {"refs": [_pdf_block(short), _pdf_block(long)]}
+
+        plan = plan_native_pdf_overflow(
+            sections,
+            native_page_cap=6,
+            native_pdf_bytes_per_document=10**9,
+            image_cap=50,
+        )
+
+        # Two pages over the cap: the smallest document gives up exactly its
+        # two-page prefix; its final page and the whole long document stay native.
+        assert plan["eligible"] is True
+        (selected,) = plan["selected"]
+        assert selected["pages"] == 3
+        assert selected["reason"] == "native_pdf_page_cap"
+        assert selected["raster_page_start"] == 0
+        assert selected["raster_page_count"] == 2
+        assert selected["native_page_count"] == 1
+        assert plan["native_pages_after"] == 6
+        assert plan["raster_pages"] == 2
+
+    def test_ineligible_when_raster_pages_exceed_image_cap(self) -> None:
+        big = _pdf_bytes(3)
+        plan = plan_native_pdf_overflow(
+            {"refs": [_pdf_block(big)]},
+            native_page_cap=100,
+            native_pdf_bytes_per_document=len(big) - 1,
+            image_cap=2,
+        )
+        assert plan["eligible"] is False
+
+
+class TestApplyNativePdfOverflow:
+    def test_every_page_retained_across_raster_and_native_suffix(self) -> None:
+        short = _pdf_bytes(3)
+        long = _pdf_bytes(5)
+        sections = {"refs": [_pdf_block(short), _pdf_block(long)]}
+        plan = plan_native_pdf_overflow(
+            sections,
+            native_page_cap=6,
+            native_pdf_bytes_per_document=10**9,
+            image_cap=50,
+        )
+
+        converted = apply_native_pdf_overflow(sections, plan, render_dpi=36, max_pages=100, include_text=False)
+
+        blocks = converted["refs"]
+        urls = [str((block.get("image_url") or {}).get("url", "")) for block in blocks]
+        rendered_images = sum(1 for url in urls if url.startswith("data:image/"))
+        native_pages = sum(
+            pdf_page_count(base64.b64decode(url[len(PDF_PREFIX) :])) for url in urls if url.startswith(PDF_PREFIX)
+        )
+        assert rendered_images == 2
+        assert native_pages == 6
+
+    def test_rejects_plan_hash_drift(self) -> None:
+        payload = _pdf_bytes(2)
+        sections = {"refs": [_pdf_block(payload)]}
+        plan = plan_native_pdf_overflow(
+            sections,
+            native_page_cap=1,
+            native_pdf_bytes_per_document=10**9,
+            image_cap=50,
+        )
+        drifted = {"refs": [_pdf_block(_pdf_bytes(2))]}
+        with pytest.raises(ValueError, match="hash drift"):
+            apply_native_pdf_overflow(drifted, plan, render_dpi=36, max_pages=100, include_text=False)
+
+
+class TestFilterMediaEligibleJudges:
+    NATIVE_STATS = {"pages": 120, "documents": 6, "bytes": 30_000_000}
+
+    def test_exclusion_reasons_are_recorded_per_cap(self) -> None:
+        judges = [
+            _judge("claude", media_mode="native_pdf", max_native_pdf_bytes=24 * 1024 * 1024),
+            _judge("gpt", media_mode="images_and_text"),
+            _judge("gemini", media_mode="native_pdf_overflow_images"),
+            _judge("roomy", media_mode="native_pdf"),
+        ]
+
+        eligible, exclusions = filter_media_eligible_judges(
+            judges,
+            native_stats=self.NATIVE_STATS,
+            estimated_images=500,
+            image_cap=450,
+            overflow_plan=None,
+        )
+
+        assert [judge.name for judge in eligible] == ["roomy"]
+        reasons = {exclusion["judges"][0]: exclusion["reason"] for exclusion in exclusions}
+        assert reasons == {
+            "claude": "native_pdf_cap",
+            "gpt": "request_image_cap_preflight",
+            "gemini": "native_pdf_overflow_unavailable",
+        }
+
+    def test_overflow_judge_eligible_only_with_eligible_plan(self) -> None:
+        judge = _judge("gemini", media_mode="native_pdf_overflow_images")
+        eligible, _ = filter_media_eligible_judges(
+            [judge],
+            native_stats=self.NATIVE_STATS,
+            estimated_images=0,
+            image_cap=450,
+            overflow_plan={"eligible": True},
+        )
+        assert [j.name for j in eligible] == ["gemini"]
+        _, exclusions = filter_media_eligible_judges(
+            [judge],
+            native_stats=self.NATIVE_STATS,
+            estimated_images=0,
+            image_cap=450,
+            overflow_plan={"eligible": False},
+        )
+        assert exclusions[0]["reason"] == "native_pdf_overflow_unavailable"
+
+
+class TestPreviewTrialJudges:
+    def test_replays_seeded_schedule_without_consuming_rng(self) -> None:
+        judges = [_judge("a"), _judge("b"), _judge("c")]
+        rng = random.Random(7)
+        state = rng.getstate()
+
+        first = [judge.name for judge in preview_trial_judges(judges, 5, rng)]
+        second = [judge.name for judge in preview_trial_judges(judges, 5, rng)]
+
+        assert first == second
+        assert rng.getstate() == state
+        # The preview is exactly what dispatch will draw from the untouched RNG.
+        assert [sample_judge(judges, rng).name for _ in range(5)] == first
+
+    def test_exclusion_then_replay_is_deterministic(self) -> None:
+        judges = [_judge("a"), _judge("b"), _judge("c")]
+        rng = random.Random(11)
+        survivors = [judge for judge in judges if judge.name != "b"]
+        assert [j.name for j in preview_trial_judges(survivors, 4, rng)] == [
+            j.name for j in preview_trial_judges(survivors, 4, rng)
+        ]
+
+
+class TestSolveCapacityAssignment:
+    def test_minimum_change_reassignment_respects_capacities(self) -> None:
+        tasks = ["t0", "t1", "t2"]
+        references = ["ra", "rb"]
+        original = {"t0": "ra", "t1": "ra", "t2": "rb"}
+
+        def cost(compatible: bool, wire: int = 1) -> PairCost:
+            return PairCost(compatible=compatible, wire_bytes=wire, raw_bytes=wire, max_file_bytes=wire, reasons=())
+
+        # t1/ra is incompatible; the only capacity-preserving repair swaps t1 and t2.
+        costs = {
+            ("t0", "ra"): cost(True),
+            ("t0", "rb"): cost(True),
+            ("t1", "ra"): cost(False),
+            ("t1", "rb"): cost(True),
+            ("t2", "ra"): cost(True),
+            ("t2", "rb"): cost(True),
+        }
+
+        result = _solve_capacity_assignment(tasks, references, original, costs)
+
+        assert result == {"t0": "ra", "t1": "rb", "t2": "ra"}
+        assert sorted(result.values()) == sorted(original.values())
+
+
+class TestFingerprintTransportRepair:
+    REF_ELOS = {"ref_a": 1000.0}
+    DIST = {"grp": {"task_ids": ["t0"], "percentage": 100.0}}
+
+    def _cfg(self) -> MultiStageRunConfig:
+        return MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": [{"num_tasks": 1}]}).stages,
+            seed=0,
+        )
+
+    def test_repair_settings_invalidate_fingerprint(self) -> None:
+        cfg = self._cfg()
+        base = compute_fingerprint(cfg, self.REF_ELOS, self.DIST, resolved_global_config={"multistage": {}})
+        repair_a = compute_fingerprint(
+            cfg,
+            self.REF_ELOS,
+            self.DIST,
+            resolved_global_config={"multistage": {"transport_assignment_repair": {"max_file_bytes": 1}}},
+        )
+        repair_b = compute_fingerprint(
+            cfg,
+            self.REF_ELOS,
+            self.DIST,
+            resolved_global_config={"multistage": {"transport_assignment_repair": {"max_file_bytes": 2}}},
+        )
+        assert repair_a != base
+        assert repair_b != base
+        assert repair_a != repair_b
+
+    def test_absent_repair_config_preserves_legacy_fingerprint(self) -> None:
+        cfg = self._cfg()
+        without_block = compute_fingerprint(cfg, self.REF_ELOS, self.DIST, resolved_global_config={})
+        empty_block = compute_fingerprint(cfg, self.REF_ELOS, self.DIST, resolved_global_config={"multistage": {}})
+        assert without_block == empty_block
+
+
+class TestOverflowRenderPageCap:
+    def test_ineligible_when_forced_raster_exceeds_render_page_cap(self) -> None:
+        big = _pdf_bytes(3)
+        sections = {"refs": [_pdf_block(big)]}
+        capped = plan_native_pdf_overflow(
+            sections,
+            native_page_cap=100,
+            native_pdf_bytes_per_document=len(big) - 1,
+            image_cap=50,
+            render_page_cap=2,
+        )
+        assert capped["eligible"] is False
+
+        roomy = plan_native_pdf_overflow(
+            sections,
+            native_page_cap=100,
+            native_pdf_bytes_per_document=len(big) - 1,
+            image_cap=50,
+            render_page_cap=3,
+        )
+        assert roomy["eligible"] is True
+        # An eligible plan renders successfully under the same page bound.
+        converted = apply_native_pdf_overflow(sections, roomy, render_dpi=36, max_pages=3, include_text=False)
+        rendered = [
+            b for b in converted["refs"] if str((b.get("image_url") or {}).get("url", "")).startswith("data:image/")
+        ]
+        assert len(rendered) == 3
+
+
+class TestOverflowAggregateCaps:
+    def test_plan_reports_post_overflow_aggregates(self) -> None:
+        short = _pdf_bytes(3)
+        long = _pdf_bytes(5)
+        sections = {"refs": [_pdf_block(short), _pdf_block(long)]}
+        plan = plan_native_pdf_overflow(
+            sections,
+            native_page_cap=6,
+            native_pdf_bytes_per_document=10**9,
+            image_cap=50,
+        )
+        # Prefix split keeps a native suffix, so both documents remain native.
+        assert plan["native_documents_after"] == 2
+        assert plan["native_bytes_after_bound"] == len(short) + len(long)
+
+        forced = plan_native_pdf_overflow(
+            {"refs": [_pdf_block(short), _pdf_block(long)]},
+            native_page_cap=100,
+            native_pdf_bytes_per_document=len(long) - 1,
+            image_cap=50,
+        )
+        # The long document is fully rasterized and leaves the native payload.
+        assert forced["native_documents_after"] == 1
+        assert forced["native_bytes_after_bound"] == len(short)
+
+    def test_overflow_judge_excluded_when_aggregate_caps_exceeded_after_overflow(self) -> None:
+        stats = {"pages": 8, "documents": 2, "bytes": 5_000}
+        plan = {"eligible": True, "native_documents_after": 2, "native_bytes_after_bound": 4_000}
+
+        capped_documents = _judge("gemini", media_mode="native_pdf_overflow_images", max_native_pdf_documents=1)
+        _, exclusions = filter_media_eligible_judges(
+            [capped_documents], native_stats=stats, estimated_images=0, image_cap=450, overflow_plan=plan
+        )
+        assert exclusions[0]["reason"] == "native_pdf_cap_after_overflow"
+
+        capped_bytes = _judge("gemini", media_mode="native_pdf_overflow_images", max_native_pdf_bytes=3_000)
+        _, exclusions = filter_media_eligible_judges(
+            [capped_bytes], native_stats=stats, estimated_images=0, image_cap=450, overflow_plan=plan
+        )
+        assert exclusions[0]["reason"] == "native_pdf_cap_after_overflow"
+
+        roomy = _judge(
+            "gemini",
+            media_mode="native_pdf_overflow_images",
+            max_native_pdf_documents=2,
+            max_native_pdf_bytes=4_000,
+        )
+        eligible, exclusions = filter_media_eligible_judges(
+            [roomy], native_stats=stats, estimated_images=0, image_cap=450, overflow_plan=plan
+        )
+        assert [j.name for j in eligible] == ["gemini"] and not exclusions
+
+    def test_legacy_plan_without_aggregates_stays_eligible(self) -> None:
+        judge = _judge("gemini", media_mode="native_pdf_overflow_images", max_native_pdf_documents=1)
+        eligible, exclusions = filter_media_eligible_judges(
+            [judge],
+            native_stats={"pages": 8, "documents": 2, "bytes": 5_000},
+            estimated_images=0,
+            image_cap=450,
+            overflow_plan={"eligible": True},
+        )
+        assert [j.name for j in eligible] == ["gemini"] and not exclusions

--- a/resources_servers/gdpval/transport_assignment.py
+++ b/resources_servers/gdpval/transport_assignment.py
@@ -1,0 +1,481 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic provider-free repair for transport-incompatible GDPVal pairs."""
+
+from __future__ import annotations
+
+import hashlib
+import heapq
+import json
+import math
+import os
+import stat
+import zipfile
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping, Sequence, Tuple
+
+
+_BINARY_EXTENSIONS = {
+    ".pdf",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".bmp",
+    ".tif",
+    ".tiff",
+    ".wav",
+    ".wave",
+    ".flac",
+    ".mp3",
+    ".m4a",
+    ".aac",
+    ".ogg",
+    ".aif",
+    ".aiff",
+    ".mp4",
+    ".mov",
+    ".mkv",
+    ".webm",
+    ".avi",
+}
+_AV_EXTENSIONS = {
+    ".wav",
+    ".wave",
+    ".flac",
+    ".mp3",
+    ".m4a",
+    ".aac",
+    ".ogg",
+    ".aif",
+    ".aiff",
+    ".mp4",
+    ".mov",
+    ".mkv",
+    ".webm",
+    ".avi",
+}
+_IGNORED_NAMES = {
+    "finish_params.json",
+    "last_responses.jsonl",
+    "last_responses.jsonl.lock",
+    "last_responses.jsonl.offset",
+}
+
+
+@dataclass(frozen=True)
+class Footprint:
+    raw_bytes: int
+    max_file_bytes: int
+    has_av: bool
+    file_count: int
+
+
+@dataclass(frozen=True)
+class PairCost:
+    compatible: bool
+    wire_bytes: int
+    raw_bytes: int
+    max_file_bytes: int
+    reasons: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _BinaryArtifact:
+    path: Path
+    member: str | None
+    suffix: str
+    size: int
+
+
+def _artifact_sha256(artifact: _BinaryArtifact) -> str:
+    digest = hashlib.sha256()
+    if artifact.member is None:
+        with artifact.path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    else:
+        with zipfile.ZipFile(artifact.path, "r") as archive, archive.open(artifact.member, "r") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _find_gdpval_config(global_config: Mapping[str, Any]) -> Mapping[str, Any]:
+    matches = []
+    for value in global_config.values():
+        if not isinstance(value, Mapping):
+            continue
+        resources = value.get("resources_servers")
+        if not isinstance(resources, Mapping):
+            continue
+        gdpval = resources.get("gdpval")
+        if isinstance(gdpval, Mapping) and gdpval.get("reference_models"):
+            matches.append(gdpval)
+    if len(matches) != 1:
+        raise ValueError(f"expected one GDPVal reference config, found {len(matches)}")
+    return matches[0]
+
+
+def _repeat_dirs(root: Path, task_id: str) -> list[Path]:
+    task = root / f"task_{task_id}"
+    if not task.is_dir():
+        return []
+    repeats = sorted(path for path in task.iterdir() if path.is_dir() and path.name.startswith("repeat_"))
+    return repeats or [task]
+
+
+def _has_valid_finish_marker(repeat_dirs: Sequence[Path]) -> bool:
+    """Whether a reference task has at least one persisted completion marker."""
+    for repeat in repeat_dirs:
+        marker = repeat / "finish_params.json"
+        try:
+            marker_stat = marker.stat()  # Follow the immutable transport-view symlink.
+            if not stat.S_ISREG(marker_stat.st_mode) or marker_stat.st_size > 16 * 1024 * 1024:
+                continue
+            document = json.loads(marker.read_text())
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        # Stirrup writes null for a normal max-turn completion without explicit
+        # finish arguments. Atomic persistence is the completion signal; reject
+        # other JSON shapes and corrupt files.
+        if document is None or isinstance(document, dict):
+            return True
+    return False
+
+
+def _footprint(directory: Path, *, include_reference_files: bool = True) -> Footprint:
+    artifacts: list[_BinaryArtifact] = []
+    # Match app.py exactly: the submission directory and its optional
+    # reference_files directory are built as two semantic sections. Reference
+    # assets recurse below reference_files; candidate run-state subdirectories
+    # are not evidence and must not affect routing.
+    paths = list(directory.iterdir())
+    reference_files = directory / "reference_files"
+    if include_reference_files and reference_files.is_dir():
+        paths.extend(reference_files.rglob("*"))
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        if not path.is_file() or path.name in _IGNORED_NAMES:
+            continue
+        suffix = path.suffix.lower()
+        if suffix == ".zip":
+            with zipfile.ZipFile(path, "r") as archive:
+                for info in archive.infolist():
+                    member = Path(info.filename.replace("\\", "/"))
+                    if (
+                        info.is_dir()
+                        or member.is_absolute()
+                        or ".." in member.parts
+                        or stat.S_ISLNK(info.external_attr >> 16)
+                    ):
+                        continue
+                    member_suffix = member.suffix.lower()
+                    if member_suffix not in _BINARY_EXTENSIONS:
+                        continue
+                    artifacts.append(
+                        _BinaryArtifact(
+                            path=path,
+                            member=info.filename,
+                            suffix=member_suffix,
+                            size=info.file_size,
+                        )
+                    )
+            continue
+        if suffix not in _BINARY_EXTENSIONS:
+            continue
+        artifacts.append(_BinaryArtifact(path=path, member=None, suffix=suffix, size=path.stat().st_size))
+
+    # A common deliverable layout includes both loose stems and a convenience
+    # ZIP containing those exact stems. The judge renderer retains the bytes
+    # once and labels byte-identical duplicates, so the provider-cap planner
+    # must use the same lossless semantic footprint. Only exact AV payloads are
+    # deduplicated; same-size but different files remain distinct evidence.
+    av_size_counts = Counter(artifact.size for artifact in artifacts if artifact.suffix in _AV_EXTENSIONS)
+    seen_av: set[tuple[int, str]] = set()
+    retained: list[_BinaryArtifact] = []
+    for artifact in artifacts:
+        if artifact.suffix in _AV_EXTENSIONS and av_size_counts[artifact.size] > 1:
+            identity = (artifact.size, _artifact_sha256(artifact))
+            if identity in seen_av:
+                continue
+            seen_av.add(identity)
+        retained.append(artifact)
+
+    raw = sum(artifact.size for artifact in retained)
+    maximum = max((artifact.size for artifact in retained), default=0)
+    count = len(retained)
+    has_av = any(artifact.suffix in _AV_EXTENSIONS for artifact in retained)
+    return Footprint(raw_bytes=raw, max_file_bytes=maximum, has_av=has_av, file_count=count)
+
+
+def _pair_cost(
+    candidate: Footprint,
+    reference: Footprint,
+    *,
+    max_file_bytes: int,
+    max_raw_bytes: int,
+    max_wire_bytes: int,
+    framing_reserve_bytes: int,
+) -> PairCost:
+    raw = candidate.raw_bytes + reference.raw_bytes
+    maximum = max(candidate.max_file_bytes, reference.max_file_bytes)
+    # Audio/video is routed only to Gemini, so its native base64 request is the
+    # binding case. PDF/image-only tasks retain GPT raster and native-PDF paths;
+    # their exact provider request is gated later by the resource server.
+    if not (candidate.has_av or reference.has_av):
+        reasons = ("file_over_cap",) if maximum > max_file_bytes else ()
+        return PairCost(not reasons, raw, raw, maximum, reasons)
+    wire = 4 * math.ceil(raw / 3) + framing_reserve_bytes
+    reasons_list = []
+    if maximum > max_file_bytes:
+        reasons_list.append("file_over_cap")
+    if raw > max_raw_bytes:
+        reasons_list.append("aggregate_raw_over_cap")
+    if wire >= max_wire_bytes:
+        reasons_list.append("serialized_request_over_cap")
+    return PairCost(not reasons_list, wire, raw, maximum, tuple(reasons_list))
+
+
+class _Edge:
+    __slots__ = ("to", "rev", "capacity", "cost")
+
+    def __init__(self, to: int, rev: int, capacity: int, cost: int) -> None:
+        self.to = to
+        self.rev = rev
+        self.capacity = capacity
+        self.cost = cost
+
+
+def _add_edge(graph: list[list[_Edge]], source: int, target: int, capacity: int, cost: int) -> None:
+    graph[source].append(_Edge(target, len(graph[target]), capacity, cost))
+    graph[target].append(_Edge(source, len(graph[source]) - 1, 0, -cost))
+
+
+def _solve_capacity_assignment(
+    task_ids: Sequence[str],
+    reference_ids: Sequence[str],
+    original: Mapping[str, str],
+    costs: Mapping[tuple[str, str], PairCost],
+) -> Dict[str, str]:
+    """Minimum-change min-cost flow with exact original reference capacities."""
+    tasks = sorted(task_ids)
+    references = sorted(reference_ids)
+    capacities = Counter(original.values())
+    maximum_pair_cost = max((pair.wire_bytes for pair in costs.values() if pair.compatible), default=0)
+    change_penalty = (maximum_pair_cost + len(references) + 1) * (len(tasks) + 1)
+
+    source = 0
+    task_base = 1
+    reference_base = task_base + len(tasks)
+    sink = reference_base + len(references)
+    graph: list[list[_Edge]] = [[] for _ in range(sink + 1)]
+    for task_index, task_id in enumerate(tasks):
+        _add_edge(graph, source, task_base + task_index, 1, 0)
+        for reference_index, reference_id in enumerate(references):
+            pair = costs[(task_id, reference_id)]
+            if not pair.compatible:
+                continue
+            changed = reference_id != original[task_id]
+            cost = (change_penalty if changed else 0) + pair.wire_bytes + reference_index
+            _add_edge(graph, task_base + task_index, reference_base + reference_index, 1, cost)
+    for reference_index, reference_id in enumerate(references):
+        _add_edge(graph, reference_base + reference_index, sink, capacities[reference_id], 0)
+
+    potential = [0] * len(graph)
+    flow = 0
+    while flow < len(tasks):
+        infinity = 10**40
+        distance = [infinity] * len(graph)
+        previous_node = [-1] * len(graph)
+        previous_edge = [-1] * len(graph)
+        distance[source] = 0
+        queue: list[tuple[int, int]] = [(0, source)]
+        while queue:
+            current_distance, node = heapq.heappop(queue)
+            if current_distance != distance[node]:
+                continue
+            for edge_index, edge in enumerate(graph[node]):
+                if edge.capacity <= 0:
+                    continue
+                candidate = current_distance + edge.cost + potential[node] - potential[edge.to]
+                if candidate < distance[edge.to]:
+                    distance[edge.to] = candidate
+                    previous_node[edge.to] = node
+                    previous_edge[edge.to] = edge_index
+                    heapq.heappush(queue, (candidate, edge.to))
+        if previous_node[sink] < 0:
+            blocked = sorted(
+                task_id
+                for task_id in tasks
+                if not any(costs[(task_id, reference_id)].compatible for reference_id in references)
+            )
+            raise ValueError(f"no count-preserving transport-compatible assignment; tasks_without_any_route={blocked}")
+        for node, value in enumerate(distance):
+            if value < infinity:
+                potential[node] += value
+        node = sink
+        while node != source:
+            parent = previous_node[node]
+            edge = graph[parent][previous_edge[node]]
+            edge.capacity -= 1
+            graph[node][edge.rev].capacity += 1
+            node = parent
+        flow += 1
+
+    result: Dict[str, str] = {}
+    for task_index, task_id in enumerate(tasks):
+        node = task_base + task_index
+        for edge in graph[node]:
+            if reference_base <= edge.to < sink and edge.capacity == 0:
+                result[task_id] = references[edge.to - reference_base]
+                break
+    if len(result) != len(tasks) or Counter(result.values()) != capacities:
+        raise RuntimeError("transport assignment solver violated its capacity contract")
+    return result
+
+
+def make_assignment_repair(
+    global_config: Mapping[str, Any],
+    config: Mapping[str, Any],
+) -> Callable[[int, Sequence[str], Mapping[str, str]], tuple[Dict[str, str], Dict[str, Any]]]:
+    """Bind filesystem roots and return the multistage plan-repair callback."""
+    gdpval = _find_gdpval_config(global_config)
+    candidate_root = Path(
+        str(gdpval.get("persist_deliverables_dir") or os.environ.get("PERSIST_DELIVERABLES_DIR", ""))
+    )
+    if not candidate_root.is_dir():
+        raise ValueError(f"candidate transport view is unreadable: {candidate_root}")
+    all_references = {
+        str(reference_id): Path(str(reference_config["deliverables_dir"]))
+        for reference_id, reference_config in (gdpval.get("reference_models") or {}).items()
+        if isinstance(reference_config, Mapping)
+    }
+    if not all_references or any(not path.is_dir() for path in all_references.values()):
+        raise ValueError("one or more reference transport views are unreadable")
+
+    max_file_bytes = int(config.get("max_file_bytes", 320 * 1024 * 1024))
+    max_raw_bytes = int(config.get("max_raw_bytes", 315 * 1024 * 1024))
+    max_wire_bytes = int(config.get("max_wire_bytes", 420 * 1024 * 1024))
+    framing_reserve_bytes = int(config.get("framing_reserve_bytes", 4 * 1024 * 1024))
+    footprint_cache: dict[tuple[str, str, bool, bool], list[Footprint]] = {}
+
+    def footprints(
+        root: Path,
+        task_id: str,
+        *,
+        require_completed_reference: bool = False,
+        include_reference_files: bool = False,
+    ) -> list[Footprint]:
+        key = (str(root), task_id, require_completed_reference, include_reference_files)
+        if key not in footprint_cache:
+            directories = _repeat_dirs(root, task_id)
+            if not directories:
+                if require_completed_reference:
+                    return []
+                raise ValueError(f"missing transport deliverable: {root}/task_{task_id}")
+            if require_completed_reference and not _has_valid_finish_marker(directories):
+                return []
+            footprint_cache[key] = [
+                _footprint(directory, include_reference_files=include_reference_files) for directory in directories
+            ]
+        return footprint_cache[key]
+
+    def repair(
+        stage_index: int,
+        reference_ids: Sequence[str],
+        original: Mapping[str, str],
+    ) -> tuple[Dict[str, str], Dict[str, Any]]:
+        references = sorted(str(reference_id) for reference_id in reference_ids)
+        missing = sorted(set(references) - set(all_references))
+        if missing:
+            raise ValueError(f"stage selected unknown reference transport views: {missing}")
+        costs: dict[tuple[str, str], PairCost] = {}
+        for task_id in sorted(original):
+            candidates = footprints(candidate_root, task_id)
+            for reference_id in references:
+                references_for_task = footprints(
+                    all_references[reference_id],
+                    task_id,
+                    require_completed_reference=True,
+                    include_reference_files=True,
+                )
+                if not references_for_task:
+                    costs[(task_id, reference_id)] = PairCost(
+                        compatible=False,
+                        wire_bytes=0,
+                        raw_bytes=0,
+                        max_file_bytes=0,
+                        reasons=("reference_incomplete",),
+                    )
+                    continue
+                combinations = [
+                    _pair_cost(
+                        candidate,
+                        reference,
+                        max_file_bytes=max_file_bytes,
+                        max_raw_bytes=max_raw_bytes,
+                        max_wire_bytes=max_wire_bytes,
+                        framing_reserve_bytes=framing_reserve_bytes,
+                    )
+                    for candidate in candidates
+                    for reference in references_for_task
+                ]
+                # One assignment must work for every candidate/reference repeat.
+                incompatible = [pair for pair in combinations if not pair.compatible]
+                if incompatible:
+                    worst = max(incompatible, key=lambda pair: (pair.wire_bytes, pair.raw_bytes))
+                    costs[(task_id, reference_id)] = worst
+                else:
+                    costs[(task_id, reference_id)] = max(
+                        combinations,
+                        key=lambda pair: (pair.wire_bytes, pair.raw_bytes),
+                    )
+
+        repaired = _solve_capacity_assignment(list(original), references, original, costs)
+        changes = []
+        for task_id in sorted(original):
+            before = original[task_id]
+            after = repaired[task_id]
+            if before != after:
+                before_cost = costs[(task_id, before)]
+                after_cost = costs[(task_id, after)]
+                changes.append(
+                    {
+                        "task_id": task_id,
+                        "before": before,
+                        "after": after,
+                        "before_compatible": before_cost.compatible,
+                        "before_reasons": list(before_cost.reasons),
+                        "before_wire_bytes": before_cost.wire_bytes,
+                        "after_wire_bytes": after_cost.wire_bytes,
+                    }
+                )
+        initially_incompatible = [
+            {
+                "task_id": task_id,
+                "reference_id": original[task_id],
+                "reasons": list(costs[(task_id, original[task_id])].reasons),
+            }
+            for task_id in sorted(original)
+            if not costs[(task_id, original[task_id])].compatible
+        ]
+        receipt = {
+            "schema": "gdpval.transport-assignment-repair.v1",
+            "stage_index": stage_index,
+            "policy": "minimum changed tasks; exact selected-reference counts; provider-free",
+            "limits": {
+                "max_file_bytes": max_file_bytes,
+                "max_raw_bytes": max_raw_bytes,
+                "max_wire_bytes": max_wire_bytes,
+                "framing_reserve_bytes": framing_reserve_bytes,
+            },
+            "reference_counts": dict(sorted(Counter(original.values()).items())),
+            "initially_incompatible": initially_incompatible,
+            "changes": changes,
+        }
+        return repaired, receipt
+
+    return repair

--- a/resources_servers/gdpval/transport_assignment.py
+++ b/resources_servers/gdpval/transport_assignment.py
@@ -37,10 +37,19 @@ _BINARY_EXTENSIONS = {
     ".aif",
     ".aiff",
     ".mp4",
+    ".m4v",
     ".mov",
     ".mkv",
     ".webm",
     ".avi",
+    ".wmv",
+    ".flv",
+    ".mpeg",
+    ".mpg",
+    ".3gp",
+    ".oga",
+    ".opus",
+    ".wma",
 }
 _AV_EXTENSIONS = {
     ".wav",
@@ -50,13 +59,22 @@ _AV_EXTENSIONS = {
     ".m4a",
     ".aac",
     ".ogg",
+    ".oga",
+    ".opus",
+    ".wma",
     ".aif",
     ".aiff",
     ".mp4",
+    ".m4v",
     ".mov",
     ".mkv",
     ".webm",
     ".avi",
+    ".wmv",
+    ".flv",
+    ".mpeg",
+    ".mpg",
+    ".3gp",
 }
 _IGNORED_NAMES = {
     "finish_params.json",
@@ -72,6 +90,10 @@ class Footprint:
     max_file_bytes: int
     has_av: bool
     file_count: int
+    # A directory whose archive contents could not be enumerated. Its true
+    # footprint is unknown, so every pair using it is costed incompatible
+    # instead of aborting the whole planning pass.
+    defective: bool = False
 
 
 @dataclass(frozen=True)
@@ -149,6 +171,7 @@ def _has_valid_finish_marker(repeat_dirs: Sequence[Path]) -> bool:
 
 def _footprint(directory: Path, *, include_reference_files: bool = True) -> Footprint:
     artifacts: list[_BinaryArtifact] = []
+    defective = False
     # Match app.py exactly: the submission directory and its optional
     # reference_files directory are built as two semantic sections. Reference
     # assets recurse below reference_files; candidate run-state subdirectories
@@ -162,7 +185,12 @@ def _footprint(directory: Path, *, include_reference_files: bool = True) -> Foot
             continue
         suffix = path.suffix.lower()
         if suffix == ".zip":
-            with zipfile.ZipFile(path, "r") as archive:
+            try:
+                archive_context = zipfile.ZipFile(path, "r")
+            except (zipfile.BadZipFile, OSError):
+                defective = True
+                continue
+            with archive_context as archive:
                 for info in archive.infolist():
                     member = Path(info.filename.replace("\\", "/"))
                     if (
@@ -208,7 +236,7 @@ def _footprint(directory: Path, *, include_reference_files: bool = True) -> Foot
     maximum = max((artifact.size for artifact in retained), default=0)
     count = len(retained)
     has_av = any(artifact.suffix in _AV_EXTENSIONS for artifact in retained)
-    return Footprint(raw_bytes=raw, max_file_bytes=maximum, has_av=has_av, file_count=count)
+    return Footprint(raw_bytes=raw, max_file_bytes=maximum, has_av=has_av, file_count=count, defective=defective)
 
 
 def _pair_cost(
@@ -218,18 +246,27 @@ def _pair_cost(
     max_file_bytes: int,
     max_raw_bytes: int,
     max_wire_bytes: int,
+    max_section_raw_bytes: int,
     framing_reserve_bytes: int,
 ) -> PairCost:
+    if candidate.defective or reference.defective:
+        return PairCost(False, 0, 0, 0, ("corrupt_archive",))
     raw = candidate.raw_bytes + reference.raw_bytes
     maximum = max(candidate.max_file_bytes, reference.max_file_bytes)
+    # Each judge section is built under its own raw budget; a directory over
+    # that share emits an omission marker at dispatch regardless of media type,
+    # which preflight then rejects for every judge.
+    section_reasons = []
+    if max(candidate.raw_bytes, reference.raw_bytes) > max_section_raw_bytes:
+        section_reasons.append("section_raw_over_cap")
     # Audio/video is routed only to Gemini, so its native base64 request is the
     # binding case. PDF/image-only tasks retain GPT raster and native-PDF paths;
     # their exact provider request is gated later by the resource server.
     if not (candidate.has_av or reference.has_av):
-        reasons = ("file_over_cap",) if maximum > max_file_bytes else ()
+        reasons = tuple((["file_over_cap"] if maximum > max_file_bytes else []) + section_reasons)
         return PairCost(not reasons, raw, raw, maximum, reasons)
     wire = 4 * math.ceil(raw / 3) + framing_reserve_bytes
-    reasons_list = []
+    reasons_list = list(section_reasons)
     if maximum > max_file_bytes:
         reasons_list.append("file_over_cap")
     if raw > max_raw_bytes:
@@ -356,9 +393,20 @@ def make_assignment_repair(
     if not all_references or any(not path.is_dir() for path in all_references.values()):
         raise ValueError("one or more reference transport views are unreadable")
 
-    max_file_bytes = int(config.get("max_file_bytes", 320 * 1024 * 1024))
-    max_raw_bytes = int(config.get("max_raw_bytes", 315 * 1024 * 1024))
-    max_wire_bytes = int(config.get("max_wire_bytes", 420 * 1024 * 1024))
+    # Defaults come from the judge-side enforcement constants so the plan-time
+    # model cannot silently drift from what dispatch actually rejects. Campaign
+    # configs may still override every knob.
+    from resources_servers.gdpval.comparison import (
+        MAX_FILE_BYTES_FOR_JUDGE,
+        MAX_SECTION_RAW_ATTACHMENT_BYTES_FOR_JUDGE,
+        MAX_TOTAL_RAW_ATTACHMENT_BYTES_FOR_JUDGE,
+        MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE,
+    )
+
+    max_file_bytes = int(config.get("max_file_bytes", MAX_FILE_BYTES_FOR_JUDGE))
+    max_raw_bytes = int(config.get("max_raw_bytes", MAX_TOTAL_RAW_ATTACHMENT_BYTES_FOR_JUDGE))
+    max_wire_bytes = int(config.get("max_wire_bytes", MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE))
+    max_section_raw_bytes = int(config.get("max_section_raw_bytes", MAX_SECTION_RAW_ATTACHMENT_BYTES_FOR_JUDGE))
     framing_reserve_bytes = int(config.get("framing_reserve_bytes", 4 * 1024 * 1024))
     footprint_cache: dict[tuple[str, str, bool, bool], list[Footprint]] = {}
 
@@ -393,8 +441,25 @@ def make_assignment_repair(
         if missing:
             raise ValueError(f"stage selected unknown reference transport views: {missing}")
         costs: dict[tuple[str, str], PairCost] = {}
+        unrepairable_tasks: list[str] = []
         for task_id in sorted(original):
-            candidates = footprints(candidate_root, task_id)
+            try:
+                candidates = footprints(candidate_root, task_id)
+            except ValueError:
+                # No candidate deliverable yet (fresh run: repair fires at
+                # stage planning, before any rollout exists). The repair cannot
+                # reason about this task; pin it to its original reference.
+                unrepairable_tasks.append(task_id)
+                for reference_id in references:
+                    pinned = reference_id == original[task_id]
+                    costs[(task_id, reference_id)] = PairCost(
+                        compatible=pinned,
+                        wire_bytes=0,
+                        raw_bytes=0,
+                        max_file_bytes=0,
+                        reasons=() if pinned else ("candidate_deliverable_missing",),
+                    )
+                continue
             for reference_id in references:
                 references_for_task = footprints(
                     all_references[reference_id],
@@ -418,6 +483,7 @@ def make_assignment_repair(
                         max_file_bytes=max_file_bytes,
                         max_raw_bytes=max_raw_bytes,
                         max_wire_bytes=max_wire_bytes,
+                        max_section_raw_bytes=max_section_raw_bytes,
                         framing_reserve_bytes=framing_reserve_bytes,
                     )
                     for candidate in candidates
@@ -470,10 +536,12 @@ def make_assignment_repair(
                 "max_file_bytes": max_file_bytes,
                 "max_raw_bytes": max_raw_bytes,
                 "max_wire_bytes": max_wire_bytes,
+                "max_section_raw_bytes": max_section_raw_bytes,
                 "framing_reserve_bytes": framing_reserve_bytes,
             },
             "reference_counts": dict(sorted(Counter(original.values()).items())),
             "initially_incompatible": initially_incompatible,
+            "unrepairable_tasks": unrepairable_tasks,
             "changes": changes,
         }
         return repaired, receipt

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -167,6 +167,25 @@ def _task_finished(deliverables_dir: Optional[str]) -> bool:
     return (root / _FINISH_MARKER_FILE).is_file()
 
 
+def _has_real_deliverable(deliverables_dir: Optional[str]) -> bool:
+    """Return whether *deliverables_dir* contains agent-produced output."""
+    if not deliverables_dir:
+        return False
+    root = Path(deliverables_dir)
+    if not root.is_dir():
+        return False
+
+    # Keep the definition of a deliverable aligned with the judge's reader so
+    # run-state files such as finish_params.json and history.json never turn a
+    # judge failure into a policy-reuse request.
+    from responses_api_agents.stirrup_agent.file_reader import is_deliverable
+
+    try:
+        return any(is_deliverable(path) for path in root.iterdir())
+    except OSError:
+        return False
+
+
 def _reference_set_key(
     reference_ids: Optional[Sequence[str]], verify_cache_namespace: Optional[str] = None
 ) -> Optional[str]:
@@ -360,12 +379,10 @@ def _attach_cached_deliverable_context(failure: Dict[str, Any], deliverables_dir
     if deliverables_dir is None:
         return failure
     failure["deliverables_dir"] = deliverables_dir
-    try:
-        artifact_exists = Path(deliverables_dir).is_dir() and any(Path(deliverables_dir).iterdir())
-    except OSError:
-        artifact_exists = False
-    if artifact_exists:
+    if _has_real_deliverable(deliverables_dir):
         failure["reuse_cached_deliverable"] = True
+    else:
+        failure.pop("reuse_cached_deliverable", None)
     return failure
 
 
@@ -1330,11 +1347,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
             # re-running the policy. Unlike server-wide judge_only, it falls back
             # to a normal rollout when no deliverable is cached yet.
             reuse_requested = bool(body_dict.get("reuse_cached_deliverable"))
-            deliverable_cached = (
-                deliverables_dir is not None
-                and Path(deliverables_dir).is_dir()
-                and any(Path(deliverables_dir).iterdir())
-            )
+            deliverable_cached = _has_real_deliverable(deliverables_dir)
             # The reference subset this request is judged against (multi-stage ELO
             # tags each row with the stage's references; empty for rubric / fixed-
             # reference comparison). A cached judgement is only valid for the exact
@@ -1485,6 +1498,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                         reason=reason,
                         skipped=False,
                         error_class="incomplete",
+                        completed_response=response_clean,
                     )
 
             # Task-only execution mode: the deliverables are already cached to
@@ -1536,6 +1550,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                         reason=reason,
                         skipped=False,
                         error_class=error_class,
+                        completed_response=response_clean,
                     )
                     failure["invalid_judge_response"] = True
                     failure["invalid_judge_retryable"] = invalid_retryable
@@ -1565,6 +1580,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     reason=f"verify failed: {type(exc).__name__}: {exc}",
                     skipped=False,
                     error_class=failure_class,
+                    completed_response=response_clean,
                 )
                 return _attach_cached_deliverable_context(failure, deliverables_dir)
 
@@ -1680,8 +1696,13 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         skipped: bool,
         error_class: Optional[str] = None,
         attempt_started: Optional[float] = None,
+        completed_response: Optional[NeMoGymResponse] = None,
     ) -> Dict[str, Any]:
-        """Return a verify-response-shaped dict for runs that never produced a deliverable.
+        """Return a verify-response-shaped failure payload.
+
+        ``completed_response`` preserves genuine policy output when failure
+        happens after execution (for example in ``/verify``). A synthetic
+        response is used only when no policy response exists.
 
         The returned payload carries routing flags read by the rollout
         dispatcher (``nemo_gym.rollout_collection``):
@@ -1714,32 +1735,34 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         else:
             suffix = "failed"
             status_word = "Failed"
-        placeholder = NeMoGymResponse(
-            id=f"{self.task_strategy.response_id(task_info)}-{suffix}",
-            created_at=int(time.time()),
-            model=fixed_params.model or "unknown",
-            object="response",
-            output=[
-                NeMoGymResponseOutputMessage(
-                    id=self.task_strategy.fallback_message_id(task_info),
-                    content=[
-                        NeMoGymResponseOutputText(
-                            type="output_text",
-                            text=f"{status_word}: {reason}",
-                            annotations=[],
-                        )
-                    ],
-                    role="assistant",
-                    status="completed",
-                    type="message",
-                )
-            ],
-            parallel_tool_calls=False,
-            tool_choice="none",
-            tools=[],
-        )
+        response = completed_response
+        if response is None:
+            response = NeMoGymResponse(
+                id=f"{self.task_strategy.response_id(task_info)}-{suffix}",
+                created_at=int(time.time()),
+                model=fixed_params.model or "unknown",
+                object="response",
+                output=[
+                    NeMoGymResponseOutputMessage(
+                        id=self.task_strategy.fallback_message_id(task_info),
+                        content=[
+                            NeMoGymResponseOutputText(
+                                type="output_text",
+                                text=f"{status_word}: {reason}",
+                                annotations=[],
+                            )
+                        ],
+                        role="assistant",
+                        status="completed",
+                        type="message",
+                    )
+                ],
+                parallel_tool_calls=False,
+                tool_choice="none",
+                tools=[],
+            )
         payload = dict(body_dict)
-        payload["response"] = placeholder.model_dump(mode="json")
+        payload["response"] = response.model_dump(mode="json")
         payload["reward"] = 0.0
         payload["skipped"] = skipped
         payload["error_message"] = reason

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hashlib
+import json
 import os
 import shutil
 import sys
@@ -106,17 +107,21 @@ def _log_timeout_once(timeout_s: float) -> None:
 # Failure classification (drives whether a failure is persisted to the main
 # rollouts jsonl, the failures sidecar, or nowhere at all).
 #
-# Five classes:
+# Failure classes:
 #   kill_shaped       Ray worker died (SIGTERM/walltime/OOM/node loss). NO row
 #                     written anywhere; resume's set-difference on the main
 #                     jsonl naturally re-dispatches, capped per-attempt by
 #                     the per-task timeout above.
-#   timeout_exceeded  TaskPerAttemptTimeoutError. Sidecar entry with
-#                     _ng_failure_terminal=True so chain-hop 2 does NOT retry.
+#   timeout_exceeded  TaskPerAttemptTimeoutError. Retryable sidecar entry,
+#                     bounded by the rollout attempt limit.
 #   skipped           TaskSampleSkipError. Sidecar entry with terminal=True.
 #   transient         verify-side ClientResponseError 5xx / connection /
 #                     asyncio.TimeoutError. Sidecar entry per attempt; retry
 #                     up to max_attempts.
+#   permanent         Verify request cannot succeed unchanged (for example,
+#                     an oversized request or context). Terminal sidecar entry.
+#   judge_invalid     Judge returned an invalid/unscorable response. Retryable
+#                     sidecar entry so cached deliverables can be re-judged.
 #   legitimate        Everything else (real Python exception with user code
 #                     in the traceback). Sidecar entry per attempt; retry
 #                     up to max_attempts.
@@ -124,7 +129,7 @@ def _log_timeout_once(timeout_s: float) -> None:
 
 # Sentinel keys the dispatcher (nemo_gym.rollout_collection) reads to route a
 # returned payload between the main jsonl, the failures sidecar, or /dev/null.
-NG_FAILURE_CLASS_KEY = "_ng_failure_class"  # str: one of the 5 class names
+NG_FAILURE_CLASS_KEY = "_ng_failure_class"  # str: one of the class names above
 NG_NO_PERSIST_KEY = "_ng_no_persist"  # bool: don't write anywhere
 NG_TERMINAL_KEY = "_ng_failure_terminal"  # bool: never retry on resume
 
@@ -162,26 +167,38 @@ def _task_finished(deliverables_dir: Optional[str]) -> bool:
     return (root / _FINISH_MARKER_FILE).is_file()
 
 
-def _reference_set_key(reference_ids: Optional[Sequence[str]]) -> Optional[str]:
+def _reference_set_key(
+    reference_ids: Optional[Sequence[str]], verify_cache_namespace: Optional[str] = None
+) -> Optional[str]:
     """Stable short key identifying a judgement's reference set, or None.
 
     A GDPVal judgement is only valid for the exact reference subset it scored
     against, and multi-stage ELO judges the *same* deliverable against a
     *different* subset each stage. So a cached judgement must be keyed by that
-    subset. Returns a short hex digest of the sorted, de-duplicated
-    ``reference_ids`` (order-independent), or ``None`` when no references are in
-    play (rubric mode, or comparison mode where every request scores against the
-    same fixed set — a single unkeyed cache slot is correct there).
+    subset. Returns a short digest of the sorted, de-duplicated
+    ``reference_ids`` plus an optional run namespace. ``None`` retains the
+    legacy unkeyed slot, while an explicit empty list gets its own key because
+    GDPVal distinguishes "all configured references" from "no references".
     """
-    if not reference_ids:
+    if reference_ids is None and verify_cache_namespace is None:
         return None
-    normalized = ",".join(sorted({str(r) for r in reference_ids}))
-    return hashlib.sha1(normalized.encode()).hexdigest()[:12]
+    normalized_references = None if reference_ids is None else sorted({str(r) for r in reference_ids})
+    if verify_cache_namespace is None and normalized_references:
+        # Preserve the pre-namespace filename so upgrades can reuse valid
+        # judgements already cached for nonempty reference sets.
+        return hashlib.sha1(",".join(normalized_references).encode()).hexdigest()[:12]
+    normalized = json.dumps(
+        {"namespace": verify_cache_namespace, "reference_ids": normalized_references},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
 
 
 def _verify_cache_path(
     deliverables_dir: Optional[str],
     reference_ids: Optional[Sequence[str]] = None,
+    verify_cache_namespace: Optional[str] = None,
 ) -> Optional[Path]:
     """Path of the cached ``/verify`` result for a task+repeat.
 
@@ -200,7 +217,7 @@ def _verify_cache_path(
     if not deliverables_dir:
         return None
     d = Path(deliverables_dir)
-    key = _reference_set_key(reference_ids)
+    key = _reference_set_key(reference_ids, verify_cache_namespace)
     suffix = f"_verify_response_{key}.json" if key else "_verify_response.json"
     return d.parent / f"{d.name}{suffix}"
 
@@ -281,18 +298,75 @@ def _classify_verify_failure(exc: BaseException) -> str:
     failures are never ``kill_shaped`` (we had a rollout response in hand)
     and never ``timeout_exceeded`` (that's a rollout-side class).
     """
+    # Nested resources servers often translate an upstream 4xx into a 500.
+    # Inspect the attached response body and exception chain before applying
+    # the generic HTTP-status policy so deterministic payload/context errors do
+    # not waste every retry hop.
+    parts: List[str] = []
+    seen: set[int] = set()
+    current: Optional[BaseException] = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        parts.append(str(current))
+        response_content = getattr(current, "response_content", None)
+        if isinstance(response_content, bytes):
+            parts.append(response_content.decode("utf-8", errors="replace"))
+        elif response_content is not None:
+            parts.append(str(response_content))
+        current = current.__cause__ or current.__context__
+    error_text = "\n".join(parts)
+    from resources_servers.gdpval.scoring import is_permanent_judge_error
+
+    permanent = is_permanent_judge_error(exc) or is_permanent_judge_error(error_text)
+
     try:
         import aiohttp
 
         if isinstance(exc, aiohttp.ClientResponseError):
+            if permanent:
+                return "permanent"
             return "transient" if 500 <= exc.status < 600 else "legitimate"
         if isinstance(exc, aiohttp.ClientConnectionError):
             return "transient"
     except ImportError:
         pass
+    if permanent:
+        return "permanent"
     if isinstance(exc, asyncio.TimeoutError):
         return "transient"
     return "legitimate"
+
+
+def _bounded_judge_diagnostic(value: Any, max_chars: int = 32_000) -> Any:
+    """Keep judge failure evidence in the sidecar without copying huge replies."""
+
+    import json
+
+    try:
+        serialized = json.dumps(value, default=str, ensure_ascii=False)
+    except Exception:
+        serialized = repr(value)
+    if len(serialized) <= max_chars:
+        return value
+    return {
+        "diagnostic_truncated": True,
+        "serialized_preview": serialized[:max_chars],
+        "original_chars": len(serialized),
+    }
+
+
+def _attach_cached_deliverable_context(failure: Dict[str, Any], deliverables_dir: Optional[str]) -> Dict[str, Any]:
+    """Preserve a completed policy artifact so judge retries do not rerun it."""
+    if deliverables_dir is None:
+        return failure
+    failure["deliverables_dir"] = deliverables_dir
+    try:
+        artifact_exists = Path(deliverables_dir).is_dir() and any(Path(deliverables_dir).iterdir())
+    except OSError:
+        artifact_exists = False
+    if artifact_exists:
+        failure["reuse_cached_deliverable"] = True
+    return failure
 
 
 # ---------------------------------------------------------------------------
@@ -1265,7 +1339,8 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
             # tags each row with the stage's references; empty for rubric / fixed-
             # reference comparison). A cached judgement is only valid for the exact
             # subset it scored, so it keys the rerun_incomplete verify cache.
-            reference_ids = body_dict.get("reference_ids") or None
+            reference_ids = body_dict.get("reference_ids") if "reference_ids" in body_dict else None
+            verify_cache_namespace = body_dict.get("verify_cache_namespace")
 
             if self.config.judge_only:
                 # Judge-only mode: do NOT run the agent. Score the pre-existing
@@ -1296,7 +1371,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 # through to /verify (which caches the fresh judgement so the next
                 # pass skips it).
                 if self.config.rerun_incomplete:
-                    cached_verify = self._read_cached_verify(deliverables_dir, reference_ids)
+                    cached_verify = self._read_cached_verify(deliverables_dir, reference_ids, verify_cache_namespace)
                     if cached_verify is not None:
                         task_info = self.task_strategy.extract_task_info(existing_metadata)
                         instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
@@ -1330,7 +1405,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 task_info = self.task_strategy.extract_task_info(existing_metadata)
                 instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
                 if not self.config.execute_only:
-                    cached_verify = self._read_cached_verify(deliverables_dir, reference_ids)
+                    cached_verify = self._read_cached_verify(deliverables_dir, reference_ids, verify_cache_namespace)
                     if cached_verify is not None:
                         print(
                             f"[stirrup-rerun_incomplete-cached-judgement] {instance_hint}: returning cached "
@@ -1442,13 +1517,37 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 )
                 await raise_for_status(verify_response)
                 verify_result = await get_response_json(verify_response)
+                if verify_result.get("invalid_judge_response"):
+                    task_info = self.task_strategy.extract_task_info(existing_metadata)
+                    judge_response = verify_result.get("judge_response")
+                    scoring_error = judge_response.get("scoring_error") if isinstance(judge_response, dict) else None
+                    reason = "judge returned an invalid response"
+                    if scoring_error:
+                        reason = f"{reason}: {scoring_error}"
+                    instance_hint = task_info.get("instance_id", task_info.get("task_id", "unknown"))
+                    invalid_retryable = verify_result.get("invalid_judge_retryable") is not False
+                    error_class = "judge_invalid" if invalid_retryable else "permanent"
+                    print(f"[stirrup-verify-{error_class}] {instance_hint}: {reason}", flush=True)
+                    failure = self._build_failed_run_payload(
+                        attempt_started=attempt_started,
+                        body_dict=body_dict,
+                        fixed_params=fixed_params,
+                        task_info=task_info,
+                        reason=reason,
+                        skipped=False,
+                        error_class=error_class,
+                    )
+                    failure["invalid_judge_response"] = True
+                    failure["invalid_judge_retryable"] = invalid_retryable
+                    failure["judge_response"] = _bounded_judge_diagnostic(judge_response)
+                    return _attach_cached_deliverable_context(failure, deliverables_dir)
                 # Task re-run mode: cache the judgement next to the deliverables so
                 # a subsequent rerun_incomplete pass returns it instead of re-judging
                 # this task. The cache is keyed by the reference subset scored, so a
                 # multi-stage ELO run caches each stage's judgement independently
                 # and only replays it for a request against the same references.
                 if self.config.rerun_incomplete:
-                    self._write_cached_verify(deliverables_dir, verify_result, reference_ids)
+                    self._write_cached_verify(deliverables_dir, verify_result, reference_ids, verify_cache_namespace)
                 return verify_result
             except Exception as exc:
                 task_info = self.task_strategy.extract_task_info(existing_metadata)
@@ -1458,7 +1557,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     f"[stirrup-verify-{failure_class}] {instance_hint}: {type(exc).__name__}: {exc}",
                     flush=True,
                 )
-                return self._build_failed_run_payload(
+                failure = self._build_failed_run_payload(
                     attempt_started=attempt_started,
                     body_dict=body_dict,
                     fixed_params=fixed_params,
@@ -1467,9 +1566,13 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                     skipped=False,
                     error_class=failure_class,
                 )
+                return _attach_cached_deliverable_context(failure, deliverables_dir)
 
     def _read_cached_verify(
-        self, deliverables_dir: Optional[str], reference_ids: Optional[Sequence[str]] = None
+        self,
+        deliverables_dir: Optional[str],
+        reference_ids: Optional[Sequence[str]] = None,
+        verify_cache_namespace: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Return the cached ``/verify`` result for *deliverables_dir*, or None.
 
@@ -1479,14 +1582,24 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         fixed-reference runs. Returns None on a missing or unreadable cache (the
         task is then judged afresh).
         """
-        cache_path = _verify_cache_path(deliverables_dir, reference_ids)
+        cache_path = _verify_cache_path(deliverables_dir, reference_ids, verify_cache_namespace)
         if cache_path is None or not cache_path.is_file():
             return None
         try:
             import json as _json
 
             with cache_path.open("r", encoding="utf-8") as f:
-                return _json.load(f)
+                cached = _json.load(f)
+            if not isinstance(cached, dict):
+                print(f"[stirrup] warning: cached verify result is not an object: {cache_path}", flush=True)
+                return None
+            if cached.get("invalid_judge_response"):
+                # Pre-fix runs cached invalid judge replies as if they were
+                # completed judgements. Treat them as a cache miss so resume
+                # re-judges the existing deliverable and overwrites the cache.
+                print(f"[stirrup] ignoring invalid cached verify result: {cache_path}", flush=True)
+                return None
+            return cached
         except Exception as exc:
             print(f"[stirrup] warning: could not read cached verify result {cache_path}: {exc}", flush=True)
             return None
@@ -1496,6 +1609,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         deliverables_dir: Optional[str],
         verify_result: Dict[str, Any],
         reference_ids: Optional[Sequence[str]] = None,
+        verify_cache_namespace: Optional[str] = None,
     ) -> None:
         """Persist *verify_result* next to *deliverables_dir* (best-effort).
 
@@ -1504,7 +1618,7 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         subset scored (multi-stage ELO), so each stage's judgement is cached
         independently. Failures are logged but never abort the run.
         """
-        cache_path = _verify_cache_path(deliverables_dir, reference_ids)
+        cache_path = _verify_cache_path(deliverables_dir, reference_ids, verify_cache_namespace)
         if cache_path is None:
             return
         try:
@@ -1574,11 +1688,11 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
 
         - ``_ng_no_persist=True`` for ``kill_shaped``: not written anywhere;
           resume's set-difference on the main jsonl re-dispatches the task.
-        - ``_ng_failure_terminal=True`` for ``skipped``: one sidecar entry,
-          never retried (the sample itself is unusable).
-        - Otherwise (``legitimate``, ``transient``, ``incomplete``): sidecar
-          entry per attempt; retried up to ``NEMO_GYM_MAX_ROLLOUT_ATTEMPTS`` on
-          chain resume.
+        - ``_ng_failure_terminal=True`` for ``skipped`` and ``permanent``:
+          one sidecar entry, never retried because unchanged input cannot help.
+        - Otherwise (``legitimate``, ``transient``, ``incomplete``,
+          ``judge_invalid``, ``timeout_exceeded``): sidecar entry per attempt;
+          retried up to ``NEMO_GYM_MAX_ROLLOUT_ATTEMPTS`` on chain resume.
         """
         if error_class == "timeout_exceeded":
             suffix = "timeout"
@@ -1591,6 +1705,9 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
             # resume_from_cache run re-dispatches it (capped by max_attempts).
             suffix = "incomplete"
             status_word = "Incomplete"
+        elif error_class == "permanent":
+            suffix = "permanent-failure"
+            status_word = "Failed permanently"
         elif skipped or error_class == "skipped":
             suffix = "skipped"
             status_word = "Skipped"
@@ -1638,8 +1755,9 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 # Don't persist: resume's set-difference on the main jsonl
                 # naturally re-dispatches. Bounded across hops by per-task timeout.
                 payload[NG_NO_PERSIST_KEY] = True
-            elif error_class == "skipped":
-                # The sample itself is unusable, so retrying cannot help.
+            elif error_class in {"skipped", "permanent"}:
+                # The sample is unusable or the unchanged request is guaranteed
+                # to fail, so retrying cannot help.
                 payload[NG_TERMINAL_KEY] = True
             elif error_class == "timeout_exceeded":
                 # Retryable: a per-task timeout measures the attempt's conditions,
@@ -1651,7 +1769,8 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 # counter still bounds a genuinely pathological task.
                 payload["_ng_timeout_inflight"] = self.inflight
                 payload["_ng_timeout_concurrency_limit"] = self.config.concurrency
-            # 'legitimate' / 'transient' / 'incomplete' / 'timeout_exceeded':
+            # 'legitimate' / 'transient' / 'incomplete' / 'judge_invalid' /
+            # 'timeout_exceeded':
             # sidecar entry per attempt; retried by chain-hop / resume up to
             # NEMO_GYM_MAX_ROLLOUT_ATTEMPTS (default 3).
         return payload

--- a/responses_api_agents/stirrup_agent/app.py
+++ b/responses_api_agents/stirrup_agent/app.py
@@ -1615,6 +1615,13 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
                 # re-judges the existing deliverable and overwrites the cache.
                 print(f"[stirrup] ignoring invalid cached verify result: {cache_path}", flush=True)
                 return None
+            if cached.get(NG_FAILURE_CLASS_KEY):
+                # A classified failure (terminal or not) is not a judgement.
+                # Replaying a cached reference_missing/eval_missing verdict
+                # would permanently delete the battle from ELO evidence even
+                # after the environment fault is repaired.
+                print(f"[stirrup] ignoring cached failure-classed verify result: {cache_path}", flush=True)
+                return None
             return cached
         except Exception as exc:
             print(f"[stirrup] warning: could not read cached verify result {cache_path}: {exc}", flush=True)
@@ -1636,6 +1643,10 @@ class StirrupAgentWrapper(SimpleResponsesAPIAgent):
         """
         cache_path = _verify_cache_path(deliverables_dir, reference_ids, verify_cache_namespace)
         if cache_path is None:
+            return
+        if verify_result.get(NG_FAILURE_CLASS_KEY):
+            # Failures are retry state, not judgements; persisting one would
+            # make _read_cached_verify replay it forever on re-judging runs.
             return
         try:
             import json as _json

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -24,6 +24,7 @@ with multimodal models (e.g., Gemini 3 Pro).
 from __future__ import annotations
 
 import base64
+import math
 import os
 import re
 import shutil
@@ -38,9 +39,28 @@ from typing import Any
 # an extension would send a routed deliverable to a capable judge and then drop
 # it here with no warning. judge_panel is stdlib-only, so this costs nothing.
 from resources_servers.gdpval.judge_panel import AUDIO_EXTS, VIDEO_EXTS
+from resources_servers.gdpval.preconvert import (
+    AttachmentBudget,
+    extract_xlsx_structured_text,
+    resolve_pdf_provenance,
+    roundtrip_ooxml_copy,
+)
 
 
 MAX_TOTAL_CHARS = 20_000
+
+
+def _bounded_text(text: str, cap: int, marker: str = "\n[...truncated]") -> str:
+    """Trim *text* including its marker so the returned string is at most *cap*."""
+
+    if cap <= 0:
+        return ""
+    if len(text) <= cap:
+        return text
+    if cap <= len(marker):
+        return marker[-cap:]
+    return text[: cap - len(marker)] + marker
+
 
 # Run state the agent writes into the SAME directory as its deliverables. These
 # are not model output, and `.json` is in TEXT_EXTS, so without this the judge is
@@ -86,94 +106,126 @@ def read_deliverable_files(output_dir: str) -> str:
         return ""
 
     parts: list[str] = []
-    total_len = 0
+    used = 0
 
     for fpath in files:
         if not is_deliverable(fpath):
             continue
 
         ext = fpath.suffix.lower()
+        prefix = "\n\n" if parts else ""
+        header = f"=== {fpath.name} ===\n"
+        remaining = MAX_TOTAL_CHARS - used - len(prefix) - len(header)
+        if remaining <= 0:
+            if parts:
+                parts[-1] = _bounded_text(parts[-1] + "x", len(parts[-1]))
+            break
         try:
-            text = _extract_text(fpath, ext)
+            text = _extract_text(fpath, ext, max_chars=remaining)
         except Exception as exc:
-            text = f"[Error reading {fpath.name}: {exc}]"
+            text = _bounded_text(f"[Error reading {fpath.name}: {exc}]", remaining)
 
         if not text:
             continue
 
-        section = f"=== {fpath.name} ===\n{text}"
-        if total_len + len(section) > MAX_TOTAL_CHARS:
-            remaining = MAX_TOTAL_CHARS - total_len
-            if remaining > 200:
-                section = section[:remaining] + "\n[...truncated]"
-                parts.append(section)
+        section = header + _bounded_text(text, remaining)
+        parts.append(section)
+        used += len(prefix) + len(section)
+        if used >= MAX_TOTAL_CHARS:
             break
 
-        parts.append(section)
-        total_len += len(section)
-
-    return "\n\n".join(parts)
+    return _bounded_text("\n\n".join(parts), MAX_TOTAL_CHARS)
 
 
-def _extract_text(fpath: Path, ext: str) -> str:
+def _extract_text(fpath: Path, ext: str, max_chars: int = MAX_TOTAL_CHARS) -> str:
     """Dispatch to the right extractor based on file extension."""
     # TEXT_EXTS, not a second shorter list: a .ts/.py/.yaml deliverable was source
     # on the block path and "[Binary file: ...]" here.
     if ext in TEXT_EXTS:
-        return _read_text(fpath)
+        return _read_text(fpath, max_chars)
     elif ext == ".docx":
-        return _read_docx(fpath)
+        return _read_docx(fpath, max_chars)
     elif ext == ".pdf":
-        return _read_pdf(fpath)
+        return _read_pdf(fpath, max_chars)
     elif ext == ".xlsx":
-        return _read_xlsx(fpath)
+        return _read_xlsx(fpath, max_chars)
     elif ext == ".pptx":
-        return _read_pptx(fpath)
+        return _read_pptx(fpath, max_chars)
     else:
         size = os.path.getsize(fpath)
         return f"[Binary file: {fpath.name}, {size} bytes]"
 
 
-def _read_text(fpath: Path) -> str:
-    return fpath.read_text(encoding="utf-8", errors="replace").strip()
+def _read_text(fpath: Path, max_chars: int = MAX_TOTAL_CHARS) -> str:
+    if max_chars <= 0:
+        return ""
+    with fpath.open("r", encoding="utf-8", errors="replace") as stream:
+        text = stream.read(max_chars + 1)
+    return _bounded_text(text, max_chars).strip()
 
 
-def _read_docx(fpath: Path) -> str:
+def _read_docx(fpath: Path, max_chars: int = MAX_TOTAL_CHARS) -> str:
     from docx import Document
 
     doc = Document(str(fpath))
-    return "\n".join(p.text for p in doc.paragraphs if p.text.strip())
+    parts: list[str] = []
+    used = 0
+    truncated = False
+    for paragraph in doc.paragraphs:
+        value = paragraph.text
+        if not value.strip():
+            continue
+        separator = 1 if parts else 0
+        remaining = max_chars - used - separator
+        if remaining <= 0:
+            truncated = True
+            break
+        parts.append(value[:remaining])
+        used += separator + min(len(value), remaining)
+        if len(value) > remaining:
+            truncated = True
+            break
+    return _bounded_text("\n".join(parts) + ("x" if truncated else ""), max_chars)
 
 
-def _read_pdf(fpath: Path) -> str:
-    from pdfminer.high_level import extract_text
+def _read_pdf(fpath: Path, max_chars: int = MAX_TOTAL_CHARS) -> str:
+    from pdfminer.high_level import extract_pages
+    from pdfminer.layout import LTTextContainer
 
-    return extract_text(str(fpath)).strip()
+    parts: list[str] = []
+    used = 0
+    truncated = False
+    for page in extract_pages(str(fpath)):
+        for element in page:
+            if not isinstance(element, LTTextContainer):
+                continue
+            value = element.get_text()
+            remaining = max_chars - used
+            if remaining <= 0:
+                truncated = True
+                break
+            parts.append(value[:remaining])
+            used += min(len(value), remaining)
+            if len(value) > remaining:
+                truncated = True
+                break
+        if truncated:
+            break
+    text = "".join(parts).strip()
+    return _bounded_text(text + ("x" if truncated else ""), max_chars)
 
 
-def _read_xlsx(fpath: Path) -> str:
-    from openpyxl import load_workbook
-
-    wb = load_workbook(str(fpath), read_only=True, data_only=True)
-    parts = []
-    for sheet_name in wb.sheetnames:
-        ws = wb[sheet_name]
-        rows = []
-        for row in ws.iter_rows(values_only=True):
-            cells = [str(c) if c is not None else "" for c in row]
-            if any(cells):
-                rows.append(", ".join(cells))
-        if rows:
-            parts.append(f"Sheet: {sheet_name}\n" + "\n".join(rows))
-    wb.close()
-    return "\n\n".join(parts)
+def _read_xlsx(fpath: Path, max_chars: int = MAX_TOTAL_CHARS) -> str:
+    return extract_xlsx_structured_text(fpath, max_chars=max_chars)
 
 
-def _read_pptx(fpath: Path) -> str:
+def _read_pptx(fpath: Path, max_chars: int = MAX_TOTAL_CHARS) -> str:
     from pptx import Presentation
 
     prs = Presentation(str(fpath))
-    parts = []
+    parts: list[str] = []
+    used = 0
+    truncated = False
     for i, slide in enumerate(prs.slides, 1):
         texts = []
         for shape in slide.shapes:
@@ -182,8 +234,18 @@ def _read_pptx(fpath: Path) -> str:
                     if para.text.strip():
                         texts.append(para.text)
         if texts:
-            parts.append(f"Slide {i}:\n" + "\n".join(texts))
-    return "\n\n".join(parts)
+            value = f"Slide {i}:\n" + "\n".join(texts)
+            separator = 2 if parts else 0
+            remaining = max_chars - used - separator
+            if remaining <= 0:
+                truncated = True
+                break
+            parts.append(value[:remaining])
+            used += separator + min(len(value), remaining)
+            if len(value) > remaining:
+                truncated = True
+                break
+    return _bounded_text("\n\n".join(parts) + ("x" if truncated else ""), max_chars)
 
 
 # ---------------------------------------------------------------------------
@@ -213,6 +275,13 @@ TEXT_SNIFF_BYTES = 8192
 # that the judge rejected outright, leaving the task silently unjudged.
 MAX_TEXT_BLOCK_CHARS = 200_000
 MAX_TOTAL_TEXT_BLOCK_CHARS = 400_000
+# Binary payload ceilings for the rubric visual request. The encoded limit is
+# the dominant wire-size term and leaves ample room below a 500 MB body ceiling
+# for the bounded text above plus JSON framing.
+MAX_FILE_ATTACHMENT_BYTES = 250 * 1024 * 1024
+MAX_TOTAL_RAW_ATTACHMENT_BYTES = 300 * 1024 * 1024
+MAX_TOTAL_ENCODED_ATTACHMENT_CHARS = 400 * 1024 * 1024
+MAX_RASTER_PAGE_PIXELS = 40_000_000
 # Header and truncation notice per block; reserved before allotting because
 # it is tokens too.
 TEXT_BLOCK_OVERHEAD_CHARS = 120
@@ -281,6 +350,39 @@ def _human_size(n: float) -> str:
             return f"{n:.0f} B" if unit == "B" else f"{n:.1f} {unit}"
         n /= 1024.0
     return f"{n:.1f} GB"
+
+
+def _attachment_omission(name: str, size: int, reason: str) -> dict[str, Any]:
+    return {
+        "type": "text",
+        "text": f"\n{name}: [attachment omitted, {_human_size(size)} ({size:,} bytes): {reason}]",
+    }
+
+
+def _reserve_attachment(path: Path, budget: AttachmentBudget) -> tuple[int, dict[str, Any] | None]:
+    """Reserve an attachment from metadata before reading or encoding it."""
+
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return 0, {"type": "text", "text": f"\n{path.name}: [attachment unavailable]"}
+    if size > MAX_FILE_ATTACHMENT_BYTES:
+        return size, _attachment_omission(path.name, size, "per-file judge payload limit")
+    if not budget.reserve(size):
+        return size, _attachment_omission(path.name, size, "aggregate judge payload budget")
+    return size, None
+
+
+def _check_render_source(path: Path) -> tuple[int, dict[str, Any] | None]:
+    """Reject a PDF source before loading it; rendered PNGs reserve separately."""
+
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return 0, {"type": "text", "text": f"\n{path.name}: [attachment unavailable]"}
+    if size > MAX_FILE_ATTACHMENT_BYTES:
+        return size, _attachment_omission(path.name, size, "per-file judge payload limit")
+    return size, None
 
 
 def _sniffs_as_text(fpath: Path) -> bool:
@@ -410,47 +512,79 @@ def _convert_office_to_pdf(fpath: Path, out_dir: Path | None = None) -> Path | N
     stage the input to a tempdir with a sanitized basename and move the PDF
     back to the original location.
     """
-    profile_dir = Path(tempfile.mkdtemp(prefix="lo-profile-"))
-    user_install = f"file://{profile_dir.as_posix()}"
     dest_dir = out_dir if out_dir is not None else fpath.parent
     out_pdf = dest_dir / (fpath.stem + ".pdf")
-    stage_dir: Path | None = None
-    input_path = fpath
-    has_whitespace = any(c.isspace() for c in fpath.name)
+    temp_dirs: list[Path] = []
+    profile_dirs: list[Path] = []
 
     try:
+        stage_dir: Path | None = None
+        input_path = fpath
+        has_whitespace = any(c.isspace() for c in fpath.name)
         if has_whitespace:
             stage_dir = Path(tempfile.mkdtemp(prefix="lo-stage-"))
+            temp_dirs.append(stage_dir)
             safe_name = re.sub(r"\s+", "_", fpath.stem) + fpath.suffix
             input_path = stage_dir / safe_name
             shutil.copy2(fpath, input_path)
-            lo_outdir = str(stage_dir)
+            first_outdir = stage_dir
         else:
-            lo_outdir = str(dest_dir)
+            first_outdir = dest_dir
 
-        cmd = [
-            "libreoffice",
-            "--headless",
-            "--nologo",
-            "--nolockcheck",
-            "--nodefault",
-            "--norestore",
-            f"-env:UserInstallation={user_install}",
-            "--convert-to",
-            "pdf",
-            "--outdir",
-            lo_outdir,
-            str(input_path),
-        ]
-        p = subprocess.run(cmd, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=120)
-        if stage_dir is not None:
-            staged_pdf = stage_dir / (input_path.stem + ".pdf")
-            if staged_pdf.exists():
-                shutil.move(str(staged_pdf), str(out_pdf))
-        if p.returncode != 0 or not out_pdf.exists():
-            print(f"[file_reader] LibreOffice conversion failed for {fpath.name}: {p.stderr[:200]}", flush=True)
-            return None
-        return out_pdf
+        def _invoke(source: Path, output: Path) -> tuple[subprocess.CompletedProcess[str], Path]:
+            profile = Path(tempfile.mkdtemp(prefix="lo-profile-"))
+            profile_dirs.append(profile)
+            command = [
+                "libreoffice",
+                "--headless",
+                "--nologo",
+                "--nolockcheck",
+                "--nodefault",
+                "--norestore",
+                f"-env:UserInstallation=file://{profile.as_posix()}",
+                "--convert-to",
+                "pdf",
+                "--outdir",
+                str(output),
+                str(source),
+            ]
+            completed = subprocess.run(
+                command,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=120,
+            )
+            return completed, output / (source.stem + ".pdf")
+
+        first_result, first_pdf = _invoke(input_path, first_outdir)
+        if first_pdf.exists():
+            if first_pdf != out_pdf:
+                shutil.move(str(first_pdf), str(out_pdf))
+            return out_pdf
+
+        retry_detail = ""
+        if fpath.suffix.lower() in OOXML_EXTS:
+            retry_dir = Path(tempfile.mkdtemp(prefix="gdpval-roundtrip-"))
+            temp_dirs.append(retry_dir)
+            retry_input = retry_dir / (re.sub(r"\s+", "_", fpath.stem) + fpath.suffix)
+            try:
+                roundtrip_ooxml_copy(fpath, retry_input)
+                retry_result, retry_pdf = _invoke(retry_input, retry_dir)
+                if retry_pdf.exists():
+                    shutil.move(str(retry_pdf), str(out_pdf))
+                    return out_pdf
+                retry_detail = f"; round-trip retry rc={retry_result.returncode}: {retry_result.stderr[:200]}"
+            except Exception as exc:
+                retry_detail = f"; round-trip retry failed: {exc!r}"
+
+        print(
+            f"[file_reader] LibreOffice conversion failed for {fpath.name} "
+            f"(rc={first_result.returncode}): {first_result.stderr[:200]}{retry_detail}",
+            flush=True,
+        )
+        return None
     except subprocess.TimeoutExpired:
         print(f"[file_reader] LibreOffice conversion timed out for {fpath.name}", flush=True)
         return None
@@ -463,9 +597,8 @@ def _convert_office_to_pdf(fpath: Path, out_dir: Path | None = None) -> Path | N
         _warn_libreoffice_unavailable(exc)
         return None
     finally:
-        shutil.rmtree(profile_dir, ignore_errors=True)
-        if stage_dir is not None:
-            shutil.rmtree(stage_dir, ignore_errors=True)
+        for directory in profile_dirs + temp_dirs:
+            shutil.rmtree(directory, ignore_errors=True)
 
 
 def _pdf_bytes_to_image_text_blocks(
@@ -474,24 +607,86 @@ def _pdf_bytes_to_image_text_blocks(
     render_dpi: int,
     max_pages: int,
     include_text: bool,
+    attachment_budget: AttachmentBudget | None = None,
 ) -> list[dict[str, Any]] | None:
-    """Rasterize PDF bytes to page-image + text blocks for image-only judges.
+    """Rasterize one page at a time and reserve each PNG before base64."""
 
-    Delegates to :mod:`resources_servers.gdpval.media_conversion` (imported
-    lazily so this module stays importable even where that package isn't on the
-    path). Returns ``None`` when the helper is unavailable or yields nothing, so
-    the caller can fall back to the native ``application/pdf`` data URL.
-    """
     try:
-        from resources_servers.gdpval.media_conversion import pdf_bytes_to_blocks
+        import fitz
     except ImportError:
         return None
-    blocks = pdf_bytes_to_blocks(
-        pdf_bytes,
-        dpi=render_dpi,
-        max_pages=max_pages,
-        include_text=include_text,
+
+    budget = attachment_budget or AttachmentBudget(
+        MAX_TOTAL_RAW_ATTACHMENT_BYTES,
+        MAX_TOTAL_ENCODED_ATTACHMENT_CHARS,
     )
+    try:
+        document = fitz.open(stream=pdf_bytes, filetype="pdf")
+    except Exception:
+        return None
+
+    images: list[dict[str, Any]] = []
+    text_parts: list[str] = []
+    text_remaining = 20_000
+    text_truncated = False
+    try:
+        total_pages = document.page_count
+        page_limit = min(total_pages, max(0, max_pages))
+        zoom = render_dpi / 72.0
+        matrix = fitz.Matrix(zoom, zoom)
+        for page_index in range(page_limit):
+            try:
+                page = document.load_page(page_index)
+                if include_text and text_remaining > 0:
+                    page_text = (page.get_text("text") or "").strip()
+                    if page_text:
+                        separator = 2 if text_parts else 0
+                        available = max(0, text_remaining - separator)
+                        take = min(len(page_text), available)
+                        if take:
+                            text_parts.append(page_text[:take])
+                            text_remaining -= separator + take
+                        if take < len(page_text):
+                            text_truncated = True
+
+                rect = page.rect
+                width = math.ceil(rect.width * zoom)
+                height = math.ceil(rect.height * zoom)
+                if width * height > MAX_RASTER_PAGE_PIXELS:
+                    images.append(
+                        {
+                            "type": "text",
+                            "text": f"[page {page_index + 1} omitted: raster dimensions too large]",
+                        }
+                    )
+                    continue
+                pixmap = page.get_pixmap(matrix=matrix, alpha=False)
+                png = pixmap.tobytes("png")
+            except Exception:
+                continue
+            if not budget.reserve(len(png)):
+                images.append(
+                    {
+                        "type": "text",
+                        "text": "[remaining rendered pages omitted: aggregate judge payload budget]",
+                    }
+                )
+                break
+            b64 = base64.b64encode(png).decode("ascii")
+            images.append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}})
+
+        if total_pages > page_limit:
+            images.append({"type": "text", "text": f"[truncated: rendered {page_limit} of {total_pages} pages]"})
+    finally:
+        document.close()
+
+    blocks: list[dict[str, Any]] = []
+    if text_parts:
+        text = "\n\n".join(text_parts)
+        if text_truncated:
+            text = _bounded_text(text + "x", 20_000, "\n[...text truncated]")
+        blocks.append({"type": "text", "text": f"[extracted text]\n{text}"})
+    blocks.extend(images)
     return blocks or None
 
 
@@ -512,6 +707,44 @@ def _av_block(mime: str, data: bytes, *, ext: str, file_type: str, openai_native
     except ImportError:
         b64 = base64.b64encode(data).decode("ascii")
         return {"type": "image_url", "image_url": {"url": f"data:{mime};base64,{b64}"}}
+
+
+def _enforce_text_block_budget(blocks: list[dict[str, Any]], cap: int) -> list[dict[str, Any]]:
+    """Apply one hard character ceiling to every text producer in a request.
+
+    The upstream builders include text that does not flow through ``_text_block``
+    (PDF extraction, Office headers, AV stubs, archive manifests, and exception
+    messages). This final pass is therefore the source of truth for the cap.
+    Binary/media blocks are retained unchanged.
+    """
+
+    result: list[dict[str, Any]] = []
+    remaining = max(0, cap)
+    omitted = False
+    last_text_index: int | None = None
+    marker = "\n[...additional text blocks omitted: aggregate text budget exhausted]"
+
+    for block in blocks:
+        if block.get("type") != "text":
+            result.append(block)
+            continue
+        text = str(block.get("text", ""))
+        if omitted or remaining <= 0:
+            omitted = omitted or bool(text)
+            continue
+        if len(text) > remaining:
+            text = _bounded_text(text, remaining, marker)
+            omitted = True
+        copied = dict(block)
+        copied["text"] = text
+        result.append(copied)
+        last_text_index = len(result) - 1
+        remaining -= len(text)
+
+    if omitted and last_text_index is not None and marker not in result[last_text_index]["text"]:
+        previous = result[last_text_index]["text"]
+        result[last_text_index]["text"] = _bounded_text(previous + marker, len(previous), marker)
+    return result
 
 
 def convert_deliverables_to_content_blocks(
@@ -559,28 +792,17 @@ def convert_deliverables_to_content_blocks(
 
     blocks: list[dict[str, Any]] = []
     scratch_dirs: list[Path] = []  # tempdirs holding PDFs this pass converted
+    attachment_budget = AttachmentBudget(
+        MAX_TOTAL_RAW_ATTACHMENT_BYTES,
+        MAX_TOTAL_ENCODED_ATTACHMENT_CHARS,
+    )
 
     entries = sorted(output_path.iterdir())
-    # A PDF an Office file renders from must not also be emitted standalone, or
-    # the judge sees the same pages twice. Both spellings count: the same-stem
-    # sidecar Plan.pptx.pdf, and the ordinary sibling Plan.pdf.
-    # How many Office files share each stem. `Report.docx` and `Report.pptx` both
-    # point at `Report.pdf`, which cannot say which of them it renders, so the
-    # plain sibling is only trustworthy when the stem is unambiguous. preconvert
-    # writes an injective `Report.docx.pdf` sidecar for the ambiguous case.
-    office_stem_counts: dict[str, int] = {}
-    for entry in entries:
-        if is_deliverable(entry) and entry.suffix.lower() in OFFICE_EXTS:
-            office_stem_counts[entry.stem] = office_stem_counts.get(entry.stem, 0) + 1
-
-    consumed_pdfs: set[Path] = set()
-    for entry in entries:
-        if is_deliverable(entry) and entry.suffix.lower() in OFFICE_EXTS:
-            sidecar = entry.with_name(entry.name + ".pdf")
-            if sidecar.is_file():
-                consumed_pdfs.add(sidecar)
-            elif office_stem_counts.get(entry.stem, 0) == 1:
-                consumed_pdfs.add(entry.with_suffix(".pdf"))
+    # Shared provenance rules keep the comparison and rubric paths in lockstep:
+    # prefer source.ext.pdf, consume derived renders, and quarantine an old
+    # source.pdf when multiple Office files share the stem.
+    provenance = resolve_pdf_provenance(entry for entry in entries if is_deliverable(entry))
+    consumed_pdfs = provenance.suppressed_pdfs
 
     # Which files the judge receives AS TEXT. Decided once and reused by both the
     # allotment and the dispatch loop: deciding it twice lets a file be emitted as
@@ -623,6 +845,44 @@ def convert_deliverables_to_content_blocks(
         emitted_chars += len(block["text"])
         return block
 
+    def _pdf_blocks(pdf_path: Path, header: str) -> list[dict[str, Any]]:
+        """Emit a PDF natively or page-by-page under the shared binary budget."""
+
+        size, source_omitted = _check_render_source(pdf_path)
+        if source_omitted is not None:
+            return [source_omitted]
+
+        data: bytes | None = None
+        if images_and_text:
+            # The PDF is a bounded rasterization input, not request payload. Its
+            # compressed source size does not predict whether a rendered PNG page
+            # fits; the renderer reserves every actual page below.
+            if not attachment_budget.can_fit(1):
+                return [_attachment_omission(pdf_path.name, size, "aggregate judge payload budget")]
+            data = pdf_path.read_bytes()
+            rendered = _pdf_bytes_to_image_text_blocks(
+                data,
+                render_dpi=render_dpi,
+                max_pages=max_pages,
+                include_text=include_text,
+                attachment_budget=attachment_budget,
+            )
+            if rendered is not None:
+                return [{"type": "text", "text": header}, *rendered]
+
+        if not attachment_budget.reserve(size):
+            return [_attachment_omission(pdf_path.name, size, "aggregate judge payload budget")]
+        if data is None:
+            data = pdf_path.read_bytes()
+        b64 = base64.b64encode(data).decode("ascii")
+        return [
+            {"type": "text", "text": header},
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:application/pdf;base64,{b64}"},
+            },
+        ]
+
     for fpath in entries:
         if not is_deliverable(fpath) or fpath in consumed_pdfs:
             continue
@@ -631,77 +891,61 @@ def convert_deliverables_to_content_blocks(
 
         try:
             if fpath in texty:
-                text = fpath.read_text(encoding="utf-8", errors="replace").strip()
+                allowance = allowance_by_name.get(fpath.name, 0)
+                if fpath.stat().st_size == 0:
+                    block = _text_block(f"{fpath.name}:", "[present but EMPTY (0 bytes of content)]", 200)
+                    blocks.append(block) if block else omitted_names.append(fpath.name)
+                    continue
+                if allowance <= 0:
+                    omitted_names.append(fpath.name)
+                    continue
+                text = _read_text(fpath, allowance)
                 if text:
-                    block = _text_block(f"{fpath.name}:", text, allowance_by_name.get(fpath.name, 0))
+                    block = _text_block(f"{fpath.name}:", text, allowance)
                 else:
                     block = _text_block(f"{fpath.name}:", "[present but EMPTY (0 bytes of content)]", 200)
                 blocks.append(block) if block else omitted_names.append(fpath.name)
 
             elif ext in OFFICE_EXTS:
+                source_size = fpath.stat().st_size
+                if source_size > MAX_FILE_ATTACHMENT_BYTES:
+                    blocks.append(_attachment_omission(fpath.name, source_size, "per-file judge payload limit"))
+                    continue
                 # Prefer a PDF preconvert already rendered. Reconverting is
                 # wasteful, needs LibreOffice on the judge host, and the cleanup
                 # below would delete someone else's artifact.
-                sidecar = fpath.with_name(fpath.name + ".pdf")
-                sibling = fpath.with_suffix(".pdf")
-                if sidecar.is_file():
-                    pdf_path = sidecar
-                elif sibling.is_file() and office_stem_counts.get(fpath.stem, 0) == 1:
-                    pdf_path = sibling
-                else:
-                    # Ambiguous stem with no sidecar: rendering it ourselves is the
-                    # only way to know which file the PDF belongs to.
-                    pdf_path = None
+                pdf_path = provenance.office_pdfs.get(fpath)
                 if pdf_path is None:
                     scratch = Path(tempfile.mkdtemp(prefix="gdpval-render-"))
                     scratch_dirs.append(scratch)
                     pdf_path = _convert_office_to_pdf(fpath, out_dir=scratch)
                 if pdf_path and pdf_path.exists():
-                    data = pdf_path.read_bytes()
-                    if images_and_text:
-                        rendered = _pdf_bytes_to_image_text_blocks(
-                            data, render_dpi=render_dpi, max_pages=max_pages, include_text=include_text
+                    header_kind = "rendered from PDF" if images_and_text else "converted to PDF"
+                    blocks.extend(_pdf_blocks(pdf_path, f"\n{fpath.name} ({header_kind}):"))
+                    if ext == ".xlsx":
+                        sheet_text = extract_xlsx_structured_text(fpath, max_chars=MAX_TEXT_BLOCK_CHARS)
+                        block = _text_block(
+                            f"{fpath.name} (structured spreadsheet cells):",
+                            sheet_text,
+                            MAX_TEXT_BLOCK_CHARS,
                         )
-                        if rendered is not None:
-                            blocks.append({"type": "text", "text": f"\n{fpath.name} (rendered from PDF):"})
-                            blocks.extend(rendered)
-                            continue
-                    b64 = base64.b64encode(data).decode("ascii")
-                    blocks.append({"type": "text", "text": f"\n{fpath.name} (converted to PDF):"})
-                    blocks.append(
-                        {
-                            "type": "image_url",
-                            "image_url": {"url": f"data:application/pdf;base64,{b64}"},
-                        }
-                    )
+                        blocks.append(block) if block else omitted_names.append(fpath.name)
                 else:
                     # Fallback to text extraction
-                    text = _extract_text(fpath, ext)
+                    text = _extract_text(fpath, ext, max_chars=MAX_TEXT_BLOCK_CHARS)
                     if text:
                         block = _text_block(f"{fpath.name} (text fallback):", text, MAX_TEXT_BLOCK_CHARS)
                         blocks.append(block) if block else omitted_names.append(fpath.name)
 
             elif ext == ".pdf":
-                data = fpath.read_bytes()
-                if images_and_text:
-                    rendered = _pdf_bytes_to_image_text_blocks(
-                        data, render_dpi=render_dpi, max_pages=max_pages, include_text=include_text
-                    )
-                    if rendered is not None:
-                        blocks.append({"type": "text", "text": f"\n{fpath.name}:"})
-                        blocks.extend(rendered)
-                        continue
-                b64 = base64.b64encode(data).decode("ascii")
-                blocks.append({"type": "text", "text": f"\n{fpath.name}:"})
-                blocks.append(
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:application/pdf;base64,{b64}"},
-                    }
-                )
+                blocks.extend(_pdf_blocks(fpath, f"\n{fpath.name}:"))
 
             elif ext in IMAGE_EXTS:
                 mime = MIME_TYPES.get(ext, "image/png")
+                _size, omitted = _reserve_attachment(fpath, attachment_budget)
+                if omitted is not None:
+                    blocks.append(omitted)
+                    continue
                 data = fpath.read_bytes()
                 b64 = base64.b64encode(data).decode("ascii")
                 blocks.append({"type": "text", "text": f"\n{fpath.name}:"})
@@ -724,6 +968,10 @@ def convert_deliverables_to_content_blocks(
                 file_type = "VIDEO" if is_video else "AUDIO"
                 if video_capable if is_video else audio_capable:
                     mime = MIME_TYPES.get(ext, "application/octet-stream")
+                    _size, omitted = _reserve_attachment(fpath, attachment_budget)
+                    if omitted is not None:
+                        blocks.append(omitted)
+                        continue
                     data = fpath.read_bytes()
                     blocks.append({"type": "text", "text": f"\n{fpath.name}:"})
                     blocks.append(_av_block(mime, data, ext=ext, file_type=file_type, openai_native=images_and_text))
@@ -754,7 +1002,7 @@ def convert_deliverables_to_content_blocks(
                 if size == 0:
                     body = "[present but EMPTY (0 bytes)]"
                 elif _sniffs_as_text(fpath):
-                    text = fpath.read_text(encoding="utf-8", errors="replace").strip()
+                    text = _read_text(fpath, MAX_TEXT_BLOCK_CHARS)
                     body = text if text else "[present but EMPTY (0 bytes of content)]"
                 else:
                     manifest = _archive_manifest(fpath)
@@ -786,4 +1034,4 @@ def convert_deliverables_to_content_blocks(
     for scratch in scratch_dirs:
         shutil.rmtree(scratch, ignore_errors=True)
 
-    return blocks
+    return _enforce_text_block_budget(blocks, MAX_TOTAL_TEXT_BLOCK_CHARS)

--- a/responses_api_agents/stirrup_agent/file_reader.py
+++ b/responses_api_agents/stirrup_agent/file_reader.py
@@ -33,6 +33,9 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from nemo_gym.deliverables import IGNORE_FILES as IGNORE_FILES
+from nemo_gym.deliverables import is_deliverable as is_deliverable
+
 # judge_panel owns the canonical audio/video extension sets and the GDPVal
 # resources server routes tasks to judges from them. Importing rather than
 # redeclaring keeps detection and emission in lockstep: a local copy that missed
@@ -60,28 +63,6 @@ def _bounded_text(text: str, cap: int, marker: str = "\n[...truncated]") -> str:
     if cap <= len(marker):
         return marker[-cap:]
     return text[: cap - len(marker)] + marker
-
-
-# Run state the agent writes into the SAME directory as its deliverables. These
-# are not model output, and `.json` is in TEXT_EXTS, so without this the judge is
-# shown the agent's own transcript and grades it as work product. Single source:
-# every judging path imports it from here.
-IGNORE_FILES = frozenset(
-    {
-        "finish_params.json",
-        "history.json",
-        "history.pkl",
-        "inprogress_history.json",
-        "metadata.json",
-        "log.txt",
-        "reference_files",
-    }
-)
-
-
-def is_deliverable(path: Path) -> bool:
-    """True if *path* is agent-produced output rather than run state."""
-    return path.is_file() and path.name not in IGNORE_FILES
 
 
 def read_deliverable_files(output_dir: str) -> str:

--- a/responses_api_agents/stirrup_agent/stirrup_utils.py
+++ b/responses_api_agents/stirrup_agent/stirrup_utils.py
@@ -20,6 +20,8 @@ nothing task-specific lives here.
 from __future__ import annotations
 
 import json
+import logging
+import re
 import uuid
 from typing import Any, List, Tuple, cast
 
@@ -37,6 +39,35 @@ from nemo_gym.openai_utils import (
 from responses_api_agents.stirrup_agent.nemo_agent import NeMoUserMessage
 
 
+LOGGER = logging.getLogger(__name__)
+
+# A provider parser can occasionally leave an otherwise valid tool invocation in
+# assistant ``content`` instead of returning it through ``tool_calls``. Feeding
+# that raw block back on the next turn teaches the model to repeat the malformed
+# format. Strip it only from the provider-bound copy; the original Stirrup
+# history remains untouched for debugging and trajectory export.
+_UNPARSED_TOOL_BLOCKS = (
+    re.compile(r"<tool_call\b[^>]*>.*?(?:</tool_call>|$)", re.IGNORECASE | re.DOTALL),
+    re.compile(r"<function=[^>]*>.*?(?:</function>|$)", re.IGNORECASE | re.DOTALL),
+)
+
+
+def _strip_unparsed_tool_blocks(content: str) -> str:
+    cleaned = content
+    for pattern in _UNPARSED_TOOL_BLOCKS:
+        cleaned = pattern.sub("", cleaned)
+    if cleaned == content:
+        return content
+    # History is serialized again on every model turn. Keep this at debug so a
+    # malformed turn does not emit the same warning hundreds of times as the
+    # immutable history grows; trajectory export still preserves the evidence.
+    LOGGER.debug(
+        "Stripped an unparsed tool-call block from provider-bound assistant history; "
+        "the original trajectory remains unchanged."
+    )
+    return re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+
+
 def restore_tool_messages_for_model(messages: list[ChatMessage]) -> list[ChatMessage]:
     """Return provider-valid history for OpenAI-compatible model calls.
 
@@ -52,7 +83,12 @@ def restore_tool_messages_for_model(messages: list[ChatMessage]) -> list[ChatMes
     for message in messages:
         if isinstance(message, AssistantMessage):
             pending_tool_call_ids = {tc.tool_call_id for tc in message.tool_calls if tc.tool_call_id}
-            restored.append(message)
+            provider_message = message
+            if not message.tool_calls and isinstance(message.content, str):
+                cleaned = _strip_unparsed_tool_blocks(message.content)
+                if cleaned != message.content:
+                    provider_message = message.model_copy(update={"content": cleaned})
+            restored.append(provider_message)
             continue
 
         if isinstance(message, NeMoUserMessage) and message.tool_call_id in pending_tool_call_ids:
@@ -101,10 +137,26 @@ def convert_stirrup_history_to_output_items(
     # keeps the raw id, so a trajectory that never repeats one is unchanged.
     call_seq: dict[str, int] = {}
     output_seq: dict[str, int] = {}
+    occurrence_ids: dict[tuple[str, int], str] = {}
+    used_ids: set[str] = set()
 
     def _disambiguate(raw: str, seen: dict[str, int]) -> str:
         seen[raw] = seen.get(raw, 0) + 1
-        return raw if seen[raw] == 1 else f"{raw}#{seen[raw]}"
+        occurrence = seen[raw]
+        key = (raw, occurrence)
+        if key in occurrence_ids:
+            return occurrence_ids[key]
+
+        preferred = raw if occurrence == 1 else f"{raw}#{occurrence}"
+        candidate = preferred
+        collision_index = 2
+        while candidate in used_ids:
+            candidate = f"{preferred}#{collision_index}"
+            collision_index += 1
+
+        occurrence_ids[key] = candidate
+        used_ids.add(candidate)
+        return candidate
 
     for turn in history:
         for msg in turn:

--- a/responses_api_agents/stirrup_agent/tests/test_app.py
+++ b/responses_api_agents/stirrup_agent/tests/test_app.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -34,6 +35,7 @@ from responses_api_agents.stirrup_agent.app import (
     StirrupAgentWrapperConfig,
     StirrupRunRequest,
     TaskPerAttemptTimeoutError,
+    _classify_verify_failure,
     _load_task_registry,
     _task_finished,
     _verify_cache_path,
@@ -650,6 +652,40 @@ class TestRerunIncompleteMode:
         cache_path = _verify_cache_path(str(deliverables_root))
         assert json.loads(cache_path.read_text()) == {"reward": 0.3, "judge_response": "fresh"}
 
+    @pytest.mark.asyncio
+    async def test_judge_only_legacy_invalid_cache_is_rejudged_and_replaced(self, tmp_path) -> None:
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "report.docx").write_text("cached deliverable")
+        cache_path = _verify_cache_path(str(deliverables_root))
+        cache_path.write_text(
+            json.dumps(
+                {
+                    "reward": 0.0,
+                    "invalid_judge_response": True,
+                    "judge_response": {"scoring_error": "no_score_in_response"},
+                }
+            )
+        )
+
+        config = _make_config(rerun_incomplete=True, judge_only=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+        request = MagicMock()
+        request.cookies = {}
+        fresh = {"reward": 0.6, "invalid_judge_response": False, "judge_response": {"score": 0.6}}
+
+        with (
+            patch.object(StirrupAgentWrapper, "responses", AsyncMock()),
+            patch("responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()),
+            patch("responses_api_agents.stirrup_agent.app.get_response_json", AsyncMock(return_value=fresh)),
+        ):
+            result = await wrapper.run(request, self._make_body())
+
+        assert result == fresh
+        assert json.loads(cache_path.read_text()) == fresh
+
 
 class TestReuseCachedDeliverable:
     """Per-request ``reuse_cached_deliverable`` (used by multi-stage ELO): reuse a
@@ -755,6 +791,205 @@ class TestReuseCachedDeliverable:
         responses_mock.assert_awaited_once()
         assert result == {"reward": 0.5}
 
+    @pytest.mark.asyncio
+    async def test_invalid_judgement_is_retryable_and_not_cached(self, tmp_path) -> None:
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "answer.txt").write_text("cached deliverable")
+
+        config = _make_config(rerun_incomplete=True, persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+        params = NeMoGymResponseCreateParamsNonStreaming(
+            input="ignored",
+            metadata={"task_id": "task-1", "prompt": "do the thing", "_ng_rollout_index": "0"},
+        )
+        body = StirrupRunRequest(
+            responses_create_params=params,
+            task_id="task-1",
+            prompt="do the thing",
+            reuse_cached_deliverable=True,
+        )
+        request = MagicMock()
+        request.cookies = {}
+        invalid_result = {
+            "reward": 0.0,
+            "invalid_judge_response": True,
+            "judge_response": {"scoring_error": "no_score_in_response"},
+        }
+
+        with (
+            patch.object(StirrupAgentWrapper, "responses", AsyncMock()),
+            patch("responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()),
+            patch(
+                "responses_api_agents.stirrup_agent.app.get_response_json",
+                AsyncMock(return_value=invalid_result),
+            ),
+        ):
+            result = await wrapper.run(request, body)
+
+        assert result[NG_FAILURE_CLASS_KEY] == "judge_invalid"
+        assert NG_TERMINAL_KEY not in result
+        assert NG_NO_PERSIST_KEY not in result
+        assert "no_score_in_response" in result["error_message"]
+        assert result["invalid_judge_response"] is True
+        assert result["judge_response"] == invalid_result["judge_response"]
+        assert result["reuse_cached_deliverable"] is True
+        assert result["deliverables_dir"] == str(deliverables_root)
+        assert not _verify_cache_path(str(deliverables_root)).exists()
+
+    @pytest.mark.asyncio
+    async def test_nonretryable_invalid_judgement_is_terminal(self, tmp_path) -> None:
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "answer.txt").write_text("cached deliverable")
+        wrapper = StirrupAgentWrapper(
+            config=_make_config(rerun_incomplete=True, persist_deliverables_dir=str(tmp_path)),
+            server_client=MagicMock(spec=ServerClient),
+        )
+        params = NeMoGymResponseCreateParamsNonStreaming(
+            input="ignored",
+            metadata={"task_id": "task-1", "prompt": "do the thing", "_ng_rollout_index": "0"},
+        )
+        body = StirrupRunRequest(
+            responses_create_params=params,
+            task_id="task-1",
+            prompt="do the thing",
+            reuse_cached_deliverable=True,
+        )
+        request = MagicMock(cookies={})
+
+        with (
+            patch.object(StirrupAgentWrapper, "responses", AsyncMock()),
+            patch("responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()),
+            patch(
+                "responses_api_agents.stirrup_agent.app.get_response_json",
+                AsyncMock(
+                    return_value={
+                        "reward": 0.0,
+                        "invalid_judge_response": True,
+                        "invalid_judge_retryable": False,
+                        "judge_response": {"scoring_error": "missing_rubric"},
+                    }
+                ),
+            ),
+        ):
+            result = await wrapper.run(request, body)
+
+        assert result[NG_FAILURE_CLASS_KEY] == "permanent"
+        assert result[NG_TERMINAL_KEY] is True
+        assert result["invalid_judge_retryable"] is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("verify_error", "expected_class", "terminal"),
+        [
+            (asyncio.TimeoutError("judge timed out"), "transient", False),
+            (
+                RuntimeError("GDPVal judge request size budget exhausted before dispatch"),
+                "permanent",
+                True,
+            ),
+        ],
+    )
+    async def test_verify_exception_reuses_completed_policy_artifact(
+        self,
+        tmp_path,
+        verify_error: Exception,
+        expected_class: str,
+        terminal: bool,
+    ) -> None:
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "answer.txt").write_text("completed policy artifact")
+        wrapper = StirrupAgentWrapper(
+            config=_make_config(persist_deliverables_dir=str(tmp_path)),
+            server_client=MagicMock(spec=ServerClient),
+        )
+        wrapper.server_client.post = AsyncMock(return_value=MagicMock())
+        body = StirrupRunRequest(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(
+                input="ignored",
+                metadata={"task_id": "task-1", "prompt": "do the thing", "_ng_rollout_index": "0"},
+            ),
+            task_id="task-1",
+            prompt="do the thing",
+        )
+        request = MagicMock(cookies={})
+        responses_mock = AsyncMock(return_value=_fake_response())
+
+        with (
+            patch.object(StirrupAgentWrapper, "responses", responses_mock),
+            patch("responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()),
+            patch(
+                "responses_api_agents.stirrup_agent.app.get_response_json",
+                AsyncMock(side_effect=verify_error),
+            ),
+        ):
+            result = await wrapper.run(request, body)
+
+        responses_mock.assert_awaited_once()
+        assert result[NG_FAILURE_CLASS_KEY] == expected_class
+        assert bool(result.get(NG_TERMINAL_KEY)) is terminal
+        assert result["deliverables_dir"] == str(deliverables_root)
+        assert result["reuse_cached_deliverable"] is True
+
+
+class TestVerifyFailureClassification:
+    def test_nested_request_size_failure_is_permanent(self) -> None:
+        outer = RuntimeError("resources server failed")
+        outer.__cause__ = RuntimeError("Request size is too large for this model")
+        assert _classify_verify_failure(outer) == "permanent"
+
+    def test_internal_request_budget_failure_is_permanent(self) -> None:
+        outer = RuntimeError(
+            "all GDPVal comparison matchups failed: GDPVal judge request size budget exhausted before dispatch"
+        )
+        assert _classify_verify_failure(outer) == "permanent"
+
+    def test_wrapped_http_500_payload_error_is_permanent(self) -> None:
+        from aiohttp import ClientResponseError
+
+        exc = ClientResponseError(
+            request_info=MagicMock(real_url="http://judge/verify"),
+            history=(),
+            status=500,
+            message="Internal Server Error",
+        )
+        exc.response_content = b'{"error":"maximum context length exceeded"}'
+        assert _classify_verify_failure(exc) == "permanent"
+
+    def test_ordinary_http_500_remains_retryable(self) -> None:
+        from aiohttp import ClientResponseError
+
+        exc = ClientResponseError(
+            request_info=MagicMock(real_url="http://judge/verify"),
+            history=(),
+            status=500,
+            message="Internal Server Error",
+        )
+        exc.response_content = b'{"error":"temporary upstream outage"}'
+        assert _classify_verify_failure(exc) == "transient"
+
+    def test_permanent_payload_is_terminal(self) -> None:
+        config = _make_config()
+        wrapper = StirrupAgentWrapper(config=config, server_client=MagicMock(spec=ServerClient))
+        params = NeMoGymResponseCreateParamsNonStreaming(
+            input="ignored",
+            metadata={"task_id": "task-1", "prompt": "do the thing"},
+        )
+        payload = wrapper._build_failed_run_payload(
+            body_dict={"task_id": "task-1"},
+            fixed_params=params,
+            task_info={"task_id": "task-1"},
+            reason="request size is too large",
+            skipped=False,
+            error_class="permanent",
+        )
+        assert payload[NG_FAILURE_CLASS_KEY] == "permanent"
+        assert payload[NG_TERMINAL_KEY] is True
+
 
 class TestReferenceKeyedVerifyCache:
     """rerun_incomplete + multi-stage ELO: the cached judgement is keyed by the
@@ -780,12 +1015,17 @@ class TestReferenceKeyedVerifyCache:
         bc = _verify_cache_path(d, ["ref_b", "ref_c"])
         cb = _verify_cache_path(d, ["ref_c", "ref_b"])
         bd = _verify_cache_path(d, ["ref_b", "ref_d"])
+        empty = _verify_cache_path(d, [])
+        namespaced_a = _verify_cache_path(d, ["ref_b", "ref_c"], "run-a")
+        namespaced_b = _verify_cache_path(d, ["ref_b", "ref_c"], "run-b")
         # No references ⇒ the single unkeyed slot.
         assert unkeyed.name == "repeat_0_verify_response.json"
-        # Reference sets get distinct, order-independent slots.
+        # Reference sets and run semantics get distinct, order-independent slots.
         assert bc == cb
         assert bc != unkeyed
         assert bc != bd
+        assert empty != unkeyed
+        assert namespaced_a not in {bc, namespaced_b}
 
     @pytest.mark.asyncio
     async def test_same_reference_set_reuses_cached_judgement(self, tmp_path) -> None:

--- a/responses_api_agents/stirrup_agent/tests/test_app.py
+++ b/responses_api_agents/stirrup_agent/tests/test_app.py
@@ -36,6 +36,7 @@ from responses_api_agents.stirrup_agent.app import (
     StirrupRunRequest,
     TaskPerAttemptTimeoutError,
     _classify_verify_failure,
+    _has_real_deliverable,
     _load_task_registry,
     _task_finished,
     _verify_cache_path,
@@ -333,6 +334,20 @@ class TestTaskFinished:
         assert _task_finished(str(tmp_path)) is False
 
 
+class TestHasRealDeliverable:
+    def test_metadata_only_directory_has_no_deliverable(self, tmp_path) -> None:
+        for name in ("finish_params.json", "history.json", "metadata.json", "log.txt"):
+            (tmp_path / name).write_text("{}")
+
+        assert _has_real_deliverable(str(tmp_path)) is False
+
+    def test_answer_artifact_is_a_deliverable(self, tmp_path) -> None:
+        (tmp_path / "finish_params.json").write_text("{}")
+        (tmp_path / "answer.txt").write_text("the answer")
+
+        assert _has_real_deliverable(str(tmp_path)) is True
+
+
 class TestRerunIncompleteMode:
     def test_rerun_incomplete_requires_persist_dir(self) -> None:
         config = _make_config(rerun_incomplete=True, persist_deliverables_dir=None)
@@ -442,6 +457,9 @@ class TestRerunIncompleteMode:
         assert result["error_class"] == "incomplete"
         assert result["reward"] == 0.0
         assert result["skipped"] is False
+        assert result["response"]["id"] == "gdpval-task-1"
+        assert result["response"]["metadata"] is None
+        assert result["response"]["output"][0]["content"][0]["text"] == "done"
         assert NG_TERMINAL_KEY not in result
         assert NG_NO_PERSIST_KEY not in result
 
@@ -792,6 +810,44 @@ class TestReuseCachedDeliverable:
         assert result == {"reward": 0.5}
 
     @pytest.mark.asyncio
+    async def test_reuse_falls_back_to_policy_for_metadata_only_directory(self, tmp_path) -> None:
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "finish_params.json").write_text("{}")
+        (deliverables_root / "history.json").write_text("[]")
+        (deliverables_root / "metadata.json").write_text("{}")
+
+        config = _make_config(persist_deliverables_dir=str(tmp_path))
+        server_client = MagicMock(spec=ServerClient)
+        server_client.post = AsyncMock(return_value=MagicMock())
+        wrapper = StirrupAgentWrapper(config=config, server_client=server_client)
+        params = NeMoGymResponseCreateParamsNonStreaming(
+            input="ignored",
+            metadata={"task_id": "task-1", "prompt": "do the thing", "_ng_rollout_index": "0"},
+        )
+        body = StirrupRunRequest(
+            responses_create_params=params,
+            task_id="task-1",
+            prompt="do the thing",
+            reuse_cached_deliverable=True,
+        )
+        request = MagicMock(cookies={})
+        responses_mock = AsyncMock(return_value=_fake_response())
+
+        with (
+            patch.object(StirrupAgentWrapper, "responses", responses_mock),
+            patch("responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()),
+            patch(
+                "responses_api_agents.stirrup_agent.app.get_response_json",
+                AsyncMock(return_value={"reward": 0.5}),
+            ),
+        ):
+            result = await wrapper.run(request, body)
+
+        responses_mock.assert_awaited_once()
+        assert result == {"reward": 0.5}
+
+    @pytest.mark.asyncio
     async def test_invalid_judgement_is_retryable_and_not_cached(self, tmp_path) -> None:
         deliverables_root = tmp_path / "task_task-1" / "repeat_0"
         deliverables_root.mkdir(parents=True)
@@ -838,6 +894,49 @@ class TestReuseCachedDeliverable:
         assert result["reuse_cached_deliverable"] is True
         assert result["deliverables_dir"] == str(deliverables_root)
         assert not _verify_cache_path(str(deliverables_root)).exists()
+
+    @pytest.mark.asyncio
+    async def test_invalid_judgement_preserves_completed_policy_response(self, tmp_path) -> None:
+        deliverables_root = tmp_path / "task_task-1" / "repeat_0"
+        deliverables_root.mkdir(parents=True)
+        (deliverables_root / "finish_params.json").write_text("{}")
+        (deliverables_root / "history.json").write_text("[]")
+
+        wrapper = StirrupAgentWrapper(
+            config=_make_config(persist_deliverables_dir=str(tmp_path)),
+            server_client=MagicMock(spec=ServerClient),
+        )
+        wrapper.server_client.post = AsyncMock(return_value=MagicMock())
+        params = NeMoGymResponseCreateParamsNonStreaming(
+            input="ignored",
+            metadata={"task_id": "task-1", "prompt": "do the thing", "_ng_rollout_index": "0"},
+        )
+        body = StirrupRunRequest(responses_create_params=params, task_id="task-1", prompt="do the thing")
+        request = MagicMock(cookies={})
+
+        with (
+            patch.object(StirrupAgentWrapper, "responses", AsyncMock(return_value=_fake_response())),
+            patch("responses_api_agents.stirrup_agent.app.raise_for_status", AsyncMock()),
+            patch(
+                "responses_api_agents.stirrup_agent.app.get_response_json",
+                AsyncMock(
+                    return_value={
+                        "reward": 0.0,
+                        "invalid_judge_response": True,
+                        "judge_response": {"scoring_error": "no_score_in_response"},
+                    }
+                ),
+            ),
+        ):
+            result = await wrapper.run(request, body)
+
+        assert result[NG_FAILURE_CLASS_KEY] == "judge_invalid"
+        assert result["response"]["id"] == "gdpval-task-1"
+        assert result["response"]["metadata"] is None
+        assert result["response"]["output"][0]["content"][0]["text"] == "done"
+        # Bookkeeping files alone must not advertise a cached policy artifact.
+        assert "reuse_cached_deliverable" not in result
+        assert result["deliverables_dir"] == str(deliverables_root)
 
     @pytest.mark.asyncio
     async def test_nonretryable_invalid_judgement_is_terminal(self, tmp_path) -> None:
@@ -934,6 +1033,9 @@ class TestReuseCachedDeliverable:
         assert bool(result.get(NG_TERMINAL_KEY)) is terminal
         assert result["deliverables_dir"] == str(deliverables_root)
         assert result["reuse_cached_deliverable"] is True
+        assert result["response"]["id"] == "gdpval-task-1"
+        assert result["response"]["metadata"] is None
+        assert result["response"]["output"][0]["content"][0]["text"] == "done"
 
 
 class TestVerifyFailureClassification:

--- a/responses_api_agents/stirrup_agent/tests/test_file_reader_deliverables.py
+++ b/responses_api_agents/stirrup_agent/tests/test_file_reader_deliverables.py
@@ -1,9 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Run state the agent writes beside its deliverables must never reach the judge."""
+"""Run state and derived artifacts must never be mistaken for deliverables."""
 
+import base64
 from pathlib import Path
 
+import pytest
+
+import responses_api_agents.stirrup_agent.file_reader as file_reader
 from responses_api_agents.stirrup_agent.file_reader import (
     IGNORE_FILES,
     convert_deliverables_to_content_blocks,
@@ -95,3 +99,74 @@ def test_ignore_list_covers_every_file_the_agent_writes(tmp_path: Path):
     """Guard against the set drifting from what the agent actually produces."""
     for name in ("finish_params.json", "history.json", "history.pkl", "metadata.json", "log.txt"):
         assert name in IGNORE_FILES
+
+
+def test_same_stem_office_sidecars_are_emitted_once_and_stale_pdf_is_quarantined(tmp_path: Path):
+    (tmp_path / "Plan.docx").write_bytes(b"docx source")
+    (tmp_path / "Plan.pptx").write_bytes(b"pptx source")
+    (tmp_path / "Plan.docx.pdf").write_bytes(b"DOCX RENDER")
+    (tmp_path / "Plan.pptx.pdf").write_bytes(b"PPTX RENDER")
+    (tmp_path / "Plan.pdf").write_bytes(b"STALE COLLIDED RENDER")
+    (tmp_path / "Appendix.pdf").write_bytes(b"INDEPENDENT PDF")
+
+    blocks = convert_deliverables_to_content_blocks(str(tmp_path))
+    attachments = [
+        base64.b64decode(block["image_url"]["url"].split(",", 1)[1])
+        for block in blocks
+        if block.get("type") == "image_url"
+    ]
+
+    assert attachments == [b"INDEPENDENT PDF", b"DOCX RENDER", b"PPTX RENDER"]
+    text = _text_of(blocks)
+    assert "Plan.docx" in text
+    assert "Plan.pptx" in text
+    assert "Plan.pdf:" not in text
+    assert "Plan.docx.pdf" not in text
+    assert "Plan.pptx.pdf" not in text
+
+
+def test_ambiguous_plain_pdf_is_ignored_while_each_office_source_is_rendered(monkeypatch, tmp_path: Path):
+    (tmp_path / "Plan.docx").write_bytes(b"docx source")
+    (tmp_path / "Plan.pptx").write_bytes(b"pptx source")
+    (tmp_path / "Plan.pdf").write_bytes(b"STALE COLLIDED RENDER")
+
+    def _render(source: Path, out_dir: Path | None = None) -> Path:
+        assert out_dir is not None
+        rendered = out_dir / f"{source.stem}.pdf"
+        rendered.write_bytes(source.suffix.upper().encode())
+        return rendered
+
+    monkeypatch.setattr(file_reader, "_convert_office_to_pdf", _render)
+
+    blocks = convert_deliverables_to_content_blocks(str(tmp_path))
+    attachments = [
+        base64.b64decode(block["image_url"]["url"].split(",", 1)[1])
+        for block in blocks
+        if block.get("type") == "image_url"
+    ]
+
+    assert attachments == [b".DOCX", b".PPTX"]
+    assert b"STALE COLLIDED RENDER" not in attachments
+    assert "Plan.pdf:" not in _text_of(blocks)
+
+
+def test_xlsx_emits_formula_text_alongside_rendered_pdf(tmp_path: Path):
+    openpyxl = pytest.importorskip("openpyxl")
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.title = "Forecast"
+    sheet["A1"] = 4
+    sheet["A2"] = 8
+    sheet["A3"] = "=SUM(A1:A2)"
+    xlsx = tmp_path / "Budget.xlsx"
+    workbook.save(xlsx)
+    workbook.close()
+    (tmp_path / "Budget.xlsx.pdf").write_bytes(b"PDF RENDER")
+
+    blocks = convert_deliverables_to_content_blocks(str(tmp_path))
+
+    assert any(block.get("type") == "image_url" for block in blocks)
+    text = _text_of(blocks)
+    assert "structured spreadsheet cells" in text
+    assert "Sheet: Forecast" in text
+    assert "A3: formula: =SUM(A1:A2)" in text

--- a/responses_api_agents/stirrup_agent/tests/test_file_reader_no_libreoffice.py
+++ b/responses_api_agents/stirrup_agent/tests/test_file_reader_no_libreoffice.py
@@ -95,3 +95,40 @@ def test_unavailability_is_announced_once(monkeypatch, capsys, tmp_path: Path):
 
     warnings = [ln for ln in capsys.readouterr().out.splitlines() if "LibreOffice is unavailable" in ln]
     assert len(warnings) == 1, f"expected exactly one warning for three files, got {len(warnings)}"
+
+
+def test_conversion_failure_retries_roundtripped_copy_without_mutating_original(monkeypatch, tmp_path: Path):
+    source = tmp_path / "report.docx"
+    original = b"original OOXML package"
+    source.write_bytes(original)
+    destination = tmp_path / "render"
+    destination.mkdir()
+    calls: list[Path] = []
+
+    class _Completed:
+        returncode = 0
+        stdout = ""
+        stderr = "Error: source file could not be loaded"
+
+    def _roundtrip(src: Path, dst: Path) -> None:
+        assert src == source
+        dst.write_bytes(b"roundtripped package")
+
+    def _run(command, *args, **kwargs):
+        input_path = Path(command[-1])
+        calls.append(input_path)
+        if len(calls) == 2:
+            outdir = Path(command[command.index("--outdir") + 1])
+            (outdir / f"{input_path.stem}.pdf").write_bytes(b"%PDF retry")
+        return _Completed()
+
+    monkeypatch.setattr(file_reader, "roundtrip_ooxml_copy", _roundtrip)
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    result = file_reader._convert_office_to_pdf(source, out_dir=destination)
+
+    assert result == destination / "report.pdf"
+    assert result.read_bytes() == b"%PDF retry"
+    assert len(calls) == 2
+    assert "gdpval-roundtrip-" in str(calls[1])
+    assert source.read_bytes() == original

--- a/responses_api_agents/stirrup_agent/tests/test_file_reader_text_caps.py
+++ b/responses_api_agents/stirrup_agent/tests/test_file_reader_text_caps.py
@@ -4,11 +4,16 @@
 
 from pathlib import Path
 
+import pytest
+
 from responses_api_agents.stirrup_agent.file_reader import (
     MAX_TEXT_BLOCK_CHARS,
+    MAX_TOTAL_CHARS,
     MAX_TOTAL_TEXT_BLOCK_CHARS,
     _fair_text_allowances,
+    _read_pptx,
     convert_deliverables_to_content_blocks,
+    read_deliverable_files,
 )
 
 
@@ -51,6 +56,69 @@ def test_aggregate_budget_bounds_the_request(tmp_path: Path):
 
     out = _text_of(convert_deliverables_to_content_blocks(str(d)))
     assert len(out) <= MAX_TOTAL_TEXT_BLOCK_CHARS * 1.15
+
+
+def test_hard_budget_counts_headers_and_truncation_markers(tmp_path: Path):
+    d = tmp_path / "repeat_0"
+    d.mkdir()
+    for i in range(100):
+        (d / f"long_header_name_{i:03d}.txt").write_text("X" * 20_000)
+
+    blocks = convert_deliverables_to_content_blocks(str(d))
+
+    assert sum(len(block.get("text", "")) for block in blocks if block.get("type") == "text") <= (
+        MAX_TOTAL_TEXT_BLOCK_CHARS
+    )
+
+
+def test_hard_budget_counts_pdf_extractor_text(monkeypatch, tmp_path: Path):
+    import responses_api_agents.stirrup_agent.file_reader as file_reader
+
+    pdf = tmp_path / "report.pdf"
+    pdf.write_bytes(b"fake pdf")
+
+    def _render(*args, **kwargs):
+        return [
+            {"type": "text", "text": "P" * (MAX_TOTAL_TEXT_BLOCK_CHARS * 2)},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}},
+        ]
+
+    monkeypatch.setattr(file_reader, "_pdf_bytes_to_image_text_blocks", _render)
+    blocks = convert_deliverables_to_content_blocks(str(tmp_path), media_mode="images_and_text")
+    text_blocks = [block["text"] for block in blocks if block.get("type") == "text"]
+
+    assert sum(map(len, text_blocks)) <= MAX_TOTAL_TEXT_BLOCK_CHARS
+    assert "aggregate text budget exhausted" in "".join(text_blocks)
+
+
+def test_plain_text_summary_includes_its_marker_within_the_cap(tmp_path: Path):
+    (tmp_path / "report.txt").write_text("R" * (MAX_TOTAL_CHARS * 2))
+
+    output = read_deliverable_files(str(tmp_path))
+
+    assert len(output) <= MAX_TOTAL_CHARS
+    assert output.endswith("[...truncated]")
+
+
+def test_empty_text_deliverable_is_not_mislabeled_as_budget_omitted(tmp_path: Path):
+    (tmp_path / "empty.txt").write_bytes(b"")
+
+    output = _text_of(convert_deliverables_to_content_blocks(str(tmp_path)))
+
+    assert "empty.txt" in output
+    assert "present but EMPTY" in output
+    assert "budget exhausted" not in output
+
+
+def test_pptx_text_that_fits_the_budget_is_returned(tmp_path: Path):
+    pptx = pytest.importorskip("pptx")
+    presentation = pptx.Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[1])
+    slide.shapes.title.text = "Quarterly evidence"
+    path = tmp_path / "report.pptx"
+    presentation.save(path)
+
+    assert "Quarterly evidence" in _read_pptx(path, max_chars=1_000)
 
 
 def test_files_dropped_for_budget_are_named_not_silently_lost(tmp_path: Path):
@@ -98,3 +166,75 @@ def test_a_single_file_may_use_the_per_file_cap(tmp_path: Path):
     out = _text_of(convert_deliverables_to_content_blocks(str(d)))
     assert "only.txt" in out
     assert "truncated" in out
+
+
+def test_text_paths_do_not_use_unbounded_path_read_text(monkeypatch, tmp_path: Path):
+    import responses_api_agents.stirrup_agent.file_reader as file_reader
+
+    (tmp_path / "large.txt").write_text("prefix evidence\n" + "X" * 1_000_000)
+
+    def _unbounded_read_forbidden(*args, **kwargs):
+        raise AssertionError("Path.read_text would load the whole deliverable")
+
+    monkeypatch.setattr(Path, "read_text", _unbounded_read_forbidden)
+
+    assert "prefix evidence" in _text_of(convert_deliverables_to_content_blocks(str(tmp_path)))
+    assert "prefix evidence" in file_reader.read_deliverable_files(str(tmp_path))
+
+
+def test_rubric_attachment_budget_rejects_before_read(monkeypatch, tmp_path: Path):
+    import responses_api_agents.stirrup_agent.file_reader as file_reader
+
+    (tmp_path / "Plan.docx").write_bytes(b"source")
+    sidecar = tmp_path / "Plan.docx.pdf"
+    sidecar.write_bytes(b"render-too-large")
+    monkeypatch.setattr(file_reader, "MAX_TOTAL_RAW_ATTACHMENT_BYTES", 4)
+    monkeypatch.setattr(file_reader, "MAX_TOTAL_ENCODED_ATTACHMENT_CHARS", 8)
+    original_read_bytes = Path.read_bytes
+
+    def _guarded_read(path: Path):
+        if path == sidecar:
+            raise AssertionError("rejected Office sidecar must not be read")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", _guarded_read)
+
+    blocks = convert_deliverables_to_content_blocks(str(tmp_path))
+
+    assert "attachment omitted" in _text_of(blocks)
+
+
+def test_rubric_attachment_budget_is_aggregate(monkeypatch, tmp_path: Path):
+    import responses_api_agents.stirrup_agent.file_reader as file_reader
+
+    (tmp_path / "a.png").write_bytes(b"AAAA")
+    (tmp_path / "b.png").write_bytes(b"BBBB")
+    monkeypatch.setattr(file_reader, "MAX_TOTAL_RAW_ATTACHMENT_BYTES", 4)
+    monkeypatch.setattr(file_reader, "MAX_TOTAL_ENCODED_ATTACHMENT_CHARS", 8)
+
+    blocks = convert_deliverables_to_content_blocks(str(tmp_path))
+
+    attachments = [block for block in blocks if block.get("type") == "image_url"]
+    assert len(attachments) == 1
+    assert "attachment omitted" in _text_of(blocks)
+
+
+def test_pdf_source_size_does_not_consume_rendered_page_budget(monkeypatch, tmp_path: Path):
+    import responses_api_agents.stirrup_agent.file_reader as file_reader
+
+    pdf = tmp_path / "compressed.pdf"
+    pdf.write_bytes(b"source-is-larger-than-output-budget")
+    monkeypatch.setattr(file_reader, "MAX_TOTAL_RAW_ATTACHMENT_BYTES", 4)
+    monkeypatch.setattr(file_reader, "MAX_TOTAL_ENCODED_ATTACHMENT_CHARS", 8)
+
+    def _render(data, *, attachment_budget, **_kwargs):
+        assert data == pdf.read_bytes()
+        assert attachment_budget.reserve(1)
+        return [{"type": "image_url", "image_url": {"url": "data:image/png;base64,UA=="}}]
+
+    monkeypatch.setattr(file_reader, "_pdf_bytes_to_image_text_blocks", _render)
+
+    blocks = convert_deliverables_to_content_blocks(str(tmp_path), media_mode="images_and_text")
+
+    assert any(block.get("type") == "image_url" for block in blocks)
+    assert "attachment omitted" not in _text_of(blocks)

--- a/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
+++ b/responses_api_agents/stirrup_agent/tests/test_nemo_client.py
@@ -137,6 +137,44 @@ def test_provider_openai_messages_convert_nemo_user_messages() -> None:
     assert serialized[1]["tool_call_id"] == "call_1"
 
 
+@pytest.mark.parametrize(
+    "raw_block",
+    [
+        '<tool_call>{"name":"code_exec","arguments":{"cmd":"true"}}</tool_call>',
+        '<function=code_exec>{"cmd":"true"}</function>',
+    ],
+)
+def test_provider_history_strips_unparsed_tool_blocks_without_mutating_history(raw_block: str) -> None:
+    """Malformed call markup must not become an in-context example on the next turn."""
+    original_content = f"short preamble\n{raw_block}\nshort epilogue"
+    message = AssistantMessage(
+        content=original_content,
+        tool_calls=[],
+        token_usage=TokenUsage(input=1, answer=1, reasoning=0),
+    )
+
+    serialized = to_provider_openai_messages([message])
+    provider_text = serialized[0]["content"][0]["text"]
+
+    assert raw_block not in provider_text
+    assert provider_text == "short preamble\n\nshort epilogue"
+    # Sanitization is wire-only; persisted/exported history stays forensic.
+    assert message.content == original_content
+
+
+def test_provider_history_does_not_strip_content_from_a_parsed_tool_call() -> None:
+    message = AssistantMessage(
+        content="calling now <tool_call>diagnostic text</tool_call>",
+        tool_calls=[ToolCall(tool_call_id="call_1", name="code_exec", arguments='{"cmd":"true"}')],
+        token_usage=TokenUsage(input=1, answer=1, reasoning=0),
+    )
+
+    serialized = to_provider_openai_messages([message])
+
+    assert serialized[0]["content"][0]["text"] == message.content
+    assert serialized[0]["tool_calls"][0]["id"] == "call_1"
+
+
 @pytest.mark.asyncio
 async def test_max_completion_tokens_cap_overrides_dynamic_size() -> None:
     """When the dynamic computation exceeds the cap, the cap should win."""

--- a/responses_api_agents/stirrup_agent/tests/test_tool_call_id_uniqueness.py
+++ b/responses_api_agents/stirrup_agent/tests/test_tool_call_id_uniqueness.py
@@ -82,3 +82,24 @@ def test_interleaved_tools_pair_independently():
         "search-a": "search-out-a",
         "search-b": "search-out-b",
     }
+
+
+def test_suffix_shaped_raw_ids_cannot_collide_with_generated_suffixes():
+    """A real raw ``x#2`` must not collide with the suffix minted for repeated ``x``."""
+    history = [
+        _turn("x", "first", "out-first"),
+        _turn("x", "second", "out-second"),
+        _turn("x#2", "literal-suffix", "out-literal-suffix"),
+    ]
+
+    _, items = convert_stirrup_history_to_output_items(history)
+    calls, outputs = _calls_and_outputs(items)
+
+    ids = [call.call_id for call in calls]
+    assert len(ids) == len(set(ids)) == 3
+    by_id = {output.call_id: output.output for output in outputs}
+    assert {call.arguments: by_id[call.call_id] for call in calls} == {
+        "first": "out-first",
+        "second": "out-second",
+        "literal-suffix": "out-literal-suffix",
+    }

--- a/tests/unit_tests/test_deliverables.py
+++ b/tests/unit_tests/test_deliverables.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for dependency-neutral deliverable classification."""
+
+from pathlib import Path
+
+from nemo_gym.deliverables import IGNORE_FILES, is_deliverable
+
+
+def test_is_deliverable_distinguishes_output_from_run_state(tmp_path: Path) -> None:
+    output = tmp_path / "answer.txt"
+    output.write_text("answer")
+    run_state = tmp_path / "finish_params.json"
+    run_state.write_text("{}")
+    reference_files = tmp_path / "reference_files"
+    reference_files.mkdir()
+
+    assert is_deliverable(output)
+    assert not is_deliverable(run_state)
+    assert not is_deliverable(reference_files)
+    assert {run_state.name, reference_files.name} <= IGNORE_FILES

--- a/tests/unit_tests/test_dispatch_latency.py
+++ b/tests/unit_tests/test_dispatch_latency.py
@@ -49,6 +49,16 @@ class TestSummary:
     def test_empty_is_stated_not_crashed(self):
         assert "No completed rollouts" in DispatchLatencyTracker().summary()
 
+    def test_all_drained_reports_count_without_completions(self):
+        t = DispatchLatencyTracker()
+        t.record_drained()
+        t.record_drained()
+
+        out = t.summary()
+
+        assert "No completed rollouts" in out
+        assert "Drained (not dispatched, no time left in the budget): 2" in out
+
 
 class TestObservedElapsed:
     def test_reads_top_level(self):

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -26,7 +26,12 @@ import yaml
 import nemo_gym.rollout_collection
 from nemo_gym.base_resources_server import AggregateMetrics, AggregateMetricsRequest
 from nemo_gym.config_types import ConfigError, ConfigPathNotFoundError
-from nemo_gym.global_config import AGENT_REF_KEY_NAME, ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
+from nemo_gym.global_config import (
+    AGENT_REF_KEY_NAME,
+    ATTEMPT_INDEX_KEY_NAME,
+    ROLLOUT_INDEX_KEY_NAME,
+    TASK_INDEX_KEY_NAME,
+)
 from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
 from nemo_gym.reward_profile import compute_aggregate_metrics
 from nemo_gym.rollout_collection import (
@@ -666,6 +671,63 @@ class TestRolloutCollection:
         ]
         assert expected_aggregate_metrics == actual_aggregate_metrics
 
+    async def test_fresh_run_clears_stale_failure_and_metrics_artifacts(
+        self, tmp_path: Path, empty_global_config: MagicMock
+    ) -> None:
+        input_fpath = tmp_path / "input.jsonl"
+        input_fpath.write_bytes(
+            orjson.dumps(
+                {
+                    "responses_create_params": {"input": []},
+                    AGENT_REF_KEY_NAME: {"name": "agent"},
+                }
+            )
+            + b"\n"
+        )
+        output_fpath = tmp_path / "output.jsonl"
+        output_fpath.write_text('{"stale":true}\n')
+        failures_fpath = _failures_path_for(output_fpath)
+        failures_fpath.write_text(
+            orjson.dumps(
+                {
+                    TASK_INDEX_KEY_NAME: 0,
+                    ROLLOUT_INDEX_KEY_NAME: 0,
+                    NG_FAILURE_CLASS_KEY: "skipped",
+                    NG_TERMINAL_KEY: True,
+                }
+            ).decode()
+            + "\n"
+        )
+        metrics_fpath = tmp_path / "output_aggregate_metrics.json"
+        metrics_fpath.write_text('{"stale":true}\n')
+
+        config = RolloutCollectionConfig(
+            input_jsonl_fpath=str(input_fpath),
+            output_jsonl_fpath=str(output_fpath),
+            resume_from_cache=False,
+            disable_aggregation=True,
+        )
+
+        class Helper(RolloutCollectionHelper):
+            def run_examples(self, examples, *args, **kwargs):
+                [row] = examples
+                future = Future()
+                future.set_result((row, {"reward": 1.0}))
+                return [future]
+
+        await Helper().run_from_config(config)
+
+        assert [orjson.loads(line) for line in output_fpath.read_bytes().splitlines()] == [
+            {
+                "reward": 1.0,
+                TASK_INDEX_KEY_NAME: 0,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                AGENT_REF_KEY_NAME: {"name": "agent"},
+            }
+        ]
+        assert failures_fpath.read_bytes() == b""
+        assert not metrics_fpath.exists()
+
     @pytest.mark.parametrize("resume_from_cache", [False, True])
     async def test_run_from_config_replaces_stale_capture_before_dispatch(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, resume_from_cache: bool
@@ -1210,6 +1272,7 @@ class TestDispatchBudget:
             input_jsonl_fpath=str(input_jsonl_fpath),
             output_jsonl_fpath=str(tmp_path / "output.jsonl"),
             disable_aggregation=True,
+            num_samples_in_parallel=1,
             dispatch_budget_s=1800.0,
             drain_margin_s=drain_margin_s,
         )
@@ -1231,6 +1294,23 @@ class TestDispatchBudget:
         # run_examples is stubbed here, so nothing was timed; the summary still
         # prints rather than being skipped.
         assert "No completed rollouts to report latency for." in out
+
+    def test_dispatch_budget_requires_finite_concurrency(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="finite positive num_samples_in_parallel"):
+            RolloutCollectionConfig(
+                input_jsonl_fpath=str(tmp_path / "input.jsonl"),
+                output_jsonl_fpath=str(tmp_path / "output.jsonl"),
+                dispatch_budget_s=1800.0,
+            )
+
+    @pytest.mark.parametrize("concurrency", [0, -1])
+    def test_concurrency_must_always_be_positive(self, tmp_path: Path, concurrency: int) -> None:
+        with pytest.raises(ValueError, match="greater than 0"):
+            RolloutCollectionConfig(
+                input_jsonl_fpath=str(tmp_path / "input.jsonl"),
+                output_jsonl_fpath=str(tmp_path / "output.jsonl"),
+                num_samples_in_parallel=concurrency,
+            )
 
     async def test_zero_budget_drains_rather_than_disabling_the_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """0.0 is a spent budget, not an absent one -- truthiness gets this wrong."""
@@ -1376,13 +1456,14 @@ class TestLongestFirstDispatch:
         assert [r[TASK_INDEX_KEY_NAME] for r in input_rows] == [0, 1, 2, 3]
 
     def test_timeout_failures_are_retried_not_gated(self, tmp_path: Path) -> None:
-        """A per-task timeout is a statement about load, not about the task."""
+        """A legacy terminal timeout is a statement about load, not the task."""
         failures = [
             {
                 TASK_INDEX_KEY_NAME: 1,
                 ROLLOUT_INDEX_KEY_NAME: 0,
                 "elapsed_seconds": 12600,
                 NG_FAILURE_CLASS_KEY: "timeout_exceeded",
+                NG_TERMINAL_KEY: True,
             }
         ]
         config = self._write_resume_state(tmp_path, failures)
@@ -1390,6 +1471,96 @@ class TestLongestFirstDispatch:
         input_rows, *_ = RolloutCollectionHelper()._load_from_cache(config)
 
         assert 1 in [r[TASK_INDEX_KEY_NAME] for r in input_rows]
+
+    def test_retry_propagates_cached_deliverable_signal(self, tmp_path: Path) -> None:
+        failures = [
+            {
+                TASK_INDEX_KEY_NAME: 2,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                NG_FAILURE_CLASS_KEY: "judge_invalid",
+                "reuse_cached_deliverable": True,
+            }
+        ]
+        config = self._write_resume_state(tmp_path, failures)
+
+        input_rows, *_ = RolloutCollectionHelper()._load_from_cache(config)
+        by_task = {row[TASK_INDEX_KEY_NAME]: row for row in input_rows}
+
+        assert by_task[2]["reuse_cached_deliverable"] is True
+        assert "reuse_cached_deliverable" not in by_task[1]
+
+    def test_legacy_invalid_judge_main_row_migrates_to_retryable_sidecar(self, tmp_path: Path) -> None:
+        config = self._write_resume_state(tmp_path, [])
+        output = Path(config.output_jsonl_fpath)
+        deliverables_dir = tmp_path / "deliverables" / "task-2"
+        deliverables_dir.mkdir(parents=True)
+        (deliverables_dir / "answer.txt").write_text("answer")
+        output.write_bytes(
+            orjson.dumps(
+                {
+                    TASK_INDEX_KEY_NAME: 2,
+                    ROLLOUT_INDEX_KEY_NAME: 0,
+                    "invalid_judge_response": True,
+                    "reward": 0.0,
+                    "deliverables_dir": str(deliverables_dir),
+                }
+            )
+            + b"\n"
+        )
+
+        input_rows, cached_rows, cached_results, _ = RolloutCollectionHelper()._load_from_cache(config)
+
+        by_task = {row[TASK_INDEX_KEY_NAME]: row for row in input_rows}
+        assert by_task[2]["reuse_cached_deliverable"] is True
+        assert by_task[2][ATTEMPT_INDEX_KEY_NAME] == 1
+        assert cached_rows == []
+        assert cached_results == []
+        assert output.read_bytes() == b""
+        migrated = [orjson.loads(line) for line in _failures_path_for(output).read_bytes().splitlines()]
+        assert len(migrated) == 1
+        assert migrated[0][NG_FAILURE_CLASS_KEY] == "judge_invalid"
+        assert migrated[0]["reuse_cached_deliverable"] is True
+
+        RolloutCollectionHelper()._load_from_cache(config)
+        assert len(_failures_path_for(output).read_bytes().splitlines()) == 1
+
+    def test_legacy_invalid_judge_without_artifact_does_not_request_reuse(self, tmp_path: Path) -> None:
+        config = self._write_resume_state(tmp_path, [])
+        output = Path(config.output_jsonl_fpath)
+        output.write_bytes(
+            orjson.dumps(
+                {
+                    TASK_INDEX_KEY_NAME: 2,
+                    ROLLOUT_INDEX_KEY_NAME: 0,
+                    "invalid_judge_response": True,
+                    "reuse_cached_deliverable": True,
+                    "deliverables_dir": str(tmp_path / "missing-deliverables"),
+                }
+            )
+            + b"\n"
+        )
+
+        input_rows, *_ = RolloutCollectionHelper()._load_from_cache(config)
+
+        by_task = {row[TASK_INDEX_KEY_NAME]: row for row in input_rows}
+        assert "reuse_cached_deliverable" not in by_task[2]
+        migrated = [orjson.loads(line) for line in _failures_path_for(output).read_bytes().splitlines()]
+        assert "reuse_cached_deliverable" not in migrated[0]
+
+    def test_skipped_failures_stay_terminal(self, tmp_path: Path) -> None:
+        failures = [
+            {
+                TASK_INDEX_KEY_NAME: 1,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                NG_FAILURE_CLASS_KEY: "skipped",
+                NG_TERMINAL_KEY: True,
+            }
+        ]
+        config = self._write_resume_state(tmp_path, failures)
+
+        input_rows, *_ = RolloutCollectionHelper()._load_from_cache(config)
+
+        assert 1 not in [r[TASK_INDEX_KEY_NAME] for r in input_rows]
 
     def test_explicitly_terminal_rows_stay_gated(self, tmp_path: Path) -> None:
         failures = [{TASK_INDEX_KEY_NAME: 1, ROLLOUT_INDEX_KEY_NAME: 0, NG_TERMINAL_KEY: True}]

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -1495,18 +1495,14 @@ class TestLongestFirstDispatch:
         deliverables_dir = tmp_path / "deliverables" / "task-2"
         deliverables_dir.mkdir(parents=True)
         (deliverables_dir / "answer.txt").write_text("answer")
-        output.write_bytes(
-            orjson.dumps(
-                {
-                    TASK_INDEX_KEY_NAME: 2,
-                    ROLLOUT_INDEX_KEY_NAME: 0,
-                    "invalid_judge_response": True,
-                    "reward": 0.0,
-                    "deliverables_dir": str(deliverables_dir),
-                }
-            )
-            + b"\n"
-        )
+        legacy_row = {
+            TASK_INDEX_KEY_NAME: 2,
+            ROLLOUT_INDEX_KEY_NAME: 0,
+            "invalid_judge_response": True,
+            "reward": 0.0,
+            "deliverables_dir": str(deliverables_dir),
+        }
+        output.write_bytes(orjson.dumps(legacy_row) + b"\n")
 
         input_rows, cached_rows, cached_results, _ = RolloutCollectionHelper()._load_from_cache(config)
 
@@ -1521,8 +1517,52 @@ class TestLongestFirstDispatch:
         assert migrated[0][NG_FAILURE_CLASS_KEY] == "judge_invalid"
         assert migrated[0]["reuse_cached_deliverable"] is True
 
+        # Simulate a crash after the sidecar append but before the main-file
+        # replacement: replaying the same attempt must not append it twice.
+        replayed_row = dict(legacy_row)
+        replayed_row[ATTEMPT_INDEX_KEY_NAME] = 0
+        output.write_bytes(orjson.dumps(replayed_row) + b"\n")
         RolloutCollectionHelper()._load_from_cache(config)
         assert len(_failures_path_for(output).read_bytes().splitlines()) == 1
+
+    def test_legacy_invalid_judge_distinct_attempts_accumulate_and_gate(self, tmp_path: Path) -> None:
+        config = self._write_resume_state(tmp_path, [])
+        output = Path(config.output_jsonl_fpath)
+        legacy_rows = [
+            {
+                TASK_INDEX_KEY_NAME: 2,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                ATTEMPT_INDEX_KEY_NAME: attempt,
+                "invalid_judge_response": True,
+            }
+            for attempt in range(_DEFAULT_MAX_ROLLOUT_ATTEMPTS)
+        ]
+        output.write_bytes(b"\n".join(map(orjson.dumps, legacy_rows)) + b"\n")
+
+        input_rows, *_ = RolloutCollectionHelper()._load_from_cache(config)
+
+        assert 2 not in [row[TASK_INDEX_KEY_NAME] for row in input_rows]
+        migrated = [orjson.loads(line) for line in _failures_path_for(output).read_bytes().splitlines()]
+        assert [row[ATTEMPT_INDEX_KEY_NAME] for row in migrated] == list(range(_DEFAULT_MAX_ROLLOUT_ATTEMPTS))
+
+    def test_legacy_invalid_judge_same_attempt_in_different_stages_stays_distinct(self, tmp_path: Path) -> None:
+        config = self._write_resume_state(tmp_path, [])
+        output = Path(config.output_jsonl_fpath)
+        legacy_rows = [
+            {
+                TASK_INDEX_KEY_NAME: 2,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                "stage_index": stage,
+                "invalid_judge_response": True,
+            }
+            for stage in (0, 1)
+        ]
+        output.write_bytes(b"\n".join(map(orjson.dumps, legacy_rows)) + b"\n")
+
+        RolloutCollectionHelper()._load_from_cache(config)
+
+        migrated = [orjson.loads(line) for line in _failures_path_for(output).read_bytes().splitlines()]
+        assert [row["stage_index"] for row in migrated] == [0, 1]
 
     def test_legacy_invalid_judge_without_artifact_does_not_request_reuse(self, tmp_path: Path) -> None:
         config = self._write_resume_state(tmp_path, [])
@@ -1535,6 +1575,34 @@ class TestLongestFirstDispatch:
                     "invalid_judge_response": True,
                     "reuse_cached_deliverable": True,
                     "deliverables_dir": str(tmp_path / "missing-deliverables"),
+                }
+            )
+            + b"\n"
+        )
+
+        input_rows, *_ = RolloutCollectionHelper()._load_from_cache(config)
+
+        by_task = {row[TASK_INDEX_KEY_NAME]: row for row in input_rows}
+        assert "reuse_cached_deliverable" not in by_task[2]
+        migrated = [orjson.loads(line) for line in _failures_path_for(output).read_bytes().splitlines()]
+        assert "reuse_cached_deliverable" not in migrated[0]
+
+    def test_legacy_invalid_judge_with_only_run_state_does_not_request_reuse(self, tmp_path: Path) -> None:
+        config = self._write_resume_state(tmp_path, [])
+        output = Path(config.output_jsonl_fpath)
+        deliverables_dir = tmp_path / "deliverables" / "task-2"
+        deliverables_dir.mkdir(parents=True)
+        (deliverables_dir / "finish_params.json").write_text("{}")
+        (deliverables_dir / "history.json").write_text("[]")
+        (deliverables_dir / "reference_files").mkdir()
+        output.write_bytes(
+            orjson.dumps(
+                {
+                    TASK_INDEX_KEY_NAME: 2,
+                    ROLLOUT_INDEX_KEY_NAME: 0,
+                    "invalid_judge_response": True,
+                    "reuse_cached_deliverable": True,
+                    "deliverables_dir": str(deliverables_dir),
                 }
             )
             + b"\n"

--- a/tests/unit_tests/test_rollout_reverification.py
+++ b/tests/unit_tests/test_rollout_reverification.py
@@ -28,6 +28,7 @@ from nemo_gym.global_config import AGENT_REF_KEY_NAME, ROLLOUT_INDEX_KEY_NAME, S
 from nemo_gym.rollout_reverification import (
     _RECOVERY_TWO_SOURCES_WARNING,
     JUDGE_FAILED_FAILURE_CLASS,
+    JUDGE_INVALID_FAILURE_CLASS,
     NG_FAILURE_CLASS_KEY,
     NG_NO_PERSIST_KEY,
     NG_TERMINAL_KEY,
@@ -48,6 +49,7 @@ from nemo_gym.rollout_reverification import (
     _is_judge_failure,
     _load_cache_keys_by_status,
     _load_reverified_results,
+    _normalize_invalid_judge_result,
     _parse_output_line_key,
     _prepare_output_fpaths,
     _prepare_payloads,
@@ -446,6 +448,24 @@ class TestBuildVerifyPayload:
 
         assert set(result.keys()) == {"task", "response"}
 
+    def test_preserves_file_and_reference_context_required_by_verifier(self) -> None:
+        pair = InputRolloutPair(
+            input={"task": "q1", "deliverables_dir": "/stale"},
+            rollout={
+                "response": {"output": "x"},
+                "deliverables_dir": "/artifacts/task-1/repeat_0",
+                "reference_ids": ["ref-b"],
+                "reward": 0.0,
+                NG_FAILURE_CLASS_KEY: JUDGE_INVALID_FAILURE_CLASS,
+            },
+        )
+
+        result = _build_verify_payload(pair)
+
+        assert result["deliverables_dir"] == "/artifacts/task-1/repeat_0"
+        assert result["reference_ids"] == ["ref-b"]
+        assert "reward" not in result and NG_FAILURE_CLASS_KEY not in result
+
 
 # ---------------------------------------------------------------------------
 # Judge-failure recovery helpers (--judge-failed-only)
@@ -455,6 +475,7 @@ class TestBuildVerifyPayload:
 class TestIsJudgeFailure:
     def test_true_only_for_judge_failed_class(self) -> None:
         assert _is_judge_failure({NG_FAILURE_CLASS_KEY: JUDGE_FAILED_FAILURE_CLASS}) is True
+        assert _is_judge_failure({NG_FAILURE_CLASS_KEY: JUDGE_INVALID_FAILURE_CLASS}) is True
 
     def test_false_for_other_failure_classes(self) -> None:
         assert _is_judge_failure({NG_FAILURE_CLASS_KEY: "timeout_exceeded"}) is False
@@ -465,6 +486,15 @@ class TestIsJudgeFailure:
     def test_legacy_judge_failed_boolean_is_not_honored(self) -> None:
         """v2 marks judge failures only via _ng_failure_class; the older boolean is ignored."""
         assert _is_judge_failure({"_ng_failure_judge_failed": True}) is False
+
+    def test_invalid_judge_result_is_retryable_unless_verifier_marks_it_permanent(self) -> None:
+        retryable = _normalize_invalid_judge_result({"invalid_judge_response": True})
+        assert retryable[NG_FAILURE_CLASS_KEY] == JUDGE_INVALID_FAILURE_CLASS
+        assert NG_TERMINAL_KEY not in retryable
+
+        permanent = _normalize_invalid_judge_result({"invalid_judge_response": True, "invalid_judge_retryable": False})
+        assert permanent[NG_FAILURE_CLASS_KEY] == "permanent"
+        assert permanent[NG_TERMINAL_KEY] is True
 
 
 class TestRecoveryRolloutPredicate:
@@ -483,6 +513,14 @@ class TestRecoveryRolloutPredicate:
         predicate = _recovery_rollout_predicate()
         assert predicate(self._row(0, failure_class="timeout_exceeded")) is False
         assert predicate(self._row(1)) is True
+
+    def test_rejects_multistage_sidecar_rows(self) -> None:
+        predicate = _recovery_rollout_predicate()
+        row = self._row(0)
+        row["stage_index"] = 1
+
+        with pytest.raises(ConfigError, match="does not support multi-stage rows"):
+            predicate(row)
 
     def test_dropped_non_judge_row_does_not_pollute_seen(self) -> None:
         """A row filtered out by the judge filter must not consume its key from the dedup set."""
@@ -609,6 +647,30 @@ class TestLoadCacheKeysByStatus:
         )
         cache = _load_cache_keys_by_status(paths)
         assert cache.terminal_keys == {(5, 0)}
+
+    def test_legacy_terminal_timeout_is_retryable(self, tmp_path: Path) -> None:
+        paths = self._paths(tmp_path)
+        self._write(
+            paths.failures,
+            [
+                {
+                    TASK_INDEX_KEY_NAME: 5,
+                    ROLLOUT_INDEX_KEY_NAME: 0,
+                    NG_FAILURE_CLASS_KEY: "timeout_exceeded",
+                    NG_TERMINAL_KEY: True,
+                },
+                {
+                    TASK_INDEX_KEY_NAME: 6,
+                    ROLLOUT_INDEX_KEY_NAME: 0,
+                    NG_FAILURE_CLASS_KEY: "skipped",
+                    NG_TERMINAL_KEY: True,
+                },
+            ],
+        )
+
+        cache = _load_cache_keys_by_status(paths)
+
+        assert cache.terminal_keys == {(6, 0)}
 
     def test_maxed_out_keys_when_attempts_reach_configured_max(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -2183,6 +2245,28 @@ class TestRunFromConfigJudgeFailedOnly:
         assert (tmp_path / "recovered.jsonl").exists()
         assert not (tmp_path / "unsafe_recovered.jsonl").exists()
 
+    async def test_migrates_legacy_invalid_main_row_before_seeding(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        legacy_invalid = self._success(0, reward=0.0)
+        legacy_invalid["invalid_judge_response"] = True
+        self._setup_fixture(
+            tmp_path,
+            materialized=[self._mat(0)],
+            successes=[legacy_invalid],
+            failures=[],
+        )
+        dispatched: list = []
+        self._patch(monkeypatch, dispatched, recovered_reward=0.8)
+
+        returned = await RolloutReverificationHelper().run_from_config(self._make_config(tmp_path))
+
+        assert [row[TASK_INDEX_KEY_NAME] for row in dispatched] == [0]
+        assert [row["reward"] for row in returned] == [0.8]
+        assert self._read_jsonl(tmp_path / "rollouts.jsonl") == []
+        migrated = self._read_jsonl(tmp_path / "rollouts_failures.jsonl")
+        assert migrated[0][NG_FAILURE_CLASS_KEY] == JUDGE_INVALID_FAILURE_CLASS
+
     async def test_prints_two_sources_warning(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
@@ -2430,7 +2514,9 @@ class TestRunFromConfigJudgeFailedOnly:
         def first_pass(payload: dict) -> dict:
             if payload[TASK_INDEX_KEY_NAME] == 1:
                 return {"reward": 1.0, "verdict": "correct"}
-            return {"reward": 0.0, NG_FAILURE_CLASS_KEY: "judge_failed"}
+            # Resource servers return this semantic invalid marker directly;
+            # reverify must normalize it into the retry sidecar itself.
+            return {"reward": 0.0, "invalid_judge_response": True}
 
         dispatched1: list = []
         self._patch_with_result(monkeypatch, dispatched1, first_pass)
@@ -2439,10 +2525,9 @@ class TestRunFromConfigJudgeFailedOnly:
         # all three judge failures were attempted; output has seeded 0 + recovered 1; 2,3 in the sidecar
         assert sorted(p[TASK_INDEX_KEY_NAME] for p in dispatched1) == [1, 2, 3]
         assert sorted(r[TASK_INDEX_KEY_NAME] for r in self._read_jsonl(tmp_path / "recovered.jsonl")) == [0, 1]
-        assert sorted(r[TASK_INDEX_KEY_NAME] for r in self._read_jsonl(tmp_path / "recovered_failures.jsonl")) == [
-            2,
-            3,
-        ]
+        first_failures = self._read_jsonl(tmp_path / "recovered_failures.jsonl")
+        assert sorted(r[TASK_INDEX_KEY_NAME] for r in first_failures) == [2, 3]
+        assert {r[NG_FAILURE_CLASS_KEY] for r in first_failures} == {JUDGE_INVALID_FAILURE_CLASS}
 
         # Second pass (--resume): only the still-failing 2,3 are retried (0,1 are cached in the output),
         # and now succeed.


### PR DESCRIPTION
## Summary

- Route malformed, truncated, or scoreless judge responses out of headline metrics and through retry-aware failure sidecars; preserve completed policy artifacts for re-judging and make deterministic payload/context failures terminal.
- Bound GDPVal text, binary, Office, PDF, media, and ZIP handling before reads and request construction; preserve sidecar provenance, attachment fairness, and A/B swap invariance while avoiding repeated hashing for payloads that already fit.
- Make standard and multi-stage collection honor finite dispatch budgets, stage-aware longest-first scheduling, attempt accounting, and cached-deliverable reuse; harden resume with config fingerprints, legacy migration, completion coverage checks, atomic writes, and stale-metric cleanup.
- Allow opt-in bounded partial completion for non-final calibration stages after persisted timeouts, with overall and per-reference evidence floors, balanced fresh assignments, frozen evidence snapshots, and fail-closed resume. The final stage still requires full evidence for a headline ELO.
- Sanitize unparsed raw tool-call blocks before provider requests and guarantee globally unique converted tool-call IDs without mutating stored trajectories.
- Align reverification with the new judge-invalid failure contract, preserve file/reference context, migrate legacy invalid rows, and reject unsafe multi-stage judge-failure recovery.

## Behavior changes

- `dispatch_budget_s` now requires a finite positive `num_samples_in_parallel`.
- Missing rubrics and deterministic request-size/context failures are terminal instead of consuming repeated judge attempts.
- `--judge-failed-only` fails fast for multi-stage sidecars; multi-stage collection resume is the supported recovery path for those rows.
- `partial_completion` is opt-in and valid only for non-final stages. Resume uses the same output path plus `--resume`; changing a policy after a partial outcome has been frozen fails closed.

## Validation

- `env PYTHONPATH=. uv run pytest resources_servers/gdpval/tests -q`
  - 310 passed, 9 optional-dependency skips
- `env PYTHONPATH=. uv run pytest tests/unit_tests/test_deliverables.py tests/unit_tests/test_dispatch_latency.py tests/unit_tests/test_rollout_collection.py tests/unit_tests/test_rollout_reverification.py -q`
  - 229 passed
- Focused multi-stage suite, including 41/45 calibration recovery, interrupted-final-stage resume, stale downstream invalidation, frozen-evidence validation, and crash-order handling:
  - 135 passed
- Ruff check and format check pass for every changed Python file.
- `git diff --check` passes.
