### PR TITLE
feat(sandbox): add per-exec CPU pinning

### DIFF
--- a/nemo_gym/sandbox/api.py
+++ b/nemo_gym/sandbox/api.py
@@ -40,6 +40,7 @@ from nemo_gym.sandbox.providers import (
     SupportsSandboxPtyAttach,
     create_provider,
 )
+from nemo_gym.sandbox.utils import wrap_command_with_cpu_pin
 
 
 T = TypeVar("T")
@@ -335,10 +336,12 @@ class AsyncSandbox:
         env: dict[str, str] | None = None,
         timeout_s: int | float | None = 180,
         user: str | int | None = None,
+        cpu_pin_enabled: bool = False,
     ) -> SandboxExecResult:
+        """Run a command, optionally sizing and pinning it to the cgroup CPU quota."""
         return await self._provider.exec(
             self._require_handle(),
-            command,
+            wrap_command_with_cpu_pin(command) if cpu_pin_enabled else command,
             cwd=cwd if cwd is not None else self._spec.workdir if self._spec is not None else None,
             env=env,
             timeout_s=timeout_s,
@@ -550,6 +553,7 @@ class Sandbox:
         env: dict[str, str] | None = None,
         timeout_s: int | float | None = 180,
         user: str | int | None = None,
+        cpu_pin_enabled: bool = False,
     ) -> SandboxExecResult:
         return self._runner.run(
             "exec",
@@ -559,6 +563,7 @@ class Sandbox:
                 env=env,
                 timeout_s=timeout_s,
                 user=user,
+                cpu_pin_enabled=cpu_pin_enabled,
             ),
         )
 

--- a/nemo_gym/sandbox/utils.py
+++ b/nemo_gym/sandbox/utils.py
@@ -14,6 +14,87 @@
 
 """Sandbox utility helpers."""
 
