### PR TITLE
feat: document `--agent-type` CLI flag and agent swapping mechanism

### DIFF
--- a/benchmarks/deepswe/opencode.yaml
+++ b/benchmarks/deepswe/opencode.yaml
@@ -5,7 +5,7 @@ config_paths:
   - responses_api_agents/opencode_sandboxed_agent/configs/opencode_sandboxed_agent.yaml
   - resources_servers/deepswe/configs/deepswe.yaml
 
-opencode_deepswe_resources_server:
+deepswe_opencode_resources_server:
   _inherit_from: deepswe_resources_server
   resources_servers:
     deepswe:
@@ -13,7 +13,7 @@ opencode_deepswe_resources_server:
         type: responses_api_models
         name: policy_model
 
-opencode_sandboxed_agent_deepswe:
+deepswe_opencode_sandboxed_agent:
   _inherit_from: opencode_sandboxed_agent
   responses_api_agents:
     opencode_sandboxed_agent:
@@ -21,7 +21,7 @@ opencode_sandboxed_agent_deepswe:
 
       resources_server:
         type: resources_servers
-        name: opencode_deepswe_resources_server
+        name: deepswe_opencode_resources_server
       datasets:
         - name: deepswe_v1_1
           type: benchmark

--- a/benchmarks/nemotron_3.5_super/eval_container_config.yaml
+++ b/benchmarks/nemotron_3.5_super/eval_container_config.yaml
@@ -96,23 +96,23 @@ policy_model:
       num_workers: 16
 
 # TODO @bxyu-nvidia: Remove these overrides to turn on various benchmarks after we do batched eval studies. This is a placeholder for container build.
-opencode_sandboxed_agent_swebench_verified:
+swebench_verified_opencode_sandboxed_agent:
   responses_api_agents:
     opencode_sandboxed_agent:
       datasets: []
-opencode_sandboxed_agent_swebench_multilingual:
+swebench_multilingual_opencode_sandboxed_agent:
   responses_api_agents:
     opencode_sandboxed_agent:
       datasets: []
-opencode_sandboxed_agent_deepswe:
+deepswe_opencode_sandboxed_agent:
   responses_api_agents:
     opencode_sandboxed_agent:
       datasets: []
-terminus_2_sandboxed_agent_terminal_bench_2_1:
+terminal_bench_2_1_terminus_2_sandboxed_agent:
   responses_api_agents:
     terminus_2_sandboxed_agent:
       datasets: []
-opencode_sandboxed_agent_swebench_pro:
+swebench_pro_opencode_sandboxed_agent:
   responses_api_agents:
     opencode_sandboxed_agent:
       datasets: []

--- a/benchmarks/nemotron_3.5_super/eval_container_config_with_staged.yaml
+++ b/benchmarks/nemotron_3.5_super/eval_container_config_with_staged.yaml
@@ -2,7 +2,7 @@ config_paths:
 - benchmarks/nemotron_3.5_super/eval_container_config.yaml
 
 # @bxyu-nvidia: We manually copy over the datasets here
-opencode_sandboxed_agent_swebench_verified:
+swebench_verified_opencode_sandboxed_agent:
   responses_api_agents:
     opencode_sandboxed_agent:
       datasets:
@@ -12,7 +12,7 @@ opencode_sandboxed_agent_swebench_verified:
           prepare_script: benchmarks/swebench/verified/prepare.py
           num_repeats: 3
 
-opencode_sandboxed_agent_swebench_multilingual:
+swebench_multilingual_opencode_sandboxed_agent:
   responses_api_agents:
     opencode_sandboxed_agent:
       datasets:
@@ -22,7 +22,7 @@ opencode_sandboxed_agent_swebench_multilingual:
           prepare_script: benchmarks/swebench/multilingual/prepare.py
           num_repeats: 3
 
-opencode_sandboxed_agent_deepswe:
+deepswe_opencode_sandboxed_agent:
   responses_api_agents:
     opencode_sandboxed_agent:
       datasets:
@@ -32,7 +32,7 @@ opencode_sandboxed_agent_deepswe:
           prepare_script: benchmarks/deepswe/prepare.py
           num_repeats: 5
 
-terminus_2_sandboxed_agent_terminal_bench_2_1:
+terminal_bench_2_1_terminus_2_sandboxed_agent:
   responses_api_agents:
     terminus_2_sandboxed_agent:
       datasets:
@@ -42,7 +42,7 @@ terminus_2_sandboxed_agent_terminal_bench_2_1:
           prepare_script: benchmarks/terminal_bench_2_1/prepare.py
           num_repeats: 8
 
-opencode_sandboxed_agent_swebench_pro:
+swebench_pro_opencode_sandboxed_agent:
   responses_api_agents:
     opencode_sandboxed_agent:
       datasets:

--- a/benchmarks/nemotron_3.5_super/sandbox_utils.yaml
+++ b/benchmarks/nemotron_3.5_super/sandbox_utils.yaml
@@ -1,48 +1,48 @@
 config_paths:
 - nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
 
-opencode_sandboxed_agent_swebench_verified:
+swebench_verified_opencode_sandboxed_agent:
   responses_api_agents:
     opencode_sandboxed_agent:
       remote_opencode_install_script_path: /mnt/s3-data/data/bxyu/opencode/install.sh
       remote_opencode_binary_path: /mnt/s3-data/data/bxyu/opencode/opencode-linux-x64
 
-opencode_sandboxed_agent_swebench_multilingual:
+swebench_multilingual_opencode_sandboxed_agent:
   responses_api_agents:
     opencode_sandboxed_agent:
       remote_opencode_install_script_path: /mnt/s3-data/data/bxyu/opencode/install.sh
       remote_opencode_binary_path: /mnt/s3-data/data/bxyu/opencode/opencode-linux-x64
 
-opencode_sandboxed_agent_deepswe:
+deepswe_opencode_sandboxed_agent:
   responses_api_agents:
     opencode_sandboxed_agent:
       remote_opencode_install_script_path: /mnt/s3-data/data/bxyu/opencode/install.sh
       remote_opencode_binary_path: /mnt/s3-data/data/bxyu/opencode/opencode-linux-x64
 
