### PR TITLE
feat(sandbox): dedicated short timeout for background status polls

### DIFF
--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
@@ -78,7 +78,7 @@ The provider constructor accepts four optional config sections:
 | `connection` | OpenSandbox SDK connection settings: domain, API key, protocol, request timeout, and server proxy mode. |
 | `create` | Sandbox create timeout, retry, image pull policy, and health-check behavior. |
 | `probe` | Post-create command probe used to verify command execution before the sandbox is returned. |
-| `operations` | Retry and timeout behavior for SDK operations after create, including command retries and close timeout. |
+| `operations` | Retry and timeout behavior for SDK operations after create, including command retries, close timeout, background command polling, and the dedicated `status_poll_timeout_s` budget for background status polls. |
 
 ## SandboxSpec Provider Options
 

--- a/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
+++ b/nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
@@ -70,6 +70,11 @@ sandbox:
       # e.g. on SWE Bench Verified 500 samples with 3 repeats = 1500 concurrent samples, we would do polling every `background_poll_interval_s` seconds
       background_poll_initial_s: 1.0
       background_poll_interval_s: 30.0
+      # Per-request budget for status polls, which are small idempotent GETs:
+      # without their own short budget, each poll against an unreachable
+      # sandbox hangs for the full connection request_timeout_s (tuned for
+      # long submits) per retry. null falls back to that shared budget.
+      status_poll_timeout_s: 10.0
     # Job attribution merged into every sandbox's metadata. OpenSandbox propagates
     # metadata as Kubernetes labels on the sandbox resources, so sandboxes are
     # attributable both via the OpenSandbox list API and at the cluster level, e.g.

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -1257,9 +1257,17 @@ class OpenSandboxProvider:
             if sdk_timeout_s is None or (self._operations.background_exec and timeout_s is None):
                 return await _dispatch()
             hard_cap_s = 2.0 * float(sdk_timeout_s) + 30.0
+            # asyncio.timeout instead of wait_for: since Python 3.11
+            # asyncio.TimeoutError IS builtin TimeoutError, so a wait_for-based
+            # cap would also catch timeouts raised INSIDE the dispatch (e.g. an
+            # exhausted status-poll budget) and relabel them as a hard-cap trip.
+            hard_cap = asyncio.timeout(hard_cap_s)
             try:
-                return await asyncio.wait_for(_dispatch(), timeout=hard_cap_s)
-            except asyncio.TimeoutError as e:
+                async with hard_cap:
+                    return await _dispatch()
+            except TimeoutError as e:
+                if not hard_cap.expired():
+                    raise
                 raise TimeoutError(
                     f"OpenSandbox exec exceeded hard cap of {hard_cap_s:g}s; the command wedged "
                     f"(sandbox_id={handle.sandbox_id!r})"

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -509,6 +509,11 @@ class OpenSandboxOperationConfig:
     # Backs off from initial to interval.
     background_poll_initial_s: float = 0.25
     background_poll_interval_s: float = 2.0
+    # Per-request budget for background-command status polls, which are small
+    # idempotent GETs: without their own short budget, each poll against an
+    # unreachable sandbox hangs for the shared request timeout (tuned for long
+    # submits) before failing. None falls back to that shared budget.
+    status_poll_timeout_s: float | None = 10.0
 
     def __post_init__(self) -> None:
         if self.retries < 0:
@@ -525,6 +530,8 @@ class OpenSandboxOperationConfig:
             raise ValueError("operations.background_poll_interval_s must be > 0")
         if self.background_poll_initial_s <= 0:
             raise ValueError("operations.background_poll_initial_s must be > 0")
+        if self.status_poll_timeout_s is not None and self.status_poll_timeout_s <= 0:
+            raise ValueError("operations.status_poll_timeout_s must be > 0")
 
 
 @dataclass(frozen=True)
@@ -794,6 +801,10 @@ class OpenSandboxProvider:
         sandbox_id: str,
         timeout_s: float | None,
         retries: int | None = None,
+        # The default classifier treats per-call timeouts as terminal, which is
+        # right for mutating calls but wrong for short idempotent polls; those
+        # callers pass their own predicate.
+        is_retryable: Callable[[BaseException], bool] = _is_retryable_sdk_operation_error,
     ) -> Any:
         AsyncRetrying, retry_if_exception, stop_after_attempt, wait_random_exponential = _require_tenacity()
         retry_count = self._operations.retries if retries is None else retries
