### PR TITLE
[GDPVal] Enforce complete comparison trial panels

### DIFF
--- a/benchmarks/gdpval/README.md
+++ b/benchmarks/gdpval/README.md
@@ -284,6 +284,15 @@ model ids with the `JUDGE_GPT_MODEL`, `JUDGE_GEMINI_MODEL`, and
   eval-perspective win/loss/tie/trial counts per member), and each matchup's
   `trial_judges`.
 
+For final/reportable ELO runs, enable `strict_comparison_trials`. The resources
+server then rejects a comparison row unless every planned reference matchup
+returns exactly `num_comparison_trials` valid votes, with no skipped matchup or
+invalid verdict. The option defaults to `false` for backward compatibility; set
+it with
+`++gdpval_resources_server.resources_servers.gdpval.strict_comparison_trials=true`.
+Rejected rows remain retryable with the normal `--resume` workflow instead of
+silently contributing fewer votes to the ELO fit.
+
 ### Reproducibility
 
 Judge selection is seeded from a stable identity so a rerun of the same task

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -175,6 +175,26 @@ class JudgePanelMember(BaseModel):
     handles_video: bool = False
 
 
+def _strict_comparison_trial_failure(
+    *,
+    attempted_matchups: int,
+    num_trials: int,
+    total_judged: int,
+    total_invalid: int,
+    ref_errors: Dict[str, List[str]],
+) -> Optional[str]:
+    """Describe an incomplete strict comparison result, or return ``None``."""
+
+    expected_judged = num_trials * attempted_matchups
+    if attempted_matchups <= 0 or ref_errors or total_invalid != 0 or total_judged != expected_judged:
+        return (
+            f"matchups={attempted_matchups} judged={total_judged}/{expected_judged} "
+            f"invalid={total_invalid} "
+            f"reference_errors={sum(len(errors) for errors in ref_errors.values())}"
+        )
+    return None
+
+
 class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     reward_mode: Literal["rubric", "comparison"] = "rubric"
 
@@ -200,6 +220,12 @@ class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     # Pairwise judge trials per task. 4 is the historical default; alternates
     # swap/no-swap to debias position effects.
     num_comparison_trials: int = 4
+
+    # Fail the whole verify request unless every planned comparison trial
+    # produced a valid vote. This keeps incomplete panel responses out of
+    # Stirrup's resume cache and prevents a later multistage plan from being
+    # selected from fewer votes than the configured scientific contract.
+    strict_comparison_trials: bool = False
 
     # ELO assigned to the (legacy single) reference model in pairwise mode.
     # Ignored when ``reference_models`` is set (each carries its own ``elo``).
@@ -667,6 +693,10 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         if not ref_dirs_by_id:
             print(f"[gdpval] no reference deliverable for task {body.task_id}", flush=True)
+            if self.config.strict_comparison_trials:
+                raise RuntimeError(
+                    f"strict comparison trial contract failed for task {body.task_id}: reference_missing"
+                )
             return GDPValVerifyResponse(
                 **body.model_dump(),
                 reward=0.0,
@@ -676,6 +706,8 @@ class GDPValResourcesServer(SimpleResourcesServer):
 
         if eval_task_dir is None or not task_attempted(str(eval_task_dir)):
             print(f"[gdpval] eval deliverable missing for task {body.task_id}", flush=True)
+            if self.config.strict_comparison_trials:
+                raise RuntimeError(f"strict comparison trial contract failed for task {body.task_id}: eval_missing")
             return GDPValVerifyResponse(
                 **body.model_dump(),
                 reward=0.0,
@@ -866,6 +898,15 @@ class GDPValResourcesServer(SimpleResourcesServer):
             )
 
         total_judged = total_wins + total_losses + total_ties
+        strict_failure = _strict_comparison_trial_failure(
+            attempted_matchups=attempted_matchups,
+            num_trials=self.config.num_comparison_trials,
+            total_judged=total_judged,
+            total_invalid=total_invalid,
+            ref_errors=ref_errors,
+        )
+        if self.config.strict_comparison_trials and strict_failure is not None:
+            raise RuntimeError(f"strict comparison trial contract failed for task {body.task_id}: {strict_failure}")
         if total_wins > total_losses:
             reward = 1.0
         elif total_losses > total_wins:

--- a/resources_servers/gdpval/tests/test_app.py
+++ b/resources_servers/gdpval/tests/test_app.py
@@ -28,6 +28,7 @@ from resources_servers.gdpval.app import (
     GDPValResourcesServerConfig,
     GDPValVerifyRequest,
     _iter_ref_repeat_dirs,
+    _strict_comparison_trial_failure,
 )
 
 
@@ -78,6 +79,195 @@ def _verify_request(**fields) -> GDPValVerifyRequest:
         rubric_pretty=fields.pop("rubric_pretty", ""),
         **fields,
     )