-opencode_sandboxed_agent_swebench_pro:
+swebench_pro_opencode_sandboxed_agent:
   responses_api_agents:
     opencode_sandboxed_agent:
       remote_opencode_install_script_path: /mnt/s3-data/data/bxyu/opencode/install_cached_opencode.sh
       remote_opencode_binary_path: /mnt/s3-data/data/bxyu/opencode/opencode-linux-x64
       remote_opencode_musl_binary_path: /mnt/s3-data/data/bxyu/opencode/opencode-linux-x64-musl-v1.17.11
 
-opencode_sandboxed_agent_terminal_bench_2_1:
+terminal_bench_2_1_opencode_sandboxed_agent:
   responses_api_agents:
     opencode_sandboxed_agent:
       remote_opencode_install_script_path: /mnt/s3-data/data/bxyu/opencode/install.sh
       remote_opencode_binary_path: /mnt/s3-data/data/bxyu/opencode/opencode-linux-x64
-opencode_terminal_bench_2_1_resources_server:
+terminal_bench_2_1_opencode_resources_server:
   resources_servers:
     terminal_bench_2_1:
       sandbox_config:
         metadata:
           nemo.nvidia.com/resources: custom
 
-terminus_2_sandboxed_agent_terminal_bench_2_1:
+terminal_bench_2_1_terminus_2_sandboxed_agent:
   responses_api_agents:
     terminus_2_sandboxed_agent:
       remote_tmux_binary_path: /mnt/s3-data/data/bxyu/tmux/tmux-3.7c-linux-x86_64
-terminus_2_sandboxed_terminal_bench_2_1_resources_server:
+terminal_bench_2_1_terminus_2_sandboxed_resources_server:
   resources_servers:
     terminal_bench_2_1:
       sandbox_config:

--- a/benchmarks/swebench/multilingual/opencode.yaml
+++ b/benchmarks/swebench/multilingual/opencode.yaml
@@ -2,16 +2,16 @@ config_paths:
 - responses_api_agents/opencode_sandboxed_agent/configs/opencode_sandboxed_agent.yaml
 - resources_servers/swebench/configs/swebench.yaml
 
-opencode_swebench_multilingual_resources_server:
+swebench_multilingual_opencode_resources_server:
   _inherit_from: swebench_resources_server
 
-opencode_sandboxed_agent_swebench_multilingual:
+swebench_multilingual_opencode_sandboxed_agent:
   _inherit_from: opencode_sandboxed_agent
   responses_api_agents:
     opencode_sandboxed_agent:
       resources_server:
         type: resources_servers
-        name: opencode_swebench_multilingual_resources_server
+        name: swebench_multilingual_opencode_resources_server
       datasets:
         - name: swebench_multilingual
           type: benchmark

--- a/benchmarks/swebench/pro/opencode.yaml
+++ b/benchmarks/swebench/pro/opencode.yaml
@@ -2,16 +2,16 @@ config_paths:
 - responses_api_agents/opencode_sandboxed_agent/configs/opencode_sandboxed_agent.yaml
 - resources_servers/swebench_pro/configs/swebench_pro.yaml
 
-opencode_swebench_pro_resources_server:
+swebench_pro_opencode_resources_server:
   _inherit_from: swebench_pro_resources_server
 
-opencode_sandboxed_agent_swebench_pro:
+swebench_pro_opencode_sandboxed_agent:
   _inherit_from: opencode_sandboxed_agent
   responses_api_agents:
     opencode_sandboxed_agent:
       resources_server:
         type: resources_servers
-        name: opencode_swebench_pro_resources_server
+        name: swebench_pro_opencode_resources_server
       datasets:
         - name: swebench_pro
           type: benchmark

--- a/benchmarks/swebench/verified/opencode.yaml
+++ b/benchmarks/swebench/verified/opencode.yaml
@@ -2,7 +2,7 @@ config_paths:
 - responses_api_agents/opencode_sandboxed_agent/configs/opencode_sandboxed_agent.yaml
 - resources_servers/swebench/configs/swebench.yaml
 
-opencode_swebench_verified_resources_server:
+swebench_verified_opencode_resources_server:
   _inherit_from: swebench_resources_server
 
   resources_servers:
@@ -11,13 +11,13 @@ opencode_swebench_verified_resources_server:
       # For SWE Bench Verified, the repos are already clean.
       apply_anti_cheating: false
 
-opencode_sandboxed_agent_swebench_verified:
+swebench_verified_opencode_sandboxed_agent:
   _inherit_from: opencode_sandboxed_agent
   responses_api_agents:
     opencode_sandboxed_agent:
       resources_server:
         type: resources_servers
-        name: opencode_swebench_verified_resources_server
+        name: swebench_verified_opencode_resources_server
       datasets:
         - name: swebench_verified
           type: benchmark

--- a/benchmarks/terminal_bench_2_1/opencode.yaml
+++ b/benchmarks/terminal_bench_2_1/opencode.yaml
@@ -3,16 +3,16 @@ config_paths:
 - resources_servers/terminal_bench_2_1/configs/terminal_bench_2_1.yaml
 
 
-opencode_terminal_bench_2_1_resources_server:
+terminal_bench_2_1_opencode_resources_server:
   _inherit_from: terminal_bench_2_1_resources_server
 
-opencode_sandboxed_agent_terminal_bench_2_1:
+terminal_bench_2_1_opencode_sandboxed_agent:
   _inherit_from: opencode_sandboxed_agent
   responses_api_agents:
     opencode_sandboxed_agent:
       resources_server:
         type: resources_servers
-        name: opencode_terminal_bench_2_1_resources_server
+        name: terminal_bench_2_1_opencode_resources_server
       datasets:
         - name: terminal_bench_2_1
           type: benchmark

--- a/benchmarks/terminal_bench_2_1/terminus_2.yaml
+++ b/benchmarks/terminal_bench_2_1/terminus_2.yaml
@@ -3,16 +3,16 @@ config_paths:
 - resources_servers/terminal_bench_2_1/configs/terminal_bench_2_1.yaml
 
 
-terminus_2_sandboxed_terminal_bench_2_1_resources_server:
+terminal_bench_2_1_terminus_2_sandboxed_resources_server:
   _inherit_from: terminal_bench_2_1_resources_server
 
-terminus_2_sandboxed_agent_terminal_bench_2_1:
+terminal_bench_2_1_terminus_2_sandboxed_agent:
   _inherit_from: terminus_2_sandboxed_agent
   responses_api_agents:
     terminus_2_sandboxed_agent:
       resources_server:
         type: resources_servers
