### PR TITLE
fix(simple-agent): execute completed calls in truncated responses

### DIFF
--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -160,15 +160,24 @@ class SimpleAgent(SimpleResponsesAPIAgent):
             usage = accumulate_response_usage(usage, model_response.usage)
             model_response.usage = None
 
-            if model_response.incomplete_details:
+            incomplete_details = model_response.incomplete_details
+            if incomplete_details:
                 invocation_status = "incomplete"
-                break
 
             all_fn_calls: List[NeMoGymResponseFunctionToolCall] = [o for o in output if o.type == "function_call"]
             all_output_messages: List[NeMoGymResponseOutputMessage] = [
                 o for o in output if o.type == "message" and o.role == "assistant"
             ]
-            if not all_fn_calls and all_output_messages:
+            stop_after_tool_outputs = False
+            if incomplete_details:
+                if incomplete_details.reason != "max_output_tokens":
+                    break
+                completed_fn_calls = [call for call in all_fn_calls if call.status == "completed"]
+                if not completed_fn_calls:
+                    break
+                all_fn_calls = completed_fn_calls
+                stop_after_tool_outputs = True
+            elif not all_fn_calls and all_output_messages:
                 break
 
             for output_function_call in all_fn_calls:
@@ -223,6 +232,9 @@ class SimpleAgent(SimpleResponsesAPIAgent):
 
             if collect_trajectory and all_fn_calls:
                 turns[-1].step_count = len(tool_records)
+
+            if stop_after_tool_outputs:
+                break
 
             # Check if max steps is not None and if we have exhausted it.
             if self.config.max_steps and step >= self.config.max_steps:

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -753,6 +753,241 @@ class TestApp:
         }
         assert expected_usage_dict == actual_usage_dict
 
