### PR TITLE
feat(nemotron_3.5_super): report the model under a caller-supplied name

### DIFF
--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -6,9 +6,6 @@ set -euo pipefail
 NUM_PREFILL_NODES=$NUM_PREFILL_NODES
 NUM_DECODE_NODES=$NUM_DECODE_NODES
 MODEL=$MODEL
-# The name vLLM serves under and the eval reports. Defaults to $MODEL, which is
-# a container path, so a caller that mounts every checkpoint at the same path
-# can still say which one it ran.
 MODEL_NAME="${MODEL_NAME:-$MODEL}"
 CONTAINER=$CONTAINER
 MOUNTS=$MOUNTS

--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -6,6 +6,10 @@ set -euo pipefail
 NUM_PREFILL_NODES=$NUM_PREFILL_NODES
 NUM_DECODE_NODES=$NUM_DECODE_NODES
 MODEL=$MODEL
+# The name vLLM serves under and the eval reports. Defaults to $MODEL, which is
+# a container path, so a caller that mounts every checkpoint at the same path
+# can still say which one it ran.
+MODEL_NAME="${MODEL_NAME:-$MODEL}"
 CONTAINER=$CONTAINER
 MOUNTS=$MOUNTS
 VLLM_CONFIG=$VLLM_CONFIG
@@ -68,7 +72,7 @@ gym eval run \
     ++reuse_existing_data_preparation=true \
     ++policy_base_url=http://\$(getent hosts "\$ROUTER_NODE" | awk 'NR == 1 {print \$1}'):$ROUTER_SERVER_PORT/v1 \
     ++policy_api_key=dummy_api_key \
-    ++policy_model_name=$MODEL \
+    ++policy_model_name=$MODEL_NAME \
     ++upload_rollouts=false \
     ++global_aiohttp_connector_limit_per_host=16384 \
     ++port_range_low=63000 \
@@ -153,14 +157,14 @@ if (( SLURM_PROCID < $NUM_PREFILL_NODES )); then
     # Prefill
     VLLM_NIXL_SIDE_CHANNEL_HOST=\$this_node_hostname \
     VLLM_NIXL_SIDE_CHANNEL_PORT=$PREFILL_VLLM_NIXL_SIDE_CHANNEL_PORT \
-    vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_PREFILL_ARGS[@]}" \
+    vllm serve "$MODEL" --served-model-name "$MODEL_NAME" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_PREFILL_ARGS[@]}" \
         --host \$this_node_hostname \
         --port $WORKER_SERVER_PORT
 else
     # Decode
     VLLM_NIXL_SIDE_CHANNEL_HOST=\$this_node_hostname \
     VLLM_NIXL_SIDE_CHANNEL_PORT=$DECODE_VLLM_NIXL_SIDE_CHANNEL_PORT \
-    vllm serve "$MODEL" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_DECODE_ARGS[@]}" \
+    vllm serve "$MODEL" --served-model-name "$MODEL_NAME" "\${VLLM_COMMON_ARGS[@]}" "\${VLLM_DECODE_ARGS[@]}" \
         --host \$this_node_hostname \
         --port $WORKER_SERVER_PORT
 fi


### PR DESCRIPTION
## Problem

In `benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh` the reported model name is derived from the serve path — one variable feeds both:

```bash
vllm serve "$MODEL"
++policy_model_name=$MODEL
```

Under the current coupling, the only way to give a run a meaningful name is to rename the mount, and that is a trap: anything else addressing that mount by path (`--chat-template /checkpoint/...`, `--reasoning-parser-plugin /checkpoint/...`) silently points at a path that is no longer mounted, and vLLM fails to load it. We hit exactly that.

## Change

`MODEL_NAME` names the model independently of where it is mounted:

- vLLM serves under it (`--served-model-name`), so the endpoint answers to it.
- The eval sends it (`++policy_model_name`), so the two cannot disagree.

This lets the caller keep the mount fixed and still say which checkpoint a run used.

Tested on a run