@@ -803,7 +814,7 @@ class OpenSandboxProvider:
             _log_operation_retry(retry_state, operation=operation, sandbox_id=sandbox_id)
 
         retry_policy = AsyncRetrying(
-            retry=retry_if_exception(_is_retryable_sdk_operation_error),
+            retry=retry_if_exception(is_retryable),
             stop=stop_after_attempt(max_attempts),
             wait=wait_random_exponential(
                 multiplier=self._operations.retry_delay_s,
@@ -1324,6 +1335,21 @@ class OpenSandboxProvider:
         poll_timeout_s = (
             float(self._connection.request_timeout_s) if self._connection.request_timeout_s is not None else 60.0
         )
+        # Status polls are sub-second GETs; against an unreachable sandbox each
+        # one would otherwise hang for the shared budget above (tuned for long
+        # submits) per retry before the typed failure fires.
+        status_timeout_s = self._operations.status_poll_timeout_s
+        if status_timeout_s is None:
+            status_timeout_s = poll_timeout_s
+
+        def _status_poll_is_retryable(exception: BaseException) -> bool:
+            # The short budget makes poll timeouts routine rather than fatal:
+            # re-polling a status is an idempotent GET, so unlike a submit
+            # (where a timeout stays terminal to avoid a double-run) a timed-out
+            # poll retries within the normal budget instead of killing the command.
+            if isinstance(exception, TimeoutError):
+                return True
+            return _is_retryable_sdk_operation_error(exception)
 
         # Poll fast at first so the many short commands an agent issues are
         # detected promptly, then back off so long ones do not spam requests.
@@ -1333,8 +1359,9 @@ class OpenSandboxProvider:
                 lambda: handle.raw.commands.get_command_status(execution_id),
                 operation="command status",
                 sandbox_id=handle.sandbox_id,
-                timeout_s=poll_timeout_s,
+                timeout_s=status_timeout_s,
                 retries=self._operations.retries,
+                is_retryable=_status_poll_is_retryable,
             )
             # A renamed SDK field must not degrade silently: a missing `running`
             # would end the poll at once, a missing `exit_code` would score a

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -898,16 +898,21 @@ async def test_exec_background_rejects_status_missing_a_field(
         await provider.exec(handle, "make build", timeout_s=30)
 
 
-async def test_exec_hard_cap_converts_wait_for_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A wedged exec (hard wall-clock cap tripping) surfaces as TimeoutError."""
+async def test_exec_hard_cap_labels_genuinely_wedged_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A wedged exec (hard wall-clock cap tripping) surfaces as the hard-cap TimeoutError.
+
+    The cap formula floors the real duration at minutes, so the test shrinks it
+    by patching asyncio.timeout to ignore the requested duration — the genuine
+    cancellation-to-TimeoutError conversion path still runs.
+    """
 
     class FakeRunCommandOpts:
         def __init__(self, **kwargs: Any) -> None:
             self.kwargs = kwargs
 
     class FakeCommands:
-        async def run(self, command: str, *, opts: FakeRunCommandOpts) -> Any:  # pragma: no cover
-            return SimpleNamespace(id="exec-wedged")
+        async def run(self, command: str, *, opts: FakeRunCommandOpts) -> Any:
+            await asyncio.Event().wait()  # wedged: never returns
 
     class FakeRaw:
         def __init__(self) -> None:
@@ -919,23 +924,77 @@ async def test_exec_hard_cap_converts_wait_for_timeout(monkeypatch: pytest.Monke
         lambda: (object, object, FakeRunCommandOpts, object, object),
     )
 
-    # Simulate the outer hard-cap wait_for timing out before _dispatch completes.
-    async def fake_wait_for(awaitable: Any, timeout: float | None = None) -> Any:
-        if asyncio.iscoroutine(awaitable):
-            awaitable.close()
-        raise asyncio.TimeoutError
-
-    monkeypatch.setattr(asyncio, "wait_for", fake_wait_for)
+    real_timeout = asyncio.timeout
+    monkeypatch.setattr(asyncio, "timeout", lambda delay: real_timeout(0.05))
 
     provider = opensandbox_provider.OpenSandboxProvider(
         connection={"request_timeout_s": 5},
         probe={"command": None},
-        operations={"background_exec": True},
     )
     handle = opensandbox_provider.SandboxHandle(sandbox_id="sandbox-wedge", provider_name="opensandbox", raw=FakeRaw())
 
     with pytest.raises(TimeoutError, match="hard cap"):
         await provider.exec(handle, "sleep 999", timeout_s=30)
+
+
+async def test_exec_hard_cap_does_not_relabel_inner_timeouts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A TimeoutError raised inside the dispatch keeps its own message.
+
+    Since Python 3.11 asyncio.TimeoutError IS builtin TimeoutError, so a
+    wait_for-based cap caught e.g. an exhausted status-poll budget (a
+    minutes-scale failure) and relabeled it as a trip of the hours-scale hard
+    cap, corrupting the failure taxonomy. Only the cap's own expiry may carry
+    the wedged message.
+    """
+
+    class FakeRunCommandOpts:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    class FakeCommands:
+        def __init__(self) -> None:
+            self.status_calls = 0
+
+        async def run(self, command: str, *, opts: FakeRunCommandOpts) -> Any:
+            return SimpleNamespace(id="exec-slowpolls")
+
+        async def get_command_status(self, execution_id: str) -> Any:
+            self.status_calls += 1
+            raise TimeoutError("simulated status poll budget expiry")
+
+        async def get_background_command_logs(self, execution_id: str) -> Any:  # pragma: no cover
+            return SimpleNamespace(content="ok", cursor=None)
+
+    monkeypatch.setattr(
+        opensandbox_provider,
+        "_require_opensandbox_sdk",
+        lambda: (object, object, FakeRunCommandOpts, object, object),
+    )
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    provider = opensandbox_provider.OpenSandboxProvider(
+        connection={"request_timeout_s": 120},
+        probe={"command": None},
+        operations={
+            "background_exec": True,
+            "retries": 1,
+            "retry_delay_s": 0.001,
+            "background_poll_interval_s": 0.01,
+        },
+    )
+    commands = FakeCommands()
+    handle = opensandbox_provider.SandboxHandle(
+        sandbox_id="sandbox-slowpolls", provider_name="opensandbox", raw=SimpleNamespace(commands=commands)
+    )
+
+    with pytest.raises(TimeoutError) as exc_info:
+        await provider.exec(handle, "echo ok", timeout_s=30)
+
+    # The poll-budget failure surfaced with its own message (after using its
+    # retry budget), not relabeled as the wall-clock hard cap tripping.
+    assert commands.status_calls == 2
+    assert "command status" in str(exc_info.value)
+    assert "hard cap" not in str(exc_info.value)
 
 
 @pytest.mark.parametrize("request_timeout_s", [None, 5])

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -432,6 +432,7 @@ def test_provider_validation_and_retry_helpers() -> None:
         {"operations": {"retry_max_delay_s": -1}},
         {"operations": {"command_retries": -1}},
         {"operations": {"close_timeout_s": 0}},
+        {"operations": {"status_poll_timeout_s": 0}},
         {"create": {"connect_attempt_timeout_s": 0}},
         {"create": {"connect_poll_s": 0}},
         {"create": {"image_pull_policy": "Sometimes"}},
@@ -1575,3 +1576,135 @@ async def test_exec_persistent_502_raises_typed_backend_unreachable(
         await provider.exec(handle, "echo ok", timeout_s=30)
 
     assert calls["n"] == 3  # operations.retries + 1 submissions, then typed failure
+
+
+@pytest.mark.parametrize(
+    ("operations_overrides", "expected_status_timeout_s"),
+    [
+        ({}, 10.0),  # config default
+        ({"status_poll_timeout_s": 5.0}, 5.0),
+        ({"status_poll_timeout_s": None}, 120.0),  # falls back to the shared request budget
+    ],
+)
+@pytest.mark.asyncio
+async def test_exec_background_status_polls_use_dedicated_timeout(
+    monkeypatch: pytest.MonkeyPatch, operations_overrides: dict[str, Any], expected_status_timeout_s: float
+) -> None:
+    """Status polls get their own short budget; the submit and logs calls keep theirs.
+
+    Status polls are sub-second GETs, so inheriting the shared request budget
+    (tuned for long submits) lets each poll against an unreachable sandbox hang
+    for minutes. status_poll_timeout_s: None restores the shared budget.
+    """
+
+    class FakeRunCommandOpts:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    class FakeCommands:
+        async def run(self, command: str, *, opts: FakeRunCommandOpts) -> Any:
+            return SimpleNamespace(id="exec-budget")
+
+        async def get_command_status(self, execution_id: str) -> Any:
+            return SimpleNamespace(running=False, exit_code=0, error=None)
+
+        async def get_background_command_logs(self, execution_id: str) -> Any:
+            return SimpleNamespace(content="ok", cursor=None)
+
+    monkeypatch.setattr(
+        opensandbox_provider,
+        "_require_opensandbox_sdk",
+        lambda: (object, object, FakeRunCommandOpts, object, object),
+    )
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    recorded: dict[str, float | None] = {}
+    real_await_sdk_call = opensandbox_provider.OpenSandboxProvider._await_sdk_call
+
+    async def recording_await_sdk_call(
+        self: Any, awaitable: Any, *, operation: str, sandbox_id: str, timeout_s: float | None
+    ) -> Any:
+        recorded[operation] = timeout_s
+        return await real_await_sdk_call(
+            self, awaitable, operation=operation, sandbox_id=sandbox_id, timeout_s=timeout_s
+        )
+
+    monkeypatch.setattr(opensandbox_provider.OpenSandboxProvider, "_await_sdk_call", recording_await_sdk_call)
+
+    provider = opensandbox_provider.OpenSandboxProvider(
+        connection={"request_timeout_s": 120},
+        probe={"command": None},
+        operations={"background_exec": True, "background_poll_interval_s": 0.01, **operations_overrides},
+    )
+    handle = opensandbox_provider.SandboxHandle(
+        sandbox_id="sandbox-budget", provider_name="opensandbox", raw=SimpleNamespace(commands=FakeCommands())
+    )
+
+    result = await provider.exec(handle, "echo ok", timeout_s=30)
+
+    assert result.return_code == 0
+    assert recorded["command status"] == expected_status_timeout_s
+    # Everything else keeps its existing budget: submit gets timeout_s + 60
+    # headroom, logs the shared request budget (payloads can be large).
+    assert recorded["command run (background submit)"] == 90.0
+    assert recorded["command logs"] == 120.0
+
+
+@pytest.mark.asyncio
+async def test_exec_background_retries_timed_out_status_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A timed-out status poll retries instead of killing the running command.
+
+    Per-call timeouts are deliberately terminal for submits (a retry could
+    double-run the command), so with the short poll budget a single slow poll
+    would otherwise fail the whole command; re-polling a status is an
+    idempotent GET and must retry within the normal budget.
+    """
+
+    class FakeRunCommandOpts:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    class FakeCommands:
+        def __init__(self) -> None:
+            self.status_calls: list[str] = []
+
+        async def run(self, command: str, *, opts: FakeRunCommandOpts) -> Any:
+            return SimpleNamespace(id="exec-slowpoll")
+
+        async def get_command_status(self, execution_id: str) -> Any:
+            self.status_calls.append(execution_id)
+            if len(self.status_calls) == 1:
+                # Surfaces through _await_sdk_call the same way an expired
+                # per-call budget does (asyncio.TimeoutError is TimeoutError).
+                raise TimeoutError("simulated status poll budget expiry")
+            return SimpleNamespace(running=False, exit_code=0, error=None)
+
+        async def get_background_command_logs(self, execution_id: str) -> Any:
+            return SimpleNamespace(content="ok", cursor=None)
+
+    monkeypatch.setattr(
+        opensandbox_provider,
+        "_require_opensandbox_sdk",
+        lambda: (object, object, FakeRunCommandOpts, object, object),
+    )
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    provider = opensandbox_provider.OpenSandboxProvider(
+        connection={"request_timeout_s": 120},
+        probe={"command": None},
+        operations={
+            "background_exec": True,
+            "retries": 2,
+            "retry_delay_s": 0.001,
+            "background_poll_interval_s": 0.01,
+        },
+    )
+    commands = FakeCommands()
+    handle = opensandbox_provider.SandboxHandle(
+        sandbox_id="sandbox-slowpoll", provider_name="opensandbox", raw=SimpleNamespace(commands=commands)
+    )
+
+    result = await provider.exec(handle, "echo ok", timeout_s=30)
+
+    assert commands.status_calls == ["exec-slowpoll", "exec-slowpoll"]
+    assert result.return_code == 0


### PR DESCRIPTION
## Summary

Background-command **status polls** are sub-second idempotent GETs, but they inherit the general `request_timeout_s` budget (tuned for long submits/creates, often minutes). Against a sandbox whose pod has become unreachable (a blackholed IP that swallows SYNs), each poll then hangs for a full TCP connect timeout before failing — retries × minutes per dead sandbox before the typed unreachable error fires, tying up a rollout slot the whole time.

### feat: dedicated short timeout for background status polls

- New `operations.status_poll_timeout_s: float | None = 10.0`: per-request budget for background-command **status polls only**. A healthy poll answers in milliseconds and even the slow legitimate path (endpoint re-resolution plus a connect retry) is a few seconds. `None` restores the previous behavior; submits keep their `timeout_s + 60` headroom and the logs fetch keeps the shared budget.
- A per-call timeout surfaces as builtin `TimeoutError`, which the default retry classifier deliberately treats as terminal (a long timeout has already burned its budget — and `TimeoutError` subclasses `OSError`, which would otherwise be retried). With a 10s budget that would make a single slow poll rollout-fatal, so `_await_sdk_operation` gains a pluggable `is_retryable` predicate (default unchanged for all other callers) and the status-poll path passes one that retries timeouts — safe because a status poll is an idempotent GET, unlike a submit where a timeout must stay terminal.
- With the retry budget, an unresponsive sandbox is detected in ~1 minute instead of ~25+.

### fix: stop relabeling inner timeouts as the exec hard cap

Pre-existing bug the short poll budget makes frequent: since Python 3.11 `asyncio.TimeoutError` IS builtin `TimeoutError`, so the `wait_for`-based hard-cap wrapper around exec dispatch also caught any `TimeoutError` raised *inside* the dispatch (e.g. a status poll exhausting its budget and retries) and relabeled that minutes-scale failure as `exceeded hard cap of <hours>s; the command wedged` — factually wrong, corrupting failure taxonomy. Now uses `asyncio.timeout` and attaches the wedged message only when the cap itself expired (`Timeout.expired()`); inner timeouts propagate with their original message.

## Note on the branch's original scope

This PR originally implemented duplicate-submission protection for background commands (adopting an already-scheduled execution after a lost submit response). Per-request tracking deployed at production scale (>115k requests across multiple 1024-way-parallel runs, with body-hash-level duplicate detection) observed **zero** duplicate submissions in practice, so that machinery was withdrawn to keep the provider simple; this PR now ships only the status-poll timeout work above.

## Tests

51 passed on the provider suite: parametrized per-operation timeout routing (poll gets the short budget; submit and logs keep theirs), `None` fallback, poll-timeout retryability, config validation, inner-timeout propagation with original message (fails against the old `wait_for` code), and a genuinely wedged dispatch still receiving the hard-cap label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