-        name: terminus_2_sandboxed_terminal_bench_2_1_resources_server
+        name: terminal_bench_2_1_terminus_2_sandboxed_resources_server
       datasets:
         - name: terminal_bench_2_1
           type: benchmark

--- a/fern/versions/latest/pages/evaluation/aggregate-metrics.mdx
+++ b/fern/versions/latest/pages/evaluation/aggregate-metrics.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Aggregate Metrics"
 description: "Compute summary statistics, customize per-environment metrics, and merge shard outputs from gym eval aggregate."
-position: 4
+position: 5
 ---
 After rollout collection, NeMo Gym computes **aggregate metrics** for each agent by calling the `/aggregate_metrics` endpoint on the agent server. The results are written to a single `_aggregate_metrics.json` file.
 

--- a/fern/versions/latest/pages/evaluation/diagnose-results.mdx
+++ b/fern/versions/latest/pages/evaluation/diagnose-results.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Diagnose Results"
 description: "Use BLADE and other analysis skills to diagnose evaluation results — why scores changed, which tasks failed, and what intervention to prioritize."
-position: 6
+position: 7
 ---
 
 NeMo Gym equips agents to diagnose evaluation results: an agent reads the raw artifacts from an evaluation run and produces a structured, evidence-backed report explaining what changed, which tasks failed, and what to fix next. It does this with **analysis skills** — reusable instructions an agent follows to interpret evaluation artifacts consistently.

--- a/fern/versions/latest/pages/evaluation/environment-list.mdx
+++ b/fern/versions/latest/pages/evaluation/environment-list.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Browse Environments"
 description: "Browse built-in benchmark and training environments."
-position: 3
+position: 4
 ---
 
 NeMo Gym includes 100+ environments covering math, coding, reasoning, knowledge, agentic tool use, instruction following, and safety. An environment includes a dataset, agent harness, verifier, and state. Some resources servers include agent composition and datasets and are runnable environments themselves; others are reusable scoring, tool, or state components and are not separate environment entries. Environments marked ✓ have a corresponding benchmark config with a canonical evaluation split and `prepare_script`.

