### PR TITLE
feat(sandbox): replace httpx-aiohttp bridge with in-house aiohttp transport

### DIFF
--- a/nemo_gym/sandbox/providers/opensandbox/aiohttp_transport.py
+++ b/nemo_gym/sandbox/providers/opensandbox/aiohttp_transport.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-house aiohttp-backed ``httpx.AsyncBaseTransport`` for the OpenSandbox SDK.
+
+The OpenSandbox SDK is httpx-based with a pluggable transport, and its hottest
+path is a long-lived SSE stream per executed command, so transport behavior on
+streams is what matters most here. Compared to the ``httpx-aiohttp`` bridge it
+replaces, this transport:
+
+- Maps errors by phase with the real cause preserved. Mid-stream peer/proxy
+  disconnects raise ``httpx.ReadError`` with a message that says the connection
+  closed mid-response (aiohttp's own message for these is a framing-parser
+  error, "Not enough data to satisfy transfer length header", which reads like
+  a server bug); payload errors caused by a timeout raise ``httpx.ReadTimeout``;
+  connection errors raise ``ConnectError`` before the response starts and
+  ``ReadError`` after. The original aiohttp exception is always chained.
+- Cannot mask an in-flight exception from its cleanup path. Closing an
+  unfinished response hard-closes the connection instead of draining it, so
+  the ``ReadTimeout``/``CancelledError`` that interrupted the stream is what
+  callers see. Fully-consumed responses still release their connection for
+  keep-alive reuse.
+- Applies connect retries, which the bridge accepts but drops.
+  ``max_keepalive_connections`` has no aiohttp equivalent and is deliberately
+  not mapped: aiohttp's ``limit_per_host`` caps active concurrent connections
+  per host (not idle ones), which would throttle all traffic to this
+  transport's single target host. Idle connections are bounded by
+  ``keepalive_expiry`` -> ``keepalive_timeout``, the only honest keepalive
+  mapping (see the comment in ``_build_session``).
+
+httpx client semantics are preserved: bodies stream incrementally, the
+``read`` timeout applies per read operation (``read=None`` keeps an SSE stream
+open indefinitely), redirects, cookies, and content-encoding stay owned by the
+httpx client, never the transport.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator, Callable
+
+import aiohttp
+import httpx
+
+
+def _chain_has_timeout(exc: BaseException, depth: int = 5) -> bool:
+    """Return whether the exception's cause/context chain contains a timeout."""
+    current: BaseException | None = exc
+    for _ in range(depth):
+        if current is None:
+            return False
+        if isinstance(current, (asyncio.TimeoutError, TimeoutError)):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def _map_exception(exc: Exception, request: httpx.Request, *, in_body: bool) -> httpx.RequestError | None:
+    """Translate an aiohttp exception into the equivalent httpx error, or None to re-raise as-is.
+
+    ``in_body`` selects the taxonomy for ambiguous classes: the same connection
+    error is a connect failure before the response starts but a read failure
+    once the body is streaming.
+    """
+    detail = f"{type(exc).__name__}: {exc}"
+    if isinstance(exc, aiohttp.ClientPayloadError):
+        # Raised by aiohttp's payload parser when the body ends before the
+        # declared length, i.e. the peer or a proxy dropped the connection
+        # mid-response (or a read timed out mid-body, hence the chain check).
+        if _chain_has_timeout(exc):
+            return httpx.ReadTimeout(detail, request=request)
+        return httpx.ReadError(
+            f"connection closed before the response body completed "
+            f"(peer or proxy dropped the connection mid-response); {detail}",
+            request=request,
+        )
+    if isinstance(exc, aiohttp.ServerTimeoutError):
+        if isinstance(exc, getattr(aiohttp, "SocketTimeoutError", ())):
+            return httpx.ReadTimeout(detail, request=request)
+        if isinstance(exc, getattr(aiohttp, "ConnectionTimeoutError", ())):
+            return httpx.ConnectTimeout(detail, request=request)
+        return httpx.TimeoutException(detail, request=request)
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):
+        timeout_cls = httpx.ReadTimeout if in_body else httpx.ConnectTimeout
+        return timeout_cls(detail, request=request)
+    if isinstance(exc, aiohttp.ServerDisconnectedError):
+        return httpx.RemoteProtocolError(
+            f"server disconnected without completing the response ({detail})", request=request
+        )
+    if isinstance(exc, aiohttp.ClientProxyConnectionError):
+        return httpx.ProxyError(detail, request=request)
+    if isinstance(exc, aiohttp.ClientConnectorError):
+        return httpx.ConnectError(detail, request=request)
+    if isinstance(exc, (aiohttp.NonHttpUrlClientError, aiohttp.InvalidUrlClientError)):
+        return httpx.UnsupportedProtocol(detail, request=request)
+    if isinstance(exc, aiohttp.ClientConnectionError):
+        connection_cls = httpx.ReadError if in_body else httpx.ConnectError
+        return connection_cls(detail, request=request)
+    if isinstance(exc, aiohttp.ClientError):
+        return httpx.TransportError(detail, request=request)
+    return None
+
+
+class _AiohttpByteStream(httpx.AsyncByteStream):
+    """Incremental byte stream over an aiohttp response body."""
+
+    CHUNK_SIZE = 64 * 1024
+
+    def __init__(self, response: aiohttp.ClientResponse, request: httpx.Request) -> None:
+        self._response = response
+        self._request = request
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        try:
+            async for chunk in self._response.content.iter_chunked(self.CHUNK_SIZE):
+                yield chunk
+        except Exception as exc:
+            mapped = _map_exception(exc, self._request, in_body=True)
+            if mapped is not None:
+                raise mapped from exc
+            raise
+
+    async def aclose(self) -> None:
+        # A fully-read response gives its connection back for keep-alive
+        # reuse; an abandoned or errored stream hard-closes it. Draining an
+        # unfinished body here (``release()``) can itself raise a payload
+        # error during cleanup and mask the exception that interrupted the
+        # stream, so it must only happen at EOF.
+        if self._response.content.is_eof():
+            self._response.release()
+        else:
+            self._response.close()
+
+
+class AiohttpTransport(httpx.AsyncBaseTransport):
+    """httpx async transport that sends requests through a shared aiohttp ClientSession.
+
+    Args:
+        limits: httpx pool limits. ``max_connections`` caps in-flight
+            connections (None = unlimited) and ``keepalive_expiry`` is the
+            idle socket lifetime. ``max_keepalive_connections`` is ignored:
+            aiohttp has no idle-pool-size knob (see ``_build_session``).
+        force_close: Close the connection after every request instead of
+            pooling it (``limits.keepalive_expiry`` is then ignored: aiohttp
+            rejects a keepalive timeout on a force-closed connector).
+        verify: Disable TLS certificate verification when False.
+        retries: Retry a failed TCP connect this many times. Connect failures
+            happen before anything is sent, so retrying cannot duplicate a
+            request.
+        client: Optional externally-owned ``aiohttp.ClientSession`` (or a
+            zero-argument factory called lazily on the running loop). When
+            given, ``limits`` and ``verify`` are ignored: the session's own
+            connector governs pooling.
+        close_client: Whether ``aclose()`` closes the session. Defaults to
+            closing only a session this transport created.
+    """
+
+    def __init__(
+        self,
+        *,
+        limits: httpx.Limits | None = None,
+        force_close: bool = False,
+        verify: bool = True,
+        retries: int = 0,
+        client: aiohttp.ClientSession | Callable[[], aiohttp.ClientSession] | None = None,
+        close_client: bool | None = None,
+    ) -> None:
+        self._limits = limits or httpx.Limits(max_connections=100, max_keepalive_connections=20)
+        self._force_close = force_close
+        self._verify = verify
+        self._retries = retries
+        self._client_arg = client
+        self._session: aiohttp.ClientSession | None = client if isinstance(client, aiohttp.ClientSession) else None
+        self._close_client = (
+            close_client if close_client is not None else not isinstance(client, aiohttp.ClientSession)
+        )
+        # Created lazily with the session: __init__ may run outside any event loop.
+        self._session_lock: asyncio.Lock | None = None
+
+    def _build_session(self) -> aiohttp.ClientSession:
+        if callable(self._client_arg):
+            return self._client_arg()
+        # A force-closed connector rejects any keepalive timeout, so the
+        # keepalive mapping only applies to pooling connectors.
+        keepalive_kwargs = {} if self._force_close else {"keepalive_timeout": self._limits.keepalive_expiry}
+        connector = aiohttp.TCPConnector(
+            # aiohttp: limit=0 means unlimited; httpx: None means unlimited.
+            limit=self._limits.max_connections or 0,
+            # limits.max_keepalive_connections is deliberately NOT mapped.
+            # httpx's knob caps IDLE reusable connections; aiohttp's
+            # limit_per_host caps ACTIVE concurrent connections per host, and
+            # this transport's traffic targets a single host, so mapping the
+            # stock value (20) would throttle all concurrency to 20. aiohttp
+            # has no idle-pool-size knob; idle connections are bounded by
+            # keepalive_timeout expiry instead.
+            limit_per_host=0,
+            force_close=self._force_close,
+            ssl=None if self._verify else False,
+            **keepalive_kwargs,
+        )
+        return aiohttp.ClientSession(
+            connector=connector,
+            timeout=aiohttp.ClientTimeout(),  # timeouts come per request from httpx
+            cookie_jar=aiohttp.DummyCookieJar(),  # httpx owns cookies
+        )
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is not None:
+            return self._session
+        if self._session_lock is None:
+            self._session_lock = asyncio.Lock()
+        async with self._session_lock:
+            if self._session is None:
+                self._session = self._build_session()
+        return self._session
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        session = await self._get_session()
+        timeout = request.extensions.get("timeout", {})
+
+        try:
+            data: bytes | httpx.AsyncByteStream = request.content
+        except httpx.RequestNotRead:
+            data = request.stream  # aiohttp handles chunked framing itself
+            request.headers.pop("transfer-encoding", None)
+
+        for attempt in range(self._retries + 1):
+            try:
+                response = await session.request(
+                    method=request.method,
+                    url=str(request.url),
+                    headers=request.headers.multi_items(),
+                    data=data,
+                    allow_redirects=False,  # httpx owns redirects
+                    auto_decompress=False,  # httpx owns content-encoding
+                    compress=False,
+                    timeout=aiohttp.ClientTimeout(
+                        sock_connect=timeout.get("connect"),
+                        sock_read=timeout.get("read"),
+                        connect=timeout.get("pool"),
+                    ),
+                )
+                break
+            except aiohttp.ClientConnectorError as exc:
+                if attempt >= self._retries:
+                    raise httpx.ConnectError(f"{type(exc).__name__}: {exc}", request=request) from exc
+            except Exception as exc:
+                mapped = _map_exception(exc, request, in_body=False)
+                if mapped is not None:
+                    raise mapped from exc
+                raise
+
+        return httpx.Response(
+            status_code=response.status,
+            headers=response.headers.items(),
+            stream=_AiohttpByteStream(response, request),
+            extensions={"http_version": b"HTTP/1.1"},
+        )
+
+    async def aclose(self) -> None:
+        if self._close_client and self._session is not None:
+            await self._session.close()