+    async def test_incomplete_max_tokens_executes_completed_function_call_before_stopping(self) -> None:
+        server, server_client = _make_agent(False)
+        model_payload = {
+            "id": "resp-incomplete-tool",
+            "created_at": 1.0,
+            "model": "model",
+            "object": "response",
+            "status": "incomplete",
+            "incomplete_details": {"reason": "max_output_tokens"},
+            "output": [
+                {
+                    "id": "fc-1",
+                    "call_id": "call-1",
+                    "name": "lookup",
+                    "arguments": '{"q":"x"}',
+                    "type": "function_call",
+                    "status": "completed",
+                }
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+        model_call_count = 0
+
+        async def post(*, server_name, url_path, **kwargs):
+            nonlocal model_call_count
+            if server_name == "model":
+                model_call_count += 1
+                if model_call_count > 1:
+                    raise AssertionError("global incomplete response must stop before a second model call")
+                return _mock_response(model_payload)
+            if (server_name, url_path) == ("resources", "/lookup"):
+                return _mock_response(content='{"result":"found"}')
+            raise AssertionError(f"unexpected server call: {server_name=}, {url_path=}")
+
+        server_client.post = AsyncMock(side_effect=post)
+        request = MagicMock(cookies={}, path_params={})
+
+        result = await server.responses(
+            request,
+            Response(),
+            NeMoGymResponseCreateParamsNonStreaming(input="question"),
+        )
+
+        assert result.status == "incomplete"
+        assert result.incomplete_details is not None
+        assert result.incomplete_details.reason == "max_output_tokens"
+        assert [item.type for item in result.output] == ["function_call", "function_call_output"]
+        function_call, function_call_output = result.output
+        assert function_call.call_id == function_call_output.call_id == "call-1"
+        assert function_call_output.output == '{"result":"found"}'
+
+        assert server_client.post.await_count == 2
+        assert [
+            (post_call.kwargs["server_name"], post_call.kwargs["url_path"])
+            for post_call in server_client.post.await_args_list
+        ] == [
+            ("model", server.url_path_for_request("/v1/responses", request)),
+            ("resources", "/lookup"),
+        ]
+        assert server_client.post.await_args_list[1].kwargs["json"] == {"q": "x"}
+
+    async def test_incomplete_max_tokens_executes_only_completed_function_calls(self) -> None:
+        server, server_client = _make_agent(False)
+        completed_function_call = {
+            "id": "fc-completed",
+            "call_id": "call-completed",
+            "name": "lookup",
+            "arguments": '{"q":"completed"}',
+            "type": "function_call",
+            "status": "completed",
+        }
+        pending_function_call = {
+            "id": "fc-pending",
+            "call_id": "call-pending",
+            "name": "lookup",
+            "arguments": '{"q":"pending"}',
+            "type": "function_call",
+            "status": "in_progress",
+        }
+        model_payload = {
+            "id": "resp-incomplete-tool",
+            "created_at": 1.0,
+            "model": "model",
+            "object": "response",
+            "status": "incomplete",
+            "incomplete_details": {"reason": "max_output_tokens"},
+            "output": [completed_function_call, pending_function_call],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+        model_call_count = 0
+
+        async def post(*, server_name, url_path, **kwargs):
+            nonlocal model_call_count
+            if kwargs.get("json") == {"q": "pending"}:
+                raise AssertionError("in-progress function call must not execute")
+            if server_name == "model":
+                model_call_count += 1
+                if model_call_count > 1:
+                    raise AssertionError("global incomplete response must stop before a second model call")
+                return _mock_response(model_payload)
+            if (server_name, url_path) == ("resources", "/lookup"):
+                if kwargs.get("json") != {"q": "completed"}:
+                    raise AssertionError(f"unexpected lookup arguments: {kwargs.get('json')!r}")
+                return _mock_response(content='{"result":"found"}')
+            raise AssertionError(f"unexpected server call: {server_name=}, {url_path=}")
+
+        server_client.post = AsyncMock(side_effect=post)
+        request = MagicMock(cookies={}, path_params={})
+
+        result = await server.responses(
+            request,
+            Response(),
+            NeMoGymResponseCreateParamsNonStreaming(input="question"),
+        )
+
+        assert result.status == "incomplete"
+        assert result.incomplete_details is not None
+        assert result.incomplete_details.reason == "max_output_tokens"
+        assert [item.type for item in result.output] == [
+            "function_call",
+            "function_call",
+            "function_call_output",
+        ]
+        assert result.output[:2] == [
+            NeMoGymResponseFunctionToolCall.model_validate(completed_function_call),
+            NeMoGymResponseFunctionToolCall.model_validate(pending_function_call),
+        ]
+        function_call_outputs = [item for item in result.output if item.type == "function_call_output"]
+        assert len(function_call_outputs) == 1
+        assert function_call_outputs[0].call_id == "call-completed"
+        assert function_call_outputs[0].output == '{"result":"found"}'
+
+        assert model_call_count == 1
+        assert server_client.post.await_count == 2
+        assert [
+            (post_call.kwargs["server_name"], post_call.kwargs["url_path"])
+            for post_call in server_client.post.await_args_list
+        ] == [
+            ("model", server.url_path_for_request("/v1/responses", request)),
+            ("resources", "/lookup"),
+        ]
+        assert server_client.post.await_args_list[1].kwargs["json"] == {"q": "completed"}
+
+    @pytest.mark.parametrize(
+        "item_status", [None, "in_progress", "incomplete"], ids=["omitted", "in_progress", "incomplete"]
+    )
+    async def test_max_token_incomplete_does_not_execute_noncompleted_function_call(
+        self, item_status: str | None
+    ) -> None:
+        server, server_client = _make_agent(False)
+        function_call = {
+            "id": "fc-1",
+            "call_id": "call-1",
+            "name": "lookup",
+            "arguments": '{"q":"x"}',
+            "type": "function_call",
+        }
+        if item_status is not None:
+            function_call["status"] = item_status
+        model_payload = {
+            "id": "resp-incomplete-tool",
+            "created_at": 1.0,
+            "model": "model",
+            "object": "response",
+            "status": "incomplete",
+            "incomplete_details": {"reason": "max_output_tokens"},
+            "output": [function_call],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+        server_client.post = AsyncMock(return_value=_mock_response(model_payload))
+        request = MagicMock(cookies={}, path_params={})
+
+        result = await server.responses(
+            request,
+            Response(),
+            NeMoGymResponseCreateParamsNonStreaming(input="question"),
+        )
+
+        assert result.output == [NeMoGymResponseFunctionToolCall.model_validate(function_call)]
+        assert result.status == "incomplete"
+        assert result.incomplete_details is not None
+        assert result.incomplete_details.reason == "max_output_tokens"
+        server_client.post.assert_awaited_once()
+        assert [
+            (post_call.kwargs["server_name"], post_call.kwargs["url_path"])
+            for post_call in server_client.post.await_args_list
+        ] == [("model", server.url_path_for_request("/v1/responses", request))]
+
+    async def test_content_filter_does_not_execute_completed_function_call(self) -> None:
+        server, server_client = _make_agent(False)
+        function_call = {
+            "id": "fc-1",
+            "call_id": "call-1",
+            "name": "lookup",
+            "arguments": '{"q":"x"}',
+            "type": "function_call",
+            "status": "completed",
+        }
+        model_payload = {
+            "id": "resp-content-filtered-tool",
+            "created_at": 1.0,
+            "model": "model",
+            "object": "response",
+            "status": "incomplete",
+            "incomplete_details": {"reason": "content_filter"},
+            "output": [function_call],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+        server_client.post = AsyncMock(return_value=_mock_response(model_payload))
+        request = MagicMock(cookies={}, path_params={})
+
+        result = await server.responses(
+            request,
+            Response(),
+            NeMoGymResponseCreateParamsNonStreaming(input="question"),
+        )
+
+        assert result.output == [NeMoGymResponseFunctionToolCall.model_validate(function_call)]
+        assert result.status == "incomplete"
+        assert result.incomplete_details is not None
+        assert result.incomplete_details.reason == "content_filter"
+        server_client.post.assert_awaited_once()
+        assert [
+            (post_call.kwargs["server_name"], post_call.kwargs["url_path"])
+            for post_call in server_client.post.await_args_list
+        ] == [("model", server.url_path_for_request("/v1/responses", request))]
+
     async def test_incomplete_details(self, monkeypatch: MonkeyPatch) -> None:
         await self._test_incomplete_details_helper(monkeypatch, {"reason": "max_output_tokens"})
         await self._test_incomplete_details_helper(monkeypatch, {"reason": "content_filter"})


### PR DESCRIPTION
## Summary

- Execute item-level `status="completed"` function calls when a Responses API turn is globally incomplete because of `max_output_tokens`.
- Append the matching `function_call_output` items, preserve the global incomplete status/details, and stop before issuing another model request.
- Continue to fail closed for omitted, `in_progress`, or `incomplete` calls and for `content_filter` or other incomplete reasons.

## Root cause

`SimpleAgent.responses()` unconditionally stopped as soon as `model_response.incomplete_details` was present. The Responses converter can validly produce both:

- top-level `status="incomplete"` with `reason="max_output_tokens"`; and
- a syntactically complete function-call item with `status="completed"`.

The early break therefore discarded a valid tool action before the agent's existing call-selection and execution logic ran.

## Why existing tests did not catch this

The existing incomplete-response test covered propagation of top-level status/details, but did not include a completed function call inside a truncated response or assert a paired tool output.

The new tests cover:

- a completed call inside a max-token incomplete response;
- mixed completed and non-completed calls;
- omitted, `in_progress`, and `incomplete` item statuses;
- a completed call under `content_filter`;
- termination before a second model request.

## Before-fix evidence

```text
FAILED test_incomplete_max_tokens_executes_completed_function_call_before_stopping
actual:   ['function_call']
expected: ['function_call', 'function_call_output']
```

The mixed-status regression failed for the same missing completed-call output.

## After-fix evidence

Focused regression tests:

```bash
uv run --extra dev pytest -q \
  responses_api_agents/simple_agent/tests/test_app.py::TestApp::test_incomplete_max_tokens_executes_completed_function_call_before_stopping \
  responses_api_agents/simple_agent/tests/test_app.py::TestApp::test_incomplete_max_tokens_executes_only_completed_function_calls \
  responses_api_agents/simple_agent/tests/test_app.py::TestApp::test_max_token_incomplete_does_not_execute_noncompleted_function_call \
  responses_api_agents/simple_agent/tests/test_app.py::TestApp::test_content_filter_does_not_execute_completed_function_call
```

```text
6 passed
```

Full component and static validation:

```text
responses_api_agents/simple_agent/tests/: 18 passed
pre-commit run --all-files: passed
nemo-gym make test:lint: 79 tests passed
```

Existing downstream black-box testcase, unchanged and still using its original token limit:

```bash
# From nmfw_tests/nemo_llm/test_suite/nemo-gym
python3 testcases/responses_api_agents/agent_tool_loop.py
```

The testcase starts the real Gym stack with the equivalent of:

```bash
gym env start \
  --resources-server example_single_tool_call \
  ++example_single_tool_call_simple_agent.responses_api_agents.simple_agent.max_steps=1 \
  --model-type inference_provider
```

It submits five real-model tasks and asserts that the returned trajectory contains a paired `function_call` and `function_call_output` while the response still reports `incomplete_details.reason == "max_output_tokens"`.

The testcase passed twice consecutively (`1/1` each time):

```text
trajectory types=['function_call', 'function_call_output']
incomplete_details={'reason': 'max_output_tokens'}
```

## Test plan

- [x] RED regression fails at the intended missing tool-output assertion before the source fix.
- [x] Focused truncation/safety tests pass after the fix.
- [x] Full SimpleAgent tests pass.
- [x] Full pre-commit suite passes.
- [x] Existing downstream real-model `agent_tool_loop` testcase passes twice without testcase changes.
- [x] Independent spec, quality, security, and integration reviews pass.
