### PR TITLE
fix(cli): add `--all` flag for `gym env test`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,8 @@ gym env start \
 # First run is slow. Use skip_venv_if_present config or place a .venv to skip venv creation.
 gym env test --resources-server example_single_tool_call
 
-# Run all server tests
-gym env test
+# Run all server tests (slow: one venv per server, so it needs an explicit opt-in)
+gym env test --all
 
 # Run core library unit tests
 pytest tests/unit_tests/ -x

--- a/fern/versions/latest/pages/contribute/development-setup.mdx
+++ b/fern/versions/latest/pages/contribute/development-setup.mdx
@@ -26,8 +26,8 @@ pre-commit install
 **Run NeMo Gym Tests**:
 ```bash
 gym dev test                                   # Run all NeMo Gym core tests
-gym env test                                   # Run all server tests
 gym env test --resources-server example_single_tool_call    # Test a single resources server
+gym env test --all                             # Run all server tests (slow: one venv per server)
 ```
 
 **View Test Coverage**:

--- a/fern/versions/latest/pages/reference/cli-commands.mdx
+++ b/fern/versions/latest/pages/reference/cli-commands.mdx
@@ -40,7 +40,7 @@ gym env init                  # scaffold a resources server, environment, or ben
 gym env resolve               # resolve and print the final merged config
 gym env validate              # validate a manifest-backed workload or legacy config without services
 gym env packages              # list packages in a server's virtual environment
-gym env test                  # exercise a workload verifier or run resources-server tests
+gym env test                  # run resources-server tests
 gym env publish               # finalize readiness and confirm registry discovery
 gym env start                 # start the servers
 gym env status                # show running servers
@@ -491,7 +491,8 @@ Exercise a manifest-backed workload's verifier fixture in its resources-server e
 | `--kind environment\|benchmark` | Resolve an ambiguous catalog name. |
 | `--update-expected` | Atomically update fixture rewards after every behavioral check passes. |
 | `--json` | Output the verifier report as JSON. |
-| `--resources-server NAME` | Resources server to test. Omit to test all servers. |
+| `--resources-server NAME` | Resources server to test. |
+| `--all` | Test every resources server. Slow: builds one venv per server, so it must be requested explicitly. |
 | `--search-dir DIR` | Extra root directory to search for named components. Repeatable. |
 
 ```bash
@@ -501,8 +502,8 @@ gym env test my_eval
 # Test a single server
 gym env test --resources-server example_single_tool_call
 
-# Test all servers
-gym env test
+# Test all servers. Slow: builds one venv per server, so it needs an explicit opt-in.
+gym env test --all
 ```
 
 ### `gym env publish`
@@ -817,7 +818,7 @@ Use the tables below to find their `gym` replacement and update your scripts and
 | `ng_pip_list` | `gym env packages` |
 | `ng_init_resources_server` | `gym env init` |
 | `ng_test` | `gym env test` |
-| `ng_test_all` | `gym env test` (no `--resources-server`) |
+| `ng_test_all` | `gym env test --all` |
 | `ng_prepare_benchmark` | `gym eval prepare` |
 | `ng_e2e_collect_rollouts` | `gym eval run` |
 | `ng_collect_rollouts` | `gym eval run --no-serve` |