--- a/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
+++ b/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
@@ -34,8 +34,9 @@ sandbox:
       # null for no cap.
       max_connections: null
       connect_retries: 2
-      # "aiohttp" routes through the optional httpx-aiohttp bridge, falling
-      # back to httpx with a warning when it is not installed.
+      # "aiohttp" uses the in-house aiohttp transport (incremental SSE
+      # streaming with clearer mid-stream error mapping); "httpx" uses the
+      # httpx default.
       transport_backend: aiohttp
     create:
       request_timeout_s: 1200

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -377,8 +377,8 @@ class OpenSandboxConnectionConfig:
     ``keepalive_expiry_s`` must stay below the server's own keep-alive idle
     timeout (uvicorn defaults to 5s), or pooled sockets are reused after the
     server has closed them; null falls back to the SDK's default transport.
-    ``transport_backend`` is "httpx" or "aiohttp" (via the optional
-    ``httpx-aiohttp`` bridge, falling back to httpx when it is absent).
+    ``transport_backend`` is "httpx" or "aiohttp" (the in-house aiohttp
+    transport, ``nemo_gym.sandbox.providers.opensandbox.aiohttp_transport``).
     The pool is shared, so ``max_connections`` also caps in-flight sandbox
     operations per process; null means no cap.
     """
@@ -692,15 +692,16 @@ class OpenSandboxProvider:
             keepalive_expiry=self._connection.keepalive_expiry_s,
         )
         if self._connection.transport_backend == "aiohttp":
-            try:
-                from httpx_aiohttp import AiohttpTransport
+            from nemo_gym.sandbox.providers.opensandbox.aiohttp_transport import AiohttpTransport
 
-                return AiohttpTransport(limits=limits, retries=self._connection.connect_retries)
-            except ImportError:
-                LOGGER.warning(
-                    "connection.transport_backend=aiohttp requested but httpx-aiohttp "
-                    "is not installed; falling back to the httpx transport"
-                )
+            return AiohttpTransport(
+                limits=limits,
+                # aiohttp has no idle-pool-size knob, so zeroing the keepalive
+                # count (how the httpx backend disables pooling) does nothing
+                # here; a force-closed connector is the aiohttp equivalent.
+                force_close=self._connection.disable_connection_pooling,
+                retries=self._connection.connect_retries,
+            )
         return httpx.AsyncHTTPTransport(limits=limits, retries=self._connection.connect_retries)
 
     async def _retire_closed_pty_sessions(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,14 +257,6 @@ sandbox = [
     # License: Apache 2.0
     "opensandbox>=0.1.15",
 
-    # httpx-aiohttp: aiohttp-backed httpx transport used by the OpenSandbox
-    # provider's `connection.transport_backend: aiohttp`; without it the
-    # provider silently falls back to the httpx transport with only a warning.
-    # Pulls in aiohttp (aiohttp<4,>=3.10).
-    # Updated: Tue Aug 11, 2026 with httpx-aiohttp>=0.2.0
-    # License: BSD 3-Clause https://github.com/karpetrosyan/httpx-aiohttp/blob/master/LICENSE
-    "httpx-aiohttp>=0.2.0",
-
     # Daytona SDK: used by the Daytona sandbox provider for create/exec/delete and file operations.
     # License: Apache 2.0 https://pypi.org/project/daytona/
     "daytona>=0.179.0",

--- a/tests/unit_tests/test_opensandbox_aiohttp_transport.py
+++ b/tests/unit_tests/test_opensandbox_aiohttp_transport.py
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import time
+from typing import AsyncIterator
+
+import aiohttp
+import httpx
+import pytest
+from aiohttp import web
+
+from nemo_gym.sandbox.providers.opensandbox.aiohttp_transport import AiohttpTransport, _map_exception
+
+
+pytestmark = pytest.mark.sandbox
+
+
+@pytest.fixture
+async def server_url() -> AsyncIterator[str]:
+    """Local aiohttp server exercising the transport behaviors that matter for the SDK."""
+
+    async def echo_json(request: web.Request) -> web.Response:
+        return web.json_response({"echo": await request.json(), "method": request.method})
+
+    async def health(request: web.Request) -> web.Response:
+        return web.json_response({"status": "ok"})
+
+    async def sse(request: web.Request) -> web.StreamResponse:
+        # SSE-style chunked stream: ?chunks=N&delay=S between chunks.
+        resp = web.StreamResponse(status=200, headers={"Content-Type": "text/event-stream"})
+        await resp.prepare(request)
+        for i in range(int(request.query.get("chunks", "4"))):
+            await resp.write(f"data: {i}\n\n".encode())
+            await asyncio.sleep(float(request.query.get("delay", "0")))
+        await resp.write_eof()
+        return resp
+
+    async def stall(request: web.Request) -> web.StreamResponse:
+        # Two quick chunks, then silence: a stalled-but-open stream.
+        resp = web.StreamResponse(status=200, headers={"Content-Type": "text/event-stream"})
+        await resp.prepare(request)
+        for i in range(2):
+            await resp.write(f"data: {i}\n\n".encode())
+            await asyncio.sleep(0.02)
+        try:
+            await asyncio.sleep(30)
+        except (ConnectionResetError, asyncio.CancelledError):
+            pass
+        return resp
+
+    async def abort(request: web.Request) -> web.StreamResponse:
+        # Hard TCP close mid-body: what a proxy reaping a connection looks like.
+        resp = web.StreamResponse(status=200, headers={"Content-Type": "text/event-stream"})
+        await resp.prepare(request)
+        await resp.write(b"data: 0\n\n")
+        await asyncio.sleep(0.02)
+        request.transport.abort()
+        return resp
+
+    async def redirect(request: web.Request) -> web.Response:
+        raise web.HTTPFound("/health")
+
+    app = web.Application()
+    app.router.add_post("/json", echo_json)
+    app.router.add_get("/health", health)
+    app.router.add_get("/sse", sse)
+    app.router.add_get("/stall", stall)
+    app.router.add_get("/abort", abort)
+    app.router.add_get("/redirect", redirect)
+
+    runner = web.AppRunner(app, access_log=None)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = runner.addresses[0][1]
+    yield f"http://127.0.0.1:{port}"
+    await runner.cleanup()
+
+
+def _client(timeout: httpx.Timeout | float = 10.0, **transport_kwargs: object) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=AiohttpTransport(**transport_kwargs), timeout=timeout)
+
+
+async def test_roundtrip_and_concurrency(server_url: str) -> None:
+    async with _client() as client:
+        response = await client.post(f"{server_url}/json", json={"a": [1, 2]})
+        assert response.status_code == 200
+        assert response.json() == {"echo": {"a": [1, 2]}, "method": "POST"}
+
+        results = await asyncio.gather(*(client.get(f"{server_url}/health") for _ in range(30)))
+        assert all(r.status_code == 200 for r in results)
+
+
+async def test_concurrency_not_capped_by_keepalive_limit(server_url: str) -> None:
+    # Regression: max_keepalive_connections (idle-connection cap in httpx)
+    # must not become aiohttp's limit_per_host (active-connection cap). All
+    # traffic targets one host, so that mis-mapping serializes requests in
+    # waves of the keepalive count: 8 requests of ~0.4s each at a cap of 2
+    # would need 4 waves (~1.6s) instead of one (~0.4s).
+    limits = httpx.Limits(max_connections=50, max_keepalive_connections=2)
+    async with _client(limits=limits) as client:
+        start = time.monotonic()
+        responses = await asyncio.gather(
+            *(client.get(f"{server_url}/sse", params={"chunks": 1, "delay": 0.4}) for _ in range(8))
+        )
+        elapsed = time.monotonic() - start
+    assert all(r.status_code == 200 for r in responses)
+    assert elapsed < 1.2, f"requests were serialized by a per-host cap: {elapsed:.2f}s for 8 x 0.4s"
+
+
+async def test_streaming_is_incremental(server_url: str) -> None:
+    # Chunks written 0.3s apart must be observed as they arrive; a transport
+    # that buffers the body would deliver them all at once (near-zero gaps).
+    arrivals = []
+    async with _client() as client:
+        async with client.stream("GET", f"{server_url}/sse", params={"chunks": 4, "delay": 0.3}) as response:
+            assert response.status_code == 200
+            async for line in response.aiter_lines():
+                if line.startswith("data:"):
+                    arrivals.append(time.monotonic())
+    assert len(arrivals) == 4
+    gaps = [b - a for a, b in zip(arrivals, arrivals[1:])]
+    assert all(gap > 0.1 for gap in gaps), f"stream was buffered, inter-chunk gaps: {gaps}"
+
+
+async def test_mid_stream_stall_raises_read_timeout(server_url: str) -> None:
+    async with _client(timeout=httpx.Timeout(10.0, read=0.3)) as client:
+        chunks = 0
+        with pytest.raises(httpx.ReadTimeout):
+            async with client.stream("GET", f"{server_url}/stall") as response:
+                async for line in response.aiter_lines():
+                    if line.startswith("data:"):
+                        chunks += 1
+        assert chunks == 2  # data flowed until the stall
+
+
+async def test_read_none_stream_outlives_other_timeouts(server_url: str) -> None:
+    # The SDK's SSE client disables the read timeout but keeps connect/write
+    # bounds; a stream whose total duration exceeds those bounds must survive
+    # (guards against mapping any timeout onto the whole stream).
+    timeout = httpx.Timeout(connect=0.3, read=None, write=0.3, pool=None)
+    async with _client(timeout=timeout) as client:
+        chunks = 0
+        async with client.stream("GET", f"{server_url}/sse", params={"chunks": 4, "delay": 0.25}) as response:
+            async for line in response.aiter_lines():
+                if line.startswith("data:"):
+                    chunks += 1
+        assert chunks == 4
+
+
+async def test_mid_stream_disconnect_raises_diagnostic_read_error(server_url: str) -> None:
+    async with _client() as client:
+        with pytest.raises(httpx.ReadError) as exc_info:
+            async with client.stream("GET", f"{server_url}/abort") as response:
+                async for _ in response.aiter_lines():
+                    pass
+    # The message must say what happened, not just aiohttp's framing-parser
+    # text, and the original aiohttp exception must stay chained for debugging.
+    assert "connection closed before the response body completed" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, aiohttp.ClientPayloadError)
+
+
+async def test_abandoned_stream_closes_cleanly_and_pool_survives(server_url: str) -> None:
+    async with _client() as client:
+        async with client.stream("GET", f"{server_url}/sse", params={"chunks": 500}) as response:
+            async for line in response.aiter_lines():
+                if line.startswith("data: 2"):
+                    break  # abandon mid-body; aclose must not raise
+        followup = await client.get(f"{server_url}/health")
+        assert followup.status_code == 200
+
+
+async def test_redirects_stay_with_httpx(server_url: str) -> None:
+    async with _client() as client:
+        response = await client.get(f"{server_url}/redirect")
+        assert response.status_code == 302
+        followed = await client.get(f"{server_url}/redirect", follow_redirects=True)
+        assert followed.status_code == 200 and len(followed.history) == 1
+
+
+async def test_connect_error_maps_and_retries_run(server_url: str) -> None:
+    async with _client(retries=2) as client:
+        with pytest.raises(httpx.ConnectError):
+            await client.get("http://127.0.0.1:9/health")  # discard port: nothing listens
+
+
+async def test_injected_session_is_shared_and_not_closed(server_url: str) -> None:
+    session = aiohttp.ClientSession(cookie_jar=aiohttp.DummyCookieJar())
+    try:
+        async with _client(client=session) as client:
+            response = await client.get(f"{server_url}/health")
+            assert response.status_code == 200
+        assert not session.closed  # externally-owned session survives aclose()
+    finally:
+        await session.close()
+
+
+async def test_limits_map_to_connector() -> None:
+    transport = AiohttpTransport(
+        limits=httpx.Limits(max_connections=7, max_keepalive_connections=3, keepalive_expiry=2.5)
+    )
+    session = await transport._get_session()
+    try:
+        assert session.connector.limit == 7
+        # max_keepalive_connections must NOT reach limit_per_host: httpx's
+        # knob caps idle connections while aiohttp's caps active concurrent
+        # connections per host, and all this transport's traffic targets one
+        # host, so mapping it would cap concurrency at the keepalive count.
+        assert session.connector.limit_per_host == 0
+        assert session.connector._keepalive_timeout == 2.5
+    finally:
+        await transport.aclose()
+    assert session.closed  # transport-owned session closes with the transport
+
+    unlimited = AiohttpTransport(limits=httpx.Limits(max_connections=None, max_keepalive_connections=0))
+    session = await unlimited._get_session()
+    try:
+        assert session.connector.limit == 0  # aiohttp spelling of "unlimited"
+        assert session.connector.limit_per_host == 0
+    finally:
+        await unlimited.aclose()
+
+    # force_close (disable_connection_pooling) reaches the connector; the
+    # keepalive timeout must be omitted then (aiohttp rejects the combination).
+    no_pooling = AiohttpTransport(limits=httpx.Limits(max_connections=7, keepalive_expiry=2.5), force_close=True)
+    session = await no_pooling._get_session()
+    try:
+        assert session.connector.force_close is True
+    finally:
+        await no_pooling.aclose()
+
+
+def test_exception_taxonomy() -> None:
+    request = httpx.Request("GET", "http://example.invalid/")
+
+    def mapped(exc: Exception, *, in_body: bool = True) -> httpx.RequestError | None:
+        return _map_exception(exc, request, in_body=in_body)
+
+    # Payload errors: read timeout when a timeout caused them, else a read
+    # error whose message states the connection closed mid-response.
+    payload = aiohttp.ClientPayloadError("Response payload is not completed")
+    assert type(mapped(payload)) is httpx.ReadError
+    assert "connection closed before the response body completed" in str(mapped(payload))
+    timed_out = aiohttp.ClientPayloadError("Response payload is not completed")
+    timed_out.__cause__ = asyncio.TimeoutError()
+    assert type(mapped(timed_out)) is httpx.ReadTimeout
+
+    assert type(mapped(aiohttp.SocketTimeoutError())) is httpx.ReadTimeout
+    assert type(mapped(aiohttp.ConnectionTimeoutError())) is httpx.ConnectTimeout
+    assert type(mapped(aiohttp.ServerTimeoutError())) is httpx.TimeoutException
+    assert type(mapped(asyncio.TimeoutError(), in_body=True)) is httpx.ReadTimeout
+    assert type(mapped(asyncio.TimeoutError(), in_body=False)) is httpx.ConnectTimeout
+    assert type(mapped(aiohttp.ServerDisconnectedError())) is httpx.RemoteProtocolError
+    # Bare connection errors are phase-dependent: connect failure before the
+    # response starts, read failure once the body is streaming.
+    assert type(mapped(aiohttp.ClientConnectionError(), in_body=False)) is httpx.ConnectError
+    assert type(mapped(aiohttp.ClientConnectionError(), in_body=True)) is httpx.ReadError
+    assert type(mapped(aiohttp.ClientError())) is httpx.TransportError
+    assert mapped(ValueError("not an aiohttp error")) is None

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -16,7 +16,6 @@
 import asyncio
 import builtins
 import logging
-import sys
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
@@ -535,7 +534,7 @@ def test_connection_config_and_image_policy(fake_opensandbox_sdk: None) -> None:
     assert "headers" not in direct._connection_config().kwargs
 
 
-def test_connection_transport_backends(fake_opensandbox_sdk: None, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_connection_transport_backends(fake_opensandbox_sdk: None) -> None:
     # Default backend is httpx, with the configured keepalive expiry on the pool.
     provider = opensandbox_provider.OpenSandboxProvider()
     transport = provider._build_transport()
@@ -555,13 +554,6 @@ def test_connection_transport_backends(fake_opensandbox_sdk: None, monkeypatch: 
     assert isinstance(transport, httpx.AsyncHTTPTransport)
     # connect_retries reaches the pool rather than silently falling back.
     assert transport._pool._retries == 1
-
-    # aiohttp requested but httpx-aiohttp unavailable: falls back to httpx.
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setitem(sys.modules, "httpx_aiohttp", None)
-        provider = opensandbox_provider.OpenSandboxProvider(connection={"transport_backend": "aiohttp"})
-        transport = provider._build_transport()
-        assert isinstance(transport, httpx.AsyncHTTPTransport)
 
     # keepalive_expiry_s=null disables transport injection entirely.
     provider = opensandbox_provider.OpenSandboxProvider(connection={"keepalive_expiry_s": None})
@@ -600,17 +592,36 @@ async def test_connection_transport_is_shared_and_closed_by_provider(fake_opensa
     assert provider._transport is None
 
 
-def test_connection_transport_backend_aiohttp_opt_in(fake_opensandbox_sdk: None) -> None:
-    # Opt-in aiohttp backend via the httpx-aiohttp bridge; the package is not a
-    # declared dependency, so this coverage only runs where it is installed.
-    httpx_aiohttp = pytest.importorskip("httpx_aiohttp", reason="optional httpx-aiohttp is not installed")
-    provider = opensandbox_provider.OpenSandboxProvider(connection={"transport_backend": "aiohttp"})
+def test_connection_transport_backend_aiohttp(fake_opensandbox_sdk: None) -> None:
+    # The "aiohttp" backend selects the in-house transport, carrying pool
+    # limits and connect retries through.
+    from nemo_gym.sandbox.providers.opensandbox.aiohttp_transport import AiohttpTransport
+
+    provider = opensandbox_provider.OpenSandboxProvider(
+        connection={
+            "transport_backend": "aiohttp",
+            "keepalive_expiry_s": 2.5,
+            "max_connections": 7,
+            "max_keepalive_connections": 3,
+            "connect_retries": 1,
+        }
+    )
     transport = provider._build_transport()
-    assert isinstance(transport, httpx_aiohttp.AiohttpTransport)
-    assert transport.limits.keepalive_expiry == 3.0
-    # Both backends honor connect_retries; the bridge default is 0, so this
-    # would catch the option being dropped on the aiohttp path.
-    assert transport.retries == 2
+    assert isinstance(transport, AiohttpTransport)
+    assert transport._limits.max_connections == 7
+    assert transport._limits.max_keepalive_connections == 3
+    assert transport._limits.keepalive_expiry == 2.5
+    assert transport._retries == 1
+    assert transport._force_close is False
+
+    # disable_connection_pooling works via force-close on this backend (the
+    # httpx backend's zeroed keepalive count means nothing to aiohttp).
+    no_pooling_provider = opensandbox_provider.OpenSandboxProvider(
+        connection={"transport_backend": "aiohttp", "disable_connection_pooling": True}
+    )
+    no_pooling_transport = no_pooling_provider._build_transport()
+    assert isinstance(no_pooling_transport, AiohttpTransport)
+    assert no_pooling_transport._force_close is True
 
     extensions = provider._resolve_extensions({"imagePullPolicy": "Never"})
     assert extensions["imagePullPolicy"] == "Never"

--- a/uv.lock
+++ b/uv.lock
@@ -1639,19 +1639,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-aiohttp"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "httpx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/87/3b2df9732a497403e5f4bbf2ec9f25427d53cec797e83070c503649863ef/httpx_aiohttp-0.2.0.tar.gz", hash = "sha256:d4796b981f04734f1d1db9b4d9326ea16bc994f126460b93b69036262cd4a9d8", size = 195714, upload-time = "2026-07-25T07:34:12.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/e2/74b6bad3a6d342aee12d8b8d825456c02d21d72319c924326d17444c5ff7/httpx_aiohttp-0.2.0-py3-none-any.whl", hash = "sha256:ccd6eb19ba18805476096e8ef0b369a6beda3955db145a538979eface2fce7ff", size = 9732, upload-time = "2026-07-25T07:34:10.939Z" },
-]
-
-[[package]]
 name = "httpx-sse"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2591,7 +2578,6 @@ all = [
     { name = "daytona" },
     { name = "defusedxml" },
     { name = "gprof2dot" },
-    { name = "httpx-aiohttp" },
     { name = "mypy" },
     { name = "opensandbox" },
     { name = "pre-commit" },
@@ -2622,7 +2608,6 @@ openshell = [
 sandbox = [
     { name = "boto3" },
     { name = "daytona" },
-    { name = "httpx-aiohttp" },
     { name = "opensandbox" },
     { name = "tenacity" },
 ]
@@ -2653,7 +2638,6 @@ requires-dist = [
     { name = "fonttools", specifier = ">=4.60.2" },
     { name = "gitpython", specifier = ">=3.1.57" },
     { name = "gprof2dot", marker = "extra == 'dev'" },
-    { name = "httpx-aiohttp", marker = "extra == 'sandbox'", specifier = ">=0.2.0" },
     { name = "hydra-core" },
     { name = "itsdangerous" },
     { name = "mcp", specifier = ">=1.28.1,<2" },


### PR DESCRIPTION
## Summary

Replaces the OpenSandbox sandbox provider's optional `httpx-aiohttp` bridge with an in-house `httpx.AsyncBaseTransport` implemented over aiohttp (`AiohttpTransport` in `nemo_gym/sandbox/providers/opensandbox/aiohttp_transport.py`).

- The existing `connection.transport_backend: "aiohttp"` config value now selects the in-house transport — **user configs keep working unchanged**, and there is no new backend name.
- The `httpx-aiohttp` dependency is removed from `pyproject.toml`/`uv.lock`, along with the provider's silent fall-back-to-httpx branch: aiohttp is already a core dependency, so the backend is always available. (`provider.py` was the only core import site; the aviary resources server pulls `httpx_aiohttp` transitively via `fhaviary` in its own isolated venv and is unaffected.)
- `transport_backend: "httpx"` behavior is unchanged.

**Behavior changes on the aiohttp path** (for reviewers): `connection.connect_retries` and `connection.disable_connection_pooling` now take effect — the bridge accepted both but silently dropped them (`retries` was stored and never used; disabling pooling worked by zeroing the keepalive count, which never reached the bridge's connector). `disable_connection_pooling` maps to a force-closed connector (fresh connection per request). Error types raised for mid-stream failures also change as described below (`ReadError`/`ReadTimeout` instead of `ConnectTimeout`/parser-level text), which interacts with retry heuristics that match on exception type or message. `connection.max_keepalive_connections` remains unmapped on this path, deliberately — see design notes.

## Motivation

The OpenSandbox SDK's hottest path is a long-lived SSE stream per executed command, so transport behavior on streams — and how stream failures surface — matters. Owning the transport fixes things the bridge gets wrong:

- **Error mapping**: mid-stream peer/proxy disconnects surface as `httpx.ReadError` with a message stating the connection closed mid-response, with the original aiohttp exception chained — instead of aiohttp's parser-level "TransferEncodingError: Not enough data to satisfy transfer length header" text, which reads like a server framing bug and misdirects debugging. Payload errors whose cause chain contains a timeout surface as `httpx.ReadTimeout`. Connection errors map by phase (`ConnectError` before the response starts, `ReadError` mid-body; the bridge maps `ClientConnectionError` to `ConnectTimeout`).
- **Cleanup cannot mask the real failure**: closing an unfinished response hard-closes the connection instead of draining it (`release()`), so a cleanup-path payload error can never replace the `ReadTimeout`/`CancelledError` that actually interrupted the stream. Fully-consumed responses still release their connection for keep-alive reuse.
- **Config knobs actually apply**: `connect_retries` retries failed TCP connects (pre-send only, so a request can never be duplicated), and `disable_connection_pooling` genuinely forces a fresh connection per request via `TCPConnector(force_close=True)`.

It also supports injecting an externally-owned `aiohttp.ClientSession` (or factory) for shared-connector setups.

## Design notes

- httpx client semantics preserved: bodies stream incrementally; the `read` timeout applies per read operation (`read=None` keeps SSE streams open indefinitely, matching the SDK's SSE client config); redirects, cookies, and content-encoding stay owned by the httpx client.
- **`limits.max_keepalive_connections` is deliberately not mapped onto the connector.** httpx's knob caps *idle reusable* connections; aiohttp's `limit_per_host` caps *active concurrent* connections per host. This transport's traffic all targets a single host, so mapping the stock value (20) turns an idle-pool tuning knob into a hard concurrency cap of 20 per process. aiohttp has no idle-pool-size equivalent; idle connections are bounded by `keepalive_expiry` -> `keepalive_timeout` expiry, the only honest keepalive mapping. `limit_per_host` stays 0 (unlimited); total concurrency remains governed by `max_connections`.
- A force-closed connector rejects a keepalive timeout, so `force_close=True` omits the keepalive mapping.
- Timeout mapping mirrors the bridge: httpx `connect`/`read`/`pool` map to aiohttp `sock_connect`/`sock_read`/`connect`; no total deadline is ever applied.
- Lazy session creation is serialized with a lock (concurrent first requests cannot leak sessions).
- Benchmarked at parity with the bridge through the same `httpx.AsyncClient` harness against a local aiohttp server: small-JSON roundtrips at high concurrency, 50 concurrent SSE streams, and 5 MB downloads were all within run-to-run noise of each other.

## Test plan

- [x] `tests/unit_tests/test_opensandbox_aiohttp_transport.py` (new, 12 tests, real local aiohttp server): GET/POST roundtrips and 30-way concurrency; **regression test that concurrency is not serialized by the keepalive count** (8 concurrent 0.4s requests with `max_keepalive_connections=2` must complete in ~one wave — this exact `limit_per_host` mis-mapping was caught in a production-scale validation run, where it capped per-process concurrency at the stock keepalive value and starved throughput); incremental SSE delivery (inter-chunk arrival gaps asserted, guards against buffering); mid-stream stall raises `httpx.ReadTimeout`; `read=None` stream outlives connect/write timeouts; mid-stream TCP abort raises diagnostic `ReadError` with cause chained; abandoned stream closes cleanly and the pool survives; redirects stay with httpx; connect errors map (with retries exercised); injected session is shared and not closed; limits map to the connector (`limit_per_host=0`, `force_close` reaches the connector with keepalive omitted); direct `_map_exception` taxonomy coverage.
- [x] `tests/unit_tests/test_opensandbox_provider.py`: `test_connection_transport_backend_aiohttp` asserts the "aiohttp" backend selects the in-house transport, carries limits/retries through, and maps `disable_connection_pooling` to `force_close`; the bridge-unavailable fallback test is removed with the fallback itself.
- [x] Full `test_opensandbox_provider.py` + new file: 58 passed.
- [x] `uv lock` diff contains only the `httpx-aiohttp` removal.
- [x] `ruff check`, `ruff format --check`, and `pre-commit run` on changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)