### PR TITLE
fix(nemotron_3.5_super): locate the cleanup script from the launcher, not cwd

### DIFF
--- a/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
+++ b/benchmarks/nemotron_3.5_super/sbatch_external_vllm.sh
@@ -252,11 +252,13 @@ EOF
 
 # --segment > 0 otherwise the engine will hang on the second or third engine step.
 submit_dir=$(pwd -P)
+# This repository, found from this script rather than from the caller's cwd.
+gym_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
 # An exported connection is sent as arguments; otherwise env.yaml is read.
 if [[ -n "$OPENSANDBOX_DOMAIN" ]]; then
     cleanup_connection=(--domain "$OPENSANDBOX_DOMAIN" --api-key "$OPENSANDBOX_API_KEY" --protocol "$OPENSANDBOX_PROTOCOL")
 else
-    cleanup_connection=(--connection-config "$submit_dir/env.yaml")
+    cleanup_connection=(--connection-config "$gym_root/env.yaml")
 fi
 cleanup_user=${NEMO_GYM_USER:-$USER}
 main_job_id=$(
@@ -296,7 +298,7 @@ if (( should_run_eval )); then
             --time=00:30:00 \
             --job-name="gym-cleanup-$main_job_id" \
             --output="$submit_dir/slurm-logs/%j-gym-cleanup-$main_job_id.log" \
-            "$submit_dir/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py" \
+            "$gym_root/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py" \
             "${cleanup_connection[@]}" \
             --run-id "$main_job_id" \
             --user "$cleanup_user" \

--- a/tests/unit_tests/test_opensandbox_cleanup.py
+++ b/tests/unit_tests/test_opensandbox_cleanup.py
@@ -663,6 +663,39 @@ def test_slurm_launcher_submits_one_dependent_cpu_cleanup_job(tmp_path: Path) ->
     assert "attacker" not in batch_command
 
 
+def test_slurm_launcher_finds_the_cleanup_script_from_another_cwd(
+    tmp_path: Path,
+) -> None:
+    """A caller may run this from anywhere; the cleanup script ships beside
+    the launcher, while the log belongs where the caller submitted from."""
+    calls_path, env = install_sbatch_stub(tmp_path)
+    env["OPENSANDBOX_DOMAIN"] = "sandbox.example"
+    env["OPENSANDBOX_API_KEY"] = TEST_ACCESS_KEY
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+
+    result = subprocess.run(
+        ["bash", str(SBATCH_SCRIPT), "--config", "benchmark.yaml"],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+        cwd=str(elsewhere),
+    )
+
+    assert result.returncode == 0, result.stderr
+    _main_call, cleanup_call = read_sbatch_calls(calls_path)
+    repo_root = SBATCH_SCRIPT.resolve().parents[2]
+    assert (
+        f"{repo_root}/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py"
+        in cleanup_call
+    )
+    assert (
+        f"--output={elsewhere.resolve()}/slurm-logs/%j-gym-cleanup-7001.log"
+        in cleanup_call
+    )
+
+
 def test_slurm_launcher_skips_cleanup_job_without_eval_args(tmp_path: Path) -> None:
     calls_path, env = install_sbatch_stub(tmp_path)
     result = subprocess.run(


### PR DESCRIPTION
## What does this PR do?

#2856 pointed the sandbox-cleanup script and `env.yaml` at `$submit_dir`, which is the caller's working directory:

```bash
"$submit_dir/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py"
```

That resolves only when the launcher is run from a Gym checkout. A caller that submits from somewhere else gets a path that does not exist and the cleanup job fails to submit. EFB is such a caller: it submits from its per-run output directory and keeps the checkout beside it, so `cwd` and the repository are two different places.

This derives the repository from the script's own location instead:

```bash
gym_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
```

`$submit_dir` keeps its other job — the cleanup job's `--output` — so the log still lands where the caller submitted from, and running the launcher from a checkout behaves exactly as it does today.

No flag and no argument parsing. #2856 removed those and this does not bring them back.

## Evidence

Running the launcher from a directory that is not the checkout, with a stub `sbatch` recording the submitted arguments:

| | path passed for `cleanup_sandboxes.py` |
|---|---|
| `main` (1a12168c0) | `<cwd>/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py` |
| this branch | `<repo>/nemo_gym/sandbox/providers/opensandbox/cleanup_sandboxes.py` |

The `--output` path is identical in both, derived from `cwd`.

## Test

`tests/unit_tests/test_opensandbox_cleanup.py` gains a case that runs the launcher with `cwd` set outside the checkout and asserts both paths independently. The existing case already asserted the script path against `SBATCH_SCRIPT.resolve().parents[2]`; it passes on `main` only because it runs with `cwd` equal to the repository root, so the two happen to coincide.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated.
- [x] All commits have DCO sign-off (`git commit -s`).
