### PR TITLE
feat(token-id-capture): attribute terminal model calls

### DIFF
--- a/nemo_gym/token_id_capture/builder.py
+++ b/nemo_gym/token_id_capture/builder.py
@@ -95,6 +95,14 @@ class BuildNotes:
     # These calls have a retry sibling that the harness may not have kept.
     # A final-call retry is unresolved because no later call identifies the survivor.
     unresolved_retries: list[str] = field(default_factory=list)
+    # Terminal attribution names the call whose response the verifier scored.
+    # ``terminal_chain`` reports what the builder did with it:
+    #   ""             no terminal was given; legacy single-chain policy applies
+    #   "delivered"    the root-to-terminal chain is clean and is the main chain
+    #   "broken"       the terminal's chain crosses a quarantined boundary
+    #   "not_captured" the named call is absent from the buildable entries
+    terminal_call_id: str | None = None
+    terminal_chain: str = ""
     # Calls without generated tokens are excluded from the chain.
     empty_generation_calls: list[str] = field(default_factory=list)
 
@@ -165,7 +173,7 @@ def _infer_parent(prompt: list[int], index: _PrefixIndex) -> tuple["_Node | None
     return index.infer_parent(prompt)
 
 
-def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
+def prefix_merging(entries: list[TokenEntry], terminal_call_id: str | None = None) -> BuildOutput:
     # A call without generated tokens has no training signal.
     # Its cumulative sequence equals its prompt.
     # Keeping it would make it the parent of another call with the same prompt.
@@ -175,7 +183,13 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
     entries = [e for e in entries if e.generation_token_ids]
     if not entries:
         return BuildOutput(
-            chains=[], notes=BuildNotes(builder="prefix_merging", empty_generation_calls=empty_generation)
+            chains=[],
+            notes=BuildNotes(
+                builder="prefix_merging",
+                empty_generation_calls=empty_generation,
+                terminal_call_id=terminal_call_id,
+                terminal_chain="not_captured" if terminal_call_id else "",
+            ),
         )
 
     # Increasing prompt length defines an order from the tokens.
@@ -187,6 +201,7 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
     roots: list[_Node] = []
     quarantined: list[str] = []
     prefix_index = _PrefixIndex()
+    nodes_by_call_id: dict[str, _Node] = {}
 
     for entry in ordered:
         prompt = list(entry.prompt_token_ids)
@@ -203,6 +218,18 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
             roots.append(node)
         nodes.append(node)
         prefix_index.add(node)
+        nodes_by_call_id[entry.model_call_id] = node
+
+    # Terminal attribution names the call whose response the verifier scored.
+    # The ancestry set holds every call on the root-to-terminal path.
+    # Retry resolution and chain selection prefer this evidence when present.
+    terminal_node = nodes_by_call_id.get(terminal_call_id) if terminal_call_id else None
+    terminal_ancestry: set[int] = set()
+    if terminal_node is not None:
+        ancestor: _Node | None = terminal_node
+        while ancestor is not None:
+            terminal_ancestry.add(id(ancestor))
+            ancestor = ancestor.parent
 
     # Resolve retry siblings.
     # A harness can retry after a timeout, server error, or dropped stream.
@@ -212,7 +239,8 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
     # A recorded parent link identifies the sibling retained by the harness.
     # Without a link, retain the sibling extended by a later call.
     # Neither method can resolve a retry of the final call.
-    # Mark that retry as unresolved.
+    # An attributed terminal resolves it: the kept sibling is on the terminal path.
+    # Otherwise mark that retry as unresolved.
     # The consumer masks the rollout instead of training on an unconfirmed generation.
     unresolved_retries: list[str] = []
     # Group calls by parent identity.
@@ -230,12 +258,20 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
         for retry_group in by_prompt.values():
             if len(retry_group) < 2:
                 continue
-            extended = [n for n in retry_group if any(not child.quarantined for child in n.children)]
-            if extended:
-                keep = set(extended)
+            on_terminal_path = [n for n in retry_group if id(n) in terminal_ancestry]
+            if on_terminal_path:
+                # The verified terminal identifies the sibling the harness kept.
+                keep = set(on_terminal_path)
             else:
-                keep = {min(retry_group, key=lambda n: n.entry.model_call_id)}
-                unresolved_retries.extend(n.entry.model_call_id for n in retry_group)
+                extended = [n for n in retry_group if any(not child.quarantined for child in n.children)]
+                if extended:
+                    keep = set(extended)
+                else:
+                    keep = {min(retry_group, key=lambda n: n.entry.model_call_id)}
+                    # With an attributed terminal, a group off the terminal path
+                    # cannot reach the delivered chain, so it never masks.
+                    if terminal_node is None:
+                        unresolved_retries.extend(n.entry.model_call_id for n in retry_group)
             for node in retry_group:
                 if node not in keep and not node.quarantined:
                     node.quarantined = True
@@ -243,17 +279,16 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
 
     chains: list[Chain] = []
 
-    # Materialize root-to-leaf chains without recursion.
-    # Agent rollouts can exceed Python's recursion limit.
-    for leaf in (node for node in nodes if not node.children):
+    def path_to(node: _Node) -> list[_Node]:
+        # Iterative root-to-node paths: agent rollouts can exceed the recursion limit.
         reverse_path: list[_Node] = []
-        current: _Node | None = leaf
+        current: _Node | None = node
         while current is not None:
             reverse_path.append(current)
             current = current.parent
-        path = list(reversed(reverse_path))
-        if any(node.quarantined for node in path):
-            continue
+        return list(reversed(reverse_path))
+
+    def chain_from(path: list[_Node]) -> Chain:
         root = path[0]
         chain = Chain(chain_id="", root_prompt=list(root.entry.prompt_token_ids))
         prev_cumulative = list(root.entry.prompt_token_ids)
@@ -261,10 +296,41 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
             interstitial = [] if step == 0 else list(node.entry.prompt_token_ids[len(prev_cumulative) :])
             chain.links.append(ChainLink(entry=node.entry, interstitial=interstitial))
             prev_cumulative = list(node.entry.prompt_token_ids) + list(node.entry.generation_token_ids)
-        chains.append(chain)
+        return chain
+
+    # The terminal chain ends at the attributed call, not at a leaf.
+    # Calls that extend the terminal were served after the kept response.
+    # They are outside the verified trajectory and are truncated away.
+    terminal_chain_status = ""
+    terminal_chain: Chain | None = None
+    if terminal_call_id:
+        if terminal_node is None:
+            terminal_chain_status = "not_captured"
+        else:
+            terminal_path = path_to(terminal_node)
+            if any(node.quarantined for node in terminal_path):
+                # A quarantined boundary on the delivered path is not
+                # repairable by attribution. The consumer masks.
+                terminal_chain_status = "broken"
+            else:
+                terminal_chain = chain_from(terminal_path)
+                terminal_chain_status = "delivered"
+
+    # Materialize root-to-leaf chains.
+    # A leaf chain through the terminal is represented by the truncated main chain.
+    for leaf in (node for node in nodes if not node.children):
+        path = path_to(leaf)
+        if any(node.quarantined for node in path):
+            continue
+        if terminal_chain is not None and terminal_node in path:
+            continue
+        chains.append(chain_from(path))
+    if terminal_chain is not None:
+        chains.insert(0, terminal_chain)
 
     # Deliver only one chain per rollout.
-    # Choose the chain whose root call completed first.
+    # An attributed terminal names the delivered chain directly.
+    # Without one, choose the chain whose root call completed first.
     #
     # Completion order matches dispatch order for a sequential harness.
     # The model server awaits token capture before returning the response.
@@ -283,8 +349,8 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
     # Ordering cannot recover that identity.
     # Some harnesses can route sub-agent calls to a different model server.
     #
-    # These shapes require future work.
-    # A split rollout reports multiple chains and a delivered fraction below 1.
+    # These shapes are exactly what terminal attribution resolves.
+    # Without it, a split rollout reports multiple chains and a delivered fraction below 1.
     def selection_key(c: Chain) -> tuple:
         # Sort by the earliest root.
         # Break timestamp ties by call ID.
@@ -295,7 +361,7 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
         return (root.created_at, root.model_call_id)
 
     if chains:
-        main = min(chains, key=selection_key)
+        main = terminal_chain if terminal_chain is not None else min(chains, key=selection_key)
         main.chain_id = "main"
         branch = 0
         for c in chains:
@@ -314,20 +380,32 @@ def prefix_merging(entries: list[TokenEntry]) -> BuildOutput:
         delivered_fraction=round(delivered / captured, 4) if captured else 0.0,
         unresolved_retries=unresolved_retries,
         empty_generation_calls=empty_generation,
+        terminal_call_id=terminal_call_id,
+        terminal_chain=terminal_chain_status,
     )
     return BuildOutput(chains=chains, quarantined=quarantined, notes=notes)
 
 
