### PR TITLE
fix: skip rewriting an up-to-date dataset metrics sidecar

### DIFF
--- a/nemo_gym/train_data_utils.py
+++ b/nemo_gym/train_data_utils.py
@@ -663,6 +663,13 @@ class TrainDataProcessor(BaseModel):
                         pass
                     else:
                         continue
+                elif metrics_fpath.exists():
+                    # The sidecar already exists and matches the freshly computed metrics (no conflict was
+                    # reported), so rewriting it would only reproduce identical bytes. Skip the write: when
+                    # the dataset lives in a shared, read-only directory, the redundant open(..., "w")
+                    # raises PermissionError for any user who does not own the pre-staged file.
+                    print(f"Aggregate metrics for {metrics_fpath} already up to date")
+                    continue
 
                 # Ensure the artifact dir exists: the metrics file is written next to the dataset's
                 # (cwd-relative) jsonl_fpath, which may not exist yet when collating from a fresh cwd.

--- a/tests/unit_tests/test_train_data_utils.py
+++ b/tests/unit_tests/test_train_data_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+import shutil
 from pathlib import Path
 from unittest.mock import MagicMock, mock_open
 
@@ -564,7 +565,69 @@ class TestValidateSamplesAndAggregateMetrics:
             == actual_dataset_type_to_aggregate_metrics.get("example").model_dump()
         )
 
-        assert write_filenames == [Path("resources_servers/example_multi_step/data/example_metrics.json")]
+        # The sidecar already exists on disk and matches the freshly computed metrics, so the
+        # (previously unconditional) rewrite is now skipped -- no metrics file is written.
+        assert write_filenames == []
+
+    def test_validate_samples_and_aggregate_metrics_skips_rewrite_when_sidecar_matches(self, tmp_path: Path) -> None:
+        """An up-to-date metrics sidecar must not be rewritten.
+
+        Rewriting a sidecar that already matches the freshly computed metrics is redundant, and when the
+        dataset lives in a shared, read-only directory the redundant ``open(..., "w")`` raises
+        ``PermissionError`` for any user who does not own the pre-staged file. This reproduces that setup
+        by making the sidecar read-only between the two passes.
+        """
+        processor = TrainDataProcessor()
+
+        # Copy the bundled example dataset into a writable temp dir so we can toggle its permissions
+        # without touching the repo. The dataset is the same one exercised by the sanity test, so its
+        # metrics aggregate cleanly.
+        source_fpath = _resolve_under_cwd_or_install("resources_servers/example_multi_step/data/example.jsonl")
+        data_fpath = tmp_path / "example.jsonl"
+        shutil.copyfile(source_fpath, data_fpath)
+        metrics_fpath = data_fpath.with_name(f"{data_fpath.stem}_metrics.json")
+
+        server_type_config_dict = {
+            "responses_api_agents": {
+                "simple_agent": {
+                    "host": "127.0.0.1",
+                    "port": 12345,
+                    "entrypoint": "app.py",
+                    "datasets": [
+                        {
+                            "name": "example",
+                            "type": "example",
+                            "jsonl_fpath": str(data_fpath),
+                            "num_repeats": 1,
+                            "gitlab_identifier": None,
+                            "license": None,
+                        }
+                    ],
+                    "resources_server": {"type": "resources_servers", "name": "test_resources_server"},
+                    "model_server": {"type": "responses_api_models", "name": "policy_model"},
+                }
+            }
+        }
+        server_config = ResponsesAPIAgentServerInstanceConfig(
+            name="test_agent",
+            server_type_config_dict=DictConfig(server_type_config_dict),
+            responses_api_agents=server_type_config_dict["responses_api_agents"],
+        )
+
+        # First pass creates the sidecar next to the dataset.
+        processor.validate_samples_and_aggregate_metrics([server_config], overwrite_metrics_conflicts=False)
+        assert metrics_fpath.exists()
+        original_bytes = metrics_fpath.read_bytes()
+
+        # Make the sidecar read-only, mimicking a shared dataset dir owned by another user. The old
+        # unconditional rewrite raised PermissionError here; the second pass must instead be a no-op.
+        metrics_fpath.chmod(0o444)
+        try:
+            processor.validate_samples_and_aggregate_metrics([server_config], overwrite_metrics_conflicts=False)
+        finally:
+            metrics_fpath.chmod(0o644)
+
+        assert metrics_fpath.read_bytes() == original_bytes
 
     def test_validate_samples_and_aggregate_metrics_conflict_raises_ValueError(self, monkeypatch: MonkeyPatch) -> None:
         mock_write_file = mock_open()


### PR DESCRIPTION
## Problem

`TrainDataProcessor.validate_samples_and_aggregate_metrics` writes the aggregate-metrics sidecar (`<dataset>_metrics.json`) next to the dataset **unconditionally** — even when the on-disk sidecar already exists and matches the freshly computed metrics:

```python
maybe_conflicting = self._validate_aggregate_metrics(aggregate_metrics_dict, metrics_fpath)
if maybe_conflicting is not None:
    ...
# always runs, even on a clean match:
with open(metrics_fpath, "w") as f:
    json.dump(aggregate_metrics_dict, f, indent=4)
```

`_validate_aggregate_metrics` already returns `None` both when the sidecar is *missing* and when it *matches*, so a matching sidecar still gets truncated and rewritten with identical bytes.

That redundant `open(..., "w")` breaks a common multi-user setup: when the dataset lives in a **shared, read-only directory** — e.g. a project-wide pre-staged benchmark workspace bind-mounted into the eval container — a user who doesn't own the pre-staged sidecar hits:

```
PermissionError: [Errno 13] Permission denied:
  'benchmarks/swebench/data/swebench_verified_benchmark_metrics.json'
  at nemo_gym/train_data_utils.py:670 (validate_samples_and_aggregate_metrics)
```

The run aborts during data preparation, before any rollout. This surfaced running SWE-bench Verified P/D on a Slurm cluster where the Gym workspace is shared across a project group.

## Fix

Skip the write when the sidecar already exists and no conflict was reported. Missing-file and overwrite-on-conflict paths are unchanged.

| sidecar state | before | after |
|---|---|---|
| missing | write | write |
| exists & matches | **rewrite (redundant)** | **skip** |
| exists & differs, `overwrite_metrics_conflicts=True` | overwrite | overwrite |
| exists & differs, `overwrite_metrics_conflicts=False` | skip + raise | skip + raise |

In the newly skipped case the write was provably a no-op (identical bytes), so on-disk output is unchanged.

## Tests

- New `test_validate_samples_and_aggregate_metrics_skips_rewrite_when_sidecar_matches`: copies the bundled example dataset into a tmp dir, runs once to create the sidecar, makes it **read-only**, and asserts a second pass neither raises nor rewrites it. Verified this fails without the fix (`PermissionError`) and passes with it.
- Updated `test_validate_samples_and_aggregate_metrics_sanity`: its bundled sidecar already matches, so it is no longer rewritten — the write assertion is now `[]`.

`pytest tests/unit_tests/test_train_data_utils.py` → 22 passed. `ruff` + `pre-commit` clean on the changed files.

## Note for maintainers

This fixes the redundant-rewrite that breaks the shared-read-only case. The deeper design point — the metrics sidecar is written *relative to cwd*, which `_resolve_under_cwd_or_install` documents as needing to be "the user's writable cwd" but which is the shared install root under a bind-mounted workspace — is left as-is. Happy to follow up if you'd prefer the sidecar target to move to an explicit output dir instead.
