### PR TITLE
docs: clarify ARC-AGI setup and execution

### DIFF
--- a/environments/arc_agi/README.md
+++ b/environments/arc_agi/README.md
@@ -1,15 +1,49 @@
 # ARC-AGI
 
-Abstraction and Reasoning Corpus for Artificial General Intelligence ([ARC-AGI](https://github.com/fchollet/ARC-AGI/)) is a benchmark with training and evaluation data to test general reasoning. It consists of grid-based puzzles, providing a few input output pairs and the system must infer the underlying abstract transformation rule and apply it to a new input. "ARC can be seen as a general artificial intelligence benchmark, as a program synthesis benchmark, or as a psychometric intelligence test. It is targeted at both humans and artificially intelligent systems that aim at emulating a human-like form of general fluid intelligence."
+The Abstraction and Reasoning Corpus for Artificial General Intelligence ([ARC-AGI-1](https://github.com/fchollet/ARC-AGI) and [ARC-AGI-2](https://github.com/arcprize/ARC-AGI-2)) is a benchmark for general reasoning. Each task provides several input-output grid pairs; the system must infer the underlying transformation and apply it to a new input.
 
-### Launch local vllm server
+The commands below use `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` with tensor parallelism set to 1. The model contains about 58.8 GiB of BF16 weights, in addition to runtime and KV-cache memory. Use an 80 GB-class CUDA GPU for this exact configuration; a 32 GB GPU is insufficient.
+
+## Install Gym once
+
+Run these commands from the parent directory of the Gym checkout:
+
 ```bash
-pip install -U "vllm>=0.12.0"
- 
-wget https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/resolve/main/nano_v3_reasoning_parser.py
- 
+cd Gym/
+uv venv
+source .venv/bin/activate
+uv sync
+```
+
+Activate this environment in every new terminal used below. You do not need to rerun `uv sync` for every evaluation.
+
+## Install and launch the local vLLM server (terminal 1)
+
+For a checkout-based run, install vLLM once in the active environment:
+
+```bash
+uv pip install -U "vllm>=0.12.0"
+```
+
+The published NeMo-Gym container already includes vLLM, but intentionally omits codec-bearing packages. vLLM 0.24 imports `torchvision` during kernel warmup for this configuration, so container users must restore the image's pinned optional dependencies before launching the server:
+
+```bash
+bash docker/install_codec_deps.sh
+```
+
+The script is idempotent. On later checkout runs, skip the vLLM installation when `vllm --version` reports version 0.12.0 or newer. The model weights are also reused from the Hugging Face cache after the first download.
+
+Then launch the server from the Gym repository root:
+
+```bash
+
+if [ ! -f nano_v3_reasoning_parser.py ]; then
+  hf download nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 \
+    nano_v3_reasoning_parser.py --local-dir .
+fi
+
 vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 \
- --max-num-seqs 8 \
+  --max-num-seqs 8 \
   --tensor-parallel-size 1 \
   --max-model-len 262144 \
   --port 10240 \
@@ -19,52 +53,75 @@ vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 \
   --reasoning-parser nano_v3
 ```
 
-### Set env.yaml in `Gym/`: 
-```
+Keep `nano_v3_reasoning_parser.py` in the Gym repository root and reuse it on later runs. The conditional command downloads it only when it is absent. `hf download` works anonymously for this public file and automatically uses an existing `HF_TOKEN` or `hf auth login` session when available. Authentication is recommended on systems that share an outbound IP, because anonymous Hugging Face resolver requests can be rate-limited.
+
+Keep this terminal running.
+
+## Configure Gym (terminal 2)
+
+From the Gym repository root, create or update `env.yaml`:
+
+```yaml
 policy_base_url: http://localhost:10240/v1
 policy_api_key: EMPTY
 policy_model_name: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
 ```
 
-### Create datasets: 
-```
-cd Gym/
+## Create the datasets (terminal 2)
 
-# ARC-AGI-1
+Clone both source repositories into the Gym repository root. Run each clone command only when that checkout is not already present.
+
+```bash
 git clone https://github.com/fchollet/ARC-AGI
+git clone https://github.com/arcprize/ARC-AGI-2
+
 cd environments/arc_agi
 python prepare.py
-
-# ARC-AGI-2
-git clone https://github.com/arcprize/ARC-AGI-2
-cd environments/arc_agi
 python prepare.py --version 2
+cd ../..
 ```
 
-### Install Gym:
-```
-cd Gym/ 
-uv venv 
-source .venv/bin/activate
-uv sync 
-```
+The preparation commands create:
 
-### Start ARC-AGI environment (we can reuse the same one for ARC-AGI-1 and 2):
+- `environments/arc_agi/data/arc_agi_1_training.jsonl`
+- `environments/arc_agi/data/arc_agi_1_evaluation.jsonl`
+- `environments/arc_agi/data/example_1.jsonl`
+- `environments/arc_agi/data/arc_agi_2_training.jsonl`
+- `environments/arc_agi/data/arc_agi_2_evaluation.jsonl`
+- `environments/arc_agi/data/example_2.jsonl`
+
+## Start the ARC-AGI environment (terminal 2)
+
+The same environment serves ARC-AGI-1 and ARC-AGI-2:
+
 ```bash
 gym env start --environment arc_agi --model-type vllm_model
 ```
 
+Keep this terminal running.
 
-### Collect rollouts:
+## Collect rollouts (terminal 3)
 
-ARC-AGI-1 example rollouts:
+Open another terminal, activate the existing Gym environment, and run from the Gym repository root:
+
 ```bash
-gym eval run --no-serve --agent arc_agi_simple_agent --input environments/arc_agi/data/example_1.jsonl --output environments/arc_agi/data/example_1_rollouts.jsonl
+source .venv/bin/activate
+
+gym eval run --no-serve \
+  --agent arc_agi_simple_agent \
+  --input environments/arc_agi/data/example_1.jsonl \
+  --output environments/arc_agi/data/example_1_rollouts.jsonl
+
+gym eval run --no-serve \
+  --agent arc_agi_simple_agent \
+  --input environments/arc_agi/data/example_2.jsonl \
+  --output environments/arc_agi/data/example_2_rollouts.jsonl
 ```
 
-ARC-AGI-2 example rollouts:
-```bash
-gym eval run --no-serve --agent arc_agi_simple_agent --input environments/arc_agi/data/example_2.jsonl --output environments/arc_agi/data/example_2_rollouts.jsonl
-```
+When both evaluations finish, stop `gym env start` and `vllm serve` with `Ctrl-C` in their respective terminals.
 
-For training, see the [docs](https://docs.nvidia.com/nemo/gym/tutorials/training-tutorials/nemo-rl-grpo).
+## Working-tree hygiene
+
+The `ARC-AGI/` and `ARC-AGI-2/` checkouts, `nano_v3_reasoning_parser.py`, generated `example_1.jsonl` and `example_2.jsonl` files, rollout outputs, and their derived sidecars are local run artifacts. The repository does not currently ignore all of these paths, so they may appear in `git status --short`. Do not commit them; remove them after the run if you need to restore a clean checkout.
+
+For training, see the [NeMo RL GRPO tutorial](https://docs.nvidia.com/nemo/gym/tutorials/training-tutorials/nemo-rl-grpo).


### PR DESCRIPTION
## Summary

- fix the ARC-AGI-2 dataset setup working directory so both source repositories are cloned at the Gym repository root
- put one-time Gym and vLLM installation before the three-terminal workflow
- document the exact 80 GB-class GPU requirement for the 30B BF16 model
- replace the repeated parser download with a conditional `hf download` command and explain cache reuse
- document container codec setup, generated datasets, terminal lifecycles, and local artifact hygiene

## Validation

The documented workflow was exercised through the companion `nmfw_tests` black-box E2E case in both supported modes on an NVIDIA H100 PCIe:

- checkout / `--no-docker`: `20260824T210330Z-66727d90` — 2/2 passed
- `nvcr.io/nvidian/nemo-gym:nightly`: `20260824T215306Z-647ff2d4` — 2/2 passed

Each run:

- cloned ARC-AGI-1 and ARC-AGI-2
- ran `prepare.py` and `prepare.py --version 2`
- produced 400/400/5 ARC-AGI-1 and 1000/120/5 ARC-AGI-2 rows
- started vLLM 0.24.0 with `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16`
- brought all three Gym servers healthy
- produced five identity-matched rollouts for each example dataset with empty failure sidecars

Docs-only change; no product source behavior changes.

Companion black-box QA MR: https://gitlab-master.nvidia.com/dl/DLQASH/nmfw_tests/-/merge_requests/377
