### PR TITLE
feat(token-id-capture): record served response IDs

### DIFF
--- a/nemo_gym/anthropic_converter.py
+++ b/nemo_gym/anthropic_converter.py
@@ -495,7 +495,11 @@ class AnthropicConverter:
         usage = response.usage.model_dump() if response.usage is not None else None
         message = NeMoGymAnthropicMessage.model_validate(
             {
-                "id": f"msg_{uuid4().hex}",
+                # Reuse the Responses envelope id instead of minting a new one.
+                # Token capture records the inner response's id.
+                # A client can then prove which served response it kept by possessing this id.
+                # A minted id here would break that join for the Messages dialect.
+                "id": str(getattr(response, "id", "") or "") or f"msg_{uuid4().hex}",
                 "type": "message",
                 "role": "assistant",
                 "model": model,

--- a/nemo_gym/token_id_capture/records.py
+++ b/nemo_gym/token_id_capture/records.py
@@ -40,7 +40,7 @@ TOKEN_FIELDS = ("prompt_token_ids", "generation_token_ids", "generation_log_prob
 # Readers must reject unsupported newer records.
 # ``extra="allow"`` otherwise hides unknown fields.
 #
-#   1  rollout and call identity, the token arrays, the output items and their carrier index
+#   1  rollout and call identity, token arrays, output items, their carrier index, and the response id
 TOKEN_ENTRY_RECORD_SCHEMA_VERSION = 1
 
 
@@ -71,6 +71,9 @@ class TokenEntry(BaseModel):
     # This index identifies the item that carried token arrays.
     # ``None`` means no item carried them.
     token_item_index: int | None = None
+    # The response id returned to the client for this model call.
+    # Terminal attribution uses it to match the agent's final response to these captured tokens.
+    response_id: str | None = None
     # This non-semantic timestamp helps diagnose retries and sibling branches.
     created_at: float = 0.0
 

--- a/nemo_gym/token_id_capture/sink.py
+++ b/nemo_gym/token_id_capture/sink.py
@@ -139,6 +139,10 @@ async def capture_tokens(response: Any) -> None:
             # Preserve content for text-based training penalties.
             output_items=content_items,
             token_item_index=token_item_index,
+            # Observe the served payload's own id; never mint one.
+            # The Anthropic mapping reuses this id on its outer envelope,
+            # so the recorded id matches what the client received in every dialect.
+            response_id=str(payload.get("id") or "") or None,
             created_at=time.time(),
         )
     except Exception:

--- a/tests/unit_tests/test_served_response_id.py
+++ b/tests/unit_tests/test_served_response_id.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test the served envelope id recorded on every captured call.
+
+Each dialect route serves a payload with one top-level id.
+Capture observes that id; it never mints one.
+The Anthropic mapping reuses the inner Responses id on its outer envelope,
+so the id a Messages-dialect client keeps is the id capture recorded.
+"""
+
+from time import time
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import Body, Request
+from fastapi.testclient import TestClient
+
+from nemo_gym.anthropic_converter import AnthropicConverter
+from nemo_gym.base_responses_api_model import BaseResponsesAPIModelConfig, SimpleResponsesAPIModel
+from nemo_gym.openai_utils import (
+    NeMoGymChatCompletion,
+    NeMoGymChatCompletionCreateParamsNonStreaming,
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+)
+from nemo_gym.server_utils import ServerClient
+from nemo_gym.token_id_capture import TokenCaptureStore, TokenEntry
+
+
+PTOKS = [1, 2, 3]
+GTOKS = [4, 5]
+LPS = [-0.1, -0.2]
+
+
+def _training_response(text: str = "hi") -> NeMoGymResponse:
+    return NeMoGymResponse(
+        id=f"resp_{uuid4().hex}",
+        created_at=int(time()),
+        model="m",
+        object="response",
+        output=[
+            {
+                "type": "message",
+                "id": f"msg_{uuid4().hex}",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": text, "annotations": []}],
+                "prompt_token_ids": PTOKS,
+                "generation_token_ids": GTOKS,
+                "generation_log_probs": LPS,
+            }
+        ],
+        tool_choice="auto",
+        parallel_tool_calls=True,
+        tools=[],
+    )
+
+
+class _CapturingModel(SimpleResponsesAPIModel):
+    config: BaseResponsesAPIModelConfig
+    model_config = {"arbitrary_types_allowed": True}
+
+    async def responses(
+        self, request: Request, body: NeMoGymResponseCreateParamsNonStreaming = Body()
+    ) -> NeMoGymResponse:
+        return _training_response()
+
+    async def chat_completions(
+        self, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
+    ) -> NeMoGymChatCompletion:
+        return NeMoGymChatCompletion.model_validate(
+            {
+                "id": f"chatcmpl_{uuid4().hex}",
+                "created": int(time()),
+                "model": "m",
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {
+                            "role": "assistant",
+                            "content": "hi",
+                            "prompt_token_ids": PTOKS,
+                            "generation_token_ids": GTOKS,
+                            "generation_log_probs": LPS,
+                        },
+                    }
+                ],
+            }
+        )
+
+
+def _client(tmp_path) -> TestClient:
+    server = _CapturingModel(
+        config=BaseResponsesAPIModelConfig(host="0.0.0.0", port=8099, entrypoint="", name="srv"),
+        server_client=MagicMock(
+            spec=ServerClient,
+            global_config_dict={"token_id_capture": {"enabled": True, "dir": str(tmp_path)}},
+        ),
+    )
+    return TestClient(server.setup_webserver())
+
+
+def test_responses_route_records_the_served_envelope_id(tmp_path):
+    client = _client(tmp_path)
+    resp = client.post("/ng-rollout/rid-a/training-token-capture/v1/responses", json={"input": "hi"})
+    assert resp.status_code == 200
+    [entry] = TokenCaptureStore(tmp_path).read_entries("rid-a")
+    assert entry.response_id == resp.json()["id"]
+    assert entry.response_id and entry.response_id.startswith("resp_")
+
+
+def test_chat_route_records_the_served_envelope_id(tmp_path):
+    client = _client(tmp_path)
+    resp = client.post(
+        "/ng-rollout/rid-b/training-token-capture/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 200
+    [entry] = TokenCaptureStore(tmp_path).read_entries("rid-b")
+    assert entry.response_id == resp.json()["id"]
+    assert entry.response_id and entry.response_id.startswith("chatcmpl_")
+
+
+def test_messages_route_serves_the_recorded_id_on_its_envelope(tmp_path):
+    # The Anthropic mapping reuses the inner Responses id on its outer envelope,
+    # so the id a Messages-dialect client keeps is the id capture recorded.
+    client = _client(tmp_path)
+    resp = client.post(
+        "/ng-rollout/rid-c/training-token-capture/v1/messages",
+        json={"model": "claude-x", "max_tokens": 16, "messages": [{"role": "user", "content": "hello"}]},
+    )
+    assert resp.status_code == 200
+    [entry] = TokenCaptureStore(tmp_path).read_entries("rid-c")
+    assert entry.response_id == resp.json()["id"]
+
+
+def test_anthropic_converter_reuses_the_responses_envelope_id():
+    response = _training_response()
+    message = AnthropicConverter().responses_to_anthropic_response(response, model="m")
+    message_id = message["id"] if isinstance(message, dict) else message.id
+    assert message_id == response.id
+
+
+def test_record_without_response_id_uses_none():
+    entry = TokenEntry.model_validate(
+        {
+            "schema_version": 1,
+            "rollout_id": "r",
+            "model_call_id": "c",
+            "prompt_token_ids": [1],
+            "generation_token_ids": [2],
+            "generation_log_probs": [-0.1],
+        }
+    )
+    assert entry.response_id is None
+
+
+def test_newer_record_is_rejected():
+    with pytest.raises(Exception):
+        TokenEntry.model_validate(
+            {
+                "schema_version": 99,
+                "rollout_id": "r",
+                "model_call_id": "c",
+                "prompt_token_ids": [1],
+                "generation_token_ids": [2],
+                "generation_log_probs": [-0.1],
+            }
+        )


### PR DESCRIPTION
## What does this PR do?

This PR records the response envelope ID on each captured model call. The ID is a lightweight receipt that an agent can retain while token IDs and log probabilities remain in the configured token sink.

- Adds the optional `TokenEntry.response_id` field to the existing version 1 record schema.
- Records the top-level ID returned by the Responses, Chat Completions, or Messages endpoint.
- Reuses the underlying Responses ID in the Anthropic conversion so the client-visible ID matches the captured ID.

## Response ID flow

```mermaid
sequenceDiagram
    participant Agent as Agent harness
    participant Capture as Capture middleware
    participant Route as Model API route
    participant Model as Model server
    participant Sink as Token sink

    Agent->>Capture: Request /ng-rollout/{rollout_id}/training-token-capture/v1/{dialect}
    Capture->>Capture: Strip prefix and set rollout_id + model_call_id
    Capture->>Route: Forward dialect request with capture context
    Route->>Model: Generate response
    Model-->>Route: NeMoGymResponse(id, output, token metadata)
    Route->>Sink: TokenEntry(model_call_id, response_id=id, token arrays, output items)
    alt Responses or Chat Completions
        Route-->>Agent: Client response carries the recorded id
    else Anthropic Messages
        Route->>Route: Convert response and preserve response.id as message.id
        Route-->>Agent: Message response carries the recorded id
    end
```

The response ID and token arrays are written to the same `TokenEntry`. The agent only needs to retain the response ID; later code can use it to locate the corresponding captured model call.

This is the first PR in the terminal-attribution stack. #2676 uses the recorded ID as one witness when resolving the model call that produced the verified response.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).