### PR TITLE
fix(gym): close global aiohttp client on owner loop

### DIFF
--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -75,6 +75,7 @@ from nemo_gym.rollout_correlation import current_rollout_id, maybe_rollout_id_fr
 
 
 _GLOBAL_AIOHTTP_CLIENT: Union[None, ClientSession] = None
+_GLOBAL_AIOHTTP_CLIENT_LOOP: Union[None, asyncio.AbstractEventLoop] = None
 _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG: bool = False
 
 
@@ -162,6 +163,9 @@ def set_global_aiohttp_client(cfg: GlobalAIOHTTPAsyncClientConfig) -> ClientSess
     global _GLOBAL_AIOHTTP_CLIENT
     _GLOBAL_AIOHTTP_CLIENT = client_session
 
+    global _GLOBAL_AIOHTTP_CLIENT_LOOP
+    _GLOBAL_AIOHTTP_CLIENT_LOOP = asyncio.get_running_loop()
+
     global _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG
     _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG = cfg.global_aiohttp_client_request_debug
 
@@ -180,10 +184,33 @@ def global_aiohttp_client_exit():  # pragma: no cover
     if not is_global_aiohttp_client_setup():
         return
 
-    global _GLOBAL_AIOHTTP_CLIENT
-    asyncio.run(_GLOBAL_AIOHTTP_CLIENT.close())
+    global _GLOBAL_AIOHTTP_CLIENT, _GLOBAL_AIOHTTP_CLIENT_LOOP
+    client = _GLOBAL_AIOHTTP_CLIENT
+    loop = _GLOBAL_AIOHTTP_CLIENT_LOOP
+    try:
+        if client.closed:
+            return
+        if loop is None or loop.is_closed():
+            # At interpreter shutdown there is no safe loop left on which to
+            # await the connector's loop-bound close futures. Detaching marks
+            # the session closed; the process will reclaim the connector.
+            client.detach()
+            return
 
-    _GLOBAL_AIOHTTP_CLIENT = None
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is loop:
+            loop.create_task(client.close())
+        elif loop.is_running():
+            asyncio.run_coroutine_threadsafe(client.close(), loop).result(timeout=5)
+        else:
+            loop.run_until_complete(client.close())
+    finally:
+        _GLOBAL_AIOHTTP_CLIENT = None
+        _GLOBAL_AIOHTTP_CLIENT_LOOP = None
 
 
 atexit.register(global_aiohttp_client_exit)

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -49,6 +49,55 @@ _TEST_ADDR_INFO = (
 
 
 class TestServerUtils:
+    def test_global_aiohttp_client_exit_uses_creation_loop(self, monkeypatch: MonkeyPatch) -> None:
+        creation_loop = nemo_gym.server_utils.asyncio.new_event_loop()
+
+        class LoopBoundClient:
+            closed = False
+
+            async def close(self) -> None:
+                assert nemo_gym.server_utils.asyncio.get_running_loop() is creation_loop
+                self.closed = True
+
+            def detach(self) -> None:
+                raise AssertionError("open creation loop must close the client")
+
+        client = LoopBoundClient()
+        monkeypatch.setattr(nemo_gym.server_utils, "_GLOBAL_AIOHTTP_CLIENT", client)
+        monkeypatch.setattr(nemo_gym.server_utils, "_GLOBAL_AIOHTTP_CLIENT_LOOP", creation_loop)
+
+        nemo_gym.server_utils.global_aiohttp_client_exit()
+
+        assert client.closed
+        assert nemo_gym.server_utils._GLOBAL_AIOHTTP_CLIENT is None
+        assert nemo_gym.server_utils._GLOBAL_AIOHTTP_CLIENT_LOOP is None
+        creation_loop.close()
+
+    def test_global_aiohttp_client_exit_detaches_after_loop_closed(self, monkeypatch: MonkeyPatch) -> None:
+        creation_loop = nemo_gym.server_utils.asyncio.new_event_loop()
+        creation_loop.close()
+
+        class LoopBoundClient:
+            closed = False
+            detached = False
+
+            async def close(self) -> None:
+                raise AssertionError("closed creation loop cannot run client close")
+
+            def detach(self) -> None:
+                self.closed = True
+                self.detached = True
+
+        client = LoopBoundClient()
+        monkeypatch.setattr(nemo_gym.server_utils, "_GLOBAL_AIOHTTP_CLIENT", client)
+        monkeypatch.setattr(nemo_gym.server_utils, "_GLOBAL_AIOHTTP_CLIENT_LOOP", creation_loop)
+
+        nemo_gym.server_utils.global_aiohttp_client_exit()
+
+        assert client.detached
+        assert nemo_gym.server_utils._GLOBAL_AIOHTTP_CLIENT is None
+        assert nemo_gym.server_utils._GLOBAL_AIOHTTP_CLIENT_LOOP is None
+
     def test_global_aiohttp_client_request_debug_enabled(self, monkeypatch: MonkeyPatch) -> None:
         monkeypatch.setattr(nemo_gym.server_utils, "_GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG", False)
         assert not nemo_gym.server_utils.is_global_aiohttp_client_request_debug_enabled()


### PR DESCRIPTION
## Issue

The process-global `aiohttp.ClientSession` is created on the active worker event loop, but the registered `atexit` handler closes it with `asyncio.run()`. That creates a different event loop. If the connector still owns loop-bound close futures, worker shutdown emits `RuntimeError: ... Future ... attached to a different loop` and skips graceful client cleanup.

This was reproduced after a successful NeMo-RL Gym rollout on a GH200 node. The training step and its correctness gate completed, but the Gym worker printed the cross-loop exception during interpreter teardown.

## Fix

- record the event loop that owns the global client when it is created;
- close the client on that owner loop when it remains usable;
- detach the session when interpreter shutdown has already closed the owner loop, allowing the process to reclaim its connector without a cross-loop await;
- clear both global references on every exit path.

This replays the focused fix from `acc388ddc929c905e29f2415ad449731759ff2f2`, where it currently exists only on feature branches, onto current Gym `main` while preserving authorship and provenance.

## Validation

- target-container test on CSCS GH200 allocation 3121021: `tests/unit_tests/test_server_utils.py` — 19 passed;
- both new owner-loop and closed-loop regressions passed;
- Ruff check passed on both changed files;
- Ruff format check passed on both changed files;
- `git diff --check` passed.
