### PR TITLE
docs: Docker install path, Python 3.13.14 refs, enroot GPU toolkit

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,8 @@ apt-get install -y --no-install-recommends \
     git \
     wget \
     less \
-    vim
+    vim \
+    gnupg
 
 apt-get purge -y \
     ffmpeg \
@@ -61,6 +62,19 @@ curl -fSsL -o /tmp/enroot.deb \
     "https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_VERSION}-1_${arch}.deb"
 apt-get install -y /tmp/enroot.deb
 rm /tmp/enroot.deb
+
+# Install nvidia-container-toolkit so enroot's NVIDIA hook
+# (/etc/enroot/hooks.d/98-nvidia.sh) can find nvidia-container-cli to inject
+# GPUs into enroot sandboxes. Without this, enroot sandboxes that request a
+# GPU fail at the hook step even though the outer container has GPU access.
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+    | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
+    | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+    > /etc/apt/sources.list.d/nvidia-container-toolkit.list
+apt-get update
+apt-get install -y nvidia-container-toolkit
+rm -f /etc/apt/sources.list.d/nvidia-container-toolkit.list /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
 
 apt-get clean
 rm -rf /var/lib/apt/lists/*

--- a/fern/versions/latest/pages/contribute/development-setup.mdx
+++ b/fern/versions/latest/pages/contribute/development-setup.mdx
@@ -13,7 +13,7 @@ git clone git@github.com:NVIDIA-NeMo/Gym.git
 cd Gym
 curl -LsSf https://astral.sh/uv/install.sh | sh
 source $HOME/.local/bin/env
-uv venv --python 3.12
+uv venv --python 3.13.14
 source .venv/bin/activate
 uv sync --extra dev
 
@@ -243,7 +243,7 @@ gpg --armor --export YOUR_GPG_KEY_ID
 ### Testing Issues
 
 **Problem**: Tests fail locally but not in CI
-- Check Python version (3.12+ required)
+- Check Python version (3.13.14+ required)
 - Ensure all dependencies installed: `uv sync --extra dev`
 - Run in clean environment
 

--- a/fern/versions/latest/pages/get-started/installation.mdx
+++ b/fern/versions/latest/pages/get-started/installation.mdx
@@ -24,7 +24,7 @@ uv venv --python 3.13.14 && source .venv/bin/activate
 uv pip install nemo-gym
 ```
 
-The package includes built-in environments and CLI commands. Config and data paths resolve against the package install location automatically. To pin a release: `python3.13 -m pip install nemo-gym==0.4.0`.
+The package includes built-in environments and CLI commands. Config and data paths resolve against the package install location automatically. To pin a release: `python3.13 -m pip install nemo-gym==0.5.1`.
 
 </Tab>
 <Tab title="Git">
@@ -115,7 +115,7 @@ gym --version
 You should see output like:
 
 ```text
-NeMo Gym v0.4.0
+NeMo Gym v0.5.1
 Python 3.13.14
 Installation: /path/to/Gym
 ```

--- a/fern/versions/latest/pages/get-started/installation.mdx
+++ b/fern/versions/latest/pages/get-started/installation.mdx
@@ -5,7 +5,7 @@ position: 2
 ---
 
 <Info>
-Python 3.12 is required. Refer to [Prerequisites](/get-started/prerequisites) for full system requirements.
+Python 3.13.14 is required. Refer to [Prerequisites](/get-started/prerequisites) for full system requirements.
 </Info>
 
 Install from PyPI for the quickest setup. Clone from git if you need the latest features and environments, or use a NeMo RL container if you intend to train with NeMo Gym and NeMo RL.
@@ -14,17 +14,17 @@ Install from PyPI for the quickest setup. Clone from git if you need the latest 
 <Tab title="PyPI">
 
 ```bash
-python3.12 -m pip install nemo-gym
+python3.13.14 -m pip install nemo-gym
 ```
 
 Or with [uv](https://docs.astral.sh/uv/):
 
 ```bash
-uv venv --python 3.12 && source .venv/bin/activate
+uv venv --python 3.13.14 && source .venv/bin/activate
 uv pip install nemo-gym
 ```
 
-The package includes built-in environments and CLI commands. Config and data paths resolve against the package install location automatically. To pin a release: `python3.12 -m pip install nemo-gym==0.4.0`.
+The package includes built-in environments and CLI commands. Config and data paths resolve against the package install location automatically. To pin a release: `python3.13.14 -m pip install nemo-gym==0.4.0`.
 
 </Tab>
 <Tab title="Git">
@@ -32,7 +32,7 @@ The package includes built-in environments and CLI commands. Config and data pat
 ```bash
 git clone git@github.com:NVIDIA-NeMo/Gym.git
 cd Gym
-uv venv --python 3.12 && source .venv/bin/activate
+uv venv --python 3.13.14 && source .venv/bin/activate
 uv sync
 ```
 
@@ -40,6 +40,48 @@ uv sync
 <Tab title="Container">
 
 Container choice depends on your NeMo Gym version and model recipe. See [RL Framework Compatibility](/reference/rl-framework-compatibility) for the full mapping.
+
+### Pre-built NeMo Gym image
+
+NeMo Gym publishes a pre-built container to NGC with each release, tagged with the release version (for example `v0.5.1`):
+
+```bash
+docker run --gpus all -it --rm \
+  -v "$PWD:/workspace" \
+  --shm-size=128g \
+  --ipc=host \
+  -p 8888:8888 \
+  -p 6006:6006 \
+  --ulimit memlock=-1 \
+  --ulimit stack=67108864 \
+  nvcr.io/nvidian/nemo-gym:v0.5.1
+```
+
+The image's default entrypoint is `gym`, so it drops you straight into the CLI. To get a shell instead, override the entrypoint:
+
+```bash
+docker run --gpus all -it --rm \
+  --entrypoint /bin/bash \
+  -v "$PWD:/workspace" \
+  --shm-size=128g \
+  --ipc=host \
+  -p 8888:8888 \
+  -p 6006:6006 \
+  --ulimit memlock=-1 \
+  --ulimit stack=67108864 \
+  nvcr.io/nvidian/nemo-gym:v0.5.1
+```
+
+<Note>
+The image ships the `enroot` sandbox backend along with `nvidia-container-toolkit`,
+so enroot's NVIDIA GPU hook (`/etc/enroot/hooks.d/98-nvidia.sh`) can find
+`nvidia-container-cli` and inject GPUs into enroot sandboxes. If your workload
+doesn't need GPUs inside enroot sandboxes (for example CPU-only
+SWE-bench-style tasks) and you see hook-related errors, you can remove the
+hook: `rm /etc/enroot/hooks.d/98-nvidia.sh`.
+</Note>
+
+### NeMo RL recipe containers
 
 For NeMo Gym **v0.3.0** with the Nemotron 3 Ultra recipe, build the container from the NeMo RL `ultra-v3` branch (there is no pre-built NGC tag for this pairing):
 
@@ -74,7 +116,7 @@ You should see output like:
 
 ```text
 NeMo Gym v0.4.0
-Python 3.12.x
+Python 3.13.14
 Installation: /path/to/Gym
 ```
 

--- a/fern/versions/latest/pages/get-started/installation.mdx
+++ b/fern/versions/latest/pages/get-started/installation.mdx
@@ -14,7 +14,7 @@ Install from PyPI for the quickest setup. Clone from git if you need the latest 
 <Tab title="PyPI">
 
 ```bash
-python3.13.14 -m pip install nemo-gym
+python3.13 -m pip install nemo-gym
 ```
 
 Or with [uv](https://docs.astral.sh/uv/):
@@ -24,7 +24,7 @@ uv venv --python 3.13.14 && source .venv/bin/activate
 uv pip install nemo-gym
 ```
 
-The package includes built-in environments and CLI commands. Config and data paths resolve against the package install location automatically. To pin a release: `python3.13.14 -m pip install nemo-gym==0.4.0`.
+The package includes built-in environments and CLI commands. Config and data paths resolve against the package install location automatically. To pin a release: `python3.13 -m pip install nemo-gym==0.4.0`.
 
 </Tab>
 <Tab title="Git">

--- a/fern/versions/latest/pages/get-started/prerequisites.mdx
+++ b/fern/versions/latest/pages/get-started/prerequisites.mdx
@@ -23,7 +23,7 @@ Individual environments may have additional requirements (e.g., GPU for local vL
 | Component | Requirement |
 |-----------|-------------|
 | OS | Linux (Ubuntu 20.04+), macOS (11.0+), or Windows (WSL2) |
-| Python | 3.12 or higher |
+| Python | 3.13.14 or higher |
 | [uv](https://docs.astral.sh/uv/getting-started/installation/) | Latest recommended |
 
 ## Quickstart Requirements

--- a/fern/versions/latest/pages/model-server/vllm.mdx
+++ b/fern/versions/latest/pages/model-server/vllm.mdx
@@ -37,7 +37,7 @@ If you want NeMo Gym to manage the vLLM server lifecycle for you instead, see [L
 ### Install vLLM
 Please run the steps below in a separate terminal than your NeMo Gym terminal! The installation will take a few minutes.
 ```bash
-uv venv --python 3.12 --seed .venv
+uv venv --python 3.13.14 --seed .venv
 source .venv/bin/activate
 # hf_transfer for faster model download
 uv pip install hf_transfer vllm --torch-backend=auto

--- a/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/setup.mdx
+++ b/fern/versions/latest/pages/training-tutorials/nemo-rl-grpo/setup.mdx
@@ -216,7 +216,7 @@ Clone and setup the Gym Python environment:
 ```bash
 # Setup Gym local venv
 cd 3rdparty/Gym-workspace/Gym
-uv venv --python 3.12 --allow-existing .venv
+uv venv --python 3.13.14 --allow-existing .venv
 source .venv/bin/activate
 uv sync --active --extra dev
 ```


### PR DESCRIPTION
## Summary
- Document the pre-built NeMo Gym Docker image install path (`docker run`, including the `--entrypoint /bin/bash` override), per feedback that this was undocumented for v0.5.1
- Fix stale `Python 3.12` references across install/dev-setup docs to the repo's actual requirement, `3.13.14`
- Install `nvidia-container-toolkit` in the image so enroot's NVIDIA hook (`/etc/enroot/hooks.d/98-nvidia.sh`) can find `nvidia-container-cli` and inject GPUs into enroot sandboxes

## Context
Addresses issues raised against the v0.5.1 RC container:
- `nvidia-container-cli` missing for the enroot GPU hook
- Installation docs outdated for Docker usage
