### PR TITLE
docs: fix wrong Hydra override key in reverify-rollouts tutorial

### DIFF
--- a/fern/versions/latest/pages/evaluation-tutorials/reverify-rollouts.mdx
+++ b/fern/versions/latest/pages/evaluation-tutorials/reverify-rollouts.mdx
@@ -107,7 +107,7 @@ Hydra overrides work the same as in other `gym eval` commands:
 ```bash
 gym eval reverify \
   --config my_resources_server.yaml \
-  "++mcqa_resources_server.resources_servers.mcqa.grading_mode=strict_single_letter_boxed" \
+  "++mcqa.resources_servers.mcqa.grading_mode=strict_single_letter_boxed" \
   --inputs results/rollouts_materialized_inputs.jsonl \
   --rollouts results/rollouts.jsonl \
   --output results/rollouts_strict_reverified.jsonl


### PR DESCRIPTION
## Issue
https://github.com/NVIDIA-NeMo/Gym/issues/2698

## Summary
- The `reverify-rollouts.mdx` Hydra override example used a nonexistent top-level key `mcqa_resources_server`, which silently does nothing to the verifier when copy-pasted.
- Corrects it to `mcqa`, matching `resources_servers/mcqa/configs/mcqa.yaml` and the equivalent (correct) example in `reference/cli-commands.mdx`.

## Test plan
- [x] Verified the top-level key in `resources_servers/mcqa/configs/mcqa.yaml` is `mcqa`, not `mcqa_resources_server`.
- [x] Confirmed the corrected line now matches the working example in `reference/cli-commands.mdx:768`.
- [x] Docs-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)