### PR TITLE
feat(data): task_data validation gating: auto mode, misplaced-field check, repo drift test

### DIFF
--- a/nemo_gym/task_data.py
+++ b/nemo_gym/task_data.py
@@ -125,29 +125,31 @@ def load_task_data_schema(server_dir: Path) -> Optional[TypeAdapter]:
 
 
 LEGACY_METADATA_KEY = "verifier_metadata"
+TASK_DATA_ROW_KEY = "task_data"
 
 
 def normalize_task_fields(row: Dict[str, Any]) -> tuple[Dict[str, Any], List[str]]:
     """The task-owned subset of a dataset row, normalized to the flat end-state shape.
 
-    Drops framework keys, then splices the contents of a legacy ``verifier_metadata`` dict up to
-    the top level (the row-format migration renames that bucket into ``task_data``, so schemas are
-    written flat).
-    A key present in both places with the same value is a harmless duplicate; with different
+    Drops framework keys, then splices the contents of a legacy ``verifier_metadata`` dict and of
+    a migrated ``task_data`` dict up to the top level (schemas are written flat, so fields
+    validate the same whether a row is flat, legacy-nested, or migrated).
+    A key present in two places with the same value is a harmless duplicate; with different
     values it is ambiguous data and gets reported. Returns ``(fields, conflicts)``.
     """
     fields = {k: v for k, v in row.items() if k not in RESERVED_ROW_KEYS}
     conflicts: List[str] = []
-    legacy = fields.pop(LEGACY_METADATA_KEY, None)
-    if isinstance(legacy, dict):
-        for key, value in legacy.items():
-            if key in fields and fields[key] != value:
-                conflicts.append(key)
-                continue
-            fields[key] = value
-    elif legacy is not None:
-        # A non-dict verifier_metadata is malformed; surface it to the schema as-is.
-        fields[LEGACY_METADATA_KEY] = legacy
+    for container_key in (LEGACY_METADATA_KEY, TASK_DATA_ROW_KEY):
+        container = fields.pop(container_key, None)
+        if isinstance(container, dict):
+            for key, value in container.items():
+                if key in fields and fields[key] != value:
+                    conflicts.append(key)
+                    continue
+                fields[key] = value
+        elif container is not None:
+            # A non-dict container is malformed; surface it to the schema as-is.
+            fields[container_key] = container
     return fields, conflicts
 
 
@@ -168,7 +170,7 @@ class TaskDataValidationReport:
 
     @property
     def clean(self) -> bool:
-        return self.error_rows == 0 and not self.conflicting_keys and not self.misplaced_keys
+        return self.error_rows == 0 and not self.conflicting_keys and not self.misplaced_keys and not self.unknown_keys
 
     def summary(self) -> str:
         parts = [
@@ -189,7 +191,7 @@ class TaskDataValidationReport:
             )
         if self.unknown_keys:
             keys = ", ".join(f"{k} ({n} rows)" for k, n in sorted(self.unknown_keys.items()))
-            parts.append(f"  keys not declared by the schema (passed through unvalidated): {keys}")
+            parts.append(f"  keys not declared by the schema (typo, or missing schema field?): {keys}")
         return "\n".join(parts)
 
 
@@ -229,7 +231,7 @@ class TaskDataValidator:
         # (schemas are flat) while the server at runtime would never see it, so it is flagged.
         # Rows already in the migrated format (a task_data key) are exempt: top-level inside
         # task_data is the correct final position.
-        if self._legacy_fields and "task_data" not in row:
+        if self._legacy_fields and TASK_DATA_ROW_KEY not in row:
             nested = row.get(LEGACY_METADATA_KEY)
             nested_keys = set(nested) if isinstance(nested, dict) else set()
             for key in (row.keys() & self._legacy_fields) - nested_keys:

--- a/nemo_gym/task_data.py
+++ b/nemo_gym/task_data.py
@@ -13,10 +13,13 @@ end-state shape: the fields as they will appear inside the unified ``task_data``
 the row-format migration. Framework-owned keys (see ``RESERVED_ROW_KEYS``) are never part of
 ``TaskData``, and neither is a ``verifier_metadata`` wrapper: rows that still carry one have its
 contents spliced up by ``normalize_task_fields`` before validation, so one flat schema validates
-both today's rows and post-migration ``task_data`` contents. Fields that live inside
-``verifier_metadata`` on today's wire should be annotated
+both today's rows and post-migration ``task_data`` contents. Fields that today's wire reads
+EXCLUSIVELY from inside ``verifier_metadata`` should be annotated
 ``Field(..., json_schema_extra={"legacy_location": "verifier_metadata"})`` — that reverse map is
-what the row-format migration and the dispatch compatibility shim consume.
+what the row-format migration and the dispatch compatibility shim consume, and validation flags
+rows that carry such a field only top-level (the server would not see it). Servers whose wire
+accepts both placements (e.g. via a before-validator that nests top-level fields itself) must
+not carry the marker.
 
 This module is a dependency-light leaf: it may import only the standard library and Pydantic, and
 per-server ``task_data.py`` modules may import only the standard library, Pydantic, this module,
@@ -159,12 +162,13 @@ class TaskDataValidationReport:
     errors: List[str] = field(default_factory=list)
     unknown_keys: Dict[str, int] = field(default_factory=dict)
     conflicting_keys: Dict[str, int] = field(default_factory=dict)
+    misplaced_keys: Dict[str, int] = field(default_factory=dict)
 
     MAX_RECORDED_ERRORS = 5
 
     @property
     def clean(self) -> bool:
