### PR TITLE
fix(token-id-capture): classify auxiliary model requests

### DIFF
--- a/fern/versions/latest/pages/training-tutorials/external-agent-harnesses.mdx
+++ b/fern/versions/latest/pages/training-tutorials/external-agent-harnesses.mdx
@@ -90,6 +90,20 @@ claude_code_agent:
 
 Both the run-wide `enabled` setting and the agent opt-in are required. To capture every configured agent, set `token_id_capture.all_agents: true` instead of setting the flag on each agent.
 
+Some harnesses probe optional model-server endpoints such as `/v1/models`. Gym does not need to implement or predict these endpoints, and no per-harness route configuration is required. An unimplemented request that returns 404 or 405 cannot contribute policy-generated text and does not make capture incomplete. Any other response from an unrecognized route fails closed because its content could enter a later prompt; the rollout is marked with `mask_sample: true`.
+
+If a custom model server implements a successful metadata, health, or tokenization route whose response cannot contain policy-generated content, declare the exact method and path once on that model server:
+
+```yaml
+responses_api_models:
+  custom_model:
+    token_id_capture_non_generating_requests:
+      - method: GET
+        path: /custom/metadata
+```
+
+Declarations belong to the model server because the server owns the route and its response semantics. Gym rejects wildcards, query strings, non-string methods, and paths without a leading slash. Do not declare title generation, summarization, compaction, or another endpoint that can return policy-generated text. Unknown redirects, server errors, exceptions, and requests that finish without starting a response all mark the rollout incomplete.
+
 <Note>
 Native Gym agents normally leave `token_id_capture` disabled because their responses already contain the token ids needed for training.
 </Note>

--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -38,6 +38,7 @@ from abc import abstractmethod
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, ClassVar, Mapping, Optional
+from urllib.parse import urlsplit, urlunsplit
 from uuid import uuid4
 
 import orjson
@@ -84,7 +85,7 @@ from nemo_gym.token_id_capture import (
 
 # The store factory needs Gym's server stack.
 # The leaf package does not re-export it.
-from nemo_gym.token_id_capture.config import token_id_capture_config
+from nemo_gym.token_id_capture.config import NonGeneratingRequest, token_id_capture_config
 from nemo_gym.token_id_capture.lineage import FileLineageStore
 from nemo_gym.token_id_capture.store import make_token_store
 
@@ -173,7 +174,8 @@ def _orjson_dispatch_response(content: Any) -> Any:
 
 
 class BaseResponsesAPIModelConfig(BaseRunServerInstanceConfig):
-    pass
+    # Exact successful routes whose responses cannot contain policy-generated content.
+    token_id_capture_non_generating_requests: list[NonGeneratingRequest] = Field(default_factory=list)
 
 
 class BaseResponsesAPIModel(BaseServer):
@@ -196,7 +198,10 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
             model_server_name=self.config.name,
             global_config_dict=self.server_client.global_config_dict,
             num_workers=self.config.num_workers,
-            non_generating_requests=self.non_generating_model_routes,
+            non_generating_requests=self.non_generating_model_routes
+            | frozenset(
+                (request.method, request.path) for request in self.config.token_id_capture_non_generating_requests
+            ),
         )
 
         model_attributes = {"nemo.gym.server.name": self.config.name}
@@ -835,9 +840,6 @@ _OBSERVED_PATHS = {
     "/v1/messages": "messages",
 }
 
