### PR TITLE
Fix protobuf dependency conflict in WMT translation

### DIFF
--- a/resources_servers/wmt_translation/requirements.txt
+++ b/resources_servers/wmt_translation/requirements.txt
@@ -7,7 +7,7 @@ torch==2.12.0
 torchvision==0.27.0
 sacrebleu>=2.4
 sentencepiece
-unbabel-comet>=2.2
+unbabel-comet<=2.2
 # GlotLID scoring dependencies.
 numpy
 fasttext-wheel==0.9.2


### PR DESCRIPTION
This is my first PR, I hope I did it right. Thank you.

<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?
Fixed protobuf dependency conflict by changing ```unbabel-comet>=2.2.0``` to ```unbabel-comet<=2.2.0```
Before fix:
```
gym env test --resources-server wmt_translation
(resources_servers/wmt_translation) Using CPython 3.13.13 interpreter at: /root/.local/bin/python3.13 (resources_servers/wmt_translation) Creating virtual environment with seed packages at: .venv (resources_servers/wmt_translation) Activate with: source .venv/bin/activate
(resources_servers/wmt_translation)   × No solution found when resolving dependencies:
(resources_servers/wmt_translation)   ╰─▶ Because unbabel-comet>=2.2.0 depends on protobuf>=4.24.4,<5.0.0 and protobuf>=6.33.5, we can conclude that unbabel-comet>=2.2.0 cannot be used.
(resources_servers/wmt_translation)       And because only the following versions of unbabel-comet are available:
(resources_servers/wmt_translation)           unbabel-comet<=2.2.0
(resources_servers/wmt_translation)           unbabel-comet==2.2.1
(resources_servers/wmt_translation)           unbabel-comet==2.2.2
(resources_servers/wmt_translation)           unbabel-comet==2.2.3
(resources_servers/wmt_translation)           unbabel-comet==2.2.4
(resources_servers/wmt_translation)           unbabel-comet==2.2.5
(resources_servers/wmt_translation)           unbabel-comet==2.2.6
(resources_servers/wmt_translation)           unbabel-comet==2.2.7
(resources_servers/wmt_translation)       and you require unbabel-comet>=2.2, we can conclude that your requirements are unsatisfiable.
You can run detailed tests via .
```

After fix:
All tests pass for ```gym env test --resources-server wmt_translation```
<!-- Briefly describe the change and the motivation. Link any related issue, e.g. "Closes #123". -->

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
