### PR TITLE
fix(deepswe): configure git identity in the agent sandbox

### DIFF
--- a/resources_servers/deepswe/app.py
+++ b/resources_servers/deepswe/app.py
@@ -251,6 +251,20 @@ class DeepSWEResourcesServer(SimpleResourcesServer):
         )
         sandbox = AsyncSandbox(provider)
         await sandbox.start(spec)
+        if phase == "agent":
+            # The task images ship no git user identity, and git's identity
+            # auto-detection is hostname-dependent: an FQDN hostname passes
+            # with a warning, while a domainless one (e.g. a K8s pod name ->
+            # 'root@<pod>.(none)') makes every `git commit` fail with "Author
+            # identity unknown". v1.1 grading collects only committed work,
+            # so seed an explicit identity instead of relying on the sandbox
+            # provider's hostname format.
+            await sandbox.exec(
+                'git config --global user.email "agent@nemo-gym.local"'
+                ' && git config --global user.name "NeMo Gym Agent"'
+                " && git config --global --add safe.directory /app || true",
+                timeout_s=60,
+            )
         return sandbox
 
     async def _stop_sandbox(self, sandbox: AsyncSandbox, *, task_id: str, phase: str) -> None:


### PR DESCRIPTION
fix(deepswe): configure git identity in the agent sandbox

The DeepSWE task images ship no git user identity, so every agent git commit in the sandbox fails with "Author identity unknown". Since v1.1 grading only collects committed work (git diff base..HEAD), this silently zeroes strict scores for any model that doesn't self-recover by running git config itself.

Measured impact (Super iter3000, 113 tasks): 36/40 commit attempts; with this fix identity errors drop to 0 and score recovers.