### PR TITLE
release: set package version to 0.6.0rc0

### DIFF
--- a/nemo_gym/package_info.py
+++ b/nemo_gym/package_info.py
@@ -15,8 +15,8 @@
 
 
 MAJOR = 0
-MINOR = 5
-PATCH = 1
+MINOR = 6
+PATCH = 0
 PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)

--- a/nemo_gym/package_info.py
+++ b/nemo_gym/package_info.py
@@ -17,7 +17,7 @@
 MAJOR = 0
 MINOR = 6
 PATCH = 0
-PRE_RELEASE = ""
+PRE_RELEASE = "rc0"
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)


### PR DESCRIPTION
## Summary

- Sets the package version on the newly cut `r0.6.0` branch to `0.6.0rc0`.

## Test plan

- [x] Import `nemo_gym.package_info.__version__` and verify it equals `0.6.0rc0`.