### PR TITLE
feat(swebench,opencode): inject CPU parallelism-cap env vars derived from the sandbox CPU limit

### DIFF
--- a/nemo_gym/sandbox/utils.py
+++ b/nemo_gym/sandbox/utils.py
@@ -14,6 +14,46 @@
 
 """Sandbox utility helpers."""
 
+# Parallelism caps for CPU-limited sandboxes, each set by cpu_cap_env() to the
+# floored CPU limit (min 1). Tools size worker pools by host core count, not
+# the cgroup limit — Python's multiprocessing.cpu_count(), BLAS/OpenMP thread
+# pools, Go's runtime, cargo, Node — so on wide hosts with small limits they
+# overcommit, CFS-throttle, and OOM. GNU nproc honors OMP_NUM_THREADS, which
+# also tames `make -j$(nproc)` builds; PYTHON_CPU_COUNT caps os/multiprocessing
+# .cpu_count() itself on Python 3.13+. MAKEFLAGS is deliberately absent:
+# injecting `-j` would flip plain `make` runs from serial to parallel, and
+# explicit `-j` flags override MAKEFLAGS anyway. Injection is intentionally
+# per-call-site (no sandbox-layer default); callers merge explicit env over it.
+CPU_CAP_ENV_VARS: tuple[str, ...] = (
+    "OMP_NUM_THREADS",
+    "OMP_THREAD_LIMIT",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "BLIS_NUM_THREADS",
+    "PYTHON_CPU_COUNT",
+    "NUMBA_NUM_THREADS",
+    "LOKY_MAX_CPU_COUNT",
+    "POLARS_MAX_THREADS",
+    "PYTEST_XDIST_AUTO_NUM_WORKERS",
+    "DJANGO_TEST_PROCESSES",
+    "GOMAXPROCS",
+    "CARGO_BUILD_JOBS",
+    "RAYON_NUM_THREADS",
+    "RUST_TEST_THREADS",
+    "UV_THREADPOOL_SIZE",
+    "CMAKE_BUILD_PARALLEL_LEVEL",
+)
+
+
+def cpu_cap_env(cpu: float | int | None) -> dict[str, str]:
+    """CPU_CAP_ENV_VARS derived from a sandbox CPU limit; empty when unset."""
+    if cpu is None:
+        return {}
+    cores = str(max(1, int(cpu)))
+    return {name: cores for name in CPU_CAP_ENV_VARS}
+
 
 def rewrite_image(image: str | None, rewrites: list[dict[str, str]]) -> str | None:
     """Apply ordered image-prefix rewrites used by sandbox configs."""

--- a/resources_servers/swebench/app.py
+++ b/resources_servers/swebench/app.py
@@ -39,6 +39,7 @@ from nemo_gym.global_config import get_global_config_dict
 from nemo_gym.rollout_observability import SandboxObservation
 from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
 from nemo_gym.sandbox.config import resolve_provider_config, resolve_provider_metadata
+from nemo_gym.sandbox.utils import cpu_cap_env
 from nemo_gym.server_utils import SESSION_ID_KEY
 from resources_servers.swebench.swebench_patches import (
     patch_swebench_multilingual_golden_patch_pass,
@@ -245,12 +246,19 @@ class SwebenchResourcesServer(SimpleResourcesServer):
 
         patch_swebench_multilingual_resources_request(resources, test_spec.instance_id)
 
+        # Derive from the final resources map (after the multilingual bump);
+        # explicit sandbox_config.env keys win over the derived caps.
+        sandbox_resources = SandboxResources.from_mapping(resources)
+        env = dict(self.config.sandbox_config.get("env", {}))
+        if self.config.sandbox_config.get("derive_cpu_env", True):
+            env = cpu_cap_env(sandbox_resources.cpu) | env
+
         eval_sandbox_spec = SandboxSpec(
             image=test_spec.instance_image_key,
             ttl_s=self.config.sandbox_config.get("ttl_s", None),
             ready_timeout_s=self.config.sandbox_config.get("ready_timeout_s", None),
             workdir=None,  # Default to container's WORKDIR
-            env=self.config.sandbox_config.get("env", {}),
+            env=env,
             files=dict(),
             metadata=provider_default_metadata
             | self.config.sandbox_config.get("metadata", {})
@@ -258,7 +266,7 @@ class SwebenchResourcesServer(SimpleResourcesServer):
                 "nemo_gym_agent": self.config.name,
                 "instance_id": test_spec.instance_id[:63],
             },
-            resources=SandboxResources.from_mapping(resources),
+            resources=sandbox_resources,
             entrypoint=None,
             provider_options=self.config.sandbox_config.get("provider_options", {}),
         )

