### PR TITLE
feat(finance_sec_search): local backend to find SEC filings by full-text search

### DIFF
--- a/resources_servers/finance_sec_search/README.md
+++ b/resources_servers/finance_sec_search/README.md
@@ -9,6 +9,7 @@ Financial information retrieval using SEC EDGAR filings with optional web search
 | Tool | Description |
 |------|-------------|
 | `sec_filing_search` | Search SEC EDGAR for filing metadata by stock ticker symbol |
+| `edgar_search` | Full-text search a read-only local SQLite FTS5 index |
 | `parse_html_page` | Fetch and parse an HTML page, optionally cache SEC content, and store it under a key |
 | `retrieve_information` | Query stored documents via LLM prompt with `{{key}}` placeholders |
 | `submit_final_result` | Submit the final answer (keeps model in tool-calling mode until ready) |
@@ -33,6 +34,12 @@ search_judge_model_name: gpt-5-mini
 
 # Optional: set TAVILY_API_KEY to enable web_search.
 tavily_api_key: ${oc.env:TAVILY_API_KEY,null}
+
+# Required when the dataset exposes edgar_search.
+local_edgar_index_path: /path/to/sap500_sec_fts.sqlite
+
+# Optional per-process JSONL latency records.
+local_edgar_metrics_dir: /path/to/search_metrics
 ```
 
 The config uses `${oc.select:tavily_api_key,null}`, so `web_search` is disabled
@@ -148,6 +155,22 @@ python resources_servers/finance_sec_search/scripts/convert_questions.py \
   --output resources_servers/finance_sec_search/data/example.jsonl \
   --include-web-search
 ```
+
+Select the local full-text search contract with `--search-tool edgar_search`:
+
+```bash
+python resources_servers/finance_sec_search/scripts/convert_questions.py \
+  --input resources_servers/finance_sec_search/data/example_questions.jsonl \
+  --output resources_servers/finance_sec_search/data/example_edgar_search.jsonl \
+  --search-tool edgar_search
+```
+
+This keeps the same user prompt and companion tools while replacing
+`sec_filing_search` with the agent-facing `edgar_search` schema. The
+`/edgar_search` route reads `local_edgar_index_path` in read-only immutable mode
+and returns sec-api-compatible filing metadata. It does not call sec-api.io.
+`parse_html_page` remains separate and may read the filing cache, filing dump,
+or SEC.gov.
 
 A pre-converted `example.jsonl` (without web search) is checked in and ready to
 use — you only need to re-run `convert_questions.py` if you modify the raw

--- a/resources_servers/finance_sec_search/README.md
+++ b/resources_servers/finance_sec_search/README.md
@@ -40,10 +40,27 @@ local_edgar_index_path: /path/to/sap500_sec_fts.sqlite
 
 # Optional per-process JSONL latency records.
 local_edgar_metrics_dir: /path/to/search_metrics
+
+# Optional. Defaults to the index path plus '.metadata' when that file exists.
+local_edgar_metadata_path: /path/to/sap500_sec_fts.sqlite.metadata
 ```
 
 The config uses `${oc.select:tavily_api_key,null}`, so `web_search` is disabled
 when `tavily_api_key` is omitted or null.
+
+## Local EDGAR index
+
+`edgar_search` reads a read-only SQLite full-text index of SEC filings. Build
+its metadata sidecar once per index, which is what keeps common queries under a
+second instead of tens of seconds:
+
+```bash
+python resources_servers/finance_sec_search/scripts/build_local_edgar_metadata.py \
+  --index /path/to/sap500_sec_fts.sqlite
+```
+
+See [docs/local-edgar-index.md](docs/local-edgar-index.md) for the schema an
+index must have, the column formats that matter, and how to obtain one.
 
 ## Cache Management
 

--- a/resources_servers/finance_sec_search/README.md
+++ b/resources_servers/finance_sec_search/README.md
@@ -43,6 +43,17 @@ local_edgar_metrics_dir: /path/to/search_metrics
 
 # Optional. Defaults to the index path plus '.metadata' when that file exists.
 local_edgar_metadata_path: /path/to/sap500_sec_fts.sqlite.metadata
+
+# Filing content. Reads try cache_dir, then sec_dump_path, then SEC.gov.
+# use_cache defaults to false, which fetches fresh every time; set it true for
+# training so filings are fetched once and reused.
+cache_dir: /path/to/shared/cache/finance_sec_search
+use_cache: true
+sec_dump_path: /path/to/step-0-download/data
+
+# Latest filing date the date-filtered tools will return. Set this to the cutoff
+# the dataset's prompts were written against.
+max_end_date: "2025-04-07"
 ```
 
 The config uses `${oc.select:tavily_api_key,null}`, so `web_search` is disabled

--- a/resources_servers/finance_sec_search/app.py
+++ b/resources_servers/finance_sec_search/app.py
@@ -57,8 +57,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
 )
 from nemo_gym.server_utils import SESSION_ID_KEY, get_response_json
-
-from .local_edgar_search import LocalEdgarSearch
+from resources_servers.finance_sec_search.local_edgar_search import LocalEdgarSearch
 
 
 logger = logging.getLogger(__name__)
@@ -147,6 +146,12 @@ class FinanceAgentResourcesServerConfig(BaseResourcesServerConfig):
     local_edgar_metrics_dir: Optional[str] = Field(
         default=None,
         description="Optional directory for per-search latency records.",
+    )
+    local_edgar_metadata_path: Optional[str] = Field(
+        default=None,
+        description="Metadata sidecar for the local EDGAR index, built by "
+        "scripts/build_local_edgar_metadata.py. Defaults to the index path plus "
+        "'.metadata' when that file exists. Searches are far slower without it.",
     )
     max_end_date: Optional[str] = Field(
         default=None,
@@ -455,10 +460,12 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                 self.config.local_edgar_index_path,
                 max_end_date=self.config.max_end_date or "2025-04-07",
                 metrics_dir=self.config.local_edgar_metrics_dir,
+                metadata_path=self.config.local_edgar_metadata_path,
             )
             logger.info(
-                "Local EDGAR search initialized from %s",
+                "Local EDGAR search initialized from %s (metadata sidecar: %s)",
                 self.config.local_edgar_index_path,
+                self._local_edgar_search.metadata_path or "none",
             )
         else:
             logger.info("local_edgar_index_path is not configured — edgar_search will be unavailable")
@@ -929,10 +936,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
         if self._local_edgar_search is None:
             return EdgarSearchResponse(
                 results=json.dumps(
-                    {
-                        "error": "edgar_search is not available. "
-                        "local_edgar_index_path is not configured."
-                    }
+                    {"error": "edgar_search is not available. local_edgar_index_path is not configured."}
                 )
             )
 

--- a/resources_servers/finance_sec_search/app.py
+++ b/resources_servers/finance_sec_search/app.py
@@ -58,6 +58,8 @@ from nemo_gym.openai_utils import (
 )
 from nemo_gym.server_utils import SESSION_ID_KEY, get_response_json
 
+from .local_edgar_search import LocalEdgarSearch
+
 
 logger = logging.getLogger(__name__)
 
@@ -138,9 +140,17 @@ class FinanceAgentResourcesServerConfig(BaseResourcesServerConfig):
         description="Per-rollout wall-clock time budget in seconds. When exceeded, tool calls return an error "
         "asking the model to submit immediately. Set to None to disable.",
     )
+    local_edgar_index_path: Optional[str] = Field(
+        default=None,
+        description="Read-only SQLite FTS5 index used by edgar_search.",
+    )
+    local_edgar_metrics_dir: Optional[str] = Field(
+        default=None,
+        description="Optional directory for per-search latency records.",
+    )
     max_end_date: Optional[str] = Field(
         default=None,
-        description="Maximum allowed end_date for all date-filtered tools (web_search, etc.). "
+        description="Maximum allowed end_date for all date-filtered tools (web_search, edgar_search, etc.). "
         "When set, dates beyond this are clamped and omitted end_dates default to this value. "
         "Set to null (default) to disable clamping.",
     )
@@ -209,6 +219,29 @@ class FinanceAgentSearchResponse(BaseModel):
     """Response model for SEC filing search."""
 
     results: str = Field(description="JSON string of filing results")
+
+
+class EdgarSearchRequest(BaseModel):
+    """Request model for local full-text EDGAR search."""
+
+    search_query: str = Field(description="Case-insensitive search term or phrase")
+    form_types: Optional[List[str]] = Field(default=None, description="Optional EDGAR form types")
+    ciks: Optional[List[str]] = Field(default=None, description="Optional CIK filters")
+    start_date: Optional[str] = Field(default="1900-01-01", description="Start date (YYYY-MM-DD)")
+    end_date: Optional[str] = Field(default=None, description="End date (YYYY-MM-DD)")
+    page: int = Field(default=1, ge=1, description="Result page number")
+    top_n_results: int = Field(default=100, ge=1, le=100, description="Maximum results to return")
+
+    @field_validator("form_types", "ciks", mode="before")
+    @classmethod
+    def _coerce_filters(cls, v: Any) -> Any:
+        return _coerce_stringified_collection(v)
+
+
+class EdgarSearchResponse(BaseModel):
+    """Response model for local full-text EDGAR search."""
+
+    results: str = Field(description="JSON string of sec-api-compatible search results")
 
 
 class RetrieveInformationRequest(BaseModel):
