### PR TITLE
[Super 3.5 evals] Update Aug 23, 2026

### DIFF
--- a/benchmarks/deepswe/opencode.yaml
+++ b/benchmarks/deepswe/opencode.yaml
@@ -9,15 +9,16 @@ opencode_deepswe_resources_server:
   _inherit_from: deepswe_resources_server
   resources_servers:
     deepswe:
-      sandbox_model_server_name: policy_model
+      sandbox_model_server:
+        type: responses_api_models
+        name: policy_model
 
 opencode_sandboxed_agent_deepswe:
   _inherit_from: opencode_sandboxed_agent
   responses_api_agents:
     opencode_sandboxed_agent:
       sandbox_timeout: 10800  # DeepSWE agent timeout override: 3 hours.
-      remote_opencode_install_script_path: /mnt/s3-data/data/bxyu/opencode/install.sh
-      remote_opencode_binary_path: /mnt/s3-data/data/bxyu/opencode/opencode-linux-x64
+
       resources_server:
         type: resources_servers
         name: opencode_deepswe_resources_server
@@ -26,4 +27,4 @@ opencode_sandboxed_agent_deepswe:
           type: benchmark
           jsonl_fpath: benchmarks/deepswe/data/deepswe_benchmark.jsonl
           prepare_script: benchmarks/deepswe/prepare.py
-          num_repeats: 3
+          num_repeats: 5

--- a/benchmarks/nemotron_3.5_super/eval_container_config.yaml
+++ b/benchmarks/nemotron_3.5_super/eval_container_config.yaml
@@ -6,11 +6,11 @@ config_paths:
 - benchmarks/scicode/config.yaml
 - benchmarks/omniscience/config.yaml
 - benchmarks/nemotron_3.5_super/benchmark_configs/hle_no_tools.yaml
-- responses_api_models/vllm_model/configs/vllm_model.yaml
-# TODO @bxyu-nvidia: Implementing in the harness x benchmark decoupling effort.
 - benchmarks/swebench/verified/opencode.yaml
+- benchmarks/swebench/multilingual/opencode.yaml
+- benchmarks/deepswe/opencode.yaml
+- responses_api_models/vllm_model/configs/vllm_model.yaml
 # - nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
-# SWE Bench Multilingual
 # SWE Bench Pro
 # Terminal Bench 2.1
 
@@ -94,14 +94,18 @@ policy_model:
     vllm_model:
       num_workers: 16
 
-# TODO @bxyu-nvidia: Remove this to turn on SWE Verified after it is validated. This is a placeholder for container build.
+# TODO @bxyu-nvidia: Remove these overrides to turn on various benchmarks after we do batched eval studies. This is a placeholder for container build.
 opencode_sandboxed_agent_swebench_verified:
-  _inherit_from: opencode_sandboxed_agent
   responses_api_agents:
     opencode_sandboxed_agent:
-      resources_server:
-        type: resources_servers
-        name: opencode_swebench_verified_resources_server
+      datasets: []
+opencode_sandboxed_agent_swebench_multilingual:
+  responses_api_agents:
+    opencode_sandboxed_agent:
+      datasets: []
+opencode_sandboxed_agent_deepswe:
+  responses_api_agents:
+    opencode_sandboxed_agent:
       datasets: []
 
 ########################################

--- a/benchmarks/nemotron_3.5_super/eval_container_config_with_staged.yaml
+++ b/benchmarks/nemotron_3.5_super/eval_container_config_with_staged.yaml
@@ -1,0 +1,34 @@
+config_paths:
+- benchmarks/nemotron_3.5_super/eval_container_config.yaml
+
+# @bxyu-nvidia: We manually copy over the datasets here
+opencode_sandboxed_agent_swebench_verified:
+  responses_api_agents:
+    opencode_sandboxed_agent:
+      datasets:
+        - name: swebench_verified
+          type: benchmark
+          jsonl_fpath: benchmarks/swebench/data/swebench_verified_benchmark.jsonl
+          prepare_script: benchmarks/swebench/verified/prepare.py
+          num_repeats: 3
+
+opencode_sandboxed_agent_swebench_multilingual:
+  responses_api_agents:
+    opencode_sandboxed_agent:
+      datasets:
+        - name: swebench_multilingual
+          type: benchmark
+          jsonl_fpath: benchmarks/swebench/data/swebench_multilingual_benchmark.jsonl
+          prepare_script: benchmarks/swebench/multilingual/prepare.py
+          num_repeats: 3
+
+opencode_sandboxed_agent_deepswe:
+  responses_api_agents:
+    opencode_sandboxed_agent:
+      datasets:
+        - name: deepswe_v1_1
+          type: benchmark
+          jsonl_fpath: benchmarks/deepswe/data/deepswe_benchmark.jsonl
+          prepare_script: benchmarks/deepswe/prepare.py
+          num_repeats: 5
+

