### PR TITLE
[Super 3.5 evals] Update Aug 19 2026

### DIFF
--- a/benchmarks/nemotron_3.5_super/eval_container_config.yaml
+++ b/benchmarks/nemotron_3.5_super/eval_container_config.yaml
@@ -5,7 +5,6 @@ config_paths:
 - benchmarks/aalcr/config.yaml
 - benchmarks/scicode/config.yaml
 - benchmarks/omniscience/config.yaml
-- benchmarks/critpt/config.yaml
 - benchmarks/nemotron_3.5_super/benchmark_configs/hle_no_tools.yaml
 - responses_api_models/vllm_model/configs/vllm_model.yaml
 # TODO @bxyu-nvidia: Implementing in the harness x benchmark decoupling effort.
@@ -14,12 +13,6 @@ config_paths:
 # SWE Bench Multilingual
 # SWE Bench Pro
 # Terminal Bench 2.1
-# TODO @bxyu-nvidia: need clarification from arajfer and config update in gym
-# HLE w/o tool
-# TODO @bxyu-nvidia: need test efficiency
-# BrowseComp
-# TODO @bxyu-nvidia: need pipeclean (may be very complex)
-# GDPVal-AA-V2
 
 ########################################
 # START Secrets

--- a/benchmarks/nemotron_3.5_super/export_to_csv.py
+++ b/benchmarks/nemotron_3.5_super/export_to_csv.py
@@ -65,8 +65,18 @@ row = {
     ),
     "SciCode": v("scicode_benchmark_agent", "subtask_accuracy"),
     "AA-LCR": v("aalcr_benchmark_simple_agent", "mean/reward"),
-    "AA-Omniscience (OmniIndex)": v("omniscience_omniscience_simple_agent", "mean/reward"),
+    "AA-Omniscience (OmniIndex)": to_pct(-v("omniscience_omniscience_simple_agent", "omniscience_index")),
+    "AA-Omniscience Non-Hall": to_pct(1 - v("is_hallucination", "mean/reward", is_pct=False)),
     "GPQA Diamond": v("gpqa_mcqa_simple_agent", "mean/reward"),
+    "CritPT": "",
+    "HLE w/o tool (text)": v("hle_benchmark_equivalence_llm_judge_simple_agent", "mean/reward"),
+    "BrowseComp": "",
+    "GDPVal-AA-V2": "",
+    "SWE Bench Verified": "",
+    "SWE Bench Multilingual": "",
+    "SWE Bench Pro": "",
+    "Terminal Bench 2.1": "",
+    "LM Arena proxy 2.0": v("lmarena_260311_benchmark_agent", "mean/reward"),
 }
 
 with open(csv_fpath, "w") as f:

--- a/benchmarks/nemotron_3.5_super/policy_model_override.yaml
+++ b/benchmarks/nemotron_3.5_super/policy_model_override.yaml
@@ -1,0 +1,7 @@
+policy_model:
+  responses_api_models:
+    vllm_model:
+      sampling_overrides:
+        max_output_tokens: null
+        max_tokens: null
+        max_completion_tokens: null

--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -29,12 +29,7 @@ PREFILL_VLLM_NIXL_SIDE_CHANNEL_PORT=5600
 DECODE_VLLM_NIXL_SIDE_CHANNEL_PORT=5700
 
 ROUTER_SERVER_PORT=8000
