### PR TITLE
feat(eval): initial version of gym compare

### DIFF
--- a/fern/versions/latest/pages/reference/cli-commands.mdx
+++ b/fern/versions/latest/pages/reference/cli-commands.mdx
@@ -52,6 +52,9 @@ gym eval aggregate            # merge sharded rollout results
 gym eval profile              # compute a reward profile from rollouts
 gym eval reverify             # recompute rewards from existing rollouts without re-running inference
 
+# Compare
+gym compare                   # compare a baseline eval run against a candidate run
+
 # Contributor helpers
 gym dev test                  # run NeMo Gym's unit tests
 ```
@@ -728,6 +731,41 @@ Writes three files next to the rollouts, named from its stem:
 | `<rollouts>_repeat_level_metrics.json` | One entry per repeat. |
 
 See [Repeat-Level Metrics](/evaluation/aggregate-metrics#repeat-level-metrics) for the full field list and how to read the variability statistics.
+
+### `gym compare`
+
+Compare a baseline eval run against a candidate run and write a report. Reads only each run's `*_aggregate_metrics.json`, derived from the rollouts JSONL path you pass — the rollouts file itself is never opened.
+
+The report contains a metric table (the change, plus each side's value and confidence interval), split into key metrics and all other metrics, and a per-task sample-flips table. Confidence intervals are read verbatim from what each run recorded; this command performs no statistical tests and issues no pass/fail verdict.
+
+| Option | Description |
+| --- | --- |
+| `--baseline PATH` | Baseline run's rollouts JSONL. |
+| `--candidates PATH[,PATH...]` | Candidate run's rollouts JSONL. Comma-separated; one candidate is supported today. |
+| `--agent NAME` | Agent to compare on both sides. Defaults to every agent present in both runs. |
+| `--baseline-agent NAME` | Agent to read from the baseline. Takes precedence over `--agent`. |
+| `--candidate-agents NAME[,NAME...]` | Agent to read from each candidate, in `--candidates` order. Takes precedence over `--agent`. |
+| `--output-dir DIR`, `-o` | Where to write the report. Defaults to the candidate run's own directory. |
+| `--report-format` | `md`, `json`, or `both` (default). |
+
+```bash
+gym compare \
+    --baseline runs/baseline/rollouts.jsonl \
+    --candidates runs/candidate/rollouts.jsonl
+```
+
+Writes into the output directory:
+
+| File | Contents |
+| --- | --- |
+| `compare_report.md` | Human-readable report. |
+| `compare_report.json` | Machine-readable result (`schema_version` 1). |
+
+<Note>
+Confidence intervals are only present for `mean/*` metrics on runs collected with `--num-repeats` of 2 or more; `pass@k` metrics never carry one, and those cells render as `—`. Metric names embed the repeat count (`pass@1[avg-of-3]` versus `pass@1[avg-of-5]`), so comparing runs collected with different `--num-repeats` leaves whole metric families reported by only one run. Tasks are matched on `_ng_task_index` alone, which assumes both runs used the same dataset, split, `--limit` and ordering.
+</Note>
+
+If a run was collected with `--disable-aggregation` it has no `*_aggregate_metrics.json`; run [`gym eval aggregate`](#gym-eval-aggregate) first, or point at the file directly with `+baseline_aggregate_metrics_fpath=` / `+candidate_aggregate_metrics_fpaths=[...]`.
 
 ### `gym eval reverify`
 

--- a/nemo_gym/cli/compare.py
+++ b/nemo_gym/cli/compare.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""`gym compare`: diff a baseline eval run's aggregate metrics against a candidate run."""
+
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Tuple
+
+import orjson
+
+from nemo_gym import _resolve_under_cwd_or_install
+from nemo_gym.cli.utils import exit_cleanly_on_config_error, print_rich_table
+from nemo_gym.compare.diff import compare_runs
+from nemo_gym.compare.loading import (
+    build_loaded_run,
+    load_run_file,
+    resolve_agent_selections,
+    run_labels,
+)
+from nemo_gym.compare.report import render_markdown
+from nemo_gym.compare.schema import CompareConfig, ComparisonResult, RunRef
+from nemo_gym.config_types import ConfigError
+from nemo_gym.global_config import GlobalConfigDictParserConfig, get_global_config_dict
+from nemo_gym.package_info import __version__
+
+
+MARKDOWN_REPORT_NAME = "compare_report.md"
+JSON_REPORT_NAME = "compare_report.json"
+
+
+def build_comparison_result(config: CompareConfig, *, command: str) -> ComparisonResult:
+    """Load both sides, pick the agent(s), and assemble the full comparison."""
+    baseline_file = load_run_file(
+        config.baseline_rollouts_jsonl_fpath,
+        role="baseline",
+        flag_label="--baseline",
+        aggregate_metrics_fpath_override=config.baseline_aggregate_metrics_fpath,
+    )
+    candidate_files = [
+        load_run_file(
+            fpath,
+            role="candidate",
+            index=index,
+            flag_label="--candidates",
+            aggregate_metrics_fpath_override=(
+                config.candidate_aggregate_metrics_fpaths[index] if config.candidate_aggregate_metrics_fpaths else None
+            ),
+        )
+        for index, fpath in enumerate(config.candidate_rollouts_jsonl_fpaths)
+    ]
+
+    selections, warnings, skipped = resolve_agent_selections(
+        baseline_file,
+        candidate_files,
+        agent_name=config.agent_name,
+        baseline_agent_name=config.baseline_agent_name,
+        candidate_agent_names=config.candidate_agent_names,
+    )
+
+    labels = run_labels([baseline_file.rollouts_jsonl_fpath, *(f.rollouts_jsonl_fpath for f in candidate_files)])
+    baseline_label, candidate_labels = labels[0], labels[1:]
+
+    comparisons = []
+    for selection in selections:
+        baseline_run = build_loaded_run(baseline_file, selection.baseline_agent, label=baseline_label)
+        candidate_runs = [
+            build_loaded_run(run_file, agent, label=candidate_labels[index])
+            for index, (run_file, agent) in enumerate(zip(candidate_files, selection.candidate_agents))
+        ]
+        comparisons.append(compare_runs(baseline_run, candidate_runs))
+
+    def run_ref(run_file, label: str, repeats) -> RunRef:
+        return RunRef(
+            role=run_file.role,
+            label=label,
+            rollouts_jsonl_fpath=str(run_file.rollouts_jsonl_fpath),
+            aggregate_metrics_fpath=str(run_file.aggregate_metrics_fpath),
+            agents=run_file.agent_names,
+            num_repeats=repeats,
+        )
+
+    first = comparisons[0]
+    return ComparisonResult(
+        generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        nemo_gym_version=__version__,
+        command=command,
+        baseline=run_ref(baseline_file, baseline_label, first.baseline_repeat_count),
+        candidates=[
+            run_ref(run_file, candidate_labels[index], first.candidate_repeat_counts[index])
+            for index, run_file in enumerate(candidate_files)
+        ],
+        comparisons=comparisons,
+        skipped_agents=skipped,
+        # Run-level warnings only. Per-comparison observations stay on their `AgentComparison.notes`
+        # so the report renders each one once, under the agent it applies to.
+        warnings=warnings,
+    )
+
+
+def resolve_output_dir(config: CompareConfig) -> Path:
+    """`--output-dir`, defaulting to the candidate run's own directory.
+
+    The default resolves the candidate path the same way loading does, so the report lands next to
+    the metrics file that was actually read rather than at a same-named path under the cwd.
+    """
+    if config.output_dirpath:
+        return Path(config.output_dirpath)
+    return _resolve_under_cwd_or_install(config.candidate_rollouts_jsonl_fpaths[-1]).parent
+
+
+def write_reports(result: ComparisonResult, output_dir: Path, report_format: str) -> List[Path]:
+    """Write the requested artifacts, returning the paths written."""
+    if output_dir.exists() and not output_dir.is_dir():
+        raise ConfigError(f"--output-dir '{output_dir}' exists and is not a directory.")
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        raise ConfigError(f"Cannot write to --output-dir '{output_dir}': {e}") from e
+
+    written: List[Path] = []
+    if report_format in ("md", "both"):
+        markdown_fpath = output_dir / MARKDOWN_REPORT_NAME
+        markdown_fpath.write_text(render_markdown(result))
+        written.append(markdown_fpath)
+    if report_format in ("json", "both"):
+        json_fpath = output_dir / JSON_REPORT_NAME
+        json_fpath.write_bytes(orjson.dumps(result.model_dump(mode="json"), option=orjson.OPT_INDENT_2))
+        written.append(json_fpath)
+    return written
+
+
+def summary_lines(result: ComparisonResult, written: List[Path]) -> Tuple[str, ...]:
+    """The short stdout recap printed after the files are written."""
+    lines = [
+        f"Baseline:  {result.baseline.aggregate_metrics_fpath}",
+        *(f"Candidate: {run.aggregate_metrics_fpath}" for run in result.candidates),
+        f"Agents compared: {', '.join(sorted({c.baseline_agent for c in result.comparisons}))}",
+    ]
+    for comparison in result.comparisons:
+        for summary in comparison.flips:
+            if summary.mode == "binary":
+                lines.append(
+                    f"Sample flips: {summary.fail_to_pass_count} fail→pass, "
+                    f"{summary.pass_to_fail_count} pass→fail over {summary.common_task_count} common tasks"
+                )
+            elif summary.mode == "continuous":
+                lines.append(
+                    f"Per-task changes: {len(summary.flips)} of {summary.common_task_count} common tasks moved"
+                )
+            else:
+                lines.append(f"Sample flips unavailable: {summary.reason}")
+    lines += [f"Wrote: {path}" for path in written]
+    return tuple(lines)
+
+
+def _print_key_metrics_table(result: ComparisonResult) -> None:  # pragma: no cover
+    from rich.markup import escape
+    from rich.table import Table
+
+    from nemo_gym.compare.report import _fmt, _fmt_ci, _fmt_delta_cell
+
+    for comparison in result.comparisons:
+        table = Table(title=f"Key metrics — {comparison.baseline_agent}")
+        table.add_column("Metric")
+        table.add_column("Drop (cand - base)", justify="right")
+        table.add_column("Baseline", justify="right")
+        table.add_column("Baseline 95% CI")
+        table.add_column("Candidate", justify="right")
+        table.add_column("Candidate 95% CI")
+        for row in comparison.metrics:
+            if not row.is_key_metric:
+                continue
+            candidate = row.candidates[0] if row.candidates else None
+            # escape() so the `[avg-of-k]` in pass@k metric names isn't parsed as Rich markup.
+            table.add_row(
+                escape(row.metric),
+                _fmt_delta_cell(candidate),
+                _fmt(row.baseline.value if row.baseline else None),
+                _fmt_ci(row.baseline),
+                _fmt(candidate.value if candidate else None),
+                _fmt_ci(candidate),
+            )
+        print_rich_table(table)
+
+
+@exit_cleanly_on_config_error
+def compare() -> None:  # pragma: no cover
+    global_config_dict = get_global_config_dict(
+        global_config_dict_parser_config=GlobalConfigDictParserConfig(
+            initial_global_config_dict=GlobalConfigDictParserConfig.NO_MODEL_GLOBAL_CONFIG_DICT,
+        )
+    )
+    config = CompareConfig.model_validate(global_config_dict)
+
+    result = build_comparison_result(config, command=shlex.join(["gym", "compare", *sys.argv[1:]]))
+    written = write_reports(result, resolve_output_dir(config), config.report_format)
+
+    _print_key_metrics_table(result)
+    print("\n".join(summary_lines(result, written)))

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -78,6 +78,15 @@ def dispatch(target: str, overrides: list[str]) -> None:
     func()
 
 
+def _hydra_quote(value: str) -> str:
+    """Quote a value for Hydra's override grammar.
+
+    `ensure_ascii=False` because Hydra does not decode `\\uXXXX` escapes: letting json.dumps emit
+    them turns a path like `runs/café` into the literal characters `runs/caf\\u00e9`.
+    """
+    return json.dumps(value, ensure_ascii=False)
+
+
 def _value_flag(
     name: str,
     hydra_key: str,
@@ -92,7 +101,7 @@ def _value_flag(
     return Flag(
         register=lambda p: p.add_argument(f"--{name}", *aliases, dest=dest, choices=choices, help=flag_help),
         translate_to_hydra=lambda args: (
-            [f"+{hydra_key}={json.dumps(getattr(args, dest)) if quote else getattr(args, dest)}"]
+            [f"+{hydra_key}={_hydra_quote(getattr(args, dest)) if quote else getattr(args, dest)}"]
             if getattr(args, dest) is not None
             else []
         ),
@@ -105,6 +114,28 @@ def _bool_flag(name: str, hydra_key: str, flag_help: str) -> Flag:
     return Flag(
         register=lambda p: p.add_argument(f"--{name}", action="store_true", help=flag_help),
         translate_to_hydra=lambda args: [f"+{hydra_key}=true"] if getattr(args, dest) else [],
+    )
+
+
+def _comma_list_flag(name: str, hydra_key: str, flag_help: str, *, metavar: str) -> Flag:
+    """A `--name "A,B"` flag that maps to the Hydra override `+<hydra_key>=["A","B"]` (omitted when unset).
+
+    Each element is quoted because Hydra's unquoted list grammar rejects values containing a space,
+    `=` or `[`. A single flag taking a list (rather than a repeatable one) keeps a future N-valued
+    form identical to today's single-valued one.
+    """
+    dest = name.replace("-", "_")
+
+    def to_hydra(args: argparse.Namespace) -> list[str]:
+        raw = getattr(args, dest)
+        if raw is None:
+            return []
+        items = [item.strip() for item in raw.split(",") if item.strip()]
+        return [f"+{hydra_key}=[{','.join(_hydra_quote(item) for item in items)}]"]
+
+    return Flag(
+        register=lambda p: p.add_argument(f"--{name}", dest=dest, metavar=metavar, help=flag_help),
+        translate_to_hydra=to_hydra,
     )
 
 
@@ -881,6 +912,45 @@ COMMANDS = {
                 register=lambda p: p.add_argument(
                     "--dry-run", action="store_true", help="Print generated job scripts without submitting."
                 ),
+            ),
+        ),
+    ),
+    "compare": Command(
+        target="nemo_gym.cli.compare:compare",
+        summary="Compare a baseline eval run against a candidate run.",
+        flags=(
+            _value_flag(
+                "baseline",
+                "baseline_rollouts_jsonl_fpath",
+                "Baseline run's rollouts JSONL (its *_aggregate_metrics.json sibling is what gets read).",
+                quote=True,
+            ),
+            _comma_list_flag(
+                "candidates",
+                "candidate_rollouts_jsonl_fpaths",
+                "Candidate run's rollouts JSONL. Comma-separated list; one candidate is supported today.",
+                metavar="PATH[,PATH...]",
+            ),
+            _value_flag("agent", "agent_name", "Agent to compare on both sides (default: all shared agents)."),
+            _value_flag("baseline-agent", "baseline_agent_name", "Agent to read from the baseline's metrics."),
+            _comma_list_flag(
+                "candidate-agents",
+                "candidate_agent_names",
+                "Agent to read from each candidate's metrics, in --candidates order.",
+                metavar="NAME[,NAME...]",
+            ),
+            _value_flag(
+                "output-dir",
+                "output_dirpath",
+                "Where to write the report (default: the candidate run's own directory).",
+                aliases=("-o",),
+                quote=True,
+            ),
+            _value_flag(
+                "report-format",
+                "report_format",
+                "Report artifacts to write (default: both).",
+                choices=("md", "json", "both"),
             ),
         ),
     ),

--- a/nemo_gym/compare/__init__.py
+++ b/nemo_gym/compare/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Baseline-vs-candidate comparison of eval runs."""

--- a/nemo_gym/compare/diff.py
+++ b/nemo_gym/compare/diff.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Diffing two loaded runs: metric rows and per-task sample flips.
+
+Pure computation -- no filesystem access, no statistics. Confidence intervals are read verbatim
+from what the runs already recorded; nothing here estimates, tests, or judges.
+"""
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from nemo_gym.compare.loading import (
+    CI_HIGH_PREFIX,
+    CI_LOW_PREFIX,
+    MEAN_ACROSS_REPEATS_PREFIX,
+    SE_PREFIX,
+    STD_ERR_ACROSS_RUNS_SUFFIX,
+    LoadedRun,
+)
+from nemo_gym.compare.schema import (
+    AgentComparison,
+    CandidateMetricValue,
+    FlipSummary,
+    MetricRow,
+    MetricValue,
+    TaskFlip,
+)
+from nemo_gym.config_types import ConfigError
+from nemo_gym.global_config import ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
+
+
+# Dispersion companions of a `mean/<field>` metric. They are summary statistics of the same
+# underlying field, not metrics in their own right, so they never get their own row.
+_DISPERSION_PREFIXES = (
+    "median/",
+    "std/",
+    "min/",
+    "max/",
+    "p25/",
+    "p75/",
+    "sem/",
+    "ci_low_95/",
+    "ci_high_95/",
+)
+# The cross-repeat family is consumed as CI columns, not as rows.
+_ACROSS_REPEATS_MARKER = "_across_repeats/"
+_STAT_SUFFIXES = ("/std_dev_across_runs", STD_ERR_ACROSS_RUNS_SUFFIX)
+
+# The per-task field flips are computed from. Every verify response carries `reward` at minimum.
+FLIP_FIELD = "reward"
+_TASK_MEAN_KEY = f"mean/{FLIP_FIELD}"
+_TASK_MIN_KEY = f"min/{FLIP_FIELD}"
+_TASK_MAX_KEY = f"max/{FLIP_FIELD}"
+# A task "passes" when the majority of its repeats scored a pass.
+_PASS_THRESHOLD = 0.5
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _numeric(value: Any) -> Optional[float]:
+    return float(value) if _is_number(value) else None
+
+
+def is_comparable_metric(name: str) -> bool:
+    """Whether an `agent_metrics` key earns its own row in the all-metrics table."""
+    if name.startswith(_DISPERSION_PREFIXES):
+        return False
+    if _ACROSS_REPEATS_MARKER in name:
+        return False
+    return not name.endswith(_STAT_SUFFIXES)
+
+
+def _ordered_metric_names(baseline: Dict[str, Any], candidates: Sequence[Dict[str, Any]]) -> List[str]:
+    """Baseline order first (it is the reference), then anything only the candidates reported."""
+    names = [name for name in baseline if _is_number(baseline[name])]
+    seen = set(names)
+    for metrics in candidates:
+        for name in metrics:
+            if name not in seen and _is_number(metrics[name]):
+                names.append(name)
+                seen.add(name)
+    return names
+
+
+def _metric_value(metrics: Dict[str, Any], name: str) -> Optional[MetricValue]:
+    value = _numeric(metrics.get(name))
+    if value is None:
+        return None
+    return MetricValue(
+        value=value,
+        ci_low=_numeric(metrics.get(f"{CI_LOW_PREFIX}{name}")),
+        ci_high=_numeric(metrics.get(f"{CI_HIGH_PREFIX}{name}")),
+        se_across_repeats=_numeric(metrics.get(f"{SE_PREFIX}{name}")),
+        mean_across_repeats=_numeric(metrics.get(f"{MEAN_ACROSS_REPEATS_PREFIX}{name}")),
+        std_err_across_runs=_numeric(metrics.get(f"{name}{STD_ERR_ACROSS_RUNS_SUFFIX}")),
+    )
+
+
+def _candidate_metric_value(
+    metrics: Dict[str, Any], name: str, baseline_value: Optional[float]
+) -> Optional[CandidateMetricValue]:
+    base = _metric_value(metrics, name)
+    if base is None:
+        return None
+    delta = None if baseline_value is None else base.value - baseline_value
+    delta_pct = None if delta is None or not baseline_value else delta / abs(baseline_value) * 100.0
+    return CandidateMetricValue(**base.model_dump(), delta=delta, delta_pct=delta_pct)
+
+
+def build_metric_rows(baseline: LoadedRun, candidates: Sequence[LoadedRun]) -> List[MetricRow]:
+    """One row per metric reported by any side, key metrics flagged."""
+    candidate_metrics = [run.agent_metrics for run in candidates]
+    key_metric_names = set(baseline.key_metrics) | {name for run in candidates for name in run.key_metrics}
+
+    rows: List[MetricRow] = []
+    for name in _ordered_metric_names(baseline.agent_metrics, candidate_metrics):
+        if not is_comparable_metric(name):
+            continue
+        baseline_value = _metric_value(baseline.agent_metrics, name)
+        candidate_values = [
+            _candidate_metric_value(metrics, name, baseline_value.value if baseline_value else None)
+            for metrics in candidate_metrics
+        ]
+        present_in = ["baseline"] if baseline_value else []
+        present_in += [f"candidate[{i}]" for i, value in enumerate(candidate_values) if value is not None]
+        rows.append(
+            MetricRow(
+                metric=name,
+                is_key_metric=name in key_metric_names,
+                present_in=present_in,
+                baseline=baseline_value,
+                candidates=candidate_values,
+            )
+        )
+    return rows
+
+
+def _groups_by_task(run: LoadedRun) -> Dict[int, Dict[str, Any]]:
+    return {group[TASK_INDEX_KEY_NAME]: group for group in run.group_level_metrics if TASK_INDEX_KEY_NAME in group}
+
+
+def _per_repeat_rewards(group: Dict[str, Any]) -> Optional[List[float]]:
+    rollout_infos = group.get("rollout_infos")
+    if not isinstance(rollout_infos, list) or not rollout_infos:
+        return None
+    ordered = sorted(rollout_infos, key=lambda info: info.get(ROLLOUT_INDEX_KEY_NAME, 0))
+    rewards = [_numeric(info.get(FLIP_FIELD)) for info in ordered]
+    return None if any(reward is None for reward in rewards) else [reward for reward in rewards if reward is not None]
+
+
+def _looks_binary(
+    common: Sequence[int], baseline_groups: Dict[int, Dict[str, Any]], candidate_groups: Dict[int, Dict[str, Any]]
+) -> bool:
+    """Whether every observed reward on both sides is exactly 0 or 1.
+
+    Uses each task's recorded min/max where available so a task whose repeats disagree (mean 0.5)
+    is still recognised as binary.
+    """
+    for task_index in common:
+        for groups in (baseline_groups, candidate_groups):
+            group = groups[task_index]
+            observed = [group.get(_TASK_MIN_KEY), group.get(_TASK_MAX_KEY)]
+            if all(value is None for value in observed):
+                observed = [group.get(_TASK_MEAN_KEY)]
+            for value in observed:
+                number = _numeric(value)
+                if number is None or number not in (0.0, 1.0):
+                    return False
+    return True
+
+
+def _flip_direction(baseline_score: float, candidate_score: float) -> Optional[str]:
+    baseline_passed = baseline_score > _PASS_THRESHOLD
+    candidate_passed = candidate_score > _PASS_THRESHOLD
+    if baseline_score == _PASS_THRESHOLD or candidate_score == _PASS_THRESHOLD:
+        return None
+    if baseline_passed and not candidate_passed:
+        return "pass_to_fail"
+    if candidate_passed and not baseline_passed:
+        return "fail_to_pass"
+    return None
+
+
+def build_flip_summary(baseline: LoadedRun, candidate: LoadedRun, *, candidate_index: int = 0) -> FlipSummary:
+    """Per-task movement between the two runs, joined on task index.
+
+    `*_aggregate_metrics.json` carries no task identity, so tasks are matched by
+    `_ng_task_index` alone -- which assumes both runs used the same dataset, split, limit and
+    ordering.
+    """
+    baseline_groups = _groups_by_task(baseline)
+    candidate_groups = _groups_by_task(candidate)
+    common = sorted(set(baseline_groups) & set(candidate_groups))
+    counts = {
+        "common_task_count": len(common),
+        "baseline_only_task_count": len(set(baseline_groups) - set(candidate_groups)),
+        "candidate_only_task_count": len(set(candidate_groups) - set(baseline_groups)),
+    }
+
+    if not baseline_groups or not candidate_groups:
+        return FlipSummary(
+            candidate_index=candidate_index,
+            mode="unavailable",
+            reason="one or both runs recorded no per-task metrics.",
+            **counts,
+        )
+    if not common:
+        return FlipSummary(
+            candidate_index=candidate_index,
+            mode="unavailable",
+            reason=(
+                f"no overlapping task indices (baseline has {len(baseline_groups)}, "
+                f"candidate has {len(candidate_groups)})."
+            ),
+            **counts,
+        )
+
+    scored: List[Tuple[int, float, float]] = []
+    for task_index in common:
+        baseline_score = _numeric(baseline_groups[task_index].get(_TASK_MEAN_KEY))
+        candidate_score = _numeric(candidate_groups[task_index].get(_TASK_MEAN_KEY))
+        if baseline_score is not None and candidate_score is not None:
+            scored.append((task_index, baseline_score, candidate_score))
+
+    if not scored:
+        return FlipSummary(
+            candidate_index=candidate_index,
+            mode="unavailable",
+            reason=f"no `{_TASK_MEAN_KEY}` recorded for the overlapping tasks.",
+            **counts,
+        )
+
+    def flip(task_index: int, baseline_score: float, candidate_score: float, direction: str) -> TaskFlip:
+        return TaskFlip(
+            task_index=task_index,
+            baseline_score=baseline_score,
+            candidate_score=candidate_score,
+            delta=candidate_score - baseline_score,
+            direction=direction,  # type: ignore[arg-type]
+            baseline_rewards=_per_repeat_rewards(baseline_groups[task_index]),
+            candidate_rewards=_per_repeat_rewards(candidate_groups[task_index]),
+        )
+
+    if not _looks_binary([task_index for task_index, _, _ in scored], baseline_groups, candidate_groups):
+        movers = [
+            flip(task_index, baseline_score, candidate_score, "changed")
+            for task_index, baseline_score, candidate_score in scored
+            if candidate_score != baseline_score
+        ]
+        movers.sort(key=lambda item: (-abs(item.delta), item.task_index))
+        return FlipSummary(
+            candidate_index=candidate_index,
+            mode="continuous",
+            unchanged_count=len(scored) - len(movers),
+            flips=movers,
+            **counts,
+        )
+
+    flips: List[TaskFlip] = []
+    tied = unchanged = 0
+    for task_index, baseline_score, candidate_score in scored:
+        direction = _flip_direction(baseline_score, candidate_score)
+        if direction is None:
+            if _PASS_THRESHOLD in (baseline_score, candidate_score):
+                tied += 1
+            else:
+                unchanged += 1
+            continue
+        flips.append(flip(task_index, baseline_score, candidate_score, direction))
+
+    # Regressions first, then by how far the task moved.
+    flips.sort(key=lambda item: (item.direction != "pass_to_fail", -abs(item.delta), item.task_index))
+    pass_to_fail = sum(1 for item in flips if item.direction == "pass_to_fail")
+    fail_to_pass = len(flips) - pass_to_fail
+    return FlipSummary(
+        candidate_index=candidate_index,
+        mode="binary",
+        pass_to_fail_count=pass_to_fail,
+        fail_to_pass_count=fail_to_pass,
+        tied_count=tied,
+        unchanged_count=unchanged,
+        net=fail_to_pass - pass_to_fail,
+        flips=flips,
+        **counts,
+    )
+
+
+def compare_runs(baseline: LoadedRun, candidates: Sequence[LoadedRun]) -> AgentComparison:
+    """Build one agent's comparison block: metric rows, flips, and anything worth flagging."""
+    rows = build_metric_rows(baseline, candidates)
+    if not any(row.baseline is not None and any(row.candidates) for row in rows):
+        baseline_only = sorted(row.metric for row in rows if row.baseline is not None)[:5]
+        candidate_only = sorted(row.metric for row in rows if row.baseline is None)[:5]
+        raise ConfigError(
+            "Baseline and candidate share no metric keys, so there is nothing to compare.\n"
+            f"  baseline-only (first 5): {', '.join(baseline_only) or 'none'}\n"
+            f"  candidate-only (first 5): {', '.join(candidate_only) or 'none'}\n"
+            "Runs collected with different --num-repeats produce different pass@k metric names."
+        )
+
+    notes: List[str] = []
+    repeat_counts = [run.num_repeats for run in candidates]
+    if baseline.num_repeats is not None and any(
+        count is not None and count != baseline.num_repeats for count in repeat_counts
+    ):
+        notes.append(
+            f"Repeat counts differ (baseline {baseline.num_repeats}, "
+            f"candidate {', '.join(str(count) for count in repeat_counts)}). Metric names that embed k "
+            "(e.g. pass@1[avg-of-k]) will not line up across the runs."
+        )
+    if not baseline.has_repeat_cis and not any(run.has_repeat_cis for run in candidates):
+        notes.append(
+            "Neither run recorded cross-repeat confidence intervals, so every CI cell is empty. "
+            "They are written for `mean/*` metrics when a run has 2 or more repeats."
+        )
+    one_sided = [row.metric for row in rows if len(row.present_in) < 1 + len(candidates)]
+    if one_sided:
+        notes.append(f"{len(one_sided)} metric(s) were reported by only one of the runs.")
+
+    return AgentComparison(
+        baseline_agent=baseline.agent_name,
+        candidate_agents=[run.agent_name for run in candidates],
+        baseline_task_count=baseline.num_tasks,
+        candidate_task_counts=[run.num_tasks for run in candidates],
+        baseline_repeat_count=baseline.num_repeats,
+        candidate_repeat_counts=list(repeat_counts),
+        metrics=rows,
+        flips=[build_flip_summary(baseline, run, candidate_index=index) for index, run in enumerate(candidates)],
+        notes=notes,
+    )

--- a/nemo_gym/compare/loading.py
+++ b/nemo_gym/compare/loading.py
@@ -1,0 +1,315 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reading `*_aggregate_metrics.json` for `gym compare`, and picking which agent to compare.
+
+All filesystem I/O for the compare feature lives here. The rollouts JSONL a user points at is
+never opened: it is the run's identity and the handle its `_aggregate_metrics.json` sibling is
+derived from.
+"""
+
+import difflib
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, FrozenSet, List, Literal, Optional, Sequence, Tuple
+
+import orjson
+
+from nemo_gym import _resolve_under_cwd_or_install
+from nemo_gym.config_types import ConfigError, ConfigPathNotFoundError
+from nemo_gym.global_config import AGENT_REF_KEY_NAME, TASK_INDEX_KEY_NAME
+from nemo_gym.path_utils import aggregate_metrics_path_for
+
+
+RunRole = Literal["baseline", "candidate"]
+
+# Prefix of the cross-repeat confidence-interval keys merged into `agent_metrics`. Only written for
+# `mean/*` metrics on runs with >= 2 repeats, and only by runs collected after repeat-level metrics
+# landed -- so its absence is normal, not an error.
+CI_LOW_PREFIX = "ci_low_95_across_repeats/"
+CI_HIGH_PREFIX = "ci_high_95_across_repeats/"
+SE_PREFIX = "se_across_repeats/"
+MEAN_ACROSS_REPEATS_PREFIX = "mean_across_repeats/"
+STD_ERR_ACROSS_RUNS_SUFFIX = "/std_err_across_runs"
+
+
+@dataclass(frozen=True)
+class RunFile:
+    """A parsed `*_aggregate_metrics.json`, indexed by agent name."""
+
+    role: RunRole
+    index: int
+    flag_label: str
+    rollouts_jsonl_fpath: Path
+    aggregate_metrics_fpath: Path
+    entries_by_agent: Dict[str, Dict[str, Any]]
+
+    @property
+    def agent_names(self) -> List[str]:
+        return sorted(self.entries_by_agent)
+
+
+@dataclass(frozen=True)
+class LoadedRun:
+    """One side of the comparison, narrowed to a single agent."""
+
+    role: RunRole
+    index: int
+    label: str
+    rollouts_jsonl_fpath: Path
+    aggregate_metrics_fpath: Path
+    available_agent_names: Tuple[str, ...]
+    agent_name: str
+    agent_metrics: Dict[str, Any]
+    key_metrics: Dict[str, Any]
+    group_level_metrics: List[Dict[str, Any]]
+    repeat_level_metrics: List[Dict[str, Any]] = field(default_factory=list)
+    num_tasks: int = 0
+    num_repeats: Optional[int] = None
+    task_indices: FrozenSet[int] = frozenset()
+    has_rollout_infos: bool = False
+    has_repeat_cis: bool = False
+
+
+@dataclass(frozen=True)
+class AgentSelection:
+    """Which agent to read from each side for one comparison block."""
+
+    baseline_agent: str
+    candidate_agents: Tuple[str, ...]
+
+
+def resolve_aggregate_metrics_fpath(rollouts_jsonl_fpath: Path, override: Optional[str]) -> Path:
+    """The `*_aggregate_metrics.json` to read: the explicit override, else the derived sibling."""
+    if override:
+        return _resolve_under_cwd_or_install(override)
+    return aggregate_metrics_path_for(rollouts_jsonl_fpath)
+
+
+def _read_agent_entries(metrics_fpath: Path) -> Dict[str, Dict[str, Any]]:
+    try:
+        raw = metrics_fpath.read_bytes()
+    except OSError as e:
+        # `exists()` is true for a directory and for a file the user cannot read, so the guard in
+        # load_run_file lets both through to here. Convert rather than surfacing a raw traceback.
+        raise ConfigError(f"Cannot read aggregate metrics at '{metrics_fpath}': {e}") from e
+
+    try:
+        payload = orjson.loads(raw)
+    except orjson.JSONDecodeError as e:
+        raise ConfigError(f"'{metrics_fpath}' is not valid JSON: {e}") from e
+
+    if not isinstance(payload, list):
+        raise ConfigError(
+            f"'{metrics_fpath}' is not a valid aggregate-metrics file (expected a JSON list of per-agent entries)."
+        )
+    if not payload:
+        raise ConfigError(f"'{metrics_fpath}' contains no agent entries.")
+
+    entries: Dict[str, Dict[str, Any]] = {}
+    for position, entry in enumerate(payload):
+        if not isinstance(entry, dict):
+            raise ConfigError(
+                f"'{metrics_fpath}' entry {position} is not an object (expected a JSON list of per-agent entries)."
+            )
+        agent_name = (entry.get(AGENT_REF_KEY_NAME) or {}).get("name")
+        if not agent_name:
+            raise ConfigError(f"'{metrics_fpath}' entry {position} has no `{AGENT_REF_KEY_NAME}.name`.")
+        if agent_name in entries:
+            raise ConfigError(f"'{metrics_fpath}' contains two entries for agent '{agent_name}'.")
+        entries[agent_name] = entry
+    return entries
+
+
+def load_run_file(
+    rollouts_jsonl_fpath: str,
+    *,
+    role: RunRole,
+    index: int = 0,
+    flag_label: str,
+    aggregate_metrics_fpath_override: Optional[str] = None,
+) -> RunFile:
+    """Resolve and parse one run's `*_aggregate_metrics.json`."""
+    rollouts_path = _resolve_under_cwd_or_install(rollouts_jsonl_fpath)
+    metrics_path = resolve_aggregate_metrics_fpath(rollouts_path, aggregate_metrics_fpath_override)
+
+    if not metrics_path.exists():
+        if not rollouts_path.exists():
+            raise ConfigPathNotFoundError(
+                f"Run not found: '{rollouts_path}' ({flag_label}). Check the path is spelled correctly."
+            )
+        raise ConfigPathNotFoundError(
+            f"Aggregate metrics not found: '{metrics_path}', derived from '{rollouts_path}' ({flag_label}). "
+            "The run may have been collected with --disable-aggregation: run `gym eval aggregate` first, "
+            "or point at the metrics file directly with "
+            f"+{'baseline_aggregate_metrics_fpath' if role == 'baseline' else 'candidate_aggregate_metrics_fpaths'}."
+        )
+
+    return RunFile(
+        role=role,
+        index=index,
+        flag_label=flag_label,
+        rollouts_jsonl_fpath=rollouts_path,
+        aggregate_metrics_fpath=metrics_path,
+        entries_by_agent=_read_agent_entries(metrics_path),
+    )
+
+
+def _sole_agent(run_file: RunFile, flag_hint: str) -> str:
+    if len(run_file.entries_by_agent) == 1:
+        return next(iter(run_file.entries_by_agent))
+    raise ConfigError(
+        f"'{run_file.aggregate_metrics_fpath}' ({run_file.flag_label}) contains "
+        f"{len(run_file.entries_by_agent)} agents: {', '.join(run_file.agent_names)}. "
+        f"Pass {flag_hint} to choose one."
+    )
+
+
+def _require_agent(run_file: RunFile, agent_name: str, flag_label: str) -> None:
+    if agent_name not in run_file.entries_by_agent:
+        # Same " Did you mean `X`?" shape the CLI uses for unknown component names, inlined so the
+        # compare package stays independent of `nemo_gym.cli`.
+        close = difflib.get_close_matches(agent_name, run_file.agent_names, n=1)
+        raise ConfigError(
+            f"Agent '{agent_name}' ({flag_label}) is not in '{run_file.aggregate_metrics_fpath}'. "
+            f"Available: {', '.join(run_file.agent_names)}." + (f" Did you mean `{close[0]}`?" if close else "")
+        )
+
+
+def resolve_agent_selections(
+    baseline_file: RunFile,
+    candidate_files: Sequence[RunFile],
+    *,
+    agent_name: Optional[str] = None,
+    baseline_agent_name: Optional[str] = None,
+    candidate_agent_names: Optional[Sequence[str]] = None,
+) -> Tuple[List[AgentSelection], List[str], Dict[str, List[str]]]:
+    """Decide which agent to read from each side.
+
+    Precedence is most-specific-first: a per-side flag beats `--agent`, which beats the default
+    full join over agent names common to every run. Returns the selections, any warnings, and the
+    agents that were present but not compared (keyed by run label).
+    """
+    warnings: List[str] = []
+    skipped: Dict[str, List[str]] = {}
+    per_side_given = baseline_agent_name is not None or candidate_agent_names is not None
+
+    if per_side_given:
+        baseline_agent = baseline_agent_name or agent_name or _sole_agent(baseline_file, "--baseline-agent")
+        _require_agent(baseline_file, baseline_agent, "--baseline-agent" if baseline_agent_name else "--agent")
+        candidates: List[str] = []
+        for position, run_file in enumerate(candidate_files):
+            explicit = candidate_agent_names[position] if candidate_agent_names else None
+            candidate_agent = explicit or agent_name or _sole_agent(run_file, "--candidate-agents")
+            _require_agent(run_file, candidate_agent, "--candidate-agents" if explicit else "--agent")
+            candidates.append(candidate_agent)
+        return [AgentSelection(baseline_agent, tuple(candidates))], warnings, skipped
+
+    if agent_name:
+        for run_file in (baseline_file, *candidate_files):
+            _require_agent(run_file, agent_name, "--agent")
+        return [AgentSelection(agent_name, tuple(agent_name for _ in candidate_files))], warnings, skipped
+
+    matched = set(baseline_file.entries_by_agent)
+    for run_file in candidate_files:
+        matched &= set(run_file.entries_by_agent)
+
+    if not matched:
+        listing = "\n".join(
+            f"  {run_file.role} ({run_file.aggregate_metrics_fpath}): {', '.join(run_file.agent_names)}"
+            for run_file in (baseline_file, *candidate_files)
+        )
+        raise ConfigError(
+            "No agent name is present in every run, so there is nothing to compare.\n"
+            f"{listing}\n"
+            "Pass --agent NAME to force one agent on both sides, or --baseline-agent / --candidate-agents "
+            "to pick a different agent per side."
+        )
+
+    for run_file in (baseline_file, *candidate_files):
+        extras = sorted(set(run_file.entries_by_agent) - matched)
+        if extras:
+            label = f"{run_file.role}[{run_file.index}]" if run_file.role == "candidate" else run_file.role
+            skipped[label] = extras
+            warnings.append(f"Agent(s) {', '.join(extras)} are present only in {label} and were not compared.")
+
+    return (
+        [AgentSelection(name, tuple(name for _ in candidate_files)) for name in sorted(matched)],
+        warnings,
+        skipped,
+    )
+
+
+def _derive_num_repeats(
+    group_level_metrics: List[Dict[str, Any]],
+    repeat_level_metrics: List[Dict[str, Any]],
+    num_agents_in_file: int,
+) -> Optional[int]:
+    """Best available repeat count, most broadly-supported source first.
+
+    `expected_num_rollouts` is present on every generation of the file, so it is tried first.
+    `repeat_level_metrics` is only usable when the file holds a single agent: aggregation writes a
+    hardcoded placeholder agent name there, so entries cannot be attributed to a real agent.
+    """
+    expected = Counter(
+        group["expected_num_rollouts"]
+        for group in group_level_metrics
+        if isinstance(group.get("expected_num_rollouts"), int)
+    )
+    if expected:
+        return expected.most_common(1)[0][0]
+    if repeat_level_metrics and num_agents_in_file == 1:
+        return len(repeat_level_metrics)
+    rollout_counts = [
+        len(group["rollout_infos"]) for group in group_level_metrics if isinstance(group.get("rollout_infos"), list)
+    ]
+    return max(rollout_counts) if rollout_counts else None
+
+
+def build_loaded_run(run_file: RunFile, agent_name: str, *, label: str) -> LoadedRun:
+    """Narrow a parsed run file to one agent."""
+    entry = run_file.entries_by_agent[agent_name]
+    agent_metrics = entry.get("agent_metrics") or {}
+    group_level_metrics = entry.get("group_level_metrics") or []
+    repeat_level_metrics = entry.get("repeat_level_metrics") or []
+
+    return LoadedRun(
+        role=run_file.role,
+        index=run_file.index,
+        label=label,
+        rollouts_jsonl_fpath=run_file.rollouts_jsonl_fpath,
+        aggregate_metrics_fpath=run_file.aggregate_metrics_fpath,
+        available_agent_names=tuple(run_file.agent_names),
+        agent_name=agent_name,
+        agent_metrics=agent_metrics,
+        key_metrics=entry.get("key_metrics") or {},
+        group_level_metrics=group_level_metrics,
+        repeat_level_metrics=repeat_level_metrics,
+        num_tasks=len(group_level_metrics),
+        num_repeats=_derive_num_repeats(group_level_metrics, repeat_level_metrics, len(run_file.entries_by_agent)),
+        task_indices=frozenset(
+            group[TASK_INDEX_KEY_NAME] for group in group_level_metrics if TASK_INDEX_KEY_NAME in group
+        ),
+        has_rollout_infos=any(isinstance(group.get("rollout_infos"), list) for group in group_level_metrics),
+        has_repeat_cis=any(key.startswith(CI_LOW_PREFIX) for key in agent_metrics),
+    )
+
+
+def run_labels(rollouts_paths: Sequence[Path]) -> List[str]:
+    """Short, unique display labels for the runs -- their parent directory names where that suffices."""
+    labels = [path.parent.name or path.stem for path in rollouts_paths]
+    if len(set(labels)) == len(labels):
+        return labels
+    return [str(Path(path.parent.parent.name) / (path.parent.name or path.stem)) for path in rollouts_paths]

--- a/nemo_gym/compare/report.py
+++ b/nemo_gym/compare/report.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Markdown rendering of a `ComparisonResult`.
+
+A pure function of the result object, so what the statistics layer eventually adds to the schema
+is the only thing that changes what this prints.
+"""
+
+from typing import List, Optional, Sequence
+
+from nemo_gym.compare.schema import (
+    AgentComparison,
+    ComparisonResult,
+    FlipSummary,
+    MetricRow,
+    MetricValue,
+    RunRef,
+)
+
+
+MISSING = "—"
+# Flips shown per direction in the markdown; the JSON always carries the full list.
+MAX_FLIPS_SHOWN = 10
+
+CI_FOOTNOTE = (
+    "CI = 95% t-interval of the per-repeat mean across repeats, read verbatim from "
+    "`ci_{low,high}_95_across_repeats/<metric>` in `*_aggregate_metrics.json`. "
+    f"`{MISSING}` means no interval was written: the metric is not a `mean/*` field, the run has fewer "
+    "than 2 repeats, or the run predates repeat-level metrics. Units differ by family — `pass@*` and "
+    "`majority@*` are on 0–100, `mean/*` are in the verifier's own units."
+)
+
+
+def _fmt(value: Optional[float]) -> str:
+    if value is None:
+        return MISSING
+    return f"{value:.4f}" if abs(value) < 10 else f"{value:.2f}"
+
+
+def _fmt_signed(value: Optional[float]) -> str:
+    if value is None:
+        return MISSING
+    return f"{value:+.4f}" if abs(value) < 10 else f"{value:+.2f}"
+
+
+def _fmt_ci(value: Optional[MetricValue]) -> str:
+    if value is None or value.ci_low is None or value.ci_high is None:
+        return MISSING
+    return f"[{_fmt(value.ci_low)}, {_fmt(value.ci_high)}]"
+
+
+def _fmt_delta_cell(candidate) -> str:
+    if candidate is None or candidate.delta is None:
+        return MISSING
+    if candidate.delta_pct is None:
+        return f"{_fmt_signed(candidate.delta)} (n/a)"
+    return f"{_fmt_signed(candidate.delta)} ({candidate.delta_pct:+.1f}%)"
+
+
+def _fmt_rewards(rewards: Optional[Sequence[float]]) -> str:
+    if not rewards:
+        return MISSING
+    return ", ".join(f"{reward:g}" for reward in rewards)
+
+
+def _table(header: Sequence[str], alignments: Sequence[str], rows: Sequence[Sequence[str]]) -> List[str]:
+    return [
+        "| " + " | ".join(header) + " |",
+        "|" + "|".join(alignments) + "|",
+        *("| " + " | ".join(row) + " |" for row in rows),
+    ]
+
+
+def _candidate_labels(result: ComparisonResult) -> List[str]:
+    if len(result.candidates) == 1:
+        return ["Candidate"]
+    return [f"Candidate {index + 1}" for index in range(len(result.candidates))]
+
+
+def _run_summary_table(result: ComparisonResult, comparison: AgentComparison) -> List[str]:
+    labels = _candidate_labels(result)
+
+    def row(name: str, baseline_cell: str, candidate_cells: Sequence[str]) -> List[str]:
+        return [name, baseline_cell, *candidate_cells]
+
+    runs: Sequence[RunRef] = result.candidates
+    rows = [
+        row("Run", f"`{result.baseline.label}`", [f"`{run.label}`" for run in runs]),
+        row(
+            "Rollouts",
+            f"`{result.baseline.rollouts_jsonl_fpath}`",
+            [f"`{run.rollouts_jsonl_fpath}`" for run in runs],
+        ),
+        row(
+            "Aggregate metrics",
+            f"`{result.baseline.aggregate_metrics_fpath}`",
+            [f"`{run.aggregate_metrics_fpath}`" for run in runs],
+        ),
+        row(
+            "Agent",
+            f"`{comparison.baseline_agent}`",
+            [f"`{agent}`" for agent in comparison.candidate_agents],
+        ),
+        row("Tasks", str(comparison.baseline_task_count), [str(count) for count in comparison.candidate_task_counts]),
+        row(
+            "Repeats",
+            str(comparison.baseline_repeat_count if comparison.baseline_repeat_count is not None else "unknown"),
+            [str(count if count is not None else "unknown") for count in comparison.candidate_repeat_counts],
+        ),
+    ]
+    header = ["", "Baseline", *labels]
+    alignments = ["---"] * len(header)
+    return _table(header, alignments, rows)
+
+
+def _metric_table(rows: Sequence[MetricRow], candidate_labels: Sequence[str]) -> List[str]:
+    header = ["Metric", "Drop (cand − base)"]
+    alignments = ["---", "---:"]
+    header += ["Baseline", "Baseline 95% CI"]
+    alignments += ["---:", "---"]
+    for label in candidate_labels:
+        header += [label, f"{label} 95% CI"]
+        alignments += ["---:", "---"]
+
+    table_rows = []
+    for row in rows:
+        cells = [f"`{row.metric}`", " / ".join(_fmt_delta_cell(candidate) for candidate in row.candidates)]
+        cells += [_fmt(row.baseline.value if row.baseline else None), _fmt_ci(row.baseline)]
+        for candidate in row.candidates:
+            cells += [_fmt(candidate.value if candidate else None), _fmt_ci(candidate)]
+        table_rows.append(cells)
+    return _table(header, alignments, table_rows)
+
+
+def _flip_section(summary: FlipSummary, label: str) -> List[str]:
+    lines = [f"### Sample flips{label}", ""]
+    if summary.mode == "unavailable":
+        lines += [f"Not available: {summary.reason}", ""]
+        return lines
+
+    if summary.mode == "binary":
+        lines += [
+            f"Field: `{summary.field}` (task mean over its repeats). A task passes when its mean is above 0.5.",
+            "",
+            f"**{summary.common_task_count} common tasks · {summary.pass_to_fail_count} pass→fail · "
+            f"{summary.fail_to_pass_count} fail→pass · net {summary.net:+d} · "
+            f"{summary.unchanged_count} unchanged · {summary.tied_count} tied**",
+            "",
+        ]
+    else:
+        lines += [
+            f"Rewards are not binary, so this lists the largest per-task changes in `{summary.field}` rather "
+            "than pass/fail flips.",
+            "",
+            f"**{summary.common_task_count} common tasks · {len(summary.flips)} changed · "
+            f"{summary.unchanged_count} unchanged**",
+            "",
+        ]
+
+    shown = _select_shown_flips(summary)
+    if shown:
+        lines += _table(
+            ["Task", "Direction", "Baseline", "Candidate", "Δ", "Baseline per-repeat", "Candidate per-repeat"],
+            ["---:", "---", "---:", "---:", "---:", "---", "---"],
+            [
+                [
+                    str(flip.task_index),
+                    flip.direction.replace("_to_", "→"),
+                    _fmt(flip.baseline_score),
+                    _fmt(flip.candidate_score),
+                    _fmt_signed(flip.delta),
+                    _fmt_rewards(flip.baseline_rewards),
+                    _fmt_rewards(flip.candidate_rewards),
+                ]
+                for flip in shown
+            ],
+        )
+        remaining = len(summary.flips) - len(shown)
+        if remaining > 0:
+            lines += ["", f"… and {remaining} more (full list in `compare_report.json`)."]
+        lines.append("")
+
+    lines += [
+        "Tasks are joined on `_ng_task_index`. `*_aggregate_metrics.json` carries no task identity, so flips "
+        "are reported by index only — this assumes both runs used the same dataset, split, `--limit` and "
+        "ordering.",
+        "",
+    ]
+    return lines
+
+
+def _select_shown_flips(summary: FlipSummary) -> List:
+    """At most `MAX_FLIPS_SHOWN` per direction, keeping the ordering `build_flip_summary` chose."""
+    shown = []
+    per_direction: dict = {}
+    for flip in summary.flips:
+        count = per_direction.get(flip.direction, 0)
+        if count >= MAX_FLIPS_SHOWN:
+            continue
+        per_direction[flip.direction] = count + 1
+        shown.append(flip)
+    return shown
+
+
+def render_markdown(result: ComparisonResult) -> str:
+    candidate_labels = _candidate_labels(result)
+    lines: List[str] = ["# gym compare", ""]
+
+    for comparison in result.comparisons:
+        if len(result.comparisons) > 1:
+            lines += [f"## Agent: `{comparison.baseline_agent}`", ""]
+        lines += _run_summary_table(result, comparison)
+        lines += [
+            "",
+            f"Generated {result.generated_at} by nemo-gym {result.nemo_gym_version}.",
+            "",
+            f"Command: `{result.command}`",
+            "",
+        ]
+
+        key_rows = [row for row in comparison.metrics if row.is_key_metric]
+        other_rows = [row for row in comparison.metrics if not row.is_key_metric]
+
+        lines += ["### Key metrics", ""]
+        if key_rows:
+            lines += _metric_table(key_rows, candidate_labels)
+        else:
+            lines += ["No key metrics were recorded for this agent."]
+        lines += ["", CI_FOOTNOTE, ""]
+
+        if other_rows:
+            lines += [
+                "<details>",
+                f"<summary>All other metrics ({len(other_rows)} rows)</summary>",
+                "",
+                *_metric_table(other_rows, candidate_labels),
+                "",
+                "</details>",
+                "",
+            ]
+
+        for index, summary in enumerate(comparison.flips):
+            label = f" — {candidate_labels[index]}" if len(comparison.flips) > 1 else ""
+            lines += _flip_section(summary, label)
+
+        one_sided = [row for row in comparison.metrics if len(row.present_in) < 1 + len(result.candidates)]
+        if one_sided:
+            lines += [
+                "### Metrics present in only one run",
+                "",
+                "Metric names embed the repeat count (`pass@1[avg-of-3]` vs `pass@1[avg-of-5]`), so runs "
+                "collected with different `--num-repeats` will not line these up.",
+                "",
+                *(
+                    f"- `{row.metric}` — {', '.join(row.present_in) or 'no numeric value on either side'}"
+                    for row in one_sided
+                ),
+                "",
+            ]
+
+        if comparison.notes:
+            lines += ["### Notes", "", *(f"- {note}" for note in comparison.notes), ""]
+
+    if result.warnings:
+        lines += ["## Warnings", "", *(f"- {warning}" for warning in result.warnings), ""]
+
+    lines += [
+        "---",
+        f"Generated by `gym compare` (nemo-gym {result.nemo_gym_version}). "
+        f"Machine-readable output: `compare_report.json` (schema_version {result.schema_version}).",
+        "",
+    ]
+    return "\n".join(lines)

--- a/nemo_gym/compare/schema.py
+++ b/nemo_gym/compare/schema.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Config and result schema for `gym compare`.
+
+Every candidate-varying field is a list, positionally parallel to `ComparisonResult.candidates`.
+v0 only ever compares one candidate, but keeping the shape list-valued means lifting that
+restriction later is a behavior change rather than a schema change.
+"""
+
+from typing import Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+from nemo_gym.config_types import BaseNeMoGymCLIConfig
+
+
+ReportFormat = Literal["md", "json", "both"]
+
+# v0 compares a single candidate. The plumbing is list-shaped throughout so raising this is a
+# one-line change plus renderer work, not a schema migration.
+MAX_CANDIDATES = 1
+
+
+class CompareConfig(BaseNeMoGymCLIConfig):
+    """Compare a baseline eval run against a candidate run.
+
+    Reads only each run's `<stem>_aggregate_metrics.json`, derived from the rollouts JSONL path you
+    pass, and writes `compare_report.md` and/or `compare_report.json`. The rollouts JSONL itself is
+    never opened -- it is the run's identity and the handle the sibling path is derived from.
+
+    Examples:
+
+    ```bash
+    gym compare \
+        --baseline outputs/run_a/rollouts.jsonl \
+        --candidates outputs/run_b/rollouts.jsonl
+    ```
+
+    To point at metrics files that do not follow the `<stem>_aggregate_metrics.json` convention,
+    set `+baseline_aggregate_metrics_fpath=...` and `+candidate_aggregate_metrics_fpaths=[...]`.
+    """
+
+    baseline_rollouts_jsonl_fpath: str = Field(
+        description="Baseline run's rollouts JSONL, as passed to `gym eval run --output`. Used to derive "
+        "`<stem>_aggregate_metrics.json`; the JSONL itself is not read."
+    )
+    candidate_rollouts_jsonl_fpaths: List[str] = Field(
+        min_length=1,
+        description="Candidate runs' rollouts JSONL paths (comma-separated via --candidates).",
+    )
+    baseline_aggregate_metrics_fpath: Optional[str] = Field(
+        default=None,
+        description="Override for the baseline's aggregate-metrics JSON. Defaults to the "
+        "`<stem>_aggregate_metrics.json` sibling of baseline_rollouts_jsonl_fpath.",
+    )
+    candidate_aggregate_metrics_fpaths: Optional[List[str]] = Field(
+        default=None,
+        description="Overrides for the candidates' aggregate-metrics JSON files. When set, must have the "
+        "same length as candidate_rollouts_jsonl_fpaths.",
+    )
+
+    agent_name: Optional[str] = Field(
+        default=None,
+        description="Agent to compare on every side. When unset, compares every agent name present in all "
+        "runs. Overridden per side by baseline_agent_name / candidate_agent_names.",
+    )
+    baseline_agent_name: Optional[str] = Field(
+        default=None,
+        description="Agent to read from the baseline's metrics. Takes precedence over agent_name.",
+    )
+    candidate_agent_names: Optional[List[str]] = Field(
+        default=None,
+        description="Agent to read from each candidate's metrics, by position. When set, must have the same "
+        "length as candidate_rollouts_jsonl_fpaths. Takes precedence over agent_name.",
+    )
+
+    output_dirpath: Optional[str] = Field(
+        default=None,
+        description="Directory to write the comparison report into. Defaults to the candidate rollouts "
+        "file's parent directory. Created if absent; existing report files are overwritten.",
+    )
+    report_format: ReportFormat = Field(
+        default="both",
+        description="Which report artifacts to write: `md`, `json`, or `both`.",
+    )
+
+    @model_validator(mode="after")
+    def _check_candidate_parallel_lists(self) -> "CompareConfig":
+        num_candidates = len(self.candidate_rollouts_jsonl_fpaths)
+        if num_candidates > MAX_CANDIDATES:
+            raise ValueError(
+                f"{num_candidates} candidates were given, but comparing more than {MAX_CANDIDATES} candidate "
+                "is not supported yet. Pass a single path to --candidates."
+            )
+        for field_name, value, flag in (
+            ("candidate_agent_names", self.candidate_agent_names, "--candidate-agents"),
+            ("candidate_aggregate_metrics_fpaths", self.candidate_aggregate_metrics_fpaths, None),
+        ):
+            if value is not None and len(value) != num_candidates:
+                hint = f" Pass {flag} once per candidate, in the same order." if flag else ""
+                raise ValueError(
+                    f"{field_name} has {len(value)} entries but {num_candidates} candidate run(s) were given.{hint}"
+                )
+        return self
+
+
+class MetricValue(BaseModel):
+    """One side's reading of a metric, plus whatever uncertainty the run recorded for it."""
+
+    value: float
+    # `ci_{low,high}_95_across_repeats/<metric>`: only written for `mean/*` metrics on runs with >= 2
+    # repeats, so these are None for pass@k families and single-repeat runs.
+    ci_low: Optional[float] = None
+    ci_high: Optional[float] = None
+    se_across_repeats: Optional[float] = None
+    mean_across_repeats: Optional[float] = None
+    # `<metric>/std_err_across_runs` from compute_pass_majority_metrics: carried through for the
+    # statistics layer, deliberately not turned into an interval here.
+    std_err_across_runs: Optional[float] = None
+
+
+class CandidateMetricValue(MetricValue):
+    """A candidate's reading, plus its movement from the baseline."""
+
+    delta: Optional[float] = None
+    delta_pct: Optional[float] = None
+
+
+class MetricRow(BaseModel):
+    metric: str
+    is_key_metric: bool
+    # Which sides carried this metric: "baseline" and/or "candidate[<i>]".
+    present_in: List[str]
+    baseline: Optional[MetricValue] = None
+    candidates: List[Optional[CandidateMetricValue]] = Field(default_factory=list)
+
+
+class TaskFlip(BaseModel):
+    task_index: int
+    baseline_score: float
+    candidate_score: float
+    delta: float
+    direction: Literal["pass_to_fail", "fail_to_pass", "changed"]
+    # Per-repeat rewards from `rollout_infos`, purely illustrative -- counts never depend on them.
+    baseline_rewards: Optional[List[float]] = None
+    candidate_rewards: Optional[List[float]] = None
+
+
+class FlipSummary(BaseModel):
+    candidate_index: int
+    mode: Literal["binary", "continuous", "unavailable"]
+    reason: Optional[str] = None
+    field: str = "reward"
+    common_task_count: int = 0
+    baseline_only_task_count: int = 0
+    candidate_only_task_count: int = 0
+    # None in continuous mode, where there is no pass/fail notion to flip.
+    pass_to_fail_count: Optional[int] = None
+    fail_to_pass_count: Optional[int] = None
+    tied_count: Optional[int] = None
+    unchanged_count: Optional[int] = None
+    net: Optional[int] = None
+    flips: List[TaskFlip] = Field(default_factory=list)
+
+
+class AgentComparison(BaseModel):
+    baseline_agent: str
+    candidate_agents: List[str]
+    baseline_task_count: int
+    candidate_task_counts: List[int]
+    baseline_repeat_count: Optional[int] = None
+    candidate_repeat_counts: List[Optional[int]] = Field(default_factory=list)
+    metrics: List[MetricRow] = Field(default_factory=list)
+    flips: List[FlipSummary] = Field(default_factory=list)
+    notes: List[str] = Field(default_factory=list)
+
+
+class RunRef(BaseModel):
+    role: Literal["baseline", "candidate"]
+    label: str
+    rollouts_jsonl_fpath: str
+    aggregate_metrics_fpath: str
+    agents: List[str] = Field(default_factory=list)
+    num_repeats: Optional[int] = None
+
+
+class ComparisonResult(BaseModel):
+    """The machine-readable artifact written as `compare_report.json`."""
+
+    schema_version: Literal["1"] = "1"
+    generated_at: str
+    nemo_gym_version: str
+    command: str
+    baseline: RunRef
+    candidates: List[RunRef]
+    comparisons: List[AgentComparison] = Field(default_factory=list)
+    skipped_agents: Dict[str, List[str]] = Field(default_factory=dict)
+    warnings: List[str] = Field(default_factory=list)

--- a/nemo_gym/path_utils.py
+++ b/nemo_gym/path_utils.py
@@ -17,3 +17,12 @@ from pathlib import Path
 
 def failures_path_for(output_fpath: Path) -> Path:
     return output_fpath.with_name(output_fpath.stem + "_failures.jsonl")
+
+
+def aggregate_metrics_path_for(output_fpath: Path) -> Path:
+    """`results/rollouts.jsonl` -> `results/rollouts_aggregate_metrics.json`.
+
+    Mirrors how rollout collection and reverification name the file they write, so consumers
+    (e.g. `gym compare`) derive the same path the writers produced.
+    """
+    return output_fpath.with_stem(output_fpath.stem + "_aggregate_metrics").with_suffix(".json")

--- a/tests/unit_tests/test_compare.py
+++ b/tests/unit_tests/test_compare.py
@@ -1,0 +1,806 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import orjson
+import pytest
+
+from nemo_gym.cli.compare import (
+    build_comparison_result,
+    resolve_output_dir,
+    summary_lines,
+    write_reports,
+)
+from nemo_gym.compare.diff import build_flip_summary, build_metric_rows, compare_runs, is_comparable_metric
+from nemo_gym.compare.loading import (
+    build_loaded_run,
+    load_run_file,
+    resolve_agent_selections,
+    run_labels,
+)
+from nemo_gym.compare.report import render_markdown
+from nemo_gym.compare.schema import CompareConfig
+from nemo_gym.config_types import ConfigError, ConfigPathNotFoundError
+from nemo_gym.path_utils import aggregate_metrics_path_for
+
+
+AGENT = "bird_sql_simple_agent"
+
+
+def _group(
+    task_index: int,
+    rewards: List[float],
+    *,
+    extra: Optional[Dict[str, Any]] = None,
+    with_rollout_infos: bool = True,
+) -> Dict[str, Any]:
+    """One `group_level_metrics` entry, shaped like what aggregation really writes."""
+    group: Dict[str, Any] = {
+        "_ng_task_index": task_index,
+        "mean/reward": sum(rewards) / len(rewards),
+        "min/reward": min(rewards),
+        "max/reward": max(rewards),
+        "num_rollouts": len(rewards),
+        "expected_num_rollouts": len(rewards),
+        "missing_num_rollouts": 0,
+    }
+    if with_rollout_infos:
+        group["rollout_infos"] = [
+            {
+                "rollout_id": f"{task_index}:{rollout_index}",
+                "_ng_task_index": task_index,
+                "_ng_rollout_index": rollout_index,
+                "reward": reward,
+            }
+            for rollout_index, reward in enumerate(rewards)
+        ]
+    group.update(extra or {})
+    return group
+
+
+def _entry(
+    *,
+    agent: str = AGENT,
+    agent_metrics: Optional[Dict[str, Any]] = None,
+    key_metrics: Optional[Dict[str, Any]] = None,
+    groups: Optional[List[Dict[str, Any]]] = None,
+    repeat_level_metrics: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    return {
+        "agent_ref": {"name": agent},
+        "agent_metrics": agent_metrics if agent_metrics is not None else {"mean/reward": 0.5},
+        "key_metrics": key_metrics if key_metrics is not None else {"mean/reward": 0.5},
+        "group_level_metrics": groups if groups is not None else [],
+        "repeat_level_metrics": repeat_level_metrics if repeat_level_metrics is not None else [],
+    }
+
+
+def _write_run(tmp_path: Path, name: str, entries: List[Dict[str, Any]], *, write_rollouts: bool = True) -> Path:
+    run_dir = tmp_path / name
+    run_dir.mkdir(parents=True, exist_ok=True)
+    rollouts = run_dir / "rollouts.jsonl"
+    if write_rollouts:
+        rollouts.write_text("")
+    aggregate_metrics_path_for(rollouts).write_bytes(orjson.dumps(entries))
+    return rollouts
+
+
+def _load(tmp_path: Path, name: str, entries: List[Dict[str, Any]], *, role="baseline", agent: str = AGENT):
+    rollouts = _write_run(tmp_path, name, entries)
+    run_file = load_run_file(str(rollouts), role=role, flag_label=f"--{role}")
+    return build_loaded_run(run_file, agent, label=name)
+
+
+class TestAggregateMetricsPath:
+    def test_derives_sibling_from_rollouts_path(self):
+        assert aggregate_metrics_path_for(Path("results/rollouts.jsonl")) == Path(
+            "results/rollouts_aggregate_metrics.json"
+        )
+
+    def test_dotted_stem_matches_the_writer(self):
+        # with_stem/with_suffix (not with_name) is what rollout collection uses, so a dotted stem
+        # resolves to the same file the writer produced.
+        assert aggregate_metrics_path_for(Path("out/rollouts.v2.jsonl")) == Path(
+            "out/rollouts.v2_aggregate_metrics.json"
+        )
+
+
+class TestLoadRunFile:
+    def test_reads_entries_keyed_by_agent(self, tmp_path):
+        rollouts = _write_run(tmp_path, "base", [_entry()])
+        run_file = load_run_file(str(rollouts), role="baseline", flag_label="--baseline")
+        assert run_file.agent_names == [AGENT]
+        assert run_file.aggregate_metrics_fpath == aggregate_metrics_path_for(rollouts)
+
+    def test_missing_rollouts_and_metrics_names_the_run(self, tmp_path):
+        with pytest.raises(ConfigPathNotFoundError, match="Run not found"):
+            load_run_file(str(tmp_path / "nope" / "rollouts.jsonl"), role="baseline", flag_label="--baseline")
+
+    def test_missing_metrics_with_present_rollouts_explains_disable_aggregation(self, tmp_path):
+        run_dir = tmp_path / "partial"
+        run_dir.mkdir()
+        (run_dir / "rollouts.jsonl").write_text("")
+        with pytest.raises(ConfigPathNotFoundError, match="disable-aggregation"):
+            load_run_file(str(run_dir / "rollouts.jsonl"), role="baseline", flag_label="--baseline")
+
+    def test_override_is_used_instead_of_the_sibling(self, tmp_path):
+        rollouts = _write_run(tmp_path, "base", [_entry()])
+        override = tmp_path / "elsewhere.json"
+        override.write_bytes(orjson.dumps([_entry(agent="other")]))
+        run_file = load_run_file(
+            str(rollouts),
+            role="baseline",
+            flag_label="--baseline",
+            aggregate_metrics_fpath_override=str(override),
+        )
+        assert run_file.agent_names == ["other"]
+
+    @pytest.mark.parametrize(
+        "payload, message",
+        [
+            ({"agent_ref": {"name": AGENT}}, "expected a JSON list"),
+            ([], "no agent entries"),
+            ([[1, 2]], "is not an object"),
+            ([{"agent_metrics": {}}], "has no `agent_ref.name`"),
+            ([_entry(), _entry()], "two entries for agent"),
+        ],
+    )
+    def test_malformed_files_are_rejected(self, tmp_path, payload, message):
+        run_dir = tmp_path / "bad"
+        run_dir.mkdir()
+        rollouts = run_dir / "rollouts.jsonl"
+        rollouts.write_text("")
+        aggregate_metrics_path_for(rollouts).write_bytes(orjson.dumps(payload))
+        with pytest.raises(ConfigError, match=message):
+            load_run_file(str(rollouts), role="baseline", flag_label="--baseline")
+
+    def test_a_directory_in_place_of_the_metrics_file_is_rejected_cleanly(self, tmp_path):
+        """`exists()` is true for a directory, so the read itself has to fail cleanly."""
+        rollouts = _write_run(tmp_path, "base", [_entry()])
+        with pytest.raises(ConfigError, match="Cannot read aggregate metrics"):
+            load_run_file(
+                str(rollouts),
+                role="baseline",
+                flag_label="--baseline",
+                aggregate_metrics_fpath_override=str(tmp_path / "base"),
+            )
+
+    def test_an_unreadable_metrics_file_is_rejected_cleanly(self, tmp_path):
+        rollouts = _write_run(tmp_path, "base", [_entry()])
+        metrics = aggregate_metrics_path_for(rollouts)
+        metrics.chmod(0o000)
+        try:
+            if os.access(metrics, os.R_OK):
+                pytest.skip("cannot make a file unreadable as this user (running as root?)")
+            with pytest.raises(ConfigError, match="Cannot read aggregate metrics"):
+                load_run_file(str(rollouts), role="baseline", flag_label="--baseline")
+        finally:
+            metrics.chmod(0o644)
+
+    def test_invalid_json_is_rejected(self, tmp_path):
+        run_dir = tmp_path / "bad"
+        run_dir.mkdir()
+        rollouts = run_dir / "rollouts.jsonl"
+        rollouts.write_text("")
+        aggregate_metrics_path_for(rollouts).write_text("{not json")
+        with pytest.raises(ConfigError, match="is not valid JSON"):
+            load_run_file(str(rollouts), role="baseline", flag_label="--baseline")
+
+
+class TestNumRepeatsDerivation:
+    def test_prefers_expected_num_rollouts(self, tmp_path):
+        run = _load(tmp_path, "base", [_entry(groups=[_group(0, [1.0, 0.0, 1.0])])])
+        assert run.num_repeats == 3
+
+    def test_falls_back_to_repeat_level_metrics_for_single_agent_files(self, tmp_path):
+        groups = [{"_ng_task_index": 0, "mean/reward": 1.0}]
+        entry = _entry(groups=groups, repeat_level_metrics=[{"_ng_rollout_index": i} for i in range(4)])
+        run = _load(tmp_path, "base", [entry])
+        assert run.num_repeats == 4
+
+    def test_falls_back_to_rollout_infos(self, tmp_path):
+        groups = [_group(0, [1.0, 0.0])]
+        groups[0].pop("expected_num_rollouts")
+        run = _load(tmp_path, "base", [_entry(groups=groups)])
+        assert run.num_repeats == 2
+
+    def test_unknown_when_nothing_records_it(self, tmp_path):
+        run = _load(tmp_path, "base", [_entry(groups=[{"_ng_task_index": 0, "mean/reward": 1.0}])])
+        assert run.num_repeats is None
+
+    def test_repeat_cis_flag_tracks_the_ci_keys(self, tmp_path):
+        without = _load(tmp_path, "a", [_entry(agent_metrics={"mean/reward": 0.5})])
+        with_ci = _load(
+            tmp_path,
+            "b",
+            [_entry(agent_metrics={"mean/reward": 0.5, "ci_low_95_across_repeats/mean/reward": 0.4})],
+        )
+        assert not without.has_repeat_cis
+        assert with_ci.has_repeat_cis
+
+
+class TestAgentSelection:
+    def _files(self, tmp_path, baseline_agents, candidate_agents):
+        baseline = load_run_file(
+            str(_write_run(tmp_path, "base", [_entry(agent=a) for a in baseline_agents])),
+            role="baseline",
+            flag_label="--baseline",
+        )
+        candidate = load_run_file(
+            str(_write_run(tmp_path, "cand", [_entry(agent=a) for a in candidate_agents])),
+            role="candidate",
+            flag_label="--candidates",
+        )
+        return baseline, candidate
+
+    def test_full_join_compares_every_shared_agent(self, tmp_path):
+        baseline, candidate = self._files(tmp_path, ["a", "b"], ["a", "b"])
+        selections, warnings, skipped = resolve_agent_selections(baseline, [candidate])
+        assert [s.baseline_agent for s in selections] == ["a", "b"]
+        assert warnings == [] and skipped == {}
+
+    def test_full_join_warns_about_agents_only_one_side_has(self, tmp_path):
+        baseline, candidate = self._files(tmp_path, ["a", "b"], ["a"])
+        selections, warnings, skipped = resolve_agent_selections(baseline, [candidate])
+        assert [s.baseline_agent for s in selections] == ["a"]
+        assert skipped == {"baseline": ["b"]}
+        assert "b" in warnings[0]
+
+    def test_disjoint_agent_names_is_fatal(self, tmp_path):
+        baseline, candidate = self._files(tmp_path, ["a"], ["b"])
+        with pytest.raises(ConfigError, match="No agent name is present in every run"):
+            resolve_agent_selections(baseline, [candidate])
+
+    def test_agent_flag_selects_one_agent_on_both_sides(self, tmp_path):
+        baseline, candidate = self._files(tmp_path, ["a", "b"], ["a", "b"])
+        selections, _, _ = resolve_agent_selections(baseline, [candidate], agent_name="b")
+        assert selections == [selections[0]]
+        assert selections[0].baseline_agent == "b" and selections[0].candidate_agents == ("b",)
+
+    def test_unknown_agent_name_is_fatal_with_a_suggestion(self, tmp_path):
+        baseline, candidate = self._files(tmp_path, ["alpha"], ["alpha"])
+        with pytest.raises(ConfigError, match="Did you mean `alpha`"):
+            resolve_agent_selections(baseline, [candidate], agent_name="alpah")
+
+    def test_per_side_agents_may_differ(self, tmp_path):
+        baseline, candidate = self._files(tmp_path, ["old_name"], ["new_name"])
+        selections, _, _ = resolve_agent_selections(
+            baseline, [candidate], baseline_agent_name="old_name", candidate_agent_names=["new_name"]
+        )
+        assert selections[0].baseline_agent == "old_name"
+        assert selections[0].candidate_agents == ("new_name",)
+
+    def test_per_side_selection_falls_back_to_a_sole_agent(self, tmp_path):
+        baseline, candidate = self._files(tmp_path, ["only"], ["new_name"])
+        selections, _, _ = resolve_agent_selections(baseline, [candidate], candidate_agent_names=["new_name"])
+        assert selections[0].baseline_agent == "only"
+
+    def test_per_side_selection_needs_a_flag_when_a_side_is_ambiguous(self, tmp_path):
+        baseline, candidate = self._files(tmp_path, ["a", "b"], ["new_name"])
+        with pytest.raises(ConfigError, match="Pass --baseline-agent to choose one"):
+            resolve_agent_selections(baseline, [candidate], candidate_agent_names=["new_name"])
+
+
+class TestMetricRows:
+    @pytest.mark.parametrize(
+        "name, comparable",
+        [
+            ("mean/reward", True),
+            ("pass@1[avg-of-3]/accuracy", True),
+            ("simple/pass@3/accuracy", True),
+            ("std/reward", False),
+            ("median/reward", False),
+            ("ci_low_95/reward", False),
+            ("mean_across_repeats/mean/reward", False),
+            ("ci_high_95_across_repeats/mean/reward", False),
+            ("pass@1[avg-of-3]/accuracy/std_err_across_runs", False),
+        ],
+    )
+    def test_only_real_metrics_get_a_row(self, name, comparable):
+        assert is_comparable_metric(name) is comparable
+
+    def test_reads_values_ci_and_delta(self, tmp_path):
+        baseline = _load(
+            tmp_path,
+            "base",
+            [
+                _entry(
+                    agent_metrics={
+                        "mean/reward": 0.80,
+                        "ci_low_95_across_repeats/mean/reward": 0.70,
+                        "ci_high_95_across_repeats/mean/reward": 0.90,
+                        "se_across_repeats/mean/reward": 0.05,
+                        "mean_across_repeats/mean/reward": 0.80,
+                    },
+                    key_metrics={"mean/reward": 0.80},
+                )
+            ],
+        )
+        candidate = _load(
+            tmp_path,
+            "cand",
+            [_entry(agent_metrics={"mean/reward": 0.60}, key_metrics={"mean/reward": 0.60})],
+            role="candidate",
+        )
+        (row,) = build_metric_rows(baseline, [candidate])
+        assert row.metric == "mean/reward" and row.is_key_metric
+        assert row.baseline.value == pytest.approx(0.80)
+        assert (row.baseline.ci_low, row.baseline.ci_high) == (0.70, 0.90)
+        assert row.baseline.se_across_repeats == pytest.approx(0.05)
+        assert row.candidates[0].delta == pytest.approx(-0.20)
+        assert row.candidates[0].delta_pct == pytest.approx(-25.0)
+        # The candidate recorded no interval of its own.
+        assert row.candidates[0].ci_low is None
+
+    def test_zero_baseline_leaves_relative_change_undefined(self, tmp_path):
+        baseline = _load(tmp_path, "base", [_entry(agent_metrics={"mean/reward": 0.0})])
+        candidate = _load(tmp_path, "cand", [_entry(agent_metrics={"mean/reward": 0.5})], role="candidate")
+        (row,) = build_metric_rows(baseline, [candidate])
+        assert row.candidates[0].delta == pytest.approx(0.5)
+        assert row.candidates[0].delta_pct is None
+
+    def test_one_sided_and_non_numeric_metrics(self, tmp_path):
+        baseline = _load(
+            tmp_path,
+            "base",
+            [_entry(agent_metrics={"mean/reward": 0.5, "pass@1/accuracy": 40.0, "per_sample_aggregate": {"a": [1]}})],
+        )
+        candidate = _load(
+            tmp_path,
+            "cand",
+            [_entry(agent_metrics={"mean/reward": 0.5, "pass@2/accuracy": 55.0})],
+            role="candidate",
+        )
+        rows = {row.metric: row for row in build_metric_rows(baseline, [candidate])}
+        assert "per_sample_aggregate" not in rows
+        assert rows["pass@1/accuracy"].present_in == ["baseline"]
+        assert rows["pass@1/accuracy"].candidates == [None]
+        assert rows["pass@2/accuracy"].present_in == ["candidate[0]"]
+        assert rows["mean/reward"].present_in == ["baseline", "candidate[0]"]
+
+
+class TestFlips:
+    def test_binary_mode_counts_flips_in_both_directions(self, tmp_path):
+        baseline = _load(
+            tmp_path,
+            "base",
+            [_entry(groups=[_group(0, [1.0, 1.0]), _group(1, [0.0, 0.0]), _group(2, [1.0, 1.0])])],
+        )
+        candidate = _load(
+            tmp_path,
+            "cand",
+            [_entry(groups=[_group(0, [0.0, 0.0]), _group(1, [1.0, 1.0]), _group(2, [1.0, 1.0])])],
+            role="candidate",
+        )
+        summary = build_flip_summary(baseline, candidate)
+        assert summary.mode == "binary"
+        assert (summary.pass_to_fail_count, summary.fail_to_pass_count) == (1, 1)
+        assert summary.unchanged_count == 1 and summary.net == 0
+        # Regressions are listed first.
+        assert [flip.direction for flip in summary.flips] == ["pass_to_fail", "fail_to_pass"]
+        assert summary.flips[0].baseline_rewards == [1.0, 1.0]
+        assert summary.flips[0].candidate_rewards == [0.0, 0.0]
+
+    def test_an_evenly_split_task_is_tied_not_flipped(self, tmp_path):
+        baseline = _load(tmp_path, "base", [_entry(groups=[_group(0, [1.0, 0.0])])])
+        candidate = _load(tmp_path, "cand", [_entry(groups=[_group(0, [1.0, 1.0])])], role="candidate")
+        summary = build_flip_summary(baseline, candidate)
+        assert summary.tied_count == 1
+        assert summary.flips == []
+
+    def test_continuous_rewards_report_largest_movers(self, tmp_path):
+        baseline = _load(tmp_path, "base", [_entry(groups=[_group(0, [0.25]), _group(1, [0.80])])])
+        candidate = _load(
+            tmp_path,
+            "cand",
+            [_entry(groups=[_group(0, [0.30]), _group(1, [0.10])])],
+            role="candidate",
+        )
+        summary = build_flip_summary(baseline, candidate)
+        assert summary.mode == "continuous"
+        assert summary.pass_to_fail_count is None
+        assert [flip.task_index for flip in summary.flips] == [1, 0]
+        assert all(flip.direction == "changed" for flip in summary.flips)
+
+    def test_no_overlapping_tasks_is_reported_not_raised(self, tmp_path):
+        baseline = _load(tmp_path, "base", [_entry(groups=[_group(0, [1.0])])])
+        candidate = _load(tmp_path, "cand", [_entry(groups=[_group(7, [1.0])])], role="candidate")
+        summary = build_flip_summary(baseline, candidate)
+        assert summary.mode == "unavailable"
+        assert "no overlapping task indices" in summary.reason
+
+    def test_missing_per_task_metrics_is_reported(self, tmp_path):
+        baseline = _load(tmp_path, "base", [_entry(groups=[])])
+        candidate = _load(tmp_path, "cand", [_entry(groups=[_group(0, [1.0])])], role="candidate")
+        assert build_flip_summary(baseline, candidate).mode == "unavailable"
+
+    def test_missing_reward_field_is_reported(self, tmp_path):
+        groups = [{"_ng_task_index": 0, "mean/score": 1.0}]
+        baseline = _load(tmp_path, "base", [_entry(groups=groups)])
+        candidate = _load(tmp_path, "cand", [_entry(groups=groups)], role="candidate")
+        summary = build_flip_summary(baseline, candidate)
+        assert summary.mode == "unavailable"
+        assert "mean/reward" in summary.reason
+
+    def test_rollout_infos_absent_leaves_per_repeat_rewards_empty(self, tmp_path):
+        baseline = _load(tmp_path, "base", [_entry(groups=[_group(0, [1.0], with_rollout_infos=False)])])
+        candidate = _load(
+            tmp_path,
+            "cand",
+            [_entry(groups=[_group(0, [0.0], with_rollout_infos=False)])],
+            role="candidate",
+        )
+        summary = build_flip_summary(baseline, candidate)
+        assert summary.flips[0].baseline_rewards is None
+
+
+class TestCompareRuns:
+    def test_no_shared_metrics_is_fatal(self, tmp_path):
+        baseline = _load(tmp_path, "base", [_entry(agent_metrics={"pass@1[avg-of-3]/accuracy": 40.0})])
+        candidate = _load(
+            tmp_path, "cand", [_entry(agent_metrics={"pass@1[avg-of-5]/accuracy": 44.0})], role="candidate"
+        )
+        with pytest.raises(ConfigError, match="share no metric keys"):
+            compare_runs(baseline, [candidate])
+
+    def test_notes_flag_repeat_mismatch_and_absent_intervals(self, tmp_path):
+        baseline = _load(tmp_path, "base", [_entry(groups=[_group(0, [1.0, 1.0, 1.0])])])
+        candidate = _load(tmp_path, "cand", [_entry(groups=[_group(0, [1.0, 0.0])])], role="candidate")
+        comparison = compare_runs(baseline, [candidate])
+        assert comparison.baseline_repeat_count == 3 and comparison.candidate_repeat_counts == [2]
+        assert any("Repeat counts differ" in note for note in comparison.notes)
+        assert any("confidence intervals" in note for note in comparison.notes)
+
+
+class TestRunLabels:
+    def test_uses_parent_directory_names(self):
+        assert run_labels([Path("out/run_a/rollouts.jsonl"), Path("out/run_b/rollouts.jsonl")]) == [
+            "run_a",
+            "run_b",
+        ]
+
+    def test_disambiguates_colliding_parents(self):
+        labels = run_labels([Path("a/artifacts/rollouts.jsonl"), Path("b/artifacts/rollouts.jsonl")])
+        assert labels == ["a/artifacts", "b/artifacts"]
+
+
+class TestCompareConfig:
+    def _config(self, **overrides) -> Dict[str, Any]:
+        return {
+            "baseline_rollouts_jsonl_fpath": "a/rollouts.jsonl",
+            "candidate_rollouts_jsonl_fpaths": ["b/rollouts.jsonl"],
+            **overrides,
+        }
+
+    def test_single_candidate_validates(self):
+        config = CompareConfig.model_validate(self._config())
+        assert config.report_format == "both"
+        assert config.output_dirpath is None
+
+    def test_multiple_candidates_are_rejected_for_now(self):
+        payload = self._config(candidate_rollouts_jsonl_fpaths=["b/r.jsonl", "c/r.jsonl"])
+        with pytest.raises(ValueError, match="is not supported yet"):
+            CompareConfig.model_validate(payload)
+
+    def test_candidate_agent_list_must_match_candidate_count(self):
+        payload = self._config(candidate_agent_names=["one", "two"])
+        with pytest.raises(ValueError, match="--candidate-agents once per candidate"):
+            CompareConfig.model_validate(payload)
+
+    def test_metrics_override_list_must_match_candidate_count(self):
+        payload = self._config(candidate_aggregate_metrics_fpaths=["x.json", "y.json"])
+        with pytest.raises(ValueError, match="candidate_aggregate_metrics_fpaths has 2 entries"):
+            CompareConfig.model_validate(payload)
+
+
+class TestCliFlagTranslation:
+    """`gym compare`'s flags must survive the argparse -> Hydra override -> pydantic round trip."""
+
+    def _overrides(self, argv: List[str]) -> List[str]:
+        from nemo_gym.cli.main import build_parser
+
+        args, unknown = build_parser().parse_known_args(argv)
+        assert unknown == [], f"flags left unparsed: {unknown}"
+        return [token for flag in args._command.flags for token in flag.translate_to_hydra(args)]
+
+    def _config(self, argv: List[str]) -> CompareConfig:
+        from hydra.core.override_parser.overrides_parser import OverridesParser
+
+        parsed = OverridesParser.create().parse_overrides(self._overrides(argv))
+        return CompareConfig.model_validate({o.key_or_group: o.value() for o in parsed})
+
+    def test_paths_round_trip_through_hydra(self, tmp_path):
+        config = self._config(
+            ["compare", "--baseline", "runs/a/rollouts.jsonl", "--candidates", "runs/b/rollouts.jsonl"]
+        )
+        assert config.baseline_rollouts_jsonl_fpath == "runs/a/rollouts.jsonl"
+        assert config.candidate_rollouts_jsonl_fpaths == ["runs/b/rollouts.jsonl"]
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "runs/café/rollouts.jsonl",  # Hydra does not decode \uXXXX escapes
+            "runs/with space/rollouts.jsonl",
+            "runs/v=2/rollouts.jsonl",
+            "runs/[v2]/rollouts.jsonl",
+        ],
+    )
+    def test_awkward_paths_survive_verbatim(self, path):
+        config = self._config(["compare", "--baseline", path, "--candidates", path, "--output-dir", path])
+        assert config.baseline_rollouts_jsonl_fpath == path
+        assert config.candidate_rollouts_jsonl_fpaths == [path]
+        assert config.output_dirpath == path
+
+    def test_comma_separated_candidates_split_into_a_list(self):
+        overrides = self._overrides(["compare", "--baseline", "a.jsonl", "--candidates", "b.jsonl, c.jsonl"])
+        assert '+candidate_rollouts_jsonl_fpaths=["b.jsonl","c.jsonl"]' in overrides
+
+    def test_report_format_and_agent_flags_translate(self):
+        overrides = self._overrides(
+            [
+                "compare",
+                "--baseline",
+                "a.jsonl",
+                "--candidates",
+                "b.jsonl",
+                "--report-format",
+                "md",
+                "--agent",
+                "my_agent",
+                "--candidate-agents",
+                "other_agent",
+            ]
+        )
+        assert "+report_format=md" in overrides
+        assert "+agent_name=my_agent" in overrides
+        assert '+candidate_agent_names=["other_agent"]' in overrides
+
+    def test_unset_flags_contribute_no_overrides(self):
+        overrides = self._overrides(["compare", "--baseline", "a.jsonl", "--candidates", "b.jsonl"])
+        assert not [token for token in overrides if "output_dirpath" in token or "agent" in token]
+
+
+class TestEndToEnd:
+    def _result(self, tmp_path, **config_overrides):
+        baseline_rollouts = _write_run(
+            tmp_path,
+            "run_a",
+            [
+                _entry(
+                    agent_metrics={
+                        "mean/reward": 0.75,
+                        "ci_low_95_across_repeats/mean/reward": 0.70,
+                        "ci_high_95_across_repeats/mean/reward": 0.80,
+                        "pass@1[avg-of-2]/accuracy": 75.0,
+                    },
+                    key_metrics={"pass@1[avg-of-2]/accuracy": 75.0},
+                    groups=[_group(0, [1.0, 1.0]), _group(1, [0.0, 0.0])],
+                )
+            ],
+        )
+        candidate_rollouts = _write_run(
+            tmp_path,
+            "run_b",
+            [
+                _entry(
+                    agent_metrics={"mean/reward": 0.25, "pass@1[avg-of-2]/accuracy": 25.0},
+                    key_metrics={"pass@1[avg-of-2]/accuracy": 25.0},
+                    groups=[_group(0, [0.0, 0.0]), _group(1, [0.0, 0.0])],
+                )
+            ],
+        )
+        config = CompareConfig.model_validate(
+            {
+                "baseline_rollouts_jsonl_fpath": str(baseline_rollouts),
+                "candidate_rollouts_jsonl_fpaths": [str(candidate_rollouts)],
+                **config_overrides,
+            }
+        )
+        return config, build_comparison_result(config, command="gym compare ...")
+
+    def test_result_carries_both_sides_and_the_flip(self, tmp_path):
+        _, result = self._result(tmp_path)
+        assert result.schema_version == "1"
+        assert result.baseline.label == "run_a" and result.candidates[0].label == "run_b"
+        comparison = result.comparisons[0]
+        key_row = next(row for row in comparison.metrics if row.is_key_metric)
+        assert key_row.metric == "pass@1[avg-of-2]/accuracy"
+        assert key_row.candidates[0].delta == pytest.approx(-50.0)
+        assert comparison.flips[0].pass_to_fail_count == 1
+
+    def test_output_dir_defaults_to_the_candidate_directory(self, tmp_path):
+        config, _ = self._result(tmp_path)
+        assert resolve_output_dir(config) == tmp_path / "run_b"
+
+    def test_output_dir_flag_wins(self, tmp_path):
+        config, _ = self._result(tmp_path, output_dirpath=str(tmp_path / "elsewhere"))
+        assert resolve_output_dir(config) == tmp_path / "elsewhere"
+
+    @pytest.mark.parametrize(
+        "report_format, expected",
+        [
+            ("both", ["compare_report.md", "compare_report.json"]),
+            ("md", ["compare_report.md"]),
+            ("json", ["compare_report.json"]),
+        ],
+    )
+    def test_report_format_selects_the_artifacts(self, tmp_path, report_format, expected):
+        _, result = self._result(tmp_path)
+        written = write_reports(result, tmp_path / "report", report_format)
+        assert [path.name for path in written] == expected
+
+    def test_json_report_round_trips(self, tmp_path):
+        _, result = self._result(tmp_path)
+        (json_fpath,) = write_reports(result, tmp_path / "report", "json")
+        payload = orjson.loads(json_fpath.read_bytes())
+        assert payload["schema_version"] == "1"
+        # Candidate-varying fields stay list-shaped so a second candidate needs no schema change.
+        assert isinstance(payload["candidates"], list)
+        assert isinstance(payload["comparisons"][0]["metrics"][0]["candidates"], list)
+
+    def test_output_dir_cannot_be_a_file(self, tmp_path):
+        _, result = self._result(tmp_path)
+        clash = tmp_path / "not_a_dir"
+        clash.write_text("")
+        with pytest.raises(ConfigError, match="is not a directory"):
+            write_reports(result, clash, "md")
+
+    def test_summary_mentions_flips_and_written_paths(self, tmp_path):
+        _, result = self._result(tmp_path)
+        written = write_reports(result, tmp_path / "report", "both")
+        text = "\n".join(summary_lines(result, written))
+        assert "Sample flips: 0 fail→pass, 1 pass→fail over 2 common tasks" in text
+        assert "compare_report.md" in text
+
+    def test_markdown_report_renders_the_expected_sections(self, tmp_path):
+        _, result = self._result(tmp_path)
+        markdown = render_markdown(result)
+        assert "# gym compare" in markdown
+        assert "### Key metrics" in markdown
+        assert (
+            "| Metric | Drop (cand − base) | Baseline | Baseline 95% CI | Candidate | Candidate 95% CI |" in markdown
+        )
+        # A metric with no recorded interval renders an em dash rather than a fabricated one.
+        assert "| `pass@1[avg-of-2]/accuracy` | -50.00 (-66.7%) | 75.00 | — | 25.00 | — |" in markdown
+        assert "| `mean/reward` | -0.5000 (-66.7%) | 0.7500 | [0.7000, 0.8000] | 0.2500 | — |" in markdown
+        assert "### Sample flips" in markdown
+        assert "1 pass→fail" in markdown
+
+
+class TestReportEdgeCases:
+    def _result(self, tmp_path, baseline_entry, candidate_entry, name="edge"):
+        baseline_rollouts = _write_run(tmp_path / name, "run_a", [baseline_entry])
+        candidate_rollouts = _write_run(tmp_path / name, "run_b", [candidate_entry])
+        config = CompareConfig.model_validate(
+            {
+                "baseline_rollouts_jsonl_fpath": str(baseline_rollouts),
+                "candidate_rollouts_jsonl_fpaths": [str(candidate_rollouts)],
+            }
+        )
+        return build_comparison_result(config, command="gym compare ...")
+
+    def test_missing_values_and_zero_baseline_render_placeholders(self, tmp_path):
+        baseline = _entry(
+            agent_metrics={"mean/reward": 0.0, "pass@1/accuracy": 10.0},
+            key_metrics={},
+            groups=[_group(0, [0.0])],
+        )
+        candidate = _entry(
+            agent_metrics={"mean/reward": 0.5},
+            key_metrics={},
+            groups=[_group(0, [0.0])],
+        )
+        markdown = render_markdown(self._result(tmp_path, baseline, candidate))
+        # No key metrics were recorded, and the one-sided metric has no delta to show.
+        assert "No key metrics were recorded for this agent." in markdown
+        assert "| `pass@1/accuracy` | — | 10.00 | — | — | — |" in markdown
+        # A zero baseline has no meaningful relative change.
+        assert "| `mean/reward` | +0.5000 (n/a) |" in markdown
+        assert "### Metrics present in only one run" in markdown
+
+    def test_continuous_mode_section(self, tmp_path):
+        baseline = _entry(groups=[_group(0, [0.20]), _group(1, [0.90])])
+        candidate = _entry(groups=[_group(0, [0.55]), _group(1, [0.90])])
+        markdown = render_markdown(self._result(tmp_path, baseline, candidate))
+        assert "Rewards are not binary" in markdown
+        assert "2 common tasks · 1 changed · 1 unchanged" in markdown
+
+    def test_unavailable_flips_explain_themselves(self, tmp_path):
+        baseline = _entry(groups=[_group(0, [1.0])])
+        candidate = _entry(groups=[_group(9, [1.0])])
+        markdown = render_markdown(self._result(tmp_path, baseline, candidate))
+        assert "Not available: no overlapping task indices" in markdown
+
+    def test_flip_table_is_capped_per_direction(self, tmp_path):
+        """The cap applies to each direction, so improvements are never crowded out by regressions."""
+        from nemo_gym.compare.report import MAX_FLIPS_SHOWN
+
+        over_cap = MAX_FLIPS_SHOWN + 3
+        # Regressions first in task order, then the same number of improvements. A single global cap
+        # would show only regressions; a per-direction cap shows MAX_FLIPS_SHOWN of each.
+        baseline_groups = [_group(i, [1.0, 1.0]) for i in range(over_cap)]
+        candidate_groups = [_group(i, [0.0, 0.0]) for i in range(over_cap)]
+        baseline_groups += [_group(over_cap + i, [0.0, 0.0]) for i in range(over_cap)]
+        candidate_groups += [_group(over_cap + i, [1.0, 1.0]) for i in range(over_cap)]
+
+        markdown = render_markdown(
+            self._result(tmp_path, _entry(groups=baseline_groups), _entry(groups=candidate_groups))
+        )
+        assert markdown.count("| pass→fail |") == MAX_FLIPS_SHOWN
+        assert markdown.count("| fail→pass |") == MAX_FLIPS_SHOWN
+        assert f"… and {2 * over_cap - 2 * MAX_FLIPS_SHOWN} more (full list in `compare_report.json`)." in markdown
+
+    def test_binary_detection_falls_back_to_task_means(self, tmp_path):
+        """Older runs may not record per-task min/max; the task mean still identifies 0/1 rewards."""
+        baseline_groups = [_group(0, [1.0]), _group(1, [0.0])]
+        candidate_groups = [_group(0, [0.0]), _group(1, [0.0])]
+        for group in baseline_groups + candidate_groups:
+            group.pop("min/reward")
+            group.pop("max/reward")
+        summary = build_flip_summary(
+            _load(tmp_path / "fb", "base", [_entry(groups=baseline_groups)]),
+            _load(tmp_path / "fb", "cand", [_entry(groups=candidate_groups)], role="candidate"),
+        )
+        assert summary.mode == "binary"
+        assert summary.pass_to_fail_count == 1
+
+    def test_flip_rows_without_rollout_infos_render_placeholders(self, tmp_path):
+        baseline = _entry(groups=[_group(0, [1.0], with_rollout_infos=False)])
+        candidate = _entry(groups=[_group(0, [0.0], with_rollout_infos=False)])
+        markdown = render_markdown(self._result(tmp_path, baseline, candidate))
+        assert "| 0 | pass→fail | 1.0000 | 0.0000 | -1.0000 | — | — |" in markdown
+
+    def test_multiple_agents_each_get_their_own_section(self, tmp_path):
+        baseline = _write_run(
+            tmp_path / "multi",
+            "run_a",
+            [_entry(agent="a", groups=[_group(0, [1.0])]), _entry(agent="b", groups=[_group(0, [1.0])])],
+        )
+        candidate = _write_run(
+            tmp_path / "multi",
+            "run_b",
+            [_entry(agent="a", groups=[_group(0, [0.0])]), _entry(agent="b", groups=[_group(0, [0.0])])],
+        )
+        config = CompareConfig.model_validate(
+            {
+                "baseline_rollouts_jsonl_fpath": str(baseline),
+                "candidate_rollouts_jsonl_fpaths": [str(candidate)],
+            }
+        )
+        markdown = render_markdown(build_comparison_result(config, command="gym compare ..."))
+        assert "## Agent: `a`" in markdown
+        assert "## Agent: `b`" in markdown
+
+    def test_warnings_section_lists_skipped_agents(self, tmp_path):
+        baseline = _write_run(
+            tmp_path / "warn",
+            "run_a",
+            [_entry(agent="a", groups=[_group(0, [1.0])]), _entry(agent="extra", groups=[_group(0, [1.0])])],
+        )
+        candidate = _write_run(tmp_path / "warn", "run_b", [_entry(agent="a", groups=[_group(0, [0.0])])])
+        config = CompareConfig.model_validate(
+            {
+                "baseline_rollouts_jsonl_fpath": str(baseline),
+                "candidate_rollouts_jsonl_fpaths": [str(candidate)],
+            }
+        )
+        result = build_comparison_result(config, command="gym compare ...")
+        assert result.skipped_agents == {"baseline": ["extra"]}
+        markdown = render_markdown(result)
+        assert "## Warnings" in markdown
+        assert "extra" in markdown


### PR DESCRIPTION

## What does this PR do?

Adds `gym compare`, a new CLI command that diffs a baseline eval run against a candidate run and writes a report.
Related epic: https://github.com/NVIDIA-NeMo/Gym/issues/1493  and issue addressed by this PR: https://github.com/NVIDIA-NeMo/Gym/issues/2531
## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
