### PR TITLE
fix(evalplus): handle non-picklable MBPP outputs

### DIFF
--- a/resources_servers/evalplus/app.py
+++ b/resources_servers/evalplus/app.py
@@ -33,7 +33,9 @@ entry point so adding MBPP+ as a separate benchmark requires only a new
 benchmark dir (no server changes).
 """
 
+import pickle
 from asyncio import Semaphore, get_running_loop
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import ray
@@ -258,19 +260,25 @@ def _load_dataset_and_expected(dataset: str, version: str) -> tuple[Dict[str, An
         tasks_only_output_not_none: List[str] = []
     elif dataset == "mbpp":
         from evalplus.data import get_mbpp_plus, get_mbpp_plus_hash
-        from evalplus.data.mbpp import mbpp_serialize_inputs  # noqa: F401  (registers serializer)
+        from evalplus.eval import MBPP_OUTPUT_NOT_NONE_TASKS
 
         problems = get_mbpp_plus(version=version)
         problems_hash = get_mbpp_plus_hash(version=version)
-        # MBPP+: a handful of tasks have no canonical solution; evalplus
-        # filters them. Mirror its convention.
-        tasks_only_output_not_none = [tid for tid, p in problems.items() if p.get("canonical_solution")]
+        # Some MBPP tasks return objects such as re.Match that cannot be pickled.
+        # EvalPlus checks only that these task outputs are not None.
+        tasks_only_output_not_none = MBPP_OUTPUT_NOT_NONE_TASKS
     else:
         raise ValueError(f"Unsupported evalplus dataset: {dataset!r}")
 
+    from evalplus.data.utils import CACHE_DIR
     from evalplus.evaluate import get_groundtruth
 
-    expected_output = get_groundtruth(problems, problems_hash, tasks_only_output_not_none)
+    try:
+        expected_output = get_groundtruth(problems, problems_hash, tasks_only_output_not_none)
+    except (EOFError, pickle.UnpicklingError):
+        # A failed pickle write can leave a corrupt cache that blocks later startups.
+        Path(CACHE_DIR, f"{problems_hash}.pkl").unlink(missing_ok=True)
+        expected_output = get_groundtruth(problems, problems_hash, tasks_only_output_not_none)
     return problems, expected_output
 
 

--- a/resources_servers/evalplus/tests/test_app.py
+++ b/resources_servers/evalplus/tests/test_app.py
@@ -350,35 +350,57 @@ class TestComputeMetrics:
 class TestLoadDatasetAndExpected:
     """Cover the dataset-loader fork without hitting HF / EvalPlus."""
 
-    def test_humaneval_path(self):
+    def test_humaneval_path(self, tmp_path):
         import app
 
         with (
             patch("evalplus.data.get_human_eval_plus", return_value={"HumanEval/0": {"task_id": "HumanEval/0"}}),
             patch("evalplus.data.get_human_eval_plus_hash", return_value="hash"),
+            patch("evalplus.data.utils.CACHE_DIR", str(tmp_path)),
             patch("evalplus.evaluate.get_groundtruth", return_value={"HumanEval/0": {"base": [], "plus": []}}),
         ):
             problems, expected = app._load_dataset_and_expected("humaneval", "default")
         assert "HumanEval/0" in problems
         assert "HumanEval/0" in expected
 
-    def test_mbpp_path(self):
+    def test_mbpp_path(self, tmp_path):
         import app
+        from evalplus.eval import MBPP_OUTPUT_NOT_NONE_TASKS
 
         with (
             patch(
                 "evalplus.data.get_mbpp_plus",
-                return_value={"Mbpp/0": {"canonical_solution": "x"}, "Mbpp/1": {"canonical_solution": ""}},
+                return_value={
+                    "Mbpp/0": {"canonical_solution": "x", "entry_point": "check_str"},
+                    "Mbpp/1": {"canonical_solution": "y", "entry_point": "regular_function"},
+                },
             ),
             patch("evalplus.data.get_mbpp_plus_hash", return_value="hash"),
-            patch("evalplus.data.mbpp.mbpp_serialize_inputs", create=True),
+            patch("evalplus.data.utils.CACHE_DIR", str(tmp_path)),
             patch("evalplus.evaluate.get_groundtruth", return_value={"Mbpp/0": {}, "Mbpp/1": {}}) as gt,
         ):
             problems, expected = app._load_dataset_and_expected("mbpp", "default")
-        # Only Mbpp/0 (with canonical_solution) is in the filter list passed to get_groundtruth.
         gt.assert_called_once()
         _, _, only_not_none = gt.call_args.args
-        assert only_not_none == ["Mbpp/0"]
+        assert only_not_none == MBPP_OUTPUT_NOT_NONE_TASKS
+
+    def test_corrupt_groundtruth_cache_is_recomputed(self, tmp_path):
+        import app
+
+        cache_file = tmp_path / "hash.pkl"
+        cache_file.write_bytes(b"incomplete pickle")
+        expected = {"HumanEval/0": {"base": [], "plus": []}}
+        with (
+            patch("evalplus.data.get_human_eval_plus", return_value={"HumanEval/0": {"task_id": "HumanEval/0"}}),
+            patch("evalplus.data.get_human_eval_plus_hash", return_value="hash"),
+            patch("evalplus.data.utils.CACHE_DIR", str(tmp_path)),
+            patch("evalplus.evaluate.get_groundtruth", side_effect=[EOFError, expected]) as gt,
+        ):
+            _, actual = app._load_dataset_and_expected("humaneval", "default")
+
+        assert actual == expected
+        assert gt.call_count == 2
+        assert not cache_file.exists()
 
     def test_unsupported_dataset_raises(self):
         import app


### PR DESCRIPTION
## Summary
- pass EvalPlus's special MBPP entry points when computing ground truth so regex match outputs are reduced to picklable booleans
- remove and recompute truncated ground-truth caches left by the prior failed pickle write
- add regression coverage for MBPP special outputs and corrupt-cache recovery

## Test plan
- [x] `python -m pytest resources_servers/evalplus/tests/test_app.py`
- [x] `ruff check resources_servers/evalplus/app.py resources_servers/evalplus/tests/test_app.py`
- [x] Fresh MBPP ground-truth computation on Python 3.13.14