-        return self.error_rows == 0 and not self.conflicting_keys
+        return self.error_rows == 0 and not self.conflicting_keys and not self.misplaced_keys
 
     def summary(self) -> str:
         parts = [
@@ -177,10 +181,37 @@ class TaskDataValidationReport:
         if self.conflicting_keys:
             keys = ", ".join(f"{k} ({n} rows)" for k, n in sorted(self.conflicting_keys.items()))
             parts.append(f"  keys with DIFFERENT values top-level vs verifier_metadata (ambiguous): {keys}")
+        if self.misplaced_keys:
+            keys = ", ".join(f"{k} ({n} rows)" for k, n in sorted(self.misplaced_keys.items()))
+            parts.append(
+                f"  keys this server's wire reads from verifier_metadata but found top-level "
+                f"(the server will not see them): {keys}"
+            )
         if self.unknown_keys:
             keys = ", ".join(f"{k} ({n} rows)" for k, n in sorted(self.unknown_keys.items()))
             parts.append(f"  keys not declared by the schema (passed through unvalidated): {keys}")
         return "\n".join(parts)
+
+
+def legacy_metadata_fields(adapter: TypeAdapter) -> frozenset:
+    """Schema fields annotated ``legacy_location: verifier_metadata`` (today's wire reads them there)."""
+    from typing import get_args
+
+    def models_of(tp, out):
+        if isinstance(tp, type) and issubclass(tp, BaseModel):
+            out.append(tp)
+            return out
+        for arg in get_args(tp):
+            models_of(arg, out)
+        return out
+
+    names = set()
+    for model in models_of(getattr(adapter, "_type", None), []):
+        for field_name, info in model.model_fields.items():
+            extra = info.json_schema_extra
+            if isinstance(extra, dict) and extra.get("legacy_location") == LEGACY_METADATA_KEY:
+                names.add(field_name)
+    return frozenset(names)
 
 
 class TaskDataValidator:
@@ -188,10 +219,21 @@ class TaskDataValidator:
 
     def __init__(self, server_name: str, adapter: TypeAdapter, dataset_fpath: str):
         self._adapter = adapter
+        self._legacy_fields = legacy_metadata_fields(adapter)
         self.report = TaskDataValidationReport(server_name=server_name, dataset_fpath=dataset_fpath)
 
     def validate_row(self, row_index: int, row: Dict[str, Any]) -> None:
         self.report.rows += 1
+        # Misplacement: the schema says today's wire reads this field from inside
+        # verifier_metadata, but the row carries it only top-level. Validation would accept it
+        # (schemas are flat) while the server at runtime would never see it, so it is flagged.
+        # Rows already in the migrated format (a task_data key) are exempt: top-level inside
+        # task_data is the correct final position.
+        if self._legacy_fields and "task_data" not in row:
+            nested = row.get(LEGACY_METADATA_KEY)
+            nested_keys = set(nested) if isinstance(nested, dict) else set()
+            for key in (row.keys() & self._legacy_fields) - nested_keys:
+                self.report.misplaced_keys[key] = self.report.misplaced_keys.get(key, 0) + 1
         subject, conflicts = normalize_task_fields(row)
         for key in conflicts:
             self.report.conflicting_keys[key] = self.report.conflicting_keys.get(key, 0) + 1

--- a/nemo_gym/train_data_utils.py
+++ b/nemo_gym/train_data_utils.py
@@ -88,15 +88,23 @@ class TrainDataProcessorConfig(BaseNeMoGymCLIConfig):
     overwrite_metrics_conflicts: bool = Field(
         default=False, description="Whether or not to overwrite metrics conflicts."
     )
-    task_data_validation: Literal["off", "warn", "error"] = Field(
-        default="warn",
+    task_data_validation: Literal["off", "warn", "error", "auto"] = Field(
+        default="auto",
         description=(
-            "Validate each dataset row against the owning resources server's task_data.py schema "
-            "during collation. 'warn' (default) prints a per-file report, 'error' fails collation "
-            "on schema violations, 'off' skips validation. Servers without a task_data.py are "
-            "always skipped."
+            "Validate each dataset row against the owning server's task_data.py schema during "
+            "collation. 'warn' prints a per-file report, 'error' fails collation on schema "
+            "violations, 'off' skips validation. The default 'auto' resolves to 'error' in "
+            "example_validation mode (the repo's PR gate, where all committed data is known "
+            "clean) and 'warn' in train_preparation mode (user datasets must not break "
+            "mid-pipeline). Servers without a task_data.py are always skipped."
         ),
     )
+
+    @property
+    def effective_task_data_validation(self) -> str:
+        if self.task_data_validation != "auto":
+            return self.task_data_validation
+        return "error" if self.mode == "example_validation" else "warn"
 
     @property
     def in_scope_dataset_types(self) -> List[DatasetType]:
@@ -923,7 +931,7 @@ This could be due to a change in how metrics are calculated, leading to outdated
             paths_to_collate = self._collate_samples_single_type(
                 type=type,
                 server_instance_configs=server_instance_configs,
-                task_data_validation=config.task_data_validation,
+                task_data_validation=config.effective_task_data_validation,
             )
             collated_fpath = parent / f"{type}.jsonl"
             with open(collated_fpath, "wb") as outfile:

--- a/resources_servers/agentif/task_data.py
+++ b/resources_servers/agentif/task_data.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Task-data schema for the agentif server (AgentIF constraint following).
+
+Rows nest everything inside an untyped ``verifier_metadata`` bucket
+(``AgentIFRunRequest`` types it ``Optional[Dict[str, Any]]``, ``extra="allow"``); the schema is
+written flat with ``legacy_location`` annotations. Every field is Optional because the wire never
+422s on the bucket's contents. verify() reads only ``constraints`` (app.py:316) and scores each
+entry with the rule/judge checkers; the remaining fields ride along as provenance.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+_VM = {"legacy_location": "verifier_metadata"}
+
+
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    constraints: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description=(
+            "Constraint specs scored by verify(): each has id, desc, other_info, and the "
+            "dimension/type keys the score breakdowns group by."
+        ),
+        json_schema_extra={"consumed_by": ["verify"], **_VM},
+    )
+    query_id: Optional[int] = Field(
+        default=None,
+        description="Source query identifier; provenance only.",
+        json_schema_extra={"consumed_by": ["provenance"], **_VM},
+    )
+    turn_id: Optional[int] = Field(
+        default=None,
+        description="Turn index within the source conversation; provenance only.",
+        json_schema_extra={"consumed_by": ["provenance"], **_VM},
+    )
+    domain: Optional[str] = Field(
+        default=None,
+        description="AgentIF domain the row came from, e.g. 'lawglm'; provenance only.",
+        json_schema_extra={"consumed_by": ["provenance"], **_VM},
+    )
+    agent_name: Optional[str] = Field(
+        default=None,
+        description="Source agent prompt name, e.g. 'Thought_prompt_lawglm'; provenance only.",
+        json_schema_extra={"consumed_by": ["provenance"], **_VM},
+    )
+    prompt_type: Optional[str] = Field(
+        default=None,
+        description="Source prompt family, e.g. 'Thought_prompt'; provenance only.",
+        json_schema_extra={"consumed_by": ["provenance"], **_VM},
+    )

--- a/resources_servers/instruction_following/task_data.py
+++ b/resources_servers/instruction_following/task_data.py
@@ -6,8 +6,9 @@ Two dataset shapes coexist by design: older blends (including the committed exam
 ``instruction_id_list``/``prompt``/``kwargs``/``grading_mode`` at the row top level, while the
 current format nests them under ``verifier_metadata`` (the server's ``_migrate_legacy_metadata``
 before-validator accepts both). This flat schema validates both generations unchanged, because
-core validation splices ``verifier_metadata`` contents up before checking; ``legacy_location``
-records the server's canonical nested wire placement. Required-ness mirrors
+core validation splices ``verifier_metadata`` contents up before checking. No field carries a
+``legacy_location`` marker: that marker means "the wire reads this field ONLY from inside
+verifier_metadata", and here the wire accepts both placements. Required-ness mirrors
 ``InstructionFollowingRunRequest``'s after-validator, which rejects rows missing
 ``instruction_id_list``/``prompt``/``kwargs`` from the merged metadata.
 """
@@ -29,14 +30,14 @@ class TaskData(BaseModel):
             "Registry keys of the verifiable instructions to check "
             "(e.g. 'length_constraints:nth_paragraph_first_word')."
         ),
-        json_schema_extra={"consumed_by": ["verify"], "legacy_location": "verifier_metadata"},
+        json_schema_extra={"consumed_by": ["verify"]},
     )
     prompt: str = Field(
         description=(
             "Original instruction prompt (duplicates the user turn in responses_create_params.input). "
             "Required by the wire after-validator but never read by verify()."
         ),
-        json_schema_extra={"consumed_by": ["provenance"], "legacy_location": "verifier_metadata"},
+        json_schema_extra={"consumed_by": ["provenance"]},
     )
     kwargs: List[Optional[Dict[str, Any]]] = Field(
         description=(
@@ -45,10 +46,10 @@ class TaskData(BaseModel):
             "first_word}, {N, relation}); entries may be null or {}, and None values inside a dict "
             "are filtered out by verify()."
         ),
-        json_schema_extra={"consumed_by": ["verify"], "legacy_location": "verifier_metadata"},
+        json_schema_extra={"consumed_by": ["verify"]},
     )
     grading_mode: Optional[str] = Field(
         default=None,
         description="'binary' (all instructions must pass) or 'fraction'; verify() defaults to 'binary'.",
-        json_schema_extra={"consumed_by": ["verify"], "legacy_location": "verifier_metadata"},
+        json_schema_extra={"consumed_by": ["verify"]},
     )

--- a/resources_servers/terminal_bench_2_1/task_data.py
+++ b/resources_servers/terminal_bench_2_1/task_data.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Task-data schema for the terminal_bench_2_1 server.
+
+Rows carry the three sandbox coordinates top-level (no verifier_metadata):
+``TerminalBench21VerifyRequest`` (app.py:46) requires ``task_name``, ``docker_image``, and
+``task_folder`` as ``str``, so this schema does too. seed_session() starts the evaluation
+sandbox from ``docker_image`` (tagging it with ``task_name``); verify() uploads the task's
+``tests/`` (and, when config.is_verifying_golden_patch=true, ``solution/``) from
+``task_folder`` into the sandbox and runs the test script there.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    task_name: str = Field(
+        description=(
+            "Terminal-Bench 2.1 task id, e.g. 'terminal-bench/path-tracing'; also keys sandbox "
+            "metadata (instance_id) and is echoed in the verify response."
+        ),
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    docker_image: str = Field(
+        description="Docker image the evaluation sandbox is started from.",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    task_folder: str = Field(
+        description=(
+            "Repo-relative path to the task directory (under benchmarks/terminal_bench_2_1/); "
+            "verify() uploads its tests/ (and solution/ in golden-patch mode) into the sandbox."
+        ),
+        json_schema_extra={"consumed_by": ["verify"]},
+    )

--- a/responses_api_agents/anyswe_agent/task_data.py
+++ b/responses_api_agents/anyswe_agent/task_data.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Task-data schema for the self-contained anyswe_agent (no resources server).
+
+Rows are prompt-only: the committed example dataset carries nothing beyond
+``responses_create_params``. ``AnySweRunRequest`` (app.py) declares no task fields and is
+``extra="allow"``, so any additional row keys ride through the wire unread by the agent.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")

--- a/responses_api_agents/anyterminal_agent/task_data.py
+++ b/responses_api_agents/anyterminal_agent/task_data.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Task-data schema for the self-contained anyterminal_agent (no resources server).
+
+Rows are prompt-only: the committed example dataset carries nothing beyond
+``responses_create_params``. ``AnyTerminalRunRequest`` (app.py) declares no task fields and is
+``extra="allow"``, so any additional row keys ride through the wire unread by the agent.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")

--- a/responses_api_agents/harbor_agent/task_data.py
+++ b/responses_api_agents/harbor_agent/task_data.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Task-data schema for the self-contained harbor_agent (no resources server).
+
+``HarborAgentRunRequest`` (app.py) wire-requires ``instance_id``; run() splits it on ``::`` to
+pick the Harbor dataset alias and task, launches the Harbor trial, and names the output artifact
+after it. Benchmarks that bridge through Harbor (legal_agent_bench, terminal_bench_2_1 input
+sets) commit rows of exactly this shape.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    instance_id: str = Field(
+        description=(
+            "Harbor task coordinate in the form '<dataset_alias>::<task_name>'; the alias must "
+            "match a dataset configured on the agent, and the task name selects the trial."
+        ),
+        json_schema_extra={"consumed_by": ["run"]},
+    )

--- a/responses_api_agents/mini_swe_agent/task_data.py
+++ b/responses_api_agents/mini_swe_agent/task_data.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Task-data schema for the self-contained mini_swe_agent (no resources server).
+
+Rows are SWE-bench instances flattened top-level, the same family as the swebench resources
+server's rows, except ``FAIL_TO_PASS``/``PASS_TO_PASS`` are real JSON lists here (swebench keeps
+them JSON-encoded strings) and there is no environment_setup_commit/difficulty/subset/split.
+``MiniSWEAgentRunRequest`` (app.py) declares no task fields (``extra="allow"``); the whole
+instance dict rides the wire as extras and is handed to the SWE-bench evaluation harness.
+"""
+
+from typing import List
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    instance_id: str = Field(
+        description="SWE-bench instance id, e.g. 'getmoto__moto-7365'; keys the evaluation.",
+        json_schema_extra={"consumed_by": ["run", "verify"]},
+    )
+    repo: str = Field(
+        description="GitHub repository the instance patches.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )
+    base_commit: str = Field(
+        description="Commit the repo is checked out at before the agent works.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )
+    patch: str = Field(
+        description="Gold patch diff; used by evaluation, not shown to the agent.",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    test_patch: str = Field(
+        description="Test-file diff applied before running the evaluation tests.",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    problem_statement: str = Field(
+        description="Issue text describing the bug.",
+        json_schema_extra={"consumed_by": ["prompt"]},
+    )
+    hints_text: str = Field(
+        description="Optional hints; rides along in the instance dump (may be empty).",
+        json_schema_extra={"consumed_by": ["provenance"]},
+    )
+    created_at: str = Field(
+        description="Instance creation timestamp; provenance only.",
+        json_schema_extra={"consumed_by": ["provenance"]},
+    )
+    version: str = Field(
+        description="Repo version tag used by the SWE-bench environment spec.",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    FAIL_TO_PASS: List[str] = Field(
+        description="Test ids that must flip to passing; a JSON list (not the encoded-string form).",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    PASS_TO_PASS: List[str] = Field(
+        description="Test ids that must keep passing; a JSON list (not the encoded-string form).",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    subset: str = Field(
+        description="SWE-bench subset the instance came from, e.g. 'verified'; provenance only.",
+        json_schema_extra={"consumed_by": ["provenance"]},
+    )
+    split: str = Field(
+        description="Dataset split the instance came from, e.g. 'test'; provenance only.",
+        json_schema_extra={"consumed_by": ["provenance"]},
+    )

--- a/responses_api_agents/osworld_agent/task_data.py
+++ b/responses_api_agents/osworld_agent/task_data.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Task-data schema for the self-contained osworld_agent (no resources server).
+
+Committed rows (benchmarks/osworld) nest everything inside ``verifier_metadata``, but the agent
+accepts both placements (``metadata.get("osworld_task") or body.model_extra.get(...)`` in
+app.py), so no field carries a ``legacy_location`` marker. ``osworld_task`` is the full OSWorld
+task spec handed to the runner; ``task_id``/``domain`` label logs and provenance and fall back to
+values inside the spec when absent.
+"""
+
+from typing import Any, Dict
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    task_id: str = Field(
+        description="OSWorld task UUID; log/provenance label (falls back to osworld_task.id).",
+        json_schema_extra={"consumed_by": ["provenance"]},
+    )
+    domain: str = Field(
+        description="OSWorld task domain (e.g. 'chrome'); log/provenance label.",
+        json_schema_extra={"consumed_by": ["provenance"]},
+    )
+    osworld_task: Dict[str, Any] = Field(
+        description=(
+            "Full OSWorld task spec (id, snapshot, instruction, config, evaluator, ...) passed "
+            "verbatim to the OSWorld runner."
+        ),
+        json_schema_extra={"consumed_by": ["run"]},
+    )

--- a/responses_api_agents/pinchbench/task_data.py
+++ b/responses_api_agents/pinchbench/task_data.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Task-data schema for the self-contained pinchbench agent (no resources server).
+
+The committed rows nest ``task_id`` inside ``verifier_metadata``; the agent accepts BOTH
+placements (``meta.get("task_id") or record.get("task_id")`` in app.py), so the field carries no
+``legacy_location`` marker. ``task_id`` selects the PinchBench task and is exported into the
+sandbox environment as ``TASK_ID``.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    task_id: str = Field(
+        description="PinchBench task name; selects the task and is exported to the sandbox as TASK_ID.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )

--- a/responses_api_agents/swe_agents/task_data.py
+++ b/responses_api_agents/swe_agents/task_data.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Task-data schema for the self-contained swe_agents harness (no resources server).
+
+Rows are SWE-bench instances flattened top-level in the HuggingFace export shape:
+``FAIL_TO_PASS``/``PASS_TO_PASS`` are JSON-encoded strings (like the swebench resources server),
+and ``environment_setup_commit``/``difficulty`` are present. ``SWEBenchRunRequest`` (app.py)
+declares no task fields (``extra="allow"``); the instance dict rides the wire as extras and is
+handed to the configured SWE harness and its evaluation.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    instance_id: str = Field(
+        description="SWE-bench instance id, e.g. 'astropy__astropy-12907'; keys the evaluation.",
+        json_schema_extra={"consumed_by": ["run", "verify"]},
+    )
+    repo: str = Field(
+        description="GitHub repository the instance patches.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )
+    base_commit: str = Field(
+        description="Commit the repo is checked out at before the agent works.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )
+    patch: str = Field(
+        description="Gold patch diff; used by evaluation, not shown to the agent.",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    test_patch: str = Field(
+        description="Test-file diff applied before running the evaluation tests.",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    problem_statement: str = Field(
+        description="Issue text describing the bug.",
+        json_schema_extra={"consumed_by": ["prompt"]},
+    )
+    hints_text: str = Field(
+        description="Optional hints; rides along in the instance dump (may be empty).",
+        json_schema_extra={"consumed_by": ["provenance"]},
+    )
+    created_at: str = Field(
+        description="Instance creation timestamp; provenance only.",
+        json_schema_extra={"consumed_by": ["provenance"]},
+    )
+    version: str = Field(
+        description="Repo version tag used by the SWE-bench environment spec.",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    FAIL_TO_PASS: str = Field(
+        description="JSON-encoded list of test ids that must flip to passing.",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    PASS_TO_PASS: str = Field(
+        description="JSON-encoded list of test ids that must keep passing.",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    environment_setup_commit: str = Field(
+        description="Commit used to build the evaluation environment.",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    difficulty: str = Field(
+        description="Human difficulty band, e.g. '15 min - 1 hour'; provenance only.",
+        json_schema_extra={"consumed_by": ["provenance"]},
+    )

--- a/responses_api_agents/tau2/task_data.py
+++ b/responses_api_agents/tau2/task_data.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Task-data schema for the self-contained tau2 agent (no resources server).
+
+``Tau2RunRequest`` (app.py) is the strictest agent wire model: it requires ``config`` (a tau2
+``TextRunConfig``), ``task`` (a tau2 ``Task``), ``seed``, ``evaluation_type``, and pins the
+remaining knobs to constants via ``Literal`` (the harness only supports text simulation with
+full review and no audio). ``config``/``task`` stay ``Dict[str, Any]`` here because their full
+shapes belong to the tau2 package and this module must stay dependency-light; the wire validates
+them precisely.
+"""
+
+from typing import Any, Dict, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    config: Dict[str, Any] = Field(
+        description="tau2 TextRunConfig dict (domain, task_split_name, llm settings, ...).",
+        json_schema_extra={"consumed_by": ["run"]},
+    )
+    task: Dict[str, Any] = Field(
+        description="tau2 Task dict (id, description, user_scenario, evaluation_criteria, ...).",
+        json_schema_extra={"consumed_by": ["run", "verify"]},
+    )
+    seed: int = Field(
+        description="Simulation seed for the user model.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )
+    evaluation_type: str = Field(
+        description="tau2 evaluation mode; committed rows use 'all'.",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    save_dir: Literal[None] = Field(
+        description="Wire-pinned to null; tau2 result saving is managed by the harness.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )
+    user_voice_settings: Literal[None] = Field(
+        description="Wire-pinned to null; audio simulation is unsupported.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )
+    user_persona_config: Literal[None] = Field(
+        description="Wire-pinned to null.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )
+    verbose_logs: Literal[False] = Field(
+        description="Wire-pinned to false.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )
+    audio_debug: Literal[False] = Field(
+        description="Wire-pinned to false; audio simulation is unsupported.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )
+    audio_taps: Literal[False] = Field(
+        description="Wire-pinned to false; audio simulation is unsupported.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )
+    auto_review: Literal[False] = Field(
+        description="Wire-pinned to false.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )
+    review_mode: Literal["full"] = Field(
+        description="Wire-pinned to 'full'.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )
+    hallucination_feedback: Literal[None] = Field(
+        description="Wire-pinned to null.",
+        json_schema_extra={"consumed_by": ["run"]},
+    )

--- a/responses_api_agents/vcqa_agent/task_data.py
+++ b/responses_api_agents/vcqa_agent/task_data.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Task-data schema for the self-contained vcqa_agent (no resources server).
+
+The wire (``VcqaAgentRunRequest``) requires a ``verifier_metadata`` object and reads task fields
+ONLY from it, so every field here carries ``legacy_location: verifier_metadata``. Required-ness
+mirrors ``VcqaVerifierMetadata`` (app.py): ``dataset_kind`` and ``artifact_key`` are wire-required,
+the rest are optional. ``language``, ``task_type``, ``task_kind``, and ``verifier_kind`` are
+open extras on the wire model that the committed rows carry; they are declared here for
+documentation and typo protection.
+"""
+
+from typing import Any, Dict, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+_VM = {"legacy_location": "verifier_metadata"}
+
+
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    dataset_kind: Literal["fileset", "githistory"] = Field(
+        description="Which VCQA artifact family the row belongs to.",
+        json_schema_extra={"consumed_by": ["run"], **_VM},
+    )
+    artifact_key: str = Field(
+        description="Artifact path joined with the configured base URL to fetch the repo tarball.",
+        json_schema_extra={"consumed_by": ["run"], **_VM},
+    )
+    task_id: Optional[str] = Field(
+        default=None,
+        description="Task identifier; provenance label.",
+        json_schema_extra={"consumed_by": ["provenance"], **_VM},
+    )
+    repo_full_name: Optional[str] = Field(
+        default=None,
+        description="GitHub repo the artifact snapshots, e.g. 'huggingface/transformers'.",
+        json_schema_extra={"consumed_by": ["run"], **_VM},
+    )
+    pre_merge_sha: Optional[str] = Field(
+        default=None,
+        description="Base commit for githistory tasks.",
+        json_schema_extra={"consumed_by": ["run"], **_VM},
+    )
+    head_sha: Optional[str] = Field(
+        default=None,
+        description="Head commit for githistory tasks.",
+        json_schema_extra={"consumed_by": ["run"], **_VM},
+    )
+    rubric: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Judge rubric ({'judge': [...]}) used to score the final answer.",
+        json_schema_extra={"consumed_by": ["verify"], **_VM},
+    )
+    verifiers: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Alternative verifier spec used by bisect-style tasks.",
+        json_schema_extra={"consumed_by": ["verify"], **_VM},
+    )
+    max_turns: Optional[int] = Field(
+        default=None,
+        description="Turn budget for the exploration loop.",
+        json_schema_extra={"consumed_by": ["run"], **_VM},
+    )
+    language: Optional[str] = Field(
+        default=None,
+        description="Repo language tag; open extra on the wire, informational.",
+        json_schema_extra={"consumed_by": ["provenance"], **_VM},
+    )
+    task_type: Optional[str] = Field(
+        default=None,
+        description="Task flavor, e.g. 'fileset_explore'; open extra on the wire, informational.",
+        json_schema_extra={"consumed_by": ["provenance"], **_VM},
+    )
+    task_kind: Optional[str] = Field(
+        default=None,
+        description="Task flavor for githistory rows, e.g. 'bisect'; open extra on the wire.",
+        json_schema_extra={"consumed_by": ["provenance"], **_VM},
+    )
+    verifier_kind: Optional[str] = Field(
+        default=None,
+        description="Which verifier family scores the row, e.g. 'judge'; open extra on the wire.",
+        json_schema_extra={"consumed_by": ["provenance"], **_VM},
+    )

--- a/tests/unit_tests/test_task_data.py
+++ b/tests/unit_tests/test_task_data.py
@@ -29,7 +29,10 @@ from nemo_gym.train_data_utils import TrainDataProcessor
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SCHEMA_FILES = sorted((REPO_ROOT / "resources_servers").glob("*/task_data.py"))
+SCHEMA_FILES = sorted(
+    list((REPO_ROOT / "resources_servers").glob("*/task_data.py"))
+    + list((REPO_ROOT / "responses_api_agents").glob("*/task_data.py"))
+)
 
 
 class TestNormalizeTaskFields:
@@ -59,6 +62,27 @@ class TestNormalizeTaskFields:
     def test_non_dict_verifier_metadata_is_kept_for_the_schema_to_reject(self):
         fields, _ = normalize_task_fields({"verifier_metadata": "oops"})
         assert fields == {"verifier_metadata": "oops"}
+
+    def test_splices_task_data_contents(self):
+        fields, conflicts = normalize_task_fields(
+            {"responses_create_params": {}, "task_data": {"expected_city": "Tokyo"}}
+        )
+        assert fields == {"expected_city": "Tokyo"}
+        assert conflicts == []
+
+    def test_empty_task_data_container_leaves_no_residue(self):
+        fields, conflicts = normalize_task_fields({"expected_city": "Tokyo", "task_data": {}})
+        assert fields == {"expected_city": "Tokyo"}
+        assert conflicts == []
+
+    def test_conflicting_task_data_duplicate_is_reported(self):
+        fields, conflicts = normalize_task_fields({"expected_city": "Paris", "task_data": {"expected_city": "Tokyo"}})
+        assert fields == {"expected_city": "Paris"}
+        assert conflicts == ["expected_city"]
+
+    def test_non_dict_task_data_is_kept_for_the_schema_to_reject(self):
+        fields, _ = normalize_task_fields({"task_data": "oops"})
+        assert fields == {"task_data": "oops"}
 
 
 class TestLoadTaskDataSchema:
@@ -141,10 +165,13 @@ class TestTaskDataValidator:
         v.validate_row(0, {"verifier_metadata": {"question": "q", "expected_answer": "a"}})
         assert v.report.clean
 
-    def test_unknown_keys_counted_not_errored(self):
+    def test_unknown_keys_counted_and_dirty_but_not_errored(self):
         v = self._validator()
         v.validate_row(0, {"question": "q", "expected_answer": "a", "difficulty": 3})
-        assert v.report.clean
+        # The row still validates (no error), but an undeclared key is likely a typo or a
+        # missing schema field, so the report is not clean.
+        assert v.report.error_rows == 0
+        assert not v.report.clean
         assert v.report.unknown_keys == {"difficulty": 1}
         assert "difficulty" in v.report.summary()
 
@@ -197,7 +224,7 @@ class TestOwningResourcesServerImpl:
 
 
 class TestShippedSchemas:
-    """CI enforcement for every committed resources_servers/*/task_data.py."""
+    """CI enforcement for every committed task_data.py (resources servers and agents)."""
 
     ALLOWED_IMPORT_PREFIXES = ("pydantic", "nemo_gym.task_data")
 
@@ -294,7 +321,9 @@ class TestUnionUnknownKeys:
         adapter = load_task_data_schema(tmp_path)
         v = TaskDataValidator(server_name="ruler2", adapter=adapter, dataset_fpath="d.jsonl")
         v.validate_row(0, {"eval_type": "string_match", "lenght": 5})
-        assert v.report.clean
+        # The typo is surfaced as an unknown key and dirties the report.
+        assert v.report.error_rows == 0
+        assert not v.report.clean
         assert v.report.unknown_keys == {"lenght": 1}
 
 
@@ -505,7 +534,11 @@ class TestRepoDataMatchesSchemas:
                             if not isinstance(d, dict) or not d.get("jsonl_fpath"):
                                 continue
                             if section == "resources_servers":
-                                rs = impl_key
+                                owner = ("resources_servers", impl_key)
+                            elif "resources_server" not in body:
+                                # Self-contained agent: its schema lives next to the agent
+                                # implementation, mirroring collate's fallback.
+                                owner = ("responses_api_agents", impl_key)
                             else:
                                 ref = body.get("resources_server") or {}
                                 name = ref.get("name") if isinstance(ref, dict) else None
@@ -521,14 +554,17 @@ class TestRepoDataMatchesSchemas:
                                     if isinstance(tgt, dict) and isinstance(tgt.get("resources_servers"), dict)
                                     else None
                                 )
-                            if rs and str(d["jsonl_fpath"]) in tracked:
-                                server_files.setdefault(rs, set()).add(str(d["jsonl_fpath"]))
+                                owner = ("resources_servers", rs) if rs else None
+                            if owner and str(d["jsonl_fpath"]) in tracked:
+                                server_files.setdefault(owner, set()).add(str(d["jsonl_fpath"]))
 
         assert len(server_files) > 50, "mapping looks broken: too few servers with committed data"
+        agent_owned = [o for o in server_files if o[0] == "responses_api_agents"]
+        assert len(agent_owned) >= 5, "mapping looks broken: self-contained agent datasets not found"
         failures = []
         rows_checked = 0
-        for server, files in sorted(server_files.items()):
-            server_dir = find_server_dir(server)
+        for (base_folder, server), files in sorted(server_files.items()):
+            server_dir = find_server_dir(server, base_folder=base_folder)
             adapter = load_task_data_schema(server_dir) if server_dir else None
             if adapter is None:
                 failures.append(f"{server}: no loadable schema")

--- a/tests/unit_tests/test_task_data.py
+++ b/tests/unit_tests/test_task_data.py
@@ -364,3 +364,179 @@ class TestSelfContainedAgentSchemaFallback:
         validator = TrainDataProcessor._task_data_validator_for(agent, self._dataset(), [agent, rs])
         assert validator is not None
         assert validator.report.server_name == "math_with_judge"
+
+
+class TestMisplacedLegacyFields:
+    def _adapter(self, tmp_path):
+        (tmp_path / "task_data.py").write_text(
+            "from pydantic import BaseModel, ConfigDict, Field\n"
+            "class TaskData(BaseModel):\n"
+            "    model_config = ConfigDict(extra='allow')\n"
+            "    expected_city: str = Field(\n"
+            "        default='Paris', json_schema_extra={'legacy_location': 'verifier_metadata'}\n"
+            "    )\n"
+        )
+        return load_task_data_schema(tmp_path)
+
+    def test_marked_field_found_only_top_level_is_flagged(self, tmp_path):
+        v = TaskDataValidator(server_name="s", adapter=self._adapter(tmp_path), dataset_fpath="d")
+        v.validate_row(0, {"expected_city": "Tokyo"})
+        assert not v.report.clean
+        assert v.report.misplaced_keys == {"expected_city": 1}
+        assert "the server will not see them" in v.report.summary()
+
+    def test_marked_field_in_verifier_metadata_is_correct(self, tmp_path):
+        v = TaskDataValidator(server_name="s", adapter=self._adapter(tmp_path), dataset_fpath="d")
+        v.validate_row(0, {"verifier_metadata": {"expected_city": "Tokyo"}})
+        assert v.report.clean
+
+    def test_duplicated_in_both_places_is_not_misplaced(self, tmp_path):
+        v = TaskDataValidator(server_name="s", adapter=self._adapter(tmp_path), dataset_fpath="d")
+        v.validate_row(0, {"expected_city": "Tokyo", "verifier_metadata": {"expected_city": "Tokyo"}})
+        assert v.report.clean
+
+    def test_migrated_row_format_is_exempt(self, tmp_path):
+        v = TaskDataValidator(server_name="s", adapter=self._adapter(tmp_path), dataset_fpath="d")
+        v.validate_row(0, {"expected_city": "Tokyo", "task_data": {}})
+        assert v.report.misplaced_keys == {}
+
+    def test_unmarked_top_level_fields_are_fine(self, tmp_path):
+        (tmp_path / "task_data.py").write_text(
+            "from pydantic import BaseModel, ConfigDict\n"
+            "class TaskData(BaseModel):\n"
+            "    model_config = ConfigDict(extra='allow')\n"
+            "    question: str\n"
+        )
+        v = TaskDataValidator(server_name="s", adapter=load_task_data_schema(tmp_path), dataset_fpath="d")
+        v.validate_row(0, {"question": "q"})
+        assert v.report.clean
+
+
+class TestAutoValidationMode:
+    def _config(self, mode, task_data_validation="auto"):
+        from nemo_gym.train_data_utils import TrainDataProcessorConfig
+
+        return TrainDataProcessorConfig(output_dirpath="out", mode=mode, task_data_validation=task_data_validation)
+
+    def test_auto_is_error_for_example_validation(self):
+        assert self._config("example_validation").effective_task_data_validation == "error"
+
+    def test_auto_is_warn_for_train_preparation(self):
+        assert self._config("train_preparation").effective_task_data_validation == "warn"
+
+    def test_explicit_setting_wins(self):
+        assert self._config("example_validation", "off").effective_task_data_validation == "off"
+        assert self._config("train_preparation", "error").effective_task_data_validation == "error"
+
+
+class TestSchemaPresence:
+    def test_every_resources_server_ships_a_schema(self):
+        missing = sorted(
+            d.name
+            for d in (REPO_ROOT / "resources_servers").iterdir()
+            if d.is_dir() and (d / "app.py").exists() and not (d / "task_data.py").exists()
+        )
+        assert not missing, (
+            f"resources servers without a task_data.py schema: {missing}. Every server must "
+            "describe its dataset rows (see nemo_gym/task_data.py for the protocol)."
+        )
+
+
+class TestRepoDataMatchesSchemas:
+    """The drift gate: every committed dataset row must validate against its server's schema.
+
+    Fails the PR that changes a schema without fixing the data, or commits data that no longer
+    matches the schema. Uses the same mapping collate uses: dataset declarations in tracked
+    configs (following config_paths chains and one _inherit_from hop) resolve to the declaring
+    resources server.
+    """
+
+    @staticmethod
+    def _merged_config(path, seen=None):
+        import yaml
+
+        seen = seen or set()
+        if path in seen:
+            return {}
+        seen.add(path)
+        try:
+            cfg = yaml.safe_load(open(path)) or {}
+        except Exception:
+            return {}
+        out = {}
+        for p in cfg.get("config_paths") or []:
+            out.update(TestRepoDataMatchesSchemas._merged_config(p, seen))
+        out.update({k: v for k, v in cfg.items() if k != "config_paths"})
+        return out
+
+    def test_all_committed_rows_validate(self, monkeypatch):
+        import subprocess
+
+        import yaml
+
+        monkeypatch.chdir(REPO_ROOT)
+        configs = [
+            c
+            for c in subprocess.run(["git", "ls-files", "*.yaml"], capture_output=True, text=True).stdout.split()
+            if c.split("/")[0] in ("resources_servers", "responses_api_agents", "benchmarks", "environments")
+        ]
+        tracked = set(subprocess.run(["git", "ls-files", "*.jsonl"], capture_output=True, text=True).stdout.split())
+
+        server_files = {}
+        for cf in configs:
+            try:
+                local = yaml.safe_load(open(cf)) or {}
+            except Exception:
+                continue
+            if not isinstance(local, dict):
+                continue
+            full = self._merged_config(cf)
+            for _inst, v in local.items():
+                if not isinstance(v, dict):
+                    continue
+                for section in ("resources_servers", "responses_api_agents"):
+                    sec = v.get(section)
+                    if not isinstance(sec, dict):
+                        continue
+                    for impl_key, body in sec.items():
+                        if not isinstance(body, dict):
+                            continue
+                        for d in body.get("datasets") or []:
+                            if not isinstance(d, dict) or not d.get("jsonl_fpath"):
+                                continue
+                            if section == "resources_servers":
+                                rs = impl_key
+                            else:
+                                ref = body.get("resources_server") or {}
+                                name = ref.get("name") if isinstance(ref, dict) else None
+                                tgt = full.get(name) if name else None
+                                if (
+                                    isinstance(tgt, dict)
+                                    and "resources_servers" not in tgt
+                                    and tgt.get("_inherit_from")
+                                ):
+                                    tgt = full.get(tgt["_inherit_from"]) or tgt
+                                rs = (
+                                    next(iter(tgt["resources_servers"]))
+                                    if isinstance(tgt, dict) and isinstance(tgt.get("resources_servers"), dict)
+                                    else None
+                                )
+                            if rs and str(d["jsonl_fpath"]) in tracked:
+                                server_files.setdefault(rs, set()).add(str(d["jsonl_fpath"]))
+
+        assert len(server_files) > 50, "mapping looks broken: too few servers with committed data"
+        failures = []
+        rows_checked = 0
+        for server, files in sorted(server_files.items()):
+            server_dir = find_server_dir(server)
+            adapter = load_task_data_schema(server_dir) if server_dir else None
+            if adapter is None:
+                failures.append(f"{server}: no loadable schema")
+                continue
+            for f in sorted(files):
+                report = validate_jsonl_rows(server, adapter, f, open(f).read().splitlines())
+                rows_checked += report.rows
+                if not report.clean:
+                    failures.append(report.summary())
+        assert rows_checked > 500, "sweep looks broken: too few rows checked"
+        assert not failures, "\n".join(failures)


### PR DESCRIPTION
## What this does

This PR turns the schema validation from #2800 into a gate.

**Auto validation mode.** `task_data_validation` gains an `auto` setting. Auto is now the default. Auto resolves to `error` in `example_validation` mode and to `warn` in `train_preparation` mode. Committed example data is known clean, so a bad row should fail the PR gate. User training data must not crash long collate jobs, so it warns instead.

Before: the default was `warn` everywhere. A bad committed example row only printed a warning.
After: `gym dataset collate +mode=example_validation` fails on a bad row with a per-row error report. Training collate still warns and completes.

**Misplaced-field check.** Some schema fields carry a `legacy_location: verifier_metadata` marker. The marker means the server reads that field only from inside `verifier_metadata`. If a row puts the field at the top level instead, the server never sees it. The validator now counts these rows and reports them as `misplaced_keys`. The instruction_following schema drops its markers because that server accepts both placements.

**Schema presence test.** Every resources server with an `app.py` must ship a `task_data.py`. New servers can no longer skip the schema.

**Repo drift test.** A new unit test walks every committed dataset in the repo and validates each row against its server's schema. If a server's wire model changes and the schema does not, this test fails. This is the drift gate requested in the #2795 review.

The presence test already paid for itself. terminal_bench_2_1 landed on main after the schema sweep and had no schema. The test caught it, and this PR adds its schema.

**Review fixes.** Three additions from the first review round. Undeclared row keys now fail the gate instead of only being reported; no committed row carries one, and the stricter gate immediately caught two missing fields in a new schema. The drift test now also validates datasets owned by self-contained agents (agents with no resources server), using the same schema fallback collate uses; schemas for the nine such agents with committed data are included. `normalize_task_fields` now unpacks a migrated `task_data` container the same way it unpacks `verifier_metadata`, so nested fields cannot dodge validation.

## Verification

- All 302 tests in `tests/unit_tests/test_task_data.py` pass.
- Live smoke: a bad row (`expected_city` as an int) fails `gym dataset collate` in `example_validation` mode with a per-row pydantic report. The same row only warns in `train_preparation` mode and the run completes.
- Golden routing gate: base capture vs branch capture, strict compare, 0 differences across 233 closures.
- ruff and pre-commit are clean.
