### PR TITLE
feat: allow to swap agents when parsing the config

### DIFF
--- a/nemo_gym/config_types.py
+++ b/nemo_gym/config_types.py
@@ -180,6 +180,10 @@ class AlmostServerError(ConfigError, ValueError):
     `error_on_almost_servers` is set, so the run is aborted."""
 
 
+class AgentCompositionError(ConfigError, ValueError):
+    """A standalone agent config could not be composed onto the merged config's agent instances."""
+
+
 ########################################
 # Dataset configs for handling and upload/download
 ########################################

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -18,6 +18,7 @@ import sys
 from argparse import ArgumentParser
 from collections import defaultdict
 from copy import deepcopy
+from dataclasses import dataclass
 from difflib import get_close_matches
 from importlib import import_module
 from os import environ, getenv
@@ -37,6 +38,7 @@ from ray import __version__ as ray_version
 
 from nemo_gym import CACHE_DIR, RESULTS_DIR, WORKING_DIR, _resolve_under_cwd_or_install, component_search_roots
 from nemo_gym.config_types import (
+    AgentCompositionError,
     AlmostServerError,
     ConfigError,
     ConfigInterpolationError,
@@ -137,6 +139,20 @@ NEMO_GYM_RESERVED_TOP_LEVEL_KEYS = [
     SKIP_VERIFICATION_KEY_NAME,
     SKIP_VERIFICATION_REWARD_KEY_NAME,
 ]
+
+AGENT_SERVER_TYPE_KEY_NAME = "responses_api_agents"
+# Carried over from the environment's agent instance onto the composed agent; every other key is dropped.
+_COMPOSED_AGENT_CARRY_OVER_KEYS = ("resources_server", "model_server", "datasets")
+
+
+@dataclass(frozen=True)
+class _AgentInstance:
+    """A top-level agent instance, with its single agent type already unwrapped."""
+
+    name: str
+    agent_type: str
+    server_config: DictConfig
+
 
 # Data keys
 TASK_INDEX_KEY_NAME = "_ng_task_index"
@@ -512,6 +528,77 @@ Duplicate config paths:
                     missing_paths.extend(self._walk_missing_value_paths(value, path))
         return missing_paths
 
+    def _agent_instances(self, global_config_dict: DictConfig) -> List[_AgentInstance]:
+        """Return every top-level agent instance in the config."""
+        instances: List[_AgentInstance] = []
+        for name, value in global_config_dict.items_ex(resolve=False):
+            if name in NEMO_GYM_RESERVED_TOP_LEVEL_KEYS or not isinstance(value, DictConfig):
+                continue
+            if AGENT_SERVER_TYPE_KEY_NAME not in value:
+                continue
+            agents = value[AGENT_SERVER_TYPE_KEY_NAME]
+            # A server instance declares exactly one agent type.
+            # Not our error to report: the type config pins exactly one, and almost-server detection flags it.
+            if not isinstance(agents, DictConfig) or len(agents) != 1:
+                continue
+            agent_type = str(next(iter(agents)))
+            instances.append(
+                _AgentInstance(
+                    name=str(name),
+                    agent_type=agent_type,
+                    server_config=agents[agent_type],
+                )
+            )
+        return instances
+
+    @staticmethod
+    def _is_unbound_agent(server_config: DictConfig) -> bool:
+        """True when the agent declares a `resources_server` but leaves its name unset, marking it a swap source."""
+        # Absent is not unset: self-contained agents omit the key entirely and must never match.
+        reference = server_config._get_node("resources_server")
+        return isinstance(reference, DictConfig) and OmegaConf.is_missing(reference, "name")
+
+    def compose_unbound_agent(self, global_config_dict: DictConfig) -> None:
+        """Rehost every other agent instance on the config's unbound agent, then drop that agent."""
+        instances = self._agent_instances(global_config_dict)
+        sources = [instance for instance in instances if self._is_unbound_agent(instance.server_config)]
+        if not sources:
+            return
+
+        if len(sources) > 1:
+            raise AgentCompositionError(
+                f"{len(sources)} agent instances leave their 'resources_server' unset, so there is no single "
+                f"agent to compose onto the others: {', '.join(sorted(repr(s.name) for s in sources))}. "
+                f"Load exactly one standalone agent config, or bind the others in your own config."
+            )
+
+        source = sources[0]
+        targets = [instance for instance in instances if instance.name != source.name]
+        if not targets:
+            raise AgentCompositionError(
+                f"Agent instance '{source.name}' leaves its 'resources_server' unset, but the merged config "
+                f"defines no other agent instance to rehost it on. Select an environment, benchmark, or "
+                f"resources server alongside the agent so there is a task for it to run."
+            )
+
+        # Struct mode would reject the key removals below - we need open_dict to allow it.
+        with open_dict(global_config_dict):
+            for target in targets:
+                composed = deepcopy(source.server_config)
+                self._carry_over_agent_bindings(target.server_config, composed)
+                # Instance names are kept: `agent_ref` is baked into prepared data, so renaming breaks collection.
+                agents = global_config_dict[target.name][AGENT_SERVER_TYPE_KEY_NAME]
+                agents.pop(target.agent_type)
+                agents[source.agent_type] = composed
+            global_config_dict.pop(source.name)
+
+    @staticmethod
+    def _carry_over_agent_bindings(original: DictConfig, composed: DictConfig) -> None:
+        """Move the environment's bindings onto the composed agent config, in place."""
+        for key in _COMPOSED_AGENT_CARRY_OVER_KEYS:
+            if key in original:
+                composed[key] = deepcopy(original[key])
+
     def raise_on_missing_values(self, global_config_dict: DictConfig) -> None:
         """Fail fast with one actionable error listing every unset '???' value.
 
@@ -696,6 +783,10 @@ Pass each config with --config (it builds the list for you), e.g.:
                 global_config_dict[CONFIG_PATHS_KEY_NAME] = config_paths
 
         self._recursively_swap_keys(global_config_dict)
+
+        # Must run after the swap above (inherited bindings must exist to carry over) and before the
+        # missing-value check below (it fills the selected agent's unset `resources_server`).
+        self.compose_unbound_agent(global_config_dict)
 
         # Fail fast with one actionable error if any required value is still '???'. Runs *after*
         # _recursively_swap_keys so that _delete_key/_inherit_from/_copy have been applied first —

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -537,7 +537,6 @@ Duplicate config paths:
             if AGENT_SERVER_TYPE_KEY_NAME not in value:
                 continue
             agents = value[AGENT_SERVER_TYPE_KEY_NAME]
-            # A server instance declares exactly one agent type.
             # Not our error to report: the type config pins exactly one, and almost-server detection flags it.
             if not isinstance(agents, DictConfig) or len(agents) != 1:
                 continue
@@ -785,7 +784,7 @@ Pass each config with --config (it builds the list for you), e.g.:
         self._recursively_swap_keys(global_config_dict)
 
         # Must run after the swap above (inherited bindings must exist to carry over) and before the
-        # missing-value check below (it fills the selected agent's unset `resources_server`).
+        # missing-value check below (it removes the unbound agent instance that still carries '???').
         self.compose_unbound_agent(global_config_dict)
 
         # Fail fast with one actionable error if any required value is still '???'. Runs *after*

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -543,7 +543,6 @@ Duplicate config paths:
             if AGENT_SERVER_TYPE_KEY_NAME not in value:
                 continue
             agents = value[AGENT_SERVER_TYPE_KEY_NAME]
-            # A server instance declares exactly one agent type.
             # Not our error to report: the type config pins exactly one, and almost-server detection flags it.
             if not isinstance(agents, DictConfig) or len(agents) != 1:
                 continue
@@ -791,7 +790,7 @@ Pass each config with --config (it builds the list for you), e.g.:
         self._recursively_swap_keys(global_config_dict)
 
         # Must run after the swap above (inherited bindings must exist to carry over) and before the
-        # missing-value check below (it fills the selected agent's unset `resources_server`).
+        # missing-value check below (it removes the unbound agent instance that still carries '???').
         self.compose_unbound_agent(global_config_dict)
 
         # Fail fast with one actionable error if any required value is still '???'. Runs *after*

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -556,11 +556,28 @@ Duplicate config paths:
         return instances
 
     @staticmethod
-    def _is_unbound_agent(server_config: DictConfig) -> bool:
+    def _resources_server_reference(server_config: DictConfig) -> Optional[DictConfig]:
+        """The agent's `resources_server` block, or None when it declares none.
+
+        Selected rather than indexed because a self-contained agent omits the key, which a struct-mode
+        config rejects outright.
+        """
+        reference = OmegaConf.select(server_config, "resources_server")
+        return reference if isinstance(reference, DictConfig) else None
+
+    def _runs_against_a_resources_server(self, server_config: DictConfig) -> bool:
+        """True when the agent has a task to hand over, so another agent can take its place.
+
+        Self-contained agents own their environment and declare no `resources_server`; swapping one out
+        would leave the incoming agent with nothing to bind to.
+        """
+        return self._resources_server_reference(server_config) is not None
+
+    def _is_unbound_agent(self, server_config: DictConfig) -> bool:
         """True when the agent declares a `resources_server` but leaves its name unset, marking it a swap source."""
         # Absent is not unset: self-contained agents omit the key entirely and must never match.
-        reference = server_config._get_node("resources_server")
-        return isinstance(reference, DictConfig) and OmegaConf.is_missing(reference, "name")
+        reference = self._resources_server_reference(server_config)
+        return reference is not None and OmegaConf.is_missing(reference, "name")
 
     def compose_unbound_agent(self, global_config_dict: DictConfig) -> None:
         """Rehost every other agent instance on the config's unbound agent, then drop that agent."""
@@ -577,7 +594,11 @@ Duplicate config paths:
             )
 
         source = sources[0]
