### PR TITLE
fix(reward-profile): narrow default key_metrics to mean/reward

### DIFF
--- a/fern/versions/latest/pages/evaluation/aggregate-metrics.mdx
+++ b/fern/versions/latest/pages/evaluation/aggregate-metrics.mdx
@@ -45,7 +45,7 @@ The output file is a JSON array with one entry per agent:
 |---|---|
 | `agent_ref` | Agent identity (`{"name": "..."}`) |
 | `agent_metrics` | Overall stats across all rollouts, plus any custom metrics from `compute_metrics()` |
-| `key_metrics` | Headline numbers (default: all `mean/*` entries from `agent_metrics`) |
+| `key_metrics` | Headline numbers (default: `mean/reward` only) |
 | `group_level_metrics` | Per-task breakdown — one entry per task with stats across that task's rollouts |
 
 ---
@@ -60,7 +60,7 @@ Receives all verify responses grouped by task. Use this for metrics that need th
 
 ### `get_key_metrics(agent_metrics)`
 
-Selects headline numbers from the final `agent_metrics` dict. Default returns all `mean/*` entries.
+Selects headline numbers from the final `agent_metrics` dict. Default returns just `mean/reward` (if present) — `agent_metrics` has a `mean/*` entry for every numeric field seen in verify responses (custom score fields, token usage counts, and so on), so surfacing all of them would produce a cluttered, non-differentiated summary. Override this to headline a different or additional metric, such as pass@k accuracy.
 
 ### Example: pass@k
 

--- a/nemo_gym/reward_profile.py
+++ b/nemo_gym/reward_profile.py
@@ -580,6 +580,20 @@ def highest_k_metrics(
     return {key: agent_metrics[key] for k, key in matches if k == max_k}
 
 
+def _default_key_metrics(agent_metrics: Dict[str, Any]) -> Dict[str, Any]:
+    """Narrow default headline metric: mean/reward only, if present.
+
+    ``agent_metrics`` has a mean/max/min/median/std entry for every numeric field seen in
+    verify responses (custom score fields, token usage counts, etc.), so naively taking all
+    mean/* entries produces a cluttered, non-differentiated summary. Reward is the one metric
+    every benchmark reports, so it is the only one surfaced unless a benchmark overrides
+    get_key_metrics() to report something more meaningful (e.g. pass@k accuracy).
+    """
+    if "mean/reward" in agent_metrics:
+        return {"mean/reward": agent_metrics["mean/reward"]}
+    return {}
+
+
 class AggregateMetricsMixin:
     """Mixin providing compute_metrics/get_key_metrics hooks and the aggregate_metrics endpoint.
 
@@ -607,9 +621,10 @@ class AggregateMetricsMixin:
     def get_key_metrics(self, agent_metrics: Dict[str, Any]) -> Dict[str, Any]:
         """Override to select headline metrics for this benchmark.
 
-        Default: all mean/* entries from agent_metrics.
+        Default: mean/reward only (see _default_key_metrics). Override for benchmarks
+        that should headline a different or additional metric, e.g. pass@k accuracy.
         """
-        return {k: v for k, v in agent_metrics.items() if k.startswith("mean/")}
+        return _default_key_metrics(agent_metrics)
 
 
 def _group_by_task(verify_responses: List[Dict[str, Any]]) -> List[List[Dict[str, Any]]]:
@@ -693,7 +708,7 @@ def compute_aggregate_metrics(
     if get_key_metrics_fn:
         key_metrics = get_key_metrics_fn(serialized_agent)
     else:
-        key_metrics = {k: v for k, v in serialized_agent.items() if k.startswith("mean/")}
+        key_metrics = _default_key_metrics(serialized_agent)
 
     return AggregateMetrics(
         group_level_metrics=serialized_group,

--- a/tests/unit_tests/test_aggregate_metrics.py
+++ b/tests/unit_tests/test_aggregate_metrics.py
@@ -119,6 +119,25 @@ class TestAggregateMetricsRoute:
         assert result.key_metrics["mean/reward"] == pytest.approx(1.0)
 
     @pytest.mark.asyncio
+    async def test_key_metrics_default_excludes_other_numeric_fields(self) -> None:
+        """Default key_metrics should surface mean/reward only, not every mean/* stat.
+
+        agent_metrics gets a mean/max/min/median/std entry for every numeric field in verify
+        responses (custom score fields, usage counts, etc.); key_metrics should stay narrow.
+        """
+        server = _make_server()
+        responses = [
+            {TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "reward": 1.0, "judgement_score": 4.0},
+            {TASK_INDEX_KEY_NAME: 1, ROLLOUT_INDEX_KEY_NAME: 0, "reward": 0.0, "judgement_score": 2.0},
+        ]
+        body = AggregateMetricsRequest(verify_responses=responses)
+
+        result = await server.aggregate_metrics(body)
+
+        assert "mean/judgement_score" in result.agent_metrics
+        assert result.key_metrics == {"mean/reward": pytest.approx(0.5)}
+
+    @pytest.mark.asyncio
     async def test_histograms_stripped(self) -> None:
         """RewardProfiler produces histograms; they should be stripped from the response."""
         server = _make_server()

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -897,7 +897,7 @@ class TestRolloutCollection:
                     "median/abc usage": 1.0,
                     "std/abc usage": 0.0,
                 },
-                "key_metrics": {"mean/abc usage": 1.0},
+                "key_metrics": {},
                 "group_level_metrics": actual_aggregate_metrics[0]["group_level_metrics"],
             }
         ]


### PR DESCRIPTION
AggregateMetricsMixin.get_key_metrics() previously surfaced every mean/* entry from agent_metrics as a "key metric" by default. Since agent_metrics gets a mean/max/min/median/std entry for every numeric field seen in verify responses (custom score fields, token usage counts, etc.), this made key_metrics just as cluttered as agent_metrics instead of a distinct, headline summary.

Default key_metrics now surfaces mean/reward only, the one metric every benchmark reports. Benchmarks that want additional headline metrics (e.g. pass@k accuracy) continue to do so via their existing get_key_metrics() overrides, which are unaffected.

Fixes #2756

<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

<!-- Briefly describe the change and the motivation. Link any related issue, e.g. "Closes #123". -->

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
