### PR TITLE
docs: fix single-step tutorial response output

### DIFF
--- a/fern/versions/latest/pages/environment-tutorials/single-step-environment.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/single-step-environment.mdx
@@ -383,7 +383,7 @@ async def test_verify_with_tool_call(server):
 async def test_verify_without_tool_call(server):
     """Reward 0.0 when the model answered without using the tool."""
     request = make_verify_request([
-        {"role": "assistant", "id": "",
+        {"type": "message", "role": "assistant", "status": "completed", "id": "",
          "content": [{"type": "output_text", "annotations": [], "text": "It's cold."}]},
     ])
     response = await server.verify(request)


### PR DESCRIPTION
## Summary

- Add the required `type: "message"` discriminator to the tutorial's assistant output fixture.
- Mark the message as completed so the copied verifier test matches the current Responses schema.

## Test plan

- [x] Replayed the tutorial scaffold, app, config, data, and tests
- [x] Ran `gym env test --resources-server my_weather_tool`.
- [x] Ran `cd fern && npm run check`.

Closes #2695.