-        targets = [instance for instance in instances if instance.name != source.name]
+        targets = [
+            instance
+            for instance in instances
+            if instance.name != source.name and self._runs_against_a_resources_server(instance.server_config)
+        ]
         if not targets:
             raise AgentCompositionError(
                 f"Agent instance '{source.name}' leaves its 'resources_server' unset, but the merged config "

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -598,10 +598,17 @@ Duplicate config paths:
 
     @staticmethod
     def _carry_over_agent_bindings(original: DictConfig, composed: DictConfig) -> None:
-        """Move the environment's bindings onto the composed agent config, in place."""
+        """Move the environment's bindings onto the composed agent config, in place.
+
+        A binding left explicitly unset is carried over still unset, so it is reported rather than
+        silently resolving to whatever the incoming agent happens to declare. It needs its own branch
+        because OmegaConf reports a '???' value as absent.
+        """
         for key in _COMPOSED_AGENT_CARRY_OVER_KEYS:
             if key in original:
                 composed[key] = deepcopy(original[key])
+            elif OmegaConf.is_missing(original, key):
+                composed[key] = MISSING
 
     def raise_on_missing_values(self, global_config_dict: DictConfig) -> None:
         """Fail fast with one actionable error listing every unset '???' value.

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -18,6 +18,7 @@ import sys
 from argparse import ArgumentParser
 from collections import defaultdict
 from copy import deepcopy
+from dataclasses import dataclass
 from difflib import get_close_matches
 from importlib import import_module
 from os import environ, getenv
@@ -37,6 +38,7 @@ from ray import __version__ as ray_version
 
 from nemo_gym import CACHE_DIR, RESULTS_DIR, WORKING_DIR, _resolve_under_cwd_or_install, component_search_roots
 from nemo_gym.config_types import (
+    AgentCompositionError,
     AlmostServerError,
     ConfigError,
     ConfigInterpolationError,
@@ -139,6 +141,20 @@ NEMO_GYM_RESERVED_TOP_LEVEL_KEYS = [
     SKIP_VERIFICATION_REWARD_KEY_NAME,
     TELEMETRY_KEY_NAME,
 ]
+
+AGENT_SERVER_TYPE_KEY_NAME = "responses_api_agents"
+# Carried over from the environment's agent instance onto the composed agent; every other key is dropped.
+_COMPOSED_AGENT_CARRY_OVER_KEYS = ("resources_server", "model_server", "datasets")
+
+
+@dataclass(frozen=True)
+class _AgentInstance:
+    """A top-level agent instance, with its single agent type already unwrapped."""
+
+    name: str
+    agent_type: str
+    server_config: DictConfig
+
 
 # Data keys
 TASK_INDEX_KEY_NAME = "_ng_task_index"
@@ -518,6 +534,77 @@ Duplicate config paths:
                     missing_paths.extend(self._walk_missing_value_paths(value, path))
         return missing_paths
 
+    def _agent_instances(self, global_config_dict: DictConfig) -> List[_AgentInstance]:
+        """Return every top-level agent instance in the config."""
+        instances: List[_AgentInstance] = []
+        for name, value in global_config_dict.items_ex(resolve=False):
+            if name in NEMO_GYM_RESERVED_TOP_LEVEL_KEYS or not isinstance(value, DictConfig):
+                continue
+            if AGENT_SERVER_TYPE_KEY_NAME not in value:
+                continue
+            agents = value[AGENT_SERVER_TYPE_KEY_NAME]
+            # A server instance declares exactly one agent type.
+            # Not our error to report: the type config pins exactly one, and almost-server detection flags it.
+            if not isinstance(agents, DictConfig) or len(agents) != 1:
+                continue
+            agent_type = str(next(iter(agents)))
+            instances.append(
+                _AgentInstance(
+                    name=str(name),
+                    agent_type=agent_type,
+                    server_config=agents[agent_type],
+                )
+            )
+        return instances
+
+    @staticmethod
+    def _is_unbound_agent(server_config: DictConfig) -> bool:
+        """True when the agent declares a `resources_server` but leaves its name unset, marking it a swap source."""
+        # Absent is not unset: self-contained agents omit the key entirely and must never match.
+        reference = server_config._get_node("resources_server")
+        return isinstance(reference, DictConfig) and OmegaConf.is_missing(reference, "name")
+
+    def compose_unbound_agent(self, global_config_dict: DictConfig) -> None:
+        """Rehost every other agent instance on the config's unbound agent, then drop that agent."""
+        instances = self._agent_instances(global_config_dict)
+        sources = [instance for instance in instances if self._is_unbound_agent(instance.server_config)]
+        if not sources:
+            return
+
+        if len(sources) > 1:
+            raise AgentCompositionError(
+                f"{len(sources)} agent instances leave their 'resources_server' unset, so there is no single "
+                f"agent to compose onto the others: {', '.join(sorted(repr(s.name) for s in sources))}. "
+                f"Load exactly one standalone agent config, or bind the others in your own config."
+            )
+
+        source = sources[0]
+        targets = [instance for instance in instances if instance.name != source.name]
+        if not targets:
+            raise AgentCompositionError(
+                f"Agent instance '{source.name}' leaves its 'resources_server' unset, but the merged config "
+                f"defines no other agent instance to rehost it on. Select an environment, benchmark, or "
+                f"resources server alongside the agent so there is a task for it to run."
+            )
+
+        # Struct mode would reject the key removals below - we need open_dict to allow it.
+        with open_dict(global_config_dict):
+            for target in targets:
+                composed = deepcopy(source.server_config)
+                self._carry_over_agent_bindings(target.server_config, composed)
+                # Instance names are kept: `agent_ref` is baked into prepared data, so renaming breaks collection.
+                agents = global_config_dict[target.name][AGENT_SERVER_TYPE_KEY_NAME]
+                agents.pop(target.agent_type)
+                agents[source.agent_type] = composed
+            global_config_dict.pop(source.name)
+
+    @staticmethod
+    def _carry_over_agent_bindings(original: DictConfig, composed: DictConfig) -> None:
+        """Move the environment's bindings onto the composed agent config, in place."""
+        for key in _COMPOSED_AGENT_CARRY_OVER_KEYS:
+            if key in original:
+                composed[key] = deepcopy(original[key])
+
     def raise_on_missing_values(self, global_config_dict: DictConfig) -> None:
         """Fail fast with one actionable error listing every unset '???' value.
 
@@ -702,6 +789,10 @@ Pass each config with --config (it builds the list for you), e.g.:
                 global_config_dict[CONFIG_PATHS_KEY_NAME] = config_paths
 
         self._recursively_swap_keys(global_config_dict)
+
+        # Must run after the swap above (inherited bindings must exist to carry over) and before the
+        # missing-value check below (it fills the selected agent's unset `resources_server`).
+        self.compose_unbound_agent(global_config_dict)
 
         # Fail fast with one actionable error if any required value is still '???'. Runs *after*
         # _recursively_swap_keys so that _delete_key/_inherit_from/_copy have been applied first —

--- a/nemo_gym/global_config.py
+++ b/nemo_gym/global_config.py
@@ -547,13 +547,12 @@ Duplicate config paths:
             if not isinstance(agents, DictConfig) or len(agents) != 1:
                 continue
             agent_type = str(next(iter(agents)))
-            instances.append(
-                _AgentInstance(
-                    name=str(name),
-                    agent_type=agent_type,
-                    server_config=agents[agent_type],
-                )
-            )
+            server_config = agents._get_node(agent_type)
+            # An unset block is read as a node rather than resolved: resolving raises MissingMandatoryValue,
+            # which is not a ConfigError, so the CLI would print a traceback instead of the usual report.
+            if not isinstance(server_config, DictConfig):
+                continue
+            instances.append(_AgentInstance(name=str(name), agent_type=agent_type, server_config=server_config))
         return instances
 
     @staticmethod

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -25,6 +25,7 @@ import nemo_gym.global_config
 import nemo_gym.server_utils
 from nemo_gym import CACHE_DIR, NEMO_GYM_EXTRA_ROOTS_ENV_VAR_NAME, RESULTS_DIR, WORKING_DIR
 from nemo_gym.config_types import (
+    AgentCompositionError,
     AlmostServerError,
     ConfigError,
     ConfigMissingValuesError,
@@ -1873,3 +1874,217 @@ class TestOpenAIVersionMatchesNemoGymConstraint:
 
         monkeypatch.setattr(importlib.metadata, "requires", raise_not_found)
         assert _openai_version_matches_nemo_gym_constraint("2.52.0") is True
+
+
+class TestComposeUnboundAgent:
+    """Composition of a standalone agent config onto the environment's agent instances."""
+
+    HARNESS_INSTANCE = "hermes_agent"
+
+    def _harness(self, **overrides) -> dict:
+        """The agent as its standalone config ships it, with `resources_server.name` left unset."""
+        block = {
+            "entrypoint": "app.py",
+            "resources_server": {"type": "resources_servers", "name": "???"},
+            "model_server": {"type": "responses_api_models", "name": "policy_model"},
+            "max_turns": 30,
+            "terminal_backend": "local",
+        }
+        block.update(overrides)
+        return {"responses_api_agents": {"hermes_agent": block}}
+
+    def _environment_agent(self, resources_server: str, **overrides) -> dict:
+        block = {
+            "entrypoint": "app.py",
+            "resources_server": {"type": "resources_servers", "name": resources_server},
+            "model_server": {"type": "responses_api_models", "name": "policy_model"},
+            "max_steps": 6,
+            "datasets": [
+                {
+                    "name": "gpqa",
+                    "type": "benchmark",
+                    "jsonl_fpath": "benchmarks/gpqa/data/gpqa_diamond_benchmark.jsonl",
+                    "prompt_config": "benchmarks/prompts/eval/aai/mcq-4choices.yaml",
+                    "prepare_script": "benchmarks/gpqa/prepare.py",
+                    "num_repeats": 8,
+                    "license": "CC-BY-4.0",
+                }
+            ],
+        }
+        block.update(overrides)
+        return {"responses_api_agents": {"simple_agent": block}}
+
+    def _config(self, **extra) -> DictConfig:
+        config = {
+            self.HARNESS_INSTANCE: self._harness(),
+            "gpqa_mcqa_simple_agent": self._environment_agent("gpqa_mcqa_resources_server"),
+            "gpqa_mcqa_resources_server": {
+                "resources_servers": {"mcqa": {"entrypoint": "app.py", "domain": "knowledge"}}
+            },
+        }
+        config.update(extra)
+        return DictConfig(config)
+
+    def _composed_block(self, config: DictConfig, instance: str) -> DictConfig:
+        agents = config[instance]["responses_api_agents"]
+        assert list(agents) == ["hermes_agent"], f"{instance} was not rehosted on the harness"
+        return agents["hermes_agent"]
+
+    def _parse(self, config: DictConfig) -> DictConfig:
+        return GlobalConfigDictParser().parse(
+            GlobalConfigDictParserConfig(
+                initial_global_config_dict=OmegaConf.merge(
+                    GlobalConfigDictParserConfig.NO_MODEL_GLOBAL_CONFIG_DICT, config
+                ),
+                skip_load_from_cli=True,
+                skip_load_from_dotenv=True,
+                offline=True,
+            )
+        )
+
+    def _parse_config_paths(self, *paths: str) -> DictConfig:
+        return self._parse(DictConfig({"config_paths": list(paths)}))
+
+    def test_noop_when_no_instance_is_unbound(self) -> None:
+        config = self._config()
+        config.pop(self.HARNESS_INSTANCE)
+        before = OmegaConf.to_container(config, resolve=False, throw_on_missing=False)
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert OmegaConf.to_container(config, resolve=False, throw_on_missing=False) == before
+
+    def test_absent_resources_server_is_not_a_source(self) -> None:
+        # Self-contained agents omit `resources_server` entirely, which is not the same as leaving it unset.
+        self_contained = {
+            "responses_api_agents": {"swe_agents": {"entrypoint": "app.py", "agent_framework": "openhands"}}
+        }
+        config = self._config()
+        config.pop(self.HARNESS_INSTANCE)
+        config["swe_agents"] = self_contained
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert list(config["swe_agents"]["responses_api_agents"]) == ["swe_agents"]
+        assert list(config["gpqa_mcqa_simple_agent"]["responses_api_agents"]) == ["simple_agent"]
+
+    def test_rehosts_environment_instance_on_the_standalone_agent(self) -> None:
+        config = self._config()
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert self.HARNESS_INSTANCE not in config
+        # _composed_block asserts the instance kept its name and now hosts the harness.
+        block = self._composed_block(config, "gpqa_mcqa_simple_agent")
+
+        # The harness's own configuration comes across.
+        assert block["entrypoint"] == "app.py"
+        assert block["terminal_backend"] == "local"
+        assert block["max_turns"] == 30
+
+        # The environment's bindings and data are carried over, its agent parameters are not.
+        assert block["resources_server"] == {"type": "resources_servers", "name": "gpqa_mcqa_resources_server"}
+        assert "max_steps" not in block
+        assert OmegaConf.to_container(block["datasets"]) == [
+            {
+                "name": "gpqa",
+                "type": "benchmark",
+                "jsonl_fpath": "benchmarks/gpqa/data/gpqa_diamond_benchmark.jsonl",
+                "prompt_config": "benchmarks/prompts/eval/aai/mcq-4choices.yaml",
+                "prepare_script": "benchmarks/gpqa/prepare.py",
+                "num_repeats": 8,
+                "license": "CC-BY-4.0",
+            }
+        ]
+
+    def test_preserves_model_server_per_instance(self) -> None:
+        # Two instances differing only by model server, as genrm_compare does.
+        config = self._config(
+            genrm_reasoning_on=self._environment_agent(
+                "genrm_resources_server",
+                model_server={"type": "responses_api_models", "name": "policy_model"},
+            ),
+            genrm_reasoning_off=self._environment_agent(
+                "genrm_resources_server",
+                model_server={"type": "responses_api_models", "name": "policy_model_reasoning_off"},
+            ),
+        )
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert self._composed_block(config, "genrm_reasoning_on")["model_server"]["name"] == "policy_model"
+        assert (
+            self._composed_block(config, "genrm_reasoning_off")["model_server"]["name"] == "policy_model_reasoning_off"
+        )
+
+    def test_replaces_every_agent_instance(self) -> None:
+        # jailbreak_detection declares five agent instances, one per category.
+        categories = [f"jailbreak_{index}" for index in range(5)]
+        config = self._config(**{name: self._environment_agent("jailbreak_resources_server") for name in categories})
+        config.pop("gpqa_mcqa_simple_agent")
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        for name in categories:
+            assert self._composed_block(config, name)["resources_server"]["name"] == "jailbreak_resources_server"
+
+    def test_falls_back_to_harness_model_environment_has_none(self) -> None:
+        # FIXME: policy_model is the default for both resources_server and model_server
+        # call them differently.
+        environment_agent = self._environment_agent("gpqa_mcqa_resources_server")
+        environment_agent["responses_api_agents"]["simple_agent"].pop("model_server")
+        config = self._config(no_model_server_agent=environment_agent)
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert self._composed_block(config, "no_model_server_agent")["model_server"]["name"] == "policy_model"
+
+    def test_raises_when_two_instances_are_unbound(self) -> None:
+        config = self._config(second_harness=self._harness())
+
+        with raises(AgentCompositionError) as exc_info:
+            GlobalConfigDictParser().compose_unbound_agent(config)
+
+        message = str(exc_info.value)
+        assert "2 agent instances leave their 'resources_server' unset" in message
+        assert "'hermes_agent'" in message
+        assert "'second_harness'" in message
+
+    def test_raises_when_there_is_nothing_to_rehost(self) -> None:
+        config = DictConfig({self.HARNESS_INSTANCE: self._harness()})
+
+        with raises(AgentCompositionError) as exc_info:
+            GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert "no other agent instance to rehost it on" in str(exc_info.value)
+
+    def test_parse_fills_unbound_binding_before_missing_value_check(self) -> None:
+        resolved = self._parse(self._config())
+
+        block = resolved["gpqa_mcqa_simple_agent"]["responses_api_agents"]["hermes_agent"]
+        assert block["resources_server"]["name"] == "gpqa_mcqa_resources_server"
+
+    def test_parse_reports_binding_still_unbound_after_composition(self) -> None:
+        environment_agent = self._environment_agent("gpqa_mcqa_resources_server")
+        environment_agent["responses_api_agents"]["simple_agent"].pop("resources_server")
+        config = self._config()
+        config.pop("gpqa_mcqa_simple_agent")
+        config["unbound_agent"] = environment_agent
+
+        with raises(ConfigMissingValuesError) as exc_info:
+            self._parse(config)
+
+        assert "unbound_agent.responses_api_agents.hermes_agent.resources_server.name" in str(exc_info.value)
+
+    def test_real_benchmark_composes_onto_real_harness(self) -> None:
+        resolved = self._parse_config_paths(
+            "benchmarks/gpqa/config.yaml",
+            "responses_api_agents/hermes_agent/configs/hermes_agent.yaml",
+        )
+
+        block = resolved["gpqa_mcqa_simple_agent"]["responses_api_agents"]["hermes_agent"]
+        assert block["resources_server"]["name"] == "gpqa_mcqa_resources_server"
+        assert block["max_turns"] == 30
+        assert "max_steps" not in block
+        assert OmegaConf.to_container(block["datasets"])[0]["num_repeats"] == 8
+        assert "hermes_agent" not in resolved

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -2095,6 +2095,34 @@ class TestComposeUnboundAgent:
 
         assert self._composed_block(config, "no_model")["model_server"]["name"] == "policy_model"
 
+    def test_leaves_self_contained_agents_alone(self) -> None:
+        # A self-contained agent declares no resources server, so there is no task to hand the new agent.
+        self_contained = self._environment_agent("unused")
+        agents = self_contained["responses_api_agents"]
+        agents["tau2"] = agents.pop("simple_agent")
+        del agents["tau2"]["resources_server"]
+        config = self._config(tau2_benchmark_agent=self_contained)
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert list(config["tau2_benchmark_agent"]["responses_api_agents"]) == ["tau2"]
+        composed = self._composed_block(config, "gpqa_mcqa_simple_agent")
+        assert composed["resources_server"]["name"] == "gpqa_mcqa_resources_server"
+
+    def test_reads_a_self_contained_agent_from_a_struct_config(self) -> None:
+        # Hydra hands the command line over in struct mode, where reading the absent `resources_server`
+        # raises instead of reporting it missing.
+        self_contained = self._environment_agent("unused")
+        agents = self_contained["responses_api_agents"]
+        agents["tau2"] = agents.pop("simple_agent")
+        del agents["tau2"]["resources_server"]
+        config = self._config(tau2_benchmark_agent=self_contained)
+        OmegaConf.set_struct(config, True)
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert list(config["tau2_benchmark_agent"]["responses_api_agents"]) == ["tau2"]
+
     def test_raises_when_two_instances_are_unbound(self) -> None:
         config = self._config(second_harness=self._harness())
 
@@ -2120,17 +2148,18 @@ class TestComposeUnboundAgent:
         block = resolved["gpqa_mcqa_simple_agent"]["responses_api_agents"]["hermes_agent"]
         assert block["resources_server"]["name"] == "gpqa_mcqa_resources_server"
 
-    def test_parse_reports_binding_still_unbound_after_composition(self) -> None:
+    def test_raises_when_every_other_agent_is_self_contained(self) -> None:
+        # Self-contained agents are left alone, so there is nothing here for the selected agent to run.
         environment_agent = self._environment_agent("gpqa_mcqa_resources_server")
         environment_agent["responses_api_agents"]["simple_agent"].pop("resources_server")
         config = self._config()
         config.pop("gpqa_mcqa_simple_agent")
-        config["unbound_agent"] = environment_agent
+        config["self_contained_agent"] = environment_agent
 
-        with raises(ConfigMissingValuesError) as exc_info:
+        with raises(AgentCompositionError) as exc_info:
             self._parse(config)
 
-        assert "unbound_agent.responses_api_agents.hermes_agent.resources_server.name" in str(exc_info.value)
+        assert "no other agent instance to rehost it on" in str(exc_info.value)
 
     def test_real_benchmark_composes_onto_real_harness(self) -> None:
         resolved = self._parse_config_paths(

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -25,6 +25,7 @@ import nemo_gym.global_config
 import nemo_gym.server_utils
 from nemo_gym import CACHE_DIR, NEMO_GYM_EXTRA_ROOTS_ENV_VAR_NAME, RESULTS_DIR, WORKING_DIR
 from nemo_gym.config_types import (
+    AgentCompositionError,
     AlmostServerError,
     ConfigError,
     ConfigMissingValuesError,
@@ -1892,3 +1893,217 @@ class TestOpenAIVersionMatchesNemoGymConstraint:
 
         monkeypatch.setattr(importlib.metadata, "requires", raise_not_found)
         assert _openai_version_matches_nemo_gym_constraint("2.52.0") is True
+
+
+class TestComposeUnboundAgent:
+    """Composition of a standalone agent config onto the environment's agent instances."""
+
+    HARNESS_INSTANCE = "hermes_agent"
+
+    def _harness(self, **overrides) -> dict:
+        """The agent as its standalone config ships it, with `resources_server.name` left unset."""
+        block = {
+            "entrypoint": "app.py",
+            "resources_server": {"type": "resources_servers", "name": "???"},
+            "model_server": {"type": "responses_api_models", "name": "policy_model"},
+            "max_turns": 30,
+            "terminal_backend": "local",
+        }
+        block.update(overrides)
+        return {"responses_api_agents": {"hermes_agent": block}}
+
+    def _environment_agent(self, resources_server: str, **overrides) -> dict:
+        block = {
+            "entrypoint": "app.py",
+            "resources_server": {"type": "resources_servers", "name": resources_server},
+            "model_server": {"type": "responses_api_models", "name": "policy_model"},
+            "max_steps": 6,
+            "datasets": [
+                {
+                    "name": "gpqa",
+                    "type": "benchmark",
+                    "jsonl_fpath": "benchmarks/gpqa/data/gpqa_diamond_benchmark.jsonl",
+                    "prompt_config": "benchmarks/prompts/eval/aai/mcq-4choices.yaml",
+                    "prepare_script": "benchmarks/gpqa/prepare.py",
+                    "num_repeats": 8,
+                    "license": "CC-BY-4.0",
+                }
+            ],
+        }
+        block.update(overrides)
+        return {"responses_api_agents": {"simple_agent": block}}
+
+    def _config(self, **extra) -> DictConfig:
+        config = {
+            self.HARNESS_INSTANCE: self._harness(),
+            "gpqa_mcqa_simple_agent": self._environment_agent("gpqa_mcqa_resources_server"),
+            "gpqa_mcqa_resources_server": {
+                "resources_servers": {"mcqa": {"entrypoint": "app.py", "domain": "knowledge"}}
+            },
+        }
+        config.update(extra)
+        return DictConfig(config)
+
+    def _composed_block(self, config: DictConfig, instance: str) -> DictConfig:
+        agents = config[instance]["responses_api_agents"]
+        assert list(agents) == ["hermes_agent"], f"{instance} was not rehosted on the harness"
+        return agents["hermes_agent"]
+
+    def _parse(self, config: DictConfig) -> DictConfig:
+        return GlobalConfigDictParser().parse(
+            GlobalConfigDictParserConfig(
+                initial_global_config_dict=OmegaConf.merge(
+                    GlobalConfigDictParserConfig.NO_MODEL_GLOBAL_CONFIG_DICT, config
+                ),
+                skip_load_from_cli=True,
+                skip_load_from_dotenv=True,
+                offline=True,
+            )
+        )
+
+    def _parse_config_paths(self, *paths: str) -> DictConfig:
+        return self._parse(DictConfig({"config_paths": list(paths)}))
+
+    def test_noop_when_no_instance_is_unbound(self) -> None:
+        config = self._config()
+        config.pop(self.HARNESS_INSTANCE)
+        before = OmegaConf.to_container(config, resolve=False, throw_on_missing=False)
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert OmegaConf.to_container(config, resolve=False, throw_on_missing=False) == before
+
+    def test_absent_resources_server_is_not_a_source(self) -> None:
+        # Self-contained agents omit `resources_server` entirely, which is not the same as leaving it unset.
+        self_contained = {
+            "responses_api_agents": {"swe_agents": {"entrypoint": "app.py", "agent_framework": "openhands"}}
+        }
+        config = self._config()
+        config.pop(self.HARNESS_INSTANCE)
+        config["swe_agents"] = self_contained
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert list(config["swe_agents"]["responses_api_agents"]) == ["swe_agents"]
+        assert list(config["gpqa_mcqa_simple_agent"]["responses_api_agents"]) == ["simple_agent"]
+
+    def test_rehosts_environment_instance_on_the_standalone_agent(self) -> None:
+        config = self._config()
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert self.HARNESS_INSTANCE not in config
+        # _composed_block asserts the instance kept its name and now hosts the harness.
+        block = self._composed_block(config, "gpqa_mcqa_simple_agent")
+
+        # The harness's own configuration comes across.
+        assert block["entrypoint"] == "app.py"
+        assert block["terminal_backend"] == "local"
+        assert block["max_turns"] == 30
+
+        # The environment's bindings and data are carried over, its agent parameters are not.
+        assert block["resources_server"] == {"type": "resources_servers", "name": "gpqa_mcqa_resources_server"}
+        assert "max_steps" not in block
+        assert OmegaConf.to_container(block["datasets"]) == [
+            {
+                "name": "gpqa",
+                "type": "benchmark",
+                "jsonl_fpath": "benchmarks/gpqa/data/gpqa_diamond_benchmark.jsonl",
+                "prompt_config": "benchmarks/prompts/eval/aai/mcq-4choices.yaml",
+                "prepare_script": "benchmarks/gpqa/prepare.py",
+                "num_repeats": 8,
+                "license": "CC-BY-4.0",
+            }
+        ]
+
+    def test_preserves_model_server_per_instance(self) -> None:
+        # Two instances differing only by model server, as genrm_compare does.
+        config = self._config(
+            genrm_reasoning_on=self._environment_agent(
+                "genrm_resources_server",
+                model_server={"type": "responses_api_models", "name": "policy_model"},
+            ),
+            genrm_reasoning_off=self._environment_agent(
+                "genrm_resources_server",
+                model_server={"type": "responses_api_models", "name": "policy_model_reasoning_off"},
+            ),
+        )
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert self._composed_block(config, "genrm_reasoning_on")["model_server"]["name"] == "policy_model"
+        assert (
+            self._composed_block(config, "genrm_reasoning_off")["model_server"]["name"] == "policy_model_reasoning_off"
+        )
+
+    def test_replaces_every_agent_instance(self) -> None:
+        # jailbreak_detection declares five agent instances, one per category.
+        categories = [f"jailbreak_{index}" for index in range(5)]
+        config = self._config(**{name: self._environment_agent("jailbreak_resources_server") for name in categories})
+        config.pop("gpqa_mcqa_simple_agent")
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        for name in categories:
+            assert self._composed_block(config, name)["resources_server"]["name"] == "jailbreak_resources_server"
+
+    def test_falls_back_to_harness_model_environment_has_none(self) -> None:
+        # FIXME: policy_model is the default for both resources_server and model_server
+        # call them differently.
+        environment_agent = self._environment_agent("gpqa_mcqa_resources_server")
+        environment_agent["responses_api_agents"]["simple_agent"].pop("model_server")
+        config = self._config(no_model_server_agent=environment_agent)
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert self._composed_block(config, "no_model_server_agent")["model_server"]["name"] == "policy_model"
+
+    def test_raises_when_two_instances_are_unbound(self) -> None:
+        config = self._config(second_harness=self._harness())
+
+        with raises(AgentCompositionError) as exc_info:
+            GlobalConfigDictParser().compose_unbound_agent(config)
+
+        message = str(exc_info.value)
+        assert "2 agent instances leave their 'resources_server' unset" in message
+        assert "'hermes_agent'" in message
+        assert "'second_harness'" in message
+
+    def test_raises_when_there_is_nothing_to_rehost(self) -> None:
+        config = DictConfig({self.HARNESS_INSTANCE: self._harness()})
+
+        with raises(AgentCompositionError) as exc_info:
+            GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert "no other agent instance to rehost it on" in str(exc_info.value)
+
+    def test_parse_fills_unbound_binding_before_missing_value_check(self) -> None:
+        resolved = self._parse(self._config())
+
+        block = resolved["gpqa_mcqa_simple_agent"]["responses_api_agents"]["hermes_agent"]
+        assert block["resources_server"]["name"] == "gpqa_mcqa_resources_server"
+
+    def test_parse_reports_binding_still_unbound_after_composition(self) -> None:
+        environment_agent = self._environment_agent("gpqa_mcqa_resources_server")
+        environment_agent["responses_api_agents"]["simple_agent"].pop("resources_server")
+        config = self._config()
+        config.pop("gpqa_mcqa_simple_agent")
+        config["unbound_agent"] = environment_agent
+
+        with raises(ConfigMissingValuesError) as exc_info:
+            self._parse(config)
+
+        assert "unbound_agent.responses_api_agents.hermes_agent.resources_server.name" in str(exc_info.value)
+
+    def test_real_benchmark_composes_onto_real_harness(self) -> None:
+        resolved = self._parse_config_paths(
+            "benchmarks/gpqa/config.yaml",
+            "responses_api_agents/hermes_agent/configs/hermes_agent.yaml",
+        )
+
+        block = resolved["gpqa_mcqa_simple_agent"]["responses_api_agents"]["hermes_agent"]
+        assert block["resources_server"]["name"] == "gpqa_mcqa_resources_server"
+        assert block["max_turns"] == 30
+        assert "max_steps" not in block
+        assert OmegaConf.to_container(block["datasets"])[0]["num_repeats"] == 8
+        assert "hermes_agent" not in resolved

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -2058,6 +2058,23 @@ class TestComposeUnboundAgent:
 
         assert self._composed_block(config, "no_model_server_agent")["model_server"]["name"] == "policy_model"
 
+    def test_skips_an_instance_whose_agent_block_is_unset(self) -> None:
+        # Resolving the block would raise MissingMandatoryValue, which is not a ConfigError, so the CLI
+        # would print a traceback instead of the usual missing-value report.
+        config = self._config(broken={"responses_api_agents": {"simple_agent": "???"}})
+
+        names = {instance.name for instance in GlobalConfigDictParser()._agent_instances(config)}
+
+        assert "broken" not in names
+
+    def test_parse_reports_an_unset_agent_block(self) -> None:
+        config = self._config(broken={"responses_api_agents": {"simple_agent": "???"}})
+
+        with raises(ConfigMissingValuesError) as exc_info:
+            self._parse(config)
+
+        assert "broken.responses_api_agents.simple_agent" in str(exc_info.value)
+
     def test_raises_when_two_instances_are_unbound(self) -> None:
         config = self._config(second_harness=self._harness())
 

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -2075,6 +2075,26 @@ class TestComposeUnboundAgent:
 
         assert "broken.responses_api_agents.simple_agent" in str(exc_info.value)
 
+    def test_carries_over_a_binding_the_environment_leaves_unset(self) -> None:
+        # OmegaConf reports a '???' value as absent, so skipping on `in` alone let the incoming agent's own
+        # model server stand in for one the environment deliberately left for the user to supply.
+        config = self._config(unset_model=self._environment_agent("gpqa_mcqa_resources_server", model_server="???"))
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        block = self._composed_block(config, "unset_model")
+        assert OmegaConf.is_missing(block, "model_server"), "an unset binding must stay unset, not silently resolve"
+
+    def test_carry_over_leaves_an_absent_binding_to_the_incoming_agent(self) -> None:
+        # Absent is not unset: the environment simply has no opinion, so the agent's own value stands.
+        environment = self._environment_agent("gpqa_mcqa_resources_server")
+        del environment["responses_api_agents"]["simple_agent"]["model_server"]
+        config = self._config(no_model=environment)
+
+        GlobalConfigDictParser().compose_unbound_agent(config)
+
+        assert self._composed_block(config, "no_model")["model_server"]["name"] == "policy_model"
+
     def test_raises_when_two_instances_are_unbound(self) -> None:
         config = self._config(second_harness=self._harness())
 


### PR DESCRIPTION
This PR introduces possibility to compose a new config at runtime by combining a benchmark / env config with an agent config template.

The mechanism is based on finding an agent config with undefined resources server:
```
codex_agent:
  responses_api_agents:
    codex_agent:
      resources_server:
        type: resources_servers
        name: ???
```
and filling the missing part with information from resources server configuration available in the global config.

The entire PR stack will introduce the following changes:

1. config composition (**this PR**)
2. `--agent-type` flag in the CLI for selecting the agent
3. safeguard preventing unsupported env <> agent pairings
4. aligning with dataset changes introduced in epic #1338
5. docs update