### PR TITLE
release: bump main to 0.7.0rc0

### DIFF
--- a/nemo_gym/package_info.py
+++ b/nemo_gym/package_info.py
@@ -15,9 +15,9 @@
 
 
 MAJOR = 0
-MINOR = 5
-PATCH = 1
-PRE_RELEASE = ""
+MINOR = 7
+PATCH = 0
+PRE_RELEASE = "rc0"
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)


### PR DESCRIPTION
## Summary

- Starts the next development cycle after cutting the `r0.6.0` release branch.
- Sets the package version on `main` to `0.7.0rc0`.

## Test plan

- [x] Import `nemo_gym.package_info.__version__` and verify it equals `0.7.0rc0`.