@@ -338,6 +371,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
     """
     SEC EDGAR Filing Search Resource Server.
     - /sec_filing_search: Search for SEC filings by ticker or company name
+    - /edgar_search: Search the local EDGAR full-text index
     - /parse_html_page: Fetch, parse, and store any HTML page (SEC URLs use XBRL-aware parsing + disk cache)
     - /retrieve_information: Query stored documents via LLM prompt with {{key}} syntax
     - /web_search: Tavily web search
@@ -415,6 +449,20 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
         else:
             logger.info("No tavily_api_key configured — web_search will be unavailable")
 
+        self._local_edgar_search: Optional[LocalEdgarSearch] = None
+        if self.config.local_edgar_index_path:
+            self._local_edgar_search = LocalEdgarSearch(
+                self.config.local_edgar_index_path,
+                max_end_date=self.config.max_end_date or "2025-04-07",
+                metrics_dir=self.config.local_edgar_metrics_dir,
+            )
+            logger.info(
+                "Local EDGAR search initialized from %s",
+                self.config.local_edgar_index_path,
+            )
+        else:
+            logger.info("local_edgar_index_path is not configured — edgar_search will be unavailable")
+
     def _get_session_storage(self, session_id: str) -> Dict[str, str]:
         """Get or create the data storage dict for a session."""
         if session_id not in self._data_storage:
@@ -464,6 +512,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
         self._load_tickers_or_fail()
 
         app.post("/sec_filing_search")(self.sec_filing_search)
+        app.post("/edgar_search")(self.edgar_search)
         app.post("/parse_html_page")(self.parse_html_page)
         app.post("/retrieve_information")(self.retrieve_information)
         app.post("/submit_final_result")(self.submit_final_result)
@@ -475,7 +524,7 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
                 "results": json.dumps(
                     {
                         "error": f"Tool '{tool_name}' does not exist. Available tools: "
-                        "sec_filing_search, parse_html_page, "
+                        "sec_filing_search, edgar_search, parse_html_page, "
                         "retrieve_information, submit_final_result, web_search"
                     }
                 )
@@ -867,6 +916,40 @@ class FinanceAgentResourcesServer(SimpleResourcesServer):
             )
 
         return FinanceAgentSearchResponse(results=json.dumps(all_results, indent=2))
+
+    # ========================================================================
+    # edgar_search Endpoint
+    # ========================================================================
+
+    async def edgar_search(self, request: Request, body: EdgarSearchRequest) -> EdgarSearchResponse:
+        """Search the local SQLite EDGAR full-text index."""
+        if timeout_msg := self._check_time_budget(request.session.get(SESSION_ID_KEY, "")):
+            return EdgarSearchResponse(results=timeout_msg)
+
+        if self._local_edgar_search is None:
+            return EdgarSearchResponse(
+                results=json.dumps(
+                    {
+                        "error": "edgar_search is not available. "
+                        "local_edgar_index_path is not configured."
+                    }
+                )
+            )
+
+        try:
+            results = await self._local_edgar_search.search_async(
+                search_query=body.search_query,
+                start_date=body.start_date or "1900-01-01",
+                end_date=body.end_date or self.config.max_end_date or "2025-04-07",
+                top_n_results=body.top_n_results,
+                page=body.page,
+                form_types=body.form_types,
+                ciks=body.ciks,
+            )
+            return EdgarSearchResponse(results=json.dumps(results, default=str))
+        except Exception as error:
+            logger.warning("edgar_search failed: %s", error)
+            return EdgarSearchResponse(results=json.dumps({"error": str(error)}))
 
     # ========================================================================
     # parse_html_page Endpoint

--- a/resources_servers/finance_sec_search/configs/finance_sec_search.yaml
+++ b/resources_servers/finance_sec_search/configs/finance_sec_search.yaml
@@ -13,6 +13,8 @@ finance_sec_search_resources_server:
       # standalone (`gym env start` / `+dry_run`); override via env / NVFlow overlay.
       # null default => web search disabled unless a key is supplied.
       tavily_api_key: ${oc.select:tavily_api_key,null}
+      local_edgar_index_path: ${oc.select:local_edgar_index_path,null}
+      local_edgar_metrics_dir: ${oc.select:local_edgar_metrics_dir,null}
       retrieval_model_server:
         type: responses_api_models
         name: policy_model

--- a/resources_servers/finance_sec_search/configs/finance_sec_search.yaml
+++ b/resources_servers/finance_sec_search/configs/finance_sec_search.yaml
@@ -15,6 +15,8 @@ finance_sec_search_resources_server:
       tavily_api_key: ${oc.select:tavily_api_key,null}
       local_edgar_index_path: ${oc.select:local_edgar_index_path,null}
       local_edgar_metrics_dir: ${oc.select:local_edgar_metrics_dir,null}
+      # null => use the sidecar sitting beside the index if one is present.
+      local_edgar_metadata_path: ${oc.select:local_edgar_metadata_path,null}
       retrieval_model_server:
         type: responses_api_models
         name: policy_model

--- a/resources_servers/finance_sec_search/configs/finance_sec_search.yaml
+++ b/resources_servers/finance_sec_search/configs/finance_sec_search.yaml
@@ -7,8 +7,13 @@ finance_sec_search_resources_server:
       verified: false
       description: SEC EDGAR filing search for financial analysis questions
       value: Enable LLMs to search and analyze SEC filings
-      cache_dir: null  # defaults to ~/.cache/nemo_gym/finance_sec_search/ if not set
-      use_cache: false  # keep false for eval to fetch fresh filings, set to true for training to reuse cached filings
+      cache_dir: ${oc.select:cache_dir,null}  # defaults to ~/.cache/nemo_gym/finance_sec_search/ if not set
+      use_cache: ${oc.select:use_cache,false}  # keep false for eval to fetch fresh filings, set to true for training to reuse cached filings
+      # Read-only corpus of pre-fetched filings, tried before sec.gov on a cache miss.
+      sec_dump_path: ${oc.select:sec_dump_path,null}
+      # Latest filing date any date-filtered tool will return. Must match the
+      # cutoff the dataset's prompts were written against.
+      max_end_date: ${oc.select:max_end_date,null}
       # Wrapped in oc.select (Gym convention, cf. labbench2_vlm) so the env resolves
       # standalone (`gym env start` / `+dry_run`); override via env / NVFlow overlay.
       # null default => web search disabled unless a key is supplied.

--- a/resources_servers/finance_sec_search/docs/local-edgar-index.md
+++ b/resources_servers/finance_sec_search/docs/local-edgar-index.md
@@ -1,0 +1,132 @@
+# Local EDGAR index
+
+The `edgar_search` tool answers full-text queries over SEC filings from a
+read-only SQLite file instead of a hosted API, so rollouts do not depend on
+network availability or request rate limits.
+
+It is a different tool from `sec_filing_search`, which looks up filing metadata
+by ticker. `edgar_search` searches the *text* of filings and returns filing
+metadata for the matches, ranked by relevance.
+
+Set `local_edgar_index_path` to enable the tool. When it is unset, the tool
+reports itself unavailable and the rest of the server works normally.
+
+## Files
+
+| File | Required | Purpose |
+|------|----------|---------|
+| `<index>.sqlite` | yes | Filing text and metadata |
+| `<index>.sqlite.metadata` | no | Metadata-only copy that makes searches fast |
+
+The sidecar is found automatically when it sits beside the index with a
+`.metadata` suffix. See [Metadata sidecar](#metadata-sidecar).
+
+## Index schema
+
+Two objects are required.
+
+```sql
+CREATE TABLE documents (
+    id               INTEGER PRIMARY KEY,
+    accession_number TEXT NOT NULL,
+    cik              TEXT NOT NULL,
+    ticker           TEXT NOT NULL,
+    company_name     TEXT NOT NULL,
+    form_type        TEXT NOT NULL,
+    document_type    TEXT NOT NULL,
+    description      TEXT,
+    filing_date      TEXT NOT NULL,
+    url              TEXT NOT NULL,
+    body             TEXT NOT NULL
+);
+
+CREATE VIRTUAL TABLE documents_fts USING fts5(
+    body,
+    content='documents',
+    content_rowid='id',
+    tokenize='unicode61 remove_diacritics 2',
+    prefix='2 3 4'
+);
+```
+
+`content_rowid='id'` is what lets a full-text hit be joined back to its row, so
+it cannot be omitted or renamed. Additional columns on `documents` are ignored.
+
+Searches filter on `cik`, `form_type` and `filing_date` together, so an index
+over those three makes filter-only browsing usable on a large corpus:
+
+```sql
+CREATE INDEX documents_filters ON documents(cik, form_type, filing_date);
+```
+
+`prefix='2 3 4'` is what makes trailing wildcards such as `artific*` resolve
+without scanning the whole term list. Queries still work without it, only more
+slowly.
+
+## Column formats
+
+Three of these will silently return wrong or empty results if stored
+differently, so they are worth getting right.
+
+**`cik`** — store with leading zeros stripped, the form `str(int(cik))`
+produces. Incoming CIKs are normalized that way before an exact string
+comparison, so an index storing `0000320193` will never match a request for
+`320193`, and CIK-filtered searches quietly return nothing.
+
+**`filing_date`** — store as `YYYY-MM-DD`. Date ranges compare as strings, so
+any other layout puts filings outside the range the caller asked for.
+
+**`ticker`** — store an empty string, not `NULL`, when a filing has no ticker.
+The tool converts empty to `null` on the way out.
+
+`body` holds the filing text that gets indexed. It is never returned to the
+agent; results contain filing metadata and URLs only.
+
+## Optional provenance
+
+An `index_metadata` table of `key`/`value` text pairs is read by nothing and is
+a good place to record how a corpus was built.
+
+## Metadata sidecar
+
+Filing text and filing metadata share one table, so ranking a common term means
+reading tens of thousands of multi-kilobyte rows just to reach the handful of
+columns a result needs. The sidecar holds the same columns without the text —
+hundreds of megabytes rather than tens of gigabytes — small enough to stay in
+the page cache, which turns those reads into memory hits. Results are identical
+either way; only the source of the metadata changes.
+
+Build it once per index:
+
+```bash
+python resources_servers/finance_sec_search/scripts/build_local_edgar_metadata.py \
+  --index /path/to/index.sqlite
+```
+
+The default output path is the one the server discovers on its own, so no
+config change is needed. Expect common queries to drop from tens of seconds to
+well under a second.
+
+**Rebuild the sidecar whenever the index is rebuilt.** The two are joined on row
+id, so a sidecar from a different index would pair filings with the wrong
+metadata. To prevent that, the sidecar records the document count and a
+fingerprint sampled from the index it came from, and the server refuses to start
+against an index that does not match.
+
+## Startup checks
+
+When `local_edgar_index_path` is set, the server verifies the index has the
+required tables, and, if a sidecar is present, that its schema version,
+document count and fingerprint match the index. A configured-but-unusable
+sidecar is a startup error rather than a silent fallback, because searches
+would still be correct without it but orders of magnitude slower.
+
+## Obtaining an index
+
+Any file matching the schema above works, so an index can be copied between
+machines — it is a single self-contained SQLite file plus its sidecar.
+
+Building one means walking a corpus of downloaded filings, extracting text from
+each document, and inserting rows into `documents` while keeping `documents_fts`
+populated. That is a property of whichever pipeline downloads the filings rather
+than of this resource server, so no builder ships here.

--- a/resources_servers/finance_sec_search/local_edgar_search.py
+++ b/resources_servers/finance_sec_search/local_edgar_search.py
@@ -1,0 +1,322 @@
+"""SQLite-backed implementation of the agent-facing EDGAR search contract."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Optional
+
+
+DEFAULT_START_DATE = "1900-01-01"
+MAX_END_DATE = "2025-04-07"
+PAGE_SIZE = 100
+TOKEN_RE = re.compile(r'"(?:[^"]|"")*"|\S+')
+BAREWORD_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+
+@dataclass(frozen=True)
+class LocalEdgarRequest:
+    search_query: str
+    form_types: tuple[str, ...] | None
+    ciks: tuple[str, ...] | None
+    start_date: str
+    end_date: str
+    page: int
+    top_n_results: int
+
+
+def _quote_fts(value: str) -> str:
+    return f'"{value.replace(chr(34), chr(34) * 2)}"'
+
+
+def _translate_term(token: str) -> str:
+    prefix = token.endswith("*")
+    value = token[:-1] if prefix else token
+    if not value:
+        raise ValueError("Wildcard requires a non-empty prefix")
+    if "*" in value:
+        raise ValueError("Wildcards are supported only at the end of a term")
+    if token.startswith('"'):
+        if prefix:
+            raise ValueError("Wildcards are not supported on quoted phrases")
+        if not token.endswith('"') or len(token) < 2:
+            raise ValueError("Unterminated quoted phrase")
+        return _quote_fts(token[1:-1].replace('""', '"'))
+    translated = value if BAREWORD_RE.fullmatch(value) else _quote_fts(value)
+    return f"{translated}*" if prefix else translated
+
+
+def translate_query(query: str) -> str:
+    if not query.strip():
+        raise ValueError("Query must not be empty")
+    if any(character in query for character in "()"):
+        raise ValueError("Parentheses are not supported")
+
+    groups: list[list[str]] = [[]]
+    exclusions: list[str] = []
+    negate_next = False
+    for raw in TOKEN_RE.findall(query):
+        if raw == "OR":
+            if not groups[-1]:
+                raise ValueError("OR must follow a search term")
+            groups.append([])
+            negate_next = False
+            continue
+        if raw == "AND":
+            raise ValueError("Explicit AND is unsupported; use spaces for implicit AND")
+        if raw == "NOT":
+            negate_next = True
+            continue
+
+        excluded = negate_next or raw.startswith("-")
+        negate_next = False
+        term = _translate_term(raw[1:] if raw.startswith("-") else raw)
+        (exclusions if excluded else groups[-1]).append(term)
+
+    if negate_next:
+        raise ValueError("NOT must be followed by a search term")
+    if not groups[-1]:
+        raise ValueError("Query must end with a positive search term")
+    expressions = [" AND ".join(group) for group in groups]
+    positive = expressions[0] if len(expressions) == 1 else f"({' OR '.join(expressions)})"
+    if not exclusions:
+        return positive
+    negative = " OR ".join(exclusions)
+    return f"{positive} NOT ({negative})" if len(exclusions) > 1 else f"{positive} NOT {negative}"
+
+
+def _date_value(name: str, value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string in yyyy-mm-dd format")
+    try:
+        return date.fromisoformat(value).isoformat()
+    except ValueError as error:
+        raise ValueError(f"{name} '{value}' is not in yyyy-mm-dd format") from error
+
+
+def _optional_strings(name: str, value: Any) -> tuple[str, ...] | None:
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise ValueError(f"The parameter {name} must be a list if provided. Was of type {type(value)}")
+    if not all(isinstance(item, str) for item in value):
+        raise ValueError(f"The parameter {name} must contain only strings")
+    return tuple(value) or None
+
+
+def normalize_request(
+    search_query: str,
+    start_date: str = DEFAULT_START_DATE,
+    end_date: str = MAX_END_DATE,
+    top_n_results: int = PAGE_SIZE,
+    page: int = 1,
+    form_types: Optional[list[str]] = None,
+    ciks: Optional[list[str]] = None,
+    *,
+    max_end_date: str = MAX_END_DATE,
+) -> LocalEdgarRequest:
+    if not isinstance(search_query, str) or not search_query.strip():
+        raise ValueError(
+            "search_query is required and cannot be empty. Provide a search term "
+            "to search the contents of SEC filings."
+        )
+
+    maximum = _date_value("max_end_date", max_end_date)
+    start = min(_date_value("start_date", start_date or DEFAULT_START_DATE), maximum)
+    end = min(_date_value("end_date", end_date or maximum), maximum)
+    if start > end:
+        raise ValueError(f"Parameter start_date '{start}' was set to a date that is later than end_date '{end}'")
+    if isinstance(page, bool) or not isinstance(page, int) or page < 1:
+        raise ValueError("page must be an integer greater than or equal to 1")
+    if isinstance(top_n_results, bool) or not isinstance(top_n_results, int) or not 1 <= top_n_results <= PAGE_SIZE:
+        raise ValueError("top_n_results must be an integer between 1 and 100")
+
+    forms = _optional_strings("form_types", form_types)
+    raw_ciks = _optional_strings("ciks", ciks)
+    try:
+        normalized_ciks = tuple(str(int(cik)) for cik in raw_ciks) if raw_ciks else None
+    except ValueError as error:
+        raise ValueError("The parameter ciks must contain numeric strings") from error
+
+    return LocalEdgarRequest(
+        search_query=search_query,
+        form_types=forms,
+        ciks=normalized_ciks,
+        start_date=start,
+        end_date=end,
+        page=page,
+        top_n_results=top_n_results,
+    )
+
+
+class LocalEdgarSearch:
+    def __init__(
+        self,
+        index_path: str | Path,
+        *,
+        max_end_date: str = MAX_END_DATE,
+        metrics_dir: str | Path | None = None,
+    ):
+        self.index_path = Path(index_path)
+        if not self.index_path.is_file():
+            raise FileNotFoundError(f"Local EDGAR index not found: {self.index_path}")
+        self._validate_index()
+        self.max_end_date = _date_value("max_end_date", max_end_date)
+        self.metrics_path: Path | None = None
+        self._metrics_lock = threading.Lock()
+        if metrics_dir:
+            destination = Path(metrics_dir)
+            destination.mkdir(parents=True, exist_ok=True)
+            identity = os.environ.get("SLURM_JOB_ID") or str(os.getpid())
+            self.metrics_path = destination / f"search-{identity}-{os.getpid()}.jsonl"
+
+    def _connect(self) -> sqlite3.Connection:
+        uri = f"file:{self.index_path}?mode=ro&immutable=1"
+        connection = sqlite3.connect(uri, uri=True)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def _validate_index(self) -> None:
+        connection = self._connect()
+        try:
+            tables = {
+                str(row[0])
+                for row in connection.execute("SELECT name FROM sqlite_master WHERE type IN ('table', 'view')")
+            }
+        finally:
+            connection.close()
+        required = {"documents", "documents_fts"}
+        missing = sorted(required - tables)
+        if missing:
+            raise ValueError("Local EDGAR index is missing required tables: " + ", ".join(missing))
+
+    def search(
+        self,
+        search_query: str,
+        start_date: str = DEFAULT_START_DATE,
+        end_date: str = MAX_END_DATE,
+        top_n_results: int = PAGE_SIZE,
+        page: int = 1,
+        form_types: Optional[list[str]] = None,
+        ciks: Optional[list[str]] = None,
+    ) -> list[dict[str, Any]]:
+        started = time.perf_counter()
+        request = normalize_request(
+            search_query,
+            start_date,
+            end_date,
+            top_n_results,
+            page,
+            form_types,
+            ciks,
+            max_end_date=self.max_end_date,
+        )
+        match_all = request.search_query.strip() == "*"
+        results = self._execute(request, match_all=match_all)
+        filter_browse_fallback = not results and not match_all and bool(request.ciks)
+        if filter_browse_fallback:
+            results = self._execute(request, match_all=True)
+        self._assert_invariants(results, request)
+        self._record_metrics(
+            request,
+            result_count=len(results),
+            latency_ms=(time.perf_counter() - started) * 1000,
+            filter_browse_fallback=filter_browse_fallback,
+        )
+        return results
+
+    def _execute(
+        self,
+        request: LocalEdgarRequest,
+        *,
+        match_all: bool,
+    ) -> list[dict[str, Any]]:
+        conditions = ["d.filing_date >= ?", "d.filing_date <= ?"]
+        parameters: list[Any] = [request.start_date, request.end_date]
+        if not match_all:
+            conditions.insert(0, "documents_fts MATCH ?")
+            parameters.insert(0, translate_query(request.search_query))
+        if request.form_types:
+            conditions.append(f"d.form_type IN ({','.join('?' for _ in request.form_types)})")
+            parameters.extend(request.form_types)
+        if request.ciks:
+            conditions.append(f"d.cik IN ({','.join('?' for _ in request.ciks)})")
+            parameters.extend(request.ciks)
+        parameters.extend([request.top_n_results, (request.page - 1) * PAGE_SIZE])
+
+        source = "documents AS d" if match_all else "documents_fts JOIN documents AS d ON d.id = documents_fts.rowid"
+        ordering = "d.filing_date DESC, d.url" if match_all else "bm25(documents_fts), d.filing_date DESC, d.url"
+        statement = f"""
+            SELECT
+                d.accession_number AS accessionNo,
+                d.cik,
+                d.company_name AS companyNameLong,
+                NULLIF(d.ticker, '') AS ticker,
+                d.description,
+                d.form_type AS formType,
+                d.document_type AS type,
+                d.url AS filingUrl,
+                d.filing_date AS filedAt
+            FROM {source}
+            WHERE {" AND ".join(conditions)}
+            ORDER BY {ordering}
+            LIMIT ? OFFSET ?
+        """
+        connection = self._connect()
+        try:
+            results = [dict(row) for row in connection.execute(statement, parameters)]
+        finally:
+            connection.close()
+        return results
+
+    async def search_async(self, **arguments: Any) -> list[dict[str, Any]]:
+        return await asyncio.to_thread(self.search, **arguments)
+
+    @staticmethod
+    def _assert_invariants(
+        results: list[dict[str, Any]],
+        request: LocalEdgarRequest,
+    ) -> None:
+        forms = set(request.form_types or ())
+        ciks = set(request.ciks or ())
+        for result in results:
+            if not request.start_date <= result["filedAt"] <= request.end_date:
+                raise RuntimeError("Local search returned a filing outside the date range")
+            if forms and result["formType"] not in forms:
+                raise RuntimeError("Local search returned an unrequested form type")
+            if ciks and str(int(result["cik"])) not in ciks:
+                raise RuntimeError("Local search returned an unrequested CIK")
+
+    def _record_metrics(
+        self,
+        request: LocalEdgarRequest,
+        *,
+        result_count: int,
+        latency_ms: float,
+        filter_browse_fallback: bool,
+    ) -> None:
+        if self.metrics_path is None:
+            return
+        record = {
+            "search_query": request.search_query,
+            "form_types": request.form_types,
+            "ciks": request.ciks,
+            "start_date": request.start_date,
+            "end_date": request.end_date,
+            "page": request.page,
+            "top_n_results": request.top_n_results,
+            "result_count": result_count,
+            "latency_ms": latency_ms,
+            "filter_browse_fallback": filter_browse_fallback,
+            "completed_at_unix_seconds": time.time(),
+        }
+        with self._metrics_lock, self.metrics_path.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(record, sort_keys=True) + "\n")

