### PR TITLE
perf: serialize non-streaming responses with orjson in model server

### DIFF
--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -156,17 +156,14 @@ def _plain(value: Any) -> Any:
 
 
 def _orjson_dispatch_response(content: Any) -> Any:
-    """Serialize a finished non-streaming dispatch result with orjson.
+    """Serialize a completed non-streaming model response with orjson.
 
-    Returning a bare model or dict makes FastAPI run ``jsonable_encoder`` — a pure-Python
-    recursive walk with one function call per element — followed by stdlib ``json.dumps``.
-    On training responses the token-id and logprob arrays make that walk the dominant CPU
-    cost of the whole server. Building the response bytes here keeps the semantics
-    (``model_dump(mode="json")`` is exactly what ``jsonable_encoder`` does first for a
-    model) while FastAPI passes a finished ``Response`` through untouched.
+    FastAPI serializes a bare dictionary or Pydantic model with ``jsonable_encoder``.
+    That function recursively visits every token ID and log probability before standard-library ``json.dumps`` runs.
 
-    Anything that is already a ``Response`` (a server override that built its own) is
-    returned as-is.
+    Convert Pydantic models to JSON-compatible values before encoding the result.
+    Return the encoded bytes as a ``Response`` so FastAPI does not encode them again.
+    Preserve ``Response`` objects created by model-server overrides.
     """
     if isinstance(content, Response):
         return content

--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -41,7 +41,7 @@ from typing import Any, Mapping, Optional
 from uuid import uuid4
 
 import orjson
-from fastapi import Body, FastAPI, Request
+from fastapi import Body, FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, ValidationError, model_validator
@@ -155,6 +155,26 @@ def _plain(value: Any) -> Any:
     return value
 
 
+def _orjson_dispatch_response(content: Any) -> Any:
+    """Serialize a finished non-streaming dispatch result with orjson.
+
+    Returning a bare model or dict makes FastAPI run ``jsonable_encoder`` — a pure-Python
+    recursive walk with one function call per element — followed by stdlib ``json.dumps``.
+    On training responses the token-id and logprob arrays make that walk the dominant CPU
+    cost of the whole server. Building the response bytes here keeps the semantics
+    (``model_dump(mode="json")`` is exactly what ``jsonable_encoder`` does first for a
+    model) while FastAPI passes a finished ``Response`` through untouched.
+
+    Anything that is already a ``Response`` (a server override that built its own) is
+    returned as-is.
+    """
+    if isinstance(content, Response):
+        return content
+    if isinstance(content, BaseModel):
+        content = content.model_dump(mode="json")
+    return Response(content=orjson.dumps(content), media_type="application/json")
+
+
 class BaseResponsesAPIModelConfig(BaseRunServerInstanceConfig):
     pass
 
@@ -224,7 +244,7 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
         """
         if not body.get("stream"):
             params = _validate_responses_params(body)
-            return await self._invoke_responses(request, params)
+            return _orjson_dispatch_response(await self._invoke_responses(request, params))
 
         cleaned, ns_map = sanitize_streaming_responses_body(body)
         try:
