### PR TITLE
fix(opensandbox): make sandbox terminate idempotent on not-found

### DIFF
--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -260,8 +260,15 @@ def _is_retryable_sdk_operation_error(exception: BaseException, seen: set[int] |
 
 
 def _is_missing_sandbox_delete_error(exception: BaseException) -> bool:
+    """Match kill errors meaning the sandbox is already gone (terminate's goal state).
+
+    Only the terminate path may treat this as success; other operations must
+    keep failing loudly on not-found.
+    """
+    if _exception_status_code(exception) == 404:
+        return True
     message = str(exception).lower()
-    return "sandbox" in message and "not found" in message
+    return "sandbox_not_found" in message or ("sandbox" in message and "not found" in message)
 
 
 def _log_create_retry(retry_state: Any) -> None:
@@ -1496,22 +1503,28 @@ class OpenSandboxProvider:
 
     async def close(self, handle: SandboxHandle) -> None:
         """Terminate the sandbox and close local SDK resources."""
+
+        async def kill_ignore_missing() -> None:
+            # Terminate is idempotent: not-found means the sandbox is already
+            # gone (double-termination race, or a previous run's leftover).
+            # Swallow it before the retry wrapper so the 404 is never retried.
+            try:
+                await handle.raw.kill()
+            except Exception as e:
+                if not _is_missing_sandbox_delete_error(e):
+                    raise
+                LOGGER.debug("OpenSandbox sandbox %r already gone; treating terminate as success", handle.sandbox_id)
+
         stop_error: Exception | None = None
         try:
             await self._await_sdk_operation(
-                lambda: handle.raw.kill(),
+                kill_ignore_missing,
                 operation="kill",
                 sandbox_id=handle.sandbox_id,
                 timeout_s=self._operations.close_timeout_s,
             )
         except Exception as e:
-            if not _is_missing_sandbox_delete_error(e):
-                stop_error = e
-            else:
-                LOGGER.info(
-                    "OpenSandbox sandbox %r was already deleted during close",
-                    handle.sandbox_id,
-                )
+            stop_error = e
 
         close_error: Exception | None = None
         try:

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -126,6 +126,15 @@ def test_sdk_import_helpers_and_retry_classification() -> None:
     assert opensandbox_provider._is_retryable_create_error(nonretryable_api_error) is False
     assert opensandbox_provider._is_retryable_create_error(SandboxException("gateway timeout")) is True
 
+    status_only_not_found = SandboxApiException("gone")
+    status_only_not_found.status_code = 404
+    assert opensandbox_provider._is_missing_sandbox_delete_error(status_only_not_found) is True
+    assert (
+        opensandbox_provider._is_missing_sandbox_delete_error(RuntimeError("[KUBERNETES::SANDBOX_NOT_FOUND]")) is True
+    )
+    assert opensandbox_provider._is_missing_sandbox_delete_error(RuntimeError("sandbox sandbox-1 not found")) is True
+    assert opensandbox_provider._is_missing_sandbox_delete_error(RuntimeError("http 500 boom")) is False
+
     retry_state = SimpleNamespace(
         outcome=SimpleNamespace(exception=lambda: RuntimeError("temporary")),
         next_action=SimpleNamespace(sleep=0.5),
@@ -1102,6 +1111,71 @@ async def test_provider_create_probe_and_close_error_paths(monkeypatch: pytest.M
                 raw=StopFailsCloseSucceedsRaw(),
             ),
         )
+
+
+async def test_close_treats_missing_sandbox_as_terminated_without_retry(caplog: pytest.LogCaptureFixture) -> None:
+    from opensandbox.exceptions import SandboxApiException  # noqa: PLC0415
+
+    provider = opensandbox_provider.OpenSandboxProvider(
+        probe={"command": None},
+        operations={"retries": 2, "retry_delay_s": 0, "retry_max_delay_s": 0},
+    )
+    not_found = SandboxApiException(
+        "Kill sandbox sandbox-1 failed: Sandbox 'sandbox-1' not found | "
+        "[KUBERNETES::SANDBOX_NOT_FOUND] Sandbox 'sandbox-1' not found"
+    )
+    not_found.status_code = 404
+    kill_calls = 0
+
+    class AlreadyGoneRaw:
+        async def kill(self) -> None:
+            nonlocal kill_calls
+            kill_calls += 1
+            raise not_found
+
+        async def close(self) -> None:
+            return None
+
+    with caplog.at_level(logging.DEBUG):
+        await provider.close(
+            opensandbox_provider.SandboxHandle(
+                sandbox_id="sandbox-1",
+                provider_name="opensandbox",
+                raw=AlreadyGoneRaw(),
+            ),
+        )
+
+    assert kill_calls == 1
+    assert any("already gone; treating terminate as success" in record.message for record in caplog.records)
+
+
+async def test_non_terminate_operation_still_raises_on_missing_sandbox() -> None:
+    from opensandbox.exceptions import SandboxApiException  # noqa: PLC0415
+
+    provider = opensandbox_provider.OpenSandboxProvider(
+        probe={"command": None},
+        operations={"retries": 2, "retry_delay_s": 0, "retry_max_delay_s": 0},
+    )
+    not_found = SandboxApiException("Get sandbox sandbox-1 failed: Sandbox 'sandbox-1' not found")
+    not_found.status_code = 404
+    get_info_calls = 0
+
+    class MissingRaw:
+        async def get_info(self) -> Any:
+            nonlocal get_info_calls
+            get_info_calls += 1
+            raise not_found
+
+    with pytest.raises(SandboxApiException, match="not found"):
+        await provider.status(
+            opensandbox_provider.SandboxHandle(
+                sandbox_id="sandbox-1",
+                provider_name="opensandbox",
+                raw=MissingRaw(),
+            ),
+        )
+
+    assert get_info_calls == 1
 
 
 async def test_create_once_and_connect_after_create_error_paths(


### PR DESCRIPTION
## Problem

Sandbox termination in the OpenSandbox provider is not idempotent. Two common producers hit an already-deleted sandbox:

1. **Double-termination races** — a rollout's failure-path cleanup deletes the sandbox, then agent/session teardown deletes it again.
2. **Startup cleanup** — cleanup kills sandboxes left over from a previous run that are already gone.

In both cases the server correctly answers HTTP 404 with error code `KUBERNETES::SANDBOX_NOT_FOUND`, but the provider routed the failed kill through the generic `close()` error path. This spams eval logs with warnings like:

```
WARNING:opensandbox.adapters.sandboxes_adapter:Failed to terminate sandbox <id>: Kill sandbox <id> failed: Sandbox '<id>' not found | [KUBERNETES::SANDBOX_NOT_FOUND] ...
```

and risks useless retry round-trips against a sandbox that no longer exists.

## Fix

Terminate's goal state is "sandbox gone", so a not-found on kill *is* success:

- `close()` now wraps the SDK `kill()` in a small coroutine that swallows not-found errors **inside the operation factory**, before the tenacity retry wrapper ever classifies them — a 404 on terminate is never retried.
- The swallowed case is logged at DEBUG (`"sandbox <id> already gone; treating terminate as success"`) instead of INFO/WARNING.
- `_is_missing_sandbox_delete_error()` now also recognizes an HTTP 404 status code (via the existing `_exception_status_code()` helper) and the `SANDBOX_NOT_FOUND` error-code marker, alongside the existing message match.
- Scope is terminate-only: every other operation (`status`, `exec`, file ops, ...) still fails loudly on a missing sandbox.

The SDK adapter's own WARNING line is emitted inside the opensandbox package before it raises, so one line per duplicate kill can still appear; this change guarantees no retry amplification and that the terminate succeeds.

## Test plan

- New: `test_close_treats_missing_sandbox_as_terminated_without_retry` — production-shaped `SandboxApiException` (404 + `KUBERNETES::SANDBOX_NOT_FOUND`) on kill with retries configured: `close()` succeeds, kill is attempted exactly once, DEBUG log emitted.
- New: `test_non_terminate_operation_still_raises_on_missing_sandbox` — the same 404 from `get_info` via `provider.status()` still raises and is not retried.
- Extended the retry-classification test with detector variants (404-status-only, error-code-only, message-only, negative case).
- `pytest tests/unit_tests/test_opensandbox_provider.py` → 48 passed; full sandbox unit-test set (`test_sandbox.py`, `test_sandbox_connect.py`, `test_opensandbox_pty.py` included) → 152 passed. `ruff check`/`ruff format` and `pre-commit` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)