### PR TITLE
feat(cli): add strict mode for gym env validate command

### DIFF
--- a/fern/versions/latest/pages/reference/cli-commands.mdx
+++ b/fern/versions/latest/pages/reference/cli-commands.mdx
@@ -438,12 +438,15 @@ gym env resolve \
 
 Validate a manifest-backed workload or legacy config without starting Ray or server subprocesses. Manifest validation resolves the Gym config offline, checks composition mirrors and datasets, and reports the resolved components. Legacy validation retains the existing config pre-flight behavior. Exits `0` when valid, or `1` with a clean message when not.
 
+By default, values a run needs but the config leaves undefined (such as `policy_base_url` from `env.yaml`) are filled with placeholders so the rest can still be checked, and reported as a warning. Pass `--strict` to fail on them instead.
+
 | Option | Description |
 | --- | --- |
 | `NAME` | Manifest-backed catalog entry to validate. |
 | `--kind environment\|benchmark` | Resolve an ambiguous catalog name. |
 | `--manifest PATH` | Validate a manifest directly instead of selecting by name. |
 | `--sync` | Atomically synchronize config-owned composition mirrors after all checks pass. |
+| `--strict` | Resolve the config exactly as a run would, with no placeholder model values. An undefined value fails instead of warning. |
 | `--json` | Output the manifest validation report as JSON. |
 | `--config PATH` | Config file to load. Repeatable. |
 | `--environment NAME` / `--benchmark NAME` | Validate a named environment / benchmark config. |
@@ -460,6 +463,9 @@ gym env validate --benchmark gsm8k
 
 # or explicit config path(s)
 gym env validate --config resources_servers/example_single_tool_call/configs/example_single_tool_call.yaml
+
+# fail unless everything a run needs is defined, credentials included
+gym env validate --resources-server example_single_tool_call --model-type openai_model --strict
 ```
 
 ### `gym env packages`

--- a/nemo_gym/cli/env.py
+++ b/nemo_gym/cli/env.py
@@ -1253,12 +1253,29 @@ def validate() -> None:
     if unsupported:
         raise ConfigError("The following options require a workload name or --manifest: " + ", ".join(unsupported))
 
-    global_config_dict = get_global_config_dict(
-        global_config_dict_parser_config=GlobalConfigDictParserConfig(
-            initial_global_config_dict=GlobalConfigDictParserConfig.NO_MODEL_GLOBAL_CONFIG_DICT,
-        ),
-    )
+    # Resolve what a run resolves. Falling back to the stand-ins keeps a config that needs no model
+    # checkable, but only an error the stand-ins account for is downgraded: any other still propagates.
+    try:
+        global_config_dict = get_global_config_dict()
+        incomplete_config_error = None
+    except ConfigError as error:
+        if command_dict.get("strict", False):
+            raise
+        incomplete_config_error = error
+        global_config_dict = get_global_config_dict(
+            global_config_dict_parser_config=GlobalConfigDictParserConfig(
+                initial_global_config_dict=GlobalConfigDictParserConfig.NO_MODEL_GLOBAL_CONFIG_DICT,
+            ),
+        )
+
     BaseNeMoGymCLIConfig.model_validate(global_config_dict)
+    if incomplete_config_error is not None:
+        rich.print(
+            "[yellow]Warning:[/yellow] this config does not define model server configuration "
+            "and will not start as-is. Re-run with [bold]--strict[/bold] to fail on this "
+            f"instead of warning.\n{incomplete_config_error}",
+            file=sys.stderr,
+        )
     rich.print("[green]✓[/green] Config is valid.")
 
 

--- a/nemo_gym/cli/main.py
+++ b/nemo_gym/cli/main.py
@@ -755,6 +755,7 @@ COMMANDS = {
             CATALOG_KIND,
             _value_flag("manifest", "manifest_path", "Manifest path to validate.", quote=True),
             _bool_flag("sync", "sync", "Synchronize composition mirrors after validation."),
+            _bool_flag("strict", "strict", "Fail instead of warning when model values are left undefined."),
             JSON,
             CONFIG,
             BENCHMARK,


### PR DESCRIPTION
Fixes #2221. Passing a config without fully defined mode emits a warning. If user passes `--strict` - the error is raised for such cases.