+
+
+class TestStrictComparisonTrials:
+    @staticmethod
+    def _comparison_server_and_body(tmp_path, *, strict: bool | None, num_references: int = 1):
+        eval_dir = tmp_path / "eval" / "task_task-1" / "repeat_0"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "finish_params.json").write_text("{}")
+
+        reference_models = {}
+        for index in range(num_references):
+            ref_id = f"ref-{index}"
+            ref_root = tmp_path / ref_id
+            ref_dir = ref_root / "task_task-1" / "repeat_0"
+            ref_dir.mkdir(parents=True)
+            (ref_dir / "finish_params.json").write_text("{}")
+            reference_models[ref_id] = {"deliverables_dir": str(ref_root), "elo": 1200.0}
+
+        extra = {}
+        if strict is not None:
+            extra["strict_comparison_trials"] = strict
+        server = _server(
+            reward_mode="comparison",
+            reference_models=reference_models,
+            preconvert_office_to_pdf=False,
+            num_comparison_trials=4,
+            **extra,
+        )
+        return server, _verify_request(deliverables_dir=str(eval_dir))
+
+    @staticmethod
+    def _missing_artifact_server_and_body(tmp_path, *, missing: str, strict: bool | None):
+        eval_dir = tmp_path / "eval" / "task_task-1" / "repeat_0"
+        ref_root = tmp_path / "ref"
+        ref_dir = ref_root / "task_task-1" / "repeat_0"
+        if missing != "eval":
+            eval_dir.mkdir(parents=True)
+            (eval_dir / "finish_params.json").write_text("{}")
+        if missing != "reference":
+            ref_dir.mkdir(parents=True)
+            (ref_dir / "finish_params.json").write_text("{}")
+
+        extra = {}
+        if strict is not None:
+            extra["strict_comparison_trials"] = strict
+        server = _server(
+            reward_mode="comparison",
+            reference_deliverables_dir=str(ref_root),
+            **extra,
+        )
+        return server, _verify_request(deliverables_dir=str(eval_dir))
+
+    @staticmethod
+    async def _verify_with_trials(server, body, side_effect):
+        run_trials = MagicMock()
+        if isinstance(side_effect, dict):
+            run_trials.return_value = side_effect
+        else:
+            run_trials.side_effect = side_effect
+        with (
+            patch("resources_servers.gdpval.comparison.run_trials", new=run_trials),
+            patch("resources_servers.gdpval.app.get_server_url", return_value="http://localhost:9999"),
+            patch("resources_servers.gdpval.comparison.build_file_section", return_value=[]),
+            patch("openai.OpenAI", return_value=MagicMock()),
+        ):
+            return await server.verify(body)
+
+    @pytest.mark.asyncio
+    async def test_complete_contract_passes_when_enabled(self, tmp_path) -> None:
+        server, body = self._comparison_server_and_body(tmp_path, strict=True)
+        complete = {
+            "winner": "[[B]]",
+            "win_count_a": 0,
+            "win_count_b": 4,
+            "tie_count": 0,
+            "task_count": 4,
+            "invalid_count": 0,
+        }
+
+        response = await self._verify_with_trials(server, body, complete)
+
+        assert response.total_wins == 4
+        assert response.judge_response["total_judged"] == 4
+        assert response.judge_response["total_invalid"] == 0
+
+    @pytest.mark.parametrize(
+        ("result", "expected"),
+        [
+            (
+                {
+                    "winner": "[[B]]",
+                    "win_count_a": 0,
+                    "win_count_b": 3,
+                    "tie_count": 0,
+                    "task_count": 3,
+                    "invalid_count": 0,
+                },
+                "matchups=1 judged=3/4 invalid=0 reference_errors=0",
+            ),
+            (
+                {
+                    "winner": "[[B]]",
+                    "win_count_a": 0,
+                    "win_count_b": 3,
+                    "tie_count": 0,
+                    "task_count": 3,
+                    "invalid_count": 1,
+                },
+                "matchups=1 judged=3/4 invalid=1 reference_errors=0",
+            ),
+        ],
+        ids=["incomplete-judged", "invalid-trial"],
+    )
+    @pytest.mark.asyncio
+    async def test_incomplete_contract_fails_when_enabled(self, tmp_path, result, expected) -> None:
+        server, body = self._comparison_server_and_body(tmp_path, strict=True)
+
+        with pytest.raises(RuntimeError, match=expected):
+            await self._verify_with_trials(server, body, result)
+
+    @pytest.mark.asyncio
+    async def test_reference_error_fails_when_enabled(self, tmp_path) -> None:
+        server, body = self._comparison_server_and_body(tmp_path, strict=True, num_references=2)
+        complete = {
+            "winner": "[[B]]",
+            "win_count_a": 0,
+            "win_count_b": 4,
+            "tie_count": 0,
+            "task_count": 4,
+            "invalid_count": 0,
+        }
+
+        with pytest.raises(
+            RuntimeError,
+            match="matchups=2 judged=4/8 invalid=0 reference_errors=1",
+        ):
+            await self._verify_with_trials(server, body, [RuntimeError("judge timeout"), complete])
+
+    def test_zero_matchups_is_incomplete(self) -> None:
+        assert (
+            _strict_comparison_trial_failure(
+                attempted_matchups=0,
+                num_trials=4,
+                total_judged=0,
+                total_invalid=0,
+                ref_errors={},
+            )
+            == "matchups=0 judged=0/0 invalid=0 reference_errors=0"
+        )
+
+    @pytest.mark.parametrize("missing", ["reference", "eval"])
+    @pytest.mark.asyncio
+    async def test_missing_artifact_fails_when_enabled(self, tmp_path, missing) -> None:
+        server, body = self._missing_artifact_server_and_body(tmp_path, missing=missing, strict=True)
+
+        with pytest.raises(
+            RuntimeError,
+            match=rf"strict comparison trial contract failed for task task-1: {missing}_missing",
+        ):
+            await server.verify(body)
+
+    @pytest.mark.parametrize("missing", ["reference", "eval"])
+    @pytest.mark.asyncio
+    async def test_missing_artifact_keeps_legacy_response_by_default(self, tmp_path, missing) -> None:
+        server, body = self._missing_artifact_server_and_body(tmp_path, missing=missing, strict=None)
+
+        response = await server.verify(body)
+
+        assert server.config.strict_comparison_trials is False
+        assert response.reward == 0.0
+        assert response.judge_response == {"error": f"{missing}_missing"}
+
+    @pytest.mark.asyncio
+    async def test_default_is_non_strict_for_backward_compatibility(self, tmp_path) -> None:
+        server, body = self._comparison_server_and_body(tmp_path, strict=None)
+        incomplete = {
+            "winner": "[[B]]",
+            "win_count_a": 0,
+            "win_count_b": 3,
+            "tie_count": 0,
+            "task_count": 3,
+            "invalid_count": 1,
+        }
+
+        response = await self._verify_with_trials(server, body, incomplete)
+
+        assert server.config.strict_comparison_trials is False
+        assert response.judge_response["total_judged"] == 3
+        assert response.judge_response["total_invalid"] == 1
 
 
 class TestIterRefRepeatDirs:

--- a/resources_servers/gdpval/tests/test_multistage_orchestrator.py
+++ b/resources_servers/gdpval/tests/test_multistage_orchestrator.py
@@ -2373,6 +2373,10 @@ class TestFingerprint:
         changed_policy["policy_model"]["responses_api_models"]["vllm"]["model"] = "/checkpoints/policy-b"
         changed_judge = deepcopy(runtime)
         changed_judge["gdpval_resources_server"]["resources_servers"]["gdpval"]["num_comparison_trials"] = 4
+        changed_strict_trials = deepcopy(runtime)
+        changed_strict_trials["gdpval_resources_server"]["resources_servers"]["gdpval"]["strict_comparison_trials"] = (
+            True
+        )
         changed_logging = deepcopy(runtime)
         changed_logging["operational_logging"]["level"] = "DEBUG"
 
@@ -2383,6 +2387,16 @@ class TestFingerprint:
                 dist,
                 materialized_rows=rows,
                 resolved_global_config=changed_policy,
+            )
+            != baseline
+        )
+        assert (
+            compute_fingerprint(
+                cfg,
+                REF_ELOS,
+                dist,
+                materialized_rows=rows,
+                resolved_global_config=changed_strict_trials,
             )
             != baseline
         )


### PR DESCRIPTION
Add an opt-in strict comparison contract for reportable ELO runs. Reject missing artifacts, failed matchups, invalid verdicts, and incomplete vote panels before results enter the resume cache. Keep legacy behavior as the default and fingerprint strict runs separately.


## Checklist

- [X] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