--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -31,7 +31,7 @@ DECODE_VLLM_NIXL_SIDE_CHANNEL_PORT=5700
 ROUTER_SERVER_PORT=8000
 WORKER_SERVER_PORT=8001
 
-EVAL_COMMAND=$(cat <<EOF
+eval_command=$(cat <<EOF
 set -euo pipefail
 
 # Activate environment in container and cd into Gym. The Gym path here may be mounted.
@@ -85,7 +85,7 @@ fi
 EOF
 )
 
-command=$(cat <<EOF
+pd_command=$(cat <<EOF
 #!/bin/bash
 
 set -euo pipefail
@@ -107,6 +107,11 @@ export UCX_RNDV_SCHEME=get_zcopy
 export UCX_RNDV_THRESH=0
 
 source "$VLLM_CONFIG"
+
+# Increase the number of file descriptors to 65k
+if [[ \$(ulimit -Hn) == "unlimited" ]] || [[ 65535 -lt \$(ulimit -Hn) ]]; then
+  ulimit -Sn 65535
+fi
 
 this_node_hostname=\$(hostname)
 if (( SLURM_PROCID == 0 )); then
@@ -176,7 +181,7 @@ srun --nodes=$NUM_NODES --ntasks=$NUM_NODES --ntasks-per-node=1 \
         set -euo pipefail
         cd "\$SLURM_SUBMIT_DIR"
         exec "\$@"
-    ' bash bash -lc "\$VLLM_PD_WORKLOAD" &
+    ' bash bash -lc "\$vllm_command" &
 server_step=\$!
 
 cleanup_server() {
@@ -207,7 +212,7 @@ if (( $should_run_eval )); then
         bash -lc '
             set -euo pipefail
             cd "\$SLURM_SUBMIT_DIR"
-            exec bash -lc "\$EVAL_COMMAND"
+            exec bash -lc "\$eval_command"
         ' &
     eval_step=\$!
 
@@ -236,9 +241,9 @@ EOF
 )
 
 # --segment > 0 otherwise the engine will hang on the second or third engine step.
-VLLM_PD_WORKLOAD="$command" \
-EVAL_COMMAND="$EVAL_COMMAND" \
-VLLM_PD_BATCH_COMMAND="$batch_command" \
+vllm_command="$pd_command" \
+eval_command="$eval_command" \
+batch_command="$batch_command" \
 sbatch \
     --nodes=$NUM_NODES \
     --time=04:00:00 \
@@ -248,4 +253,4 @@ sbatch \
     --comment="$SLURM_COMMENT" \
     --exclusive \
     --segment=$NUM_NODES \
-    --wrap 'exec bash -lc "$VLLM_PD_BATCH_COMMAND"'
+    --wrap 'exec bash -lc "$batch_command"'

--- a/benchmarks/nemotron_3.5_super/vllm_configs/nemotron_3.5_lightning.sh
+++ b/benchmarks/nemotron_3.5_super/vllm_configs/nemotron_3.5_lightning.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# @bxyu-nvidia: `--skip-mm-profiling` Is needed to get Super VL checkpoint working, even with text benchmarks
 VLLM_COMMON_ARGS=(
     --trust-remote-code
     --disable-uvicorn-access-log
@@ -12,7 +11,6 @@ VLLM_COMMON_ARGS=(
     --reasoning-parser nemotron_v3
     --enable-chunked-prefill
     --enable-prefix-caching
-    --max-model-len 262144
     --kv-cache-dtype fp8
     --no-disable-hybrid-kv-cache-manager
     --no-async-scheduling
@@ -21,7 +19,6 @@ VLLM_COMMON_ARGS=(
     --mamba-ssm-cache-dtype float32
     --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 96}'
     --enable-expert-parallel
-    --skip-mm-profiling
     --data-parallel-size 1
     --api-server-count 1
 )

--- a/nemo_gym/benchmarks.py
+++ b/nemo_gym/benchmarks.py
@@ -88,7 +88,8 @@ class BenchmarkConfig(BaseModel):
         if len(datasets) < 1:
             return
 
-        assert len(datasets) == 1, f"Expected 1 benchmark dataset for config {path}, but found {len(datasets)}!"
+        if len(datasets) > 1:
+            print(f"Expected 1 benchmark dataset for config {path}, but found {len(datasets)}!")
 
         dataset = datasets[0]
 

--- a/nemo_gym/environment/scaffold.py
+++ b/nemo_gym/environment/scaffold.py
@@ -298,13 +298,17 @@ def _asset_config(composition: _Composition) -> str:
     }
     if composition.rollout_driver:
         config["rollout_collection_driver"] = composition.rollout_driver
-    return yaml.safe_dump(config, sort_keys=False, allow_unicode=True)
+
+    res = yaml.safe_dump(config, sort_keys=False, allow_unicode=True)
+    res = f"\n{composition.agent_instance}".join(res.split(composition.agent_instance, maxsplit=1))
+
+    return res
 
 
 def _render_manifest_composition(root: Path, composition: _Composition) -> dict[Path, str]:
     asset = composition.asset_dir
     files = {
-        asset / "__init__.py": _license_header(),
+        asset / "__init__.py": _license_header().removesuffix("\n"),
         asset / "manifest.yaml": dump_manifest(_manifest(composition)),
         asset / "config.yaml": _asset_config(composition),
         asset / "README.md": _asset_readme(composition),
@@ -320,7 +324,7 @@ def _render_manifest_composition(root: Path, composition: _Composition) -> dict[
             }
         )
     else:
-        files[asset / "data" / "example.jsonl"] = _environment_example(composition.agent_instance)
+        files[asset / "data" / "example.jsonl"] = _environment_example()
 
     if composition.reused_verifier is None:
         resource_dir = root / "resources_servers" / composition.module_name
@@ -362,7 +366,7 @@ def _asset_readme(composition: _Composition) -> str:
     )
 
 
-def _environment_example(agent_instance: str) -> str:
+def _environment_example() -> str:
     return (
         json.dumps(
             {
@@ -370,7 +374,6 @@ def _environment_example(agent_instance: str) -> str:
                     "input": [{"role": "user", "content": "What is 6 x 7? Reply with only the answer."}]
                 },
                 "expected_answer": "42",
-                "agent_ref": {"type": "responses_api_agents", "name": agent_instance},
             }
         )
         + "\n"
@@ -437,14 +440,15 @@ def _resource_component_files(
     requirements: str,
 ) -> dict[Path, str]:
     return {
-        directory / "__init__.py": _license_header(),
+        directory / "__init__.py": _license_header().removesuffix("\n"),
         directory / "README.md": readme,
         directory / "app.py": _resources_server_app(module_name),
         directory / "configs" / f"{module_name}.yaml": config,
         directory / "requirements.txt": requirements,
-        directory / "tests" / "__init__.py": _license_header(),
+        directory / "tests" / "__init__.py": _license_header().removesuffix("\n"),
         directory / "tests" / "test_app.py": _resources_server_test(),
         directory / "tests" / "verifier_cases.jsonl": _verifier_cases(),
+        directory / "example.jsonl": _environment_example(),
     }
 
 
@@ -676,7 +680,7 @@ def _agent_files(root: Path, directory: Path, composition: _Composition) -> dict
             " Replace run() with external episode delegation, then make responses() raise NotImplementedError."
         )
     return {
-        directory / "__init__.py": _license_header(),
+        directory / "__init__.py": _license_header().removesuffix("\n"),
         directory / "README.md": f"# {composition.agent_implementation}\n\n{instruction}\n",
         directory / "app.py": _agent_app(composition.module_name, composition.profile),
         directory / "requirements.txt": _requirements(directory, _gym_checkout_root(root)),

--- a/nemo_gym/exporters/wandb.py
+++ b/nemo_gym/exporters/wandb.py
@@ -69,7 +69,8 @@ class WandbExporter(BaseExporter):
         self._active_run().config.update(OmegaConf.to_container(config_dict))
 
     def _log_metrics(self, metrics: dict[str, Any], step: Optional[int] = None) -> None:
-        self._active_run().log(metrics, step=step)
+        # @bxyu-nvidia: Commit here so the rollouts show up in W&B on the current step, rather than being flushed in the next step
+        self._active_run().log(metrics, step=step, commit=True)
 
     def _log_rollouts(self, rollouts: list[dict[str, Any]]) -> None:
         # One JSON blob per row: rollouts have no stable column set across environments.

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -974,7 +974,8 @@ class RolloutCollectionHelper(BaseModel):
 
             current_pct = 100 * len(results) / len(input_rows)
             if pcts_to_print and current_pct >= pcts_to_print[0]:
-                pcts_to_print.pop(0)
+                while pcts_to_print and current_pct >= pcts_to_print[0]:
+                    pcts_to_print.pop(0)
 
                 time_taken_s = time() - start_time
                 time_taken = timedelta(seconds=int(time_taken_s))
@@ -996,6 +997,16 @@ class RolloutCollectionHelper(BaseModel):
 """
                 # Use tqdm.write here so we can print properly with tqdm being used.
                 tqdm.write(print_str)
+
+                if get_exporters():
+                    step_metrics = {
+                        f"progress/{agent_name}/reward": round(
+                            100 * metrics["reward"] / agent_name_to_counts[agent_name], 2
+                        )
+                        for agent_name, metrics in agent_name_to_metrics.items()
+                    }
+
+                    export_metrics(step_metrics, step=int(current_pct))
 
         results_file.close()
         failures_file.close()

--- a/resources_servers/deepswe/app.py
+++ b/resources_servers/deepswe/app.py
@@ -14,10 +14,10 @@ from copy import deepcopy
 from dataclasses import dataclass
 from math import ceil
 from pathlib import Path
+from shutil import rmtree
 from time import monotonic
 from traceback import format_exc
 from typing import Any
-from urllib.parse import urlparse
 
 from fastapi import Request
 from pydantic import BaseModel, ConfigDict, Field
@@ -31,6 +31,7 @@ from nemo_gym.base_resources_server import (
     ReverifyMode,
     SimpleResourcesServer,
 )
+from nemo_gym.config_types import ModelServerRef
 from nemo_gym.global_config import get_global_config_dict
 from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
 from nemo_gym.sandbox.config import resolve_provider_config, resolve_provider_metadata
@@ -71,8 +72,7 @@ class DeepSWEResourcesServerConfig(BaseResourcesServerConfig):
     sandbox_provider: str
     sandbox_config: dict[str, Any]
     enforce_agent_no_network: bool = True
-    sandbox_model_base_url: str | None = None
-    sandbox_model_server_name: str | None = None
+    sandbox_model_server: ModelServerRef | None = None
 
     logs_dir: Path = Path("resources_servers/deepswe/logs")
     clear_verifier_logs: bool = False
@@ -132,6 +132,7 @@ class VerifierResult(BaseModel):
     apply_failed: bool = False
     verifier_exit_code: int | None = None
     verifier_error: str | None = None
+    test_output: str | None = None
     f2p_total: int = 0
     f2p_passed: int = 0
     p2p_total: int = 0
@@ -202,19 +203,14 @@ class DeepSWEResourcesServer(SimpleResourcesServer):
         return options
 
     def _model_egress_target(self) -> str | None:
-        if self.config.sandbox_model_base_url:
-            parsed = urlparse(self.config.sandbox_model_base_url)
-            if parsed.scheme not in {"http", "https"} or not parsed.hostname:
-                raise ValueError(f"Invalid DeepSWE sandbox_model_base_url: {self.config.sandbox_model_base_url!r}")
-            target = parsed.hostname
-        elif self.config.sandbox_model_server_name:
+        if self.config.sandbox_model_server:
             model_config = get_first_server_config_dict(
                 get_global_config_dict(),
-                self.config.sandbox_model_server_name,
+                self.config.sandbox_model_server.name,
             )
             target = str(model_config.get("host") or "")
             if not target:
-                raise ValueError(f"Model server {self.config.sandbox_model_server_name!r} does not have a host")
+                raise ValueError(f"Model server {self.config.sandbox_model_server.name!r} does not have a host")
         else:
             return None
 
@@ -327,9 +323,6 @@ class DeepSWEResourcesServer(SimpleResourcesServer):
 
         log_dir.mkdir(parents=True, exist_ok=True)
         combined_output = (command_result.stdout or "") + (command_result.stderr or "")
-        stdout_path = log_dir / "test-stdout.txt"
-        stdout_path.write_text(combined_output, encoding="utf-8", errors="replace")
-        await sandbox.upload(stdout_path, "/logs/verifier/test-stdout.txt")
 
         artifact_paths = {
             "reward.json": log_dir / "reward.json",
@@ -346,6 +339,7 @@ class DeepSWEResourcesServer(SimpleResourcesServer):
                 reward=0.0,
                 verifier_exit_code=command_result.return_code,
                 verifier_error="Verifier did not produce /logs/verifier/reward.json",
+                test_output=combined_output,
             )
         try:
             reward_data = json.loads(artifact_paths["reward.json"].read_text(encoding="utf-8"))
@@ -355,6 +349,7 @@ class DeepSWEResourcesServer(SimpleResourcesServer):
                 reward=0.0,
                 verifier_exit_code=command_result.return_code,
                 verifier_error=f"Invalid verifier reward.json: {error}",
+                test_output=combined_output,
             )
 
         reward = float(reward_data.get("reward", 0.0))
@@ -364,6 +359,7 @@ class DeepSWEResourcesServer(SimpleResourcesServer):
                 reward=0.0,
                 verifier_exit_code=command_result.return_code,
                 verifier_error=f"Verifier returned non-binary reward: {reward!r}",
+                test_output=combined_output,
             )
         if not present["ctrf.json"]:
             return VerifierResult(
@@ -371,6 +367,7 @@ class DeepSWEResourcesServer(SimpleResourcesServer):
                 reward=0.0,
                 verifier_exit_code=command_result.return_code,
                 verifier_error="Verifier did not produce /logs/verifier/ctrf.json",
+                test_output=combined_output,
             )
 
         return VerifierResult(
@@ -378,6 +375,7 @@ class DeepSWEResourcesServer(SimpleResourcesServer):
             reward=reward,
             apply_failed=bool(reward_data.get("apply_failed", False)),
             verifier_exit_code=command_result.return_code,
+            test_output=combined_output,
             f2p_total=int(reward_data.get("f2p_total", 0)),
             f2p_passed=int(reward_data.get("f2p_passed", 0)),
             p2p_total=int(reward_data.get("p2p_total", 0)),
@@ -495,28 +493,16 @@ class DeepSWEResourcesServer(SimpleResourcesServer):
                 if sandbox is not None:
                     await self._stop_sandbox(sandbox, task_id=current_task_id, phase="verifier")
 
-        if self.config.clear_verifier_logs and result.evaluation_completed:
-            for path in log_dir.glob("*"):
-                path.unlink(missing_ok=True)
-            log_dir.rmdir()
+        if self.config.clear_verifier_logs:
+            rmtree(str(log_dir), ignore_errors=True)
+            log_dir = ""
 
         return DeepSWEVerifyResponse.model_validate(
             body.model_dump()
+            | result.model_dump()
             | {
-                "reward": result.reward,
                 "task_id": current_task_id,
                 "sandbox_handle": sandbox_handle,
-                "evaluation_completed": result.evaluation_completed,
-                "apply_failed": result.apply_failed,
-                "verifier_exit_code": result.verifier_exit_code,
-                "verifier_error": result.verifier_error,
-                "f2p_total": result.f2p_total,
-                "f2p_passed": result.f2p_passed,
-                "p2p_total": result.p2p_total,
-                "p2p_passed": result.p2p_passed,
-                "f2p": result.f2p,
-                "p2p": result.p2p,
-                "partial": result.partial,
                 "model_patch": model_patch.decode("utf-8", errors="replace")
                 if self.config.include_model_patch_in_response
                 else None,

--- a/resources_servers/deepswe/configs/deepswe.yaml
+++ b/resources_servers/deepswe/configs/deepswe.yaml
@@ -13,8 +13,7 @@ deepswe_resources_server:
 
       sandbox_provider: sandbox
       enforce_agent_no_network: true
-      sandbox_model_base_url: ${oc.env:NEMO_GYM_SANDBOX_MODEL_BASE_URL,null}
-      sandbox_model_server_name: null
+      sandbox_model_server: null
       sandbox_config:
         ttl_s: 18000
         ready_timeout_s: 1200
@@ -23,5 +22,5 @@ deepswe_resources_server:
           istio.io/dataplane-mode: none
 
       logs_dir: resources_servers/deepswe/logs
-      clear_verifier_logs: false
-      include_model_patch_in_response: false
+      clear_verifier_logs: true
+      include_model_patch_in_response: true

--- a/resources_servers/deepswe/tests/test_app.py
+++ b/resources_servers/deepswe/tests/test_app.py
@@ -8,6 +8,7 @@ import pytest
 from pytest import MonkeyPatch
 
 import resources_servers.deepswe.app as app_module
+from nemo_gym.config_types import ModelServerRef
 from nemo_gym.sandbox import SandboxResources
 from nemo_gym.server_utils import SESSION_ID_KEY, ServerClient
 from resources_servers.deepswe.app import (
@@ -62,9 +63,16 @@ def _request() -> dict:
     }
 
 
-def test_model_endpoint_is_the_only_added_egress_target(task_assets: Path, tmp_path: Path) -> None:
+def test_model_endpoint_is_the_only_added_egress_target(
+    monkeypatch: MonkeyPatch, task_assets: Path, tmp_path: Path
+) -> None:
     config = _config(task_assets)
-    config.sandbox_model_base_url = "http://model.internal:8000"
+    config.sandbox_model_server = ModelServerRef(type="responses_api_models", name="policy_model")
+
+    monkeypatch.setattr(
+        "resources_servers.deepswe.app.get_global_config_dict",
+        lambda: {"policy_model": {"responses_api_agents": {"model": {"host": "model.internal", "port": 8000}}}},
+    )
     config.sandbox_config = {
         "provider_options": {
             "network_policy": {
@@ -84,9 +92,14 @@ def test_model_endpoint_is_the_only_added_egress_target(task_assets: Path, tmp_p
     }
 
 
-def test_loopback_model_endpoint_is_rejected(task_assets: Path, tmp_path: Path) -> None:
+def test_loopback_model_endpoint_is_rejected(monkeypatch: MonkeyPatch, task_assets: Path, tmp_path: Path) -> None:
     config = _config(task_assets)
-    config.sandbox_model_base_url = "http://127.0.0.1:8000"
+    config.sandbox_model_server = ModelServerRef(type="responses_api_models", name="policy_model")
+
+    monkeypatch.setattr(
+        "resources_servers.deepswe.app.get_global_config_dict",
+        lambda: {"policy_model": {"responses_api_agents": {"model": {"host": "127.0.0.1", "port": 8000}}}},
+    )
     server = DeepSWEResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
 
     with pytest.raises(ValueError, match="loopback model host"):

--- a/responses_api_agents/opencode_sandboxed_agent/app.py
+++ b/responses_api_agents/opencode_sandboxed_agent/app.py
@@ -142,7 +142,14 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
 
         return sandbox
 
-    def _create_opencode_config(self) -> Dict[str, Any]:
+    async def _create_opencode_config(self, request: Request) -> Dict[str, Any]:
+        base_url = (
+            self.base_url_for_run(
+                base_url=get_server_url(self.config.model_server.name),
+                body=await request.json(),
+            )
+            + "/v1"
+        )
         return {
             "model": "nemo_gym/dummy_model",
             "$schema": "https://opencode.ai/config.json",
@@ -151,7 +158,7 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
                     # TODO @bxyu-nvidia: We should use @ai-sdk/openai here but there is some /v1/responses streaming error.
                     "npm": "@ai-sdk/openai-compatible",
                     "options": {
-                        "baseURL": f"{get_server_url(self.config.model_server.name)}/v1",
+                        "baseURL": base_url,
                         "apiKey": "dummy_key",  # pragma: allowlist secret
                         "timeout": False,
                         "chunkTimeout": 600000,  # in milliseconds, 10 min
@@ -303,7 +310,7 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
         && echo "OpenCode run finished"
         """
 
-        opencode_config_content = json.dumps(self._create_opencode_config())
+        opencode_config_content = json.dumps(await self._create_opencode_config(request))
 
         if self.config.debug:
             print(f"Running command:\n```bash\n{command}\n```\n", file=sys.stderr)

--- a/responses_api_agents/opencode_sandboxed_agent/tests/test_app.py
+++ b/responses_api_agents/opencode_sandboxed_agent/tests/test_app.py
@@ -135,7 +135,7 @@ class TestOpenCodeSandboxedAgent:
 
         sandbox_mock = AsyncMock()
         monkeypatch.setattr(server, "_sandbox_id_to_sandbox", {"": sandbox_mock})
-        monkeypatch.setattr(server, "_create_opencode_config", lambda: dict())
+        monkeypatch.setattr(server, "_create_opencode_config", AsyncMock(return_value=dict()))
 
         sandbox_mock.return_value.exec.return_value = MagicMock()
         sandbox_mock.return_value.exec.return_value.stdout = "my dir"

--- a/tests/unit_tests/test_environment_scaffold.py
+++ b/tests/unit_tests/test_environment_scaffold.py
@@ -116,6 +116,7 @@ def test_standalone_resources_server_keeps_its_combined_composition(tmp_path: Pa
         "app.py",
         "configs/shared.yaml",
         "data/.gitignore",
+        "example.jsonl",
         "requirements.txt",
         "tests/__init__.py",
         "tests/test_app.py",

--- a/tests/unit_tests/test_exporters.py
+++ b/tests/unit_tests/test_exporters.py
@@ -300,7 +300,7 @@ class TestWandbExporter:
 
         exporter._log_metrics({"reward": 1.0}, step=3)
 
-        run.log.assert_called_once_with({"reward": 1.0}, step=3)
+        run.log.assert_called_once_with({"reward": 1.0}, step=3, commit=True)
 
     def test_teardown_finishes_the_run_and_is_idempotent(
         self, monkeypatch: MonkeyPatch, wandb_config: DictConfig


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

1. DeepSWE cleanup: benchmarks/deepswe/opencode.yaml, resources_servers/deepswe/configs/deepswe.yaml, resources_servers/deepswe/tests/test_app.py, resources_servers/deepswe/app.py
2. Add Nemotron 3.5 Lightning config to Super 3.5 evals: benchmarks/nemotron_3.5_super/vllm_configs/nemotron_3.5_lightning.sh
3. Rollout collection logs intermediate progress: nemo_gym/rollout_collection.py
4. Enable Opencode agent observability: responses_api_agents/opencode_sandboxed_agent/app.py
5. Misc: benchmarks/nemotron_3.5_super/vllm_configs/nemotron_3.5_super.sh, benchmarks/nemotron_3.5_super/eval_container_config.yaml, benchmarks/nemotron_3.5_super/eval_container_config_with_staged.yaml, benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh, nemo_gym/environment/scaffold.py, tests/unit_tests/test_environment_scaffold.py

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