-# OpenAI model discovery cannot return policy-generated text.
-_NON_GENERATING_REQUESTS = frozenset({("GET", "/v1/models")})
-
 _TERMINAL_SSE_LINES: dict[str, dict[bytes, str]] = {
     "responses": {
         b"event: response.completed": "complete",
@@ -855,6 +857,43 @@ def _headers_content_type(headers: list) -> bytes:
         if key.lower() == b"content-type":
             return value
     return b""
+
+
+def _preserve_capture_prefix_on_redirect(
+    message: dict[str, Any],
+    *,
+    capture_prefix: str,
+    request_headers: list[tuple[bytes, bytes]],
+) -> dict[str, Any]:
+    """Keep rollout correlation on root-relative and same-origin redirects."""
+    status = int(message.get("status") or 0)
+    if not 300 <= status < 400:
+        return message
+
+    request_host = next(
+        (value.decode("latin-1") for key, value in request_headers if key.lower() == b"host"),
+        "",
+    )
+    headers = list(message.get("headers") or [])
+    changed = False
+    for index, (key, value) in enumerate(headers):
+        if key.lower() != b"location":
+            continue
+        location = value.decode("latin-1")
+        parts = urlsplit(location)
+        if parts.netloc and parts.netloc != request_host:
+            continue
+        if not parts.path.startswith("/") or parts.path.startswith(f"{capture_prefix}/"):
+            continue
+        headers[index] = (
+            key,
+            urlunsplit(parts._replace(path=f"{capture_prefix}{parts.path}")).encode("latin-1"),
+        )
+        changed = True
+
+    if not changed:
+        return message
+    return {**message, "headers": headers}
 
 
 def _consume_terminal_sse_event(buffer: bytearray, dialect: str) -> Optional[str]:
@@ -1208,7 +1247,7 @@ class _CaptureMiddleware:
         # A framework may stage records from its inference worker.
         # This process still resolves the capture identity.
         self._token_capture_enabled = token_capture_enabled
-        self._non_generating_requests = _NON_GENERATING_REQUESTS | non_generating_requests
+        self._non_generating_requests = non_generating_requests
 
     async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
         if scope.get("type") != "http":
@@ -1218,16 +1257,18 @@ class _CaptureMiddleware:
         path = scope.get("path", "")
         rollout_from_path: Optional[str] = None
         token_capture_requested = False
+        capture_prefix = ""
         prefix_match = _ROLLOUT_PATH_RE.match(path)
         if prefix_match:
             rollout_from_path = prefix_match.group("rollout_id")
             token_capture_requested = prefix_match.group("token_capture") is not None
+            capture_prefix = path[: prefix_match.start("rest")]
             path = prefix_match.group("rest")
             scope = {**scope, "path": path, "raw_path": path.encode("utf-8")}
 
         method = str(scope.get("method") or "").upper()
         dialect = _OBSERVED_PATHS.get(path)
-        known_non_generating = method == "HEAD" or (method, path) in self._non_generating_requests
+        known_non_generating = (method, path) in self._non_generating_requests
 
         # Forward when no active store needs this correlated endpoint.
         # The prefix is already stripped.
@@ -1240,31 +1281,55 @@ class _CaptureMiddleware:
         # Installed sinks are resolved for each request.
         token_sink = self._configured_sink or installed_token_sink() or self._token_store
         capture_wanted = token_capture_requested and (token_sink is not None or self._token_capture_enabled)
-        if token_capture_requested and dialect is None and not known_non_generating and token_sink is not None:
-            # Failed probes cannot return policy-generated content.
-            # Successful unclassified routes may return content that enters a later prompt.
-            # Mark them before the response start reaches the client.
+        if token_capture_requested and dialect is None and token_sink is not None:
             marked_incomplete = False
+            response_started = False
+
+            async def _mark_unobserved_incomplete(reason: str) -> None:
+                nonlocal marked_incomplete
+                if marked_incomplete:
+                    return
+                marked_incomplete = True
+                try:
+                    await token_sink.mark_incomplete(rollout_from_path, "")
+                    logger.warning(
+                        f"Marked rollout {rollout_from_path} incomplete because unclassified model request "
+                        f"{method} {path} {reason}. Declare the exact request on the model server only if its "
+                        "response cannot contain policy-generated content."
+                    )
+                except Exception:
+                    logger.warning(
+                        f"Could not mark rollout {rollout_from_path} incomplete for unobserved path {path}.",
+                        exc_info=True,
+                    )
 
             async def _send_unobserved(message: dict[str, Any]) -> None:
-                nonlocal marked_incomplete
+                nonlocal response_started
                 if message.get("type") == "http.response.start":
+                    response_started = True
                     status = int(message.get("status") or 0)
-                    response_can_have_content = 200 <= status < 300 and status not in {204, 205}
-                    if response_can_have_content and not marked_incomplete:
-                        marked_incomplete = True
-                        try:
-                            await token_sink.mark_incomplete(rollout_from_path, "")
-                        except Exception:
-                            logger.warning(
-                                "Could not mark rollout %s incomplete for unobserved path %s.",
-                                rollout_from_path,
-                                path,
-                                exc_info=True,
-                            )
+                    safe_without_capture = status in {404, 405}
+                    if not known_non_generating and not safe_without_capture:
+                        await _mark_unobserved_incomplete(f"returned HTTP {status}")
+                    message = _preserve_capture_prefix_on_redirect(
+                        message,
+                        capture_prefix=capture_prefix,
+                        request_headers=list(scope.get("headers") or []),
+                    )
                 await send(message)
 
-            await self._app(scope, receive, _send_unobserved)
+            try:
+                await self._app(scope, receive, _send_unobserved)
+            except asyncio.CancelledError:
+                if not known_non_generating and not response_started:
+                    await _mark_unobserved_incomplete("was cancelled before starting a response")
+                raise
+            except Exception:
+                if not known_non_generating and not response_started:
+                    await _mark_unobserved_incomplete("failed before starting a response")
+                raise
+            if not known_non_generating and not response_started:
+                await _mark_unobserved_incomplete("completed without starting a response")
             return
         if (self._store is None and not capture_wanted) or rollout_from_path is None or dialect is None:
             await self._app(scope, receive, send)

--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -37,7 +37,7 @@ import time
 from abc import abstractmethod
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Any, ClassVar, Mapping, Optional
 from uuid import uuid4
 
 import orjson
@@ -181,6 +181,10 @@ class BaseResponsesAPIModel(BaseServer):
 
 
 class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
+    # Subclasses can declare successful metadata or health routes here.
+    # Unknown successful routes fail closed during training-token capture.
+    non_generating_model_routes: ClassVar[frozenset[tuple[str, str]]] = frozenset()
+
     def setup_webserver(self) -> FastAPI:
         app = FastAPI()
 
@@ -192,6 +196,7 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
             model_server_name=self.config.name,
             global_config_dict=self.server_client.global_config_dict,
             num_workers=self.config.num_workers,
+            non_generating_requests=self.non_generating_model_routes,
         )
 
         model_attributes = {"nemo.gym.server.name": self.config.name}
@@ -830,6 +835,9 @@ _OBSERVED_PATHS = {
     "/v1/messages": "messages",
 }
 
+# OpenAI model discovery cannot return policy-generated text.
+_NON_GENERATING_REQUESTS = frozenset({("GET", "/v1/models")})
+
 _TERMINAL_SSE_LINES: dict[str, dict[bytes, str]] = {
     "responses": {
         b"event: response.completed": "complete",
@@ -1185,6 +1193,7 @@ class _CaptureMiddleware:
         lineage_store: Any = None,
         delta_records: bool = False,
         token_capture_enabled: bool = False,
+        non_generating_requests: frozenset[tuple[str, str]] = frozenset(),
     ) -> None:
         self._app = app
         self._store = store
@@ -1199,6 +1208,7 @@ class _CaptureMiddleware:
         # A framework may stage records from its inference worker.
         # This process still resolves the capture identity.
         self._token_capture_enabled = token_capture_enabled
+        self._non_generating_requests = _NON_GENERATING_REQUESTS | non_generating_requests
 
     async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
         if scope.get("type") != "http":
@@ -1215,7 +1225,9 @@ class _CaptureMiddleware:
             path = prefix_match.group("rest")
             scope = {**scope, "path": path, "raw_path": path.encode("utf-8")}
 
+        method = str(scope.get("method") or "").upper()
         dialect = _OBSERVED_PATHS.get(path)
+        known_non_generating = method == "HEAD" or (method, path) in self._non_generating_requests
 
         # Forward when no active store needs this correlated endpoint.
         # The prefix is already stripped.
@@ -1228,20 +1240,32 @@ class _CaptureMiddleware:
         # Installed sinks are resolved for each request.
         token_sink = self._configured_sink or installed_token_sink() or self._token_store
         capture_wanted = token_capture_requested and (token_sink is not None or self._token_capture_enabled)
-        if token_capture_requested and dialect is None:
-            # An uncapturable call must not look complete.
-            # Its output can still feed later prompts.
-            # Mark the rollout before forwarding so consumers retain that evidence.
-            if token_sink is not None:
-                try:
-                    await token_sink.mark_incomplete(rollout_from_path, "")
-                except Exception:
-                    logger.warning(
-                        "Could not mark rollout %s incomplete for unobserved path %s.",
-                        rollout_from_path,
-                        path,
-                        exc_info=True,
-                    )
+        if token_capture_requested and dialect is None and not known_non_generating and token_sink is not None:
+            # Failed probes cannot return policy-generated content.
+            # Successful unclassified routes may return content that enters a later prompt.
+            # Mark them before the response start reaches the client.
+            marked_incomplete = False
+
+            async def _send_unobserved(message: dict[str, Any]) -> None:
+                nonlocal marked_incomplete
+                if message.get("type") == "http.response.start":
+                    status = int(message.get("status") or 0)
+                    response_can_have_content = 200 <= status < 300 and status not in {204, 205}
+                    if response_can_have_content and not marked_incomplete:
+                        marked_incomplete = True
+                        try:
+                            await token_sink.mark_incomplete(rollout_from_path, "")
+                        except Exception:
+                            logger.warning(
+                                "Could not mark rollout %s incomplete for unobserved path %s.",
+                                rollout_from_path,
+                                path,
+                                exc_info=True,
+                            )
+                await send(message)
+
+            await self._app(scope, receive, _send_unobserved)
+            return
         if (self._store is None and not capture_wanted) or rollout_from_path is None or dialect is None:
             await self._app(scope, receive, send)
             return
@@ -1434,6 +1458,7 @@ def install_model_call_capture(
     model_server_name: str | None = None,
     global_config_dict: Any = None,
     num_workers: int | None = None,
+    non_generating_requests: frozenset[tuple[str, str]] = frozenset(),
 ) -> None:
     """Install model-call capture middleware.
 
@@ -1495,6 +1520,7 @@ def install_model_call_capture(
         lineage_store=lineage_store,
         delta_records=(capture_settings.token_id_capture.delta_records if capture_settings is not None else False),
         token_capture_enabled=capture_settings.enabled if capture_settings is not None else False,
+        non_generating_requests=non_generating_requests,
     )
 
 

--- a/nemo_gym/token_id_capture/config.py
+++ b/nemo_gym/token_id_capture/config.py
@@ -25,6 +25,13 @@ env:
       lineage_store: my_pkg.sinks:MyResolver  # Required with a custom sink (same backend namespace).
       delta_records: true                  # Store RESOLVED continuations as parent-relative suffixes.
       max_mask_fraction: 0.5               # Abort a run that is mostly producing masked rollouts.
+
+my_model:
+  responses_api_models:
+    custom_model:
+      token_id_capture_non_generating_requests:
+        - method: GET
+          path: /custom/metadata
 ```
 
 Evaluation capture uses ``/ng-rollout/<id>/...``.
@@ -72,7 +79,7 @@ from importlib import import_module
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from nemo_gym.token_id_capture.protocols import (
     LineageStore,
@@ -85,6 +92,34 @@ from nemo_gym.token_id_capture.protocols import (
 logger = logging.getLogger(__name__)
 
 TOKEN_ID_CAPTURE_BLOCK = "token_id_capture"
+
+
+class NonGeneratingRequest(BaseModel):
+    """Declare one exact model request that cannot return policy-generated content."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    method: str
+    path: str
+
+    @field_validator("method", mode="before")
+    @classmethod
+    def _normalize_method(cls, value: Any) -> str:
+        if not isinstance(value, str):
+            raise ValueError("method must be a string")
+        method = value.upper()
+        if not method or not method.isascii() or not method.isalpha():
+            raise ValueError("method must be an HTTP method without wildcards")
+        return method
+
+    @field_validator("path")
+    @classmethod
+    def _validate_path(cls, path: str) -> str:
+        if not path.startswith("/"):
+            raise ValueError("path must start with '/'")
+        if any(character in path for character in "?#*{}"):
+            raise ValueError("path must be exact and cannot contain query strings, fragments, or wildcards")
+        return path
 
 
 class TokenIdCaptureSettings(BaseModel):

--- a/responses_api_models/local_vllm_model/app.py
+++ b/responses_api_models/local_vllm_model/app.py
@@ -17,7 +17,7 @@ import sys
 from argparse import Namespace
 from pathlib import Path
 from time import sleep
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
 
 import ray
 import requests
@@ -74,6 +74,7 @@ class GetInnerVLLMConfigResponse(BaseModel):
 
 
 class LocalVLLMModel(VLLMModel):
+    non_generating_model_routes: ClassVar[frozenset[tuple[str, str]]] = frozenset({("GET", "/get_inner_vllm_config")})
     config: LocalVLLMModelConfig
 
     _local_vllm_model_actor: LocalVLLMModelActor

--- a/responses_api_models/local_vllm_model/tests/test_app.py
+++ b/responses_api_models/local_vllm_model/tests/test_app.py
@@ -43,6 +43,9 @@ class TestApp:
 
         assert _get_local_dp_ranks(placement_groups) == [0, 0, 1, 1]
 
+    def test_inner_config_route_is_non_generating(self) -> None:
+        assert ("GET", "/get_inner_vllm_config") in LocalVLLMModel.non_generating_model_routes
+
     def test_sanity_vllm_import(self) -> None:
         import vllm
 

--- a/responses_api_models/vllm_model_with_compaction/app.py
+++ b/responses_api_models/vllm_model_with_compaction/app.py
@@ -4,7 +4,7 @@
 """vLLM model server with exact-prefix context-compaction support."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 from fastapi import Body, Request
 from fastapi.exceptions import RequestValidationError
@@ -52,6 +52,7 @@ def _validate_context_compaction_params(body: Dict[str, Any]) -> VLLMContextComp
 class VLLMModelWithCompaction(VLLMModel):
     """Dedicated vLLM adapter for context-compacted generation."""
 
+    non_generating_model_routes: ClassVar[frozenset[tuple[str, str]]] = frozenset({("POST", "/tokenize")})
     _TOKENIZE_CHAT_FIELDS = (*VLLMModel._TOKENIZE_CHAT_FIELDS, "required_prefix_token_ids")
 
     def setup_webserver(self):

--- a/responses_api_models/vllm_model_with_compaction/tests/test_app.py
+++ b/responses_api_models/vllm_model_with_compaction/tests/test_app.py
@@ -36,6 +36,10 @@ def _make_model() -> VLLMModelWithCompaction:
     )
 
 
+def test_tokenize_route_is_non_generating() -> None:
+    assert ("POST", "/tokenize") in VLLMModelWithCompaction.non_generating_model_routes
+
+
 def test_base_vllm_model_has_no_compaction_routes() -> None:
     config = VLLMModelConfig(
         host="0.0.0.0",

--- a/tests/unit_tests/test_token_id_capture.py
+++ b/tests/unit_tests/test_token_id_capture.py
@@ -35,6 +35,7 @@ from uuid import uuid4
 import orjson
 import pytest
 from fastapi import Body, Request
+from fastapi.responses import RedirectResponse, Response
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, ValidationError
 
@@ -440,6 +441,42 @@ def test_config_keeps_settings_when_capture_is_off(tmp_path):
     assert cfg.build_sink() is None
 
 
+def test_model_config_accepts_exact_non_generating_requests():
+    cfg = BaseResponsesAPIModelConfig(
+        host="0.0.0.0",
+        port=8099,
+        entrypoint="app.py",
+        name="custom_model",
+        token_id_capture_non_generating_requests=[{"method": "get", "path": "/custom/metadata"}],
+    )
+
+    assert [(request.method, request.path) for request in cfg.token_id_capture_non_generating_requests] == [
+        ("GET", "/custom/metadata")
+    ]
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    [
+        {"method": "*", "path": "/v1/models"},
+        {"method": 123, "path": "/v1/models"},
+        {"method": True, "path": "/v1/models"},
+        {"method": "GET", "path": "v1/models"},
+        {"method": "GET", "path": "/v1/*"},
+        {"method": "GET", "path": "/v1/models?all=true"},
+    ],
+)
+def test_model_config_rejects_invalid_non_generating_requests(declaration):
+    with pytest.raises(ValidationError):
+        BaseResponsesAPIModelConfig(
+            host="0.0.0.0",
+            port=8099,
+            entrypoint="app.py",
+            name="custom_model",
+            token_id_capture_non_generating_requests=[declaration],
+        )
+
+
 def test_mask_fraction_limit_defaults_off_and_parses():
     default = TokenIdCaptureConfig.model_validate(_block(dir="/tmp/token-capture"))
     configured = TokenIdCaptureConfig.model_validate(_block(dir="/tmp/token-capture", max_mask_fraction=0.5))
@@ -710,23 +747,25 @@ def test_uncorrelated_call_captures_nothing(tmp_path):
     assert list(tmp_path.glob("*.tokens.jsonl")) == []
 
 
-def test_model_discovery_does_not_mark_capture_incomplete(tmp_path):
+def test_unimplemented_model_discovery_does_not_mark_capture_incomplete(tmp_path):
     client = TestClient(_server(_both_enabled(tmp_path)).setup_webserver())
     response = client.get("/ng-rollout/models-roll0/training-token-capture/v1/models")
 
-    assert response.status_code in {200, 404, 405}
+    assert response.status_code == 404
     assert TokenCaptureStore(tmp_path).freeze_now("models-roll0").incomplete is False
 
 
-@pytest.mark.parametrize("path", ["/api/tags", "/v1/props", "/version", "/api/show"])
-def test_failed_unknown_probe_does_not_mark_capture_incomplete(tmp_path, path):
-    client = TestClient(_server(_both_enabled(tmp_path)).setup_webserver())
-    response = client.post(
-        f"/ng-rollout/probe-roll0/training-token-capture{path}",
-        json={},
-    )
+def test_unimplemented_method_does_not_mark_capture_incomplete(tmp_path):
+    app = _server(_both_enabled(tmp_path)).setup_webserver()
 
-    assert response.status_code in {404, 405}
+    @app.get("/metadata")
+    async def metadata():
+        return {"kind": "metadata"}
+
+    client = TestClient(app)
+    response = client.post("/ng-rollout/probe-roll0/training-token-capture/metadata")
+
+    assert response.status_code == 405
     assert TokenCaptureStore(tmp_path).freeze_now("probe-roll0").incomplete is False
 
 
@@ -747,13 +786,111 @@ def test_successful_unknown_capture_path_fails_closed(tmp_path):
     assert TokenCaptureStore(tmp_path).freeze_now("unknown-roll0").incomplete is True
 
 
-def test_model_server_can_declare_successful_non_generating_route(tmp_path):
-    class MetadataModel(_CapturingModel):
-        non_generating_model_routes = frozenset({("POST", "/v1/custom-metadata")})
+def test_unknown_head_request_fails_closed(tmp_path):
+    app = _server(_both_enabled(tmp_path)).setup_webserver()
 
-    server = MetadataModel(
-        config=BaseResponsesAPIModelConfig(host="0.0.0.0", port=8099, entrypoint="", name="srv"),
-        server_client=MagicMock(spec=ServerClient, global_config_dict=_both_enabled(tmp_path)),
+    @app.head("/metadata")
+    async def metadata():
+        return Response(status_code=200)
+
+    client = TestClient(app)
+    response = client.head("/ng-rollout/head-roll0/training-token-capture/metadata")
+
+    assert response.status_code == 200
+    assert TokenCaptureStore(tmp_path).freeze_now("head-roll0").incomplete is True
+
+
+def test_unknown_redirect_fails_closed(tmp_path):
+    app = _server(_both_enabled(tmp_path)).setup_webserver()
+
+    @app.get("/redirect")
+    async def redirect():
+        return RedirectResponse("/v1/responses", status_code=307)
+
+    client = TestClient(app, follow_redirects=False)
+    response = client.get("/ng-rollout/redirect-roll0/training-token-capture/redirect")
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/ng-rollout/redirect-roll0/training-token-capture/v1/responses"
+    assert TokenCaptureStore(tmp_path).freeze_now("redirect-roll0").incomplete is True
+
+
+def test_router_redirect_preserves_capture_prefix(tmp_path):
+    app = _server(_both_enabled(tmp_path)).setup_webserver()
+
+    @app.get("/metadata/")
+    async def metadata():
+        return {"kind": "metadata"}
+
+    client = TestClient(app, follow_redirects=False)
+    response = client.get("/ng-rollout/router-redirect-roll0/training-token-capture/metadata")
+
+    assert response.status_code == 307
+    assert (
+        response.headers["location"]
+        == "http://testserver/ng-rollout/router-redirect-roll0/training-token-capture/metadata/"
+    )
+    assert TokenCaptureStore(tmp_path).freeze_now("router-redirect-roll0").incomplete is True
+
+
+@pytest.mark.parametrize("status", [204, 400, 500])
+def test_unknown_status_other_than_not_found_or_method_not_allowed_fails_closed(tmp_path, status):
+    app = _server(_both_enabled(tmp_path)).setup_webserver()
+
+    @app.get("/status")
+    async def status_response():
+        return Response(status_code=status)
+
+    client = TestClient(app)
+    response = client.get("/ng-rollout/status-roll0/training-token-capture/status")
+
+    assert response.status_code == status
+    assert TokenCaptureStore(tmp_path).freeze_now("status-roll0").incomplete is True
+
+
+def test_unknown_exception_before_response_fails_closed(tmp_path):
+    app = _server(_both_enabled(tmp_path)).setup_webserver()
+
+    @app.get("/crash")
+    async def crash():
+        raise RuntimeError("boom")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/ng-rollout/crash-roll0/training-token-capture/crash")
+
+    assert response.status_code == 500
+    assert TokenCaptureStore(tmp_path).freeze_now("crash-roll0").incomplete is True
+
+
+def test_unknown_request_without_response_start_fails_closed(tmp_path):
+    app = _server(_both_enabled(tmp_path)).setup_webserver()
+
+    async def silent_app(scope, receive, send):
+        return
+
+    app.mount("/silent", silent_app)
+    client = TestClient(app)
+
+    with pytest.raises(RuntimeError, match="No response returned"):
+        client.get("/ng-rollout/silent-roll0/training-token-capture/silent/")
+
+    assert TokenCaptureStore(tmp_path).freeze_now("silent-roll0").incomplete is True
+
+
+def test_model_server_can_declare_successful_non_generating_route(tmp_path):
+    config = _both_enabled(tmp_path)
+
+    server = _CapturingModel(
+        config=BaseResponsesAPIModelConfig(
+            host="0.0.0.0",
+            port=8099,
+            entrypoint="",
+            name="srv",
+            token_id_capture_non_generating_requests=[
+                {"method": "POST", "path": "/v1/custom-metadata"},
+            ],
+        ),
+        server_client=MagicMock(spec=ServerClient, global_config_dict=config),
     )
     app = server.setup_webserver()
 

--- a/tests/unit_tests/test_token_id_capture.py
+++ b/tests/unit_tests/test_token_id_capture.py
@@ -710,6 +710,67 @@ def test_uncorrelated_call_captures_nothing(tmp_path):
     assert list(tmp_path.glob("*.tokens.jsonl")) == []
 
 
+def test_model_discovery_does_not_mark_capture_incomplete(tmp_path):
+    client = TestClient(_server(_both_enabled(tmp_path)).setup_webserver())
+    response = client.get("/ng-rollout/models-roll0/training-token-capture/v1/models")
+
+    assert response.status_code in {200, 404, 405}
+    assert TokenCaptureStore(tmp_path).freeze_now("models-roll0").incomplete is False
+
+
+@pytest.mark.parametrize("path", ["/api/tags", "/v1/props", "/version", "/api/show"])
+def test_failed_unknown_probe_does_not_mark_capture_incomplete(tmp_path, path):
+    client = TestClient(_server(_both_enabled(tmp_path)).setup_webserver())
+    response = client.post(
+        f"/ng-rollout/probe-roll0/training-token-capture{path}",
+        json={},
+    )
+
+    assert response.status_code in {404, 405}
+    assert TokenCaptureStore(tmp_path).freeze_now("probe-roll0").incomplete is False
+
+
+def test_successful_unknown_capture_path_fails_closed(tmp_path):
+    app = _server(_both_enabled(tmp_path)).setup_webserver()
+
+    @app.post("/v1/unsupported-generation")
+    async def unsupported_generation():
+        return {"output": "generated"}
+
+    client = TestClient(app)
+    response = client.post(
+        "/ng-rollout/unknown-roll0/training-token-capture/v1/unsupported-generation",
+        json={"input": "hi"},
+    )
+
+    assert response.status_code == 200
+    assert TokenCaptureStore(tmp_path).freeze_now("unknown-roll0").incomplete is True
+
+
+def test_model_server_can_declare_successful_non_generating_route(tmp_path):
+    class MetadataModel(_CapturingModel):
+        non_generating_model_routes = frozenset({("POST", "/v1/custom-metadata")})
+
+    server = MetadataModel(
+        config=BaseResponsesAPIModelConfig(host="0.0.0.0", port=8099, entrypoint="", name="srv"),
+        server_client=MagicMock(spec=ServerClient, global_config_dict=_both_enabled(tmp_path)),
+    )
+    app = server.setup_webserver()
+
+    @app.post("/v1/custom-metadata")
+    async def custom_metadata():
+        return {"capabilities": ["tools"]}
+
+    client = TestClient(app)
+    response = client.post(
+        "/ng-rollout/declared-roll0/training-token-capture/v1/custom-metadata",
+        json={},
+    )
+
+    assert response.status_code == 200
+    assert TokenCaptureStore(tmp_path).freeze_now("declared-roll0").incomplete is False
+
+
 def test_package_is_dependency_free_leaf():
     """Keep token capture independent of Gym's server stack.
 


### PR DESCRIPTION
## Summary
- exempt standard non-generating model discovery and failed probes without weakening unknown successful-route handling
- let built-in and bring-your-own agents declare exact non-generating model requests in agent configuration
- log auxiliary request method, path, and status to make future harness changes discoverable

## Runtime validation
- Hermes: observed `GET /v1/models` plus normal `/v1/chat/completions` generation
- Claude Code, Cline, Codex, Kilo Code, OpenClaw, OpenCode, and Pi: no auxiliary policy-model requests observed
- no additional harness-specific defaults are currently required beyond the protocol-level `GET /v1/models` exemption

## Test plan
- [x] `uv run pytest tests/unit_tests/test_token_id_capture.py -q`
- [x] targeted Ruff lint and format checks
- [x] representative live rollout or direct Responses probe for all eight harnesses

Closes #2678.