### PR TITLE
fix(eval): reject -i/--input in end-to-end eval run instead of silently ignoring it

### DIFF
--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -445,6 +445,21 @@ class E2ERolloutCollectionConfig(SharedRolloutCollectionConfig):
     split: Union[Literal["train"], Literal["validation"], Literal["benchmark"]]
     reuse_existing_data_preparation: bool = False
 
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_input_jsonl_fpath(cls, data):
+        # This config has no input_jsonl_fpath field, so pydantic would silently drop it and
+        # e2e collection would overwrite it with the prepared split path — the user's file
+        # would be ignored without any indication.
+        if isinstance(data, dict) and "input_jsonl_fpath" in data:
+            raise ConfigError(
+                "`input_jsonl_fpath` (-i/--input) is not supported when serving end-to-end: the input is "
+                "always the prepared dataset for the requested split. Either add --no-serve to collect "
+                "rollouts from your own input file against already-running servers, or drop -i/--input "
+                "to use the prepared data."
+            )
+        return data
+
 
 class RolloutCollectionConfig(SharedRolloutCollectionConfig):
     """

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -35,6 +35,7 @@ from nemo_gym.rollout_collection import (
     _DEFAULT_MAX_ROLLOUT_ATTEMPTS,
     NG_FAILURE_CLASS_KEY,
     NG_NO_PERSIST_KEY,
+    E2ERolloutCollectionConfig,
     RolloutAggregationConfig,
     RolloutAggregationHelper,
     RolloutCollectionConfig,
@@ -2140,3 +2141,25 @@ class TestRolloutCarriesTokenIds:
     )
     def test_false_without_them(self, response) -> None:
         assert rollout_carries_token_ids({"response": response}) is False
+
+
+class TestE2EInputJsonlFpathRejected:
+    def test_e2e_config_rejects_input_jsonl_fpath(self) -> None:
+        with pytest.raises(ConfigError, match=r"not supported when serving end-to-end"):
+            E2ERolloutCollectionConfig.model_validate(
+                {
+                    "output_jsonl_fpath": "out.jsonl",
+                    "split": "train",
+                    "input_jsonl_fpath": "my_data.jsonl",
+                }
+            )
+
+    def test_e2e_config_accepts_without_input_jsonl_fpath(self) -> None:
+        config = E2ERolloutCollectionConfig.model_validate({"output_jsonl_fpath": "out.jsonl", "split": "train"})
+        assert config.split == "train"
+
+    def test_no_serve_config_still_accepts_input_jsonl_fpath(self) -> None:
+        config = RolloutCollectionConfig.model_validate(
+            {"output_jsonl_fpath": "out.jsonl", "input_jsonl_fpath": "my_data.jsonl"}
+        )
+        assert config.input_jsonl_fpath == "my_data.jsonl"


### PR DESCRIPTION
## What

`gym eval run -i myfile.jsonl` **without** `--no-serve` silently ignores `-i`: `E2ERolloutCollectionConfig` has no `input_jsonl_fpath` field (Pydantic `extra="ignore"` drops it), and the e2e path then unconditionally overwrites the input with the prepared split it generates. The run proceeds on different data than the user asked for, with no warning.

## Fix

A `model_validator` on `E2ERolloutCollectionConfig` raises a clean `ConfigError` when `input_jsonl_fpath` is passed in e2e mode, telling the user to either add `--no-serve` (run on their file against already-running servers) or drop `-i` (use the prepared data). `--no-serve -i` behavior is unchanged. E2e mode generating its own input is correct and unchanged — this only makes the contradictory flag combination loud instead of a silent no-op.

## Tests

3 new tests (error fires in e2e; e2e without `-i` still validates; `--no-serve` + `-i` unaffected); full `test_rollout_collection.py` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)