### PR TITLE
docs(legal): PinchBench modified-component notice and NVIDIA disclaimer

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -226,8 +226,6 @@ upstream copyright header and adds an NVIDIA modifications block.
 
 The following components are **not vendored** in this repository but are cloned
 from upstream at container image build time and patched by NVIDIA before use.
-The patch is checked into this repository. The upstream source is unmodified
-except where the patch is applied.
 
 | Component | Version | License | Upstream | Patch location | Files modified |
 |-----------|---------|---------|----------|----------------|----------------|

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -222,38 +222,11 @@ upstream copyright header and adds an NVIDIA modifications block.
 
 ---
 
-## Cloned and Modified Components (retrieved and patched at image build)
+## Cloned and Modified Components
 
-The following components are **not vendored** in this repository but are cloned
-from upstream at container image build time and patched by NVIDIA before use.
-
-| Component | Version | License | Upstream | Patch location | Files modified |
-|-----------|---------|---------|----------|----------------|----------------|
-| PinchBench skill | tag pinned in `Dockerfile.benchmark` | MIT | https://github.com/pinchbench/skill | `responses_api_agents/pinchbench/setup_scripts/nvidia-pinchbench.patch` | `scripts/lib_agent.py` (NVIDIA endpoint integration) |
-
-### PinchBench MIT License
-
-```text
-Copyright (c) PinchBench
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
+| Component | License | Upstream | Notes |
+|-----------|---------|----------|-------|
+| PinchBench skill | MIT | https://github.com/pinchbench/skill | Cloned and patched at image build (modification). |
 
 ---
 

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -222,6 +222,43 @@ upstream copyright header and adds an NVIDIA modifications block.
 
 ---
 
+## Cloned and Modified Components (retrieved and patched at image build)
+
+The following components are **not vendored** in this repository but are cloned
+from upstream at container image build time and patched by NVIDIA before use.
+The patch is checked into this repository. The upstream source is unmodified
+except where the patch is applied.
+
+| Component | Version | License | Upstream | Patch location | Files modified |
+|-----------|---------|---------|----------|----------------|----------------|
+| PinchBench skill | tag pinned in `Dockerfile.benchmark` | MIT | https://github.com/pinchbench/skill | `responses_api_agents/pinchbench/setup_scripts/nvidia-pinchbench.patch` | `scripts/lib_agent.py` (NVIDIA endpoint integration) |
+
+### PinchBench MIT License
+
+```text
+Copyright (c) PinchBench
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
 ## Full License Texts
 
 The complete license text for each Python package dependency follows.

--- a/README.md
+++ b/README.md
@@ -399,3 +399,7 @@ If you use NeMo Gym in your research, please cite it using the following BibTeX 
   note = {GitHub repository},
 }
 ```
+
+## ⚠️ Notice and Disclaimer
+
+This software automatically retrieves, accesses or interacts with external materials. Those retrieved materials are not distributed with this software and are governed solely by separate terms, conditions and licenses. You are solely responsible for finding, reviewing and complying with all applicable terms, conditions, and licenses, and for verifying the security, integrity and suitability of any retrieved materials for your specific use case. This software is provided "AS IS", without warranty of any kind. The author makes no representations or warranties regarding any retrieved materials, and assumes no liability for any losses, damages, liabilities or legal consequences from your use or inability to use this software or any retrieved materials. Use this software and the retrieved materials at your own risk.


### PR DESCRIPTION
## Summary

- Adds a **"Cloned and Modified Components"** section to `ATTRIBUTIONS.md` covering PinchBench: cloned at image build time from https://github.com/pinchbench/skill and patched via `nvidia-pinchbench.patch` (touches `scripts/lib_agent.py` only). Includes MIT license text. Addresses Legal's finding that PinchBench being "cloned & patched at image build" is a modification requiring explicit attribution.
- Adds the **NVIDIA retrieved-materials Notice and Disclaimer** to `README.md` as required for containers that automatically retrieve external materials (models, data, assets) at runtime.

Closes items 10 and 11 from OSRB guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)