### PR TITLE
fix(equivalence_llm_judge): do not abort the run on a judge failure

### DIFF
--- a/resources_servers/equivalence_llm_judge/app.py
+++ b/resources_servers/equivalence_llm_judge/app.py
@@ -129,10 +129,19 @@ class LLMJudgeVerifyRequest(LLMJudgeRunRequest, BaseVerifyRequest):
     pass
 
 
+# Marks a rollout whose verdict is absent because the judge service failed,
+# as distinct from a judge that ran and returned no parseable verdict.
+JUDGE_ERROR_LABEL = "JUDGE_ERROR"
+
+
 class JudgeEvaluation(BaseModel):
     responses_create_params: NeMoGymResponseCreateParamsNonStreaming
-    response: NeMoGymResponse
-    # Extracted verdict token from judge output, e.g., "[[A=B]]" or "[[A!=B]]".
+    # None when the judge could not be reached or returned an unusable payload.
+    # The rollout is still recorded so the failure is visible in the artifacts
+    # rather than taking down the run that produced it.
+    response: Optional[NeMoGymResponse] = None
+    # Extracted verdict token from judge output, e.g., "[[A=B]]" or "[[A!=B]]",
+    # or JUDGE_ERROR_LABEL when the judge itself failed.
     verdict_label: Optional[str] = None
 
 
@@ -482,7 +491,18 @@ class LLMJudgeResourcesServer(SimpleResourcesServer):
                     f"DEBUG: LLMJudgeResourcesServer: judge model server HTTP POST error: {e}",
                     flush=True,
                 )
-                raise
+                # Do not re-raise. The judge is a separate service, and a
+                # transient failure from it is not a failure of the rollout:
+                # propagating here aborts the whole evaluation and discards every
+                # rollout already generated, which can be many hours of work.
+                # Record the failure on the rollout and score it not-equal, so
+                # the run completes and a downstream check can decide whether the
+                # judge-error rate makes the score untrustworthy.
+                return False, JudgeEvaluation(
+                    responses_create_params=responses_create_params,
+                    response=None,
+                    verdict_label=JUDGE_ERROR_LABEL,
+                )
 
         eval_record = JudgeEvaluation(
             responses_create_params=responses_create_params,


### PR DESCRIPTION
A `JudgeError` is propagated out of the verify path, which aborts the whole evaluation and discards every rollout already generated. 
Observed on HLE: a transient 500 error from the judge ended a run.

The judge is a separate service, so its availability is not a property of the rollout being scored. Record the failure on the rollout instead: `response` becomes optional and `verdict_label` is set to `JUDGE_ERROR`, the rollout scores not-equal, and the run completes. The judge-error rate is then visible in the artifacts, so a caller can decide whether it is low enough to trust the score.