### PR TITLE
feat(nooa-agent): embed Gym-backed runtime

### DIFF
--- a/responses_api_agents/nooa_agent/gym_llm.py
+++ b/responses_api_agents/nooa_agent/gym_llm.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from nooa.unifiedllm import LLMResponse, Tool, ToolCall, UnifiedLLM
+from pydantic import BaseModel
+
+from nemo_gym.openai_utils import (
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseFunctionToolCall,
+    NeMoGymResponseOutputMessage,
+)
+from nemo_gym.server_utils import ServerClient, get_response_json, raise_for_status
+
+
+class PolicyCallBudgetExceeded(RuntimeError):
+    """Raised when one rollout exceeds its configured policy-call budget."""
+
+
+def _dump(value: Any) -> Any:
+    return value.model_dump(mode="json", exclude_none=True) if isinstance(value, BaseModel) else value
+
+
+def _responses_input(messages: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], str | None]:
+    instructions: list[str] = []
+    result: list[dict[str, Any]] = []
+    for message in messages:
+        if message.get("role") == "system":
+            if content := message.get("content"):
+                instructions.append(str(content))
+            continue
+        if "_batch" in message:
+            batch = message["_batch"]
+            if not isinstance(batch, list):
+                raise ValueError("NOOA assistant _batch must be a list of Responses items")
+            result.extend(_dump(item) for item in batch)
+            continue
+        if "type" in message:
+            result.append(_dump(message))
+            continue
+        if message.get("role") == "tool":
+            result.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": message["tool_call_id"],
+                    "output": message.get("content", ""),
+                }
+            )
+            continue
+        if message.get("role") == "assistant" and message.get("tool_calls"):
+            if message.get("content"):
+                result.append({"role": "assistant", "content": message["content"]})
+            for call in message["tool_calls"]:
+                function = call.get("function", {})
+                result.append(
+                    {
+                        "type": "function_call",
+                        "call_id": call["id"],
+                        "name": function.get("name", ""),
+                        "arguments": function.get("arguments", ""),
+                    }
+                )
+            continue
+        result.append(_dump(message))
+    return result, "\n\n".join(instructions) or None
+
+
+def _tool_schema(tool: Tool) -> dict[str, Any]:
+    schema = tool.get_parameter_schema()
+    return {
+        "type": "function",
+        "name": tool.name,
+        "description": tool.description,
+        "parameters": schema,
+        "strict": set(schema.get("required", [])) == set(schema.get("properties", {})),
+    }
+
+
+def _output_text(response: NeMoGymResponse) -> str:
+    parts: list[str] = []
+    for item in response.output:
+        if isinstance(item, NeMoGymResponseOutputMessage):
+            parts.extend(part.text for part in item.content if part.type == "output_text")
+    return "\n".join(parts)
+
+
+class GymResponsesLLM(UnifiedLLM):
+    """NOOA LLM implementation backed exclusively by a Gym Responses model server."""
+
+    def __init__(
+        self,
+        *,
+        server_client: ServerClient,
+        model_server_name: str,
+        model_url_path: str,
+        max_steps: int,
+        response_collector: list[NeMoGymResponse],
+        cookies: dict[str, str],
+        model: str = "gym-policy",
+    ) -> None:
+        super().__init__(model=model)
+        self._server_client = server_client
+        self._model_server_name = model_server_name
+        self._model_url_path = model_url_path
+        self._max_steps = max_steps
+        self._response_collector = response_collector
+        self._cookies = cookies
+        self._calls = 0
+
+    @property
+    def calls(self) -> int:
+        return self._calls
+
+    def call(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[Tool] | None = None,
+        output_model: type[BaseModel] | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        raise RuntimeError("GymResponsesLLM supports async NOOA entrypoints only")
+
+    async def acall(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[Tool] | None = None,
+        output_model: type[BaseModel] | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        if self._calls >= self._max_steps:
+            raise PolicyCallBudgetExceeded(f"NOOA policy call budget exhausted after {self._max_steps} calls")
+        self._calls += 1
+
+        input_items, instructions = _responses_input(messages)
+        request: dict[str, Any] = {
+            "input": input_items,
+            "instructions": instructions,
+            "model": None,
+            "parallel_tool_calls": False,
+            "tools": [_tool_schema(tool) for tool in tools or []],
+        }
+        if output_model is not None:
+            request["text"] = {
+                "format": {
+                    "type": "json_schema",
+                    "name": output_model.__name__,
+                    "schema": output_model.model_json_schema(),
+                    "strict": True,
+                }
+            }
+
+        aliases = {"max_tokens": "max_output_tokens"}
+        supported = set(NeMoGymResponseCreateParamsNonStreaming.model_fields)
+        for name, value in kwargs.items():
+            destination = aliases.get(name, name)
+            if destination in supported and value is not None:
+                request[destination] = value
+
+        body = NeMoGymResponseCreateParamsNonStreaming.model_validate(request)
+        http_response = await self._server_client.post(
+            server_name=self._model_server_name,
+            url_path=self._model_url_path,
+            json=body,
+            cookies=self._cookies,
+        )
+        await raise_for_status(http_response)
+        raw = await get_response_json(http_response)
+        response = NeMoGymResponse.model_validate(raw)
+        self._cookies.update({name: morsel.value for name, morsel in http_response.cookies.items()})
+        self._response_collector.append(response)
+
+        dumped_output = [item.model_dump(mode="json", exclude_none=True) for item in response.output]
+        function_calls = [item for item in response.output if isinstance(item, NeMoGymResponseFunctionToolCall)]
+        usage = response.usage.model_dump(mode="json") if response.usage is not None else None
+        if function_calls:
+            return LLMResponse(
+                raw_response=response,
+                content="",
+                tool_calls=[
+                    ToolCall(id=item.call_id, name=item.name, arguments=item.arguments) for item in function_calls
+                ],
+                finish_reason="tool_calls",
+                assistant_message={"_batch": dumped_output},
+                usage=usage,
+            )
+
+        content: str | BaseModel = _output_text(response)
+        if output_model is not None:
+            try:
+                content = output_model.model_validate(json.loads(content))
+            except (json.JSONDecodeError, ValueError, TypeError) as error:
+                raise ValueError(f"Gym model returned invalid {output_model.__name__} JSON") from error
+
+        reasoning = [
+            item.model_dump(mode="json", exclude_none=True) for item in response.output if item.type == "reasoning"
+        ]
+        return LLMResponse(
+            raw_response=response,
+            content=content,
+            tool_calls=[],
+            finish_reason="length" if response.incomplete_details else "stop",
+            assistant_message={"role": "assistant", "content": _output_text(response)},
+            reasoning=json.dumps(reasoning) if reasoning else None,
+            usage=usage,
+        )

--- a/responses_api_agents/nooa_agent/gym_tools.py
+++ b/responses_api_agents/nooa_agent/gym_tools.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import inspect
+import json
+from dataclasses import dataclass
+from time import perf_counter, time
+from types import MethodType
+from typing import Any
+from uuid import uuid4
+
+from jsonschema import Draft202012Validator, ValidationError
+from pydantic import BaseModel
+
+from nemo_gym.server_utils import ServerClient
+
+
+@dataclass(slots=True)
+class GymToolExecution:
+    tool_call_id: str
+    name: str
+    arguments: dict[str, Any]
+    output: Any
+    status: str
+    started_at: float
+    completed_at: float
+    duration_ms: float
+    error_type: str | None = None
+
+
+def _as_tool_dict(tool: Any) -> dict[str, Any]:
+    return tool.model_dump(mode="json", exclude_none=True) if isinstance(tool, BaseModel) else dict(tool)
+
+
+def _annotation(schema: dict[str, Any]) -> Any:
+    schema_type = schema.get("type")
+    if schema_type == "string":
+        return str
+    if schema_type == "integer":
+        return int
+    if schema_type == "number":
+        return float
+    if schema_type == "boolean":
+        return bool
+    if schema_type == "array":
+        return list
+    if schema_type == "object":
+        return dict
+    return Any
+
+
+class GymTools:
+    """Per-rollout namespace of Resources server methods available to generated NOOA code."""
+
+    def __init__(
+        self,
+        *,
+        server_client: ServerClient,
+        resources_server_name: str,
+        tools: list[Any],
+        cookies: dict[str, str],
+        observations: list[GymToolExecution],
+    ) -> None:
+        self._server_client = server_client
+        self._resources_server_name = resources_server_name
+        self._cookies = cookies
+        self._observations = observations
+        self._install(tools)
+
+    def _install(self, tools: list[Any]) -> None:
+        seen: set[str] = set()
+        for raw_tool in tools:
+            tool = _as_tool_dict(raw_tool)
+            if tool.get("type") != "function":
+                raise ValueError(f"gym_tools supports function tools only, received {tool.get('type')!r}")
+            name = tool.get("name")
+            if not isinstance(name, str) or not name.isidentifier() or name.startswith("_"):
+                raise ValueError(f"resource tool name must be a public Python identifier, received {name!r}")
+            if name in seen or hasattr(self, name):
+                raise ValueError(f"duplicate or reserved resource tool name {name!r}")
+            seen.add(name)
+
+            schema = tool.get("parameters") or {"type": "object", "properties": {}}
+            try:
+                Draft202012Validator.check_schema(schema)
+            except Exception as error:
+                raise ValueError(f"resource tool {name!r} has an invalid JSON Schema: {error}") from error
+            if schema.get("type") != "object":
+                raise ValueError(f"resource tool {name!r} parameters must use an object JSON Schema")
+
+            method = self._make_method(name, tool.get("description") or "", schema)
+            setattr(self, name, MethodType(method, self))
+
+    @staticmethod
+    def _make_method(name: str, description: str, schema: dict[str, Any]) -> Any:
+        validator = Draft202012Validator(schema)
+
+        async def invoke(namespace: GymTools, **kwargs: Any) -> Any:
+            started_at = time()
+            started_monotonic = perf_counter()
+            call_id = f"gym_tool_{uuid4().hex}"
+            status = "completed"
+            error_type = None
+            try:
+                validator.validate(kwargs)
+            except ValidationError as error:
+                output: Any = {"error": f"Invalid arguments for {name}: {error.message}"}
+                status = "failed"
+                error_type = "invalid_arguments"
+            else:
+                response = await namespace._server_client.post(
+                    server_name=namespace._resources_server_name,
+                    url_path=f"/{name}",
+                    json=kwargs,
+                    cookies=namespace._cookies,
+                )
+                namespace._cookies.update({key: morsel.value for key, morsel in response.cookies.items()})
+                body = (await response.content.read()).decode(errors="replace")
+                try:
+                    output = json.loads(body)
+                except json.JSONDecodeError:
+                    output = body
+                if not 200 <= response.status < 400:
+                    status = "failed"
+                    error_type = f"http_{response.status}"
+
+            completed_at = max(started_at, time())
+            namespace._observations.append(
+                GymToolExecution(
+                    tool_call_id=call_id,
+                    name=name,
+                    arguments=kwargs,
+                    output=output,
+                    status=status,
+                    started_at=started_at,
+                    completed_at=completed_at,
+                    duration_ms=(perf_counter() - started_monotonic) * 1000,
+                    error_type=error_type,
+                )
+            )
+            return output
+
+        invoke.__name__ = name
+        invoke.__qualname__ = f"GymTools.{name}"
+        invoke.__doc__ = description or f"Call the Gym Resources server's {name} tool."
+        properties = schema.get("properties", {})
+        required = set(schema.get("required", []))
+        parameters = [inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD)]
+        for parameter_name, parameter_schema in properties.items():
+            if not parameter_name.isidentifier() or parameter_name.startswith("_"):
+                raise ValueError(f"resource tool {name!r} has invalid parameter name {parameter_name!r}")
+            default = inspect.Parameter.empty if parameter_name in required else None
+            parameters.append(
+                inspect.Parameter(
+                    parameter_name,
+                    inspect.Parameter.KEYWORD_ONLY,
+                    default=default,
+                    annotation=_annotation(parameter_schema),
+                )
+            )
+        invoke.__signature__ = inspect.Signature(parameters, return_annotation=Any)
+        return invoke

--- a/responses_api_agents/nooa_agent/runner.py
+++ b/responses_api_agents/nooa_agent/runner.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from nooa import Agent
+
+from nemo_gym.openai_utils import NeMoGymResponse
+from nemo_gym.server_utils import ServerClient
+from responses_api_agents.nooa_agent.config import NOOAInvocationConfig, validate_invocation
+from responses_api_agents.nooa_agent.gym_llm import GymResponsesLLM
+from responses_api_agents.nooa_agent.gym_tools import GymToolExecution, GymTools
+from responses_api_agents.nooa_agent.mapping import materialize_arguments
+
+
+@dataclass(slots=True)
+class NOOARunRequest:
+    row: Any
+    rollout_id: str
+    task_id: str
+    model_url_path: str
+    model_cookies: dict[str, str] = field(default_factory=dict)
+    resource_cookies: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class NOOARunResult:
+    return_value: Any
+    agent: Agent
+    model_responses: list[NeMoGymResponse]
+    tool_executions: list[GymToolExecution]
+    model_cookies: dict[str, str]
+    resource_cookies: dict[str, str]
+
+
+class NOOARunner(Protocol):
+    async def run(self, request: NOOARunRequest) -> NOOARunResult: ...
+
+
+class EmbeddedNOOARunner:
+    """Construct and invoke one isolated NOOA agent instance per Gym rollout."""
+
+    def __init__(
+        self,
+        *,
+        invocation: NOOAInvocationConfig,
+        server_client: ServerClient,
+        model_server_name: str,
+        resources_server_name: str,
+        max_steps: int,
+    ) -> None:
+        self._invocation = invocation
+        self._server_client = server_client
+        self._model_server_name = model_server_name
+        self._resources_server_name = resources_server_name
+        self._max_steps = max_steps
+        self._agent_class, _ = validate_invocation(invocation)
+
+    async def run(self, request: NOOARunRequest) -> NOOARunResult:
+        responses: list[NeMoGymResponse] = []
+        executions: list[GymToolExecution] = []
+        llm = GymResponsesLLM(
+            server_client=self._server_client,
+            model_server_name=self._model_server_name,
+            model_url_path=request.model_url_path,
+            max_steps=self._max_steps,
+            response_collector=responses,
+            cookies=request.model_cookies,
+        )
+        agent = self._agent_class(llm=llm, **self._invocation.init_kwargs)
+        tools = GymTools(
+            server_client=self._server_client,
+            resources_server_name=self._resources_server_name,
+            tools=list(request.row.responses_create_params.tools),
+            cookies=request.resource_cookies,
+            observations=executions,
+        )
+        agent.gym_tools = tools
+
+        arguments = materialize_arguments(request.row, self._invocation.arguments)
+        entrypoint = getattr(agent, self._invocation.entrypoint)
+        return_value = await entrypoint(**arguments)
+        return NOOARunResult(
+            return_value=return_value,
+            agent=agent,
+            model_responses=responses,
+            tool_executions=executions,
+            model_cookies=request.model_cookies,
+            resource_cookies=request.resource_cookies,
+        )

--- a/responses_api_agents/nooa_agent/tests/test_gym_llm.py
+++ b/responses_api_agents/nooa_agent/tests/test_gym_llm.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from http.cookies import SimpleCookie
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from nooa.unifiedllm import Tool
+from pydantic import BaseModel
+
+from nemo_gym.openai_utils import (
+    NeMoGymResponse,
+    NeMoGymResponseFunctionToolCallForTraining,
+    NeMoGymResponseOutputMessageForTraining,
+    NeMoGymResponseOutputText,
+)
+from responses_api_agents.nooa_agent.gym_llm import GymResponsesLLM, PolicyCallBudgetExceeded
+
+
+class FakeContent:
+    def __init__(self, payload: dict) -> None:
+        self._payload = json.dumps(payload).encode()
+
+    async def read(self) -> bytes:
+        return self._payload
+
+
+class FakeHTTPResponse:
+    ok = True
+    status = 200
+
+    def __init__(self, payload: dict, cookies: SimpleCookie | None = None) -> None:
+        self.content = FakeContent(payload)
+        self.cookies = cookies or SimpleCookie()
+
+    async def read(self) -> bytes:
+        return await self.content.read()
+
+
+class StructuredAnswer(BaseModel):
+    verdict: str
+
+
+def weather(city: str) -> str:
+    """Get weather for a city."""
+
+    return city
+
+
+def model_response(*outputs: object, response_id: str = "resp-1") -> dict:
+    return NeMoGymResponse(
+        id=response_id,
+        created_at=0.0,
+        model="policy",
+        object="response",
+        output=list(outputs),
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    ).model_dump(mode="json")
+
+
+def make_llm(payload: dict, *, max_steps: int = 2) -> tuple[GymResponsesLLM, MagicMock, list[NeMoGymResponse]]:
+    server_client = MagicMock()
+    server_client.post = AsyncMock(return_value=FakeHTTPResponse(payload))
+    collected: list[NeMoGymResponse] = []
+    llm = GymResponsesLLM(
+        server_client=server_client,
+        model_server_name="policy_model",
+        model_url_path="/ng-rollout/rollout-1/v1/responses",
+        max_steps=max_steps,
+        response_collector=collected,
+        cookies={},
+    )
+    return llm, server_client, collected
+
+
+@pytest.mark.asyncio
+async def test_routes_messages_tools_and_sampling_to_gym() -> None:
+    output = NeMoGymResponseOutputMessageForTraining(
+        id="msg-1",
+        content=[NeMoGymResponseOutputText(annotations=[], text="Cold", logprobs=[])],
+        prompt_token_ids=[1, 2],
+        generation_token_ids=[3],
+        generation_log_probs=[-0.2],
+        routed_experts=[[[0, 1]]],
+    )
+    llm, client, collected = make_llm(model_response(output))
+
+    result = await llm.acall(
+        [{"role": "system", "content": "Be concise."}, {"role": "user", "content": "Weather?"}],
+        tools=[Tool(name="weather", description="Get weather", callable=weather)],
+        temperature=0.3,
+        max_tokens=128,
+    )
+
+    request = client.post.await_args.kwargs
+    assert request["server_name"] == "policy_model"
+    assert request["url_path"] == "/ng-rollout/rollout-1/v1/responses"
+    assert request["json"].instructions == "Be concise."
+    assert request["json"].temperature == 0.3
+    assert request["json"].max_output_tokens == 128
+    assert request["json"].tools[0]["name"] == "weather"
+    assert result.content == "Cold"
+    assert collected[0].output[0].prompt_token_ids == [1, 2]
+    assert collected[0].output[0].routed_experts == [[[0, 1]]]
+
+
+@pytest.mark.asyncio
+async def test_preserves_function_call_token_metadata() -> None:
+    output = NeMoGymResponseFunctionToolCallForTraining(
+        id="fc-1",
+        call_id="call-1",
+        name="weather",
+        arguments='{"city":"Paris"}',
+        prompt_token_ids=[10],
+        generation_token_ids=[11, 12],
+        generation_log_probs=[-0.1, -0.2],
+    )
+    llm, _, _ = make_llm(model_response(output))
+
+    result = await llm.acall([{"role": "user", "content": "Weather?"}])
+
+    assert result.finish_reason == "tool_calls"
+    assert result.tool_calls[0].name == "weather"
+    assert result.assistant_message["_batch"][0]["generation_token_ids"] == [11, 12]
+
+
+@pytest.mark.asyncio
+async def test_structured_output_schema_and_parsing() -> None:
+    output = NeMoGymResponseOutputMessageForTraining(
+        id="msg-1",
+        content=[NeMoGymResponseOutputText(annotations=[], text='{"verdict":"positive"}')],
+        prompt_token_ids=[1],
+        generation_token_ids=[2],
+        generation_log_probs=[-0.1],
+    )
+    llm, client, _ = make_llm(model_response(output))
+
+    result = await llm.acall([{"role": "user", "content": "Classify"}], output_model=StructuredAnswer)
+
+    assert result.content == StructuredAnswer(verdict="positive")
+    assert client.post.await_args.kwargs["json"].text["format"]["name"] == "StructuredAnswer"
+
+
+@pytest.mark.asyncio
+async def test_enforces_total_policy_call_budget() -> None:
+    output = NeMoGymResponseOutputMessageForTraining(
+        id="msg-1",
+        content=[NeMoGymResponseOutputText(annotations=[], text="done")],
+        prompt_token_ids=[1],
+        generation_token_ids=[2],
+        generation_log_probs=[-0.1],
+    )
+    llm, client, _ = make_llm(model_response(output), max_steps=1)
+    await llm.acall([{"role": "user", "content": "first"}])
+
+    with pytest.raises(PolicyCallBudgetExceeded, match="exhausted"):
+        await llm.acall([{"role": "user", "content": "second"}])
+
+    client.post.assert_awaited_once()
+
+
+def test_rejects_synchronous_policy_calls() -> None:
+    llm, _, _ = make_llm(model_response())
+
+    with pytest.raises(RuntimeError, match="async"):
+        llm.call([])

--- a/responses_api_agents/nooa_agent/tests/test_gym_tools.py
+++ b/responses_api_agents/nooa_agent/tests/test_gym_tools.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import json
+from http.cookies import SimpleCookie
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from responses_api_agents.nooa_agent.gym_tools import GymToolExecution, GymTools
+
+
+class FakeContent:
+    def __init__(self, value: object) -> None:
+        self._payload = json.dumps(value).encode()
+
+    async def read(self) -> bytes:
+        return self._payload
+
+
+class FakeResponse:
+    def __init__(self, value: object, status: int = 200, cookie: tuple[str, str] | None = None) -> None:
+        self.content = FakeContent(value)
+        self.status = status
+        self.cookies = SimpleCookie()
+        if cookie:
+            self.cookies[cookie[0]] = cookie[1]
+
+
+def weather_tool() -> dict:
+    return {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Return the weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+                "units": {"type": "string"},
+            },
+            "required": ["city"],
+            "additionalProperties": False,
+        },
+    }
+
+
+def make_tools(response: FakeResponse) -> tuple[GymTools, MagicMock, dict[str, str], list[GymToolExecution]]:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=response)
+    cookies = {"session": "old"}
+    observations: list[GymToolExecution] = []
+    tools = GymTools(
+        server_client=client,
+        resources_server_name="weather_resources",
+        tools=[weather_tool()],
+        cookies=cookies,
+        observations=observations,
+    )
+    return tools, client, cookies, observations
+
+
+@pytest.mark.asyncio
+async def test_generated_method_has_typed_signature_and_routes_with_cookies() -> None:
+    tools, client, cookies, observations = make_tools(
+        FakeResponse({"city": "Paris", "weather": "cold"}, cookie=("session", "new"))
+    )
+
+    output = await tools.get_weather(city="Paris")
+
+    signature = inspect.signature(tools.get_weather)
+    assert signature.parameters["city"].annotation is str
+    assert signature.parameters["city"].default is inspect.Parameter.empty
+    assert signature.parameters["units"].default is None
+    assert tools.get_weather.__doc__ == "Return the weather for a city."
+    assert output == {"city": "Paris", "weather": "cold"}
+    assert client.post.await_args.kwargs == {
+        "server_name": "weather_resources",
+        "url_path": "/get_weather",
+        "json": {"city": "Paris"},
+        "cookies": {"session": "new"},
+    }
+    assert cookies == {"session": "new"}
+    assert observations[0].status == "completed"
+    assert observations[0].arguments == {"city": "Paris"}
+
+
+@pytest.mark.asyncio
+async def test_invalid_arguments_are_model_visible_without_http_call() -> None:
+    tools, client, _, observations = make_tools(FakeResponse({}))
+
+    output = await tools.get_weather(city=7)
+
+    assert "Invalid arguments" in output["error"]
+    client.post.assert_not_awaited()
+    assert observations[0].status == "failed"
+    assert observations[0].error_type == "invalid_arguments"
+
+
+@pytest.mark.asyncio
+async def test_resource_http_error_is_returned_and_observed() -> None:
+    tools, _, _, observations = make_tools(FakeResponse({"detail": "unavailable"}, status=503))
+
+    output = await tools.get_weather(city="Paris")
+
+    assert output == {"detail": "unavailable"}
+    assert observations[0].status == "failed"
+    assert observations[0].error_type == "http_503"
+
+
+@pytest.mark.parametrize(
+    ("tools", "message"),
+    [
+        ([{"type": "web_search_preview"}], "function tools only"),
+        ([weather_tool(), weather_tool()], "duplicate"),
+        ([weather_tool() | {"name": "_private"}], "public Python identifier"),
+        ([weather_tool() | {"parameters": {"type": "array"}}], "object JSON Schema"),
+    ],
+)
+def test_rejects_unsupported_or_colliding_tool_definitions(tools: list[dict], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        GymTools(
+            server_client=MagicMock(),
+            resources_server_name="resources",
+            tools=tools,
+            cookies={},
+            observations=[],
+        )

--- a/responses_api_agents/nooa_agent/tests/test_runner.py
+++ b/responses_api_agents/nooa_agent/tests/test_runner.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from http.cookies import SimpleCookie
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from nooa import Agent
+from pydantic import BaseModel, ConfigDict
+
+from nemo_gym.openai_utils import NeMoGymResponseCreateParamsNonStreaming
+from responses_api_agents.nooa_agent.config import NOOAInvocationConfig
+from responses_api_agents.nooa_agent.runner import EmbeddedNOOARunner, NOOARunRequest
+
+
+class ValidAgent(Agent):
+    def __init__(self, *, llm: Any, label: str) -> None:
+        super().__init__(llm=llm)
+        self.label = label
+
+    async def analyze(self, text: str, customer_id: str) -> str: ...
+
+
+class FakeAgent:
+    instances = 0
+
+    def __init__(self, *, llm: Any, label: str) -> None:
+        type(self).instances += 1
+        self.llm = llm
+        self.label = label
+        self.gym_tools: Any = None
+
+    async def analyze(self, text: str, customer_id: str) -> str:
+        weather = await self.gym_tools.get_weather(city=customer_id)
+        return f"{text}: {weather['weather']}"
+
+
+class Row(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    responses_create_params: NeMoGymResponseCreateParamsNonStreaming
+    customer_id: str
+
+
+class FakeContent:
+    async def read(self) -> bytes:
+        return json.dumps({"weather": "cold"}).encode()
+
+
+class FakeResponse:
+    status = 200
+    content = FakeContent()
+    cookies = SimpleCookie()
+
+
+def make_runner() -> tuple[EmbeddedNOOARunner, MagicMock]:
+    invocation = NOOAInvocationConfig.model_validate(
+        {
+            "agent_class": f"{__name__}:ValidAgent",
+            "entrypoint": "analyze",
+            "init_kwargs": {"label": "configured"},
+            "arguments": {
+                "text": {
+                    "source": "responses_create_params.input",
+                    "transform": "latest_user_text",
+                },
+                "customer_id": {"source": "customer_id"},
+            },
+        }
+    )
+    client = MagicMock()
+    client.post = AsyncMock(return_value=FakeResponse())
+    runner = EmbeddedNOOARunner(
+        invocation=invocation,
+        server_client=client,
+        model_server_name="policy_model",
+        resources_server_name="weather_resources",
+        max_steps=3,
+    )
+    runner._agent_class = FakeAgent
+    return runner, client
+
+
+def row(customer_id: str) -> Row:
+    return Row(
+        customer_id=customer_id,
+        responses_create_params={
+            "input": [{"role": "user", "content": "Check delivery"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "strict": True,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                        "additionalProperties": False,
+                    },
+                }
+            ],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_embedded_runner_maps_full_row_and_attaches_gym_tools() -> None:
+    runner, client = make_runner()
+
+    result = await runner.run(
+        NOOARunRequest(
+            row=row("Paris"),
+            rollout_id="rollout-1",
+            task_id="task-1",
+            model_url_path="/ng-rollout/rollout-1/v1/responses",
+            resource_cookies={"session": "one"},
+        )
+    )
+
+    assert result.return_value == "Check delivery: cold"
+    assert result.agent.label == "configured"
+    assert result.agent.llm.model == "gym-policy"
+    assert result.tool_executions[0].name == "get_weather"
+    assert client.post.await_args.kwargs["json"] == {"city": "Paris"}
+
+
+@pytest.mark.asyncio
+async def test_constructs_a_fresh_agent_for_every_rollout() -> None:
+    runner, _ = make_runner()
+    FakeAgent.instances = 0
+
+    first = await runner.run(
+        NOOARunRequest(
+            row=row("Paris"),
+            rollout_id="one",
+            task_id="task",
+            model_url_path="/one/v1/responses",
+        )
+    )
+    second = await runner.run(
+        NOOARunRequest(
+            row=row("Berlin"),
+            rollout_id="two",
+            task_id="task",
+            model_url_path="/two/v1/responses",
+        )
+    )
+
+    assert FakeAgent.instances == 2
+    assert first.agent is not second.agent
+    assert first.resource_cookies is not second.resource_cookies


### PR DESCRIPTION
## summary

- create a fresh embedded nooa agent for every rollout and pass it arguments derived from the task row
- route policy calls through the gym model server while preserving token metadata and enforcing a call budget
- expose resource-server tools as typed agent methods with argument validation, cookie forwarding, and serialized execution

## data flow

```mermaid
flowchart LR
    request["NOOARunRequest"] --> runner["EmbeddedNOOARunner.run()"]
    runner --> subclass["create_agent_class_with_resource_methods()"]
    subclass --> entrypoint["configured async entrypoint"]

    entrypoint --> llm["GymResponsesLLM.acall()"]
    llm --> model_post["ServerClient.post()"]
    model_post --> model["gym model server<br/>/v1/responses"]
    model --> llm_result["LLMResponse<br/>ModelCallRef + token metadata"]
    llm_result --> entrypoint

    entrypoint --> method["generated resource method"]
    method --> dispatcher["ResourceToolDispatcher.call()"]
    dispatcher --> schema["Draft202012Validator"]
    schema --> resources["gym resources server<br/>/{name}"]
    resources --> tool_result["tool output + cookies"]
    tool_result --> entrypoint

    entrypoint --> result["NOOARunResult"]
```

Closes #2567
