### PR TITLE
fix(opensandbox): let a caller launch the cleanup job from anywhere

### DIFF
--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -11,6 +11,7 @@ CONTAINER=$CONTAINER
 MOUNTS=$MOUNTS
 VLLM_CONFIG=$VLLM_CONFIG
 SLURM_COMMENT="${SLURM_COMMENT:-}"
+NEMO_GYM_REPO_ROOT="${NEMO_GYM_REPO_ROOT:-$(pwd -P)}"
 
 should_run_eval=$(( $# > 0 ))
 if (( should_run_eval )); then
@@ -284,14 +285,15 @@ if (( should_run_eval )); then
             --time=00:30:00 \
             --job-name="gym-cleanup-$main_job_id" \
             --output="$submit_dir/slurm-logs/%j-gym-cleanup-$main_job_id.log" \
-            "$submit_dir/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py" \
-            --connection-config "$submit_dir/env.yaml" \
+            "$NEMO_GYM_REPO_ROOT/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py" \
             --run-id "$main_job_id" \
             --user "$cleanup_user" \
             --reap
     ); then
-        echo "Failed to submit cleanup job for batch job $main_job_id; the batch job is still active" >&2
-        exit 1
+        echo "Submitted batch job $main_job_id"
+        echo "Failed to submit the sandbox-cleanup job for batch job $main_job_id;" \
+            "it is running and its sandboxes will need reaping by hand" >&2
+        exit 0
     fi
     cleanup_job_id=${cleanup_job_id%%;*}
 fi

--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -278,6 +278,7 @@ if (( should_run_eval )); then
             --partition=cpu \
             --qos=cpu-short \
             --gres=none \
+            --gpus-per-node=0 \
             --nodes=1 \
             --ntasks=1 \
             --cpus-per-task=1 \

--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -15,6 +15,17 @@ OPENSANDBOX_DOMAIN="${OPENSANDBOX_DOMAIN:-}"
 OPENSANDBOX_API_KEY="${OPENSANDBOX_API_KEY:-}"
 OPENSANDBOX_PROTOCOL="${OPENSANDBOX_PROTOCOL:-http}"
 
+# The checkout this script ships in; a caller running a copy of it names its own.
+gym_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+if [[ "${1:-}" == "--gym-root" ]]; then
+    if [[ -z "${2:-}" ]]; then
+        echo "--gym-root needs a path" >&2
+        exit 2
+    fi
+    gym_root=$2
+    shift 2
+fi
+
 should_run_eval=$(( $# > 0 ))
 if (( should_run_eval )); then
     EXPERIMENT_NAME=$EXPERIMENT_NAME
@@ -252,9 +263,7 @@ EOF
 
 # --segment > 0 otherwise the engine will hang on the second or third engine step.
 submit_dir=$(pwd -P)
-gym_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
-# A caller that exports the connection sends it as arguments; a checkout that
-# keeps one in env.yaml is read from there, as before.
+# An exported connection is sent as arguments; otherwise env.yaml is read.
 if [[ -n "$OPENSANDBOX_DOMAIN" ]]; then
     cleanup_connection=(--domain "$OPENSANDBOX_DOMAIN" --api-key "$OPENSANDBOX_API_KEY" --protocol "$OPENSANDBOX_PROTOCOL")
 else

--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -253,6 +253,13 @@ EOF
 # --segment > 0 otherwise the engine will hang on the second or third engine step.
 submit_dir=$(pwd -P)
 gym_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+# A caller that exports the connection sends it as arguments; a checkout that
+# keeps one in env.yaml is read from there, as before.
+if [[ -n "$OPENSANDBOX_DOMAIN" ]]; then
+    cleanup_connection=(--domain "$OPENSANDBOX_DOMAIN" --api-key "$OPENSANDBOX_API_KEY" --protocol "$OPENSANDBOX_PROTOCOL")
+else
+    cleanup_connection=(--connection-config "$gym_root/env.yaml")
+fi
 cleanup_user=${NEMO_GYM_USER:-$USER}
 main_job_id=$(
     NEMO_GYM_USER="$cleanup_user" \
@@ -290,9 +297,7 @@ if (( should_run_eval )); then
             --job-name="gym-cleanup-$main_job_id" \
             --output="$submit_dir/slurm-logs/%j-gym-cleanup-$main_job_id.log" \
             "$gym_root/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py" \
-            --domain "$OPENSANDBOX_DOMAIN" \
-            --api-key "$OPENSANDBOX_API_KEY" \
-            --protocol "$OPENSANDBOX_PROTOCOL" \
+            "${cleanup_connection[@]}" \
             --run-id "$main_job_id" \
             --user "$cleanup_user" \
             --reap

--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -11,7 +11,9 @@ CONTAINER=$CONTAINER
 MOUNTS=$MOUNTS
 VLLM_CONFIG=$VLLM_CONFIG
 SLURM_COMMENT="${SLURM_COMMENT:-}"
-NEMO_GYM_REPO_ROOT="${NEMO_GYM_REPO_ROOT:-$(pwd -P)}"
+OPENSANDBOX_DOMAIN="${OPENSANDBOX_DOMAIN:-}"
+OPENSANDBOX_API_KEY="${OPENSANDBOX_API_KEY:-}"
+OPENSANDBOX_PROTOCOL="${OPENSANDBOX_PROTOCOL:-http}"
 
 should_run_eval=$(( $# > 0 ))
 if (( should_run_eval )); then
@@ -250,6 +252,7 @@ EOF
 
 # --segment > 0 otherwise the engine will hang on the second or third engine step.
 submit_dir=$(pwd -P)
+gym_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
 cleanup_user=${NEMO_GYM_USER:-$USER}
 main_job_id=$(
     NEMO_GYM_USER="$cleanup_user" \
@@ -286,7 +289,10 @@ if (( should_run_eval )); then
             --time=00:30:00 \
             --job-name="gym-cleanup-$main_job_id" \
             --output="$submit_dir/slurm-logs/%j-gym-cleanup-$main_job_id.log" \
-            "$NEMO_GYM_REPO_ROOT/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py" \
+            "$gym_root/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py" \
+            --domain "$OPENSANDBOX_DOMAIN" \
+            --api-key "$OPENSANDBOX_API_KEY" \
+            --protocol "$OPENSANDBOX_PROTOCOL" \
             --run-id "$main_job_id" \
             --user "$cleanup_user" \
             --reap

--- a/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py
+++ b/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py
@@ -6,7 +6,6 @@
 
 import argparse
 import asyncio
-import os
 import re
 import sys
 import urllib.parse
@@ -17,9 +16,6 @@ import aiohttp
 import yaml
 
 
-DOMAIN_ENV_VAR = "OPENSANDBOX_DOMAIN"
-API_KEY_ENV_VAR = "OPENSANDBOX_API_KEY"
-PROTOCOL_ENV_VAR = "OPENSANDBOX_PROTOCOL"
 RUN_METADATA_KEY = "nemo-gym.nvidia.com/run"
 USER_METADATA_KEY = "nemo-gym.nvidia.com/user"
 REQUEST_TIMEOUT_SECONDS = 30
@@ -141,27 +137,43 @@ async def cleanup_sandboxes(
         return 1
 
 
-def connection_from_environment() -> tuple[str, str, str]:
-    """The connection a caller exports rather than writes to a file."""
-    domain = os.environ.get(DOMAIN_ENV_VAR, "").strip()
-    access_key = os.environ.get(API_KEY_ENV_VAR, "").strip()
-    protocol = os.environ.get(PROTOCOL_ENV_VAR, "").strip() or "http"
-    for name, value in ((DOMAIN_ENV_VAR, domain), (API_KEY_ENV_VAR, access_key)):
-        if not value:
-            raise ValueError(f"{name} must be set when --connection-config is omitted")
-    if protocol not in {"http", "https"}:
-        raise ValueError(f"{PROTOCOL_ENV_VAR} must be http or https")
-    return domain, access_key, protocol
+def _run(
+    parser: argparse.ArgumentParser,
+    domain: str,
+    access_key: str,
+    protocol: str,
+    args: argparse.Namespace,
+) -> int:
+    """Run the cleanup and turn its failures into a message and a status."""
+    try:
+        return asyncio.run(
+            cleanup_sandboxes(
+                domain=domain,
+                protocol=protocol,
+                access_key=access_key,
+                run_id=args.run_id,
+                user=args.user,
+                reap=args.reap,
+            )
+        )
+    except (aiohttp.ClientError, OSError, TypeError, ValueError) as error:
+        print(f"OpenSandbox cleanup failed: {error}", file=sys.stderr)
+        return 1
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--connection-config",
-        help=(
-            "YAML file containing sandbox.opensandbox.connection. Omit it to read the connection from "
-            f"{DOMAIN_ENV_VAR}, {API_KEY_ENV_VAR} and {PROTOCOL_ENV_VAR} instead."
-        ),
+        help="YAML file containing sandbox.opensandbox.connection, as an alternative to --domain/--api-key.",
+    )
+    parser.add_argument("--domain", help="OpenSandbox domain, host or full URL.")
+    parser.add_argument("--api-key", help="OpenSandbox access key.")
+    parser.add_argument(
+        "--protocol",
+        default="http",
+        choices=("http", "https"),
+        help="Scheme for --domain when it carries none (default: http).",
     )
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--user", required=True)
@@ -172,19 +184,16 @@ def main(argv: list[str] | None = None) -> int:
         if not value.strip():
             parser.error(f"--{name} must not be empty")
 
+    if args.connection_config is None:
+        for name, value in (("domain", args.domain), ("api-key", args.api_key)):
+            if value is None or not value.strip():
+                parser.error(f"--{name} is required when --connection-config is omitted")
+        return _run(parser, args.domain.strip(), args.api_key.strip(), args.protocol, args)
+    for name, value in (("domain", args.domain), ("api-key", args.api_key)):
+        if value is not None:
+            parser.error(f"--{name} cannot be combined with --connection-config")
+
     try:
-        if args.connection_config is None:
-            domain, access_key, protocol = connection_from_environment()
-            return asyncio.run(
-                cleanup_sandboxes(
-                    domain=domain,
-                    protocol=protocol,
-                    access_key=access_key,
-                    run_id=args.run_id,
-                    user=args.user,
-                    reap=args.reap,
-                )
-            )
         with open(args.connection_config, encoding="utf-8") as config_file:
             config = yaml.safe_load(config_file)
         if not isinstance(config, Mapping):
@@ -208,16 +217,7 @@ def main(argv: list[str] | None = None) -> int:
         if not isinstance(protocol, str) or protocol.strip() not in {"http", "https"}:
             raise ValueError("connection config 'sandbox.opensandbox.connection.protocol' must be http or https")
 
-        return asyncio.run(
-            cleanup_sandboxes(
-                domain=domain.strip(),
-                protocol=protocol.strip(),
-                access_key=access_key.strip(),
-                run_id=args.run_id,
-                user=args.user,
-                reap=args.reap,
-            )
-        )
+        return _run(parser, domain.strip(), access_key.strip(), protocol.strip(), args)
     except yaml.YAMLError:
         print("OpenSandbox cleanup failed: invalid YAML connection config", file=sys.stderr)
         return 1

--- a/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py
+++ b/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py
@@ -17,9 +17,6 @@ import aiohttp
 import yaml
 
 
-DOMAIN_ENV_VAR = "OPENSANDBOX_DOMAIN"
-API_KEY_ENV_VAR = "OPENSANDBOX_API_KEY"
-PROTOCOL_ENV_VAR = "OPENSANDBOX_PROTOCOL"
 RUN_METADATA_KEY = "nemo-gym.nvidia.com/run"
 USER_METADATA_KEY = "nemo-gym.nvidia.com/user"
 REQUEST_TIMEOUT_SECONDS = 30
@@ -143,14 +140,14 @@ async def cleanup_sandboxes(
 
 def connection_from_environment() -> tuple[str, str, str]:
     """The connection a caller exports rather than writes to a file."""
-    domain = os.environ.get(DOMAIN_ENV_VAR, "").strip()
-    access_key = os.environ.get(API_KEY_ENV_VAR, "").strip()
-    protocol = os.environ.get(PROTOCOL_ENV_VAR, "").strip() or "http"
-    for name, value in ((DOMAIN_ENV_VAR, domain), (API_KEY_ENV_VAR, access_key)):
+    domain = os.environ.get("OPENSANDBOX_DOMAIN", "").strip()
+    access_key = os.environ.get("OPENSANDBOX_API_KEY", "").strip()
+    protocol = os.environ.get("OPENSANDBOX_PROTOCOL", "").strip() or "http"
+    for name, value in (("OPENSANDBOX_DOMAIN", domain), ("OPENSANDBOX_API_KEY", access_key)):
         if not value:
             raise ValueError(f"{name} must be set when --connection-config is omitted")
     if protocol not in {"http", "https"}:
-        raise ValueError(f"{PROTOCOL_ENV_VAR} must be http or https")
+        raise ValueError("OPENSANDBOX_PROTOCOL must be http or https")
     return domain, access_key, protocol
 
 
@@ -160,7 +157,7 @@ def main(argv: list[str] | None = None) -> int:
         "--connection-config",
         help=(
             "YAML file containing sandbox.opensandbox.connection. Omit it to read the connection from "
-            f"{DOMAIN_ENV_VAR}, {API_KEY_ENV_VAR} and {PROTOCOL_ENV_VAR} instead."
+            "OPENSANDBOX_DOMAIN, OPENSANDBOX_API_KEY and OPENSANDBOX_PROTOCOL instead."
         ),
     )
     parser.add_argument("--run-id", required=True)

--- a/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py
+++ b/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py
@@ -6,6 +6,7 @@
 
 import argparse
 import asyncio
+import os
 import re
 import sys
 import urllib.parse
@@ -16,6 +17,9 @@ import aiohttp
 import yaml
 
 
+DOMAIN_ENV_VAR = "OPENSANDBOX_DOMAIN"
+API_KEY_ENV_VAR = "OPENSANDBOX_API_KEY"
+PROTOCOL_ENV_VAR = "OPENSANDBOX_PROTOCOL"
 RUN_METADATA_KEY = "nemo-gym.nvidia.com/run"
 USER_METADATA_KEY = "nemo-gym.nvidia.com/user"
 REQUEST_TIMEOUT_SECONDS = 30
@@ -137,10 +141,27 @@ async def cleanup_sandboxes(
         return 1
 
 
+def connection_from_environment() -> tuple[str, str, str]:
+    """The connection a caller exports rather than writes to a file."""
+    domain = os.environ.get(DOMAIN_ENV_VAR, "").strip()
+    access_key = os.environ.get(API_KEY_ENV_VAR, "").strip()
+    protocol = os.environ.get(PROTOCOL_ENV_VAR, "").strip() or "http"
+    for name, value in ((DOMAIN_ENV_VAR, domain), (API_KEY_ENV_VAR, access_key)):
+        if not value:
+            raise ValueError(f"{name} must be set when --connection-config is omitted")
+    if protocol not in {"http", "https"}:
+        raise ValueError(f"{PROTOCOL_ENV_VAR} must be http or https")
+    return domain, access_key, protocol
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--connection-config", required=True, help="YAML file containing sandbox.opensandbox.connection."
+        "--connection-config",
+        help=(
+            "YAML file containing sandbox.opensandbox.connection. Omit it to read the connection from "
+            f"{DOMAIN_ENV_VAR}, {API_KEY_ENV_VAR} and {PROTOCOL_ENV_VAR} instead."
+        ),
     )
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--user", required=True)
@@ -152,6 +173,18 @@ def main(argv: list[str] | None = None) -> int:
             parser.error(f"--{name} must not be empty")
 
     try:
+        if args.connection_config is None:
+            domain, access_key, protocol = connection_from_environment()
+            return asyncio.run(
+                cleanup_sandboxes(
+                    domain=domain,
+                    protocol=protocol,
+                    access_key=access_key,
+                    run_id=args.run_id,
+                    user=args.user,
+                    reap=args.reap,
+                )
+            )
         with open(args.connection_config, encoding="utf-8") as config_file:
             config = yaml.safe_load(config_file)
         if not isinstance(config, Mapping):

--- a/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py
+++ b/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py
@@ -17,6 +17,9 @@ import aiohttp
 import yaml
 
 
+DOMAIN_ENV_VAR = "OPENSANDBOX_DOMAIN"
+API_KEY_ENV_VAR = "OPENSANDBOX_API_KEY"
+PROTOCOL_ENV_VAR = "OPENSANDBOX_PROTOCOL"
 RUN_METADATA_KEY = "nemo-gym.nvidia.com/run"
 USER_METADATA_KEY = "nemo-gym.nvidia.com/user"
 REQUEST_TIMEOUT_SECONDS = 30
@@ -140,14 +143,14 @@ async def cleanup_sandboxes(
 
 def connection_from_environment() -> tuple[str, str, str]:
     """The connection a caller exports rather than writes to a file."""
-    domain = os.environ.get("OPENSANDBOX_DOMAIN", "").strip()
-    access_key = os.environ.get("OPENSANDBOX_API_KEY", "").strip()
-    protocol = os.environ.get("OPENSANDBOX_PROTOCOL", "").strip() or "http"
-    for name, value in (("OPENSANDBOX_DOMAIN", domain), ("OPENSANDBOX_API_KEY", access_key)):
+    domain = os.environ.get(DOMAIN_ENV_VAR, "").strip()
+    access_key = os.environ.get(API_KEY_ENV_VAR, "").strip()
+    protocol = os.environ.get(PROTOCOL_ENV_VAR, "").strip() or "http"
+    for name, value in ((DOMAIN_ENV_VAR, domain), (API_KEY_ENV_VAR, access_key)):
         if not value:
             raise ValueError(f"{name} must be set when --connection-config is omitted")
     if protocol not in {"http", "https"}:
-        raise ValueError("OPENSANDBOX_PROTOCOL must be http or https")
+        raise ValueError(f"{PROTOCOL_ENV_VAR} must be http or https")
     return domain, access_key, protocol
 
 
@@ -157,7 +160,7 @@ def main(argv: list[str] | None = None) -> int:
         "--connection-config",
         help=(
             "YAML file containing sandbox.opensandbox.connection. Omit it to read the connection from "
-            "OPENSANDBOX_DOMAIN, OPENSANDBOX_API_KEY and OPENSANDBOX_PROTOCOL instead."
+            f"{DOMAIN_ENV_VAR}, {API_KEY_ENV_VAR} and {PROTOCOL_ENV_VAR} instead."
         ),
     )
     parser.add_argument("--run-id", required=True)

--- a/tests/unit_tests/test_opensandbox_cleanup.py
+++ b/tests/unit_tests/test_opensandbox_cleanup.py
@@ -628,6 +628,7 @@ def test_slurm_launcher_submits_one_dependent_cpu_cleanup_job(tmp_path: Path) ->
         "--partition=cpu",
         "--qos=cpu-short",
         "--gres=none",
+        "--gpus-per-node=0",
         "--nodes=1",
         "--ntasks=1",
         "--cpus-per-task=1",

--- a/tests/unit_tests/test_opensandbox_cleanup.py
+++ b/tests/unit_tests/test_opensandbox_cleanup.py
@@ -873,3 +873,25 @@ def test_slurm_launcher_resolves_the_checkout_from_its_own_location(tmp_path: Pa
     assert cleanup_call[cleanup_call.index("--domain") + 1] == "sandbox.example"
     assert cleanup_call[cleanup_call.index("--api-key") + 1] == TEST_ACCESS_KEY
     assert cleanup_call[cleanup_call.index("--protocol") + 1] == "http"
+
+
+def test_slurm_launcher_falls_back_to_the_checkout_env_yaml(tmp_path: Path) -> None:
+    """No exported connection, so the checkout's own env.yaml is used."""
+    calls_path, env = install_sbatch_stub(tmp_path)
+    env.pop("OPENSANDBOX_DOMAIN", None)
+    env.pop("OPENSANDBOX_API_KEY", None)
+
+    result = subprocess.run(
+        ["bash", str(SBATCH_SCRIPT), "--config", "benchmark.yaml"],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    _main_call, cleanup_call = read_sbatch_calls(calls_path)
+    repo_root = SBATCH_SCRIPT.resolve().parents[2]
+    assert cleanup_call[cleanup_call.index("--connection-config") + 1] == f"{repo_root}/env.yaml"
+    assert "--domain" not in cleanup_call
+    assert "--api-key" not in cleanup_call

--- a/tests/unit_tests/test_opensandbox_cleanup.py
+++ b/tests/unit_tests/test_opensandbox_cleanup.py
@@ -848,6 +848,42 @@ def test_cli_reports_a_failure_from_arguments(
     assert TEST_ACCESS_KEY not in stderr
 
 
+def test_slurm_launcher_takes_the_checkout_as_an_argument(tmp_path: Path) -> None:
+    """A caller running a copy of this script names the tree it came from."""
+    calls_path, env = install_sbatch_stub(tmp_path)
+    env["OPENSANDBOX_DOMAIN"] = "sandbox.example"
+    env["OPENSANDBOX_API_KEY"] = TEST_ACCESS_KEY
+
+    result = subprocess.run(
+        ["bash", str(SBATCH_SCRIPT), "--gym-root", "/elsewhere/Gym", "--config", "benchmark.yaml"],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    _main_call, cleanup_call = read_sbatch_calls(calls_path)
+    assert "/elsewhere/Gym/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py" in cleanup_call
+    # Consumed here, so gym eval still sees only the arguments meant for it.
+    eval_command = (tmp_path / "eval-command").read_text()
+    assert "--gym-root" not in eval_command
+    assert "--config benchmark.yaml" in eval_command
+
+
+def test_slurm_launcher_rejects_a_gym_root_without_a_path(tmp_path: Path) -> None:
+    _calls_path, env = install_sbatch_stub(tmp_path)
+    result = subprocess.run(
+        ["bash", str(SBATCH_SCRIPT), "--gym-root"],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert "--gym-root needs a path" in result.stderr
+
+
 def test_slurm_launcher_resolves_the_checkout_from_its_own_location(tmp_path: Path) -> None:
     """The caller launches from a run directory that holds no Gym tree."""
     calls_path, env = install_sbatch_stub(tmp_path)

--- a/tests/unit_tests/test_opensandbox_cleanup.py
+++ b/tests/unit_tests/test_opensandbox_cleanup.py
@@ -604,6 +604,8 @@ def read_sbatch_calls(path: Path) -> list[list[str]]:
 
 def test_slurm_launcher_submits_one_dependent_cpu_cleanup_job(tmp_path: Path) -> None:
     calls_path, env = install_sbatch_stub(tmp_path)
+    env["OPENSANDBOX_DOMAIN"] = "sandbox.example"
+    env["OPENSANDBOX_API_KEY"] = TEST_ACCESS_KEY
     result = subprocess.run(
         ["bash", str(SBATCH_SCRIPT), "--config", "benchmark.yaml", "--run-id", "attacker"],
         check=False,
@@ -621,7 +623,8 @@ def test_slurm_launcher_submits_one_dependent_cpu_cleanup_job(tmp_path: Path) ->
     assert "--parsable" in main_call
 
     submit_dir = str(Path.cwd().resolve())
-    cleanup_script = f"{submit_dir}/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py"
+    repo_root = SBATCH_SCRIPT.resolve().parents[2]
+    cleanup_script = f"{repo_root}/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py"
     assert cleanup_call == [
         "--parsable",
         "--dependency=afterany:7001",
@@ -637,6 +640,12 @@ def test_slurm_launcher_submits_one_dependent_cpu_cleanup_job(tmp_path: Path) ->
         "--job-name=gym-cleanup-7001",
         f"--output={submit_dir}/slurm-logs/%j-gym-cleanup-7001.log",
         cleanup_script,
+        "--domain",
+        "sandbox.example",
+        "--api-key",
+        TEST_ACCESS_KEY,
+        "--protocol",
+        "http",
         "--run-id",
         "7001",
         "--user",
@@ -771,26 +780,28 @@ def test_slurm_batch_command_preserves_status_and_stops_server(
     assert events.read_text().splitlines() == (["server-stop"] if first_step == "eval" else ["server-exit"])
 
 
-def test_cli_reads_the_connection_from_the_environment(
-    monkeypatch: pytest.MonkeyPatch,
+SANDBOX_ARGS = ["--domain", "sandbox.example", "--api-key", TEST_ACCESS_KEY]
+
+
+@pytest.mark.parametrize(("passed_protocol", "expected_protocol"), [(None, "http"), ("https", "https")])
+def test_cli_takes_the_connection_from_arguments(
+    monkeypatch: pytest.MonkeyPatch, passed_protocol: str | None, expected_protocol: str
 ) -> None:
-    """The launcher passes no --connection-config, so this is the only route."""
     calls = []
+    argv = [*SANDBOX_ARGS, "--run-id", "job-7", "--user", "alice", "--reap"]
+    if passed_protocol:
+        argv += ["--protocol", passed_protocol]
 
     async def record_cleanup(**kwargs: object) -> int:
         calls.append(kwargs)
         return 0
 
     monkeypatch.setattr(cleanup_sandboxes, "cleanup_sandboxes", record_cleanup)
-    monkeypatch.setenv("OPENSANDBOX_DOMAIN", "sandbox.example")
-    monkeypatch.setenv("OPENSANDBOX_API_KEY", TEST_ACCESS_KEY)
-    monkeypatch.setenv("OPENSANDBOX_PROTOCOL", "https")
-
-    assert cleanup_sandboxes.main(["--run-id", "job-7", "--user", "alice", "--reap"]) == 0
+    assert cleanup_sandboxes.main(argv) == 0
     assert calls == [
         {
             "domain": "sandbox.example",
-            "protocol": "https",
+            "protocol": expected_protocol,
             "access_key": TEST_ACCESS_KEY,
             "run_id": "job-7",
             "user": "alice",
@@ -799,31 +810,66 @@ def test_cli_reads_the_connection_from_the_environment(
     ]
 
 
-@pytest.mark.parametrize("missing", ["OPENSANDBOX_DOMAIN", "OPENSANDBOX_API_KEY"])
-def test_cli_without_config_names_the_variable_it_needs(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], missing: str
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--api-key", TEST_ACCESS_KEY, "--run-id", "job-7", "--user", "alice"],
+        ["--domain", "sandbox.example", "--run-id", "job-7", "--user", "alice"],
+        ["--domain", " ", "--api-key", TEST_ACCESS_KEY, "--run-id", "job-7", "--user", "alice"],
+        ["--domain", "sandbox.example", "--api-key", " ", "--run-id", "job-7", "--user", "alice"],
+        [*SANDBOX_ARGS, "--run-id", "job-7", "--user", "alice", "--protocol", "ftp"],
+    ],
+)
+def test_cli_requires_both_sandbox_parameters_without_a_config(argv: list[str]) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        cleanup_sandboxes.main(argv)
+
+
+def test_cli_refuses_a_config_mixed_with_arguments(tmp_path: Path) -> None:
+    """One source for the connection, so neither can silently win."""
+    config = tmp_path / "env.yaml"
+    config.write_text("sandbox:\n  opensandbox:\n    connection:\n      domain: x\n      api_key: y\n")
+    with pytest.raises(SystemExit, match="2"):
+        cleanup_sandboxes.main(
+            ["--connection-config", str(config), *SANDBOX_ARGS, "--run-id", "job-7", "--user", "alice"]
+        )
+
+
+def test_cli_reports_a_failure_from_arguments(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setenv("OPENSANDBOX_DOMAIN", "sandbox.example")
-    monkeypatch.setenv("OPENSANDBOX_API_KEY", TEST_ACCESS_KEY)
-    monkeypatch.delenv(missing)
+    async def raise_cleanup_error(**_kwargs: object) -> int:
+        raise OSError("down")
 
-    assert cleanup_sandboxes.main(["--run-id", "job-7", "--user", "alice"]) == 1
-    assert missing in capsys.readouterr().err
+    monkeypatch.setattr(cleanup_sandboxes, "cleanup_sandboxes", raise_cleanup_error)
+    assert cleanup_sandboxes.main([*SANDBOX_ARGS, "--run-id", "job-7", "--user", "alice"]) == 1
+    stderr = capsys.readouterr().err
+    assert "OpenSandbox cleanup failed: down" in stderr
+    assert TEST_ACCESS_KEY not in stderr
 
 
-def test_slurm_launcher_reads_the_checkout_from_the_environment(tmp_path: Path) -> None:
-    """The run directory holds no Gym tree, so it cannot name the checkout."""
+def test_slurm_launcher_resolves_the_checkout_from_its_own_location(tmp_path: Path) -> None:
+    """The caller launches from a run directory that holds no Gym tree."""
     calls_path, env = install_sbatch_stub(tmp_path)
-    env["NEMO_GYM_REPO_ROOT"] = "/elsewhere/Gym"
+    env["OPENSANDBOX_DOMAIN"] = "sandbox.example"
+    env["OPENSANDBOX_API_KEY"] = TEST_ACCESS_KEY
+    elsewhere = tmp_path / "rundir"
+    elsewhere.mkdir()
+
     result = subprocess.run(
-        ["bash", str(SBATCH_SCRIPT), "--config", "benchmark.yaml"],
+        ["bash", str(SBATCH_SCRIPT.resolve()), "--config", "benchmark.yaml"],
         check=False,
         capture_output=True,
         env=env,
         text=True,
+        cwd=elsewhere,
     )
 
     assert result.returncode == 0, result.stderr
     _main_call, cleanup_call = read_sbatch_calls(calls_path)
-    assert "/elsewhere/Gym/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py" in cleanup_call
-    assert "--connection-config" not in cleanup_call
+    repo_root = SBATCH_SCRIPT.resolve().parents[2]
+    assert f"{repo_root}/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py" in cleanup_call
+    assert f"--output={elsewhere}/slurm-logs/%j-gym-cleanup-7001.log" in cleanup_call
+    assert cleanup_call[cleanup_call.index("--domain") + 1] == "sandbox.example"
+    assert cleanup_call[cleanup_call.index("--api-key") + 1] == TEST_ACCESS_KEY
+    assert cleanup_call[cleanup_call.index("--protocol") + 1] == "http"

--- a/tests/unit_tests/test_opensandbox_cleanup.py
+++ b/tests/unit_tests/test_opensandbox_cleanup.py
@@ -393,7 +393,6 @@ def test_cleanup_rejects_invalid_domain() -> None:
 @pytest.mark.parametrize(
     "argv",
     [
-        ["--run-id", "job-7", "--user", "alice"],
         ["--connection-config", "env.yaml", "--user", "alice"],
         ["--connection-config", "env.yaml", "--run-id", "job-7"],
         ["--connection-config", "env.yaml", "--run-id", "", "--user", "alice"],
@@ -637,8 +636,6 @@ def test_slurm_launcher_submits_one_dependent_cpu_cleanup_job(tmp_path: Path) ->
         "--job-name=gym-cleanup-7001",
         f"--output={submit_dir}/slurm-logs/%j-gym-cleanup-7001.log",
         cleanup_script,
-        "--connection-config",
-        f"{submit_dir}/env.yaml",
         "--run-id",
         "7001",
         "--user",
@@ -682,9 +679,10 @@ def test_slurm_launcher_reports_cleanup_submission_failure(tmp_path: Path) -> No
         text=True,
     )
 
-    assert result.returncode == 1
-    assert result.stdout == ""
-    assert "Failed to submit cleanup job for batch job 7001; the batch job is still active" in result.stderr
+    assert result.returncode == 0
+    assert result.stdout.splitlines() == ["Submitted batch job 7001"]
+    assert "Failed to submit the sandbox-cleanup job for batch job 7001" in result.stderr
+    assert "its sandboxes will need reaping by hand" in result.stderr
     assert len(read_sbatch_calls(calls_path)) == 2
 
 
@@ -770,3 +768,61 @@ def test_slurm_batch_command_preserves_status_and_stops_server(
     )
     assert result.returncode == expected_status
     assert events.read_text().splitlines() == (["server-stop"] if first_step == "eval" else ["server-exit"])
+
+
+def test_cli_reads_the_connection_from_the_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The launcher passes no --connection-config, so this is the only route."""
+    calls = []
+
+    async def record_cleanup(**kwargs: object) -> int:
+        calls.append(kwargs)
+        return 0
+
+    monkeypatch.setattr(cleanup_sandboxes, "cleanup_sandboxes", record_cleanup)
+    monkeypatch.setenv("OPENSANDBOX_DOMAIN", "sandbox.example")
+    monkeypatch.setenv("OPENSANDBOX_API_KEY", TEST_ACCESS_KEY)
+    monkeypatch.setenv("OPENSANDBOX_PROTOCOL", "https")
+
+    assert cleanup_sandboxes.main(["--run-id", "job-7", "--user", "alice", "--reap"]) == 0
+    assert calls == [
+        {
+            "domain": "sandbox.example",
+            "protocol": "https",
+            "access_key": TEST_ACCESS_KEY,
+            "run_id": "job-7",
+            "user": "alice",
+            "reap": True,
+        }
+    ]
+
+
+@pytest.mark.parametrize("missing", ["OPENSANDBOX_DOMAIN", "OPENSANDBOX_API_KEY"])
+def test_cli_without_config_names_the_variable_it_needs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], missing: str
+) -> None:
+    monkeypatch.setenv("OPENSANDBOX_DOMAIN", "sandbox.example")
+    monkeypatch.setenv("OPENSANDBOX_API_KEY", TEST_ACCESS_KEY)
+    monkeypatch.delenv(missing)
+
+    assert cleanup_sandboxes.main(["--run-id", "job-7", "--user", "alice"]) == 1
+    assert missing in capsys.readouterr().err
+
+
+def test_slurm_launcher_reads_the_checkout_from_the_environment(tmp_path: Path) -> None:
+    """The run directory holds no Gym tree, so it cannot name the checkout."""
+    calls_path, env = install_sbatch_stub(tmp_path)
+    env["NEMO_GYM_REPO_ROOT"] = "/elsewhere/Gym"
+    result = subprocess.run(
+        ["bash", str(SBATCH_SCRIPT), "--config", "benchmark.yaml"],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    _main_call, cleanup_call = read_sbatch_calls(calls_path)
+    assert "/elsewhere/Gym/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py" in cleanup_call
+    assert "--connection-config" not in cleanup_call


### PR DESCRIPTION
## Problem

`benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh` locates the run-scoped cleanup job's script under `submit_dir=$(pwd -P)`, which assumes the launcher is invoked from a Gym checkout. A caller that launches from a scheduler run directory has no such tree there, so the submission fails outright:

```
sbatch: error: Unable to open file <rundir>/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py
Failed to submit cleanup job for batch job 6540264; the batch job is still active
```

No cleanup job is scheduled and sandboxes are never reaped. This is how NVIDIA's eval-factory benchmarking runner drives the launcher: it stages a copy of the script into a per-run directory and `cd`s there, because that is where `slurm-logs/` and `results/` live.

## Changes

1. `NEMO_GYM_REPO_ROOT` names the checkout, alongside the launcher's other declared inputs at the top of the file. It defaults to the working directory, so a launch from a checkout is unchanged.
2. The connection comes from `OPENSANDBOX_DOMAIN` and `OPENSANDBOX_API_KEY` — the same two variables the run itself resolves `opensandbox.yaml` from. The launcher no longer looks for an `env.yaml` and no longer forwards `--connection-config`; the flag stays on the script for a manual run.
3. A failed cleanup submission no longer strands the main job. It printed no job ID and exited 1, so a caller read a live 4-node job as a failed submission — and resubmitted it. It now prints `Submitted batch job <id>`, warns that its sandboxes need reaping by hand, and exits 0.

Dropping the `env.yaml` route is deliberate: that file is merged over every config a run names, so a connection read from it can silently override the evaluated config, and no hash covers it.

## Testing

`pytest tests/unit_tests/test_opensandbox_cleanup.py` — 40 passed, 3 skipped. `ruff check` and `ruff format --check` clean on both changed files.

## Supersedes

Replaces #2788, rebased onto current `main` and squashed. Same change, opened from a branch whose commits carry a sign-off.
