### PR TITLE
Load a sandbox provider config from sbatch_external_vllm.sh (SANDBOX_CONFIG)

### DIFF
--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -14,6 +14,16 @@ SLURM_COMMENT="${SLURM_COMMENT:-}"
 OPENSANDBOX_DOMAIN="${OPENSANDBOX_DOMAIN:-}"
 OPENSANDBOX_API_KEY="${OPENSANDBOX_API_KEY:-}"
 OPENSANDBOX_PROTOCOL="${OPENSANDBOX_PROTOCOL:-http}"
+SANDBOX_CONFIG="${SANDBOX_CONFIG:-}"
+
+# Hand-assembled --config lists keep omitting the sandbox provider config; for
+# OpenSandbox that silently flips the SDK to proxy-less sandbox health checks
+# that compute nodes cannot reach, and every create times out at ready_timeout.
+# Injected before the caller's args, so explicit --config / ++ overrides win.
+if [[ -z "$SANDBOX_CONFIG" && -n "$OPENSANDBOX_DOMAIN" && -n "$OPENSANDBOX_API_KEY" ]]; then
+    SANDBOX_CONFIG=nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
+fi
+SANDBOX_CONFIG_ARG=${SANDBOX_CONFIG:+--config $SANDBOX_CONFIG}
 
 should_run_eval=$(( $# > 0 ))
 if (( should_run_eval )); then
@@ -45,7 +55,7 @@ cd /opt/Gym
 export NEMO_GYM_RUN_ID="\$SLURM_JOB_ID"
 export NEMO_GYM_USER="\${NEMO_GYM_USER:-\$SLURM_JOB_USER}"
 
-gym eval prepare $@ +use_cached_prepared_benchmarks=true
+gym eval prepare $SANDBOX_CONFIG_ARG $@ +use_cached_prepared_benchmarks=true
 
 experiment_name=$EXPERIMENT_NAME/slurm_job_id_\$SLURM_JOB_ID/date_\$(date +%Y%m%d_%H%M%S)
 # export_to_csv.py derives <base>_aggregate_metrics.json from this, so the
@@ -59,6 +69,7 @@ rollouts_fpath=\${ROLLOUTS_FPATH:-results/\$experiment_name.jsonl}
 # global_aiohttp_connector_limit_per_host: 16k concurrent requests should be enough. We can raise further if our inference is efficient enough to support.
 # port_range_low, port_range_high: Move into ephemeral ports
 gym eval run \
+    $SANDBOX_CONFIG_ARG \
     $@ \
     +wandb_project=$USER-gym-eval \
     +wandb_name=\$experiment_name \


### PR DESCRIPTION
## Summary

Hand-assembled `--config` lists keep omitting the sandbox provider config (e.g. `nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml`). For OpenSandbox, omitting it means the connection config falls back to the dataclass default `use_server_proxy=false`, so the opensandbox SDK health-checks every sandbox over a **direct connection to the sandbox**, which compute nodes cannot reach. Every create then times out at `ready_timeout` with:

```
ERROR:opensandbox.sandbox:Sandbox health check timed out after 1200.0s (14 attempts). Health check returned false continuously.
```

…while the sandboxes are actually healthy on the cluster (verified server-side: they reach `Running` within a minute; only the client-side health check fails). It presents as a total, deterministic run failure and has burned multiple users, most recently on a swebench-pro eval.

## Change

`sbatch_external_vllm.sh` gains a `SANDBOX_CONFIG` env knob naming the sandbox provider config to inject into `gym eval prepare` / `gym eval run` — any provider's yaml works, not just OpenSandbox:

- defaults to the shipped OpenSandbox config when the launch targets OpenSandbox (both `OPENSANDBOX_DOMAIN` and `OPENSANDBOX_API_KEY` exported); gated on both env vars because that yaml resolves `${oc.env:OPENSANDBOX_API_KEY}`. Non-sandbox launches are untouched.
- injected **ahead of the caller's arguments**, so an explicit `--config` or `++sandbox.<provider>.*` override still wins (later config-path entries override earlier ones)
- callers that already pass the same file just merge it twice with identical values (harmless no-op)

## Test plan

- [x] `bash -n` on the wrapper
- [x] `pre-commit run --files benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh`
- [x] Verified the failure mechanism end-to-end on a live reproduction: identical run command without the config layer → 100% create timeouts with the error above; sandboxes concurrently observed `Running` server-side; runs launched with the config layer present are healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)