### PR TITLE
fix(terminus-2): preserve terminal response ID

### DIFF
--- a/responses_api_agents/terminus_2_agent/app.py
+++ b/responses_api_agents/terminus_2_agent/app.py
@@ -381,7 +381,7 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
         body: NeMoGymResponseCreateParamsNonStreaming,
         instruction: str,
         api_base: str,
-    ) -> tuple[dict[str, Any], AgentContext, dict[str, bool], bool, bool]:
+    ) -> tuple[dict[str, Any], AgentContext, dict[str, bool], bool, bool, str | None]:
         logs_dir = self._logs_dir()
         temporary_workspace: Optional[Path] = None
         try:
@@ -409,7 +409,9 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
             trajectory_path = logs_dir / "trajectory.json"
             trajectory = json.loads(trajectory_path.read_text()) if trajectory_path.exists() else {"steps": []}
             flags = {"context_length_exceeded": agent.context_length_exceeded}
-            return trajectory, context, flags, timed_out, agent.finished_naturally
+            llm = getattr(agent, "_llm", None)
+            terminal_response_id = llm.last_response_id if isinstance(llm, NemoGymLLM) else None
+            return trajectory, context, flags, timed_out, agent.finished_naturally, terminal_response_id
         finally:
             if not self.config.keep_logs:
                 shutil.rmtree(logs_dir, ignore_errors=True)
@@ -436,7 +438,7 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
             self._rollout_id(request),
         )
         async with self.sem:
-            trajectory, context, flags, timed_out, finished_naturally = await self._run_terminus(
+            trajectory, context, flags, timed_out, finished_naturally, terminal_response_id = await self._run_terminus(
                 body, instruction, api_base
             )
         output_items = trajectory_to_responses(trajectory)
@@ -461,7 +463,7 @@ class Terminus2Agent(SimpleResponsesAPIAgent):
             cached_tokens = context.n_cache_tokens or 0
 
         return NeMoGymResponse(
-            id=f"resp_{uuid4().hex}",
+            id=terminal_response_id or f"resp_{uuid4().hex}",
             created_at=int(time()),
             model=self._model_name(body),
             object="response",

--- a/responses_api_agents/terminus_2_agent/llm.py
+++ b/responses_api_agents/terminus_2_agent/llm.py
@@ -83,6 +83,7 @@ class NemoGymLLM(BaseLLM):
         self._ambiguous_routed_expert_keys: set[_RolloutDetailsKey] = set()
 
         self.context_length_exceeded = False
+        self.last_response_id: str | None = None
         self._extra_chat_params = self._build_extra_chat_params(responses_create_params or {})
 
     @retry(
@@ -134,6 +135,9 @@ class NemoGymLLM(BaseLLM):
             raise ContextLengthExceededError(
                 f"Model {self._model_name} context length exceeded (detected fake response id='chtcmpl-123')"
             )
+        response_id = response_dict.get("id")
+        if isinstance(response_id, str) and response_id:
+            self.last_response_id = response_id
 
         choices = response_dict.get("choices", [])
         choice = choices[0] if isinstance(choices, list) and choices else {}

--- a/responses_api_agents/terminus_2_agent/tests/test_app.py
+++ b/responses_api_agents/terminus_2_agent/tests/test_app.py
@@ -204,7 +204,7 @@ class TestResponses:
             "final_metrics": {"total_prompt_tokens": 10, "total_completion_tokens": 4},
         }
         context = AgentContext(n_input_tokens=10, n_output_tokens=4, n_cache_tokens=0)
-        agent._run_terminus = AsyncMock(return_value=(trajectory, context, {}, False, True))
+        agent._run_terminus = AsyncMock(return_value=(trajectory, context, {}, False, True, "chatcmpl-terminal"))
 
         body = NeMoGymResponseCreateParamsNonStreaming(
             model="ignored-request-model",
@@ -217,6 +217,7 @@ class TestResponses:
             response = await agent.responses(request=None, body=body)
 
         assert response.model == "test-model"
+        assert response.id == "chatcmpl-terminal"
         assert response.temperature == 0.7
         assert [item.type for item in response.output] == ["message", "function_call", "function_call_output"]
         assert response.usage.total_tokens == 14
@@ -227,7 +228,7 @@ class TestResponses:
     @pytest.mark.asyncio
     async def test_empty_trajectory_gets_assistant_message(self) -> None:
         agent = _make_agent()
-        agent._run_terminus = AsyncMock(return_value=({"steps": []}, AgentContext(), {}, False, False))
+        agent._run_terminus = AsyncMock(return_value=({"steps": []}, AgentContext(), {}, False, False, None))
         body = NeMoGymResponseCreateParamsNonStreaming(model="model", input="task")
 
         with patch.object(Terminus2Agent, "resolve_model_base_url", return_value="http://model/v1"):
@@ -240,7 +241,7 @@ class TestResponses:
     async def test_direct_response_waits_for_concurrency_slot(self) -> None:
         agent = _make_agent()
         agent.sem = asyncio.Semaphore(0)
-        agent._run_terminus = AsyncMock(return_value=({"steps": []}, AgentContext(), {}, False, False))
+        agent._run_terminus = AsyncMock(return_value=({"steps": []}, AgentContext(), {}, False, False, None))
         body = NeMoGymResponseCreateParamsNonStreaming(model="model", input="task")
 
         with patch.object(Terminus2Agent, "resolve_model_base_url", return_value="http://model/v1"):

--- a/responses_api_agents/terminus_2_agent/tests/test_llm.py
+++ b/responses_api_agents/terminus_2_agent/tests/test_llm.py
@@ -59,6 +59,7 @@ async def test_extracts_openai_shape():
         llm,
         _mock_response(
             content="hello",
+            id="chatcmpl-terminal",
             extra_message={"generation_token_ids": [7, 8]},
             extra_choice={"logprobs": {"content": [{"logprob": -0.1}, {"logprob": -0.2}]}},
             prompt_token_ids=[1, 2, 3],
@@ -73,6 +74,7 @@ async def test_extracts_openai_shape():
     assert response.logprobs == [-0.1, -0.2]
     assert response.usage.prompt_tokens == 10
     assert response.usage.cache_tokens == 4
+    assert llm.last_response_id == "chatcmpl-terminal"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Preserve the final model server response ID inside the Terminus 2 LLM adapter.
- Reuse that ID on the outer agent response so terminal attribution can join the verified response to the captured model call.
- Keep the existing generated response ID as a fallback when no model response ID is available.

This is needed when Terminus 2 uses out-of-band token capture. Responses that already carry native token IDs continue to use the existing short-circuit and do not perform terminal attribution.

## Test plan
- [x] Run the Terminus 2 agent tests (41 passed).
- [x] Run Ruff checks and formatting validation on all changed files.