### PR TITLE
fix(mini_swe_agent_2): remove duplicate datasets key in config

### DIFF
--- a/responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+++ b/responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
@@ -56,4 +56,3 @@ mini_swe_agent_2:
       eval_timeout: 1800
       skip_if_exists: false
       step_limit: 250
-      datasets: []

--- a/tests/unit_tests/test_global_config.py
+++ b/tests/unit_tests/test_global_config.py
@@ -1840,6 +1840,25 @@ class TestConfigLoadErrors:
         config = DictConfig({"my_server": {"resources_servers": {"x": {"entrypoint": "app.py", "domain": "other"}}}})
         parser.raise_on_no_server_instances(config)
 
+    def test_all_repo_configs_load_without_duplicate_keys(self) -> None:
+        # OmegaConf.load (the loader `gym env start` actually uses) rejects duplicate YAML keys,
+        # but a plain PyYAML parse silently allows them (last-writer-wins). A repeated key like a
+        # second `datasets:` block can land unnoticed and only surface at runtime. Sweep every real
+        # config in the repo so this fails fast in CI instead.
+        repo_root = Path(__file__).resolve().parents[2]
+        config_dirs = ("responses_api_agents", "resources_servers", "nemo_gym/sandbox/providers")
+        config_paths = [p for d in config_dirs for p in (repo_root / d).rglob("*.yaml")]
+        assert config_paths, "no config files discovered -- sweep dirs may have moved"
+
+        failures = []
+        for path in config_paths:
+            try:
+                OmegaConf.load(path)
+            except Exception as e:
+                failures.append(f"{path.relative_to(repo_root)}: {e}")
+
+        assert not failures, "malformed config(s) found:\n" + "\n".join(failures)
+
 
 class TestOpenAIVersionMatchesNemoGymConstraint:
     @mark.parametrize(


### PR DESCRIPTION
## Summary
- `mini_swe_agent_2.yaml` had two `datasets: []` keys in the same mapping (lines 25 and 59) — two separate PRs each independently added one, unnoticed
- `OmegaConf.load` (the actual loader Gym uses) rejects duplicate keys, so `gym env start` with the enroot backend fails with `Malformed YAML ... found duplicate key datasets`
- Keeps the first, documented declaration and drops the redundant one at the end
- Adds a regression test that sweeps every config under `responses_api_agents/`, `resources_servers/`, and `nemo_gym/sandbox/providers/` through `OmegaConf.load`, so a duplicate/malformed key anywhere in the repo fails CI instead of surfacing at runtime

## Context
Found while investigating NVBug 6648140. The RC image itself was never affected (confirmed clean on `r0.5.1`), but `main` genuinely had this duplicate — worth cleaning up independently of the release.

No existing test would have caught this: the only repo-wide config sweep (`test_every_repo_benchmark_appears_in_listing`) is scoped to `BENCHMARKS_DIR` only, which doesn't include agent configs.

## Test plan
- [x] `OmegaConf.load` on the file succeeds with a single `datasets` key
- [x] New test passes at HEAD (281 configs swept, ~0.6s)
- [x] Verified the new test reproduces the exact original error when the duplicate key is reintroduced, then passes again once reverted
- [x] `pre-commit run --files responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml`