### PR TITLE
fix: harden environment catalog discovery for manifest migration

### DIFF
--- a/nemo_gym/benchmarks.py
+++ b/nemo_gym/benchmarks.py
@@ -36,6 +36,7 @@ from nemo_gym.global_config import (
 
 BENCHMARKS_SUBDIR = "benchmarks"
 BENCHMARKS_DIR = PARENT_DIR / BENCHMARKS_SUBDIR
+MANIFEST_FILENAME = "manifest.yaml"
 
 
 class BenchmarkConfig(BaseModel):
@@ -136,13 +137,18 @@ def _is_benchmark_config(config_path: Path) -> bool:
 def _benchmark_config_paths(benchmarks_dir: Path) -> List[Path]:
     """Sorted config paths under one dir that declare a benchmark, discovered by content.
 
-    A config is a benchmark iff it declares a `type: benchmark` dataset, regardless of filename, so we scan
-    every yaml. :func:`_is_benchmark_config` is a cheap prefilter (pay the resolve cost only on real
-    candidates) that also catches non-`config.yaml` names like tau2's `configs/*.yaml`. Empty if dir missing.
+    A runnable config is a benchmark iff it declares a `type: benchmark` dataset, regardless of its config
+    filename. The environment manifest is metadata rather than runnable config, so it is excluded before
+    the content prefilter. :func:`_is_benchmark_config` keeps the scan format-agnostic and catches names
+    such as tau2's `configs/*.yaml`. Empty if the directory is missing.
     """
     if not benchmarks_dir.is_dir():
         return []
-    config_paths = [benchmarks_dir / p for p in glob("**/*.yaml", root_dir=benchmarks_dir, recursive=True)]
+    config_paths = [
+        benchmarks_dir / p
+        for p in glob("**/*.yaml", root_dir=benchmarks_dir, recursive=True)
+        if Path(p).name != MANIFEST_FILENAME
+    ]
     return sorted(p for p in config_paths if _is_benchmark_config(p))
 
 

--- a/nemo_gym/cli/env.py
+++ b/nemo_gym/cli/env.py
@@ -72,7 +72,8 @@ from nemo_gym.global_config import (
 )
 from nemo_gym.registry import (
     EnvironmentCatalogEntry,
-    discover_environment_catalog,
+    EnvironmentCatalogReport,
+    discover_environment_catalog_report,
     read_environment_details,
     resolve_catalog_entry,
 )
@@ -1202,7 +1203,8 @@ def _manifest_entry(config: ManifestCommandConfig) -> Optional[EnvironmentCatalo
         raise ConfigError("--kind is only valid when selecting a catalog name")
     if config.onboarding_name is None:
         return None
-    return resolve_catalog_entry(config.onboarding_name, config.catalog_kind)
+    report = discover_environment_catalog_report()
+    return resolve_catalog_entry(config.onboarding_name, config.catalog_kind, report=report)
 
 
 def _print_validation_report(report: EnvironmentValidationReport, *, json_output: bool) -> None:
@@ -1365,16 +1367,22 @@ def _run_manifest_verifier(
 
 def _inspect_environment(
     name: str,
-    entries: Tuple[EnvironmentCatalogEntry, ...],
+    report: EnvironmentCatalogReport,
     global_config_dict: DictConfig,
 ) -> None:
     """Render one entry from the unified environment catalog."""
     kind = global_config_dict.get("catalog_kind")
+    entries = report.entries
     matching_names = {entry.name: entry for entry in entries}
     if name not in matching_names:
+        if any(
+            diagnostic.name == name and (kind is None or diagnostic.kind == str(getattr(kind, "value", kind)))
+            for diagnostic in report.diagnostics
+        ):
+            resolve_catalog_entry(name, kind, report=report)
         exit_unknown_component(name, matching_names, "environment")
         return
-    entry = resolve_catalog_entry(name, kind, entries=entries)
+    entry = resolve_catalog_entry(name, kind, report=report)
     parsed = read_environment_details(entry.config_path)
     details = {"config": str(entry.config_path.resolve()), "status": entry.status}
     if entry.manifest_path is not None:
@@ -1435,13 +1443,23 @@ def list_environments() -> None:
     global_config_dict = _command_overrides()
     BaseNeMoGymCLIConfig.model_validate(global_config_dict)
 
-    discovered = discover_environment_catalog()
+    catalog_report = discover_environment_catalog_report()
+    discovered = catalog_report.entries
     entries = list(discovered)
 
     name = global_config_dict.get(COMPONENT_NAME_KEY_NAME)
     if name:
-        _inspect_environment(name, discovered, global_config_dict)
+        _inspect_environment(name, catalog_report, global_config_dict)
         return
+
+    for diagnostic in catalog_report.diagnostics:
+        identity = f"{diagnostic.kind} {diagnostic.name!r}" if diagnostic.name is not None else diagnostic.kind
+        print(
+            f"Warning: catalog could not use the manifest for {identity}; "
+            "a runnable legacy config remains listed as no-manifest when present.\n"
+            f"{diagnostic.message}",
+            file=sys.stderr,
+        )
 
     query = global_config_dict.get(QUERY_KEY_NAME)
     if query:

--- a/nemo_gym/environment/publication.py
+++ b/nemo_gym/environment/publication.py
@@ -12,7 +12,12 @@ from nemo_gym.config_types import ConfigError
 from nemo_gym.environment.manifest import EnvironmentKind, load_manifest
 from nemo_gym.environment.onboarding import VerifierReport
 from nemo_gym.environment.validation import EnvironmentValidationReport
-from nemo_gym.registry import EnvironmentCatalogEntry, discover_environment_catalog
+from nemo_gym.registry import (
+    EnvironmentCatalogEntry,
+    RegistryError,
+    discover_environment_catalog_report,
+    resolve_catalog_entry,
+)
 
 
 class EnvironmentPublicationError(ConfigError):
@@ -77,21 +82,21 @@ def finalize_publication(
     if verifier.name != entry.name or verifier.kind != entry.kind or not verifier.cases:
         raise EnvironmentPublicationError("Verifier report does not describe a passing fixture for this workload.")
 
-    entries = tuple(discover_environment_catalog() if catalog_entries is None else catalog_entries)
     selected_manifest = Path(entry.manifest_path).resolve()
-    matches = [
-        candidate
-        for candidate in entries
-        if candidate.name == entry.name
-        and candidate.kind == entry.kind
-        and candidate.manifest_path is not None
-        and candidate.manifest_path.resolve() == selected_manifest
-    ]
-    if len(matches) != 1:
+    try:
+        published = (
+            resolve_catalog_entry(entry.name, entry.kind, report=discover_environment_catalog_report())
+            if catalog_entries is None
+            else resolve_catalog_entry(entry.name, entry.kind, entries=catalog_entries)
+        )
+    except RegistryError as error:
+        raise EnvironmentPublicationError(
+            f"Catalog did not resolve {entry.kind} {entry.name!r} after publication checks: {error}"
+        ) from error
+    if published.manifest_path is None or published.manifest_path.resolve() != selected_manifest:
         raise EnvironmentPublicationError(
             f"Catalog did not resolve {entry.kind} {entry.name!r} to its exact manifest after publication checks."
         )
-    published = matches[0]
     if published.status != "experimental":
         raise EnvironmentPublicationError(
             f"Newly published workloads must enter as experimental, observed {published.status!r}."

--- a/nemo_gym/registry.py
+++ b/nemo_gym/registry.py
@@ -71,6 +71,25 @@ class EnvironmentEntry(EnvironmentCatalogEntry):
     kind: CatalogKind = field(default="environment", init=False)
 
 
+@dataclass(frozen=True)
+class CatalogDiagnostic:
+    """A non-fatal problem found while building the catalog."""
+
+    kind: CatalogKind
+    name: Optional[str]
+    manifest_path: Path
+    message: str
+    code: Literal["invalid-manifest", "invalid-catalog-entry"] = "invalid-manifest"
+
+
+@dataclass(frozen=True)
+class EnvironmentCatalogReport:
+    """Catalog entries together with non-fatal discovery diagnostics."""
+
+    entries: tuple[EnvironmentCatalogEntry, ...]
+    diagnostics: tuple[CatalogDiagnostic, ...]
+
+
 def _enum_value(value: object) -> Optional[str]:
     if value is None:
         return None
@@ -235,6 +254,8 @@ def _discover_registry_tree(
     kind: CatalogKind,
     *,
     claimed: frozenset[tuple[CatalogKind, str]] = frozenset(),
+    diagnostics: list[CatalogDiagnostic] | None = None,
+    strict_registry_errors: bool = True,
 ) -> Dict[tuple[CatalogKind, str], EnvironmentCatalogEntry]:
     """Discover one catalog tree without importing or resolving runnable components."""
     if not tree_dir.is_dir():
@@ -243,12 +264,37 @@ def _discover_registry_tree(
     entries: Dict[tuple[CatalogKind, str], EnvironmentCatalogEntry] = {}
     manifest_configs: set[Path] = set()
     for manifest_path in sorted(tree_dir.rglob(MANIFEST_FILENAME)):
-        key = (kind, _path_identity(tree_dir, manifest_path))
-        if key in claimed:
-            continue
+        name: Optional[str] = None
         try:
+            name = _path_identity(tree_dir, manifest_path)
+            key = (kind, name)
+            if key in claimed:
+                continue
             entry = _manifest_entry(tree_dir, manifest_path, kind)
-        except ManifestError:
+        except ManifestError as error:
+            if diagnostics is not None:
+                diagnostics.append(
+                    CatalogDiagnostic(
+                        kind=kind,
+                        name=name,
+                        manifest_path=manifest_path,
+                        message=str(error),
+                    )
+                )
+            continue
+        except RegistryError as error:
+            if strict_registry_errors:
+                raise
+            if diagnostics is not None:
+                diagnostics.append(
+                    CatalogDiagnostic(
+                        code="invalid-catalog-entry",
+                        kind=kind,
+                        name=name,
+                        manifest_path=manifest_path,
+                        message=str(error),
+                    )
+                )
             continue
         entries[key] = entry
         manifest_configs.add(entry.config_path.resolve())
@@ -282,15 +328,40 @@ def discover_environments() -> Dict[str, EnvironmentEntry]:
     return environments
 
 
-def discover_environment_catalog() -> tuple[EnvironmentCatalogEntry, ...]:
-    """Discover manifest and legacy runnable units across all workload locations."""
+def _discover_environment_catalog(*, strict_registry_errors: bool) -> EnvironmentCatalogReport:
+    """Build the catalog once, optionally retaining structural entry errors."""
     entries: Dict[tuple[CatalogKind, str], EnvironmentCatalogEntry] = {}
+    diagnostics: list[CatalogDiagnostic] = []
     for root in component_search_roots():
         for kind, subdir in (("environment", ENVIRONMENTS_SUBDIR), ("benchmark", BENCHMARKS_SUBDIR)):
-            discovered = _discover_registry_tree(root / subdir, kind, claimed=frozenset(entries))
+            discovered = _discover_registry_tree(
+                root / subdir,
+                kind,
+                claimed=frozenset(entries),
+                diagnostics=diagnostics,
+                strict_registry_errors=strict_registry_errors,
+            )
             entries.update(discovered)
         entries.update(_discover_resource_workloads(root / RESOURCES_SERVERS_SUBDIR, claimed=frozenset(entries)))
-    return tuple(sorted(entries.values(), key=lambda entry: (entry.name.casefold(), entry.name, entry.kind)))
+    return EnvironmentCatalogReport(
+        entries=tuple(sorted(entries.values(), key=lambda entry: (entry.name.casefold(), entry.name, entry.kind))),
+        diagnostics=tuple(diagnostics),
+    )
+
+
+def discover_environment_catalog_report() -> EnvironmentCatalogReport:
+    """Discover catalog entries and retain non-fatal manifest and structural diagnostics."""
+    return _discover_environment_catalog(strict_registry_errors=False)
+
+
+def discover_environment_catalog() -> tuple[EnvironmentCatalogEntry, ...]:
+    """Discover manifest and legacy runnable units across all workload locations.
+
+    This compatibility surface intentionally returns only entries. Call
+    :func:`discover_environment_catalog_report` when non-fatal diagnostics must
+    be visible.
+    """
+    return _discover_environment_catalog(strict_registry_errors=True).entries
 
 
 def resolve_catalog_entry(
@@ -298,11 +369,25 @@ def resolve_catalog_entry(
     kind: CatalogKind | str | None = None,
     *,
     entries: Iterable[EnvironmentCatalogEntry] | None = None,
+    report: EnvironmentCatalogReport | None = None,
 ) -> EnvironmentCatalogEntry:
     """Resolve a catalog name, requiring its kind only for a cross-kind collision."""
+    if entries is not None and report is not None:
+        raise RegistryError("Pass catalog entries or a catalog report, not both.")
     selected_kind = _enum_value(kind)
     if selected_kind not in (None, "environment", "benchmark"):
         raise RegistryError(f"Unknown catalog kind '{selected_kind}'.")
+
+    report_diagnostics: tuple[CatalogDiagnostic, ...] = ()
+    diagnostics: list[CatalogDiagnostic] = []
+    if report is not None:
+        report_diagnostics = report.diagnostics
+        diagnostics = [
+            diagnostic
+            for diagnostic in report_diagnostics
+            if diagnostic.name == name and (selected_kind is None or diagnostic.kind == selected_kind)
+        ]
+        entries = report.entries
 
     matches = [
         entry
@@ -310,12 +395,35 @@ def resolve_catalog_entry(
         if entry.name == name and (selected_kind is None or entry.kind == selected_kind)
     ]
     if not matches:
+        if diagnostics:
+            diagnostic = diagnostics[0]
+            raise RegistryError(
+                f"Catalog entry '{name}' has an unusable manifest at '{diagnostic.manifest_path}': "
+                f"{diagnostic.message}"
+            )
         suffix = f" with kind '{selected_kind}'" if selected_kind else ""
         raise RegistryError(f"Unknown catalog entry '{name}'{suffix}.")
     if len(matches) > 1:
         kinds = ", ".join(sorted(entry.kind for entry in matches))
         raise RegistryError(f"Catalog name '{name}' is ambiguous ({kinds}); specify a kind.")
-    return matches[0]
+    selected = matches[0]
+    selected_diagnostic = next(
+        (
+            diagnostic
+            for diagnostic in report_diagnostics
+            if diagnostic.kind == selected.kind
+            and selected.manifest_path is None
+            and diagnostic.manifest_path.with_name(ENVIRONMENT_CONFIG_FILENAME).resolve()
+            == selected.config_path.resolve()
+        ),
+        None,
+    )
+    if selected_diagnostic is not None:
+        raise RegistryError(
+            f"Catalog entry '{name}' has an unusable manifest at '{selected_diagnostic.manifest_path}': "
+            f"{selected_diagnostic.message}"
+        )
+    return selected
 
 
 def read_environment_details(config_path: Path) -> Dict[str, object]:

--- a/tests/unit_tests/test_benchmarks.py
+++ b/tests/unit_tests/test_benchmarks.py
@@ -57,6 +57,10 @@ class TestListBenchmarks:
 
         (tmp_path / "standard").mkdir()
         (tmp_path / "standard" / "config.yaml").write_text("x:\n  datasets:\n  - type: benchmark\n")
+        # A benchmark manifest mirrors its benchmark dataset, but it is metadata rather than a runnable config.
+        (tmp_path / "standard" / "manifest.yaml").write_text(
+            "name: standard\ndatasets:\n  - {name: test, type: benchmark}\n"
+        )
         (tmp_path / "flavored" / "configs").mkdir(parents=True)
         (tmp_path / "flavored" / "configs" / "myflavor.yaml").write_text("x:\n  datasets:\n  - type: benchmark\n")
         (tmp_path / "notbench").mkdir()

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -56,7 +56,12 @@ from nemo_gym.cli.env import (
 from nemo_gym.cli.utils import exit_cleanly_on_config_error
 from nemo_gym.config_types import ConfigError, NoServerInstancesError, ResourcesServerInstanceConfig
 from nemo_gym.environment.scaffold import ScaffoldError
-from nemo_gym.registry import EnvironmentCatalogEntry
+from nemo_gym.registry import (
+    CatalogDiagnostic,
+    EnvironmentCatalogEntry,
+    EnvironmentCatalogReport,
+    RegistryError,
+)
 
 
 class TestSelectShard:
@@ -497,6 +502,14 @@ class TestOnboardingCommandAdapters:
         manifest_path=Path("environments/alpha/manifest.yaml"),
     )
 
+    @pytest.fixture(autouse=True)
+    def _catalog_report(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            nemo_gym.cli.env,
+            "discover_environment_catalog_report",
+            lambda: EnvironmentCatalogReport(entries=(self._ENTRY,), diagnostics=()),
+        )
+
     def test_init_environment_forwards_typed_scaffold_options(self, monkeypatch: MonkeyPatch, capsys) -> None:
         monkeypatch.setattr(
             nemo_gym.cli.env,
@@ -552,8 +565,35 @@ class TestOnboardingCommandAdapters:
 
         assert resolver.call_args.args[0] == "alpha"
         assert resolver.call_args.args[1].value == "environment"
+        assert resolver.call_args.kwargs["report"].entries == (self._ENTRY,)
         validator.assert_called_once_with(self._ENTRY.manifest_path, self._ENTRY.config_path, sync=True)
         assert json.loads(capsys.readouterr().out) == {"name": "alpha", "kind": "environment"}
+
+    def test_manifest_command_rejects_selected_catalog_diagnostic(self, monkeypatch: MonkeyPatch) -> None:
+        degraded = EnvironmentCatalogEntry(
+            name=self._ENTRY.name,
+            kind=self._ENTRY.kind,
+            path=self._ENTRY.path,
+            config_path=self._ENTRY.config_path,
+        )
+        diagnostic = CatalogDiagnostic(
+            kind="environment",
+            name="alpha",
+            manifest_path=self._ENTRY.manifest_path,
+            message="Malformed YAML in environment manifest.",
+        )
+        monkeypatch.setattr(
+            nemo_gym.cli.env,
+            "discover_environment_catalog_report",
+            lambda: EnvironmentCatalogReport(
+                entries=(degraded,),
+                diagnostics=(diagnostic,),
+            ),
+        )
+        config = nemo_gym.cli.env.ManifestCommandConfig(onboarding_name="alpha")
+
+        with raises(RegistryError, match="unusable manifest"):
+            nemo_gym.cli.env._manifest_entry(config)
 
     def test_validation_human_report(self, capsys) -> None:
         report = SimpleNamespace(
@@ -773,6 +813,7 @@ class TestListEnvironments:
         *,
         overrides: dict | None = None,
         entries: tuple[EnvironmentCatalogEntry, ...] | None = None,
+        diagnostics: tuple[CatalogDiagnostic, ...] = (),
     ) -> None:
         monkeypatch.setattr(
             nemo_gym.cli.env,
@@ -781,8 +822,11 @@ class TestListEnvironments:
         )
         monkeypatch.setattr(
             nemo_gym.cli.env,
-            "discover_environment_catalog",
-            lambda: (self._ALPHA, self._BETA) if entries is None else entries,
+            "discover_environment_catalog_report",
+            lambda: EnvironmentCatalogReport(
+                entries=(self._ALPHA, self._BETA) if entries is None else entries,
+                diagnostics=diagnostics,
+            ),
         )
 
     def test_lists_discovered_environments(self, monkeypatch: MonkeyPatch, capsys) -> None:
@@ -821,6 +865,51 @@ class TestListEnvironments:
                 "lifecycle": "active",
             }
         ]
+
+    def test_invalid_manifest_diagnostic_is_visible_without_corrupting_json(
+        self, monkeypatch: MonkeyPatch, capsys
+    ) -> None:
+        diagnostic = CatalogDiagnostic(
+            kind="benchmark",
+            name="broken",
+            manifest_path=Path("benchmarks/broken/manifest.yaml"),
+            message="Malformed YAML in environment manifest 'benchmarks/broken/manifest.yaml' at line 2, column 1.",
+        )
+        self._mock_catalog(
+            monkeypatch,
+            overrides={"json": True},
+            entries=(self._ALPHA,),
+            diagnostics=(diagnostic,),
+        )
+
+        list_environments()
+
+        captured = capsys.readouterr()
+        assert json.loads(captured.out)[0]["name"] == "alpha"
+        assert "could not use the manifest for benchmark 'broken'" in captured.err
+        assert "Malformed YAML" in captured.err
+
+    def test_inspection_rejects_the_selected_degraded_manifest(self, monkeypatch: MonkeyPatch, capsys) -> None:
+        diagnostic = CatalogDiagnostic(
+            kind="benchmark",
+            name="beta",
+            manifest_path=Path("benchmarks/beta/manifest.yaml"),
+            message="Malformed YAML in environment manifest.",
+        )
+        self._mock_catalog(
+            monkeypatch,
+            overrides={"component_name": "beta", "catalog_kind": "benchmark"},
+            entries=(self._BETA,),
+            diagnostics=(diagnostic,),
+        )
+
+        with raises(SystemExit) as error:
+            list_environments()
+
+        captured = capsys.readouterr()
+        assert error.value.code == 1
+        assert "unusable manifest" in captured.out
+        assert captured.err == ""
 
     def test_query_filters_environments(self, monkeypatch: MonkeyPatch, capsys) -> None:
         self._mock_catalog(monkeypatch, overrides={"query": "alpha"})

--- a/tests/unit_tests/test_environment_publication.py
+++ b/tests/unit_tests/test_environment_publication.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import nemo_gym.environment.publication as publication_module
 from nemo_gym import NEMO_GYM_EXTRA_ROOTS_ENV_VAR_NAME
 from nemo_gym.environment.manifest import dump_manifest, load_manifest
 from nemo_gym.environment.onboarding import verify_environment
@@ -17,7 +18,13 @@ from nemo_gym.environment.publication import (
 )
 from nemo_gym.environment.scaffold import scaffold_environment
 from nemo_gym.environment.validation import validate_environment
-from nemo_gym.registry import EnvironmentCatalogEntry, discover_environment_catalog, resolve_catalog_entry
+from nemo_gym.registry import (
+    CatalogDiagnostic,
+    EnvironmentCatalogEntry,
+    EnvironmentCatalogReport,
+    discover_environment_catalog,
+    resolve_catalog_entry,
+)
 
 
 def _entry(tmp_path: Path, **manifest_updates: object) -> EnvironmentCatalogEntry:
@@ -126,6 +133,46 @@ def test_publication_report_serializes() -> None:
     )
 
     assert report.to_dict()["verifier_cases"] == 3
+
+
+def test_publication_ignores_unrelated_catalog_diagnostics(tmp_path: Path, monkeypatch) -> None:
+    entry = _entry(tmp_path)
+    validation, verifier = _reports()
+    unrelated = CatalogDiagnostic(
+        kind="environment",
+        name="other",
+        manifest_path=tmp_path / "environments/other/manifest.yaml",
+        message="Malformed YAML in environment manifest.",
+    )
+    monkeypatch.setattr(
+        publication_module,
+        "discover_environment_catalog_report",
+        lambda: EnvironmentCatalogReport(entries=(entry,), diagnostics=(unrelated,)),
+    )
+
+    report = finalize_publication(entry, validation, verifier)
+
+    assert report.name == "sample"
+
+
+def test_publication_rejects_a_diagnostic_for_the_selected_manifest(tmp_path: Path, monkeypatch) -> None:
+    entry = _entry(tmp_path)
+    assert entry.manifest_path is not None
+    validation, verifier = _reports()
+    selected = CatalogDiagnostic(
+        kind="environment",
+        name=entry.name,
+        manifest_path=entry.manifest_path,
+        message="Malformed YAML in environment manifest.",
+    )
+    monkeypatch.setattr(
+        publication_module,
+        "discover_environment_catalog_report",
+        lambda: EnvironmentCatalogReport(entries=(), diagnostics=(selected,)),
+    )
+
+    with pytest.raises(EnvironmentPublicationError, match="unusable manifest"):
+        finalize_publication(entry, validation, verifier)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_registry.py
+++ b/tests/unit_tests/test_registry.py
@@ -23,6 +23,7 @@ from nemo_gym.registry import (
     RegistryError,
     _discover_environments_in_dir,
     discover_environment_catalog,
+    discover_environment_catalog_report,
     discover_environments,
     resolve_catalog_entry,
 )
@@ -249,7 +250,15 @@ class TestEnvironmentCatalog:
         manifest: dict,
     ) -> None:
         _write_manifest(tmp_path, tree, path_name, manifest)
+        _write_manifest(tmp_path, "environments", "valid_neighbor", _manifest("valid_neighbor"))
         monkeypatch.setattr(registry_module, "component_search_roots", lambda: [tmp_path])
+
+        report = discover_environment_catalog_report()
+        assert resolve_catalog_entry("valid_neighbor", "environment", report=report).status == "experimental"
+        assert len(report.diagnostics) == 1
+        assert report.diagnostics[0].code == "invalid-catalog-entry"
+        assert report.diagnostics[0].name == path_name
+        assert "catalog path" in report.diagnostics[0].message
 
         with pytest.raises(RegistryError, match="catalog path"):
             discover_environment_catalog()
@@ -262,7 +271,14 @@ class TestEnvironmentCatalog:
             _manifest("missing_config"),
             with_config=False,
         )
+        _write_manifest(tmp_path, "environments", "valid_neighbor", _manifest("valid_neighbor"))
         monkeypatch.setattr(registry_module, "component_search_roots", lambda: [tmp_path])
+
+        report = discover_environment_catalog_report()
+        assert resolve_catalog_entry("valid_neighbor", "environment", report=report).status == "experimental"
+        assert len(report.diagnostics) == 1
+        assert report.diagnostics[0].code == "invalid-catalog-entry"
+        assert "sibling config.yaml" in report.diagnostics[0].message
 
         with pytest.raises(RegistryError, match="sibling config.yaml"):
             discover_environment_catalog()
@@ -272,25 +288,112 @@ class TestEnvironmentCatalog:
         directory.mkdir(parents=True)
         (directory / "manifest.yaml").write_text("name: [invalid\n", encoding="utf-8")
         (directory / "config.yaml").write_text("{}\n", encoding="utf-8")
+        _write_manifest(tmp_path, "environments", "valid_neighbor", _manifest("valid_neighbor"))
         monkeypatch.setattr(registry_module, "component_search_roots", lambda: [tmp_path])
 
-        entries = discover_environment_catalog()
+        report = discover_environment_catalog_report()
 
-        assert resolve_catalog_entry("draft", "environment", entries=entries).status == "no-manifest"
+        assert resolve_catalog_entry("draft", "environment", entries=report.entries).status == "no-manifest"
+        with pytest.raises(RegistryError, match="unusable manifest"):
+            resolve_catalog_entry("draft", "environment", report=report)
+        assert resolve_catalog_entry("valid_neighbor", "environment", report=report).status == "experimental"
+        assert len(report.diagnostics) == 1
+        diagnostic = report.diagnostics[0]
+        assert diagnostic.code == "invalid-manifest"
+        assert diagnostic.kind == "environment"
+        assert diagnostic.name == "draft"
+        assert diagnostic.manifest_path == directory / "manifest.yaml"
+        assert "Malformed YAML" in diagnostic.message
+
+        # The original tuple-returning API remains source compatible.
+        assert discover_environment_catalog() == report.entries
+
+    def test_schema_invalid_manifest_is_diagnosed(self, tmp_path: Path, monkeypatch) -> None:
+        directory = tmp_path / "benchmarks" / "draft"
+        directory.mkdir(parents=True)
+        (directory / "manifest.yaml").write_text("name: draft\nkind: benchmark\n", encoding="utf-8")
+        (directory / "config.yaml").write_text(
+            "agent:\n  responses_api_agents:\n    simple_agent:\n"
+            "      datasets:\n      - {name: test, type: benchmark}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(registry_module, "component_search_roots", lambda: [tmp_path])
+
+        report = discover_environment_catalog_report()
+
+        assert resolve_catalog_entry("draft", "benchmark", entries=report.entries).status == "no-manifest"
+        assert len(report.diagnostics) == 1
+        assert report.diagnostics[0].code == "invalid-manifest"
+        assert "Invalid environment manifest" in report.diagnostics[0].message
+
+    def test_tree_root_manifest_is_diagnosed_without_hiding_neighbors(self, tmp_path: Path, monkeypatch) -> None:
+        tree = tmp_path / "environments"
+        tree.mkdir(parents=True)
+        (tree / "manifest.yaml").write_text(dump_manifest(_manifest("misplaced")), encoding="utf-8")
+        _write_manifest(tmp_path, "environments", "valid_neighbor", _manifest("valid_neighbor"))
+        monkeypatch.setattr(registry_module, "component_search_roots", lambda: [tmp_path])
+
+        report = discover_environment_catalog_report()
+
+        assert resolve_catalog_entry("valid_neighbor", "environment", report=report).status == "experimental"
+        assert len(report.diagnostics) == 1
+        diagnostic = report.diagnostics[0]
+        assert diagnostic.code == "invalid-catalog-entry"
+        assert diagnostic.name is None
+        assert "named catalog directory" in diagnostic.message
+        with pytest.raises(RegistryError, match="named catalog directory"):
+            discover_environment_catalog()
 
     def test_root_precedence_wins_before_manifest_precedence(self, tmp_path: Path, monkeypatch) -> None:
         high = tmp_path / "high"
         low = tmp_path / "low"
         _make_env(high / "environments", "shared", _ENV_CONFIG.format(name="shared"))
+        (high / "environments" / "shared" / "manifest.yaml").write_text("name: [invalid\n", encoding="utf-8")
         _write_manifest(low, "environments", "shared", _manifest("shared"))
         _write_manifest(high, "environments", "manifest_wins", _manifest("manifest_wins"))
         monkeypatch.setattr(registry_module, "component_search_roots", lambda: [high, low])
 
-        entries = {(entry.kind, entry.name): entry for entry in discover_environment_catalog()}
+        report = discover_environment_catalog_report()
+        entries = {(entry.kind, entry.name): entry for entry in report.entries}
 
         assert entries[("environment", "shared")].status == "no-manifest"
         assert entries[("environment", "shared")].path == high / "environments" / "shared"
         assert entries[("environment", "manifest_wins")].status == "experimental"
+        assert [(diagnostic.kind, diagnostic.name) for diagnostic in report.diagnostics] == [("environment", "shared")]
+
+    def test_invalid_higher_root_does_not_mask_healthy_lower_manifest(self, tmp_path: Path, monkeypatch) -> None:
+        high = tmp_path / "high"
+        low = tmp_path / "low"
+        invalid = high / "environments" / "shared" / "manifest.yaml"
+        invalid.parent.mkdir(parents=True)
+        invalid.write_text("name: [invalid\n", encoding="utf-8")
+        _write_manifest(low, "environments", "shared", _manifest("shared"))
+        monkeypatch.setattr(registry_module, "component_search_roots", lambda: [high, low])
+
+        report = discover_environment_catalog_report()
+        entry = resolve_catalog_entry("shared", "environment", report=report)
+
+        assert entry.status == "experimental"
+        assert entry.manifest_path == low / "environments" / "shared" / "manifest.yaml"
+        assert [(diagnostic.kind, diagnostic.name) for diagnostic in report.diagnostics] == [("environment", "shared")]
+
+    def test_nested_benchmark_fallback_is_linked_to_its_sibling_diagnostic(self, tmp_path: Path, monkeypatch) -> None:
+        directory = tmp_path / "benchmarks" / "suite" / "draft"
+        directory.mkdir(parents=True)
+        (directory / "manifest.yaml").write_text("name: [invalid\n", encoding="utf-8")
+        (directory / "config.yaml").write_text(
+            "agent:\n  responses_api_agents:\n    simple_agent:\n"
+            "      datasets:\n      - {name: test, type: benchmark}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(registry_module, "component_search_roots", lambda: [tmp_path])
+
+        report = discover_environment_catalog_report()
+
+        assert report.diagnostics[0].name == "suite/draft"
+        assert resolve_catalog_entry("suite/draft/config", "benchmark", entries=report.entries).status == "no-manifest"
+        with pytest.raises(RegistryError, match="unusable manifest"):
+            resolve_catalog_entry("suite/draft/config", "benchmark", report=report)
 
     def test_benchmark_manifest_suppresses_only_its_sibling_config(self, tmp_path: Path, monkeypatch) -> None:
         _write_manifest(tmp_path, "benchmarks", "suite", _manifest("suite", "benchmark"))


### PR DESCRIPTION
## Summary

Mixed manifest and legacy workload trees are intentional during the onboarding migration. This PR makes catalog discovery failure-isolated and truthful while preserving the existing compatibility API.

- Exclude reserved `manifest.yaml` metadata from runnable benchmark discovery.
- Add a structured catalog report around the existing registry while preserving the tuple-returning `discover_environment_catalog()` API.
- Surface malformed, schema-invalid, and structurally invalid manifests without blocking unrelated entries or healthy lower-precedence roots.
- Make exact selection and local publication reject only the affected unusable manifest-backed fallback.
- Cover nested benchmark identities, manifest/config sibling association, root precedence, CLI JSON/stderr separation, and publication isolation.

## Why

Before this change, `manifest.yaml` could be considered a runnable benchmark YAML candidate. Invalid manifests were also either hidden from broad discovery or handled inconsistently by exact selection and publication. That made mixed manifest/legacy trees unreliable precisely while the repository is migrating incrementally.

The implementation keeps catalog identity and precedence in the existing registry and resolver. Callers receive scoped diagnostics without introducing a second registry or changing healthy legacy discovery.

## Scope

This PR contains catalog hardening only. It does **not** add workload manifests or verifier fixtures, add changed-workload reporting or CI enforcement, implement migration inventory/backfill, infer dependency impact, integrate Evergreen, certify workloads, or change any RFC requirement to complete.

## Validation

- 144 catalog-focused tests passed (143 in the sandbox plus the socket-binding test outside it)
- Ruff check and format check
- `git diff --check`
