### PR TITLE
feat(nooa-agent): add safe declarative configuration

### DIFF
--- a/responses_api_agents/nooa_agent/__init__.py
+++ b/responses_api_agents/nooa_agent/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/responses_api_agents/nooa_agent/config.py
+++ b/responses_api_agents/nooa_agent/config.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from collections.abc import Callable
+from typing import Any, Literal
+
+from nooa import Agent
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from nemo_gym.base_responses_api_agent import BaseResponsesAPIAgentConfig
+from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
+
+
+class NOOAArgumentBinding(BaseModel):
+    """Map one entrypoint argument from a Gym run row."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    transform: str = "identity"
+
+    @field_validator("source")
+    @classmethod
+    def validate_source(cls, source: str) -> str:
+        from responses_api_agents.nooa_agent.mapping import validate_source_path
+
+        validate_source_path(source)
+        return source
+
+    @field_validator("transform")
+    @classmethod
+    def validate_transform(cls, transform: str) -> str:
+        from responses_api_agents.nooa_agent.mapping import get_transform
+
+        get_transform(transform)
+        return transform
+
+
+class NOOAInvocationConfig(BaseModel):
+    """Configuration for constructing and invoking a NOOA agent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    agent_class: str
+    entrypoint: str
+    execution_mode: Literal["embedded"] = "embedded"
+    init_kwargs: dict[str, Any] = Field(default_factory=dict)
+    arguments: dict[str, NOOAArgumentBinding]
+
+    @field_validator("agent_class")
+    @classmethod
+    def validate_agent_class_path(cls, value: str) -> str:
+        module_name, separator, class_name = value.partition(":")
+        if not separator or not module_name or not class_name or "." in class_name:
+            raise ValueError("agent_class must use the format 'module.path:ClassName'")
+        return value
+
+    @field_validator("entrypoint")
+    @classmethod
+    def validate_entrypoint_name(cls, value: str) -> str:
+        if not value.isidentifier() or value.startswith("_"):
+            raise ValueError("entrypoint must be a public Python method name")
+        return value
+
+    @model_validator(mode="after")
+    def validate_argument_names(self) -> "NOOAInvocationConfig":
+        invalid = sorted(name for name in self.arguments if not name.isidentifier() or name.startswith("_"))
+        if invalid:
+            raise ValueError(f"argument mapping names must be public Python identifiers: {invalid}")
+        if "llm" in self.init_kwargs:
+            raise ValueError("init_kwargs.llm is reserved; Gym always injects the rollout LLM")
+        return self
+
+
+class NOOAAgentConfig(BaseResponsesAPIAgentConfig):
+    """Gym server configuration for the NOOA adapter."""
+
+    resources_server: ResourcesServerRef
+    model_server: ModelServerRef
+    nooa: NOOAInvocationConfig
+    max_steps: int = Field(default=10, gt=0)
+    concurrency: int = Field(default=8, gt=0)
+    run_timeout_secs: float = Field(default=2100, gt=0)
+
+
+def load_agent_class(path: str) -> type[Agent]:
+    """Import and validate a ``module:Class`` NOOA agent reference."""
+
+    module_name, _, class_name = path.partition(":")
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as error:
+        raise ValueError(f"could not import NOOA agent module {module_name!r}") from error
+
+    try:
+        candidate = getattr(module, class_name)
+    except AttributeError as error:
+        raise ValueError(f"module {module_name!r} has no attribute {class_name!r}") from error
+
+    if not inspect.isclass(candidate) or not issubclass(candidate, Agent):
+        raise ValueError(f"{path!r} must resolve to a subclass of nooa.Agent")
+    return candidate
+
+
+def validate_invocation(config: NOOAInvocationConfig) -> tuple[type[Agent], Callable[..., Any]]:
+    """Validate imports and constructor/entrypoint signatures at server startup."""
+
+    agent_class = load_agent_class(config.agent_class)
+    try:
+        inspect.signature(agent_class).bind(llm=object(), **config.init_kwargs)
+    except TypeError as error:
+        raise ValueError(f"init_kwargs do not match {config.agent_class}: {error}") from error
+
+    entrypoint = getattr(agent_class, config.entrypoint, None)
+    if entrypoint is None or not callable(entrypoint):
+        raise ValueError(f"{config.agent_class} has no callable entrypoint {config.entrypoint!r}")
+    if not inspect.iscoroutinefunction(entrypoint):
+        raise ValueError(f"entrypoint {config.entrypoint!r} must be async")
+
+    signature = inspect.signature(entrypoint)
+    parameters = {
+        name: parameter
+        for name, parameter in signature.parameters.items()
+        if name != "self" and parameter.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    }
+    accepts_kwargs = any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values()
+    )
+
+    unknown = set(config.arguments) - set(parameters)
+    if unknown and not accepts_kwargs:
+        raise ValueError(f"arguments not accepted by {config.entrypoint}: {sorted(unknown)}")
+
+    positional_only = {
+        name for name, parameter in parameters.items() if parameter.kind == inspect.Parameter.POSITIONAL_ONLY
+    }
+    mapped_positional_only = positional_only & set(config.arguments)
+    if mapped_positional_only:
+        raise ValueError(f"entrypoint parameters must accept keyword arguments: {sorted(mapped_positional_only)}")
+
+    required = {
+        name
+        for name, parameter in parameters.items()
+        if parameter.default is inspect.Parameter.empty and parameter.kind != inspect.Parameter.POSITIONAL_ONLY
+    }
+    missing = required - set(config.arguments)
+    if missing:
+        raise ValueError(f"required entrypoint arguments are not mapped: {sorted(missing)}")
+
+    return agent_class, entrypoint