--- a/resources_servers/finance_sec_search/local_edgar_search.py
+++ b/resources_servers/finance_sec_search/local_edgar_search.py
@@ -1,9 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """SQLite-backed implementation of the agent-facing EDGAR search contract."""
 
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
+import logging
 import os
 import re
 import sqlite3
@@ -15,11 +31,63 @@ from pathlib import Path
 from typing import Any, Optional
 
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_START_DATE = "1900-01-01"
 MAX_END_DATE = "2025-04-07"
 PAGE_SIZE = 100
 TOKEN_RE = re.compile(r'"(?:[^"]|"")*"|\S+')
 BAREWORD_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+SIDECAR_SCHEMA_VERSION = 1
+SIDECAR_SUFFIX = ".metadata"
+SIDECAR_ALIAS = "meta"
+SIDECAR_TABLE = f"{SIDECAR_ALIAS}.documents_meta"
+FINGERPRINT_SAMPLES = 64
+
+# Mirrored into the sidecar so that swapping the metadata source leaves every
+# column name the search query references unchanged.
+METADATA_COLUMNS = (
+    "id",
+    "accession_number",
+    "cik",
+    "ticker",
+    "company_name",
+    "form_type",
+    "document_type",
+    "description",
+    "filing_date",
+    "url",
+)
+
+
+def default_sidecar_path(index_path: str | Path) -> Path:
+    return Path(str(index_path) + SIDECAR_SUFFIX)
+
+
+def fingerprint_source_index(connection: sqlite3.Connection) -> str:
+    """Fingerprint the row identity of an index.
+
+    The sidecar is joined to the full-text index on rowid, so a rebuilt index
+    that reassigns rowids would silently pair filings with the wrong metadata.
+    Sampling by primary key keeps this cheap enough to verify on every startup.
+    """
+    highest = connection.execute("SELECT MAX(id) FROM documents").fetchone()[0]
+    if not highest:
+        return "empty"
+    stride = max(1, highest // FINGERPRINT_SAMPLES)
+    sampled = [1 + offset * stride for offset in range(FINGERPRINT_SAMPLES)]
+    placeholders = ",".join("?" for _ in sampled)
+    rows = connection.execute(
+        f"SELECT id, accession_number, filing_date FROM documents WHERE id IN ({placeholders}) ORDER BY id",
+        sampled,
+    ).fetchall()
+    digest = hashlib.sha256()
+    digest.update(f"{highest}\x1e".encode())
+    for row in rows:
+        digest.update("\x1f".join(str(value) for value in row).encode())
+        digest.update(b"\x1e")
+    return digest.hexdigest()
 
 
 @dataclass(frozen=True)
@@ -164,25 +232,116 @@ class LocalEdgarSearch:
         *,
         max_end_date: str = MAX_END_DATE,
         metrics_dir: str | Path | None = None,
+        metadata_path: str | Path | None = None,
     ):
         self.index_path = Path(index_path)
         if not self.index_path.is_file():
             raise FileNotFoundError(f"Local EDGAR index not found: {self.index_path}")
         self._validate_index()
