### PR TITLE
feat: add raw_rewards_and_lengths to group-level reward profile metrics

### DIFF
--- a/nemo_gym/reward_profile.py
+++ b/nemo_gym/reward_profile.py
@@ -263,6 +263,14 @@ class RewardProfiler:
                 task_idx_to_rollout_infos[task_idx],
                 key=lambda r: r[ROLLOUT_INDEX_KEY_NAME],
             )
+            group_metrics["raw_rewards_and_lengths"] = [
+                {
+                    key: info[key]
+                    for key in (ROLLOUT_INDEX_KEY_NAME, "reward", "input_tokens", "output_tokens", "total_tokens")
+                    if key in info
+                }
+                for info in group_metrics["rollout_infos"]
+            ]
 
         agent_level_df = df.drop(columns=[ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME]).groupby("agent_name")
         agent_level_metrics = self.calculate_metrics_single_df(agent_level_df)

--- a/tests/unit_tests/test_reward_profile.py
+++ b/tests/unit_tests/test_reward_profile.py
@@ -32,6 +32,7 @@ class TestRewardProfile:
                     "num_rollouts",
                     "reward_profile_completion_pct",
                     "rollout_infos",
+                    "raw_rewards_and_lengths",
                 }:
                     row.pop(key)
 
@@ -402,6 +403,22 @@ class TestRewardProfile:
         ]
         assert row["mean/input_tokens"] == 4.0
         assert row["mean/verifier_score"] == 2.5
+        assert row["raw_rewards_and_lengths"] == [
+            {
+                "_ng_rollout_index": 0,
+                "reward": 0.0,
+                "input_tokens": 3,
+                "output_tokens": 4,
+                "total_tokens": 7,
+            },
+            {
+                "_ng_rollout_index": 1,
+                "reward": 1.0,
+                "input_tokens": 5,
+                "output_tokens": 7,
+                "total_tokens": 12,
+            },
+        ]
 
     def test_profile_from_data_missing_rollouts_requires_partial_flag(self) -> None:
         rows = [self._row(0, 0), self._row(0, 1)]


### PR DESCRIPTION
  ## What does this PR do?

  Adds a `raw_rewards_and_lengths` field to each per-task (group-level) row in the
  reward profiling output produced by `RewardProfiler.profile_from_data`.

  The field contains one entry per rollout, sorted by rollout index, with
  `_ng_rollout_index`, `reward`, and `input_tokens`/`output_tokens`/`total_tokens`
  (token keys included only when present in the rollout's usage). It is a cheap
  projection of the existing `rollout_infos`, so it flows through unchanged to both
  the `*_reward_profiling.jsonl` artifact and the group-level metrics returned by
  `compute_aggregate_metrics`.

  **Motivation:** aggregate stats like pass rate discard the per-rollout evidence
  behind them. Preserving each rollout's reward and length in the profiled output
  enables downstream length-aware filtering, checking whether passing rollouts are
  systematically shorter/longer than failing ones, and re-deriving pass rates
  (`passed = count(reward > 0)`, `total = len(list)`) without re-running rollouts.

  **Changes** (+25 lines, no deletions):
  - `nemo_gym/reward_profile.py`: build `raw_rewards_and_lengths` from the sorted
    `rollout_infos` in `profile_from_data` (+8)
  - `tests/unit_tests/test_reward_profile.py`: assert the new field's exact
    per-rollout contents in `test_rollout_infos_are_sorted_and_pass_rate_is_recoverable`,
    and add the key to the `_clean_metrics` ignore set (+17)

  ## Checklist

  - [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
  - [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
  - [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
  - [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
  - [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).