### PR TITLE
feat(observability): add per-rollout and per-run aggregate observability metrics

### DIFF
--- a/fern/versions/latest/pages/model-server/model-call-capture.mdx
+++ b/fern/versions/latest/pages/model-server/model-call-capture.mdx
@@ -258,6 +258,34 @@ Each `SandboxObservation` covers one sandbox execution. Usage fields contain mea
 configured limits. A tool observation can reference its enclosing `sandbox_id`, but overlapping tool
 calls cannot share sandbox-level CPU or memory usage as if it were per-call usage.
 
+## Performance summary: `ng_perf` and `perf_summary`
+
+When observability is enabled and at least one agent invocation was observed, `rollout_collection`
+assembles a per-rollout `ng_perf` field from `ng_trajectory`: reasoning-turn count, tool-call count,
+prompt/completion/reasoning/cached-prompt token totals (summed only over calls owned by a reasoning
+turn, excluding compaction), and an independently measured wall-clock `total_latency_ms`. Like
+`ng_model_call_capture`, each field is present only when the underlying data was collected; `ng_perf`
+itself is entirely absent, not null, when observability is disabled.
+
+```json
+{
+  "ng_perf": {
+    "num_turns": 7,
+    "num_tool_calls": 15,
+    "prompt_tokens": 4210,
+    "cached_prompt_tokens": 2100,
+    "completion_tokens": 1820,
+    "reasoning_tokens": 0,
+    "total_latency_ms": 22100
+  }
+}
+```
+
+`_aggregate_metrics.json` includes a matching `perf_summary` block per agent, aggregated across every
+rollout's `ng_perf`: mean/median/total token stats, mean/median tokens-per-turn, a
+mean/median/std/min/p90/max distribution for `num_turns`, and p50/p90/p99/mean `total_latency_ms`.
+`perf_summary` is absent when no rollout in the run carried `ng_perf`.
+
 ## Limitations
 
 The model-server boundary observes model HTTP requests and responses. It can record tool calls,

--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -1370,6 +1370,11 @@ def model_call_capture_dirs_from_config(global_config_dict: Any) -> list[Path]:
     return [config.model_call_capture_dir]
 
 
+def observability_enabled_from_config(global_config_dict: Any) -> bool:
+    """Return the run-wide ``observability_enabled`` flag directly, without going through capture dirs."""
+    return ModelCallCaptureConfig.model_validate(global_config_dict).observability_enabled
+
+
 def _store_for_rollout(rollout_id: str, capture_dirs: list[Path]) -> Optional[CaptureStore]:
     for directory in capture_dirs:
         store = CaptureStore(directory)

--- a/nemo_gym/config_types.py
+++ b/nemo_gym/config_types.py
@@ -858,6 +858,14 @@ class AggregateMetrics(BaseModel):
         default_factory=dict,
         description="Headline metrics for this benchmark. Subset of agent_metrics.",
     )
+    perf_summary: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Cross-rollout efficiency stats aggregated from each rollout's ng_perf field. "
+            "Absent (not null-valued keys) when no rollout in this batch carried ng_perf, "
+            "i.e. observability was disabled for the whole run."
+        ),
+    )
 
 
 ########################################

--- a/nemo_gym/reward_profile.py
+++ b/nemo_gym/reward_profile.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import math
 import re