+        self.metadata_path = self._resolve_metadata_path(metadata_path)
         self.max_end_date = _date_value("max_end_date", max_end_date)
         self.metrics_path: Path | None = None
         self._metrics_lock = threading.Lock()
+        self._local = threading.local()
         if metrics_dir:
             destination = Path(metrics_dir)
             destination.mkdir(parents=True, exist_ok=True)
             identity = os.environ.get("SLURM_JOB_ID") or str(os.getpid())
             self.metrics_path = destination / f"search-{identity}-{os.getpid()}.jsonl"
 
+    @property
+    def uses_metadata_sidecar(self) -> bool:
+        return self.metadata_path is not None
+
+    def _resolve_metadata_path(self, metadata_path: str | Path | None) -> Path | None:
+        """Locate the metadata sidecar, requiring it to match the index if present.
+
+        A configured-but-unusable sidecar is an error rather than a downgrade:
+        searches would still answer correctly without it, but orders of magnitude
+        more slowly, and that is worth failing loudly for.
+        """
+        if metadata_path is None:
+            candidate = default_sidecar_path(self.index_path)
+            if not candidate.is_file():
+                logger.info(
+                    "No metadata sidecar at %s — searches will read filing metadata from "
+                    "the full-text index, which is substantially slower",
+                    candidate,
+                )
+                return None
+        else:
+            candidate = Path(metadata_path)
+            if not candidate.is_file():
+                raise FileNotFoundError(f"Local EDGAR metadata sidecar not found: {candidate}")
+
+        self._validate_metadata_sidecar(candidate)
+        logger.info("Local EDGAR metadata sidecar initialized from %s", candidate)
+        return candidate
+
+    def _validate_metadata_sidecar(self, candidate: Path) -> None:
+        sidecar = sqlite3.connect(f"file:{candidate}?mode=ro", uri=True)
+        try:
+            recorded = {str(row[0]): str(row[1]) for row in sidecar.execute("SELECT key, value FROM sidecar_metadata")}
+        except sqlite3.DatabaseError as error:
+            raise ValueError(f"Metadata sidecar {candidate} is not readable: {error}") from error
+        finally:
+            sidecar.close()
+
+        version = recorded.get("schema_version")
+        if version != str(SIDECAR_SCHEMA_VERSION):
+            raise ValueError(
+                f"Metadata sidecar {candidate} has schema version {version!r}, "
+                f"expected {SIDECAR_SCHEMA_VERSION}. Rebuild it with "
+                f"scripts/build_local_edgar_metadata.py."
+            )
+
+        connection = self._connect()
+        try:
+            documents = connection.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+            fingerprint = fingerprint_source_index(connection)
+        finally:
+            connection.close()
+
+        if recorded.get("document_count") != str(documents):
+            raise ValueError(
+                f"Metadata sidecar {candidate} covers {recorded.get('document_count')} documents "
+                f"but the index holds {documents}. Rebuild it with "
+                f"scripts/build_local_edgar_metadata.py."
+            )
+        if recorded.get("source_fingerprint") != fingerprint:
+            raise ValueError(
+                f"Metadata sidecar {candidate} was built from a different index. Rebuild it with "
+                f"scripts/build_local_edgar_metadata.py."
+            )
+
     def _connect(self) -> sqlite3.Connection:
         uri = f"file:{self.index_path}?mode=ro&immutable=1"
         connection = sqlite3.connect(uri, uri=True)
         connection.row_factory = sqlite3.Row
         return connection
