### PR TITLE
fix(longmt): derive runtime caches from Gym config

### DIFF
--- a/resources_servers/longmt_eval/README.md
+++ b/resources_servers/longmt_eval/README.md
@@ -114,7 +114,7 @@ same one (creation order is `[GPU0×A, GPU1×A, ...]`; dispatch order becomes
 
 uv ships python-build-standalone binaries whose absolute paths differ across
 containers. `segale_actor.py` copies the venv's Python root to a
-shared-FS path at `LONGMT_EVAL_PY_CACHE` (default `/opt/Gym/.cache/longmt-python`)
+shared-FS path at `LONGMT_EVAL_PY_CACHE` (default `<Gym cache directory>/longmt-python`)
 so remote Ray workers can resolve a stable `py_executable` at runtime. Set
 `LONGMT_EVAL_PY_CACHE` to a Lustre path when running across nodes.
 
@@ -196,11 +196,12 @@ For a full SLURM run with SEGALE enabled on WMT24++ see
 
 | Variable | Purpose |
 |----------|---------|
-| `LASER_HOME` | Path to the LASER2 model weights (required for SEGALE actors) |
+| `LASER_HOME` | Path to the LASER2 model weights; defaults to `<Gym cache directory>/longmt-laser` |
 | `HF_HOME` / `HF_HUB_CACHE` | HuggingFace cache; COMETKiwi checkpoint resolved here |
 | `HF_HUB_OFFLINE` | Set to `1` to prevent any HF Hub network calls |
-| `ERSATZ` | Path to the ersatz segmenter model weights |
-| `LONGMT_EVAL_PY_CACHE` | Shared-FS path for the mirrored uv Python root used by Ray workers |
+| `ERSATZ` | Path to the ersatz segmenter model weights; defaults to `<Gym cache directory>/longmt-ersatz` |
+| `LONGMT_COMET_CACHE` | Path to downloaded COMET checkpoints; defaults to `<Gym cache directory>/longmt-comet` |
+| `LONGMT_EVAL_PY_CACHE` | Shared-FS path for the mirrored uv Python root; defaults to `<Gym cache directory>/longmt-python` |
 
 ## Licensing
 

--- a/resources_servers/longmt_eval/segale_actor.py
+++ b/resources_servers/longmt_eval/segale_actor.py
@@ -22,11 +22,21 @@ from typing import Dict, List, Optional
 
 import ray
 
+from nemo_gym import CACHE_DIR
+from nemo_gym.global_config import CACHE_DIR_KEY_NAME, maybe_get_global_config_dict
+
 
 LOG = logging.getLogger(__name__)
 
 
-def _mirror_python(cache_env_var: str, default_cache: str) -> Path:
+def _cache_dir() -> Path:
+    """Return the configured Gym cache directory without triggering a config parse."""
+    global_config_dict = maybe_get_global_config_dict()
+    configured = global_config_dict.get(CACHE_DIR_KEY_NAME) if global_config_dict is not None else None
+    return Path(configured) if configured else CACHE_DIR
+
+
+def _mirror_python(cache_env_var: str, default_cache: str | Path) -> Path:
     """Mirror the venv's uv Python install to a shared-FS path for Ray workers.
 
     Identical strategy to wmt_translation/app.py: uv ships python-build-
@@ -103,7 +113,7 @@ def _download_comet_model(comet_model: str) -> str:
     """Fetch a COMET checkpoint once and return its path; its non-HF URL fallback isn't race-safe."""
     from comet import download_model
 
-    cache_root = os.environ.get("LONGMT_COMET_CACHE", "/opt/Gym/.cache/longmt-comet")
+    cache_root = os.environ.get("LONGMT_COMET_CACHE", str(_cache_dir() / "longmt-comet"))
     dest = os.path.join(cache_root, comet_model.replace("/", "__"))
     _download_once(dest, lambda tmp: download_model(comet_model, saving_directory=tmp))
     # Files are present now; resolve the checkpoint path locally, no network.
@@ -127,9 +137,10 @@ def _build_segale_actor_class(actors_per_gpu: int = 1, use_extra_gpu: bool = Fal
         Use this when the gym joins the vLLM Ray cluster and a separate node has
         been registered with `ray start --resources='{"extra_gpu": N}'`.
     """
+    cache_dir = _cache_dir()
     mirrored_bin = _mirror_python(
         "LONGMT_EVAL_PY_CACHE",
-        "/opt/Gym/.cache/longmt-python",
+        cache_dir / "longmt-python",
     )
 
     venv_dir = Path(sys.executable).parent.parent
@@ -151,8 +162,9 @@ def _build_segale_actor_class(actors_per_gpu: int = 1, use_extra_gpu: bool = Fal
     for key in ("HF_HOME", "HF_HUB_OFFLINE", "HF_HUB_CACHE", "TRANSFORMERS_CACHE"):
         if os.environ.get(key):
             env_vars[key] = os.environ[key]
-    env_vars["LASER_HOME"] = os.environ.get("LASER_HOME", "/opt/Gym/.cache/longmt-laser")
-    env_vars["ERSATZ"] = os.environ.get("ERSATZ", "/opt/Gym/.cache/longmt-ersatz")
+    env_vars["LASER_HOME"] = os.environ.get("LASER_HOME", str(cache_dir / "longmt-laser"))
+    env_vars["ERSATZ"] = os.environ.get("ERSATZ", str(cache_dir / "longmt-ersatz"))
+    env_vars["LONGMT_COMET_CACHE"] = os.environ.get("LONGMT_COMET_CACHE", str(cache_dir / "longmt-comet"))
 
     gpu_fraction = 1 / actors_per_gpu
     if use_extra_gpu:

--- a/resources_servers/longmt_eval/tests/test_app.py
+++ b/resources_servers/longmt_eval/tests/test_app.py
@@ -384,6 +384,30 @@ class TestBuildSegaleActorClass:
         assert py_exec.endswith("bin/python3.12")
         assert (mirror_root / "cpython-3.12.12-linux-x86_64-gnu" / "bin" / "python3.12").exists()
 
+    def test_default_paths_use_configured_gym_cache_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        import segale_actor as sa_module
+
+        fake_python = self._fake_venv(tmp_path)
+        cache_dir = tmp_path / "gym_cache"
+
+        monkeypatch.setattr(sys, "executable", str(fake_python))
+        monkeypatch.setattr(sa_module, "maybe_get_global_config_dict", lambda: {"cache_dir": str(cache_dir)})
+        monkeypatch.delenv("LONGMT_EVAL_PY_CACHE", raising=False)
+        monkeypatch.delenv("LASER_HOME", raising=False)
+        monkeypatch.delenv("ERSATZ", raising=False)
+        monkeypatch.delenv("LONGMT_COMET_CACHE", raising=False)
+
+        captured = {}
+        monkeypatch.setattr(sa_module, "ray", MagicMock(remote=self._stub_ray_remote(captured)))
+
+        sa_module._build_segale_actor_class()
+
+        runtime_env = captured["decorator_kwargs"]["runtime_env"]
+        assert runtime_env["py_executable"].startswith(str(cache_dir / "longmt-python"))
+        assert runtime_env["env_vars"]["LASER_HOME"] == str(cache_dir / "longmt-laser")
+        assert runtime_env["env_vars"]["ERSATZ"] == str(cache_dir / "longmt-ersatz")
+        assert runtime_env["env_vars"]["LONGMT_COMET_CACHE"] == str(cache_dir / "longmt-comet")
+
     def test_extra_gpu_sets_noset_cuda_env_var(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """use_extra_gpu=True must set RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES."""
         import segale_actor as sa_module
@@ -802,6 +826,24 @@ class TestDownloadCometModel:
         assert calls[0][0].endswith(".tmp")
         assert calls[1] == (str(dest), True)
         assert not list(dest.parent.glob("*.tmp"))
+
+    def test_default_path_uses_configured_gym_cache_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        import segale_actor
+
+        comet = pytest.importorskip("comet")
+        calls: list = []
+        monkeypatch.setattr(comet, "download_model", self._fake_download_model(calls))
+        monkeypatch.setattr(
+            segale_actor,
+            "maybe_get_global_config_dict",
+            lambda: {"cache_dir": str(tmp_path / "gym_cache")},
+        )
+        monkeypatch.delenv("LONGMT_COMET_CACHE", raising=False)
+
+        ckpt = segale_actor._download_comet_model("model")
+
+        dest = tmp_path / "gym_cache" / "longmt-comet" / "model"
+        assert ckpt == str(dest / "checkpoints" / "model.ckpt")
 
     def test_idempotent_second_call_only_resolves(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         import segale_actor


### PR DESCRIPTION
## Summary
- resolve LongMT runtime cache defaults through Gym's configured `cache_dir` instead of `/opt/Gym/.cache`
- propagate the resolved COMET cache to Ray actors while preserving all existing environment-variable overrides
- document the defaults and add regression coverage for configured cache paths

## Test plan
- [x] Run `resources_servers/longmt_eval/tests/test_app.py`
- [x] Run scoped pre-commit checks for the changed files