### PR TITLE
refactor(sandbox): rename SandboxSpec.resources to resource_limits

### DIFF
--- a/fern/versions/latest/pages/infrastructure/sandbox/adding-a-provider.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/adding-a-provider.mdx
@@ -128,7 +128,7 @@ async def create(self, spec: SandboxSpec) -> SandboxHandle:
     ...
 ```
 
-This keeps common fields such as `image`, `env`, `files`, `metadata`, and `resources` portable while still giving a provider room for runtime-specific behavior.
+This keeps common fields such as `image`, `env`, `files`, `metadata`, and `resource_limits` portable while still giving a provider room for runtime-specific behavior.
 
 ## Registry
 

--- a/fern/versions/latest/pages/infrastructure/sandbox/apptainer.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/apptainer.mdx
@@ -81,7 +81,7 @@ These binds are added on top of the provider's staging mount and `exec.default_b
 | `env` | Passed as `--env KEY=VALUE` at instance start and on each `exec()`. |
 | `workdir` | Used as the default command working directory through `--pwd`. |
 | `files` | Seed files uploaded before the first command. |
-| `resources` | Mapped to cgroup and GPU flags when supported by the host. |
+| `resource_limits` | Mapped to cgroup and GPU flags when supported by the host. |
 | `provider_options.binds` | Extra per-sandbox bind mounts. |
 | `ttl_s` | Not supported by Apptainer; the provider logs a warning and ignores it. |
 

--- a/fern/versions/latest/pages/infrastructure/sandbox/docker.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/docker.mdx
@@ -87,7 +87,7 @@ sandbox_spec:
 | `env` | Passed as `--env KEY=VALUE` at `docker run` and re-applied on each `exec()`. |
 | `workdir` | `-w` at `docker run` (created if absent) and the default `exec()` working directory. |
 | `files` | Seed files uploaded before the first command. |
-| `resources` | Mapped to CPU, memory, and GPU flags (see Resource Mapping). |
+| `resource_limits` | Mapped to CPU, memory, and GPU flags (see Resource Mapping). |
 | `entrypoint` | Overrides the keep-alive: the container runs this as its main process instead. |
 | `provider_options` | `volumes` and `run_args`, applied per-sandbox. |
 | `ttl_s` | Max lifetime: the keep-alive sleeps for `ttl_s` and the container self-removes (`--rm`) on exit. Ignored when a custom `entrypoint` owns the container lifetime. |
@@ -129,7 +129,7 @@ Docker containers share the host kernel. This is process and namespace isolation
 
 - Never run with `--privileged` and never mount the Docker socket into the sandbox; either grants host root.
 - Networking is on by default because most tasks need egress (pip, git). Set `network: none` to cut it entirely, or `network: <name>` to attach a locked-down internal network.
-- Harden with `read_only: true`, `cap_drop: ["ALL"]`, `security_opt: ["no-new-privileges"]`, and `pids_limit: <n>` as a fork-bomb guard. Enforce `resources` so one sandbox cannot starve the host.
+- Harden with `read_only: true`, `cap_drop: ["ALL"]`, `security_opt: ["no-new-privileges"]`, and `pids_limit: <n>` as a fork-bomb guard. Enforce `resource_limits` so one sandbox cannot starve the host.
 - Rootless Docker narrows the blast radius (container root is not host root) and is recommended for shared machines; `docker cp` ownership and some `--user` behaviors differ under it.
 - Every container is labeled `nemo-gym.sandbox=1`. Reap leaks from an unclean shutdown with `docker rm -f $(docker ps -aq --filter label=nemo-gym.sandbox=1)`.
 

--- a/fern/versions/latest/pages/infrastructure/sandbox/ecs-fargate.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/ecs-fargate.mdx
@@ -20,7 +20,7 @@ uv pip install boto3
 
 ## Provider Configuration
 
