### PR TITLE
Retry PTY takeover attach when execd's eviction times out

### DIFF
--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -32,6 +32,7 @@ from nemo_gym.sandbox.providers.base import (
     SandboxEndpoint,
     SandboxExecResult,
     SandboxHandle,
+    SandboxPtyError,
     SandboxPtySession,
     SandboxPtySpec,
     SandboxResources,
@@ -1489,18 +1490,31 @@ class OpenSandboxProvider:
         since: int | None = None,
     ) -> SandboxPtySession:
         """Re-attach to an existing execd PTY session by id."""
-        from nemo_gym.sandbox.providers.opensandbox.pty import attach_pty_session
+        from nemo_gym.sandbox.providers.opensandbox.pty import _PTY_TAKEOVER_RETRY_DELAYS, attach_pty_session
 
         base_url, headers, request_timeout_s = await self._pty_target(handle)
-        session = await attach_pty_session(
-            client=self._pty_http_client(),
-            base_url=base_url,
-            headers=headers,
-            session_id=session_id,
-            takeover=takeover,
-            since=since,
-            request_timeout_s=request_timeout_s,
-        )
+        # A takeover evicts the attached client, and execd waits for that
+        # client to acknowledge. A half-open peer (silently dropped along the
+        # proxy path) cannot answer, so execd's eviction times out and the
+        # attach comes back as a policy-violation close — reported as "already
+        # has an attached client" — while the stale client is torn down in the
+        # background. A fresh attempt then lands, so retry exactly that case.
+        for delay in (*_PTY_TAKEOVER_RETRY_DELAYS, None):
+            try:
+                session = await attach_pty_session(
+                    client=self._pty_http_client(),
+                    base_url=base_url,
+                    headers=headers,
+                    session_id=session_id,
+                    takeover=takeover,
+                    since=since,
+                    request_timeout_s=request_timeout_s,
+                )
+                break
+            except SandboxPtyError as e:
+                if not takeover or delay is None or "already has an attached client" not in str(e):
+                    raise
+            await asyncio.sleep(delay)
         await self._retire_closed_pty_sessions()
         self._pty_sessions.add(session)
         return session

--- a/nemo_gym/sandbox/providers/opensandbox/pty.py
+++ b/nemo_gym/sandbox/providers/opensandbox/pty.py
@@ -55,6 +55,11 @@ WS_CLOSE_POLICY_VIOLATION = 1008
 # window; the tail rides out per-replica informer lag (each retry re-rolls the
 # load-balanced replica, so 404 "pod IP not yet available" clears quickly).
 _PTY_RETRY_DELAYS = (0.25, 0.5, 1.0, 2.0, 4.0, 8.0)
+# A takeover that finds a half-open peer waits out execd's eviction timeout
+# before the policy-violation close arrives, so these are spaced in seconds,
+# not fractions: the stale client is torn down in the background and a later
+# attempt lands.
+_PTY_TAKEOVER_RETRY_DELAYS = (2.0, 5.0, 10.0)
 
 # Mirrors execd's shell pick (bash when available, else sh) for env-only specs.
 _DEFAULT_SHELL_SNIPPET = 'exec "$(command -v bash || echo sh)"'

--- a/nemo_gym/sandbox/providers/opensandbox/pty.py
+++ b/nemo_gym/sandbox/providers/opensandbox/pty.py
@@ -60,6 +60,12 @@ _PTY_RETRY_DELAYS = (0.25, 0.5, 1.0, 2.0, 4.0, 8.0)
 # not fractions: the stale client is torn down in the background and a later
 # attempt lands.
 _PTY_TAKEOVER_RETRY_DELAYS = (2.0, 5.0, 10.0)
+# Long-held PTY sockets cross an NLB and the server proxy, either of which can
+# drop them silently. Heartbeats keep intermediaries from idle-reaping the
+# connection and surface a dead socket as a failed ping within about a minute
+# (triggering the reattach path) instead of leaving a half-open client behind
+# for the next takeover to time out against.
+_PTY_WS_HEARTBEAT_S = 30.0
 
 # Mirrors execd's shell pick (bash when available, else sh) for env-only specs.
 _DEFAULT_SHELL_SNIPPET = 'exec "$(command -v bash || echo sh)"'
