### PR TITLE
[GDPVal] Make partial-calibration waivable failure classes configurable

### DIFF
--- a/resources_servers/gdpval/multistage_elo.py
+++ b/resources_servers/gdpval/multistage_elo.py
@@ -48,7 +48,7 @@ import json
 import random
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from resources_servers.gdpval.comparison import calculate_mle_elo
 
@@ -67,15 +67,17 @@ class PartialStagePolicy:
     stage. ``min_per_reference_success_fraction`` and
     ``min_successful_rows_per_reference`` apply independently to every selected
     reference model, so an anchor cannot disappear entirely from a partial fit.
-    Only persisted task timeouts may be newly waived. Rows already resolved by
-    the standard terminal/max-attempt rules remain eligible, but every omission
-    still counts against the configured coverage floors. Drained/no-persist and
-    missing rows keep the stage open.
+    ``waivable_failure_classes`` lists the persisted failure classes that may be
+    newly waived; it defaults to task timeouts only, preserving the original
+    behaviour. Rows already resolved by the standard terminal/max-attempt rules
+    remain eligible, but every omission still counts against the configured
+    coverage floors. Drained/no-persist and missing rows keep the stage open.
     """
 
     min_success_fraction: float = 1.0
     min_per_reference_success_fraction: float = 1.0
     min_successful_rows_per_reference: int = 1
+    waivable_failure_classes: Tuple[str, ...] = ("timeout_exceeded",)
 
 
 @dataclass

--- a/resources_servers/gdpval/multistage_orchestrator.py
+++ b/resources_servers/gdpval/multistage_orchestrator.py
@@ -206,6 +206,7 @@ def _partial_policy_record(policy: PartialStagePolicy) -> Dict[str, Any]:
         "min_success_fraction": policy.min_success_fraction,
         "min_per_reference_success_fraction": policy.min_per_reference_success_fraction,
         "min_successful_rows_per_reference": policy.min_successful_rows_per_reference,
+        "newly_waivable_failure_classes": sorted(policy.waivable_failure_classes),
     }
 
 
@@ -297,7 +298,11 @@ def _partial_stage_outcome(
     result_by_key = {_stage_key(result): result for result in new_results}
     for key in unresolved_keys:
         result = result_by_key.get(key)
-        if result is None or result.get(NG_NO_PERSIST_KEY) or result.get(NG_FAILURE_CLASS_KEY) != "timeout_exceeded":
+        if (
+            result is None
+            or result.get(NG_NO_PERSIST_KEY)
+            or result.get(NG_FAILURE_CLASS_KEY) not in policy.waivable_failure_classes
+        ):
             return None
 
     per_reference = {
@@ -319,7 +324,7 @@ def _partial_stage_outcome(
         "success_fraction": success_fraction,
         "persisted_success_fraction": len(successful_by_key) / len(planned_by_key),
         "per_reference": per_reference,
-        "policy": {**_partial_policy_record(policy), "newly_waivable_failure_classes": ["timeout_exceeded"]},
+        "policy": _partial_policy_record(policy),
     }
 
 
@@ -346,17 +351,23 @@ def _cached_partial_snapshot_is_valid(
         "min_success_fraction",
         "min_per_reference_success_fraction",
         "min_successful_rows_per_reference",
+        "newly_waivable_failure_classes",
     }
     if (
         expected_policy is None
         or not isinstance(policy_record, Mapping)
         or not required_policy_fields <= set(policy_record)
-        or policy_record.get("newly_waivable_failure_classes") != ["timeout_exceeded"]
         or {field: policy_record[field] for field in required_policy_fields} != _partial_policy_record(expected_policy)
     ):
         return False
+    # The durable record spells the waiver set `newly_waivable_failure_classes`;
+    # the config field is `waivable_failure_classes`. Map it back before parsing.
+    replayed_policy_fields = {
+        field: policy_record[field] for field in required_policy_fields if field != "newly_waivable_failure_classes"
+    }
+    replayed_policy_fields["waivable_failure_classes"] = policy_record["newly_waivable_failure_classes"]
     try:
-        policy = _parse_partial_stage_policy({field: policy_record[field] for field in required_policy_fields})
+        policy = _parse_partial_stage_policy(replayed_policy_fields)
     except (TypeError, ValueError):
         return False
     if policy is None:
@@ -525,6 +536,13 @@ class MultiStageRunConfig:
     reuse_cached_deliverables: bool = True
 
 
+# Failure classes a partial-calibration policy may newly waive. A waived row is
+# omitted from the fit and still counts against every coverage floor, so this is
+# a bound on which *causes* are acceptable, not on how much may be missing.
+# `skipped` is excluded: an unusable sample is not evidence of anything.
+_WAIVABLE_FAILURE_CLASSES = frozenset({"timeout_exceeded", "transient"})
+
+
 def _validate_partial_stage_policy(policy: PartialStagePolicy) -> None:
     """Validate parsed and directly constructed partial policies."""
     for name in ("min_success_fraction", "min_per_reference_success_fraction"):
@@ -534,6 +552,15 @@ def _validate_partial_stage_policy(policy: PartialStagePolicy) -> None:
     minimum_rows = policy.min_successful_rows_per_reference
     if isinstance(minimum_rows, bool) or not isinstance(minimum_rows, int) or minimum_rows <= 0:
         raise ValueError("partial_completion.min_successful_rows_per_reference must be a positive integer")
+    waivable = policy.waivable_failure_classes
+    if isinstance(waivable, (str, bytes)) or not isinstance(waivable, Sequence) or not waivable:
+        raise ValueError("partial_completion.waivable_failure_classes must be a non-empty sequence of strings")
+    unknown_classes = sorted(set(map(str, waivable)) - _WAIVABLE_FAILURE_CLASSES)
+    if unknown_classes:
+        raise ValueError(
+            "partial_completion.waivable_failure_classes may only contain "
+            f"{sorted(_WAIVABLE_FAILURE_CLASSES)}; got {unknown_classes}"
+        )
 
 
 def _parse_partial_stage_policy(raw: Any) -> Optional[PartialStagePolicy]:
@@ -547,13 +574,20 @@ def _parse_partial_stage_policy(raw: Any) -> Optional[PartialStagePolicy]:
         "min_success_fraction",
         "min_per_reference_success_fraction",
         "min_successful_rows_per_reference",
+        "waivable_failure_classes",
     }
     unknown_fields = sorted(set(raw) - allowed_fields)
     if unknown_fields:
         raise ValueError(f"unknown partial_completion field(s): {', '.join(map(str, unknown_fields))}")
 
-    if any(isinstance(raw.get(field), bool) for field in allowed_fields if field in raw):
+    numeric_fields = allowed_fields - {"waivable_failure_classes"}
+    if any(isinstance(raw.get(field), bool) for field in numeric_fields if field in raw):
         raise ValueError("partial_completion thresholds must be numeric, not boolean")
+
+    raw_waivable = raw.get("waivable_failure_classes", ("timeout_exceeded",))
+    if isinstance(raw_waivable, (str, bytes)) or not isinstance(raw_waivable, Sequence):
+        raise ValueError("partial_completion.waivable_failure_classes must be a sequence of strings")
+    waivable = tuple(str(value) for value in raw_waivable)
 
     try:
         raw_minimum_rows = raw.get("min_successful_rows_per_reference", 1)
@@ -562,6 +596,7 @@ def _parse_partial_stage_policy(raw: Any) -> Optional[PartialStagePolicy]:
             min_success_fraction=float(raw.get("min_success_fraction", 1.0)),
             min_per_reference_success_fraction=float(raw.get("min_per_reference_success_fraction", 1.0)),
             min_successful_rows_per_reference=minimum_rows,
+            waivable_failure_classes=waivable,
         )
     except (TypeError, ValueError) as exc:
         raise ValueError("partial_completion thresholds must be numeric") from exc

--- a/resources_servers/gdpval/tests/test_multistage_orchestrator.py
+++ b/resources_servers/gdpval/tests/test_multistage_orchestrator.py
@@ -19,7 +19,7 @@ import json
 from copy import deepcopy
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import pytest
 
@@ -1276,6 +1276,7 @@ class TestPartialStageCompletion:
         min_success_fraction: float = 0.6,
         min_per_reference_success_fraction: float = 0.6,
         min_successful_rows_per_reference: int = 1,
+        waivable_failure_classes: Optional[Sequence[str]] = None,
     ) -> MultiStageRunConfig:
         first_stage: Dict[str, Any] = {"num_tasks": 10}
         if enabled:
@@ -1284,6 +1285,8 @@ class TestPartialStageCompletion:
                 "min_per_reference_success_fraction": min_per_reference_success_fraction,
                 "min_successful_rows_per_reference": min_successful_rows_per_reference,
             }
+            if waivable_failure_classes is not None:
+                first_stage["partial_completion"]["waivable_failure_classes"] = list(waivable_failure_classes)
         return MultiStageRunConfig(
             enabled=True,
             stages=parse_multistage_config(
@@ -1747,6 +1750,62 @@ class TestPartialStageCompletion:
         assert set(dispatched_stages) == {0}
         assert len(summaries) == 1
         assert resume.completed == []
+
+    async def test_transient_omission_advances_when_explicitly_waivable(self) -> None:
+        """A judge-failure `transient` row is waivable only when the policy says so.
+
+        This is the `dc6c776f3af506df` case: one unresolved `transient` rollout
+        (an empty-PDF 400 from the judge panel) held the whole run at stage 1
+        under the timeout-only default, costing 176 of 220 tasks.
+        """
+        task_ids = [f"t{i}" for i in range(10)]
+        resume = self._balanced_resume(task_ids)
+        dispatched_stages: List[int] = []
+
+        _, summaries = await run_multistage_stages(
+            self._config(enabled=True, waivable_failure_classes=["timeout_exceeded", "transient"]),
+            {"a": 1000.0, "b": 1200.0},
+            _distribution(task_ids),
+            _materialized_rows(task_ids),
+            self._runner(
+                {0, 1, 2, 3},
+                failure_class="transient",
+                dispatched_stages=dispatched_stages,
+            ),
+            resume=resume,
+        )
+
+        assert set(dispatched_stages) == {0, 1}
+        assert len(summaries) == 2
+        assert summaries[0]["partial"] is True
+        assert summaries[0]["num_omitted"] == 4
+        outcome = resume.completed[0][1]
+        assert outcome["status"] == "partial_complete"
+        assert outcome["policy"]["newly_waivable_failure_classes"] == ["timeout_exceeded", "transient"]
+
+    async def test_unknown_waivable_failure_class_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="waivable_failure_classes"):
+            parse_multistage_config(
+                {
+                    "enabled": True,
+                    "stages": [
+                        {"num_tasks": 10, "partial_completion": {"waivable_failure_classes": ["skipped"]}},
+                        {"num_tasks": 10},
+                    ],
+                }
+            )
+
+    async def test_empty_waivable_failure_classes_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="waivable_failure_classes"):
+            parse_multistage_config(
+                {
+                    "enabled": True,
+                    "stages": [
+                        {"num_tasks": 10, "partial_completion": {"waivable_failure_classes": []}},
+                        {"num_tasks": 10},
+                    ],
+                }
+            )
 
     async def test_policy_rejects_missing_elo_fit(self) -> None:
         task_ids = [f"t{i}" for i in range(10)]


### PR DESCRIPTION
On top of #2588, `PartialStagePolicy.waivable_failure_classes` becomes a configurable tuple instead of being hardcoded to `("timeout_exceeded",)`. The default is unchanged, so existing configs behave identically.

## Change

- Commit: `36767c8052c76c7047551262e19fb1afd481233e`, branched off `14125b7650317b1d1269987c840ea70deba7e5f4` (the tip of #2588 at the time).
- Files touched: `resources_servers/gdpval/multistage_elo.py` (new field), `resources_servers/gdpval/multistage_orchestrator.py` (7 edits: policy record now emits `newly_waivable_failure_classes`; the waiver check consults the configured set; `_WAIVABLE_FAILURE_CLASSES` validation frozenset is `{"timeout_exceeded", "transient"}`; snapshot revalidation maps the record key `newly_waivable_failure_classes` back to the config key `waivable_failure_classes`), plus 3 new tests in `resources_servers/gdpval/tests/test_multistage_orchestrator.py` (`test_transient_omission_advances_when_explicitly_waivable`, `test_unknown_waivable_failure_class_is_rejected`, `test_empty_waivable_failure_classes_is_rejected`).
- Test status: 313 passed, 9 skipped across `resources_servers/gdpval/tests/`.

## Motivation

The operative blocker was NOT the waiver scope: `partial_completion` is opt-in and was never set, so `multistage_orchestrator.py:1090` took the strict branch and required every planned non-final rollout to carry battle evidence. That cost two GDPVal-AA-v2 runs their entire stage 2 (`dc6c776f3af506df` and `6c5ee8b81773b2b6`, 44/220 each, `eval_elo` null). Once `partial_completion` is enabled, a `transient` judge failure still stopped the stage because the waiver set was hardcoded — which this PR fixes.

## Production evidence

From Nemotron Super 3.5 run `590aeb2c72b1de1d` on this commit:

- stage 1 log line: `[multistage-elo] stage 1/2 accepted partial calibration: success coverage 91.1%, omitted 4 rollout(s)`
- omitted rollouts and classes: task 78 `timeout_exceeded`, task 155 `timeout_exceeded`, task 159 `timeout_exceeded`, task 136 `transient`
- `success_fraction` 0.9111, worst per-reference 0.8, `multistage_state` stage-0 status `partial_complete`
- stage 2 then ran to completion: `eval ELO = 737.5` over 4 refs. The predecessor run died at 44/220 with `eval_elo` null.
- The run also spanned a slurm TIMEOUT resume, and the partial stage was correctly reloaded: `[multistage-elo] resuming multi-stage run from cache (fingerprint match)` and `[multistage-elo] stage 1/2 reused partial result from cache: eval ELO = 627.4 (41 cached rollout(s))` — so the `newly_waivable_failure_classes` <-> `waivable_failure_classes` round-trip works across legs.
- A second run on the same commit, Qwen3.5-122B-A10B `df318339a24e9384`, completed at `eval ELO = 882.6` with a clean 45/45 stage-1 close (the waiver path did not fire there).

## Pre-merge validation

Against `36767c80`, with policy `{min_success_fraction: 0.9, min_per_reference_success_fraction: 0.5, min_successful_rows_per_reference: 1, waivable_failure_classes: [timeout_exceeded, transient]}` and a synthetic 45-rollout stage: an omission of class `timeout_exceeded` accepts at `success_fraction` 0.9778, `transient` accepts at 0.9778, and `legitimate` is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
