### PR TITLE
feat(data): batch 1: request models inherit their TaskData schema (51 servers)

### DIFF
--- a/nemo_gym/task_data.py
+++ b/nemo_gym/task_data.py
@@ -24,7 +24,9 @@ not carry the marker.
 This module is a dependency-light leaf: it may import only the standard library and Pydantic, and
 per-server ``task_data.py`` modules may import only the standard library, Pydantic, this module,
 and other servers' ``task_data`` modules. That keeps schemas loadable by data tooling (collate,
-``gym env schema``, dataset import) without installing any server's requirements.
+``gym env schema``, dataset import) without installing any server's requirements. A schema may
+import another server's ``task_data`` only when its own ``app.py`` imports that server, so that
+schema inheritance mirrors a real verifier dependency instead of coupling unrelated servers.
 
 Conventions for ``TaskData`` models:
 - ``model_config = ConfigDict(extra="allow")`` by default. ``extra="forbid"`` is opt-in for

--- a/resources_servers/aalcr/app.py
+++ b/resources_servers/aalcr/app.py
@@ -16,6 +16,8 @@
 import json
 from typing import Any, Dict, Literal, Optional
 
+from pydantic import ConfigDict
+
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
     BaseVerifyRequest,
@@ -62,7 +64,10 @@ class AalcrResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class AALCRVerifyRequest(TaskData, BaseVerifyRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class AALCRVerifyResponse(AALCRVerifyRequest, BaseVerifyResponse):

--- a/resources_servers/aalcr/app.py
+++ b/resources_servers/aalcr/app.py
@@ -25,6 +25,7 @@ from nemo_gym.base_resources_server import (
 from nemo_gym.config_types import ModelServerRef
 from nemo_gym.judge import JudgeError, call_judge
 from nemo_gym.openai_utils import NeMoGymResponse, NeMoGymResponseCreateParamsNonStreaming
+from resources_servers.aalcr.task_data import TaskData
 
 
 LEGACY_JUDGE_PROTOCOL = "legacy_v1_0"
@@ -60,19 +61,8 @@ class AalcrResourcesServerConfig(BaseResourcesServerConfig):
     judge_responses_create_params_overrides: Dict[str, Any]
 
 
-class AALCRVerifyRequest(BaseVerifyRequest):
-    document_category: str
-    document_set_id: str
-    question_id: int
-    question: str
-    answer: str
-    data_source_filenames: str
-    data_source_urls: str
-    input_tokens: int
-    input_tokens_band: str
-    aa_lcr_version: str = "1.0.0"
-    aa_lcr_dataset_revision: str = V1_0_DATASET_REVISION
-    aa_lcr_judge_protocol: JudgeProtocol = LEGACY_JUDGE_PROTOCOL
+class AALCRVerifyRequest(TaskData, BaseVerifyRequest):
+    pass
 
 
 class AALCRVerifyResponse(AALCRVerifyRequest, BaseVerifyResponse):

--- a/resources_servers/aalcr/app.py
+++ b/resources_servers/aalcr/app.py
@@ -64,9 +64,6 @@ class AalcrResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class AALCRVerifyRequest(TaskData, BaseVerifyRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/abstention/app.py
+++ b/resources_servers/abstention/app.py
@@ -50,6 +50,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
 )
+from resources_servers.abstention.task_data import TaskData
 
 
 # ---------------------------------------------------------------------------
@@ -263,12 +264,11 @@ class AbstentionConfig(BaseResourcesServerConfig):
     incorrect_reward: float = Field(default=0.0, description="Reward for an incorrect answer.")
 
 
-class AbstentionRunRequest(BaseRunRequest):
+class AbstentionRunRequest(TaskData, BaseRunRequest):
     model_config = ConfigDict(extra="allow")
 
     id: Optional[Union[int, str]] = None
     question: Optional[str] = None
-    answer: Optional[str] = None
 
 
 class AbstentionVerifyRequest(AbstentionRunRequest, BaseVerifyRequest):

--- a/resources_servers/abstention/app.py
+++ b/resources_servers/abstention/app.py
@@ -31,7 +31,7 @@ INCORRECT, or NOT_ATTEMPTED. NOT_ATTEMPTED is treated as implicit abstention.
 from __future__ import annotations
 
 import re
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from fastapi import FastAPI
 from pydantic import ConfigDict, Field
@@ -266,9 +266,6 @@ class AbstentionConfig(BaseResourcesServerConfig):
 
 class AbstentionRunRequest(TaskData, BaseRunRequest):
     model_config = ConfigDict(extra="allow")
-
-    id: Optional[Union[int, str]] = None
-    question: Optional[str] = None
 
 
 class AbstentionVerifyRequest(AbstentionRunRequest, BaseVerifyRequest):

--- a/resources_servers/abstention/task_data.py
+++ b/resources_servers/abstention/task_data.py
@@ -2,27 +2,38 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the abstention server.
 
-Judge-QA family heir: extends simpleqa's ``JudgeQATaskDataCore`` (optional id + question) with
-the ground truth under the name ``answer`` instead of the family's ``expected_answer``. The LLM
-judge grades the extracted ``\\boxed{}`` answer against it; an abstention-token match
-short-circuits the judge. Required-ness mirrors ``AbstentionRunRequest`` (app.py): every task
-field is Optional on the wire (verify() reads ``body.answer or ""`` / ``body.question or ""``)
-with ``extra="allow"``.
+An optional id + question + ground truth (named ``answer``). The LLM judge grades the extracted
+``\\boxed{}`` answer against ``answer``; an abstention-token match short-circuits the judge.
+Required-ness mirrors ``AbstentionRunRequest`` (app.py): every task field is Optional on the wire
+(verify() reads ``body.answer or ""`` / ``body.question or ""``) with ``extra="allow"``.
 """
 
-from typing import Optional
+from typing import Optional, Union
 
-from pydantic import Field
-
-from resources_servers.simpleqa.task_data import JudgeQATaskDataCore
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class TaskData(JudgeQATaskDataCore):
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: Optional[Union[int, str]] = Field(
+        default=None,
+        description="Ride-along task identifier; never read by verify() or metrics.",
+        json_schema_extra={"consumed_by": ["provenance"]},
+    )
+    question: Optional[str] = Field(
+        default=None,
+        description=(
+            "Question text interpolated into the LLM-judge prompt ({question} placeholder); "
+            "verify() falls back to '' when absent."
+        ),
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
     answer: Optional[str] = Field(
         default=None,
         description=(
             "Ground-truth answer the LLM judge grades the extracted \\boxed{} answer against; verify() "
-            "falls back to '' when absent. Family twin of simpleqa's expected_answer under another name."
+            "falls back to '' when absent."
         ),
         json_schema_extra={"consumed_by": ["verify"]},
     )

--- a/resources_servers/arc_agi/app.py
+++ b/resources_servers/arc_agi/app.py
@@ -25,17 +25,15 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.arc_agi.task_data import TaskData
 
 
 class ARCAGIResourcesServerConfig(BaseResourcesServerConfig):
     pass
 
 
-class ARCAGIRunRequest(BaseRunRequest):
-    train: List[dict] = []
-    test_input: List[List[int]] = []
-    expected_output: List[List[int]] = []
-    task_id: Optional[str] = None
+class ARCAGIRunRequest(TaskData, BaseRunRequest):
+    pass
 
 
 class ARCAGIVerifyRequest(ARCAGIRunRequest, BaseVerifyRequest):

--- a/resources_servers/arc_agi/app.py
+++ b/resources_servers/arc_agi/app.py
@@ -17,6 +17,7 @@ import re
 from typing import List, Optional
 
 from fastapi import FastAPI
+from pydantic import ConfigDict
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -33,7 +34,10 @@ class ARCAGIResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class ARCAGIRunRequest(TaskData, BaseRunRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class ARCAGIVerifyRequest(ARCAGIRunRequest, BaseVerifyRequest):

--- a/resources_servers/arc_agi/app.py
+++ b/resources_servers/arc_agi/app.py
@@ -34,9 +34,6 @@ class ARCAGIResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class ARCAGIRunRequest(TaskData, BaseRunRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/arc_agi/task_data.py
+++ b/resources_servers/arc_agi/task_data.py
@@ -5,8 +5,7 @@
 Task fields ride at the row top level (no verifier_metadata). All four fields carry permissive
 defaults on the wire (ARCAGIRunRequest), so none is required here. verify() reads only
 ``expected_output`` (exact grid equality against the parsed ``\\boxed{[[...]]}`` answer);
-``train``/``test_input`` exist because the same fields seed the prompt. nvarc's TaskData
-subclasses this model.
+``train``/``test_input`` exist because the same fields seed the prompt.
 """
 
 from typing import Any, Dict, List, Optional

--- a/resources_servers/arena_judge/app.py
+++ b/resources_servers/arena_judge/app.py
@@ -67,6 +67,7 @@ from nemo_gym.reward_profile import (
     compute_subset_metrics,
     highest_k_metrics,
 )
+from resources_servers.arena_judge.task_data import TaskData
 
 
 logger = logging.getLogger(__name__)
@@ -135,7 +136,7 @@ class ArenaJudgeConfig(BaseResourcesServerConfig):
     sanitize_generations: bool = False
 
 
-class ArenaJudgeRunRequest(BaseRunRequest):
+class ArenaJudgeRunRequest(TaskData, BaseRunRequest):
     """Run request with per-task fields flowed through from the JSONL row.
 
     The JSONL rows produced by ``benchmarks/arena_hard_v2/prepare.py``
@@ -144,11 +145,6 @@ class ArenaJudgeRunRequest(BaseRunRequest):
     """
 
     model_config = ConfigDict(extra="allow")
-
-    question: Optional[str] = None
-    baseline_answer: Optional[str] = None
-    category: Optional[str] = None
-    uid: Optional[str] = None
 
 
 class ArenaJudgeVerifyRequest(ArenaJudgeRunRequest, BaseVerifyRequest):

--- a/resources_servers/asr_with_pc/app.py
+++ b/resources_servers/asr_with_pc/app.py
@@ -46,6 +46,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.reward_profile import compute_pass_majority_metrics, highest_k_metrics
+from resources_servers.asr_with_pc.task_data import TaskData
 
 
 # Hallucination detection: chars/min above this rate signal repetition/hallucination.
@@ -232,17 +233,10 @@ class ASRWithPCConfig(BaseResourcesServerConfig):
     task_type: _TASK_TYPES = "ASR-PC"
 
 
-class ASRWithPCVerifyRequest(BaseVerifyRequest):
+class ASRWithPCVerifyRequest(TaskData, BaseVerifyRequest):
     # Allow benchmark-specific reference fields (e.g. ``text_tn``,
     # ``text_itn`` for ASR_LEADERBOARD) to ride on the request.
     model_config = ConfigDict(extra="allow")
-
-    expected_answer: str = ""
-    sample_id: Optional[str] = None
-    split: Optional[str] = None
-    task_type: Optional[_TASK_TYPES] = None
-    audio_duration: Optional[float] = None
-    reference_fields: Optional[List[str]] = None
 
 
 class ASRWithPCVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/aviary/task_data.py
+++ b/resources_servers/aviary/task_data.py
@@ -6,7 +6,7 @@ Stateful environment: the row is a pointer whose only task datum is ``task_idx``
 index into an aviary ``TaskDataset`` supplied OUT of the row by the concrete subclass server
 (the aviary_bbh / aviary_bixbench / aviary_gsm8k / aviary_hotpotqa environments). Reward
 accumulates server-side across /step calls keyed by env_id; verify() reads that state, never the
-row. toolsandbox's TaskData subclasses this model.
+row.
 """
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/resources_servers/bird_sql/app.py
+++ b/resources_servers/bird_sql/app.py
@@ -31,6 +31,7 @@ from nemo_gym.reward_profile import (
 )
 from resources_servers.bird_sql.eval_utils import execute_and_compare
 from resources_servers.bird_sql.setup_bird_sql import ensure_bird_sql
+from resources_servers.bird_sql.task_data import TaskData
 
 
 logger = logging.getLogger(__name__)
@@ -92,14 +93,8 @@ class BirdSqlResourcesServerConfig(BaseResourcesServerConfig):
     sql_execution_timeout_s: float = 30.0
 
 
-class BirdSqlVerifyRequest(BaseVerifyRequest):
+class BirdSqlVerifyRequest(TaskData, BaseVerifyRequest):
     model_config = ConfigDict(extra="allow")
-
-    question: str
-    gt_sql: str
-    db_id: str
-    difficulty: Optional[str] = None
-    id: Optional[int] = None
 
 
 class BirdSqlVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/browsecomp_advanced_harness/task_data.py
+++ b/resources_servers/browsecomp_advanced_harness/task_data.py
@@ -2,17 +2,29 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the browsecomp_advanced_harness server.
 
-This server reuses the tavily_search lineage: its app.py redeclares ``TavilySearchRunRequest``
-with the identical two required fields (question, ground_truth), so the task schema is imported
-from tavily_search rather than redefined. Rows additionally carry tools inside
-``responses_create_params`` (framework-owned, not typed here). verify() branches on server
-config.use_judge — LLM judge against ground_truth, or (when use_judge=false) exact string
-equality between ground_truth and the span extracted from the last assistant message by a fixed
-"Answer: ... Confidence:" pattern; ground_truth is never interpreted as a regex.
+Two required top-level strings, mirroring ``TavilySearchRunRequest`` as redeclared in this
+server's app.py. Rows additionally carry tools inside ``responses_create_params``
+(framework-owned, not typed here). verify() branches on server config.use_judge — LLM judge
+against ground_truth, or (when use_judge=false) exact string equality between ground_truth and
+the span extracted from the last assistant message by a fixed "Answer: ... Confidence:" pattern;
+ground_truth is never interpreted as a regex.
 """
 
-from resources_servers.tavily_search.task_data import TaskData as TavilySearchTaskData
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class TaskData(TavilySearchTaskData):
-    """BrowseComp rows validate against the shared tavily_search task schema (no extra fields)."""
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    question: str = Field(
+        description="The search question posed to the agent; also fed to the LLM judge prompt.",
+        json_schema_extra={"consumed_by": ["verify", "prompt"]},
+    )
+    ground_truth: str = Field(
+        description=(
+            "Reference answer. Judge target when config.use_judge=true; otherwise compared for "
+            "exact string equality against the span extracted (by a fixed 'Answer: ... Confidence:' "
+            "pattern) from the last assistant message — never interpreted as a regex."
+        ),
+        json_schema_extra={"consumed_by": ["verify"]},
+    )

--- a/resources_servers/bunsenbench_chemistry_mcq/app.py
+++ b/resources_servers/bunsenbench_chemistry_mcq/app.py
@@ -12,6 +12,7 @@ from typing import Any, ClassVar, Optional
 
 from nemo_gym.base_resources_server import ReverifyMode
 from nemo_gym.reward_profile import compute_pass_majority_metrics, highest_k_metrics
+from resources_servers.bunsenbench_chemistry_mcq.task_data import TaskData
 from resources_servers.mcqa.app import (
     MCQAResourcesServer,
     MCQAResourcesServerConfig,
@@ -27,12 +28,8 @@ class BunsenChemResourcesServerConfig(MCQAResourcesServerConfig):
     REVERIFY_MODE: ClassVar[ReverifyMode] = ReverifyMode.UNKNOWN
 
 
-class BunsenChemVerifyRequest(MCQAVerifyRequest):
-    bunsen_id: Optional[str] = None
-    choices: Optional[list[str | dict[str, Any]]] = None
-    source: Optional[str] = None
-    bct_field: Optional[str] = None
-    bct_subfield: Optional[str] = None
+class BunsenChemVerifyRequest(TaskData, MCQAVerifyRequest):
+    pass
 
 
 class BunsenChemVerifyResponse(MCQAVerifyResponse):

--- a/resources_servers/bunsenbench_chemistry_mcq/app.py
+++ b/resources_servers/bunsenbench_chemistry_mcq/app.py
@@ -10,6 +10,8 @@ import unicodedata
 from collections import defaultdict
 from typing import Any, ClassVar, Optional
 
+from pydantic import ConfigDict
+
 from nemo_gym.base_resources_server import ReverifyMode
 from nemo_gym.reward_profile import compute_pass_majority_metrics, highest_k_metrics
 from resources_servers.bunsenbench_chemistry_mcq.task_data import TaskData
@@ -29,7 +31,10 @@ class BunsenChemResourcesServerConfig(MCQAResourcesServerConfig):
 
 
 class BunsenChemVerifyRequest(TaskData, MCQAVerifyRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class BunsenChemVerifyResponse(MCQAVerifyResponse):

--- a/resources_servers/bunsenbench_chemistry_mcq/app.py
+++ b/resources_servers/bunsenbench_chemistry_mcq/app.py
@@ -31,9 +31,6 @@ class BunsenChemResourcesServerConfig(MCQAResourcesServerConfig):
 
 
 class BunsenChemVerifyRequest(TaskData, MCQAVerifyRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/circle_click/app.py
+++ b/resources_servers/circle_click/app.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 import json
 import math
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from fastapi import FastAPI
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -25,6 +25,7 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.circle_click.task_data import TaskData
 
 
 class CircleClickConfig(BaseResourcesServerConfig):
@@ -41,9 +42,8 @@ class ClickResponse(BaseModel):
     y: Any
 
 
-class CircleClickVerifyRequest(BaseVerifyRequest):
-    circles: List[Dict[str, Any]] = Field(default_factory=list)
-    target_color: str = ""
+class CircleClickVerifyRequest(TaskData, BaseVerifyRequest):
+    pass
 
 
 class CircleClickVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/circle_click/app.py
+++ b/resources_servers/circle_click/app.py
@@ -43,9 +43,6 @@ class ClickResponse(BaseModel):
 
 
 class CircleClickVerifyRequest(TaskData, BaseVerifyRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/circle_click/app.py
+++ b/resources_servers/circle_click/app.py
@@ -17,7 +17,7 @@ import math
 from typing import Any, Dict, Optional
 
 from fastapi import FastAPI
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -43,7 +43,10 @@ class ClickResponse(BaseModel):
 
 
 class CircleClickVerifyRequest(TaskData, BaseVerifyRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class CircleClickVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/circle_count/app.py
+++ b/resources_servers/circle_count/app.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
-from typing import Any, Dict, List, Optional
+from typing import Optional
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -21,15 +21,15 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.circle_count.task_data import TaskData
 
 
 class CircleCountConfig(BaseResourcesServerConfig):
     pass
 
 
-class CircleCountVerifyRequest(BaseVerifyRequest):
-    circles: List[Dict[str, Any]] = []
-    target_color: str = ""
+class CircleCountVerifyRequest(TaskData, BaseVerifyRequest):
+    pass
 
 
 class CircleCountVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/circle_count/app.py
+++ b/resources_servers/circle_count/app.py
@@ -15,6 +15,8 @@
 import re
 from typing import Optional
 
+from pydantic import ConfigDict
+
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
     BaseVerifyRequest,
@@ -29,7 +31,10 @@ class CircleCountConfig(BaseResourcesServerConfig):
 
 
 class CircleCountVerifyRequest(TaskData, BaseVerifyRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class CircleCountVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/circle_count/app.py
+++ b/resources_servers/circle_count/app.py
@@ -31,9 +31,6 @@ class CircleCountConfig(BaseResourcesServerConfig):
 
 
 class CircleCountVerifyRequest(TaskData, BaseVerifyRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/code_fim/task_data.py
+++ b/resources_servers/code_fim/task_data.py
@@ -6,8 +6,7 @@ Pointer rows: the only task-owned field is ``verifier_metadata.task_id``. The ac
 payload (prefix/prompt, suffix, tests, entry point) lives OUT of the row, in the
 ``human_eval_infilling`` package: it is loaded at server startup via
 ``read_problems(config.split)`` (split: single_line | multi_line | random_span |
-random_span_light) and looked up by task_id at verify time. evalplus's TaskData subclasses this
-model — same pointer shape, different task-id namespace.
+random_span_light) and looked up by task_id at verify time.
 """
 
 from typing import Optional

--- a/resources_servers/competitive_coding_challenges/app.py
+++ b/resources_servers/competitive_coding_challenges/app.py
@@ -29,6 +29,7 @@ from nemo_gym.base_resources_server import (
 )
 from nemo_gym.reward_profile import compute_pass_majority_metrics, highest_k_metrics
 from resources_servers.competitive_coding_challenges.ccc_eval import CCCEvaluator
+from resources_servers.competitive_coding_challenges.task_data import TaskData
 
 
 LOG = logging.getLogger(__name__)
@@ -36,14 +37,8 @@ LOG = logging.getLogger(__name__)
 LOG_JSONL_PATH = os.environ.get("CCC_LOG_JSONL_PATH", None)
 
 
-class CompetitiveCodingChallengesVerifyRequest(BaseVerifyRequest):
+class CompetitiveCodingChallengesVerifyRequest(TaskData, BaseVerifyRequest):
     model_config = ConfigDict(extra="allow")
-
-    competition_id: Optional[str] = None
-    problem_id: str
-    subtask: Optional[str] = None
-    name: Optional[str] = None
-    subtask_score: Optional[float] = None
 
 
 class CompetitiveCodingChallengesVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/conversational_tool_use_simulation/app.py
+++ b/resources_servers/conversational_tool_use_simulation/app.py
@@ -42,6 +42,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
 )
 from nemo_gym.server_utils import SESSION_ID_KEY, get_response_json, raise_for_status, rollout_path_prefix
+from resources_servers.conversational_tool_use_simulation.task_data import TaskData
 
 
 TRAJECTORY_COMPLETE_INDICATOR = "###STOP###"
@@ -425,7 +426,7 @@ class DiscardSessionResponse(BaseModel):
     discarded: bool
 
 
-class ConversationalToolUseVerifyRequest(BaseVerifyRequest):
+class ConversationalToolUseVerifyRequest(TaskData, BaseVerifyRequest):
     model_config = ConfigDict(extra="allow")
 
 

--- a/resources_servers/conversational_tool_use_simulation/app.py
+++ b/resources_servers/conversational_tool_use_simulation/app.py
@@ -42,7 +42,6 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
 )
 from nemo_gym.server_utils import SESSION_ID_KEY, get_response_json, raise_for_status, rollout_path_prefix
-from resources_servers.conversational_tool_use_simulation.task_data import TaskData
 
 
 TRAJECTORY_COMPLETE_INDICATOR = "###STOP###"
@@ -426,7 +425,9 @@ class DiscardSessionResponse(BaseModel):
     discarded: bool
 
 
-class ConversationalToolUseVerifyRequest(TaskData, BaseVerifyRequest):
+class ConversationalToolUseVerifyRequest(BaseVerifyRequest):
+    # Not inheriting TaskData: this stateful server consumes task fields at seed_session, and
+    # verify() reads none of them, so the verify wire must not require row fields.
     model_config = ConfigDict(extra="allow")
 
 

--- a/resources_servers/equivalence_llm_judge/app.py
+++ b/resources_servers/equivalence_llm_judge/app.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import asyncio
 import re
 from contextlib import nullcontext
-from typing import Any, Optional
+from typing import Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel, ConfigDict
@@ -43,6 +43,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
 )
+from resources_servers.equivalence_llm_judge.task_data import TaskData
 
 
 class LLMJudgeResourcesServerConfig(BaseResourcesServerConfig):
@@ -110,7 +111,7 @@ class LLMJudgeResourcesServerConfig(BaseResourcesServerConfig):
     reward_if_full_generation_succeeds: float = 0.5
 
 
-class LLMJudgeRunRequest(BaseRunRequest):
+class LLMJudgeRunRequest(TaskData, BaseRunRequest):
     """Run/verify request payload.
 
     Compatible with MCQA-like datasets. Only `expected_answer` is required for
@@ -118,11 +119,6 @@ class LLMJudgeRunRequest(BaseRunRequest):
     """
 
     model_config = ConfigDict(extra="allow")
-
-    uuid: Optional[str | int] = None
-    expected_answer: Optional[str] = None
-    options: Optional[list[dict[str, str]]] = None
-    metadata: Optional[dict[str, Any]] = None
 
 
 class LLMJudgeVerifyRequest(LLMJudgeRunRequest, BaseVerifyRequest):

--- a/resources_servers/equivalence_rule/app.py
+++ b/resources_servers/equivalence_rule/app.py
@@ -31,6 +31,7 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.equivalence_rule.task_data import TaskData
 
 
 class GradingRule(str, Enum):
@@ -45,10 +46,8 @@ class EquivalenceRuleResourcesServerConfig(BaseResourcesServerConfig):
     grading_rule: GradingRule = GradingRule.EXACT
 
 
-class EquivalenceRuleRunRequest(BaseRunRequest):
-    model_config = ConfigDict(extra="allow")
-
-    expected_answer: str
+class EquivalenceRuleRunRequest(TaskData, BaseRunRequest):
+    pass
 
 
 class EquivalenceRuleVerifyRequest(EquivalenceRuleRunRequest, BaseVerifyRequest):

--- a/resources_servers/equivalence_rule/task_data.py
+++ b/resources_servers/equivalence_rule/task_data.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the equivalence_rule server.
 
-Required-expected_answer QA family heir: extends hotpotqa_qa's ``ExpectedAnswerTaskDataCore``.
 ``expected_answer`` is the only field ``verify()`` consumes (graded by the config-selected rule:
 exact / seq_match / weighted_seq_match on normalized strings); question/dataset/source/hashid/
 context_length are long-context (mrcr-style) provenance passthrough surviving via
@@ -12,12 +11,16 @@ context_length are long-context (mrcr-style) provenance passthrough surviving vi
 
 from typing import Optional, Union
 
-from pydantic import Field
-
-from resources_servers.hotpotqa_qa.task_data import ExpectedAnswerTaskDataCore
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class TaskData(ExpectedAnswerTaskDataCore):
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    expected_answer: str = Field(
+        description="Required ground-truth answer string; the only row field verify() consumes.",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
     question: Optional[str] = Field(
         default=None,
         description="Task instruction/question text; provenance only (the prompt lives in the input messages).",

--- a/resources_servers/evalplus/task_data.py
+++ b/resources_servers/evalplus/task_data.py
@@ -2,15 +2,25 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the evalplus server.
 
-Same pointer shape as code_fim (imported, not redefined): rows carry only
-``verifier_metadata.task_id``. Here task_id is an EvalPlus key such as 'HumanEval/0' or 'Mbpp/2';
-prompts, tests, and ground truth live OUT of the row in the ``evalplus`` package, selected by
-``config.dataset`` (humaneval | mbpp) at server startup. Both dataset flows share this row shape
-— only the task_id namespace differs.
+Pointer rows: the only task-owned field is ``verifier_metadata.task_id``, an EvalPlus key such as
+'HumanEval/0' or 'Mbpp/2'. Prompts, tests, and ground truth live OUT of the row in the
+``evalplus`` package, selected by ``config.dataset`` (humaneval | mbpp) at server startup. Both
+dataset flows share this row shape — only the task_id namespace differs.
 """
 
-from resources_servers.code_fim.task_data import TaskData as CodeFIMTaskData
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class TaskData(CodeFIMTaskData):
-    """EvalPlus pointer row; ``task_id`` is namespaced 'HumanEval/<n>' or 'Mbpp/<n>'."""
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    task_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Key into the out-of-row EvalPlus problem registry, namespaced 'HumanEval/<n>' or 'Mbpp/<n>'. "
+            "Wire-optional: verify() reads it via .get() and scores 0.0 with an error when missing or unknown."
+        ),
+        json_schema_extra={"consumed_by": ["verify"], "legacy_location": "verifier_metadata"},
+    )

--- a/resources_servers/example_multi_step/app.py
+++ b/resources_servers/example_multi_step/app.py
@@ -25,6 +25,7 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.example_multi_step.task_data import TaskData
 
 
 class ExampleMultiStepResourcesServerConfig(BaseResourcesServerConfig):
@@ -47,12 +48,8 @@ class ExtractSynonymValuesResponse(BaseModel):
     success: bool
 
 
-class ExampleMultiStepRunRequest(BaseRunRequest):
-    id: int
-    expected_synonym_values: List[int]
-    expected_synonyms: List[str]
-    minefield_label: str
-    minefield_label_value: int
+class ExampleMultiStepRunRequest(TaskData, BaseRunRequest):
+    pass
 
 
 class ExampleMultiStepVerifyRequest(ExampleMultiStepRunRequest, BaseVerifyRequest):

--- a/resources_servers/example_multi_step/app.py
+++ b/resources_servers/example_multi_step/app.py
@@ -49,9 +49,6 @@ class ExtractSynonymValuesResponse(BaseModel):
 
 
 class ExampleMultiStepRunRequest(TaskData, BaseRunRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/example_multi_step/app.py
+++ b/resources_servers/example_multi_step/app.py
@@ -16,7 +16,7 @@ import json
 from typing import List
 
 from fastapi import FastAPI
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -49,7 +49,10 @@ class ExtractSynonymValuesResponse(BaseModel):
 
 
 class ExampleMultiStepRunRequest(TaskData, BaseRunRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class ExampleMultiStepVerifyRequest(ExampleMultiStepRunRequest, BaseVerifyRequest):

--- a/resources_servers/example_session_state_mgmt/app.py
+++ b/resources_servers/example_session_state_mgmt/app.py
@@ -26,6 +26,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.server_utils import SESSION_ID_KEY
+from resources_servers.example_session_state_mgmt.task_data import TaskData
 
 
 class StatefulCounterResourcesServerConfig(BaseResourcesServerConfig):
@@ -44,8 +45,8 @@ class GetCounterValueResponse(BaseModel):
     count: int
 
 
-class StatefulCounterVerifyRequest(BaseVerifyRequest):
-    expected_count: int
+class StatefulCounterVerifyRequest(TaskData, BaseVerifyRequest):
+    pass
 
 
 class StatefulCounterSeedSessionRequest(BaseSeedSessionRequest):

--- a/resources_servers/example_session_state_mgmt/app.py
+++ b/resources_servers/example_session_state_mgmt/app.py
@@ -15,7 +15,7 @@
 from typing import Dict
 
 from fastapi import FastAPI, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -46,7 +46,10 @@ class GetCounterValueResponse(BaseModel):
 
 
 class StatefulCounterVerifyRequest(TaskData, BaseVerifyRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class StatefulCounterSeedSessionRequest(BaseSeedSessionRequest):

--- a/resources_servers/example_session_state_mgmt/app.py
+++ b/resources_servers/example_session_state_mgmt/app.py
@@ -46,9 +46,6 @@ class GetCounterValueResponse(BaseModel):
 
 
 class StatefulCounterVerifyRequest(TaskData, BaseVerifyRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/example_tool_call_multireward/app.py
+++ b/resources_servers/example_tool_call_multireward/app.py
@@ -47,6 +47,7 @@ from nemo_gym.base_resources_server import (
     BaseVerifyRequest,
     SimpleResourcesServer,
 )
+from resources_servers.example_tool_call_multireward.task_data import TaskData
 
 
 class ToolCallMultiRewardResourcesServerConfig(BaseResourcesServerConfig):
@@ -62,10 +63,10 @@ class GetWeatherResponse(BaseModel):
     weather_description: str
 
 
-class ToolCallMultiRewardVerifyRequest(BaseVerifyRequest):
+class ToolCallMultiRewardVerifyRequest(TaskData, BaseVerifyRequest):
+    pass
     # The single tool call the model is expected to make, e.g.
     # {"name": "get_weather", "arguments": {"city": "San Francisco"}}.
-    expected_call: Dict[str, Any] = Field(default_factory=dict)
 
 
 class ToolCallMultiRewardVerifyResponse(BaseMultiRewardVerifyResponse):

--- a/resources_servers/example_tool_call_multireward/app.py
+++ b/resources_servers/example_tool_call_multireward/app.py
@@ -39,7 +39,7 @@ import json
 from typing import Any, Dict, List
 
 from fastapi import FastAPI
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from nemo_gym.base_resources_server import (
     BaseMultiRewardVerifyResponse,
@@ -64,7 +64,10 @@ class GetWeatherResponse(BaseModel):
 
 
 class ToolCallMultiRewardVerifyRequest(TaskData, BaseVerifyRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
     # The single tool call the model is expected to make, e.g.
     # {"name": "get_weather", "arguments": {"city": "San Francisco"}}.
 

--- a/resources_servers/example_tool_call_multireward/app.py
+++ b/resources_servers/example_tool_call_multireward/app.py
@@ -64,9 +64,6 @@ class GetWeatherResponse(BaseModel):
 
 
 class ToolCallMultiRewardVerifyRequest(TaskData, BaseVerifyRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
     # The single tool call the model is expected to make, e.g.
     # {"name": "get_weather", "arguments": {"city": "San Francisco"}}.

--- a/resources_servers/finance_sec_search/task_data.py
+++ b/resources_servers/finance_sec_search/task_data.py
@@ -2,24 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the finance_sec_search server.
 
-Wire-identical to math_with_judge's two-field core: ``FinanceAgentRunRequest`` (app.py:321)
-requires ``question`` and ``expected_answer``, so this schema reuses the family parent and only
-re-annotates ``question``. Quirk: verify() (app.py:1300) never reads ``body.question`` — it
-re-extracts the question from the last user message in ``responses_create_params.input`` when
-filling the judge prompt — but the field stays required because the wire 422s without it. Scoring
-compares the agent's submit_final_result payload against ``expected_answer`` via an LLM judge,
-falling back to case-insensitive substring match when no judge_model_server is configured.
+``FinanceAgentRunRequest`` (app.py:321) requires ``question`` and ``expected_answer``. Quirk:
+verify() (app.py:1300) never reads ``body.question`` — it re-extracts the question from the last
+user message in ``responses_create_params.input`` when filling the judge prompt — but the field
+stays required because the wire 422s without it. Scoring compares the agent's submit_final_result
+payload against ``expected_answer`` via an LLM judge, falling back to case-insensitive substring
+match when no judge_model_server is configured.
 
 Only ``data/example.jsonl`` contains task rows; ``example_questions.jsonl`` is a pre-conversion
 question source (no responses_create_params) and ``example_rollouts.jsonl`` is rollout output.
 """
 
-from pydantic import Field
-
-from resources_servers.math_with_judge.task_data import TaskData as MathWithJudgeTaskData
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class TaskData(MathWithJudgeTaskData):
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     question: str = Field(
         description=(
             "The SEC-filings research question. Wire-required but unread by verify(), which re-extracts "

--- a/resources_servers/format_verification/app.py
+++ b/resources_servers/format_verification/app.py
@@ -23,13 +23,16 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.format_verification.task_data import TaskData
 
 
 class FormatVerificationResourcesServerConfig(BaseResourcesServerConfig):
     pass
 
 
-class FormatVerificationVerifyRequest(BaseVerifyRequest):
+class FormatVerificationVerifyRequest(TaskData, BaseVerifyRequest):
+    # Redeclared: verify() dispatches on verifier.get("type") and reads it as a plain dict,
+    # so the task_data union types must not replace it on the wire.
     verifier: Dict[str, Any]
 
 

--- a/resources_servers/format_verification/app.py
+++ b/resources_servers/format_verification/app.py
@@ -16,6 +16,7 @@ import re
 from typing import Any, Dict, List, Tuple
 
 from fastapi import FastAPI
+from pydantic import ConfigDict
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -33,6 +34,10 @@ class FormatVerificationResourcesServerConfig(BaseResourcesServerConfig):
 class FormatVerificationVerifyRequest(TaskData, BaseVerifyRequest):
     # Redeclared: verify() dispatches on verifier.get("type") and reads it as a plain dict,
     # so the task_data union types must not replace it on the wire.
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
     verifier: Dict[str, Any]
 
 

--- a/resources_servers/format_verification/app.py
+++ b/resources_servers/format_verification/app.py
@@ -32,11 +32,7 @@ class FormatVerificationResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class FormatVerificationVerifyRequest(TaskData, BaseVerifyRequest):
-    # Redeclared: verify() dispatches on verifier.get("type") and reads it as a plain dict,
-    # so the task_data union types must not replace it on the wire.
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    # Redeclared: verify() reads this as a plain dict.
     model_config = ConfigDict(extra="ignore")
     verifier: Dict[str, Any]
 

--- a/resources_servers/frontierscience_judge/app.py
+++ b/resources_servers/frontierscience_judge/app.py
@@ -60,6 +60,7 @@ from nemo_gym.reward_profile import (
     compute_subset_metrics,
     highest_k_metrics,
 )
+from resources_servers.frontierscience_judge.task_data import TaskData
 
 
 _DEFAULT_JUDGE_PROMPT_PATH = str(Path(__file__).parent / "prompts" / "judge.yaml")
@@ -208,14 +209,12 @@ class FrontierScienceJudgeConfig(BaseResourcesServerConfig):
     )
 
 
-class FrontierScienceJudgeRunRequest(BaseRunRequest):
+class FrontierScienceJudgeRunRequest(TaskData, BaseRunRequest):
     model_config = ConfigDict(extra="allow")
 
     id: Optional[Union[int, str]] = None
-    subject: Optional[str] = None
     question: Optional[str] = None
     expected_answer: Optional[str] = None
-    rubric: Optional[str] = None
 
 
 class FrontierScienceJudgeVerifyRequest(FrontierScienceJudgeRunRequest, BaseVerifyRequest):

--- a/resources_servers/frontierscience_judge/app.py
+++ b/resources_servers/frontierscience_judge/app.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Optional
 
 import yaml
 from pydantic import ConfigDict, Field
@@ -211,10 +211,6 @@ class FrontierScienceJudgeConfig(BaseResourcesServerConfig):
 
 class FrontierScienceJudgeRunRequest(TaskData, BaseRunRequest):
     model_config = ConfigDict(extra="allow")
-
-    id: Optional[Union[int, str]] = None
-    question: Optional[str] = None
-    expected_answer: Optional[str] = None
 
 
 class FrontierScienceJudgeVerifyRequest(FrontierScienceJudgeRunRequest, BaseVerifyRequest):

--- a/resources_servers/frontierscience_judge/task_data.py
+++ b/resources_servers/frontierscience_judge/task_data.py
@@ -2,21 +2,41 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the frontierscience_judge server.
 
-Judge-QA family heir: extends simpleqa's ``TaskData`` (optional id/question/expected_answer,
-all read defensively by the LLM-judge ``verify()``) with a ``subject`` metrics column and an
-optional ``rubric`` used by the research judge_mode. Required-ness mirrors
-``FrontierScienceJudgeRunRequest`` (app.py): every task field is Optional on the wire with
-``extra="allow"``.
+An optional id/question/expected_answer, all read defensively by the LLM-judge ``verify()``, plus
+a ``subject`` metrics column and an optional ``rubric`` used by the research judge_mode.
+Required-ness mirrors ``FrontierScienceJudgeRunRequest`` (app.py): every task field is Optional
+on the wire with ``extra="allow"``.
 """
 
-from typing import Optional
+from typing import Optional, Union
 
-from pydantic import Field
-
-from resources_servers.simpleqa.task_data import TaskData as SimpleQATaskData
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class TaskData(SimpleQATaskData):
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: Optional[Union[int, str]] = Field(
+        default=None,
+        description="Ride-along task identifier; never read by verify() or metrics.",
+        json_schema_extra={"consumed_by": ["provenance"]},
+    )
+    question: Optional[str] = Field(
+        default=None,
+        description=(
+            "Question text interpolated into the LLM-judge prompt ({question} placeholder); "
+            "verify() falls back to '' when absent."
+        ),
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    expected_answer: Optional[str] = Field(
+        default=None,
+        description=(
+            "Ground-truth answer interpolated into the judge prompt; also the rubric fallback in the "
+            "research judge_mode when ``rubric`` is absent. verify() falls back to '' when absent."
+        ),
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
     subject: Optional[str] = Field(
         default=None,
         description=(

--- a/resources_servers/genrm_compare/app.py
+++ b/resources_servers/genrm_compare/app.py
@@ -49,6 +49,7 @@ from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymResponseCreateParamsNonStreaming,
 )
+from resources_servers.genrm_compare.task_data import TaskData
 from resources_servers.genrm_compare.utils import (
     GenRMOutputParseError,
     aggregate_scores,
@@ -144,8 +145,12 @@ class GenRMCompareConfig(BaseResourcesServerConfig):
     genrm_parse_retry_sleep_s: float = 0.2
 
 
-class GenRMCompareVerifyRequest(BaseVerifyRequest):
-    """Verify request with optional principle for cohort-based GenRM comparison."""
+class GenRMCompareVerifyRequest(TaskData, BaseVerifyRequest):
+    """Verify request with optional principle for cohort-based GenRM comparison.
+
+    The fields below are injected by the agent at verify time, not carried by dataset rows,
+    so they stay declared here rather than on TaskData.
+    """
 
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 

--- a/resources_servers/genrm_compare/app.py
+++ b/resources_servers/genrm_compare/app.py
@@ -146,11 +146,7 @@ class GenRMCompareConfig(BaseResourcesServerConfig):
 
 
 class GenRMCompareVerifyRequest(TaskData, BaseVerifyRequest):
-    """Verify request with optional principle for cohort-based GenRM comparison.
-
-    The fields below are injected by the agent at verify time, not carried by dataset rows,
-    so they stay declared here rather than on TaskData.
-    """
+    """Verify request; the fields below are agent-injected at verify time, not dataset rows."""
 
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 

--- a/resources_servers/graphwalks/app.py
+++ b/resources_servers/graphwalks/app.py
@@ -46,17 +46,16 @@ from nemo_gym.reward_profile import (
     compute_subset_metrics,
     highest_k_metrics,
 )
+from resources_servers.graphwalks.task_data import TaskData
 
 
 class GraphWalksResourcesServerConfig(BaseResourcesServerConfig):
     pass
 
 
-class GraphWalksVerifyRequest(BaseVerifyRequest):
+class GraphWalksVerifyRequest(TaskData, BaseVerifyRequest):
     expected_answer: str
-    problem_type: str
     n_tokens: Optional[int] = None
-    prompt_chars: Optional[int] = None
 
 
 class GraphWalksVerifyResponse(GraphWalksVerifyRequest, BaseVerifyResponse):

--- a/resources_servers/graphwalks/app.py
+++ b/resources_servers/graphwalks/app.py
@@ -56,9 +56,6 @@ class GraphWalksResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class GraphWalksVerifyRequest(TaskData, BaseVerifyRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
     expected_answer: str
     n_tokens: Optional[int] = None

--- a/resources_servers/graphwalks/app.py
+++ b/resources_servers/graphwalks/app.py
@@ -35,6 +35,8 @@ import json
 import re
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from pydantic import ConfigDict
+
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
     BaseVerifyRequest,
@@ -54,6 +56,10 @@ class GraphWalksResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class GraphWalksVerifyRequest(TaskData, BaseVerifyRequest):
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
     expected_answer: str
     n_tokens: Optional[int] = None
 

--- a/resources_servers/graphwalks/task_data.py
+++ b/resources_servers/graphwalks/task_data.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the graphwalks server.
 
-Task fields ride at the row top level (no verifier_metadata in data or code). ``GraphWalksCore``
-holds the fields shared with the lc_niah server, whose rows are derived from graphwalks data;
-lc_niah's TaskData imports it instead of redefining. ``problem_type`` is deliberately NOT part of
-the core because its required-ness differs per wire: GraphWalksVerifyRequest requires it, while
-lc_niah's wire only sees it as an untyped extra.
+Task fields ride at the row top level (no verifier_metadata in data or code). ``problem_type`` is
+wire-required (GraphWalksVerifyRequest) and drives the per-subset metrics breakdown.
 """
 
 from typing import Optional
@@ -14,9 +11,7 @@ from typing import Optional
 from pydantic import BaseModel, ConfigDict, Field
 
 
-class GraphWalksCore(BaseModel):
-    """Fields shared by graphwalks and its lc_niah derivative."""
-
+class TaskData(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     expected_answer: str = Field(
@@ -31,9 +26,6 @@ class GraphWalksCore(BaseModel):
         description="Prompt size in tokens; wire-optional passthrough, never read by verify().",
         json_schema_extra={"consumed_by": ["provenance"]},
     )
-
-
-class TaskData(GraphWalksCore):
     problem_type: str = Field(
         description=(
             "Task family, e.g. 'parents' or 'bfs'. Wire-required (GraphWalksVerifyRequest) but unread by "

--- a/resources_servers/gui_coordinate/app.py
+++ b/resources_servers/gui_coordinate/app.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
-from typing import Any, Optional
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -24,6 +24,7 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.gui_coordinate.task_data import TaskData
 
 
 POINT_PATTERN = re.compile(r"<point>\s*\[?\s*\(\s*(\d+)\s*,\s*(\d+)\s*\)\s*\]?\s*</point>")
@@ -33,10 +34,8 @@ class GuiCoordinateResourcesServerConfig(BaseResourcesServerConfig):
     pass
 
 
-class GuiCoordinateRunRequest(BaseRunRequest):
-    expected_answer: str  # "x,y" normalized 0-1 coordinates
-    max_dist: float = 0.15
-    metadata: Optional[dict[str, Any]] = None
+class GuiCoordinateRunRequest(TaskData, BaseRunRequest):
+    pass
 
 
 class GuiCoordinateVerifyRequest(GuiCoordinateRunRequest, BaseVerifyRequest):

--- a/resources_servers/gui_coordinate/app.py
+++ b/resources_servers/gui_coordinate/app.py
@@ -36,9 +36,6 @@ class GuiCoordinateResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class GuiCoordinateRunRequest(TaskData, BaseRunRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/gui_coordinate/app.py
+++ b/resources_servers/gui_coordinate/app.py
@@ -16,6 +16,7 @@ import re
 from typing import Optional
 
 from fastapi import FastAPI
+from pydantic import ConfigDict
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -35,7 +36,10 @@ class GuiCoordinateResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class GuiCoordinateRunRequest(TaskData, BaseRunRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class GuiCoordinateVerifyRequest(GuiCoordinateRunRequest, BaseVerifyRequest):

--- a/resources_servers/hotpotqa_qa/app.py
+++ b/resources_servers/hotpotqa_qa/app.py
@@ -48,6 +48,7 @@ from resources_servers.hotpotqa_qa.scoring import (
     normalize_gt,
     parse_generation,
 )
+from resources_servers.hotpotqa_qa.task_data import TaskData
 
 
 class HotpotQAQAResourcesServerConfig(BaseResourcesServerConfig):
@@ -59,10 +60,8 @@ class HotpotQAQAResourcesServerConfig(BaseResourcesServerConfig):
     report_filtered_metrics: bool = True
 
 
-class HotpotQAQARunRequest(BaseRunRequest):
-    model_config = ConfigDict(extra="allow")
-
-    expected_answer: str
+class HotpotQAQARunRequest(TaskData, BaseRunRequest):
+    pass
 
 
 class HotpotQAQAVerifyRequest(HotpotQAQARunRequest, BaseVerifyRequest):

--- a/resources_servers/hotpotqa_qa/task_data.py
+++ b/resources_servers/hotpotqa_qa/task_data.py
@@ -2,13 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the hotpotqa_qa server.
 
-Parent of the required-expected_answer QA family (hotpotqa_qa, equivalence_rule): the wire
-requires a single ``expected_answer: str`` — the only field ``verify()`` consumes (here graded
+The wire requires a single ``expected_answer: str`` — the only field ``verify()`` consumes (graded
 with SQuAD-normalized exact match and token-overlap F1) — and everything else rides through
-``extra="allow"``. Heirs import ``ExpectedAnswerTaskDataCore`` instead of redefining the field.
-Required-ness mirrors ``HotpotQAQARunRequest`` (app.py): ``expected_answer`` is the sole
-wire-declared field; question/id/type/level are HotpotQA provenance passthrough that nothing
-reads (no subset metrics on type/level).
+``extra="allow"``. Required-ness mirrors ``HotpotQAQARunRequest`` (app.py): ``expected_answer``
+is the sole wire-declared field; question/id/type/level are HotpotQA provenance passthrough that
+nothing reads (no subset metrics on type/level).
 """
 
 from typing import Optional, Union
@@ -16,18 +14,13 @@ from typing import Optional, Union
 from pydantic import BaseModel, ConfigDict, Field
 
 
-class ExpectedAnswerTaskDataCore(BaseModel):
-    """Shared core of the family: a required ground-truth answer string, sole verify() input."""
-
+class TaskData(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     expected_answer: str = Field(
         description="Required ground-truth answer string; the only row field verify() consumes.",
         json_schema_extra={"consumed_by": ["verify"]},
     )
-
-
-class TaskData(ExpectedAnswerTaskDataCore):
     question: Optional[str] = Field(
         default=None,
         description="Original HotpotQA question text; provenance only (the prompt lives in the input messages).",

--- a/resources_servers/image_tools/app.py
+++ b/resources_servers/image_tools/app.py
@@ -50,6 +50,7 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.image_tools.task_data import TaskData
 
 
 # Reuse the exact parser and IoU the image-tools agent uses at rollout time, so
@@ -354,13 +355,8 @@ class ImageToolsPivotResourcesServerConfig(BaseResourcesServerConfig):
     log_unparsed_every_n: int = 50
 
 
-class ImageToolsPivotRunRequest(BaseRunRequest):
+class ImageToolsPivotRunRequest(TaskData, BaseRunRequest):
     model_config = ConfigDict(extra="allow")
-
-    uuid: Optional[str | int] = None
-    expected_action: Optional[dict[str, Any]] = None
-    expected_answer: Optional[str] = None
-    metadata: Optional[dict[str, Any]] = None
 
 
 class ImageToolsPivotVerifyRequest(ImageToolsPivotRunRequest, BaseVerifyRequest):

--- a/resources_servers/imo_gradingbench/app.py
+++ b/resources_servers/imo_gradingbench/app.py
@@ -61,6 +61,7 @@ from nemo_gym.base_resources_server import (
 )
 from nemo_gym.openai_utils import NeMoGymResponse
 from nemo_gym.reward_profile import compute_pass_majority_metrics, highest_k_metrics
+from resources_servers.imo_gradingbench.task_data import TaskData
 
 
 # ---------------------------------------------------------------------------
@@ -173,14 +174,10 @@ class ImoGradingBenchConfig(BaseResourcesServerConfig):
     """
 
 
-class ImoGradingBenchRunRequest(BaseRunRequest):
+class ImoGradingBenchRunRequest(TaskData, BaseRunRequest):
     """Run-time fields carried through the verify response for metrics."""
 
     model_config = ConfigDict(extra="allow")
-
-    expected_answer: Optional[str] = None
-    grading_id: Optional[str] = None
-    problem_id: Optional[str] = None
 
 
 class ImoGradingBenchVerifyRequest(ImoGradingBenchRunRequest, BaseVerifyRequest):

--- a/resources_servers/indirect_prompt_injection/app.py
+++ b/resources_servers/indirect_prompt_injection/app.py
@@ -38,7 +38,13 @@ from resources_servers.indirect_prompt_injection.it_helpdesk_tools import TOOL_H
 from resources_servers.indirect_prompt_injection.legal_tools import TOOL_HANDLERS as LEGAL_HANDLERS
 from resources_servers.indirect_prompt_injection.logistics_tools import TOOL_HANDLERS as LOGISTICS_HANDLERS
 from resources_servers.indirect_prompt_injection.real_estate_tools import TOOL_HANDLERS as REAL_ESTATE_HANDLERS
+from resources_servers.indirect_prompt_injection.task_data import InjectionSpecData, TaskData
 from resources_servers.indirect_prompt_injection.verifier import check_injection_followed, extract_function_calls
+
+
+# The wire model for the row's injection spec now lives in task_data.py; tests and downstream
+# code keep importing it from here under its historical name.
+InjectionSpec = InjectionSpecData
 
 
 TOOL_HANDLERS = {
@@ -61,19 +67,6 @@ class IPIResourcesServerConfig(BaseResourcesServerConfig):
     pass
 
 
-class InjectionSpec(BaseModel):
-    model_config = ConfigDict(extra="allow")
-    goal: str
-    target_tool: str
-    target_args: Dict[str, Any]
-    verification_type: str
-    attack_strategy: str
-    attack_difficulty: str
-    vector: str
-    injection_text: str
-    category: str
-
-
 class IPISeedSessionRequest(BaseSeedSessionRequest):
     environment: Dict[str, Any]
     model_config = ConfigDict(extra="allow")
@@ -88,9 +81,7 @@ class ToolCallResponse(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
-class IPIVerifyRequest(BaseVerifyRequest):
-    injection: InjectionSpec
-    required_tools: List[str] = Field(default_factory=list)
+class IPIVerifyRequest(TaskData, BaseVerifyRequest):
     model_config = ConfigDict(extra="allow")
 
 

--- a/resources_servers/indirect_prompt_injection/app.py
+++ b/resources_servers/indirect_prompt_injection/app.py
@@ -42,8 +42,7 @@ from resources_servers.indirect_prompt_injection.task_data import InjectionSpecD
 from resources_servers.indirect_prompt_injection.verifier import check_injection_followed, extract_function_calls
 
 
-# The wire model for the row's injection spec now lives in task_data.py; tests and downstream
-# code keep importing it from here under its historical name.
+# Historical import name for the spec model, now defined in task_data.py.
 InjectionSpec = InjectionSpecData
 
 

--- a/resources_servers/indirect_prompt_injection/tests/test_app.py
+++ b/resources_servers/indirect_prompt_injection/tests/test_app.py
@@ -242,6 +242,7 @@ class TestApp:
             ]
         )
         verify_request = IPIVerifyRequest(
+            environment=SAMPLE_ENV,
             responses_create_params=SAMPLE_RESPONSES_CREATE_PARAMS,
             response=response,
             injection=SAMPLE_INJECTION,
@@ -258,6 +259,7 @@ class TestApp:
         server = self.init_server(config)
         response = _make_response([])  # No tool calls at all
         verify_request = IPIVerifyRequest(
+            environment=SAMPLE_ENV,
             responses_create_params=SAMPLE_RESPONSES_CREATE_PARAMS,
             response=response,
             injection=SAMPLE_INJECTION,
@@ -282,6 +284,7 @@ class TestApp:
             ]
         )
         verify_request = IPIVerifyRequest(
+            environment=SAMPLE_ENV,
             responses_create_params=SAMPLE_RESPONSES_CREATE_PARAMS,
             response=response,
             injection=SAMPLE_INJECTION,
@@ -302,6 +305,7 @@ class TestApp:
             ]
         )
         verify_request = IPIVerifyRequest(
+            environment=SAMPLE_ENV,
             responses_create_params=SAMPLE_RESPONSES_CREATE_PARAMS,
             response=response,
             injection=SAMPLE_INJECTION,
@@ -319,6 +323,7 @@ class TestApp:
             ]
         )
         verify_request = IPIVerifyRequest(
+            environment=SAMPLE_ENV,
             responses_create_params=SAMPLE_RESPONSES_CREATE_PARAMS,
             response=response,
             injection=SAMPLE_INJECTION,
@@ -341,6 +346,7 @@ class TestApp:
             ]
         )
         verify_request = IPIVerifyRequest(
+            environment=SAMPLE_ENV,
             responses_create_params=SAMPLE_RESPONSES_CREATE_PARAMS,
             response=response,
             injection=SAMPLE_INJECTION,
@@ -357,6 +363,7 @@ class TestApp:
             incomplete_details={"reason": "max_output_tokens"},
         )
         verify_request = IPIVerifyRequest(
+            environment=SAMPLE_ENV,
             responses_create_params=SAMPLE_RESPONSES_CREATE_PARAMS,
             response=response,
             injection=SAMPLE_INJECTION,
@@ -379,6 +386,7 @@ class TestApp:
 
         response = _make_response([_make_function_call_output("get_lab_results", '{"patient_id": "P001"}')])
         verify_request = IPIVerifyRequest(
+            environment=SAMPLE_ENV,
             responses_create_params=SAMPLE_RESPONSES_CREATE_PARAMS,
             response=response,
             injection=SAMPLE_INJECTION,

--- a/resources_servers/inverse_if/app.py
+++ b/resources_servers/inverse_if/app.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import json
 import re
 from enum import Enum
-from typing import Any, List, Optional
+from typing import List
 
 from fastapi import FastAPI
 from pydantic import BaseModel, ConfigDict, Field
@@ -55,6 +55,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
 )
+from resources_servers.inverse_if.task_data import TaskData
 
 
 # ---------------------------------------------------------------------------
@@ -129,19 +130,10 @@ class InverseIFConfig(BaseResourcesServerConfig):
 # ---------------------------------------------------------------------------
 
 
-class InverseIFRunRequest(BaseRunRequest):
+class InverseIFRunRequest(TaskData, BaseRunRequest):
     """Run request payload for Inverse IF tasks."""
 
     model_config = ConfigDict(extra="allow")
-
-    uuid: Optional[str | int] = None
-    task_id: Optional[int] = None
-    prompt: Optional[str] = None
-    rubric: Optional[List[dict]] = None
-    reference_response: Optional[str] = None
-    judge_prompt_template: Optional[str] = None
-    judge_system_prompt: Optional[str] = None
-    metadata: Optional[dict[str, Any]] = None
 
 
 class InverseIFVerifyRequest(InverseIFRunRequest, BaseVerifyRequest):

--- a/resources_servers/lc_niah/app.py
+++ b/resources_servers/lc_niah/app.py
@@ -46,6 +46,7 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.lc_niah.task_data import TaskData
 
 
 class OverlapMetricRule(str, Enum):
@@ -67,10 +68,8 @@ class LCNIAHResourcesServerConfig(BaseResourcesServerConfig):
     overlap_grading_rule: OverlapGradingRule = OverlapGradingRule.MULTIPLY
 
 
-class LCNIAHRunRequest(BaseRunRequest):
-    model_config = ConfigDict(extra="allow")
-
-    expected_answer: str
+class LCNIAHRunRequest(TaskData, BaseRunRequest):
+    pass
 
 
 class LCNIAHVerifyRequest(LCNIAHRunRequest, BaseVerifyRequest):

--- a/resources_servers/lc_niah/task_data.py
+++ b/resources_servers/lc_niah/task_data.py
@@ -2,21 +2,31 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the lc_niah server.
 
-Rows are graphwalks-derived long-context needle-in-a-haystack tasks, so the shared core
-(``expected_answer`` + ``n_tokens``) is imported from ``resources_servers.graphwalks.task_data``
-instead of redefined. Only ``expected_answer`` is typed on the wire (LCNIAHRunRequest,
-extra='allow'); every other task field arrives as an untyped extra and is therefore Optional
-here even though committed rows always carry it.
+Rows are graphwalks-derived long-context needle-in-a-haystack tasks. Only ``expected_answer`` is
+typed on the wire (LCNIAHRunRequest, extra='allow'); every other task field arrives as an untyped
+extra and is therefore Optional here even though committed rows always carry it.
 """
 
 from typing import Optional
 
-from pydantic import Field
-
-from resources_servers.graphwalks.task_data import GraphWalksCore
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class TaskData(GraphWalksCore):
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    expected_answer: str = Field(
+        description=(
+            "JSON-encoded list of expected node-name strings, e.g. '[\"node_1\", \"node_2\"]' or '[]'. "
+            "verify() json.loads it into a set for F1 scoring; parse failure falls back to the empty set."
+        ),
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    n_tokens: Optional[int] = Field(
+        default=None,
+        description="Prompt size in tokens; wire-optional passthrough, never read by verify().",
+        json_schema_extra={"consumed_by": ["provenance"]},
+    )
     problem_type: Optional[str] = Field(
         default=None,
         description="Task family ('parents' | 'bfs'); untyped wire extra, unread by verify().",

--- a/resources_servers/litmus_agent/app.py
+++ b/resources_servers/litmus_agent/app.py
@@ -112,6 +112,7 @@ from nemo_gym.judge import judge_failsafe
 from nemo_gym.reward_profile import compute_pass_majority_metrics, highest_k_metrics
 from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
 from nemo_gym.server_utils import SESSION_ID_KEY
+from resources_servers.litmus_agent.task_data import TaskData
 
 
 # ---------------------------------------------------------------------------
@@ -294,24 +295,18 @@ class LitmusAgentConfig(BaseResourcesServerConfig):
 # ---------------------------------------------------------------------------
 
 
-class LitmusAgentRunRequest(BaseRunRequest):
+class LitmusAgentRunRequest(TaskData, BaseRunRequest):
     # extra="allow": domain-context fields (source_id, smiles, method, tier,
     # provenance, ...) pass through validated-but-untouched and are echoed back.
     model_config = ConfigDict(extra="allow")
 
-    expected_answer: Union[str, float, int]
     # Selects how the answer is parsed. Optional so legacy rows carrying only
     # ``property_type`` still resolve via _PROPERTY_TYPE_TO_ANSWER_TYPE.
-    answer_type: Optional[str] = None
     # Preferred parser: a regex string carried directly on the row (exactly one
     # capture group). When present it wins over ``answer_format``; see
     # extract_predicted_value for the full resolution order.
-    output_regex: Optional[str] = None
-    answer_format: Optional[str] = None
-    use_box_format: bool = False
     # Per-row reward-rule override: {"rule": <name>, **params}. When absent, the
     # default rule for the resolved answer_type (_DEFAULT_RULE) applies.
-    match: Optional[Dict[str, Any]] = None
 
 
 class LitmusAgentVerifyRequest(LitmusAgentRunRequest, BaseVerifyRequest):
@@ -815,7 +810,11 @@ class LitmusAgentResourcesServer(SimpleResourcesServer):
             await self._cleanup_session(request.session.get(SESSION_ID_KEY))
 
     async def verify(self, body: LitmusAgentVerifyRequest) -> LitmusAgentVerifyResponse:
-        extra = body.model_extra or {}
+        # property_type is a typed field now (task_data.py), so it no longer lands in
+        # model_extra; the legacy resolution path below still expects it in this dict.
+        extra = dict(body.model_extra or {})
+        if body.property_type is not None:
+            extra.setdefault("property_type", body.property_type)
         answer_type, parsing_answer_type, effective_match = _resolve_verification_policy(
             body.answer_type,
             extra,

--- a/resources_servers/litmus_agent/app.py
+++ b/resources_servers/litmus_agent/app.py
@@ -810,8 +810,7 @@ class LitmusAgentResourcesServer(SimpleResourcesServer):
             await self._cleanup_session(request.session.get(SESSION_ID_KEY))
 
     async def verify(self, body: LitmusAgentVerifyRequest) -> LitmusAgentVerifyResponse:
-        # property_type is a typed field now (task_data.py), so it no longer lands in
-        # model_extra; the legacy resolution path below still expects it in this dict.
+        # property_type is typed now, so it no longer lands in model_extra.
         extra = dict(body.model_extra or {})
         if body.property_type is not None:
             extra.setdefault("property_type", body.property_type)

--- a/resources_servers/math_advanced_calculations/app.py
+++ b/resources_servers/math_advanced_calculations/app.py
@@ -39,6 +39,7 @@ from resources_servers.math_advanced_calculations.math_advanced_calculations_too
     sin,
     subtract,
 )
+from resources_servers.math_advanced_calculations.task_data import TaskData
 
 
 class MultiVerseMathHardResourcesServerConfig(BaseResourcesServerConfig):
@@ -56,11 +57,8 @@ class MultiVerseMathHardResponse(BaseModel):
     solution: float
 
 
-class MultiVerseMathHardVerifyRequest(BaseVerifyRequest):
-    ground_truth: list[float] | str
-    id: int
-    depth: int
-    breadth: int
+class MultiVerseMathHardVerifyRequest(TaskData, BaseVerifyRequest):
+    pass
 
 
 class MultiVerseMathHardVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/math_advanced_calculations/app.py
+++ b/resources_servers/math_advanced_calculations/app.py
@@ -16,7 +16,7 @@ import json
 from typing import Optional
 
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -58,7 +58,10 @@ class MultiVerseMathHardResponse(BaseModel):
 
 
 class MultiVerseMathHardVerifyRequest(TaskData, BaseVerifyRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class MultiVerseMathHardVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/math_advanced_calculations/app.py
+++ b/resources_servers/math_advanced_calculations/app.py
@@ -58,9 +58,6 @@ class MultiVerseMathHardResponse(BaseModel):
 
 
 class MultiVerseMathHardVerifyRequest(TaskData, BaseVerifyRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/math_proof_judgement/app.py
+++ b/resources_servers/math_proof_judgement/app.py
@@ -51,6 +51,7 @@ from nemo_gym.base_resources_server import (
 )
 from nemo_gym.openai_utils import NeMoGymResponse
 from nemo_gym.reward_profile import compute_pass_majority_metrics, highest_k_metrics
+from resources_servers.math_proof_judgement.task_data import TaskData
 
 
 # ---------------------------------------------------------------------------
@@ -125,7 +126,7 @@ class MathProofJudgementConfig(BaseResourcesServerConfig):
     """
 
 
-class MathProofJudgementRunRequest(BaseRunRequest):
+class MathProofJudgementRunRequest(TaskData, BaseRunRequest):
     """Run-time fields carried through the verify response for metrics.
 
     Besides the gold ``expected_judgement`` (always required), optional fields
@@ -133,11 +134,6 @@ class MathProofJudgementRunRequest(BaseRunRequest):
     """
 
     model_config = ConfigDict(extra="allow")
-
-    expected_judgement: Optional[str] = None
-    problem_id: Optional[str] = None
-    problem: Optional[str] = None
-    proof: Optional[str] = None
 
 
 class MathProofJudgementVerifyRequest(MathProofJudgementRunRequest, BaseVerifyRequest):

--- a/resources_servers/math_with_judge/task_data.py
+++ b/resources_servers/math_with_judge/task_data.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the math_with_judge server.
 
-Family parent for the library-judge math servers: math_with_autograder, physics_judge, polymath,
-ugphysics_judge, and finance_sec_search all inherit or mirror this two-field core on the wire
-(``LibraryJudgeMathRunRequest`` at app.py:54: ``question`` + ``expected_answer``, both required).
+Parent schema for the servers whose app.py subclasses ``LibraryJudgeMathResourcesServer``
+(math_with_autograder, physics_judge, polymath, ugphysics_judge); their wire models inherit this
+two-field core (``LibraryJudgeMathRunRequest`` at app.py:54: ``question`` + ``expected_answer``,
+both required).
 verify() runs math-verify symbolically against ``expected_answer`` first, then falls back to an
 Arena-Hard-style bidirectional judge whose prompt is filled from ``question`` and
 ``expected_answer``. Rows carry both fields at the top level; no ``verifier_metadata`` bucket.

--- a/resources_servers/mrcr/app.py
+++ b/resources_servers/mrcr/app.py
@@ -40,17 +40,15 @@ from nemo_gym.reward_profile import (
     compute_subset_metrics,
     highest_k_metrics,
 )
+from resources_servers.mrcr.task_data import TaskData
 
 
 class MRCRResourcesServerConfig(BaseResourcesServerConfig):
     pass
 
 
-class MRCRVerifyRequest(BaseVerifyRequest):
-    expected_answer: str
-    random_string_to_prepend: str
-    n_needles: int
-    n_tokens: int
+class MRCRVerifyRequest(TaskData, BaseVerifyRequest):
+    pass
 
 
 class MRCRVerifyResponse(MRCRVerifyRequest, BaseVerifyResponse):

--- a/resources_servers/mrcr/app.py
+++ b/resources_servers/mrcr/app.py
@@ -50,9 +50,6 @@ class MRCRResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class MRCRVerifyRequest(TaskData, BaseVerifyRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/mrcr/app.py
+++ b/resources_servers/mrcr/app.py
@@ -29,6 +29,8 @@ response and expected answer and compute `SequenceMatcher.ratio()` in
 from difflib import SequenceMatcher
 from typing import Any, Dict, List, Union
 
+from pydantic import ConfigDict
+
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
     BaseVerifyRequest,
@@ -48,7 +50,10 @@ class MRCRResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class MRCRVerifyRequest(TaskData, BaseVerifyRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class MRCRVerifyResponse(MRCRVerifyRequest, BaseVerifyResponse):

--- a/resources_servers/multichallenge/app.py
+++ b/resources_servers/multichallenge/app.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import re
 from enum import Enum
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from fastapi import FastAPI
 from pydantic import BaseModel, ConfigDict, Field
@@ -50,6 +50,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
 )
+from resources_servers.multichallenge.task_data import TaskData
 
 
 class AggregationMode(str, Enum):
@@ -133,16 +134,10 @@ Analyze carefully, then respond with exactly [[YES]] or [[NO]] on the last line.
     no_label: str = Field(default="[[NO]]", description="Label indicating NO verdict")
 
 
-class MultiChallengeRunRequest(BaseRunRequest):
+class MultiChallengeRunRequest(TaskData, BaseRunRequest):
     """Run request payload for MultiChallenge tasks."""
 
     model_config = ConfigDict(extra="allow")
-
-    uuid: Optional[str | int] = None
-    task_id: Optional[int] = None
-    rubric: Optional[List[dict]] = None
-    context: Optional[str] = None
-    metadata: Optional[dict[str, Any]] = None
 
 
 class MultiChallengeVerifyRequest(MultiChallengeRunRequest, BaseVerifyRequest):

--- a/resources_servers/nvarc/task_data.py
+++ b/resources_servers/nvarc/task_data.py
@@ -2,27 +2,40 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the nvarc server.
 
-nvarc rows extend the arc_agi shape (imported, not redefined) with an ``agent_mode`` switch and
-augmentation/difficulty provenance. NVARCRunRequest does not set extra='allow', so the untyped
-provenance fields below are silently dropped at today's verify boundary (Pydantic default
-extra='ignore'); they are declared here as loose Optional passthrough so the row data stays
-described without over-constraining it.
+nvarc rows carry the ARC grid fields (train / test_input / expected_output / task_id) plus an
+``agent_mode`` switch and augmentation/difficulty provenance. NVARCRunRequest does not set
+extra='allow', so the untyped provenance fields below are silently dropped at today's verify
+boundary (Pydantic default extra='ignore'); they are declared here as loose Optional passthrough
+so the row data stays described without over-constraining it.
 """
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import Field
-
-from resources_servers.arc_agi.task_data import TaskData as ARCAGITaskData
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class TaskData(ARCAGITaskData):
-    # Re-declared from the arc_agi parent because nvarc's verify() also consumes the test grid
-    # (it feeds the extracted program in inductive mode).
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    train: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description="Demonstration pairs [{'input': grid, 'output': grid}, ...] used to build the prompt.",
+        json_schema_extra={"consumed_by": ["prompt"]},
+    )
     test_input: List[List[int]] = Field(
         default_factory=list,
         description="Test grid; prompt-side, and read by verify() in inductive agent_mode.",
         json_schema_extra={"consumed_by": ["verify", "prompt"]},
+    )
+    expected_output: List[List[int]] = Field(
+        default_factory=list,
+        description="Ground-truth output grid; verify() checks exact equality against the extracted grid.",
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    task_id: Optional[str] = Field(
+        default=None,
+        description="Upstream ARC task identifier.",
+        json_schema_extra={"consumed_by": ["provenance"]},
     )
     agent_mode: Optional[str] = Field(
         default=None,

--- a/resources_servers/omniscience/app.py
+++ b/resources_servers/omniscience/app.py
@@ -56,6 +56,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
 )
 from nemo_gym.reward_profile import compute_pass_majority_metrics, highest_k_metrics
+from resources_servers.omniscience.task_data import TaskData
 
 
 # ---------------------------------------------------------------------------
@@ -152,12 +153,10 @@ class OmniscienceConfig(BaseResourcesServerConfig):
     )
 
 
-class OmniscienceRunRequest(BaseRunRequest):
+class OmniscienceRunRequest(TaskData, BaseRunRequest):
     model_config = ConfigDict(extra="allow")
 
     id: Optional[Union[int, str]] = None
-    domain: Optional[str] = None
-    topic: Optional[str] = None
     question: Optional[str] = None
     expected_answer: Optional[str] = None
 

--- a/resources_servers/omniscience/app.py
+++ b/resources_servers/omniscience/app.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import yaml
 from fastapi import FastAPI
@@ -155,10 +155,6 @@ class OmniscienceConfig(BaseResourcesServerConfig):
 
 class OmniscienceRunRequest(TaskData, BaseRunRequest):
     model_config = ConfigDict(extra="allow")
-
-    id: Optional[Union[int, str]] = None
-    question: Optional[str] = None
-    expected_answer: Optional[str] = None
 
 
 class OmniscienceVerifyRequest(OmniscienceRunRequest, BaseVerifyRequest):

--- a/resources_servers/omniscience/task_data.py
+++ b/resources_servers/omniscience/task_data.py
@@ -2,20 +2,40 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the omniscience server.
 
-Judge-QA family heir: extends simpleqa's ``TaskData`` (optional id/question/expected_answer,
-all read defensively by the LLM-judge ``verify()``) with ``domain``/``topic`` provenance
-columns. Required-ness mirrors ``OmniscienceRunRequest`` (app.py): every task field is Optional
-on the wire with ``extra="allow"``.
+An optional id/question/expected_answer, all read defensively by the LLM-judge ``verify()``, plus
+``domain``/``topic`` provenance columns. Required-ness mirrors ``OmniscienceRunRequest`` (app.py):
+every task field is Optional on the wire with ``extra="allow"``.
 """
 
-from typing import Optional
+from typing import Optional, Union
 
-from pydantic import Field
-
-from resources_servers.simpleqa.task_data import TaskData as SimpleQATaskData
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class TaskData(SimpleQATaskData):
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: Optional[Union[int, str]] = Field(
+        default=None,
+        description="Ride-along task identifier; never read by verify() or metrics.",
+        json_schema_extra={"consumed_by": ["provenance"]},
+    )
+    question: Optional[str] = Field(
+        default=None,
+        description=(
+            "Question text interpolated into the LLM-judge prompt ({question} placeholder); "
+            "verify() falls back to '' when absent."
+        ),
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
+    expected_answer: Optional[str] = Field(
+        default=None,
+        description=(
+            "Ground-truth answer interpolated into the judge prompt ({expected_answer} placeholder) and "
+            "echoed on the verify response; verify() falls back to '' when absent."
+        ),
+        json_schema_extra={"consumed_by": ["verify"]},
+    )
     domain: Optional[str] = Field(
         default=None,
         description=(

--- a/resources_servers/proof_genselect/app.py
+++ b/resources_servers/proof_genselect/app.py
@@ -15,6 +15,7 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.proof_genselect.task_data import TaskData
 
 
 LOG = logging.getLogger(__name__)
@@ -46,13 +47,8 @@ class ProofGenSelectResourcesServerConfig(BaseResourcesServerConfig):
     assert_think_end: bool = False
 
 
-class ProofGenSelectVerifyRequest(BaseVerifyRequest):
-    problem: str
-    proof_1: str
-    proof_2: str
-    correct_index: int
-    score_1: Optional[float] = None
-    score_2: Optional[float] = None
+class ProofGenSelectVerifyRequest(TaskData, BaseVerifyRequest):
+    pass
 
 
 class ProofGenSelectResourcesServer(SimpleResourcesServer):

--- a/resources_servers/proof_genselect/app.py
+++ b/resources_servers/proof_genselect/app.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from pydantic import PrivateAttr
+from pydantic import ConfigDict, PrivateAttr
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -48,7 +48,10 @@ class ProofGenSelectResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class ProofGenSelectVerifyRequest(TaskData, BaseVerifyRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class ProofGenSelectResourcesServer(SimpleResourcesServer):

--- a/resources_servers/proof_genselect/app.py
+++ b/resources_servers/proof_genselect/app.py
@@ -48,9 +48,6 @@ class ProofGenSelectResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class ProofGenSelectVerifyRequest(TaskData, BaseVerifyRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/proof_judge/app.py
+++ b/resources_servers/proof_judge/app.py
@@ -38,6 +38,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
 )
 from nemo_gym.server_utils import get_response_json
+from resources_servers.proof_judge.task_data import TaskData
 
 
 LOG = logging.getLogger(__name__)
@@ -202,8 +203,8 @@ class ProofWithJudgeResourcesServerConfig(BaseResourcesServerConfig):
             raise ValueError("expected_group_size must be > 0 when zero_reward_incorrect_groups is enabled")
 
 
-class ProofWithJudgeVerifyRequest(BaseVerifyRequest):
-    problem: str = ""
+class ProofWithJudgeVerifyRequest(TaskData, BaseVerifyRequest):
+    pass
 
 
 class ProofWithJudgeVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/proof_judge/app.py
+++ b/resources_servers/proof_judge/app.py
@@ -204,7 +204,10 @@ class ProofWithJudgeResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class ProofWithJudgeVerifyRequest(TaskData, BaseVerifyRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class ProofWithJudgeVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/proof_judge/app.py
+++ b/resources_servers/proof_judge/app.py
@@ -204,9 +204,6 @@ class ProofWithJudgeResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class ProofWithJudgeVerifyRequest(TaskData, BaseVerifyRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/proof_verification/app.py
+++ b/resources_servers/proof_verification/app.py
@@ -28,6 +28,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
 )
 from nemo_gym.server_utils import get_response_json
+from resources_servers.proof_verification.task_data import TaskData
 
 
 LOG = logging.getLogger(__name__)
@@ -166,11 +167,8 @@ class ProofVerificationResourcesServerConfig(BaseResourcesServerConfig):
     assert_think_end: bool = False
 
 
-class ProofVerificationVerifyRequest(BaseVerifyRequest):
-    problem: str = ""
-    proof: str = ""
-    ground_truth_judgement: str
-    ground_truth_verify_score: float
+class ProofVerificationVerifyRequest(TaskData, BaseVerifyRequest):
+    pass
 
 
 class ProofVerificationVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/proof_verification/app.py
+++ b/resources_servers/proof_verification/app.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import yaml
-from pydantic import PrivateAttr
+from pydantic import ConfigDict, PrivateAttr
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -168,7 +168,10 @@ class ProofVerificationResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class ProofVerificationVerifyRequest(TaskData, BaseVerifyRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class ProofVerificationVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/proof_verification/app.py
+++ b/resources_servers/proof_verification/app.py
@@ -168,9 +168,6 @@ class ProofVerificationResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class ProofVerificationVerifyRequest(TaskData, BaseVerifyRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/ragtruth/app.py
+++ b/resources_servers/ragtruth/app.py
@@ -56,6 +56,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.openai_utils import NeMoGymResponse
+from resources_servers.ragtruth.task_data import TaskData
 
 
 LOG = logging.getLogger(__name__)
@@ -169,13 +170,11 @@ class RagtruthResourcesServerConfig(BaseResourcesServerConfig):
     think_tag: str = "think"
 
 
-class RagtruthRunRequest(BaseRunRequest):
+class RagtruthRunRequest(TaskData, BaseRunRequest):
     model_config = ConfigDict(extra="allow")
 
     # Gold "does this case contain a hallucination?" label, precomputed at prep
     # time as ``bool(labels)`` from the upstream RAGTruth annotations.
-    is_halu: bool = False
-    task_type: str = ""
 
 
 class RagtruthVerifyRequest(RagtruthRunRequest, BaseVerifyRequest):

--- a/resources_servers/ruler/app.py
+++ b/resources_servers/ruler/app.py
@@ -21,16 +21,15 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.ruler.task_data import TaskData
 
 
 class RulerResourcesServerConfig(BaseResourcesServerConfig):
     pass
 
 
-class RulerVerifyRequest(BaseVerifyRequest):
-    outputs: List[str]
-    length: int
-    subset: str
+class RulerVerifyRequest(TaskData, BaseVerifyRequest):
+    pass
 
 
 class RulerVerifyResponse(RulerVerifyRequest, BaseVerifyResponse):

--- a/resources_servers/ruler/app.py
+++ b/resources_servers/ruler/app.py
@@ -15,6 +15,8 @@
 
 from typing import List, Optional
 
+from pydantic import ConfigDict
+
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
     BaseVerifyRequest,
@@ -29,7 +31,10 @@ class RulerResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class RulerVerifyRequest(TaskData, BaseVerifyRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class RulerVerifyResponse(RulerVerifyRequest, BaseVerifyResponse):

--- a/resources_servers/ruler/app.py
+++ b/resources_servers/ruler/app.py
@@ -31,9 +31,6 @@ class RulerResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class RulerVerifyRequest(TaskData, BaseVerifyRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/simpleqa/app.py
+++ b/resources_servers/simpleqa/app.py
@@ -55,6 +55,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
 )
 from nemo_gym.reward_profile import compute_pass_majority_metrics, highest_k_metrics
+from resources_servers.simpleqa.task_data import TaskData
 
 
 _DEFAULT_JUDGE_PROMPT_PATH = str(Path(__file__).parent / "prompts" / "judge.yaml")
@@ -133,12 +134,11 @@ class SimpleQAConfig(BaseResourcesServerConfig):
     )
 
 
-class SimpleQARunRequest(BaseRunRequest):
+class SimpleQARunRequest(TaskData, BaseRunRequest):
     model_config = ConfigDict(extra="allow")
 
     id: Optional[Union[int, str]] = None
     question: Optional[str] = None
-    expected_answer: Optional[str] = None
 
 
 class SimpleQAVerifyRequest(SimpleQARunRequest, BaseVerifyRequest):

--- a/resources_servers/simpleqa/app.py
+++ b/resources_servers/simpleqa/app.py
@@ -33,7 +33,7 @@ Computes:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import yaml
 from pydantic import ConfigDict, Field
@@ -136,9 +136,6 @@ class SimpleQAConfig(BaseResourcesServerConfig):
 
 class SimpleQARunRequest(TaskData, BaseRunRequest):
     model_config = ConfigDict(extra="allow")
-
-    id: Optional[Union[int, str]] = None
-    question: Optional[str] = None
 
 
 class SimpleQAVerifyRequest(SimpleQARunRequest, BaseVerifyRequest):

--- a/resources_servers/simpleqa/task_data.py
+++ b/resources_servers/simpleqa/task_data.py
@@ -2,14 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the simpleqa server.
 
-Parent of the defensive judge-QA family (simpleqa, omniscience, frontierscience_judge,
-abstention): an optional id + question + ground-truth answer, every field read defensively by an
-LLM-judge ``verify()`` (a missing field becomes an empty string in the judge prompt), with
-``extra="allow"`` provenance passthrough. Heirs import ``JudgeQATaskDataCore`` (id + question;
-abstention names its answer field ``answer``) or ``TaskData`` (adds ``expected_answer``) instead
-of redefining these fields. Required-ness mirrors ``SimpleQARunRequest`` (app.py): all task
-fields are Optional on the wire. The judge prompt template and judge model come from server
-config, not the row.
+An optional id + question + ground-truth answer, every field read defensively by the LLM-judge
+``verify()`` (a missing field becomes an empty string in the judge prompt), with ``extra="allow"``
+provenance passthrough. Required-ness mirrors ``SimpleQARunRequest`` (app.py): all task fields are
+Optional on the wire. The judge prompt template and judge model come from server config, not the
+row.
 """
 
 from typing import Optional, Union
@@ -17,9 +14,7 @@ from typing import Optional, Union
 from pydantic import BaseModel, ConfigDict, Field
 
 
-class JudgeQATaskDataCore(BaseModel):
-    """Shared id + question core of the judge-QA family."""
-
+class TaskData(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     id: Optional[Union[int, str]] = Field(
@@ -35,9 +30,6 @@ class JudgeQATaskDataCore(BaseModel):
         ),
         json_schema_extra={"consumed_by": ["verify"]},
     )
-
-
-class TaskData(JudgeQATaskDataCore):
     expected_answer: Optional[str] = Field(
         default=None,
         description=(

--- a/resources_servers/single_step_tool_use_with_argument_comparison/app.py
+++ b/resources_servers/single_step_tool_use_with_argument_comparison/app.py
@@ -28,13 +28,17 @@ from resources_servers.single_step_tool_use_with_argument_comparison.common.veri
     StepRewardCategory,
     ToolCallComparatorConfig,
 )
+from resources_servers.single_step_tool_use_with_argument_comparison.task_data import TaskData
 
 
 class SingleStepToolUseArgumentComparisonResourcesServerConfig(BaseResourcesServerConfig):
     tool_call_comparator_config: ToolCallComparatorConfig
 
 
-class SingleStepToolUseArgumentComparisonRunRequest(BaseRunRequest):
+class SingleStepToolUseArgumentComparisonRunRequest(TaskData, BaseRunRequest):
+    # Redeclared to keep the verification_utils action classes on the wire: the comparators
+    # isinstance-check and pattern-match those exact classes, so the task_data mirror types
+    # must not replace them here.
     expected_action: ExpectedAction
 
 

--- a/resources_servers/single_step_tool_use_with_argument_comparison/app.py
+++ b/resources_servers/single_step_tool_use_with_argument_comparison/app.py
@@ -37,12 +37,7 @@ class SingleStepToolUseArgumentComparisonResourcesServerConfig(BaseResourcesServ
 
 
 class SingleStepToolUseArgumentComparisonRunRequest(TaskData, BaseRunRequest):
-    # Redeclared to keep the verification_utils action classes on the wire: the comparators
-    # isinstance-check and pattern-match those exact classes, so the task_data mirror types
-    # must not replace them here.
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    # Redeclared: the comparators isinstance-check these exact classes.
     model_config = ConfigDict(extra="ignore")
     expected_action: ExpectedAction
 

--- a/resources_servers/single_step_tool_use_with_argument_comparison/app.py
+++ b/resources_servers/single_step_tool_use_with_argument_comparison/app.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from fastapi import FastAPI
+from pydantic import ConfigDict
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -39,6 +40,10 @@ class SingleStepToolUseArgumentComparisonRunRequest(TaskData, BaseRunRequest):
     # Redeclared to keep the verification_utils action classes on the wire: the comparators
     # isinstance-check and pattern-match those exact classes, so the task_data mirror types
     # must not replace them here.
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
     expected_action: ExpectedAction
 
 

--- a/resources_servers/single_step_tool_use_with_argument_comparison/task_data.py
+++ b/resources_servers/single_step_tool_use_with_argument_comparison/task_data.py
@@ -7,10 +7,6 @@ message / function_call / function_call_batch actions that verify() compares the
 against. The action models mirror ``common/verification_utils.py`` field-for-field (including the
 ``min_length=1`` constraint on batch calls) but are redeclared here so this module stays a
 dependency-light leaf importable without the server's requirements.
-
-This file is the parent of the expected-action schema family: ``terminal_multi_harness`` imports
-the message/function_call variants (its batch variant differs), and ``swe_pivot``'s untyped
-``expected_action`` dict carries the same function_call shape.
 """
 
 from typing import Annotated, List, Literal, TypeAlias, Union

--- a/resources_servers/spartqa/app.py
+++ b/resources_servers/spartqa/app.py
@@ -39,7 +39,7 @@ import re
 import string
 from typing import Any, Dict, List, Optional
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -49,6 +49,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.openai_utils import NeMoGymResponse
+from resources_servers.spartqa.task_data import TaskData
 
 
 PROMPT = """\
@@ -233,7 +234,7 @@ class SpartqaResourcesServerConfig(BaseResourcesServerConfig):
     name: str = "spartqa"
 
 
-class SpartqaRunRequest(BaseRunRequest):
+class SpartqaRunRequest(TaskData, BaseRunRequest):
     model_config = ConfigDict(extra="allow")
 
     # ``target`` is the single gold CO label; ``options`` are the two story
@@ -243,8 +244,6 @@ class SpartqaRunRequest(BaseRunRequest):
     # (``options`` never arrives that way). The options therefore also ride in
     # ``verifier_metadata``, which the driver forwards intact; verify() falls
     # back to it so the full candidate set is always available.
-    target: str = ""
-    options: List[str] = Field(default_factory=list)
     verifier_metadata: Optional[Dict[str, Any]] = None
 
 

--- a/resources_servers/spider2_lite/app.py
+++ b/resources_servers/spider2_lite/app.py
@@ -23,6 +23,7 @@ from resources_servers.spider2_lite.eval_utils import (
     execute_sqlite_async,
 )
 from resources_servers.spider2_lite.setup_spider2 import ensure_spider2_lite
+from resources_servers.spider2_lite.task_data import TaskData
 
 
 logger = logging.getLogger(__name__)
@@ -82,20 +83,8 @@ class Spider2LiteResourcesServerConfig(BaseResourcesServerConfig):
     sql_execution_timeout_s: float = 30.0
 
 
-class Spider2LiteVerifyRequest(BaseVerifyRequest):
+class Spider2LiteVerifyRequest(TaskData, BaseVerifyRequest):
     model_config = ConfigDict(extra="allow")
-
-    uuid: Optional[str | int] = None
-    instance_id: Optional[str] = None
-    db_id: str
-    question: str
-
-    gold_sql: Optional[str] = None
-    gold_result: Optional[list[list[list[Any]]]] = None
-
-    ignore_order: bool = True
-    condition_cols: Optional[list] = None
-    metadata: Optional[dict[str, Any]] = None
 
 
 class Spider2LiteVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/string_match/app.py
+++ b/resources_servers/string_match/app.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import re
 import unicodedata
-from typing import Any, Literal, Optional
+from typing import Optional
 
 from fastapi import FastAPI
 
@@ -25,22 +25,15 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.string_match.task_data import TaskData
 
 
 class StringMatchResourcesServerConfig(BaseResourcesServerConfig):
     pass
 
 
-class StringMatchRunRequest(BaseRunRequest):
-    expected_answer: str
-    extraction_mode: Literal[
-        "boxed",
-        "final_answer",
-        "last_line",
-        "full_response",
-    ] = "final_answer"
-    case_sensitive: bool = False
-    metadata: Optional[dict[str, Any]] = None
+class StringMatchRunRequest(TaskData, BaseRunRequest):
+    pass
 
 
 class StringMatchVerifyRequest(StringMatchRunRequest, BaseVerifyRequest):

--- a/resources_servers/string_match/app.py
+++ b/resources_servers/string_match/app.py
@@ -17,6 +17,7 @@ import unicodedata
 from typing import Optional
 
 from fastapi import FastAPI
+from pydantic import ConfigDict
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -33,7 +34,10 @@ class StringMatchResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class StringMatchRunRequest(TaskData, BaseRunRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class StringMatchVerifyRequest(StringMatchRunRequest, BaseVerifyRequest):

--- a/resources_servers/string_match/app.py
+++ b/resources_servers/string_match/app.py
@@ -34,9 +34,6 @@ class StringMatchResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class StringMatchRunRequest(TaskData, BaseRunRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/swe_pivot/app.py
+++ b/resources_servers/swe_pivot/app.py
@@ -42,6 +42,7 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.swe_pivot.task_data import TaskData
 
 
 logger = logging.getLogger(__name__)
@@ -485,13 +486,8 @@ class SwePivotResourcesServerConfig(BaseResourcesServerConfig):
     diff_size_alpha: float = 0.1  # Max penalty for large edits
 
 
-class SwePivotRunRequest(BaseRunRequest):
+class SwePivotRunRequest(TaskData, BaseRunRequest):
     model_config = ConfigDict(extra="allow")
-
-    uuid: Optional[str | int] = None
-    expected_answer: Optional[str] = None
-    expected_action: Optional[dict[str, Any]] = None
-    metadata: Optional[dict[str, Any]] = None
 
 
 class SwePivotVerifyRequest(SwePivotRunRequest, BaseVerifyRequest):

--- a/resources_servers/swerl_gen/app.py
+++ b/resources_servers/swerl_gen/app.py
@@ -35,6 +35,7 @@ from resources_servers.swerl_gen.eval.process_patch import (
 from resources_servers.swerl_gen.eval.singularity_utils import (
     compute_score,
 )
+from resources_servers.swerl_gen.task_data import TaskData
 
 
 class SWEGenResourcesServerConfig(BaseResourcesServerConfig):
@@ -44,15 +45,8 @@ class SWEGenResourcesServerConfig(BaseResourcesServerConfig):
     relaxed_formatting: bool = False
 
 
-class SWEGenRunRequest(BaseRunRequest):
-    instance: dict[
-        str, Any
-    ]  ## dictionary keys: instance_id, repo, setup_script, test_script, regression_script, PASS_TO_PASS, FAIL_TO_PASS, patch
-    dataset_name: Optional[str] = None
-    dataset_split: Optional[str] = None
-    metadata: dict[str, Any] = {}  ## keys: relevant_file_contents, remove_repo_name, image
-    partial_similarity: Optional[bool] = None
-    mode: str = "eval"  ## eval or repro-gen
+class SWEGenRunRequest(TaskData, BaseRunRequest):
+    pass
 
 
 class SWEGenVerifyRequest(SWEGenRunRequest, BaseVerifyRequest):

--- a/resources_servers/swerl_gen/app.py
+++ b/resources_servers/swerl_gen/app.py
@@ -19,6 +19,7 @@ from asyncio import Semaphore
 from typing import Any, Optional
 
 from fastapi import FastAPI
+from pydantic import ConfigDict
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -46,7 +47,10 @@ class SWEGenResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class SWEGenRunRequest(TaskData, BaseRunRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class SWEGenVerifyRequest(SWEGenRunRequest, BaseVerifyRequest):

--- a/resources_servers/swerl_gen/app.py
+++ b/resources_servers/swerl_gen/app.py
@@ -47,9 +47,6 @@ class SWEGenResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class SWEGenRunRequest(TaskData, BaseRunRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/swerl_llm_judge/app.py
+++ b/resources_servers/swerl_llm_judge/app.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
-from typing import Any, Literal, Optional
+from typing import Any, Optional
 
 from fastapi import FastAPI
 
@@ -24,20 +24,15 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.swerl_llm_judge.task_data import TaskData
 
 
 class SWEJudgeResourcesServerConfig(BaseResourcesServerConfig):
     pass
 
 
-class SWEJudgeRunRequest(BaseRunRequest):
-    instance_id: Optional[str] = None
-    dataset_name: Optional[str] = None
-    dataset_split: Optional[str] = None
-    expected_answer: Optional[str | list[str]] = None
-    options: Optional[list[dict[str, str]]] = None
-    metadata: Optional[dict[str, Any]] = None
-    grading_mode: Literal["lenient", "strict"] = "lenient"
+class SWEJudgeRunRequest(TaskData, BaseRunRequest):
+    pass
 
 
 class SWEJudgeVerifyRequest(SWEJudgeRunRequest, BaseVerifyRequest):

--- a/resources_servers/swerl_llm_judge/app.py
+++ b/resources_servers/swerl_llm_judge/app.py
@@ -33,9 +33,6 @@ class SWEJudgeResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class SWEJudgeRunRequest(TaskData, BaseRunRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/swerl_llm_judge/app.py
+++ b/resources_servers/swerl_llm_judge/app.py
@@ -16,6 +16,7 @@ import re
 from typing import Any, Optional
 
 from fastapi import FastAPI
+from pydantic import ConfigDict
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -32,7 +33,10 @@ class SWEJudgeResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class SWEJudgeRunRequest(TaskData, BaseRunRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class SWEJudgeVerifyRequest(SWEJudgeRunRequest, BaseVerifyRequest):

--- a/resources_servers/tavily_search/task_data.py
+++ b/resources_servers/tavily_search/task_data.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Task-data schema for the tavily_search server (parent of the search-QA pair).
+"""Task-data schema for the tavily_search server.
 
 Two required top-level strings, mirroring ``TavilySearchRunRequest`` (app.py) exactly; there is
 no verifier_metadata. Whether verification runs an LLM judge or an exact string match is chosen
@@ -8,8 +8,6 @@ by server config (``use_judge``), not by row data — both paths consume the sam
 ``use_judge=false``, verify() extracts the span between "Answer:" and "Confidence:" in the last
 assistant message (a fixed extraction regex; ground_truth itself is never a regex) and requires
 exact string equality with ground_truth.
-browsecomp_advanced_harness shares this schema verbatim (its app.py redeclares the identical
-request model) and imports it.
 """
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/resources_servers/terminal_bench_2_1/app.py
+++ b/resources_servers/terminal_bench_2_1/app.py
@@ -12,6 +12,7 @@ from traceback import format_exc
 from typing import Any, ClassVar, Dict, List, Optional, Tuple
 
 from fastapi import Request
+from pydantic import ConfigDict
 
 from nemo_gym import PARENT_DIR
 from nemo_gym.base_resources_server import (
@@ -48,7 +49,10 @@ class TerminalBench21SeedSessionResponse(BaseSeedSessionResponse):
 
 
 class TerminalBench21SeedSessionRequest(TaskData):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class TerminalBench21VerifyRequest(TerminalBench21SeedSessionRequest, BaseVerifyRequest):

--- a/resources_servers/terminal_bench_2_1/app.py
+++ b/resources_servers/terminal_bench_2_1/app.py
@@ -12,7 +12,6 @@ from traceback import format_exc
 from typing import Any, ClassVar, Dict, List, Optional, Tuple
 
 from fastapi import Request
-from pydantic import BaseModel
 
 from nemo_gym import PARENT_DIR
 from nemo_gym.base_resources_server import (
@@ -28,6 +27,7 @@ from nemo_gym.sandbox import AsyncSandbox, SandboxResources, SandboxSpec
 from nemo_gym.sandbox.config import resolve_provider_config, resolve_provider_metadata
 from nemo_gym.sandbox.utils import cpu_cap_env
 from nemo_gym.server_utils import SESSION_ID_KEY
+from resources_servers.terminal_bench_2_1.task_data import TaskData
 
 
 class TerminalBench21ResourcesServerConfig(BaseResourcesServerConfig):
@@ -47,10 +47,8 @@ class TerminalBench21SeedSessionResponse(BaseSeedSessionResponse):
     sandbox_handle: str  # @bxyu-nvidia: Just a plain string URI for now for OpenSandbox backend.
 
 
-class TerminalBench21SeedSessionRequest(BaseModel):
-    task_name: str
-    docker_image: str
-    task_folder: str
+class TerminalBench21SeedSessionRequest(TaskData):
+    pass
 
 
 class TerminalBench21VerifyRequest(TerminalBench21SeedSessionRequest, BaseVerifyRequest):

--- a/resources_servers/terminal_bench_2_1/app.py
+++ b/resources_servers/terminal_bench_2_1/app.py
@@ -49,9 +49,6 @@ class TerminalBench21SeedSessionResponse(BaseSeedSessionResponse):
 
 
 class TerminalBench21SeedSessionRequest(TaskData):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/terminal_multi_harness/task_data.py
+++ b/resources_servers/terminal_multi_harness/task_data.py
@@ -2,13 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the terminal_multi_harness server.
 
-Rows pair an ``expected_action`` (the same discriminated union family as
-single_step_tool_use_with_argument_comparison, whose message/function_call variants are imported
-here) with harness-specific verification context: which ``harness``'s tool conventions to grade
-under, the ``declared_tools`` schemas used to validate tool-call arguments, and an optional
-per-row similarity ``threshold``. This server's batch variant differs from the parent's — it adds
-``ordered`` and allows an empty ``calls`` list — so it is redeclared locally, mirroring
-``common/verification_utils.py``.
+Rows pair an ``expected_action`` (a discriminated union of message / function_call /
+function_call_batch actions) with harness-specific verification context: which ``harness``'s tool
+conventions to grade under, the ``declared_tools`` schemas used to validate tool-call arguments,
+and an optional per-row similarity ``threshold``. The action models mirror
+``common/verification_utils.py`` field-for-field; the batch variant adds ``ordered`` and allows
+an empty ``calls`` list.
 
 Committed rows also carry ``uuid`` and ``metadata`` ({harness, example_kind}), which are NOT
 fields of today's wire request model (``TerminalMultiHarnessRunRequest`` uses pydantic's default
@@ -20,14 +19,28 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, TypeAlias, Uni
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from resources_servers.single_step_tool_use_with_argument_comparison.task_data import (
-    FunctionCallAction,
-    MessageAction,
-)
+
+class MessageAction(BaseModel):
+    """The expected action is an assistant chat message."""
+
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["message"]
+    content: str
+
+
+class FunctionCallAction(BaseModel):
+    """The expected action is a single tool call."""
+
+    model_config = ConfigDict(extra="allow")
+
+    type: Literal["function_call"]
+    name: str
+    arguments: str = Field(description="JSON-encoded object string of the expected tool-call arguments.")
 
 
 class FunctionCallBatchAction(BaseModel):
-    """This server's batch variant: adds ``ordered`` and (unlike the parent's) allows empty calls."""
+    """The expected action is a batch of tool calls; ``ordered`` controls order sensitivity."""
 
     model_config = ConfigDict(extra="allow")
 

--- a/resources_servers/text_to_sql/app.py
+++ b/resources_servers/text_to_sql/app.py
@@ -43,6 +43,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
 )
 from resources_servers.text_to_sql.prompts import SQL_JUDGE_PROMPT_TEMPLATE, SQL_JUDGE_SYSTEM_MESSAGE
+from resources_servers.text_to_sql.task_data import TaskData
 
 
 class FailureCode(str, Enum):
@@ -162,17 +163,10 @@ class TextToSqlResourcesServerConfig(BaseResourcesServerConfig):
     reward_if_swap_fails: float = 0.0
 
 
-class TextToSqlRunRequest(BaseRunRequest):
+class TextToSqlRunRequest(TaskData, BaseRunRequest):
     """Run/verify request payload for text-to-SQL tasks."""
 
     model_config = ConfigDict(extra="allow")
-
-    uuid: Optional[str | int] = None
-    sql: str  # Ground truth SQL query (required)
-    sql_dialect: str  # SQL dialect: mysql, postgresql, sqlite (required)
-    sql_context: str = ""  # Database schema (CREATE/INSERT statements)
-    sql_prompt: str  # Natural language question (required)
-    metadata: Optional[dict[str, Any]] = None
 
 
 class TextToSqlVerifyRequest(TextToSqlRunRequest, BaseVerifyRequest):

--- a/resources_servers/toolsandbox/task_data.py
+++ b/resources_servers/toolsandbox/task_data.py
@@ -2,15 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 """Task-data schema for the toolsandbox server.
 
-Same pointer shape as aviary (imported, not redefined): the row's only task datum is
-``task_idx``, here an index into the deterministic sorted registry of vendored ToolSandbox
-scenarios built in-process at runtime — the task definition lives in code, OUT of the row
-(wire-required by ToolSandboxSeedSessionRequest). verify() is a cached-reward lookup keyed by
-env_id (milestone similarity computed at /close, defaulting to 0.0).
+Pointer rows: the row's only task datum is ``task_idx``, an index into the deterministic sorted
+registry of vendored ToolSandbox scenarios built in-process at runtime — the task definition lives
+in code, OUT of the row (wire-required by ToolSandboxSeedSessionRequest). verify() is a
+cached-reward lookup keyed by env_id (milestone similarity computed at /close, defaulting to 0.0).
 """
 
-from resources_servers.aviary.task_data import TaskData as AviaryTaskData
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class TaskData(AviaryTaskData):
-    """ToolSandbox pointer row; ``task_idx`` indexes the vendored scenario registry."""
+class TaskData(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    task_idx: int = Field(
+        description=(
+            "Index into the sorted registry of vendored ToolSandbox scenarios. Wire-required by "
+            "ToolSandboxSeedSessionRequest and consumed by /seed_session to instantiate the episode; "
+            "not read by verify()."
+        ),
+        json_schema_extra={"consumed_by": ["prompt"]},
+    )

--- a/resources_servers/verifif/app.py
+++ b/resources_servers/verifif/app.py
@@ -43,6 +43,7 @@ from nemo_gym.base_resources_server import (
 )
 from nemo_gym.judge import JudgeError
 from nemo_gym.openai_utils import NeMoGymAsyncOpenAI
+from resources_servers.verifif.task_data import LLMJudgeItem, TaskData
 
 
 # Per-request collector for judge failures. A ContextVar is shared by reference
@@ -151,40 +152,8 @@ class TuringVIFResourcesServerConfig(BaseResourcesServerConfig):
 # ============================================================================
 
 
-class InstructionItem(BaseModel):
-    """A single instruction with its parameters."""
-
-    instruction_id: str
-    # Additional kwargs are captured via model_extra
-    model_config = {"extra": "allow"}
-
-
-class LLMJudgeItem(BaseModel):
-    """A custom LLM judge question."""
-
-    uid: int
-    content: str
-    pass_criteria: Literal["YES", "NO"] = Field(
-        default="YES",
-        description="Expected verdict from judge for the response to pass. 'YES' means judge must say YES for pass, 'NO' means judge must say NO for pass.",
-    )
-    source: Literal["user", "system"]
-    is_misalignment_check: bool
-
-
-class TuringVIFRunRequest(BaseRunRequest):
+class TuringVIFRunRequest(TaskData, BaseRunRequest):
     """Request model for the VerifIF resource server."""
-
-    id: int = Field(default=0, description="Request identifier")
-    instructions: List[Dict[str, Any]] = Field(
-        default_factory=list, description="List of instruction objects with instruction_id and kwargs"
-    )
-    llm_judge: List[LLMJudgeItem] = Field(default_factory=list, description="List of custom LLM judge questions")
-    prompt: Optional[str] = Field(default=None, description="The original user prompt")
-    language: str = Field(
-        default="en",
-        description="Language code for multi-language validation (e.g., 'en', 'es', 'ja', 'zh', 'hi', 'ar')",
-    )
 
 
 class TuringVIFVerifyRequest(TuringVIFRunRequest, BaseVerifyRequest):

--- a/resources_servers/verifif/app.py
+++ b/resources_servers/verifif/app.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple
 
 from fastapi import FastAPI
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -154,6 +154,11 @@ class TuringVIFResourcesServerConfig(BaseResourcesServerConfig):
 
 class TuringVIFRunRequest(TaskData, BaseRunRequest):
     """Request model for the VerifIF resource server."""
+
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class TuringVIFVerifyRequest(TuringVIFRunRequest, BaseVerifyRequest):

--- a/resources_servers/verifif/app.py
+++ b/resources_servers/verifif/app.py
@@ -155,9 +155,6 @@ class TuringVIFResourcesServerConfig(BaseResourcesServerConfig):
 class TuringVIFRunRequest(TaskData, BaseRunRequest):
     """Request model for the VerifIF resource server."""
 
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/vlm_eval_kit/app.py
+++ b/resources_servers/vlm_eval_kit/app.py
@@ -26,19 +26,16 @@ from nemo_gym.base_resources_server import (
     BaseVerifyResponse,
     SimpleResourcesServer,
 )
+from resources_servers.vlm_eval_kit.task_data import TaskData
 
 
 class VlmEvalKitResourcesServerConfig(BaseResourcesServerConfig):
     pass
 
 
-class VLMEvalKitVerifyRequest(BaseVerifyRequest):
+class VLMEvalKitVerifyRequest(TaskData, BaseVerifyRequest):
     # We allow extra inputs here since there are many VLMEvalKit benchmarks that are run through the same resources server.
     model_config = ConfigDict(extra="allow")
-
-    benchmark_name: str
-    category: str
-    answer: Any
 
 
 class VLMEvalKitVerifyResponse(VLMEvalKitVerifyRequest, BaseVerifyResponse):

--- a/resources_servers/workplace_assistant/app.py
+++ b/resources_servers/workplace_assistant/app.py
@@ -26,6 +26,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.server_utils import SESSION_ID_KEY
+from resources_servers.workplace_assistant.task_data import TaskData
 from resources_servers.workplace_assistant.utils import get_tools, is_correct
 
 
@@ -41,11 +42,8 @@ class WorkbenchResponse(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
-class WorkbenchVerifyRequest(BaseVerifyRequest):
-    ground_truth: list[Dict[str, str]] | str
-    id: int
-    category: str
-    environment_name: str
+class WorkbenchVerifyRequest(TaskData, BaseVerifyRequest):
+    pass
 
 
 class WorkbenchVerifyResponse(BaseVerifyResponse):

--- a/resources_servers/workplace_assistant/app.py
+++ b/resources_servers/workplace_assistant/app.py
@@ -43,9 +43,6 @@ class WorkbenchResponse(BaseModel):
 
 
 class WorkbenchVerifyRequest(TaskData, BaseVerifyRequest):
-    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
-    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
-    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
     model_config = ConfigDict(extra="ignore")
 
 

--- a/resources_servers/workplace_assistant/app.py
+++ b/resources_servers/workplace_assistant/app.py
@@ -43,7 +43,10 @@ class WorkbenchResponse(BaseModel):
 
 
 class WorkbenchVerifyRequest(TaskData, BaseVerifyRequest):
-    pass
+    # Explicit ignore preserves the wire's pre-existing handling of UNDECLARED fields
+    # (they are dropped, as before this refactor). Fields TaskData declares are typed and
+    # kept. Flipping undeclared-field handling to allow is a separate, per-server decision.
+    model_config = ConfigDict(extra="ignore")
 
 
 class WorkbenchVerifyResponse(BaseVerifyResponse):

--- a/tests/unit_tests/test_task_data.py
+++ b/tests/unit_tests/test_task_data.py
@@ -232,26 +232,54 @@ class TestShippedSchemas:
         names = {p.parent.name for p in SCHEMA_FILES}
         assert {"example_multi_step", "example_mcp_weather", "example_single_tool_call"} <= names
 
+    @staticmethod
+    def _imported_modules(py_file: Path) -> list[str]:
+        modules = []
+        for node in ast.walk(ast.parse(py_file.read_text())):
+            if isinstance(node, ast.Import):
+                modules.extend(a.name for a in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.level == 0:
+                modules.append(node.module or "")
+        return modules
+
     @pytest.mark.parametrize("schema_file", SCHEMA_FILES, ids=lambda p: p.parent.name)
     def test_imports_are_dependency_light(self, schema_file):
-        tree = ast.parse(schema_file.read_text())
-        for node in ast.walk(tree):
-            modules = []
-            if isinstance(node, ast.Import):
-                modules = [a.name for a in node.names]
-            elif isinstance(node, ast.ImportFrom) and node.level == 0:
-                modules = [node.module or ""]
-            for module in modules:
-                root = module.split(".")[0]
-                allowed = (
-                    root in sys.stdlib_module_names
-                    or module.startswith(self.ALLOWED_IMPORT_PREFIXES)
-                    or (module.startswith("resources_servers.") and module.endswith(".task_data"))
-                )
-                assert allowed, (
-                    f"{schema_file}: import of {module!r} is not allowed in task_data.py "
-                    "(stdlib, pydantic, nemo_gym.task_data, and other servers' task_data only)"
-                )
+        for module in self._imported_modules(schema_file):
+            root = module.split(".")[0]
+            allowed = (
+                root in sys.stdlib_module_names
+                or module.startswith(self.ALLOWED_IMPORT_PREFIXES)
+                or (module.startswith("resources_servers.") and module.endswith(".task_data"))
+            )
+            assert allowed, (
+                f"{schema_file}: import of {module!r} is not allowed in task_data.py "
+                "(stdlib, pydantic, nemo_gym.task_data, and other servers' task_data only)"
+            )
+
+    @pytest.mark.parametrize("schema_file", SCHEMA_FILES, ids=lambda p: p.parent.name)
+    def test_cross_server_schema_imports_mirror_app_imports(self, schema_file):
+        """A schema may import another server's schema only when its own app.py imports that server.
+
+        Sharing field declarations between servers whose app.py files have no relationship couples
+        independent verifiers for no reason, and once a request model inherits its TaskData the foreign
+        server becomes a runtime dependency of the verifier.
+        """
+        own = schema_file.parent.name
+        app_file = schema_file.parent / "app.py"
+        app_imports = self._imported_modules(app_file) if app_file.exists() else []
+        for module in self._imported_modules(schema_file):
+            if not (module.startswith("resources_servers.") and module.endswith(".task_data")):
+                continue
+            target = module.split(".")[1]
+            if target == own:
+                continue
+            app_depends_on_target = any(
+                m == f"resources_servers.{target}" or m.startswith(f"resources_servers.{target}.") for m in app_imports
+            )
+            assert app_depends_on_target, (
+                f"{schema_file}: imports {module!r} but {own}/app.py does not import resources_servers.{target}. "
+                "Inline the fields instead; schema inheritance must mirror a real app.py dependency."
+            )
 
     @pytest.mark.parametrize("schema_file", SCHEMA_FILES, ids=lambda p: p.parent.name)
     def test_loads_and_bans_extra_ignore(self, schema_file):


### PR DESCRIPTION
## What this does

Each server's run/verify request model now inherits its `task_data.py` schema. Task fields are declared once, in the schema. The wire model and the schema can no longer drift apart, because they are the same class.

Before:
```python
class StringMatchRunRequest(BaseRunRequest):
    expected_answer: str
    extraction_mode: Literal["boxed", "final_answer", "last_line", "full_response"] = "final_answer"
    case_sensitive: bool = False
    metadata: Optional[dict[str, Any]] = None
```
After:
```python
class StringMatchRunRequest(TaskData, BaseRunRequest):
    pass
```

This is batch 1 of the inherit refactor: the 51 flat-row servers whose models import in the core venv. Later batches cover the servers that nest fields in `verifier_metadata` (xstest, longmemeval, deepswe, and the vm family), the 13 servers that keep an explicit `extra="ignore"`, the heavy-dependency servers that need their own venvs, and the base-model servers whose verify ignores task fields.

## Behavior changes, all intentional

- **Handling of undeclared fields does not change.** Models that dropped unknown fields before keep an explicit `extra="ignore"` with a comment, so a stray column in user data behaves exactly as it does today. Only fields the schema declares are kept and typed. Widening any server to `extra="allow"` is a separate, per-server decision for a later PR.
- **69 fields become typed.** Row fields the schema declares but the old wire did not (for example `bird_sql.sql_context`, `litmus_agent.smiles`) used to ride as untyped extras. They are now declared fields with types.
- **14 documented contract deltas** where the reviewed schema is deliberately stricter than the old wire. Examples: `arc_agi.train` loses its `[]` wire default (the default masked missing data and produced a degenerate comparison), and `math_advanced_calculations.ground_truth` drops the `list[float]` branch (that branch crashed verify() with `json.loads` on a list). The full list with justifications is in the verification report comment on this PR.

Two servers needed a code fix, not just the model swap. `litmus_agent.verify()` read legacy `property_type` out of `model_extra`; the typed field no longer lands there, so the resolver now receives it explicitly. `indirect_prompt_injection`'s tests construct verify requests by hand and now supply the wire-required `environment` row field. Three servers keep duplicated field classes out of the schema on purpose: `single_step_tool_use_with_argument_comparison` and `format_verification` redeclare one field each because their verify logic isinstance-checks or dict-reads those exact types, and `verifif`/`indirect_prompt_injection` re-point their item classes to the schema module so there is a single definition.

## How this was verified

- **Contract gate.** Every `*RunRequest`/`*VerifyRequest` model on this branch was dumped (fields, types, required-ness, defaults, extra config) and diffed against the same dump from the parent branch. Result: 0 unexplained differences and 0 extra-config changes. The only changes are the typed field additions and the 14 documented deltas.
- **Row gate.** Every committed data row of all 51 servers was validated by both the old and the new models: 910 (model, row) pairs. Accept/reject agrees on every pair. Overlapping dump values are equal on every pair. The only dump difference is 133 schema-declared fields the old wire silently dropped and the new one keeps as typed fields. Undeclared fields are dropped exactly as before.
- **Server tests.** All 51 servers' own test suites pass. Three suites (asr_with_pc, conversational_tool_use_simulation, math_proof_judgement) fail identically on the parent branch because the shared core venv lacks their extra dependencies; `gym env test` covers those with per-server venvs.
- **Core suite and drift gate.** The full `tests/unit_tests/` suite passes, including the repo-wide row-vs-schema drift test from the parent PR.
- **Golden routing gate.** Parent-branch capture vs this branch, strict compare, 0 differences.





## Also in this PR: schemas no longer inherit across unrelated servers

#2800 made 17 `task_data.py` files import another server's schema. 6 of those mirror a real `app.py` dependency (the mcqa and math_with_judge heirs) and stay. The other 11 shared two or three field declarations between verifiers whose code has no relationship. That was a mistake in #2800. With this PR it gets worse: once a request model inherits its `TaskData`, the foreign schema sits in the verifier's inheritance chain at runtime.

Before, abstention's schema:
```python
from resources_servers.simpleqa.task_data import JudgeQATaskDataCore

class TaskData(JudgeQATaskDataCore):
    answer: Optional[str] = ...
```
After:
```python
class TaskData(BaseModel):
    model_config = ConfigDict(extra="allow")
    id: Optional[Union[int, str]] = ...
    question: Optional[str] = ...
    answer: Optional[str] = ...
```

- Inlined the fields in the 11 heirs and collapsed the shared base classes that lost all their heirs. Three inherited descriptions were wrong for the heir (evalplus, toolsandbox, frontierscience_judge) and are now correct.
- Removed the `id`/`question`/`expected_answer` redeclarations the codemod left behind in the four judge-QA request models. They come from `TaskData` now.
- Added a unit test: a `task_data.py` may import another server's `task_data` only if its own `app.py` imports that server.

Verified: JSON schema of all 20 touched `TaskData` classes is structurally identical before and after (7 differ in descriptions only). Request-model wire contracts of the 6 affected servers are identical. Schema tests, the drift test, and the full core suite pass.



## Rebased onto main (2026-09-10)

Two conflicts, both from main changes that landed after this branch forked:

- **aalcr.** #3152 added three protocol-version fields to the request model and to the schema. The request model now inherits them from `TaskData`. Main's schema types `aa_lcr_version` as a Literal and constrains `aa_lcr_dataset_revision` to a 40-hex pattern, where the old wire had plain `str`. Both values were already rejected by `_validate_protocol_metadata` inside verify; a bad row now fails at the wire with a 422 instead of inside verify with a 500. Two more entries for the documented-delta list.
- **terminal_bench_2_1.** Main split the request into `TerminalBench21SeedSessionRequest` plus a verify request that inherits it. The seed-session model now inherits `TaskData`; fields and defaults are identical to main, and the implicit default `extra="ignore"` is explicit.

Re-verified after the rebase: schema tests and the drift test pass against main's 434 cases, aalcr and terminal_bench_2_1 suites pass, full core suite passes.
