### PR TITLE
fix(workplace-assistant): install wcwidth for SDG notebook

### DIFF
--- a/resources_servers/workplace_assistant/notebooks/synthetic-data-generation/README.md
+++ b/resources_servers/workplace_assistant/notebooks/synthetic-data-generation/README.md
@@ -13,6 +13,9 @@ Generate synthetic training data for multi-step tool-calling agents using [NeMo 
 # From this directory
 uv pip install -r requirements.txt
 
+# Gym excludes wcwidth globally; install it separately in the active environment.
+uv pip install --no-config --no-deps wcwidth==0.8.2
+
 # Or with pip
 pip install -r requirements.txt
 ```

--- a/resources_servers/workplace_assistant/notebooks/synthetic-data-generation/requirements.txt
+++ b/resources_servers/workplace_assistant/notebooks/synthetic-data-generation/requirements.txt
@@ -3,3 +3,6 @@ duckdb==1.4.4
 pydantic==2.12.5
 pandas==2.3.3
 notebook==7.6.2
+# Gym's uv config excludes wcwidth. This entry supports pip installs;
+# uv users install it separately as documented in README.md.
+wcwidth==0.8.2


### PR DESCRIPTION
## What does this PR do?

Fixes a bug, where the `multistep-toolcalling-sdg.ipynb` kernel failed to start because `prompt_toolkit` could not import `wcwidth`.

This change:

- Adds `wcwidth==0.8.2` to the tutorial requirements for pip users.
- Documents a targeted uv installation step because Gym excludes `wcwidth` globally.
- Preserves the existing global exclusion and avoids changes to `pyproject.toml` or `uv.lock`.

Validated in a clean Python 3.13.14 environment with 166 compatible packages. A real Jupyter kernel successfully executed the notebook’s first code cell.


## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
