### PR TITLE
feat(rollout): agent_map override + pre-dispatch agent validation

### DIFF
--- a/.agents/skills/nemo-gym-reward-profiling/references/quick-start.md
+++ b/.agents/skills/nemo-gym-reward-profiling/references/quick-start.md
@@ -44,7 +44,7 @@ gym eval profile \
     --rollouts "$ROLLOUTS_JSONL"
 ```
 
-If rows already contain `agent_ref`, leave `AGENT_NAME` empty. Passing `+agent_name` supplies a default for rows without one.
+Passing `--agent`/`+agent_name` routes EVERY row to that agent, overriding any `agent_ref` baked into rows (it is shorthand for `+agent_map={_default: <name>}`). To keep the rows' own `agent_ref` routing, leave `AGENT_NAME` empty. To re-route only specific agents, use `+agent_map` with per-agent entries instead of `_default`.
 
 ## Partial Rollouts
 

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -1254,12 +1254,21 @@ Aggregate metrics: {aggregate_metrics_fpath}""")
         after valid rows have already been dispatched.
         """
         requested = {name for row in examples if (name := (row.get(AGENT_REF_KEY_NAME) or {}).get("name")) is not None}
-        available = set(global_config_dict.keys())
+        available = {
+            str(name)
+            for name, block in global_config_dict.items()
+            if isinstance(block, DictConfig) and "responses_api_agents" in block
+        }
         unknown = sorted(requested - available)
         if not unknown:
             return
         hints = []
         for name in unknown:
+            # Naming a non-agent instance (e.g. a resources server via agent_map) is as fatal as a
+            # typo: /run only exists on agent servers.
+            if name in global_config_dict:
+                hints.append(f"{name!r} (exists but is not an agent instance)")
+                continue
             close = get_close_matches(name, available, n=1)
             hints.append(f"{name!r}" + (f" (did you mean {close[0]!r}?)" if close else ""))
         raise ValueError(

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -23,13 +23,14 @@ from collections import Counter, defaultdict
 from contextlib import nullcontext
 from copy import deepcopy
 from datetime import timedelta
+from difflib import get_close_matches
 from itertools import repeat
 from pathlib import Path
 from time import time
 from typing import Any, Dict, Iterator, List, Literal, Optional, Tuple, Union
 
 import orjson
-from omegaconf import OmegaConf
+from omegaconf import DictConfig, OmegaConf
 from pydantic import BaseModel, Field, field_validator, model_validator
 from tqdm.asyncio import tqdm
 
@@ -505,7 +506,20 @@ class RolloutCollectionConfig(SharedRolloutCollectionConfig):
 
     agent_name: Optional[str] = Field(
         default=None,
-        description="The agent to collect rollouts from. If not specified, uses agent_ref from each data row.",
+        description=(
+            "The agent to collect rollouts from. Routes every row to this agent, overriding any "
+            "agent_ref already present in the data (a warning lists overridden values). "
+            "Shorthand for agent_map={_default: <agent_name>}."
+        ),
+    )
+    agent_map: Optional[Dict[str, str]] = Field(
+        default=None,
+        description=(
+            "Explicit per-agent re-routing, keyed by the agent_ref.name found in the data "
+            "(e.g. {old_agent: new_agent}). The special key '_default' applies to every row "
+            "whose agent_ref.name has no specific entry, including rows with no agent_ref at all. "
+            "Precedence: agent_map[<row value>] > agent_map._default > row agent_ref."
+        ),
     )
     input_jsonl_fpath: str = Field(
         description="The input data source to use to collect rollouts, in the form of a file path to a jsonl file."
@@ -547,6 +561,20 @@ class RolloutCollectionConfig(SharedRolloutCollectionConfig):
         return 1 if v is None else v
 
     @model_validator(mode="after")
+    def _fold_agent_name_into_agent_map(self) -> "RolloutCollectionConfig":
+        # agent_name is sugar for agent_map._default; fold it so downstream code has one knob.
+        if self.agent_name is None:
+            return self
+        existing_default = (self.agent_map or {}).get("_default")
+        if existing_default is not None and existing_default != self.agent_name:
+            raise ValueError(
+                f"agent_name={self.agent_name!r} conflicts with agent_map._default={existing_default!r}. "
+                "Set only one of them."
+            )
+        self.agent_map = {**(self.agent_map or {}), "_default": self.agent_name}
+        return self
+
+    @model_validator(mode="after")
     def _validate_num_repeats(self) -> "RolloutCollectionConfig":
         nr = self.num_repeats
         if isinstance(nr, int):
@@ -586,8 +614,8 @@ class RolloutCollectionHelper(BaseModel):
                 "Adding unique `seed` values to each input via metadata.extra_body (only honored by vLLM model servers)"
             )
 
-        if config.agent_name:
-            print(f"Using `{config.agent_name}` for rows that do not already have an agent ref")
+        if config.agent_map:
+            print(f"Routing rows via agent_map {config.agent_map}")
 
         if config.responses_create_params:
             print(f"Overriding responses_create_params fields with {config.responses_create_params}")
@@ -651,13 +679,21 @@ class RolloutCollectionHelper(BaseModel):
         row_idxs_missing_agent_ref: List[int] = []
         agents_missing_from_num_repeats: set[str] = set()
         rows: List[Dict] = []
+        overridden_agents: set[Tuple[str, str]] = set()
         for row_idx, row_str, row in raw_rows:
-            # Resolve agent name. Missing agent_ref is a hard error reported in
-            # bulk after the loop; skip the row immediately so the rest of the
-            # body can assume agent_name is non-None.
-            if config.agent_name:
-                row.setdefault(AGENT_REF_KEY_NAME, {"name": config.agent_name})
+            # Resolve agent name: agent_map[<row value>] > agent_map._default > row agent_ref.
+            # Missing resolution is a hard error reported in bulk after the loop; skip the row
+            # immediately so the rest of the body can assume agent_name is non-None.
             agent_name = (row.get(AGENT_REF_KEY_NAME) or {}).get("name")
+            if config.agent_map:
+                mapped = config.agent_map.get(agent_name) if agent_name is not None else None
+                if mapped is None:
+                    mapped = config.agent_map.get("_default")
+                if mapped is not None:
+                    if agent_name is not None and agent_name != mapped:
+                        overridden_agents.add((agent_name, mapped))
+                    agent_name = mapped
+                    row[AGENT_REF_KEY_NAME] = {"name": agent_name}
             if agent_name is None:
                 row_idxs_missing_agent_ref.append(row_idx)
                 continue
@@ -707,9 +743,18 @@ class RolloutCollectionHelper(BaseModel):
 
                 rows.append(row)
 
+        if overridden_agents:
+            warnings.warn(
+                "agent_map overrode agent_ref values already present in the data: "
+                f"{sorted(overridden_agents)}. Prior to this release, +agent_name only filled rows "
+                "missing an agent_ref; it now re-routes every row.",
+                stacklevel=2,
+            )
+
         if row_idxs_missing_agent_ref:
             raise ValueError(
-                f"No agent specified for rows {row_idxs_missing_agent_ref}. Either provide +agent_name config or include agent_ref in data."
+                f"No agent specified for rows {row_idxs_missing_agent_ref}. Provide +agent_name (or "
+                "+agent_map with a _default entry), or include agent_ref in the data."
             )
 
         if agents_missing_from_num_repeats:
@@ -1201,6 +1246,27 @@ Aggregate metrics: {aggregate_metrics_fpath}""")
 
         return metrics_fpath
 
+    @staticmethod
+    def _validate_agent_names(examples: List[Dict], global_config_dict: DictConfig) -> None:
+        """Fail before any dispatch when a row names an agent absent from the running config.
+
+        Without this, the first bad row dies mid-collection with a raw omegaconf ConfigKeyError
+        after valid rows have already been dispatched.
+        """
+        requested = {name for row in examples if (name := (row.get(AGENT_REF_KEY_NAME) or {}).get("name")) is not None}
+        available = set(global_config_dict.keys())
+        unknown = sorted(requested - available)
+        if not unknown:
+            return
+        hints = []
+        for name in unknown:
+            close = get_close_matches(name, available, n=1)
+            hints.append(f"{name!r}" + (f" (did you mean {close[0]!r}?)" if close else ""))
+        raise ValueError(
+            f"Rows reference agents not present in the running config: {', '.join(hints)}. "
+            "Include the agent's config in the run, or re-route with +agent_map/+agent_name."
+        )
+
     def run_examples(
         self,
         examples: List[Dict],
@@ -1211,6 +1277,7 @@ Aggregate metrics: {aggregate_metrics_fpath}""")
         We provide this function as a lower level interface for running rollout collection.
         """
         server_client = self.setup_server_client(head_server_config)
+        self._validate_agent_names(examples, server_client.global_config_dict)
         semaphore = semaphore or nullcontext()
 
         async def _post_subroutine(row: Dict) -> Tuple[Dict, Dict]:

--- a/responses_api_agents/remote_agent/tests/test_app.py
+++ b/responses_api_agents/remote_agent/tests/test_app.py
@@ -868,12 +868,18 @@ class TestCollectorRoundTrip:
 
         class InProcessHelper(RolloutCollectionHelper):
             def setup_server_client(self, *args, **kwargs):
+                from omegaconf import OmegaConf
+
                 async def _post(server_name, url_path, json=None, **kw):
                     response = agent_http.post(url_path, json=json)
                     return FakeServerClientResponse(response.json(), status=response.status_code)
 
                 server_client = MagicMock(spec=ServerClient)
                 server_client.post = AsyncMock(side_effect=_post)
+                # Pre-dispatch agent validation reads the running config off the client.
+                server_client.global_config_dict = OmegaConf.create(
+                    {"remote_agent": {"responses_api_agents": {"impl": {}}}}
+                )
                 return server_client
 
             async def _call_aggregate_metrics(self, results, rows, output_fpath):

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -24,6 +24,7 @@ from unittest.mock import AsyncMock, MagicMock
 import orjson
 import pytest
 import yaml
+from omegaconf import OmegaConf
 
 import nemo_gym.rollout_collection
 import nemo_gym.token_id_capture.delivery
@@ -358,6 +359,7 @@ class TestRolloutCollection:
 
         mock_server_client = MagicMock()
         mock_server_client.post = AsyncMock(return_value=response)
+        mock_server_client.global_config_dict = OmegaConf.create({"my_agent": {}})
 
         monkeypatch.setattr(
             nemo_gym.rollout_collection, "setup_server_client_utils", lambda *args, **kwargs: mock_server_client
@@ -2241,3 +2243,96 @@ class TestE2EInputJsonlFpathRejected:
             {"output_jsonl_fpath": "out.jsonl", "input_jsonl_fpath": "my_data.jsonl"}
         )
         assert config.input_jsonl_fpath == "my_data.jsonl"
+
+
+class TestAgentMapRouting:
+    """Pins the agent_map / agent_name routing contract (see dataset-decoupling RFC).
+
+    These exist to fail loudly if the precedence semantics are ever changed silently
+    (the #761 failure mode, where override quietly became backfill).
+    """
+
+    def _write_rows(self, tmp_path, rows):
+        fpath = tmp_path / "input.jsonl"
+        fpath.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+        return fpath
+
+    def _config(self, tmp_path, fpath, **kwargs):
+        return RolloutCollectionConfig(
+            input_jsonl_fpath=str(fpath), output_jsonl_fpath=str(tmp_path / "out.jsonl"), **kwargs
+        )
+
+    def _rcp_row(self, agent=None, content="q"):
+        row = {"responses_create_params": {"input": [{"role": "user", "content": content}]}}
+        if agent is not None:
+            row["agent_ref"] = {"name": agent}
+        return row
+
+    def test_agent_name_overrides_existing_agent_ref(self, tmp_path) -> None:
+        """agent_name re-routes ALL rows (restored #568 semantics), warning about the override."""
+        fpath = self._write_rows(tmp_path, [self._rcp_row("old_agent"), self._rcp_row()])
+        config = self._config(tmp_path, fpath, agent_name="new_agent")
+        with pytest.warns(UserWarning, match="overrode agent_ref"):
+            rows = RolloutCollectionHelper._preprocess_rows_from_config(None, config)
+        assert [r["agent_ref"]["name"] for r in rows] == ["new_agent", "new_agent"]
+
+    def test_agent_name_is_sugar_for_agent_map_default(self, tmp_path) -> None:
+        config = self._config(tmp_path, self._write_rows(tmp_path, [self._rcp_row()]), agent_name="a")
+        assert config.agent_map == {"_default": "a"}
+
+    def test_agent_name_conflicting_with_agent_map_default_raises(self, tmp_path) -> None:
+        fpath = self._write_rows(tmp_path, [self._rcp_row()])
+        with pytest.raises(ValueError, match="conflicts with agent_map._default"):
+            self._config(tmp_path, fpath, agent_name="a", agent_map={"_default": "b"})
+
+    def test_agent_map_specific_beats_default(self, tmp_path) -> None:
+        fpath = self._write_rows(tmp_path, [self._rcp_row("x"), self._rcp_row("y"), self._rcp_row()])
+        config = self._config(tmp_path, fpath, agent_map={"x": "mapped_x", "_default": "fallback"})
+        with pytest.warns(UserWarning, match="overrode agent_ref"):
+            rows = RolloutCollectionHelper._preprocess_rows_from_config(None, config)
+        assert [r["agent_ref"]["name"] for r in rows] == ["mapped_x", "fallback", "fallback"]
+
+    def test_agent_map_without_default_leaves_unmapped_rows_alone(self, tmp_path) -> None:
+        fpath = self._write_rows(tmp_path, [self._rcp_row("x"), self._rcp_row("y")])
+        config = self._config(tmp_path, fpath, agent_map={"x": "mapped_x"})
+        with pytest.warns(UserWarning, match="overrode agent_ref"):
+            rows = RolloutCollectionHelper._preprocess_rows_from_config(None, config)
+        assert [r["agent_ref"]["name"] for r in rows] == ["mapped_x", "y"]
+
+    def test_row_agent_ref_wins_when_no_map(self, tmp_path) -> None:
+        fpath = self._write_rows(tmp_path, [self._rcp_row("x")])
+        rows = RolloutCollectionHelper._preprocess_rows_from_config(None, self._config(tmp_path, fpath))
+        assert rows[0]["agent_ref"]["name"] == "x"
+
+    def test_missing_agent_still_hard_errors(self, tmp_path) -> None:
+        fpath = self._write_rows(tmp_path, [self._rcp_row()])
+        config = self._config(tmp_path, fpath, agent_map={"x": "y"})
+        with pytest.raises(ValueError, match="No agent specified"):
+            RolloutCollectionHelper._preprocess_rows_from_config(None, config)
+
+    def test_identity_mapping_does_not_warn(self, tmp_path) -> None:
+        fpath = self._write_rows(tmp_path, [self._rcp_row("a")])
+        config = self._config(tmp_path, fpath, agent_name="a")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            rows = RolloutCollectionHelper._preprocess_rows_from_config(None, config)
+        assert rows[0]["agent_ref"]["name"] == "a"
+
+
+class TestValidateAgentNames:
+    def _rows(self, *names):
+        return [{"agent_ref": {"name": n}} for n in names]
+
+    def test_all_known_passes(self) -> None:
+        cfg = OmegaConf.create({"agent_a": {}, "agent_b": {}})
+        RolloutCollectionHelper._validate_agent_names(self._rows("agent_a", "agent_b"), cfg)
+
+    def test_unknown_agent_raises_with_suggestion(self) -> None:
+        cfg = OmegaConf.create({"math_with_judge_simple_agent": {}})
+        with pytest.raises(ValueError, match="did you mean 'math_with_judge_simple_agent'"):
+            RolloutCollectionHelper._validate_agent_names(self._rows("math_with_judge_simple_agnet"), cfg)
+
+    def test_unknown_agent_without_close_match_raises(self) -> None:
+        cfg = OmegaConf.create({"a": {}})
+        with pytest.raises(ValueError, match="not present in the running config"):
+            RolloutCollectionHelper._validate_agent_names(self._rows("zzz_completely_unrelated"), cfg)

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -359,7 +359,7 @@ class TestRolloutCollection:
 
         mock_server_client = MagicMock()
         mock_server_client.post = AsyncMock(return_value=response)
-        mock_server_client.global_config_dict = OmegaConf.create({"my_agent": {}})
+        mock_server_client.global_config_dict = OmegaConf.create({"my_agent": {"responses_api_agents": {"impl": {}}}})
 
         monkeypatch.setattr(
             nemo_gym.rollout_collection, "setup_server_client_utils", lambda *args, **kwargs: mock_server_client
@@ -2323,16 +2323,29 @@ class TestValidateAgentNames:
     def _rows(self, *names):
         return [{"agent_ref": {"name": n}} for n in names]
 
+    def _cfg(self, **entries):
+        return OmegaConf.create(
+            {name: {"responses_api_agents": {"impl": {}}} for name in entries.get("agents", [])}
+            | entries.get("extra", {})
+        )
+
     def test_all_known_passes(self) -> None:
-        cfg = OmegaConf.create({"agent_a": {}, "agent_b": {}})
+        cfg = self._cfg(agents=["agent_a", "agent_b"])
         RolloutCollectionHelper._validate_agent_names(self._rows("agent_a", "agent_b"), cfg)
 
     def test_unknown_agent_raises_with_suggestion(self) -> None:
-        cfg = OmegaConf.create({"math_with_judge_simple_agent": {}})
+        cfg = self._cfg(agents=["math_with_judge_simple_agent"])
         with pytest.raises(ValueError, match="did you mean 'math_with_judge_simple_agent'"):
             RolloutCollectionHelper._validate_agent_names(self._rows("math_with_judge_simple_agnet"), cfg)
 
     def test_unknown_agent_without_close_match_raises(self) -> None:
-        cfg = OmegaConf.create({"a": {}})
+        cfg = self._cfg(agents=["a"])
         with pytest.raises(ValueError, match="not present in the running config"):
             RolloutCollectionHelper._validate_agent_names(self._rows("zzz_completely_unrelated"), cfg)
+
+    def test_non_agent_instance_raises(self) -> None:
+        """Routing to an existing but non-agent instance (e.g. agent_map to an RS name) must fail
+        pre-dispatch: /run only exists on agent servers."""
+        cfg = self._cfg(agents=["math_agent"], extra={"math_rs": {"resources_servers": {"impl": {}}}})
+        with pytest.raises(ValueError, match="exists but is not an agent instance"):
+            RolloutCollectionHelper._validate_agent_names(self._rows("math_rs"), cfg)


### PR DESCRIPTION
## Problem

Dataset rows carry `agent_ref` (the agent that runs them), stamped at data prep. Two problems today:

1. **You cannot re-route a stamped dataset.** `--agent` only fills rows that have no `agent_ref`. It never overrides one. To run the same data with a different agent, you must regenerate the dataset.
2. **A stale `agent_ref` crashes mid-run.** If a row names an agent not in the running config, dispatch throws a raw `ConfigKeyError` after earlier rows were already sent. 7 committed datasets in this repo hit this today.

## Change

**1. New `agent_map` config: explicit re-routing.**

```bash
# Before: train.jsonl stamped with agent A. To run it with agent B: regenerate the dataset.
# After:
gym eval run --no-serve -i train.jsonl '+agent_map={agent_a: agent_b}'
```

`agent_map` is a lookup table: "when a row says *this* agent, send it to *that* agent instead." Keys are `agent_ref.name` values found in the data. The reserved key `_default` is a catch-all: it matches every row that has no specific entry, including rows with no `agent_ref` at all.

Per row, first hit wins:
1. `agent_map[<row's agent_ref.name>]` → use it
2. `agent_map._default` → use it
3. row's own `agent_ref` → use it (no `agent_ref` either → hard error, same as today)

Worked example — input rows carry `agent_a`, `agent_b`, and (none):

| You pass | `agent_a` row | `agent_b` row | no-ref row |
|---|---|---|---|
| *(nothing)* | agent_a | agent_b | error |
| `+agent_map={agent_a: agent_x}` | **agent_x** | agent_b | error |
| `+agent_map={agent_a: agent_x, _default: agent_y}` | **agent_x** | **agent_y** | **agent_y** |
| `--agent agent_z` | **agent_z** | **agent_z** | **agent_z** |

**2. `--agent X` now means `agent_map={_default: X}`: it routes every row to X.**

```bash
# Before: --agent B only affected rows missing agent_ref; stamped rows kept their agent silently.
# After:  --agent B routes ALL rows to B. A warning lists any values it overrode.
```

This restores the semantics #568 shipped. #761 changed it to fill-only with no test, no doc, and no mention in the commit message. No existing test pins fill-only.

**3. Agent names are validated before dispatch.**

```text
# Before: first bad row → raw omegaconf ConfigKeyError mid-collection, partial output on disk.
# After, before any request is sent:
ValueError: Rows reference agents not present in the running config:
'math_with_judge_simple_agnet' (did you mean 'math_with_judge_simple_agent'?).
Include the agent's config in the run, or re-route with +agent_map/+agent_name.
```

## What does NOT change

- Rows with no `agent_ref` and no `--agent`: same hard error as before.
- Runs that never pass `--agent`/`agent_map`: identical routing. Verified by replaying rollout preprocessing + dispatch for all 220 runnable config closures in the repo: 165 healthy inputs are byte-identical; the only diffs are the 7 stale-`agent_ref` datasets now failing pre-dispatch instead of mid-run.

## Tests

98 passed. New contract tests pin the precedence order and the validation errors, so the semantics cannot flip silently again.

## Context

Bottom PR of the dataset↔agent decoupling stack (RFC: gym-dataset-preparation, Open Question 1). Later PRs move routing out of dataset rows entirely; this PR makes today's stamped datasets re-routable and makes routing failures loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
