### PR TITLE
fix: preserve HTTP errors across process boundaries

### DIFF
--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -25,7 +25,7 @@ from os import environ, getenv
 from pathlib import Path
 from threading import Thread
 from traceback import format_exc, print_exc
-from typing import Any, List, Literal, Optional, TextIO, Tuple, Type, Union, Unpack
+from typing import Any, List, Literal, NamedTuple, Optional, TextIO, Tuple, Type, Union, Unpack
 from uuid import uuid4
 
 import orjson
@@ -47,6 +47,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.exception_handlers import request_validation_exception_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from multidict import CIMultiDict
 from omegaconf import DictConfig, OmegaConf, open_dict
 from pydantic import BaseModel, ConfigDict, Field
 from requests.exceptions import ConnectionError
@@ -77,6 +78,13 @@ from nemo_gym.rollout_correlation import current_rollout_id, maybe_rollout_id_fr
 
 _GLOBAL_AIOHTTP_CLIENT: Union[None, ClientSession] = None
 _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG: bool = False
+
+
+class _PickleSafeRequestInfo(NamedTuple):
+    url: str
+    method: str
+    headers: CIMultiDict[str]
+    real_url: str
 
 
 class GlobalAIOHTTPAsyncClientConfig(BaseModel):
@@ -287,6 +295,18 @@ Response content: {content}""")
         except ClientResponseError as e:
             # Set the response content here so we have access to it down the line.
             e.response_content = content
+            # aiohttp stores unpicklable multidict proxies in this exception.
+            # Preserve request details as pickle-safe values for cross-process propagation.
+            request_info = e.request_info
+            e.request_info = _PickleSafeRequestInfo(
+                url=str(request_info.url),
+                method=request_info.method,
+                headers=CIMultiDict(request_info.headers),
+                real_url=str(request_info.real_url),
+            )
+            e.history = ()
+            e.headers = CIMultiDict(e.headers) if e.headers is not None else None
+            e.args = (e.request_info, e.history)
             raise e
 
 

--- a/tests/unit_tests/test_server_utils.py
+++ b/tests/unit_tests/test_server_utils.py
@@ -12,11 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import multiprocessing
 import socket
+from concurrent.futures import ProcessPoolExecutor
 from unittest.mock import AsyncMock, MagicMock
 
-from aiohttp import ClientOSError
+from aiohttp import ClientOSError, ClientResponseError, RequestInfo
+from multidict import CIMultiDict, CIMultiDictProxy
 from pytest import MonkeyPatch, raises
+from yarl import URL
 
 import nemo_gym.global_config
 import nemo_gym.server_utils
@@ -34,6 +38,7 @@ from nemo_gym.server_utils import (
     SimpleServer,
     _make_keepalive_socket_factory,
     initialize_ray,
+    raise_for_status,
 )
 
 
@@ -49,7 +54,66 @@ _TEST_ADDR_INFO = (
 )
 
 
+def _return_exception_from_child_process(error: ClientResponseError) -> ClientResponseError:
+    return error
+
+
 class TestServerUtils:
+    async def test_raise_for_status_preserves_message_across_process_boundary(self) -> None:
+        headers = CIMultiDictProxy(
+            CIMultiDict(
+                [
+                    ("x-request-id", "request-123"),
+                    ("Retry-After", "10"),
+                    ("retry-after", "20"),
+                    ("Set-Cookie", "session=abc"),
+                    ("Set-Cookie", "preferences=dark"),
+                ]
+            )
+        )
+        request_info = RequestInfo(
+            url=URL("http://resources-server.test/verify"),
+            method="POST",
+            headers=headers,
+            real_url=URL("http://resources-server.test/verify"),
+        )
+        original_error = ClientResponseError(
+            request_info=request_info,
+            history=(),
+            status=500,
+            message="verifier failed",
+            headers=headers,
+        )
+        response = MagicMock()
+        response.ok = False
+        response.content.read = AsyncMock(return_value=b'{"detail":"backend unavailable"}')
+        response.request_info = request_info
+        response.raise_for_status.side_effect = original_error
+
+        with raises(ClientResponseError) as exc_info:
+            await raise_for_status(response)
+
+        error = exc_info.value
+        assert str(error) == ("500, message='verifier failed', url='http://resources-server.test/verify'")
+        assert error.response_content == b'{"detail":"backend unavailable"}'
+
+        with ProcessPoolExecutor(max_workers=1, mp_context=multiprocessing.get_context("spawn")) as executor:
+            restored_error = executor.submit(_return_exception_from_child_process, error).result()
+
+        assert isinstance(restored_error, ClientResponseError)
+        assert str(restored_error) == str(error)
+        assert restored_error.status == 500
+        assert restored_error.message == "verifier failed"
+        assert restored_error.response_content == error.response_content
+        assert restored_error.request_info.method == "POST"
+        assert isinstance(restored_error.request_info.headers, CIMultiDict)
+        assert restored_error.request_info.headers["X-REQUEST-ID"] == "request-123"
+        assert restored_error.request_info.headers.getall("RETRY-AFTER") == ["10", "20"]
+        assert restored_error.request_info.headers.getall("set-cookie") == ["session=abc", "preferences=dark"]
+        assert isinstance(restored_error.headers, CIMultiDict)
+        assert restored_error.headers.getall("retry-after") == ["10", "20"]
+        assert restored_error.headers.getall("SET-COOKIE") == ["session=abc", "preferences=dark"]
+
     def test_global_aiohttp_client_request_debug_enabled(self, monkeypatch: MonkeyPatch) -> None:
         monkeypatch.setattr(nemo_gym.server_utils, "_GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG", False)
         assert not nemo_gym.server_utils.is_global_aiohttp_client_request_debug_enabled()


### PR DESCRIPTION
## Summary
- replace unpicklable `aiohttp.ClientResponseError` proxy metadata with pickle-safe values before propagation
- preserve HTTP status, message, URL, case-insensitive multi-value request and response headers, and response body
- verify the exception and header semantics survive a spawned-process round trip

This extracts and hardens the exception-handling fix proposed by @yuchenwang3 in #1788. The original PR also changes rollout retries; this PR intentionally contains only the serialization fix.

Co-authored-by: Yuchen Wang <yuchenwang3@users.noreply.github.com>

## Test plan
- [x] `uv run --extra dev pre-commit run --files nemo_gym/server_utils.py tests/unit_tests/test_server_utils.py`
- [x] `uv run --extra dev pytest tests/unit_tests/test_server_utils.py -q`