### PR TITLE
feat(local_vllm_model): support vLLM 0.25.1

### DIFF
--- a/docker/install_codec_deps.sh
+++ b/docker/install_codec_deps.sh
@@ -25,7 +25,7 @@
 # --no-config bypasses the project's sys_platform=='never' overrides.
 set -euo pipefail
 
-if python -c "import cv2, torchvision, torchaudio" 2>/dev/null; then
+if python -c "import cv2, PyNvVideoCodec, torchcodec, torchvision, torchaudio" 2>/dev/null; then
     echo "[codec-deps] Already installed, skipping."
     exit 0
 fi
@@ -33,6 +33,8 @@ fi
 echo "[codec-deps] Installing codec-bearing packages..."
 uv pip install --no-config \
     "opencv-python-headless==5.0.0.93" \
+    "pynvvideocodec==2.0.4" \
+    "torchcodec==0.16.0" \
     "torchvision==0.26.0" \
     "torchaudio==2.11.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,12 +242,12 @@ all = [
 
 vllm = [
     # Pin to the same version used by local_vllm_model / genrm_model server venvs.
-    # Updated: Mon Aug 04, 2026 with vllm==0.24.0
-    "vllm==0.24.0",
-    # Pin flashinfer to the exact version vllm 0.24.0 specifies, ensuring pre-compiled
+    # Updated: Mon Aug 24, 2026 with vllm==0.25.1
+    "vllm==0.25.1",
+    # Pin flashinfer to the exact version vllm 0.25.1 specifies, ensuring pre-compiled
     # CUDA kernels are used (avoids JIT compilation on first generation == slow step time).
     # flashinfer>=0.2 bundles compiled kernels in the python package directly.
-    "flashinfer-python==0.6.12",
+    "flashinfer-python==0.6.13",
 ]
 
 sandbox = [
@@ -348,6 +348,8 @@ dev = [
 # update the script when uv lock bumps them.
 codec = [
     "opencv-python-headless",
+    "pynvvideocodec",
+    "torchcodec",
     "torchvision",
     "torchaudio",
 ]
@@ -379,6 +381,8 @@ override-dependencies = [
     # [tool.uv] override-dependencies (pyproject.toml servers), which takes
     # precedence. Reinstall for testing via docker/install_codec_deps.sh.
     "opencv-python-headless; sys_platform == 'never'",
+    "pynvvideocodec; sys_platform == 'never'",
+    "torchcodec; sys_platform == 'never'",
     "torchvision; sys_platform == 'never'",
     "torchaudio; sys_platform == 'never'",
     "pycountry; sys_platform == 'never'",

--- a/responses_api_models/genrm_model/setup.py
+++ b/responses_api_models/genrm_model/setup.py
@@ -22,9 +22,9 @@ dependencies = [
     "nemo-gym[dev]",
 
     # We specifically pin the vllm dependency because we have tested on this version.
-    # Updated Mon Aug 04, 2026 with vllm==0.24.0
-    # License: Apache 2.0 https://github.com/vllm-project/vllm/blob/main/LICENSE
-    # "vllm==0.24.0",
+    # Updated Mon Aug 24, 2026 with vllm==0.25.1
+    # License: Apache 2.0 https://github.com/vllm-project/vllm/blob/752a3a504485790a2e8491cacbb35c137339ad34/LICENSE
+    # "vllm==0.25.1",
     # VLLM is resolved below since installation on Macs requires special workarounds.
 
     # hf_transfer for faster model download from HuggingFace
@@ -47,12 +47,12 @@ dependencies = [
 if platform == "darwin":
     dependencies.append("vllm==0.11.0")
 else:
-    dependencies.append("vllm==0.24.0")
-    # Pin flashinfer to the exact version vllm 0.24.0 requires — pre-compiled CUDA kernels,
+    dependencies.append("vllm==0.25.1")
+    # Pin flashinfer to the exact version vllm 0.25.1 requires — pre-compiled CUDA kernels,
     # avoids JIT compilation on first generation. Must stay in sync with pyproject.toml [vllm].
-    # Updated Mon Aug 04, 2026 with flashinfer-python==0.6.12
-    # License: Apache 2.0 https://github.com/flashinfer-ai/flashinfer/blob/main/LICENSE
-    dependencies.append("flashinfer-python==0.6.12")
+    # Updated Mon Aug 24, 2026 with flashinfer-python==0.6.13
+    # License: Apache 2.0 https://github.com/flashinfer-ai/flashinfer/blob/57ba7eeb7ea3003a2d6ad5d9a057c4f952709bac/LICENSE
+    dependencies.append("flashinfer-python==0.6.13")
 
 
 setuptools.setup(install_requires=dependencies)

--- a/responses_api_models/local_vllm_model/local_vllm_model_actor.py
+++ b/responses_api_models/local_vllm_model/local_vllm_model_actor.py
@@ -24,6 +24,18 @@ import ray
 from ray.util.placement_group import PlacementGroup
 
 
+def _get_local_dp_ranks(placement_groups: list[PlacementGroup]) -> list[int]:
+    """Return each engine's rank among engines whose first worker shares a node."""
+    node_engine_counts: dict[str, int] = {}
+    local_dp_ranks = []
+    for placement_group in placement_groups:
+        placement_group_data = ray.util.placement_group_table(placement_group)
+        worker_node_id = placement_group_data["bundles_to_node_id"][0]
+        local_dp_ranks.append(node_engine_counts.get(worker_node_id, 0))
+        node_engine_counts[worker_node_id] = local_dp_ranks[-1] + 1
+    return local_dp_ranks
+
+
 def _vllm_asyncio_task(server_args: Namespace):
     from vllm.entrypoints.openai.api_server import run_server
 
@@ -221,7 +233,6 @@ class LocalVLLMModelActor:
             START Use our initial placement group
             """
             placement_groups: list[PlacementGroup] = [head_node_placement_group]
-            local_dp_ranks: list[int] = [0]
             """
             END Use our initial placement group
             """
@@ -332,7 +343,11 @@ class LocalVLLMModelActor:
                 )
 
                 placement_groups.append(pg)
-                local_dp_ranks.append(0)
+
+            # vLLM 0.25.1 uses the node-local DP rank to select a disjoint TCPStore port window.
+            # Wait for placement so the rank reflects the node hosting each engine's first worker.
+            ray.get([placement_group.ready() for placement_group in placement_groups])
+            local_dp_ranks = _get_local_dp_ranks(placement_groups)
 
             if len(placement_groups) < dp_size:
                 raise ValueError(

--- a/responses_api_models/local_vllm_model/setup.py
+++ b/responses_api_models/local_vllm_model/setup.py
@@ -19,9 +19,9 @@ dependencies = [
     "nemo-gym[dev]",
 
     # We specifically pin the vllm dependency because we have tested on this version.
-    # Updated Mon Aug 04, 2026 with vllm==0.24.0
-    # License: Apache 2.0 https://github.com/vllm-project/vllm/blob/main/LICENSE
-    # "vllm==0.24.0",
+    # Updated Mon Aug 24, 2026 with vllm==0.25.1
+    # License: Apache 2.0 https://github.com/vllm-project/vllm/blob/752a3a504485790a2e8491cacbb35c137339ad34/LICENSE
+    # "vllm==0.25.1",
     # VLLM is resolved below since installation on Macs requires special workarounds.
 
     # hf_transfer for faster model download from HuggingFace
@@ -44,12 +44,12 @@ dependencies = [
 if platform == "darwin":
     dependencies.append("vllm==0.11.0")
 else:
-    dependencies.append("vllm==0.24.0")
-    # Pin flashinfer to the exact version vllm 0.24.0 requires — pre-compiled CUDA kernels,
+    dependencies.append("vllm==0.25.1")
+    # Pin flashinfer to the exact version vllm 0.25.1 requires — pre-compiled CUDA kernels,
     # avoids JIT compilation on first generation. Must stay in sync with pyproject.toml [vllm].
-    # Updated Mon Aug 04, 2026 with flashinfer-python==0.6.12
-    # License: Apache 2.0 https://github.com/flashinfer-ai/flashinfer/blob/main/LICENSE
-    dependencies.append("flashinfer-python==0.6.12")
+    # Updated Mon Aug 24, 2026 with flashinfer-python==0.6.13
+    # License: Apache 2.0 https://github.com/flashinfer-ai/flashinfer/blob/57ba7eeb7ea3003a2d6ad5d9a057c4f952709bac/LICENSE
+    dependencies.append("flashinfer-python==0.6.13")
 
 
 setuptools.setup(install_requires=dependencies)

--- a/responses_api_models/local_vllm_model/tests/test_app.py
+++ b/responses_api_models/local_vllm_model/tests/test_app.py
@@ -24,9 +24,25 @@ from vllm.platforms import resolve_obj_by_qualname
 import responses_api_models.local_vllm_model.app
 from nemo_gym.global_config import DISALLOWED_PORTS_KEY_NAME, DictConfig
 from responses_api_models.local_vllm_model.app import LocalVLLMModel, LocalVLLMModelConfig
+from responses_api_models.local_vllm_model.local_vllm_model_actor import _get_local_dp_ranks
 
 
 class TestApp:
+    def test_local_dp_ranks_increment_per_worker_node(self, monkeypatch) -> None:
+        placement_groups = [object(), object(), object(), object()]
+        node_ids = ["node-a", "node-b", "node-a", "node-b"]
+        placement_group_data = {
+            placement_group: {"bundles_to_node_id": {0: node_id}}
+            for placement_group, node_id in zip(placement_groups, node_ids)
+        }
+        monkeypatch.setattr(
+            responses_api_models.local_vllm_model.local_vllm_model_actor.ray.util,
+            "placement_group_table",
+            placement_group_data.__getitem__,
+        )
+
+        assert _get_local_dp_ranks(placement_groups) == [0, 0, 1, 1]
+
     def test_sanity_vllm_import(self) -> None:
         import vllm
 

--- a/uv.lock
+++ b/uv.lock
@@ -15,8 +15,10 @@ constraints = [{ name = "grpcio", specifier = ">=1.81.0rc1" }]
 overrides = [
     { name = "opencv-python-headless", marker = "sys_platform == 'never'" },
     { name = "pycountry", marker = "sys_platform == 'never'" },
+    { name = "pynvvideocodec", marker = "sys_platform == 'never'" },
     { name = "spacy", specifier = ">=3.8.13" },
     { name = "torchaudio", marker = "sys_platform == 'never'" },
+    { name = "torchcodec", marker = "sys_platform == 'never'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
 ]
 excludes = [
@@ -1320,15 +1322,15 @@ wheels = [
 
 [[package]]
 name = "flashinfer-cubin"
-version = "0.6.12"
+version = "0.6.13"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/c6/63b1bb7b1a7ae612ecf53c0e568312c3d004f9f7558b0ab5edcf7900c360/flashinfer_cubin-0.6.12-py3-none-any.whl", hash = "sha256:01de132c493bb21d5df42ebe6890966cf83b40aa970dae06b2a3c0bed85f13ec", size = 447533460, upload-time = "2026-05-29T23:45:27.579Z" },
+    { url = "https://files.pythonhosted.org/packages/19/43/ce916b4cdec4705173e222ca29c68e09004b47526888746094c5ffb29fca/flashinfer_cubin-0.6.13-py3-none-any.whl", hash = "sha256:41e4848c2d09d220e8394489b2fb6cfec6b6ad09f897b5ab8b39fc23055f6c24", size = 457984995, upload-time = "2026-06-25T00:29:26.08Z" },
 ]
 
 [[package]]
 name = "flashinfer-python"
-version = "0.6.12"
+version = "0.6.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-tvm-ffi" },
@@ -1347,9 +1349,9 @@ dependencies = [
     { name = "torch" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/d0/114a64319f5a804def2f307d5ed8f95e6d94a2acdacac4ed5f57525cbf46/flashinfer_python-0.6.12.tar.gz", hash = "sha256:bed67f9c46d81dd22611dfef2787998fc412b2fe2648d9e7d336861dda912694", size = 9453326, upload-time = "2026-05-29T23:45:16.466Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/f7/7f6dd2b03f4277509dfd1e5c7a8ec1de2662fd245d2e663f44a3493882b1/flashinfer_python-0.6.13.tar.gz", hash = "sha256:8a6d7d3708c7c87952390ec4e3aabe6e1c356defa8c7211b26bccaa355a61c59", size = 9638085, upload-time = "2026-06-24T22:46:29.391Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/26/3ca33edbf64906603633cb91904798e427c0ac1c55a13707f8081708f3ae/flashinfer_python-0.6.12-py3-none-any.whl", hash = "sha256:0c7a01e586b4796810d974cbf13a9c0eb2ade6a94d12e3220cf7782a1c09b8d3", size = 13985243, upload-time = "2026-05-29T23:45:13.477Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/50/e8920ed7f68e0116a385e3ab814ac2f0010579852fc483bfb48819d11976/flashinfer_python-0.6.13-py3-none-any.whl", hash = "sha256:239e6ddc3cbbaf0bee251861a8c7c69438b1171830d69ddfa133ddea4494850d", size = 14191198, upload-time = "2026-06-24T22:46:26.565Z" },
 ]
 
 [[package]]
@@ -1697,7 +1699,7 @@ wheels = [
 
 [[package]]
 name = "humming-kernels"
-version = "0.1.6"
+version = "0.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-bindings" },
@@ -1711,9 +1713,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "triton" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/5a/fbf574dcd83e9fea6aa3fa96b37bbdec40b8672407b1ed9679efa31fff1d/humming_kernels-0.1.6.tar.gz", hash = "sha256:882b9f382a010165a7cf8eecbad943bfe8d6b17566328fb57611c9a34bdccc9a", size = 214408, upload-time = "2026-06-20T04:04:43.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/4f/6977a31451c3f7aa1deaa76506d6cdeb74ef418ad8bcba2e98f7510b26ec/humming_kernels-0.1.10.tar.gz", hash = "sha256:da3e46fb9fc9eba2a9327c2e8135ead68e390c955acd7449f97ee7c71666c8b1", size = 220110, upload-time = "2026-07-02T10:22:57.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/85/490681b9ba24531da91d0bae801d2b26850e5a80bbd02c2efc500756e36b/humming_kernels-0.1.6-py3-none-any.whl", hash = "sha256:e64c0883fca930074bf920f4ba47cbf3acd244d7352f6c74c8d2182439770d8f", size = 178759, upload-time = "2026-06-20T04:04:41.66Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ba/869bc24591d2b4fb0d8da821528072971052a934af077a11f77a0f2b3e79/humming_kernels-0.1.10-py3-none-any.whl", hash = "sha256:4ded0998ff085afeddde70baf93f97c2929969ec3d4a63a52cfec5072bc972b4", size = 184889, upload-time = "2026-07-02T10:22:56.031Z" },
 ]
 
 [package.optional-dependencies]
@@ -2634,7 +2636,9 @@ vllm = [
 [package.dev-dependencies]
 codec = [
     { name = "opencv-python-headless", marker = "sys_platform == 'never'" },
+    { name = "pynvvideocodec", marker = "sys_platform == 'never'" },
     { name = "torchaudio", marker = "sys_platform == 'never'" },
+    { name = "torchcodec", marker = "sys_platform == 'never'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
 ]
 
@@ -2649,7 +2653,7 @@ requires-dist = [
     { name = "defusedxml", marker = "extra == 'dev'", specifier = ">=0.7.1" },
     { name = "devtools" },
     { name = "fastapi" },
-    { name = "flashinfer-python", marker = "extra == 'vllm'", specifier = "==0.6.12" },
+    { name = "flashinfer-python", marker = "extra == 'vllm'", specifier = "==0.6.13" },
     { name = "fonttools", specifier = ">=4.60.2" },
     { name = "gitpython", specifier = ">=3.1.57" },
     { name = "gprof2dot", marker = "extra == 'dev'" },
@@ -2688,7 +2692,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn" },
     { name = "uvloop" },
-    { name = "vllm", marker = "extra == 'vllm'", specifier = "==0.24.0" },
+    { name = "vllm", marker = "extra == 'vllm'", specifier = "==0.25.1" },
     { name = "wandb" },
     { name = "yappi", specifier = ">=1.7.6" },
 ]
@@ -2697,7 +2701,9 @@ provides-extras = ["all", "vllm", "sandbox", "openshell", "dev"]
 [package.metadata.requires-dev]
 codec = [
     { name = "opencv-python-headless" },
+    { name = "pynvvideocodec" },
     { name = "torchaudio" },
+    { name = "torchcodec" },
     { name = "torchvision" },
 ]
 
@@ -3201,6 +3207,26 @@ resolution-markers = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/6b/d5756f485012b920475cbc01457c1b9a7d0485bfb04b92598c5e1ef3e9ab/nvidia_nvvm-13.3.73-py3-none-win_amd64.whl", hash = "sha256:b5c91dfa59ee4cee90b2dfb19c6203f31c914b9c9b5ca10726c2da7cf8ed401d", size = 59981103, upload-time = "2026-06-29T17:21:43.334Z" },
+]
+
+[[package]]
+name = "nvtx"
+version = "0.2.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/dd/692765e87de30bae1522cdffaa0f2b52949658a92a0fa6d96b1a01eae9d2/nvtx-0.2.15.tar.gz", hash = "sha256:2287d3be05b85661deb386f878d1f536c2e532774aa9ec7a50c434942ed81ae5", size = 121230, upload-time = "2026-03-18T10:01:25.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/c9/8341224b8284f7deb6a634119939de5885adc421e64b6743693b30da2186/nvtx-0.2.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d28660d9c46f8ba750d781572b6aa5a1e6221abba224ab32d7fb32c2d0fd67df", size = 780787, upload-time = "2026-03-18T10:10:40.634Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/4a5bb7897918de7c7e0191d9342df8ae4cb797ff07276e0f20d13e497ce7/nvtx-0.2.15-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10749686633f880ad53dcdbb2179fad41b45dcf5b7631d4a1070a577577bd386", size = 782575, upload-time = "2026-03-18T10:13:57.3Z" },
+    { url = "https://files.pythonhosted.org/packages/38/b9/6b381ac7c5a3ded331aebbf25f8959d19b51d320fb2514c76c6b6edddaaa/nvtx-0.2.15-cp313-cp313-win_amd64.whl", hash = "sha256:a6650b029263d12f8427a4dee8bd59cb9c91bccb60543bfcb20bc2b00fdcd672", size = 128764, upload-time = "2026-03-18T10:02:33.343Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/a9acb6d95d2e0e381b2956544768528dd8d7a9e827af8c2014169d838284/nvtx-0.2.15-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25813ead4fff4d3a6e04f69a72507b096a6bdbecefa369f1100b0e584767bca8", size = 833375, upload-time = "2026-03-18T10:06:31.955Z" },
+    { url = "https://files.pythonhosted.org/packages/38/56/c7e8645061cc2fc23f3a54f33e1e340df59216f07dcfb97d46b8ae7dd26c/nvtx-0.2.15-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3741edac4678b92f03d22a3f0a2dfd469f422f85e63db71b038e02525b2404ad", size = 788639, upload-time = "2026-03-18T10:12:01.69Z" },
+    { url = "https://files.pythonhosted.org/packages/96/03/fadd82acdbca6d1c49ac517081a0c3714346f52f4c7e1d4449d77605b4aa/nvtx-0.2.15-cp313-cp313t-win_amd64.whl", hash = "sha256:8be06c3c8c267eba56a0396366b9593092e0b75ea8d3702b303d48c0a1662f0e", size = 142609, upload-time = "2026-03-18T10:01:48.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/5b/ca0ba6fa769d08174b7a5b4775c279e2e26611cdd5e7833aa699187871c7/nvtx-0.2.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5171b8283dd3ea9ae688a86d16901b4c2c142c4eb0a4bdbf6c222f5f67f9524", size = 781769, upload-time = "2026-03-18T10:08:59.357Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/e1/e02fafc01c18f1868a2d2c030953f49e38d65f2d95884789a6c46ff308f1/nvtx-0.2.15-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c6d0f27d4f8a2f479eb64a6b842c13aee32120348a1715d995b9bb9f75b35cf", size = 774614, upload-time = "2026-03-18T10:12:46.979Z" },
+    { url = "https://files.pythonhosted.org/packages/20/77/a2b64335bab7c75fe1c054cc4ebe2d3b3234cbdb04d2e1d6ca73551c54f5/nvtx-0.2.15-cp314-cp314-win_amd64.whl", hash = "sha256:9934fad0b441cfa6e896a848b092498ba23e2ff205c2b9a7b60520ff8367ffef", size = 130932, upload-time = "2026-03-18T10:03:43.507Z" },
+    { url = "https://files.pythonhosted.org/packages/db/24/528619230976c18364eda2340906ea67b3bf7588b7ce59e054723614abae/nvtx-0.2.15-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aca61135c76b8107ae3c994325613afa661e1336a991c59cc9c6176829b3b32c", size = 834439, upload-time = "2026-03-18T10:05:01.181Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/7b/c1b96f13ef89bdf2a8c2f326a97bed89699271990d7c8624fda3fedc6e61/nvtx-0.2.15-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58653bf6fd8453947b9e5153da2ad7aeb0ceafa030de7f133efb3eada5da7ca7", size = 790247, upload-time = "2026-03-18T10:11:39.124Z" },
+    { url = "https://files.pythonhosted.org/packages/14/5d/e000de781d92b732d52c572517db0e9e3a0085795f8bdc18201713c52d1f/nvtx-0.2.15-cp314-cp314t-win_amd64.whl", hash = "sha256:9d1d10db4fb4a3b0ffd6ed37bf25f0a966a3b4d34b3c9abb1f6572732959a6e5", size = 149109, upload-time = "2026-03-18T10:03:21.615Z" },
 ]
 
 [[package]]
@@ -4190,6 +4216,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a384
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
+
+[[package]]
+name = "pynvvideocodec"
+version = "2.0.4"
+source = { registry = "https://pypi.org/simple" }
 
 [[package]]
 name = "pyparsing"
@@ -5265,6 +5296,11 @@ version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
 
 [[package]]
+name = "torchcodec"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
 name = "torchvision"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5429,7 +5465,7 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.24.0"
+version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -5462,6 +5498,7 @@ dependencies = [
     { name = "numpy" },
     { name = "nvidia-cudnn-frontend" },
     { name = "nvidia-cutlass-dsl", extra = ["cu13"] },
+    { name = "nvtx" },
     { name = "openai" },
     { name = "openai-harmony" },
     { name = "opencv-python-headless", marker = "sys_platform == 'never'" },
@@ -5479,6 +5516,7 @@ dependencies = [
     { name = "py-cpuinfo" },
     { name = "pybase64" },
     { name = "pydantic" },
+    { name = "pynvvideocodec", marker = "sys_platform == 'never'" },
     { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "pyzmq" },
@@ -5494,9 +5532,10 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tilelang" },
     { name = "tokenizers" },
-    { name = "tokenspeed-mla" },
+    { name = "tokenspeed-mla", marker = "sys_platform == 'linux'" },
     { name = "torch" },
     { name = "torchaudio", marker = "sys_platform == 'never'" },
+    { name = "torchcodec", marker = "sys_platform == 'never'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
     { name = "tqdm" },
     { name = "transformers" },
@@ -5504,10 +5543,10 @@ dependencies = [
     { name = "watchfiles" },
     { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/17/ea541f9ffb31d438ed6a5a8e1f7b9805410664abf97e326f28416147a5da/vllm-0.24.0.tar.gz", hash = "sha256:0862453adc1f3339f1a0c9dca1179c34d6ed6e118f87b6e5bddd120af614ac66", size = 37236989, upload-time = "2026-06-30T01:18:35.996Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/ce/542315fe84e23a73b919d64794350233d4f1c70b2544ba0afd5348005aff/vllm-0.25.1.tar.gz", hash = "sha256:ddbdec3f1c0f21afa70b7eb6ddf3faa29d26b1302ee4b5d5e00ec3af41b0c2e4", size = 37731826, upload-time = "2026-07-14T08:58:23.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/80/51a071305b4eed0f6f512dc1c1c6957cbb14ccce38db1be90ffcff2a2844/vllm-0.24.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:700db71c3cf14697d42583521f38b12fac38db1e7a8ad062e8e4d63a5dadebd5", size = 271361241, upload-time = "2026-06-30T01:17:52.566Z" },
-    { url = "https://files.pythonhosted.org/packages/00/33/3f0abda52acff437a471cf3a2bf204213eb4102975b2677512cd76f2b45e/vllm-0.24.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2d2831aeba311292250df0132dbc4d8e9f42c654536eaec48e6fe58acb1822cf", size = 279209310, upload-time = "2026-06-30T01:18:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/40055709d6625a4f96fce5b82625860625d66723979ac092c10bef03d8c1/vllm-0.25.1-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:902be760af4c5ebfad8af5b8ea07a53ae14e5a6c839c8ab56da30581abb75ad2", size = 244036150, upload-time = "2026-07-14T08:58:44.737Z" },
+    { url = "https://files.pythonhosted.org/packages/35/9d/c379618ce0abfc2679607d403c0f586b07e9c9c33d08c5bdd6196cb524e0/vllm-0.25.1-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:16fc7a28df1576eb6f7ca0455026551b8f9adb674c19c66059359ef3e964bd1e", size = 250100306, upload-time = "2026-07-14T08:59:06.476Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- upgrade local vLLM and GenRM servers to vLLM 0.25.1 and its matching FlashInfer release
- isolate new codec-bearing transitive dependencies behind the existing codec installation path
- derive node-local DP ranks from scheduled placement groups so co-located DP engines use distinct TCPStore port windows

Depends on [#2456](https://github.com/NVIDIA-NeMo/Gym/pull/2456), which updates Gym for the OpenAI version required by vLLM 0.25.1.

## Test plan
- [x] Run pre-commit hooks on changed files
- [x] Run focused local vLLM model unit tests
- [x] Start a DP=2 local vLLM server on two GPUs and complete a chat request
- [x] Start the 32B GenRM checkpoint with TP=2 and verify model-specific scoring