+
+    def _session(self) -> sqlite3.Connection:
+        """Return this thread's connection, reusing it across searches.
+
+        Reuse matters more than it looks: a fresh connection starts with an empty
+        page cache, so every search would re-read the index pages it just read.
+        """
+        connection: sqlite3.Connection | None = getattr(self._local, "connection", None)
+        if connection is None:
+            connection = self._connect()
+            if self.metadata_path is not None:
+                connection.execute(
+                    "ATTACH DATABASE ? AS " + SIDECAR_ALIAS,
+                    (f"file:{self.metadata_path}?mode=ro",),
+                )
+            self._local.connection = connection
+        return connection
+
+    def close(self) -> None:
+        connection: sqlite3.Connection | None = getattr(self._local, "connection", None)
+        if connection is not None:
+            connection.close()
+            self._local.connection = None
 
     def _validate_index(self) -> None:
         connection = self._connect()
@@ -252,7 +411,21 @@ class LocalEdgarSearch:
             parameters.extend(request.ciks)
         parameters.extend([request.top_n_results, (request.page - 1) * PAGE_SIZE])
 
-        source = "documents AS d" if match_all else "documents_fts JOIN documents AS d ON d.id = documents_fts.rowid"
+        # The metadata source mirrors the index's column names, so switching it
+        # leaves the filters, ordering and paging below unchanged and the results
+        # identical.
+        table = SIDECAR_TABLE if self.metadata_path is not None else "documents"
+        if match_all:
+            # Browsing has no full-text term to rank, so the filter columns are
+            # the only way in and their index is what makes it quick.
+            source = f"{table} AS d"
+        else:
+            # NOT INDEXED forces the full-text match to drive the join and the
+            # metadata to be fetched by rowid. Left to its own judgement the
+            # planner sometimes inverts this, scanning every filing that matches
+            # the form and date filters and probing the full-text index once per
+            # row, which costs hundreds of times more.
+            source = f"documents_fts JOIN {table} AS d NOT INDEXED ON d.id = documents_fts.rowid"
         ordering = "d.filing_date DESC, d.url" if match_all else "bm25(documents_fts), d.filing_date DESC, d.url"
         statement = f"""
             SELECT
@@ -270,12 +443,8 @@ class LocalEdgarSearch:
             ORDER BY {ordering}
             LIMIT ? OFFSET ?
         """
-        connection = self._connect()
-        try:
-            results = [dict(row) for row in connection.execute(statement, parameters)]
-        finally:
-            connection.close()
-        return results
+        connection = self._session()
+        return [dict(row) for row in connection.execute(statement, parameters)]
 
     async def search_async(self, **arguments: Any) -> list[dict[str, Any]]:
         return await asyncio.to_thread(self.search, **arguments)

