### PR TITLE
feat(nooa-agent): retain model-visible requests

### DIFF
--- a/responses_api_agents/nooa_agent/gym_llm.py
+++ b/responses_api_agents/nooa_agent/gym_llm.py
@@ -131,6 +131,7 @@ class GymResponsesLLM(UnifiedLLM):
         model_server_name: str,
         model_url_path: str,
         max_steps: int,
+        request_collector: list[NeMoGymResponseCreateParamsNonStreaming],
         response_collector: list[NeMoGymResponse],
         cookies: dict[str, str],
         timeline: list[TraceEvent] | None = None,
@@ -143,6 +144,7 @@ class GymResponsesLLM(UnifiedLLM):
         self._model_server_name = model_server_name
         self._model_url_path = model_url_path
         self._max_steps = max_steps
+        self._request_collector = request_collector
         self._response_collector = response_collector
         self._cookies = cookies
         self._timeline = timeline
@@ -203,6 +205,7 @@ class GymResponsesLLM(UnifiedLLM):
                 request[destination] = value
 
         body = NeMoGymResponseCreateParamsNonStreaming.model_validate(request)
+        self._request_collector.append(body.model_copy(deep=True))
         http_response = await self._server_client.post(
             server_name=self._model_server_name,
             url_path=self._model_url_path,

--- a/responses_api_agents/nooa_agent/runner.py
+++ b/responses_api_agents/nooa_agent/runner.py
@@ -20,7 +20,7 @@ from typing import Any, Protocol
 
 from nooa import Agent
 
-from nemo_gym.openai_utils import NeMoGymResponse
+from nemo_gym.openai_utils import NeMoGymResponse, NeMoGymResponseCreateParamsNonStreaming
 from nemo_gym.rollout_observability import ObservationGap
 from nemo_gym.server_utils import ServerClient
 from responses_api_agents.nooa_agent.config import NOOAInvocationConfig, validate_invocation
@@ -48,6 +48,7 @@ class NOOARunRequest:
 class NOOARunResult:
     return_value: Any
     agent: Agent
+    model_requests: list[NeMoGymResponseCreateParamsNonStreaming]
     model_responses: list[NeMoGymResponse]
     tool_executions: list[GymToolExecution]
     model_cookies: dict[str, str]
@@ -83,6 +84,7 @@ class EmbeddedNOOARunner:
         self._agent_class, _ = validate_invocation(invocation)
 
     async def run(self, request: NOOARunRequest) -> NOOARunResult:
+        model_requests: list[NeMoGymResponseCreateParamsNonStreaming] = []
         responses: list[NeMoGymResponse] = []
         executions: list[GymToolExecution] = []
         timeline: list[TraceEvent] = []
@@ -93,6 +95,7 @@ class EmbeddedNOOARunner:
             model_server_name=self._model_server_name,
             model_url_path=request.model_url_path,
             max_steps=self._max_steps,
+            request_collector=model_requests,
             response_collector=responses,
             cookies=request.model_cookies,
             timeline=timeline,
@@ -131,6 +134,7 @@ class EmbeddedNOOARunner:
         return NOOARunResult(
             return_value=return_value,
             agent=agent,
+            model_requests=model_requests,
             model_responses=responses,
             tool_executions=executions,
             model_cookies=request.model_cookies,

--- a/responses_api_agents/nooa_agent/tests/test_app.py
+++ b/responses_api_agents/nooa_agent/tests/test_app.py
@@ -110,6 +110,7 @@ def runner_result(run_request: object) -> NOOARunResult:
     return NOOARunResult(
         return_value="The weather is cold.",
         agent=MagicMock(),
+        model_requests=[],
         model_responses=[],
         tool_executions=[],
         model_cookies=run_request.model_cookies,

--- a/responses_api_agents/nooa_agent/tests/test_gym_llm.py
+++ b/responses_api_agents/nooa_agent/tests/test_gym_llm.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel
 
 from nemo_gym.openai_utils import (
     NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCallForTraining,
     NeMoGymResponseOutputMessageForTraining,
     NeMoGymResponseOutputText,
@@ -83,6 +84,7 @@ def make_llm(
     *,
     max_steps: int = 2,
     observation_gaps: list[ObservationGap] | None = None,
+    request_collector: list[NeMoGymResponseCreateParamsNonStreaming] | None = None,
 ) -> tuple[GymResponsesLLM, MagicMock, list[NeMoGymResponse]]:
     server_client = MagicMock()
     server_client.post = AsyncMock(return_value=FakeHTTPResponse(payload))
@@ -92,6 +94,7 @@ def make_llm(
         model_server_name="policy_model",
         model_url_path="/ng-rollout/rollout-1/v1/responses",
         max_steps=max_steps,
+        request_collector=request_collector if request_collector is not None else [],
         response_collector=collected,
         cookies={},
         observation_gaps=observation_gaps,
@@ -109,7 +112,8 @@ async def test_routes_messages_tools_and_sampling_to_gym() -> None:
         generation_log_probs=[-0.2],
         routed_experts=[[[0, 1]]],
     )
-    llm, client, collected = make_llm(model_response(output))
+    requests: list[NeMoGymResponseCreateParamsNonStreaming] = []
+    llm, client, collected = make_llm(model_response(output), request_collector=requests)
 
     result = await llm.acall(
         [{"role": "system", "content": "Be concise."}, {"role": "user", "content": "Weather?"}],
@@ -125,6 +129,8 @@ async def test_routes_messages_tools_and_sampling_to_gym() -> None:
     assert request["json"].temperature == 0.3
     assert request["json"].max_output_tokens == 128
     assert request["json"].tools[0]["name"] == "weather"
+    assert requests == [request["json"]]
+    assert requests[0] is not request["json"]
     assert result.content == "Cold"
     assert collected[0].output[0].prompt_token_ids == [1, 2]
     assert collected[0].output[0].routed_experts == [[[0, 1]]]

--- a/responses_api_agents/nooa_agent/tests/test_runner.py
+++ b/responses_api_agents/nooa_agent/tests/test_runner.py
@@ -325,11 +325,25 @@ async def test_real_nooa_codeact_rollout_calls_generated_gym_tool() -> None:
     )
 
     assert result.return_value == "cold"
+    assert result.model_requests == client.model_requests
+    assert result.model_requests is not client.model_requests
     assert [response.id for response in result.model_responses] == ["resp-1", "resp-2"]
     assert result.model_responses[0].output[0].generation_token_ids == [3, 4]
     prior_call = next(
         item for item in client.model_requests[1].input if item.type == "function_call" and item.call_id == "code-1"
     )
     assert prior_call.generation_token_ids == [3, 4]
+    code_output = next(
+        item
+        for item in client.model_requests[1].input
+        if item.type == "function_call_output" and item.call_id == "code-1"
+    )
+    assert code_output.output == "status: complete"
+    python_output = next(
+        item
+        for item in result.model_requests[1].input
+        if item.type == "message" and "PythonOutput" in str(item.content) and "cold" in str(item.content)
+    )
+    assert "cold" in str(python_output.content)
     assert result.tool_executions[0].name == "get_weather"
     assert [event.kind for event in result.timeline] == ["model", "tool", "model"]


### PR DESCRIPTION
## Summary
- capture a deep copy of every exact Responses request issued by the NOOA LLM adapter
- expose model requests alongside responses in `NOOARunResult`, preserving internal tool outputs and all model-visible context
- verify real CodeAct stdout and tool-result content can be reconstructed from the run result

## Stack architecture
The cross-PR module and request-flow diagram is maintained in [the base PR, #2744](https://github.com/NVIDIA-NeMo/Gym/pull/2744#stack-architecture-and-request-flow).

## Test plan
- [x] `uv run --with nooa==0.0.9 pytest responses_api_agents/nooa_agent/tests -q`
- [x] `uv run pre-commit run --files responses_api_agents/nooa_agent/gym_llm.py responses_api_agents/nooa_agent/runner.py responses_api_agents/nooa_agent/tests/test_app.py responses_api_agents/nooa_agent/tests/test_gym_llm.py responses_api_agents/nooa_agent/tests/test_runner.py`