--- a/responses_api_agents/nooa_agent/mapping.py
+++ b/responses_api_agents/nooa_agent/mapping.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+
+if TYPE_CHECKING:
+    from responses_api_agents.nooa_agent.config import NOOAArgumentBinding
+
+
+Transform = Callable[[Any], Any]
+
+_FORBIDDEN_SOURCE_ROOTS = frozenset(
+    {
+        "agent_ref",
+        "ng_agent_observations",
+        "ng_trajectory",
+        "response",
+        "reward",
+        "verifier_metadata",
+    }
+)
+_FORBIDDEN_SOURCE_PREFIXES = ("_",)
+
+
+def validate_source_path(source: str) -> None:
+    """Reject unsafe or malformed paths before a rollout starts."""
+
+    parts = source.split(".")
+    if not source or any(not part or not (part.isidentifier() or part.isdigit()) for part in parts):
+        raise ValueError("source must be a non-empty dotted path of identifiers or sequence indexes")
+
+    root = parts[0]
+    if (
+        root in _FORBIDDEN_SOURCE_ROOTS
+        or root.startswith(_FORBIDDEN_SOURCE_PREFIXES)
+        or any(part.startswith("_") for part in parts)
+    ):
+        raise ValueError(f"mapping from Gym-internal or verifier field {root!r} is not allowed")
+
+
+def resolve_source(row: Any, source: str) -> Any:
+    """Resolve a dotted path against a complete Gym run row."""
+
+    validate_source_path(source)
+    value = row
+    for part in source.split("."):
+        if isinstance(value, BaseModel):
+            if not hasattr(value, part):
+                raise ValueError(f"source {source!r} does not exist at {part!r}")
+            value = getattr(value, part)
+        elif isinstance(value, Mapping):
+            if part not in value:
+                raise ValueError(f"source {source!r} does not exist at {part!r}")
+            value = value[part]
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)) and part.isdigit():
+            index = int(part)
+            try:
+                value = value[index]
+            except IndexError as error:
+                raise ValueError(f"source {source!r} has no index {index}") from error
+        else:
+            raise ValueError(f"source {source!r} cannot traverse {part!r}")
+    return value
+
+
+def identity(value: Any) -> Any:
+    """Return a mapped value unchanged."""
+
+    return value
+
+
+def normalize_responses_input(value: Any) -> str | list[Any]:
+    """Convert Pydantic Responses input items into plain Python values."""
+
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray)):
+        raise ValueError("Responses input must be a string or a sequence of input items")
+    return [item.model_dump(exclude_none=True) if isinstance(item, BaseModel) else item for item in value]
+
+
+def latest_user_text(value: Any) -> str:
+    """Extract text from the most recent user message in Responses input."""
+
+    normalized = normalize_responses_input(value)
+    if isinstance(normalized, str):
+        return normalized
+
+    for item in reversed(normalized):
+        if not isinstance(item, Mapping) or item.get("role") != "user":
+            continue
+        content = item.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, Sequence) and not isinstance(content, (str, bytes, bytearray)):
+            text_parts = [
+                part["text"]
+                for part in content
+                if isinstance(part, Mapping)
+                and part.get("type") in {"input_text", "output_text"}
+                and isinstance(part.get("text"), str)
+            ]
+            if text_parts:
+                return "\n".join(text_parts)
+        raise ValueError("latest user message does not contain text content")
+
+    raise ValueError("Responses input does not contain a user message")
+
+
+TRANSFORMS: Mapping[str, Transform] = {
+    "identity": identity,
+    "latest_user_text": latest_user_text,
+    "normalize_responses_input": normalize_responses_input,
+}
+
+
+def get_transform(name: str) -> Transform:
+    """Look up a built-in transform by its configuration name."""
+
+    try:
+        return TRANSFORMS[name]
+    except KeyError as error:
+        raise ValueError(f"unknown transform {name!r}; available transforms: {sorted(TRANSFORMS)}") from error
+
+
+def materialize_arguments(row: Any, bindings: Mapping[str, NOOAArgumentBinding]) -> dict[str, Any]:
+    """Build keyword arguments for a configured NOOA entrypoint."""
+
+    return {
+        argument_name: get_transform(binding.transform)(resolve_source(row, binding.source))
+        for argument_name, binding in bindings.items()
+    }