--- a/resources_servers/finance_sec_search/scripts/build_local_edgar_metadata.py
+++ b/resources_servers/finance_sec_search/scripts/build_local_edgar_metadata.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Build the metadata sidecar used by the local EDGAR search backend.
+
+The full-text index stores each filing's body in the same table as its metadata,
+so reading a filing's form type or date pulls a multi-kilobyte record. Searches
+need those columns for every candidate match, which turns a common-term query
+into tens of thousands of large random reads.
+
+This script copies the non-body columns into a separate, much smaller database.
+Search reads metadata from the sidecar and never touches the body column, which
+leaves query results identical while removing the dominant I/O cost.
+
+Usage:
+    python build_local_edgar_metadata.py --index INDEX.sqlite [--output SIDECAR]
+
+The default output path is the one the search backend looks for automatically:
+the index path with a ``.metadata`` suffix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from resources_servers.finance_sec_search.local_edgar_search import (  # noqa: E402
+    METADATA_COLUMNS,
+    SIDECAR_SCHEMA_VERSION,
+    default_sidecar_path,
+    fingerprint_source_index,
+)
+
+
+BATCH_SIZE = 20_000
+
+
+def build(index_path: Path, output_path: Path, *, batch_size: int = BATCH_SIZE) -> None:
+    if not index_path.is_file():
+        raise SystemExit(f"Index not found: {index_path}")
+
+    temporary_path = output_path.with_suffix(output_path.suffix + ".partial")
+    for stale in (temporary_path, temporary_path.with_name(temporary_path.name + "-journal")):
+        if stale.exists():
+            stale.unlink()
+
+    source = sqlite3.connect(f"file:{index_path}?mode=ro&immutable=1", uri=True)
+    try:
+        total = source.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        print(f"source documents: {total}", flush=True)
+
+        destination = sqlite3.connect(str(temporary_path))
+        try:
+            # A larger page size cuts the number of reads needed to warm the
+            # sidecar from shared storage.
+            destination.execute("PRAGMA page_size = 8192")
+            destination.execute("PRAGMA journal_mode = OFF")
+            destination.execute("PRAGMA synchronous = OFF")
+            _create_schema(destination)
+
+            projection = ", ".join(METADATA_COLUMNS)
+            cursor = source.execute(f"SELECT {projection} FROM documents ORDER BY id")
+            placeholders = ", ".join("?" for _ in METADATA_COLUMNS)
+            insert = f"INSERT INTO documents_meta ({projection}) VALUES ({placeholders})"
+
+            copied = 0
+            started = time.monotonic()
+            while True:
+                rows = cursor.fetchmany(batch_size)
+                if not rows:
+                    break
+                destination.executemany(insert, rows)
+                destination.commit()
+                copied += len(rows)
+                elapsed = time.monotonic() - started
+                rate = copied / elapsed if elapsed else 0.0
+                print(
+                    f"  copied {copied}/{total} ({100 * copied / total:.1f}%) {rate:.0f} rows/s",
+                    flush=True,
+                )
+
+            if copied != total:
+                raise SystemExit(f"Copied {copied} rows but the index holds {total}")
+
+            print("creating indexes", flush=True)
+            _create_indexes(destination)
+            _record_provenance(destination, source, document_count=total)
+            destination.commit()
+            destination.execute("VACUUM")
+            destination.commit()
+        finally:
+            destination.close()
+    finally:
+        source.close()
+
+    os.replace(temporary_path, output_path)
+    size_mb = output_path.stat().st_size / 1e6
+    print(f"wrote {output_path} ({size_mb:.0f} MB)", flush=True)
+
+
+def _create_schema(destination: sqlite3.Connection) -> None:
+    destination.execute(
+        """
+        CREATE TABLE documents_meta (
+            id INTEGER PRIMARY KEY,
+            accession_number TEXT NOT NULL,
+            cik TEXT NOT NULL,
+            ticker TEXT NOT NULL,
+            company_name TEXT NOT NULL,
+            form_type TEXT NOT NULL,
+            document_type TEXT NOT NULL,
+            description TEXT,
+            filing_date TEXT NOT NULL,
+            url TEXT NOT NULL
+        )
+        """
+    )
+    destination.execute(
+        """
+        CREATE TABLE sidecar_metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+        """
+    )
+
+
+def _create_indexes(destination: sqlite3.Connection) -> None:
+    destination.execute("CREATE INDEX documents_meta_cik ON documents_meta(cik, form_type, filing_date)")
+    destination.execute("CREATE INDEX documents_meta_form ON documents_meta(form_type, filing_date)")
+    destination.execute("CREATE INDEX documents_meta_date ON documents_meta(filing_date)")
+
+
+def _record_provenance(
+    destination: sqlite3.Connection,
+    source: sqlite3.Connection,
+    *,
+    document_count: int,
+) -> None:
+    entries = {
+        "schema_version": str(SIDECAR_SCHEMA_VERSION),
+        "document_count": str(document_count),
+        "source_fingerprint": fingerprint_source_index(source),
+        "built_at_unix_seconds": str(int(time.time())),
+    }
+    destination.executemany(
+        "INSERT OR REPLACE INTO sidecar_metadata (key, value) VALUES (?, ?)",
+        sorted(entries.items()),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--index", required=True, type=Path, help="Full-text index to read")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Sidecar destination (defaults to the index path plus '.metadata')",
+    )
+    parser.add_argument("--batch-size", type=int, default=BATCH_SIZE)
+    arguments = parser.parse_args()
+
+    output = arguments.output or default_sidecar_path(arguments.index)
+    build(arguments.index, output, batch_size=arguments.batch_size)
+
+
+if __name__ == "__main__":
+    main()

--- a/resources_servers/finance_sec_search/scripts/convert_questions.py
+++ b/resources_servers/finance_sec_search/scripts/convert_questions.py
@@ -75,6 +75,54 @@ SEC_FILING_SEARCH_TOOL = {
     "strict": False,
 }
 