+# Sandboxes can expose the host's CPU count despite a smaller CFS quota. Keep
+# this POSIX-shell preamble silent and fail-open because images vary widely.
+_CPU_PIN_PREAMBLE = r"""
+_ng_cpu_quota=
+_ng_cpu_period=
+_ng_cpu_list=
+if [ -r /sys/fs/cgroup/cpu.max ]; then
+    read -r _ng_cpu_quota _ng_cpu_period < /sys/fs/cgroup/cpu.max || :
+else
+    for _ng_cpu_dir in /sys/fs/cgroup/cpu /sys/fs/cgroup/cpu,cpuacct; do
+        if [ -r "$_ng_cpu_dir/cpu.cfs_quota_us" ]; then
+            _ng_cpu_quota=$(cat "$_ng_cpu_dir/cpu.cfs_quota_us" 2>/dev/null || :)
+            _ng_cpu_period=$(cat "$_ng_cpu_dir/cpu.cfs_period_us" 2>/dev/null || :)
+            [ "x$_ng_cpu_quota" = "x-1" ] && _ng_cpu_quota=max
+            break
+        fi
+    done
+fi
+if [ -r /proc/self/status ] && command -v awk >/dev/null 2>&1; then
+    _ng_cpu_list=$(awk '$1 == "Cpus_allowed_list:" {print $2; exit}' /proc/self/status 2>/dev/null || :)
+fi
+if [ -z "$_ng_cpu_list" ] && [ -r /sys/fs/cgroup/cpuset.cpus.effective ]; then
+    _ng_cpu_list=$(cat /sys/fs/cgroup/cpuset.cpus.effective 2>/dev/null || :)
+elif [ -z "$_ng_cpu_list" ] && [ -r /sys/fs/cgroup/cpuset/cpuset.effective_cpus ]; then
+    _ng_cpu_list=$(cat /sys/fs/cgroup/cpuset/cpuset.effective_cpus 2>/dev/null || :)
+fi
+[ -n "$_ng_cpu_list" ] || _ng_cpu_list="0-$(( $(nproc 2>/dev/null || echo 1) - 1 ))"
+if [ -n "$_ng_cpu_quota" ] && [ "$_ng_cpu_quota" != "max" ] \
+    && [ "${_ng_cpu_period:-0}" -gt 0 ] 2>/dev/null; then
+    _ng_cpu_count=$(( (_ng_cpu_quota + _ng_cpu_period - 1) / _ng_cpu_period ))
+    [ "$_ng_cpu_count" -ge 1 ] || _ng_cpu_count=1
+    if command -v awk >/dev/null 2>&1; then
+        _ng_cpu_available=$(printf %s "$_ng_cpu_list" | awk -F, '
+            {for (i=1;i<=NF;i++) {
+                split($i,r,"-"); lo=r[1]+0; hi=(r[2]==""?lo:r[2]+0)
+                total += hi-lo+1
+            }}
+            END {print total+0}' 2>/dev/null || :)
+        if [ "${_ng_cpu_available:-0}" -gt 0 ] 2>/dev/null \
+            && [ "$_ng_cpu_count" -gt "$_ng_cpu_available" ]; then
+            _ng_cpu_count=$_ng_cpu_available
+        fi
+    fi
+    export OMP_NUM_THREADS=$_ng_cpu_count OPENBLAS_NUM_THREADS=$_ng_cpu_count \
+        MKL_NUM_THREADS=$_ng_cpu_count NUMEXPR_NUM_THREADS=$_ng_cpu_count \
+        VECLIB_MAXIMUM_THREADS=$_ng_cpu_count UV_THREADPOOL_SIZE=$_ng_cpu_count \
+        MAKEFLAGS=-j$_ng_cpu_count
+    if command -v taskset >/dev/null 2>&1 && command -v awk >/dev/null 2>&1; then
+        _ng_cpu_seed=$$
+        if [ -r /dev/urandom ] && command -v od >/dev/null 2>&1 && command -v tr >/dev/null 2>&1; then
+            _ng_cpu_random=$(od -An -N2 -tu2 /dev/urandom 2>/dev/null | tr -dc 0-9 2>/dev/null || :)
+            case $_ng_cpu_random in
+                ''|*[!0-9]*) ;;
+                *) _ng_cpu_seed=$(( _ng_cpu_random + $$ )) ;;
+            esac
+        fi
+        _ng_cpu_selection=$(printf %s "$_ng_cpu_list" | awk \
+            -v n="$_ng_cpu_count" -v seed="$_ng_cpu_seed" -F, '
+            {for (i=1;i<=NF;i++) {
+                split($i,r,"-"); lo=r[1]+0; hi=(r[2]==""?lo:r[2]+0)
+                for (cpu=lo;cpu<=hi;cpu++) allowed[count++]=cpu
+            }}
+            END {
+                if (!count) exit
+                if (n>count) n=count
+                srand(seed%2147483647); offset=int(rand()*count)
+                for (i=0;i<n;i++) selected=selected (i?",":"") allowed[(offset+i)%count]
+                print selected
+            }')
+        if [ -n "$_ng_cpu_selection" ]; then
+            taskset -pc "$_ng_cpu_selection" $$ >/dev/null 2>&1 || :
+        fi
+    fi
+fi
+""".strip()
+
+
+def wrap_command_with_cpu_pin(command: str) -> str:
+    """Size thread pools to the cgroup quota and best-effort pin ``command``."""
+    return f"{_CPU_PIN_PREAMBLE}\n{command}"
+
 
 def rewrite_image(image: str | None, rewrites: list[dict[str, str]]) -> str | None:
     """Apply ordered image-prefix rewrites used by sandbox configs."""

--- a/tests/unit_tests/test_sandbox.py
+++ b/tests/unit_tests/test_sandbox.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import importlib.util
+import inspect
 import threading
 from datetime import timedelta
 from pathlib import Path
@@ -43,7 +44,7 @@ from nemo_gym.sandbox import (
     resolve_provider_metadata,
 )
 from nemo_gym.sandbox.api import _AsyncLoopRunner
-from nemo_gym.sandbox.utils import rewrite_image
+from nemo_gym.sandbox.utils import rewrite_image, wrap_command_with_cpu_pin
 from responses_api_agents.mini_swe_agent_2.sandbox_environment import MiniSWESandboxEnvironment
 
 
@@ -291,6 +292,8 @@ async def _assert_sandbox_facade_uses_public_provider_api(tmp_path: Path) -> Non
         "timeout_s": 60,
         "user": "agent",
     }
