### PR TITLE
fix(code_gen): make LCB mock sys.stdin.buffer a real byte stream

### DIFF
--- a/resources_servers/code_gen/lcb_integration/testing_util.py
+++ b/resources_servers/code_gen/lcb_integration/testing_util.py
@@ -27,7 +27,7 @@ import traceback
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from io import StringIO
+from io import BytesIO, StringIO
 
 # from pyext import RuntimeModule
 from types import ModuleType
@@ -118,13 +118,26 @@ class MockStdinWithBuffer:
 class MockBuffer:
     def __init__(self, inputs: str):
         self.inputs = inputs.encode("utf-8")  # Convert to bytes
+        self._bytesio = BytesIO(self.inputs)
 
     def read(self, *args):
         # Return as byte strings that can be split
-        return self.inputs
+        return self._bytesio.read(*args)
 
     def readline(self, *args):
-        return self.inputs.split(b"\n")[0] + b"\n"
+        return self._bytesio.readline(*args)
+
+    def readlines(self, *args):
+        return self._bytesio.readlines(*args)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._bytesio)
+
+    def __getattr__(self, name):
+        return getattr(self._bytesio, name)
 
 
 def clean_if_name(code: str) -> str:

--- a/resources_servers/code_gen/tests/test_mock_stdin.py
+++ b/resources_servers/code_gen/tests/test_mock_stdin.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+"""Tests for the `sys.stdin` mock used when grading submitted code."""
+
+from __future__ import annotations
+
+from lcb_integration.testing_util import MockStdinWithBuffer
+
+
+INPUTS = "2\n10 20 30\n40 50 60\n"
+
+
+class TestMockBufferIsStateful:
+    """`sys.stdin.buffer` must behave like a real byte stream, not replay its first line."""
+
+    def test_readline_advances(self):
+        buffer = MockStdinWithBuffer(INPUTS).buffer
+
+        assert buffer.readline() == b"2\n"
+        assert buffer.readline() == b"10 20 30\n"
+        assert buffer.readline() == b"40 50 60\n"
+        assert buffer.readline() == b""
+
+    def test_readlines_returns_all_lines(self):
+        buffer = MockStdinWithBuffer(INPUTS).buffer
+
+        assert buffer.readlines() == [b"2\n", b"10 20 30\n", b"40 50 60\n"]
+
+    def test_iteration_yields_each_line_once(self):
+        buffer = MockStdinWithBuffer(INPUTS).buffer
+
+        assert list(buffer) == [b"2\n", b"10 20 30\n", b"40 50 60\n"]
+
+    def test_read_returns_whole_payload(self):
+        buffer = MockStdinWithBuffer(INPUTS).buffer
+
+        assert buffer.read() == INPUTS.encode("utf-8")
+
+    def test_read_after_readline_returns_remainder(self):
+        buffer = MockStdinWithBuffer(INPUTS).buffer
+
+        assert buffer.readline() == b"2\n"
+        assert buffer.read() == b"10 20 30\n40 50 60\n"
+
+    def test_seek_rewinds(self):
+        buffer = MockStdinWithBuffer(INPUTS).buffer
+
+        assert buffer.readline() == b"2\n"
+        buffer.seek(0)
+        assert buffer.readline() == b"2\n"


### PR DESCRIPTION
The LCB grader's MockBuffer replayed the first input line on every readline() call and exposed no readlines()/iteration, so submitted solutions that read via sys.stdin.buffer were graded against corrupted input. readline()-based solutions silently scored as wrong answers and readlines()-based solutions raised AttributeError and were recorded as runtime errors, in both cases penalizing correct code.

Back MockBuffer with a BytesIO and delegate to it, mirroring how the sibling text mock already delegates to StringIO. This also makes seek() and the rest of the byte-stream API available instead of raising.

Note read() is now positional: read() after readline() returns the remainder rather than the whole payload again, matching real stream semantics. This changes LiveCodeBench scores for models that emit sys.stdin.buffer-based solutions.

<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

<!-- Briefly describe the change and the motivation. Link any related issue, e.g. "Closes #123". -->

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