+EDGAR_SEARCH_TOOL = {
+    "type": "function",
+    "name": "edgar_search",
+    "description": "Search the EDGAR Database through the SEC API. You should provide a search query. You can also optionally provide a start date, an end date, a page number, top N results, a list of form types, and/or a list of CIKs. The results are returned as a list of dictionaries, each containing the metadata for a filing. It does not contain the full text of the filing.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "search_query": {
+                "type": "string",
+                "description": 'The case-insensitive search-term or phrase to search the contents of fillings and their attachments. This can be a single word, phrase, or combination of words and phrases. Supported search features include wildcards (*), Boolean operators (OR, NOT), and exact phrase matching by enclosing phrases in quotation marks ("exact phrase"). By default, all terms are joined by an implicit AND operator.',
+            },
+            "form_types": {
+                "type": "array",
+                "description": "(optional) Limits search to specific EDGAR form types (e.g., ['8-K', '10-Q']) list of strings. Default: all form types",
+                "items": {"type": "string"},
+            },
+            "ciks": {
+                "type": "array",
+                "description": '(optional) Filters results to filings from specified CIKs, type list of strings. Leading zeros are optional but may be included. Example: [ "0001811414", "1318605" ]. Default: all CIKs',
+                "items": {"type": "string"},
+            },
+            "start_date": {
+                "type": "string",
+                "description": "(optional) Start date for the search range in yyyy-mm-dd format. If the value is a date that is later than 2025-04-07, it will be set to 2025-04-07.",
+                "default": "1900-01-01",
+            },
+            "end_date": {
+                "type": "string",
+                "description": "(optional) End date for the search range, in the same format as startDate. If the value is a date that is later than 2025-04-07, it will be set to 2025-04-07.",
+                "default": "2025-04-07",
+            },
+            "page": {
+                "type": "integer",
+                "description": "(optional) Used for pagination. Each page contains up to 100 matching filings. Increase the page number to retrieve the next set of 100 filings. Example: 3 retrieves the third page. Default: 1",
+                "default": 1,
+            },
+            "top_n_results": {
+                "type": "integer",
+                "description": "(optional) Return only the first N results out of 100 from the page. If not provided, all 100 results will be returned. E.g. if page is 2, and number_of_results is 10, you will receive results 100 to 110.",
+                "maximum": 100,
+                "default": 100,
+            },
+        },
+        "required": ["search_query"],
+    },
+    "strict": False,
+}
+
 PARSE_HTML_TOOL = {
     "type": "function",
     "name": "parse_html_page",
@@ -171,22 +219,35 @@ WEB_TOOL = {
 }
 
 
+SEARCH_TOOLS = {
+    "sec_filing_search": SEC_FILING_SEARCH_TOOL,
+    "edgar_search": EDGAR_SEARCH_TOOL,
+}
+
+
 def convert_entry(
     data: dict,
     include_web_search: bool = False,
+    search_tool: str = "sec_filing_search",
 ) -> dict:
     """Convert a single question entry to test format with tool definitions.
 
     Args:
         data: Dict with "question" and "expected_answer" keys.
         include_web_search: Whether to include the web search tool.
+        search_tool: Which filing-search tool to expose. One of
+            "sec_filing_search" (ticker-based metadata lookup) or
+            "edgar_search" (full-text search).
 
     Returns:
         Converted dict with responses_create_params and tools.
     """
+    if search_tool not in SEARCH_TOOLS:
+        raise ValueError(f"search_tool must be one of {sorted(SEARCH_TOOLS)}, got '{search_tool}'")
+
     question = data.get("question") or data.get("problem", "")
 
-    tools = [RETRIEVE_INFORMATION_TOOL, PARSE_HTML_TOOL, SEC_FILING_SEARCH_TOOL]
+    tools = [RETRIEVE_INFORMATION_TOOL, PARSE_HTML_TOOL, SEARCH_TOOLS[search_tool]]
     if include_web_search:
         tools = [WEB_TOOL] + tools
     tools.append(SUBMIT_TOOL)
@@ -205,7 +266,7 @@ def convert_entry(
     }
 
 
-def convert_file(input_file, output_file, include_web_search=False):
+def convert_file(input_file, output_file, include_web_search=False, search_tool="sec_filing_search"):
     """Convert a questions JSONL file to test format."""
     with open(input_file, "r") as f_in, open(output_file, "w") as f_out:
         for line in f_in:
@@ -213,7 +274,7 @@ def convert_file(input_file, output_file, include_web_search=False):
             if not line:
                 continue
             data = json.loads(line)
-            output = convert_entry(data, include_web_search)
+            output = convert_entry(data, include_web_search, search_tool)
             f_out.write(json.dumps(output) + "\n")
 
 
@@ -222,10 +283,17 @@ if __name__ == "__main__":
     parser.add_argument("--input", "-i", required=True, help="Input questions JSONL file")
     parser.add_argument("--output", "-o", required=True, help="Output test JSONL file")
     parser.add_argument("--include-web-search", "-w", action="store_true", help="Include web_search tool")
+    parser.add_argument(
+        "--search-tool",
+        "-s",
+        choices=sorted(SEARCH_TOOLS),
+        default="sec_filing_search",
+        help="Which filing-search tool to expose (default: sec_filing_search)",
+    )
     args = parser.parse_args()
 
-    convert_file(args.input, args.output, args.include_web_search)
+    convert_file(args.input, args.output, args.include_web_search, args.search_tool)
     print(f"Converted {args.input} -> {args.output}")
-    sample = convert_entry({"question": "", "expected_answer": ""}, args.include_web_search)
+    sample = convert_entry({"question": "", "expected_answer": ""}, args.include_web_search, args.search_tool)
     tools_list = [t["name"] for t in sample["responses_create_params"]["tools"]]
     print(f"Tools: {', '.join(tools_list)}")

--- a/resources_servers/finance_sec_search/tests/test_local_edgar_search.py
+++ b/resources_servers/finance_sec_search/tests/test_local_edgar_search.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nemo_gym.server_utils import ServerClient
+from resources_servers.finance_sec_search.app import (
+    EdgarSearchRequest,
+    FinanceAgentResourcesServer,
+    FinanceAgentResourcesServerConfig,
+)
+from resources_servers.finance_sec_search.local_edgar_search import (
+    LocalEdgarSearch,
+    normalize_request,
+    translate_query,
+)
+from resources_servers.finance_sec_search.scripts.convert_questions import (
+    EDGAR_SEARCH_TOOL,
+    PROMPT,
+    convert_entry,
+)
+
+
+def _index(path: Path) -> Path:
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE documents (
+            id INTEGER PRIMARY KEY,
+            accession_number TEXT NOT NULL,
+            cik TEXT NOT NULL,
+            company_name TEXT NOT NULL,
+            ticker TEXT NOT NULL,
+            description TEXT,
+            form_type TEXT NOT NULL,
+            document_type TEXT NOT NULL,
+            filing_date TEXT NOT NULL,
+            url TEXT NOT NULL,
+            body TEXT NOT NULL
+        );
+        CREATE VIRTUAL TABLE documents_fts USING fts5(
+            body,
+            content='documents',
+            content_rowid='id'
+        );
+        """
+    )
+    rows = [
+        (
+            1,
+            "0000320193-24-000001",
+            "320193",
+            "Apple Inc.",
+            "AAPL",
+            "10-K",
+            "10-K",
+            "10-K",
+            "2024-11-01",
+            "https://www.sec.gov/Archives/edgar/data/320193/000032019324000001/aapl.htm",
+            "quantum pineapple net income",
+        ),
+        (
+            2,
+            "0000789019-25-000001",
+            "789019",
+            "Microsoft Corporation",
+            "MSFT",
+            "EX-99.1",
+            "8-K",
+            "EX-99.1",
+            "2025-04-08",
+            "https://www.sec.gov/Archives/edgar/data/789019/000078901925000001/msft-ex991.htm",
+            "quantum pineapple guidance",
+        ),
+    ]
+    connection.executemany(
+        """
+        INSERT INTO documents (
+            id, accession_number, cik, company_name, ticker, description,
+            form_type, document_type, filing_date, url, body
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        rows,
+    )
+    connection.executemany(
+        "INSERT INTO documents_fts(rowid, body) VALUES (?, ?)",
+        [(row[0], row[-1]) for row in rows],
+    )
+    connection.commit()
+    connection.close()
+    return path
+
+
+def _server_config(tmp_path: Path, **overrides: object) -> FinanceAgentResourcesServerConfig:
+    prompt_dir = Path(__file__).resolve().parents[1] / "prompt_templates"
+    values = {
+        "host": "0.0.0.0",
+        "port": 8080,
+        "entrypoint": "",
+        "name": "finance_sec_search_test",
+        "cache_dir": str(tmp_path / "cache"),
+        "judge_prompt_template_fpath": str(prompt_dir / "finance_sec_search_judge.yaml"),
+        "retrieval_system_prompt_fpath": str(prompt_dir / "finance_sec_search_retrieval.yaml"),
+    }
+    values.update(overrides)
+    return FinanceAgentResourcesServerConfig(**values)
+
+
+def _request() -> MagicMock:
+    request = MagicMock()
+    request.session = {"session_id": "test-session"}
+    return request
+
+
+def test_converter_preserves_prompt_and_exposes_edgar_search() -> None:
+    converted = convert_entry(
+        {"question": "What was revenue?", "expected_answer": "Example"},
+        search_tool="edgar_search",
+    )
+
+    params = converted["responses_create_params"]
+    assert params["input"][0]["content"] == PROMPT + "What was revenue?"
+    assert [tool["name"] for tool in params["tools"]] == [
+        "retrieve_information",
+        "parse_html_page",
+        "edgar_search",
+        "submit_final_result",
+    ]
+    assert params["tools"][2] == EDGAR_SEARCH_TOOL
+
+
+def test_query_language_translation() -> None:
+    assert translate_query("apple revenue") == "apple AND revenue"
+    assert translate_query('"net income"') == '"net income"'
+    assert translate_query("apple OR microsoft") == "(apple OR microsoft)"
+    assert translate_query("software NOT hardware") == "software NOT hardware"
+    assert translate_query("cyber*") == "cyber*"
+
+
+def test_search_contract_filters_and_cutoff(tmp_path: Path) -> None:
+    search = LocalEdgarSearch(_index(tmp_path / "index.sqlite"))
+
+    results = search.search(
+        "quantum pineapple",
+        form_types=["10-K"],
+        ciks=["0000320193"],
+        end_date="2030-01-01",
+    )
+
+    assert results == [
+        {
+            "accessionNo": "0000320193-24-000001",
+            "cik": "320193",
+            "companyNameLong": "Apple Inc.",
+            "ticker": "AAPL",
+            "description": "10-K",
+            "formType": "10-K",
+            "type": "10-K",
+            "filingUrl": ("https://www.sec.gov/Archives/edgar/data/320193/000032019324000001/aapl.htm"),
+            "filedAt": "2024-11-01",
+        }
+    ]
+
+
+def test_match_all_and_filtered_browse_fallback(tmp_path: Path) -> None:
+    search = LocalEdgarSearch(_index(tmp_path / "index.sqlite"))
+
+    match_all = search.search("*", form_types=["10-K"], ciks=["0000320193"])
+    fallback = search.search(
+        "Apple annual report 2024",
+        form_types=["10-K"],
+        ciks=["320193"],
+    )
+
+    assert match_all[0]["accessionNo"] == "0000320193-24-000001"
+    assert fallback[0]["accessionNo"] == "0000320193-24-000001"
+
+
+def test_index_schema_is_validated_at_startup(tmp_path: Path) -> None:
+    path = tmp_path / "invalid.sqlite"
+    sqlite3.connect(path).close()
+
+    with pytest.raises(ValueError, match="documents"):
+        LocalEdgarSearch(path)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"search_query": ""}, "search_query"),
+        ({"search_query": "x", "start_date": "not-a-date"}, "start_date"),
+        ({"search_query": "x", "form_types": "10-K"}, "form_types"),
+        ({"search_query": "x", "ciks": ["AAPL"]}, "numeric strings"),
+        ({"search_query": "x", "page": 0}, "page"),
+        ({"search_query": "x", "top_n_results": 101}, "top_n_results"),
+    ],
+)
+def test_request_validation(kwargs: dict, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        normalize_request(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_server_routes_edgar_search_to_local_index(tmp_path: Path) -> None:
+    metrics_dir = tmp_path / "metrics"
+    config = _server_config(
+        tmp_path,
+        local_edgar_index_path=str(_index(tmp_path / "index.sqlite")),
+        local_edgar_metrics_dir=str(metrics_dir),
+        max_end_date="2025-04-07",
+    )
+    server = FinanceAgentResourcesServer(
+        config=config,
+        server_client=MagicMock(spec=ServerClient),
+    )
+
+    response = await server.edgar_search(
+        _request(),
+        EdgarSearchRequest(
+            search_query="quantum pineapple",
+            form_types=["10-K"],
+            ciks=["320193"],
+        ),
+    )
+
+    results = json.loads(response.results)
+    assert results[0]["ticker"] == "AAPL"
+    metric_files = list(metrics_dir.glob("search-*.jsonl"))
+    assert len(metric_files) == 1
+    metric = json.loads(metric_files[0].read_text(encoding="utf-8"))
+    assert metric["result_count"] == 1
+    assert "completed_at_unix_seconds" in metric
+
+
+@pytest.mark.asyncio
+async def test_edgar_search_requires_local_index_configuration(tmp_path: Path) -> None:
+    server = FinanceAgentResourcesServer(
+        config=_server_config(tmp_path),
+        server_client=MagicMock(spec=ServerClient),
+    )
+
+    response = await server.edgar_search(
+        _request(),
+        EdgarSearchRequest(search_query="revenue"),
+    )
+
+    assert "local_edgar_index_path is not configured" in response.results

--- a/resources_servers/finance_sec_search/tests/test_local_edgar_search.py
+++ b/resources_servers/finance_sec_search/tests/test_local_edgar_search.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from __future__ import annotations
 
 import json
@@ -15,9 +29,11 @@ from resources_servers.finance_sec_search.app import (
 )
 from resources_servers.finance_sec_search.local_edgar_search import (
     LocalEdgarSearch,
+    default_sidecar_path,
     normalize_request,
     translate_query,
 )
+from resources_servers.finance_sec_search.scripts.build_local_edgar_metadata import build
 from resources_servers.finance_sec_search.scripts.convert_questions import (
     EDGAR_SEARCH_TOOL,
     PROMPT,
@@ -234,6 +250,144 @@ async def test_server_routes_edgar_search_to_local_index(tmp_path: Path) -> None
     metric = json.loads(metric_files[0].read_text(encoding="utf-8"))
     assert metric["result_count"] == 1
     assert "completed_at_unix_seconds" in metric
+
+
+def _varied_index(path: Path, documents: int = 400) -> Path:
+    """An index broad enough that filters, paging and ranking all have work to do."""
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE documents (
+            id INTEGER PRIMARY KEY,
+            accession_number TEXT NOT NULL,
+            cik TEXT NOT NULL,
+            company_name TEXT NOT NULL,
+            ticker TEXT NOT NULL,
+            description TEXT,
+            form_type TEXT NOT NULL,
+            document_type TEXT NOT NULL,
+            filing_date TEXT NOT NULL,
+            url TEXT NOT NULL,
+            body TEXT NOT NULL
+        );
+        CREATE VIRTUAL TABLE documents_fts USING fts5(
+            body,
+            content='documents',
+            content_rowid='id'
+        );
+        """
+    )
+    rows = []
+    for number in range(1, documents + 1):
+        company = number % 7
+        rows.append(
+            (
+                number,
+                f"000-{number:06d}",
+                str(300000 + company),
+                f"Company {company}",
+                f"TCK{company}",
+                "10-K" if number % 2 else "EX-1",
+                "10-K" if number % 2 else "8-K",
+                "10-K" if number % 2 else "EX-1",
+                f"202{number % 5}-0{1 + number % 9}-1{number % 9}",
+                f"https://example.test/{number}.htm",
+                ("revenue growth " * (number % 9 + 1)) + ("pineapple" if number % 13 == 0 else ""),
+            )
+        )
+    connection.executemany(
+        """
+        INSERT INTO documents (
+            id, accession_number, cik, company_name, ticker, description,
+            form_type, document_type, filing_date, url, body
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        rows,
+    )
+    connection.executemany(
+        "INSERT INTO documents_fts(rowid, body) VALUES (?, ?)",
+        [(row[0], row[-1]) for row in rows],
+    )
+    connection.commit()
+    connection.close()
+    return path
+
+
+SIDECAR_PARITY_QUERIES = [
+    {"search_query": "revenue"},
+    {"search_query": "revenue", "form_types": ["10-K"]},
+    {"search_query": "revenue", "ciks": ["300001"]},
+    {"search_query": "revenue", "form_types": ["10-K"], "ciks": ["300003"]},
+    {"search_query": "pineapple"},
+    {"search_query": "revenue growth"},
+    {"search_query": "revenue OR pineapple"},
+    {"search_query": "reven*"},
+    {"search_query": "revenue NOT pineapple"},
+    {"search_query": "*", "form_types": ["10-K"]},
+    {"search_query": "revenue", "top_n_results": 7, "page": 2},
+    {"search_query": "revenue", "start_date": "2022-01-01", "end_date": "2024-12-31"},
+    {"search_query": "Company annual report", "ciks": ["300002"]},
+]
+
+
+@pytest.mark.parametrize("query", SIDECAR_PARITY_QUERIES, ids=lambda q: q["search_query"])
+def test_metadata_sidecar_returns_identical_results(tmp_path: Path, query: dict) -> None:
+    index = _varied_index(tmp_path / "index.sqlite")
+    without_sidecar = LocalEdgarSearch(index, max_end_date="2030-01-01")
+    assert not without_sidecar.uses_metadata_sidecar
+
+    build(index, default_sidecar_path(index))
+    with_sidecar = LocalEdgarSearch(index, max_end_date="2030-01-01")
+    assert with_sidecar.uses_metadata_sidecar
+
+    assert with_sidecar.search(**query) == without_sidecar.search(**query)
+
+
+def test_sidecar_beside_the_index_is_discovered(tmp_path: Path) -> None:
+    index = _varied_index(tmp_path / "index.sqlite")
+    build(index, default_sidecar_path(index))
+
+    assert LocalEdgarSearch(index).metadata_path == default_sidecar_path(index)
+
+
+def test_configured_sidecar_must_exist(tmp_path: Path) -> None:
+    index = _index(tmp_path / "index.sqlite")
+
+    with pytest.raises(FileNotFoundError, match="sidecar"):
+        LocalEdgarSearch(index, metadata_path=tmp_path / "absent.metadata")
+
+
+def test_sidecar_built_from_another_index_is_rejected(tmp_path: Path) -> None:
+    index = _varied_index(tmp_path / "index.sqlite")
+    other = _varied_index(tmp_path / "other.sqlite", documents=200)
+    build(other, default_sidecar_path(other))
+
+    with pytest.raises(ValueError, match="Rebuild it"):
+        LocalEdgarSearch(index, metadata_path=default_sidecar_path(other))
+
+
+@pytest.mark.asyncio
+async def test_server_uses_sidecar_when_configured(tmp_path: Path) -> None:
+    index = _index(tmp_path / "index.sqlite")
+    sidecar = default_sidecar_path(index)
+    build(index, sidecar)
+
+    server = FinanceAgentResourcesServer(
+        config=_server_config(
+            tmp_path,
+            local_edgar_index_path=str(index),
+            local_edgar_metadata_path=str(sidecar),
+            max_end_date="2025-04-07",
+        ),
+        server_client=MagicMock(spec=ServerClient),
+    )
+
+    response = await server.edgar_search(
+        _request(),
+        EdgarSearchRequest(search_query="quantum pineapple", form_types=["10-K"]),
+    )
+
+    assert json.loads(response.results)[0]["ticker"] == "AAPL"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a local backend for `edgar_search` in `finance_sec_search`, answering
full-text queries over SEC filings from a read-only SQLite FTS5 index.

The tool name, description and parameter schema match the hosted equivalent,
so an existing dataset runs against it unmodified.

Opt-in and additive:

- `local_edgar_index_path` enables it; unset (the default) and `edgar_search`
  reports itself unavailable.
- `convert_questions.py` still defaults to `sec_filing_search`, so
  `data/example.jsonl` is unchanged.

## What's included

- `local_edgar_search.py` — query translation, filtering, paging, ranking.
- Optional metadata sidecar built by `scripts/build_local_edgar_metadata.py`,
  validated at startup against a fingerprint of its source index. On a ~570k
  document index it takes common queries from tens of seconds to under one.
- `convert_questions.py --search-tool` to choose the filing-search tool.
- `docs/local_edgar_index.md` — the index schema, the column formats it
  depends on, and how to obtain an index. No builder ships here; an index is
  a self-contained file plus its sidecar and can be copied between machines.

## Training

Used for GRPO training runs against a held-out financial analysis benchmark
(not included here), 3 seeds, mean ± std across seeds. Baseline is the
untrained model with the same tool set, so the comparison is like for like.

|  | Baseline | Step 6 | Step 16 | Step 18 | Step 21 |
|---|---|---|---|---|---|
| Balanced accuracy | 19.58 ± 2.26 | 21.38 ± 1.53 | 24.44 ± 4.50 | 25.45 ± 2.08 | 26.23 ± 1.11 |
| Accuracy | 24.50 ± 1.50 | 25.67 ± 2.02 | 29.17 ± 3.51 | 30.83 ± 2.52 | 30.83 ± 1.26 |
| Turns / question | 19.4 ± 0.4 | 19.5 ± 1.2 | 18.1 ± 0.4 | 17.0 ± 0.5 | 17.0 ± 0.5 |
| Output tokens / question | 21293 ± 203 | 20742 ± 756 | 13214 ± 429 | 11973 ± 295 | 11358 ± 132 |
| `edgar_search` calls | 3.34 ± 0.10 | 3.33 ± 0.29 | 2.99 ± 0.29 | 3.02 ± 0.22 | 2.75 ± 0.08 |
| `parse_html_page` calls | 3.30 ± 0.22 | 3.24 ± 0.23 | 2.85 ± 0.06 | 2.70 ± 0.11 | 2.66 ± 0.07 |
| `retrieve_information` calls | 4.61 ± 0.28 | 4.57 ± 0.28 | 4.53 ± 0.07 | 4.33 ± 0.14 | 4.25 ± 0.09 |
| `web_search` calls | 7.20 ± 0.14 | 7.42 ± 0.59 | 6.76 ± 0.26 | 6.00 ± 0.17 | 6.39 ± 0.29 |

Accuracy rises from 24.50 to 30.83 while output tokens per question fall by
47%, with fewer calls to every tool.

## Testing

`ng_test +entrypoint=resources_servers/finance_sec_search` — 84 passed.

New coverage: query translation, request normalization, date/form/CIK
filtering, paging, ranking order, filter-only browsing, sidecar build and
fingerprint rejection, latency metrics, and the server route with and
without an index configured.