### PR TITLE
feat: add shared failure-kind registry

### DIFF
--- a/nemo_gym/base_resources_server.py
+++ b/nemo_gym/base_resources_server.py
@@ -95,6 +95,9 @@ class BaseVerifyRequest(BaseRunRequest):
 
 class BaseVerifyResponse(BaseVerifyRequest):
     reward: float
+    # Stable machine-readable grouping key.
+    # Custom environments may use namespaced values outside the shared registry.
+    failure_kind: Optional[str] = None
 
 
 class BaseMultiRewardVerifyResponse(BaseVerifyResponse):

--- a/nemo_gym/failure_kinds.py
+++ b/nemo_gym/failure_kinds.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared machine-readable failure kinds.
+
+The constants are stable grouping keys for rollout and verification artifacts.
+They do not decide whether a sample is masked or whether a run may continue.
+Retryability, delivery state, and policy attribution belong to each failure record.
+Environments may add namespaced values such as ``my_server:quota_exhausted``.
+"""
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Literal, Mapping
+
+
+RegistryStatus = Literal["active", "reserved"]
+
+
+@dataclass(frozen=True)
+class FailureKindRegistration:
+    """Registration state and provenance for one shared failure kind."""
+
+    status: RegistryStatus
+    source: str
+
+
+# Active kinds have producers on main.
+JUDGE_FAILED = "judge_failed"
+KILL_SHAPED = "kill_shaped"
+TIMEOUT_EXCEEDED = "timeout_exceeded"
+SKIPPED = "skipped"
+TRANSIENT = "transient"
+LEGITIMATE = "legitimate"
+REMOTE_AGENT_ERROR = "remote_agent_error"
+EVAL_TIMEOUT = "eval_timeout"
+SANDBOX = "sandbox"
+OOM_KILLED = "oom_killed"
+
+# Reserved kinds belong to changes that have not landed.
+SESSION_LOST = "session_lost"
+AGENT_REQUEST_FAILED = "agent_request_failed"
+VERIFY_REQUEST_FAILED = "verify_request_failed"
+UNREACHABLE = "unreachable"
+RESOURCE = "resource"
+PEER_DROP = "peer_drop"
+TIMEOUT = "timeout"
+FATAL = "fatal"
+COHORT_TIMEOUT = "cohort_timeout"
+NO_COMPARISONS = "no_comparisons"
+AGGREGATION_FAILED = "aggregation_failed"
+
+
+FAILURE_KIND_REGISTRY: Mapping[str, FailureKindRegistration] = MappingProxyType(
+    {
+        JUDGE_FAILED: FailureKindRegistration(
+            status="active",
+            source="nemo_gym.judge",
+        ),
+        KILL_SHAPED: FailureKindRegistration(
+            status="active",
+            source="responses_api_agents.stirrup_agent",
+        ),
+        TIMEOUT_EXCEEDED: FailureKindRegistration(
+            status="active",
+            source="responses_api_agents.stirrup_agent",
+        ),
+        SKIPPED: FailureKindRegistration(
+            status="active",
+            source="responses_api_agents.stirrup_agent",
+        ),
+        TRANSIENT: FailureKindRegistration(
+            status="active",
+            source="responses_api_agents.stirrup_agent",
+        ),
+        LEGITIMATE: FailureKindRegistration(
+            status="active",
+            source="responses_api_agents.stirrup_agent",
+        ),
+        REMOTE_AGENT_ERROR: FailureKindRegistration(
+            status="active",
+            source="responses_api_agents.remote_agent",
+        ),
+        EVAL_TIMEOUT: FailureKindRegistration(
+            status="active",
+            source="responses_api_agents.anyswe_agent",
+        ),
+        SANDBOX: FailureKindRegistration(
+            status="active",
+            source="responses_api_agents.anyswe_agent",
+        ),
+        OOM_KILLED: FailureKindRegistration(
+            status="active",
+            source="responses_api_agents.swe_agents",
+        ),
+        SESSION_LOST: FailureKindRegistration(
+            status="reserved",
+            source="#2611",
+        ),
+        AGENT_REQUEST_FAILED: FailureKindRegistration(
+            status="reserved",
+            source="#2363",
+        ),
+        VERIFY_REQUEST_FAILED: FailureKindRegistration(
+            status="reserved",
+            source="#2363",
+        ),
+        UNREACHABLE: FailureKindRegistration(
+            status="reserved",
+            source="#2361",
+        ),
+        RESOURCE: FailureKindRegistration(
+            status="reserved",
+            source="#2361",
+        ),
+        PEER_DROP: FailureKindRegistration(
+            status="reserved",
+            source="#2361",
+        ),
+        TIMEOUT: FailureKindRegistration(
+            status="reserved",
+            source="#2361",
+        ),
+        FATAL: FailureKindRegistration(
+            status="reserved",
+            source="#2361",
+        ),
+        COHORT_TIMEOUT: FailureKindRegistration(
+            status="reserved",
+            source="#2385",
+        ),
+        NO_COMPARISONS: FailureKindRegistration(
+            status="reserved",
+            source="#2385",
+        ),
+        AGGREGATION_FAILED: FailureKindRegistration(
+            status="reserved",
+            source="#2385",
+        ),
+    }
+)
+
+ACTIVE_FAILURE_KINDS = frozenset(
+    kind for kind, metadata in FAILURE_KIND_REGISTRY.items() if metadata.status == "active"
+)
+RESERVED_FAILURE_KINDS = frozenset(
+    kind for kind, metadata in FAILURE_KIND_REGISTRY.items() if metadata.status == "reserved"
+)

--- a/tests/unit_tests/test_base_resources_server.py
+++ b/tests/unit_tests/test_base_resources_server.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 from nemo_gym.base_resources_server import (
     BaseMultiRewardVerifyResponse,
     BaseResourcesServerConfig,
+    BaseVerifyResponse,
     ReverifyMode,
     SimpleResourcesServer,
 )
@@ -33,6 +34,20 @@ def _resources_server() -> SimpleResourcesServer:
             pass
 
     return TestSimpleResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+
+
+class TestBaseVerifyResponse:
+    def test_failure_kind_is_optional_and_accepts_namespaced_extensions(self) -> None:
+        response = BaseVerifyResponse(
+            responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input="hi"),
+            response=NeMoGymResponse.model_construct(id="resp-1", output=[]),
+            reward=0.0,
+        )
+        assert response.failure_kind is None
+        assert response.model_dump()["failure_kind"] is None
+
+        namespaced = response.model_copy(update={"failure_kind": "my_server:quota_exhausted"})
+        assert namespaced.failure_kind == "my_server:quota_exhausted"
 
 
 class TestBaseMultiRewardVerifyResponse:

--- a/tests/unit_tests/test_failure_kinds.py
+++ b/tests/unit_tests/test_failure_kinds.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemo_gym.failure_kinds import (
+    ACTIVE_FAILURE_KINDS,
+    FAILURE_KIND_REGISTRY,
+    RESERVED_FAILURE_KINDS,
+)
+
+
+def test_every_failure_kind_is_in_exactly_one_registry_tier() -> None:
+    assert ACTIVE_FAILURE_KINDS.isdisjoint(RESERVED_FAILURE_KINDS)
+    assert ACTIVE_FAILURE_KINDS | RESERVED_FAILURE_KINDS == FAILURE_KIND_REGISTRY.keys()
+
+    for kind in ACTIVE_FAILURE_KINDS:
+        assert FAILURE_KIND_REGISTRY[kind].status == "active"
+    for kind in RESERVED_FAILURE_KINDS:
+        assert FAILURE_KIND_REGISTRY[kind].status == "reserved"
+
+
+def test_reserved_failure_kinds_name_their_source_pr() -> None:
+    for kind in RESERVED_FAILURE_KINDS:
+        assert FAILURE_KIND_REGISTRY[kind].source.startswith("#")


### PR DESCRIPTION
## Summary
- add an optional `failure_kind` machine key to `BaseVerifyResponse` while allowing namespaced environment extensions
- register active failure strings already produced on main and reserve vocabulary from the in-flight recovery PRs
- deliberately keep retryability, delivery state, policy attribution, and masking out of the registry because those vary per failure event

## Test plan
- [x] `uv run --extra dev pre-commit run --files nemo_gym/failure_kinds.py nemo_gym/base_resources_server.py tests/unit_tests/test_failure_kinds.py tests/unit_tests/test_base_resources_server.py`
- [x] `uv run --extra dev pytest tests/unit_tests/test_failure_kinds.py tests/unit_tests/test_base_resources_server.py -q`