-_BUILDERS: dict[str, Callable[[list[TokenEntry]], BuildOutput]] = {
+_BUILDERS: dict[str, Callable[..., BuildOutput]] = {
     "per_request": per_request,
     "prefix_merging": prefix_merging,
 }
 
 
-def run_builder(entries: list[TokenEntry], builder: str = "prefix_merging") -> BuildOutput:
-    """Chain frozen snapshot entries with the named strategy."""
+def run_builder(
+    entries: list[TokenEntry],
+    builder: str = "prefix_merging",
+    terminal_call_id: str | None = None,
+) -> BuildOutput:
+    """Chain frozen snapshot entries with the named strategy.
+
+    ``terminal_call_id`` anchors chain selection for ``prefix_merging``.
+    ``per_request`` has no chain selection and ignores it.
+    """
     if builder not in _BUILDERS:
         raise ValueError(f"unknown builder {builder!r}; known: {sorted(_BUILDERS)}")
+    if builder == "prefix_merging":
+        return prefix_merging(entries, terminal_call_id=terminal_call_id)
     return _BUILDERS[builder](entries)
 
 

--- a/nemo_gym/token_id_capture/consumer.py
+++ b/nemo_gym/token_id_capture/consumer.py
@@ -41,6 +41,7 @@ from nemo_gym.token_id_capture.builder import (
 from nemo_gym.token_id_capture.protocols import TokenSource
 from nemo_gym.token_id_capture.records import TokenEntry
 from nemo_gym.token_id_capture.store import TokenCaptureStore
+from nemo_gym.token_id_capture.terminal import TerminalAttribution, resolve_terminal
 
 
 logger = logging.getLogger(__name__)
@@ -96,6 +97,9 @@ def _assemble(
     entries: list[TokenEntry],
     builder: str,
     model: str,
+    *,
+    verified_response: dict | None = None,
+    explicit_terminal_call_id: str | None = None,
 ) -> dict:
     if builder == "per_request":
         # Single-response delivery cannot represent multiple trajectories.
@@ -105,11 +109,40 @@ def _assemble(
             "per_request returns multiple trajectories and is not supported by single-response delivery",
             n_calls=len(entries),
         )
+    # Attribute the verified terminal before building.
+    # ``verified_response`` is the scored response from the /run result.
+    # Attribution anchors chain selection; its absence falls back to the
+    # strict single-chain policy. It must never fail a build.
+    try:
+        attribution = resolve_terminal(entries, verified_response, explicit_terminal_call_id)
+    except Exception:
+        logger.warning("Terminal attribution failed for rollout %s.", rollout_id, exc_info=True)
+        attribution = TerminalAttribution(None, reason="attribution_error")
+
     # Mask a malformed rollout instead of failing the caller.
     # The contiguity check and projection can raise.
     # An uncaught exception could fail a full rollout or training batch.
+    def _attribution_metric(chain_status: str) -> dict:
+        return {
+            "method": attribution.method or "none",
+            "call_id": attribution.model_call_id,
+            "reason": attribution.reason,
+            "chain": chain_status,
+        }
+
     try:
-        out = run_builder(entries, builder)
+        out = run_builder(entries, builder, terminal_call_id=attribution.model_call_id)
+    except (AssertionError, ValueError, KeyError, IndexError, TypeError) as error:
+        logger.warning(
+            "Could not build a trajectory for rollout %s from %d captured call(s): %s",
+            rollout_id,
+            len(entries),
+            error,
+        )
+        failed = _failed_build(rollout_id, builder, f"{type(error).__name__}: {error}", n_calls=len(entries))
+        failed["metrics"]["terminal_attribution"] = _attribution_metric("error")
+        return failed
+    try:
         for chain in out.chains:
             chain.validate()
         response = project_main_chain_response(rollout_id, out, model=model)
@@ -121,18 +154,20 @@ def _assemble(
             len(entries),
             error,
         )
-        return _failed_build(
-            rollout_id,
-            builder,
-            f"{type(error).__name__}: {error}",
-            n_calls=len(entries),
-        )
+        failed = _failed_build(rollout_id, builder, f"{type(error).__name__}: {error}", n_calls=len(entries))
+        # The builder's verdict survives a failed projection.
+        # A broken terminal chain must stay diagnosable in aggregate metrics.
+        failed["metrics"]["terminal_attribution"] = _attribution_metric(out.notes.terminal_chain or "error")
+        return failed
 
     notes = out.notes
     # Report everything dropped by the build.
     # A partial build must not appear complete.
     metrics = {
         "n_calls": len(entries),
+        # Attribution names the call whose response the verifier scored.
+        # ``chain`` reports what the builder did with that name.
+        "terminal_attribution": _attribution_metric(notes.terminal_chain),
         "chains": notes.chains,
         "roots": notes.roots,
         "quarantined_calls": len(out.quarantined),
@@ -145,14 +180,26 @@ def _assemble(
         "empty_generation_calls": len(notes.empty_generation_calls),
     }
     unresolved = notes.unresolved_retries
+    if notes.terminal_chain == "delivered":
+        # The verified chain is attributed and intact.
+        # Off-path calls (auxiliary calls, sub-agent forks, abandoned retries)
+        # are excluded from delivery instead of masking the rollout.
+        mask = False
+    elif attribution.attributed:
+        # Attribution succeeded but its chain is broken or unbuildable.
+        # The rollout's verified trajectory is known and undeliverable.
+        mask = True
+    else:
+        # No attribution: the strict single-chain policy applies.
+        # A retry of the final call can leave two plausible generations.
+        # Mask the rollout when the client-selected generation is unknown.
+        mask = bool(unresolved) or notes.roots != 1 or notes.chains != 1
     return {
         "rollout_id": rollout_id,
         "builder": builder,
         "rebuilt_response": response,
         "metrics": metrics,
-        # A retry of the final call can leave two plausible generations.
-        # Mask the rollout when the client-selected generation is unknown.
-        "mask_sample": bool(unresolved) or notes.roots != 1 or notes.chains != 1,
+        "mask_sample": mask,
         "unresolved_retries": list(unresolved),
     }
 
@@ -163,6 +210,8 @@ def trajectories_for_rollout(
     *,
     builder: str = "prefix_merging",
     model: str = "",
+    verified_response: dict | None = None,
+    explicit_terminal_call_id: str | None = None,
 ) -> dict | None:
     """Build trajectories from a frozen local token-store snapshot.
 
@@ -180,7 +229,14 @@ def trajectories_for_rollout(
         if not snapshot.entries:
             built = _failed_build(rollout_id, builder, "capture contains no token records")
         else:
-            built = _assemble(rollout_id, list(snapshot.entries), builder, model)
+            built = _assemble(
+                rollout_id,
+                list(snapshot.entries),
+                builder,
+                model,
+                verified_response=verified_response,
+                explicit_terminal_call_id=explicit_terminal_call_id,
+            )
         if snapshot.incomplete:
             built["mask_sample"] = True
             built.setdefault("metrics", {})["capture_incomplete"] = True
@@ -198,6 +254,8 @@ async def trajectories_from_source(
     *,
     builder: str = "prefix_merging",
     model: str = "",
+    verified_response: dict | None = None,
+    explicit_terminal_call_id: str | None = None,
 ) -> dict | None:
     """Build trajectories from a frozen ``TokenSource`` snapshot.
 
@@ -212,7 +270,17 @@ async def trajectories_from_source(
     if not snapshot.entries:
         built = _failed_build(rollout_id, builder, "capture contains no token records")
     else:
-        built = await asyncio.to_thread(_assemble, rollout_id, list(snapshot.entries), builder, model)
+        entries = list(snapshot.entries)
+        built = await asyncio.to_thread(
+            lambda: _assemble(
+                rollout_id,
+                entries,
+                builder,
+                model,
+                verified_response=verified_response,
+                explicit_terminal_call_id=explicit_terminal_call_id,
+            )
+        )
     if snapshot.incomplete:
         built["mask_sample"] = True
         built.setdefault("metrics", {})["capture_incomplete"] = True

--- a/nemo_gym/token_id_capture/delivery.py
+++ b/nemo_gym/token_id_capture/delivery.py
@@ -49,6 +49,11 @@ TOKEN_CAPTURE_KEY = "_ng_token_capture"
 MASK_SAMPLE_KEY = "mask_sample"
 _REDUNDANT_CAPTURE_KEY = "_redundant_capture"
 
+# A caller that knows the kept model call names it here on the result.
+# A gate seal or an agent-declared terminal id uses this key.
+# It joins with the response-id and content witnesses for terminal attribution.
+TERMINAL_CALL_KEY = "_ng_terminal_model_call_id"
+
 
 def rollout_carries_token_ids(result: dict) -> bool:
     """Whether this rollout already holds what training needs.
@@ -144,8 +149,17 @@ async def finalize_rollout_token_capture(result: dict, source: TokenSource | Non
         )
 
     response = result.get("response") if isinstance(result.get("response"), dict) else {}
+    explicit_terminal = result.get(TERMINAL_CALL_KEY)
     try:
-        built = await trajectories_from_source(rollout_id, source, model=str(response.get("model") or ""))
+        # The result's response is what the verifier scored.
+        # Terminal attribution joins it to one captured call.
+        built = await trajectories_from_source(
+            rollout_id,
+            source,
+            model=str(response.get("model") or ""),
+            verified_response=response or None,
+            explicit_terminal_call_id=str(explicit_terminal) if explicit_terminal else None,
+        )
     except Exception as error:
         # A transport failure may be unrelated to this rollout.
         # Mask this rollout instead of failing the entire batch.

--- a/nemo_gym/token_id_capture/fingerprint.py
+++ b/nemo_gym/token_id_capture/fingerprint.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fingerprint conversation content across serving dialects.
+
+These are pure functions over message lists.
+They hold no state and read no store.
+Any server may import them.
+Lineage state stays confined to the capture locus and the finalizer.
+
+``assistant_fingerprint`` hashes only model-authored turns.
+It identifies the call that produced the last model-authored turn.
+``conversation_digest`` hashes every turn, including tool results.
+A parent resolver uses it to verify context before reusing tokens.
+
+Chat, Responses, and Anthropic shapes normalize to the same hash input.
+The hash layout is tagged and length-delimited.
+No concatenation of fields can collide with another field boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+import orjson
+
+
+# Increment when fingerprint canonicalization or hash layout changes.
+# Resolvers ignore entries stamped with a different version.
+FINGERPRINT_VERSION = 1
+
+_FINGERPRINT_DOMAIN = b"nemo-gym-lineage"
+_CONTEXT_DOMAIN = b"nemo-gym-lineage-context"
+
+
+def assistant_fingerprint(messages: list[dict]) -> str:
+    """Fingerprint the model-authored turns of a request, in order.
+
+    The fingerprint identifies the call that produced the last model-authored turn.
+    User and tool content is excluded from the lookup key.
+    Dialect-specific tool-call shapes normalize to the same hash input.
+    """
+    hasher = hashlib.sha256(_FINGERPRINT_DOMAIN)
+    count = 0
+    for message in messages or []:
+        if not isinstance(message, dict):
+            raise ValueError(f"request item is not an object: {type(message).__name__}")
+        if not _is_assistant_authored(message):
+            continue
+        count += 1
+        for content_type, payload in _content_of(message.get("content")):
+            _update_field(hasher, b"\x00", content_type)
+            _update_field(hasher, b"\x01", payload)
+        for call_id, name, arguments in _tools_of(message):
+            _update_field(hasher, b"\x02", call_id)
+            _update_field(hasher, b"\x03", name)
+            _update_field(hasher, b"\x04", arguments)
+    if count == 0:
+        return ""
+    return hasher.hexdigest()
+
+
+def conversation_digest(messages: list[dict]) -> str:
+    """Hash every turn of a conversation, model-authored or not.
+
+    ``assistant_fingerprint`` ignores user and tool content.
+    This digest covers that omitted context.
+    A mismatch rejects the parent before its tokens are reused.
+    """
+    hasher = hashlib.sha256(_CONTEXT_DOMAIN)
+    for message in messages or []:
+        if not isinstance(message, dict):
+            raise ValueError(f"request item is not an object: {type(message).__name__}")
+        _update_field(hasher, b"\x00", str(message.get("role") or message.get("type") or ""))
+        for content_type, payload in _content_of(message.get("content")):
+            _update_field(hasher, b"\x01", content_type)
+            _update_field(hasher, b"\x02", payload)
+        for call_id, name, arguments in _tools_of(message):
+            _update_field(hasher, b"\x03", call_id)
+            _update_field(hasher, b"\x04", name)
+            _update_field(hasher, b"\x05", arguments)
+        # Include tool results.
+        # Summarizing, redacting, or truncating a result changes the request context.
+        for call_id, output in _tool_results_of(message):
+            _update_field(hasher, b"\x06", call_id)
+            _update_field(hasher, b"\x07", output)
+    return hasher.hexdigest()
+
+
+def canonicalize_tool_arguments(value: Any) -> str:
+    """Normalize a tool call's arguments for comparison only.
+
+    Harnesses can reserialize tool-call arguments between turns.
+    Comparison uses sorted-key JSON with normalized separators.
+    The record retains the model's original string.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError):
+            return value.strip()
+    else:
+        parsed = value
+    return _canonical_json(parsed)
+
+
+def _is_assistant_authored(message: dict) -> bool:
+    """Return whether the model produced this item.
+
+    Chat and Anthropic use the ``assistant`` role.
+    Responses tool calls are roleless ``function_call`` items.
+    """
+    if message.get("role") == "assistant":
+        return True
+    # Reasoning is deliberately excluded.
+    # A harness need not echo standalone reasoning items.
+    # Including reasoning would make fingerprints depend on the dialect and echo behavior.
+    # Reasoning-only collisions resolve as ambiguous and fall back.
+    return message.get("type") == "function_call"
+
+
+def _content_of(content: Any) -> list[tuple[str, str]]:
+    """Return typed content parts without discarding prompt-shaping blocks.
+
+    Tool calls are normalized separately by ``_tools_of``.
+    Tool results are normalized separately by ``_tool_results_of``.
+    """
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return [("text", content)] if content else []
+    if not isinstance(content, list):
+        raise ValueError(f"unsupported message content: {type(content).__name__}")
+    parts: list[tuple[str, str]] = []
+    for block in content:
+        if isinstance(block, str):
+            if block:
+                parts.append(("text", block))
+            continue
+        if not isinstance(block, dict):
+            raise ValueError(f"unsupported content block: {type(block).__name__}")
+        block_type = str(block.get("type") or "")
+        if block_type in {"tool_use", "tool_result"}:
+            continue
+        if isinstance(block.get("text"), str) and block_type in {
+            "",
+            "text",
+            "input_text",
+            "output_text",
+        }:
+            if block["text"]:
+                parts.append(("text", block["text"]))
+            continue
+        if not block_type:
+            raise ValueError("content block has no supported type")
+        parts.append((block_type, _canonical_json(block)))
+    return parts
+
+
+def _tools_of(message: dict) -> list[tuple[str, str, str]]:
+    """Return tool calls as ``(id, name, canonical arguments)`` tuples.
+
+    Chat stores calls in the message's ``tool_calls`` field.
+    Anthropic stores calls in ``tool_use`` content blocks.
+    Responses stores each call as a standalone ``function_call`` item.
+    """
+    tools: list[tuple[str, str, str]] = []
+    # A Responses item is the tool call.
+    if message.get("type") == "function_call":
+        tools.append(
+            (
+                str(message.get("call_id") or message.get("id") or ""),
+                str(message.get("name", "")),
+                canonicalize_tool_arguments(message.get("arguments")),
+            )
+        )
+    content = message.get("content")
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                tools.append(
+                    (
+                        str(block.get("id") or ""),
+                        str(block.get("name", "")),
+                        canonicalize_tool_arguments(block.get("input")),
+                    )
+                )
+    for call in message.get("tool_calls") or []:
+        function = (call or {}).get("function") or {}
+        tools.append(
+            (
+                str((call or {}).get("id") or ""),
+                str(function.get("name", "")),
+                canonicalize_tool_arguments(function.get("arguments")),
+            )
+        )
+    return tools
+
+
+def _tool_results_of(message: dict) -> list[tuple[str, str]]:
+    """Return tool result identities and payloads across dialects.
+
+    Responses stores results in standalone ``function_call_output`` items.
+    Anthropic stores results in ``tool_result`` content blocks.
+    Chat stores results as plain message content.
+    """
+    parts: list[tuple[str, str]] = []
+    if message.get("type") == "function_call_output":
+        output = message.get("output")
+        parts.append(
+            (
+                str(message.get("call_id") or message.get("id") or ""),
+                output if isinstance(output, str) else _canonical_json(output),
+            )
+        )
+    elif message.get("role") == "tool":
+        content = message.get("content")
+        parts.append(
+            (
+                str(message.get("tool_call_id") or ""),
+                content if isinstance(content, str) else _canonical_json(content),
+            )
+        )
+    content = message.get("content")
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_result":
+                inner = block.get("content")
+                payload = inner if isinstance(inner, str) else _canonical_json(inner)
+                parts.append((str(block.get("tool_use_id") or block.get("id") or ""), payload))
+    return parts
+
+
+def _canonical_json(value: Any) -> str:
+    """Serialize JSON-compatible prompt content without losing structure."""
+    try:
+        return orjson.dumps(value, option=orjson.OPT_SORT_KEYS).decode("utf-8")
+    except (TypeError, orjson.JSONEncodeError) as error:
+        raise ValueError(f"unsupported prompt content: {type(value).__name__}") from error
+
+
+def _update_field(hasher: Any, tag: bytes, value: str) -> None:
+    """Hash one tagged, length-delimited UTF-8 field."""
+    encoded = value.encode("utf-8")
+    hasher.update(tag)
+    hasher.update(len(encoded).to_bytes(8, "big"))
+    hasher.update(encoded)

--- a/nemo_gym/token_id_capture/terminal.py
+++ b/nemo_gym/token_id_capture/terminal.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Attribute a finished rollout's verified terminal model call.
+
+Every agent's ``/run`` result carries ``response``: the object the verifier
+scored. Capture, by contrast, records every call the model server served,
+including auxiliary calls, abandoned retries, and sub-agent branches. Terminal
+attribution joins the verified response to exactly one captured call, so the
+builder can deliver the chain that earned the reward instead of guessing among
+chains or masking a healthy rollout.
+
+The join is **independent witnesses with corroboration**, not a trust
+hierarchy. The fact "which call was kept" is emitted in different places by
+different agent classes, so up to three witnesses testify:
+
+  explicit     — the caller names the kept call directly (a gate seal or an
+                 agent-declared terminal id).
+  response_id  — the ``/run`` response's ``id`` equals the served id recorded
+                 on exactly one entry. Possession of the id proves which
+                 response the client actually received.
+  content      — the fingerprint of the response's model-authored items
+                 matches one entry. Three readings are pooled: the entry's
+                 cumulative ``continuation_fingerprint`` when a lineage-aware
+                 writer recorded one (a full-transcript response), the
+                 fingerprint of the entry's own output (a final-turn-only
+                 response), and the transcript's trailing model-authored
+                 block (a merged multi-turn transcript).
+
+Each witness abstains rather than guesses (ambiguity inside a witness is an
+abstention, not a vote). The verdict then follows the stack's rule that claims
+are verified, never ranked: witnesses that agree — or that name calls with
+identical full token sequences — attribute; witnesses that contradict each
+other attribute nothing and persist the disagreement, because a contradiction
+is evidence of a real defect (a stale seal mapping, backend id reuse, a
+transcript-synthesis bug) that outranking would silently bury. A rollout with
+no witness, or with disagreeing witnesses, falls back to the builder's strict
+single-chain policy.
+
+The content witness deliberately uses ``assistant_fingerprint`` alone, without
+a request-context digest. Attribution selects a chain whose tokens the builder
+verifies independently; it never reuses tokens across the matched boundary.
+Requiring context verification would spuriously refuse synthesized transcripts
+that reformat tool output, without adding safety.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from nemo_gym.token_id_capture.fingerprint import (
+    FINGERPRINT_VERSION,
+    _is_assistant_authored,
+    assistant_fingerprint,
+)
+from nemo_gym.token_id_capture.records import TokenEntry
+
+
+@dataclass(frozen=True)
+class TerminalAttribution:
+    """The joined terminal call, or the reasons no witness could name one."""
+
+    model_call_id: str | None
+    # The strongest agreeing witness: "explicit", "response_id",
+    # "content_cumulative", "content_output", or "" when unattributed.
+    method: str = ""
+    # The abstention/disagreement trail, kept on success and failure alike,
+    # plus corroboration notes when several witnesses agreed.
+    reason: str = ""
+
+    @property
+    def attributed(self) -> bool:
+        return self.model_call_id is not None
+
+
+def resolve_terminal(
+    entries: list[TokenEntry],
+    response: dict | None,
+    explicit_call_id: str | None = None,
+) -> TerminalAttribution:
+    """Join the verified ``/run`` response to one captured model call.
+
+    ``entries`` is the frozen snapshot. ``response`` is the result's scored
+    response object (or ``None`` when the record carries none). This function
+    never raises: malformed content is an abstention, not an error.
+    """
+    reasons: list[str] = []
+    by_call_id = {entry.model_call_id: entry for entry in entries}
+    # Witnesses in precedence order for *naming* only (which call id and
+    # method label an agreeing verdict reports) — never for outranking.
+    witnesses: list[tuple[str, TokenEntry]] = []
+
+    if explicit_call_id:
+        named = by_call_id.get(explicit_call_id)
+        if named is not None:
+            witnesses.append(("explicit", named))
+        else:
+            reasons.append("explicit_terminal_not_captured")
+
+    if isinstance(response, dict):
+        response_id = str(response.get("id") or "")
+        if response_id:
+            id_matches = [entry for entry in entries if entry.response_id and entry.response_id == response_id]
+            if id_matches:
+                winner = _collapse_identical(id_matches)
+                if winner is not None:
+                    witnesses.append(("response_id", winner))
+                else:
+                    reasons.append("response_id_ambiguous")
+            else:
+                reasons.append("response_id_no_match")
+        else:
+            reasons.append("response_has_no_id")
+        content = _content_witness(entries, response, reasons)
+        if content is not None:
+            witnesses.append(content)
+    else:
+        reasons.append("no_response_object")
+
+    if not witnesses:
+        return TerminalAttribution(None, reason=",".join(reasons))
+
+    # Corroborate: all witnesses must name the same call, or calls whose full
+    # token sequences are identical (interchangeable for training). A
+    # contradiction attributes nothing — it is evidence of a stale mapping or
+    # a synthesis defect, and outranking would bury it.
+    if _collapse_identical([entry for _, entry in witnesses]) is None:
+        detail = ";".join(f"{method}={entry.model_call_id}" for method, entry in witnesses)
+        reasons.append(f"witness_disagreement[{detail}]")
+        return TerminalAttribution(None, reason=",".join(reasons))
+
+    method, named = witnesses[0]
+    if len(witnesses) > 1:
+        reasons.append("corroborated_by=" + "+".join(other for other, _ in witnesses[1:]))
+    # The trail is kept even on success: a witness that abstained (e.g. a
+    # duplicated response id) is a diagnosable defect even when another
+    # witness attributes the rollout.
+    return TerminalAttribution(named.model_call_id, method=method, reason=",".join(reasons))
+
+
+def _sequence_identity(entry: TokenEntry) -> tuple:
+    """Identify an entry by its full token sequence.
+
+    A lineage-aware writer records a cumulative digest and length.
+    Records without one compare their token arrays directly.
+    Both identify the delivered sequence, which is what training consumes.
+    """
+    digest = getattr(entry, "digest", None)
+    cum_len = getattr(entry, "cum_len", None)
+    if digest and cum_len is not None:
+        return (digest, cum_len)
+    return (tuple(entry.prompt_token_ids), tuple(entry.generation_token_ids))
+
+
+def _collapse_identical(candidates: list[TokenEntry]) -> TokenEntry | None:
+    """Reduce candidates that carry the same full token sequence to one.
+
+    Identical retries produce entries whose sequences match; any of them
+    yields the same delivered chain, so the smallest call id wins
+    deterministically. Candidates with different sequences are genuinely
+    ambiguous and collapse to ``None``.
+    """
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+    identities = {_sequence_identity(entry) for entry in candidates}
+    if len(identities) == 1:
+        return min(candidates, key=lambda entry: entry.model_call_id)
+    return None
+
+
+def _content_witness(entries: list[TokenEntry], response: dict, reasons: list[str]) -> tuple[str, TokenEntry] | None:
+    """The content witness: fingerprint the response's model-authored items.
+
+    Three readings of one response are possible and must compete, not race. A
+    full transcript matches an entry's cumulative fingerprint (the
+    model-authored spine of request context + that call's output); a
+    final-turn-only response matches the fingerprint of one entry's own
+    output; a merged transcript's trailing model-authored block matches the
+    terminal call's own output. The readings can name different calls — a
+    first call's cumulative fingerprint IS its own-output fingerprint, because
+    non-model turns never contribute — so candidates from all keys pool before
+    the ambiguity decision.
+    """
+    output = response.get("output")
+    if not isinstance(output, list) or not output:
+        reasons.append("response_has_no_output")
+        return None
+    items = [item for item in output if isinstance(item, dict)]
+    try:
+        target = assistant_fingerprint(items)
+    except ValueError:
+        reasons.append("response_output_unfingerprintable")
+        return None
+    if not target:
+        reasons.append("no_model_authored_output")
+        return None
+
+    # Third reading: the transcript's trailing model-authored block.
+    # A merged multi-turn transcript hashes over every model turn, so it can
+    # only match a cumulative fingerprint — which requires a lineage-aware
+    # writer. The final block of consecutive model-authored items is the
+    # terminal call's own output, matchable on any base. A transcript ending
+    # in a non-model item (a pending tool result) has no trailing block and
+    # skips this reading rather than matching the wrong call.
+    trailing: list[dict] = []
+    for item in reversed(items):
+        if not _is_assistant_authored(item):
+            break
+        trailing.append(item)
+    trailing.reverse()
+    tail = ""
+    if trailing and len(trailing) != len(items):
+        try:
+            tail = assistant_fingerprint(trailing)
+        except ValueError:
+            tail = ""
+
+    matches: dict[str, TokenEntry] = {}
+    cumulative_hit = False
+    for entry in entries:
+        continuation = getattr(entry, "continuation_fingerprint", None)
+        version = getattr(entry, "fingerprint_version", None)
+        if continuation and continuation == target and (version is None or version == FINGERPRINT_VERSION):
+            matches[entry.model_call_id] = entry
+            cumulative_hit = True
+        if entry.output_items:
+            try:
+                own = assistant_fingerprint(list(entry.output_items))
+            except ValueError:
+                continue
+            if own and (own == target or (tail and own == tail)):
+                matches[entry.model_call_id] = entry
+    winner = _collapse_identical(list(matches.values()))
+    if winner is not None:
+        return ("content_cumulative" if cumulative_hit else "content_output", winner)
+    reasons.append("content_ambiguous" if matches else "no_content_match")
+    return None

--- a/tests/unit_tests/test_conversation_fingerprint.py
+++ b/tests/unit_tests/test_conversation_fingerprint.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test the dialect-blind conversation fingerprints.
+
+The same content served in Chat, Responses, or Anthropic shape must hash
+identically: terminal attribution compares a harness-dialect transcript
+against capture's normalized view, and the comparison is only sound if the
+fingerprint erases the dialect.
+"""
+
+import pytest
+
+from nemo_gym.token_id_capture.fingerprint import assistant_fingerprint, conversation_digest
+
+
+def test_the_three_dialect_shapes_hash_identically():
+    chat = {"role": "assistant", "content": "hi"}
+    responses = {
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "content": [{"type": "output_text", "text": "hi", "annotations": []}],
+    }
+    anthropic = {"role": "assistant", "content": [{"type": "text", "text": "hi"}]}
+    fingerprints = {assistant_fingerprint([shape]) for shape in (chat, responses, anthropic)}
+    assert len(fingerprints) == 1 and fingerprints != {""}
+
+
+def test_tool_calls_normalize_across_dialects():
+    responses_call = {"type": "function_call", "call_id": "c1", "name": "f", "arguments": '{"a": 2, "b": 1}'}
+    chat_call = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": '{"b":1,"a":2}'}}],
+    }
+    anthropic_call = {
+        "role": "assistant",
+        "content": [{"type": "tool_use", "id": "c1", "name": "f", "input": {"b": 1, "a": 2}}],
+    }
+    fingerprints = {assistant_fingerprint([shape]) for shape in (responses_call, chat_call, anthropic_call)}
+    assert len(fingerprints) == 1 and fingerprints != {""}
+
+
+def test_argument_reserialization_is_tolerated_but_argument_changes_are_not():
+    base = {"type": "function_call", "call_id": "c1", "name": "f", "arguments": '{"a": 1, "b": 2}'}
+    reserialized = dict(base, arguments='{"b":2,"a":1}')
+    changed = dict(base, arguments='{"a": 1, "b": 3}')
+    assert assistant_fingerprint([base]) == assistant_fingerprint([reserialized])
+    assert assistant_fingerprint([base]) != assistant_fingerprint([changed])
+
+
+def test_reasoning_items_are_excluded():
+    # A harness need not echo standalone reasoning items; including them would
+    # make the fingerprint depend on dialect and echo behavior.
+    message = {"role": "assistant", "content": "answer"}
+    reasoning = {"type": "reasoning", "summary": [{"type": "summary_text", "text": "thinking"}]}
+    assert assistant_fingerprint([reasoning, message]) == assistant_fingerprint([message])
+
+
+def test_no_model_authored_turn_yields_the_empty_fingerprint():
+    assert assistant_fingerprint([{"role": "user", "content": "question"}]) == ""
+    assert assistant_fingerprint([]) == ""
+
+
+def test_conversation_digest_covers_tool_results_the_fingerprint_ignores():
+    # A summarized or truncated tool result changes the request context, so the
+    # digest must see it — while the assistant fingerprint must not.
+    turns_a = [
+        {"role": "assistant", "content": "calling"},
+        {"type": "function_call_output", "call_id": "c1", "output": "result A"},
+    ]
+    turns_b = [
+        {"role": "assistant", "content": "calling"},
+        {"type": "function_call_output", "call_id": "c1", "output": "result B"},
+    ]
+    assert conversation_digest(turns_a) != conversation_digest(turns_b)
+    assert assistant_fingerprint(turns_a) == assistant_fingerprint(turns_b)
+
+
+def test_a_non_object_item_raises_for_the_caller_to_handle():
+    with pytest.raises(ValueError):
+        assistant_fingerprint([42])
+    with pytest.raises(ValueError):
+        conversation_digest(["not a dict"])

--- a/tests/unit_tests/test_terminal_attribution.py
+++ b/tests/unit_tests/test_terminal_attribution.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test terminal attribution: the witnesses join.
+
+The ``/run`` result's ``response`` is the object the verifier scored.
+Attribution joins it to exactly one captured call.
+The builder then delivers the root-to-terminal chain that earned the reward.
+Unattributed rollouts keep the strict single-chain policy bit-for-bit.
+"""
+
+from nemo_gym.token_id_capture import TokenEntry
+from nemo_gym.token_id_capture.fingerprint import assistant_fingerprint
+from nemo_gym.token_id_capture.terminal import resolve_terminal
+
+
+# --- helpers ------------------------------------------------------------------
+
+
+def _assistant_item(text: str) -> dict:
+    return {
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "content": [{"type": "output_text", "text": text, "annotations": []}],
+    }
+
+
+def _entry(
+    call_id: str,
+    prompt: list[int],
+    gen: list[int],
+    *,
+    text: str | None = None,
+    response_id: str | None = None,
+    created_at: float = 0.0,
+    **extra,
+) -> TokenEntry:
+    output_items = [_assistant_item(text)] if text is not None else []
+    return TokenEntry(
+        rollout_id="r",
+        model_call_id=call_id,
+        prompt_token_ids=prompt,
+        generation_token_ids=gen,
+        generation_log_probs=[-0.1] * len(gen),
+        output_items=output_items,
+        token_item_index=0 if output_items else None,
+        response_id=response_id,
+        created_at=created_at,
+        **extra,
+    )
+
+
+def _chain_entries() -> list[TokenEntry]:
+    """Two chained calls: call2 continues call1's cumulative sequence."""
+    return [
+        _entry("call1", [1, 2], [3, 4], text="step one", response_id="resp_1", created_at=2.0),
+        _entry("call2", [1, 2, 3, 4, 5, 6], [7, 8], text="final answer", response_id="resp_2", created_at=3.0),
+    ]
+
+
+def _response(items: list[dict], response_id: str = "") -> dict:
+    return {"id": response_id, "model": "m", "object": "response", "output": items}
+
+
+# --- resolve_terminal: the witnesses ------------------------------------------
+
+
+def test_explicit_witness_attributes():
+    entries = _chain_entries()
+    att = resolve_terminal(entries, None, explicit_call_id="call2")
+    assert att.attributed and att.model_call_id == "call2" and att.method == "explicit"
+
+
+def test_explicit_terminal_not_captured_abstains():
+    att = resolve_terminal(_chain_entries(), None, explicit_call_id="ghost")
+    assert not att.attributed
+    assert "explicit_terminal_not_captured" in att.reason
+
+
+def test_response_id_witness_attributes_a_merged_transcript():
+    # simple_agent-shaped result: the final call's envelope id with a merged
+    # transcript. The trailing-block content reading names the same call.
+    entries = _chain_entries()
+    response = _response(
+        [
+            _assistant_item("step one"),
+            {"type": "function_call_output", "call_id": "c", "output": "ok"},
+            _assistant_item("final answer"),
+        ],
+        response_id="resp_2",
+    )
+    att = resolve_terminal(entries, response)
+    assert att.attributed and att.model_call_id == "call2" and att.method == "response_id"
+    assert "corroborated_by=content_output" in att.reason
+
+
+def test_trailing_block_attributes_a_merged_transcript_without_ids():
+    # The blackbox multi-turn case: a synthesized transcript with no served id.
+    # The final block of model-authored items is the terminal call's own output.
+    entries = _chain_entries()
+    response = _response(
+        [
+            _assistant_item("step one"),
+            {"type": "function_call_output", "call_id": "c", "output": "ok"},
+            _assistant_item("final answer"),
+        ]
+    )
+    att = resolve_terminal(entries, response)
+    assert att.attributed and att.model_call_id == "call2" and att.method == "content_output"
+
+
+def test_transcript_ending_in_a_tool_result_skips_the_trailing_reading():
+    # A truncated rollout ends with a pending tool result: there is no trailing
+    # model-authored block, so the content witness must not match a mid-chain call.
+    entries = _chain_entries()
+    response = _response(
+        [
+            _assistant_item("step one"),
+            _assistant_item("final answer"),
+            {"type": "function_call_output", "call_id": "c", "output": "ok"},
+        ]
+    )
+    att = resolve_terminal(entries, response)
+    assert not att.attributed and "no_content_match" in att.reason
+
+
+def test_repeated_identical_output_abstains_without_an_id():
+    # The model produced the same text at two different depths. The trailing
+    # reading matches both entries, their token sequences differ, and no id
+    # exists to break the tie: abstain and mask rather than guess.
+    entries = [
+        _entry("call1", [1, 2], [3, 4], text="done", created_at=1.0),
+        _entry("call2", [1, 2, 3, 4, 5, 6], [7, 8], text="done", created_at=2.0),
+    ]
+    response = _response(
+        [
+            _assistant_item("done"),
+            {"type": "function_call_output", "call_id": "c", "output": "ok"},
+            _assistant_item("done"),
+        ]
+    )
+    att = resolve_terminal(entries, response)
+    assert not att.attributed and "content_ambiguous" in att.reason
+
+
+def test_content_witness_attributes_a_final_turn_response():
+    # A single-turn (or last-response-only) result matches the entry's own output.
+    entries = _chain_entries()
+    response = _response([_assistant_item("final answer")])
+    att = resolve_terminal(entries, response)
+    assert att.attributed and att.model_call_id == "call2" and att.method == "content_output"
+    assert "response_has_no_id" in att.reason
+
+
+def test_cumulative_fingerprint_reading_from_a_lineage_aware_writer():
+    # A lineage-aware writer stamps continuation_fingerprint (request + own output).
+    # The full merged transcript then matches it even though own-output does not.
+    transcript = [_assistant_item("step one"), _assistant_item("final answer")]
+    target = assistant_fingerprint(transcript)
+    entries = [
+        _entry("call1", [1, 2], [3, 4], text="step one", created_at=2.0),
+        _entry(
+            "call2",
+            [1, 2, 3, 4, 5, 6],
+            [7, 8],
+            text="final answer",
+            created_at=3.0,
+            continuation_fingerprint=target,
+        ),
+    ]
+    att = resolve_terminal(entries, _response(transcript))
+    assert att.attributed and att.model_call_id == "call2" and att.method == "content_cumulative"
+
+
+def test_identical_retries_collapse_to_one_call():
+    # Two servings of the same content and tokens are interchangeable for training.
+    entries = [
+        _entry("call_b", [1, 2], [3, 4], text="same", response_id="resp_b"),
+        _entry("call_a", [1, 2], [3, 4], text="same", response_id="resp_a"),
+    ]
+    att = resolve_terminal(entries, _response([_assistant_item("same")]))
+    assert att.attributed and att.model_call_id == "call_a" and att.method == "content_output"
+
+
+def test_divergent_final_retries_resolve_by_id_and_abstain_on_content():
+    # Same prompt, different generations: content cannot say which was kept,
+    # but possession of the served id can.
+    entries = [
+        _entry("call_a", [1, 2], [3, 4], text="answer A", response_id="resp_a"),
+        _entry("call_b", [1, 2], [5, 6], text="answer B", response_id="resp_b"),
+    ]
+    att = resolve_terminal(entries, _response([_assistant_item("answer B")], response_id="resp_b"))
+    assert att.attributed and att.model_call_id == "call_b"
+    # Both the id and the content witness name call_b; either may lead.
+    assert att.method in ("response_id", "content_output")
+    assert "corroborated_by=" in att.reason
+
+
+def test_witness_disagreement_fails_closed():
+    entries = _chain_entries()
+    # The explicit witness names call1; the response id names call2.
+    response = _response([_assistant_item("unrelated")], response_id="resp_2")
+    att = resolve_terminal(entries, response, explicit_call_id="call1")
+    assert not att.attributed
+    assert "witness_disagreement[" in att.reason
+
+
+def test_a_mutated_echo_matches_nothing():
+    # A verifier that rewrites the echoed response breaks the echo contract;
+    # the join must fail closed, never land on a near-miss.
+    entries = _chain_entries()
+    response = _response([_assistant_item("final answer [redacted]")])
+    att = resolve_terminal(entries, response)
+    assert not att.attributed and "no_content_match" in att.reason
+
+
+def test_no_response_object_abstains():
+    att = resolve_terminal(_chain_entries(), None)
+    assert not att.attributed and "no_response_object" in att.reason
+
+
+def test_duplicated_response_id_abstains_but_content_can_still_attribute():
+    # Backend id reuse across different generations is a defect; the id witness
+    # abstains and leaves the trail, while content still attributes.
+    entries = [
+        _entry("call_a", [1, 2], [3, 4], text="answer A", response_id="resp_dup"),
+        _entry("call_b", [1, 2], [5, 6], text="answer B", response_id="resp_dup"),
+    ]
+    att = resolve_terminal(entries, _response([_assistant_item("answer B")], response_id="resp_dup"))
+    assert att.attributed and att.model_call_id == "call_b" and att.method == "content_output"
+    assert "response_id_ambiguous" in att.reason

--- a/tests/unit_tests/test_terminal_attribution.py
+++ b/tests/unit_tests/test_terminal_attribution.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test terminal attribution: the witnesses join.
+"""Test terminal attribution: the witnesses join, the anchored builder, and delivery.
 
 The ``/run`` result's ``response`` is the object the verifier scored.
 Attribution joins it to exactly one captured call.
@@ -20,7 +20,17 @@ The builder then delivers the root-to-terminal chain that earned the reward.
 Unattributed rollouts keep the strict single-chain policy bit-for-bit.
 """
 
-from nemo_gym.token_id_capture import TokenEntry
+import asyncio
+
+from nemo_gym.token_id_capture import TokenCaptureStore, TokenEntry
+from nemo_gym.token_id_capture.builder import run_builder
+from nemo_gym.token_id_capture.consumer import _assemble
+from nemo_gym.token_id_capture.delivery import (
+    MASK_SAMPLE_KEY,
+    TERMINAL_CALL_KEY,
+    TOKEN_CAPTURE_KEY,
+    finalize_rollout_token_capture,
+)
 from nemo_gym.token_id_capture.fingerprint import assistant_fingerprint
 from nemo_gym.token_id_capture.terminal import resolve_terminal
 
@@ -241,3 +251,172 @@ def test_duplicated_response_id_abstains_but_content_can_still_attribute():
     att = resolve_terminal(entries, _response([_assistant_item("answer B")], response_id="resp_dup"))
     assert att.attributed and att.model_call_id == "call_b" and att.method == "content_output"
     assert "response_id_ambiguous" in att.reason
+
+
+# --- the builder under an attributed terminal ---------------------------------
+
+
+def _aux_entries() -> list[TokenEntry]:
+    """A two-call main chain plus an earlier-completing auxiliary call."""
+    return _chain_entries() + [
+        # A title-generator call: unrelated prompt, finished first.
+        _entry("aux", [90, 91], [92], text="A Title", response_id="resp_aux", created_at=1.0),
+    ]
+
+
+def test_unattributed_aux_call_masks_and_picks_the_wrong_root():
+    out = run_builder(_aux_entries())
+    assert out.notes.roots == 2 and out.notes.chains == 2
+    # Legacy selection picks the earliest root: the auxiliary call.
+    main = [c for c in out.chains if c.chain_id == "main"][0]
+    assert main.links[0].entry.model_call_id == "aux"
+
+
+def test_attributed_terminal_delivers_the_verified_chain_and_excludes_aux():
+    out = run_builder(_aux_entries(), terminal_call_id="call2")
+    assert out.notes.terminal_chain == "delivered"
+    main = [c for c in out.chains if c.chain_id == "main"][0]
+    assert [link.entry.model_call_id for link in main.links] == ["call1", "call2"]
+
+
+def test_terminal_truncates_calls_served_after_the_kept_response():
+    entries = _chain_entries() + [
+        _entry("call3", [1, 2, 3, 4, 5, 6, 7, 8, 9], [10], text="post-terminal", created_at=4.0),
+    ]
+    out = run_builder(entries, terminal_call_id="call2")
+    assert out.notes.terminal_chain == "delivered"
+    main = [c for c in out.chains if c.chain_id == "main"][0]
+    assert [link.entry.model_call_id for link in main.links] == ["call1", "call2"]
+
+
+def test_terminal_resolves_a_final_retry_group():
+    entries = [
+        _entry("call_a", [1, 2], [3, 4], text="answer A", response_id="resp_a"),
+        _entry("call_b", [1, 2], [5, 6], text="answer B", response_id="resp_b"),
+    ]
+    out = run_builder(entries, terminal_call_id="call_b")
+    assert out.notes.terminal_chain == "delivered"
+    assert out.notes.unresolved_retries == []
+    main = [c for c in out.chains if c.chain_id == "main"][0]
+    assert [link.entry.model_call_id for link in main.links] == ["call_b"]
+    # Without attribution the same shape is unresolved.
+    legacy = run_builder(entries)
+    assert set(legacy.notes.unresolved_retries) == {"call_a", "call_b"}
+
+
+def test_terminal_not_captured_is_reported():
+    out = run_builder(_chain_entries(), terminal_call_id="ghost")
+    assert out.notes.terminal_chain == "not_captured"
+
+
+# --- consumer mask semantics ---------------------------------------------------
+
+
+def test_assemble_attributed_aux_rollout_is_not_masked():
+    entries = _aux_entries()
+    response = _response(
+        [_assistant_item("step one"), _assistant_item("final answer")],
+        response_id="resp_2",
+    )
+    built = _assemble("r", entries, "prefix_merging", "m", verified_response=response)
+    assert built[MASK_SAMPLE_KEY] is False
+    attribution = built["metrics"]["terminal_attribution"]
+    assert attribution["method"] == "response_id" and attribution["chain"] == "delivered"
+    # The rebuilt response carries only the verified chain's tokens.
+    delivered = [i for i in built["rebuilt_response"]["output"] if i.get("generation_token_ids")]
+    assert [i["generation_token_ids"] for i in delivered] == [[3, 4], [7, 8]]
+
+
+def test_assemble_unattributed_aux_rollout_keeps_the_strict_policy():
+    built = _assemble("r", _aux_entries(), "prefix_merging", "m", verified_response=None)
+    assert built[MASK_SAMPLE_KEY] is True
+    assert built["metrics"]["terminal_attribution"]["method"] == "none"
+
+
+def test_assemble_attributed_but_undeliverable_chain_masks():
+    # The named terminal is not among the buildable entries.
+    built = _assemble(
+        "r",
+        _chain_entries(),
+        "prefix_merging",
+        "m",
+        explicit_terminal_call_id="ghost",
+        verified_response=None,
+    )
+    # "ghost" is not captured: no witness lands, so this is unattributed and
+    # falls back to the strict policy (single clean chain -> deliverable).
+    assert built["metrics"]["terminal_attribution"]["method"] == "none"
+    assert built[MASK_SAMPLE_KEY] is False
+
+
+def test_assemble_broken_terminal_chain_masks():
+    # Attribution succeeds but the terminal's ancestry is quarantined.
+    e1a = _entry("dup_a", [1, 2], [3, 4], text="same", created_at=1.0)
+    e1b = _entry("dup_b", [1, 2], [3, 4], text="same", created_at=1.5)
+    child = _entry("child", [1, 2, 3, 4, 9], [10], text="final", response_id="resp_child", created_at=2.0)
+    built = _assemble(
+        "r",
+        [e1a, e1b, child],
+        "prefix_merging",
+        "m",
+        explicit_terminal_call_id="child",
+    )
+    assert built["metrics"]["terminal_attribution"]["chain"] == "broken"
+    assert built[MASK_SAMPLE_KEY] is True
+
+
+# --- delivery end to end -------------------------------------------------------
+
+
+def _delivery_case(tmp_path, result: dict) -> dict:
+    store = TokenCaptureStore(tmp_path)
+
+    async def go() -> dict:
+        for entry in _aux_entries():
+            await store.put(entry.model_copy(update={"rollout_id": "t0-r0"}))
+        return await finalize_rollout_token_capture(result, store)
+
+    return asyncio.run(go())
+
+
+def test_finalize_attributes_from_the_result_response(tmp_path):
+    result = {
+        "_ng_rollout_id": "t0-r0",
+        "response": _response(
+            [_assistant_item("step one"), _assistant_item("final answer")],
+            response_id="resp_2",
+        ),
+        "reward": 1.0,
+    }
+    built = _delivery_case(tmp_path, result)
+    assert built[MASK_SAMPLE_KEY] is False
+    assert result.get(MASK_SAMPLE_KEY) is not True
+    attribution = result[TOKEN_CAPTURE_KEY]["terminal_attribution"]
+    assert attribution["method"] == "response_id" and attribution["chain"] == "delivered"
+    delivered = [i for i in result["response"]["output"] if i.get("generation_token_ids")]
+    assert [i["generation_token_ids"] for i in delivered] == [[3, 4], [7, 8]]
+
+
+def test_finalize_honors_an_explicit_terminal_key(tmp_path):
+    result = {
+        "_ng_rollout_id": "t0-r0",
+        "response": {"id": "", "model": "m", "object": "response", "output": []},
+        TERMINAL_CALL_KEY: "call2",
+        "reward": 1.0,
+    }
+    built = _delivery_case(tmp_path, result)
+    assert built[MASK_SAMPLE_KEY] is False
+    attribution = result[TOKEN_CAPTURE_KEY]["terminal_attribution"]
+    assert attribution["method"] == "explicit" and attribution["chain"] == "delivered"
+
+
+def test_finalize_without_witnesses_keeps_the_strict_policy(tmp_path):
+    result = {
+        "_ng_rollout_id": "t0-r0",
+        "response": {"id": "", "model": "m", "object": "response", "output": []},
+        "reward": 1.0,
+    }
+    built = _delivery_case(tmp_path, result)
+    # Two roots (main chain + aux) and no attribution: masked, as before.
+    assert built[MASK_SAMPLE_KEY] is True
+    assert result[MASK_SAMPLE_KEY] is True

--- a/tests/unit_tests/test_trajectory_builder.py
+++ b/tests/unit_tests/test_trajectory_builder.py
@@ -671,9 +671,9 @@ def test_the_builder_runs_once_per_rollout(tmp_path, monkeypatch):
     calls = []
     real_run_builder = consumer_module.run_builder
 
-    def counting_run_builder(entries, builder="prefix_merging"):
+    def counting_run_builder(entries, builder="prefix_merging", **kwargs):
         calls.append(builder)
-        return real_run_builder(entries, builder)
+        return real_run_builder(entries, builder, **kwargs)
 
     monkeypatch.setattr(consumer_module, "run_builder", counting_run_builder)
     built = trajectories_for_rollout("t0-r0", [tmp_path])


### PR DESCRIPTION
## What does this PR do?

This PR identifies the captured model call that produced the response scored by the verifier, then anchors trajectory selection to that call. It depends on #2675.

- Normalizes model-authored content across Responses, Chat Completions, and Anthropic message shapes.
- Resolves the terminal model call from an explicit call ID, the served response ID, and content fingerprints.
- Requires independent witnesses to agree and abstains when evidence is missing, duplicated, or contradictory.
- Selects the root-to-terminal token chain, excluding auxiliary calls, sub-agent branches, and later retries.
- Preserves the existing strict single-chain behavior when no terminal call can be attributed.
- Records the attribution result and masking reason in rollout metrics.

## Terminal attribution flow

```mermaid
flowchart TD
    Result["Completed /run result<br/>response scored by verifier"] --> Finalize["finalize_rollout_token_capture"]
    Store["Frozen TokenEntry snapshot<br/>one entry per captured model call"] --> Finalize
    Finalize --> Resolve["resolve_terminal"]

    Explicit["Explicit terminal model_call_id<br/>when supplied"] --> Agreement
    ResponseId["Response ID witness<br/>result.response.id = TokenEntry.response_id"] --> Agreement
    Content["Content witness<br/>cross-dialect fingerprint match"] --> Agreement
    Resolve --> Explicit
    Resolve --> ResponseId
    Resolve --> Content

    Agreement{"Do all available witnesses<br/>identify the same token sequence?"}
    Agreement -- Yes --> Terminal["Resolved terminal model_call_id"]
    Agreement -- No witnesses or disagreement --> Abstain["No attribution"]

    Terminal --> Builder["Build token-prefix forest<br/>and select root-to-terminal chain"]
    Builder --> Intact{"Is the terminal chain intact?"}
    Intact -- Yes --> Deliver["Deliver verified chain unmasked<br/>exclude auxiliary calls and sibling branches"]
    Intact -- No --> Mask["Mask rollout<br/>known terminal is not safely deliverable"]

    Abstain --> Strict["Use existing strict single-chain policy"]
    Strict --> Unique{"Exactly one unambiguous chain?"}
    Unique -- Yes --> Deliver
    Unique -- No --> Mask
```

The response ID does not directly determine a trajectory. It identifies a captured `TokenEntry`, whose `model_call_id` anchors selection in the token-prefix forest. Content and explicit-ID witnesses independently check that join. A disagreement fails closed instead of allowing one witness to override another.

## Known limitations

- Agent observation bundles are not yet consumed as an additional terminal witness.
- Token-prefix reconstruction can still split legitimate multi-call tool loops when a harness reserializes structured turns. Terminal attribution chooses the verified root; it does not restore missing token continuity.
- Hermes currently sends auxiliary model-server requests through the capture prefix. The middleware treats those requests as missing generation captures and masks an otherwise complete rollout. #2678 tracks that separate completeness bug.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).