### PR TITLE
fix(docker): drop --ldconfig arg from enroot NVIDIA hook

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,10 +64,7 @@ apt-get install -y /tmp/enroot.deb
 rm /tmp/enroot.deb
 
 # Drop the --ldconfig arg from enroot's NVIDIA hook so nvidia-container-cli
-# reuses the sandbox's existing ld.so.cache instead of regenerating it. The
-# regeneration step fails under some Slurm/pyxis GPU cgroup configurations
-# ("ldcache error: process /usr/sbin/ldconfig.real failed with error code: 1"),
-# breaking GPU passthrough for nested enroot sandboxes.
+# reuses the sandbox's existing ld.so.cache instead of regenerating it.
 sed -i 's/cli_args=("--no-cgroups" "--ldconfig=@$(command -v ldconfig.real || command -v ldconfig)")/cli_args=("--no-cgroups")/' \
     /etc/enroot/hooks.d/98-nvidia.sh
 grep -q '^cli_args=("--no-cgroups")$' /etc/enroot/hooks.d/98-nvidia.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,6 +63,16 @@ curl -fSsL -o /tmp/enroot.deb \
 apt-get install -y /tmp/enroot.deb
 rm /tmp/enroot.deb
 
+# Drop the --ldconfig arg from enroot's NVIDIA hook. nvidia-container-cli's
+# ldconfig re-exec fails with "ldcache error: process /usr/sbin/ldconfig.real
+# failed with error code: 1" on this class of Slurm/pyxis GPU cgroup setup
+# (confirmed independently by NVIDIA's computelab team and reproduced here);
+# dropping the flag makes nvidia-container-cli reuse the existing ld.so.cache
+# instead of regenerating it, which sidesteps the failure.
+sed -i 's/cli_args=("--no-cgroups" "--ldconfig=@$(command -v ldconfig.real || command -v ldconfig)")/cli_args=("--no-cgroups")/' \
+    /etc/enroot/hooks.d/98-nvidia.sh
+grep -q '^cli_args=("--no-cgroups")$' /etc/enroot/hooks.d/98-nvidia.sh
+
 # Install nvidia-container-toolkit so enroot's NVIDIA hook
 # (/etc/enroot/hooks.d/98-nvidia.sh) can find nvidia-container-cli to inject
 # GPUs into enroot sandboxes. Without this, enroot sandboxes that request a

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,12 +63,11 @@ curl -fSsL -o /tmp/enroot.deb \
 apt-get install -y /tmp/enroot.deb
 rm /tmp/enroot.deb
 
-# Drop the --ldconfig arg from enroot's NVIDIA hook. nvidia-container-cli's
-# ldconfig re-exec fails with "ldcache error: process /usr/sbin/ldconfig.real
-# failed with error code: 1" on this class of Slurm/pyxis GPU cgroup setup
-# (confirmed independently by NVIDIA's computelab team and reproduced here);
-# dropping the flag makes nvidia-container-cli reuse the existing ld.so.cache
-# instead of regenerating it, which sidesteps the failure.
+# Drop the --ldconfig arg from enroot's NVIDIA hook so nvidia-container-cli
+# reuses the sandbox's existing ld.so.cache instead of regenerating it. The
+# regeneration step fails under some Slurm/pyxis GPU cgroup configurations
+# ("ldcache error: process /usr/sbin/ldconfig.real failed with error code: 1"),
+# breaking GPU passthrough for nested enroot sandboxes.
 sed -i 's/cli_args=("--no-cgroups" "--ldconfig=@$(command -v ldconfig.real || command -v ldconfig)")/cli_args=("--no-cgroups")/' \
     /etc/enroot/hooks.d/98-nvidia.sh
 grep -q '^cli_args=("--no-cgroups")$' /etc/enroot/hooks.d/98-nvidia.sh


### PR DESCRIPTION
## Summary
- Patches `/etc/enroot/hooks.d/98-nvidia.sh` at build time to drop the `--ldconfig=@...` arg passed to `nvidia-container-cli`
- Fixes nested enroot GPU sandboxes failing with:
  ```
  nvidia-container-cli: ldcache error: process /usr/sbin/ldconfig.real failed with error code: 1
  [ERROR] /etc/enroot/hooks.d/98-nvidia.sh exited with return code 1
  ```

## Context
Nested enroot GPU passthrough under Slurm/pyxis fails under some GPU cgroup configurations because `nvidia-container-cli`'s `--ldconfig=@...` flag makes it re-exec the sandbox's `ldconfig` to regenerate `ld.so.cache`, and that regeneration step crashes. Dropping the flag makes it reuse the existing cache instead, which avoids the failure. Reproduces with any container doing nested enroot GPU passthrough on affected clusters, not something specific to Gym.

## Test plan
- [x] Verified live on a cluster hitting this failure: with this patch applied to a running container's hook script, `nvidia-smi` succeeds inside a nested `enroot` sandbox (GPU visible) — previously failed at the hook step with the exact error above
- [ ] Verify a full image build applies the patch correctly (`grep` assertion in the Dockerfile fails the build loudly if the hook content changes upstream and the sed no longer matches)
- [ ] Re-run the real `gym env start` + `mini_swe_agent_2` + enroot repro from the original bug report against the rebuilt image