--- a/resources_servers/swebench/configs/swebench.yaml
+++ b/resources_servers/swebench/configs/swebench.yaml
@@ -18,6 +18,8 @@ swebench_resources_server:          # instance name — how agents/CLI refer to 
       sandbox_config:
         ttl_s: 18000
         ready_timeout_s: 1200
+        # cpu also derives parallelism-cap env vars (OMP_NUM_THREADS etc.)
+        # injected into the sandbox; derive_cpu_env: false disables.
         resources:
           cpu: 2
           memory_mib: 16384

--- a/resources_servers/swebench/tests/test_app.py
+++ b/resources_servers/swebench/tests/test_app.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -20,6 +22,7 @@ from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 
 from nemo_gym.sandbox import SandboxExecResult, SandboxHandle
+from nemo_gym.sandbox.utils import CPU_CAP_ENV_VARS
 from nemo_gym.server_utils import ServerClient
 from resources_servers.swebench.app import (
     DockerContainer,
@@ -116,6 +119,42 @@ class TestApp:
             "resource_usage_source": None,
             "error_type": None,
         }
+
+    async def test_create_sandbox_derives_cpu_cap_env_from_cpu_limit(self, monkeypatch: MonkeyPatch) -> None:
+        sandbox = MagicMock()
+        sandbox.start = AsyncMock()
+        monkeypatch.setattr("resources_servers.swebench.app.get_global_config_dict", lambda: {})
+        monkeypatch.setattr("resources_servers.swebench.app.resolve_provider_config", lambda *_: MagicMock())
+        monkeypatch.setattr("resources_servers.swebench.app.resolve_provider_metadata", lambda *_: {})
+        monkeypatch.setattr("resources_servers.swebench.app.AsyncSandbox", MagicMock(return_value=sandbox))
+        monkeypatch.setattr("resources_servers.swebench.app.patch_swebench_multilingual_sandbox", AsyncMock())
+        test_spec = SimpleNamespace(
+            instance_image_key="img:key", instance_id="astropy__astropy-12907", repo="astropy/astropy"
+        )
+
+        async def created_spec(sandbox_config: dict[str, Any]) -> Any:
+            config = SwebenchResourcesServerConfig(
+                host="0.0.0.0",
+                port=8080,
+                entrypoint="",
+                name="",
+                sandbox_provider="test",
+                sandbox_config=sandbox_config,
+                is_verifying_golden_patch=True,
+            )
+            server = SwebenchResourcesServer(config=config, server_client=MagicMock(spec=ServerClient))
+            await server._create_sandbox(test_spec)
+            return sandbox.start.await_args.args[0]
+
+        # Floored to whole cores; explicit sandbox_config.env keys win over the derived caps.
+        spec = await created_spec({"resources": {"cpu": 2.7}, "env": {"OMP_NUM_THREADS": "16"}})
+        assert spec.env["OMP_NUM_THREADS"] == "16"
+        derived = [name for name in CPU_CAP_ENV_VARS if name != "OMP_NUM_THREADS"]
+        assert {name: spec.env[name] for name in derived} == {name: "2" for name in derived}
+
+        # Opt-out and no-cpu-limit paths keep env untouched.
+        assert (await created_spec({"resources": {"cpu": 2}, "derive_cpu_env": False})).env == {}
+        assert (await created_spec({"resources": {"memory_mib": 1024}})).env == {}
 
     def test_unobserved_response_omits_optional_field(self) -> None:
         response = SWEBenchVerifyResponse.model_construct(verifier_sandbox_observation=None)

--- a/responses_api_agents/opencode_sandboxed_agent/app.py
+++ b/responses_api_agents/opencode_sandboxed_agent/app.py
@@ -61,6 +61,7 @@ from nemo_gym.rollout_observability import (
 )
 from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec, create_provider
 from nemo_gym.sandbox.config import resolve_provider_config, resolve_provider_metadata