--- a/fern/versions/latest/pages/evaluation/harness.mdx
+++ b/fern/versions/latest/pages/evaluation/harness.mdx
@@ -1,0 +1,79 @@
+---
+title: "Compare Harnesses"
+description: "Run the same environment with a different agent harness to measure how much of a score comes from the harness rather than the model."
+position: 3
+---
+
+An agent harness turns a model into an agent: it manages conversation state, routes tool calls, and
+decides when a task is complete. Two harnesses running the same model on the same tasks can score very
+differently, so a harness is a variable worth isolating rather than a fixed part of the environment.
+
+`--agent-type` runs an environment or benchmark with a harness other than the one its config names,
+without editing any config:
+
+```bash
+gym list agents
+gym eval run --agent-type hermes_agent --benchmark gpqa --model-type vllm_model
+```
+
+Holding the model, dataset, and repeat count fixed while changing only `--agent-type` gives you the
+harness contribution to the score. Refer to
+[Swapping the agent](/reference/cli-commands#swapping-the-agent) for the flag reference.
+
+## The composed instance is renamed
+
+Composition replaces the environment's agent and renames the server instance after the harness that
+runs it, so metrics and `gym env status` report what actually ran. Composing `hermes_agent` onto
+`gpqa_mcqa_simple_agent` produces `gpqa_mcqa_hermes_agent`.
+
+That name is what you use to route rollouts when the servers are already up:
+
+```bash
+gym env start --agent-type hermes_agent --benchmark gpqa --model-type vllm_model
+gym eval run --no-serve --agent gpqa_mcqa_hermes_agent --input rows.jsonl
+```
+
+End-to-end rollouts collection (without the `--no-serve` flag) keeps working — rows stamped with the
+pre-swap instance are re-routed for you under the hood.
+
+## Not every pairing is valid
+
+A verifier is written against the behavior of a particular harness. A resources server can declare
+which harnesses are compatible with it in
+[`allowed_agents`](/reference/configuration#resources-server-fields), and Gym refuses an undeclared
+pairing before any server starts:
+
+```text
+'hermes_agent' is not declared compatible with 1 of the agent instance(s) it would replace,
+so it cannot be scored correctly:
+  - gsm8k_aviary_agent uses gsm8k_aviary_resources_server and accepts aviary_agent
+
+Select one of: aviary_agent. Or pass --allow-unsupported-pairing (or set
+NEMO_GYM_ALLOW_UNSUPPORTED_PAIRING=1) to bypass the check.
+```
+
+<Warning>
+`--allow-unsupported-pairing` runs the pairing anyway. Scores from an undeclared pairing may not mean
+what they appear to mean — the harness might not be compatible with the resources server.
+</Warning>
+
+A server that declares nothing accepts any harness — such environments are swappable without further
+setup.
+
+## Self-contained environments
+
+Some agent servers own their environment and declare no resources server. Those are left alone by a swap,
+because there would be nothing for the incoming harness to bind to. If every agent in a config
+is self-contained, selecting a harness fails with `no other agent instance to rehost it on`.
+
+<Cards>
+
+<Card title="Configure Agents" href="/agent-server">
+Set up a built-in or custom agent harness.
+</Card>
+
+<Card title="CLI Reference" href="/reference/cli-commands#swapping-the-agent">
+Flags, modes, and error messages for agent selection.
+</Card>
+
+</Cards>

--- a/fern/versions/latest/pages/evaluation/harness.mdx
+++ b/fern/versions/latest/pages/evaluation/harness.mdx
@@ -12,7 +12,10 @@ without editing any config. To ablate the harness, hold everything else fixed â€
 
 ```bash
 gym list agents
-gym eval run --agent-type hermes_agent --benchmark gpqa --model-type vllm_model
+gym eval run \
+    --benchmark terminal_bench_2_1/opencode \
+    --agent-type terminus_2_sandboxed_agent \
+    --model-type vllm_model
 ```
 
 Each run writes its own `_aggregate_metrics.json` next to its rollouts file. Comparing those across harnesses *is* the ablation â€” for example (illustrative, not real output):

--- a/fern/versions/latest/pages/evaluation/harness.mdx
+++ b/fern/versions/latest/pages/evaluation/harness.mdx
@@ -22,9 +22,8 @@ Each run writes its own `_aggregate_metrics.json` next to its rollouts file. Com
 
 | Harness | Pass rate |
 |---|---|
-| `simple_agent` | 41% |
-| `hermes_agent` | 68% |
-| `openclaw_agent` | 35% |
+| `opencode_sandboxed_agent` | 41% |
+| `terminus_2_sandboxed_agent` | 68% |
 
 A spread this size, with the model and dataset held identical, means the harness — not the model — is the lever to pull. Refer to [Diagnose Results](/evaluation/diagnose-results) to have an agent explain *why* the harnesses diverged, or [Aggregate Metrics](/evaluation/aggregate-metrics) to build your own comparison across shards. For the flag reference itself, see
 [Swapping the agent](/reference/cli-commands#swapping-the-agent).
@@ -32,14 +31,18 @@ A spread this size, with the model and dataset held identical, means the harness
 ## The composed instance is renamed
 
 Composition replaces the environment's agent and renames the server instance after the harness that
-runs it, so metrics and `gym env status` report what actually ran. Composing `hermes_agent` onto
-`gpqa_mcqa_simple_agent` produces `gpqa_mcqa_hermes_agent`.
+runs it, so metrics and `gym env status` report what actually ran. Composing
+`terminus_2_sandboxed_agent` onto `terminal_bench_2_1_opencode_sandboxed_agent` produces
+`terminal_bench_2_1_terminus_2_sandboxed_agent`.
 
 That name is what you use to route rollouts when the servers are already up:
 
 ```bash
-gym env start --agent-type hermes_agent --benchmark gpqa --model-type vllm_model
-gym eval run --no-serve --agent gpqa_mcqa_hermes_agent --input rows.jsonl
+gym env start \
+    --benchmark terminal_bench_2_1/opencode \
+    --agent-type terminus_2_sandboxed_agent \
+    --model-type vllm_model
+gym eval run --no-serve --agent terminal_bench_2_1_terminus_2_sandboxed_agent --input rows.jsonl
 ```
 
 End-to-end rollouts collection (without the `--no-serve` flag) keeps working — rows stamped with the
@@ -53,12 +56,13 @@ which harnesses are compatible with it in
 pairing before any server starts:
 
 ```text
-'hermes_agent' is not declared compatible with 1 of the agent instance(s) it would replace,
+'simple_agent' is not declared compatible with 1 of the agent instance(s) it would replace,
 so it cannot be scored correctly:
-  - gsm8k_aviary_agent uses gsm8k_aviary_resources_server and accepts aviary_agent
+  - terminal_bench_2_1_opencode_sandboxed_agent uses terminal_bench_2_1_opencode_resources_server
+    and accepts opencode_sandboxed_agent, terminus_2_sandboxed_agent
 
-Select one of: aviary_agent. Or pass --allow-unsupported-pairing (or set
-NEMO_GYM_ALLOW_UNSUPPORTED_PAIRING=1) to bypass the check.
+Select one of: opencode_sandboxed_agent, terminus_2_sandboxed_agent. Or pass
+--allow-unsupported-pairing (or set NEMO_GYM_ALLOW_UNSUPPORTED_PAIRING=1) to bypass the check.
 ```
 
 <Warning>

--- a/fern/versions/latest/pages/evaluation/harness.mdx
+++ b/fern/versions/latest/pages/evaluation/harness.mdx
@@ -1,24 +1,30 @@
 ---
 title: "Compare Harnesses"
-description: "Run the same environment with a different agent harness to measure how much of a score comes from the harness rather than the model."
+description: "Ablate the agent harness the same way you ablate the model — swap it, hold everything else fixed, and measure the score delta."
 position: 3
 ---
 
 An agent harness turns a model into an agent: it manages conversation state, routes tool calls, and
-decides when a task is complete. Two harnesses running the same model on the same tasks can score very
-differently, so a harness is a variable worth isolating rather than a fixed part of the environment.
+decides when a task is complete. Two harnesses running the same model on the same tasks can score vary differently, and a harness that performs well on one model can perform poorly on another. Treat the harness as a variable worth isolating, not a fixed part of the environment.
 
 `--agent-type` runs an environment or benchmark with a harness other than the one its config names,
-without editing any config:
+without editing any config. To ablate the harness, hold everything else fixed — model, dataset, and repeat count — and vary only `--agent-type`, writing each run to its own output:
 
 ```bash
 gym list agents
 gym eval run --agent-type hermes_agent --benchmark gpqa --model-type vllm_model
 ```
 
-Holding the model, dataset, and repeat count fixed while changing only `--agent-type` gives you the
-harness contribution to the score. Refer to
-[Swapping the agent](/reference/cli-commands#swapping-the-agent) for the flag reference.
+Each run writes its own `_aggregate_metrics.json` next to its rollouts file. Comparing those across harnesses *is* the ablation — for example (illustrative, not real output):
+
+| Harness | Pass rate |
+|---|---|
+| `simple_agent` | 41% |
+| `hermes_agent` | 68% |
+| `openclaw_agent` | 35% |
+
+A spread this size, with the model and dataset held identical, means the harness — not the model — is the lever to pull. Refer to [Diagnose Results](/evaluation/diagnose-results) to have an agent explain *why* the harnesses diverged, or [Aggregate Metrics](/evaluation/aggregate-metrics) to build your own comparison across shards. For the flag reference itself, see
+[Swapping the agent](/reference/cli-commands#swapping-the-agent).
 
 ## The composed instance is renamed
 
@@ -53,7 +59,7 @@ NEMO_GYM_ALLOW_UNSUPPORTED_PAIRING=1) to bypass the check.
 ```
 
 <Warning>
-`--allow-unsupported-pairing` runs the pairing anyway. Scores from an undeclared pairing may not mean
+`--allow-unsupported-pairing` bypasses this check at your own risk: an unsupported harness can score incorrectly without erroring.
 what they appear to mean — the harness might not be compatible with the resources server.
 </Warning>
 

--- a/fern/versions/latest/pages/evaluation/harness.mdx
+++ b/fern/versions/latest/pages/evaluation/harness.mdx
@@ -5,7 +5,7 @@ position: 3
 ---
 
 An agent harness turns a model into an agent: it manages conversation state, routes tool calls, and
-decides when a task is complete. Two harnesses running the same model on the same tasks can score vary differently, and a harness that performs well on one model can perform poorly on another. Treat the harness as a variable worth isolating, not a fixed part of the environment.
+decides when a task is complete. Two harnesses can produce materially different scores on the same model and tasks, and a harness that performs well with one model may underperform with another. Treat the harness as an experimental variable to isolate and evaluate, not a fixed part of the environment
 
 `--agent-type` runs an environment or benchmark with a harness other than the one its config names,
 without editing any config. To ablate the harness, hold everything else fixed — model, dataset, and repeat count — and vary only `--agent-type`, writing each run to its own output:
@@ -63,7 +63,6 @@ NEMO_GYM_ALLOW_UNSUPPORTED_PAIRING=1) to bypass the check.
 
 <Warning>
 `--allow-unsupported-pairing` bypasses this check at your own risk: an unsupported harness can score incorrectly without erroring.
-what they appear to mean — the harness might not be compatible with the resources server.
 </Warning>
 
 A server that declares nothing accepts any harness — such environments are swappable without further

--- a/fern/versions/latest/pages/evaluation/index.mdx
+++ b/fern/versions/latest/pages/evaluation/index.mdx
@@ -48,6 +48,10 @@ An agent harness is the orchestration layer that turns a model into an agent —
 
 <Cards>
 
+<Card title="Compare Harnesses" href="/evaluation/harness">
+Run the same environment with a different harness to isolate its contribution to the score.
+</Card>
+
 <Card title="Configure Agents" href="/agent-server">
 Set up a built-in or custom agent harness.
 </Card>

--- a/fern/versions/latest/pages/evaluation/rollout-health.mdx
+++ b/fern/versions/latest/pages/evaluation/rollout-health.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Rollout Health Checks"
 description: "Verify that evaluation rollouts contain complete, internally consistent trajectory and model-call evidence."
-position: 5
+position: 6
 ---
 
 Rollout health checks verify the integrity and observability of completed evaluation artifacts. They detect unreadable records,

--- a/fern/versions/latest/pages/reference/cli-commands.mdx
+++ b/fern/versions/latest/pages/reference/cli-commands.mdx
@@ -98,23 +98,30 @@ config. It resolves to `responses_api_agents/NAME/configs/NAME.yaml`; use `NAME/
 non-default config in that directory.
 
 ```bash
-# Run GPQA with the Hermes harness instead of the one its config names
-gym eval run --agent-type hermes_agent --benchmark gpqa --model-type vllm_model
+# Run Terminal-Bench 2.1 under Terminus 2 instead of the OpenCode harness its config names
+gym eval run \
+    --benchmark terminal_bench_2_1/opencode \
+    --agent-type terminus_2_sandboxed_agent \
+    --model-type vllm_model
 ```
 
 Available on `gym env start`, `gym env validate`, `gym env prefetch`, and `gym eval run`. Like the other
-selectors it is pure shorthand, so `--agent-type hermes_agent` and `--config <that file>` behave
-identically.
+selectors it is pure shorthand, so `--agent-type terminus_2_sandboxed_agent` and `--config <that file>`
+behave identically.
 
 Run `gym list agents` to see the harnesses you can pass.
 
 **The composed server instance is renamed after the agent that runs it**, so metrics and `gym env status`
-report the harness actually used: composing `hermes_agent` onto `gpqa_mcqa_simple_agent` produces
-`gpqa_mcqa_hermes_agent`. `gym env start` prints the instance list, which matters for the two-step flow:
+report the harness actually used: composing `terminus_2_sandboxed_agent` onto
+`terminal_bench_2_1_opencode_sandboxed_agent` produces `terminal_bench_2_1_terminus_2_sandboxed_agent`.
+`gym env start` prints the instance list, which matters for the two-step flow:
 
 ```bash
-gym env start --agent-type hermes_agent --benchmark gpqa --model-type vllm_model
-gym eval run --no-serve --agent gpqa_mcqa_hermes_agent --input rows.jsonl
+gym env start \
+    --benchmark terminal_bench_2_1/opencode \
+    --agent-type terminus_2_sandboxed_agent \
+    --model-type vllm_model
+gym eval run --no-serve --agent terminal_bench_2_1_terminus_2_sandboxed_agent --input rows.jsonl
 ```
 
 <Note>
@@ -128,7 +135,8 @@ instance, and Gym says so rather than failing later:
 
 ```text
 Routing names agent instances that no longer exist once the agent is swapped:
-  - agent_name: 'gpqa_mcqa_simple_agent' is now 'gpqa_mcqa_hermes_agent'
+  - agent_name: 'terminal_bench_2_1_opencode_sandboxed_agent' is now
+    'terminal_bench_2_1_terminus_2_sandboxed_agent'
 
 Use the name the composed config reports.
 ```
@@ -141,12 +149,13 @@ required for the task with [`allowed_agents`](/reference/configuration#resources
 Gym refuses a pairing it does not list, before any server starts:
 
 ```text
-'hermes_agent' is not declared compatible with 1 of the agent instance(s) it would replace,
+'simple_agent' is not declared compatible with 1 of the agent instance(s) it would replace,
 so it cannot be scored correctly:
-  - gsm8k_aviary_agent uses gsm8k_aviary_resources_server and accepts aviary_agent
+  - terminal_bench_2_1_opencode_sandboxed_agent uses terminal_bench_2_1_opencode_resources_server
+    and accepts opencode_sandboxed_agent, terminus_2_sandboxed_agent
 
-Select one of: aviary_agent. Or pass --allow-unsupported-pairing (or set
-NEMO_GYM_ALLOW_UNSUPPORTED_PAIRING=1) to bypass the check.
+Select one of: opencode_sandboxed_agent, terminus_2_sandboxed_agent. Or pass
+--allow-unsupported-pairing (or set NEMO_GYM_ALLOW_UNSUPPORTED_PAIRING=1) to bypass the check.
 ```
 
 Results from an undeclared pairing might not be valid.

--- a/fern/versions/latest/pages/reference/cli-commands.mdx
+++ b/fern/versions/latest/pages/reference/cli-commands.mdx
@@ -68,14 +68,14 @@ These options are shared across many commands.
 | `--benchmark NAME` | Select a registered benchmark by name instead of a config path. |
 | `--resources-server NAME` | Select a registered resources server by name. |
 | `--model-type NAME` | Select a registered model server type by name (such as `openai_model` or `vllm_model`). |
-| `--agent NAME[/FLAVOR]` | Run the environment with a different agent harness. Refer to [Swapping the agent](#swapping-the-agent). |
+| `--agent-type NAME[/FLAVOR]` | Run the environment with a different agent harness. Refer to [Swapping the agent](#swapping-the-agent). |
 | `--search-dir DIR` | Extra root directory to search for components and configs. Repeatable. Applies everywhere Gym resolves paths — discovery, the `--<component>` selectors, `config_paths`, prompt configs, and data files — and is inherited by spawned servers. Equivalent to the `NEMO_GYM_EXTRA_ROOTS` environment variable; see [Configuration](/reference/configuration). |
 | `--json` | Emit machine-readable JSON instead of human-readable output (reporting commands only). Accepted before or after the subcommand; commands that emit no JSON reject it. |
 | `-v`, `--verbose` | Set the logging level to DEBUG. Flows through to spun-up servers. |
 | `-h`, `--help` | Show help for any group or command. |
 
 <Tip>
-The `--benchmark`, `--resources-server`, `--model-type`, and `--agent` selectors resolve a component name to its config file for you, so you do not need to know the project's directory layout. If you mistype a name, the CLI suggests the closest match. To point at a config file directly, use `--config <path>` instead.
+The `--benchmark`, `--resources-server`, `--model-type`, and `--agent-type` selectors resolve a component name to its config file for you, so you do not need to know the project's directory layout. If you mistype a name, the CLI suggests the closest match. To point at a config file directly, use `--config <path>` instead.
 </Tip>
 
 
@@ -93,17 +93,18 @@ Commands that need a model (`gym env start`, `gym eval run`) configure it throug
 
 ### Swapping the agent
 
-`--agent NAME` runs an environment or benchmark with a different agent harness, without editing any
+`--agent-type NAME` runs an environment or benchmark with a different agent harness, without editing any
 config. It resolves to `responses_api_agents/NAME/configs/NAME.yaml`; use `NAME/FLAVOR` to pick a
 non-default config in that directory.
 
 ```bash
 # Run GPQA with the Hermes harness instead of the one its config names
-gym eval run --agent hermes_agent --benchmark gpqa --model-type vllm_model
+gym eval run --agent-type hermes_agent --benchmark gpqa --model-type vllm_model
 ```
 
 Available on `gym env start`, `gym env validate`, `gym env prefetch`, and `gym eval run`. Like the other
-selectors it is pure shorthand, so `--agent hermes_agent` and `--config <that file>` behave identically.
+selectors it is pure shorthand, so `--agent-type hermes_agent` and `--config <that file>` behave
+identically.
 
 Run `gym list agents` to see the harnesses you can pass.
 
@@ -112,26 +113,39 @@ report the harness actually used: composing `hermes_agent` onto `gpqa_mcqa_simpl
 `gpqa_mcqa_hermes_agent`. `gym env start` prints the instance list, which matters for the two-step flow:
 
 ```bash
-gym env start --agent hermes_agent --benchmark gpqa --model-type vllm_model
+gym env start --agent-type hermes_agent --benchmark gpqa --model-type vllm_model
 gym eval run --no-serve --agent gpqa_mcqa_hermes_agent --input rows.jsonl
 ```
 
 <Note>
-With `--no-serve`, `--agent` names an already-running server instance to collect rollouts from, because
-the servers were composed when they were started. Without it, `--agent` selects the harness to compose.
+`--agent-type` chooses the harness to compose; `--agent` names the running instance to collect rollouts
+from. Because the harness is settled once the servers are up, `--agent-type` is rejected with
+`--no-serve`.
 </Note>
+
+Anything that routes rows — `--agent`, `+agent_map` values, `+fan_out` entries — must name the composed
+instance, and Gym says so rather than failing later:
+
+```text
+Routing names agent instances that no longer exist once the agent is swapped:
+  - agent_name: 'gpqa_mcqa_simple_agent' is now 'gpqa_mcqa_hermes_agent'
+
+Use the name the composed config reports.
+```
+
+Rows collected before the swap are re-routed for you, so existing rollout files stay usable.
 
 <Warning>
 Some tasks only work with the harness they were built for. A resources server may pin the harnesses
-required for the task with [`requires_agent`](/reference/configuration#resources-server-fields), and
+required for the task with [`allowed_agents`](/reference/configuration#resources-server-fields), and
 Gym refuses a pairing it does not list, before any server starts:
 
 ```text
 'hermes_agent' is not declared compatible with 1 of the agent instance(s) it would replace,
 so it cannot be scored correctly:
-  - scicode_benchmark_agent uses scicode_benchmark_resources_server and accepts scicode_agent
+  - gsm8k_aviary_agent uses gsm8k_aviary_resources_server and accepts aviary_agent
 
-Select one of: scicode_agent. Or pass --allow-unsupported-pairing (or set
+Select one of: aviary_agent. Or pass --allow-unsupported-pairing (or set
 NEMO_GYM_ALLOW_UNSUPPORTED_PAIRING=1) to bypass the check.
 ```
 
@@ -503,7 +517,7 @@ By default, values a run needs but the config leaves undefined (such as `policy_
 | `--resources-server NAME` | Validate a named resources server config. |
 | `--model-type NAME` | Also load a named model config (otherwise a dummy `policy_model` is used). |
 | `--search-dir DIR` | Extra root directory to search for named components. Repeatable. |
-| `--agent NAME[/FLAVOR]` | Compose the environment with the named agent harness. Refer to [Swapping the agent](#swapping-the-agent). |
+| `--agent-type NAME[/FLAVOR]` | Compose the environment with the named agent harness. Refer to [Swapping the agent](#swapping-the-agent). |
 | `--allow-unsupported-pairing` | Run even if the resources server does not declare support for the selected agent. |
 | `--model` / `--model-url` / `--model-api-key` | Override model name, base URL, and API key. |
 
@@ -591,7 +605,7 @@ Start the NeMo Gym servers (agents, models, resources) defined by the provided c
 | `--resources-server NAME` | Load the named resources server config. |
 | `--model-type NAME` | Load the named model server type config. |
 | `--search-dir DIR` | Extra root directory to search for named components. Repeatable. |
-| `--agent NAME[/FLAVOR]` | Compose the environment with the named agent harness. Refer to [Swapping the agent](#swapping-the-agent). |
+| `--agent-type NAME[/FLAVOR]` | Compose the environment with the named agent harness. Refer to [Swapping the agent](#swapping-the-agent). |
 | `--allow-unsupported-pairing` | Run even if the resources server does not declare support for the selected agent. |
 | `--model`, `-m` | Served model identifier. See [Selecting the model server](#selecting-the-model-server). |
 | `--model-url` | Model server base URL. |
@@ -670,7 +684,8 @@ Collate data, start the servers, and collect rollouts. This is the main evaluati
 | `--search-dir DIR` | Extra root directory to search for named components. Repeatable. |
 | `--no-serve` | Collect against already-running servers instead of starting them. |
 | `--resume` | Resume from cached rollouts instead of recollecting. Maps to legacy `+resume_from_cache=true`. Refer to [Resume interrupted runs](#resume-interrupted-runs). |
-| `--agent`, `-a` | With `--no-serve`: the running server instance to collect rollouts from. Otherwise: the agent harness to compose. Refer to [Swapping the agent](#swapping-the-agent). |
+| `--agent-type NAME[/FLAVOR]` | Compose the environment with the named agent harness. Rejected with `--no-serve`. Refer to [Swapping the agent](#swapping-the-agent). |
+| `--agent`, `-a` | Agent instance to collect rollouts with. |
 | `--allow-unsupported-pairing` | Run even if the resources server does not declare support for the selected agent. |
 | `--input`, `-i` | Input tasks JSONL file. |
 | `--output`, `-o` | Output rollouts JSONL file. |
@@ -981,7 +996,7 @@ The most common Hydra overrides now have dedicated flags:
 | Legacy Hydra override | New flag |
 | --- | --- |
 | `"+config_paths=[a.yaml,b.yaml]"` | `--config a.yaml --config b.yaml` |
-| `+agent_name=...` | `--agent` (with `--no-serve`) |
+| `+agent_name=...` | `--agent` |
 | `+input_jsonl_fpath=...` | `--input` |
 | `+input_glob=...` | `--input-glob` |
 | `+output_jsonl_fpath=...` | `--output` |

--- a/fern/versions/latest/pages/reference/cli-commands.mdx
+++ b/fern/versions/latest/pages/reference/cli-commands.mdx
@@ -68,13 +68,14 @@ These options are shared across many commands.
 | `--benchmark NAME` | Select a registered benchmark by name instead of a config path. |
 | `--resources-server NAME` | Select a registered resources server by name. |
 | `--model-type NAME` | Select a registered model server type by name (such as `openai_model` or `vllm_model`). |
+| `--agent NAME[/FLAVOR]` | Run the environment with a different agent harness. Refer to [Swapping the agent](#swapping-the-agent). |
 | `--search-dir DIR` | Extra root directory to search for components and configs. Repeatable. Applies everywhere Gym resolves paths — discovery, the `--<component>` selectors, `config_paths`, prompt configs, and data files — and is inherited by spawned servers. Equivalent to the `NEMO_GYM_EXTRA_ROOTS` environment variable; see [Configuration](/reference/configuration). |
 | `--json` | Emit machine-readable JSON instead of human-readable output (reporting commands only). Accepted before or after the subcommand; commands that emit no JSON reject it. |
 | `-v`, `--verbose` | Set the logging level to DEBUG. Flows through to spun-up servers. |
 | `-h`, `--help` | Show help for any group or command. |
 
 <Tip>
-The `--benchmark`, `--resources-server`, and `--model-type` selectors resolve a component name to its config file for you, so you do not need to know the project's directory layout. If you mistype a name, the CLI suggests the closest match. To point at a config file directly, use `--config <path>` instead.
+The `--benchmark`, `--resources-server`, `--model-type`, and `--agent` selectors resolve a component name to its config file for you, so you do not need to know the project's directory layout. If you mistype a name, the CLI suggests the closest match. To point at a config file directly, use `--config <path>` instead.
 </Tip>
 
 
@@ -89,6 +90,53 @@ Commands that need a model (`gym env start`, `gym eval run`) configure it throug
 | `--model-url` | Base URL of an existing model server endpoint. Maps to `policy_base_url`. |
 | `--model-api-key` | API key for the model server. Maps to `policy_api_key`. |
 
+
+### Swapping the agent
+
+`--agent NAME` runs an environment or benchmark with a different agent harness, without editing any
+config. It resolves to `responses_api_agents/NAME/configs/NAME.yaml`; use `NAME/FLAVOR` to pick a
+non-default config in that directory.
+
+```bash
+# Run GPQA with the Hermes harness instead of the one its config names
+gym eval run --agent hermes_agent --benchmark gpqa --model-type vllm_model
+```
+
+Available on `gym env start`, `gym env validate`, `gym env prefetch`, and `gym eval run`. Like the other
+selectors it is pure shorthand, so `--agent hermes_agent` and `--config <that file>` behave identically.
+
+Run `gym list agents` to see the harnesses you can pass.
+
+**The composed server instance is renamed after the agent that runs it**, so metrics and `gym env status`
+report the harness actually used: composing `hermes_agent` onto `gpqa_mcqa_simple_agent` produces
+`gpqa_mcqa_hermes_agent`. `gym env start` prints the instance list, which matters for the two-step flow:
+
+```bash
+gym env start --agent hermes_agent --benchmark gpqa --model-type vllm_model
+gym eval run --no-serve --agent gpqa_mcqa_hermes_agent --input rows.jsonl
+```
+
+<Note>
+With `--no-serve`, `--agent` names an already-running server instance to collect rollouts from, because
+the servers were composed when they were started. Without it, `--agent` selects the harness to compose.
+</Note>
+
+<Warning>
+Some tasks only work with the harness they were built for. A resources server may pin the harnesses
+required for the task with [`requires_agent`](/reference/configuration#resources-server-fields), and
+Gym refuses a pairing it does not list, before any server starts:
+
+```text
+'hermes_agent' is not declared compatible with 1 of the agent instance(s) it would replace,
+so it cannot be scored correctly:
+  - scicode_benchmark_agent uses scicode_benchmark_resources_server and accepts scicode_agent
+
+Select one of: scicode_agent. Or pass --allow-unsupported-pairing (or set
+NEMO_GYM_ALLOW_UNSUPPORTED_PAIRING=1) to bypass the check.
+```
+
+Results from an undeclared pairing might not be valid.
+</Warning>
 
 ### Hydra overrides (escape hatch)
 
@@ -455,6 +503,8 @@ By default, values a run needs but the config leaves undefined (such as `policy_
 | `--resources-server NAME` | Validate a named resources server config. |
 | `--model-type NAME` | Also load a named model config (otherwise a dummy `policy_model` is used). |
 | `--search-dir DIR` | Extra root directory to search for named components. Repeatable. |
+| `--agent NAME[/FLAVOR]` | Compose the environment with the named agent harness. Refer to [Swapping the agent](#swapping-the-agent). |
+| `--allow-unsupported-pairing` | Run even if the resources server does not declare support for the selected agent. |
 | `--model` / `--model-url` / `--model-api-key` | Override model name, base URL, and API key. |
 
 ```bash
@@ -541,6 +591,8 @@ Start the NeMo Gym servers (agents, models, resources) defined by the provided c
 | `--resources-server NAME` | Load the named resources server config. |
 | `--model-type NAME` | Load the named model server type config. |
 | `--search-dir DIR` | Extra root directory to search for named components. Repeatable. |
+| `--agent NAME[/FLAVOR]` | Compose the environment with the named agent harness. Refer to [Swapping the agent](#swapping-the-agent). |
+| `--allow-unsupported-pairing` | Run even if the resources server does not declare support for the selected agent. |
 | `--model`, `-m` | Served model identifier. See [Selecting the model server](#selecting-the-model-server). |
 | `--model-url` | Model server base URL. |
 | `--model-api-key` | Model server API key. |
@@ -618,7 +670,8 @@ Collate data, start the servers, and collect rollouts. This is the main evaluati
 | `--search-dir DIR` | Extra root directory to search for named components. Repeatable. |
 | `--no-serve` | Collect against already-running servers instead of starting them. |
 | `--resume` | Resume from cached rollouts instead of recollecting. Maps to legacy `+resume_from_cache=true`. Refer to [Resume interrupted runs](#resume-interrupted-runs). |
-| `--agent`, `-a` | Agent to collect rollouts with. |
+| `--agent`, `-a` | With `--no-serve`: the running server instance to collect rollouts from. Otherwise: the agent harness to compose. Refer to [Swapping the agent](#swapping-the-agent). |
+| `--allow-unsupported-pairing` | Run even if the resources server does not declare support for the selected agent. |
 | `--input`, `-i` | Input tasks JSONL file. |
 | `--output`, `-o` | Output rollouts JSONL file. |
 | `--limit` | Maximum number of tasks to run. |
@@ -928,7 +981,7 @@ The most common Hydra overrides now have dedicated flags:
 | Legacy Hydra override | New flag |
 | --- | --- |
 | `"+config_paths=[a.yaml,b.yaml]"` | `--config a.yaml --config b.yaml` |
-| `+agent_name=...` | `--agent` |
+| `+agent_name=...` | `--agent` (with `--no-serve`) |
 | `+input_jsonl_fpath=...` | `--input` |
 | `+input_glob=...` | `--input-glob` |
 | `+output_jsonl_fpath=...` | `--output` |

--- a/fern/versions/latest/pages/reference/configuration.mdx
+++ b/fern/versions/latest/pages/reference/configuration.mdx
@@ -121,7 +121,13 @@ my_resource:                                  # Server ID (your choice — agent
       verified: false                         # Passed reward profiling and training checks (default: false)
       description: "Short description"        # Server description
       value: "What this improves"             # Training value provided
+      requires_agent: [my_agent]              # Optional: agents that score this task correctly
 ```
+
+**`requires_agent`** pins the agent harnesses that verify this server's tasks correctly. Omit it (the
+default) when any harness will do. When it is set, [`--agent`](/reference/cli-commands#swapping-the-agent)
+refuses to substitute an agent that is not listed. Declare it on every config that writes this server's
+block — server configs are self-contained, so a config written from scratch does not inherit it.
 
 **Domain values:** `math`, `coding`, `agent`, `knowledge`, `instruction_following`, `long_context`, `safety`, `games`, `translation`, `e2e`, `rlhf`, `other` (see `Domain`)
 

--- a/fern/versions/latest/pages/reference/configuration.mdx
+++ b/fern/versions/latest/pages/reference/configuration.mdx
@@ -121,11 +121,11 @@ my_resource:                                  # Server ID (your choice — agent
       verified: false                         # Passed reward profiling and training checks (default: false)
       description: "Short description"        # Server description
       value: "What this improves"             # Training value provided
-      requires_agent: [my_agent]              # Optional: agents that score this task correctly
+      allowed_agents: [my_agent]              # Optional: agents that score this task correctly
 ```
 
-**`requires_agent`** pins the agent harnesses that verify this server's tasks correctly. Omit it (the
-default) when any harness will do. When it is set, [`--agent`](/reference/cli-commands#swapping-the-agent)
+**`allowed_agents`** pins the agent harnesses that verify this server's tasks correctly. Omit it (the
+default) when any harness will do. When it is set, [`--agent-type`](/reference/cli-commands#swapping-the-agent)
 refuses to substitute an agent that is not listed. Declare it on every config that writes this server's
 block — server configs are self-contained, so a config written from scratch does not inherit it.
 

--- a/responses_api_agents/tau2/configs/tau2_agent_turn_limit.yaml
+++ b/responses_api_agents/tau2/configs/tau2_agent_turn_limit.yaml
@@ -19,7 +19,7 @@ tau2_agent_turn_limit:
       # Each valid generated assistant message uses one agent step, whether it
       # contains text or one or more tool calls. Tau2's fixed initial greeting,
       # user messages, and environment tool results do not count. Leave this
-      # unset/null for unlimited steps and no reminders, as in tau2_agent.yaml.
+      # unset/null for unlimited steps and no reminders, as in tau2.yaml.
       max_agent_steps: 10
       # With a limit set, append "ENVIRONMENT REMINDER: You have N turns left to
       # complete the task." to every Nth non-tool user message sent to the agent.


### PR DESCRIPTION
This PR documents the new `--agent` CLI flag and agent swapping mechanism. It should be merge as the last as it documents features that are not yet in the`main` branch.

The entire PR stack will introduce the following changes:

1. config composition
2. `--agent-type` flag in the CLI for selecting the agent
3. safeguard preventing unsupported env <> agent pairings
4. aligning with dataset changes introduced in epic #1338
5. docs update (**this PR**)