-NeMo Gym ships this provider config at `nemo_gym/sandbox/providers/ecs_fargate/configs/ecs_fargate.yaml`. It defines a top-level `sandbox` block that an agent selects with `sandbox_provider: sandbox`. Region-only is enough; everything else auto-discovers from SSM (explicit YAML always wins), and task cpu/memory/disk come from the agent's `sandbox_spec.resources`:
+NeMo Gym ships this provider config at `nemo_gym/sandbox/providers/ecs_fargate/configs/ecs_fargate.yaml`. It defines a top-level `sandbox` block that an agent selects with `sandbox_provider: sandbox`. Region-only is enough; everything else auto-discovers from SSM (explicit YAML always wins), and task cpu/memory/disk come from the agent's `sandbox_spec.resource_limits`:
 
 ```yaml
 sandbox:
@@ -91,7 +91,7 @@ spec = SandboxSpec(
     image="python:3.13.14-slim",
     ttl_s=1800,
     ready_timeout_s=300,
-    resources=SandboxResources(cpu=2, memory_mib=8192),
+    resource_limits=SandboxResources(cpu=2, memory_mib=8192),
 )
 
 

--- a/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
@@ -60,8 +60,8 @@ The public API is part of `nemo-gym`. Runtime backends can have optional depende
 | --- | --- |
 | `AsyncSandbox` | Async facade for FastAPI servers, async agents, and rollout code. Use this inside async code. |
 | `Sandbox` | Sync facade for synchronous harnesses. It owns a private event loop and rejects calls from an already-running async loop. |
-| `SandboxSpec` | Provider-neutral sandbox creation request. Includes image, TTL, working directory, files, metadata, resources, entrypoint, and provider options. |
-| `SandboxResources` | Typed resource request with CPU, memory, disk, and GPU fields. |
+| `SandboxSpec` | Provider-neutral sandbox creation request. Includes image, TTL, working directory, files, metadata, resource limits, entrypoint, and provider options. |
+| `SandboxResources` | Typed resource quantities with CPU, memory, disk, and GPU fields. |
 | `SandboxExecResult` | Command result with `stdout`, `stderr`, `return_code`, and optional `error_type`. |
 | `SandboxStatus` | Provider-neutral lifecycle status: `starting`, `running`, `stopped`, `error`, or `unknown`. |
 | `SandboxCreateError` | Base create-time failure for provider allocation and readiness errors. |
@@ -87,7 +87,7 @@ spec = SandboxSpec(
     files={
         "/sandbox/hello.py": "print('hello from sandbox')\n",
     },
-    resources=SandboxResources(cpu=1, memory_mib=1024, disk_gib=5),
+    resource_limits=SandboxResources(cpu=1, memory_mib=1024, disk_gib=5),
     metadata={"example": "first-run"},
 )
 
@@ -134,7 +134,7 @@ mini_swe_agent_2:
     mini_swe_agent_2:
       sandbox_provider: sandbox
       sandbox_spec:
-        resources:
+        resource_limits:
           cpu: 2
           memory_mib: 8192
         provider_options:
@@ -176,7 +176,7 @@ spec = SandboxSpec(
     ttl_s=18000,
     ready_timeout_s=1200,
     workdir="/workspace",
-    resources=SandboxResources(cpu=2, memory_mib=8192, disk_gib=20),
+    resource_limits=SandboxResources(cpu=2, memory_mib=8192, disk_gib=20),
     metadata={"benchmark": "my-benchmark", "task_id": "task-001"},
 )
 
@@ -223,16 +223,16 @@ Do not call `Sandbox` from FastAPI handlers, async resources servers, or async a
 | `env` | Environment variables injected into the sandbox. Forward only values required by the task. |
 | `files` | Text files to upload at startup, keyed by remote target path. |
 | `metadata` | String metadata for tracing, debugging, and backend labels. Providers may normalize values for their runtime. |
-| `resources` | `SandboxResources` or a mapping with `cpu`, `memory_mib`, `disk_gib`, `gpu`, and `gpu_type`. |
+| `resource_limits` | `SandboxResources` or a mapping with `cpu`, `memory_mib`, `disk_gib`, `gpu`, and `gpu_type`. `resources` is a deprecated alias accepted for one release. |
 | `entrypoint` | Optional container entrypoint override. |
 | `provider_options` | Provider-specific options that do not fit the common schema. |
 
-You can pass resources as either a `SandboxResources` instance or a mapping:
+You can pass resource limits as either a `SandboxResources` instance or a mapping:
 
 ```python
 spec = SandboxSpec(
     image="ghcr.io/example/eval-image:py312",
-    resources={
+    resource_limits={
         "cpu": 2,
         "memory_mib": 8192,
         "disk_gib": 20,

--- a/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/opensandbox.mdx
@@ -121,7 +121,7 @@ Unknown provider option keys raise `ValueError`; values with the wrong type rais
 | `env` | Passed to OpenSandbox create and command execution. |
 | `files` | Seed files uploaded before the first command. |
 | `metadata` | Passed to OpenSandbox create after provider-specific normalization. |
-| `resources` | Mapped to OpenSandbox resource quantities. |
+| `resource_limits` | Mapped to OpenSandbox resource quantities. |
 | `entrypoint` | Passed to OpenSandbox create when set. |
 | `provider_options` | Per-sandbox OpenSandbox options such as `image_auth`, `platform`, `snapshot_id`, `volumes`, `skip_health_check`, and `extensions`. |
 

--- a/nemo_gym/sandbox/providers/apptainer/README.md
+++ b/nemo_gym/sandbox/providers/apptainer/README.md
@@ -38,7 +38,7 @@ spec = SandboxSpec(
     workdir="/sandbox",
     env={"GREETING": "hello"},
     files={"/sandbox/input.txt": "some seed content"},
-    resources={"cpu": 2, "memory_mib": 4096},
+    resource_limits={"cpu": 2, "memory_mib": 4096},
 )
 
 with Sandbox({"apptainer": {}}, spec) as sandbox:
@@ -107,7 +107,7 @@ Settings for starting the instance (`apptainer instance start`).
 | `mount_point` | `/sandbox` | Absolute path inside the container where the host staging dir is bind-mounted. Powers the file-transfer fast path. |
 | `start_timeout_s` | `600` | Max seconds to wait for `instance start` (`None` = no timeout). |
 | `extra_start_args` | `[]` | Extra raw flags appended to `instance start`. |
-| `apply_resource_limits` | `true` | Add CPU/memory cgroup flags from `SandboxSpec.resources`. |
+| `apply_resource_limits` | `true` | Add CPU/memory cgroup flags from `SandboxSpec.resource_limits`. |
 
 ### `exec` — `ApptainerExecConfig`
 

--- a/nemo_gym/sandbox/providers/apptainer/provider.py
+++ b/nemo_gym/sandbox/providers/apptainer/provider.py
@@ -389,7 +389,7 @@ class ApptainerProvider:
            name = INSTANCE_NAME_PREFIX + uuid4().hex.
         4. Build argv: [binary, "instance", "start", <--bind staging:mount_point>,
            <config default_binds>, <spec.provider_options["binds"]>, <--env-file ...>,
-           _resource_flags(spec.resources), <extra_start_args>, image, name].
+           _resource_flags(spec.resource_limits), <extra_start_args>, image, name].
         5. await self._run(argv, timeout_s=self._create_config.start_timeout_s);
            on non-zero return, clean up the staging dir and raise
            ApptainerCreateError(stderr).
@@ -430,7 +430,7 @@ class ApptainerProvider:
         for bind in extra_binds:
             argv += ["--bind", bind]
         start_args = list(self._create_config.extra_start_args)
-        resource_limit_flags = _resource_limit_flags(spec.resources)
+        resource_limit_flags = _resource_limit_flags(spec.resource_limits)
         if resource_limit_flags and self._create_config.apply_resource_limits:
             if "--fakeroot" in start_args:
                 LOGGER.warning(
@@ -438,7 +438,7 @@ class ApptainerProvider:
                 )
             else:
                 argv += resource_limit_flags
-        argv += _resource_passthrough_flags(spec.resources)
+        argv += _resource_passthrough_flags(spec.resource_limits)
         argv += start_args
 
         # start the instance; clean up the staging dir on any failure.

--- a/nemo_gym/sandbox/providers/base.py
+++ b/nemo_gym/sandbox/providers/base.py
@@ -14,8 +14,9 @@
 
 """Provider-facing sandbox protocol."""
 
+import warnings
 from collections.abc import AsyncIterator, Mapping
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
@@ -63,7 +64,7 @@ class SandboxEndpoint:
 
 @dataclass(frozen=True)
 class SandboxResources:
-    """Provider-neutral resource request."""
+    """Provider-neutral resource quantities (used for both limits and requests)."""
 
     cpu: float | None = None
     memory_mib: int | None = None
@@ -101,14 +102,28 @@ class SandboxSpec:
     env: dict[str, str] = field(default_factory=dict)
     files: dict[str, str] = field(default_factory=dict)
     metadata: dict[str, str] = field(default_factory=dict)
-    resources: SandboxResources | Mapping[str, Any] = field(default_factory=SandboxResources)
+    resource_limits: SandboxResources | Mapping[str, Any] = field(default_factory=SandboxResources)
     entrypoint: list[str] | None = None
     provider_options: dict[str, Any] = field(default_factory=dict)
     ports: tuple[int, ...] | list[int] = field(default_factory=tuple)
+    # Deprecated alias for resource_limits, accepted for one deprecation cycle.
+    resources: InitVar[SandboxResources | Mapping[str, Any] | None] = None
 
-    def __post_init__(self) -> None:
-        if not isinstance(self.resources, SandboxResources):
-            object.__setattr__(self, "resources", SandboxResources.from_mapping(self.resources))
+    def __post_init__(self, resources: SandboxResources | Mapping[str, Any] | None) -> None:
+        if not isinstance(self.resource_limits, SandboxResources):
+            object.__setattr__(self, "resource_limits", SandboxResources.from_mapping(self.resource_limits))
+        if resources is not None:
+            warnings.warn(
+                "`SandboxSpec.resources` is deprecated; use `resource_limits` (the values are the "
+                "Kubernetes-style resource limits, matching the existing OpenSandbox `resource_requests`).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            # An explicit `resource_limits` wins, so callers can migrate without removing the old key.
+            if self.resource_limits == SandboxResources():
+                if not isinstance(resources, SandboxResources):
+                    resources = SandboxResources.from_mapping(resources)
+                object.__setattr__(self, "resource_limits", resources)
         if not isinstance(self.ports, (list, tuple)):
             raise TypeError("Sandbox ports must be a list or tuple of TCP port numbers")
         normalized_ports: list[int] = []

--- a/nemo_gym/sandbox/providers/daytona/provider.py
+++ b/nemo_gym/sandbox/providers/daytona/provider.py
@@ -414,18 +414,18 @@ def _coerce_int(name: str, value: Any) -> int:
 
 def _quantity_to_int(name: str, value: Any) -> int:
     if isinstance(value, bool):
-        raise ValueError(f"resources.{name} must be an integer-like quantity")
+        raise ValueError(f"resource_limits.{name} must be an integer-like quantity")
     if isinstance(value, int):
         return value
     if isinstance(value, float):
         if not value.is_integer():
-            raise ValueError(f"resources.{name} must be an integer-like quantity")
+            raise ValueError(f"resource_limits.{name} must be an integer-like quantity")
         return int(value)
 
     text = str(value).strip()
     match = re.fullmatch(r"(\d+(?:\.\d+)?)([A-Za-z]*)", text)
     if match is None:
-        raise ValueError(f"resources.{name} must be an integer-like quantity")
+        raise ValueError(f"resource_limits.{name} must be an integer-like quantity")
     number = float(match.group(1))
     unit = match.group(2).lower()
     if name == "cpu" and unit == "m":
@@ -434,7 +434,7 @@ def _quantity_to_int(name: str, value: Any) -> int:
         return math.ceil(number / 1024)
     if unit in {"", "g", "gb", "gi", "gib"}:
         return math.ceil(number)
-    raise ValueError(f"resources.{name} uses unsupported unit {unit!r}")
+    raise ValueError(f"resource_limits.{name} uses unsupported unit {unit!r}")
 
 
 def _spec_extensions(spec: SandboxSpec) -> dict[str, str]:
@@ -458,7 +458,7 @@ def _resources_requested(resources: SandboxResources | Mapping[str, Any]) -> boo
 
 def _mib_to_gib(name: str, value: Any) -> int:
     if isinstance(value, bool):
-        raise ValueError(f"resources.{name} must be an integer-like quantity")
+        raise ValueError(f"resource_limits.{name} must be an integer-like quantity")
     return math.ceil(float(value) / 1024)
 
 
@@ -760,12 +760,12 @@ class DaytonaProvider:
         kwargs = self._base_create_kwargs(spec)
         if spec.image is not None:
             kwargs["image"] = spec.image
-            resources = _to_resources(spec.resources) if _resources_requested(spec.resources) else None
+            resources = _to_resources(spec.resource_limits) if _resources_requested(spec.resource_limits) else None
             if resources is not None:
                 kwargs["resources"] = resources
             return ImageParams(**kwargs)
         if snapshot_id is not None:
-            if _resources_requested(spec.resources):
+            if _resources_requested(spec.resource_limits):
                 raise ValueError("Daytona snapshot creation does not support resource overrides")
             kwargs["snapshot"] = snapshot_id
             return SnapshotParams(**kwargs)

--- a/nemo_gym/sandbox/providers/docker/README.md
+++ b/nemo_gym/sandbox/providers/docker/README.md
@@ -36,7 +36,7 @@ spec = SandboxSpec(
     workdir="/sandbox",
     env={"GREETING": "hello"},
     files={"/sandbox/input.txt": "some seed content"},
-    resources={"cpu": 2, "memory_mib": 4096},
+    resource_limits={"cpu": 2, "memory_mib": 4096},
     ports=[8000],
 )
 
@@ -94,7 +94,7 @@ docker:
 | `security_opt` | `[]` | `--security-opt` values, e.g. `["no-new-privileges"]` (blocks setuid escalation). |
 | `pids_limit` | `None` | Cap the container's process count (`--pids-limit`). |
 | `extra_run_args` | `[]` | Extra raw flags appended to `docker run`. |
-| `apply_resource_limits` | `true` | Apply CPU/memory flags from `SandboxSpec.resources`. |
+| `apply_resource_limits` | `true` | Apply CPU/memory flags from `SandboxSpec.resource_limits`. |
 | `publish_host` | `127.0.0.1` | Host address used for dynamic mappings declared by `SandboxSpec.ports`. |
 
 ### `exec` — `DockerExecConfig`

--- a/nemo_gym/sandbox/providers/docker/provider.py
+++ b/nemo_gym/sandbox/providers/docker/provider.py
@@ -316,8 +316,8 @@ class DockerProvider:
         for key, value in spec.env.items():
             argv += ["--env", f"{key}={value}"]
         if cfg.apply_resource_limits:
-            argv += _resource_limit_flags(spec.resources)
-        argv += _resource_passthrough_flags(spec.resources)
+            argv += _resource_limit_flags(spec.resource_limits)
+        argv += _resource_passthrough_flags(spec.resource_limits)
         if cfg.network is not None:
             argv += ["--network", cfg.network]
         if cfg.read_only:

--- a/nemo_gym/sandbox/providers/ecs_fargate/configs/ecs_fargate.yaml
+++ b/nemo_gym/sandbox/providers/ecs_fargate/configs/ecs_fargate.yaml
@@ -21,6 +21,6 @@ sandbox:
   ecs_fargate:
     # Region-only: cluster / subnets / security-groups / roles and the SSH-sidecar key ARNs
     # auto-discover from SSM (/<ssm_project>/ecs-sandbox/config; ssm_project defaults to harbor).
-    # Task cpu / memory / disk come from the agent's sandbox_spec.resources (mapped onto the
+    # Task cpu / memory / disk come from the agent's sandbox_spec.resource_limits (mapped onto the
     # Fargate task); set cpu / memory / ephemeral_storage_gib here only to change the defaults.
     region: ${oc.env:AWS_REGION}

--- a/nemo_gym/sandbox/providers/ecs_fargate/provider.py
+++ b/nemo_gym/sandbox/providers/ecs_fargate/provider.py
@@ -85,11 +85,11 @@ def _apply_spec_overrides(cfg: engine.EcsFargateConfig, spec: SandboxSpec) -> en
         overrides["startup_timeout_sec"] = float(spec.ready_timeout_s)
     if spec.ttl_s is not None:
         overrides["max_task_lifetime_sec"] = int(spec.ttl_s)
-    resources = spec.resources
+    resources = spec.resource_limits
     if not isinstance(resources, SandboxResources):
         resources = SandboxResources.from_mapping(resources)
     if resources.gpu:
-        raise SandboxCreateError("ECS Fargate does not support GPU sandboxes (spec.resources.gpu)")
+        raise SandboxCreateError("ECS Fargate does not support GPU sandboxes (spec.resource_limits.gpu)")
     if resources.cpu is not None:
         overrides["cpu"] = str(int(resources.cpu * 1024))
     if resources.memory_mib is not None:

--- a/nemo_gym/sandbox/providers/enroot/provider.py
+++ b/nemo_gym/sandbox/providers/enroot/provider.py
@@ -442,7 +442,7 @@ class EnrootProvider:
         """Import/create the rootfs, launch a detached init, and return a ready handle."""
         if spec.ttl_s is not None:
             LOGGER.warning("ttl_s is not supported by the enroot provider; it will be ignored.")
-        resources = spec.resources
+        resources = spec.resource_limits
         if resources.cpu is not None or resources.memory_mib is not None or resources.disk_gib is not None:
             LOGGER.warning(
                 "cpu/memory_mib/disk_gib are not enforced by standalone enroot (that is pyxis/Slurm's job); "

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -549,8 +549,8 @@ class OpenSandboxProviderOptions:
     volumes: tuple[Mapping[str, Any], ...] = ()
     skip_health_check: bool | None = None
     extensions: Mapping[str, str] = field(default_factory=dict)
-    # Scheduling requests (same keys as SandboxSpec.resources, which become the
-    # limits). Unset, the server applies the single resources map as both.
+    # Scheduling requests (same keys as SandboxSpec.resource_limits). Unset,
+    # the server applies the single limits map as both.
     resource_requests: Mapping[str, Any] | None = None
 
     @classmethod
@@ -1048,7 +1048,7 @@ class OpenSandboxProvider:
         kwargs: dict[str, Any] = {
             "env": spec.env,
             "metadata": spec.metadata,
-            "resource": _resource_map(spec.resources),
+            "resource": _resource_map(spec.resource_limits),
             "extensions": self._resolve_extensions(options.extensions),
             "connection_config": self._connection_config(request_timeout_s=self._create.request_timeout_s),
         }

--- a/nemo_gym/sandbox/providers/openshell/provider.py
+++ b/nemo_gym/sandbox/providers/openshell/provider.py
@@ -464,7 +464,7 @@ class OpenShellProvider:
             kwargs["policy"] = self._build_policy(options.policy)
         if options.providers:
             kwargs["providers"] = options.providers
-        resources = spec.resources
+        resources = spec.resource_limits
         if resources.gpu:
             kwargs["resource_requirements"] = openshell_pb2.ResourceRequirements(
                 gpu=openshell_pb2.GpuResourceRequirements(count=resources.gpu)

--- a/resources_servers/deepswe/app.py
+++ b/resources_servers/deepswe/app.py
@@ -227,10 +227,12 @@ class DeepSWEResourcesServer(SimpleResourcesServer):
         provider_metadata = resolve_provider_metadata(self.config.sandbox_provider, global_config)
 
         current_task_id = task_id(task)
-        resources = task_sandbox_resources(task, phase=phase)
-        resources["cpu"] *= self.config.task_cpu_multiplier
-        resources["memory_mib"] = ceil(resources["memory_mib"] * self.config.task_memory_multiplier)
-        resources.update(self.config.sandbox_config.get("resources", {}))
+        resource_limits = task_sandbox_resources(task, phase=phase)
+        resource_limits["cpu"] *= self.config.task_cpu_multiplier
+        resource_limits["memory_mib"] = ceil(resource_limits["memory_mib"] * self.config.task_memory_multiplier)
+        resource_limits.update(
+            self.config.sandbox_config.get("resource_limits", self.config.sandbox_config.get("resources", {}))
+        )
         spec = SandboxSpec(
             image=task_image(task),
             ttl_s=self.config.sandbox_config.get("ttl_s"),
@@ -246,7 +248,10 @@ class DeepSWEResourcesServer(SimpleResourcesServer):
                 "deepswe-phase": phase,
                 "nemo_gym_agent": self.config.name or "deepswe",
             },
-            resources=SandboxResources.from_mapping(resources),
+            resource_limits=SandboxResources.from_mapping(resource_limits),
+            # Deprecated alias, folded into resource_limits above; passed through so
+            # SandboxSpec emits its deprecation warning.
+            resources=self.config.sandbox_config.get("resources"),
             provider_options=self._provider_options(phase=phase),
         )
         sandbox = AsyncSandbox(provider)

--- a/resources_servers/deepswe/tests/test_app.py
+++ b/resources_servers/deepswe/tests/test_app.py
@@ -148,7 +148,7 @@ async def test_create_sandbox_scales_phase_limits_from_task_toml(
 
     assert created is sandbox
     spec = sandbox.start.await_args.args[0]
-    assert spec.resources == expected_resources
+    assert spec.resource_limits == expected_resources
     assert spec.image == UPSTREAM_IMAGE
 
 
@@ -159,7 +159,7 @@ async def test_create_sandbox_allows_resource_multiplier_and_explicit_overrides(
     config = _config(task_assets)
     config.task_cpu_multiplier = 1.5
     config.task_memory_multiplier = 1.25
-    config.sandbox_config = {"resources": {"memory_mib": 20000}}
+    config.sandbox_config = {"resource_limits": {"memory_mib": 20000}}
     server = DeepSWEResourcesServer(
         config=config,
         server_client=MagicMock(spec=ServerClient),
@@ -173,7 +173,7 @@ async def test_create_sandbox_allows_resource_multiplier_and_explicit_overrides(
     await server._create_sandbox(server._task_store.get("example-task"), phase="agent")
 
     spec = sandbox.start.await_args.args[0]
-    assert spec.resources == SandboxResources(cpu=3, memory_mib=20000, disk_gib=20)
+    assert spec.resource_limits == SandboxResources(cpu=3, memory_mib=20000, disk_gib=20)
 
 
 async def test_golden_verify_passes_structured_result(

--- a/resources_servers/litmus_agent/app.py
+++ b/resources_servers/litmus_agent/app.py
@@ -721,7 +721,9 @@ class LitmusAgentResourcesServer(SimpleResourcesServer):
             env=dict(spec.pop("env", {})),
             files=files,
             metadata=dict(spec.pop("metadata", {})),
-            resources=SandboxResources.from_mapping(spec.pop("resources", {})),
+            resource_limits=SandboxResources.from_mapping(spec.pop("resource_limits", {})),
+            # Deprecated alias; SandboxSpec warns and maps it onto resource_limits.
+            resources=spec.pop("resources", None),
             entrypoint=spec.pop("entrypoint", None),
             provider_options=dict(spec.pop("provider_options", {})),
         )

--- a/resources_servers/litmus_agent/configs/litmus_agent.yaml
+++ b/resources_servers/litmus_agent/configs/litmus_agent.yaml
@@ -54,7 +54,7 @@ litmus_agent:
         ready_timeout_s: 1200
         # OpenSandbox does not create workdir; must be a dir that exists in the image.
         workdir: /tmp
-        resources:
+        resource_limits:
           cpu: 2
           memory_mib: 4096
           disk_gib: 10

--- a/resources_servers/litmus_agent/configs/litmus_agent_apptainer.yaml
+++ b/resources_servers/litmus_agent/configs/litmus_agent_apptainer.yaml
@@ -46,7 +46,7 @@ litmus_agent:
         # if the compute node has no outbound network.
         image: ${oc.env:LITMUS_AGENT_SANDBOX_IMAGE,docker://python:3.12-slim}
         workdir: /sandbox
-        resources:
+        resource_limits:
           cpu: 2
           memory_mib: 4096
         # ttl_s intentionally omitted: Apptainer has no native auto-expiry and

--- a/resources_servers/swebench/app.py
+++ b/resources_servers/swebench/app.py
@@ -241,9 +241,11 @@ class SwebenchResourcesServer(SimpleResourcesServer):
         global_config_dict = get_global_config_dict()
         resolved_sandbox_provider = resolve_provider_config(self.config.sandbox_provider, global_config_dict)
         provider_default_metadata = resolve_provider_metadata(self.config.sandbox_provider, global_config_dict)
-        resources = dict(self.config.sandbox_config.get("resources", {}))
+        resource_limits = dict(
+            self.config.sandbox_config.get("resource_limits", self.config.sandbox_config.get("resources", {}))
+        )
 
-        patch_swebench_multilingual_resources_request(resources, test_spec.instance_id)
+        patch_swebench_multilingual_resources_request(resource_limits, test_spec.instance_id)
 
         eval_sandbox_spec = SandboxSpec(
             image=test_spec.instance_image_key,
@@ -258,7 +260,10 @@ class SwebenchResourcesServer(SimpleResourcesServer):
                 "nemo_gym_agent": self.config.name,
                 "instance_id": test_spec.instance_id[:63],
             },
-            resources=SandboxResources.from_mapping(resources),
+            resource_limits=SandboxResources.from_mapping(resource_limits),
+            # Deprecated alias, folded into resource_limits above; passed through so
+            # SandboxSpec emits its deprecation warning.
+            resources=self.config.sandbox_config.get("resources"),
             entrypoint=None,
             provider_options=self.config.sandbox_config.get("provider_options", {}),
         )

--- a/resources_servers/swebench/configs/swebench.yaml
+++ b/resources_servers/swebench/configs/swebench.yaml
@@ -18,7 +18,7 @@ swebench_resources_server:          # instance name — how agents/CLI refer to 
       sandbox_config:
         ttl_s: 18000
         ready_timeout_s: 1200
-        resources:
+        resource_limits:
           cpu: 2
           memory_mib: 16384
           # 30 GiB works on every provider: within Fargate's 21-200 GiB ephemeral range

--- a/responses_api_agents/anyswe_agent/app.py
+++ b/responses_api_agents/anyswe_agent/app.py
@@ -327,7 +327,9 @@ class AnySweAgent(SimpleResponsesAPIAgent):
             env=config.pop("env", {}),
             files=files or {},
             metadata=metadata,
-            resources=SandboxResources.from_mapping(config.pop("resources", {})),
+            resource_limits=SandboxResources.from_mapping(config.pop("resource_limits", {})),
+            # Deprecated alias; SandboxSpec warns and maps it onto resource_limits.
+            resources=config.pop("resources", None),
             entrypoint=config.pop("entrypoint", None),
             provider_options=provider_options,
         )

--- a/responses_api_agents/anyswe_agent/tests/test_app.py
+++ b/responses_api_agents/anyswe_agent/tests/test_app.py
@@ -130,7 +130,7 @@ class TestSandboxAPI:
             sandbox_spec={
                 "ttl_s": 600,
                 "ready_timeout_s": 300,
-                "resources": {"cpu": 2, "memory_mib": 4096},
+                "resource_limits": {"cpu": 2, "memory_mib": 4096},
                 "provider_options": {"platform": {"arch": "amd64"}},
             },
             sandbox_default_metadata={"sandbox-api": "opensandbox-sdk"},
@@ -142,7 +142,7 @@ class TestSandboxAPI:
         spec = AnySweAgent._sandbox_spec(params, files={"/tmp/input": "data"})
         assert spec.image == "image:tag"
         assert spec.ttl_s == 600
-        assert spec.resources.cpu == 2
+        assert spec.resource_limits.cpu == 2
         assert spec.metadata["sandbox-api"] == "opensandbox-sdk"
         assert spec.provider_options == {"platform": {"arch": "amd64"}}
         assert spec.files == {"/tmp/input": "data"}

--- a/responses_api_agents/harbor_agent/custom_envs/nemo_gym_sandbox/environment.py
+++ b/responses_api_agents/harbor_agent/custom_envs/nemo_gym_sandbox/environment.py
@@ -196,15 +196,15 @@ class NemoGymSandboxEnvironment(BaseEnvironment):
 
     def _build_spec(self) -> SandboxSpec:
         config = self.task_env_config
-        resources: dict[str, Any] = {}
+        resource_limits: dict[str, Any] = {}
         if config.cpus:
-            resources["cpu"] = float(config.cpus)
+            resource_limits["cpu"] = float(config.cpus)
         if config.memory_mb:
-            resources["memory_mib"] = int(config.memory_mb)
+            resource_limits["memory_mib"] = int(config.memory_mb)
         if config.storage_mb:
-            resources["disk_gib"] = max(1, round(config.storage_mb / 1024))
+            resource_limits["disk_gib"] = max(1, round(config.storage_mb / 1024))
         if config.gpus:
-            resources["gpu"] = int(config.gpus)
+            resource_limits["gpu"] = int(config.gpus)
 
         metadata = {
             "harbor-session": self.session_id,
@@ -220,7 +220,7 @@ class NemoGymSandboxEnvironment(BaseEnvironment):
             workdir=self._workdir,
             env=self._sandbox_env,
             metadata=metadata,
-            resources=resources,
+            resource_limits=resource_limits,
             provider_options=dict(self._sandbox_provider_options),
         )
 

--- a/responses_api_agents/harbor_agent/tests/test_environment.py
+++ b/responses_api_agents/harbor_agent/tests/test_environment.py
@@ -151,8 +151,8 @@ class TestStartStop:
         assert spec.image == "docker.io/example/task:1.0"
         assert spec.ttl_s == 1234
         assert spec.ready_timeout_s == 56
-        assert spec.resources.cpu == 4.0
-        assert spec.resources.memory_mib == 8192
+        assert spec.resource_limits.cpu == 4.0
+        assert spec.resource_limits.memory_mib == 8192
         assert spec.metadata["harbor-session"] == "example-task__trial-1"
         assert spec.metadata["harbor-task"] == "example-task"
         assert spec.metadata["harbor-benchmark"] == "tb-2-1"
@@ -177,7 +177,7 @@ class TestStartStop:
         # keeps the task's own smaller limits and disk-heavy tasks get evicted.
         env = _make_environment(tmp_path, override_cpus=8, override_memory_mb=16384, override_storage_mb=30720)
         await env.start(force_build=False)
-        resources = _provider().created_specs[0].resources
+        resources = _provider().created_specs[0].resource_limits
         assert resources.cpu == 8.0
         assert resources.memory_mib == 16384
         assert resources.disk_gib == 30

--- a/responses_api_agents/mini_swe_agent_2/README.md
+++ b/responses_api_agents/mini_swe_agent_2/README.md
@@ -173,7 +173,7 @@ mini_swe_agent_2:
       sandbox_spec:
         ttl_s: 18000
         ready_timeout_s: 1200
-        resources:
+        resource_limits:
           cpu: 2
           memory_mib: 8192
           disk_gib: 20
@@ -262,7 +262,7 @@ my_provider = "my_pkg.provider:MyProvider"
 
 Optional `sandbox_resource_profiles` can be configured as a list of resource
 maps. When present, the agent hashes `instance_id` and deterministically merges
-one profile into `sandbox_spec.resources`. This is useful for spreading
+one profile into `sandbox_spec.resource_limits`. This is useful for spreading
 SWE-bench tasks across a small set of resource sizes without changing the input
 data.
 
@@ -655,7 +655,7 @@ environment:
     opensandbox:
       connection: ...
   spec:
-    resources: ...
+    resource_limits: ...
     provider_options:
       platform: ...
     metadata: ...

--- a/responses_api_agents/mini_swe_agent_2/app.py
+++ b/responses_api_agents/mini_swe_agent_2/app.py
@@ -213,11 +213,14 @@ def _sandbox_spec_for_instance(
     if not resource_profiles:
         return instance_spec
 
-    resources = dict(instance_spec.get("resources") or {})
+    # Merge into whichever key the spec uses so a deprecated `resources` key
+    # still reaches SandboxSpec and emits its deprecation warning.
+    key = "resources" if "resources" in instance_spec and "resource_limits" not in instance_spec else "resource_limits"
+    resources = dict(instance_spec.get(key) or {})
     digest = hashlib.sha256(instance_id.encode("utf-8")).digest()
     profile = resource_profiles[int.from_bytes(digest[:4], "big") % len(resource_profiles)]
     resources.update(profile)
-    instance_spec["resources"] = resources
+    instance_spec[key] = resources
     return instance_spec
 
 

--- a/responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+++ b/responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
@@ -31,7 +31,7 @@ mini_swe_agent_2:
         ttl_s: 18000
         ready_timeout_s: 1200
         # Limits (burst ceiling); memory-spiky test suites OOM-kill below this.
-        resources:
+        resource_limits:
           cpu: 2
           memory_mib: 8192
           # 30 GiB works on every provider: within Fargate's 21-200 GiB ephemeral range

--- a/responses_api_agents/mini_swe_agent_2/sandbox_environment.py
+++ b/responses_api_agents/mini_swe_agent_2/sandbox_environment.py
@@ -101,7 +101,9 @@ class MiniSWESandboxEnvironment:
                     "nemo_gym_agent": "mini_swe_agent_2",
                     "instance_id": (self.config.instance_id or "unknown")[:63],
                 },
-                resources=SandboxResources.from_mapping(spec_config.pop("resources", {})),
+                resource_limits=SandboxResources.from_mapping(spec_config.pop("resource_limits", {})),
+                # Deprecated alias; SandboxSpec warns and maps it onto resource_limits.
+                resources=spec_config.pop("resources", None),
                 entrypoint=spec_config.pop("entrypoint", None),
                 provider_options=provider_options,
             )

--- a/responses_api_agents/mini_swe_agent_2/tests/test_app.py
+++ b/responses_api_agents/mini_swe_agent_2/tests/test_app.py
@@ -344,7 +344,7 @@ class TestApp:
 
     def test_sandbox_resource_profiles_override_static_resources(self) -> None:
         spec = _sandbox_spec_for_instance(
-            {"resources": {"cpu": 1, "memory_mib": 8192, "disk_gib": 20}},
+            {"resource_limits": {"cpu": 1, "memory_mib": 8192, "disk_gib": 20}},
             resource_profiles=[
                 {"cpu": 0.25, "memory_mib": 3072, "disk_gib": 1},
                 {"cpu": 0.5, "memory_mib": 4096, "disk_gib": 1},
@@ -352,11 +352,21 @@ class TestApp:
             instance_id="django__django-12345",
         )
 
-        assert spec["resources"] in (
+        assert spec["resource_limits"] in (
             {"cpu": 0.25, "memory_mib": 3072, "disk_gib": 1},
             {"cpu": 0.5, "memory_mib": 4096, "disk_gib": 1},
         )
         assert _sandbox_spec_for_instance(None, resource_profiles=None, instance_id="task") == {}
+
+        # A spec still using the deprecated `resources` key keeps it, so the
+        # SandboxSpec deprecation warning fires downstream.
+        legacy = _sandbox_spec_for_instance(
+            {"resources": {"cpu": 1}},
+            resource_profiles=[{"cpu": 0.25}],
+            instance_id="task",
+        )
+        assert "resource_limits" not in legacy
+        assert legacy["resources"] == {"cpu": 0.25}
 
     def test_sandbox_provider_config_dump_strips_api_key(self) -> None:
         provider = {

--- a/responses_api_agents/opencode_sandboxed_agent/app.py
+++ b/responses_api_agents/opencode_sandboxed_agent/app.py
@@ -459,7 +459,9 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
             | {
                 "nemo_gym_agent": self.config.name,
             },
-            resources=SandboxResources.from_mapping(self.config.sandbox_config.get("resources", {})),
+            resource_limits=SandboxResources.from_mapping(self.config.sandbox_config.get("resource_limits", {})),
+            # Deprecated alias; SandboxSpec warns and maps it onto resource_limits.
+            resources=self.config.sandbox_config.get("resources"),
             entrypoint=None,
             provider_options=self.config.sandbox_config.get("provider_options", {}),
         )

--- a/responses_api_agents/opencode_sandboxed_agent/configs/opencode_agent.yaml
+++ b/responses_api_agents/opencode_sandboxed_agent/configs/opencode_agent.yaml
@@ -146,7 +146,7 @@ opencode_sandboxed_agent:
       sandbox_config:
         ttl_s: 18000
         ready_timeout_s: 1200
-        resources:
+        resource_limits:
           cpu: 2
           memory_mib: 8192
           # 30 GiB works on every provider: within Fargate's 21-200 GiB ephemeral range

--- a/responses_api_agents/osworld_agent/configs/osworld_agent.yaml
+++ b/responses_api_agents/osworld_agent/configs/osworld_agent.yaml
@@ -24,7 +24,7 @@ osworld_simple_agent:
           DISK_SIZE: 32G
           RAM_SIZE: 4G
           CPU_CORES: "4"
-        resources:
+        resource_limits:
           cpu: 4
           memory_mib: 16384
           disk_gib: 40

--- a/responses_api_agents/osworld_agent/tests/test_sandbox_provider.py
+++ b/responses_api_agents/osworld_agent/tests/test_sandbox_provider.py
@@ -48,7 +48,7 @@ def test_build_spec_mounts_read_only_snapshot_and_requests_runtime(tmp_path, mon
         {
             "image": "docker://osworld@sha256:abc",
             "ports": None,
-            "resources": {"cpu": 4, "memory_mib": 16384},
+            "resource_limits": {"cpu": 4, "memory_mib": 16384},
             "provider_options": {"run_args": ["--security-opt", "label=disable"]},
         },
     )
@@ -60,7 +60,7 @@ def test_build_spec_mounts_read_only_snapshot_and_requests_runtime(tmp_path, mon
     assert spec.entrypoint == list(osworld_sandbox.OSWORLD_IMAGE_ENTRYPOINT)
     assert spec.env["HEADLESS"] == "Y"
     assert spec.env["KVM"] == "Y"
-    assert spec.resources.cpu == 4
+    assert spec.resource_limits.cpu == 4
     assert f"{vm_path.resolve()}:/System.qcow2:ro" in spec.provider_options["volumes"]
     assert osworld_sandbox._has_option(spec.provider_options["run_args"], "--cap-add", "NET_ADMIN")
     assert osworld_sandbox._has_option(spec.provider_options["run_args"], "--device", "/dev/kvm")
@@ -133,7 +133,7 @@ def test_build_spec_uses_sdk_compatibility_image_for_opensandbox_pool(monkeypatc
             "image": "busybox:1.36",
             "entrypoint": ["/run/entry.sh"],
             "env": {"KVM": "Y"},
-            "resources": {"cpu": 4, "memory_mib": 16384},
+            "resource_limits": {"cpu": 4, "memory_mib": 16384},
             "provider_options": {
                 "skip_health_check": True,
                 "extensions": {"poolRef": "osworld-kvm"},
@@ -158,7 +158,7 @@ def test_build_spec_uses_sdk_compatibility_image_for_opensandbox_pool(monkeypatc
     assert spec.metadata["run-id"] == "opensandbox-run"
     assert spec.entrypoint is None
     assert spec.env == {}
-    assert spec.resources.cpu is None
+    assert spec.resource_limits.cpu is None
 
 
 def test_build_spec_rejects_invalid_opensandbox_pool_spec() -> None:

--- a/responses_api_agents/pinchbench/app.py
+++ b/responses_api_agents/pinchbench/app.py
@@ -251,7 +251,9 @@ class PinchBenchAgent(SimpleResponsesAPIAgent):
             ttl_s=cfg.get("ttl_s"),
             ready_timeout_s=cfg.get("ready_timeout_s"),
             workdir=cfg.get("workdir"),
-            resources=SandboxResources.from_mapping(cfg.get("resources", {})),
+            resource_limits=SandboxResources.from_mapping(cfg.get("resource_limits", {})),
+            # Deprecated alias; SandboxSpec warns and maps it onto resource_limits.
+            resources=cfg.get("resources"),
             provider_options=cfg.get("provider_options", {}),
             env=self._task_env(task_id, rollout_id),
             metadata={"task_id": task_id},

--- a/responses_api_agents/pinchbench/configs/pinchbench.yaml
+++ b/responses_api_agents/pinchbench/configs/pinchbench.yaml
@@ -22,7 +22,7 @@ pinchbench_agent:
       sandbox_spec:
         image: ${sandbox_image}
         ready_timeout_s: 600
-        resources:
+        resource_limits:
           cpu: 4
           memory_mib: 8192
       task_timeout_s: 1800

--- a/responses_api_agents/pinchbench/tests/test_app.py
+++ b/responses_api_agents/pinchbench/tests/test_app.py
@@ -112,13 +112,13 @@ def test_build_spec_from_config(tmp_path):
         sandbox_spec={
             "image": str(image),
             "ready_timeout_s": 600,
-            "resources": {"cpu": 4, "memory_mib": 8192},
+            "resource_limits": {"cpu": 4, "memory_mib": 8192},
         }
     )
     spec = agent._build_spec("task_x")
     assert spec.image == str(image)
     assert spec.ready_timeout_s == 600
-    assert spec.resources.cpu == 4 and spec.resources.memory_mib == 8192
+    assert spec.resource_limits.cpu == 4 and spec.resource_limits.memory_mib == 8192
     assert spec.metadata == {"task_id": "task_x"}
     # the per-task env (incl the in-sandbox gateway token) is injected into the spec
     assert spec.env["TASK_ID"] == "task_x"

--- a/tests/unit_tests/test_apptainer_provider.py
+++ b/tests/unit_tests/test_apptainer_provider.py
@@ -280,7 +280,7 @@ async def test_create_builds_argv_and_runs_probe(
     spec = SandboxSpec(
         image="ubuntu:22.04",
         env={"FOO": "bar"},
-        resources={"cpu": 2, "memory_mib": 1024, "gpu": 1},
+        resource_limits={"cpu": 2, "memory_mib": 1024, "gpu": 1},
         ttl_s=60,
     )
 
@@ -328,7 +328,7 @@ async def test_create_skips_cgroup_resource_limits(
         return (0, "", "")
 
     provider, rec = _make_provider(monkeypatch, responder, create=create_config)
-    await provider.create(SandboxSpec(image="ubuntu:22.04", resources={"cpu": 2, "memory_mib": 1024, "gpu": 1}))
+    await provider.create(SandboxSpec(image="ubuntu:22.04", resource_limits={"cpu": 2, "memory_mib": 1024, "gpu": 1}))
 
     start_argv = rec.calls[0]["argv"]
     assert "--cpus" not in start_argv

--- a/tests/unit_tests/test_daytona_provider.py
+++ b/tests/unit_tests/test_daytona_provider.py
@@ -264,11 +264,11 @@ def test_conversion_helpers_and_config_validation(fake_daytona_sdk: None) -> Non
 
     assert daytona_provider._to_resources({}) is None
     assert daytona_provider._to_resources({"gpu": "1"}).kwargs == {"gpu": 1}
-    assert daytona_provider._to_resources(SandboxSpec(resources={"memory_mib": 2048}).resources).kwargs == {
-        "memory": 2
-    }
+    assert daytona_provider._to_resources(
+        SandboxSpec(resource_limits={"memory_mib": 2048}).resource_limits
+    ).kwargs == {"memory": 2}
     with pytest.raises(ValueError, match="gpu_type"):
-        daytona_provider._to_resources(SandboxSpec(resources={"gpu_type": "a100"}).resources)
+        daytona_provider._to_resources(SandboxSpec(resource_limits={"gpu_type": "a100"}).resource_limits)
     assert daytona_provider._to_sandbox_status("creating") == SandboxStatus.STARTING
     assert daytona_provider._to_sandbox_status("deleted") == SandboxStatus.STOPPED
     assert daytona_provider._to_sandbox_status("failed") == SandboxStatus.ERROR
@@ -303,7 +303,7 @@ def test_snapshot_creation_rejects_ignored_resources(fake_daytona_sdk: None) -> 
     provider = daytona_provider.DaytonaProvider(probe={"command": None})
     spec = SandboxSpec(
         provider_options={"snapshot_id": "snapshot-1"},
-        resources={"cpu": 2},
+        resource_limits={"cpu": 2},
     )
 
     with pytest.raises(ValueError, match="snapshot creation does not support resource overrides"):
@@ -315,7 +315,7 @@ def test_image_creation_keeps_resource_overrides(fake_daytona_sdk: None) -> None
     params = provider._to_create_params(
         SandboxSpec(
             image="python:3.12",
-            resources={"cpu": 2, "memory_mib": 2048, "disk_gib": 9},
+            resource_limits={"cpu": 2, "memory_mib": 2048, "disk_gib": 9},
         )
     )
 

--- a/tests/unit_tests/test_docker_provider.py
+++ b/tests/unit_tests/test_docker_provider.py
@@ -232,7 +232,7 @@ async def test_create_builds_argv_and_runs_probe(fake_binary: str, monkeypatch: 
         image="ubuntu:22.04",
         workdir="/sandbox",
         env={"FOO": "bar"},
-        resources={"cpu": 2, "memory_mib": 1024, "gpu": 1},
+        resource_limits={"cpu": 2, "memory_mib": 1024, "gpu": 1},
         ports=[5000, 9222],
     )
     handle = await provider.create(spec)
@@ -284,7 +284,7 @@ async def test_create_skips_cgroup_resource_limits(fake_binary: str, monkeypatch
         return (0, "", "")
 
     provider, rec = _make_provider(monkeypatch, responder, create={"apply_resource_limits": False})
-    await provider.create(SandboxSpec(image="ubuntu:22.04", resources={"cpu": 2, "memory_mib": 1024, "gpu": 1}))
+    await provider.create(SandboxSpec(image="ubuntu:22.04", resource_limits={"cpu": 2, "memory_mib": 1024, "gpu": 1}))
 
     run_argv = rec.calls[0]["argv"]
     assert "--cpus" not in run_argv

--- a/tests/unit_tests/test_ecs_fargate_provider.py
+++ b/tests/unit_tests/test_ecs_fargate_provider.py
@@ -407,7 +407,7 @@ def test_apply_spec_overrides_maps_resources_and_ttl():
         image="img",
         ttl_s=3600,
         ready_timeout_s=120,
-        resources={"cpu": 2, "memory_mib": 4096, "disk_gib": 50},
+        resource_limits={"cpu": 2, "memory_mib": 4096, "disk_gib": 50},
     )
     out = _apply_spec_overrides(cfg, spec)
     assert out.max_task_lifetime_sec == 3600
@@ -424,7 +424,7 @@ def test_apply_spec_overrides_rejects_gpu():
 
     cfg = engine.EcsFargateConfig(region="us-east-1")
     with pytest.raises(SandboxCreateError, match="GPU"):
-        _apply_spec_overrides(cfg, SandboxSpec(image="img", resources={"gpu": 1}))
+        _apply_spec_overrides(cfg, SandboxSpec(image="img", resource_limits={"gpu": 1}))
 
 
 # ── Phase B review fixes ──────────────────────────────────────────────

--- a/tests/unit_tests/test_enroot_provider.py
+++ b/tests/unit_tests/test_enroot_provider.py
@@ -300,7 +300,7 @@ async def test_create_builds_argv_and_runs_probe(
     spec = SandboxSpec(
         image="ubuntu:22.04",
         env={"FOO": "bar"},
-        resources={"cpu": 2, "memory_mib": 1024, "gpu": 1, "disk_gib": 50},
+        resource_limits={"cpu": 2, "memory_mib": 1024, "gpu": 1, "disk_gib": 50},
         ttl_s=60,
         provider_options={"mounts": ["/host/a:/code/a"]},
     )

--- a/tests/unit_tests/test_opensandbox_provider.py
+++ b/tests/unit_tests/test_opensandbox_provider.py
@@ -224,7 +224,7 @@ async def test_direct_create_passes_resource_requests_to_sdk_create(
     await provider.create(
         SandboxSpec(
             image="mirror.gcr.io/astral/uv:python3.12-bookworm-slim",
-            resources={"cpu": 1, "memory_mib": 8192, "disk_gib": 30},
+            resource_limits={"cpu": 1, "memory_mib": 8192, "disk_gib": 30},
             provider_options={"resource_requests": {"cpu": 0.5, "memory_mib": 2048, "disk_gib": 30}},
         ),
     )
@@ -1177,7 +1177,7 @@ async def test_create_once_and_connect_after_create_error_paths(
         image="image:tag",
         ttl_s=10,
         ready_timeout_s=20,
-        resources=SandboxResources(cpu=2, memory_mib=8192, disk_gib=20, gpu=1, gpu_type="H100"),
+        resource_limits=SandboxResources(cpu=2, memory_mib=8192, disk_gib=20, gpu=1, gpu_type="H100"),
         entrypoint=["/bin/sh"],
         provider_options={
             "snapshot_id": "snapshot-1",

--- a/tests/unit_tests/test_openshell_provider.py
+++ b/tests/unit_tests/test_openshell_provider.py
@@ -330,7 +330,7 @@ async def test_create_success_maps_spec(make_provider, fake_client: FakeClient) 
         env={"FOO": "bar"},
         metadata={"task": "demo", SANDBOX_LABEL: "user-override"},
         workdir="/workspace",
-        resources={"gpu": 2},
+        resource_limits={"gpu": 2},
         provider_options={"providers": ["nvidia"]},
     )
     handle = await provider.create(spec)
@@ -410,7 +410,7 @@ async def test_create_unknown_provider_option_raises(make_provider, fake_client:
 async def test_create_warns_on_unmapped_resources(make_provider, fake_client: FakeClient, caplog) -> None:
     provider = make_provider()
     with caplog.at_level("WARNING"):
-        await provider.create(SandboxSpec(resources={"cpu": 2, "memory_mib": 1024}))
+        await provider.create(SandboxSpec(resource_limits={"cpu": 2, "memory_mib": 1024}))
     assert "not mapped by this provider" in caplog.text
     assert "template_resources" in caplog.text
 

--- a/tests/unit_tests/test_sandbox.py
+++ b/tests/unit_tests/test_sandbox.py
@@ -379,12 +379,12 @@ def test_rewrite_image_validation() -> None:
 
 
 def test_sandbox_resources_validation() -> None:
-    spec = SandboxSpec(resources={"cpu": "0.5", "memory_mib": "4096", "disk_gib": "8"}, ports=[8000, "9222"])
-    assert spec.resources == SandboxResources(cpu=0.5, memory_mib=4096, disk_gib=8)
+    spec = SandboxSpec(resource_limits={"cpu": "0.5", "memory_mib": "4096", "disk_gib": "8"}, ports=[8000, "9222"])
+    assert spec.resource_limits == SandboxResources(cpu=0.5, memory_mib=4096, disk_gib=8)
     assert spec.ports == (8000, 9222)
 
     with pytest.raises(ValueError, match="Unknown sandbox resource keys"):
-        SandboxSpec(resources={"memory": "4Gi"})
+        SandboxSpec(resource_limits={"memory": "4Gi"})
     with pytest.raises(ValueError, match="Duplicate sandbox TCP port"):
         SandboxSpec(ports=[8000, 8000])
     with pytest.raises(ValueError, match="between 1 and 65535"):
@@ -393,6 +393,17 @@ def test_sandbox_resources_validation() -> None:
         SandboxSpec(ports=[8000.5])
     with pytest.raises(ValueError, match="absolute URL"):
         SandboxEndpoint(endpoint="/relative/path")
+
+
+def test_sandbox_resources_deprecated_alias_maps_to_resource_limits() -> None:
+    with pytest.warns(DeprecationWarning, match="resource_limits"):
+        spec = SandboxSpec(resources={"cpu": 1})
+    assert spec.resource_limits == SandboxResources(cpu=1.0)
+
+    # An explicit resource_limits wins over the deprecated alias.
+    with pytest.warns(DeprecationWarning, match="resource_limits"):
+        spec = SandboxSpec(resource_limits={"cpu": 2}, resources={"cpu": 1})
+    assert spec.resource_limits == SandboxResources(cpu=2.0)
 
 
 def test_sandbox_endpoint_is_an_optional_provider_capability() -> None:
@@ -1154,7 +1165,7 @@ def test_mini_swe_sandbox_environment_owns_conda_setup(monkeypatch) -> None:
         spec={
             "image_rewrites": [{"from": "upstream/", "to": "mirror/"}],
             "metadata": {"suite": "unit"},
-            "resources": {"cpu": 1},
+            "resource_limits": {"cpu": 1},
         },
         env={"STATIC_KEY": "static-value"},
         forward_env=["FORWARDED_KEY"],
@@ -1179,7 +1190,7 @@ def test_mini_swe_sandbox_environment_owns_conda_setup(monkeypatch) -> None:
             "FORWARDED_KEY": "forwarded-value",
             "STATIC_KEY": "static-value",
         }
-        assert provider.created_specs[0].resources == SandboxResources(cpu=1.0)
+        assert provider.created_specs[0].resource_limits == SandboxResources(cpu=1.0)
 
         result = env.execute("pytest -q", is_eval=True)
         assert result == {"output": "ok", "returncode": 0, "exception_info": ""}


### PR DESCRIPTION
## Summary

Renames the provider-neutral `SandboxSpec.resources` field to `resource_limits` across the sandbox subsystem. `resources` is ambiguous, while the field's semantics are exactly Kubernetes resource **limits**: the OpenSandbox provider forwards it to the SDK create call, which the server applies as the pod limits (and as the requests too when none are given). The new name states that, and restores naming symmetry with the OpenSandbox provider's existing per-sandbox `resource_requests` option.

## Old → new mapping

| Surface | Old | New |
| --- | --- | --- |
| `SandboxSpec` field / kwarg | `resources` | `resource_limits` |
| Agent & server YAML (`sandbox_spec` / `sandbox_config`) | `resources:` | `resource_limits:` |

`SandboxResources` and the OpenSandbox `resource_requests` provider option are unchanged.

## Backward compatibility

Follows the repo's established one-cycle deprecation pattern (`UploadRolloutsConfigMixin`): `SandboxSpec` still accepts `resources` as an init-only alias, emits a `DeprecationWarning`, and maps it onto `resource_limits` (an explicit `resource_limits` wins). Agents that hand-extract the key from their YAML forward the legacy value through the deprecated kwarg so the warning still fires; existing user configs keep working unchanged for one cycle.

> **Breaking change:** reading the attribute `spec.resources` is no longer supported — custom providers or harnesses that read it must switch to `spec.resource_limits`. Spec **construction** with the old name still works (with a warning) for one deprecation cycle.

## Files touched

- **Core:** `nemo_gym/sandbox/providers/base.py` (field rename + deprecated alias)
- **Providers:** opensandbox, docker, apptainer, enroot, ecs_fargate (incl. shipped YAML comment), openshell, daytona (incl. validation messages)
- **Agents / servers:** mini_swe_agent_2, anyswe_agent, opencode_sandboxed_agent, pinchbench, osworld_agent, harbor_agent, litmus_agent, swebench, deepswe
- **Shipped configs:** mini_swe_agent_2, opencode_agent, pinchbench, osworld_agent, litmus_agent (x2), swebench
- **Docs:** `fern/versions/latest/pages/infrastructure/sandbox/` (index, adding-a-provider, apptainer, docker, ecs-fargate, opensandbox) + provider/agent READMEs; frozen doc snapshots untouched
- **Tests:** all sandbox provider unit tests + touched agent/server tests; new coverage for the deprecated alias (warns, maps, loses to an explicit `resource_limits`)

## Test plan

- `tests/unit_tests/` full run: **2961 passed, 7 skipped** (1 deselected: `test_enroot_provider.py::test_create_start_timeout_cleans_up` scans `/proc` and fails on macOS on pristine `main` too — pre-existing, unrelated)
- Touched agent/server suites: mini_swe_agent_2 + pinchbench + anyswe_agent + osworld_agent (87 passed), litmus_agent + opencode (125 passed), harbor_agent (25 passed), deepswe (14 passed), swebench (10 passed)
- `ruff check` / `ruff format` clean; `pre-commit` scoped to changed files passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)