### PR TITLE
fix: preserve batch wrapper exit status

### DIFF
--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -285,7 +285,7 @@ main_job_id=$(
         --comment="$SLURM_COMMENT" \
         --exclusive \
         --segment=$NUM_NODES \
-        --wrap 'exec bash -lc "$batch_command"'
+        --wrap 'exec bash -c "$batch_command"'
 )
 main_job_id=${main_job_id%%;*}
 

--- a/tests/unit_tests/test_opensandbox_cleanup.py
+++ b/tests/unit_tests/test_opensandbox_cleanup.py
@@ -621,6 +621,8 @@ def test_slurm_launcher_submits_one_dependent_cpu_cleanup_job(tmp_path: Path) ->
     ]
     main_call, cleanup_call = read_sbatch_calls(calls_path)
     assert "--parsable" in main_call
+    wrap_index = main_call.index("--wrap")
+    assert main_call[wrap_index + 1] == 'exec bash -c "$batch_command"'
 
     submit_dir = str(Path.cwd().resolve())
     repo_root = SBATCH_SCRIPT.resolve().parents[2]
@@ -698,7 +700,7 @@ def test_slurm_launcher_reports_cleanup_submission_failure(tmp_path: Path) -> No
 
 @pytest.mark.parametrize(
     ("first_step", "eval_status", "expected_status"),
-    [("eval", 37, 37), ("eval", 143, 143), ("server", 0, 41)],
+    [("eval", 0, 0), ("eval", 37, 37), ("eval", 143, 143), ("server", 0, 41)],
 )
 def test_slurm_batch_command_preserves_status_and_stops_server(
     tmp_path: Path, first_step: str, eval_status: int, expected_status: int


### PR DESCRIPTION
## Summary

- run the generated batch command with a non-login shell
- preserve its exit status through server teardown
- cover the submitted wrapper and clean lifecycle path

## Tests

- pytest -q tests/unit_tests/test_opensandbox_cleanup.py
- pytest -q tests/unit_tests/ -m "not sandbox"
- pre-commit run --all-files