### PR TITLE
fix(workplace-assistant): install Jupyter for SDG notebook

### DIFF
--- a/resources_servers/workplace_assistant/notebooks/synthetic-data-generation/requirements.txt
+++ b/resources_servers/workplace_assistant/notebooks/synthetic-data-generation/requirements.txt
@@ -2,3 +2,4 @@ data-designer==0.5.2
 duckdb==1.4.4
 pydantic==2.12.5
 pandas==2.3.3
+notebook==7.6.2


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

Adds Jupyter Notebook to the synthetic data generation notebook requirements.

The documented setup completed successfully but did not install the `jupyter` command. As a
result, running `jupyter notebook multistep-toolcalling-sdg.ipynb` failed with `jupyter:
command not found`.

This change adds `notebook==7.6.2` to the requirements.

Validation:

- Installed the updated requirements in a clean Python 3.12.3 environment.
- Confirmed `jupyter notebook --version` returns `7.6.2`.
- Confirmed `notebook` and `ipykernel` import successfully.
- Confirmed `git diff --check` passes.


## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