--- a/nemo_gym/cli/env.py
+++ b/nemo_gym/cli/env.py
@@ -930,7 +930,7 @@ class TestAllConfig(BaseNeMoGymCLIConfig):
     Examples:
 
     ```bash
-    gym env test
+    gym env test --all
     ```
     """
 

--- a/nemo_gym/cli/legacy.py
+++ b/nemo_gym/cli/legacy.py
@@ -30,7 +30,7 @@ from nemo_gym.cli.main import main as gym_main
 LEGACY = {
     "run": ["env", "start"],
     "test": ["env", "test"],
-    "test_all": ["env", "test"],
+    "test_all": ["env", "test", "--all"],
     "dev_test": ["dev", "test"],
     "init_resources_server": ["env", "init"],
     "list_benchmarks": ["list", "benchmarks"],

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -524,6 +524,8 @@ def _env_test(args: argparse.Namespace, overrides: list[str]) -> None:
     manifest_options = any(_has_override(overrides, key) for key in ("catalog_kind", "update_expected", "json"))
     if manifest_selected and legacy_selected:
         args._parser.error("select a workload name or --resources-server, not both")
+    if args.all and (manifest_selected or legacy_selected):
+        args._parser.error("--all tests every resources server, so it cannot be combined with a named target")
     if manifest_options and not manifest_selected:
         args._parser.error("--kind, --update-expected, and --json require a workload name")
     if manifest_selected:
@@ -532,9 +534,15 @@ def _env_test(args: argparse.Namespace, overrides: list[str]) -> None:
 
     # Run a single server's tests if +entrypoint was passed. No need to check for
     # --resources-server because it is translated to +entrypoint in the flag definition.
-    dispatch(
-        "nemo_gym.cli.env:test" if _has_override(overrides, "entrypoint") else "nemo_gym.cli.env:test_all", overrides
-    )
+    if _has_override(overrides, "entrypoint"):
+        dispatch("nemo_gym.cli.env:test", overrides)
+        return
+
+    if not args.all:
+        args._parser.error(
+            "requires a target: a workload name, --resources-server NAME, or --all to test every resources server."
+        )
+    dispatch("nemo_gym.cli.env:test_all", overrides)
 
 
 def _dataset_upload(args: argparse.Namespace, overrides: list[str]) -> None:
@@ -761,6 +769,13 @@ COMMANDS = {
             JSON,
             RESOURCES_SERVER,
             SEARCH_DIR,
+            Flag(
+                register=lambda p: p.add_argument(
+                    "--all",
+                    action="store_true",
+                    help="Test every resources server. Slow: builds one venv per server.",
+                )
+            ),
         ),
     ),
     "env publish": Command(

--- a/tests/unit_tests/test_cli_legacy.py
+++ b/tests/unit_tests/test_cli_legacy.py
@@ -55,6 +55,15 @@ class TestLegacyDeprecation:
 
         assert "deprecated" in capsys.readouterr().err
 
+    def test_test_all_alias_still_reaches_the_all_servers_run(self, monkeypatch: MonkeyPatch, capsys) -> None:
+        captured: dict = {}
+        monkeypatch.setattr(cli_main, "dispatch", lambda target, overrides: captured.update(target=target))
+        monkeypatch.setattr(sys, "argv", ["ng_test_all", "+num_shards=4"])
+
+        legacy.main()
+
+        assert captured["target"] == "nemo_gym.cli.env:test_all"
+
     def test_legacy_mapping_is_populated(self) -> None:
         # Guard so the parametrized test below can't pass vacuously if LEGACY is emptied.
         assert len(legacy.LEGACY) > 1

--- a/tests/unit_tests/test_cli_main.py
+++ b/tests/unit_tests/test_cli_main.py
@@ -265,10 +265,22 @@ class TestEvalRunFlags:
 
 
 class TestEnvTestResourceServerFlag:
-    def test_no_resource_server_runs_all(self, monkeypatch: MonkeyPatch) -> None:
-        target, overrides = _dispatch_for(monkeypatch, ["env", "test"])
+    def test_no_target_refuses_instead_of_testing_every_server(self, monkeypatch: MonkeyPatch) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _dispatch_for(monkeypatch, ["env", "test"])
+        assert exc_info.value.code == 2
+
+    def test_all_flag_runs_every_server(self, monkeypatch: MonkeyPatch) -> None:
+        target, overrides = _dispatch_for(monkeypatch, ["env", "test", "--all"])
         assert target == "nemo_gym.cli.env:test_all"
         assert overrides == []
+
+    @pytest.mark.parametrize("argv", [["--all", "--resources-server", "gpqa"], ["--all", "gpqa"]])
+    def test_all_flag_conflicts_with_a_named_target(self, monkeypatch: MonkeyPatch, capsys, argv) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            _dispatch_for(monkeypatch, ["env", "test", *argv])
+        assert exc_info.value.code == 2
+        assert "cannot be combined with a named target" in capsys.readouterr().err
 
     def test_resource_server_name_translates_to_entrypoint(self, monkeypatch: MonkeyPatch) -> None:
         target, overrides = _dispatch_for(monkeypatch, ["env", "test", "--resources-server", "gpqa"])


### PR DESCRIPTION
Fixes #2690. The new flag prevents users from accidentally running the full test suite for all resources servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)