+import statistics
 from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -652,6 +653,91 @@ def _group_by_task(verify_responses: List[Dict[str, Any]]) -> List[List[Dict[str
     return [groups[k] for k in sorted(groups)]
 
 
+def _stat(values: List[float], stat: str) -> float:
+    if stat == "mean":
+        return statistics.fmean(values)
+    if stat == "median":
+        return statistics.median(values)
+    if stat == "total":
+        return sum(values)
+    if stat == "std":
+        return statistics.pstdev(values)
+    if stat == "min":
+        return min(values)
+    if stat == "max":
+        return max(values)
+    if stat.startswith("p"):
+        # Series.quantile() default (linear interpolation) matches numpy.percentile's default
+        # and, unlike statistics.quantiles, handles a single-value series with no special-casing.
+        return float(Series(values).quantile(int(stat[1:]) / 100))
+    raise ValueError(f"Unknown stat {stat!r}")
+
+
+# Per-rollout ng_perf token fields, each summarized with the same mean/median/total stats
+# (simpler than RFC R3's literal per-field list, which asymmetrically omits median/total for
+# some fields). Result keys are f"{stat}_{field}" except total_latency_ms, which uses
+# total_latency_{stat}_ms -- see the dedicated block in compute_perf_summary.
+_PERF_SUMMARY_TOKEN_FIELDS: Tuple[str, ...] = (
+    "prompt_tokens",
+    "cached_prompt_tokens",
+    "completion_tokens",
+    "reasoning_tokens",
+)
+_PERF_SUMMARY_TOKEN_STATS: Tuple[str, ...] = ("mean", "median", "total")
+_PERF_SUMMARY_NUM_TURNS_STATS: Tuple[str, ...] = ("mean", "median", "std", "min", "p90", "max")
+_PERF_SUMMARY_LATENCY_STATS: Tuple[str, ...] = ("p50", "p90", "p99", "mean")
+
+
+def compute_perf_summary(ng_perf_records: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Aggregate per-rollout ``ng_perf`` dicts into the ``perf_summary`` block (RFC R3).
+
+    Returns ``None`` when no rollout in this batch carried ``ng_perf`` -- e.g. observability
+    was disabled for the whole run -- so ``perf_summary`` stays absent from
+    ``_aggregate_metrics.json`` entirely, mirroring ``ng_perf``'s own absent-not-null contract.
+    Each individual stat is likewise included only when at least one rollout reported the
+    underlying field (a provider that never reports cache usage yields no
+    ``mean_cached_prompt_tokens``, for example).
+    """
+    if not ng_perf_records:
+        return None
+
+    def _values(key: str) -> List[float]:
+        return [record[key] for record in ng_perf_records if isinstance(record.get(key), (int, float))]
+
+    summary: Dict[str, Any] = {}
+
+    for field in _PERF_SUMMARY_TOKEN_FIELDS:
+        values = _values(field)
+        if not values:
+            continue
+        for stat in _PERF_SUMMARY_TOKEN_STATS:
+            summary[f"{stat}_{field}"] = _stat(values, stat)
+
+    num_turns_values = _values("num_turns")
+    if num_turns_values:
+        for stat in _PERF_SUMMARY_NUM_TURNS_STATS:
+            summary[f"{stat}_num_turns"] = _stat(num_turns_values, stat)
+
+    # Per-rollout ratio, then distribution of that ratio across rollouts.
+    tokens_per_turn = [
+        record["completion_tokens"] / record["num_turns"]
+        for record in ng_perf_records
+        if isinstance(record.get("completion_tokens"), (int, float))
+        and isinstance(record.get("num_turns"), (int, float))
+        and record["num_turns"] > 0
+    ]
+    if tokens_per_turn:
+        summary["mean_tokens_per_turn"] = _stat(tokens_per_turn, "mean")
+        summary["median_tokens_per_turn"] = _stat(tokens_per_turn, "median")
+
+    latency_values = _values("total_latency_ms")
+    if latency_values:
+        for stat in _PERF_SUMMARY_LATENCY_STATS:
+            summary[f"total_latency_{stat}_ms"] = _stat(latency_values, stat)
+
+    return summary or None
+
+
 def compute_aggregate_metrics(
     verify_responses: List[Dict[str, Any]],
     compute_metrics_fn=None,
@@ -727,10 +813,13 @@ def compute_aggregate_metrics(
     else:
         key_metrics = {k: v for k, v in serialized_agent.items() if k.startswith("mean/")}
 
+    ng_perf_records = [vr["ng_perf"] for vr in verify_responses if isinstance(vr.get("ng_perf"), dict)]
+
     return AggregateMetrics(
         group_level_metrics=serialized_group,
         agent_metrics=serialized_agent,
         key_metrics=key_metrics,
+        perf_summary=compute_perf_summary(ng_perf_records),
     )
 
 

--- a/nemo_gym/reward_profile.py
+++ b/nemo_gym/reward_profile.py
@@ -688,23 +688,36 @@ _PERF_SUMMARY_NUM_TURNS_STATS: Tuple[str, ...] = ("mean", "median", "std", "min"
 _PERF_SUMMARY_LATENCY_STATS: Tuple[str, ...] = ("p50", "p90", "p99", "mean")
 
 
-def compute_perf_summary(ng_perf_records: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+def compute_perf_summary(ng_perf_records: List[Dict[str, Any]], total_rollouts: int) -> Optional[Dict[str, Any]]:
     """Aggregate per-rollout ``ng_perf`` dicts into the ``perf_summary`` block (RFC R3).
 
-    Returns ``None`` when no rollout in this batch carried ``ng_perf`` -- e.g. observability
-    was disabled for the whole run -- so ``perf_summary`` stays absent from
-    ``_aggregate_metrics.json`` entirely, mirroring ``ng_perf``'s own absent-not-null contract.
-    Each individual stat is likewise included only when at least one rollout reported the
+    ``total_rollouts`` is the full rollout count for this batch, including rollouts that never
+    produced ``ng_perf`` at all -- the denominator for ``overall_observability_coverage`` and
+    ``token_observability_coverage``.
+
+    Returns ``None`` when there are no rollouts at all, or when none of them carried ``ng_perf``
+    (observability off for the whole run, or on but nothing was collected) -- perf_summary is
+    absent rather than present with a 0.0 coverage either way; a coverage value, when present, is
+    always > 0. Every other stat is included only when at least one rollout reported the
     underlying field (a provider that never reports cache usage yields no
     ``mean_cached_prompt_tokens``, for example).
     """
-    if not ng_perf_records:
+    if total_rollouts <= 0 or not ng_perf_records:
         return None
 
     def _values(key: str) -> List[float]:
         return [record[key] for record in ng_perf_records if isinstance(record.get(key), (int, float))]
 
-    summary: Dict[str, Any] = {}
+    summary: Dict[str, Any] = {
+        "overall_observability_coverage": len(ng_perf_records) / total_rollouts,
+        "token_observability_coverage": sum(
+            1
+            for record in ng_perf_records
+            if isinstance(record.get("token_observability_coverage"), (int, float))
+            and record["token_observability_coverage"] > 0
+        )
+        / total_rollouts,
+    }
 
     for field in _PERF_SUMMARY_TOKEN_FIELDS:
         values = _values(field)
@@ -735,7 +748,7 @@ def compute_perf_summary(ng_perf_records: List[Dict[str, Any]]) -> Optional[Dict
         for stat in _PERF_SUMMARY_LATENCY_STATS:
             summary[f"total_latency_{stat}_ms"] = _stat(latency_values, stat)
 
-    return summary or None
+    return summary
 
 
 def compute_aggregate_metrics(
@@ -819,7 +832,7 @@ def compute_aggregate_metrics(
         group_level_metrics=serialized_group,
         agent_metrics=serialized_agent,
         key_metrics=key_metrics,
-        perf_summary=compute_perf_summary(ng_perf_records),
+        perf_summary=compute_perf_summary(ng_perf_records, total_rollouts=len(verify_responses)),
     )
 
 

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -396,10 +396,12 @@ def _build_ng_perf(result: dict[str, Any], *, rollout_latency_ms: Optional[float
     Token fields are summed only over model calls owned by a reasoning-turn ``AgentInvocation``,
     excluding compaction calls -- mixing in compaction overhead would skew the token efficiency signal.
 
-    ``num_turns`` counts reasoning turns, where explicit ``TrajectoryTurn`` records are preferred;
-    harnesses that don't emit them fall back to the invocation-owned model call count (one assistant
-    response per turn, and the same call set the token sums cover), then to the invocation count as a
-    lower bound when no call references resolved.
+    ``num_turns`` counts reasoning turns summed across all invocations (an ``AgentInvocation``
+    is one root-agent or subagent conversation that may span many turns). Each invocation
+    contributes its explicit ``TrajectoryTurn`` count when the harness emits turn records,
+    falling back to its owned model-call count (one assistant response per turn), then to 1
+    (an invocation that ran had at least one turn) -- so hybrid trajectories where only some
+    invocations report turns still count every conversation.
     """
     raw_trajectory = result.get(NG_TRAJECTORY_KEY)
     if not isinstance(raw_trajectory, dict):
@@ -418,12 +420,14 @@ def _build_ng_perf(result: dict[str, Any], *, rollout_latency_ms: Optional[float
     # invocations could otherwise claim -- and double-count -- the same physical call.
     seen_call_ids: set[str] = set()
     owned_calls = []
+    owned_calls_by_invocation: Counter = Counter()
     for invocation in trajectory.invocations:
         for ref in invocation.model_calls:
             if ref.model_call_id not in calls_by_id or ref.model_call_id in seen_call_ids:
                 continue
             seen_call_ids.add(ref.model_call_id)
             owned_calls.append(calls_by_id[ref.model_call_id])
+            owned_calls_by_invocation[invocation.invocation_id] += 1
     tool_calls_by_invocation = Counter(tool.invocation_id for tool in trajectory.tool_calls)
     num_tool_calls = sum(
         tool_calls_by_invocation.get(invocation.invocation_id, 0) for invocation in trajectory.invocations
@@ -435,7 +439,13 @@ def _build_ng_perf(result: dict[str, Any], *, rollout_latency_ms: Optional[float
         ]
         return sum(values) if values else None
 
-    num_turns = len(trajectory.turns) or len(owned_calls) or len(trajectory.invocations)
+    turns_by_invocation = Counter(turn.invocation_id for turn in trajectory.turns)
+    num_turns = sum(
+        turns_by_invocation.get(invocation.invocation_id, 0)
+        or owned_calls_by_invocation.get(invocation.invocation_id, 0)
+        or 1
+        for invocation in trajectory.invocations
+    )
     ng_perf: dict[str, Any] = {
         "num_turns": num_turns,
         "num_tool_calls": num_tool_calls,

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -395,6 +395,11 @@ def _build_ng_perf(result: dict[str, Any], *, rollout_latency_ms: Optional[float
 
     Token fields are summed only over model calls owned by a reasoning-turn ``AgentInvocation``,
     excluding compaction calls -- mixing in compaction overhead would skew the token efficiency signal.
+
+    ``num_turns`` counts reasoning turns, where explicit ``TrajectoryTurn`` records are preferred;
+    harnesses that don't emit them fall back to the invocation-owned model call count (one assistant
+    response per turn, and the same call set the token sums cover), then to the invocation count as a
+    lower bound when no call references resolved.
     """
     raw_trajectory = result.get(NG_TRAJECTORY_KEY)
     if not isinstance(raw_trajectory, dict):
@@ -430,8 +435,9 @@ def _build_ng_perf(result: dict[str, Any], *, rollout_latency_ms: Optional[float
         ]
         return sum(values) if values else None
 
+    num_turns = len(trajectory.turns) or len(owned_calls) or len(trajectory.invocations)
     ng_perf: dict[str, Any] = {
-        "num_turns": len(trajectory.invocations),
+        "num_turns": num_turns,
         "num_tool_calls": num_tool_calls,
     }
     for ng_perf_key, token_stats_attr in (

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -67,6 +67,7 @@ from nemo_gym.rollout_correlation import maybe_rollout_id_from_run_body
 from nemo_gym.rollout_observability import (
     AgentInvocation,
     AgentObservationBundle,
+    ModelCallRef,
     ObservationGap,
     ToolCallObservation,
     TrajectoryModelCall,
@@ -413,20 +414,55 @@ def _build_ng_perf(result: dict[str, Any], *, rollout_latency_ms: Optional[float
     if not trajectory.invocations:
         return None
 
-    calls_by_id = {call.model_call_id: call for call in trajectory.model_calls if call.model_call_id}
-    # De-duplicate by model_call_id rather than trusting each invocation's claim in isolation:
-    # join_model_call_observations leaves a conflicted ref attached to its losing invocation
-    # (unremoved, just gap-flagged), so if a ref ever carries a real model_call_id pre-join, two
-    # invocations could otherwise claim -- and double-count -- the same physical call.
-    seen_call_ids: set[str] = set()
+    # Index captured calls by both identities ModelCallRef supports, mirroring
+    # join_model_call_observations: a ref may carry model_call_id, or the exact
+    # (model_ref, response_id) pair.
+    calls_by_id: dict[str, list[int]] = {}
+    calls_by_response: dict[tuple[str, str, str], list[int]] = {}
+    for index, call in enumerate(trajectory.model_calls):
+        if call.model_call_id:
+            calls_by_id.setdefault(call.model_call_id, []).append(index)
+        call_model_ref = call.response_metadata.model_ref
+        call_response_id = call.response_metadata.response_id
+        if call_model_ref is not None and call_response_id:
+            calls_by_response.setdefault((call_model_ref.type, call_model_ref.name, call_response_id), []).append(
+                index
+            )
+
+    def _match_call_index(ref: ModelCallRef) -> Optional[int]:
+        if ref.model_call_id:
+            candidates = [
+                index
+                for index in calls_by_id.get(ref.model_call_id, [])
+                if (
+                    ref.model_ref is None or ref.model_ref == trajectory.model_calls[index].response_metadata.model_ref
+                )
+                and (
+                    ref.response_id is None
+                    or ref.response_id == trajectory.model_calls[index].response_metadata.response_id
+                )
+            ]
+        elif ref.model_ref is not None and ref.response_id:
+            candidates = calls_by_response.get((ref.model_ref.type, ref.model_ref.name, ref.response_id), [])
+        else:
+            candidates = []
+        return candidates[0] if len(candidates) == 1 else None
+
+    # De-duplicate by matched call *position* rather than model_call_id; the id is
+    # optional because a (model_ref, response_id)-only match has none. One physical call
+    # can't be claimed twice even if two invocations' refs both resolve to it (e.g. a
+    # join_model_call_observations conflict that left a ref attached to its losing
+    # invocation, unremoved, just gap-flagged).
+    seen_positions: set[int] = set()
     owned_calls = []
     owned_calls_by_invocation: Counter = Counter()
     for invocation in trajectory.invocations:
         for ref in invocation.model_calls:
-            if ref.model_call_id not in calls_by_id or ref.model_call_id in seen_call_ids:
+            index = _match_call_index(ref)
+            if index is None or index in seen_positions:
                 continue
-            seen_call_ids.add(ref.model_call_id)
-            owned_calls.append(calls_by_id[ref.model_call_id])
+            seen_positions.add(index)
+            owned_calls.append(trajectory.model_calls[index])
             owned_calls_by_invocation[invocation.invocation_id] += 1
     tool_calls_by_invocation = Counter(tool.invocation_id for tool in trajectory.tool_calls)
     num_tool_calls = sum(

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -39,6 +39,7 @@ from nemo_gym.base_responses_api_model import (
     clear_model_call_captures_for_rollouts,
     merge_model_call_capture_into_record,
     model_call_capture_dirs_from_config,
+    observability_enabled_from_config,
 )
 from nemo_gym.config_types import (
     BaseNeMoGymCLIConfig,
@@ -135,6 +136,8 @@ NG_FAILURE_CLASS_KEY = "_ng_failure_class"
 NG_NO_PERSIST_KEY = "_ng_no_persist"
 NG_TERMINAL_KEY = "_ng_failure_terminal"
 NG_TRAJECTORY_KEY = "ng_trajectory"
+NG_PERF_KEY = "ng_perf"
+_NG_ROLLOUT_LATENCY_MS_KEY = "_ng_rollout_latency_ms"
 _MODEL_CALL_PAYLOAD_KEYS = ("request", "response", "request_raw", "response_raw")
 
 _DEFAULT_MAX_ROLLOUT_ATTEMPTS = 3
@@ -381,6 +384,85 @@ def _attach_trajectory_record(row: dict[str, Any], result: dict[str, Any]) -> No
         # Raw capture payloads remain as a fallback on failure. After success,
         # ng_trajectory owns them, so remove only the duplicate copies.
         _strip_capture_payloads(result)
+
+
+def _build_ng_perf(result: dict[str, Any], *, rollout_latency_ms: Optional[float]) -> Optional[dict[str, Any]]:
+    """Assemble the per-rollout ``ng_perf`` summary from ``ng_trajectory``.
+
+    Returns ``None`` (``ng_perf`` stays absent) unless at least one reasoning turn was
+    observed: per-turn evidence is needed rather than just raw model-call capture,
+    so a rollout collected with observability disabled produces no ``ng_perf`` at all.
+
+    Token fields are summed only over model calls owned by a reasoning-turn ``AgentInvocation``,
+    excluding compaction calls -- mixing in compaction overhead would skew the token efficiency signal.
+    """
+    raw_trajectory = result.get(NG_TRAJECTORY_KEY)
+    if not isinstance(raw_trajectory, dict):
+        return None
+    try:
+        trajectory = TrajectoryRecord.model_validate(raw_trajectory)
+    except Exception:
+        return None
+    if not trajectory.invocations:
+        return None
+
+    calls_by_id = {call.model_call_id: call for call in trajectory.model_calls if call.model_call_id}
+    # De-duplicate by model_call_id rather than trusting each invocation's claim in isolation:
+    # join_model_call_observations leaves a conflicted ref attached to its losing invocation
+    # (unremoved, just gap-flagged), so if a ref ever carries a real model_call_id pre-join, two
+    # invocations could otherwise claim -- and double-count -- the same physical call.
+    seen_call_ids: set[str] = set()
+    owned_calls = []
+    for invocation in trajectory.invocations:
+        for ref in invocation.model_calls:
+            if ref.model_call_id not in calls_by_id or ref.model_call_id in seen_call_ids:
+                continue
+            seen_call_ids.add(ref.model_call_id)
+            owned_calls.append(calls_by_id[ref.model_call_id])
+    tool_calls_by_invocation = Counter(tool.invocation_id for tool in trajectory.tool_calls)
+    num_tool_calls = sum(
+        tool_calls_by_invocation.get(invocation.invocation_id, 0) for invocation in trajectory.invocations
+    )
+
+    def _sum_tokens(attr: str) -> Optional[int]:
+        values = [
+            getattr(call.token_stats, attr) for call in owned_calls if getattr(call.token_stats, attr) is not None
+        ]
+        return sum(values) if values else None
+
+    ng_perf: dict[str, Any] = {
+        "num_turns": len(trajectory.invocations),
+        "num_tool_calls": num_tool_calls,
+    }
+    for ng_perf_key, token_stats_attr in (
+        ("prompt_tokens", "prompt_tokens"),
+        ("cached_prompt_tokens", "cached_tokens"),
+        ("completion_tokens", "completion_tokens"),
+        ("reasoning_tokens", "reasoning_tokens"),
+    ):
+        value = _sum_tokens(token_stats_attr)
+        if value is not None:
+            ng_perf[ng_perf_key] = value
+
+    if isinstance(rollout_latency_ms, (int, float)):
+        ng_perf["total_latency_ms"] = rollout_latency_ms
+
+    return ng_perf
+
+
+def _attach_ng_perf(result: dict[str, Any], *, observability_enabled: bool) -> None:
+    rollout_latency_ms = result.pop(_NG_ROLLOUT_LATENCY_MS_KEY, None)
+    if not observability_enabled:
+        # ng_perf stays absent entirely when observability is off (OQ4): a caller who
+        # disabled it only wants the final score, not partial/best-effort perf evidence.
+        return
+    try:
+        ng_perf = _build_ng_perf(result, rollout_latency_ms=rollout_latency_ms)
+    except Exception:
+        logger.warning("Could not assemble ng_perf for a rollout.", exc_info=True)
+        return
+    if ng_perf is not None:
+        result[NG_PERF_KEY] = ng_perf
 
 
 def _get_max_rollout_attempts() -> int:
@@ -1003,6 +1085,7 @@ class RolloutCollectionHelper(BaseModel):
         # into its record below (uniform across agents; no-op when capture is off / dirs absent).
         global_config = get_global_config_dict()
         capture_dirs = model_call_capture_dirs_from_config(global_config)
+        observability_enabled = observability_enabled_from_config(global_config)
         # Resolve the training-token store directory once.
         # Training capture is independent of evaluation capture.
         # An empty result disables training-token capture.
@@ -1086,6 +1169,11 @@ class RolloutCollectionHelper(BaseModel):
 
             if "ng_model_call_capture" in result or "ng_agent_observations" in result or NG_TRAJECTORY_KEY in result:
                 _attach_trajectory_record(row, result)
+
+            # Assembles ng_perf from ng_trajectory when observability is enabled;
+            # additionally drops the internal wall-clock timer key so it never
+            # leaks into a persisted rollout.
+            _attach_ng_perf(result, observability_enabled=observability_enabled)
 
             # Freeze and rebuild tokens only for participating agents.
             # This step does not retire the frozen snapshot.
@@ -1487,6 +1575,7 @@ Aggregate metrics: {aggregate_metrics_fpath}""")
 
         async def _post_subroutine(row: Dict) -> Tuple[Dict, Dict]:
             async with semaphore:
+                started_at = time()
                 res = await server_client.post(server_name=row["agent_ref"]["name"], url_path="/run", json=row)
                 try:
                     await raise_for_status(res)
@@ -1499,7 +1588,11 @@ Aggregate metrics: {aggregate_metrics_fpath}""")
                             flush=True,
                         )
                     raise
-                return row, await get_response_json(res)
+                result = await get_response_json(res)
+                # Independently-measured task wall-clock (ng_perf.total_latency_ms), not derived
+                # from summed model-call/tool latencies to account for additional overhead.
+                result[_NG_ROLLOUT_LATENCY_MS_KEY] = (time() - started_at) * 1000
+                return row, result
 
         return tqdm.as_completed(
             map(_post_subroutine, examples),

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -1409,6 +1409,8 @@ Aggregate metrics: {aggregate_metrics_fpath}""")
                 "key_metrics": agg_result.key_metrics,
                 "group_level_metrics": agg_result.group_level_metrics,
             }
+            if agg_result.perf_summary is not None:
+                agent_entry["perf_summary"] = agg_result.perf_summary
             return agent_entry
 
         all_agent_metrics: List[Dict] = []

--- a/nemo_gym/rollout_collection.py
+++ b/nemo_gym/rollout_collection.py
@@ -403,6 +403,10 @@ def _build_ng_perf(result: dict[str, Any], *, rollout_latency_ms: Optional[float
     falling back to its owned model-call count (one assistant response per turn), then to 1
     (an invocation that ran had at least one turn) -- so hybrid trajectories where only some
     invocations report turns still count every conversation.
+
+    ``token_observability_coverage`` reports what fraction of those turns actually resolved to a
+    captured call: a turn whose ``ModelCallRef`` was unmatched or ambiguous silently loses its
+    tokens from the sums below, and this is the only signal that it happened.
     """
     raw_trajectory = result.get(NG_TRAJECTORY_KEY)
     if not isinstance(raw_trajectory, dict):
@@ -485,6 +489,7 @@ def _build_ng_perf(result: dict[str, Any], *, rollout_latency_ms: Optional[float
     ng_perf: dict[str, Any] = {
         "num_turns": num_turns,
         "num_tool_calls": num_tool_calls,
+        "token_observability_coverage": min(1.0, len(owned_calls) / num_turns),
     }
     for ng_perf_key, token_stats_attr in (
         ("prompt_tokens", "prompt_tokens"),

--- a/resources_servers/gdpval/multistage_orchestrator.py
+++ b/resources_servers/gdpval/multistage_orchestrator.py
@@ -827,9 +827,11 @@ async def run_e2e_multistage(
     """
     from contextlib import nullcontext
 
-    from nemo_gym.rollout_collection import RolloutCollectionHelper
+    from nemo_gym.base_responses_api_model import observability_enabled_from_config
+    from nemo_gym.rollout_collection import RolloutCollectionHelper, _attach_ng_perf
 
     multistage_config = parse_multistage_config(global_config_dict.get("multistage") or {})
+    observability_enabled = observability_enabled_from_config(global_config_dict)
 
     helper = RolloutCollectionHelper()
     materialized_rows = helper._preprocess_rows_from_config(rollout_collection_config)
@@ -859,6 +861,7 @@ async def run_e2e_multistage(
         results: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
         for future in helper.run_examples(rows, semaphore=semaphore or nullcontext()):
             row, result = await future
+            _attach_ng_perf(result, observability_enabled=observability_enabled)
             results.append((row, result))
         return results
 

--- a/tests/unit_tests/test_aggregate_metrics.py
+++ b/tests/unit_tests/test_aggregate_metrics.py
@@ -478,15 +478,46 @@ class TestAddAvgSampleStdDev:
 
 
 class TestComputePerfSummary:
-    def test_empty_input_returns_none(self) -> None:
-        assert compute_perf_summary([]) is None
+    def test_zero_total_rollouts_returns_none(self) -> None:
+        assert compute_perf_summary([], total_rollouts=0) is None
+
+    def test_zero_total_rollouts_returns_none_even_with_inconsistent_ng_perf_records(self) -> None:
+        # A caller could in principle pass ng_perf_records inconsistent with total_rollouts
+        # (never happens via compute_aggregate_metrics, which derives both from the same
+        # verify_responses list) -- this must return None rather than divide by zero.
+        assert compute_perf_summary([{"num_turns": 1}], total_rollouts=0) is None
+
+    def test_no_ng_perf_returns_none_even_with_nonzero_rollouts(self) -> None:
+        # No rollout in this batch carried ng_perf (observability off for the whole run, or on
+        # but nothing was collected) so perf_summary stays absent.
+        assert compute_perf_summary([], total_rollouts=10) is None
+
+    def test_overall_observability_coverage_counts_ng_perf_bearing_rollouts(self) -> None:
+        # 3 of 10 rollouts in this batch carried ng_perf at all.
+        ng_perf_records = [{"num_turns": 1}, {"num_turns": 1}, {"num_turns": 1}]
+
+        summary = compute_perf_summary(ng_perf_records, total_rollouts=10)
+
+        assert summary["overall_observability_coverage"] == 0.3
+
+    def test_token_observability_coverage_denominated_by_all_rollouts(self) -> None:
+        # Of 4 total rollouts: one has ng_perf with token data (coverage > 0), one has ng_perf
+        # but zero resolved token data, two have no ng_perf at all. Only the first counts.
+        ng_perf_records = [
+            {"num_turns": 1, "token_observability_coverage": 1.0},
+            {"num_turns": 1, "token_observability_coverage": 0.0},
+        ]
+
+        summary = compute_perf_summary(ng_perf_records, total_rollouts=4)
+
+        assert summary["token_observability_coverage"] == 0.25
 
     def test_percentiles_and_means_over_five_rollouts(self) -> None:
         # total_latency_ms = 100, 200, 300, 400, 500 -> exact quartile/percentile boundaries at
         # this size make the expected linear-interpolation values easy to hand-verify.
         ng_perf_records = [{"total_latency_ms": ms, "num_turns": 1} for ms in (100, 200, 300, 400, 500)]
 
-        summary = compute_perf_summary(ng_perf_records)
+        summary = compute_perf_summary(ng_perf_records, total_rollouts=len(ng_perf_records))
 
         assert summary["total_latency_mean_ms"] == 300.0
         assert summary["total_latency_p50_ms"] == 300.0
@@ -494,7 +525,7 @@ class TestComputePerfSummary:
         assert summary["total_latency_p99_ms"] == 496.0
 
     def test_single_rollout_std_is_zero_not_nan(self) -> None:
-        summary = compute_perf_summary([{"num_turns": 4}])
+        summary = compute_perf_summary([{"num_turns": 4}], total_rollouts=1)
 
         assert summary["mean_num_turns"] == 4.0
         assert summary["std_num_turns"] == 0.0
@@ -508,7 +539,7 @@ class TestComputePerfSummary:
             {"prompt_tokens": 300, "completion_tokens": 60, "num_turns": 4},
         ]
 
-        summary = compute_perf_summary(ng_perf_records)
+        summary = compute_perf_summary(ng_perf_records, total_rollouts=len(ng_perf_records))
 
         assert summary["total_prompt_tokens"] == 400
         assert summary["mean_prompt_tokens"] == 200.0
@@ -524,7 +555,7 @@ class TestComputePerfSummary:
         # surfaces cache usage) -- those stats must be missing, not present as 0 or None.
         ng_perf_records = [{"prompt_tokens": 100, "completion_tokens": 20, "num_turns": 2}]
 
-        summary = compute_perf_summary(ng_perf_records)
+        summary = compute_perf_summary(ng_perf_records, total_rollouts=len(ng_perf_records))
 
         for absent_key in (
             "mean_cached_prompt_tokens",
@@ -542,7 +573,7 @@ class TestComputePerfSummary:
             {"completion_tokens": 20, "num_turns": 2},
         ]
 
-        summary = compute_perf_summary(ng_perf_records)
+        summary = compute_perf_summary(ng_perf_records, total_rollouts=len(ng_perf_records))
 
         assert summary["mean_tokens_per_turn"] == 10.0
 
@@ -554,7 +585,7 @@ class TestComputePerfSummary:
             {"num_turns": 1},
         ]
 
-        summary = compute_perf_summary(ng_perf_records)
+        summary = compute_perf_summary(ng_perf_records, total_rollouts=len(ng_perf_records))
 
         assert summary["mean_cached_prompt_tokens"] == 40.0
         assert summary["total_cached_prompt_tokens"] == 40
@@ -562,6 +593,9 @@ class TestComputePerfSummary:
 
 class TestPerfSummaryInAggregateMetrics:
     def test_absent_when_no_rollout_carries_ng_perf(self) -> None:
+        # No rollout in this batch carried ng_perf -- observability off for the whole run, or on
+        # but nothing was collected, are indistinguishable here. Either way perf_summary stays
+        # absent rather than present with a 0.0 coverage.
         responses = [
             {TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "reward": 1.0, "response": {}},
         ]
@@ -588,3 +622,7 @@ class TestPerfSummaryInAggregateMetrics:
         assert result.perf_summary["mean_num_turns"] == 3.0
         assert result.perf_summary["total_prompt_tokens"] == 90
         assert result.perf_summary["total_latency_mean_ms"] == 1000.0
+        # 1 of 2 rollouts carried ng_perf at all; that one doesn't itself set
+        # token_observability_coverage (hand-built dict), so it doesn't count as token-covered.
+        assert result.perf_summary["overall_observability_coverage"] == 0.5
+        assert result.perf_summary["token_observability_coverage"] == 0.0

--- a/tests/unit_tests/test_aggregate_metrics.py
+++ b/tests/unit_tests/test_aggregate_metrics.py
@@ -28,6 +28,7 @@ from nemo_gym.reward_profile import (
     add_avg_sample_std_dev,
     compute_aggregate_metrics,
     compute_pass_majority_metrics,
+    compute_perf_summary,
     compute_subset_metrics,
     highest_k_metrics,
 )
@@ -474,3 +475,116 @@ class TestAddAvgSampleStdDev:
         before = dict(metrics)
         add_avg_sample_std_dev(metrics, all_score_dicts, score_names, max_k)
         assert metrics == before
+
+
+class TestComputePerfSummary:
+    def test_empty_input_returns_none(self) -> None:
+        assert compute_perf_summary([]) is None
+
+    def test_percentiles_and_means_over_five_rollouts(self) -> None:
+        # total_latency_ms = 100, 200, 300, 400, 500 -> exact quartile/percentile boundaries at
+        # this size make the expected linear-interpolation values easy to hand-verify.
+        ng_perf_records = [{"total_latency_ms": ms, "num_turns": 1} for ms in (100, 200, 300, 400, 500)]
+
+        summary = compute_perf_summary(ng_perf_records)
+
+        assert summary["total_latency_mean_ms"] == 300.0
+        assert summary["total_latency_p50_ms"] == 300.0
+        assert summary["total_latency_p90_ms"] == 460.0
+        assert summary["total_latency_p99_ms"] == 496.0
+
+    def test_single_rollout_std_is_zero_not_nan(self) -> None:
+        summary = compute_perf_summary([{"num_turns": 4}])
+
+        assert summary["mean_num_turns"] == 4.0
+        assert summary["std_num_turns"] == 0.0
+        assert summary["min_num_turns"] == 4.0
+        assert summary["max_num_turns"] == 4.0
+        assert summary["p90_num_turns"] == 4.0
+
+    def test_token_totals_and_means(self) -> None:
+        ng_perf_records = [
+            {"prompt_tokens": 100, "completion_tokens": 20, "num_turns": 2},
+            {"prompt_tokens": 300, "completion_tokens": 60, "num_turns": 4},
+        ]
+
+        summary = compute_perf_summary(ng_perf_records)
+
+        assert summary["total_prompt_tokens"] == 400
+        assert summary["mean_prompt_tokens"] == 200.0
+        assert summary["median_prompt_tokens"] == 200.0
+        assert summary["total_completion_tokens"] == 80
+        assert summary["mean_completion_tokens"] == 40.0
+        # tokens_per_turn is a per-rollout ratio, averaged after division: 20/2=10, 60/4=15.
+        assert summary["mean_tokens_per_turn"] == 12.5
+        assert summary["median_tokens_per_turn"] == 12.5
+
+    def test_field_absent_when_no_rollout_reports_it(self) -> None:
+        # No rollout reports cached_prompt_tokens or reasoning_tokens (e.g. the provider never
+        # surfaces cache usage) -- those stats must be missing, not present as 0 or None.
+        ng_perf_records = [{"prompt_tokens": 100, "completion_tokens": 20, "num_turns": 2}]
+
+        summary = compute_perf_summary(ng_perf_records)
+
+        for absent_key in (
+            "mean_cached_prompt_tokens",
+            "total_cached_prompt_tokens",
+            "mean_reasoning_tokens",
+            "total_latency_mean_ms",
+        ):
+            assert absent_key not in summary
+
+    def test_tokens_per_turn_skips_zero_turn_rollouts(self) -> None:
+        # A rollout with num_turns == 0 would divide by zero; it must be excluded from the ratio
+        # rather than raising or being silently treated as some default.
+        ng_perf_records = [
+            {"completion_tokens": 10, "num_turns": 0},
+            {"completion_tokens": 20, "num_turns": 2},
+        ]
+
+        summary = compute_perf_summary(ng_perf_records)
+
+        assert summary["mean_tokens_per_turn"] == 10.0
+
+    def test_mixed_presence_only_averages_over_reporting_rollouts(self) -> None:
+        # Rollout 2 never reports cached_prompt_tokens -- the mean must be computed over the
+        # rollouts that did report it (just rollout 1's value), not treat the missing one as 0.
+        ng_perf_records = [
+            {"cached_prompt_tokens": 40, "num_turns": 1},
+            {"num_turns": 1},
+        ]
+
+        summary = compute_perf_summary(ng_perf_records)
+
+        assert summary["mean_cached_prompt_tokens"] == 40.0
+        assert summary["total_cached_prompt_tokens"] == 40
+
+
+class TestPerfSummaryInAggregateMetrics:
+    def test_absent_when_no_rollout_carries_ng_perf(self) -> None:
+        responses = [
+            {TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "reward": 1.0, "response": {}},
+        ]
+
+        result = compute_aggregate_metrics(responses)
+
+        assert result.perf_summary is None
+
+    def test_present_when_a_rollout_carries_ng_perf(self) -> None:
+        responses = [
+            {
+                TASK_INDEX_KEY_NAME: 0,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                "reward": 1.0,
+                "response": {},
+                "ng_perf": {"num_turns": 3, "prompt_tokens": 90, "total_latency_ms": 1000.0},
+            },
+            {TASK_INDEX_KEY_NAME: 1, ROLLOUT_INDEX_KEY_NAME: 0, "reward": 0.0, "response": {}},
+        ]
+
+        result = compute_aggregate_metrics(responses)
+
+        assert result.perf_summary is not None
+        assert result.perf_summary["mean_num_turns"] == 3.0
+        assert result.perf_summary["total_prompt_tokens"] == 90
+        assert result.perf_summary["total_latency_mean_ms"] == 1000.0

--- a/tests/unit_tests/test_base_responses_api_model.py
+++ b/tests/unit_tests/test_base_responses_api_model.py
@@ -613,6 +613,18 @@ def test_model_call_capture_config_requires_absolute_dir_when_enabled(tmp_path, 
     assert model_call_capture_dirs_from_config(nested_config) == []
 
 
+def test_observability_enabled_from_config(tmp_path):
+    from nemo_gym.base_responses_api_model import observability_enabled_from_config
+
+    assert observability_enabled_from_config({}) is False
+
+    global_config = OmegaConf.create({"observability_enabled": True, "model_call_capture_dir": str(tmp_path)})
+    assert observability_enabled_from_config(global_config) is True
+
+    with pytest.raises(ValueError, match="required"):
+        observability_enabled_from_config({"observability_enabled": True})
+
+
 def test_make_capture_store_init_failure_returns_none(monkeypatch):
     import nemo_gym.base_responses_api_model as obs
 

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -467,6 +467,93 @@ class TestRolloutCollection:
         assert ng_perf["prompt_tokens"] == 100
         assert ng_perf["completion_tokens"] == 10
 
+    def test_ng_perf_matches_model_calls_by_response_id_pair_like_simple_agent(self) -> None:
+        # Integration test: simple_agent sets result["ng_trajectory"] directly (see
+        # responses_api_agents/simple_agent/app.py), bypassing join_model_call_observations
+        # entirely -- so its ModelCallRef is never canonicalized with a model_call_id and only
+        # ever carries (model_ref, response_id). Token fields must still populate.
+        row = {TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0}
+        result = {
+            NG_TRAJECTORY_KEY: {
+                "task_id": "0",
+                "rollout_id": "0-0",
+                "invocations": [
+                    {
+                        "invocation_id": "root",
+                        "model_calls": [
+                            {
+                                "model_ref": {"type": "responses_api_models", "name": "policy_model"},
+                                "response_id": "resp_123",
+                            }
+                        ],
+                    }
+                ],
+            },
+            "ng_model_call_capture": {
+                "calls": [
+                    {
+                        "model_call_id": "captured-1",
+                        "response_id": "resp_123",
+                        "model_ref": {"type": "responses_api_models", "name": "policy_model"},
+                        "tokens_in": 100,
+                        "tokens_out": 20,
+                    }
+                ]
+            },
+        }
+
+        _attach_trajectory_record(row, result)
+        ng_perf = _build_ng_perf(result, rollout_latency_ms=None)
+
+        assert ng_perf["prompt_tokens"] == 100
+        assert ng_perf["completion_tokens"] == 20
+
+    def test_ng_perf_does_not_guess_an_ambiguous_response_id_match(self) -> None:
+        # Two captured calls share the same (model_ref, response_id) pair -- the ref must
+        # resolve to no match rather than guessing either one, so its tokens stay uncounted.
+        row = {TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0}
+        result = {
+            NG_TRAJECTORY_KEY: {
+                "task_id": "0",
+                "rollout_id": "0-0",
+                "invocations": [
+                    {
+                        "invocation_id": "root",
+                        "model_calls": [
+                            {
+                                "model_ref": {"type": "responses_api_models", "name": "policy_model"},
+                                "response_id": "resp_dup",
+                            }
+                        ],
+                    }
+                ],
+            },
+            "ng_model_call_capture": {
+                "calls": [
+                    {
+                        "model_call_id": "captured-1",
+                        "response_id": "resp_dup",
+                        "model_ref": {"type": "responses_api_models", "name": "policy_model"},
+                        "tokens_in": 100,
+                        "tokens_out": 20,
+                    },
+                    {
+                        "model_call_id": "captured-2",
+                        "response_id": "resp_dup",
+                        "model_ref": {"type": "responses_api_models", "name": "policy_model"},
+                        "tokens_in": 999,
+                        "tokens_out": 999,
+                    },
+                ]
+            },
+        }
+
+        _attach_trajectory_record(row, result)
+        ng_perf = _build_ng_perf(result, rollout_latency_ms=None)
+
+        assert "prompt_tokens" not in ng_perf
+        assert "completion_tokens" not in ng_perf
+
     def test_build_ng_perf_counts_explicit_turns_over_invocations(self) -> None:
         # simple_agent-style trajectory: the whole multi-turn loop runs under a single "root"
         # invocation with one TrajectoryTurn per step. num_turns must count the turns (3), not

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -410,6 +410,7 @@ class TestRolloutCollection:
         assert ng_perf == {
             "num_turns": 2,
             "num_tool_calls": 3,
+            "token_observability_coverage": 1.0,
             "prompt_tokens": 150,
             "cached_prompt_tokens": 10,
             "completion_tokens": 25,
@@ -438,7 +439,7 @@ class TestRolloutCollection:
             "total_latency_ms",
         ):
             assert absent_key not in ng_perf
-        assert ng_perf == {"num_turns": 1, "num_tool_calls": 0}
+        assert ng_perf == {"num_turns": 1, "num_tool_calls": 0, "token_observability_coverage": 0.0}
 
     def test_build_ng_perf_dedupes_model_call_claimed_by_two_invocations(self) -> None:
         # Simulates a join_model_call_observations conflict: the losing invocation keeps an
@@ -466,6 +467,7 @@ class TestRolloutCollection:
         assert ng_perf["num_turns"] == 2
         assert ng_perf["prompt_tokens"] == 100
         assert ng_perf["completion_tokens"] == 10
+        assert ng_perf["token_observability_coverage"] == 0.5
 
     def test_ng_perf_matches_model_calls_by_response_id_pair_like_simple_agent(self) -> None:
         # Integration test: simple_agent sets result["ng_trajectory"] directly (see
@@ -584,6 +586,7 @@ class TestRolloutCollection:
 
         assert ng_perf["num_turns"] == 3
         assert ng_perf["completion_tokens"] == 30
+        assert ng_perf["token_observability_coverage"] == pytest.approx(1 / 3)
 
     def test_build_ng_perf_sums_turns_across_invocations_with_per_invocation_fallback(self) -> None:
         # Hybrid trajectory: "root" emits explicit TrajectoryTurn records (2 turns), "sub-a"
@@ -619,6 +622,7 @@ class TestRolloutCollection:
 
         assert ng_perf["num_turns"] == 7
         assert ng_perf["completion_tokens"] == 40
+        assert ng_perf["token_observability_coverage"] == pytest.approx(4 / 7)
 
     def test_attach_ng_perf_absent_when_observability_disabled(self) -> None:
         result = {
@@ -647,7 +651,12 @@ class TestRolloutCollection:
 
         _attach_ng_perf(result, observability_enabled=True)
 
-        assert result[NG_PERF_KEY] == {"num_turns": 1, "num_tool_calls": 0, "total_latency_ms": 42.0}
+        assert result[NG_PERF_KEY] == {
+            "num_turns": 1,
+            "num_tool_calls": 0,
+            "token_observability_coverage": 0.0,
+            "total_latency_ms": 42.0,
+        }
         assert "_ng_rollout_latency_ms" not in result
 
     def test_attach_ng_perf_swallows_build_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -460,10 +460,10 @@ class TestRolloutCollection:
 
         ng_perf = _build_ng_perf(result, rollout_latency_ms=None)
 
-        # One physical model call means one reasoning turn: with no explicit TrajectoryTurn
-        # records, num_turns falls back to the deduplicated owned-call count, so the shared
-        # call contributes a single turn and a single token attribution.
-        assert ng_perf["num_turns"] == 1
+        # Token dedup must not erase the losing invocation from the turn count: the shared
+        # call contributes one owned-call turn to "root", and "sub" -- a real conversation
+        # left with no owned calls -- still counts as at least one turn.
+        assert ng_perf["num_turns"] == 2
         assert ng_perf["prompt_tokens"] == 100
         assert ng_perf["completion_tokens"] == 10
 
@@ -497,6 +497,41 @@ class TestRolloutCollection:
 
         assert ng_perf["num_turns"] == 3
         assert ng_perf["completion_tokens"] == 30
+
+    def test_build_ng_perf_sums_turns_across_invocations_with_per_invocation_fallback(self) -> None:
+        # Hybrid trajectory: "root" emits explicit TrajectoryTurn records (2 turns), "sub-a"
+        # emits none but owns 4 resolved model calls, "sub-b" emits nothing at all. Each
+        # invocation contributes its own best turn count: 2 + 4 + 1 = 7.
+        result = {
+            NG_TRAJECTORY_KEY: {
+                "task_id": "t",
+                "rollout_id": "t-0",
+                "invocations": [
+                    {"invocation_id": "root"},
+                    {"invocation_id": "sub-a", "model_calls": [{"model_call_id": f"call-{i}"} for i in range(4)]},
+                    {"invocation_id": "sub-b"},
+                ],
+                "turns": [
+                    {
+                        "invocation_id": "root",
+                        "task_id": "t",
+                        "rollout_id": "t-0",
+                        "turn_no": turn_no,
+                        "timestamp": 1.0,
+                        "step_count": 0,
+                    }
+                    for turn_no in (1, 2)
+                ],
+                "model_calls": [
+                    {"model_call_id": f"call-{i}", "token_stats": {"completion_tokens": 10}} for i in range(4)
+                ],
+            }
+        }
+
+        ng_perf = _build_ng_perf(result, rollout_latency_ms=None)
+
+        assert ng_perf["num_turns"] == 7
+        assert ng_perf["completion_tokens"] == 40
 
     def test_attach_ng_perf_absent_when_observability_disabled(self) -> None:
         result = {

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -1086,6 +1086,7 @@ class TestRolloutCollection:
                 },
                 "key_metrics": {"mean/abc usage": 1.0},
                 "group_level_metrics": actual_aggregate_metrics[0]["group_level_metrics"],
+                "perf_summary": None,
             }
         ]
         assert expected_aggregate_metrics == actual_aggregate_metrics
@@ -1749,6 +1750,64 @@ class TestRolloutCollection:
             assert "ng_model_call_capture" not in item
             assert "ng_trajectory" not in item
             assert "usage" in item["response"]
+
+    async def test_call_aggregate_metrics_includes_perf_summary_when_present(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """perf_summary must survive _call_aggregate_metrics' hand-picked agent_entry dict --
+        it's easy to add a field to AggregateMetrics and forget this call site only forwards an
+        explicit allowlist rather than the whole model."""
+        agg = AggregateMetrics(
+            agent_metrics={"mean/reward": 0.5},
+            key_metrics={"mean/reward": 0.5},
+            group_level_metrics=[{"mean/reward": 1.0}],
+            perf_summary={"mean_num_turns": 3.0, "total_latency_mean_ms": 1000.0},
+        )
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.read = AsyncMock(return_value=orjson.dumps(agg.model_dump()))
+        mock_response.status = 200
+
+        mock_server_client = MagicMock()
+        mock_server_client.post = AsyncMock(return_value=mock_response)
+        monkeypatch.setattr(
+            nemo_gym.rollout_collection, "setup_server_client_utils", lambda *args, **kwargs: mock_server_client
+        )
+        helper = RolloutCollectionHelper()
+
+        rows = [{AGENT_REF_KEY_NAME: {"name": "my_agent"}, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0}]
+        results = [{TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "reward": 1.0}]
+
+        metrics_fpath = await helper._call_aggregate_metrics(results, rows, tmp_path / "output.jsonl")
+
+        written = json.loads(metrics_fpath.read_text())
+        assert written[0]["perf_summary"] == {"mean_num_turns": 3.0, "total_latency_mean_ms": 1000.0}
+
+    async def test_call_aggregate_metrics_omits_perf_summary_when_absent(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        agg = AggregateMetrics(agent_metrics={"mean/reward": 0.5}, key_metrics={"mean/reward": 0.5})
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.read = AsyncMock(return_value=orjson.dumps(agg.model_dump()))
+        mock_response.status = 200
+
+        mock_server_client = MagicMock()
+        mock_server_client.post = AsyncMock(return_value=mock_response)
+        monkeypatch.setattr(
+            nemo_gym.rollout_collection, "setup_server_client_utils", lambda *args, **kwargs: mock_server_client
+        )
+        helper = RolloutCollectionHelper()
+
+        rows = [{AGENT_REF_KEY_NAME: {"name": "my_agent"}, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0}]
+        results = [{TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0, "reward": 1.0}]
+
+        metrics_fpath = await helper._call_aggregate_metrics(results, rows, tmp_path / "output.jsonl")
+
+        written = json.loads(metrics_fpath.read_text())
+        assert "perf_summary" not in written[0]
 
     async def test_call_aggregate_metrics_multiple_agents(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -37,12 +37,16 @@ from nemo_gym.rollout_collection import (
     _DEFAULT_MAX_ROLLOUT_ATTEMPTS,
     NG_FAILURE_CLASS_KEY,
     NG_NO_PERSIST_KEY,
+    NG_PERF_KEY,
+    NG_TRAJECTORY_KEY,
     E2ERolloutCollectionConfig,
     RolloutAggregationConfig,
     RolloutAggregationHelper,
     RolloutCollectionConfig,
     RolloutCollectionHelper,
+    _attach_ng_perf,
     _attach_trajectory_record,
+    _build_ng_perf,
     _build_trajectory_record,
     _expand_input_glob,
     _failures_path_for,
@@ -340,6 +344,168 @@ class TestRolloutCollection:
             sanitized = _rollout_for_export(malformed_result)
             assert b"secret" not in orjson.dumps(sanitized)
 
+    def test_build_ng_perf_absent_without_trajectory(self) -> None:
+        assert _build_ng_perf({}, rollout_latency_ms=12.0) is None
+        assert _build_ng_perf({NG_TRAJECTORY_KEY: "not-a-dict"}, rollout_latency_ms=12.0) is None
+
+    def test_build_ng_perf_absent_when_trajectory_invalid(self) -> None:
+        result = {NG_TRAJECTORY_KEY: {"invocations": [{"invocation_id": "root"}, {"invocation_id": "root"}]}}
+        assert _build_ng_perf(result, rollout_latency_ms=12.0) is None
+
+    def test_build_ng_perf_absent_without_invocations(self) -> None:
+        result = {NG_TRAJECTORY_KEY: {"task_id": "t", "rollout_id": "t-0", "invocations": []}}
+        assert _build_ng_perf(result, rollout_latency_ms=12.0) is None
+
+    def test_build_ng_perf_sums_owned_calls_and_matched_tool_calls(self) -> None:
+        result = {
+            NG_TRAJECTORY_KEY: {
+                "task_id": "t",
+                "rollout_id": "t-0",
+                "invocations": [
+                    {
+                        "invocation_id": "root",
+                        "model_calls": [{"model_call_id": "call-1"}],
+                    },
+                    {
+                        "invocation_id": "sub",
+                        "model_calls": [{"model_call_id": "call-2"}, {"model_call_id": "unresolved-response"}],
+                    },
+                ],
+                "tool_calls": [
+                    {"invocation_id": "root", "tool_call_id": "t1"},
+                    {"invocation_id": "sub", "tool_call_id": "t2"},
+                    {"invocation_id": "sub", "tool_call_id": "t3"},
+                    # Orphaned: no invocation in this trajectory owns "ghost".
+                    {"invocation_id": "ghost", "tool_call_id": "t4"},
+                ],
+                "model_calls": [
+                    {
+                        "model_call_id": "call-1",
+                        "token_stats": {
+                            "prompt_tokens": 100,
+                            "completion_tokens": 20,
+                            "cached_tokens": 10,
+                        },
+                    },
+                    {
+                        "model_call_id": "call-2",
+                        "token_stats": {
+                            "prompt_tokens": 50,
+                            "completion_tokens": 5,
+                            "reasoning_tokens": 3,
+                        },
+                    },
+                    # Present in raw capture but never referenced by any invocation's
+                    # model_calls (e.g. compaction-owned, or unjoined) -- must not be summed.
+                    {
+                        "model_call_id": "unowned",
+                        "token_stats": {"prompt_tokens": 999, "completion_tokens": 999},
+                    },
+                ],
+            }
+        }
+
+        ng_perf = _build_ng_perf(result, rollout_latency_ms=1234.5)
+
+        assert ng_perf == {
+            "num_turns": 2,
+            "num_tool_calls": 3,
+            "prompt_tokens": 150,
+            "cached_prompt_tokens": 10,
+            "completion_tokens": 25,
+            "reasoning_tokens": 3,
+            "total_latency_ms": 1234.5,
+        }
+
+    def test_build_ng_perf_omits_absent_token_fields_and_latency(self) -> None:
+        # No model_calls/tool_calls at all on the trajectory, and no independent latency
+        # measurement, so every optional ng_perf field must be *absent*, not present-as-None.
+        result = {
+            NG_TRAJECTORY_KEY: {
+                "task_id": "t",
+                "rollout_id": "t-0",
+                "invocations": [{"invocation_id": "root"}],
+            }
+        }
+
+        ng_perf = _build_ng_perf(result, rollout_latency_ms=None)
+
+        for absent_key in (
+            "prompt_tokens",
+            "cached_prompt_tokens",
+            "completion_tokens",
+            "reasoning_tokens",
+            "total_latency_ms",
+        ):
+            assert absent_key not in ng_perf
+        assert ng_perf == {"num_turns": 1, "num_tool_calls": 0}
+
+    def test_build_ng_perf_dedupes_model_call_claimed_by_two_invocations(self) -> None:
+        # Simulates a join_model_call_observations conflict: the losing invocation keeps an
+        # unresolved ref pointing at a model_call_id another invocation already claimed. Tokens
+        # for that call must be counted once, not twice.
+        result = {
+            NG_TRAJECTORY_KEY: {
+                "task_id": "t",
+                "rollout_id": "t-0",
+                "invocations": [
+                    {"invocation_id": "root", "model_calls": [{"model_call_id": "shared"}]},
+                    {"invocation_id": "sub", "model_calls": [{"model_call_id": "shared"}]},
+                ],
+                "model_calls": [
+                    {"model_call_id": "shared", "token_stats": {"prompt_tokens": 100, "completion_tokens": 10}},
+                ],
+            }
+        }
+
+        ng_perf = _build_ng_perf(result, rollout_latency_ms=None)
+
+        # Both invocations are still real, distinct turns -- the dedup applies only to token
+        # attribution, not to num_turns, which must still count both.
+        assert ng_perf["num_turns"] == 2
+        assert ng_perf["prompt_tokens"] == 100
+        assert ng_perf["completion_tokens"] == 10
+
+    def test_attach_ng_perf_absent_when_observability_disabled(self) -> None:
+        result = {
+            "_ng_rollout_latency_ms": 42.0,
+            NG_TRAJECTORY_KEY: {
+                "task_id": "t",
+                "rollout_id": "t-0",
+                "invocations": [{"invocation_id": "root"}],
+            },
+        }
+
+        _attach_ng_perf(result, observability_enabled=False)
+
+        assert NG_PERF_KEY not in result
+        assert "_ng_rollout_latency_ms" not in result
+
+    def test_attach_ng_perf_sets_ng_perf_when_enabled(self) -> None:
+        result = {
+            "_ng_rollout_latency_ms": 42.0,
+            NG_TRAJECTORY_KEY: {
+                "task_id": "t",
+                "rollout_id": "t-0",
+                "invocations": [{"invocation_id": "root"}],
+            },
+        }
+
+        _attach_ng_perf(result, observability_enabled=True)
+
+        assert result[NG_PERF_KEY] == {"num_turns": 1, "num_tool_calls": 0, "total_latency_ms": 42.0}
+        assert "_ng_rollout_latency_ms" not in result
+
+    def test_attach_ng_perf_swallows_build_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An unexpected assembly failure must never take down rollout collection over an observability side-channel.
+        result = {"_ng_rollout_latency_ms": 42.0, NG_TRAJECTORY_KEY: {}}
+        monkeypatch.setattr(nemo_gym.rollout_collection, "_build_ng_perf", MagicMock(side_effect=ValueError))
+
+        _attach_ng_perf(result, observability_enabled=True)
+
+        assert NG_PERF_KEY not in result
+        assert "_ng_rollout_latency_ms" not in result
+
     @pytest.mark.parametrize("request_debug_enabled", [True, False])
     async def test_run_examples_logs_failed_run_when_request_debug_enabled(
         self,
@@ -390,6 +556,24 @@ class TestRolloutCollection:
             assert "do not log this" not in captured.out
         else:
             assert "[rollout_collection] /run failed" not in captured.out
+
+    async def test_run_examples_stamps_independent_rollout_latency(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        row = {AGENT_REF_KEY_NAME: {"name": "my_agent"}, TASK_INDEX_KEY_NAME: 0, ROLLOUT_INDEX_KEY_NAME: 0}
+        response = MagicMock()
+        response.status = 200
+
+        mock_server_client = MagicMock()
+        mock_server_client.post = AsyncMock(return_value=response)
+        monkeypatch.setattr(
+            nemo_gym.rollout_collection, "setup_server_client_utils", lambda *args, **kwargs: mock_server_client
+        )
+        monkeypatch.setattr(nemo_gym.rollout_collection, "raise_for_status", AsyncMock())
+        monkeypatch.setattr(nemo_gym.rollout_collection, "get_response_json", AsyncMock(return_value={"response": {}}))
+
+        _, result = await next(RolloutCollectionHelper().run_examples([row]))
+
+        assert isinstance(result["_ng_rollout_latency_ms"], float)
+        assert result["_ng_rollout_latency_ms"] >= 0
 
     def test_preprocess_rows_with_prompt_config(self, tmp_path: Path) -> None:
         """prompt_config builds responses_create_params.input from template."""

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -727,6 +727,7 @@ class TestRolloutCollection:
 
         mock_server_client = MagicMock()
         mock_server_client.post = AsyncMock(return_value=response)
+        mock_server_client.global_config_dict = OmegaConf.create({"my_agent": {"responses_api_agents": {"impl": {}}}})
         monkeypatch.setattr(
             nemo_gym.rollout_collection, "setup_server_client_utils", lambda *args, **kwargs: mock_server_client
         )

--- a/tests/unit_tests/test_rollout_collection.py
+++ b/tests/unit_tests/test_rollout_collection.py
@@ -460,11 +460,43 @@ class TestRolloutCollection:
 
         ng_perf = _build_ng_perf(result, rollout_latency_ms=None)
 
-        # Both invocations are still real, distinct turns -- the dedup applies only to token
-        # attribution, not to num_turns, which must still count both.
-        assert ng_perf["num_turns"] == 2
+        # One physical model call means one reasoning turn: with no explicit TrajectoryTurn
+        # records, num_turns falls back to the deduplicated owned-call count, so the shared
+        # call contributes a single turn and a single token attribution.
+        assert ng_perf["num_turns"] == 1
         assert ng_perf["prompt_tokens"] == 100
         assert ng_perf["completion_tokens"] == 10
+
+    def test_build_ng_perf_counts_explicit_turns_over_invocations(self) -> None:
+        # simple_agent-style trajectory: the whole multi-turn loop runs under a single "root"
+        # invocation with one TrajectoryTurn per step. num_turns must count the turns (3), not
+        # the invocations (1) -- otherwise tokens-per-turn degenerates into total tokens.
+        result = {
+            NG_TRAJECTORY_KEY: {
+                "task_id": "t",
+                "rollout_id": "t-0",
+                "invocations": [{"invocation_id": "root", "model_calls": [{"model_call_id": "call-1"}]}],
+                "turns": [
+                    {
+                        "invocation_id": "root",
+                        "task_id": "t",
+                        "rollout_id": "t-0",
+                        "turn_no": turn_no,
+                        "timestamp": 1.0,
+                        "step_count": 0,
+                    }
+                    for turn_no in (1, 2, 3)
+                ],
+                "model_calls": [
+                    {"model_call_id": "call-1", "token_stats": {"prompt_tokens": 100, "completion_tokens": 30}},
+                ],
+            }
+        }
+
+        ng_perf = _build_ng_perf(result, rollout_latency_ms=None)
+
+        assert ng_perf["num_turns"] == 3
+        assert ng_perf["completion_tokens"] == 30
 
     def test_attach_ng_perf_absent_when_observability_disabled(self) -> None:
         result = {


### PR DESCRIPTION
## What does this PR do?

Implements the P0 scope of the "Automated Insights" RFC (#1703): surfaces per-rollout token efficiency metrics that currently require custom extraction scripts against raw observability data.
- `ng_perf`: a new field attached to each rollout record (alongside `ng_trajectory`/ `ng_model_call_capture`)
  - contains `num_turns`, `num_tool_calls`, `prompt_tokens`, `cached_prompt_tokens`, `completion_tokens`, `reasoning_tokens`, and an independently measured `total_latency_ms`
  - `num_turns` sums each invocation's own reasoning-turn count (explicit TrajectoryTurn records when the harness emits them, falling back to its resolved model-call count, then to 1) so a single invocation spanning many steps isn't undercounted as one turn
  - token fields exclude compaction-owned model calls so they reflect task-solving cost, not compaction overhead. Present only when `observability_enabled=True` and at least one reasoning turn was observed
  - each individual field is absent (not null) when its underlying data wasn't collected.
- `perf_summary`: a new block in `_aggregate_metrics.json`
  - aggregates every rollout's `ng_perf` into mean/median/total token stats, mean/median tokens-per-turn, a full distribution (mean/median/std/min/p90/max) for `num_turns`, and p50/p90/p99/mean `total_latency_ms`
  - absent when no rollout in the run carried `ng_perf`.

Both are purely additive; see `fern/versions/latest/pages/model-server/model-call-capture.mdx` for the schema.

Completes P0 scope of NVIDIA-NeMo/Gym#1703 (P1+ to follow).

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
