### PR TITLE
docs(verifier): require verify to return the scored response

### DIFF
--- a/fern/versions/latest/pages/environment-tutorials/resources-server-apis.mdx
+++ b/fern/versions/latest/pages/environment-tutorials/resources-server-apis.mdx
@@ -103,6 +103,7 @@ async def verify(
 - **`body` in `seed_session()`** contains fields used to initialize an episode. Define a `BaseSeedSessionRequest` subclass for fields such as an initial board, task ID, or sandbox image. The default implementation is a no-op.
 - **`body.responses_create_params` in `verify()`** is the original model request.
 - **`body.response` in `verify()`** is the completed `NeMoGymResponse`, including the trajectory assembled by the Agent Server.
+- **The `verify()` result must preserve `body.response` unchanged.** Re-verification and terminal model-call attribution rely on the returned response being the same response that the verifier scored.
 - **Custom task metadata** requires a `BaseVerifyRequest` subclass. Declare fields such as `answer` or `expected_state`; undeclared fields are not retained by the base Pydantic model.
 - **`request: Request`**, when added to either method signature, provides access to the per-rollout session ID.
 

--- a/nemo_gym/verifier_fixture.py
+++ b/nemo_gym/verifier_fixture.py
@@ -10,6 +10,7 @@ import math
 import os
 import tempfile
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -21,6 +22,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_valida
 _CaseKind = Literal["full_reward", "zero_reward", "malformed", "determinism"]
 _FixtureInvocation = Callable[[object, BaseModel], object | Awaitable[object]]
 _FiniteReward = Annotated[float, Field(strict=True, allow_inf_nan=False)]
+_MISSING = object()
 
 
 class VerifierFixtureError(ValueError):
@@ -99,6 +101,37 @@ def _reward_from(result: object, case: VerifierFixtureCase) -> float:
     return float(reward)
 
 
+def _plain_value(value: object) -> object:
+    return value.model_dump(mode="python") if isinstance(value, BaseModel) else value
+
+
+def _response_snapshot(request: BaseModel) -> object:
+    response = getattr(request, "response", _MISSING)
+    return _MISSING if response is _MISSING else deepcopy(_plain_value(response))
+
+
+def _assert_response_preserved(
+    request: BaseModel,
+    result: object,
+    snapshot: object,
+    case: VerifierFixtureCase,
+) -> None:
+    if snapshot is _MISSING:
+        return
+
+    request_response = _plain_value(getattr(request, "response", _MISSING))
+    if request_response != snapshot:
+        raise VerifierFixtureError(f"Case '{case.name}' mutated request.response during verification")
+
+    result_response = (
+        result.get("response", _MISSING) if isinstance(result, Mapping) else getattr(result, "response", _MISSING)
+    )
+    if result_response is _MISSING:
+        raise VerifierFixtureError(f"Case '{case.name}' returned no response")
+    if _plain_value(result_response) != snapshot:
+        raise VerifierFixtureError(f"Case '{case.name}' returned a response that differs from request.response")
+
+
 async def _observe(
     fixture: VerifierFixture,
     case: VerifierFixtureCase,
@@ -118,6 +151,7 @@ async def _observe(
             seeded = fixture.reseed(server, request)
             if inspect.isawaitable(seeded):
                 await seeded
+        response_snapshot = _response_snapshot(request)
         if fixture.invoke is None:
             verify = getattr(server, "verify", None)
             if not callable(verify):
@@ -131,6 +165,7 @@ async def _observe(
         if expect_error:
             raise
         raise VerifierFixtureError(f"Case '{case.name}' failed: {error}") from error
+    _assert_response_preserved(request, result, response_snapshot, case)
     return _reward_from(result, case)
 
 

--- a/tests/unit_tests/test_verifier_fixture.py
+++ b/tests/unit_tests/test_verifier_fixture.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from nemo_gym.verifier_fixture import (
     VerifierFixture,
@@ -63,6 +63,10 @@ class _Request(BaseModel):
     seed: int | None = None
 
 
+class _ResponseRequest(_Request):
+    response: dict[str, str] = Field(default_factory=lambda: {"id": "response-1", "output": "answer"})
+
+
 class _Server:
     def __init__(self, sample: Callable[[], float], full_reward: float = 1.0, zero_reward: float = 0.0):
         self._sample = sample
@@ -75,6 +79,21 @@ class _Server:
         if request.outcome == "sample":
             return {"reward": self._sample()}
         return {"reward": self._full_reward if request.outcome == "full" else self._zero_reward}
+
+
+class _ResponseServer(_Server):
+    def __init__(self, mode: str):
+        super().__init__(lambda: 0.5)
+        self._mode = mode
+
+    async def verify(self, request: _ResponseRequest) -> dict:
+        result = await super().verify(request)
+        if self._mode == "mutate":
+            request.response["output"] = "changed"
+        if self._mode == "missing":
+            return result
+        response = {"id": "response-2", "output": "different"} if self._mode == "replace" else request.response
+        return {**result, "response": response}
 
 
 def _fixture(
@@ -101,6 +120,14 @@ def _fixture(
     )
 
 
+def _response_fixture(path: Path, mode: str) -> VerifierFixture:
+    return VerifierFixture(
+        server_factory=lambda: _ResponseServer(mode),
+        request_model=_ResponseRequest,
+        cases_path=path,
+    )
+
+
 async def test_exercises_the_four_case_floor(tmp_path: Path) -> None:
     path = tmp_path / "cases.jsonl"
     original = _write_cases(path)
@@ -110,6 +137,33 @@ async def test_exercises_the_four_case_floor(tmp_path: Path) -> None:
     assert [result.kind for result in results] == ["full_reward", "zero_reward", "malformed", "determinism"]
     assert results[-1].observed_rewards == (0.5, 0.5)
     assert path.read_text(encoding="utf-8") == original
+
+
+async def test_accepts_a_verifier_that_preserves_the_request_response(tmp_path: Path) -> None:
+    path = tmp_path / "cases.jsonl"
+    _write_cases(path, determinism=False)
+
+    await exercise_verifier_fixture(_response_fixture(path, "preserve"), reward_range=(0, 1), determinism="unknown")
+
+
+@pytest.mark.parametrize(
+    ("mode", "message"),
+    [
+        ("mutate", "mutated request.response"),
+        ("missing", "returned no response"),
+        ("replace", "differs from request.response"),
+    ],
+)
+async def test_rejects_a_verifier_that_changes_the_request_response(
+    tmp_path: Path,
+    mode: str,
+    message: str,
+) -> None:
+    path = tmp_path / "cases.jsonl"
+    _write_cases(path, determinism=False)
+
+    with pytest.raises(VerifierFixtureError, match=message):
+        await exercise_verifier_fixture(_response_fixture(path, mode), reward_range=(0, 1), determinism="unknown")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

A resources server receives the completed agent response in `body.response`, calculates a reward, and returns a verification result. This PR documents and tests that the result must contain the same response that was passed to the verifier.

When a resources server is tested through `VerifierFixture`, the test now:

- Saves `request.response` before calling `verify()`.
- Fails if `verify()` mutates the request response.
- Fails if the returned result omits the response or returns different content.
- Accepts equivalent Pydantic and dictionary representations.
- Does nothing for generic scorer fixtures whose request model has no `response` field.

The response returned by `verify()` becomes part of the completed `/run` result and the persisted rollout. Re-verification must score that same response again. Model-call attribution must also match that response to the model call that produced it. Replacing the response inside `verify()` would mean that the verifier scored one object while downstream code received another.

## Scope

This is a test-time check for resources servers that export and run a `VerifierFixture`. It does not change runtime verification and does not enforce the requirement across resources servers that do not yet provide a fixture.

A verifier that needs derived diagnostics should add separate fields to its verification result. Sanitization or redaction should happen before verification so the verifier scores and returns the same normalized response. If a workflow intentionally returns a different response, it needs an explicit attribution and re-verification design rather than silently replacing `response`.

`terminus_judge` sanitizes lone Unicode surrogates but preserves normal responses. Lone-surrogate responses cannot be stored by the token capture path, so they are already unusable for training.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).