### PR TITLE
docs: update standalone Python runtime examples

### DIFF
--- a/fern/versions/latest/pages/infrastructure/sandbox/docker.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/docker.mdx
@@ -10,7 +10,7 @@ The `docker` provider runs each sandbox as one long-lived container on the local
 
 Install Docker and make sure the `docker` binary is on `PATH` with a running daemon. The provider does not install or start Docker; constructing it raises `RuntimeError` if the binary is missing, and `create()` fails if the daemon is unreachable.
 
-Images can be any reference the daemon can run, such as `ubuntu:22.04`, `python:3.12-slim`, or a registry reference. An Apptainer-style `docker://` prefix is tolerated and stripped. GPU passthrough needs the NVIDIA Container Toolkit; CPU and memory limits need cgroups.
+Images can be any reference the daemon can run, such as `ubuntu:22.04`, `python:3.13.14-slim`, or a registry reference. An Apptainer-style `docker://` prefix is tolerated and stripped. GPU passthrough needs the NVIDIA Container Toolkit; CPU and memory limits need cgroups.
 
 ## Provider Config
 

--- a/fern/versions/latest/pages/infrastructure/sandbox/ecs-fargate.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/ecs-fargate.mdx
@@ -88,7 +88,7 @@ from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
 
 provider_config = {"ecs_fargate": {"region": "us-east-1"}}
 spec = SandboxSpec(
-    image="python:3.12-slim",
+    image="python:3.13.14-slim",
     ttl_s=1800,
     ready_timeout_s=300,
     resources=SandboxResources(cpu=2, memory_mib=8192),

--- a/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
@@ -80,7 +80,7 @@ from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
 provider_config = {"apptainer": {}}
 
 spec = SandboxSpec(
-    image="docker://python:3.12-slim",
+    image="docker://python:3.13.14-slim",
     ttl_s=1800,
     ready_timeout_s=300,
     workdir="/sandbox",
@@ -295,7 +295,7 @@ from nemo_gym.sandbox import rewrite_image
 
 
 image = rewrite_image(
-    "docker.io/library/python:3.12-slim",
+    "docker.io/library/python:3.13.14-slim",
     [{"from": "docker.io/", "to": "mirror.example.com/dockerhub/"}],
 )
 ```

--- a/fern/versions/latest/pages/model-server/vllm.mdx
+++ b/fern/versions/latest/pages/model-server/vllm.mdx
@@ -37,7 +37,7 @@ If you want NeMo Gym to manage the vLLM server lifecycle for you instead, see [L
 ### Install vLLM
 Please run the steps below in a separate terminal than your NeMo Gym terminal! The installation will take a few minutes.
 ```bash
-uv venv --python 3.12 --seed .venv
+uv venv --python 3.13.14 --seed .venv
 source .venv/bin/activate
 # hf_transfer for faster model download
 uv pip install hf_transfer vllm --torch-backend=auto

--- a/fern/versions/v0.5.0/pages/infrastructure/sandbox/docker.mdx
+++ b/fern/versions/v0.5.0/pages/infrastructure/sandbox/docker.mdx
@@ -10,7 +10,7 @@ The `docker` provider runs each sandbox as one long-lived container on the local
 
 Install Docker and make sure the `docker` binary is on `PATH` with a running daemon. The provider does not install or start Docker; constructing it raises `RuntimeError` if the binary is missing, and `create()` fails if the daemon is unreachable.
 
-Images can be any reference the daemon can run, such as `ubuntu:22.04`, `python:3.12-slim`, or a registry reference. An Apptainer-style `docker://` prefix is tolerated and stripped. GPU passthrough needs the NVIDIA Container Toolkit; CPU and memory limits need cgroups.
+Images can be any reference the daemon can run, such as `ubuntu:22.04`, `python:3.13.14-slim`, or a registry reference. An Apptainer-style `docker://` prefix is tolerated and stripped. GPU passthrough needs the NVIDIA Container Toolkit; CPU and memory limits need cgroups.
 
 ## Provider Config
 

--- a/fern/versions/v0.5.0/pages/infrastructure/sandbox/ecs-fargate.mdx
+++ b/fern/versions/v0.5.0/pages/infrastructure/sandbox/ecs-fargate.mdx
@@ -88,7 +88,7 @@ from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
 
 provider_config = {"ecs_fargate": {"region": "us-east-1"}}
 spec = SandboxSpec(
-    image="python:3.12-slim",
+    image="python:3.13.14-slim",
     ttl_s=1800,
     ready_timeout_s=300,
     resources=SandboxResources(cpu=2, memory_mib=8192),

--- a/fern/versions/v0.5.0/pages/infrastructure/sandbox/index.mdx
+++ b/fern/versions/v0.5.0/pages/infrastructure/sandbox/index.mdx
@@ -80,7 +80,7 @@ from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
 provider_config = {"apptainer": {}}
 
 spec = SandboxSpec(
-    image="docker://python:3.12-slim",
+    image="docker://python:3.13.14-slim",
     ttl_s=1800,
     ready_timeout_s=300,
     workdir="/sandbox",
@@ -295,7 +295,7 @@ from nemo_gym.sandbox import rewrite_image
 
 
 image = rewrite_image(
-    "docker.io/library/python:3.12-slim",
+    "docker.io/library/python:3.13.14-slim",
     [{"from": "docker.io/", "to": "mirror.example.com/dockerhub/"}],
 )
 ```

--- a/fern/versions/v0.5.0/pages/model-server/vllm.mdx
+++ b/fern/versions/v0.5.0/pages/model-server/vllm.mdx
@@ -37,7 +37,7 @@ If you want NeMo Gym to manage the vLLM server lifecycle for you instead, see [L
 ### Install vLLM
 Please run the steps below in a separate terminal than your NeMo Gym terminal! The installation will take a few minutes.
 ```bash
-uv venv --python 3.12 --seed .venv
+uv venv --python 3.13.14 --seed .venv
 source .venv/bin/activate
 # hf_transfer for faster model download
 uv pip install hf_transfer vllm --torch-backend=auto


### PR DESCRIPTION
## Summary
- update standalone vLLM setup examples to Python 3.13.14 in Main and v0.5.0 docs
- update sandbox image examples to the published `python:3.13.14-slim` image
- keep these runtime-example changes independent from the NeMo Gym minimum-version correction in #2715

## Test plan
- [x] `npm --prefix fern run check -- --warnings`
- [ ] Verify the `python:3.13.14-slim` multi-platform image manifest exists
- [ ] On Linux with a supported NVIDIA GPU, install vLLM under Python 3.13.14, start the server, and verify its health endpoint