### PR TITLE
fix(vllm pd): let the caller name the rollouts file

### DIFF
--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -41,6 +41,13 @@ cd /opt/Gym
 gym eval prepare $@ +use_cached_prepared_benchmarks=true
 
 experiment_name=$EXPERIMENT_NAME/slurm_job_id_\$SLURM_JOB_ID/date_\$(date +%Y%m%d_%H%M%S)
+# Where the rollouts land, and with them the aggregate metrics that
+# export_to_csv.py derives as <base>_aggregate_metrics.json. The default nests
+# them under the experiment name, the job id and a timestamp, which keeps
+# concurrent runs apart in a shared results directory. Set ROLLOUTS_FPATH when
+# the results directory is already per-run and something downstream has to find
+# the aggregate without knowing the timestamp.
+rollouts_fpath=\${ROLLOUTS_FPATH:-results/\$experiment_name.jsonl}
 # +uv_venv_dir=/opt/uv_venvs is from the container.
 # +skip_venv_if_present=true will reuse the venvs baked into the container if possible.
 # ++use_absolute_ip=true: Necessary for communication between harness in sandbox and Gym model servers
@@ -54,7 +61,7 @@ gym eval run \
     +uv_venv_dir=/opt/uv_venvs \
     +nemo_gym_log_dir=results/\$experiment_name/logs \
     +skip_venv_if_present=true \
-    ++output_jsonl_fpath=results/\$experiment_name.jsonl \
+    ++output_jsonl_fpath=\$rollouts_fpath \
     ++overwrite_metrics_conflicts=true \
     ++split=benchmark \
     ++use_absolute_ip=true \
@@ -71,10 +78,10 @@ gym eval run \
 if (( $EXPORT_TO_CSV )); then
     python benchmarks/nemotron_3.5_super/export_to_csv.py \
         --model-path $MODEL \
-        --jsonl-fpath-base \$(realpath results/\$experiment_name)
+        --jsonl-fpath-base \$(realpath "\${rollouts_fpath%.jsonl}")
 
     if (( $EXPORT_CSV_TO_MODEL_DIR )); then
-        cp results/\$experiment_name_export.csv $MODEL/export.csv
+        cp "\${rollouts_fpath%.jsonl}_export.csv" $MODEL/export.csv
     fi
 fi
 

--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -41,12 +41,9 @@ cd /opt/Gym
 gym eval prepare $@ +use_cached_prepared_benchmarks=true
 
 experiment_name=$EXPERIMENT_NAME/slurm_job_id_\$SLURM_JOB_ID/date_\$(date +%Y%m%d_%H%M%S)
-# Where the rollouts land, and with them the aggregate metrics that
-# export_to_csv.py derives as <base>_aggregate_metrics.json. The default nests
-# them under the experiment name, the job id and a timestamp, which keeps
-# concurrent runs apart in a shared results directory. Set ROLLOUTS_FPATH when
-# the results directory is already per-run and something downstream has to find
-# the aggregate without knowing the timestamp.
+# export_to_csv.py derives <base>_aggregate_metrics.json from this, so the
+# default timestamped name makes the aggregate unfindable to anything that
+# did not watch the job run. Override it when results/ is already per-run.
 rollouts_fpath=\${ROLLOUTS_FPATH:-results/\$experiment_name.jsonl}
 # +uv_venv_dir=/opt/uv_venvs is from the container.
 # +skip_venv_if_present=true will reuse the venvs baked into the container if possible.


### PR DESCRIPTION
`sbatch_external_vllm.sh` hardcoded the rollouts path and appended its
`++output_jsonl_fpath` **after** the caller's arguments. Duplicate `++`
overrides are last-wins, so a caller could not choose the path even by passing
it explicitly.

`export_to_csv.py` derives the aggregate as `<base>_aggregate_metrics.json`, so
that name carries the timestamp too — and anything reading the aggregate
without having watched the job run has to glob for it.

`ROLLOUTS_FPATH` overrides the path. Unset, behaviour is unchanged.

Also fixes the CSV copy beside it: `cp results/$experiment_name_export.csv`
expanded `${experiment_name_export}`, an unset variable. It sits behind
`EXPORT_CSV_TO_MODEL_DIR` (default 0), so it had not been hit.

Tested by rendering the submitted script with a stubbed `sbatch` and simulating
the job-side resolution:

```
default:    results/<exp>/slurm_job_id_12345/date_20260821_101500_aggregate_metrics.json
overridden: results/evaluator_rollouts_aggregate_metrics.json
```

`bash -n` clean.