-PREFILL_SERVER_PORT=8001
-DECODE_SERVER_PORT=8002
-
-PREFILL_DP_RPC_PORT=13345
-DECODE_DP_RPC_PORT=13346
-
+WORKER_SERVER_PORT=8001
 
 EVAL_COMMAND=$(cat <<EOF
 set -euo pipefail
@@ -64,7 +59,7 @@ gym eval run \
     ++split=benchmark \
     ++use_absolute_ip=true \
     ++reuse_existing_data_preparation=true \
-    ++policy_base_url=http://\$(getent hosts "\$PREFILL_HEAD" | awk 'NR == 1 {print \$1}'):$ROUTER_SERVER_PORT/v1 \
+    ++policy_base_url=http://\$(getent hosts "\$ROUTER_NODE" | awk 'NR == 1 {print \$1}'):$ROUTER_SERVER_PORT/v1 \
     ++policy_api_key=dummy_api_key \
     ++policy_model_name=$MODEL \
     ++upload_rollouts_to_wandb=false \
@@ -91,10 +86,6 @@ command=$(cat <<EOF
 
 set -euo pipefail
 
-# Input arguments and validation
-PREFILL_HEAD=\$PREFILL_HEAD
-DECODE_HEAD=\$DECODE_HEAD
-
 # Nemotron's three-read Mamba SSM state must use the dimension-sequence layout when KV transfer is enabled.
 # Not used when the model has no Mamba layers.
 export VLLM_SSM_CONV_STATE_LAYOUT=DS
@@ -114,69 +105,52 @@ export UCX_RNDV_THRESH=0
 source "$VLLM_CONFIG"
 
 this_node_hostname=\$(hostname)
-# Split nodes here by index
 if (( SLURM_PROCID == 0 )); then
-    # Prefill head
-
-    VLLM_NIXL_SIDE_CHANNEL_HOST=\$this_node_hostname \
-    VLLM_NIXL_SIDE_CHANNEL_PORT=$PREFILL_VLLM_NIXL_SIDE_CHANNEL_PORT \
-    vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_PREFILL_ARGS[@]}" \
-        --host \$this_node_hostname \
-        --port $PREFILL_SERVER_PORT \
-        --data-parallel-size $NUM_PREFILL_NODES \
-        --data-parallel-address \$this_node_hostname \
-        --data-parallel-rpc-port $PREFILL_DP_RPC_PORT \
-        --api-server-count 1 \
-        &
-    prefill_pid=\$!
-    trap 'kill "\$prefill_pid" 2>/dev/null || true' EXIT
+    read -r -a nodes <<< "\$ALL_NODES"
 
     # @bxyu-nvidia: for --intra-node-data-parallel-size: Not sure what to set this to other than 1. I can't tell from the docs what is appropriate and 1 seems to work fine.
     # Set a super long request timeout since some reasoning requests may take a long time to generate.
     # Don't manually wait as vllm-router will wait for the URLs to come up
-    vllm-router \
-        --policy consistent_hash \
+    router_args=( \
+        --prefill-policy cache_aware \
+        --decode-policy cache_aware \
         --vllm-pd-disaggregation \
-        --prefill http://\$PREFILL_HEAD:$PREFILL_SERVER_PORT \
-        --decode http://\$DECODE_HEAD:$DECODE_SERVER_PORT \
-        --host \$PREFILL_HEAD \
+        --host \$this_node_hostname \
         --port $ROUTER_SERVER_PORT \
         --intra-node-data-parallel-size 1 \
         --request-timeout-secs 86400 \
         --log-level error
-elif (( SLURM_PROCID < $NUM_PREFILL_NODES )); then
-    # Prefill worker
+    )
+
+    for (( i = 0; i < $NUM_PREFILL_NODES; i++ )); do
+        router_args+=(--prefill "http://\${nodes[i]}:$WORKER_SERVER_PORT")
+    done
+    for (( i = 0; i < $NUM_DECODE_NODES; i++ )); do
+        node_idx=\$(( $NUM_PREFILL_NODES + i ))
+        router_args+=(--decode "http://\${nodes[node_idx]}:$WORKER_SERVER_PORT")
+    done
+
+    vllm-router "\${router_args[@]}" &
+
+    router_pid=\$!
+    trap 'kill "\$router_pid" 2>/dev/null || true' EXIT
+fi
+
+# Split nodes here by index
+if (( SLURM_PROCID < $NUM_PREFILL_NODES )); then
+    # Prefill
     VLLM_NIXL_SIDE_CHANNEL_HOST=\$this_node_hostname \
     VLLM_NIXL_SIDE_CHANNEL_PORT=$PREFILL_VLLM_NIXL_SIDE_CHANNEL_PORT \
     vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_PREFILL_ARGS[@]}" \
-        --headless \
-        --data-parallel-size $NUM_PREFILL_NODES \
-        --data-parallel-start-rank \$SLURM_PROCID \
-        --data-parallel-address \$PREFILL_HEAD \
-        --data-parallel-rpc-port $PREFILL_DP_RPC_PORT
-elif (( SLURM_PROCID == NUM_PREFILL_NODES )); then
-    # Decode head
-
+        --host \$this_node_hostname \
+        --port $WORKER_SERVER_PORT
+else
+    # Decode
     VLLM_NIXL_SIDE_CHANNEL_HOST=\$this_node_hostname \
     VLLM_NIXL_SIDE_CHANNEL_PORT=$DECODE_VLLM_NIXL_SIDE_CHANNEL_PORT \
     vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_DECODE_ARGS[@]}" \
         --host \$this_node_hostname \
-        --port $DECODE_SERVER_PORT \
-        --data-parallel-size $NUM_DECODE_NODES \
-        --data-parallel-address \$DECODE_HEAD \
-        --data-parallel-rpc-port $DECODE_DP_RPC_PORT \
-        --api-server-count 1
-else
-    # Decode worker
-
-    VLLM_NIXL_SIDE_CHANNEL_HOST=\$this_node_hostname \
-    VLLM_NIXL_SIDE_CHANNEL_PORT=$DECODE_VLLM_NIXL_SIDE_CHANNEL_PORT \
-    vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_DECODE_ARGS[@]}" \
-        --headless \
-        --data-parallel-size $NUM_DECODE_NODES \
-        --data-parallel-start-rank \$(( SLURM_PROCID - $NUM_PREFILL_NODES )) \
-        --data-parallel-address \$DECODE_HEAD \
-        --data-parallel-rpc-port $DECODE_DP_RPC_PORT
+        --port $WORKER_SERVER_PORT
 fi
 EOF
 )
