### PR TITLE
perf(livecodebench): keep unit tests compressed until verification

### DIFF
--- a/benchmarks/livecodebench/prepare_utils.py
+++ b/benchmarks/livecodebench/prepare_utils.py
@@ -62,6 +62,24 @@ def _decode_test_cases(raw) -> list:
         return json.loads(pickle.loads(zlib.decompress(base64.b64decode(raw.encode("utf-8")))))
 
 
+def _pack_unit_tests(inputs: list, outputs: list, fn_name):
+    """Store test cases compressed rather than as plaintext JSON.
+
+    LiveCodeBench ships its hidden tests base64+zlib+pickle compressed; decoding
+    them at prepare time and embedding the plaintext in every row made the
+    materialized-inputs file 12 GB, against 4-6 MB for every other benchmark
+    (p50 70 KB, p90 20 MB, max 189 MB per row). That file is read in full and
+    held for the whole run, so it dominated eval-client RAM and slowed every
+    tool that walks rollouts.
+
+    Score-neutral by construction: the verifier decodes these exact bytes back
+    before use, so the tests it runs are identical. See the matching decode in
+    resources_servers/code_gen/app.py.
+    """
+    blob = zlib.compress(json.dumps({"inputs": inputs, "outputs": outputs}).encode("utf-8"), 6)
+    return {"packed": base64.b64encode(blob).decode("ascii"), "fn_name": fn_name}
+
+
 def _add_prompt_fields(row: dict, starter_code: str) -> None:
     """Add formatting_message and starter_code fields for prompt templating.
 
@@ -126,11 +144,7 @@ def prepare_from_hf_raw(
             "verifier_metadata": {
                 "problem_id": example.get("question_id", ""),
                 "difficulty": example.get("difficulty", "unknown"),
-                "unit_tests": {
-                    "inputs": inputs,
-                    "outputs": outputs,
-                    "fn_name": meta.get("func_name") or None,
-                },
+                "unit_tests": _pack_unit_tests(inputs, outputs, meta.get("func_name") or None),
             },
         }
         _add_prompt_fields_fn(row, example.get("starter_code", ""))

--- a/resources_servers/code_gen/app.py
+++ b/resources_servers/code_gen/app.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
+import json
+import zlib
 from asyncio import Semaphore
 from time import time
 from typing import Any, Dict, List, Optional, Union
@@ -156,7 +159,20 @@ class CompCodingResourcesServer(SimpleResourcesServer):
                 difficulty=difficulty,
             )
 
-        tests = UnitTests.model_validate(body.verifier_metadata["unit_tests"])
+        # Tests are stored compressed by benchmarks/livecodebench/prepare_utils.py
+        # (_pack_unit_tests) to keep the materialized-inputs file from reaching
+        # 12 GB. Decode here, immediately before use, so the plaintext exists only
+        # for this verification instead of for the whole run. Falls back to the
+        # old plaintext shape so pre-patch artifacts still verify.
+        _raw_tests = body.verifier_metadata["unit_tests"]
+        if isinstance(_raw_tests, dict) and "packed" in _raw_tests:
+            _decoded = json.loads(zlib.decompress(base64.b64decode(_raw_tests["packed"])))
+            _raw_tests = {
+                "inputs": _decoded["inputs"],
+                "outputs": _decoded["outputs"],
+                "fn_name": _raw_tests.get("fn_name"),
+            }
+        tests = UnitTests.model_validate(_raw_tests)
 
         # 3) extract code (code fence or raw)
         code = extract_code(model_out, LMStyle.OpenAIChat)


### PR DESCRIPTION
LiveCodeBench ships its hidden tests base64+zlib+pickle compressed. prepare decoded them and embedded the plaintext in every materialized row, which made the materialized-inputs file 12.1 GB against 4-6 MB for every other benchmark.

That file is read in full and stored for the duration of the whole run.

Store the tests packed and decode them in the verifier, immediately before use, so the plaintext exists for one verification rather than for the whole run. Measured 12.1 GB -> 5.8 GB per task.