+    await sandbox.exec("make", cpu_pin_enabled=True)
+    assert provider.exec_calls[1]["command"] == wrap_command_with_cpu_pin("make")
     assert await sandbox.status() == SandboxStatus.RUNNING
     assert await sandbox.endpoint(8000) == SandboxEndpoint(
         endpoint="http://127.0.0.1:8000",
@@ -376,6 +379,60 @@ async def _assert_async_sandbox_requires_spec_and_reports_unknown_status() -> No
 def test_rewrite_image_validation() -> None:
     assert rewrite_image(None, []) is None
     assert rewrite_image("image:tag", [{"from": "other/", "to": "mirror/"}]) == "image:tag"
+
+
+def test_cpu_pin_enabled_is_exec_only() -> None:
+    from nemo_gym.sandbox import SandboxPty
+
+    for method in (AsyncSandbox.exec, Sandbox.exec):
+        option = inspect.signature(method).parameters["cpu_pin_enabled"]
+        assert option.kind is inspect.Parameter.KEYWORD_ONLY
+        assert option.default is False
+
+    for target in (AsyncSandbox, Sandbox, SandboxPty.exec, SandboxPty.create, SandboxSpec):
+        assert "cpu_pin_enabled" not in inspect.signature(target).parameters
+
+
+def test_cpu_pin_wrapper_is_posix_and_preserves_command_status() -> None:
+    import subprocess
+
+    script = wrap_command_with_cpu_pin("exit 37")
+    syntax = subprocess.run(["sh", "-n"], input=script, capture_output=True, text=True, timeout=30)
+    assert syntax.returncode == 0, syntax.stderr
+
+    result = subprocess.run(["sh", "-c", script], capture_output=True, text=True, timeout=30)
+    assert result.returncode == 37
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_cpu_pin_wrapper_uses_process_affinity_and_clamps_threads(tmp_path: Path) -> None:
+    import os
+    import subprocess
+
+    cpu_max = tmp_path / "cpu.max"
+    cpu_max.write_text("300000 100000\n", encoding="utf-8")
+    process_status = tmp_path / "status"
+    process_status.write_text("Name:\ttest\nCpus_allowed_list:\t46-47\n", encoding="utf-8")
+
+    taskset_trace = tmp_path / "taskset.trace"
+    taskset = tmp_path / "taskset"
+    taskset.write_text('#!/bin/sh\nprintf \'%s\\n\' "$*" > "$NG_TASKSET_TRACE"\n', encoding="utf-8")
+    taskset.chmod(0o755)
+
+    script = wrap_command_with_cpu_pin("printf '%s\\n' \"$OMP_NUM_THREADS,$OPENBLAS_NUM_THREADS,$MAKEFLAGS\"").replace(
+        "/sys/fs/cgroup/cpu.max", str(cpu_max)
+    )
+    script = script.replace("/proc/self/status", str(process_status))
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}", "NG_TASKSET_TRACE": str(taskset_trace)}
+    result = subprocess.run(["sh", "-c", script], capture_output=True, text=True, timeout=30, env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "2,2,-j2\n"
+    assert result.stderr == ""
+    taskset_args = taskset_trace.read_text(encoding="utf-8").split()
+    assert taskset_args[0] == "-pc"
+    assert set(taskset_args[1].split(",")) == {"46", "47"}
 
 
 def test_sandbox_resources_validation() -> None:
@@ -648,6 +705,8 @@ def test_sync_sandbox_facade_uses_public_provider_api(tmp_path: Path) -> None:
             "timeout_s": 60,
             "user": "agent",
         }
+        sandbox.exec("make", cpu_pin_enabled=True)
+        assert provider.exec_calls[1]["command"] == wrap_command_with_cpu_pin("make")
         assert sandbox.status() == SandboxStatus.RUNNING
 
         upload_path = tmp_path / "sync-upload.txt"


### PR DESCRIPTION
## What

- add a keyword-only `cpu_pin_enabled` option to async and sync sandbox `exec`
- centralize quota- and affinity-aware CPU pinning in a provider-neutral sandbox utility
- keep the default command path and provider interfaces unchanged

## Why

Sandbox processes can observe the host CPU count despite a smaller CFS quota. Thread pools then oversubscribe the quota, increasing throttling and tail latency. This makes the behavior explicit per command instead of attaching it to sandbox initialization or provider configuration.

## Behavior

- derives the usable width from cgroup v2/v1 CPU quota
- clamps it to the process's current `Cpus_allowed_list`
- caps common native thread pools and make parallelism
- best-effort pins to a randomized subset of currently allowed CPUs
- remains silent and fail-open when quota or affinity facilities are unavailable
- does not alter sandbox init/spec, provider APIs, or PTY sessions

## Checks

- `.venv/bin/pytest -q tests/unit_tests/test_sandbox.py` — 51 passed
- scoped pre-commit hooks for all changed files
- Ruff check and format check
- `git diff --check`