@@ -591,7 +597,10 @@ async def _connect_ws(
     # definitive answers (404 gone, 409 held) propagate immediately.
     for delay in (*_PTY_RETRY_DELAYS, None):
         try:
-            return await asyncio.wait_for(client.ws_connect(ws_url, headers=headers), timeout=request_timeout_s)
+            return await asyncio.wait_for(
+                client.ws_connect(ws_url, headers=headers, heartbeat=_PTY_WS_HEARTBEAT_S),
+                timeout=request_timeout_s,
+            )
         except aiohttp.WSServerHandshakeError as e:
             if e.status not in (502, 503) or delay is None:
                 raise

--- a/resources_servers/terminal_bench_2_1/app.py
+++ b/resources_servers/terminal_bench_2_1/app.py
@@ -104,13 +104,6 @@ class TerminalBench21ResourcesServer(SimpleResourcesServer):
     async def seed_session(self, request: Request, body: TerminalBench21VerifyRequest) -> BaseSeedSessionResponse:
         eval_sandbox, pty_session = await self._create_sandbox(body)
         self._session_id_to_sandbox[request.session[SESSION_ID_KEY]] = eval_sandbox, pty_session
-        # Hand the terminal over without leaving our client attached: a socket
-        # idling through the whole agent phase is the one most likely to go
-        # half-open, and the next attach would then have to evict a peer that
-        # can no longer answer. The server-side session keeps running; a later
-        # user reattaches (or attaches fresh with takeover) when it needs it.
-        if hasattr(pty_session, "detach"):
-            await pty_session.detach()
 
         return TerminalBench21SeedSessionResponse(sandbox_handle=eval_sandbox._handle.sandbox_id)
 

--- a/resources_servers/terminal_bench_2_1/app.py
+++ b/resources_servers/terminal_bench_2_1/app.py
@@ -104,6 +104,13 @@ class TerminalBench21ResourcesServer(SimpleResourcesServer):
     async def seed_session(self, request: Request, body: TerminalBench21VerifyRequest) -> BaseSeedSessionResponse:
         eval_sandbox, pty_session = await self._create_sandbox(body)
         self._session_id_to_sandbox[request.session[SESSION_ID_KEY]] = eval_sandbox, pty_session
+        # Hand the terminal over without leaving our client attached: a socket
+        # idling through the whole agent phase is the one most likely to go
+        # half-open, and the next attach would then have to evict a peer that
+        # can no longer answer. The server-side session keeps running; a later
+        # user reattaches (or attaches fresh with takeover) when it needs it.
+        if hasattr(pty_session, "detach"):
+            await pty_session.detach()
 
         return TerminalBench21SeedSessionResponse(sandbox_handle=eval_sandbox._handle.sandbox_id)
 

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -621,7 +621,9 @@ async def test_provider_attach_pty_retries_timed_out_takeover(monkeypatch: pytes
     rejected.closed = True
     clients = [FakeHttpClient(ws=rejected), FakeHttpClient(ws=FakeWs([CONNECTED]))]
     handed_out: list[FakeHttpClient] = []
-    monkeypatch.setattr(provider, "_pty_http_client", lambda: handed_out.append(clients[len(handed_out)]) or handed_out[-1])
+    monkeypatch.setattr(
+        provider, "_pty_http_client", lambda: handed_out.append(clients[len(handed_out)]) or handed_out[-1]
+    )
     monkeypatch.setattr(pty_module, "_PTY_TAKEOVER_RETRY_DELAYS", (0.0,))
     handle = SandboxHandle(sandbox_id="sb-1", provider_name="opensandbox", raw=FakeRaw())
     session = await provider.attach_pty(handle, "s-7", takeover=True)

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -584,6 +584,58 @@ async def test_provider_attach_pty_reuses_endpoint(monkeypatch: pytest.MonkeyPat
     await session.close()
 
 
+async def test_provider_attach_pty_retries_timed_out_takeover(monkeypatch: pytest.MonkeyPatch) -> None:
+    # execd waits for the evicted client to acknowledge a takeover; a
+    # half-open peer cannot, so the first attach closes 1008 while the stale
+    # client is torn down in the background. The provider re-dials and lands.
+    pytest.importorskip("tenacity", reason="tenacity optional sandbox dependency is not installed")
+    pytest.importorskip("opensandbox", reason="opensandbox SDK is not installed")
+    from nemo_gym.sandbox.providers.opensandbox.provider import OpenSandboxProvider
+
+    class FakeRaw:
+        async def get_endpoint(self, port: int) -> SimpleNamespace:
+            return SimpleNamespace(endpoint="server/v1/sandboxes/sb-1/proxy/44772", headers={})
+
+    provider = OpenSandboxProvider(connection={"domain": "server", "api_key": "k", "protocol": "https"})
+    rejected = FakeWs([], close_code=1008)
+    rejected.closed = True
+    clients = [FakeHttpClient(ws=rejected), FakeHttpClient(ws=FakeWs([CONNECTED]))]
+    handed_out: list[FakeHttpClient] = []
+    monkeypatch.setattr(provider, "_pty_http_client", lambda: handed_out.append(clients[len(handed_out)]) or handed_out[-1])
+    monkeypatch.setattr(pty_module, "_PTY_TAKEOVER_RETRY_DELAYS", (0.0,))
+    handle = SandboxHandle(sandbox_id="sb-1", provider_name="opensandbox", raw=FakeRaw())
+    session = await provider.attach_pty(handle, "s-7", takeover=True)
+    assert len(handed_out) == 2, "the timed-out takeover must be re-dialed once"
+    assert handed_out[0].closed, "the failed attempt's client must be released"
+    await session.close()
+
+
+async def test_provider_attach_pty_does_not_retry_without_takeover(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("tenacity", reason="tenacity optional sandbox dependency is not installed")
+    pytest.importorskip("opensandbox", reason="opensandbox SDK is not installed")
+    from nemo_gym.sandbox.providers.opensandbox.provider import OpenSandboxProvider
+
+    class FakeRaw:
+        async def get_endpoint(self, port: int) -> SimpleNamespace:
+            return SimpleNamespace(endpoint="server/v1/sandboxes/sb-1/proxy/44772", headers={})
+
+    provider = OpenSandboxProvider(connection={"domain": "server", "api_key": "k", "protocol": "https"})
+    rejected = FakeWs([], close_code=1008)
+    rejected.closed = True
+    clients_handed = 0
+
+    def _client() -> FakeHttpClient:
+        nonlocal clients_handed
+        clients_handed += 1
+        return FakeHttpClient(ws=rejected)
+
+    monkeypatch.setattr(provider, "_pty_http_client", _client)
+    handle = SandboxHandle(sandbox_id="sb-1", provider_name="opensandbox", raw=FakeRaw())
+    with pytest.raises(SandboxPtyError, match="already has an attached client"):
+        await provider.attach_pty(handle, "s-7", takeover=False)
+    assert clients_handed == 1, "without takeover the rejection is definitive"
+
+
 async def test_create_rejected_before_connected_raises_and_cleans_up() -> None:
     # The session we created is torn down when the socket is rejected.
     ws = FakeWs([], close_code=1008)

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -125,8 +125,10 @@ class FakeHttpClient:
         self.delete_calls.append((url, headers))
         return FakeResponse(200)
 
-    async def ws_connect(self, url: str, *, headers: dict[str, str]) -> FakeWs:
+    async def ws_connect(self, url: str, *, headers: dict[str, str], heartbeat: float | None = None) -> FakeWs:
         self.ws_calls.append((url, headers))
+        self.ws_heartbeats: list[float | None] = getattr(self, "ws_heartbeats", [])
+        self.ws_heartbeats.append(heartbeat)
         if isinstance(self._ws_error, list):
             if self._ws_error:
                 raise self._ws_error.pop(0)
@@ -581,6 +583,24 @@ async def test_provider_attach_pty_reuses_endpoint(monkeypatch: pytest.MonkeyPat
     handle = SandboxHandle(sandbox_id="sb-1", provider_name="opensandbox", raw=FakeRaw())
     session = await provider.attach_pty(handle, "s-7", takeover=True, since=10)
     assert client.ws_calls[0][0] == "wss://server/v1/sandboxes/sb-1/proxy/44772/pty/s-7/ws?takeover=1&since=10"
+    await session.close()
+
+
+async def test_pty_sockets_dial_with_heartbeat() -> None:
+    # Silent half-open sockets are what takeover timeouts are made of; every
+    # PTY dial requests websocket heartbeats so a dead peer is detected and
+    # re-dialed instead of dangling until the next takeover.
+    from nemo_gym.sandbox.providers.opensandbox.pty import attach_pty_session
+
+    client = FakeHttpClient(ws=FakeWs([CONNECTED]))
+    session = await attach_pty_session(
+        client=client,  # type: ignore[arg-type]
+        base_url="http://server/base",
+        headers={},
+        session_id="s-1",
+        request_timeout_s=5.0,
+    )
+    assert client.ws_heartbeats == [pty_module._PTY_WS_HEARTBEAT_S]
     await session.close()
 
 


### PR DESCRIPTION
## Problem

On terminal-bench 2.1 runs at 1k-sandbox scale, verify-phase re-attaches intermittently fail with:

```
nemo_gym.sandbox.providers.base.SandboxPtyError: PTY session already has an attached client
```

even though the attach passes `takeover=True`.

## Root cause

The tb2.1 flow passes one PTY session through three holders — resources server (create) → opencode agent → resources server (verify) — and every handoff relies on takeover-evicting the previous client. execd implements takeover as a cooperative eviction with a timeout (its binary carries `takeover timed out for pty session`). Eviction is only cheap while the previous client is alive: a socket idled through the whole agent phase is exactly the one the NLB/server-proxy path drops silently, so the next takeover waits out execd's eviction timeout and surfaces as a policy-violation close, which the client maps to "already has an attached client". The stale peer is torn down in the background, so a fresh attempt lands.

## Changes

1. **Retry the takeover attach** (`provider.attach_pty`): up to three re-dials (2s/5s/10s) on exactly that signature, fresh HTTP client per attempt. Non-takeover rejections and other errors stay definitive.
2. **Detach the baton instead of dangling it** (`tb2.1 seed_session`): the creator detaches right after creating the session, so the agent's attach finds nothing to evict; the server-side session keeps running and replays on reattach. Takeover+retry becomes the recovery path for crashed holders, not the routine handoff.
3. **Websocket heartbeats on every PTY dial** (30s): intermediaries stop idle-reaping healthy sockets, and a dead socket surfaces as a failed ping and re-dials via the existing reattach path within ~a minute instead of dangling half-open until the next takeover times out against it.

### For the tb2.1 dev branch (#2175) — same contract, two snippets

The agent-attach and verify-reattach code paths live on the dev branch, so two spots there complete the pattern:

- opencode agent server, when the rollout finishes: `await pty_session.detach()` — whoever is done with the terminal detaches; takeover is for crashes.
- verify, restoring a client: keep `attach(session_id=..., takeover=True)` (it now retries), or reattach the stored session when it is merely detached.

## Testing

- Unit: `tests/unit_tests/test_opensandbox_pty.py` — 61 passed (new: takeover-timeout retry lands on re-dial with the failed client released; no retry without takeover; every dial passes the heartbeat).
- E2E against the cell-2 OpenSandbox cluster (real execd through the server proxy), full three-holder flow with this branch's code:
  - creator opened a session, ran a command, **detached**;
  - agent takeover-attached (nothing to evict), set shell state, **detached**;
  - verify takeover-attached and ran the check **detached across multiple reattach polls** (12s command, 4s poll);
  - shell state set by the agent (`$AGENT_MARK`) was visible in verify — one server-side session across all three handoffs; exit code 0; sandbox deleted cleanly.
  - Separately verified live takeover of an attached client (evictee sees close 4001 "taken over") and that a no-takeover attach against a held session returns exactly the retried signature.

Companion platform ask (separate): execd should force-close the stale socket instead of waiting for a half-open peer, and use a distinct close code for takeover-timeout vs genuinely-attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)