### PR TITLE
fix(scicode): write generated code to a file instead of passing it via argv

### DIFF
--- a/resources_servers/scicode/scicode_integration/runner.py
+++ b/resources_servers/scicode/scicode_integration/runner.py
@@ -25,9 +25,11 @@ H5PY_FILE = "/data/test_data.h5"; here it is injected from config.
 """
 
 import json
+import os
 import re
 import subprocess
 import sys
+import tempfile
 
 
 # Helper functions ported verbatim from nemo-skills scicode_utils.eval_prefix. H5PY_FILE and the
@@ -216,9 +218,29 @@ def build_test_program(full_generation: str, h5_path: str, step_number: str, san
 
 def run_substep(program: str, timeout_secs: float) -> dict:
     """Run one sub-step program in a subprocess. Exit code 0 == all assertions passed."""
+    # Passing a large generated solution through `python -c <program>` is
+    # bounded by Linux's execve argument-size limit (ARG_MAX). SciCode's
+    # accumulated solutions can exceed that late in a run. A temporary source
+    # file has no such limit and preserves the per-substep subprocess isolation.
+    source_path = None
     try:
-        proc = subprocess.run([sys.executable, "-c", program], capture_output=True, timeout=timeout_secs)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            suffix=".py",
+            prefix="scicode-substep-",
+            delete=False,
+        ) as source:
+            source.write(program)
+            source_path = source.name
+        proc = subprocess.run([sys.executable, source_path], capture_output=True, timeout=timeout_secs)
     except subprocess.TimeoutExpired:
         return {"passed": False, "error": "timeout"}
+    finally:
+        if source_path is not None:
+            try:
+                os.unlink(source_path)
+            except FileNotFoundError:
+                pass
     passed = proc.returncode == 0
     return {"passed": passed, "error": "" if passed else proc.stderr.decode("utf-8", errors="replace")[-_STDERR_TAIL:]}


### PR DESCRIPTION
SciCode executed candidate solutions with `python3 -c <program>`, so the whole code is a single argv entry. Runs that accumulate enough context exceed the kernel's ARG_MAX and the interpreter never starts, `raising OSError: [Errno 7] Argument list too long.`

Write the program to a temporary file and execute that instead.