--- a/responses_api_agents/nooa_agent/requirements.txt
+++ b/responses_api_agents/nooa_agent/requirements.txt
@@ -1,0 +1,2 @@
+-e nemo-gym[dev] @ ../../
+nooa

--- a/responses_api_agents/nooa_agent/tests/__init__.py
+++ b/responses_api_agents/nooa_agent/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/responses_api_agents/nooa_agent/tests/test_config_mapping.py
+++ b/responses_api_agents/nooa_agent/tests/test_config_mapping.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+import pytest
+from nooa import Agent
+from pydantic import BaseModel, ValidationError
+
+from responses_api_agents.nooa_agent.config import (
+    NOOAArgumentBinding,
+    NOOAInvocationConfig,
+    load_agent_class,
+    validate_invocation,
+)
+from responses_api_agents.nooa_agent.mapping import (
+    latest_user_text,
+    materialize_arguments,
+    normalize_responses_input,
+    resolve_source,
+)
+
+
+class ExampleAgent(Agent):
+    async def analyze(self, text: str, customer_id: str, optional: bool = False) -> str:
+        """Analyze customer feedback."""
+
+        ...
+
+
+class NotAnAgent:
+    pass
+
+
+class ConstructorAgent(Agent):
+    def __init__(self, *, llm: Any, label: str) -> None:
+        super().__init__(llm=llm)
+        self.label = label
+
+    async def analyze(self, text: str) -> str:
+        return text
+
+
+class SyncAgent(Agent):
+    def analyze(self, text: str) -> str:
+        return text
+
+
+class InputItem(BaseModel):
+    role: str
+    content: str
+
+
+def invocation_config(**overrides: Any) -> NOOAInvocationConfig:
+    values = {
+        "agent_class": f"{__name__}:ExampleAgent",
+        "entrypoint": "analyze",
+        "arguments": {
+            "text": {
+                "source": "responses_create_params.input",
+                "transform": "latest_user_text",
+            },
+            "customer_id": {"source": "customer_id"},
+        },
+    }
+    values.update(overrides)
+    return NOOAInvocationConfig.model_validate(values)
+
+
+def test_materialize_arguments_from_complete_run_row() -> None:
+    config = invocation_config()
+    row = {
+        "responses_create_params": {
+            "input": [
+                {"role": "developer", "content": "Classify customer feedback."},
+                {"role": "user", "content": [{"type": "input_text", "text": "Shipping was slow."}]},
+            ]
+        },
+        "customer_id": "customer-42",
+    }
+
+    assert materialize_arguments(row, config.arguments) == {
+        "text": "Shipping was slow.",
+        "customer_id": "customer-42",
+    }
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "verifier_metadata.answer",
+        "agent_ref.name",
+        "_ng_rollout_id",
+        "response.output",
+        "reward",
+        "items.__class__",
+    ],
+)
+def test_forbids_sensitive_and_internal_sources(source: str) -> None:
+    with pytest.raises(ValidationError, match="not allowed"):
+        NOOAArgumentBinding(source=source)
+
+
+def test_rejects_unknown_transform() -> None:
+    with pytest.raises(ValidationError, match="unknown transform"):
+        NOOAArgumentBinding(source="customer_id", transform="lambda value: value")
+
+
+def test_resolves_pydantic_models_and_sequence_indexes() -> None:
+    row = {"items": [InputItem(role="user", content="hello")]}
+
+    assert resolve_source(row, "items.0.content") == "hello"
+
+
+@pytest.mark.parametrize("source", ["", "items..content", "items.-1", "items.not-valid"])
+def test_rejects_malformed_source_paths(source: str) -> None:
+    with pytest.raises(ValueError, match="dotted path"):
+        resolve_source({}, source)
+
+
+def test_missing_source_reports_full_path_and_segment() -> None:
+    with pytest.raises(ValueError, match=r"'customer\.profile\.id'.*'profile'"):
+        resolve_source({"customer": {}}, "customer.profile.id")
+
+
+def test_latest_user_text_uses_last_user_message() -> None:
+    assert (
+        latest_user_text(
+            [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "reply"},
+                {"role": "user", "content": "second"},
+            ]
+        )
+        == "second"
+    )
+
+
+def test_normalize_responses_input_dumps_models() -> None:
+    assert normalize_responses_input([InputItem(role="user", content="hello")]) == [
+        {"role": "user", "content": "hello"}
+    ]
+
+
+def test_validate_invocation_returns_agent_and_entrypoint() -> None:
+    agent_class, entrypoint = validate_invocation(invocation_config())
+
+    assert agent_class is ExampleAgent
+    assert entrypoint is ExampleAgent.analyze
+
+
+def test_validate_invocation_rejects_missing_required_mapping() -> None:
+    config = invocation_config(
+        arguments={
+            "text": {
+                "source": "responses_create_params.input",
+                "transform": "latest_user_text",
+            }
+        }
+    )
+
+    with pytest.raises(ValueError, match="customer_id"):
+        validate_invocation(config)
+
+
+def test_validate_invocation_rejects_unknown_argument() -> None:
+    config = invocation_config(
+        arguments={
+            "text": {"source": "responses_create_params.input", "transform": "latest_user_text"},
+            "customer_id": {"source": "customer_id"},
+            "answer": {"source": "answer"},
+        }
+    )
+
+    with pytest.raises(ValueError, match="answer"):
+        validate_invocation(config)
+
+
+def test_validate_invocation_checks_constructor_with_injected_llm() -> None:
+    config = invocation_config(
+        agent_class=f"{__name__}:ConstructorAgent",
+        init_kwargs={"label": "production"},
+        arguments={"text": {"source": "responses_create_params.input", "transform": "latest_user_text"}},
+    )
+
+    agent_class, _ = validate_invocation(config)
+
+    assert agent_class is ConstructorAgent
+
+
+def test_validate_invocation_rejects_invalid_constructor_kwargs() -> None:
+    config = invocation_config(
+        agent_class=f"{__name__}:ConstructorAgent",
+        init_kwargs={"unknown": True},
+        arguments={"text": {"source": "responses_create_params.input", "transform": "latest_user_text"}},
+    )
+
+    with pytest.raises(ValueError, match="init_kwargs"):
+        validate_invocation(config)
+
+
+def test_rejects_static_llm_override() -> None:
+    with pytest.raises(ValidationError, match="Gym always injects"):
+        invocation_config(init_kwargs={"llm": "provider-model"})
+
+
+def test_validate_invocation_rejects_synchronous_entrypoint() -> None:
+    config = invocation_config(
+        agent_class=f"{__name__}:SyncAgent",
+        arguments={"text": {"source": "responses_create_params.input", "transform": "latest_user_text"}},
+    )
+
+    with pytest.raises(ValueError, match="must be async"):
+        validate_invocation(config)
+
+
+def test_rejects_private_or_invalid_argument_names() -> None:
+    with pytest.raises(ValidationError, match="public Python identifiers"):
+        invocation_config(
+            arguments={
+                "not-valid": {"source": "customer_id"},
+                "_private": {"source": "customer_id"},
+            }
+        )
+
+
+def test_load_agent_class_rejects_non_agent_class() -> None:
+    with pytest.raises(ValueError, match="subclass of nooa.Agent"):
+        load_agent_class(f"{__name__}:NotAnAgent")


### PR DESCRIPTION
## summary

- add structured configuration for selecting a nooa agent, entrypoint, constructor settings, and task-field mappings
- validate agent imports, constructors, asynchronous entrypoints, and argument mappings when the server starts
- restrict mappings to agent-visible data and provide safe transforms for common responses api inputs

## data flow

```mermaid
flowchart LR
    yaml["nooa yaml config"] --> config["NOOAAgentConfig<br/>NOOAInvocationConfig<br/>NOOAArgumentBinding"]
    config --> validate["validate_invocation()"]
    validate --> symbols["validated agent_class<br/>and entrypoint"]

    row["complete gym row"] --> materialize["materialize_arguments()"]
    materialize --> gate{"validate_source_path()"}
    gate -->|"allowed source"| resolve["resolve_source()"]
    resolve --> transform["get_transform()"]
    transform --> kwargs["entrypoint kwargs"]
    gate -->|"verifier or routing field"| reject["reject mapping"]
```

Closes #2566