@@ -268,7 +288,7 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
         """
         if body.get("stream") is not True:
             params = _validate_chat_params(body)
-            return await self._invoke_chat_completions(request, params)
+            return _orjson_dispatch_response(await self._invoke_chat_completions(request, params))
 
         cleaned, include_usage = sanitize_streaming_chat_body(body)
         params = _validate_chat_params(cleaned)
@@ -321,7 +341,7 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
                 _ANTHROPIC_CONVERTER.anthropic_response_to_sse(anthropic_response),
                 media_type="text/event-stream",
             )
-        return anthropic_response
+        return _orjson_dispatch_response(anthropic_response)
 
     async def _invoke_responses(
         self, request: Request, params: NeMoGymResponseCreateParamsNonStreaming

--- a/tests/unit_tests/test_base_responses_api_model.py
+++ b/tests/unit_tests/test_base_responses_api_model.py
@@ -18,9 +18,10 @@ from unittest.mock import MagicMock
 
 import orjson
 import pytest
-from fastapi import Body, FastAPI
+from fastapi import Body, FastAPI, Response
 from fastapi.testclient import TestClient
 from omegaconf import OmegaConf
+from pydantic import BaseModel
 
 from nemo_gym.base_responses_api_agent import SimpleResponsesAPIAgent
 from nemo_gym.base_responses_api_model import (
@@ -29,6 +30,7 @@ from nemo_gym.base_responses_api_model import (
     CaptureStore,
     ModelCallCaptureConfig,
     SimpleResponsesAPIModel,
+    _orjson_dispatch_response,
     build_model_call_record,
     install_model_call_capture,
     make_capture_store,
@@ -66,6 +68,32 @@ class TestBaseResponsesAPIModel:
         server_client.global_config_dict = {}
         model = TestSimpleResponsesAPIModel(config=config, server_client=server_client)
         model.setup_webserver()
+
+
+class _DispatchPayload(BaseModel):
+    text: str
+    token_ids: list[int]
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ({"text": "café", "token_ids": [1, 2, 3]}, {"text": "café", "token_ids": [1, 2, 3]}),
+        (_DispatchPayload(text="café", token_ids=[1, 2, 3]), {"text": "café", "token_ids": [1, 2, 3]}),
+    ],
+)
+def test_orjson_dispatch_response_serializes_json(content, expected):
+    response = _orjson_dispatch_response(content)
+
+    assert type(response) is Response
+    assert response.body == orjson.dumps(expected)
+    assert response.headers["content-type"] == "application/json"
+
+
+def test_orjson_dispatch_response_preserves_existing_response():
+    existing_response = Response(content=b"already encoded", media_type="application/octet-stream", status_code=202)
+
+    assert _orjson_dispatch_response(existing_response) is existing_response
 
 
 def _capture_config(tmp_path, *, enabled: bool = True) -> ModelCallCaptureConfig:


### PR DESCRIPTION
## Summary

FastAPI serializes dictionaries and Pydantic models by recursively converting them with `jsonable_encoder` and then calling the standard-library JSON encoder. Token IDs and log-probability arrays make this conversion a significant part of model-server time for training-shaped responses.

This change serializes completed non-streaming Responses, Chat Completions, and Anthropic Messages results with `orjson`, then returns the encoded bytes as a finished FastAPI `Response`. Existing `Response` objects pass through unchanged. Streaming responses and request validation keep their existing behavior.

## Performance methodology

A synthetic benchmark used a deterministic `SimpleResponsesAPIModel` that returns cached, training-shaped dictionaries to isolate model inference from Gym's dispatch, middleware, serialization, and HTTP serving costs from model inference cost.

tested along with https://github.com/NVIDIA-NeMo/Gym/pull/2869 vs baseline in main.

The matrix covered:

- 32 output tokens (4.9 KB response) at 1,024, 4,096, and 8,192 concurrent requests
- 1,024 output tokens (22.6 KB response) at 1,024 and 4,096 concurrent requests
- 65,536 output tokens (1.40 MB response) at 1,024 concurrent requests

Median throughput improved by 14–22% for 4.9 KB responses, 50–70% for 22.6 KB responses, and 17.0x for 1.40 MB responses. No client request failed, and parsed response payloads matched the expected token counts.

<img width="1205" height="780" alt="Screenshot 2026-08-28 at 5 11 33 PM" src="https://github.com/user-attachments/assets/cc84c180-f0c3-478d-bdd7-ab9fe82aa1da" />
<img width="1200" height="233" alt="Screenshot 2026-08-28 at 5 11 42 PM" src="https://github.com/user-attachments/assets/5914f1c6-578a-4691-ad38-b766fb2419a2" />


## Test plan

- [x] `uv run pytest tests/unit_tests/test_base_responses_api_model.py -q`
- [x] `uv run pre-commit run --files nemo_gym/base_responses_api_model.py`