@@ -186,11 +160,8 @@ batch_command=$(cat <<EOF
 set -euo pipefail
 
 nodes=(\$(scontrol show hostnames "\$SLURM_JOB_NODELIST"))
-PREFILL_HEAD="\${nodes[0]}"
-DECODE_HEAD="\${nodes[$NUM_PREFILL_NODES]}"
 
-PREFILL_HEAD="\$PREFILL_HEAD" \
-DECODE_HEAD="\$DECODE_HEAD" \
+ALL_NODES="\${nodes[*]}" \
 srun --nodes=$NUM_NODES --ntasks=$NUM_NODES --ntasks-per-node=1 \
     --container-image=$CONTAINER \
     --container-name=container-on-node \
@@ -222,8 +193,7 @@ if (( $should_run_eval )); then
     fi
 
     # @bxyu-nvidia: We need --cpus-per-task=SLURM_CPUS_ON_NODE, otherwise we run into a lot of ServerDisconnectedError and ConnectionResetByPeer errors from Gym servers and vLLM. Not sure what the correlation is
-    eval_status=0
-    PREFILL_HEAD="\$PREFILL_HEAD" \
+    ROUTER_NODE="\${nodes[0]}" \
     srun --overlap --exact --nodes=1 --ntasks=1 --cpus-per-task=\$SLURM_CPUS_ON_NODE --nodelist="\$EVAL_NODE" --gpus=0 \
         --container-image=$CONTAINER \
         --container-name=eval-container-on-node \
@@ -234,11 +204,27 @@ if (( $should_run_eval )); then
             set -euo pipefail
             cd "\$SLURM_SUBMIT_DIR"
             exec bash -lc "\$EVAL_COMMAND"
-        ' || eval_status=\$?
+        ' &
+    eval_step=\$!
+
+    completed_pid=""
+    completed_status=0
+    wait -n -p completed_pid "\$server_step" "\$eval_step" || completed_status=\$?
+
+    if [[ "\$completed_pid" == "\$server_step" ]]; then
+        if (( completed_status == 0 )); then
+            completed_status=1
+        fi
+        echo "vLLM server step exited unexpectedly with status \$completed_status" >&2
+        kill "\$eval_step" 2>/dev/null || true
+        wait "\$eval_step" 2>/dev/null || true
+        trap - EXIT INT TERM
+        exit "\$completed_status"
+    fi
 
     cleanup_server
     trap - EXIT INT TERM
-    exit "\$eval_status"
+    exit "\$completed_status"
 fi
 
 wait "\$server_step"

--- a/benchmarks/nemotron_3.5_super/vllm_configs/nemotron_3.5_super.sh
+++ b/benchmarks/nemotron_3.5_super/vllm_configs/nemotron_3.5_super.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 VLLM_COMMON_ARGS=(
+    --trust-remote-code
     --disable-uvicorn-access-log
     --gpu-memory-utilization 0.9
     --distributed-executor-backend mp
@@ -18,10 +19,12 @@ VLLM_COMMON_ARGS=(
     --mamba-ssm-cache-dtype float32
     --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 96}'
     --enable-expert-parallel
+    --data-parallel-size 1
+    --api-server-count 1
 )
 VLLM_PREFILL_ARGS=(
     --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_load_failure_policy":"fail"}'
-    --max-num-batched-tokens 33920
+    --max-num-batched-tokens 135680
     --max-num-seqs 1024
     --data-parallel-size-local 1
     --tensor-parallel-size 4

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -877,8 +877,10 @@ class RolloutCollectionHelper(BaseModel):
 """
                 for agent_name in sorted(agent_name_to_metrics):
                     metrics = agent_name_to_metrics[agent_name]
+                    agent_total_samples = counts_left[agent_name] + agent_name_to_counts[agent_name]
+                    agent_sample_pct = 100 * agent_name_to_counts[agent_name] / agent_total_samples
                     avg_metrics = {k: v / agent_name_to_counts[agent_name] for k, v in metrics.items()}
-                    print_str += f"""Found {agent_name_to_counts[agent_name]} rollouts for `{agent_name}`.
+                    print_str += f"""Found {agent_name_to_counts[agent_name]} / {agent_total_samples} ({agent_sample_pct:.2f}%) rollouts for `{agent_name}`.
 {json.dumps(avg_metrics, indent=4)}
 """
                 # Use tqdm.write here so we can print properly with tqdm being used.

--- a/resources_servers/swebench/app.py
+++ b/resources_servers/swebench/app.py
@@ -248,7 +248,7 @@ class SwebenchResourcesServer(SimpleResourcesServer):
             anti_cheat_setup_fpath = Path(__file__).parent / "anti_cheat_setup.sh"
             await eval_sandbox.upload(anti_cheat_setup_fpath, f"{wd}/anti_cheat_setup.sh")
             result = await eval_sandbox.exec(
-                f"""WORKING_DIRECTORY={wd} bash anti_cheat_setup.sh && rm anti_cheat_setup.sh"""
+                f"""git reset --hard && WORKING_DIRECTORY={wd} bash anti_cheat_setup.sh && rm anti_cheat_setup.sh"""
             )
             if result.return_code != 0:
                 print(f"""Failed to setup anti-cheating for {test_spec.instance_id}. Return code: {result.return_code}

--- a/resources_servers/swebench/print_test_outputs.py
+++ b/resources_servers/swebench/print_test_outputs.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from argparse import ArgumentParser
+
+import orjson
+from tqdm.auto import tqdm
+
+
+parser = ArgumentParser()
+parser.add_argument("--rollout-jsonl", type=str, required=True)
+parser.add_argument("--instance-id", type=str, required=True)
+args = parser.parse_args()
+
+instance_id_to_row = dict()
+with open("benchmarks/swebench/data/swebench_multilingual_benchmark.jsonl") as f:
+    for line in f:
+        row = orjson.loads(line)
+        instance_id_to_row[row["instance_id"]] = row
+
+
+num = 0
+with open(args.rollout_jsonl) as f_in:
+    for line in tqdm(f_in):
+        row = orjson.loads(line)
+        if row["instance_id"] != args.instance_id:
+            continue
+
+        print(f"Verification time taken: {row['patch_verification_time_taken']}")
+
+        if row["test_output"].strip():
+            to_write = f"Reward: {row['reward']}\n\nTest output:\n{row['test_output']}"
+            # to_write = f"Reward: {row['reward']}\n\nTest output:\n{row['test_output']}\n\nModel patch:\n{row['model_patch']}\n\nOpencode stdout:\n{row['opencode_run_stdout']}"
+        else:
+            to_write = f"Reward: {row['reward']}\n\nOpencode stdout:\n{row['opencode_run_stdout']}"
+
+        sample = instance_id_to_row[args.instance_id]
+        sample["patch"] = row["model_patch"]
+        with open("temp.jsonl", "wb") as f:
+            f.write(orjson.dumps(instance_id_to_row[args.instance_id]) + b"\n")
+
+        with open(f"temp_{num}.log", "w") as f_out:
+            f_out.write(to_write)
+        num += 1

--- a/responses_api_agents/opencode_sandboxed_agent/app.py
+++ b/responses_api_agents/opencode_sandboxed_agent/app.py
@@ -65,6 +65,7 @@ class OpenCodeSandboxedAgentConfig(BaseResponsesAPIAgentConfig):
     remote_opencode_install_script_path: Optional[str] = None
     remote_opencode_binary_path: Optional[str] = None
     opencode_config: Dict[str, Any] = Field(default_factory=dict)
+    opencode_max_context_window: int
 
     # Sandbox config
     sandbox_provider: str
@@ -152,16 +153,16 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
                     "options": {
                         "baseURL": f"{get_server_url(self.config.model_server.name)}/v1",
                         "apiKey": "dummy_key",  # pragma: allowlist secret
+                        "timeout": False,
+                        "chunkTimeout": 600000,  # in milliseconds, 10 min
                     },
                     "models": {
                         "dummy_model": {
                             "limit": {
-                                "context": 0,
-                                "input": 0,
-                                # @bxyu-nvidia: OpenCode defaults to 32k here https://github.com/anomalyco/opencode/blob/58a99916bb96edf5cf605dc03e1be1e4bacf9ff7/packages/opencode/src/provider/transform.ts#L21
-                                # and there is no way to set it to null.
-                                # We set it here to explicitly acknowledge that this parameter is set.
-                                "output": 32_000,
+                                "context": self.config.opencode_max_context_window,
+                                "input": self.config.opencode_max_context_window,
+                                # See the OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX flag below for more information.
+                                "output": self.config.opencode_max_context_window,
                             },
                         },
                     },
@@ -298,7 +299,7 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
         && {install_str} \
         && export PATH=$HOME/.opencode/bin:$PATH \
         && echo "Installed OpenCode" \
-        && opencode run {opencode_debug_str} {opencode_thinking_str} {quote(query)} \
+        && opencode run {opencode_debug_str} {opencode_thinking_str} -- {quote(query)} \
         && echo "OpenCode run finished"
         """
 
@@ -312,7 +313,14 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
             result = await sandbox.exec(
                 command=command,
                 timeout_s=self.config.sandbox_timeout,
-                env={"OPENCODE_CONFIG_CONTENT": opencode_config_content},
+                env={
+                    "OPENCODE_CONFIG_CONTENT": opencode_config_content,
+                    # @bxyu-nvidia: OpenCode defaults to 32k here https://github.com/anomalyco/opencode/blob/58a99916bb96edf5cf605dc03e1be1e4bacf9ff7/packages/opencode/src/provider/transform.ts#L21
+                    # and there is no way to set it to null.
+                    # Here, we set an exorbitantly high number that cannot ever be reached.
+                    # In future versions of OpenCode, this can be directly passed via maxOutputTokens in the limit config above https://github.com/anomalyco/opencode/blob/1b18a50418f730aca32630ccfcde850f2b5fc360/packages/opencode/src/provider/transform.ts#L1418
+                    "OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX": str(1_000_000_000),
+                },
             )
         except:
             result = None
@@ -326,6 +334,7 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
         try:
             export_result = await sandbox.exec(
                 command=f"""export PATH=$HOME/.opencode/bin:$PATH \
+            && (command -v jq >/dev/null 2>&1 || (apt-get update && apt-get install -y --no-install-recommends jq)) \
             && session_id=$(opencode session list --format json | jq -r '.[0].id') \
             && opencode export $session_id > {export_fname}"""
             )
@@ -353,6 +362,9 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
                 await sandbox.download(str(results_remote_fpath), results_local_fpath)
             except:
                 print(f"Failed to download export results to {results_local_fpath}", format_exc(), file=sys.stderr)
+                if export_result:
+                    print("Export stdout:\n", export_result.stdout, file=sys.stderr)
+                    print("Export stderr:\n", export_result.stderr, file=sys.stderr)
 
         opencode_export = dict()
         if results_local_fpath.exists():

--- a/responses_api_agents/opencode_sandboxed_agent/configs/opencode_agent.yaml
+++ b/responses_api_agents/opencode_sandboxed_agent/configs/opencode_agent.yaml
@@ -13,6 +13,9 @@ opencode_sandboxed_agent:
       debug: false
 
       opencode_version: 1.17.11
+      # @bxyu-nvidia: This needs to be set appropriately for every model!
+      opencode_max_context_window: 262144
+
       remote_opencode_install_script_path: null
       remote_opencode_binary_path: null
 

--- a/responses_api_agents/opencode_sandboxed_agent/tests/test_app.py
+++ b/responses_api_agents/opencode_sandboxed_agent/tests/test_app.py
@@ -51,6 +51,7 @@ class TestOpenCodeSandboxedAgent:
             sandbox_provider="",
             sandbox_config=dict(),
             sandbox_timeout=0,
+            opencode_max_context_window=0,
         )
 
     @fixture

--- a/responses_api_models/vllm_model/configs/vllm_model.yaml
+++ b/responses_api_models/vllm_model/configs/vllm_model.yaml
@@ -9,5 +9,6 @@ policy_model:
       uses_reasoning_parser: true
       uses_interleaved_reasoning: true
       chat_template_kwargs: null
+      sampling_overrides: null
       extra_body: null
       default_headers: {}


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

1. Swap from DP > 1 to DP = 1 to match Tomer's config and fix accuracy issues: benchmarks/nemotron_3.5_super/vllm_configs/nemotron_3.5_super.sh, benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
2. Update Super 3.5 configs and export: benchmarks/nemotron_3.5_super/eval_container_config.yaml, benchmarks/nemotron_3.5_super/export_to_csv.py
3. OpenCode each turn uses full max length: benchmarks/nemotron_3.5_super/policy_model_override.yaml, responses_api_agents/opencode_sandboxed_agent/configs/opencode_agent.yaml, responses_api_agents/opencode_sandboxed_agent/app.py, responses_api_models/vllm_model/configs/vllm_model.yaml
4. SWE Bench Multilingual fixes: resources_servers/swebench/app.py
5. Misc: nemo_gym/rollout_collection.py, responses_api_agents/opencode_sandboxed_agent/app.py, resources_servers/swebench/print_test_outputs.py

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
