### PR TITLE
ci: retry apt-get from Actions side instead of apt's own timeout

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -146,11 +146,13 @@ jobs:
             uv-${{ runner.os }}-
 
       - name: Install system test dependencies
-        timeout-minutes: 5
+        timeout-minutes: 20
         run: |
-          APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
-          sudo apt-get update $APT_OPTS
-          sudo apt-get install -y --no-install-recommends $APT_OPTS git curl ca-certificates
+          for i in 1 2 3 4; do
+            timeout 5m sudo bash -c "apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates" && exit 0
+            echo "apt-get attempt $i/4 failed or timed out after 5m; retrying"
+          done
+          exit 1
 
       - name: Core unit tests
         if: needs.detect.outputs.run_full == 'true'
@@ -232,11 +234,13 @@ jobs:
             uv-${{ runner.os }}-
 
       - name: Install system test dependencies
-        timeout-minutes: 5
+        timeout-minutes: 20
         run: |
-          APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
-          sudo apt-get update $APT_OPTS
-          sudo apt-get install -y --no-install-recommends $APT_OPTS git curl ca-certificates
+          for i in 1 2 3 4; do
+            timeout 5m sudo bash -c "apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates" && exit 0
+            echo "apt-get attempt $i/4 failed or timed out after 5m; retrying"
+          done
+          exit 1
 
       - name: Server tests (shard ${{ matrix.shard }}/${{ env.NUM_SHARDS }})
         run: ./scripts/ci/server_tests.sh "${{ matrix.shard }}" "${{ env.NUM_SHARDS }}"


### PR DESCRIPTION
## Summary
- Follow-up to #2603. That PR added `Acquire::Retries=3` / `Acquire::http(s)::Timeout=30` to apt itself plus a 5-min step timeout.
- Verified locally (Docker repro of the exact stall — TLS connection accepted, headers sent, then silence) that apt's own retry/timeout options **do** work against a stall at that layer, but production logs show the real stall doesn't even get one retry cycle logged before going fully silent for the whole step duration — suggesting the actual failure is a lower-layer network/NAT issue that apt's own idle-read timeout isn't reliably catching.
- This PR removes the apt-level `Acquire::*` options and replaces them with a step-level retry loop instead: up to 4 attempts of `apt-get update && apt-get install`, each hard-bounded to 5 minutes via `timeout 5m`, for a 20-minute worst-case total per step (`timeout-minutes: 20`).