+from nemo_gym.sandbox.utils import cpu_cap_env
 from nemo_gym.server_utils import (
     SESSION_ID_KEY,
     get_response_json,
@@ -446,20 +447,23 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
         if self.config.debug:
             print("Creating new sandbox since one wasn't provided", file=sys.stderr)
 
+        resources = SandboxResources.from_mapping(self.config.sandbox_config.get("resources", {}))
+        env = cpu_cap_env(resources.cpu) if self.config.sandbox_config.get("derive_cpu_env", True) else {}
+
         # TODO @bxyu-nvidia: Refactor this after Hemil's swap from Python dataclass to Pydantic BaseModel
         sandbox_spec = SandboxSpec(
             image="swebench/sweb.eval.x86_64.astropy_1776_astropy-12907",  # This is just the first SWE Bench Verified image for now
             ttl_s=self.config.sandbox_config.get("ttl_s", None),
             ready_timeout_s=self.config.sandbox_config.get("ready_timeout_s", None),
             workdir=None,  # Default to container's WORKDIR
-            env=dict(),
+            env=env,
             files=dict(),
             metadata=provider_default_metadata
             | self.config.sandbox_config.get("metadata", {})
             | {
                 "nemo_gym_agent": self.config.name,
             },
-            resources=SandboxResources.from_mapping(self.config.sandbox_config.get("resources", {})),
+            resources=resources,
             entrypoint=None,
             provider_options=self.config.sandbox_config.get("provider_options", {}),
         )

--- a/responses_api_agents/opencode_sandboxed_agent/configs/opencode_agent.yaml
+++ b/responses_api_agents/opencode_sandboxed_agent/configs/opencode_agent.yaml
@@ -146,6 +146,8 @@ opencode_sandboxed_agent:
       sandbox_config:
         ttl_s: 18000
         ready_timeout_s: 1200
+        # cpu also derives parallelism-cap env vars (OMP_NUM_THREADS etc.)
+        # injected into the sandbox; derive_cpu_env: false disables.
         resources:
           cpu: 2
           memory_mib: 8192

--- a/responses_api_agents/opencode_sandboxed_agent/tests/test_app.py
+++ b/responses_api_agents/opencode_sandboxed_agent/tests/test_app.py
@@ -45,7 +45,9 @@ from nemo_gym.rollout_observability import (
     ToolCallObservation,
 )
 from nemo_gym.sandbox import SandboxHandle
+from nemo_gym.sandbox.utils import CPU_CAP_ENV_VARS
 from nemo_gym.server_utils import SESSION_ID_KEY, ServerClient
+from responses_api_agents.opencode_sandboxed_agent import app as app_module
 from responses_api_agents.opencode_sandboxed_agent.app import (
     OpenCodeSandboxedAgent,
     OpenCodeSandboxedAgentConfig,
@@ -77,6 +79,32 @@ class TestOpenCodeSandboxedAgent:
             opencode_max_context_window=0,
             token_id_capture=True,
         )
+
+    async def test_start_sandbox_derives_cpu_cap_env_from_cpu_limit(self, monkeypatch: MonkeyPatch) -> None:
+        sandbox = MagicMock()
+        sandbox.start = AsyncMock()
+        monkeypatch.setattr(app_module, "get_global_config_dict", lambda: {})
+        monkeypatch.setattr(app_module, "create_provider", lambda *_: MagicMock())
+        monkeypatch.setattr(app_module, "resolve_provider_config", lambda *_: MagicMock())
+        monkeypatch.setattr(app_module, "resolve_provider_metadata", lambda *_: {})
+        monkeypatch.setattr(app_module, "AsyncSandbox", MagicMock(return_value=sandbox))
+
+        async def created_spec(sandbox_config: Dict[str, Any]) -> Any:
+            config = self._create_config()
+            config.sandbox_config = sandbox_config
+            server = OpenCodeSandboxedAgent(config=config, server_client=MagicMock(spec=ServerClient))
+            await server._start_sandbox()
+            return sandbox.start.await_args.args[0]
+
+        # Floored to whole cores; every cap gets the same value.
+        spec = await created_spec({"resources": {"cpu": 2.7, "memory_mib": 8192}})
+        assert spec.env == {name: "2" for name in CPU_CAP_ENV_VARS}
+        spec = await created_spec({"resources": {"cpu": 0.5}})
+        assert spec.env["OMP_NUM_THREADS"] == "1"
+
+        # Opt-out and no-cpu-limit paths inject nothing.
+        assert (await created_spec({"resources": {"cpu": 2}, "derive_cpu_env": False})).env == {}
+        assert (await created_spec({"resources": {"memory_mib": 8192}})).env == {}
 
     @fixture
     def opencode_export_test_data(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Motivation

Tools inside CPU-limited sandboxes size their parallelism by **host** core count, not the cgroup limit: `multiprocessing.cpu_count()` ignores the CFS quota (Django's `runtests.py` forks `cpu_count()` test workers), BLAS/OpenMP pools spawn host-width threads on every numpy import, Go's `runtime.NumCPU`/cargo/node size the same way, and `nproc`-driven builds (`make -j$(nproc)`) fan out to full host width. On 128-192-core nodes with 2-8 CPU pod limits this causes CFS throttling and OOM-killed sandboxes. Measured at production scale, injecting these caps reduced sandbox-fatal rollout failures by ~94% (35 → 2 per ~1,400 rollouts) with quality unchanged.

## Change

**Scoped to the SWE-bench flow per review — no sandbox-layer default.** The env is seeded at the two places SWE-bench sandboxes are actually created:

1. **`swebench` resources server** (`_create_sandbox`, the benchmark path): in the real flow the agent only *connects* to the sandbox the server created (`seed_session` → `sandbox_handle`), so this is where the caps must be injected. Derivation uses the final resources map (after the multilingual resource bump).
2. **`opencode_sandboxed_agent`** (`_start_sandbox` create branch, the standalone/debug path where the agent creates its own sandbox).

Each var is set to `str(max(1, floor(cpu)))`. Explicit `sandbox_config.env` keys win over the derived defaults; `sandbox_config.derive_cpu_env: false` disables (default `true` at these two sites only); no cpu limit → no-op. The 19-name constant plus a tiny `cpu_cap_env()` helper live in `nemo_gym/sandbox/utils.py` so the two call sites don't duplicate it — it's a plain helper, not an automatic layer; nothing else calls it.

| Variable | Tames |
| --- | --- |
| `OMP_NUM_THREADS`, `OMP_THREAD_LIMIT` | OpenMP pools; GNU `nproc` honors `OMP_NUM_THREADS`, capping `make -j$(nproc)` |
| `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, `NUMEXPR_NUM_THREADS`, `VECLIB_MAXIMUM_THREADS`, `BLIS_NUM_THREADS` | BLAS/numpy thread pools spawned on import |
| `PYTHON_CPU_COUNT` | Python 3.13+: `os.cpu_count()`, `os.process_cpu_count()`, and `multiprocessing.cpu_count()` themselves — cascades into anything that sizes off cpu_count; no-op on older Pythons |
| `NUMBA_NUM_THREADS` | Numba parallel-target pool (defaults to `multiprocessing.cpu_count()`; documented as independent of the OMP/MKL vars) |
| `LOKY_MAX_CPU_COUNT` | joblib/loky cpu detection — scikit-learn `n_jobs=-1` spawns host-width workers otherwise |
| `POLARS_MAX_THREADS` | Polars' private rayon pool (the global `RAYON_NUM_THREADS` does not govern it) |
| `PYTEST_XDIST_AUTO_NUM_WORKERS` | `pytest -n auto` / `-n logical` worker count (defaults to physical cores; one process per worker) |
| `DJANGO_TEST_PROCESSES` | Django's own `runtests.py` `--parallel` default (SWE-bench django tasks) |
| `GOMAXPROCS` | Go runtime scheduler width |
| `CARGO_BUILD_JOBS`, `RAYON_NUM_THREADS`, `RUST_TEST_THREADS` | cargo build jobs, Rust rayon pools, rustc test-harness concurrency (`cargo test` defaults to ncpus) |
| `UV_THREADPOOL_SIZE` | Node libuv threadpool (and astral-uv's blocking pool) |
| `CMAKE_BUILD_PARALLEL_LEVEL` | Default `-j` for `cmake --build` when `--parallel` is not given — chiefly caps ninja (defaults to ncores+2). Make-backed `cmake --build` goes serial → parallel-n, acceptable because CMake-generated Makefiles are parallel-safe by construction |

**Dropped: `MAKEFLAGS`.** Injecting `-j{n}` would flip plain `make` runs from serial to parallel-n for every Makefile in the image (a behavior change that can break non-parallel-safe builds), while explicit `-j` flags override `MAKEFLAGS` anyway — and the `-j$(nproc)` case is already capped via `nproc` honoring `OMP_NUM_THREADS`. Risk without benefit. Also considered and rejected: `JOBS` (node-gyp; name too generic), `ZSTD_NBTHREADS`/`XZ_DEFAULTS` (flip single-threaded defaults to parallel — a behavior change, not a cap), JVM opts (modern JVMs read the cgroup quota natively), `JULIA_NUM_THREADS`/`MC_CORES` (defaults are 1-2; injecting would raise parallelism).

## Test plan

- New tests on both create paths asserting the derived env lands in the spec passed to `AsyncSandbox.start`: swebench server `_create_sandbox` (explicit-env-wins, opt-out, no-cpu-limit) and opencode `_start_sandbox` (fractional-floor, opt-out, no-cpu-limit).
- `PYTHON_CPU_COUNT` and `LOKY_MAX_CPU_COUNT` semantics verified against the repo venv (Python 3.13 / installed joblib); the rest against upstream docs.
- Full `tests/unit_tests/`: **3229 passed, 84 skipped** (1 deselected: pre-existing macOS-only `/proc` enroot test failure, fails on `main` too); swebench suite 11 passed; opencode suite 11 passed
- `ruff check`/`format` clean; scoped `pre-commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)