### PR TITLE
feat(sandbox): IdeGYM sandbox provider

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -62,7 +62,7 @@ jobs:
           curl -LsSf "$UV_INSTALL_URL" | sh
           uv venv
           source .venv/bin/activate
-          uv sync --extra dev --extra sandbox --extra openshell
+          uv sync --extra dev --extra sandbox --extra openshell --extra idegym
 
       - name: Test
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -160,7 +160,7 @@ jobs:
         if: needs.detect.outputs.run_full == 'true'
         run: |
           source ./scripts/ci/setup_dev.sh
-          uv sync --extra dev --extra sandbox --extra openshell
+          uv sync --extra dev --extra sandbox --extra openshell --extra idegym
 
       # Sandbox is public-GitHub-only and is intentionally outside scripts/ci contract v3.
       - name: Sandbox unit tests

--- a/fern/versions/latest/pages/infrastructure/sandbox/idegym.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/idegym.mdx
@@ -4,7 +4,7 @@ description: "Run NeMo Gym sandboxes as IdeGYM server pods on Kubernetes."
 position: 3
 ---
 
-The `idegym` provider runs each sandbox as an [IdeGYM](https://github.com/JetBrains-Research/idegym) *server*: a Kubernetes pod provisioned through the IdeGYM orchestrator and driven over the HTTP API the orchestrator forwards to it. Use it when your evaluation environments already live in IdeGYM — SWE-bench-style repository tasks, IDE-backed environments, or anything else IdeGYM images provide — and you want to run them through NeMo Gym's agents and benchmarks.
+The `idegym` provider runs each sandbox as an [IdeGYM](https://github.com/JetBrains-Research/idegym) *server*: a Kubernetes pod provisioned through the IdeGYM orchestrator and driven over the HTTP API the orchestrator forwards to it. Use it when your evaluation environments already live in IdeGYM — SWE-bench-style repository tasks, IDE-backed environments, or anything else IdeGYM images provide.
 
 It implements the provider-neutral `SandboxProvider` contract, so any sandbox-backed agent or resources server can use it by selecting `idegym` in its sandbox config.
 
@@ -26,10 +26,42 @@ export IDEGYM_AUTH_PASSWORD=...
 ```
 
 <Warning>
-`spec.image` must be an **IdeGYM server image**. The pod runs the IdeGYM server, and that server is what exposes the API the orchestrator forwards commands to, so a plain benchmark image such as `swebench/sweb.eval.x86_64.*` does not boot one and fails readiness. Build IdeGYM images with IdeGYM's image builder and map upstream tags onto them with `image_rewrites` — see [Images](#images).
+`spec.image` must be an **IdeGYM server image**. The pod runs the IdeGYM server, and that server is what exposes the API the orchestrator forwards commands to, so a plain benchmark image such as `swebench/sweb.eval.x86_64.*` never boots one and never passes readiness. Build IdeGYM images with IdeGYM's image builder and map upstream tags onto them with `image_rewrites` — see [Images](#images).
 </Warning>
 
-## Named Provider Config
+```python
+import asyncio
+
+from nemo_gym.sandbox import AsyncSandbox, SandboxSpec
+
+provider_config = {
+    "idegym": {
+        "connection": {"orchestrator_url": "idegym.example.com", "namespace": "idegym"},
+        "create": {"run_as_root": True},
+    }
+}
+
+spec = SandboxSpec(
+    image="registry.example.com/idegym/my-env:latest",
+    workdir="/testbed",
+    resources={"cpu": 2, "memory_mib": 8192, "disk_gib": 30},
+    metadata={"instance_id": "django__django-11099"},
+)
+
+
+async def main() -> None:
+    async with AsyncSandbox(provider_config, spec) as sandbox:
+        await sandbox.start()
+        result = await sandbox.exec("python -m pytest -q", timeout_s=600)
+        print(result.stdout or result.stderr)
+
+
+asyncio.run(main())
+```
+
+Leaving the `async with` block stops the server and deletes its Kubernetes resources.
+
+## Provider Config
 
 `nemo_gym/sandbox/providers/idegym/configs/idegym.yaml` ships the full block with every knob commented. The essentials:
 
@@ -64,23 +96,15 @@ gym env start \
     --config $MODEL
 ```
 
-### Config sections
-
-| Section | Purpose |
-| --- | --- |
-| `connection` | Orchestrator URL, namespace, auth, client name, HTTP pooling, tracing. |
-| `create` | Readiness budget, retries, generated server names, pod defaults, orchestrator polling backoff. |
-| `exec` | Default command timeout, client-side overhead, how `exec(user=...)` is honored. |
-| `verify` | The post-start working-directory check. |
-| `files` | Upload and download chunk sizes and the download size cap. |
-| `operations` | Status and teardown timeouts and retries. |
-| `attribution` | How the registered IdeGYM client name is derived when it is not pinned. |
+The remaining sections are `verify` (the post-start working-directory check), `files` (transfer chunk
+sizes and the download cap), `operations` (status and teardown timeouts and retries), and
+`attribution` (how the client name is derived when it is not pinned).
 
 <Note>
 Tracing is off unless `connection.tracing_endpoint` is set. The IdeGYM SDK otherwise traces to its own default off-box collector, and NeMo Gym does not send telemetry to a third party implicitly. Point `tracing_endpoint` at your own OTLP HTTP collector to opt in.
 </Note>
 
-## Provider Options
+## SandboxSpec Provider Options
 
 `SandboxSpec.provider_options` carries the IdeGYM pod options that have no neutral equivalent. They are validated before a pod is allocated.
 
@@ -119,6 +143,17 @@ mini_swe_agent_2:
           instance_id: django__django-11099
 ```
 
+## Relevant SandboxSpec Fields
+
+| Field | Behavior |
+| --- | --- |
+| `workdir` | Not a pod setting. Each command `cd`s into it, and `create()` fails early if it does not exist (`verify.check_workdir`). |
+| `env` | Exported per command. IdeGYM can only put ConfigMap/Secret env on the pod, via `provider_options.env_from`. |
+| `metadata` | Not Kubernetes labels — IdeGYM has no per-server label API. `create.server_name_metadata_keys` folds selected keys (default `instance_id`) into the pod name. |
+| `ttl_s` | Not enforced; warns. IdeGYM servers live until stopped, and its watcher reaps servers whose client stops heartbeating. |
+| `ports` | Ignored; warns. An IdeGYM pod exposes only its own API port. |
+| `entrypoint` | Rejected. The container entrypoint starts the IdeGYM server. |
+
 ## Resource Mapping
 
 | `SandboxSpec` field | IdeGYM mapping |
@@ -131,50 +166,42 @@ mini_swe_agent_2:
 
 IdeGYM's resource quota accounting reads limits first, so `spec.resources` is what counts against your quota rule — not the smaller `resource_requests`.
 
-## Spec Fields With Different Semantics
+## Lifecycle
 
-| Field | Behavior |
-| --- | --- |
-| `workdir` | Not a pod setting. Each command `cd`s into it, and `create()` fails early if it does not exist (`verify.check_workdir`). |
-| `env` | Exported per command. IdeGYM can only put ConfigMap/Secret env on the pod, via `provider_options.env_from`. |
-| `metadata` | Not Kubernetes labels — IdeGYM has no per-server label API. `create.server_name_metadata_keys` folds selected keys (default `instance_id`) into the pod name. |
-| `ttl_s` | Not enforced; warns. IdeGYM servers live until stopped, and its watcher reaps servers whose client stops heartbeating. |
-| `ports` | Ignored; warns. An IdeGYM pod exposes only its own API port. |
-| `entrypoint` | Rejected. The container entrypoint starts the IdeGYM server. |
-
-## First-Run Example
-
-```python
-import asyncio
-
-from nemo_gym.sandbox import AsyncSandbox, SandboxSpec
-
-provider_config = {
-    "idegym": {
-        "connection": {"orchestrator_url": "idegym.example.com", "namespace": "idegym"},
-        "create": {"run_as_root": True},
-    }
-}
-
-spec = SandboxSpec(
-    image="registry.example.com/idegym/my-env:latest",
-    workdir="/testbed",
-    resources={"cpu": 2, "memory_mib": 8192, "disk_gib": 30},
-    metadata={"instance_id": "django__django-11099"},
-)
-
-
-async def main() -> None:
-    async with AsyncSandbox(provider_config, spec) as sandbox:
-        await sandbox.start()
-        result = await sandbox.exec("python -m pytest -q", timeout_s=600)
-        print(result.stdout or result.stderr)
-
-
-asyncio.run(main())
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant P as IdeGymProvider
+    participant O as Orchestrator
+    participant K as Pod
+    A->>P: create(spec)
+    P->>O: start_server
+    O->>K: schedule + pull image
+    K-->>O: readiness probe passes
+    O-->>P: server id
+    P->>K: [ -d workdir ]
+    A->>P: exec / upload / download
+    P->>K: bash script
+    A->>P: close()
+    P->>O: stop_server
+    O->>K: delete pod
 ```
 
-Leaving the `async with` block stops the server and deletes its Kubernetes resources.
+**Create trusts IdeGYM's readiness wait.** The orchestrator reports a server only once its pod passes the Kubernetes readiness probe against the server's health endpoint, so `create()` adds one check of its own: that `spec.workdir` exists. Anything that fails after provisioning stops the server.
+
+**One registered client per process.** IdeGYM's unit of ownership is a *client*: a heartbeating entity that owns N server pods, carries the resource quota keyed on its name, and terminates all of its servers when it stops. Every sandbox with an identical `connection` config shares one, reference-counted; the last release unregisters it, which also cleans up any server never closed. `connection.max_connections` bounds in-flight HTTP across all of them — bounding requests rather than whole operations, so provisioning a new sandbox cannot block execs on sandboxes already running.
+
+**`close()` always deletes** the pod and its Kubernetes resources; it is idempotent, and a server the orchestrator no longer has counts as success.
+
+## Job Attribution
+
+Resource-limit rules are matched by regex against the client name, so set `connection.client_name` to whatever your deployment's rule expects. Left unset, the name is derived from job attribution — `NEMO_GYM_TEAM` / `NEMO_GYM_USER` / `NEMO_GYM_WORKLOAD`, then Slurm job variables — as `nemo-gym-<team>-<user>-<workload>`, so a run is attributable in the IdeGYM dashboard. The run id is deliberately excluded: a name that changes per launch defeats both quota matching and dashboard grouping.
+
+## File Transfer
+
+Uploads and downloads ride base64 over the bash tool, chunked in both directions: uploads to stay inside the ~100 KiB a command may occupy, downloads because each chunk's stdout is persisted as an async-operation result. `files.max_download_bytes` (64 MiB by default) caps a download.
+
+This is fine for the config files, patches, and logs a benchmark moves around, but it is not a bulk channel — have the sandbox fetch large inputs itself.
 
 ## Images
 
@@ -189,17 +216,11 @@ sandbox_spec:
 
 Rewrites are ordered and the first matching prefix wins. The provider does not build images.
 
-## Operational Notes
+## User and Runtime Notes
 
-**One registered client per process.** IdeGYM's unit of ownership is a *client*: a registered, heartbeating entity that owns N server pods, carries the resource quota keyed on its name, and terminates all of its servers when it stops. Every sandbox created from an identical `connection` config shares one registered client, reference-counted; the last release unregisters it, which also cleans up any server that was never closed. `connection.max_connections` bounds in-flight HTTP across all of them; bounding requests rather than whole operations means provisioning a new sandbox cannot block the exec calls of sandboxes already running.
+**Commands run as the container's user.** IdeGYM's bash tool has no user field, so `provider_options.run_as_root` decides this at pod level. `exec.user_mode` can wrap commands in `runuser` or `su` for images that ship them; both pin `/bin/bash` rather than inheriting a login shell that may be `/sbin/nologin`.
 
-**Client naming matters.** Resource-limit rules are matched by regex against the client name, so set `connection.client_name` to whatever your deployment's rule expects. Left unset, the name is derived from job attribution (`NEMO_GYM_TEAM` / `NEMO_GYM_USER` / `NEMO_GYM_WORKLOAD`, then Slurm job variables) so a run is attributable in the IdeGYM dashboard.
-
-**Create trusts IdeGYM's readiness wait.** The orchestrator reports a server only once its pod passes the Kubernetes readiness probe against the server's health endpoint, so `create()` adds just one check of its own: that `spec.workdir` exists. Anything that fails after provisioning stops the server.
-
-**Command and output limits.** A command may not exceed roughly 100 KiB once shaped into a script — IdeGYM passes it to the shell as a single `execve()` argument — and an oversized command is reported as a failed `SandboxExecResult` with `error_type="command_too_long"` rather than raising. The IdeGYM executor also strips leading and trailing whitespace from stdout and stderr.
-
-**File transfer is not a bulk channel.** Uploads and downloads ride base64 over the bash tool, chunked in both directions, and `files.max_download_bytes` (64 MiB by default) caps a download. Have the sandbox fetch large inputs itself.
+**Command and output limits.** A command may not exceed roughly 100 KiB once shaped into a script — IdeGYM passes it to the shell as a single `execve()` argument — and an oversized command comes back as a failed `SandboxExecResult` with `error_type="command_too_long"` rather than raising. The executor also strips leading and trailing whitespace from stdout and stderr.
 
 ## Unavailable Capabilities
 
@@ -208,4 +229,3 @@ Rewrites are ordered and the first matching prefix wins. The provider does not b
 | `sandbox.endpoint(port)` | The orchestrator forwards API requests rather than routing raw TCP to arbitrary container ports. |
 | `sandbox.pty` | IdeGYM has no terminal API. |
 | `sandbox.serialize()` / `AsyncSandbox.connect()` | A server is only reachable through the registered client that owns it. Front this provider with a sandbox server to share a sandbox across processes. |
-| `exec(user=...)` | IdeGYM's bash tool has no user field; commands run as the container's user, which `provider_options.run_as_root` controls. `exec.user_mode` can wrap commands in `runuser` or `su` for images that ship them. |

--- a/fern/versions/latest/pages/infrastructure/sandbox/idegym.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/idegym.mdx
@@ -71,7 +71,7 @@ gym env start \
 | `connection` | Orchestrator URL, namespace, auth, client name, HTTP pooling, tracing. |
 | `create` | Readiness budget, retries, generated server names, pod defaults, orchestrator polling backoff. |
 | `exec` | Default command timeout, client-side overhead, how `exec(user=...)` is honored. |
-| `probe` | Post-start readiness verification and the working-directory check. |
+| `verify` | The post-start working-directory check. |
 | `files` | Upload and download chunk sizes and the download size cap. |
 | `operations` | Status and teardown timeouts and retries. |
 | `attribution` | How the registered IdeGYM client name is derived when it is not pinned. |
@@ -135,7 +135,7 @@ IdeGYM's resource quota accounting reads limits first, so `spec.resources` is wh
 
 | Field | Behavior |
 | --- | --- |
-| `workdir` | Not a pod setting. Each command `cd`s into it, and `create()` fails early if it does not exist (`probe.verify_workdir`). |
+| `workdir` | Not a pod setting. Each command `cd`s into it, and `create()` fails early if it does not exist (`verify.check_workdir`). |
 | `env` | Exported per command. IdeGYM can only put ConfigMap/Secret env on the pod, via `provider_options.env_from`. |
 | `metadata` | Not Kubernetes labels — IdeGYM has no per-server label API. `create.server_name_metadata_keys` folds selected keys (default `instance_id`) into the pod name. |
 | `ttl_s` | Not enforced; warns. IdeGYM servers live until stopped, and its watcher reaps servers whose client stops heartbeating. |
@@ -195,7 +195,7 @@ Rewrites are ordered and the first matching prefix wins. The provider does not b
 
 **Client naming matters.** Resource-limit rules are matched by regex against the client name, so set `connection.client_name` to whatever your deployment's rule expects. Left unset, the name is derived from job attribution (`NEMO_GYM_TEAM` / `NEMO_GYM_USER` / `NEMO_GYM_WORKLOAD`, then Slurm job variables) so a run is attributable in the IdeGYM dashboard.
 
-**Create waits for readiness.** A scheduled pod is not yet a usable sandbox, so `create()` returns only after the probe command passes `probe.stable_count` times and `spec.workdir` is confirmed to exist. Anything that fails after provisioning stops the server.
+**Create trusts IdeGYM's readiness wait.** The orchestrator reports a server only once its pod passes the Kubernetes readiness probe against the server's health endpoint, so `create()` adds just one check of its own: that `spec.workdir` exists. Anything that fails after provisioning stops the server.
 
 **Command and output limits.** A command may not exceed roughly 100 KiB once shaped into a script — IdeGYM passes it to the shell as a single `execve()` argument — and an oversized command is reported as a failed `SandboxExecResult` with `error_type="command_too_long"` rather than raising. The IdeGYM executor also strips leading and trailing whitespace from stdout and stderr.
 

--- a/fern/versions/latest/pages/infrastructure/sandbox/idegym.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/idegym.mdx
@@ -77,7 +77,7 @@ gym env start \
 | `attribution` | How the registered IdeGYM client name is derived when it is not pinned. |
 
 <Note>
-Tracing is off unless `connection.tracing_endpoint` is set. The IdeGYM SDK otherwise defaults to a JetBrains-hosted collector, and NeMo Gym does not send telemetry to a third party implicitly.
+Tracing is off unless `connection.tracing_endpoint` is set. The IdeGYM SDK otherwise traces to its own default off-box collector, and NeMo Gym does not send telemetry to a third party implicitly. Point `tracing_endpoint` at your own OTLP HTTP collector to opt in.
 </Note>
 
 ## Provider Options
@@ -95,7 +95,7 @@ Tracing is off unless `connection.tracing_endpoint` is set. The IdeGYM SDK other
 | `service_account_name` | ServiceAccount for the pod. |
 | `pod_overrides` | Partial `V1PodSpec` deep-merged into the generated pod spec (tolerations, affinity, ...). |
 | `reuse_strategy`, `server_kind`, `snapshot`, `max_restarts` | Passed through to IdeGYM. |
-| `server_name` | Pins the server name, opting into IdeGYM's server reuse. Otherwise a unique name is generated per sandbox. |
+| `server_name` | Pins the server name IdeGYM's reuse lookup matches on. Otherwise it is derived from the name prefix and metadata hints. |
 | `service_port`, `container_port` | Override the configured ports. |
 
 ```yaml

--- a/fern/versions/latest/pages/infrastructure/sandbox/idegym.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/idegym.mdx
@@ -26,7 +26,7 @@ export IDEGYM_AUTH_PASSWORD=...
 ```
 
 <Warning>
-`spec.image` must be an **IdeGYM server image**. The pod runs the IdeGYM server, and that server is what exposes the API the orchestrator forwards commands to, so a plain benchmark image such as `swebench/sweb.eval.x86_64.*` never boots one and never passes readiness. Build IdeGYM images with IdeGYM's image builder and map upstream tags onto them with `image_rewrites` — see [Images](#images).
+`spec.image` must be an **IdeGYM server image**. The pod runs the IdeGYM server, and that server exposes the API this provider talks to. A plain benchmark image such as `swebench/sweb.eval.x86_64.*` has none, so it never becomes ready and `create()` fails. See [Images](#images).
 </Warning>
 
 ```python
@@ -152,7 +152,7 @@ mini_swe_agent_2:
 | `metadata` | Not Kubernetes labels — IdeGYM has no per-server label API. `create.server_name_metadata_keys` folds selected keys (default `instance_id`) into the pod name. |
 | `ttl_s` | Not enforced; warns. IdeGYM servers live until stopped, and its watcher reaps servers whose client stops heartbeating. |
 | `ports` | Ignored; warns. An IdeGYM pod exposes only its own API port. |
-| `entrypoint` | Rejected. The container entrypoint starts the IdeGYM server. |
+| `entrypoint` | Fails `create()`. The container entrypoint starts the IdeGYM server. |
 
 ## Resource Mapping
 
@@ -205,7 +205,7 @@ This is fine for the config files, patches, and logs a benchmark moves around, b
 
 ## Images
 
-Build IdeGYM server images with IdeGYM's image builder, publish them where your cluster can pull them, then map upstream benchmark tags onto them:
+Every sandbox image needs an IdeGYM server inside it — that server provides the bash tool this provider runs commands through, and the health endpoint the pod's readiness check polls. Build such images with IdeGYM's image builder, publish them where your cluster can pull them, then map upstream benchmark tags onto them:
 
 ```yaml
 sandbox_spec:

--- a/fern/versions/latest/pages/infrastructure/sandbox/idegym.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/idegym.mdx
@@ -1,0 +1,211 @@
+---
+title: "IdeGYM Provider"
+description: "Run NeMo Gym sandboxes as IdeGYM server pods on Kubernetes."
+position: 3
+---
+
+The `idegym` provider runs each sandbox as an [IdeGYM](https://github.com/JetBrains-Research/idegym) *server*: a Kubernetes pod provisioned through the IdeGYM orchestrator and driven over the HTTP API the orchestrator forwards to it. Use it when your evaluation environments already live in IdeGYM — SWE-bench-style repository tasks, IDE-backed environments, or anything else IdeGYM images provide — and you want to run them through NeMo Gym's agents and benchmarks.
+
+It implements the provider-neutral `SandboxProvider` contract, so any sandbox-backed agent or resources server can use it by selecting `idegym` in its sandbox config.
+
+## Setup
+
+Install the optional dependency:
+
+```bash
+uv pip install 'nemo-gym[idegym]'
+```
+
+Point the provider at your orchestrator:
+
+```bash
+export IDEGYM_ORCHESTRATOR_URL=idegym.example.com
+export IDEGYM_NAMESPACE=idegym
+export IDEGYM_AUTH_USERNAME=...
+export IDEGYM_AUTH_PASSWORD=...
+```
+
+<Warning>
+`spec.image` must be an **IdeGYM server image**. The pod runs the IdeGYM server, and that server is what exposes the API the orchestrator forwards commands to, so a plain benchmark image such as `swebench/sweb.eval.x86_64.*` does not boot one and fails readiness. Build IdeGYM images with IdeGYM's image builder and map upstream tags onto them with `image_rewrites` — see [Images](#images).
+</Warning>
+
+## Named Provider Config
+
+`nemo_gym/sandbox/providers/idegym/configs/idegym.yaml` ships the full block with every knob commented. The essentials:
+
+```yaml
+sandbox:
+  default_metadata:
+    sandbox-api: idegym-client
+  idegym:
+    connection:
+      orchestrator_url: ${oc.env:IDEGYM_ORCHESTRATOR_URL,idegym.test}
+      namespace: ${oc.env:IDEGYM_NAMESPACE,idegym}
+      username: ${oc.env:IDEGYM_AUTH_USERNAME,null}
+      password: ${oc.env:IDEGYM_AUTH_PASSWORD,null}
+      # Quota rules match this name by regex; pin it to whatever your rule expects.
+      client_name: ${oc.env:IDEGYM_CLIENT_NAME,null}
+      max_connections: 64
+    create:
+      ready_timeout_s: 1200
+      run_as_root: true
+    exec:
+      default_timeout_s: 180
+```
+
+Every shipped provider config binds the same instance name `sandbox`, so switching a benchmark to IdeGYM is swapping one config path:
+
+```bash
+AGENT=responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+MODEL=responses_api_models/vllm_model/configs/vllm_model.yaml
+gym env start \
+    --config $AGENT \
+    --config nemo_gym/sandbox/providers/idegym/configs/idegym.yaml \
+    --config $MODEL
+```
+
+### Config sections
+
+| Section | Purpose |
+| --- | --- |
+| `connection` | Orchestrator URL, namespace, auth, client name, HTTP pooling, tracing. |
+| `create` | Readiness budget, retries, generated server names, pod defaults, orchestrator polling backoff. |
+| `exec` | Default command timeout, client-side overhead, how `exec(user=...)` is honored. |
+| `probe` | Post-start readiness verification and the working-directory check. |
+| `files` | Upload and download chunk sizes and the download size cap. |
+| `operations` | Status and teardown timeouts and retries. |
+| `attribution` | How the registered IdeGYM client name is derived when it is not pinned. |
+
+<Note>
+Tracing is off unless `connection.tracing_endpoint` is set. The IdeGYM SDK otherwise defaults to a JetBrains-hosted collector, and NeMo Gym does not send telemetry to a third party implicitly.
+</Note>
+
+## Provider Options
+
+`SandboxSpec.provider_options` carries the IdeGYM pod options that have no neutral equivalent. They are validated before a pod is allocated.
+
+| Option | Notes |
+| --- | --- |
+| `resource_requests` | Kubernetes *requests*, paired with `spec.resources` as the limits. |
+| `runtime_class_name` | e.g. `gvisor` for a sandboxed runtime. |
+| `run_as_root` | Overrides `create.run_as_root` for this sandbox. |
+| `node_selector` | Node labels for scheduling. |
+| `volumes`, `volume_mounts` | Native Kubernetes shapes. |
+| `env_from` | ConfigMap/Secret env import — the only way to put environment on the *pod*. |
+| `service_account_name` | ServiceAccount for the pod. |
+| `pod_overrides` | Partial `V1PodSpec` deep-merged into the generated pod spec (tolerations, affinity, ...). |
+| `reuse_strategy`, `server_kind`, `snapshot`, `max_restarts` | Passed through to IdeGYM. |
+| `server_name` | Pins the server name, opting into IdeGYM's server reuse. Otherwise a unique name is generated per sandbox. |
+| `service_port`, `container_port` | Override the configured ports. |
+
+```yaml
+mini_swe_agent_2:
+  responses_api_agents:
+    mini_swe_agent_2:
+      sandbox_provider: sandbox
+      sandbox_spec:
+        ready_timeout_s: 1200
+        workdir: /testbed
+        resources:
+          cpu: 2
+          memory_mib: 8192
+          disk_gib: 30
+        provider_options:
+          resource_requests:
+            cpu: 0.5
+            memory_mib: 2048
+          runtime_class_name: gvisor
+        metadata:
+          instance_id: django__django-11099
+```
+
+## Resource Mapping
+
+| `SandboxSpec` field | IdeGYM mapping |
+| --- | --- |
+| `resources.cpu` | Kubernetes CPU **limit** (`2`, `500m`). |
+| `resources.memory_mib` | Memory **limit** (`8192Mi`). |
+| `resources.disk_gib` | `ephemeral-storage` **limit** (`30Gi`). |
+| `provider_options.resource_requests` | The matching Kubernetes **requests**. |
+| `resources.gpu`, `resources.gpu_type` | Not mapped; warns. Request accelerators via `node_selector` or `pod_overrides`. |
+
+IdeGYM's resource quota accounting reads limits first, so `spec.resources` is what counts against your quota rule — not the smaller `resource_requests`.
+
+## Spec Fields With Different Semantics
+
+| Field | Behavior |
+| --- | --- |
+| `workdir` | Not a pod setting. Each command `cd`s into it, and `create()` fails early if it does not exist (`probe.verify_workdir`). |
+| `env` | Exported per command. IdeGYM can only put ConfigMap/Secret env on the pod, via `provider_options.env_from`. |
+| `metadata` | Not Kubernetes labels — IdeGYM has no per-server label API. `create.server_name_metadata_keys` folds selected keys (default `instance_id`) into the pod name. |
+| `ttl_s` | Not enforced; warns. IdeGYM servers live until stopped, and its watcher reaps servers whose client stops heartbeating. |
+| `ports` | Ignored; warns. An IdeGYM pod exposes only its own API port. |
+| `entrypoint` | Rejected. The container entrypoint starts the IdeGYM server. |
+
+## First-Run Example
+
+```python
+import asyncio
+
+from nemo_gym.sandbox import AsyncSandbox, SandboxSpec
+
+provider_config = {
+    "idegym": {
+        "connection": {"orchestrator_url": "idegym.example.com", "namespace": "idegym"},
+        "create": {"run_as_root": True},
+    }
+}
+
+spec = SandboxSpec(
+    image="registry.example.com/idegym/my-env:latest",
+    workdir="/testbed",
+    resources={"cpu": 2, "memory_mib": 8192, "disk_gib": 30},
+    metadata={"instance_id": "django__django-11099"},
+)
+
+
+async def main() -> None:
+    async with AsyncSandbox(provider_config, spec) as sandbox:
+        await sandbox.start()
+        result = await sandbox.exec("python -m pytest -q", timeout_s=600)
+        print(result.stdout or result.stderr)
+
+
+asyncio.run(main())
+```
+
+Leaving the `async with` block stops the server and deletes its Kubernetes resources.
+
+## Images
+
+Build IdeGYM server images with IdeGYM's image builder, publish them where your cluster can pull them, then map upstream benchmark tags onto them:
+
+```yaml
+sandbox_spec:
+  image_rewrites:
+    - from: "swebench/"
+      to: "registry.example.com/idegym-swebench/"
+```
+
+Rewrites are ordered and the first matching prefix wins. The provider does not build images.
+
+## Operational Notes
+
+**One registered client per process.** IdeGYM's unit of ownership is a *client*: a registered, heartbeating entity that owns N server pods, carries the resource quota keyed on its name, and terminates all of its servers when it stops. Every sandbox created from an identical `connection` config shares one registered client, reference-counted; the last release unregisters it, which also cleans up any server that was never closed. `connection.max_connections` bounds in-flight HTTP across all of them; bounding requests rather than whole operations means provisioning a new sandbox cannot block the exec calls of sandboxes already running.
+
+**Client naming matters.** Resource-limit rules are matched by regex against the client name, so set `connection.client_name` to whatever your deployment's rule expects. Left unset, the name is derived from job attribution (`NEMO_GYM_TEAM` / `NEMO_GYM_USER` / `NEMO_GYM_WORKLOAD`, then Slurm job variables) so a run is attributable in the IdeGYM dashboard.
+
+**Create waits for readiness.** A scheduled pod is not yet a usable sandbox, so `create()` returns only after the probe command passes `probe.stable_count` times and `spec.workdir` is confirmed to exist. Anything that fails after provisioning stops the server.
+
+**Command and output limits.** A command may not exceed roughly 100 KiB once shaped into a script — IdeGYM passes it to the shell as a single `execve()` argument — and an oversized command is reported as a failed `SandboxExecResult` with `error_type="command_too_long"` rather than raising. The IdeGYM executor also strips leading and trailing whitespace from stdout and stderr.
+
+**File transfer is not a bulk channel.** Uploads and downloads ride base64 over the bash tool, chunked in both directions, and `files.max_download_bytes` (64 MiB by default) caps a download. Have the sandbox fetch large inputs itself.
+
+## Unavailable Capabilities
+
+| Capability | Reason |
+| --- | --- |
+| `sandbox.endpoint(port)` | The orchestrator forwards API requests rather than routing raw TCP to arbitrary container ports. |
+| `sandbox.pty` | IdeGYM has no terminal API. |
+| `sandbox.serialize()` / `AsyncSandbox.connect()` | A server is only reachable through the registered client that owns it. Front this provider with a sandbox server to share a sandbox across processes. |
+| `exec(user=...)` | IdeGYM's bash tool has no user field; commands run as the container's user, which `provider_options.run_as_root` controls. `exec.user_mode` can wrap commands in `runuser` or `su` for images that ship them. |

--- a/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
+++ b/fern/versions/latest/pages/infrastructure/sandbox/index.mdx
@@ -42,6 +42,12 @@ Run sandboxes as AWS ECS Fargate tasks reached over an SSH sidecar.
 <Badge minimal outlined>provider</Badge> <Badge minimal outlined>ecs-fargate</Badge>
 </Card>
 
+<Card title="IdeGYM Provider" href="/infrastructure/sandbox/idegym">
+Run sandboxes as IdeGYM server pods on Kubernetes, through the IdeGYM orchestrator.
+
+<Badge minimal outlined>provider</Badge> <Badge minimal outlined>idegym</Badge>
+</Card>
+
 <Card title="Adding a Provider" href="/infrastructure/sandbox/adding-a-provider">
 Implement the `SandboxProvider` protocol and register a new runtime backend.
 

--- a/nemo_gym/sandbox/providers/idegym/DESIGN-DECISIONS.md
+++ b/nemo_gym/sandbox/providers/idegym/DESIGN-DECISIONS.md
@@ -1,9 +1,5 @@
 # IdeGYM Sandbox Provider — Design Decisions
 
-Why this provider is built the way it is: the choices with real alternatives, and the constraints
-that forced them. It exists so the next person to touch the code does not have to re-derive them
-from the IdeGYM and NeMo Gym sources.
-
 ## The shape of the integration
 
 ```mermaid
@@ -16,8 +12,20 @@ flowchart LR
     O -.->|"HTTP forwarded<br/>as JSON text"| Pod
 ```
 
-Two properties of that chain drive most of what follows: the *client* is the unit of ownership and
-quota, and the orchestrator relays requests as JSON text rather than proxying a socket.
+A NeMo Gym sandbox is one *server pod*, but nothing addresses that pod directly. Everything goes
+through the orchestrator, and the orchestrator will only talk to a pod on behalf of a registered
+*client*.
+
+Two properties of that chain shape most of what follows.
+
+The **client is the unit of ownership**: it holds the heartbeat, it carries the resource quota, and
+it owns every server it started — so its lifetime, not any single sandbox's, decides when pods go
+away. That is why the session is shared and counted rather than created per sandbox.
+
+The **orchestrator relays rather than proxies**: a request is stored and replayed as JSON text, not
+carried over a socket held open to the pod. That rules out streaming binary, raw TCP to a container
+port, and anything resembling an interactive terminal — hence base64 file transfer and the
+capabilities gaps at the end of this document.
 
 ## Choices with real alternatives
 
@@ -29,14 +37,14 @@ simply be a SWE-bench tag.
 
 | Option | Decision |
 | --- | --- |
-| **Pass pre-built IdeGYM images through; document `image_rewrites` for mapping benchmark images onto them** | **Chosen** |
-| Integrate IdeGYM's image builder so the provider builds and pushes a wrapped image on demand | Rejected for a first milestone: needs a registry, cluster build permissions, and a build-cache story |
-| Validate the image against an allow-prefix and refuse anything else | Rejected as too rigid — registry layouts vary |
+| **Pass pre-built IdeGYM images through, and document `image_rewrites` for mapping benchmark images onto them** | **Chosen** |
+| Build and push a wrapped image on demand, using IdeGYM's image builder | Deferred: needs a registry, cluster build permissions, and a build-cache story |
+| Accept any image that serves the same health endpoint, without an IdeGYM server behind it | Not yet workable. The image change is the small part: a server counts as alive only while requests to it keep completing, so an idle sandbox would be reaped mid-run unless the deployment's inactivity timeout is raised to roughly an hour. It would also lose the bash tool the whole provider is built on |
 
-`spec.image` is therefore normalized (`docker://` stripped) and validated against IdeGYM's OCI
-reference pattern, and nothing more. A non-IdeGYM image fails inside the orchestrator instead: its
-container never answers the health endpoint the pod's readiness probe polls, so `start_server` times
-out rather than handing back a server that cannot run commands.
+`spec.image` is therefore normalized (`docker://` stripped) and checked against IdeGYM's OCI
+reference pattern, and nothing more. The provider does not try to detect a wrong image: one without
+an IdeGYM server never reports ready, so `start_server` fails instead of handing back a sandbox that
+cannot run commands.
 
 ### What `close()` does
 
@@ -47,7 +55,7 @@ IdeGYM distinguishes `stop_server` (delete the pod and its Kubernetes resources)
 | --- | --- |
 | `stop_server` only | **Chosen** |
 | `stop` by default, with `finish` + reuse behind a config knob | Not implemented in this milestone |
-| `finish` by default | Rejected: keeps pods warm but leaks them whenever a run dies |
+| `finish` by default | Not chosen: keeps pods warm, but leaks them whenever a run dies |
 
 So `close()` always deletes. Reuse stays reachable — pin `provider_options.server_name` and set
 `reuse_strategy` to opt into IdeGYM's own matching — but the provider manages no warm pool, and
@@ -59,7 +67,7 @@ becomes the bottleneck on long benchmarks, a `finish`-based warm pool is the fol
 | Option | Decision |
 | --- | --- |
 | Opt-in extra `nemo-gym[idegym]`, imported lazily, with an actionable `ModuleNotFoundError` | **Chosen** |
-| Core dependency alongside `opensandbox` / `daytona` / `boto3` | Rejected: IdeGYM is a third-party control plane, and its SDK should not be in installs that will never talk to one |
+| Core dependency alongside `opensandbox` / `daytona` / `boto3` | Not chosen: IdeGYM is a third-party control plane, and its SDK should not sit in installs that will never talk to one |
 
 This follows the `nemo-gym[openshell]` precedent. CI installs the extra alongside the other sandbox
 extras so the SDK-gated tests run rather than skip.
@@ -72,18 +80,15 @@ the resolution untouched, at the cost of a second resolution to maintain.
 
 ## Implementation decisions
 
-These follow from reading the two codebases. Each is recorded because a reviewer might reasonably
-expect the alternative.
-
 ### One registered client per process, not per sandbox
 
 A *client* is a registered, heartbeating entity that owns N server pods, carries the resource quota
 (matched by regex against its **name**), and terminates all of its servers when it stops.
 
-Registering one per sandbox looked simpler but does not survive a benchmark fan-out: the orchestrator
-takes `LOCK TABLE clients IN EXCLUSIVE MODE` per registration, heartbeats multiply by the concurrency,
-and one job's pods scatter across many owners in the dashboard. A session is therefore shared by every
-sandbox with an identical `connection` config, and reference-counted across providers.
+Registering one per sandbox looked simpler but does not survive a benchmark fan-out: registrations
+are serialized on the orchestrator, heartbeats multiply by the concurrency, and one job's pods scatter
+across many owners in the dashboard. A session is therefore shared by every sandbox with an identical
+`connection` config, and reference-counted across providers.
 
 The refcount is correctness, not efficiency: unregistering a client **terminates all of its servers**,
 so releasing early would kill live sandboxes belonging to other providers.
@@ -195,12 +200,12 @@ the SDK raises it only after spending the budget it was given.
 
 ### Concurrency is bounded by the HTTP pool, not by serializing operations
 
-An earlier draft held a semaphore for the duration of each session operation. That bounds *operations*
-rather than requests, and an IdeGYM create polls for as long as the readiness timeout — so with the
-shipped pool and `mini_swe_agent_2`'s concurrency, provisioning would have blocked the exec calls of
-sandboxes already running, and teardown behind provisioning. The limit lives where it belongs, on
-`connection.max_connections`, which both transports honor (the aiohttp bridge maps it onto the
-connector's `limit`).
+The obvious way to bound load is a semaphore around each session operation, and it is the wrong one
+here. A create polls for as long as the readiness timeout, so holding a slot for the whole operation
+would let provisioning block the exec calls of sandboxes already running, and queue teardown behind
+provisioning. What actually needs bounding is in-flight *requests*, which is what
+`connection.max_connections` does — both transports honor it, and the aiohttp bridge maps it onto the
+connector's `limit`.
 
 ### Failure paths get the same fidelity as success paths
 

--- a/nemo_gym/sandbox/providers/idegym/DESIGN-DECISIONS.md
+++ b/nemo_gym/sandbox/providers/idegym/DESIGN-DECISIONS.md
@@ -24,8 +24,9 @@ the image cannot simply be a SWE-bench tag.
 | Validate the image against an allow-prefix and refuse anything else | Rejected as too rigid — registry layouts vary |
 
 Consequence: `spec.image` is normalized (`docker://` stripped) and validated against IdeGYM's OCI
-reference pattern, and nothing more. The failure mode for a non-IdeGYM image is a readiness-probe
-failure, which is why `create()` probes at all instead of trusting "pod is running".
+reference pattern, and nothing more. A non-IdeGYM image fails inside the orchestrator instead: its
+container never answers the health endpoint the pod's readiness probe polls, so `start_server` times
+out rather than handing back a server that cannot run commands.
 
 ### 2. What should `close()` do?
 
@@ -149,13 +150,14 @@ behavior explicit: `ignore` (default) warns once per provider, while `runuser` a
 script for images that ship those tools. `create.run_as_root` defaults to `true` in the shipped
 config, which makes `exec(user="root")` — what `mini_swe_agent_2` passes — a no-op rather than a lie.
 
-### `create()` verifies before returning
+### `create()` checks only the workdir
 
-Two checks, both because their absence produces a confusing failure much later:
-
-- The readiness probe, because a scheduled pod is not yet a sandbox that can run commands.
-- `spec.workdir` exists, because otherwise every later command fails on `cd` and reads like a broken
-  agent rather than a mis-set path.
+IdeGYM does not report a server until `wait_for_pods_ready` sees its pod `Running` with every
+container ready, and the container's readiness probe is an HTTP GET against the IdeGYM server's own
+health endpoint on the port the bash tool is served from. A provider-side readiness probe would only
+re-ask that question, so `create()` adds one check the orchestrator cannot make: that `spec.workdir`
+exists, because otherwise every later command fails on `cd` and reads like a broken agent rather
+than a mis-set path.
 
 ### Capabilities stands in for a status endpoint
 

--- a/nemo_gym/sandbox/providers/idegym/DESIGN-DECISIONS.md
+++ b/nemo_gym/sandbox/providers/idegym/DESIGN-DECISIONS.md
@@ -1,0 +1,267 @@
+# IdeGYM Sandbox Provider — Design Decisions
+
+A record of the questions this integration raised, what was chosen, and why. It exists so a reviewer
+can see which choices were deliberate and which are open, and so the next person to touch this
+provider does not have to re-derive the constraints from the IdeGYM and NeMo Gym sources.
+
+Written against **NeMo Gym** at `2251ef7` and **idegym 0.11.1** (`idegym-client` 0.11.1 on PyPI).
+
+## Questions put to the maintainer
+
+Three decisions were genuinely the maintainer's to make, because different answers would have meant
+materially different work. They were asked before implementation.
+
+### 1. How should `SandboxSpec.image` be resolved?
+
+The constraint: an IdeGYM sandbox is a pod running the **IdeGYM server**, and that server is what
+exposes the API the orchestrator forwards commands to. A plain benchmark image does not boot one, so
+the image cannot simply be a SWE-bench tag.
+
+| Option | Decision |
+| --- | --- |
+| **Pass pre-built IdeGYM images through; document `image_rewrites` for mapping upstream benchmark images onto them** | **Chosen** |
+| Integrate IdeGYM's image builder so the provider can build and push a wrapped image on demand | Rejected for a first milestone: needs a registry, cluster build permissions, and a build-cache story |
+| Validate the image against an allow-prefix and refuse anything else | Rejected as too rigid — registry layouts vary |
+
+Consequence: `spec.image` is normalized (`docker://` stripped) and validated against IdeGYM's OCI
+reference pattern, and nothing more. The failure mode for a non-IdeGYM image is a readiness-probe
+failure, which is why `create()` probes at all instead of trusting "pod is running".
+
+### 2. What should `close()` do?
+
+IdeGYM distinguishes `stop_server` (delete the pod and its Kubernetes resources) from
+`finish_server` (mark the server free, keep the pod warm for reuse).
+
+| Option | Decision |
+| --- | --- |
+| `stop_server` only | **Chosen** |
+| `stop` by default with `finish` + reuse available behind a config knob | Not implemented in this milestone |
+| `finish` by default | Rejected: keeps pods warm but leaks them whenever a run dies |
+
+Consequence: `close()` always deletes. Reuse is still reachable — pinning
+`provider_options.server_name` and setting `reuse_strategy` opts into IdeGYM's own server matching —
+but the provider does not manage a warm pool, and `operations` has no `close_action` knob to get
+wrong. Pod startup cost is therefore paid per task; if that becomes the bottleneck on long
+benchmarks, a `finish`-based warm pool is the follow-up.
+
+### 3. Where does the SDK dependency live?
+
+| Option | Decision |
+| --- | --- |
+| Opt-in extra `nemo-gym[idegym]`, imported lazily, with an actionable `ModuleNotFoundError` | **Chosen** |
+| Core dependency alongside `opensandbox` / `daytona` / `boto3` | Rejected: IdeGYM is a third-party control plane, and its SDK should not be in installs that will never talk to one |
+
+This follows the `nemo-gym[openshell]` precedent. CI installs the extra alongside the other sandbox
+extras so the SDK-gated tests run rather than skip.
+
+**One consequence worth a maintainer's attention.** `uv.lock` resolves all extras together, so adding
+this one raises two locked versions for every install, not just for IdeGYM users:
+
+| Package | Before | After | Cause |
+| --- | --- | --- | --- |
+| `hydra-core` | 1.3.2 | 1.3.5 | `idegym-common-utils` requires `hydra-core>=1.3.4` |
+| `pyyaml` | 6.0.2 | 6.0.3 | pulled in by that resolution |
+
+Both are patch bumps inside the line `pyproject.toml` already allows (`hydra-core` is unpinned), and
+the full core unit-test suite passes on them. If keeping the resolution untouched matters more, the
+alternative is declaring the extra conflicting in `[tool.uv]` so it resolves separately — at the cost
+of a second resolution to maintain.
+
+## Decisions taken without asking
+
+These follow from reading the two codebases; they are recorded because each has a plausible
+alternative that a reviewer might expect instead.
+
+### One registered IdeGYM client per process, not per sandbox
+
+IdeGYM's unit of ownership is a **client**: a registered, heartbeating entity that owns N server
+pods, carries the resource quota (matched by regex against its *name*), and terminates all of its
+servers when it stops.
+
+Registering one per sandbox looked simpler but does not scale to a benchmark fan-out: the
+orchestrator takes `LOCK TABLE clients IN EXCLUSIVE MODE` per registration, heartbeats multiply by
+the concurrency, and one job's pods end up scattered across many owners in the dashboard. So a
+session is shared by every sandbox with an identical `connection` config and reference-counted across
+providers.
+
+The refcount matters for correctness, not just efficiency: the SDK unregisters a client by stopping
+it, which **terminates all of its servers**. Releasing early would kill live sandboxes belonging to
+other providers.
+
+### The shared client runs on a private event loop
+
+The SDK's client owns an httpx session and a heartbeat task, so it belongs to the loop that created
+it. NeMo Gym drives sandboxes from two directions: `AsyncSandbox` on the caller's loop, and the sync
+`Sandbox` facade — which gives *every sandbox its own* loop in its own thread, and is what
+`mini_swe_agent_2` uses. Binding the shared client to whichever loop happened to create it first
+would tie one registration's lifetime to one sandbox's.
+
+Alternative considered: key sessions on `(connection, running loop)`. That is simpler, and correct
+for the async case, but degenerates to one registration per sandbox under the sync facade — exactly
+the case that motivated sharing.
+
+### Tracing is off unless configured
+
+`IdeGYMClient` defaults its OTLP endpoint to a JetBrains-hosted collector, so constructing it with no
+`otel_config` sends traces to a third party. The session always passes an explicit `OTELConfig`, and
+`connection.tracing_endpoint` is `null` by default. Opting in is a config change.
+
+### The SDK's httpx transport is replaced
+
+`AGENTS.md` requires async HTTP to go through aiohttp — httpx's connection pool is O(n²) at high
+concurrency — and says to swap the transport when wrapping a library that uses httpx internally. The
+IdeGYM client builds its own `httpx.AsyncClient` and exposes no hook, so the swap reaches into
+`client._http_client._transport`. That private access is isolated in one function, degrades to a
+warning plus the SDK's own transport if the shape changes, and is guarded by a test. Pool limits and
+`connection.max_connections` bounds orchestrator load either way.
+
+### Files move as base64 over the bash tool
+
+IdeGYM's server does have a filesystem API, but not one reachable here: its read endpoint streams raw
+bytes while the orchestrator forwards requests by storing and replaying them as JSON *text*, so
+binary content does not survive; and its typed file endpoints only write UTF-8. base64 over the bash
+tool is binary-safe in both directions and needs nothing but coreutils.
+
+Both directions are chunked, for different reasons, and the numbers are not arbitrary:
+
+- **Uploads** embed the payload in the script, and the IdeGYM executor passes the script as a single
+  `execve()` argument. Linux caps that at `MAX_ARG_STRLEN` (128 KiB) and fails with `E2BIG`, so a raw
+  chunk has to stay under ~96 KiB once base64 inflates it by 4/3. The default is 48 KiB, and the
+  config rejects anything that could not fit.
+- **Downloads** come back as a command's stdout, which the orchestrator persists as the text result
+  of an async operation, so a whole-file read would put an inflated copy of the file through its
+  database.
+
+The download chunk script deliberately does *not* set `pipefail`: `head -c` closes the pipe as soon
+as it has its bytes, so `tail` normally dies of SIGPIPE and would make a perfectly good chunk look
+like a failure. The decoded-length check is the real guard.
+
+### Command context is expressed in the script
+
+IdeGYM's bash tool takes a command, a timeout and a graceful-termination timeout — no
+working-directory, environment or user arguments. So `cwd` becomes `cd -- ... || exit 1`, `env`
+becomes `export`, and the whole thing is wrapped in one `{ ... }` group because the executor runs
+`source <bash-integration> && <script>` and `&&` binds only to the first statement of a
+multi-statement script.
+
+`user` has no equivalent at all. Rather than silently dropping it, `exec.user_mode` makes the
+behavior explicit: `ignore` (default) warns once per provider, while `runuser` and `su` wrap the
+script for images that ship those tools. `create.run_as_root` defaults to `true` in the shipped
+config, which makes `exec(user="root")` — what `mini_swe_agent_2` passes — a no-op rather than a lie.
+
+### `create()` verifies before returning
+
+Two checks, both because their absence produces a confusing failure much later:
+
+- The readiness probe, because a scheduled pod is not yet a sandbox that can run commands.
+- `spec.workdir` exists, because otherwise every later command fails on `cd` and reads like a broken
+  agent rather than a mis-set path.
+
+### Capabilities stands in for a status endpoint
+
+IdeGYM has no per-server status endpoint. `list_capabilities` is the cheapest call that validates the
+server's database record *and* reaches the pod, which is exactly the liveness question `status()`
+asks. Its answers map cleanly: 404 (unknown client/server) and 410 (terminal state) mean the sandbox
+is gone; anything else that fails leaves the status `unknown`.
+
+### HTTP status is recovered by parsing exception text
+
+The SDK collapses every HTTP failure into a plain `RuntimeError` whose message embeds the status and
+body. Telling "the sandbox is gone" from "the control plane is busy" from "the command timed out"
+requires that status, so the parsing lives in `errors.py` — one module, both message shapes, covered
+by tests — rather than being spread across the provider. If the SDK ever raises typed errors, that is
+the only place to change.
+
+### Transport failures are classified by httpx's hierarchy, not Python's
+
+The SDK lets httpx's exceptions through unwrapped, and none of them are builtins: `httpx.ConnectError`
+is *not* a `ConnectionError` and `httpx.ReadTimeout` is *not* a `TimeoutError`. Classifying on the
+builtins alone would leave the most common transient failure — the orchestrator being briefly
+unreachable — unretried, so `is_retryable` checks `httpx.TransportError` explicitly. `ConnectTimeout`
+is excluded from the *command*-timeout check: failing to reach the orchestrator is a connectivity
+problem, not a slow command.
+
+### `ready_timeout_s` is a deadline for the whole create, not per attempt
+
+`_start_server` tracks a deadline across retries and hands each attempt only the remaining budget,
+because the config documents `ready_timeout_s` as bounding the whole call. Per-attempt budgets would
+let a *late* retryable failure — a 503 after 1100s of a 1200s wait — start a fresh full-length
+attempt, up to 80 minutes on the shipped default. A bare `TimeoutError` is additionally never
+retried: the SDK raises it only after spending the budget it was given.
+
+### Concurrency is bounded by the HTTP pool, not by serializing operations
+
+An earlier draft held a semaphore for the duration of each session operation. That bounds *operations*
+rather than requests, and an IdeGYM create polls for as long as the readiness timeout — so with the
+shipped 32-slot pool and `mini_swe_agent_2`'s concurrency of 64, provisioning would have blocked the
+exec calls of sandboxes that were already running, and teardown behind provisioning. The limit now
+lives where it belongs, on `connection.max_connections`, which both transports honor (the aiohttp
+bridge maps it onto the connector's `limit`).
+
+### Failure paths get the same fidelity as success paths
+
+Three places where the SDK's or the shell's failure behavior is not the obvious one, each covered by a
+test:
+
+- `stop_server` reports a failed delete by *returning* an `ErrorResponse` rather than raising, so the
+  return value is checked; an unchecked one records a live pod as stopped.
+- A server is dropped from the session's bookkeeping only once it is really stopped. Dropping it on
+  failure would make the caller's own retry look like "already stopped" and leave the pod running.
+- The generated script opens with `:` so the brace group is never empty: a blank or comment-only
+  command would otherwise fail with a bash syntax error attributed to the caller.
+
+### Failures are classified on structure, not on substring
+
+An orchestrator error relays the sandbox's own output in its `body`, so both the status and the
+timeout patterns are anchored to the surrounding message. Searching the whole string would let tool
+output like `curl failed: status=404` mark a healthy sandbox as gone, or `pytest ... timed out after
+30s` read as a command timeout.
+
+### Retries re-name the server
+
+A start-server retry takes a fresh uniqueness suffix, because an attempt whose response was lost may
+have landed anyway; reusing the name would make IdeGYM offer that half-created server back as a reuse
+candidate. The orphan is reaped by IdeGYM's watcher once the client stops heartbeating. A pinned
+`provider_options.server_name` is kept across retries, since pinning is an explicit opt-in to reuse.
+
+### Metadata cannot become labels
+
+On OpenSandbox, `SandboxSpec.metadata` becomes queryable Kubernetes labels. IdeGYM has no per-server
+label API — `pod_overrides` is a partial `V1PodSpec`, not object metadata — so metadata is used for
+naming instead: `create.server_name_metadata_keys` folds selected keys (default `instance_id`) into
+the pod name, and job attribution names the registered client, which is what the dashboard groups by
+and what quota rules match. The run id is deliberately excluded from the client name: it changes per
+launch, and a name that changes per launch defeats both quota matching and dashboard grouping.
+
+## Capabilities deliberately not claimed
+
+| Capability | Why not |
+| --- | --- |
+| `SupportsSandboxEndpoint` (`endpoint()`) | The orchestrator forwards API requests through an async-operation indirection; it does not route raw TCP to arbitrary container ports, so there is no honest URL to hand back. |
+| `SupportsSandboxPty` | IdeGYM has no terminal API. |
+| `ConnectableProvider` (`serialize()` / `connect()`) | A server is only reachable through the registered client that owns it. Attaching from another process would mean a client with no registration and no heartbeat, and tearing one down cleanly is not expressible through the SDK's public surface without also stopping the client — which would kill the original process's sandboxes. Sharing a sandbox across processes is possible by fronting this provider with a sandbox server. |
+
+## Verified and not verified
+
+Verified locally:
+
+- The generated bash scripts — quoting, `cd`, `export`, base64 chunking at unaligned boundaries,
+  empty files, filenames with dashes and quotes — by executing them with real `bash`.
+- Every session call shape binds against the published `idegym-client` 0.11.1 signatures, and the
+  plain-dict start-server request validates into the SDK's own pydantic models.
+- The documented launch command resolves end-to-end:
+  `gym env resolve --config <mini_swe_agent_2> --config <idegym> --config <vllm_model>`.
+- The full `-m sandbox` suite and the core unit tests, with no new failures.
+  (`test_enroot_provider.py::test_create_start_timeout_cleans_up` fails on a clean checkout too.)
+
+**Not** verified: nothing has been run against a real IdeGYM orchestrator or Kubernetes cluster. The
+end-to-end acceptance criterion — `mini_swe_agent_2` completing a small evaluation on IdeGYM — needs a
+reachable orchestrator and IdeGYM-wrapped benchmark images, and is the next step rather than a
+finished claim.
+
+## One fix outside the provider
+
+`mini_swe_agent_2.yaml` declared `datasets: []` twice, which the strict YAML loader rejects, so
+`gym env resolve` and `gym env start` failed for *every* sandbox provider — the launch command
+documented across all the provider configs. The duplicate is removed here because the provider's own
+quick-start depends on it.

--- a/nemo_gym/sandbox/providers/idegym/DESIGN-DECISIONS.md
+++ b/nemo_gym/sandbox/providers/idegym/DESIGN-DECISIONS.md
@@ -102,8 +102,8 @@ the case that motivated sharing.
 
 ### Tracing is off unless configured
 
-`IdeGYMClient` defaults its OTLP endpoint to a JetBrains-hosted collector, so constructing it with no
-`otel_config` sends traces to a third party. The session always passes an explicit `OTELConfig`, and
+`IdeGYMClient` ships a default OTLP endpoint, so constructing it with no `otel_config` sends traces
+off-box to a third party. The session always passes an explicit `OTELConfig`, and
 `connection.tracing_endpoint` is `null` by default. Opting in is a config change.
 
 ### The SDK's httpx transport is replaced
@@ -217,12 +217,22 @@ timeout patterns are anchored to the surrounding message. Searching the whole st
 output like `curl failed: status=404` mark a healthy sandbox as gone, or `pytest ... timed out after
 30s` read as a command timeout.
 
-### Retries re-name the server
+### Server names are not made unique
 
-A start-server retry takes a fresh uniqueness suffix, because an attempt whose response was lost may
-have landed anyway; reusing the name would make IdeGYM offer that half-created server back as a reuse
-candidate. The orphan is reaped by IdeGYM's watcher once the client stops heartbeating. A pinned
-`provider_options.server_name` is kept across retries, since pinning is an explicit opt-in to reuse.
+The provider sends `<prefix>-<metadata hints>` and stops there. IdeGYM appends its own autoincrement
+id to derive `generated_name`, and that is the name Kubernetes sees and the only one the database
+keeps unique (`server_name` is an unconstrained column). Adding a random suffix on top would buy no
+uniqueness, cost 9 characters of the 63-character budget that instance ids need, and make pod names
+harder to read.
+
+It would also mislead: a suffix looks like it prevents unintended reuse, but reuse is skipped
+entirely unless `reuse_strategy` is `RESTART`/`RESET`, and even then only servers left `FINISHED`
+qualify — while this provider always *stops* the servers it creates, which marks them `STOPPED`.
+
+The same reasoning applies to retries, which keep the name rather than re-rolling it: an attempt whose
+response was lost may have landed anyway, but that orphan gets its own `generated_name` and is reaped
+by the watcher once the client stops heartbeating. Renaming would only break the name matching that a
+pinned `provider_options.server_name` exists to drive.
 
 ### Metadata cannot become labels
 

--- a/nemo_gym/sandbox/providers/idegym/DESIGN-DECISIONS.md
+++ b/nemo_gym/sandbox/providers/idegym/DESIGN-DECISIONS.md
@@ -1,51 +1,60 @@
 # IdeGYM Sandbox Provider — Design Decisions
 
-A record of the questions this integration raised, what was chosen, and why. It exists so a reviewer
-can see which choices were deliberate and which are open, and so the next person to touch this
-provider does not have to re-derive the constraints from the IdeGYM and NeMo Gym sources.
+Why this provider is built the way it is: the choices with real alternatives, and the constraints
+that forced them. It exists so the next person to touch the code does not have to re-derive them
+from the IdeGYM and NeMo Gym sources.
 
-Written against **NeMo Gym** at `2251ef7` and **idegym 0.11.1** (`idegym-client` 0.11.1 on PyPI).
+## The shape of the integration
 
-## Questions put to the maintainer
+```mermaid
+flowchart LR
+    P["IdeGymProvider<br/>one per sandbox"] --> S["IdeGymSession<br/>shared, refcounted"]
+    S --> C["Registered client<br/>heartbeat · quota · owns N servers"]
+    C --> O["Orchestrator"]
+    O --> K["Kubernetes"]
+    K --> Pod["Server pod"]
+    O -.->|"HTTP forwarded<br/>as JSON text"| Pod
+```
 
-Three decisions were genuinely the maintainer's to make, because different answers would have meant
-materially different work. They were asked before implementation.
+Two properties of that chain drive most of what follows: the *client* is the unit of ownership and
+quota, and the orchestrator relays requests as JSON text rather than proxying a socket.
 
-### 1. How should `SandboxSpec.image` be resolved?
+## Choices with real alternatives
 
-The constraint: an IdeGYM sandbox is a pod running the **IdeGYM server**, and that server is what
-exposes the API the orchestrator forwards commands to. A plain benchmark image does not boot one, so
-the image cannot simply be a SWE-bench tag.
+### How `SandboxSpec.image` is resolved
+
+An IdeGYM sandbox is a pod running the **IdeGYM server**, and that server exposes the API the
+orchestrator forwards commands to. A plain benchmark image does not boot one, so the image cannot
+simply be a SWE-bench tag.
 
 | Option | Decision |
 | --- | --- |
-| **Pass pre-built IdeGYM images through; document `image_rewrites` for mapping upstream benchmark images onto them** | **Chosen** |
-| Integrate IdeGYM's image builder so the provider can build and push a wrapped image on demand | Rejected for a first milestone: needs a registry, cluster build permissions, and a build-cache story |
+| **Pass pre-built IdeGYM images through; document `image_rewrites` for mapping benchmark images onto them** | **Chosen** |
+| Integrate IdeGYM's image builder so the provider builds and pushes a wrapped image on demand | Rejected for a first milestone: needs a registry, cluster build permissions, and a build-cache story |
 | Validate the image against an allow-prefix and refuse anything else | Rejected as too rigid — registry layouts vary |
 
-Consequence: `spec.image` is normalized (`docker://` stripped) and validated against IdeGYM's OCI
+`spec.image` is therefore normalized (`docker://` stripped) and validated against IdeGYM's OCI
 reference pattern, and nothing more. A non-IdeGYM image fails inside the orchestrator instead: its
 container never answers the health endpoint the pod's readiness probe polls, so `start_server` times
 out rather than handing back a server that cannot run commands.
 
-### 2. What should `close()` do?
+### What `close()` does
 
-IdeGYM distinguishes `stop_server` (delete the pod and its Kubernetes resources) from
-`finish_server` (mark the server free, keep the pod warm for reuse).
+IdeGYM distinguishes `stop_server` (delete the pod and its Kubernetes resources) from `finish_server`
+(mark the server free, keep the pod warm for reuse).
 
 | Option | Decision |
 | --- | --- |
 | `stop_server` only | **Chosen** |
-| `stop` by default with `finish` + reuse available behind a config knob | Not implemented in this milestone |
+| `stop` by default, with `finish` + reuse behind a config knob | Not implemented in this milestone |
 | `finish` by default | Rejected: keeps pods warm but leaks them whenever a run dies |
 
-Consequence: `close()` always deletes. Reuse is still reachable — pinning
-`provider_options.server_name` and setting `reuse_strategy` opts into IdeGYM's own server matching —
-but the provider does not manage a warm pool, and `operations` has no `close_action` knob to get
-wrong. Pod startup cost is therefore paid per task; if that becomes the bottleneck on long
-benchmarks, a `finish`-based warm pool is the follow-up.
+So `close()` always deletes. Reuse stays reachable — pin `provider_options.server_name` and set
+`reuse_strategy` to opt into IdeGYM's own matching — but the provider manages no warm pool, and
+`operations` has no `close_action` knob to get wrong. Pod startup cost is paid per task; if that
+becomes the bottleneck on long benchmarks, a `finish`-based warm pool is the follow-up.
 
-### 3. Where does the SDK dependency live?
+### Where the SDK dependency lives
 
 | Option | Decision |
 | --- | --- |
@@ -55,51 +64,46 @@ benchmarks, a `finish`-based warm pool is the follow-up.
 This follows the `nemo-gym[openshell]` precedent. CI installs the extra alongside the other sandbox
 extras so the SDK-gated tests run rather than skip.
 
-**One consequence worth a maintainer's attention.** `uv.lock` resolves all extras together, so adding
-this one raises two locked versions for every install, not just for IdeGYM users:
+One consequence worth knowing: `uv.lock` resolves all extras together, so adding this one raises two
+locked versions for every install, not just for IdeGYM users — `hydra-core` 1.3.2 → 1.3.5 (required
+by `idegym-common-utils`) and `pyyaml` 6.0.2 → 6.0.3 pulled in behind it. Both are patch bumps inside
+the range `pyproject.toml` already allows. Declaring the extra conflicting in `[tool.uv]` would keep
+the resolution untouched, at the cost of a second resolution to maintain.
 
-| Package | Before | After | Cause |
-| --- | --- | --- | --- |
-| `hydra-core` | 1.3.2 | 1.3.5 | `idegym-common-utils` requires `hydra-core>=1.3.4` |
-| `pyyaml` | 6.0.2 | 6.0.3 | pulled in by that resolution |
+## Implementation decisions
 
-Both are patch bumps inside the line `pyproject.toml` already allows (`hydra-core` is unpinned), and
-the full core unit-test suite passes on them. If keeping the resolution untouched matters more, the
-alternative is declaring the extra conflicting in `[tool.uv]` so it resolves separately — at the cost
-of a second resolution to maintain.
+These follow from reading the two codebases. Each is recorded because a reviewer might reasonably
+expect the alternative.
 
-## Decisions taken without asking
+### One registered client per process, not per sandbox
 
-These follow from reading the two codebases; they are recorded because each has a plausible
-alternative that a reviewer might expect instead.
+A *client* is a registered, heartbeating entity that owns N server pods, carries the resource quota
+(matched by regex against its **name**), and terminates all of its servers when it stops.
 
-### One registered IdeGYM client per process, not per sandbox
+Registering one per sandbox looked simpler but does not survive a benchmark fan-out: the orchestrator
+takes `LOCK TABLE clients IN EXCLUSIVE MODE` per registration, heartbeats multiply by the concurrency,
+and one job's pods scatter across many owners in the dashboard. A session is therefore shared by every
+sandbox with an identical `connection` config, and reference-counted across providers.
 
-IdeGYM's unit of ownership is a **client**: a registered, heartbeating entity that owns N server
-pods, carries the resource quota (matched by regex against its *name*), and terminates all of its
-servers when it stops.
-
-Registering one per sandbox looked simpler but does not scale to a benchmark fan-out: the
-orchestrator takes `LOCK TABLE clients IN EXCLUSIVE MODE` per registration, heartbeats multiply by
-the concurrency, and one job's pods end up scattered across many owners in the dashboard. So a
-session is shared by every sandbox with an identical `connection` config and reference-counted across
-providers.
-
-The refcount matters for correctness, not just efficiency: the SDK unregisters a client by stopping
-it, which **terminates all of its servers**. Releasing early would kill live sandboxes belonging to
-other providers.
+The refcount is correctness, not efficiency: unregistering a client **terminates all of its servers**,
+so releasing early would kill live sandboxes belonging to other providers.
 
 ### The shared client runs on a private event loop
 
-The SDK's client owns an httpx session and a heartbeat task, so it belongs to the loop that created
-it. NeMo Gym drives sandboxes from two directions: `AsyncSandbox` on the caller's loop, and the sync
+The SDK client owns an httpx session and a heartbeat task, so it belongs to the loop that created it.
+NeMo Gym drives sandboxes from two directions: `AsyncSandbox` on the caller's loop, and the sync
 `Sandbox` facade — which gives *every sandbox its own* loop in its own thread, and is what
-`mini_swe_agent_2` uses. Binding the shared client to whichever loop happened to create it first
-would tie one registration's lifetime to one sandbox's.
+`mini_swe_agent_2` uses. Binding the shared client to whichever loop created it first would tie one
+registration's lifetime to one sandbox's.
 
-Alternative considered: key sessions on `(connection, running loop)`. That is simpler, and correct
-for the async case, but degenerates to one registration per sandbox under the sync facade — exactly
-the case that motivated sharing.
+For the same reason the provider's own session guard is a `threading.Lock`, never an `asyncio.Lock`:
+one provider can be reached from two loops, and an `asyncio.Lock` cannot span them without
+deadlocking. Nothing is awaited while it is held, so a racing acquirer simply returns its spare
+reference.
+
+Alternative considered: key sessions on `(connection, running loop)`. Simpler, and correct for the
+async case, but it degenerates to one registration per sandbox under the sync facade — exactly the
+case that motivated sharing.
 
 ### Tracing is off unless configured
 
@@ -113,66 +117,64 @@ off-box to a third party. The session always passes an explicit `OTELConfig`, an
 concurrency — and says to swap the transport when wrapping a library that uses httpx internally. The
 IdeGYM client builds its own `httpx.AsyncClient` and exposes no hook, so the swap reaches into
 `client._http_client._transport`. That private access is isolated in one function, degrades to a
-warning plus the SDK's own transport if the shape changes, and is guarded by a test. Pool limits and
-`connection.max_connections` bounds orchestrator load either way.
+warning plus the SDK's own transport if the shape changes, and is guarded by a test.
 
 ### Files move as base64 over the bash tool
 
-IdeGYM's server does have a filesystem API, but not one reachable here: its read endpoint streams raw
-bytes while the orchestrator forwards requests by storing and replaying them as JSON *text*, so
-binary content does not survive; and its typed file endpoints only write UTF-8. base64 over the bash
-tool is binary-safe in both directions and needs nothing but coreutils.
+IdeGYM's server has a filesystem API, but not one reachable here: its read endpoint streams raw bytes
+while the orchestrator forwards requests by storing and replaying them as JSON *text*, so binary
+content does not survive; and its typed file endpoints only write UTF-8. base64 over the bash tool is
+binary-safe both ways and needs nothing but coreutils.
 
 Both directions are chunked, for different reasons, and the numbers are not arbitrary:
 
-- **Uploads** embed the payload in the script, and the IdeGYM executor passes the script as a single
-  `execve()` argument. Linux caps that at `MAX_ARG_STRLEN` (128 KiB) and fails with `E2BIG`, so a raw
-  chunk has to stay under ~96 KiB once base64 inflates it by 4/3. The default is 48 KiB, and the
-  config rejects anything that could not fit.
-- **Downloads** come back as a command's stdout, which the orchestrator persists as the text result
-  of an async operation, so a whole-file read would put an inflated copy of the file through its
-  database.
+- **Uploads** embed the payload in the script, which the executor passes as a single `execve()`
+  argument. Linux caps that at `MAX_ARG_STRLEN` (128 KiB) and fails with `E2BIG`, so a raw chunk must
+  stay under ~96 KiB once base64 inflates it by 4/3. The default is 48 KiB, and the config rejects
+  anything that could not fit.
+- **Downloads** come back as a command's stdout, which the orchestrator persists as the text result of
+  an async operation, so a whole-file read would put an inflated copy of the file through its database.
 
-The download chunk script deliberately does *not* set `pipefail`: `head -c` closes the pipe as soon
-as it has its bytes, so `tail` normally dies of SIGPIPE and would make a perfectly good chunk look
-like a failure. The decoded-length check is the real guard.
+The download chunk script deliberately does *not* set `pipefail`: `head -c` closes the pipe as soon as
+it has its bytes, so `tail` normally dies of SIGPIPE and would make a perfectly good chunk look like a
+failure. The decoded-length check is the real guard.
 
 ### Command context is expressed in the script
 
-IdeGYM's bash tool takes a command, a timeout and a graceful-termination timeout — no
-working-directory, environment or user arguments. So `cwd` becomes `cd -- ... || exit 1`, `env`
-becomes `export`, and the whole thing is wrapped in one `{ ... }` group because the executor runs
-`source <bash-integration> && <script>` and `&&` binds only to the first statement of a
-multi-statement script.
+IdeGYM's bash tool takes a command, a timeout and a graceful-termination timeout — no working
+directory, environment or user. So `cwd` becomes `cd -- ... || exit 1`, `env` becomes `export`, and
+the whole thing is wrapped in one `{ ... }` group because the executor runs
+`source <bash-integration> && <script>` and `&&` binds only to the first statement.
 
-`user` has no equivalent at all. Rather than silently dropping it, `exec.user_mode` makes the
-behavior explicit: `ignore` (default) warns once per provider, while `runuser` and `su` wrap the
-script for images that ship those tools. `create.run_as_root` defaults to `true` in the shipped
-config, which makes `exec(user="root")` — what `mini_swe_agent_2` passes — a no-op rather than a lie.
+`user` has no equivalent at all. Rather than dropping it silently, `exec.user_mode` makes the behavior
+explicit: `ignore` (default) warns once per provider, while `runuser` and `su` wrap the script for
+images that ship those tools — both pinning `/bin/bash` rather than inheriting a login shell that may
+be `/sbin/nologin`. `create.run_as_root` defaults to `true` in the shipped config, which makes
+`exec(user="root")` — what `mini_swe_agent_2` passes — a no-op rather than a lie.
 
 ### `create()` checks only the workdir
 
 IdeGYM does not report a server until `wait_for_pods_ready` sees its pod `Running` with every
-container ready, and the container's readiness probe is an HTTP GET against the IdeGYM server's own
-health endpoint on the port the bash tool is served from. A provider-side readiness probe would only
-re-ask that question, so `create()` adds one check the orchestrator cannot make: that `spec.workdir`
-exists, because otherwise every later command fails on `cd` and reads like a broken agent rather
-than a mis-set path.
+container ready, and that readiness probe is an HTTP GET against the IdeGYM server's own health
+endpoint on the port the bash tool is served from. A provider-side readiness probe would only re-ask
+the question, so `create()` adds the one check the orchestrator cannot make: that `spec.workdir`
+exists, because otherwise every later command fails on `cd` and reads like a broken agent rather than
+a mis-set path.
 
 ### Capabilities stands in for a status endpoint
 
 IdeGYM has no per-server status endpoint. `list_capabilities` is the cheapest call that validates the
 server's database record *and* reaches the pod, which is exactly the liveness question `status()`
-asks. Its answers map cleanly: 404 (unknown client/server) and 410 (terminal state) mean the sandbox
-is gone; anything else that fails leaves the status `unknown`.
+asks. Its answers map cleanly: 404 (unknown client/server) and 410 (terminal state) mean gone;
+anything else that fails leaves the status `unknown`.
 
 ### HTTP status is recovered by parsing exception text
 
 The SDK collapses every HTTP failure into a plain `RuntimeError` whose message embeds the status and
 body. Telling "the sandbox is gone" from "the control plane is busy" from "the command timed out"
-requires that status, so the parsing lives in `errors.py` — one module, both message shapes, covered
-by tests — rather than being spread across the provider. If the SDK ever raises typed errors, that is
-the only place to change.
+needs that status, so the parsing lives in `errors.py` — one module, both message shapes, covered by
+tests — rather than spread across the provider. If the SDK ever raises typed errors, that is the only
+place to change.
 
 ### Transport failures are classified by httpx's hierarchy, not Python's
 
@@ -188,17 +190,17 @@ problem, not a slow command.
 `_start_server` tracks a deadline across retries and hands each attempt only the remaining budget,
 because the config documents `ready_timeout_s` as bounding the whole call. Per-attempt budgets would
 let a *late* retryable failure — a 503 after 1100s of a 1200s wait — start a fresh full-length
-attempt, up to 80 minutes on the shipped default. A bare `TimeoutError` is additionally never
-retried: the SDK raises it only after spending the budget it was given.
+attempt, up to 80 minutes on the shipped default. A bare `TimeoutError` is additionally never retried:
+the SDK raises it only after spending the budget it was given.
 
 ### Concurrency is bounded by the HTTP pool, not by serializing operations
 
 An earlier draft held a semaphore for the duration of each session operation. That bounds *operations*
 rather than requests, and an IdeGYM create polls for as long as the readiness timeout — so with the
-shipped 32-slot pool and `mini_swe_agent_2`'s concurrency of 64, provisioning would have blocked the
-exec calls of sandboxes that were already running, and teardown behind provisioning. The limit now
-lives where it belongs, on `connection.max_connections`, which both transports honor (the aiohttp
-bridge maps it onto the connector's `limit`).
+shipped pool and `mini_swe_agent_2`'s concurrency, provisioning would have blocked the exec calls of
+sandboxes already running, and teardown behind provisioning. The limit lives where it belongs, on
+`connection.max_connections`, which both transports honor (the aiohttp bridge maps it onto the
+connector's `limit`).
 
 ### Failure paths get the same fidelity as success paths
 
@@ -207,10 +209,13 @@ test:
 
 - `stop_server` reports a failed delete by *returning* an `ErrorResponse` rather than raising, so the
   return value is checked; an unchecked one records a live pod as stopped.
-- A server is dropped from the session's bookkeeping only once it is really stopped. Dropping it on
-  failure would make the caller's own retry look like "already stopped" and leave the pod running.
+- A server leaves the session's bookkeeping only once it is really stopped. Dropping it on failure
+  would make the caller's own retry look like "already stopped" and leave the pod running.
 - The generated script opens with `:` so the brace group is never empty: a blank or comment-only
   command would otherwise fail with a bash syntax error attributed to the caller.
+
+An `exec` failure the classifier does not recognize is logged with its traceback before being turned
+into a return value, because that return value is the only other place it would ever appear.
 
 ### Failures are classified on structure, not on substring
 
@@ -223,13 +228,12 @@ output like `curl failed: status=404` mark a healthy sandbox as gone, or `pytest
 
 The provider sends `<prefix>-<metadata hints>` and stops there. IdeGYM appends its own autoincrement
 id to derive `generated_name`, and that is the name Kubernetes sees and the only one the database
-keeps unique (`server_name` is an unconstrained column). Adding a random suffix on top would buy no
-uniqueness, cost 9 characters of the 63-character budget that instance ids need, and make pod names
-harder to read.
+keeps unique (`server_name` is an unconstrained column). A random suffix on top would buy no
+uniqueness, cost 9 of the 63 name characters that instance ids need, and make pod names harder to read.
 
-It would also mislead: a suffix looks like it prevents unintended reuse, but reuse is skipped
-entirely unless `reuse_strategy` is `RESTART`/`RESET`, and even then only servers left `FINISHED`
-qualify — while this provider always *stops* the servers it creates, which marks them `STOPPED`.
+It would also mislead: a suffix looks like it prevents unintended reuse, but reuse is skipped entirely
+unless `reuse_strategy` is `RESTART`/`RESET`, and even then only servers left `FINISHED` qualify —
+while this provider always *stops* the ones it creates, which marks them `STOPPED`.
 
 The same reasoning applies to retries, which keep the name rather than re-rolling it: an attempt whose
 response was lost may have landed anyway, but that orphan gets its own `generated_name` and is reaped
@@ -251,29 +255,4 @@ launch, and a name that changes per launch defeats both quota matching and dashb
 | --- | --- |
 | `SupportsSandboxEndpoint` (`endpoint()`) | The orchestrator forwards API requests through an async-operation indirection; it does not route raw TCP to arbitrary container ports, so there is no honest URL to hand back. |
 | `SupportsSandboxPty` | IdeGYM has no terminal API. |
-| `ConnectableProvider` (`serialize()` / `connect()`) | A server is only reachable through the registered client that owns it. Attaching from another process would mean a client with no registration and no heartbeat, and tearing one down cleanly is not expressible through the SDK's public surface without also stopping the client — which would kill the original process's sandboxes. Sharing a sandbox across processes is possible by fronting this provider with a sandbox server. |
-
-## Verified and not verified
-
-Verified locally:
-
-- The generated bash scripts — quoting, `cd`, `export`, base64 chunking at unaligned boundaries,
-  empty files, filenames with dashes and quotes — by executing them with real `bash`.
-- Every session call shape binds against the published `idegym-client` 0.11.1 signatures, and the
-  plain-dict start-server request validates into the SDK's own pydantic models.
-- The documented launch command resolves end-to-end:
-  `gym env resolve --config <mini_swe_agent_2> --config <idegym> --config <vllm_model>`.
-- The full `-m sandbox` suite and the core unit tests, with no new failures.
-  (`test_enroot_provider.py::test_create_start_timeout_cleans_up` fails on a clean checkout too.)
-
-**Not** verified: nothing has been run against a real IdeGYM orchestrator or Kubernetes cluster. The
-end-to-end acceptance criterion — `mini_swe_agent_2` completing a small evaluation on IdeGYM — needs a
-reachable orchestrator and IdeGYM-wrapped benchmark images, and is the next step rather than a
-finished claim.
-
-## One fix outside the provider
-
-`mini_swe_agent_2.yaml` declared `datasets: []` twice, which the strict YAML loader rejects, so
-`gym env resolve` and `gym env start` failed for *every* sandbox provider — the launch command
-documented across all the provider configs. The duplicate is removed here because the provider's own
-quick-start depends on it.
+| `ConnectableProvider` (`serialize()` / `connect()`) | A server is reachable only through the registered client that owns it. Attaching from another process would mean a client with no registration and no heartbeat, and tearing one down cleanly is not expressible through the SDK's public surface without also stopping the client — which would kill the original process's sandboxes. Sharing a sandbox across processes is possible by fronting this provider with a sandbox server. |

--- a/nemo_gym/sandbox/providers/idegym/README.md
+++ b/nemo_gym/sandbox/providers/idegym/README.md
@@ -107,7 +107,7 @@ Per-sandbox IdeGYM options with no neutral equivalent, validated before a pod is
 | `service_account_name` | ServiceAccount for the pod. |
 | `pod_overrides` | Partial `V1PodSpec` deep-merged into the generated pod spec (tolerations, affinity, ...). |
 | `reuse_strategy`, `server_kind`, `snapshot`, `max_restarts` | Passed through to IdeGYM. |
-| `server_name` | Pins the server name, opting into IdeGYM's server reuse. Otherwise a unique name is generated per sandbox. |
+| `server_name` | Pins the server name IdeGYM's reuse lookup matches on. Otherwise it is derived from the name prefix and metadata hints. |
 | `service_port`, `container_port` | Override the configured ports. |
 
 ### `SandboxSpec` mapping

--- a/nemo_gym/sandbox/providers/idegym/README.md
+++ b/nemo_gym/sandbox/providers/idegym/README.md
@@ -1,0 +1,225 @@
+# IdeGYM Sandbox Provider
+
+Runs each NeMo Gym sandbox as an [IdeGYM](https://github.com/JetBrains-Research/idegym) *server*: a
+Kubernetes pod provisioned through the IdeGYM orchestrator, driven over the HTTP API the orchestrator
+forwards to it. Use it when your evaluation environments already live in IdeGYM — SWE-bench-style
+repository tasks, IDE-backed environments, or anything else IdeGYM images provide — and you want to
+run them through NeMo Gym's agents and benchmarks.
+
+The provider implements the provider-neutral `SandboxProvider` contract, so any sandbox-backed agent
+(for example `mini_swe_agent_2`) can use it by pointing at this provider's config.
+
+## Requirements
+
+- A reachable IdeGYM orchestrator, and Basic auth credentials for it.
+- The client SDK: `uv pip install 'nemo-gym[idegym]'` (pulls `idegym-client`, `idegym-api`,
+  `idegym-common-utils`).
+- **An IdeGYM server image.** This is the one requirement that is easy to miss: the pod must run the
+  IdeGYM server, because that server is what exposes the API the orchestrator forwards commands to. A
+  plain benchmark image (`swebench/sweb.eval.x86_64.*`, say) does not boot one, and starting it will
+  fail readiness. See [Images](#images) below.
+- `base64`, `wc`, `tail` and `head` in the image — coreutils, present in practically every Linux base
+  image. File transfer uses them.
+
+## Quick start
+
+```bash
+export IDEGYM_ORCHESTRATOR_URL=idegym.example.com
+export IDEGYM_NAMESPACE=idegym
+export IDEGYM_AUTH_USERNAME=...
+export IDEGYM_AUTH_PASSWORD=...
+
+AGENT=responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+MODEL=responses_api_models/vllm_model/configs/vllm_model.yaml
+gym env start \
+    --config $AGENT \
+    --config nemo_gym/sandbox/providers/idegym/configs/idegym.yaml \
+    --config $MODEL
+```
+
+Every shipped provider config binds the same instance name `sandbox`, so switching a benchmark from
+OpenSandbox or Docker to IdeGYM is swapping that one config path — no agent edit.
+
+Directly from Python:
+
+```python
+import asyncio
+
+from nemo_gym.sandbox import AsyncSandbox, SandboxSpec
+
+provider_config = {
+    "idegym": {
+        "connection": {"orchestrator_url": "idegym.example.com", "namespace": "idegym"},
+        "create": {"run_as_root": True},
+    }
+}
+
+spec = SandboxSpec(
+    image="registry.example.com/idegym/my-env:latest",
+    workdir="/testbed",
+    resources={"cpu": 2, "memory_mib": 8192, "disk_gib": 30},
+    provider_options={"resource_requests": {"cpu": 0.5, "memory_mib": 2048}},
+    metadata={"instance_id": "django__django-11099"},
+)
+
+
+async def main() -> None:
+    async with AsyncSandbox(provider_config, spec) as sandbox:
+        await sandbox.start()
+        result = await sandbox.exec("python -m pytest -q", timeout_s=600)
+        print(result.stdout or result.stderr)
+
+
+asyncio.run(main())
+# leaving the `async with` block stops the server and deletes its Kubernetes resources
+```
+
+Credentials come from `IDEGYM_AUTH_USERNAME` / `IDEGYM_AUTH_PASSWORD` when `connection.username` and
+`connection.password` are unset, which is how they should normally be passed.
+
+## Configuration
+
+`configs/idegym.yaml` is the shipped config block, with every knob commented. The provider constructor
+takes one section per concern:
+
+| Section | Purpose |
+| --- | --- |
+| `connection` | Orchestrator URL, namespace, auth, client name, HTTP pooling, tracing. |
+| `create` | Readiness budget, retries, generated server names, pod defaults (`run_as_root`, ports), orchestrator polling backoff. |
+| `exec` | Default command timeout, client-side overhead, how `exec(user=...)` is honored. |
+| `probe` | Post-start readiness verification and the working-directory check. |
+| `files` | Upload/download chunk sizes and the download size cap. |
+| `operations` | Status and teardown timeouts and retries. |
+| `attribution` | How the registered IdeGYM client name is derived when it is not pinned. |
+
+### `provider_options`
+
+Per-sandbox IdeGYM options with no neutral equivalent, validated before a pod is allocated:
+
+| Option | Notes |
+| --- | --- |
+| `resource_requests` | Kubernetes *requests*, paired with `spec.resources` as the limits. |
+| `runtime_class_name` | e.g. `gvisor` for a sandboxed runtime. |
+| `run_as_root` | Overrides `create.run_as_root` for this sandbox. |
+| `node_selector` | Node labels for scheduling. |
+| `volumes`, `volume_mounts` | Native Kubernetes shapes. |
+| `env_from` | ConfigMap/Secret env import — the only way to put environment on the *pod*. |
+| `service_account_name` | ServiceAccount for the pod. |
+| `pod_overrides` | Partial `V1PodSpec` deep-merged into the generated pod spec (tolerations, affinity, ...). |
+| `reuse_strategy`, `server_kind`, `snapshot`, `max_restarts` | Passed through to IdeGYM. |
+| `server_name` | Pins the server name, opting into IdeGYM's server reuse. Otherwise a unique name is generated per sandbox. |
+| `service_port`, `container_port` | Override the configured ports. |
+
+### `SandboxSpec` mapping
+
+| Field | Mapping |
+| --- | --- |
+| `image` | The IdeGYM server image. `docker://` is stripped; the rest must be a valid lowercase OCI reference. |
+| `workdir` | Not a pod setting — each command `cd`s into it, and create fails early if it does not exist (`probe.verify_workdir`). |
+| `env` | Exported per command, since IdeGYM can only put ConfigMap/Secret env on the pod (`provider_options.env_from`). |
+| `resources` | Kubernetes **limits**. `cpu` → cores/millicores, `memory_mib` → `Mi`, `disk_gib` → `ephemeral-storage`. |
+| `files` | Uploaded after start by the sandbox API, through this provider's `upload_file`. |
+| `metadata` | Not labels — IdeGYM has no per-server label API. `create.server_name_metadata_keys` folds selected keys into the pod name; the rest is kept for diagnostics. |
+| `ready_timeout_s` | Overrides `create.ready_timeout_s`. |
+| `ttl_s` | Not enforced; warns. IdeGYM servers live until stopped (its watcher reaps servers whose client stops heartbeating). |
+| `ports` | Ignored; warns. An IdeGYM pod exposes only its own API port. |
+| `entrypoint` | Rejected. The entrypoint starts the IdeGYM server. |
+| `resources.gpu`, `resources.gpu_type` | Not mapped; warns. Request accelerators via `node_selector` or `pod_overrides`. |
+
+Note that IdeGYM's resource quota accounting reads **limits** first, so `spec.resources` is what
+counts against your quota rule, not the smaller `resource_requests`.
+
+## How it works
+
+```
+AsyncSandbox / Sandbox
+        │
+   IdeGymProvider ──── spec.py      SandboxSpec  → start-server request
+        │         ──── naming.py    RFC-1035 server names, client names
+        │         ──── shell.py     cwd / env / user  → one bash script
+        │         ──── transfer.py  files → base64 over the bash tool
+        │         ──── errors.py    SDK exception → "gone" / "busy" / "timed out"
+        │
+   IdeGymSession  ←── the only module that imports the idegym SDK
+        │
+   IdeGYM orchestrator ── forwards ──→ server pod (IdeGYM server + your project)
+```
+
+**One registered client per process.** IdeGYM's unit of ownership is a *client*: a registered,
+heartbeating entity that owns N server pods, carries the resource quota keyed on its name, and
+terminates all of its servers when it stops. Every sandbox created from an identical `connection`
+config shares one registered client, reference-counted across providers; the last release
+unregisters it, which also cleans up any server that was never closed.
+
+**That client runs on a private event loop** in a daemon thread. The SDK's client is loop-bound (an
+httpx session plus a heartbeat task), while NeMo Gym drives sandboxes both from a caller's loop
+(`AsyncSandbox`) and from one loop per sandbox (the sync `Sandbox` facade the mini-swe-agent harness
+uses). A private loop lets one registration serve every sandbox regardless of who asked.
+
+**Commands are shaped into a script.** IdeGYM's bash tool takes a command and nothing else — each
+call is a fresh `bash -c` in the server's project directory with a cleaned environment — so `cwd`,
+`env` and `user` are expressed inside the generated script. The script is emitted as one `{ ... }`
+group, because IdeGYM runs `source <bash-integration> && <script>` and `&&` binds only to the first
+statement.
+
+**Create waits for readiness.** A scheduled pod is not yet a usable sandbox, so `create()` returns
+only after the probe command has passed `probe.stable_count` times, and after checking that
+`spec.workdir` exists. Anything that fails after provisioning stops the server.
+
+**Files ride base64 over bash.** IdeGYM's filesystem API is not usable through the orchestrator: its
+read endpoint streams raw bytes while the orchestrator forwards requests as JSON text, and its typed
+file endpoints only write UTF-8. Uploads are chunked to stay under the sandbox shell's 128 KiB
+argument limit; downloads are chunked because each chunk's stdout is persisted as an
+async-operation result.
+
+**Status** uses the capabilities call — the cheapest orchestrator call that validates the server's
+record *and* reaches the pod. A 404 or 410 means the sandbox is gone; anything else that fails leaves
+the status `unknown` rather than guessing.
+
+## Images
+
+`spec.image` must be an image that runs the IdeGYM server. Build those with IdeGYM's own image
+builder, publish them to a registry your cluster can pull from, then map upstream benchmark images
+onto them with the sandbox spec's `image_rewrites`:
+
+```yaml
+mini_swe_agent_2:
+  responses_api_agents:
+    mini_swe_agent_2:
+      sandbox_provider: sandbox
+      sandbox_spec:
+        image_rewrites:
+          - from: "swebench/"
+            to: "registry.example.com/idegym-swebench/"
+```
+
+Rewrites are ordered and the first matching prefix wins. The provider does not build images.
+
+## Limitations
+
+- **No `endpoint()`.** The orchestrator forwards API requests rather than routing raw TCP to
+  arbitrary container ports, so a long-lived service inside the sandbox cannot be reached this way.
+- **No PTY sessions.** IdeGYM has no terminal API, so `sandbox.pty` is unavailable.
+- **No `serialize()` / `connect()`.** A server is only reachable through the registered client that
+  owns it, so sharing one across processes needs a sandbox server in front of this provider.
+- **No `user` switching by default.** IdeGYM's bash tool has no user field; commands run as the
+  container's user, which `provider_options.run_as_root` controls at pod level. `exec.user_mode` can
+  wrap commands in `runuser` or `su` for images that ship them.
+- **Command and output sizes.** A command may not exceed ~100 KiB once shaped into a script, and the
+  IdeGYM executor strips leading and trailing whitespace from stdout and stderr.
+- **`ttl_s` is not enforced**, so a crashed process leaks pods until its client stops heartbeating
+  and IdeGYM's watcher reaps them.
+
+## Development
+
+```bash
+uv pip install 'nemo-gym[idegym]'
+pytest tests/unit_tests/test_idegym_provider.py tests/unit_tests/test_idegym_session.py
+```
+
+The provider tests need no orchestrator: they run against a fake session, and the file-transfer and
+command-shaping tests execute the generated scripts with local `bash`. The session tests that bind
+against the real SDK signatures skip when `idegym-client` is not installed.
+
+See [DESIGN-DECISIONS.md](DESIGN-DECISIONS.md) for the choices behind this layout and the
+alternatives that were rejected.

--- a/nemo_gym/sandbox/providers/idegym/README.md
+++ b/nemo_gym/sandbox/providers/idegym/README.md
@@ -87,7 +87,7 @@ takes one section per concern:
 | `connection` | Orchestrator URL, namespace, auth, client name, HTTP pooling, tracing. |
 | `create` | Readiness budget, retries, generated server names, pod defaults (`run_as_root`, ports), orchestrator polling backoff. |
 | `exec` | Default command timeout, client-side overhead, how `exec(user=...)` is honored. |
-| `probe` | Post-start readiness verification and the working-directory check. |
+| `verify` | The post-start working-directory check. |
 | `files` | Upload/download chunk sizes and the download size cap. |
 | `operations` | Status and teardown timeouts and retries. |
 | `attribution` | How the registered IdeGYM client name is derived when it is not pinned. |
@@ -115,7 +115,7 @@ Per-sandbox IdeGYM options with no neutral equivalent, validated before a pod is
 | Field | Mapping |
 | --- | --- |
 | `image` | The IdeGYM server image. `docker://` is stripped; the rest must be a valid lowercase OCI reference. |
-| `workdir` | Not a pod setting — each command `cd`s into it, and create fails early if it does not exist (`probe.verify_workdir`). |
+| `workdir` | Not a pod setting — each command `cd`s into it, and create fails early if it does not exist (`verify.check_workdir`). |
 | `env` | Exported per command, since IdeGYM can only put ConfigMap/Secret env on the pod (`provider_options.env_from`). |
 | `resources` | Kubernetes **limits**. `cpu` → cores/millicores, `memory_mib` → `Mi`, `disk_gib` → `ephemeral-storage`. |
 | `files` | Uploaded after start by the sandbox API, through this provider's `upload_file`. |
@@ -162,9 +162,10 @@ call is a fresh `bash -c` in the server's project directory with a cleaned envir
 group, because IdeGYM runs `source <bash-integration> && <script>` and `&&` binds only to the first
 statement.
 
-**Create waits for readiness.** A scheduled pod is not yet a usable sandbox, so `create()` returns
-only after the probe command has passed `probe.stable_count` times, and after checking that
-`spec.workdir` exists. Anything that fails after provisioning stops the server.
+**Create trusts IdeGYM's readiness wait.** The orchestrator reports a server only once its pod
+passes the Kubernetes readiness probe against the server's health endpoint, so `create()` adds just
+one check of its own: that `spec.workdir` exists. Anything that fails after provisioning stops the
+server.
 
 **Files ride base64 over bash.** IdeGYM's filesystem API is not usable through the orchestrator: its
 read endpoint streams raw bytes while the orchestrator forwards requests as JSON text, and its typed

--- a/nemo_gym/sandbox/providers/idegym/README.md
+++ b/nemo_gym/sandbox/providers/idegym/README.md
@@ -1,25 +1,21 @@
 # IdeGYM Sandbox Provider
 
 Runs each NeMo Gym sandbox as an [IdeGYM](https://github.com/JetBrains-Research/idegym) *server*: a
-Kubernetes pod provisioned through the IdeGYM orchestrator, driven over the HTTP API the orchestrator
-forwards to it. Use it when your evaluation environments already live in IdeGYM — SWE-bench-style
-repository tasks, IDE-backed environments, or anything else IdeGYM images provide — and you want to
-run them through NeMo Gym's agents and benchmarks.
+Kubernetes pod provisioned through the IdeGYM orchestrator and driven over the HTTP API the
+orchestrator forwards to it. Use it when your environments already live in IdeGYM — SWE-bench-style
+repository tasks, IDE-backed environments, anything else IdeGYM images provide.
 
-The provider implements the provider-neutral `SandboxProvider` contract, so any sandbox-backed agent
-(for example `mini_swe_agent_2`) can use it by pointing at this provider's config.
+It implements the provider-neutral `SandboxProvider` contract, so any sandbox-backed agent (for
+example `mini_swe_agent_2`) can use it by pointing at this provider's config.
 
 ## Requirements
 
 - A reachable IdeGYM orchestrator, and Basic auth credentials for it.
-- The client SDK: `uv pip install 'nemo-gym[idegym]'` (pulls `idegym-client`, `idegym-api`,
-  `idegym-common-utils`).
-- **An IdeGYM server image.** This is the one requirement that is easy to miss: the pod must run the
-  IdeGYM server, because that server is what exposes the API the orchestrator forwards commands to. A
-  plain benchmark image (`swebench/sweb.eval.x86_64.*`, say) does not boot one, and starting it will
-  fail readiness. See [Images](#images) below.
-- `base64`, `wc`, `tail` and `head` in the image — coreutils, present in practically every Linux base
-  image. File transfer uses them.
+- The client SDK: `uv pip install 'nemo-gym[idegym]'`.
+- **An IdeGYM server image.** The easy one to miss: the pod runs the IdeGYM server, and that server
+  is what exposes the API the orchestrator forwards commands to. A plain benchmark image such as
+  `swebench/sweb.eval.x86_64.*` does not boot one and never passes readiness. See [Images](#images).
+- `base64`, `wc`, `tail` and `head` in the image. File transfer uses them; coreutils covers it.
 
 ## Quick start
 
@@ -37,8 +33,8 @@ gym env start \
     --config $MODEL
 ```
 
-Every shipped provider config binds the same instance name `sandbox`, so switching a benchmark from
-OpenSandbox or Docker to IdeGYM is swapping that one config path — no agent edit.
+Every shipped provider config binds the same instance name `sandbox`, so moving a benchmark from
+Docker or OpenSandbox to IdeGYM is swapping that one config path. No agent edit.
 
 Directly from Python:
 
@@ -74,114 +70,106 @@ asyncio.run(main())
 # leaving the `async with` block stops the server and deletes its Kubernetes resources
 ```
 
-Credentials come from `IDEGYM_AUTH_USERNAME` / `IDEGYM_AUTH_PASSWORD` when `connection.username` and
-`connection.password` are unset, which is how they should normally be passed.
+Leave `connection.username` and `connection.password` unset and the SDK reads
+`IDEGYM_AUTH_USERNAME` / `IDEGYM_AUTH_PASSWORD`. That is the normal way to pass them.
 
-## Configuration
+## Selecting and configuring the provider
 
-`configs/idegym.yaml` is the shipped config block, with every knob commented. The provider constructor
-takes one section per concern:
+`configs/idegym.yaml` is the shipped block, with every knob commented — it is the reference for
+individual settings. The constructor takes one section per concern:
 
 | Section | Purpose |
 | --- | --- |
 | `connection` | Orchestrator URL, namespace, auth, client name, HTTP pooling, tracing. |
-| `create` | Readiness budget, retries, generated server names, pod defaults (`run_as_root`, ports), orchestrator polling backoff. |
+| `create` | Readiness budget, retries, generated server names, pod defaults, polling backoff. |
 | `exec` | Default command timeout, client-side overhead, how `exec(user=...)` is honored. |
 | `verify` | The post-start working-directory check. |
-| `files` | Upload/download chunk sizes and the download size cap. |
+| `files` | Upload and download chunk sizes, and the download size cap. |
 | `operations` | Status and teardown timeouts and retries. |
-| `attribution` | How the registered IdeGYM client name is derived when it is not pinned. |
+| `attribution` | How the registered client name is derived when it is not pinned. |
 
-### `provider_options`
+`SandboxSpec.provider_options` carries the per-sandbox Kubernetes options that have no neutral
+equivalent — `runtime_class_name`, `node_selector`, `volumes`, `env_from`, `pod_overrides` and the
+rest — validated before a pod is allocated. The
+[provider docs](https://docs.nvidia.com/nemo/gym/latest/infrastructure/sandbox/idegym) list them all.
 
-Per-sandbox IdeGYM options with no neutral equivalent, validated before a pod is allocated:
+### Spec fields that behave differently here
 
-| Option | Notes |
+| Field | Behavior |
 | --- | --- |
-| `resource_requests` | Kubernetes *requests*, paired with `spec.resources` as the limits. |
-| `runtime_class_name` | e.g. `gvisor` for a sandboxed runtime. |
-| `run_as_root` | Overrides `create.run_as_root` for this sandbox. |
-| `node_selector` | Node labels for scheduling. |
-| `volumes`, `volume_mounts` | Native Kubernetes shapes. |
-| `env_from` | ConfigMap/Secret env import — the only way to put environment on the *pod*. |
-| `service_account_name` | ServiceAccount for the pod. |
-| `pod_overrides` | Partial `V1PodSpec` deep-merged into the generated pod spec (tolerations, affinity, ...). |
-| `reuse_strategy`, `server_kind`, `snapshot`, `max_restarts` | Passed through to IdeGYM. |
-| `server_name` | Pins the server name IdeGYM's reuse lookup matches on. Otherwise it is derived from the name prefix and metadata hints. |
-| `service_port`, `container_port` | Override the configured ports. |
-
-### `SandboxSpec` mapping
-
-| Field | Mapping |
-| --- | --- |
-| `image` | The IdeGYM server image. `docker://` is stripped; the rest must be a valid lowercase OCI reference. |
-| `workdir` | Not a pod setting — each command `cd`s into it, and create fails early if it does not exist (`verify.check_workdir`). |
-| `env` | Exported per command, since IdeGYM can only put ConfigMap/Secret env on the pod (`provider_options.env_from`). |
-| `resources` | Kubernetes **limits**. `cpu` → cores/millicores, `memory_mib` → `Mi`, `disk_gib` → `ephemeral-storage`. |
-| `files` | Uploaded after start by the sandbox API, through this provider's `upload_file`. |
-| `metadata` | Not labels — IdeGYM has no per-server label API. `create.server_name_metadata_keys` folds selected keys into the pod name; the rest is kept for diagnostics. |
-| `ready_timeout_s` | Overrides `create.ready_timeout_s`. |
-| `ttl_s` | Not enforced; warns. IdeGYM servers live until stopped (its watcher reaps servers whose client stops heartbeating). |
-| `ports` | Ignored; warns. An IdeGYM pod exposes only its own API port. |
-| `entrypoint` | Rejected. The entrypoint starts the IdeGYM server. |
-| `resources.gpu`, `resources.gpu_type` | Not mapped; warns. Request accelerators via `node_selector` or `pod_overrides`. |
-
-Note that IdeGYM's resource quota accounting reads **limits** first, so `spec.resources` is what
-counts against your quota rule, not the smaller `resource_requests`.
+| `image` | Must run the IdeGYM server. `docker://` is stripped; the rest must be a valid lowercase OCI reference. |
+| `workdir` | Not a pod setting — each command `cd`s into it, and create fails early if it is missing (`verify.check_workdir`). |
+| `env` | Exported per command. IdeGYM can only put ConfigMap/Secret env on the pod, via `provider_options.env_from`. |
+| `resources` | Kubernetes **limits**; `provider_options.resource_requests` supplies the requests. Quota accounting reads the limits, so `spec.resources` is what counts against your rule. |
+| `metadata` | Not labels — IdeGYM has no per-server label API. `create.server_name_metadata_keys` folds selected keys into the pod name; the rest is diagnostics. |
+| `ttl_s`, `ports`, `resources.gpu` | Unsupported; each warns once. `entrypoint` is rejected outright, since the entrypoint starts the IdeGYM server. |
 
 ## How it works
 
-```
-AsyncSandbox / Sandbox
-        │
-   IdeGymProvider ──── spec.py      SandboxSpec  → start-server request
-        │         ──── naming.py    RFC-1035 server names, client names
-        │         ──── shell.py     cwd / env / user  → one bash script
-        │         ──── transfer.py  files → base64 over the bash tool
-        │         ──── errors.py    SDK exception → "gone" / "busy" / "timed out"
-        │
-   IdeGymSession  ←── the only module that imports the idegym SDK
-        │
-   IdeGYM orchestrator ── forwards ──→ server pod (IdeGYM server + your project)
+```mermaid
+flowchart TB
+    API["AsyncSandbox / Sandbox"] --> P["IdeGymProvider"]
+    P --> S["IdeGymSession<br/>the only module importing the SDK"]
+    S --> O["IdeGYM orchestrator"]
+    O -->|forwards| Pod["Server pod<br/>IdeGYM server + your project"]
 ```
 
-**One registered client per process.** IdeGYM's unit of ownership is a *client*: a registered,
-heartbeating entity that owns N server pods, carries the resource quota keyed on its name, and
-terminates all of its servers when it stops. Every sandbox created from an identical `connection`
-config shares one registered client, reference-counted across providers; the last release
-unregisters it, which also cleans up any server that was never closed.
+`IdeGymProvider` is the composition point; the pieces around it each turn one neutral concept into
+IdeGYM's shape:
 
-**That client runs on a private event loop** in a daemon thread. The SDK's client is loop-bound (an
-httpx session plus a heartbeat task), while NeMo Gym drives sandboxes both from a caller's loop
-(`AsyncSandbox`) and from one loop per sandbox (the sync `Sandbox` facade the mini-swe-agent harness
-uses). A private loop lets one registration serve every sandbox regardless of who asked.
+| Module | Turns |
+| --- | --- |
+| `spec.py` | a `SandboxSpec` into a start-server request |
+| `naming.py` | a prefix, metadata and attribution into RFC-1035 server and client names |
+| `shell.py` | `cwd` / `env` / `user` into one bash script |
+| `transfer.py` | files into base64 over the bash tool |
+| `errors.py` | an SDK exception into "gone" / "busy" / "timed out" |
+
+**One registered client per process.** IdeGYM's unit of ownership is a *client*: a heartbeating
+entity that owns N server pods, carries the resource quota keyed on its name, and terminates all of
+its servers when it stops. Every sandbox with an identical `connection` config shares one, reference
+counted across providers — the last release unregisters it, cleaning up anything never closed.
+
+```mermaid
+flowchart LR
+    subgraph Process["One process"]
+        P1["Provider A"] --> C
+        P2["Provider B"] --> C
+        C["Registered client<br/>refcount 2"]
+    end
+    C --> S1["server pod"]
+    C --> S2["server pod"]
+    C --> S3["server pod"]
+```
+
+**That client runs on a private event loop** in a daemon thread. The SDK client is loop-bound — an
+httpx session plus a heartbeat task — while NeMo Gym drives sandboxes both from the caller's loop
+(`AsyncSandbox`) and from one loop per sandbox (the sync `Sandbox` facade). A private loop lets one
+registration serve every sandbox whichever loop asks.
 
 **Commands are shaped into a script.** IdeGYM's bash tool takes a command and nothing else — each
 call is a fresh `bash -c` in the server's project directory with a cleaned environment — so `cwd`,
-`env` and `user` are expressed inside the generated script. The script is emitted as one `{ ... }`
+`env` and `user` are expressed inside the generated script. That script is emitted as one `{ ... }`
 group, because IdeGYM runs `source <bash-integration> && <script>` and `&&` binds only to the first
 statement.
 
 **Create trusts IdeGYM's readiness wait.** The orchestrator reports a server only once its pod
-passes the Kubernetes readiness probe against the server's health endpoint, so `create()` adds just
-one check of its own: that `spec.workdir` exists. Anything that fails after provisioning stops the
-server.
+passes the Kubernetes readiness probe against the server's health endpoint, so `create()` adds one
+check of its own: that `spec.workdir` exists. Anything that fails after provisioning stops the server.
 
-**Files ride base64 over bash.** IdeGYM's filesystem API is not usable through the orchestrator: its
-read endpoint streams raw bytes while the orchestrator forwards requests as JSON text, and its typed
-file endpoints only write UTF-8. Uploads are chunked to stay under the sandbox shell's 128 KiB
-argument limit; downloads are chunked because each chunk's stdout is persisted as an
-async-operation result.
+**Files ride base64 over bash.** IdeGYM's filesystem API is not reachable through the orchestrator:
+its read endpoint streams raw bytes while the orchestrator forwards requests as JSON text, and its
+typed file endpoints only write UTF-8. Uploads are chunked to stay under the shell's argument limit;
+downloads because each chunk's stdout is persisted as an async-operation result.
 
-**Status** uses the capabilities call — the cheapest orchestrator call that validates the server's
-record *and* reaches the pod. A 404 or 410 means the sandbox is gone; anything else that fails leaves
-the status `unknown` rather than guessing.
+**Status** uses the capabilities call, the cheapest one that validates the server's database record
+*and* reaches the pod. A 404 or 410 means gone; any other failure leaves the status `unknown` rather
+than guessing.
 
 ## Images
 
-`spec.image` must be an image that runs the IdeGYM server. Build those with IdeGYM's own image
-builder, publish them to a registry your cluster can pull from, then map upstream benchmark images
-onto them with the sandbox spec's `image_rewrites`:
+`spec.image` must run the IdeGYM server. Build those with IdeGYM's own image builder, publish them
+where your cluster can pull them, then map upstream benchmark tags onto them with `image_rewrites`:
 
 ```yaml
 mini_swe_agent_2:
@@ -201,15 +189,15 @@ Rewrites are ordered and the first matching prefix wins. The provider does not b
 - **No `endpoint()`.** The orchestrator forwards API requests rather than routing raw TCP to
   arbitrary container ports, so a long-lived service inside the sandbox cannot be reached this way.
 - **No PTY sessions.** IdeGYM has no terminal API, so `sandbox.pty` is unavailable.
-- **No `serialize()` / `connect()`.** A server is only reachable through the registered client that
-  owns it, so sharing one across processes needs a sandbox server in front of this provider.
-- **No `user` switching by default.** IdeGYM's bash tool has no user field; commands run as the
-  container's user, which `provider_options.run_as_root` controls at pod level. `exec.user_mode` can
-  wrap commands in `runuser` or `su` for images that ship them.
+- **No `serialize()` / `connect()`.** A server is reachable only through the registered client that
+  owns it; sharing one across processes needs a sandbox server in front of this provider.
+- **No user switching by default.** IdeGYM's bash tool has no user field, so commands run as the
+  container's user, which `provider_options.run_as_root` sets at pod level. `exec.user_mode` can wrap
+  commands in `runuser` or `su` for images that ship them.
 - **Command and output sizes.** A command may not exceed ~100 KiB once shaped into a script, and the
-  IdeGYM executor strips leading and trailing whitespace from stdout and stderr.
+  executor strips leading and trailing whitespace from stdout and stderr.
 - **`ttl_s` is not enforced**, so a crashed process leaks pods until its client stops heartbeating
-  and IdeGYM's watcher reaps them.
+  and the watcher reaps them.
 
 ## Development
 
@@ -218,9 +206,9 @@ uv pip install 'nemo-gym[idegym]'
 pytest tests/unit_tests/test_idegym_provider.py tests/unit_tests/test_idegym_session.py
 ```
 
-The provider tests need no orchestrator: they run against a fake session, and the file-transfer and
-command-shaping tests execute the generated scripts with local `bash`. The session tests that bind
-against the real SDK signatures skip when `idegym-client` is not installed.
+The tests need no orchestrator. They run against a fake session, and the file-transfer and
+command-shaping tests execute the generated scripts with local `bash`. The tests that bind against
+real SDK signatures skip when `idegym-client` is not installed.
 
 See [DESIGN-DECISIONS.md](DESIGN-DECISIONS.md) for the choices behind this layout and the
-alternatives that were rejected.
+alternatives rejected along the way.

--- a/nemo_gym/sandbox/providers/idegym/README.md
+++ b/nemo_gym/sandbox/providers/idegym/README.md
@@ -12,9 +12,9 @@ example `mini_swe_agent_2`) can use it by pointing at this provider's config.
 
 - A reachable IdeGYM orchestrator, and Basic auth credentials for it.
 - The client SDK: `uv pip install 'nemo-gym[idegym]'`.
-- **An IdeGYM server image.** The easy one to miss: the pod runs the IdeGYM server, and that server
-  is what exposes the API the orchestrator forwards commands to. A plain benchmark image such as
-  `swebench/sweb.eval.x86_64.*` does not boot one and never passes readiness. See [Images](#images).
+- **An IdeGYM server image.** The pod runs the IdeGYM server, and that server exposes the API this
+  provider talks to. A plain benchmark image such as `swebench/sweb.eval.x86_64.*` has none, so it
+  never becomes ready. See [Images](#images).
 - `base64`, `wc`, `tail` and `head` in the image. File transfer uses them; coreutils covers it.
 
 ## Quick start
@@ -102,28 +102,23 @@ rest — validated before a pod is allocated. The
 | `env` | Exported per command. IdeGYM can only put ConfigMap/Secret env on the pod, via `provider_options.env_from`. |
 | `resources` | Kubernetes **limits**; `provider_options.resource_requests` supplies the requests. Quota accounting reads the limits, so `spec.resources` is what counts against your rule. |
 | `metadata` | Not labels — IdeGYM has no per-server label API. `create.server_name_metadata_keys` folds selected keys into the pod name; the rest is diagnostics. |
-| `ttl_s`, `ports`, `resources.gpu` | Unsupported; each warns once. `entrypoint` is rejected outright, since the entrypoint starts the IdeGYM server. |
+| `ttl_s`, `ports`, `resources.gpu` | Unsupported; each warns once. `entrypoint` fails `create()`, since the entrypoint starts the IdeGYM server. |
 
 ## How it works
 
 ```mermaid
-flowchart TB
-    API["AsyncSandbox / Sandbox"] --> P["IdeGymProvider"]
-    P --> S["IdeGymSession<br/>the only module importing the SDK"]
-    S --> O["IdeGYM orchestrator"]
-    O -->|forwards| Pod["Server pod<br/>IdeGYM server + your project"]
+flowchart LR
+    API["AsyncSandbox<br/>Sandbox"] --> P["IdeGymProvider"]
+    P --> S["IdeGymSession<br/>registered client · private event loop<br/>the only SDK import"]
+    S -->|HTTP| O["Orchestrator"]
+    O -->|"forwards as JSON text"| Pod["Server pod<br/>IdeGYM server + your project"]
+
+    P -.-> SP["spec.py — spec → start-server request"]
+    P -.-> NA["naming.py — RFC-1035 server and client names"]
+    P -.-> SH["shell.py — cwd/env/user → one bash script"]
+    P -.-> TR["transfer.py — files → base64 chunks"]
+    P -.-> ER["errors.py — SDK error → gone / busy / timed out"]
 ```
-
-`IdeGymProvider` is the composition point; the pieces around it each turn one neutral concept into
-IdeGYM's shape:
-
-| Module | Turns |
-| --- | --- |
-| `spec.py` | a `SandboxSpec` into a start-server request |
-| `naming.py` | a prefix, metadata and attribution into RFC-1035 server and client names |
-| `shell.py` | `cwd` / `env` / `user` into one bash script |
-| `transfer.py` | files into base64 over the bash tool |
-| `errors.py` | an SDK exception into "gone" / "busy" / "timed out" |
 
 **One registered client per process.** IdeGYM's unit of ownership is a *client*: a heartbeating
 entity that owns N server pods, carries the resource quota keyed on its name, and terminates all of

--- a/nemo_gym/sandbox/providers/idegym/__init__.py
+++ b/nemo_gym/sandbox/providers/idegym/__init__.py
@@ -13,3 +13,59 @@
 # limitations under the License.
 
 """IdeGYM sandbox provider package."""
+
+from nemo_gym.sandbox.providers.idegym.config import (
+    IdeGymAttributionConfig,
+    IdeGymConnectionConfig,
+    IdeGymCreateConfig,
+    IdeGymExecConfig,
+    IdeGymFilesConfig,
+    IdeGymOperationsConfig,
+    IdeGymPollingConfig,
+    IdeGymProbeConfig,
+    TransportBackend,
+    UserMode,
+)
+from nemo_gym.sandbox.providers.idegym.errors import (
+    IdeGymCommandTooLongError,
+    IdeGymCreateError,
+    IdeGymCreateVerificationError,
+    IdeGymError,
+    IdeGymOperationError,
+    IdeGymTransferError,
+    IdeGymUnknownServerError,
+)
+from nemo_gym.sandbox.providers.idegym.provider import IdeGymProvider
+from nemo_gym.sandbox.providers.idegym.session import IdeGymBashResult, IdeGymServerRef, IdeGymSession
+from nemo_gym.sandbox.providers.idegym.shell import BashScriptBuilder
+from nemo_gym.sandbox.providers.idegym.spec import IdeGymProviderOptions, ServerRequestTranslator
+from nemo_gym.sandbox.providers.idegym.transfer import Base64BashFileTransfer
+
+
+__all__ = [
+    "BashScriptBuilder",
+    "Base64BashFileTransfer",
+    "IdeGymAttributionConfig",
+    "IdeGymBashResult",
+    "IdeGymCommandTooLongError",
+    "IdeGymConnectionConfig",
+    "IdeGymCreateConfig",
+    "IdeGymCreateError",
+    "IdeGymCreateVerificationError",
+    "IdeGymError",
+    "IdeGymExecConfig",
+    "IdeGymFilesConfig",
+    "IdeGymOperationError",
+    "IdeGymOperationsConfig",
+    "IdeGymPollingConfig",
+    "IdeGymProbeConfig",
+    "IdeGymProvider",
+    "IdeGymProviderOptions",
+    "IdeGymServerRef",
+    "IdeGymSession",
+    "IdeGymTransferError",
+    "IdeGymUnknownServerError",
+    "ServerRequestTranslator",
+    "TransportBackend",
+    "UserMode",
+]

--- a/nemo_gym/sandbox/providers/idegym/__init__.py
+++ b/nemo_gym/sandbox/providers/idegym/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IdeGYM sandbox provider package."""

--- a/nemo_gym/sandbox/providers/idegym/__init__.py
+++ b/nemo_gym/sandbox/providers/idegym/__init__.py
@@ -22,7 +22,7 @@ from nemo_gym.sandbox.providers.idegym.config import (
     IdeGymFilesConfig,
     IdeGymOperationsConfig,
     IdeGymPollingConfig,
-    IdeGymProbeConfig,
+    IdeGymVerifyConfig,
     TransportBackend,
     UserMode,
 )
@@ -58,7 +58,7 @@ __all__ = [
     "IdeGymOperationError",
     "IdeGymOperationsConfig",
     "IdeGymPollingConfig",
-    "IdeGymProbeConfig",
+    "IdeGymVerifyConfig",
     "IdeGymProvider",
     "IdeGymProviderOptions",
     "IdeGymServerRef",

--- a/nemo_gym/sandbox/providers/idegym/config.py
+++ b/nemo_gym/sandbox/providers/idegym/config.py
@@ -15,7 +15,7 @@
 """Configuration objects for the IdeGYM sandbox provider.
 
 The provider constructor takes one section per concern — ``connection``, ``create``,
-``exec``, ``probe``, ``files``, ``operations``, ``attribution`` — mirroring the shipped
+``exec``, ``verify``, ``files``, ``operations``, ``attribution`` — mirroring the shipped
 ``configs/idegym.yaml`` block. Every section validates in ``__post_init__`` so a bad
 Hydra value fails at server start rather than mid-rollout, and every section is frozen
 and hashable so the shared orchestrator session can be keyed on its connection config.
@@ -42,10 +42,6 @@ MAX_COMMAND_BYTES = 100 * 1024
 # the command budget with the `cd`, the `mkdir -p`, and the caller's env exports, so the
 # limit leaves real headroom rather than filling the budget with payload alone.
 MAX_UPLOAD_CHUNK_BYTES = 64 * 1024
-
-# The probe asserts stdout equality, so these two only make sense as a pair.
-DEFAULT_PROBE_COMMAND = "printf idegym-sandbox-ready"
-DEFAULT_PROBE_EXPECTED = "idegym-sandbox-ready"
 
 # RFC-1035 caps Kubernetes resource names at 63 characters, and the orchestrator derives
 # the pod name as `<server_name>-<server_id>`, so the name the provider sends leaves room
@@ -236,33 +232,21 @@ class IdeGymExecConfig:
 
 
 @dataclass(frozen=True)
-class IdeGymProbeConfig:
-    """Readiness verification run after the orchestrator reports a started server.
+class IdeGymVerifyConfig:
+    """Post-start verification, on top of the orchestrator's own readiness wait.
 
-    A started pod is not the same as a sandbox that can run commands, so ``create()``
-    only returns once this probe has passed ``stable_count`` times.
+    IdeGYM reports a server only once its pod passes the Kubernetes readiness probe
+    against the server's health endpoint, so the one thing left worth checking is that
+    ``spec.workdir`` exists in the image.
     """
 
-    command: str | None = DEFAULT_PROBE_COMMAND
-    expected_stdout: str | None = DEFAULT_PROBE_EXPECTED
     timeout_s: float = 30.0
-    deadline_s: float | None = 180.0
-    stable_count: int = 1
-    # Non-zero: the probe polls a remote orchestrator, so back-to-back retries would
-    # hammer it for the whole deadline while a pod is still warming up.
-    stable_delay_s: float = 2.0
     # Fail create on a missing `spec.workdir` instead of letting every later exec fail
     # on `cd`, long after the cause is visible.
-    verify_workdir: bool = True
+    check_workdir: bool = True
 
     def __post_init__(self) -> None:
-        if self.stable_count < 1:
-            raise ValueError("probe.stable_count must be >= 1")
-        # Always validated: the workdir check uses this timeout even when the probe
-        # command is disabled.
-        _require_positive(self.timeout_s, "probe.timeout_s")
-        _require_positive(self.deadline_s, "probe.deadline_s", allow_none=True)
-        _require_non_negative(self.stable_delay_s, "probe.stable_delay_s")
+        _require_positive(self.timeout_s, "verify.timeout_s")
 
 
 @dataclass(frozen=True)

--- a/nemo_gym/sandbox/providers/idegym/config.py
+++ b/nemo_gym/sandbox/providers/idegym/config.py
@@ -1,0 +1,346 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration objects for the IdeGYM sandbox provider.
+
+The provider constructor takes one section per concern — ``connection``,
+``create``, ``exec``, ``probe``, ``files``, ``operations``, ``attribution`` —
+mirroring the shipped ``configs/idegym.yaml`` block. Every section validates in
+``__post_init__`` so a bad Hydra value fails at server start rather than in the
+middle of a rollout, and every section is frozen and hashable so the shared
+orchestrator session can be keyed on its connection config.
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from nemo_gym.sandbox.providers.utils import coerce_config
+
+
+# The sandbox runs `/bin/sh -c "bash -c <script>"`, so the script travels as one
+# execve() argument. Linux caps that at MAX_ARG_STRLEN (128 KiB) and rejects longer
+# ones with E2BIG, so generated scripts stay comfortably below it.
+MAX_COMMAND_BYTES = 100 * 1024
+
+# Ceiling for one upload chunk. base64 inflates by 4/3, and the encoded payload shares
+# the command budget with the `cd`, the `mkdir -p`, and the caller's env exports, so the
+# limit leaves real headroom rather than filling the budget with payload alone.
+MAX_UPLOAD_CHUNK_BYTES = 64 * 1024
+
+DEFAULT_PROBE_COMMAND = "printf idegym-sandbox-ready"
+DEFAULT_PROBE_EXPECTED = "idegym-sandbox-ready"
+
+# RFC-1035 caps Kubernetes resource names at 63 characters, and the orchestrator
+# derives the pod name as `<server_name>-<server_id>`, so the name the provider sends
+# leaves room for that suffix as well as for its own uniqueness suffix.
+MAX_SERVER_NAME_LENGTH = 63
+SERVER_ID_SUFFIX_RESERVE = 8
+SERVER_NAME_UNIQUE_SUFFIX_LENGTH = 8
+
+
+class UserMode(StrEnum):
+    """How ``exec(user=...)`` is honored.
+
+    The IdeGYM bash tool has no user field: commands run as whatever user the
+    server container runs as (``provider_options.run_as_root`` decides that at
+    pod level). ``IGNORE`` therefore drops the request with one warning, while
+    the two switch modes wrap the script in a privilege-dropping command for
+    images that ship one.
+    """
+
+    IGNORE = "ignore"
+    RUNUSER = "runuser"
+    SU = "su"
+
+
+class TransportBackend(StrEnum):
+    """HTTP transport used underneath the IdeGYM client's httpx session."""
+
+    AIOHTTP = "aiohttp"
+    HTTPX = "httpx"
+
+
+def _require_positive(value: float | int | None, name: str, *, allow_none: bool = False) -> None:
+    if value is None:
+        if allow_none:
+            return
+        raise ValueError(f"{name} must be set")
+    if value <= 0:
+        raise ValueError(f"{name} must be > 0, got {value!r}")
+
+
+def _require_non_negative(value: float | int, name: str) -> None:
+    if value < 0:
+        raise ValueError(f"{name} must be >= 0, got {value!r}")
+
+
+@dataclass(frozen=True)
+class IdeGymConnectionConfig:
+    """How to reach the IdeGYM orchestrator and how to identify this process to it.
+
+    One registered IdeGYM client is shared by every sandbox created from an
+    identical connection config (see :mod:`nemo_gym.sandbox.providers.idegym.session`),
+    so this section doubles as that session's cache key and must stay hashable.
+    """
+
+    orchestrator_url: str = "idegym.test"
+    namespace: str = "idegym"
+    # Quotas are enforced per client *name*, so all sandboxes of one job should
+    # share it. Left unset, the session derives a name from job attribution.
+    client_name: str | None = None
+    username: str | None = None
+    password: str | None = None
+    # Dedicated Kubernetes nodes requested at registration. 0 uses the shared pool.
+    nodes_count: int = 0
+    heartbeat_interval_s: int = 60
+    request_timeout_s: int = 60
+    transport_backend: str = TransportBackend.AIOHTTP
+    # Bounds in-flight HTTP to the orchestrator across every sandbox sharing this
+    # connection. Bounding requests rather than whole operations matters: a create
+    # holds its connection only while polling, so provisioning cannot block the
+    # exec calls of sandboxes that are already running. null means no cap.
+    max_connections: int | None = 64
+    max_keepalive_connections: int = 20
+    keepalive_expiry_s: float | None = 5.0
+    connect_retries: int = 2
+    # The IdeGYM client SDK traces to a JetBrains-hosted collector unless told
+    # otherwise. NeMo Gym does not send telemetry to third parties implicitly, so
+    # tracing stays off until an endpoint is configured here.
+    tracing_endpoint: str | None = None
+    tracing_timeout_s: float = 10.0
+    tracing_username: str | None = None
+    tracing_password: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.orchestrator_url:
+            raise ValueError("connection.orchestrator_url must be a non-empty URL or host")
+        if not self.namespace:
+            raise ValueError("connection.namespace must be a non-empty Kubernetes namespace")
+        if self.client_name is not None and not self.client_name.strip():
+            raise ValueError("connection.client_name must be non-empty when set")
+        _require_non_negative(self.nodes_count, "connection.nodes_count")
+        _require_positive(self.heartbeat_interval_s, "connection.heartbeat_interval_s")
+        _require_positive(self.request_timeout_s, "connection.request_timeout_s")
+        if self.transport_backend not in tuple(TransportBackend):
+            raise ValueError(
+                f"connection.transport_backend must be one of {[m.value for m in TransportBackend]}, "
+                f"got {self.transport_backend!r}"
+            )
+        _require_positive(self.max_connections, "connection.max_connections", allow_none=True)
+        _require_non_negative(self.max_keepalive_connections, "connection.max_keepalive_connections")
+        _require_positive(self.keepalive_expiry_s, "connection.keepalive_expiry_s", allow_none=True)
+        _require_non_negative(self.connect_retries, "connection.connect_retries")
+        _require_positive(self.tracing_timeout_s, "connection.tracing_timeout_s")
+
+    @property
+    def tracing_enabled(self) -> bool:
+        return bool(self.tracing_endpoint)
+
+
+@dataclass(frozen=True)
+class IdeGymPollingConfig:
+    """Backoff for the orchestrator's async-operation polling.
+
+    Every mutating IdeGYM call returns an operation id that the SDK polls until it
+    reaches a terminal state, so these knobs decide how hard a large fan-out of
+    sandboxes hammers the orchestrator while it provisions pods.
+    """
+
+    initial_delay_s: float = 0.25
+    # Fixed interval; 0 selects the exponential schedule below instead.
+    interval_s: float = 0.0
+    backoff_factor: float = 1.5
+    max_delay_s: float = 30.0
+
+    def __post_init__(self) -> None:
+        _require_positive(self.initial_delay_s, "polling.initial_delay_s")
+        _require_non_negative(self.interval_s, "polling.interval_s")
+        if self.backoff_factor < 1:
+            raise ValueError("polling.backoff_factor must be >= 1")
+        _require_positive(self.max_delay_s, "polling.max_delay_s")
+
+
+@dataclass(frozen=True)
+class IdeGymCreateConfig:
+    """Server provisioning: readiness budget, retries, and pod shape defaults."""
+
+    # Bounds the whole start_server call, including the orchestrator's own wait
+    # for the pod to become ready and its internal 429 back-pressure retries.
+    ready_timeout_s: float = 900.0
+    retries: int = 3
+    retry_delay_s: float = 5.0
+    retry_max_delay_s: float = 60.0
+    # Handed to the SDK, which retries the orchestrator's 429 back-pressure
+    # itself — inside one start-server call — until `ready_timeout_s` runs out.
+    busy_retry_delay_s: float = 15.0
+    # RFC-1035 prefix for the generated Kubernetes resource name.
+    server_name_prefix: str = "nemo-gym"
+    # Metadata keys folded into the generated server name, in order, so a pod can
+    # be traced back to its task from `kubectl get pods` and the IdeGYM dashboard.
+    server_name_metadata_keys: tuple[str, ...] = ("instance_id",)
+    # NONE recreates from scratch. The provider generates a unique name per
+    # sandbox, so there is nothing to reuse unless a caller pins the name through
+    # `provider_options.server_name`.
+    reuse_strategy: str = "NONE"
+    run_as_root: bool = False
+    service_port: int = 80
+    container_port: int = 8000
+    # Pod restarts tolerated before IdeGYM tears the server down. 0 surfaces the
+    # first crash instead of looping restarts.
+    max_restarts: int = 0
+    polling: IdeGymPollingConfig | Mapping[str, Any] = field(default_factory=IdeGymPollingConfig)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "polling", coerce_config(self.polling, IdeGymPollingConfig))
+        _require_positive(self.ready_timeout_s, "create.ready_timeout_s")
+        _require_non_negative(self.retries, "create.retries")
+        _require_non_negative(self.retry_delay_s, "create.retry_delay_s")
+        _require_non_negative(self.retry_max_delay_s, "create.retry_max_delay_s")
+        _require_non_negative(self.busy_retry_delay_s, "create.busy_retry_delay_s")
+        if not self.server_name_prefix:
+            raise ValueError("create.server_name_prefix must be non-empty")
+        object.__setattr__(self, "server_name_metadata_keys", tuple(self.server_name_metadata_keys or ()))
+        if not 0 <= self.service_port <= 65535:
+            raise ValueError(f"create.service_port must be between 0 and 65535, got {self.service_port}")
+        if not 0 <= self.container_port <= 65535:
+            raise ValueError(f"create.container_port must be between 0 and 65535, got {self.container_port}")
+        _require_non_negative(self.max_restarts, "create.max_restarts")
+
+
+@dataclass(frozen=True)
+class IdeGymExecConfig:
+    """Command execution through the IdeGYM bash tool."""
+
+    default_timeout_s: float | None = 180.0
+    # Passed to the sandbox: how long a timed-out process group gets to exit on
+    # SIGTERM before it is SIGKILLed.
+    graceful_termination_timeout_s: float = 2.0
+    # Client-side budget on top of the command timeout, covering the orchestrator
+    # round trip. Keeping it non-zero means the sandbox's own timeout fires first, so
+    # the caller gets the partial output instead of a bare transport error.
+    request_overhead_s: float = 60.0
+    user_mode: str = UserMode.IGNORE
+
+    def __post_init__(self) -> None:
+        _require_positive(self.default_timeout_s, "exec.default_timeout_s", allow_none=True)
+        _require_non_negative(self.graceful_termination_timeout_s, "exec.graceful_termination_timeout_s")
+        _require_non_negative(self.request_overhead_s, "exec.request_overhead_s")
+        if self.user_mode not in tuple(UserMode):
+            raise ValueError(f"exec.user_mode must be one of {[m.value for m in UserMode]}, got {self.user_mode!r}")
+
+
+@dataclass(frozen=True)
+class IdeGymProbeConfig:
+    """Readiness verification run after the orchestrator reports a started server.
+
+    A started pod is not the same as a sandbox that can run commands, so
+    ``create()`` only returns once this probe has passed ``stable_count`` times.
+    """
+
+    command: str | None = DEFAULT_PROBE_COMMAND
+    expected_stdout: str | None = DEFAULT_PROBE_EXPECTED
+    timeout_s: float = 30.0
+    deadline_s: float | None = 180.0
+    stable_count: int = 1
+    # Non-zero: the probe polls a remote orchestrator, so back-to-back retries
+    # would hammer it for the whole deadline while a pod is still warming up.
+    stable_delay_s: float = 2.0
+    # Fail create when `spec.workdir` is missing in the image. Without the check,
+    # every later exec fails on `cd` instead, long after the cause is visible.
+    verify_workdir: bool = True
+
+    def __post_init__(self) -> None:
+        # Always validated: the workdir check uses this timeout even when the probe
+        # command is disabled.
+        _require_positive(self.timeout_s, "probe.timeout_s")
+        _require_positive(self.deadline_s, "probe.deadline_s", allow_none=True)
+        if self.stable_count < 1:
+            raise ValueError("probe.stable_count must be >= 1")
+        _require_non_negative(self.stable_delay_s, "probe.stable_delay_s")
+
+
+@dataclass(frozen=True)
+class IdeGymFilesConfig:
+    """File transfer, which rides base64 over the bash tool.
+
+    IdeGYM has no binary transfer endpoint reachable through the orchestrator's
+    JSON request forwarding, so bytes are chunked and shell-encoded. Upload chunks
+    share the command budget with the caller's ``env`` exports, so a large ``env``
+    can still push a legal chunk over it; download chunks are bounded by how much
+    text the orchestrator is willing to store per operation.
+    """
+
+    upload_chunk_bytes: int = 48 * 1024
+    download_chunk_bytes: int = 192 * 1024
+    # Refuse oversized downloads rather than filling the caller's memory with a
+    # base64-inflated copy of, say, a multi-gigabyte build tree.
+    max_download_bytes: int | None = 64 * 1024 * 1024
+    timeout_s: float = 300.0
+
+    def __post_init__(self) -> None:
+        if self.upload_chunk_bytes < 1:
+            raise ValueError("files.upload_chunk_bytes must be >= 1")
+        if self.upload_chunk_bytes > MAX_UPLOAD_CHUNK_BYTES:
+            raise ValueError(
+                f"files.upload_chunk_bytes must be <= {MAX_UPLOAD_CHUNK_BYTES} so the base64-encoded chunk "
+                f"still leaves room for the rest of the command, got {self.upload_chunk_bytes}"
+            )
+        if self.download_chunk_bytes < 1:
+            raise ValueError("files.download_chunk_bytes must be >= 1")
+        _require_positive(self.max_download_bytes, "files.max_download_bytes", allow_none=True)
+        _require_positive(self.timeout_s, "files.timeout_s")
+
+
+@dataclass(frozen=True)
+class IdeGymOperationsConfig:
+    """Post-create lifecycle calls: status polling and teardown."""
+
+    close_timeout_s: float = 180.0
+    status_timeout_s: float = 60.0
+    # Retries for control-plane calls that are safe to repeat (status, delete).
+    retries: int = 2
+    retry_delay_s: float = 1.0
+    retry_max_delay_s: float = 15.0
+
+    def __post_init__(self) -> None:
+        _require_positive(self.close_timeout_s, "operations.close_timeout_s")
+        _require_positive(self.status_timeout_s, "operations.status_timeout_s")
+        _require_non_negative(self.retries, "operations.retries")
+        _require_non_negative(self.retry_delay_s, "operations.retry_delay_s")
+        _require_non_negative(self.retry_max_delay_s, "operations.retry_max_delay_s")
+
+
+@dataclass(frozen=True)
+class IdeGymAttributionConfig:
+    """Job attribution for the registered IdeGYM client name and sandbox metadata.
+
+    IdeGYM has no per-server label API, so attribution cannot become Kubernetes
+    labels the way it does on OpenSandbox. What it can do is name the registered
+    client — which is what the IdeGYM dashboard and its per-name resource quota key
+    on — so a team's sandboxes are attributable and quota-bounded together.
+    """
+
+    enabled: bool = True
+    team: str | None = None
+    user: str | None = None
+    workload: str | None = None
+    run: str | None = None
+    # Prefix of the derived client name; the resolved attribution fields follow.
+    client_name_prefix: str = "nemo-gym"
+
+    def __post_init__(self) -> None:
+        if not self.client_name_prefix:
+            raise ValueError("attribution.client_name_prefix must be non-empty")

--- a/nemo_gym/sandbox/providers/idegym/config.py
+++ b/nemo_gym/sandbox/providers/idegym/config.py
@@ -14,12 +14,15 @@
 
 """Configuration objects for the IdeGYM sandbox provider.
 
-The provider constructor takes one section per concern — ``connection``,
-``create``, ``exec``, ``probe``, ``files``, ``operations``, ``attribution`` —
-mirroring the shipped ``configs/idegym.yaml`` block. Every section validates in
-``__post_init__`` so a bad Hydra value fails at server start rather than in the
-middle of a rollout, and every section is frozen and hashable so the shared
-orchestrator session can be keyed on its connection config.
+The provider constructor takes one section per concern — ``connection``, ``create``,
+``exec``, ``probe``, ``files``, ``operations``, ``attribution`` — mirroring the shipped
+``configs/idegym.yaml`` block. Every section validates in ``__post_init__`` so a bad
+Hydra value fails at server start rather than mid-rollout, and every section is frozen
+and hashable so the shared orchestrator session can be keyed on its connection config.
+
+Comments here cover only what a reader of the code needs: sentinel values, cross-field
+constraints, and the reason behind a default. Knob-by-knob operator guidance lives once,
+in ``configs/idegym.yaml``.
 """
 
 from collections.abc import Mapping
@@ -40,25 +43,24 @@ MAX_COMMAND_BYTES = 100 * 1024
 # limit leaves real headroom rather than filling the budget with payload alone.
 MAX_UPLOAD_CHUNK_BYTES = 64 * 1024
 
+# The probe asserts stdout equality, so these two only make sense as a pair.
 DEFAULT_PROBE_COMMAND = "printf idegym-sandbox-ready"
 DEFAULT_PROBE_EXPECTED = "idegym-sandbox-ready"
 
-# RFC-1035 caps Kubernetes resource names at 63 characters, and the orchestrator
-# derives the pod name as `<server_name>-<server_id>`, so the name the provider sends
-# leaves room for that suffix as well as for its own uniqueness suffix.
+# RFC-1035 caps Kubernetes resource names at 63 characters, and the orchestrator derives
+# the pod name as `<server_name>-<server_id>`, so the name the provider sends leaves room
+# for that suffix.
 MAX_SERVER_NAME_LENGTH = 63
 SERVER_ID_SUFFIX_RESERVE = 8
-SERVER_NAME_UNIQUE_SUFFIX_LENGTH = 8
 
 
 class UserMode(StrEnum):
     """How ``exec(user=...)`` is honored.
 
-    The IdeGYM bash tool has no user field: commands run as whatever user the
-    server container runs as (``provider_options.run_as_root`` decides that at
-    pod level). ``IGNORE`` therefore drops the request with one warning, while
-    the two switch modes wrap the script in a privilege-dropping command for
-    images that ship one.
+    The IdeGYM bash tool has no user field: commands run as whatever user the server
+    container runs as, which ``provider_options.run_as_root`` decides at pod level.
+    ``IGNORE`` therefore drops the request with one warning, while the two switch modes
+    wrap the script in a privilege-dropping command for images that ship one.
     """
 
     IGNORE = "ignore"
@@ -91,34 +93,31 @@ def _require_non_negative(value: float | int, name: str) -> None:
 class IdeGymConnectionConfig:
     """How to reach the IdeGYM orchestrator and how to identify this process to it.
 
-    One registered IdeGYM client is shared by every sandbox created from an
-    identical connection config (see :mod:`nemo_gym.sandbox.providers.idegym.session`),
-    so this section doubles as that session's cache key and must stay hashable.
+    One registered IdeGYM client is shared by every sandbox created from an identical
+    connection config (see :mod:`nemo_gym.sandbox.providers.idegym.session`), so this
+    section doubles as that session's cache key and must stay hashable.
     """
 
     orchestrator_url: str = "idegym.test"
     namespace: str = "idegym"
-    # Quotas are enforced per client *name*, so all sandboxes of one job should
-    # share it. Left unset, the session derives a name from job attribution.
+    # Quotas match the client *name*, so every sandbox of one job shares it. Left unset,
+    # the session derives it from job attribution.
     client_name: str | None = None
     username: str | None = None
     password: str | None = None
-    # Dedicated Kubernetes nodes requested at registration. 0 uses the shared pool.
+    # 0 uses the shared node pool.
     nodes_count: int = 0
     heartbeat_interval_s: int = 60
     request_timeout_s: int = 60
     transport_backend: str = TransportBackend.AIOHTTP
-    # Bounds in-flight HTTP to the orchestrator across every sandbox sharing this
-    # connection. Bounding requests rather than whole operations matters: a create
-    # holds its connection only while polling, so provisioning cannot block the
-    # exec calls of sandboxes that are already running. null means no cap.
+    # Caps in-flight requests rather than whole operations: a create holds a connection
+    # only while polling, so provisioning cannot block execs on running sandboxes.
     max_connections: int | None = 64
     max_keepalive_connections: int = 20
     keepalive_expiry_s: float | None = 5.0
     connect_retries: int = 2
-    # The IdeGYM client SDK traces to a JetBrains-hosted collector unless told
-    # otherwise. NeMo Gym does not send telemetry to third parties implicitly, so
-    # tracing stays off until an endpoint is configured here.
+    # The SDK ships a default OTLP endpoint, so tracing stays off until one is set here:
+    # NeMo Gym does not send telemetry to third parties implicitly.
     tracing_endpoint: str | None = None
     tracing_timeout_s: float = 10.0
     tracing_username: str | None = None
@@ -131,14 +130,14 @@ class IdeGymConnectionConfig:
             raise ValueError("connection.namespace must be a non-empty Kubernetes namespace")
         if self.client_name is not None and not self.client_name.strip():
             raise ValueError("connection.client_name must be non-empty when set")
-        _require_non_negative(self.nodes_count, "connection.nodes_count")
-        _require_positive(self.heartbeat_interval_s, "connection.heartbeat_interval_s")
-        _require_positive(self.request_timeout_s, "connection.request_timeout_s")
-        if self.transport_backend not in tuple(TransportBackend):
+        if self.transport_backend not in TransportBackend:
             raise ValueError(
                 f"connection.transport_backend must be one of {[m.value for m in TransportBackend]}, "
                 f"got {self.transport_backend!r}"
             )
+        _require_non_negative(self.nodes_count, "connection.nodes_count")
+        _require_positive(self.heartbeat_interval_s, "connection.heartbeat_interval_s")
+        _require_positive(self.request_timeout_s, "connection.request_timeout_s")
         _require_positive(self.max_connections, "connection.max_connections", allow_none=True)
         _require_non_negative(self.max_keepalive_connections, "connection.max_keepalive_connections")
         _require_positive(self.keepalive_expiry_s, "connection.keepalive_expiry_s", allow_none=True)
@@ -160,16 +159,16 @@ class IdeGymPollingConfig:
     """
 
     initial_delay_s: float = 0.25
-    # Fixed interval; 0 selects the exponential schedule below instead.
+    # Fixed interval; 0 selects the exponential schedule below.
     interval_s: float = 0.0
     backoff_factor: float = 1.5
     max_delay_s: float = 30.0
 
     def __post_init__(self) -> None:
-        _require_positive(self.initial_delay_s, "polling.initial_delay_s")
-        _require_non_negative(self.interval_s, "polling.interval_s")
         if self.backoff_factor < 1:
             raise ValueError("polling.backoff_factor must be >= 1")
+        _require_positive(self.initial_delay_s, "polling.initial_delay_s")
+        _require_non_negative(self.interval_s, "polling.interval_s")
         _require_positive(self.max_delay_s, "polling.max_delay_s")
 
 
@@ -177,46 +176,41 @@ class IdeGymPollingConfig:
 class IdeGymCreateConfig:
     """Server provisioning: readiness budget, retries, and pod shape defaults."""
 
-    # Bounds the whole start_server call, including the orchestrator's own wait
-    # for the pod to become ready and its internal 429 back-pressure retries.
+    # Bounds the whole start_server call: pod scheduling, image pull, and the
+    # orchestrator's own 429 back-pressure retries.
     ready_timeout_s: float = 900.0
     retries: int = 3
     retry_delay_s: float = 5.0
     retry_max_delay_s: float = 60.0
-    # Handed to the SDK, which retries the orchestrator's 429 back-pressure
-    # itself — inside one start-server call — until `ready_timeout_s` runs out.
+    # The SDK's own in-call retry delay for a 429, bounded by `ready_timeout_s`.
     busy_retry_delay_s: float = 15.0
-    # RFC-1035 prefix for the generated Kubernetes resource name.
     server_name_prefix: str = "nemo-gym"
-    # Metadata keys folded into the generated server name, in order, so a pod can
-    # be traced back to its task from `kubectl get pods` and the IdeGYM dashboard.
+    # Folded into the generated server name, in order, so a pod traces back to its task.
     server_name_metadata_keys: tuple[str, ...] = ("instance_id",)
-    # NONE recreates from scratch. The provider generates a unique name per
-    # sandbox, so there is nothing to reuse unless a caller pins the name through
-    # `provider_options.server_name`.
+    # The only strategy that can apply here: the reuse lookup considers servers left
+    # FINISHED, and this provider always stops the ones it creates.
     reuse_strategy: str = "NONE"
     run_as_root: bool = False
     service_port: int = 80
     container_port: int = 8000
-    # Pod restarts tolerated before IdeGYM tears the server down. 0 surfaces the
-    # first crash instead of looping restarts.
+    # 0 surfaces the first crash instead of looping restarts.
     max_restarts: int = 0
     polling: IdeGymPollingConfig | Mapping[str, Any] = field(default_factory=IdeGymPollingConfig)
 
     def __post_init__(self) -> None:
+        # Frozen dataclass, so normalizing a field goes through object.__setattr__.
         object.__setattr__(self, "polling", coerce_config(self.polling, IdeGymPollingConfig))
+        object.__setattr__(self, "server_name_metadata_keys", tuple(self.server_name_metadata_keys or ()))
+        if not self.server_name_prefix:
+            raise ValueError("create.server_name_prefix must be non-empty")
+        for name, port in (("service_port", self.service_port), ("container_port", self.container_port)):
+            if not 0 <= port <= 65535:
+                raise ValueError(f"create.{name} must be between 0 and 65535, got {port}")
         _require_positive(self.ready_timeout_s, "create.ready_timeout_s")
         _require_non_negative(self.retries, "create.retries")
         _require_non_negative(self.retry_delay_s, "create.retry_delay_s")
         _require_non_negative(self.retry_max_delay_s, "create.retry_max_delay_s")
         _require_non_negative(self.busy_retry_delay_s, "create.busy_retry_delay_s")
-        if not self.server_name_prefix:
-            raise ValueError("create.server_name_prefix must be non-empty")
-        object.__setattr__(self, "server_name_metadata_keys", tuple(self.server_name_metadata_keys or ()))
-        if not 0 <= self.service_port <= 65535:
-            raise ValueError(f"create.service_port must be between 0 and 65535, got {self.service_port}")
-        if not 0 <= self.container_port <= 65535:
-            raise ValueError(f"create.container_port must be between 0 and 65535, got {self.container_port}")
         _require_non_negative(self.max_restarts, "create.max_restarts")
 
 
@@ -225,29 +219,28 @@ class IdeGymExecConfig:
     """Command execution through the IdeGYM bash tool."""
 
     default_timeout_s: float | None = 180.0
-    # Passed to the sandbox: how long a timed-out process group gets to exit on
-    # SIGTERM before it is SIGKILLed.
+    # Grace period a timed-out process group gets on SIGTERM before it is SIGKILLed.
     graceful_termination_timeout_s: float = 2.0
-    # Client-side budget on top of the command timeout, covering the orchestrator
-    # round trip. Keeping it non-zero means the sandbox's own timeout fires first, so
-    # the caller gets the partial output instead of a bare transport error.
+    # Client-side budget on top of the command timeout, covering the orchestrator round
+    # trip. Keeping it non-zero means the sandbox's own timeout fires first, so the
+    # caller gets the partial output instead of a bare transport error.
     request_overhead_s: float = 60.0
     user_mode: str = UserMode.IGNORE
 
     def __post_init__(self) -> None:
+        if self.user_mode not in UserMode:
+            raise ValueError(f"exec.user_mode must be one of {[m.value for m in UserMode]}, got {self.user_mode!r}")
         _require_positive(self.default_timeout_s, "exec.default_timeout_s", allow_none=True)
         _require_non_negative(self.graceful_termination_timeout_s, "exec.graceful_termination_timeout_s")
         _require_non_negative(self.request_overhead_s, "exec.request_overhead_s")
-        if self.user_mode not in tuple(UserMode):
-            raise ValueError(f"exec.user_mode must be one of {[m.value for m in UserMode]}, got {self.user_mode!r}")
 
 
 @dataclass(frozen=True)
 class IdeGymProbeConfig:
     """Readiness verification run after the orchestrator reports a started server.
 
-    A started pod is not the same as a sandbox that can run commands, so
-    ``create()`` only returns once this probe has passed ``stable_count`` times.
+    A started pod is not the same as a sandbox that can run commands, so ``create()``
+    only returns once this probe has passed ``stable_count`` times.
     """
 
     command: str | None = DEFAULT_PROBE_COMMAND
@@ -255,20 +248,20 @@ class IdeGymProbeConfig:
     timeout_s: float = 30.0
     deadline_s: float | None = 180.0
     stable_count: int = 1
-    # Non-zero: the probe polls a remote orchestrator, so back-to-back retries
-    # would hammer it for the whole deadline while a pod is still warming up.
+    # Non-zero: the probe polls a remote orchestrator, so back-to-back retries would
+    # hammer it for the whole deadline while a pod is still warming up.
     stable_delay_s: float = 2.0
-    # Fail create when `spec.workdir` is missing in the image. Without the check,
-    # every later exec fails on `cd` instead, long after the cause is visible.
+    # Fail create on a missing `spec.workdir` instead of letting every later exec fail
+    # on `cd`, long after the cause is visible.
     verify_workdir: bool = True
 
     def __post_init__(self) -> None:
+        if self.stable_count < 1:
+            raise ValueError("probe.stable_count must be >= 1")
         # Always validated: the workdir check uses this timeout even when the probe
         # command is disabled.
         _require_positive(self.timeout_s, "probe.timeout_s")
         _require_positive(self.deadline_s, "probe.deadline_s", allow_none=True)
-        if self.stable_count < 1:
-            raise ValueError("probe.stable_count must be >= 1")
         _require_non_negative(self.stable_delay_s, "probe.stable_delay_s")
 
 
@@ -276,11 +269,11 @@ class IdeGymProbeConfig:
 class IdeGymFilesConfig:
     """File transfer, which rides base64 over the bash tool.
 
-    IdeGYM has no binary transfer endpoint reachable through the orchestrator's
-    JSON request forwarding, so bytes are chunked and shell-encoded. Upload chunks
-    share the command budget with the caller's ``env`` exports, so a large ``env``
-    can still push a legal chunk over it; download chunks are bounded by how much
-    text the orchestrator is willing to store per operation.
+    IdeGYM exposes no binary transfer endpoint through the orchestrator's JSON request
+    forwarding, so bytes are chunked and shell-encoded. Upload chunks share the command
+    budget with the caller's ``env`` exports, so a large ``env`` can still push a legal
+    chunk over it; download chunks are bounded by how much text the orchestrator is
+    willing to store per operation.
     """
 
     upload_chunk_bytes: int = 48 * 1024
@@ -325,20 +318,21 @@ class IdeGymOperationsConfig:
 
 @dataclass(frozen=True)
 class IdeGymAttributionConfig:
-    """Job attribution for the registered IdeGYM client name and sandbox metadata.
+    """Job attribution, which names the registered IdeGYM client.
 
-    IdeGYM has no per-server label API, so attribution cannot become Kubernetes
-    labels the way it does on OpenSandbox. What it can do is name the registered
-    client — which is what the IdeGYM dashboard and its per-name resource quota key
-    on — so a team's sandboxes are attributable and quota-bounded together.
+    IdeGYM has no per-server label API, so attribution cannot become Kubernetes labels
+    the way it does on OpenSandbox. Naming the client instead is what the dashboard
+    groups by and what per-name resource quotas key on, so a team's sandboxes stay
+    attributable and quota-bounded together as ``<prefix>-<team>-<user>-<workload>``.
     """
 
     enabled: bool = True
     team: str | None = None
     user: str | None = None
     workload: str | None = None
+    # Resolved and logged, but deliberately kept out of the client name, which has to
+    # stay stable across launches for quota matching to work.
     run: str | None = None
-    # Prefix of the derived client name; the resolved attribution fields follow.
     client_name_prefix: str = "nemo-gym"
 
     def __post_init__(self) -> None:

--- a/nemo_gym/sandbox/providers/idegym/configs/idegym.yaml
+++ b/nemo_gym/sandbox/providers/idegym/configs/idegym.yaml
@@ -1,0 +1,152 @@
+# IdeGYM sandbox provider config.
+#
+# `sandbox` is the instance name an agent references via `sandbox_provider: sandbox`;
+# the child key `idegym` selects the provider class and its value is passed to the
+# provider constructor.
+#
+# Every shipped provider config binds the same name `sandbox`, so swapping providers is
+# swapping this config path in `+config_paths` (no agent edit):
+#
+#   AGENT=responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+#   MODEL=responses_api_models/vllm_model/configs/vllm_model.yaml
+#   gym env start \
+#       --config $AGENT \
+#       --config nemo_gym/sandbox/providers/idegym/configs/idegym.yaml \
+#       --config $MODEL
+#
+# Requires a reachable IdeGYM orchestrator (github.com/JetBrains-Research/idegym) and
+# the SDK: `uv pip install 'nemo-gym[idegym]'`. See ../README.md for the image
+# requirement -- the sandbox image must be an IdeGYM *server* image, not a plain
+# benchmark image.
+#
+# `default_metadata` (optional) is merged into every sandbox's spec metadata
+# (SandboxSpec.metadata); an agent's own sandbox_spec.metadata overrides it. IdeGYM has
+# no per-server label API, so metadata is used for naming and diagnostics rather than
+# becoming queryable Kubernetes labels.
+sandbox:
+  default_metadata:
+    sandbox-api: idegym-client
+  idegym:
+    connection:
+      # Orchestrator URL. A bare host gets an https:// scheme; the literal
+      # `idegym.test` is the SDK's unauthenticated local-testing host.
+      orchestrator_url: ${oc.env:IDEGYM_ORCHESTRATOR_URL,idegym.test}
+      # Kubernetes namespace the client and its server pods live in.
+      namespace: ${oc.env:IDEGYM_NAMESPACE,idegym}
+      # Basic auth. Left null, the SDK falls back to IDEGYM_AUTH_USERNAME /
+      # IDEGYM_AUTH_PASSWORD, which is the preferred way to pass credentials.
+      username: ${oc.env:IDEGYM_AUTH_USERNAME,null}
+      password: ${oc.env:IDEGYM_AUTH_PASSWORD,null}
+      # IdeGYM registers ONE client per process and shares it across every sandbox
+      # created from this config. Resource quotas are matched by regex against this
+      # name, so pin it to whatever your deployment's rule expects. Left null, it is
+      # derived from job attribution (see `attribution` below).
+      client_name: ${oc.env:IDEGYM_CLIENT_NAME,null}
+      # Dedicated nodes requested at registration; 0 uses the shared pool.
+      nodes_count: 0
+      heartbeat_interval_s: 60
+      request_timeout_s: 60
+      # "aiohttp" routes the SDK's httpx client through the httpx-aiohttp bridge,
+      # falling back to httpx with a warning when it is not installed.
+      transport_backend: aiohttp
+      # Bounds in-flight HTTP to the orchestrator across ALL sandboxes sharing this
+      # connection. null for no cap.
+      max_connections: 64
+      max_keepalive_connections: 20
+      keepalive_expiry_s: 5.0
+      connect_retries: 2
+      # The IdeGYM SDK traces to a JetBrains-hosted collector unless an endpoint is
+      # given here, so tracing stays off by default. Set an OTLP HTTP endpoint to
+      # opt in.
+      tracing_endpoint: ${oc.env:IDEGYM_OTEL_TRACING_ENDPOINT,null}
+    create:
+      # Bounds the whole start-server call: pod scheduling, image pull, the IdeGYM
+      # server coming up, and the orchestrator's own retries of its 429 back-pressure.
+      # An agent's sandbox_spec.ready_timeout_s overrides this per sandbox.
+      ready_timeout_s: 1200
+      # Retries of the whole start-server call for transient control-plane failures
+      # (429/502/503/504 and connection errors). Each retry takes a fresh server name.
+      retries: 3
+      retry_delay_s: 5.0
+      retry_max_delay_s: 60.0
+      # Delay the SDK waits between its own in-call retries of a 429.
+      busy_retry_delay_s: 15.0
+      # RFC-1035 prefix of the generated server name, which becomes the pod name.
+      server_name_prefix: nemo-gym
+      # Metadata keys folded into that name so a pod is traceable to its task from
+      # `kubectl get pods` and the IdeGYM dashboard.
+      server_name_metadata_keys: [instance_id]
+      # NONE recreates from scratch. Names are unique per sandbox, so there is nothing
+      # to reuse unless provider_options.server_name pins one.
+      reuse_strategy: NONE
+      # Run the server container as UID 0. SWE-bench style images generally need this,
+      # and it is also what makes exec(user="root") a no-op rather than a warning.
+      run_as_root: true
+      service_port: 80
+      container_port: 8000
+      # Pod restarts tolerated before IdeGYM tears the server down. 0 surfaces the
+      # first crash instead of looping restarts.
+      max_restarts: 0
+      # Backoff for the orchestrator's async-operation polling, which every mutating
+      # call goes through. Raising the delays trades latency for orchestrator load.
+      polling:
+        initial_delay_s: 0.25
+        # 0 selects the exponential schedule below.
+        interval_s: 0.0
+        backoff_factor: 1.5
+        max_delay_s: 30.0
+    exec:
+      default_timeout_s: 180
+      # Grace period the sandbox gives a timed-out process group before SIGKILL.
+      graceful_termination_timeout_s: 2.0
+      # Client-side budget on top of the command timeout, covering the orchestrator
+      # round trip. Keep it non-zero so the sandbox's timeout fires first and the
+      # caller gets the partial output instead of a transport error.
+      request_overhead_s: 60
+      # IdeGYM's bash tool has no user field: commands run as the container's user.
+      # "ignore" drops exec(user=...) with one warning; "runuser"/"su" wrap the script
+      # for images that ship those tools.
+      user_mode: ignore
+    probe:
+      # Verification after the orchestrator reports the pod up: a scheduled pod is not
+      # yet a sandbox that can run commands.
+      command: printf idegym-sandbox-ready
+      expected_stdout: idegym-sandbox-ready
+      timeout_s: 30
+      deadline_s: 180
+      stable_count: 1
+      stable_delay_s: 2.0
+      # Fail create when sandbox_spec.workdir is missing in the image, instead of
+      # letting every later command fail on `cd`.
+      verify_workdir: true
+    files:
+      # Uploads and downloads ride base64 over the bash tool. Upload chunks are capped
+      # by the sandbox shell's 128 KiB argument limit; download chunks by how much text
+      # the orchestrator stores per async operation.
+      upload_chunk_bytes: 49152
+      download_chunk_bytes: 196608
+      # null for no cap. Guards against pulling a base64-inflated multi-gigabyte tree
+      # through the orchestrator.
+      max_download_bytes: 67108864
+      timeout_s: 300
+    operations:
+      # A failing teardown can take up to (retries + 1) * close_timeout_s in total.
+      close_timeout_s: 180
+      status_timeout_s: 60
+      retries: 2
+      retry_delay_s: 1.0
+      retry_max_delay_s: 15.0
+    # Job attribution. IdeGYM has no per-server label API, so unlike OpenSandbox this
+    # cannot become Kubernetes labels; instead it names the registered client, which is
+    # what the IdeGYM dashboard groups by and what resource-limit rules match. Unset
+    # fields auto-detect from NEMO_GYM_TEAM / NEMO_GYM_USER / NEMO_GYM_WORKLOAD, then
+    # Slurm job env vars, then the OS login name for `user` and the gym CLI's
+    # NEMO_GYM_CONFIG_PATH server instance name for `workload`. `run` is resolved and
+    # logged but kept out of the name, which has to stay stable across launches for
+    # quota matching to work. An explicit connection.client_name always wins.
+    attribution:
+      enabled: true
+      client_name_prefix: nemo-gym
+      # team: my-team
+      # user: my-user
+      # workload: my-benchmark

--- a/nemo_gym/sandbox/providers/idegym/configs/idegym.yaml
+++ b/nemo_gym/sandbox/providers/idegym/configs/idegym.yaml
@@ -15,32 +15,30 @@
 #       --config $MODEL
 #
 # Requires a reachable IdeGYM orchestrator (github.com/JetBrains-Research/idegym) and
-# the SDK: `uv pip install 'nemo-gym[idegym]'`. See ../README.md for the image
-# requirement -- the sandbox image must be an IdeGYM *server* image, not a plain
-# benchmark image.
+# the SDK: `uv pip install 'nemo-gym[idegym]'`. The sandbox image must be an IdeGYM
+# *server* image, not a plain benchmark image -- see ../README.md.
 #
 # `default_metadata` (optional) is merged into every sandbox's spec metadata
 # (SandboxSpec.metadata); an agent's own sandbox_spec.metadata overrides it. IdeGYM has
-# no per-server label API, so metadata is used for naming and diagnostics rather than
-# becoming queryable Kubernetes labels.
+# no per-server label API, so metadata drives naming and diagnostics only -- it does not
+# become queryable Kubernetes labels.
 sandbox:
   default_metadata:
     sandbox-api: idegym-client
   idegym:
     connection:
-      # Orchestrator URL. A bare host gets an https:// scheme; the literal
-      # `idegym.test` is the SDK's unauthenticated local-testing host.
+      # A bare host gets an https:// scheme; the literal `idegym.test` is the SDK's
+      # unauthenticated local-testing host.
       orchestrator_url: ${oc.env:IDEGYM_ORCHESTRATOR_URL,idegym.test}
-      # Kubernetes namespace the client and its server pods live in.
+      # Namespace the client and its server pods live in.
       namespace: ${oc.env:IDEGYM_NAMESPACE,idegym}
-      # Basic auth. Left null, the SDK falls back to IDEGYM_AUTH_USERNAME /
+      # Basic auth. Left null, the SDK reads IDEGYM_AUTH_USERNAME /
       # IDEGYM_AUTH_PASSWORD, which is the preferred way to pass credentials.
       username: ${oc.env:IDEGYM_AUTH_USERNAME,null}
       password: ${oc.env:IDEGYM_AUTH_PASSWORD,null}
-      # IdeGYM registers ONE client per process and shares it across every sandbox
-      # created from this config. Resource quotas are matched by regex against this
-      # name, so pin it to whatever your deployment's rule expects. Left null, it is
-      # derived from job attribution (see `attribution` below).
+      # Names the one client this process registers and shares across all its
+      # sandboxes. Resource quotas match it by regex, so pin it to whatever your
+      # deployment's rule expects. Null derives it from `attribution` below.
       client_name: ${oc.env:IDEGYM_CLIENT_NAME,null}
       # Dedicated nodes requested at registration; 0 uses the shared pool.
       nodes_count: 0
@@ -49,23 +47,21 @@ sandbox:
       # "aiohttp" routes the SDK's httpx client through the httpx-aiohttp bridge,
       # falling back to httpx with a warning when it is not installed.
       transport_backend: aiohttp
-      # Bounds in-flight HTTP to the orchestrator across ALL sandboxes sharing this
+      # Caps in-flight HTTP to the orchestrator across every sandbox sharing this
       # connection. null for no cap.
       max_connections: 64
       max_keepalive_connections: 20
       keepalive_expiry_s: 5.0
       connect_retries: 2
-      # The IdeGYM SDK traces to a JetBrains-hosted collector unless an endpoint is
-      # given here, so tracing stays off by default. Set an OTLP HTTP endpoint to
-      # opt in.
+      # Set your own OTLP HTTP endpoint to collect the SDK's traces (with
+      # tracing_username / tracing_password if it needs auth). Null keeps tracing off.
       tracing_endpoint: ${oc.env:IDEGYM_OTEL_TRACING_ENDPOINT,null}
     create:
-      # Bounds the whole start-server call: pod scheduling, image pull, the IdeGYM
-      # server coming up, and the orchestrator's own retries of its 429 back-pressure.
-      # An agent's sandbox_spec.ready_timeout_s overrides this per sandbox.
+      # Bounds the whole start-server call: pod scheduling, image pull, and the IdeGYM
+      # server coming up. An agent's sandbox_spec.ready_timeout_s overrides it.
       ready_timeout_s: 1200
-      # Retries of the whole start-server call for transient control-plane failures
-      # (429/502/503/504 and connection errors). Each retry takes a fresh server name.
+      # Retries of the whole call on transient control-plane failures (429/502/503/504
+      # and connection errors). Each retry takes a fresh server name.
       retries: 3
       retry_delay_s: 5.0
       retry_max_delay_s: 60.0
@@ -73,14 +69,14 @@ sandbox:
       busy_retry_delay_s: 15.0
       # RFC-1035 prefix of the generated server name, which becomes the pod name.
       server_name_prefix: nemo-gym
-      # Metadata keys folded into that name so a pod is traceable to its task from
-      # `kubectl get pods` and the IdeGYM dashboard.
+      # Metadata keys folded into that name, so a pod traces back to its task. IdeGYM
+      # appends its own `-<server_id>`, which is what makes the pod name unique.
       server_name_metadata_keys: [instance_id]
-      # NONE recreates from scratch. Names are unique per sandbox, so there is nothing
-      # to reuse unless provider_options.server_name pins one.
+      # The reuse lookup only considers servers left FINISHED, and the provider always
+      # stops the ones it creates, so NONE is the only strategy that can apply.
       reuse_strategy: NONE
-      # Run the server container as UID 0. SWE-bench style images generally need this,
-      # and it is also what makes exec(user="root") a no-op rather than a warning.
+      # Run the container as UID 0. SWE-bench style images generally need this, and it
+      # is what makes exec(user="root") a no-op rather than a warning.
       run_as_root: true
       service_port: 80
       container_port: 8000
@@ -88,7 +84,7 @@ sandbox:
       # first crash instead of looping restarts.
       max_restarts: 0
       # Backoff for the orchestrator's async-operation polling, which every mutating
-      # call goes through. Raising the delays trades latency for orchestrator load.
+      # call goes through. Longer delays trade latency for orchestrator load.
       polling:
         initial_delay_s: 0.25
         # 0 selects the exponential schedule below.
@@ -97,10 +93,10 @@ sandbox:
         max_delay_s: 30.0
     exec:
       default_timeout_s: 180
-      # Grace period the sandbox gives a timed-out process group before SIGKILL.
+      # Grace period a timed-out process group gets before SIGKILL.
       graceful_termination_timeout_s: 2.0
       # Client-side budget on top of the command timeout, covering the orchestrator
-      # round trip. Keep it non-zero so the sandbox's timeout fires first and the
+      # round trip. Keep it non-zero so the sandbox's own timeout fires first and the
       # caller gets the partial output instead of a transport error.
       request_overhead_s: 60
       # IdeGYM's bash tool has no user field: commands run as the container's user.
@@ -108,42 +104,42 @@ sandbox:
       # for images that ship those tools.
       user_mode: ignore
     probe:
-      # Verification after the orchestrator reports the pod up: a scheduled pod is not
-      # yet a sandbox that can run commands.
+      # Verification after the orchestrator reports the pod up -- a scheduled pod is
+      # not yet a sandbox that can run commands.
       command: printf idegym-sandbox-ready
       expected_stdout: idegym-sandbox-ready
       timeout_s: 30
       deadline_s: 180
       stable_count: 1
       stable_delay_s: 2.0
-      # Fail create when sandbox_spec.workdir is missing in the image, instead of
+      # Fail create when sandbox_spec.workdir is missing from the image, instead of
       # letting every later command fail on `cd`.
       verify_workdir: true
     files:
-      # Uploads and downloads ride base64 over the bash tool. Upload chunks are capped
-      # by the sandbox shell's 128 KiB argument limit; download chunks by how much text
-      # the orchestrator stores per async operation.
+      # Transfers ride base64 over the bash tool. Upload chunks are capped by the
+      # sandbox shell's 128 KiB argument limit, downloads by how much text the
+      # orchestrator stores per async operation.
       upload_chunk_bytes: 49152
       download_chunk_bytes: 196608
-      # null for no cap. Guards against pulling a base64-inflated multi-gigabyte tree
-      # through the orchestrator.
+      # Guards against pulling a base64-inflated multi-gigabyte tree through the
+      # orchestrator. null for no cap.
       max_download_bytes: 67108864
       timeout_s: 300
     operations:
-      # A failing teardown can take up to (retries + 1) * close_timeout_s in total.
+      # A failing teardown can take up to (retries + 1) * close_timeout_s.
       close_timeout_s: 180
       status_timeout_s: 60
       retries: 2
       retry_delay_s: 1.0
       retry_max_delay_s: 15.0
-    # Job attribution. IdeGYM has no per-server label API, so unlike OpenSandbox this
-    # cannot become Kubernetes labels; instead it names the registered client, which is
-    # what the IdeGYM dashboard groups by and what resource-limit rules match. Unset
-    # fields auto-detect from NEMO_GYM_TEAM / NEMO_GYM_USER / NEMO_GYM_WORKLOAD, then
-    # Slurm job env vars, then the OS login name for `user` and the gym CLI's
-    # NEMO_GYM_CONFIG_PATH server instance name for `workload`. `run` is resolved and
-    # logged but kept out of the name, which has to stay stable across launches for
-    # quota matching to work. An explicit connection.client_name always wins.
+    # Who this run belongs to. IdeGYM has no per-server label API, so attribution's
+    # only effect is the registered client name -- `nemo-gym-<team>-<user>-<workload>`
+    # -- which the IdeGYM dashboard groups by and resource-limit rules match. Fields
+    # left unset are auto-detected from NEMO_GYM_TEAM / NEMO_GYM_USER /
+    # NEMO_GYM_WORKLOAD, then Slurm job env vars, then the OS login name (`user`) and
+    # the running server's instance name (`workload`). `run` is logged but kept out of
+    # the name, which has to stay stable across launches for quota matching to work.
+    # Setting connection.client_name above bypasses all of this.
     attribution:
       enabled: true
       client_name_prefix: nemo-gym

--- a/nemo_gym/sandbox/providers/idegym/configs/idegym.yaml
+++ b/nemo_gym/sandbox/providers/idegym/configs/idegym.yaml
@@ -103,18 +103,13 @@ sandbox:
       # "ignore" drops exec(user=...) with one warning; "runuser"/"su" wrap the script
       # for images that ship those tools.
       user_mode: ignore
-    probe:
-      # Verification after the orchestrator reports the pod up -- a scheduled pod is
-      # not yet a sandbox that can run commands.
-      command: printf idegym-sandbox-ready
-      expected_stdout: idegym-sandbox-ready
+    verify:
+      # IdeGYM already waits for the pod's Kubernetes readiness probe against the
+      # server's health endpoint, so all that is left is the working-directory check.
       timeout_s: 30
-      deadline_s: 180
-      stable_count: 1
-      stable_delay_s: 2.0
       # Fail create when sandbox_spec.workdir is missing from the image, instead of
       # letting every later command fail on `cd`.
-      verify_workdir: true
+      check_workdir: true
     files:
       # Transfers ride base64 over the bash tool. Upload chunks are capped by the
       # sandbox shell's 128 KiB argument limit, downloads by how much text the

--- a/nemo_gym/sandbox/providers/idegym/errors.py
+++ b/nemo_gym/sandbox/providers/idegym/errors.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IdeGYM provider exceptions and orchestrator failure classification.
+
+The SDK collapses every HTTP failure into a plain ``RuntimeError`` whose message
+embeds the status and body, and the orchestrator relays a sandbox-side failure as a
+500 carrying the sandbox's own error text. The provider still has to tell "the sandbox
+is gone" from "the control plane is busy" from "the command timed out", so the message
+parsing that recovers that lives here, in one tested place.
+"""
+
+import re
+from http import HTTPStatus
+from types import ModuleType
+
+from nemo_gym.sandbox.providers.base import SandboxCreateError, SandboxCreateVerificationError
+
+
+# Both patterns are anchored to the surrounding message rather than searching it: an
+# orchestrator error carries the sandbox's own output in its `body`, and matching a
+# bare `status=404` or `'status_code': 404` from there would read a live sandbox as
+# gone. `HTTPUtils.make_request` formats failures as
+# "Request failed: url=... status=404 reason='Not Found' data='...'".
+_STATUS_PATTERN = re.compile(r"Request failed: url=\S* status=(\d{3})\b")
+# An orchestrator ErrorResponse is relayed by dumping the model, whose first key is
+# `status_code`; `[^{]*` keeps the match on that outer dict.
+_STATUS_CODE_PATTERN = re.compile(r"^[^{]*\{'status_code': (\d{3})\b")
+# The sandbox's own wording, from BashCommandExecutionTimeoutError, returned as a 500
+# body. Matched in full rather than on "timed out after", which ordinary tool output
+# relayed in that body could also contain.
+_TIMEOUT_PATTERN = re.compile(r"Command execution timed out after", re.IGNORECASE)
+
+# Statuses that mean the sandbox no longer exists as far as the orchestrator is
+# concerned: 404 for an unknown client/server, 410 for one in a terminal state
+# (see the orchestrator's `validate_server`).
+GONE_STATUSES = frozenset({HTTPStatus.NOT_FOUND.value, HTTPStatus.GONE.value})
+
+
+class IdeGymError(RuntimeError):
+    """Base class for IdeGYM provider failures."""
+
+
+class IdeGymCreateError(SandboxCreateError):
+    """Raised when the IdeGYM orchestrator cannot provide a ready server."""
+
+
+class IdeGymCreateVerificationError(SandboxCreateVerificationError):
+    """Raised when a started IdeGYM server fails its readiness probe."""
+
+
+class IdeGymOperationError(IdeGymError):
+    """Raised when an IdeGYM operation on a live sandbox fails."""
+
+
+class IdeGymUnknownServerError(IdeGymError):
+    """Raised when a session is asked about a server it does not hold.
+
+    Distinct from a generic failure so callers can treat it as "already stopped"
+    rather than as a live problem: the session only forgets a server after stopping
+    it, so this is what a second teardown of the same sandbox looks like.
+    """
+
+
+class IdeGymCommandTooLongError(ValueError):
+    """Raised when a generated script exceeds the sandbox's shell argument limit.
+
+    A ``ValueError`` rather than an ``IdeGymError``: nothing is wrong with the
+    sandbox, the command simply cannot be delivered as written. ``exec()`` turns it
+    into a failed :class:`~nemo_gym.sandbox.providers.base.SandboxExecResult` so an
+    oversized model-generated command cannot end a rollout.
+    """
+
+
+class IdeGymTransferError(IdeGymOperationError):
+    """Raised when a file upload or download through the bash tool fails."""
+
+
+def orchestrator_status(exc: BaseException) -> int | None:
+    """Return the HTTP status carried by an IdeGYM SDK failure, or ``None``.
+
+    The SDK raises ``RuntimeError`` for both direct request failures and relayed
+    orchestrator error responses, so both message shapes are recognized.
+    """
+    message = str(exc)
+    for pattern in (_STATUS_PATTERN, _STATUS_CODE_PATTERN):
+        match = pattern.search(message)
+        if match is not None:
+            return int(match.group(1))
+    return None
+
+
+def is_sandbox_gone(exc: BaseException) -> bool:
+    """Whether a failure means the orchestrator no longer has this sandbox."""
+    return orchestrator_status(exc) in GONE_STATUSES
+
+
+def _httpx() -> ModuleType | None:
+    """The ``httpx`` module, or ``None``. The SDK's transport errors are httpx's."""
+    try:
+        import httpx
+    except ImportError:  # pragma: no cover - httpx ships with the idegym SDK
+        return None
+    return httpx
+
+
+def is_command_timeout(exc: BaseException) -> bool:
+    """Whether a failure means the command ran out of time.
+
+    Covers the sandbox killing the process group and answering with a 500, and the
+    client giving up waiting. ``httpx.ConnectTimeout`` is excluded: failing to reach
+    the orchestrator at all is a connectivity problem, not a slow command.
+    """
+    if isinstance(exc, TimeoutError):
+        return True
+    httpx = _httpx()
+    if httpx is not None and isinstance(exc, httpx.TimeoutException):
+        return not isinstance(exc, httpx.ConnectTimeout)
+    return bool(_TIMEOUT_PATTERN.search(str(exc)))
+
+
+def is_retryable(exc: BaseException) -> bool:
+    """Whether a control-plane failure is transient enough to retry.
+
+    Covers transport failures — the SDK lets httpx's through unwrapped, and
+    ``httpx.TransportError`` is not a builtin ``ConnectionError`` — plus the
+    orchestrator's back-pressure and availability statuses. Anything else is more
+    likely a bad request or a bug than a blip, so it is not retried.
+    """
+    if isinstance(exc, (ConnectionError, TimeoutError)):
+        return True
+    httpx = _httpx()
+    if httpx is not None and isinstance(exc, httpx.TransportError):
+        return True
+    status = orchestrator_status(exc)
+    if status == HTTPStatus.TOO_MANY_REQUESTS.value:
+        return True
+    return status in {
+        HTTPStatus.REQUEST_TIMEOUT.value,
+        HTTPStatus.BAD_GATEWAY.value,
+        HTTPStatus.SERVICE_UNAVAILABLE.value,
+        HTTPStatus.GATEWAY_TIMEOUT.value,
+    }

--- a/nemo_gym/sandbox/providers/idegym/errors.py
+++ b/nemo_gym/sandbox/providers/idegym/errors.py
@@ -116,12 +116,7 @@ def _httpx() -> ModuleType | None:
 
 
 def is_command_timeout(exc: BaseException) -> bool:
-    """Whether a failure means the command ran out of time.
-
-    Covers the sandbox killing the process group and answering with a 500, and the
-    client giving up waiting. ``httpx.ConnectTimeout`` is excluded: failing to reach
-    the orchestrator at all is a connectivity problem, not a slow command.
-    """
+    """Whether a failure means the command ran out of time."""
     if isinstance(exc, TimeoutError):
         return True
     httpx = _httpx()
@@ -131,13 +126,7 @@ def is_command_timeout(exc: BaseException) -> bool:
 
 
 def is_retryable(exc: BaseException) -> bool:
-    """Whether a control-plane failure is transient enough to retry.
-
-    Covers transport failures — the SDK lets httpx's through unwrapped, and
-    ``httpx.TransportError`` is not a builtin ``ConnectionError`` — plus the
-    orchestrator's back-pressure and availability statuses. Anything else is more
-    likely a bad request or a bug than a blip, so it is not retried.
-    """
+    """Whether a control-plane failure is transient enough to retry."""
     if isinstance(exc, (ConnectionError, TimeoutError)):
         return True
     httpx = _httpx()

--- a/nemo_gym/sandbox/providers/idegym/naming.py
+++ b/nemo_gym/sandbox/providers/idegym/naming.py
@@ -16,29 +16,26 @@
 
 Names carry more weight in IdeGYM than in most backends, which is why they get their
 own module. A *client* name is what resource-quota rules match by regex and what groups
-a job in the dashboard. A *server* name becomes the Kubernetes resource name, is what
-IdeGYM matches when looking for a server to reuse, and must satisfy RFC-1035 syntax
-with room left for the ``-<server_id>`` suffix the orchestrator appends.
+a job in the dashboard. A *server* name is one of the filters IdeGYM matches on when a
+``RESTART``/``RESET`` reuse strategy sends it looking for a server to reuse, and it
+prefixes the Kubernetes resource name, so it must satisfy RFC-1035 syntax with room
+left for the ``-<server_id>`` suffix the orchestrator appends. It need not be unique:
+that suffix is what makes the Kubernetes name unique.
 """
 
 import re
-import uuid
 
-from nemo_gym.sandbox.providers.idegym.config import (
-    MAX_SERVER_NAME_LENGTH,
-    SERVER_ID_SUFFIX_RESERVE,
-    SERVER_NAME_UNIQUE_SUFFIX_LENGTH,
-)
+from nemo_gym.sandbox.providers.idegym.config import MAX_SERVER_NAME_LENGTH, SERVER_ID_SUFFIX_RESERVE
 
 
-# Names end up in Kubernetes objects, log lines, and operator-written regexes, so
-# they are reduced to a conservative DNS-ish alphabet: an attribution value or task
-# id picked up from the environment must not be able to produce something invalid.
+# Names end up in Kubernetes objects, log lines, and operator-written regexes, so an
+# attribution value or task id picked up from the environment is reduced to a
+# conservative DNS-ish alphabet rather than trusted to be valid.
 _UNSAFE_NAME_CHARS = re.compile(r"[^a-z0-9-]+")
 
 MAX_CLIENT_NAME_LENGTH = 63
-# RFC-1035 label names must start with a letter, so a stem that survives
-# sanitization but starts with a digit needs a fallback.
+# RFC-1035 labels must start with a letter, so a stem that survives sanitization but
+# starts with a digit needs a fallback.
 FALLBACK_SERVER_NAME_STEM = "idegym"
 
 
@@ -52,32 +49,23 @@ def clamp_client_name(value: str) -> str:
     return value[:MAX_CLIENT_NAME_LENGTH].rstrip("-")
 
 
-def refresh_unique_suffix(name: str) -> str:
-    """Return ``name`` with a fresh uniqueness suffix.
+def generate_server_name(prefix: str, hints: list[str]) -> str:
+    """Build an RFC-1035 server name from ``prefix`` and ``hints``.
 
-    Used when a start-server call is retried: the previous attempt may have landed
-    even though its response was lost, and reusing the name would make IdeGYM treat
-    that half-created server as a reuse candidate.
+    ``hints`` are best-effort context (a benchmark instance id) and are truncated away
+    first when the budget runs out. The name deliberately carries no uniqueness suffix:
+    IdeGYM appends its own autoincrement id to derive ``<server_name>-<server_id>``,
+    and that is the name Kubernetes sees and the column the database keeps unique.
     """
-    stem, _, _ = name.rpartition("-")
-    return f"{stem or name}-{uuid.uuid4().hex[:SERVER_NAME_UNIQUE_SUFFIX_LENGTH]}"
-
-
-def generate_server_name(prefix: str, hints: list[str], *, unique_suffix: str | None = None) -> str:
-    """Build a unique RFC-1035 server name from ``prefix`` and ``hints``.
-
-    ``hints`` are best-effort context (a benchmark instance id, say) and are
-    truncated away first when the budget runs out; the uniqueness suffix is never
-    dropped, because two concurrent sandboxes sharing a name would make IdeGYM
-    treat one as a candidate for reusing the other.
-    """
-    suffix = unique_suffix or uuid.uuid4().hex[:SERVER_NAME_UNIQUE_SUFFIX_LENGTH]
-    budget = MAX_SERVER_NAME_LENGTH - SERVER_ID_SUFFIX_RESERVE - len(suffix) - 1
+    budget = MAX_SERVER_NAME_LENGTH - SERVER_ID_SUFFIX_RESERVE
     if budget < 1:
-        raise ValueError(f"Server name suffix {suffix!r} leaves no room for a name stem")
-    stem = sanitize_name("-".join([prefix, *hints]))[:budget].rstrip("-")
-    if not stem or not stem[0].isalpha():
-        stem = sanitize_name(prefix)[:budget].rstrip("-")
-    if not stem or not stem[0].isalpha():
-        stem = FALLBACK_SERVER_NAME_STEM[:budget]
-    return f"{stem}-{suffix}"
+        raise ValueError(
+            f"MAX_SERVER_NAME_LENGTH={MAX_SERVER_NAME_LENGTH} leaves no room for a name after "
+            f"reserving {SERVER_ID_SUFFIX_RESERVE} for the server id IdeGYM appends"
+        )
+    name = sanitize_name("-".join([prefix, *hints]))[:budget].rstrip("-")
+    if not name or not name[0].isalpha():
+        name = sanitize_name(prefix)[:budget].rstrip("-")
+    if not name or not name[0].isalpha():
+        name = FALLBACK_SERVER_NAME_STEM[:budget]
+    return name

--- a/nemo_gym/sandbox/providers/idegym/naming.py
+++ b/nemo_gym/sandbox/providers/idegym/naming.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Naming rules for IdeGYM clients and servers.
+
+Names carry more weight in IdeGYM than in most backends, which is why they get their
+own module. A *client* name is what resource-quota rules match by regex and what groups
+a job in the dashboard. A *server* name becomes the Kubernetes resource name, is what
+IdeGYM matches when looking for a server to reuse, and must satisfy RFC-1035 syntax
+with room left for the ``-<server_id>`` suffix the orchestrator appends.
+"""
+
+import re
+import uuid
+
+from nemo_gym.sandbox.providers.idegym.config import (
+    MAX_SERVER_NAME_LENGTH,
+    SERVER_ID_SUFFIX_RESERVE,
+    SERVER_NAME_UNIQUE_SUFFIX_LENGTH,
+)
+
+
+# Names end up in Kubernetes objects, log lines, and operator-written regexes, so
+# they are reduced to a conservative DNS-ish alphabet: an attribution value or task
+# id picked up from the environment must not be able to produce something invalid.
+_UNSAFE_NAME_CHARS = re.compile(r"[^a-z0-9-]+")
+
+MAX_CLIENT_NAME_LENGTH = 63
+# RFC-1035 label names must start with a letter, so a stem that survives
+# sanitization but starts with a digit needs a fallback.
+FALLBACK_SERVER_NAME_STEM = "idegym"
+
+
+def sanitize_name(value: str) -> str:
+    """Lowercase ``value`` and collapse everything outside ``[a-z0-9-]``."""
+    return _UNSAFE_NAME_CHARS.sub("-", value.strip().lower()).strip("-")
+
+
+def clamp_client_name(value: str) -> str:
+    """Trim a client name to what IdeGYM accepts."""
+    return value[:MAX_CLIENT_NAME_LENGTH].rstrip("-")
+
+
+def refresh_unique_suffix(name: str) -> str:
+    """Return ``name`` with a fresh uniqueness suffix.
+
+    Used when a start-server call is retried: the previous attempt may have landed
+    even though its response was lost, and reusing the name would make IdeGYM treat
+    that half-created server as a reuse candidate.
+    """
+    stem, _, _ = name.rpartition("-")
+    return f"{stem or name}-{uuid.uuid4().hex[:SERVER_NAME_UNIQUE_SUFFIX_LENGTH]}"
+
+
+def generate_server_name(prefix: str, hints: list[str], *, unique_suffix: str | None = None) -> str:
+    """Build a unique RFC-1035 server name from ``prefix`` and ``hints``.
+
+    ``hints`` are best-effort context (a benchmark instance id, say) and are
+    truncated away first when the budget runs out; the uniqueness suffix is never
+    dropped, because two concurrent sandboxes sharing a name would make IdeGYM
+    treat one as a candidate for reusing the other.
+    """
+    suffix = unique_suffix or uuid.uuid4().hex[:SERVER_NAME_UNIQUE_SUFFIX_LENGTH]
+    budget = MAX_SERVER_NAME_LENGTH - SERVER_ID_SUFFIX_RESERVE - len(suffix) - 1
+    if budget < 1:
+        raise ValueError(f"Server name suffix {suffix!r} leaves no room for a name stem")
+    stem = sanitize_name("-".join([prefix, *hints]))[:budget].rstrip("-")
+    if not stem or not stem[0].isalpha():
+        stem = sanitize_name(prefix)[:budget].rstrip("-")
+    if not stem or not stem[0].isalpha():
+        stem = FALLBACK_SERVER_NAME_STEM[:budget]
+    return f"{stem}-{suffix}"

--- a/nemo_gym/sandbox/providers/idegym/provider.py
+++ b/nemo_gym/sandbox/providers/idegym/provider.py
@@ -58,7 +58,6 @@ from nemo_gym.sandbox.providers.idegym.errors import (
     is_retryable,
     is_sandbox_gone,
 )
-from nemo_gym.sandbox.providers.idegym.naming import refresh_unique_suffix
 from nemo_gym.sandbox.providers.idegym.session import (
     IdeGymServerRef,
     IdeGymSession,
@@ -177,7 +176,7 @@ class IdeGymProvider:
         session = await self.session()
         ready_timeout_s = float(spec.ready_timeout_s or self._create.ready_timeout_s)
 
-        ref = await self._start_server(session, request, ready_timeout_s, rename_on_retry=options.server_name is None)
+        ref = await self._start_server(session, request, ready_timeout_s)
         sandbox = _IdeGymSandbox(
             server_id=ref.server_id,
             server_name=ref.server_name,
@@ -201,17 +200,14 @@ class IdeGymProvider:
         session: IdeGymSession,
         request: dict[str, Any],
         ready_timeout_s: float,
-        *,
-        rename_on_retry: bool,
     ) -> IdeGymServerRef:
         """Issue start-server, retrying failures that look transient.
 
         ``ready_timeout_s`` is a deadline for the whole call, not per attempt: each
         retry gets only the remaining budget, so a late failure cannot multiply the
-        wait the caller configured. Unless the name was pinned to opt into IdeGYM's
-        server reuse, a retry also takes a fresh one — an attempt whose response was
-        lost may have landed anyway, and reusing the name would make IdeGYM offer that
-        half-created server back as a reuse candidate.
+        wait the caller configured. Retries keep the same server name: IdeGYM derives
+        the Kubernetes name from its own server id, so a lost response that landed
+        anyway leaves an orphan the watcher reaps, not a name collision.
         """
         create = self._create
         loop = asyncio.get_running_loop()
@@ -243,8 +239,6 @@ class IdeGymProvider:
                 )
                 await asyncio.sleep(backoff)
                 delay = min(delay * 2, create.retry_max_delay_s) if delay > 0 else create.retry_delay_s
-                if rename_on_retry:
-                    request = {**request, "server_name": refresh_unique_suffix(str(request["server_name"]))}
 
     async def _verify(self, handle: SandboxHandle) -> None:
         """Check that the new sandbox can actually run commands.

--- a/nemo_gym/sandbox/providers/idegym/provider.py
+++ b/nemo_gym/sandbox/providers/idegym/provider.py
@@ -28,6 +28,7 @@ through the registered client that owns it.
 
 import asyncio
 import logging
+import threading
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -46,7 +47,7 @@ from nemo_gym.sandbox.providers.idegym.config import (
     IdeGymExecConfig,
     IdeGymFilesConfig,
     IdeGymOperationsConfig,
-    IdeGymProbeConfig,
+    IdeGymVerifyConfig,
 )
 from nemo_gym.sandbox.providers.idegym.errors import (
     IdeGymCommandTooLongError,
@@ -119,7 +120,7 @@ class IdeGymProvider:
         connection: IdeGymConnectionConfig | Mapping[str, Any] | None = None,
         create: IdeGymCreateConfig | Mapping[str, Any] | None = None,
         exec: IdeGymExecConfig | Mapping[str, Any] | None = None,
-        probe: IdeGymProbeConfig | Mapping[str, Any] | None = None,
+        verify: IdeGymVerifyConfig | Mapping[str, Any] | None = None,
         files: IdeGymFilesConfig | Mapping[str, Any] | None = None,
         operations: IdeGymOperationsConfig | Mapping[str, Any] | None = None,
         attribution: IdeGymAttributionConfig | Mapping[str, Any] | None = None,
@@ -127,7 +128,7 @@ class IdeGymProvider:
         self._connection = coerce_config(connection, IdeGymConnectionConfig)
         self._create = coerce_config(create, IdeGymCreateConfig)
         self._exec = coerce_config(exec, IdeGymExecConfig)
-        self._probe = coerce_config(probe, IdeGymProbeConfig)
+        self._verify = coerce_config(verify, IdeGymVerifyConfig)
         self._files = coerce_config(files, IdeGymFilesConfig)
         self._operations = coerce_config(operations, IdeGymOperationsConfig)
         self._attribution = coerce_config(attribution, IdeGymAttributionConfig)
@@ -137,27 +138,42 @@ class IdeGymProvider:
         # The session registers a client with the orchestrator, which is async, so
         # it is acquired on first use rather than in this constructor.
         self._session: IdeGymSession | None = None
-        self._session_lock = asyncio.Lock()
+        self._session_lock = threading.Lock()
         self._closed = False
 
     # --- session -----------------------------------------------------------
 
     async def session(self) -> IdeGymSession:
-        """Return this provider's shared orchestrator session, acquiring it once."""
+        """Return this provider's shared orchestrator session, acquiring it once.
+
+        A thread lock, not an ``asyncio.Lock``: one provider can be shared by two
+        sandboxes, and the sync ``Sandbox`` facade runs each on its own event loop,
+        which an ``asyncio.Lock`` cannot span without deadlocking.
+
+        The acquire therefore happens outside the lock, so two callers can race. That
+        is safe: ``acquire_session`` hands both of them the same session, and the loser
+        gives its spare reference back.
+        """
         if self._closed:
             raise IdeGymOperationError("This idegym provider has been closed")
         if self._session is not None:
             return self._session
-        async with self._session_lock:
-            if self._session is None:
-                self._session = await acquire_session(self._connection, self._attribution)
-            return self._session
+        session = await acquire_session(self._connection, self._attribution)
+        with self._session_lock:
+            if self._session is None and not self._closed:
+                self._session = session
+                return session
+            winner = self._session
+        await release_session(session)
+        if winner is None:
+            raise IdeGymOperationError("This idegym provider has been closed")
+        return winner
 
     async def health(self) -> str:
-        """Return the orchestrator's health status, registering the client if needed.
+        """Return the orchestrator's health, registering the client if needed.
 
-        Reaching this point already proves more than the endpoint being up: the
-        session had to register a client to exist.
+        Reaching this proves more than the endpoint being up: the session had to
+        register a client to exist.
         """
         session = await self.session()
         return await session.health()
@@ -167,9 +183,10 @@ class IdeGymProvider:
     async def create(self, spec: SandboxSpec) -> SandboxHandle:
         """Start an IdeGYM server for ``spec`` and return it ready to run commands.
 
-        The pod being scheduled is not the same as the sandbox being usable, so a
-        readiness probe runs before the handle is returned, and the server is torn
-        down if anything after provisioning fails.
+        The orchestrator reports a server only once its pod passes the Kubernetes
+        readiness probe against the IdeGYM server's own health endpoint, so the one
+        thing left to check is ``spec.workdir``. A failure after provisioning tears
+        the server down.
         """
         options = IdeGymProviderOptions.from_mapping(spec.provider_options)
         request = self._translator.translate(spec, options)
@@ -189,8 +206,9 @@ class IdeGymProvider:
         handle = SandboxHandle(sandbox_id=str(ref.server_id), provider_name=self.name, raw=sandbox)
         LOGGER.debug(f"Started IdeGYM sandbox {sandbox} from {sandbox.image!r} with metadata {sandbox.metadata}")
         try:
-            await self._verify(handle)
-        except BaseException:
+            await self._verify_workdir(handle)
+        except BaseException as e:
+            LOGGER.warning(f"Tearing down the IdeGYM sandbox {sandbox}, which create could not finish: {e!r}")
             await self._discard(handle)
             raise
         return handle
@@ -203,11 +221,10 @@ class IdeGymProvider:
     ) -> IdeGymServerRef:
         """Issue start-server, retrying failures that look transient.
 
-        ``ready_timeout_s`` is a deadline for the whole call, not per attempt: each
-        retry gets only the remaining budget, so a late failure cannot multiply the
-        wait the caller configured. Retries keep the same server name: IdeGYM derives
-        the Kubernetes name from its own server id, so a lost response that landed
-        anyway leaves an orphan the watcher reaps, not a name collision.
+        ``ready_timeout_s`` bounds the whole call, not each attempt, so a late failure
+        cannot multiply the wait the caller configured. Retries keep the server name:
+        IdeGYM derives the Kubernetes name from its own server id, so a lost response
+        that landed anyway leaves an orphan for the watcher, not a name collision.
         """
         create = self._create
         loop = asyncio.get_running_loop()
@@ -240,16 +257,6 @@ class IdeGymProvider:
                 await asyncio.sleep(backoff)
                 delay = min(delay * 2, create.retry_max_delay_s) if delay > 0 else create.retry_delay_s
 
-    async def _verify(self, handle: SandboxHandle) -> None:
-        """Check that the new sandbox can actually run commands.
-
-        The probe runs first: it is the retrying, deadline-bounded check, so letting
-        the single-shot workdir check go first would report a server that is merely
-        still warming up as a mis-set working directory.
-        """
-        await self._verify_probe(handle)
-        await self._verify_workdir(handle)
-
     async def _verify_workdir(self, handle: SandboxHandle) -> None:
         """Fail create when ``spec.workdir`` does not exist in the image.
 
@@ -257,11 +264,11 @@ class IdeGymProvider:
         ``cd``, which reads like a broken agent rather than a mis-set workdir.
         """
         sandbox: _IdeGymSandbox = handle.raw
-        if not self._probe.verify_workdir or not sandbox.workdir:
+        if not self._verify.check_workdir or not sandbox.workdir:
             return
         # Deliberately no cwd: the point is to test the directory, not enter it.
         script = self._script.build(directory_exists_script(sandbox.workdir))
-        result = await self._exec_script(handle, script, timeout_s=self._probe.timeout_s)
+        result = await self._exec_script(handle, script, timeout_s=self._verify.timeout_s)
         if result.return_code != 0:
             raise IdeGymCreateVerificationError(
                 f"The working directory {sandbox.workdir!r} is not usable in the IdeGYM sandbox {sandbox} "
@@ -269,40 +276,6 @@ class IdeGymProvider:
                 f"stderr {(result.stderr or '').strip()!r}. Point sandbox_spec.workdir at the image's project "
                 f"directory, or leave it unset to use the IdeGYM server's own project directory."
             )
-
-    async def _verify_probe(self, handle: SandboxHandle) -> None:
-        """Poll the readiness command until it passes ``stable_count`` times."""
-        probe = self._probe
-        if probe.command is None:
-            return
-        script = self._script.build(probe.command, cwd=handle.raw.workdir)
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + probe.deadline_s if probe.deadline_s is not None else None
-        consecutive = 0
-        detail = "no probe attempt completed"
-        while True:
-            result = await self._exec_script(handle, script, timeout_s=probe.timeout_s)
-            passed = result.return_code == 0 and (
-                probe.expected_stdout is None or probe.expected_stdout in (result.stdout or "")
-            )
-            if passed:
-                consecutive += 1
-                if consecutive >= probe.stable_count:
-                    return
-            else:
-                consecutive = 0
-                detail = f"return code {result.return_code}, stderr {(result.stderr or '').strip()!r}"
-                if deadline is None:
-                    raise IdeGymCreateVerificationError(
-                        f"IdeGYM sandbox {handle.raw} failed its readiness probe: {detail}"
-                    )
-            if deadline is not None and loop.time() >= deadline:
-                raise IdeGymCreateVerificationError(
-                    f"IdeGYM sandbox {handle.raw} did not pass its readiness probe within "
-                    f"{probe.deadline_s:g}s: {detail}"
-                )
-            if probe.stable_delay_s > 0:
-                await asyncio.sleep(probe.stable_delay_s)
 
     async def _discard(self, handle: SandboxHandle) -> None:
         """Best-effort teardown of a sandbox that never became usable."""
@@ -378,7 +351,11 @@ class IdeGymProvider:
                 )
             if is_sandbox_gone(e) or isinstance(e, IdeGymUnknownServerError):
                 sandbox.stopped = True
+                LOGGER.debug(f"IdeGYM sandbox {sandbox} is gone; further commands will short-circuit: {e}")
                 return _runtime_failure(f"IdeGYM sandbox {sandbox} is no longer available: {e}", error_type="sandbox")
+            # Unclassified: the return value keeps the rollout alive but throws the
+            # traceback away, so this is the only place it can still be recovered.
+            LOGGER.warning(f"IdeGYM sandbox {sandbox} failed to run the command", exc_info=True)
             return _runtime_failure(f"IdeGYM sandbox {sandbox} failed to run the command: {e}", error_type="sandbox")
         return SandboxExecResult(stdout=result.stdout, stderr=result.stderr, return_code=result.exit_code)
 
@@ -403,11 +380,10 @@ class IdeGymProvider:
     async def status(self, handle: SandboxHandle) -> SandboxStatus:
         """Report the sandbox's lifecycle status.
 
-        IdeGYM has no server-status endpoint, so the capabilities call stands in:
-        it validates the server's database record *and* reaches the pod, which is
-        exactly the liveness question being asked. A "gone" answer from the
-        orchestrator (unknown or terminal server) is a stopped sandbox; anything
-        else that fails leaves the status unknown rather than guessing.
+        IdeGYM has no server-status endpoint, so the capabilities call stands in: it
+        validates the database record *and* reaches the pod, which is the liveness
+        question being asked. A "gone" answer means stopped; any other failure leaves
+        the status unknown rather than guessing.
         """
         sandbox: _IdeGymSandbox = handle.raw
         if sandbox.stopped:
@@ -426,10 +402,10 @@ class IdeGymProvider:
     async def close(self, handle: SandboxHandle) -> None:
         """Stop the sandbox and delete its Kubernetes resources.
 
-        Idempotent, and a server the orchestrator or the session no longer has counts
-        as success, so cleanup paths can call this without checking first. A stop that
-        fails for real raises and leaves the sandbox marked live, so ``status()``
-        keeps telling the truth and a caller can try again.
+        Idempotent, and a server neither the orchestrator nor the session still has
+        counts as success, so cleanup paths need not check first. A stop that fails for
+        real raises and leaves the sandbox marked live, so ``status()`` keeps telling
+        the truth and a caller can try again.
         """
         sandbox: _IdeGymSandbox = handle.raw
         if sandbox.stopped:
@@ -457,7 +433,12 @@ class IdeGymProvider:
                 if attempt >= self._operations.retries:
                     raise IdeGymOperationError(f"Failed to stop IdeGYM sandbox {sandbox}: {e}") from e
                 attempt += 1
-                await asyncio.sleep(min(delay, self._operations.retry_max_delay_s))
+                backoff = min(delay, self._operations.retry_max_delay_s)
+                LOGGER.warning(
+                    f"stop_server attempt {attempt}/{self._operations.retries + 1} for {sandbox} failed; "
+                    f"retrying in {backoff:g}s: {e}"
+                )
+                await asyncio.sleep(backoff)
                 delay = min(delay * 2, self._operations.retry_max_delay_s) if delay > 0 else 0.0
             else:
                 sandbox.stopped = True
@@ -469,9 +450,10 @@ class IdeGymProvider:
         The last provider to release it unregisters the IdeGYM client, which also
         terminates any server that was never closed.
         """
-        if self._closed:
-            return
-        self._closed = True
-        session, self._session = self._session, None
+        with self._session_lock:
+            if self._closed:
+                return
+            self._closed = True
+            session, self._session = self._session, None
         if session is not None:
             await release_session(session)

--- a/nemo_gym/sandbox/providers/idegym/provider.py
+++ b/nemo_gym/sandbox/providers/idegym/provider.py
@@ -1,0 +1,483 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IdeGYM sandbox provider: sandboxes as IdeGYM server pods on Kubernetes.
+
+One sandbox is one IdeGYM *server*: a Kubernetes pod provisioned through the IdeGYM
+orchestrator, running the IdeGYM server image whose HTTP API the orchestrator forwards
+requests to. This module composes the layers around it — :mod:`.session` (the shared
+registered client), :mod:`.spec` (spec translation), :mod:`.shell` (command shaping),
+:mod:`.transfer` (files), :mod:`.errors` (failure classification).
+
+Capabilities deliberately not claimed: ``endpoint()``, because the orchestrator
+forwards API requests rather than routing raw TCP; PTY sessions, because IdeGYM has no
+terminal API; and ``serialize()`` / ``connect()``, because a server is only reachable
+through the registered client that owns it.
+"""
+
+import asyncio
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from nemo_gym.sandbox.providers.base import (
+    SandboxExecResult,
+    SandboxHandle,
+    SandboxSpec,
+    SandboxStatus,
+)
+from nemo_gym.sandbox.providers.idegym.config import (
+    IdeGymAttributionConfig,
+    IdeGymConnectionConfig,
+    IdeGymCreateConfig,
+    IdeGymExecConfig,
+    IdeGymFilesConfig,
+    IdeGymOperationsConfig,
+    IdeGymProbeConfig,
+)
+from nemo_gym.sandbox.providers.idegym.errors import (
+    IdeGymCommandTooLongError,
+    IdeGymCreateError,
+    IdeGymCreateVerificationError,
+    IdeGymOperationError,
+    IdeGymUnknownServerError,
+    is_command_timeout,
+    is_retryable,
+    is_sandbox_gone,
+)
+from nemo_gym.sandbox.providers.idegym.naming import refresh_unique_suffix
+from nemo_gym.sandbox.providers.idegym.session import (
+    IdeGymServerRef,
+    IdeGymSession,
+    acquire_session,
+    release_session,
+)
+from nemo_gym.sandbox.providers.idegym.shell import BashScriptBuilder, directory_exists_script
+from nemo_gym.sandbox.providers.idegym.spec import IdeGymProviderOptions, ServerRequestTranslator
+from nemo_gym.sandbox.providers.idegym.transfer import Base64BashFileTransfer
+from nemo_gym.sandbox.providers.utils import coerce_config
+
+
+LOGGER = logging.getLogger(__name__)
+
+# Returned by exec() when the sandbox runtime failed instead of the command. Same
+# sentinel the other Gym providers use, so callers can treat it uniformly.
+SANDBOX_RUNTIME_RETURN_CODE = 125
+
+# IdeGYM's bash tool needs a finite, JSON-serializable command timeout, so "no
+# timeout" is expressed as a ceiling long enough that no benchmark command reaches
+# it before the sandbox itself is torn down.
+NO_TIMEOUT_COMMAND_SECONDS = 24 * 60 * 60.0
+
+
+@dataclass
+class _IdeGymSandbox:
+    """Provider-owned state for one sandbox, carried in ``SandboxHandle.raw``."""
+
+    server_id: int
+    server_name: str
+    namespace: str
+    image: str
+    workdir: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
+    metadata: dict[str, str] = field(default_factory=dict)
+    stopped: bool = False
+
+    def __str__(self) -> str:
+        return f"{self.server_name} (id={self.server_id})"
+
+
+def _runtime_failure(message: str, *, error_type: str) -> SandboxExecResult:
+    return SandboxExecResult(
+        stdout=None,
+        stderr=message,
+        return_code=SANDBOX_RUNTIME_RETURN_CODE,
+        error_type=error_type,
+    )
+
+
+class IdeGymProvider:
+    """Sandbox provider backed by an IdeGYM orchestrator."""
+
+    name = "idegym"
+
+    def __init__(
+        self,
+        *,
+        connection: IdeGymConnectionConfig | Mapping[str, Any] | None = None,
+        create: IdeGymCreateConfig | Mapping[str, Any] | None = None,
+        exec: IdeGymExecConfig | Mapping[str, Any] | None = None,
+        probe: IdeGymProbeConfig | Mapping[str, Any] | None = None,
+        files: IdeGymFilesConfig | Mapping[str, Any] | None = None,
+        operations: IdeGymOperationsConfig | Mapping[str, Any] | None = None,
+        attribution: IdeGymAttributionConfig | Mapping[str, Any] | None = None,
+    ) -> None:
+        self._connection = coerce_config(connection, IdeGymConnectionConfig)
+        self._create = coerce_config(create, IdeGymCreateConfig)
+        self._exec = coerce_config(exec, IdeGymExecConfig)
+        self._probe = coerce_config(probe, IdeGymProbeConfig)
+        self._files = coerce_config(files, IdeGymFilesConfig)
+        self._operations = coerce_config(operations, IdeGymOperationsConfig)
+        self._attribution = coerce_config(attribution, IdeGymAttributionConfig)
+
+        self._translator = ServerRequestTranslator(self._create)
+        self._script = BashScriptBuilder(self._exec)
+        # The session registers a client with the orchestrator, which is async, so
+        # it is acquired on first use rather than in this constructor.
+        self._session: IdeGymSession | None = None
+        self._session_lock = asyncio.Lock()
+        self._closed = False
+
+    # --- session -----------------------------------------------------------
+
+    async def session(self) -> IdeGymSession:
+        """Return this provider's shared orchestrator session, acquiring it once."""
+        if self._closed:
+            raise IdeGymOperationError("This idegym provider has been closed")
+        if self._session is not None:
+            return self._session
+        async with self._session_lock:
+            if self._session is None:
+                self._session = await acquire_session(self._connection, self._attribution)
+            return self._session
+
+    async def health(self) -> str:
+        """Return the orchestrator's health status, registering the client if needed.
+
+        Reaching this point already proves more than the endpoint being up: the
+        session had to register a client to exist.
+        """
+        session = await self.session()
+        return await session.health()
+
+    # --- create ------------------------------------------------------------
+
+    async def create(self, spec: SandboxSpec) -> SandboxHandle:
+        """Start an IdeGYM server for ``spec`` and return it ready to run commands.
+
+        The pod being scheduled is not the same as the sandbox being usable, so a
+        readiness probe runs before the handle is returned, and the server is torn
+        down if anything after provisioning fails.
+        """
+        options = IdeGymProviderOptions.from_mapping(spec.provider_options)
+        request = self._translator.translate(spec, options)
+        session = await self.session()
+        ready_timeout_s = float(spec.ready_timeout_s or self._create.ready_timeout_s)
+
+        ref = await self._start_server(session, request, ready_timeout_s, rename_on_retry=options.server_name is None)
+        sandbox = _IdeGymSandbox(
+            server_id=ref.server_id,
+            server_name=ref.server_name,
+            namespace=ref.namespace,
+            image=str(request["image_tag"]),
+            workdir=spec.workdir,
+            env={str(key): str(value) for key, value in spec.env.items()},
+            metadata={str(key): str(value) for key, value in spec.metadata.items()},
+        )
+        handle = SandboxHandle(sandbox_id=str(ref.server_id), provider_name=self.name, raw=sandbox)
+        LOGGER.debug(f"Started IdeGYM sandbox {sandbox} from {sandbox.image!r} with metadata {sandbox.metadata}")
+        try:
+            await self._verify(handle)
+        except BaseException:
+            await self._discard(handle)
+            raise
+        return handle
+
+    async def _start_server(
+        self,
+        session: IdeGymSession,
+        request: dict[str, Any],
+        ready_timeout_s: float,
+        *,
+        rename_on_retry: bool,
+    ) -> IdeGymServerRef:
+        """Issue start-server, retrying failures that look transient.
+
+        ``ready_timeout_s`` is a deadline for the whole call, not per attempt: each
+        retry gets only the remaining budget, so a late failure cannot multiply the
+        wait the caller configured. Unless the name was pinned to opt into IdeGYM's
+        server reuse, a retry also takes a fresh one — an attempt whose response was
+        lost may have landed anyway, and reusing the name would make IdeGYM offer that
+        half-created server back as a reuse candidate.
+        """
+        create = self._create
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + ready_timeout_s
+        delay = create.retry_delay_s
+        attempt = 0
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise IdeGymCreateError(
+                    f"IdeGYM did not start a server for image {request['image_tag']!r} within {ready_timeout_s:g}s"
+                )
+            try:
+                return await session.start_server(request, polling=create.polling, timeout_s=remaining)
+            except Exception as e:
+                backoff = min(delay, create.retry_max_delay_s)
+                # A bare TimeoutError means the SDK spent the budget it was given, so
+                # it is never worth another attempt even if the clock disagrees.
+                # Transport timeouts are a different exception type and stay retryable.
+                exhausted = type(e) is TimeoutError or deadline - loop.time() <= backoff
+                if attempt >= create.retries or exhausted or not is_retryable(e):
+                    raise IdeGymCreateError(
+                        f"IdeGYM could not start a server for image {request['image_tag']!r}: {e}"
+                    ) from e
+                attempt += 1
+                LOGGER.warning(
+                    f"start_server attempt {attempt}/{create.retries + 1} for {request['server_name']!r} failed "
+                    f"transiently; retrying in {backoff:g}s: {e}"
+                )
+                await asyncio.sleep(backoff)
+                delay = min(delay * 2, create.retry_max_delay_s) if delay > 0 else create.retry_delay_s
+                if rename_on_retry:
+                    request = {**request, "server_name": refresh_unique_suffix(str(request["server_name"]))}
+
+    async def _verify(self, handle: SandboxHandle) -> None:
+        """Check that the new sandbox can actually run commands.
+
+        The probe runs first: it is the retrying, deadline-bounded check, so letting
+        the single-shot workdir check go first would report a server that is merely
+        still warming up as a mis-set working directory.
+        """
+        await self._verify_probe(handle)
+        await self._verify_workdir(handle)
+
+    async def _verify_workdir(self, handle: SandboxHandle) -> None:
+        """Fail create when ``spec.workdir`` does not exist in the image.
+
+        Without this check the mismatch shows up as every later command failing on
+        ``cd``, which reads like a broken agent rather than a mis-set workdir.
+        """
+        sandbox: _IdeGymSandbox = handle.raw
+        if not self._probe.verify_workdir or not sandbox.workdir:
+            return
+        # Deliberately no cwd: the point is to test the directory, not enter it.
+        script = self._script.build(directory_exists_script(sandbox.workdir))
+        result = await self._exec_script(handle, script, timeout_s=self._probe.timeout_s)
+        if result.return_code != 0:
+            raise IdeGymCreateVerificationError(
+                f"The working directory {sandbox.workdir!r} is not usable in the IdeGYM sandbox {sandbox} "
+                f"(image {sandbox.image!r}): return code {result.return_code}, "
+                f"stderr {(result.stderr or '').strip()!r}. Point sandbox_spec.workdir at the image's project "
+                f"directory, or leave it unset to use the IdeGYM server's own project directory."
+            )
+
+    async def _verify_probe(self, handle: SandboxHandle) -> None:
+        """Poll the readiness command until it passes ``stable_count`` times."""
+        probe = self._probe
+        if probe.command is None:
+            return
+        script = self._script.build(probe.command, cwd=handle.raw.workdir)
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + probe.deadline_s if probe.deadline_s is not None else None
+        consecutive = 0
+        detail = "no probe attempt completed"
+        while True:
+            result = await self._exec_script(handle, script, timeout_s=probe.timeout_s)
+            passed = result.return_code == 0 and (
+                probe.expected_stdout is None or probe.expected_stdout in (result.stdout or "")
+            )
+            if passed:
+                consecutive += 1
+                if consecutive >= probe.stable_count:
+                    return
+            else:
+                consecutive = 0
+                detail = f"return code {result.return_code}, stderr {(result.stderr or '').strip()!r}"
+                if deadline is None:
+                    raise IdeGymCreateVerificationError(
+                        f"IdeGYM sandbox {handle.raw} failed its readiness probe: {detail}"
+                    )
+            if deadline is not None and loop.time() >= deadline:
+                raise IdeGymCreateVerificationError(
+                    f"IdeGYM sandbox {handle.raw} did not pass its readiness probe within "
+                    f"{probe.deadline_s:g}s: {detail}"
+                )
+            if probe.stable_delay_s > 0:
+                await asyncio.sleep(probe.stable_delay_s)
+
+    async def _discard(self, handle: SandboxHandle) -> None:
+        """Best-effort teardown of a sandbox that never became usable."""
+        try:
+            await self.close(handle)
+        except Exception as e:
+            LOGGER.warning(
+                f"Failed to stop the half-created IdeGYM sandbox {handle.raw}; it may be left running on the "
+                f"cluster until the orchestrator reaps it: {e}"
+            )
+
+    # --- exec --------------------------------------------------------------
+
+    async def exec(
+        self,
+        handle: SandboxHandle,
+        command: str,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_s: int | float | None = None,
+        user: str | int | None = None,
+    ) -> SandboxExecResult:
+        """Run ``command`` in the sandbox; never raises for a failing command.
+
+        A command that cannot be delivered at all (too long for the sandbox's
+        shell, or an environment name ``export`` cannot carry) is reported the same
+        way, so a bad model-generated command cannot end a rollout.
+        """
+        sandbox: _IdeGymSandbox = handle.raw
+        merged_env = {**sandbox.env, **{str(key): str(value) for key, value in (env or {}).items()}}
+        effective_cwd = cwd if cwd is not None else sandbox.workdir
+        try:
+            script = self._script.build(command, cwd=effective_cwd, env=merged_env, user=user)
+        except IdeGymCommandTooLongError as e:
+            return _runtime_failure(str(e), error_type="command_too_long")
+        except ValueError as e:
+            return _runtime_failure(str(e), error_type="invalid_request")
+        timeout = timeout_s if timeout_s is not None else self._exec.default_timeout_s
+        return await self._exec_script(handle, script, timeout_s=timeout)
+
+    async def _exec_script(
+        self,
+        handle: SandboxHandle,
+        script: str,
+        *,
+        timeout_s: int | float | None,
+    ) -> SandboxExecResult:
+        """Send one prepared script to the sandbox and normalize the outcome."""
+        sandbox: _IdeGymSandbox = handle.raw
+        if sandbox.stopped:
+            return _runtime_failure(f"IdeGYM sandbox {sandbox} has been stopped", error_type="sandbox")
+        session = await self.session()
+        command_timeout = float(timeout_s) if timeout_s is not None else NO_TIMEOUT_COMMAND_SECONDS
+        # The sandbox's own timeout has to fire before the client stops waiting,
+        # otherwise a timed-out command comes back as a transport error with none
+        # of the output the caller needs.
+        request_timeout = command_timeout + self._exec.request_overhead_s
+        try:
+            result = await session.execute_bash(
+                sandbox.server_id,
+                script,
+                command_timeout_s=command_timeout,
+                graceful_termination_timeout_s=self._exec.graceful_termination_timeout_s,
+                request_timeout_s=request_timeout,
+                polling=self._create.polling,
+            )
+        except Exception as e:
+            if is_command_timeout(e):
+                return _runtime_failure(
+                    f"Command timed out after {command_timeout}s in IdeGYM sandbox {sandbox}: {e}",
+                    error_type="timeout",
+                )
+            if is_sandbox_gone(e) or isinstance(e, IdeGymUnknownServerError):
+                sandbox.stopped = True
+                return _runtime_failure(f"IdeGYM sandbox {sandbox} is no longer available: {e}", error_type="sandbox")
+            return _runtime_failure(f"IdeGYM sandbox {sandbox} failed to run the command: {e}", error_type="sandbox")
+        return SandboxExecResult(stdout=result.stdout, stderr=result.stderr, return_code=result.exit_code)
+
+    # --- files -------------------------------------------------------------
+
+    def _transfer(self, handle: SandboxHandle) -> Base64BashFileTransfer:
+        async def run(command: str, *, timeout_s: int | float | None = None) -> SandboxExecResult:
+            return await self.exec(handle, command, timeout_s=timeout_s)
+
+        return Base64BashFileTransfer(self._files, run)
+
+    async def upload_file(self, handle: SandboxHandle, source_path: Path, target_path: str) -> None:
+        """Upload one local file into the sandbox."""
+        await self._transfer(handle).upload(Path(source_path), target_path)
+
+    async def download_file(self, handle: SandboxHandle, source_path: str, target_path: Path) -> None:
+        """Download one sandbox file to the local filesystem."""
+        await self._transfer(handle).download(source_path, Path(target_path))
+
+    # --- status and teardown ----------------------------------------------
+
+    async def status(self, handle: SandboxHandle) -> SandboxStatus:
+        """Report the sandbox's lifecycle status.
+
+        IdeGYM has no server-status endpoint, so the capabilities call stands in:
+        it validates the server's database record *and* reaches the pod, which is
+        exactly the liveness question being asked. A "gone" answer from the
+        orchestrator (unknown or terminal server) is a stopped sandbox; anything
+        else that fails leaves the status unknown rather than guessing.
+        """
+        sandbox: _IdeGymSandbox = handle.raw
+        if sandbox.stopped:
+            return SandboxStatus.STOPPED
+        session = await self.session()
+        try:
+            async with asyncio.timeout(self._operations.status_timeout_s):
+                await session.list_capabilities(sandbox.server_id)
+        except Exception as e:
+            if is_sandbox_gone(e) or isinstance(e, IdeGymUnknownServerError):
+                return SandboxStatus.STOPPED
+            LOGGER.debug(f"Could not determine the status of IdeGYM sandbox {sandbox}: {e}")
+            return SandboxStatus.UNKNOWN
+        return SandboxStatus.RUNNING
+
+    async def close(self, handle: SandboxHandle) -> None:
+        """Stop the sandbox and delete its Kubernetes resources.
+
+        Idempotent, and a server the orchestrator or the session no longer has counts
+        as success, so cleanup paths can call this without checking first. A stop that
+        fails for real raises and leaves the sandbox marked live, so ``status()``
+        keeps telling the truth and a caller can try again.
+        """
+        sandbox: _IdeGymSandbox = handle.raw
+        if sandbox.stopped:
+            return
+        session = await self.session()
+        delay = self._operations.retry_delay_s
+        attempt = 0
+        while True:
+            try:
+                async with asyncio.timeout(self._operations.close_timeout_s):
+                    await session.stop_server(
+                        sandbox.server_id,
+                        polling=self._create.polling,
+                        timeout_s=self._operations.close_timeout_s,
+                    )
+            except IdeGymUnknownServerError:
+                # The session only forgets a server after stopping it, so this is a
+                # second teardown of the same sandbox.
+                sandbox.stopped = True
+                return
+            except Exception as e:
+                if is_sandbox_gone(e):
+                    sandbox.stopped = True
+                    return
+                if attempt >= self._operations.retries:
+                    raise IdeGymOperationError(f"Failed to stop IdeGYM sandbox {sandbox}: {e}") from e
+                attempt += 1
+                await asyncio.sleep(min(delay, self._operations.retry_max_delay_s))
+                delay = min(delay * 2, self._operations.retry_max_delay_s) if delay > 0 else 0.0
+            else:
+                sandbox.stopped = True
+                return
+
+    async def aclose(self) -> None:
+        """Give back this provider's reference to the shared session.
+
+        The last provider to release it unregisters the IdeGYM client, which also
+        terminates any server that was never closed.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        session, self._session = self._session, None
+        if session is not None:
+            await release_session(session)

--- a/nemo_gym/sandbox/providers/idegym/session.py
+++ b/nemo_gym/sandbox/providers/idegym/session.py
@@ -1,0 +1,647 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The registered IdeGYM client shared by every sandbox in a process.
+
+The only module that imports the ``idegym`` SDK, so the layers above it work in the
+provider-owned types declared here and the tests have one seam to fake.
+
+*One registered client per process, not per sandbox,* reference-counted across
+providers: IdeGYM's client is a heartbeating owner of N server pods that carries the
+resource quota keyed on its name, and the orchestrator takes a table-level database
+lock per registration. *That client lives on a private event loop* in a daemon thread,
+because the SDK client is loop-bound (an httpx session plus a heartbeat task) while the
+sync ``Sandbox`` facade — the one the mini-swe-agent harness uses — gives every sandbox
+its own loop.
+"""
+
+import asyncio
+import concurrent.futures
+import logging
+import math
+import threading
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, TypeVar
+
+from nemo_gym.sandbox.attribution import RUN_KEY, log_attribution_once, resolve_attribution, resolve_run_id
+from nemo_gym.sandbox.providers.idegym.config import (
+    IdeGymAttributionConfig,
+    IdeGymConnectionConfig,
+    IdeGymPollingConfig,
+    TransportBackend,
+)
+from nemo_gym.sandbox.providers.idegym.errors import IdeGymError, IdeGymUnknownServerError
+from nemo_gym.sandbox.providers.idegym.naming import clamp_client_name, sanitize_name
+
+
+LOGGER = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+SESSION_THREAD_NAME = "nemo-gym-idegym-session"
+# Grace period for the private loop thread to unwind once the session shuts down.
+LOOP_JOIN_TIMEOUT_S = 10.0
+
+
+def resolve_client_name(connection: IdeGymConnectionConfig, attribution: IdeGymAttributionConfig) -> str:
+    """Return the IdeGYM client name this process registers under.
+
+    An explicit ``connection.client_name`` always wins, because IdeGYM matches
+    resource-quota rules by regex against this name. Otherwise it is derived from job
+    attribution, which is the closest IdeGYM gets to the per-sandbox Kubernetes labels
+    other providers offer.
+    """
+    if connection.client_name:
+        return clamp_client_name(connection.client_name)
+    if not attribution.enabled:
+        return clamp_client_name(attribution.client_name_prefix)
+    resolved = resolve_attribution(
+        team=attribution.team,
+        user=attribution.user,
+        workload=attribution.workload,
+    )
+    resolved[RUN_KEY] = resolve_run_id(attribution.run)
+    log_attribution_once(resolved)
+    # `run` is deliberately left out of the name: it changes per launch, and a name
+    # that changes per launch defeats both quota-rule matching and the dashboard
+    # grouping the name exists for.
+    parts = [attribution.client_name_prefix, *(resolved.get(key) or "" for key in ("team", "user", "workload"))]
+    name = sanitize_name("-".join(part for part in parts if part))
+    return clamp_client_name(name or attribution.client_name_prefix)
+
+
+@dataclass(frozen=True)
+class IdeGymServerRef:
+    """Identity of one started IdeGYM server pod."""
+
+    server_id: int
+    server_name: str
+    namespace: str
+
+
+@dataclass(frozen=True)
+class IdeGymBashResult:
+    """Outcome of one ``/api/tools/bash`` call."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+def _resolve(future: "concurrent.futures.Future[Any]", exception: BaseException | None = None) -> None:
+    """Complete ``future`` unless a racing cancellation already finished it."""
+    try:
+        if exception is not None:
+            future.set_exception(exception)
+        else:
+            future.set_result(None)
+    except concurrent.futures.InvalidStateError:
+        pass
+
+
+async def _settle(coro: Awaitable[T], future: "concurrent.futures.Future[T]") -> None:
+    """Run ``coro`` and report its outcome through ``future``.
+
+    A cancelled caller cancels ``future`` but not this coroutine, so the orchestrator
+    call finishes and its result is dropped. That is deliberate: the sandbox-side work
+    has already started, and abandoning it mid-flight would leave the orchestrator's
+    view and ours disagreeing.
+    """
+    try:
+        result = await coro
+    except BaseException as e:  # noqa: BLE001 - the future is the only channel back to the caller
+        try:
+            future.set_exception(e)
+        except concurrent.futures.InvalidStateError:
+            pass
+    else:
+        try:
+            future.set_result(result)
+        except concurrent.futures.InvalidStateError:
+            pass
+
+
+class _SessionLoop:
+    """A private asyncio event loop running in a daemon thread."""
+
+    def __init__(self, name: str) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._pending: set[concurrent.futures.Future[Any]] = set()
+        self._pending_lock = threading.Lock()
+        started = threading.Event()
+        self._thread = threading.Thread(target=self._run, args=(started,), name=name, daemon=True)
+        self._thread.start()
+        started.wait()
+
+    def _run(self, started: threading.Event) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.call_soon(started.set)
+        self._loop.run_forever()
+
+    def call_soon(self, callback: Callable[[], None]) -> None:
+        self._loop.call_soon_threadsafe(callback)
+
+    def submit(self, factory: Callable[[], Awaitable[T]]) -> "concurrent.futures.Future[T]":
+        """Schedule ``factory()`` on the private loop and return its future.
+
+        The coroutine is created *on* the loop, so anything the factory allocates
+        (locks, tasks) is bound to the right loop.
+        """
+        if self._loop.is_closed():
+            # Reported as a session error rather than asyncio's bare "Event loop is
+            # closed", which says nothing about which session was stopped or why.
+            raise IdeGymError("The IdeGYM session has been stopped and can no longer run operations")
+        future: concurrent.futures.Future[T] = concurrent.futures.Future()
+        with self._pending_lock:
+            self._pending.add(future)
+
+        def forget(_: Any) -> None:
+            with self._pending_lock:
+                self._pending.discard(future)
+
+        future.add_done_callback(forget)
+
+        def start() -> None:
+            try:
+                coro = factory()
+            except BaseException as e:  # noqa: BLE001 - the future is the only channel back
+                # A factory can raise before it ever awaits (an unknown server id, say).
+                # Left to the loop's exception handler, that would never resolve the
+                # future and the caller would wait forever.
+                _resolve(future, e)
+                return
+            task = self._loop.create_task(_settle(coro, future))
+            # Hold a reference until the future completes so the task cannot be
+            # garbage-collected mid-flight.
+            future.add_done_callback(lambda _: task)
+
+        self._loop.call_soon_threadsafe(start)
+        return future
+
+    def stop(self) -> None:
+        """Stop the loop, join its thread, and fail anything still in flight.
+
+        Without the last part a caller awaiting an operation when the session is
+        released would wait forever: the loop stops before its task can resolve the
+        future, and nothing else ever will. Safe to call more than once.
+        """
+        if self._loop.is_closed():
+            return
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=LOOP_JOIN_TIMEOUT_S)
+        if self._thread.is_alive():  # pragma: no cover - only reachable with a wedged loop
+            LOGGER.warning(
+                f"IdeGYM session loop thread did not exit within {LOOP_JOIN_TIMEOUT_S:g}s; leaving it running"
+            )
+            return
+        self._loop.close()
+        with self._pending_lock:
+            abandoned, self._pending = self._pending, set()
+        for future in abandoned:
+            _resolve(future, IdeGymError("The IdeGYM session was stopped while this operation was in flight"))
+
+
+class IdeGymSession:
+    """A registered IdeGYM client plus the private loop it runs on.
+
+    Instances are created and released through :func:`acquire_session` and
+    :func:`release_session` rather than directly: the registry is what makes them
+    shared and reference-counted.
+    """
+
+    def __init__(self, connection: IdeGymConnectionConfig, client_name: str) -> None:
+        self._connection = connection
+        self._client_name = client_name
+        self._loop = _SessionLoop(SESSION_THREAD_NAME)
+        self._client: Any = None
+        self._shutdown: asyncio.Event | None = None
+        self._serving: concurrent.futures.Future[None] | None = None
+        # SDK server handles, keyed by server id. Only ever touched on the private
+        # loop, so the dict needs no lock of its own.
+        self._servers: dict[int, Any] = {}
+
+    @property
+    def client_name(self) -> str:
+        """The IdeGYM client name this session registered under. Used in log lines."""
+        return self._client_name
+
+    def _require_client(self) -> Any:
+        client = self._client
+        if client is None:
+            raise IdeGymError("The IdeGYM session is not running")
+        return client
+
+    # --- lifecycle ---------------------------------------------------------
+
+    def start(self) -> "concurrent.futures.Future[None]":
+        """Register the client on the private loop.
+
+        The returned future resolves once the client is registered and
+        heartbeating; the session then keeps serving until :meth:`stop`.
+        """
+        ready: concurrent.futures.Future[None] = concurrent.futures.Future()
+        serving = self._loop.submit(lambda: self._serve(ready))
+        self._serving = serving
+        # An unexpected raise before `ready` is resolved would otherwise leave
+        # every acquirer waiting forever.
+        serving.add_done_callback(lambda finished: _propagate_failure(finished, ready))
+        return ready
+
+    async def _serve(self, ready: "concurrent.futures.Future[None]") -> None:
+        """Own the SDK client's context for the whole session lifetime."""
+        self._shutdown = asyncio.Event()
+        client = self._build_client()
+        # `async with` registers the client and starts its heartbeat; on exit it stops
+        # the client, which also terminates any server the process failed to close.
+        # Holding the context for the session's lifetime makes that a guarantee.
+        try:
+            async with client:
+                self._client = client
+                _resolve(ready)
+                await self._shutdown.wait()
+        finally:
+            self._client = None
+            self._servers.clear()
+
+    async def stop(self) -> None:
+        """Unregister the client, then stop the private loop.
+
+        Stopping the loop joins its thread, so it runs in a worker thread rather than
+        blocking the caller's, and it happens even if unregistering failed — otherwise
+        the thread leaks for the life of the process.
+        """
+        serving, self._serving = self._serving, None
+        try:
+            if serving is not None and self._shutdown is not None:
+                shutdown = self._shutdown
+                self._loop.call_soon(shutdown.set)
+                await asyncio.wrap_future(serving)
+        finally:
+            await asyncio.to_thread(self._loop.stop)
+
+    # --- SDK construction --------------------------------------------------
+
+    def _build_client(self) -> Any:
+        from idegym.api.auth import BasicAuth
+        from idegym.api.config import OTELConfig, TracingConfig
+        from idegym.client import IdeGYMClient
+
+        connection = self._connection
+        auth = None
+        if connection.username is not None or connection.password is not None:
+            auth = BasicAuth(username=connection.username, password=connection.password)
+        # Always pass an explicit OTEL config: left to its own devices the SDK
+        # defaults to a JetBrains-hosted trace collector, and NeMo Gym does not
+        # ship telemetry to a third party unless it was configured to.
+        otel_config = OTELConfig(
+            service_name=f"nemo-gym-{self._client_name}",
+            tracing=TracingConfig(
+                endpoint=connection.tracing_endpoint,
+                timeout=connection.tracing_timeout_s,
+                auth=BasicAuth(username=connection.tracing_username, password=connection.tracing_password),
+            ),
+        )
+        client = IdeGYMClient(
+            orchestrator_url=connection.orchestrator_url,
+            name=self._client_name,
+            namespace=connection.namespace,
+            nodes_count=connection.nodes_count,
+            auth=auth,
+            heartbeat_interval_in_seconds=connection.heartbeat_interval_s,
+            request_timeout_in_seconds=connection.request_timeout_s,
+            otel_config=otel_config,
+        )
+        install_transport(client, connection)
+        return client
+
+    # --- request plumbing --------------------------------------------------
+
+    async def _call(self, factory: Callable[[], Awaitable[T]]) -> T:
+        """Run ``factory()`` on the session loop and await it on the caller's."""
+        return await asyncio.wrap_future(self._loop.submit(factory))
+
+    def _polling_config(self, polling: IdeGymPollingConfig, wait_timeout_s: float) -> Any:
+        from idegym.client.operations.utils import PollingConfig
+
+        return PollingConfig(
+            initial_delay_in_sec=polling.initial_delay_s,
+            wait_timeout_in_sec=max(1, math.ceil(wait_timeout_s)),
+            poll_interval_in_sec=polling.interval_s,
+            factor_for_exponential_wait=polling.backoff_factor,
+            max_delay_for_exponential_wait_in_sec=polling.max_delay_s,
+        )
+
+    # --- operations --------------------------------------------------------
+
+    async def health(self) -> str:
+        """Return the orchestrator's reported health status."""
+        response = await self._call(lambda: self._require_client().health_check())
+        return str(getattr(response, "status", "") or "")
+
+    async def start_server(
+        self,
+        request: Mapping[str, Any],
+        *,
+        polling: IdeGymPollingConfig,
+        timeout_s: float,
+    ) -> IdeGymServerRef:
+        """Start one server pod and return its identity once it is up.
+
+        ``request`` is the plain-dict form of the IdeGYM start-server arguments
+        produced by :mod:`nemo_gym.sandbox.providers.idegym.spec`; the SDK models
+        it needs are built here so nothing above this module imports them.
+        """
+        kwargs = self._build_start_kwargs(request, polling=polling, timeout_s=timeout_s)
+        server = await self._call(lambda: self._start_and_track(kwargs))
+        return IdeGymServerRef(
+            server_id=int(server.server_id),
+            server_name=str(kwargs["server_name"]),
+            namespace=self._connection.namespace,
+        )
+
+    async def _start_and_track(self, kwargs: dict[str, Any]) -> Any:
+        server = await self._require_client().start_server(**kwargs)
+        self._servers[int(server.server_id)] = server
+        return server
+
+    def _build_start_kwargs(
+        self,
+        request: Mapping[str, Any],
+        *,
+        polling: IdeGymPollingConfig,
+        timeout_s: float,
+    ) -> dict[str, Any]:
+        from idegym.api.orchestrator.servers import ServerKind, ServerReuseStrategy, SnapshotRef
+        from idegym.api.pod_spec import (
+            KubernetesEnvFromSource,
+            KubernetesPodOverrides,
+            KubernetesVolume,
+            KubernetesVolumeMount,
+        )
+        from idegym.api.resources import KubernetesResources
+
+        kwargs = dict(request)
+        if (resources := kwargs.get("resources")) is not None:
+            kwargs["resources"] = KubernetesResources.model_validate(resources)
+        if volumes := kwargs.get("volumes"):
+            kwargs["volumes"] = [KubernetesVolume.model_validate(volume) for volume in volumes]
+        if mounts := kwargs.get("volume_mounts"):
+            kwargs["volume_mounts"] = [KubernetesVolumeMount.model_validate(mount) for mount in mounts]
+        if env_from := kwargs.get("env_from"):
+            kwargs["env_from"] = [KubernetesEnvFromSource.model_validate(source) for source in env_from]
+        if (overrides := kwargs.get("pod_overrides")) is not None:
+            kwargs["pod_overrides"] = KubernetesPodOverrides.model_validate(overrides)
+        if (snapshot := kwargs.get("snapshot")) is not None:
+            kwargs["snapshot"] = SnapshotRef.model_validate(snapshot)
+        if (reuse := kwargs.get("reuse_strategy")) is not None:
+            kwargs["reuse_strategy"] = ServerReuseStrategy(reuse)
+        if (kind := kwargs.get("server_kind")) is not None:
+            kwargs["server_kind"] = ServerKind(kind)
+        kwargs["namespace"] = self._connection.namespace
+        # The SDK enforces the readiness budget itself, including its retries on
+        # the orchestrator's 429 back-pressure, so it gets the whole budget.
+        kwargs["server_start_wait_timeout_in_seconds"] = max(1, math.ceil(timeout_s))
+        kwargs["polling_config"] = self._polling_config(polling, timeout_s)
+        return kwargs
+
+    async def execute_bash(
+        self,
+        server_id: int,
+        script: str,
+        *,
+        command_timeout_s: float,
+        graceful_termination_timeout_s: float,
+        request_timeout_s: float,
+        polling: IdeGymPollingConfig,
+    ) -> IdeGymBashResult:
+        """Run ``script`` through the server's bash tool."""
+        request_timeout = max(1, math.ceil(request_timeout_s))
+        polling_config = self._polling_config(polling, request_timeout_s)
+        response = await self._call(
+            lambda: self._server(server_id).execute_bash(
+                script=script,
+                command_timeout=command_timeout_s,
+                graceful_termination_timeout=graceful_termination_timeout_s,
+                request_timeout=request_timeout,
+                polling_config=polling_config,
+            )
+        )
+        return IdeGymBashResult(
+            stdout=response.stdout or "",
+            stderr=response.stderr or "",
+            exit_code=int(response.exit_code),
+        )
+
+    async def list_capabilities(self, server_id: int) -> list[str]:
+        """Return the plugins loaded in the running server container.
+
+        This is the cheapest orchestrator call that touches both the server's
+        database record and the pod itself, which makes it the provider's liveness
+        probe.
+        """
+        response = await self._call(lambda: self._server(server_id).list_capabilities())
+        return [str(plugin) for plugin in (response.plugins or [])]
+
+    async def stop_server(self, server_id: int, *, polling: IdeGymPollingConfig, timeout_s: float) -> None:
+        """Delete the server pod and its Kubernetes resources."""
+        polling_config = self._polling_config(polling, timeout_s)
+        await self._call(lambda: self._stop_and_forget(server_id, polling_config))
+
+    async def _stop_and_forget(self, server_id: int, polling_config: Any) -> None:
+        server = self._server(server_id)
+        response = await self._require_client().stop_server(server, polling_config=polling_config)
+        # The SDK reports a failed delete operation by *returning* an ErrorResponse
+        # rather than raising, so an unchecked return records a live pod as stopped.
+        self._raise_for_error_response(response, f"Deleting IdeGYM server {server_id}")
+        # Forgotten only on success: a server dropped after a failed delete would make
+        # the caller's next attempt look like "already stopped".
+        self._servers.pop(server_id, None)
+
+    @staticmethod
+    def _raise_for_error_response(response: Any, action: str) -> None:
+        from idegym.api.orchestrator.servers import ErrorResponse
+
+        if isinstance(response, ErrorResponse):
+            # The dump carries `status_code`, which the error classifier reads to tell
+            # an already-gone server from a real failure.
+            raise IdeGymError(f"{action} failed: {response.model_dump()}")
+
+    def _server(self, server_id: int) -> Any:
+        server = self._servers.get(server_id)
+        if server is None:
+            raise IdeGymUnknownServerError(
+                f"IdeGYM server {server_id} is not held by this session; it was already stopped or "
+                f"belongs to another process"
+            )
+        return server
+
+
+def _propagate_failure(source: "concurrent.futures.Future[Any]", target: "concurrent.futures.Future[None]") -> None:
+    if target.done():
+        return
+    exception: BaseException | None = None
+    if not source.cancelled():
+        exception = source.exception()
+    _resolve(target, exception or IdeGymError("The IdeGYM session ended before it became ready"))
+
+
+_TRANSPORT_WARNED = False
+
+
+def install_transport(client: Any, connection: IdeGymConnectionConfig) -> None:
+    """Replace the SDK's HTTP transport with a pool-bounded one.
+
+    The IdeGYM client builds its own ``httpx.AsyncClient`` and exposes no transport
+    hook, so the pool limits and the aiohttp backend Gym expects can only be installed
+    by swapping it out afterwards. That reaches into a private attribute, so a shape
+    change in the SDK degrades to a warning rather than failing the run.
+    """
+    global _TRANSPORT_WARNED
+
+    http_client = getattr(client, "_http_client", None)
+    if http_client is None or not hasattr(http_client, "_transport"):
+        if not _TRANSPORT_WARNED:
+            _TRANSPORT_WARNED = True
+            LOGGER.warning(
+                "The installed idegym-client does not expose the httpx client this provider configures "
+                "connection pooling on; falling back to the SDK's own transport. Pool limits and "
+                "connection.transport_backend have no effect."
+            )
+        return
+    # The transport being replaced was built moments ago and has never issued a
+    # request, so its connection pool holds nothing that needs closing.
+    http_client._transport = build_transport(connection)
+
+
+def build_transport(connection: IdeGymConnectionConfig) -> Any:
+    """Build the httpx transport for the configured backend and pool limits."""
+    import httpx
+
+    limits = httpx.Limits(
+        max_connections=connection.max_connections,
+        max_keepalive_connections=connection.max_keepalive_connections,
+        keepalive_expiry=connection.keepalive_expiry_s,
+    )
+    if connection.transport_backend == TransportBackend.AIOHTTP:
+        try:
+            from httpx_aiohttp import AiohttpTransport
+        except ImportError:
+            LOGGER.warning(
+                "connection.transport_backend=aiohttp requested but httpx-aiohttp is not installed; "
+                "falling back to the httpx transport"
+            )
+        else:
+            return AiohttpTransport(limits=limits, retries=connection.connect_retries)
+    return httpx.AsyncHTTPTransport(limits=limits, retries=connection.connect_retries)
+
+
+@dataclass
+class _SessionEntry:
+    session: IdeGymSession
+    ready: "concurrent.futures.Future[None]"
+    refcount: int = field(default=0)
+
+
+_SESSIONS: dict[tuple[IdeGymConnectionConfig, str], _SessionEntry] = {}
+_SESSIONS_LOCK = threading.Lock()
+
+
+def _observe(source: "concurrent.futures.Future[None]") -> "concurrent.futures.Future[None]":
+    """A private view of ``source`` for one waiter.
+
+    Concurrent acquirers of a session all wait on the same readiness future, and
+    ``asyncio.wrap_future`` propagates cancellation into what it wraps — so without a
+    per-waiter view, one cancelled acquirer would cancel registration for the rest.
+    """
+    view: concurrent.futures.Future[None] = concurrent.futures.Future()
+
+    def relay(finished: "concurrent.futures.Future[None]") -> None:
+        if finished.cancelled():
+            view.cancel()
+            return
+        _resolve(view, finished.exception())
+
+    source.add_done_callback(relay)
+    return view
+
+
+def require_idegym_client() -> None:
+    """Fail with an actionable message when the IdeGYM SDK is not installed."""
+    try:
+        import idegym.client  # noqa: F401
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "The idegym-client SDK is required for the idegym sandbox provider. Install it with "
+            "`uv pip install 'nemo-gym[idegym]'` (or `pip install idegym-client`) in the runtime "
+            "environment before selecting the idegym sandbox provider."
+        ) from e
+
+
+async def acquire_session(connection: IdeGymConnectionConfig, attribution: IdeGymAttributionConfig) -> IdeGymSession:
+    """Return the shared session for ``connection``, registering it if needed.
+
+    Every acquired session must be handed back to :func:`release_session` exactly
+    once; the last release unregisters the IdeGYM client.
+    """
+    require_idegym_client()
+    key = (connection, resolve_client_name(connection, attribution))
+    with _SESSIONS_LOCK:
+        entry = _SESSIONS.get(key)
+        if entry is None:
+            session = IdeGymSession(connection, key[1])
+            entry = _SessionEntry(session=session, ready=session.start())
+            _SESSIONS[key] = entry
+        entry.refcount += 1
+    try:
+        await asyncio.wrap_future(_observe(entry.ready))
+    except BaseException:
+        # Registration failed for everyone waiting on this entry. Drop the
+        # reference so a later acquire starts a fresh session rather than
+        # inheriting the failure.
+        await _release_entry(key, entry)
+        raise
+    return entry.session
+
+
+async def release_session(session: IdeGymSession) -> None:
+    """Give back one reference to a shared session."""
+    with _SESSIONS_LOCK:
+        key = next((candidate for candidate, entry in _SESSIONS.items() if entry.session is session), None)
+        entry = _SESSIONS.get(key) if key is not None else None
+    if key is None or entry is None:
+        return
+    await _release_entry(key, entry)
+
+
+async def _release_entry(key: tuple[IdeGymConnectionConfig, str], entry: _SessionEntry) -> None:
+    with _SESSIONS_LOCK:
+        if _SESSIONS.get(key) is not entry:
+            return
+        entry.refcount -= 1
+        if entry.refcount > 0:
+            return
+        # Remove before tearing down: an acquire racing this release must start a
+        # new session rather than take a reference on a dying one.
+        _SESSIONS.pop(key, None)
+    try:
+        await entry.session.stop()
+    except Exception:
+        LOGGER.warning(f"Failed to unregister the IdeGYM client {entry.session.client_name!r} cleanly", exc_info=True)
+
+
+def active_session_count() -> int:
+    """Number of live shared sessions. Exposed for tests and diagnostics."""
+    with _SESSIONS_LOCK:
+        return len(_SESSIONS)

--- a/nemo_gym/sandbox/providers/idegym/session.py
+++ b/nemo_gym/sandbox/providers/idegym/session.py
@@ -14,16 +14,18 @@
 
 """The registered IdeGYM client shared by every sandbox in a process.
 
-The only module that imports the ``idegym`` SDK, so the layers above it work in the
+The only module that imports the ``idegym`` SDK, so everything above works in the
 provider-owned types declared here and the tests have one seam to fake.
 
-*One registered client per process, not per sandbox,* reference-counted across
-providers: IdeGYM's client is a heartbeating owner of N server pods that carries the
-resource quota keyed on its name, and the orchestrator takes a table-level database
-lock per registration. *That client lives on a private event loop* in a daemon thread,
-because the SDK client is loop-bound (an httpx session plus a heartbeat task) while the
-sync ``Sandbox`` facade — the one the mini-swe-agent harness uses — gives every sandbox
-its own loop.
+*One client per process, not per sandbox.* An IdeGYM client is a heartbeating owner of
+N server pods; registering one takes a table-level lock on the orchestrator's database,
+and the resource quota is matched against its name. Sharing then forces the reference
+count: stopping a client also terminates every server it owns, so it may only be
+unregistered once the last provider has let go.
+
+*The client lives on a private event loop* in a daemon thread. It is loop-bound -- an
+httpx session plus a heartbeat task -- while the sync ``Sandbox`` facade gives every
+sandbox a loop of its own.
 """
 
 import asyncio
@@ -100,13 +102,15 @@ class IdeGymBashResult:
     exit_code: int
 
 
-def _resolve(future: "concurrent.futures.Future[Any]", exception: BaseException | None = None) -> None:
+def _resolve(
+    future: "concurrent.futures.Future[Any]", exception: BaseException | None = None, result: Any = None
+) -> None:
     """Complete ``future`` unless a racing cancellation already finished it."""
     try:
         if exception is not None:
             future.set_exception(exception)
         else:
-            future.set_result(None)
+            future.set_result(result)
     except concurrent.futures.InvalidStateError:
         pass
 
@@ -122,15 +126,9 @@ async def _settle(coro: Awaitable[T], future: "concurrent.futures.Future[T]") ->
     try:
         result = await coro
     except BaseException as e:  # noqa: BLE001 - the future is the only channel back to the caller
-        try:
-            future.set_exception(e)
-        except concurrent.futures.InvalidStateError:
-            pass
+        _resolve(future, e)
     else:
-        try:
-            future.set_result(result)
-        except concurrent.futures.InvalidStateError:
-            pass
+        _resolve(future, result=result)
 
 
 class _SessionLoop:
@@ -392,23 +390,24 @@ class IdeGymSession:
         )
         from idegym.api.resources import KubernetesResources
 
+        models = {"resources": KubernetesResources, "pod_overrides": KubernetesPodOverrides, "snapshot": SnapshotRef}
+        model_lists = {
+            "volumes": KubernetesVolume,
+            "volume_mounts": KubernetesVolumeMount,
+            "env_from": KubernetesEnvFromSource,
+        }
+        enums = {"reuse_strategy": ServerReuseStrategy, "server_kind": ServerKind}
+
         kwargs = dict(request)
-        if (resources := kwargs.get("resources")) is not None:
-            kwargs["resources"] = KubernetesResources.model_validate(resources)
-        if volumes := kwargs.get("volumes"):
-            kwargs["volumes"] = [KubernetesVolume.model_validate(volume) for volume in volumes]
-        if mounts := kwargs.get("volume_mounts"):
-            kwargs["volume_mounts"] = [KubernetesVolumeMount.model_validate(mount) for mount in mounts]
-        if env_from := kwargs.get("env_from"):
-            kwargs["env_from"] = [KubernetesEnvFromSource.model_validate(source) for source in env_from]
-        if (overrides := kwargs.get("pod_overrides")) is not None:
-            kwargs["pod_overrides"] = KubernetesPodOverrides.model_validate(overrides)
-        if (snapshot := kwargs.get("snapshot")) is not None:
-            kwargs["snapshot"] = SnapshotRef.model_validate(snapshot)
-        if (reuse := kwargs.get("reuse_strategy")) is not None:
-            kwargs["reuse_strategy"] = ServerReuseStrategy(reuse)
-        if (kind := kwargs.get("server_kind")) is not None:
-            kwargs["server_kind"] = ServerKind(kind)
+        for key, model in models.items():
+            if (value := kwargs.get(key)) is not None:
+                kwargs[key] = model.model_validate(value)
+        for key, model in model_lists.items():
+            if value := kwargs.get(key):
+                kwargs[key] = [model.model_validate(entry) for entry in value]
+        for key, enum in enums.items():
+            if (value := kwargs.get(key)) is not None:
+                kwargs[key] = enum(value)
         kwargs["namespace"] = self._connection.namespace
         # The SDK enforces the readiness budget itself, including its retries on
         # the orchestrator's 429 back-pressure, so it gets the whole budget.
@@ -491,9 +490,7 @@ class IdeGymSession:
 def _propagate_failure(source: "concurrent.futures.Future[Any]", target: "concurrent.futures.Future[None]") -> None:
     if target.done():
         return
-    exception: BaseException | None = None
-    if not source.cancelled():
-        exception = source.exception()
+    exception = None if source.cancelled() else source.exception()
     _resolve(target, exception or IdeGymError("The IdeGYM session ended before it became ready"))
 
 

--- a/nemo_gym/sandbox/providers/idegym/session.py
+++ b/nemo_gym/sandbox/providers/idegym/session.py
@@ -302,9 +302,9 @@ class IdeGymSession:
         auth = None
         if connection.username is not None or connection.password is not None:
             auth = BasicAuth(username=connection.username, password=connection.password)
-        # Always pass an explicit OTEL config: left to its own devices the SDK
-        # defaults to a JetBrains-hosted trace collector, and NeMo Gym does not
-        # ship telemetry to a third party unless it was configured to.
+        # Always pass an explicit OTEL config: left to its own devices the SDK traces
+        # to its default off-box collector, and NeMo Gym does not ship telemetry to a
+        # third party unless it was configured to.
         otel_config = OTELConfig(
             service_name=f"nemo-gym-{self._client_name}",
             tracing=TracingConfig(

--- a/nemo_gym/sandbox/providers/idegym/shell.py
+++ b/nemo_gym/sandbox/providers/idegym/shell.py
@@ -20,8 +20,8 @@ everything ``exec(command, cwd=, env=, user=)`` promises is expressed inside the
 script. Two sandbox-side details shape it: the executor runs
 ``source <bash-integration> && <script>`` where ``&&`` binds only to the first
 statement, so the script is emitted as one ``{ ... }`` group; and it travels as a single
-``execve()`` argument capped at 128 KiB, so an oversized script is rejected here rather
-than failing with a confusing ``E2BIG``.
+``execve()`` argument, which Linux caps at 128 KiB, so an oversized script is rejected
+here against ``MAX_COMMAND_BYTES`` rather than failing with a confusing ``E2BIG``.
 """
 
 import logging
@@ -94,8 +94,8 @@ class BashScriptBuilder:
             # and silently running in the image's project directory instead would
             # make the command look like it merely failed.
             lines.append(f"cd -- {quote(cwd)} || exit 1")
-        for name, value in (env or {}).items():
-            name = str(name)
+        for key, value in (env or {}).items():
+            name = str(key)
             if not _ENV_NAME.fullmatch(name):
                 raise ValueError(
                     f"Environment variable name {name!r} is not a valid shell identifier, so the idegym "
@@ -120,15 +120,19 @@ class BashScriptBuilder:
                     f"image ships one of those tools."
                 )
             return script
+        # Both tools resolve the user through getpwnam, so a bare uid is not something
+        # they can be handed.
         if isinstance(user, int) or str(user).isdigit():
             raise ValueError(
                 f"exec.user_mode={mode.value!r} needs a user name, but got the numeric id {user!r}. Pass a "
                 f"name, or use exec.user_mode='ignore' to run as the container's own user."
             )
         name = quote(str(user))
+        # Both pin the shell to bash rather than inherit the target user's login shell,
+        # which is `/sbin/nologin` on a service account and would refuse the command.
         if mode is UserMode.RUNUSER:
             return f"exec runuser -u {name} -- bash -c {quote(script)}"
-        return f"exec su {name} -c {quote(script)}"
+        return f"exec su -s /bin/bash -c {quote(script)} {name}"
 
     def _check_size(self, script: str, command: str) -> None:
         size = len(script.encode())

--- a/nemo_gym/sandbox/providers/idegym/shell.py
+++ b/nemo_gym/sandbox/providers/idegym/shell.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Turning a sandbox exec request into one script for IdeGYM's bash tool.
+
+``/api/tools/bash`` takes a command and nothing else — each call is a fresh
+``bash -c`` in the server's project directory with a cleaned environment — so
+everything ``exec(command, cwd=, env=, user=)`` promises is expressed inside the
+script. Two sandbox-side details shape it: the executor runs
+``source <bash-integration> && <script>`` where ``&&`` binds only to the first
+statement, so the script is emitted as one ``{ ... }`` group; and it travels as a single
+``execve()`` argument capped at 128 KiB, so an oversized script is rejected here rather
+than failing with a confusing ``E2BIG``.
+"""
+
+import logging
+import re
+import shlex
+
+from nemo_gym.sandbox.providers.idegym.config import MAX_COMMAND_BYTES, IdeGymExecConfig, UserMode
+from nemo_gym.sandbox.providers.idegym.errors import IdeGymCommandTooLongError
+
+
+LOGGER = logging.getLogger(__name__)
+
+# POSIX portable environment variable names. `export` cannot carry anything else, so an
+# invalid name has to be a hard error rather than a silently dropped value. Matched with
+# `fullmatch`, since `$` would also accept a trailing newline.
+_ENV_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def quote(value: str) -> str:
+    """Shell-quote one value for inclusion in a generated script."""
+    return shlex.quote(value)
+
+
+def directory_exists_script(path: str) -> str:
+    """A script that succeeds only if ``path`` is a directory in the sandbox."""
+    return f"[ -d {quote(path)} ]"
+
+
+class BashScriptBuilder:
+    """Builds the bash script for one sandbox command.
+
+    Stateless apart from its config, so one builder is shared by every sandbox of
+    a provider.
+    """
+
+    def __init__(self, config: IdeGymExecConfig) -> None:
+        self._config = config
+        self._warned_about_user = False
+
+    def build(
+        self,
+        command: str,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        user: str | int | None = None,
+    ) -> str:
+        """Return the script that runs ``command`` under the requested context.
+
+        Raises:
+            ValueError: If ``env`` holds a name ``export`` cannot carry, or a user
+                switch is configured but the requested user cannot be expressed.
+            IdeGymCommandTooLongError: If the finished script exceeds what the
+                sandbox's shell can accept as a single argument.
+        """
+        inner = self._inner_script(command, cwd=cwd, env=env)
+        script = self._apply_user(inner, user)
+        # A group keeps every statement conditional on the executor's `source` prefix
+        # and makes the group's last statement supply the exit code. The leading `:`
+        # keeps the group non-empty: a blank or comment-only command would otherwise
+        # make bash fail on `{ }` with a syntax error attributed to the caller.
+        script = f"{{ :\n{script}\n}}"
+        self._check_size(script, command)
+        return script
+
+    def _inner_script(self, command: str, *, cwd: str | None, env: dict[str, str] | None) -> str:
+        lines: list[str] = []
+        if cwd:
+            # Fail loudly: a missing working directory is a configuration problem,
+            # and silently running in the image's project directory instead would
+            # make the command look like it merely failed.
+            lines.append(f"cd -- {quote(cwd)} || exit 1")
+        for name, value in (env or {}).items():
+            name = str(name)
+            if not _ENV_NAME.fullmatch(name):
+                raise ValueError(
+                    f"Environment variable name {name!r} is not a valid shell identifier, so the idegym "
+                    f"provider cannot export it into the sandbox"
+                )
+            lines.append(f"export {name}={quote(str(value))}")
+        lines.append(command)
+        return "\n".join(lines)
+
+    def _apply_user(self, script: str, user: str | int | None) -> str:
+        """Wrap ``script`` so it runs as ``user``, per the configured user mode."""
+        if user is None:
+            return script
+        mode = UserMode(self._config.user_mode)
+        if mode is UserMode.IGNORE:
+            if not self._warned_about_user:
+                self._warned_about_user = True
+                LOGGER.warning(
+                    f"The idegym provider cannot run commands as user={user!r}: the IdeGYM bash tool has no "
+                    f"user field. Commands run as the server container's user, which "
+                    f"provider_options.run_as_root controls. Set exec.user_mode to 'runuser' or 'su' if the "
+                    f"image ships one of those tools."
+                )
+            return script
+        if isinstance(user, int) or str(user).isdigit():
+            raise ValueError(
+                f"exec.user_mode={mode.value!r} needs a user name, but got the numeric id {user!r}. Pass a "
+                f"name, or use exec.user_mode='ignore' to run as the container's own user."
+            )
+        name = quote(str(user))
+        if mode is UserMode.RUNUSER:
+            return f"exec runuser -u {name} -- bash -c {quote(script)}"
+        return f"exec su {name} -c {quote(script)}"
+
+    def _check_size(self, script: str, command: str) -> None:
+        size = len(script.encode())
+        if size <= MAX_COMMAND_BYTES:
+            return
+        raise IdeGymCommandTooLongError(
+            f"The generated sandbox script is {size} bytes, over the {MAX_COMMAND_BYTES} byte limit the "
+            f"IdeGYM bash tool can pass to the shell as one argument. Write the payload to a file and run "
+            f"that instead (command starts with {command[:80]!r})."
+        )

--- a/nemo_gym/sandbox/providers/idegym/spec.py
+++ b/nemo_gym/sandbox/providers/idegym/spec.py
@@ -14,9 +14,6 @@
 
 """Translating a ``SandboxSpec`` into IdeGYM's start-server request.
 
-The neutral spec and IdeGYM's pod-shaped request overlap only partly; the mismatches
-are what this module exists for:
-
 ``image``
     Passed through minus a ``docker://`` scheme. It has to be an IdeGYM *server*
     image; map benchmark images onto one with ``sandbox_spec.image_rewrites``.
@@ -49,8 +46,9 @@ from nemo_gym.sandbox.providers.idegym.naming import generate_server_name
 LOGGER = logging.getLogger(__name__)
 
 IMAGE_SCHEME_PREFIX = "docker://"
-# `idegym.api.type.OCIImageName`. Validated here so a bad image fails with an
-# explanation rather than as a pydantic error deep inside the SDK.
+# Mirrors `idegym.api.type.OCIImageName` (1-383 characters, lowercase only). Checked
+# here so a bad image fails with an explanation rather than as a pydantic error deep
+# inside the SDK.
 _OCI_IMAGE = re.compile(r"[a-z0-9._/:@-]{1,383}")
 
 
@@ -72,7 +70,7 @@ def normalize_image(image: str | None) -> str:
 
 
 def format_cpu(cores: float) -> str:
-    """Format a CPU count the way Kubernetes expects it."""
+    """Format a CPU count as a Kubernetes quantity: ``2``, or ``500m`` below whole cores."""
     millicores = round(cores * 1000)
     if millicores <= 0:
         raise IdeGymCreateError(f"CPU request must be greater than zero, got {cores!r}")
@@ -80,12 +78,14 @@ def format_cpu(cores: float) -> str:
 
 
 def format_mib(mib: int) -> str:
+    """Format a memory size as a Kubernetes quantity: ``8192Mi``."""
     if mib <= 0:
         raise IdeGymCreateError(f"Memory request must be greater than zero, got {mib!r}")
     return f"{int(mib)}Mi"
 
 
 def format_gib(gib: int) -> str:
+    """Format a disk size as a Kubernetes quantity: ``30Gi``."""
     if gib <= 0:
         raise IdeGymCreateError(f"Disk request must be greater than zero, got {gib!r}")
     return f"{int(gib)}Gi"
@@ -127,8 +127,6 @@ class IdeGymProviderOptions:
     server_kind: str | None = None
     snapshot: Mapping[str, Any] | None = None
     max_restarts: int | None = None
-    # Pin the server name to opt into IdeGYM's server reuse; the provider
-    # otherwise generates a unique name per sandbox.
     server_name: str | None = None
     service_port: int | None = None
     container_port: int | None = None
@@ -176,7 +174,7 @@ def _mapping(value: Any, name: str) -> dict[str, Any] | None:
 def _mapping_tuple(value: Any, name: str) -> tuple[Mapping[str, Any], ...]:
     if not value:
         return ()
-    if isinstance(value, Mapping) or not isinstance(value, (list, tuple)):
+    if not isinstance(value, (list, tuple)):
         raise TypeError(f"provider_options[{name!r}] must be a list of mappings, got {type(value).__name__}")
     entries: list[Mapping[str, Any]] = []
     for index, entry in enumerate(value):
@@ -184,6 +182,11 @@ def _mapping_tuple(value: Any, name: str) -> tuple[Mapping[str, Any], ...]:
             raise TypeError(f"provider_options[{name!r}][{index}] must be a mapping, got {type(entry).__name__}")
         entries.append(dict(entry))
     return tuple(entries)
+
+
+def _or_default(option: Any, default: Any) -> Any:
+    """Return ``option``, falling back to ``default`` only when it was left unset."""
+    return default if option is None else option
 
 
 class ServerRequestTranslator:
@@ -203,15 +206,14 @@ class ServerRequestTranslator:
     def server_name(self, spec: SandboxSpec) -> str:
         """Generate the RFC-1035 server name for one sandbox.
 
-        Names are unique per sandbox so concurrent sandboxes cannot collide on
-        IdeGYM's name-based server matching, and they carry the configured metadata
-        hints so a pod is traceable back to its task. Pin
-        ``provider_options.server_name`` instead to opt into IdeGYM's server reuse.
+        The name carries the configured metadata hints so a pod is traceable back to
+        its task. It is not made unique: IdeGYM appends its own server id, which is
+        what Kubernetes sees and what the database keeps unique.
         """
         hints = [
-            str(spec.metadata[key])
+            str(value)
             for key in self._create.server_name_metadata_keys
-            if spec.metadata.get(key) not in (None, "")
+            if (value := spec.metadata.get(key)) not in (None, "")
         ]
         return generate_server_name(self._create.server_name_prefix, hints)
 
@@ -226,11 +228,12 @@ class ServerRequestTranslator:
         request: dict[str, Any] = {
             "image_tag": normalize_image(spec.image),
             "server_name": options.server_name or self.server_name(spec),
-            "run_as_root": create.run_as_root if options.run_as_root is None else options.run_as_root,
-            "service_port": create.service_port if options.service_port is None else options.service_port,
-            "container_port": create.container_port if options.container_port is None else options.container_port,
+            "run_as_root": _or_default(options.run_as_root, create.run_as_root),
+            "service_port": _or_default(options.service_port, create.service_port),
+            "container_port": _or_default(options.container_port, create.container_port),
             "reuse_strategy": options.reuse_strategy or create.reuse_strategy,
-            "max_restarts": create.max_restarts if options.max_restarts is None else options.max_restarts,
+            "max_restarts": _or_default(options.max_restarts, create.max_restarts),
+            # How long the SDK waits before retrying its own 429; it takes whole seconds.
             "retry_delay_in_seconds": max(1, round(create.busy_retry_delay_s)),
         }
         if resources := self._resources(spec, options):
@@ -261,8 +264,8 @@ class ServerRequestTranslator:
             resources["limits"] = limits
         return resources
 
-    def _warn_about_gpu(self, *requests: SandboxResources | None) -> None:
-        if any(resources is not None and (resources.gpu or resources.gpu_type) for resources in requests):
+    def _warn_about_gpu(self, *blocks: SandboxResources | None) -> None:
+        if any(block is not None and (block.gpu or block.gpu_type) for block in blocks):
             self._warn_once(
                 "gpu",
                 "The idegym provider cannot map GPU resource requests: IdeGYM's resource model covers "
@@ -286,6 +289,6 @@ class ServerRequestTranslator:
             self._warn_once(
                 "ports",
                 f"spec.ports {list(spec.ports)!r} is ignored by the idegym provider: an IdeGYM server pod "
-                f"exposes only its own API port, and the orchestrator forwards requests rather than routing "
-                f"raw TCP. sandbox.endpoint() is unavailable on this provider.",
+                "exposes only its own API port, and the orchestrator forwards requests rather than routing "
+                "raw TCP. sandbox.endpoint() is unavailable on this provider.",
             )

--- a/nemo_gym/sandbox/providers/idegym/spec.py
+++ b/nemo_gym/sandbox/providers/idegym/spec.py
@@ -1,0 +1,291 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Translating a ``SandboxSpec`` into IdeGYM's start-server request.
+
+The neutral spec and IdeGYM's pod-shaped request overlap only partly; the mismatches
+are what this module exists for:
+
+``image``
+    Passed through minus a ``docker://`` scheme. It has to be an IdeGYM *server*
+    image; map benchmark images onto one with ``sandbox_spec.image_rewrites``.
+``resources``
+    Becomes Kubernetes *limits*, with ``provider_options.resource_requests`` as the
+    *requests*. IdeGYM's quota accounting reads limits first.
+``env``
+    IdeGYM only imports pod environment from ConfigMaps and Secrets, so plain values
+    are exported per command by :mod:`~nemo_gym.sandbox.providers.idegym.shell`.
+``metadata``
+    Cannot become Kubernetes labels — IdeGYM has no per-server label API — so
+    selected keys name the pod instead.
+``ttl_s`` / ``ports`` / ``entrypoint``
+    Unsupported: servers live until stopped, expose only their own service port, and
+    own their container entrypoint.
+"""
+
+import logging
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from nemo_gym.sandbox.providers.base import SandboxResources, SandboxSpec
+from nemo_gym.sandbox.providers.idegym.config import IdeGymCreateConfig
+from nemo_gym.sandbox.providers.idegym.errors import IdeGymCreateError
+from nemo_gym.sandbox.providers.idegym.naming import generate_server_name
+
+
+LOGGER = logging.getLogger(__name__)
+
+IMAGE_SCHEME_PREFIX = "docker://"
+# `idegym.api.type.OCIImageName`. Validated here so a bad image fails with an
+# explanation rather than as a pydantic error deep inside the SDK.
+_OCI_IMAGE = re.compile(r"[a-z0-9._/:@-]{1,383}")
+
+
+def normalize_image(image: str | None) -> str:
+    """Return ``image`` as an IdeGYM OCI image tag."""
+    if not image:
+        raise IdeGymCreateError(
+            "spec.image is required by the idegym provider: the sandbox is a Kubernetes pod running an "
+            "IdeGYM server image."
+        )
+    if image.startswith(IMAGE_SCHEME_PREFIX):
+        image = image[len(IMAGE_SCHEME_PREFIX) :]
+    if not _OCI_IMAGE.fullmatch(image):
+        raise IdeGymCreateError(
+            f"spec.image {image!r} is not a valid OCI image reference for IdeGYM, which accepts only "
+            f"lowercase [a-z0-9._/:@-]. Use sandbox_spec.image_rewrites to map it onto an IdeGYM server image."
+        )
+    return image
+
+
+def format_cpu(cores: float) -> str:
+    """Format a CPU count the way Kubernetes expects it."""
+    millicores = round(cores * 1000)
+    if millicores <= 0:
+        raise IdeGymCreateError(f"CPU request must be greater than zero, got {cores!r}")
+    return str(millicores // 1000) if millicores % 1000 == 0 else f"{millicores}m"
+
+
+def format_mib(mib: int) -> str:
+    if mib <= 0:
+        raise IdeGymCreateError(f"Memory request must be greater than zero, got {mib!r}")
+    return f"{int(mib)}Mi"
+
+
+def format_gib(gib: int) -> str:
+    if gib <= 0:
+        raise IdeGymCreateError(f"Disk request must be greater than zero, got {gib!r}")
+    return f"{int(gib)}Gi"
+
+
+def resource_quantities(resources: SandboxResources) -> dict[str, str]:
+    """Render one neutral resource request as a Kubernetes quantity mapping."""
+    quantities: dict[str, str] = {}
+    if resources.cpu is not None:
+        quantities["cpu"] = format_cpu(resources.cpu)
+    if resources.memory_mib is not None:
+        quantities["memory"] = format_mib(resources.memory_mib)
+    if resources.disk_gib is not None:
+        # Pod-local scratch space; IdeGYM has no separate volume-size knob.
+        quantities["ephemeral-storage"] = format_gib(resources.disk_gib)
+    return quantities
+
+
+@dataclass(frozen=True)
+class IdeGymProviderOptions:
+    """Per-sandbox IdeGYM options carried in ``SandboxSpec.provider_options``.
+
+    These are a validated pass-through of the IdeGYM start-server request fields
+    that have no neutral equivalent. Validating here means a typo fails before a
+    pod is allocated.
+    """
+
+    # Scheduling requests, paired with `spec.resources` as the limits.
+    resource_requests: SandboxResources | None = None
+    runtime_class_name: str | None = None
+    run_as_root: bool | None = None
+    node_selector: dict[str, str] = field(default_factory=dict)
+    volumes: tuple[Mapping[str, Any], ...] = ()
+    volume_mounts: tuple[Mapping[str, Any], ...] = ()
+    env_from: tuple[Mapping[str, Any], ...] = ()
+    service_account_name: str | None = None
+    pod_overrides: Mapping[str, Any] | None = None
+    reuse_strategy: str | None = None
+    server_kind: str | None = None
+    snapshot: Mapping[str, Any] | None = None
+    max_restarts: int | None = None
+    # Pin the server name to opt into IdeGYM's server reuse; the provider
+    # otherwise generates a unique name per sandbox.
+    server_name: str | None = None
+    service_port: int | None = None
+    container_port: int | None = None
+
+    @classmethod
+    def from_mapping(cls, options: Mapping[str, Any] | None) -> "IdeGymProviderOptions":
+        if not options:
+            return cls()
+        allowed = set(cls.__dataclass_fields__)
+        unknown = set(options) - allowed
+        if unknown:
+            raise ValueError(
+                f"Unknown idegym provider_options keys: {sorted(unknown)}. Allowed keys: {sorted(allowed)}"
+            )
+        # The structured fields are validated and removed one by one; whatever
+        # remains is scalar pass-through the dataclass can take as-is.
+        scalars = dict(options)
+        requests = scalars.pop("resource_requests", None)
+        node_selector = _mapping(scalars.pop("node_selector", None), "node_selector") or {}
+        volumes = _mapping_tuple(scalars.pop("volumes", None), "volumes")
+        volume_mounts = _mapping_tuple(scalars.pop("volume_mounts", None), "volume_mounts")
+        env_from = _mapping_tuple(scalars.pop("env_from", None), "env_from")
+        pod_overrides = _mapping(scalars.pop("pod_overrides", None), "pod_overrides")
+        snapshot = _mapping(scalars.pop("snapshot", None), "snapshot")
+        return cls(
+            resource_requests=SandboxResources.from_mapping(requests) if requests is not None else None,
+            node_selector={str(key): str(value) for key, value in node_selector.items()},
+            volumes=volumes,
+            volume_mounts=volume_mounts,
+            env_from=env_from,
+            pod_overrides=pod_overrides,
+            snapshot=snapshot,
+            **scalars,
+        )
+
+
+def _mapping(value: Any, name: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise TypeError(f"provider_options[{name!r}] must be a mapping, got {type(value).__name__}")
+    return dict(value)
+
+
+def _mapping_tuple(value: Any, name: str) -> tuple[Mapping[str, Any], ...]:
+    if not value:
+        return ()
+    if isinstance(value, Mapping) or not isinstance(value, (list, tuple)):
+        raise TypeError(f"provider_options[{name!r}] must be a list of mappings, got {type(value).__name__}")
+    entries: list[Mapping[str, Any]] = []
+    for index, entry in enumerate(value):
+        if not isinstance(entry, Mapping):
+            raise TypeError(f"provider_options[{name!r}][{index}] must be a mapping, got {type(entry).__name__}")
+        entries.append(dict(entry))
+    return tuple(entries)
+
+
+class ServerRequestTranslator:
+    """Builds IdeGYM start-server requests from neutral sandbox specs."""
+
+    def __init__(self, create: IdeGymCreateConfig) -> None:
+        self._create = create
+        # A benchmark translates one spec per task, so an unsupported field would
+        # otherwise warn on every sandbox in the run.
+        self._warned: set[str] = set()
+
+    def _warn_once(self, key: str, message: str) -> None:
+        if key not in self._warned:
+            self._warned.add(key)
+            LOGGER.warning(message)
+
+    def server_name(self, spec: SandboxSpec) -> str:
+        """Generate the RFC-1035 server name for one sandbox.
+
+        Names are unique per sandbox so concurrent sandboxes cannot collide on
+        IdeGYM's name-based server matching, and they carry the configured metadata
+        hints so a pod is traceable back to its task. Pin
+        ``provider_options.server_name`` instead to opt into IdeGYM's server reuse.
+        """
+        hints = [
+            str(spec.metadata[key])
+            for key in self._create.server_name_metadata_keys
+            if spec.metadata.get(key) not in (None, "")
+        ]
+        return generate_server_name(self._create.server_name_prefix, hints)
+
+    def translate(self, spec: SandboxSpec, options: IdeGymProviderOptions) -> dict[str, Any]:
+        """Return the plain-dict start-server request for ``spec``.
+
+        Raises:
+            IdeGymCreateError: If the spec asks for something IdeGYM cannot express.
+        """
+        self._reject_unsupported(spec)
+        create = self._create
+        request: dict[str, Any] = {
+            "image_tag": normalize_image(spec.image),
+            "server_name": options.server_name or self.server_name(spec),
+            "run_as_root": create.run_as_root if options.run_as_root is None else options.run_as_root,
+            "service_port": create.service_port if options.service_port is None else options.service_port,
+            "container_port": create.container_port if options.container_port is None else options.container_port,
+            "reuse_strategy": options.reuse_strategy or create.reuse_strategy,
+            "max_restarts": create.max_restarts if options.max_restarts is None else options.max_restarts,
+            "retry_delay_in_seconds": max(1, round(create.busy_retry_delay_s)),
+        }
+        if resources := self._resources(spec, options):
+            request["resources"] = resources
+        for key, value in (
+            ("runtime_class_name", options.runtime_class_name),
+            ("node_selector", options.node_selector or None),
+            ("volumes", list(options.volumes) or None),
+            ("volume_mounts", list(options.volume_mounts) or None),
+            ("env_from", list(options.env_from) or None),
+            ("service_account_name", options.service_account_name),
+            ("pod_overrides", options.pod_overrides),
+            ("server_kind", options.server_kind),
+            ("snapshot", options.snapshot),
+        ):
+            if value is not None:
+                request[key] = value
+        return request
+
+    def _resources(self, spec: SandboxSpec, options: IdeGymProviderOptions) -> dict[str, Any]:
+        limits = resource_quantities(spec.resources)
+        requests = resource_quantities(options.resource_requests) if options.resource_requests is not None else {}
+        self._warn_about_gpu(spec.resources, options.resource_requests)
+        resources: dict[str, Any] = {}
+        if requests:
+            resources["requests"] = requests
+        if limits:
+            resources["limits"] = limits
+        return resources
+
+    def _warn_about_gpu(self, *requests: SandboxResources | None) -> None:
+        if any(resources is not None and (resources.gpu or resources.gpu_type) for resources in requests):
+            self._warn_once(
+                "gpu",
+                "The idegym provider cannot map GPU resource requests: IdeGYM's resource model covers "
+                "cpu, memory, and ephemeral-storage only. Request accelerators through "
+                "provider_options.node_selector or provider_options.pod_overrides instead.",
+            )
+
+    def _reject_unsupported(self, spec: SandboxSpec) -> None:
+        if spec.entrypoint:
+            raise IdeGymCreateError(
+                "spec.entrypoint is not supported by the idegym provider: the container's entrypoint starts "
+                "the IdeGYM server that the sandbox API talks to."
+            )
+        if spec.ttl_s is not None:
+            self._warn_once(
+                "ttl_s",
+                "spec.ttl_s is not enforced by the idegym provider; servers live until close(). The IdeGYM "
+                "orchestrator's own watcher reaps servers whose client stops heartbeating.",
+            )
+        if spec.ports:
+            self._warn_once(
+                "ports",
+                f"spec.ports {list(spec.ports)!r} is ignored by the idegym provider: an IdeGYM server pod "
+                f"exposes only its own API port, and the orchestrator forwards requests rather than routing "
+                f"raw TCP. sandbox.endpoint() is unavailable on this provider.",
+            )

--- a/nemo_gym/sandbox/providers/idegym/transfer.py
+++ b/nemo_gym/sandbox/providers/idegym/transfer.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""File transfer in and out of an IdeGYM sandbox, over its bash tool.
+
+IdeGYM's filesystem API is unusable here: its read endpoint streams raw bytes while
+the orchestrator forwards requests as JSON text, and its typed file endpoints only
+write UTF-8. So bytes travel base64-encoded through the bash tool, chunked in both
+directions — uploads to stay inside
+:data:`~nemo_gym.sandbox.providers.idegym.config.MAX_COMMAND_BYTES`, downloads because
+each chunk's stdout is persisted as an async-operation result.
+
+Good enough for the config files, patches, and logs a benchmark moves around, but not a
+bulk channel — have the sandbox fetch large inputs itself.
+"""
+
+import asyncio
+import base64
+import binascii
+import logging
+import posixpath
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+from nemo_gym.sandbox.providers.base import SandboxExecResult
+from nemo_gym.sandbox.providers.idegym.config import IdeGymFilesConfig
+from nemo_gym.sandbox.providers.idegym.errors import IdeGymTransferError
+from nemo_gym.sandbox.providers.idegym.shell import quote
+
+
+LOGGER = logging.getLogger(__name__)
+
+# Runs a command in the sandbox. Bound to one sandbox by the provider, so the
+# transfer layer never needs to know about handles or sessions.
+ExecRunner = Callable[..., Awaitable[SandboxExecResult]]
+
+
+def _describe(result: SandboxExecResult) -> str:
+    detail = (result.stderr or result.stdout or "").strip()
+    suffix = f": {detail}" if detail else ""
+    return f"exit code {result.return_code}{suffix}"
+
+
+class Base64BashFileTransfer:
+    """Moves single files between the local filesystem and an IdeGYM sandbox."""
+
+    def __init__(self, config: IdeGymFilesConfig, run: ExecRunner) -> None:
+        self._config = config
+        self._run = run
+
+    async def upload(self, source_path: Path, target_path: str) -> None:
+        """Upload one local file, creating its parent directory in the sandbox."""
+        data = await asyncio.to_thread(Path(source_path).read_bytes)
+        chunk_size = self._config.upload_chunk_bytes
+        # An empty file still needs one (empty) chunk, so the file is created.
+        chunks = [data[offset : offset + chunk_size] for offset in range(0, len(data), chunk_size)] or [b""]
+        for index, chunk in enumerate(chunks):
+            script = self._write_chunk_script(target_path, chunk, first=index == 0)
+            result = await self._run(script, timeout_s=self._config.timeout_s)
+            if result.return_code != 0:
+                raise IdeGymTransferError(
+                    f"Uploading {source_path} to {target_path!r} failed on chunk "
+                    f"{index + 1}/{len(chunks)} ({_describe(result)})"
+                )
+
+    async def download(self, source_path: str, target_path: Path) -> None:
+        """Download one sandbox file to ``target_path``."""
+        size = await self._remote_size(source_path)
+        max_bytes = self._config.max_download_bytes
+        if max_bytes is not None and size > max_bytes:
+            raise IdeGymTransferError(
+                f"Refusing to download {source_path!r}: {size} bytes exceeds files.max_download_bytes "
+                f"({max_bytes}). Archive and split it in the sandbox, or raise the limit."
+            )
+        chunk_size = self._config.download_chunk_bytes
+        data = bytearray()
+        # Every chunk asserts its own decoded length, so the concatenation is
+        # complete by construction; a file that shrinks mid-read fails on the chunk
+        # that came back short.
+        for offset in range(0, size, chunk_size) if size else ():
+            length = min(chunk_size, size - offset)
+            data.extend(await self._read_chunk(source_path, offset, length))
+        target_path = Path(target_path)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(target_path.write_bytes, bytes(data))
+
+    # --- script construction ----------------------------------------------
+
+    def _write_chunk_script(self, target_path: str, chunk: bytes, *, first: bool) -> str:
+        """Decode one base64 chunk into ``target_path``.
+
+        Each chunk is encoded independently, so appending decoded chunks
+        reconstructs the file byte for byte regardless of chunk alignment.
+        """
+        encoded = base64.b64encode(chunk).decode("ascii")
+        redirect = ">" if first else ">>"
+        lines: list[str] = []
+        if first and (parent := posixpath.dirname(target_path)):
+            lines.append(f"mkdir -p {quote(parent)}")
+        # The pipeline's exit code is `base64 -d`'s, which is the failure that
+        # matters: a decode error or a write error both surface through it.
+        lines.append(f"printf '%s' {quote(encoded)} | base64 -d {redirect} {quote(target_path)}")
+        return "\n".join(lines)
+
+    def _size_script(self, source_path: str) -> str:
+        path = quote(source_path)
+        # `wc -c` over a redirect rather than an argument: a path that starts with a
+        # dash would otherwise be read as an option.
+        return f"[ -f {path} ] || {{ printf 'not a regular file\\n' >&2; exit 1; }}\nwc -c < {path}"
+
+    def _read_chunk_script(self, source_path: str, offset: int, length: int) -> str:
+        path = quote(source_path)
+        # No `pipefail` on purpose: `head -c` closes the pipe once it has its bytes, so
+        # `tail` normally dies of SIGPIPE and would make a good chunk look failed. The
+        # decoded length check below is the real guard against a short read.
+        return f"tail -c +{offset + 1} < {path} | head -c {length} | base64"
+
+    # --- sandbox round trips ----------------------------------------------
+
+    async def _remote_size(self, source_path: str) -> int:
+        result = await self._run(self._size_script(source_path), timeout_s=self._config.timeout_s)
+        if result.return_code != 0:
+            raise IdeGymTransferError(f"Cannot read {source_path!r} from the sandbox ({_describe(result)})")
+        text = (result.stdout or "").strip()
+        if not text.isdigit():
+            raise IdeGymTransferError(f"The sandbox reported an unparsable size for {source_path!r}: {text[:200]!r}")
+        return int(text)
+
+    async def _read_chunk(self, source_path: str, offset: int, length: int) -> bytes:
+        result = await self._run(
+            self._read_chunk_script(source_path, offset, length), timeout_s=self._config.timeout_s
+        )
+        if result.return_code != 0:
+            raise IdeGymTransferError(
+                f"Reading {length} bytes at offset {offset} of {source_path!r} failed ({_describe(result)})"
+            )
+        try:
+            chunk = base64.b64decode("".join((result.stdout or "").split()), validate=True)
+        except (binascii.Error, ValueError) as e:
+            raise IdeGymTransferError(f"The sandbox returned invalid base64 for {source_path!r}: {e}") from e
+        if len(chunk) != length:
+            raise IdeGymTransferError(
+                f"Expected {length} bytes at offset {offset} of {source_path!r} but got {len(chunk)}"
+            )
+        return chunk

--- a/nemo_gym/sandbox/providers/idegym/transfer.py
+++ b/nemo_gym/sandbox/providers/idegym/transfer.py
@@ -14,15 +14,14 @@
 
 """File transfer in and out of an IdeGYM sandbox, over its bash tool.
 
-IdeGYM's filesystem API is unusable here: its read endpoint streams raw bytes while
-the orchestrator forwards requests as JSON text, and its typed file endpoints only
-write UTF-8. So bytes travel base64-encoded through the bash tool, chunked in both
-directions — uploads to stay inside
-:data:`~nemo_gym.sandbox.providers.idegym.config.MAX_COMMAND_BYTES`, downloads because
-each chunk's stdout is persisted as an async-operation result.
+IdeGYM's filesystem API is unusable here: its read endpoint streams raw bytes while the
+orchestrator forwards requests as JSON text, and its typed file endpoints only write
+UTF-8. So bytes travel base64-encoded through the bash tool, chunked both ways — uploads
+to stay inside :data:`~nemo_gym.sandbox.providers.idegym.config.MAX_COMMAND_BYTES`,
+downloads because each chunk's stdout is persisted as an async-operation result.
 
-Good enough for the config files, patches, and logs a benchmark moves around, but not a
-bulk channel — have the sandbox fetch large inputs itself.
+Fine for the config files, patches, and logs a benchmark moves around, but not a bulk
+channel — have the sandbox fetch large inputs itself.
 """
 
 import asyncio
@@ -41,15 +40,13 @@ from nemo_gym.sandbox.providers.idegym.shell import quote
 
 LOGGER = logging.getLogger(__name__)
 
-# Runs a command in the sandbox. Bound to one sandbox by the provider, so the
-# transfer layer never needs to know about handles or sessions.
+# Runs one command in the sandbox; the provider binds it to a handle.
 ExecRunner = Callable[..., Awaitable[SandboxExecResult]]
 
 
 def _describe(result: SandboxExecResult) -> str:
     detail = (result.stderr or result.stdout or "").strip()
-    suffix = f": {detail}" if detail else ""
-    return f"exit code {result.return_code}{suffix}"
+    return f"exit code {result.return_code}" + (f": {detail}" if detail else "")
 
 
 class Base64BashFileTransfer:
@@ -63,11 +60,10 @@ class Base64BashFileTransfer:
         """Upload one local file, creating its parent directory in the sandbox."""
         data = await asyncio.to_thread(Path(source_path).read_bytes)
         chunk_size = self._config.upload_chunk_bytes
-        # An empty file still needs one (empty) chunk, so the file is created.
+        # An empty file still needs one (empty) chunk, so that it gets created.
         chunks = [data[offset : offset + chunk_size] for offset in range(0, len(data), chunk_size)] or [b""]
         for index, chunk in enumerate(chunks):
-            script = self._write_chunk_script(target_path, chunk, first=index == 0)
-            result = await self._run(script, timeout_s=self._config.timeout_s)
+            result = await self._exec(self._write_chunk_script(target_path, chunk, first=index == 0))
             if result.return_code != 0:
                 raise IdeGymTransferError(
                     f"Uploading {source_path} to {target_path!r} failed on chunk "
@@ -77,59 +73,57 @@ class Base64BashFileTransfer:
     async def download(self, source_path: str, target_path: Path) -> None:
         """Download one sandbox file to ``target_path``."""
         size = await self._remote_size(source_path)
-        max_bytes = self._config.max_download_bytes
-        if max_bytes is not None and size > max_bytes:
+        cap = self._config.max_download_bytes
+        if cap is not None and size > cap:
             raise IdeGymTransferError(
                 f"Refusing to download {source_path!r}: {size} bytes exceeds files.max_download_bytes "
-                f"({max_bytes}). Archive and split it in the sandbox, or raise the limit."
+                f"({cap}). Archive and split it in the sandbox, or raise the limit."
             )
         chunk_size = self._config.download_chunk_bytes
         data = bytearray()
-        # Every chunk asserts its own decoded length, so the concatenation is
-        # complete by construction; a file that shrinks mid-read fails on the chunk
-        # that came back short.
-        for offset in range(0, size, chunk_size) if size else ():
-            length = min(chunk_size, size - offset)
-            data.extend(await self._read_chunk(source_path, offset, length))
-        target_path = Path(target_path)
-        target_path.parent.mkdir(parents=True, exist_ok=True)
-        await asyncio.to_thread(target_path.write_bytes, bytes(data))
+        # Each chunk asserts its own decoded length, so the concatenation needs no
+        # separate check and a file that shrinks mid-read fails on the short chunk.
+        for offset in range(0, size, chunk_size):
+            data.extend(await self._read_chunk(source_path, offset, min(chunk_size, size - offset)))
+        target = Path(target_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(target.write_bytes, bytes(data))
+
+    async def _exec(self, script: str) -> SandboxExecResult:
+        return await self._run(script, timeout_s=self._config.timeout_s)
 
     # --- script construction ----------------------------------------------
 
     def _write_chunk_script(self, target_path: str, chunk: bytes, *, first: bool) -> str:
-        """Decode one base64 chunk into ``target_path``.
+        """Decode one base64 chunk into ``target_path``, appending unless ``first``.
 
-        Each chunk is encoded independently, so appending decoded chunks
-        reconstructs the file byte for byte regardless of chunk alignment.
+        Chunks are encoded independently, so appending the decoded bytes rebuilds the
+        file exactly, whatever the chunk alignment.
         """
-        encoded = base64.b64encode(chunk).decode("ascii")
-        redirect = ">" if first else ">>"
-        lines: list[str] = []
+        lines = []
         if first and (parent := posixpath.dirname(target_path)):
             lines.append(f"mkdir -p {quote(parent)}")
-        # The pipeline's exit code is `base64 -d`'s, which is the failure that
-        # matters: a decode error or a write error both surface through it.
-        lines.append(f"printf '%s' {quote(encoded)} | base64 -d {redirect} {quote(target_path)}")
+        # The pipeline's exit code is `base64 -d`'s, so a decode or write error surfaces.
+        encoded = quote(base64.b64encode(chunk).decode("ascii"))
+        lines.append(f"printf '%s' {encoded} | base64 -d {'>' if first else '>>'} {quote(target_path)}")
         return "\n".join(lines)
 
     def _size_script(self, source_path: str) -> str:
         path = quote(source_path)
-        # `wc -c` over a redirect rather than an argument: a path that starts with a
-        # dash would otherwise be read as an option.
+        # `-f` rejects directories and devices, whose read would never end; the redirect
+        # keeps a leading-dash path from being taken as a `wc` option.
         return f"[ -f {path} ] || {{ printf 'not a regular file\\n' >&2; exit 1; }}\nwc -c < {path}"
 
     def _read_chunk_script(self, source_path: str, offset: int, length: int) -> str:
-        path = quote(source_path)
-        # No `pipefail` on purpose: `head -c` closes the pipe once it has its bytes, so
-        # `tail` normally dies of SIGPIPE and would make a good chunk look failed. The
-        # decoded length check below is the real guard against a short read.
-        return f"tail -c +{offset + 1} < {path} | head -c {length} | base64"
+        # No `pipefail`: `head -c` closes the pipe once it has its bytes, so `tail` dies
+        # of SIGPIPE and would make a good chunk look failed. `_read_chunk` checks the
+        # decoded length instead.
+        return f"tail -c +{offset + 1} < {quote(source_path)} | head -c {length} | base64"
 
     # --- sandbox round trips ----------------------------------------------
 
     async def _remote_size(self, source_path: str) -> int:
-        result = await self._run(self._size_script(source_path), timeout_s=self._config.timeout_s)
+        result = await self._exec(self._size_script(source_path))
         if result.return_code != 0:
             raise IdeGymTransferError(f"Cannot read {source_path!r} from the sandbox ({_describe(result)})")
         text = (result.stdout or "").strip()
@@ -138,19 +132,14 @@ class Base64BashFileTransfer:
         return int(text)
 
     async def _read_chunk(self, source_path: str, offset: int, length: int) -> bytes:
-        result = await self._run(
-            self._read_chunk_script(source_path, offset, length), timeout_s=self._config.timeout_s
-        )
+        what = f"{length} bytes at offset {offset} of {source_path!r}"
+        result = await self._exec(self._read_chunk_script(source_path, offset, length))
         if result.return_code != 0:
-            raise IdeGymTransferError(
-                f"Reading {length} bytes at offset {offset} of {source_path!r} failed ({_describe(result)})"
-            )
+            raise IdeGymTransferError(f"Reading {what} failed ({_describe(result)})")
         try:
             chunk = base64.b64decode("".join((result.stdout or "").split()), validate=True)
         except (binascii.Error, ValueError) as e:
             raise IdeGymTransferError(f"The sandbox returned invalid base64 for {source_path!r}: {e}") from e
         if len(chunk) != length:
-            raise IdeGymTransferError(
-                f"Expected {length} bytes at offset {offset} of {source_path!r} but got {len(chunk)}"
-            )
+            raise IdeGymTransferError(f"Expected {what} but got {len(chunk)}")
         return chunk

--- a/nemo_gym/sandbox/providers/registry.py
+++ b/nemo_gym/sandbox/providers/registry.py
@@ -137,6 +137,12 @@ def _load_opensandbox_provider() -> ProviderClass:
     return OpenSandboxProvider
 
 
+def _load_idegym_provider() -> ProviderClass:
+    from nemo_gym.sandbox.providers.idegym import IdeGymProvider
+
+    return IdeGymProvider
+
+
 def _load_apptainer_provider() -> ProviderClass:
     from nemo_gym.sandbox.providers.apptainer import ApptainerProvider
 
@@ -172,5 +178,6 @@ _BUILTIN_PROVIDER_LOADERS["daytona"] = _load_daytona_provider
 _BUILTIN_PROVIDER_LOADERS["docker"] = _load_docker_provider
 _BUILTIN_PROVIDER_LOADERS["ecs_fargate"] = _load_ecs_fargate_provider
 _BUILTIN_PROVIDER_LOADERS["enroot"] = _load_enroot_provider
+_BUILTIN_PROVIDER_LOADERS["idegym"] = _load_idegym_provider
 _BUILTIN_PROVIDER_LOADERS["opensandbox"] = _load_opensandbox_provider
 _BUILTIN_PROVIDER_LOADERS["openshell"] = _load_openshell_provider

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,6 +288,29 @@ openshell = [
     "openshell>=0.0.92,<0.1",
 ]
 
+# Keep IdeGYM opt-in: it is a third-party control plane, so its SDK should not be
+# pulled into installs that will never talk to one.
+idegym = [
+    # IdeGYM client SDK: used by the IdeGYM sandbox provider for client registration and
+    # server start/exec/stop against an IdeGYM orchestrator. Pulls in idegym-api and
+    # idegym-common-utils (its request/response models and logging helpers).
+    # Lower bound 0.11.1: the first release whose start-server API carries the pod_spec
+    # overrides and max_restarts fields the provider passes through. Upper bound <0.12:
+    # the SDK is pre-1.0, and the provider depends on the shape of its client and server
+    # operation classes; the SDK-conformance unit test guards raising this ceiling.
+    # Updated: Wed Aug 19, 2026 with idegym-client>=0.11.1,<0.12
+    # License: Apache 2.0 https://github.com/JetBrains-Research/idegym/blob/main/LICENSE
+    "idegym-client>=0.11.1,<0.12",
+
+    # httpx-aiohttp: the IdeGYM provider swaps the SDK's httpx transport for this
+    # aiohttp-backed one. Without it the provider falls back to raw httpx, whose
+    # connection pool is O(n^2) at high concurrency. Also in the `sandbox` extra, but
+    # repeated here so `nemo-gym[idegym]` alone is a working install.
+    # Updated: Wed Aug 19, 2026 with httpx-aiohttp>=0.2.0
+    # License: MIT https://github.com/karpetrosyan/httpx-aiohttp/blob/master/LICENSE
+    "httpx-aiohttp>=0.2.0",
+]
+
 # We include dev dependencies as an extra since technically each server module is a consumer (which means we cannot use dependency groups, which are intended to be within a project).
 dev = [
     # gprof2dot: Used for outputting dot graphs for profiling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -295,12 +295,12 @@ idegym = [
     # server start/exec/stop against an IdeGYM orchestrator. Pulls in idegym-api and
     # idegym-common-utils (its request/response models and logging helpers).
     # Lower bound 0.11.1: the first release whose start-server API carries the pod_spec
-    # overrides and max_restarts fields the provider passes through. Upper bound <0.12:
-    # the SDK is pre-1.0, and the provider depends on the shape of its client and server
-    # operation classes; the SDK-conformance unit test guards raising this ceiling.
-    # Updated: Wed Aug 19, 2026 with idegym-client>=0.11.1,<0.12
+    # overrides and max_restarts fields the provider passes through. No upper bound, so
+    # new IdeGYM releases are picked up as they ship; the SDK-conformance unit test is
+    # what catches a change to the client and server operation shapes the provider uses.
+    # Updated: Wed Aug 19, 2026 with idegym-client>=0.11.1
     # License: Apache 2.0 https://github.com/JetBrains-Research/idegym/blob/main/LICENSE
-    "idegym-client>=0.11.1,<0.12",
+    "idegym-client>=0.11.1",
 
     # httpx-aiohttp: the IdeGYM provider swaps the SDK's httpx transport for this
     # aiohttp-backed one. Without it the provider falls back to raw httpx, whose

--- a/responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+++ b/responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
@@ -56,4 +56,3 @@ mini_swe_agent_2:
       eval_timeout: 1800
       skip_if_exists: false
       step_limit: 250
-      datasets: []

--- a/responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+++ b/responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
@@ -56,3 +56,4 @@ mini_swe_agent_2:
       eval_timeout: 1800
       skip_if_exists: false
       step_limit: 250
+      datasets: []

--- a/tests/unit_tests/test_idegym_provider.py
+++ b/tests/unit_tests/test_idegym_provider.py
@@ -41,6 +41,7 @@ from nemo_gym.sandbox.providers.base import (
     SandboxSpec,
     SandboxStatus,
 )
+from nemo_gym.sandbox.providers.idegym import naming as idegym_naming
 from nemo_gym.sandbox.providers.idegym import provider as idegym_provider
 from nemo_gym.sandbox.providers.idegym import session as idegym_session
 from nemo_gym.sandbox.providers.idegym.config import (
@@ -62,7 +63,6 @@ from nemo_gym.sandbox.providers.idegym.errors import (
 from nemo_gym.sandbox.providers.idegym.naming import (
     MAX_CLIENT_NAME_LENGTH,
     generate_server_name,
-    refresh_unique_suffix,
     sanitize_name,
 )
 from nemo_gym.sandbox.providers.idegym.provider import (
@@ -452,12 +452,13 @@ def test_sanitize_and_clamp_names() -> None:
     assert len(long_name) == MAX_CLIENT_NAME_LENGTH
 
 
-def test_generated_server_names_fit_kubernetes_and_stay_unique() -> None:
+def test_generated_server_names_leave_room_for_the_appended_server_id() -> None:
     name = generate_server_name("nemo-gym", ["django__django-11099"])
-    assert name.startswith("nemo-gym-django-django-11099-")
+    assert name == "nemo-gym-django-django-11099"
     # Room must be left for the `-<server_id>` suffix the orchestrator appends.
     assert len(name) + len("-9999999") <= MAX_SERVER_NAME_LENGTH
-    assert generate_server_name("nemo-gym", []) != generate_server_name("nemo-gym", [])
+    # A hint too long for that budget is truncated rather than overflowing it.
+    assert len(generate_server_name("nemo-gym", ["x" * 200])) + len("-9999999") <= MAX_SERVER_NAME_LENGTH
 
 
 def test_generated_server_names_satisfy_rfc1035() -> None:
@@ -473,16 +474,15 @@ def test_generated_server_names_satisfy_rfc1035() -> None:
         assert pattern.match(generate_server_name(prefix, hints)), (prefix, hints)
 
 
-def test_server_name_suffix_must_leave_room_for_a_stem() -> None:
-    with pytest.raises(ValueError, match="no room for a name stem"):
-        generate_server_name("nemo-gym", [], unique_suffix="s" * MAX_SERVER_NAME_LENGTH)
+def test_server_id_reserve_must_leave_room_for_a_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Raising the reserve to the 63-character cap must fail loudly.
 
-
-def test_refresh_unique_suffix_keeps_the_stem() -> None:
-    original = generate_server_name("nemo-gym", ["task-1"])
-    refreshed = refresh_unique_suffix(original)
-    assert refreshed != original
-    assert refreshed.rpartition("-")[0] == original.rpartition("-")[0]
+    The budget is fixed by the length constants, so the alternative to raising is an
+    empty name that Kubernetes then rejects.
+    """
+    monkeypatch.setattr(idegym_naming, "SERVER_ID_SUFFIX_RESERVE", MAX_SERVER_NAME_LENGTH)
+    with pytest.raises(ValueError, match="leaves no room for a name"):
+        generate_server_name("nemo-gym", [])
 
 
 # --- spec translation ------------------------------------------------------
@@ -498,7 +498,7 @@ def test_translate_maps_resources_to_limits_and_requests() -> None:
         "requests": {"cpu": "500m", "memory": "2048Mi"},
         "limits": {"cpu": "2", "memory": "8192Mi", "ephemeral-storage": "30Gi"},
     }
-    assert request["server_name"].startswith("nemo-gym-task-9-")
+    assert request["server_name"] == "nemo-gym-task-9"
     assert request["reuse_strategy"] == "NONE"
 
 
@@ -654,7 +654,10 @@ async def test_create_can_skip_the_probe_entirely(make_provider, fake_session: F
     assert fake_session.bash_calls == []
 
 
-async def test_create_retries_transient_failures_with_a_fresh_name(make_provider, fake_session: FakeSession) -> None:
+async def test_create_retries_transient_failures_keeping_the_generated_name(
+    make_provider, fake_session: FakeSession
+) -> None:
+    """Renaming would defeat a RESTART/RESET reuse strategy, which matches on the name."""
     fake_session.start_results = [
         orchestrator_error(429),
         IdeGymServerRef(server_id=9, server_name="nemo-gym-second", namespace="idegym"),
@@ -663,8 +666,7 @@ async def test_create_retries_transient_failures_with_a_fresh_name(make_provider
     handle = await provider.create(spec())
     assert handle.sandbox_id == "9"
     first, second = (call["request"]["server_name"] for call in fake_session.start_calls)
-    assert first != second
-    assert first.rpartition("-")[0] == second.rpartition("-")[0]
+    assert first == second
 
 
 async def test_create_keeps_a_pinned_name_across_retries(make_provider, fake_session: FakeSession) -> None:
@@ -817,13 +819,26 @@ async def test_exec_user_request_warns_once(
 
 @pytest.mark.parametrize(
     ("mode", "expected"),
-    [("runuser", "exec runuser -u tester -- bash -c"), ("su", "exec su tester -c")],
+    [("runuser", "exec runuser -u tester -- bash -c"), ("su", "exec su -s /bin/bash -c")],
 )
 def test_user_switch_modes_wrap_the_script(mode: str, expected: str) -> None:
+    """Both modes pin bash: a service account's login shell may be /sbin/nologin."""
     builder = BashScriptBuilder(IdeGymExecConfig(user_mode=mode))
     script = builder.build("true", cwd="/w", user="tester")
     assert expected in script
+    assert "tester" in script
     assert "cd -- /w" in script
+
+
+@requires_bash
+@pytest.mark.parametrize("mode", ["runuser", "su"])
+def test_a_user_switched_script_is_valid_bash(mode: str) -> None:
+    """The wrap nests two levels of quoting, which a substring assertion cannot check."""
+    script = BashScriptBuilder(IdeGymExecConfig(user_mode=mode)).build(
+        "echo hi && ls 'a b'", cwd="/testbed", env={"FOO": "a b"}, user="tester"
+    )
+    completed = subprocess.run(["bash", "-n", "-c", script], capture_output=True, text=True, check=False)
+    assert completed.returncode == 0, completed.stderr
 
 
 @pytest.mark.parametrize("mode", ["runuser", "su"])

--- a/tests/unit_tests/test_idegym_provider.py
+++ b/tests/unit_tests/test_idegym_provider.py
@@ -507,7 +507,7 @@ def test_translate_passes_pod_shape_options_through() -> None:
             {
                 "runtime_class_name": "gvisor",
                 "node_selector": {"pool": "sandbox"},
-                "volumes": [{"name": "creds", "secret": {"secretName": "creds"}}],
+                "volumes": [{"name": "creds", "secret": {"secretName": "creds"}}],  # pragma: allowlist secret
                 "volume_mounts": [{"name": "creds", "mountPath": "/etc/creds"}],
                 "env_from": [{"secretRef": {"name": "creds"}}],
                 "service_account_name": "runner",
@@ -526,7 +526,7 @@ def test_translate_passes_pod_shape_options_through() -> None:
     assert request["server_name"] == "pinned-name"
     assert request["runtime_class_name"] == "gvisor"
     assert request["node_selector"] == {"pool": "sandbox"}
-    assert request["volumes"] == [{"name": "creds", "secret": {"secretName": "creds"}}]
+    assert request["volumes"] == [{"name": "creds", "secret": {"secretName": "creds"}}]  # pragma: allowlist secret
     assert request["env_from"] == [{"secretRef": {"name": "creds"}}]
     assert request["pod_overrides"]["tolerations"][0]["key"] == "dedicated"
     assert request["snapshot"] == {"id": "17"}

--- a/tests/unit_tests/test_idegym_provider.py
+++ b/tests/unit_tests/test_idegym_provider.py
@@ -28,6 +28,7 @@ import builtins
 import inspect
 import shutil
 import subprocess
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -98,8 +99,9 @@ def forward_error(status: int, body: str) -> RuntimeError:
 class FakeSession:
     """Stands in for ``IdeGymSession``; records calls and replays queued results.
 
-    A queued ``Exception`` is raised instead of returned, and the last queued entry
-    repeats, so a test only has to queue the interesting prefix.
+    A queued ``BaseException`` is raised instead of returned -- ``BaseException`` so a
+    test can inject cancellation -- and the last queued entry repeats, so a test only
+    has to queue the interesting prefix.
     """
 
     def __init__(self) -> None:
@@ -121,7 +123,7 @@ class FakeSession:
     @staticmethod
     def _next(queue: list[Any]) -> Any:
         result = queue.pop(0) if len(queue) > 1 else queue[0]
-        if isinstance(result, Exception):
+        if isinstance(result, BaseException):
             raise result
         return result
 
@@ -218,7 +220,6 @@ def make_provider(monkeypatch: pytest.MonkeyPatch, fake_session: FakeSession):
         monkeypatch.setattr(idegym_provider, "release_session", fake_release)
         kwargs: dict[str, Any] = {
             "create": {"retry_delay_s": 0.0, "retry_max_delay_s": 0.0, "ready_timeout_s": 30},
-            "probe": {"stable_delay_s": 0.0, "deadline_s": 0.2},
             "operations": {"retry_delay_s": 0.0, "retry_max_delay_s": 0.0, "close_timeout_s": 5.0},
         }
         for key, value in overrides.items():
@@ -352,11 +353,7 @@ def test_provider_binds_the_session_api_it_calls() -> None:
         ("exec", {"graceful_termination_timeout_s": -1}),
         ("exec", {"request_overhead_s": -1}),
         ("exec", {"user_mode": "sudo"}),
-        ("probe", {"timeout_s": 0}),
-        ("probe", {"command": None, "timeout_s": 0}),
-        ("probe", {"deadline_s": 0}),
-        ("probe", {"stable_count": 0}),
-        ("probe", {"stable_delay_s": -1}),
+        ("verify", {"timeout_s": 0}),
         ("files", {"upload_chunk_bytes": 0}),
         ("files", {"upload_chunk_bytes": MAX_UPLOAD_CHUNK_BYTES + 1}),
         ("files", {"download_chunk_bytes": 0}),
@@ -574,7 +571,9 @@ def test_translate_rejects_non_positive_resources(value: int) -> None:
 # --- create ----------------------------------------------------------------
 
 
-async def test_create_starts_probes_and_returns_a_ready_handle(make_provider, fake_session: FakeSession) -> None:
+async def test_create_verifies_the_workdir_and_returns_a_ready_handle(
+    make_provider, fake_session: FakeSession
+) -> None:
     provider = make_provider()
     handle = await provider.create(
         spec(workdir="/testbed", env={"FOO": "bar"}, ready_timeout_s=99, metadata={"instance_id": "task-1"})
@@ -584,12 +583,11 @@ async def test_create_starts_probes_and_returns_a_ready_handle(make_provider, fa
     assert handle.raw.workdir == "/testbed"
     assert handle.raw.env == {"FOO": "bar"}
     assert fake_session.start_calls[0]["timeout_s"] == pytest.approx(99, abs=1)
-    # The retrying probe runs first, so a server that is merely still warming up is
-    # not misreported as a mis-set workdir. The workdir check must not `cd` into the
-    # directory it is verifying.
-    assert "printf idegym-sandbox-ready" in fake_session.bash_calls[0]["script"]
-    assert "[ -d /testbed ]" in fake_session.bash_calls[1]["script"]
-    assert "cd -- /testbed" not in fake_session.bash_calls[1]["script"]
+    # IdeGYM already waited for pod readiness, so the workdir check is the only
+    # command create runs -- and it must not `cd` into the directory it is verifying.
+    assert len(fake_session.bash_calls) == 1
+    assert "[ -d /testbed ]" in fake_session.bash_calls[0]["script"]
+    assert "cd -- /testbed" not in fake_session.bash_calls[0]["script"]
 
 
 async def test_create_falls_back_to_configured_ready_timeout(make_provider, fake_session: FakeSession) -> None:
@@ -598,59 +596,39 @@ async def test_create_falls_back_to_configured_ready_timeout(make_provider, fake
     assert fake_session.start_calls[0]["timeout_s"] == pytest.approx(45, abs=1)
 
 
-async def test_create_waits_for_the_probe_to_stabilize(make_provider, fake_session: FakeSession) -> None:
-    fake_session.bash_results = [
-        IdeGymBashResult(stdout="", stderr="not up yet", exit_code=1),
-        IdeGymBashResult(stdout="idegym-sandbox-ready", stderr="", exit_code=0),
-    ]
-    provider = make_provider(probe={"stable_count": 2})
-    await provider.create(spec())
-    assert len(fake_session.bash_calls) == 3
-
-
-async def test_create_probe_failure_stops_the_server(make_provider, fake_session: FakeSession) -> None:
-    fake_session.bash_results = [IdeGymBashResult(stdout="", stderr="broken", exit_code=1)]
+async def test_create_fails_when_the_workdir_is_unusable(
+    make_provider, fake_session: FakeSession, caplog: pytest.LogCaptureFixture
+) -> None:
+    fake_session.bash_results = [IdeGymBashResult(stdout="", stderr="", exit_code=1)]
     provider = make_provider()
-    with pytest.raises(SandboxCreateVerificationError, match="did not pass its readiness probe"):
-        await provider.create(spec())
-    assert fake_session.stop_calls == [{"server_id": 7, "timeout_s": 5.0}]
-
-
-async def test_create_probe_backs_off_between_attempts(make_provider, fake_session: FakeSession) -> None:
-    """A remote orchestrator must not be hammered for the whole probe deadline."""
-    fake_session.bash_results = [
-        IdeGymBashResult(stdout="", stderr="not up yet", exit_code=1),
-        IdeGymBashResult(stdout="idegym-sandbox-ready", stderr="", exit_code=0),
-    ]
-    provider = make_provider(probe={"stable_delay_s": 0.02, "deadline_s": 5.0})
-    started = asyncio.get_running_loop().time()
-    await provider.create(spec())
-    assert asyncio.get_running_loop().time() - started >= 0.02
-    assert len(fake_session.bash_calls) == 2
-
-
-async def test_create_probe_without_deadline_fails_on_first_miss(make_provider, fake_session: FakeSession) -> None:
-    fake_session.bash_results = [IdeGymBashResult(stdout="", stderr="broken", exit_code=1)]
-    provider = make_provider(probe={"deadline_s": None})
-    with pytest.raises(SandboxCreateVerificationError, match="failed its readiness probe"):
-        await provider.create(spec())
-
-
-async def test_create_fails_when_the_workdir_is_unusable(make_provider, fake_session: FakeSession) -> None:
-    fake_session.bash_results = [
-        IdeGymBashResult(stdout="idegym-sandbox-ready", stderr="", exit_code=0),
-        IdeGymBashResult(stdout="", stderr="", exit_code=1),
-    ]
-    provider = make_provider()
-    with pytest.raises(SandboxCreateVerificationError, match="is not usable in the IdeGYM sandbox"):
+    with caplog.at_level("WARNING"), pytest.raises(SandboxCreateVerificationError, match="is not usable"):
         await provider.create(spec(workdir="/nope"))
-    assert len(fake_session.bash_calls) == 2
+    assert len(fake_session.bash_calls) == 1
+    assert fake_session.stop_calls == [{"server_id": 7, "timeout_s": 5.0}]
+    # Nothing else records that a pod was started and thrown away.
+    assert "Tearing down the IdeGYM sandbox" in caplog.text
+
+
+async def test_create_logs_the_teardown_when_it_is_cancelled(
+    make_provider, fake_session: FakeSession, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A cancelled create still tears down a live pod, and CancelledError says nothing."""
+    fake_session.bash_results = [asyncio.CancelledError()]
+    provider = make_provider()
+    with caplog.at_level("WARNING"), pytest.raises(asyncio.CancelledError):
+        await provider.create(spec(workdir="/testbed"))
+    assert "Tearing down the IdeGYM sandbox" in caplog.text
+    assert "CancelledError" in caplog.text
     assert fake_session.stop_calls
 
 
-async def test_create_can_skip_the_probe_entirely(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None, "verify_workdir": False})
+async def test_create_runs_no_command_when_there_is_no_workdir_to_check(
+    make_provider, fake_session: FakeSession
+) -> None:
+    provider = make_provider(verify={"check_workdir": False})
     await provider.create(spec(workdir="/testbed"))
+    assert fake_session.bash_calls == []
+    await provider.create(spec())
     assert fake_session.bash_calls == []
 
 
@@ -725,7 +703,7 @@ async def test_create_teardown_failure_only_warns(
     fake_session.stop_results = [orchestrator_error(500)]
     provider = make_provider()
     with caplog.at_level("WARNING"), pytest.raises(SandboxCreateVerificationError):
-        await provider.create(spec())
+        await provider.create(spec(workdir="/nope"))
     assert "may be left running on the cluster" in caplog.text
 
 
@@ -733,7 +711,7 @@ async def test_create_teardown_failure_only_warns(
 
 
 async def test_exec_shapes_the_script_and_the_timeouts(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None, "verify_workdir": False})
+    provider = make_provider(verify={"check_workdir": False})
     handle = await provider.create(spec(workdir="/testbed", env={"CONDA_ENV": "testbed"}))
     fake_session.bash_results = [IdeGymBashResult(stdout="out", stderr="err", exit_code=3)]
     # A value needing quoting proves the export is shell-safe; the call's env is
@@ -751,21 +729,21 @@ async def test_exec_shapes_the_script_and_the_timeouts(make_provider, fake_sessi
 
 
 async def test_exec_cwd_argument_overrides_the_sandbox_workdir(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None, "verify_workdir": False})
+    provider = make_provider(verify={"check_workdir": False})
     handle = await provider.create(spec(workdir="/testbed"))
     await provider.exec(handle, "true", cwd="/other")
     assert "cd -- /other" in fake_session.bash_calls[-1]["script"]
 
 
 async def test_exec_without_timeout_uses_a_finite_ceiling(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None}, exec={"default_timeout_s": None})
+    provider = make_provider(exec={"default_timeout_s": None})
     handle = await provider.create(spec())
     await provider.exec(handle, "true")
     assert fake_session.bash_calls[-1]["command_timeout_s"] == NO_TIMEOUT_COMMAND_SECONDS
 
 
 async def test_exec_reports_a_sandbox_side_timeout(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     handle = await provider.create(spec())
     fake_session.bash_results = [forward_error(500, "Command execution timed out after 5 seconds")]
     result = await provider.exec(handle, "sleep 100", timeout_s=5)
@@ -774,7 +752,7 @@ async def test_exec_reports_a_sandbox_side_timeout(make_provider, fake_session: 
 
 
 async def test_exec_on_a_deleted_sandbox_marks_it_stopped(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     handle = await provider.create(spec())
     fake_session.bash_results = [orchestrator_error(410, "gone")]
     result = await provider.exec(handle, "true")
@@ -787,16 +765,22 @@ async def test_exec_on_a_deleted_sandbox_marks_it_stopped(make_provider, fake_se
     assert len(fake_session.bash_calls) == calls_before
 
 
-async def test_exec_other_failures_are_reported_not_raised(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None})
+async def test_exec_other_failures_are_reported_not_raised(
+    make_provider, fake_session: FakeSession, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An unclassified failure becomes a return value, so the log is the only traceback."""
+    provider = make_provider()
     handle = await provider.create(spec())
     fake_session.bash_results = [orchestrator_error(500, "kaboom")]
-    result = await provider.exec(handle, "true")
+    with caplog.at_level("WARNING"):
+        result = await provider.exec(handle, "true")
     assert (result.error_type, result.return_code) == ("sandbox", SANDBOX_RUNTIME_RETURN_CODE)
+    assert "failed to run the command" in caplog.text
+    assert "Traceback" in caplog.text
 
 
 async def test_exec_reports_an_undeliverable_command_instead_of_raising(make_provider) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     handle = await provider.create(spec())
     too_long = await provider.exec(handle, "echo " + "x" * MAX_COMMAND_BYTES)
     assert too_long.error_type == "command_too_long"
@@ -808,7 +792,7 @@ async def test_exec_reports_an_undeliverable_command_instead_of_raising(make_pro
 async def test_exec_user_request_warns_once(
     make_provider, fake_session: FakeSession, caplog: pytest.LogCaptureFixture
 ) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     handle = await provider.create(spec())
     with caplog.at_level("WARNING"):
         await provider.exec(handle, "true", user="root")
@@ -914,7 +898,7 @@ async def test_file_transfer_round_trips_binary_content(make_provider, tmp_path:
     # under test rather than a single-chunk shortcut.
     provider = make_provider(
         session,
-        probe={"command": None, "verify_workdir": False},
+        verify={"check_workdir": False},
         files={"upload_chunk_bytes": 100, "download_chunk_bytes": 60},
     )
     remote = tmp_path / "sandbox"
@@ -934,7 +918,7 @@ async def test_file_transfer_round_trips_binary_content(make_provider, tmp_path:
 
 @requires_bash
 async def test_file_transfer_handles_empty_files_and_odd_names(make_provider, tmp_path: Path) -> None:
-    provider = make_provider(LocalBashSession(), probe={"command": None, "verify_workdir": False})
+    provider = make_provider(LocalBashSession(), verify={"check_workdir": False})
     handle = await provider.create(spec())
     empty = tmp_path / "empty"
     empty.write_bytes(b"")
@@ -948,7 +932,7 @@ async def test_file_transfer_handles_empty_files_and_odd_names(make_provider, tm
 
 @requires_bash
 async def test_upload_resolves_relative_paths_against_the_workdir(make_provider, tmp_path: Path) -> None:
-    provider = make_provider(LocalBashSession(), probe={"command": None, "verify_workdir": False})
+    provider = make_provider(LocalBashSession(), verify={"check_workdir": False})
     handle = await provider.create(spec(workdir=str(tmp_path)))
     source = tmp_path / "src.txt"
     source.write_text("hello\n")
@@ -958,7 +942,7 @@ async def test_upload_resolves_relative_paths_against_the_workdir(make_provider,
 
 @requires_bash
 async def test_download_of_a_missing_file_raises(make_provider, tmp_path: Path) -> None:
-    provider = make_provider(LocalBashSession(), probe={"command": None, "verify_workdir": False})
+    provider = make_provider(LocalBashSession(), verify={"check_workdir": False})
     handle = await provider.create(spec())
     with pytest.raises(idegym_provider.IdeGymOperationError, match="Cannot read"):
         await provider.download_file(handle, str(tmp_path / "nope"), tmp_path / "out")
@@ -966,9 +950,7 @@ async def test_download_of_a_missing_file_raises(make_provider, tmp_path: Path) 
 
 @requires_bash
 async def test_download_refuses_files_over_the_configured_cap(make_provider, tmp_path: Path) -> None:
-    provider = make_provider(
-        LocalBashSession(), probe={"command": None, "verify_workdir": False}, files={"max_download_bytes": 8}
-    )
+    provider = make_provider(LocalBashSession(), verify={"check_workdir": False}, files={"max_download_bytes": 8})
     handle = await provider.create(spec())
     big = tmp_path / "big.bin"
     big.write_bytes(b"x" * 64)
@@ -979,7 +961,7 @@ async def test_download_refuses_files_over_the_configured_cap(make_provider, tmp
 async def test_upload_failure_reports_the_failing_chunk(
     make_provider, fake_session: FakeSession, tmp_path: Path
 ) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     handle = await provider.create(spec())
     source = tmp_path / "src.bin"
     source.write_bytes(b"abcdefghij")
@@ -990,7 +972,7 @@ async def test_upload_failure_reports_the_failing_chunk(
 
 async def test_upload_failure_names_a_later_chunk(make_provider, fake_session: FakeSession, tmp_path: Path) -> None:
     """The reported index counts chunks, and a later chunk must still be attempted."""
-    provider = make_provider(probe={"command": None}, files={"upload_chunk_bytes": 4})
+    provider = make_provider(files={"upload_chunk_bytes": 4})
     handle = await provider.create(spec())
     source = tmp_path / "src.bin"
     source.write_bytes(b"abcdefghij")
@@ -1007,7 +989,7 @@ async def test_download_without_a_cap_is_uncapped(make_provider, tmp_path: Path)
     """`max_download_bytes: null` disables the check rather than comparing against None."""
     provider = make_provider(
         LocalBashSession(),
-        probe={"command": None, "verify_workdir": False},
+        verify={"check_workdir": False},
         files={"max_download_bytes": None, "download_chunk_bytes": 16},
     )
     handle = await provider.create(spec())
@@ -1022,7 +1004,7 @@ async def test_download_without_a_cap_is_uncapped(make_provider, tmp_path: Path)
 async def test_download_rejects_unparsable_size_and_bad_base64(
     make_provider, fake_session: FakeSession, tmp_path: Path
 ) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     handle = await provider.create(spec())
     fake_session.bash_results = [IdeGymBashResult(stdout="not-a-number", stderr="", exit_code=0)]
     with pytest.raises(idegym_provider.IdeGymOperationError, match="unparsable size"):
@@ -1039,7 +1021,7 @@ async def test_download_rejects_unparsable_size_and_bad_base64(
 async def test_download_chunk_failure_names_the_offset(
     make_provider, fake_session: FakeSession, tmp_path: Path
 ) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     handle = await provider.create(spec())
     fake_session.bash_results = [
         IdeGymBashResult(stdout="16", stderr="", exit_code=0),
@@ -1052,7 +1034,7 @@ async def test_download_chunk_failure_names_the_offset(
 async def test_download_short_read_is_detected(make_provider, fake_session: FakeSession, tmp_path: Path) -> None:
     import base64
 
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     handle = await provider.create(spec())
     fake_session.bash_results = [
         IdeGymBashResult(stdout="8", stderr="", exit_code=0),
@@ -1066,7 +1048,7 @@ async def test_download_short_read_is_detected(make_provider, fake_session: Fake
 
 
 async def test_status_running_stopped_and_unknown(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     handle = await provider.create(spec())
     assert await provider.status(handle) is SandboxStatus.RUNNING
 
@@ -1078,7 +1060,7 @@ async def test_status_running_stopped_and_unknown(make_provider, fake_session: F
 
 
 async def test_status_of_a_closed_sandbox_is_stopped(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     handle = await provider.create(spec())
     await provider.close(handle)
     assert await provider.status(handle) is SandboxStatus.STOPPED
@@ -1089,7 +1071,7 @@ async def test_status_of_a_closed_sandbox_is_stopped(make_provider, fake_session
 
 
 async def test_close_is_idempotent(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     handle = await provider.create(spec())
     await provider.close(handle)
     await provider.close(handle)
@@ -1097,14 +1079,14 @@ async def test_close_is_idempotent(make_provider, fake_session: FakeSession) -> 
 
 
 async def test_close_treats_an_already_gone_server_as_success(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     handle = await provider.create(spec())
     fake_session.stop_results = [orchestrator_error(404)]
     await provider.close(handle)
 
 
 async def test_close_treats_a_server_the_session_forgot_as_success(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     handle = await provider.create(spec())
     fake_session.live_servers.clear()
     await provider.close(handle)
@@ -1118,7 +1100,7 @@ async def test_a_failed_stop_can_be_retried_against_the_same_server(make_provide
     after a failure reaches the same pod rather than an "already stopped" answer that
     would leave it running.
     """
-    provider = make_provider(probe={"command": None}, operations={"retries": 0})
+    provider = make_provider(operations={"retries": 0})
     handle = await provider.create(spec())
     fake_session.stop_results = [orchestrator_error(500), None]
     with pytest.raises(IdeGymOperationError):
@@ -1130,7 +1112,7 @@ async def test_a_failed_stop_can_be_retried_against_the_same_server(make_provide
 
 
 async def test_close_retries_then_raises_and_keeps_the_sandbox_live(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None}, operations={"retries": 2})
+    provider = make_provider(operations={"retries": 2})
     handle = await provider.create(spec())
     fake_session.stop_results = [orchestrator_error(500)]
     with pytest.raises(IdeGymOperationError, match="Failed to stop IdeGYM sandbox"):
@@ -1143,7 +1125,7 @@ async def test_close_retries_then_raises_and_keeps_the_sandbox_live(make_provide
 
 
 async def test_close_succeeds_after_a_transient_failure(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     handle = await provider.create(spec())
     fake_session.stop_results = [orchestrator_error(503), None]
     await provider.close(handle)
@@ -1151,7 +1133,7 @@ async def test_close_succeeds_after_a_transient_failure(make_provider, fake_sess
 
 
 async def test_aclose_releases_the_session_once(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     await provider.create(spec())
     await provider.aclose()
     await provider.aclose()
@@ -1173,6 +1155,66 @@ async def test_health_reports_the_orchestrator_status(make_provider, fake_sessio
 
 
 async def test_the_session_is_acquired_only_once(make_provider, fake_session: FakeSession) -> None:
-    provider = make_provider(probe={"command": None})
+    provider = make_provider()
     first, second = await asyncio.gather(provider.session(), provider.session())
     assert first is second is fake_session
+
+
+async def test_a_racing_acquire_hands_back_its_surplus_reference(
+    make_provider, fake_session: FakeSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without a lock held across the await, two callers can both acquire.
+
+    ``acquire_session`` refcounts, so the loser must release or the shared client is
+    never unregistered and its pods outlive the run.
+    """
+    provider = make_provider()
+    acquired = 0
+
+    async def slow_acquire(connection: Any, attribution: Any) -> Any:
+        nonlocal acquired
+        acquired += 1
+        await asyncio.sleep(0)  # let the other caller past the "already set?" check
+        return fake_session
+
+    monkeypatch.setattr(idegym_provider, "acquire_session", slow_acquire)
+    first, second = await asyncio.gather(provider.session(), provider.session())
+    assert first is second is fake_session
+    assert acquired == 2
+    assert provider.released == [fake_session]
+
+
+def test_the_session_survives_being_reached_from_two_event_loops(
+    make_provider, fake_session: FakeSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The sync Sandbox facade runs each sandbox on its own loop.
+
+    Two of them sharing one provider is legal -- ``AsyncSandbox`` takes a provider
+    instance -- and an ``asyncio.Lock`` here deadlocks the second loop: the release runs
+    on the first loop while the waiter's future belongs to the second. The slow acquire
+    is what forces that overlap; without it the lock is never contended.
+    """
+    provider = make_provider()
+    started = threading.Event()
+
+    async def slow_acquire(connection: Any, attribution: Any) -> Any:
+        started.set()
+        await asyncio.sleep(0.5)
+        return fake_session
+
+    # After make_provider(), which patches acquire_session itself.
+    monkeypatch.setattr(idegym_provider, "acquire_session", slow_acquire)
+    seen: list[Any] = []
+
+    def use() -> None:
+        seen.append(asyncio.run(provider.session()))
+
+    first = threading.Thread(target=use, daemon=True)
+    first.start()
+    assert started.wait(5), "the first loop never reached acquire_session"
+    second = threading.Thread(target=use, daemon=True)
+    second.start()
+    for thread in (first, second):
+        thread.join(10)
+    assert [first.is_alive(), second.is_alive()] == [False, False], "a loop deadlocked on the session lock"
+    assert seen == [fake_session, fake_session]

--- a/tests/unit_tests/test_idegym_provider.py
+++ b/tests/unit_tests/test_idegym_provider.py
@@ -1,0 +1,1132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the IdeGYM sandbox provider.
+
+The provider is exercised against a fake :class:`IdeGymSession`, which is the
+provider's whole view of IdeGYM. Two things keep that fake honest: a signature
+test that binds the provider's session call shapes against the real class, and a
+``bash``-backed session that runs the generated scripts for real, so the parts
+most likely to be wrong -- the shell quoting, the ``cd``, the base64 chunking --
+are tested by executing them rather than by comparing strings.
+"""
+
+import asyncio
+import builtins
+import inspect
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from nemo_gym.sandbox.providers.base import (
+    SandboxCreateError,
+    SandboxCreateVerificationError,
+    SandboxExecResult,
+    SandboxHandle,
+    SandboxSpec,
+    SandboxStatus,
+)
+from nemo_gym.sandbox.providers.idegym import provider as idegym_provider
+from nemo_gym.sandbox.providers.idegym import session as idegym_session
+from nemo_gym.sandbox.providers.idegym.config import (
+    MAX_COMMAND_BYTES,
+    MAX_UPLOAD_CHUNK_BYTES,
+    IdeGymConnectionConfig,
+    IdeGymExecConfig,
+    IdeGymFilesConfig,
+)
+from nemo_gym.sandbox.providers.idegym.errors import (
+    IdeGymCommandTooLongError,
+    IdeGymOperationError,
+    IdeGymUnknownServerError,
+    is_command_timeout,
+    is_retryable,
+    is_sandbox_gone,
+    orchestrator_status,
+)
+from nemo_gym.sandbox.providers.idegym.naming import (
+    MAX_CLIENT_NAME_LENGTH,
+    generate_server_name,
+    refresh_unique_suffix,
+    sanitize_name,
+)
+from nemo_gym.sandbox.providers.idegym.provider import (
+    NO_TIMEOUT_COMMAND_SECONDS,
+    SANDBOX_RUNTIME_RETURN_CODE,
+    IdeGymProvider,
+    _IdeGymSandbox,
+)
+from nemo_gym.sandbox.providers.idegym.session import IdeGymBashResult, IdeGymServerRef
+from nemo_gym.sandbox.providers.idegym.shell import BashScriptBuilder
+from nemo_gym.sandbox.providers.idegym.spec import IdeGymProviderOptions, ServerRequestTranslator
+from nemo_gym.sandbox.providers.idegym.transfer import Base64BashFileTransfer
+from nemo_gym.sandbox.providers.registry import get_provider_class
+
+
+pytestmark = pytest.mark.sandbox
+
+MAX_SERVER_NAME_LENGTH = 63
+
+requires_bash = pytest.mark.skipif(shutil.which("bash") is None, reason="bash is not available")
+
+
+def orchestrator_error(status: int, body: str = "boom") -> RuntimeError:
+    """An error shaped like the IdeGYM SDK's request failures."""
+    return RuntimeError(f"Request failed: url=/api/idegym-servers status={status} reason='x' data='{body}'")
+
+
+def forward_error(status: int, body: str) -> RuntimeError:
+    """An error shaped like the SDK's relayed orchestrator error responses."""
+    return RuntimeError(f"Failed to forward request POST /api/x: {{'status_code': {status}, 'body': '{body}'}}")
+
+
+class FakeSession:
+    """Stands in for ``IdeGymSession``; records calls and replays queued results.
+
+    A queued ``Exception`` is raised instead of returned, and the last queued entry
+    repeats, so a test only has to queue the interesting prefix.
+    """
+
+    def __init__(self) -> None:
+        self.client_name = "nemo-gym-test"
+        self.start_calls: list[dict[str, Any]] = []
+        self.bash_calls: list[dict[str, Any]] = []
+        self.capability_calls: list[int] = []
+        self.stop_calls: list[dict[str, Any]] = []
+        self.health_calls = 0
+        self.live_servers: set[int] = set()
+        self.start_results: list[Any] = [
+            IdeGymServerRef(server_id=7, server_name="nemo-gym-abcdef12", namespace="idegym")
+        ]
+        self.bash_results: list[Any] = [IdeGymBashResult(stdout="idegym-sandbox-ready", stderr="", exit_code=0)]
+        self.capability_results: list[Any] = [["tools"]]
+        self.stop_results: list[Any] = [None]
+        self.health_results: list[Any] = ["healthy"]
+
+    @staticmethod
+    def _next(queue: list[Any]) -> Any:
+        result = queue.pop(0) if len(queue) > 1 else queue[0]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    async def health(self) -> str:
+        self.health_calls += 1
+        return self._next(self.health_results)
+
+    async def start_server(self, request: Any, *, polling: Any, timeout_s: float) -> Any:
+        self.start_calls.append({"request": dict(request), "polling": polling, "timeout_s": timeout_s})
+        ref = self._next(self.start_results)
+        self.live_servers.add(ref.server_id)
+        return ref
+
+    async def execute_bash(
+        self,
+        server_id: int,
+        script: str,
+        *,
+        command_timeout_s: float,
+        graceful_termination_timeout_s: float,
+        request_timeout_s: float,
+        polling: Any,
+    ) -> Any:
+        self.bash_calls.append(
+            {
+                "server_id": server_id,
+                "script": script,
+                "command_timeout_s": command_timeout_s,
+                "graceful_termination_timeout_s": graceful_termination_timeout_s,
+                "request_timeout_s": request_timeout_s,
+            }
+        )
+        return self._next(self.bash_results)
+
+    async def list_capabilities(self, server_id: int) -> Any:
+        self.capability_calls.append(server_id)
+        return self._next(self.capability_results)
+
+    async def stop_server(self, server_id: int, *, polling: Any, timeout_s: float) -> Any:
+        self.stop_calls.append({"server_id": server_id, "timeout_s": timeout_s})
+        # Faithful to the real session's bookkeeping: a server is forgotten only once it
+        # is actually stopped, so a retry after a failed stop still addresses it, and
+        # only a genuinely unknown id raises IdeGymUnknownServerError.
+        if server_id not in self.live_servers:
+            raise IdeGymUnknownServerError(f"IdeGYM server {server_id} is not held by this session")
+        result = self._next(self.stop_results)
+        self.live_servers.discard(server_id)
+        return result
+
+
+class LocalBashSession(FakeSession):
+    """A fake session that actually runs the generated scripts with local ``bash``.
+
+    Mirrors the parts of IdeGYM's executor that the generated scripts depend on:
+    a fresh ``bash -c`` per call, and stdout/stderr stripped on the way back.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.scripts: list[str] = []
+
+    async def execute_bash(self, server_id: int, script: str, **kwargs: Any) -> Any:
+        self.scripts.append(script)
+        completed = await asyncio.to_thread(
+            subprocess.run, ["bash", "-c", script], capture_output=True, text=True, check=False
+        )
+        return IdeGymBashResult(
+            stdout=completed.stdout.strip(),
+            stderr=completed.stderr.strip(),
+            exit_code=completed.returncode,
+        )
+
+
+@pytest.fixture
+def fake_session() -> FakeSession:
+    return FakeSession()
+
+
+@pytest.fixture
+def make_provider(monkeypatch: pytest.MonkeyPatch, fake_session: FakeSession):
+    """Build a provider whose session is the fake, with test-speed timings."""
+    released: list[Any] = []
+
+    def factory(session: Any = None, **overrides: Any) -> IdeGymProvider:
+        target = session if session is not None else fake_session
+
+        async def fake_acquire(connection: Any, attribution: Any) -> Any:
+            return target
+
+        async def fake_release(released_session: Any) -> None:
+            released.append(released_session)
+
+        monkeypatch.setattr(idegym_provider, "acquire_session", fake_acquire)
+        monkeypatch.setattr(idegym_provider, "release_session", fake_release)
+        kwargs: dict[str, Any] = {
+            "create": {"retry_delay_s": 0.0, "retry_max_delay_s": 0.0, "ready_timeout_s": 30},
+            "probe": {"stable_delay_s": 0.0, "deadline_s": 0.2},
+            "operations": {"retry_delay_s": 0.0, "retry_max_delay_s": 0.0, "close_timeout_s": 5.0},
+        }
+        for key, value in overrides.items():
+            if isinstance(value, dict) and isinstance(kwargs.get(key), dict):
+                kwargs[key] = {**kwargs[key], **value}
+            else:
+                kwargs[key] = value
+        provider = IdeGymProvider(**kwargs)
+        provider.released = released  # type: ignore[attr-defined]
+        return provider
+
+    return factory
+
+
+def make_handle(
+    *,
+    server_id: int = 7,
+    workdir: str | None = None,
+    env: dict[str, str] | None = None,
+    stopped: bool = False,
+) -> SandboxHandle:
+    return SandboxHandle(
+        sandbox_id=str(server_id),
+        provider_name="idegym",
+        raw=_IdeGymSandbox(
+            server_id=server_id,
+            server_name="nemo-gym-abcdef12",
+            namespace="idegym",
+            image="registry.example.com/idegym/env:1",
+            workdir=workdir,
+            env=env or {},
+            stopped=stopped,
+        ),
+    )
+
+
+def spec(**overrides: Any) -> SandboxSpec:
+    values: dict[str, Any] = {"image": "registry.example.com/idegym/env:1"}
+    values.update(overrides)
+    return SandboxSpec(**values)
+
+
+# --- registration and dependency ------------------------------------------
+
+
+def test_registry_resolves_idegym() -> None:
+    assert get_provider_class("idegym") is IdeGymProvider
+
+
+def test_missing_idegym_dependency_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals_: dict[str, Any] | None = None,
+        locals_: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        if name == "idegym" or name.startswith("idegym."):
+            raise ModuleNotFoundError(name)
+        return real_import(name, globals_, locals_, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ModuleNotFoundError, match=r"nemo-gym\[idegym\]"):
+        idegym_session.require_idegym_client()
+
+
+def test_provider_binds_the_session_api_it_calls() -> None:
+    """The fake session is only trustworthy if it matches the real one's shape.
+
+    Binding the provider's exact call shapes against ``IdeGymSession`` means a
+    signature change there fails these tests instead of passing against a fake
+    that has quietly drifted.
+    """
+    real = idegym_session.IdeGymSession
+    inspect.signature(real.start_server).bind(None, {}, polling=None, timeout_s=1.0)
+    inspect.signature(real.execute_bash).bind(
+        None,
+        1,
+        "true",
+        command_timeout_s=1.0,
+        graceful_termination_timeout_s=2.0,
+        request_timeout_s=3.0,
+        polling=None,
+    )
+    inspect.signature(real.list_capabilities).bind(None, 1)
+    inspect.signature(real.stop_server).bind(None, 1, polling=None, timeout_s=1.0)
+    inspect.signature(real.health).bind(None)
+    for name in ("start_server", "execute_bash", "list_capabilities", "stop_server", "health"):
+        # Names and kinds only: the fake annotates loosely on purpose, but a
+        # renamed, reordered, added or removed parameter has to fail here.
+        def parameters(owner: type) -> list[tuple[str, Any]]:
+            return [(p.name, p.kind) for p in inspect.signature(getattr(owner, name)).parameters.values()]
+
+        assert parameters(real) == parameters(FakeSession), name
+
+
+# --- config ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("group", "kwargs"),
+    [
+        ("connection", {"orchestrator_url": ""}),
+        ("connection", {"namespace": ""}),
+        ("connection", {"client_name": "  "}),
+        ("connection", {"nodes_count": -1}),
+        ("connection", {"heartbeat_interval_s": 0}),
+        ("connection", {"request_timeout_s": 0}),
+        ("connection", {"transport_backend": "curl"}),
+        ("connection", {"max_connections": 0}),
+        ("connection", {"max_keepalive_connections": -1}),
+        ("connection", {"keepalive_expiry_s": 0}),
+        ("connection", {"connect_retries": -1}),
+        ("connection", {"tracing_timeout_s": 0}),
+        ("create", {"ready_timeout_s": 0}),
+        ("create", {"retries": -1}),
+        ("create", {"retry_delay_s": -1}),
+        ("create", {"retry_max_delay_s": -1}),
+        ("create", {"busy_retry_delay_s": -1}),
+        ("create", {"server_name_prefix": ""}),
+        ("create", {"service_port": 70000}),
+        ("create", {"container_port": -1}),
+        ("create", {"max_restarts": -1}),
+        ("create", {"polling": {"initial_delay_s": 0}}),
+        ("create", {"polling": {"interval_s": -1}}),
+        ("create", {"polling": {"backoff_factor": 0.5}}),
+        ("create", {"polling": {"max_delay_s": 0}}),
+        ("exec", {"default_timeout_s": 0}),
+        ("exec", {"graceful_termination_timeout_s": -1}),
+        ("exec", {"request_overhead_s": -1}),
+        ("exec", {"user_mode": "sudo"}),
+        ("probe", {"timeout_s": 0}),
+        ("probe", {"command": None, "timeout_s": 0}),
+        ("probe", {"deadline_s": 0}),
+        ("probe", {"stable_count": 0}),
+        ("probe", {"stable_delay_s": -1}),
+        ("files", {"upload_chunk_bytes": 0}),
+        ("files", {"upload_chunk_bytes": MAX_UPLOAD_CHUNK_BYTES + 1}),
+        ("files", {"download_chunk_bytes": 0}),
+        ("files", {"max_download_bytes": 0}),
+        ("files", {"timeout_s": 0}),
+        ("operations", {"close_timeout_s": 0}),
+        ("operations", {"status_timeout_s": 0}),
+        ("operations", {"retries": -1}),
+        ("operations", {"retry_delay_s": -1}),
+        ("operations", {"retry_max_delay_s": -1}),
+        ("attribution", {"client_name_prefix": ""}),
+    ],
+)
+def test_config_validation_rejects_bad_values(group: str, kwargs: dict[str, Any]) -> None:
+    with pytest.raises(ValueError):
+        IdeGymProvider(**{group: kwargs})
+
+
+def test_config_coercion_and_defaults() -> None:
+    provider = IdeGymProvider(connection={"orchestrator_url": "idegym.example", "namespace": "gym"})
+    assert provider._connection == IdeGymConnectionConfig(orchestrator_url="idegym.example", namespace="gym")
+    assert provider._connection.tracing_enabled is False
+    assert provider._files == IdeGymFilesConfig()
+
+
+def test_invalid_config_type_raises() -> None:
+    with pytest.raises(TypeError, match="IdeGymConnectionConfig"):
+        IdeGymProvider(connection=["not", "a", "mapping"])
+
+
+def test_provider_options_validation() -> None:
+    with pytest.raises(ValueError, match="Unknown idegym provider_options keys"):
+        IdeGymProviderOptions.from_mapping({"nope": 1})
+    with pytest.raises(TypeError, match="node_selector"):
+        IdeGymProviderOptions.from_mapping({"node_selector": ["a"]})
+    with pytest.raises(TypeError, match="pod_overrides"):
+        IdeGymProviderOptions.from_mapping({"pod_overrides": []})
+    with pytest.raises(TypeError, match="snapshot"):
+        IdeGymProviderOptions.from_mapping({"snapshot": "latest"})
+    with pytest.raises(TypeError, match="volumes.*list of mappings"):
+        IdeGymProviderOptions.from_mapping({"volumes": {"name": "x"}})
+    with pytest.raises(TypeError, match=r"volume_mounts'\]\[0\]"):
+        IdeGymProviderOptions.from_mapping({"volume_mounts": ["x"]})
+    assert IdeGymProviderOptions.from_mapping(None) == IdeGymProviderOptions()
+
+
+# --- error classification --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("error", "status", "gone", "retryable"),
+    [
+        (orchestrator_error(404), 404, True, False),
+        (orchestrator_error(410), 410, True, False),
+        (orchestrator_error(429), 429, False, True),
+        (orchestrator_error(503), 503, False, True),
+        (orchestrator_error(400), 400, False, False),
+        (forward_error(410, "gone"), 410, True, False),
+        (RuntimeError("no status here"), None, False, False),
+        (ConnectionError("refused"), None, False, True),
+    ],
+)
+def test_error_classification(error: Exception, status: int | None, gone: bool, retryable: bool) -> None:
+    assert orchestrator_status(error) == status
+    assert is_sandbox_gone(error) is gone
+    assert is_retryable(error) is retryable
+
+
+def test_command_timeout_classification() -> None:
+    assert is_command_timeout(TimeoutError("client gave up")) is True
+    assert is_command_timeout(forward_error(500, "Command execution timed out after 5 seconds")) is True
+    assert is_command_timeout(orchestrator_error(500, "kaboom")) is False
+
+
+def test_transport_failures_are_retryable() -> None:
+    """The SDK lets httpx's exceptions through, and none of them are builtins."""
+    import httpx
+
+    for error in (httpx.ConnectError("refused"), httpx.ReadTimeout("slow"), httpx.PoolTimeout("full")):
+        assert is_retryable(error) is True, error
+    # A read timeout means we stopped waiting; failing to connect at all does not.
+    assert is_command_timeout(httpx.ReadTimeout("slow")) is True
+    assert is_command_timeout(httpx.ConnectTimeout("unreachable")) is False
+
+
+# --- naming ----------------------------------------------------------------
+
+
+def test_sanitize_and_clamp_names() -> None:
+    assert sanitize_name("  My Team/Foo  ") == "my-team-foo"
+    assert sanitize_name("///") == ""
+    long_name = idegym_session.clamp_client_name("a" * 200)
+    assert len(long_name) == MAX_CLIENT_NAME_LENGTH
+
+
+def test_generated_server_names_fit_kubernetes_and_stay_unique() -> None:
+    name = generate_server_name("nemo-gym", ["django__django-11099"])
+    assert name.startswith("nemo-gym-django-django-11099-")
+    # Room must be left for the `-<server_id>` suffix the orchestrator appends.
+    assert len(name) + len("-9999999") <= MAX_SERVER_NAME_LENGTH
+    assert generate_server_name("nemo-gym", []) != generate_server_name("nemo-gym", [])
+
+
+def test_generated_server_names_satisfy_rfc1035() -> None:
+    import re
+
+    pattern = re.compile(r"^[a-z]([-a-z0-9]*[a-z0-9])?$")
+    for prefix, hints in (
+        ("nemo-gym", ["A_VERY::Odd/Instance ID"]),
+        ("nemo-gym", ["x" * 200]),
+        ("9bad", ["also-bad"]),
+        ("---", []),
+    ):
+        assert pattern.match(generate_server_name(prefix, hints)), (prefix, hints)
+
+
+def test_server_name_suffix_must_leave_room_for_a_stem() -> None:
+    with pytest.raises(ValueError, match="no room for a name stem"):
+        generate_server_name("nemo-gym", [], unique_suffix="s" * MAX_SERVER_NAME_LENGTH)
+
+
+def test_refresh_unique_suffix_keeps_the_stem() -> None:
+    original = generate_server_name("nemo-gym", ["task-1"])
+    refreshed = refresh_unique_suffix(original)
+    assert refreshed != original
+    assert refreshed.rpartition("-")[0] == original.rpartition("-")[0]
+
+
+# --- spec translation ------------------------------------------------------
+
+
+def test_translate_maps_resources_to_limits_and_requests() -> None:
+    translator = ServerRequestTranslator(idegym_provider.IdeGymCreateConfig())
+    request = translator.translate(
+        spec(resources={"cpu": 2, "memory_mib": 8192, "disk_gib": 30}, metadata={"instance_id": "task-9"}),
+        IdeGymProviderOptions.from_mapping({"resource_requests": {"cpu": 0.5, "memory_mib": 2048}}),
+    )
+    assert request["resources"] == {
+        "requests": {"cpu": "500m", "memory": "2048Mi"},
+        "limits": {"cpu": "2", "memory": "8192Mi", "ephemeral-storage": "30Gi"},
+    }
+    assert request["server_name"].startswith("nemo-gym-task-9-")
+    assert request["reuse_strategy"] == "NONE"
+
+
+def test_translate_passes_pod_shape_options_through() -> None:
+    translator = ServerRequestTranslator(idegym_provider.IdeGymCreateConfig())
+    request = translator.translate(
+        spec(),
+        IdeGymProviderOptions.from_mapping(
+            {
+                "runtime_class_name": "gvisor",
+                "node_selector": {"pool": "sandbox"},
+                "volumes": [{"name": "creds", "secret": {"secretName": "creds"}}],
+                "volume_mounts": [{"name": "creds", "mountPath": "/etc/creds"}],
+                "env_from": [{"secretRef": {"name": "creds"}}],
+                "service_account_name": "runner",
+                "pod_overrides": {"tolerations": [{"key": "dedicated", "operator": "Exists"}]},
+                "server_kind": "idegym",
+                "snapshot": {"id": "17"},
+                "max_restarts": 3,
+                "reuse_strategy": "RESET",
+                "server_name": "pinned-name",
+                "service_port": 8080,
+                "container_port": 9000,
+                "run_as_root": True,
+            }
+        ),
+    )
+    assert request["server_name"] == "pinned-name"
+    assert request["runtime_class_name"] == "gvisor"
+    assert request["node_selector"] == {"pool": "sandbox"}
+    assert request["volumes"] == [{"name": "creds", "secret": {"secretName": "creds"}}]
+    assert request["env_from"] == [{"secretRef": {"name": "creds"}}]
+    assert request["pod_overrides"]["tolerations"][0]["key"] == "dedicated"
+    assert request["snapshot"] == {"id": "17"}
+    assert (request["max_restarts"], request["service_port"], request["container_port"]) == (3, 8080, 9000)
+    assert request["run_as_root"] is True
+    assert "resources" not in request
+
+
+def test_translate_normalizes_and_validates_the_image() -> None:
+    translator = ServerRequestTranslator(idegym_provider.IdeGymCreateConfig())
+    request = translator.translate(spec(image="docker://reg.example/env:1"), IdeGymProviderOptions())
+    assert request["image_tag"] == "reg.example/env:1"
+    with pytest.raises(SandboxCreateError, match="not a valid OCI image reference"):
+        translator.translate(spec(image="Reg.Example/Env:1"), IdeGymProviderOptions())
+    with pytest.raises(SandboxCreateError, match="spec.image is required"):
+        translator.translate(spec(image=None), IdeGymProviderOptions())
+
+
+def test_translate_rejects_entrypoint_and_warns_about_unsupported_fields(caplog: pytest.LogCaptureFixture) -> None:
+    translator = ServerRequestTranslator(idegym_provider.IdeGymCreateConfig())
+    with pytest.raises(SandboxCreateError, match="spec.entrypoint is not supported"):
+        translator.translate(spec(entrypoint=["/bin/sh"]), IdeGymProviderOptions())
+    unsupported = spec(ttl_s=60, ports=[8080], resources={"gpu": 1})
+    with caplog.at_level("WARNING"):
+        translator.translate(unsupported, IdeGymProviderOptions())
+        translator.translate(unsupported, IdeGymProviderOptions())
+    # Once each, not once per sandbox: a benchmark translates one spec per task, and
+    # the agent config that ships with mini_swe_agent_2 sets ttl_s.
+    assert caplog.text.count("spec.ttl_s is not enforced") == 1
+    assert caplog.text.count("sandbox.endpoint() is unavailable") == 1
+    assert caplog.text.count("cannot map GPU resource requests") == 1
+
+
+@pytest.mark.parametrize("value", [0, -1])
+def test_translate_rejects_non_positive_resources(value: int) -> None:
+    translator = ServerRequestTranslator(idegym_provider.IdeGymCreateConfig())
+    for key in ("cpu", "memory_mib", "disk_gib"):
+        with pytest.raises(SandboxCreateError, match="greater than zero"):
+            translator.translate(spec(resources={key: value}), IdeGymProviderOptions())
+
+
+# --- create ----------------------------------------------------------------
+
+
+async def test_create_starts_probes_and_returns_a_ready_handle(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider()
+    handle = await provider.create(
+        spec(workdir="/testbed", env={"FOO": "bar"}, ready_timeout_s=99, metadata={"instance_id": "task-1"})
+    )
+    assert handle.provider_name == "idegym"
+    assert handle.sandbox_id == "7"
+    assert handle.raw.workdir == "/testbed"
+    assert handle.raw.env == {"FOO": "bar"}
+    assert fake_session.start_calls[0]["timeout_s"] == pytest.approx(99, abs=1)
+    # The retrying probe runs first, so a server that is merely still warming up is
+    # not misreported as a mis-set workdir. The workdir check must not `cd` into the
+    # directory it is verifying.
+    assert "printf idegym-sandbox-ready" in fake_session.bash_calls[0]["script"]
+    assert "[ -d /testbed ]" in fake_session.bash_calls[1]["script"]
+    assert "cd -- /testbed" not in fake_session.bash_calls[1]["script"]
+
+
+async def test_create_falls_back_to_configured_ready_timeout(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(create={"ready_timeout_s": 45})
+    await provider.create(spec())
+    assert fake_session.start_calls[0]["timeout_s"] == pytest.approx(45, abs=1)
+
+
+async def test_create_waits_for_the_probe_to_stabilize(make_provider, fake_session: FakeSession) -> None:
+    fake_session.bash_results = [
+        IdeGymBashResult(stdout="", stderr="not up yet", exit_code=1),
+        IdeGymBashResult(stdout="idegym-sandbox-ready", stderr="", exit_code=0),
+    ]
+    provider = make_provider(probe={"stable_count": 2})
+    await provider.create(spec())
+    assert len(fake_session.bash_calls) == 3
+
+
+async def test_create_probe_failure_stops_the_server(make_provider, fake_session: FakeSession) -> None:
+    fake_session.bash_results = [IdeGymBashResult(stdout="", stderr="broken", exit_code=1)]
+    provider = make_provider()
+    with pytest.raises(SandboxCreateVerificationError, match="did not pass its readiness probe"):
+        await provider.create(spec())
+    assert fake_session.stop_calls == [{"server_id": 7, "timeout_s": 5.0}]
+
+
+async def test_create_probe_backs_off_between_attempts(make_provider, fake_session: FakeSession) -> None:
+    """A remote orchestrator must not be hammered for the whole probe deadline."""
+    fake_session.bash_results = [
+        IdeGymBashResult(stdout="", stderr="not up yet", exit_code=1),
+        IdeGymBashResult(stdout="idegym-sandbox-ready", stderr="", exit_code=0),
+    ]
+    provider = make_provider(probe={"stable_delay_s": 0.02, "deadline_s": 5.0})
+    started = asyncio.get_running_loop().time()
+    await provider.create(spec())
+    assert asyncio.get_running_loop().time() - started >= 0.02
+    assert len(fake_session.bash_calls) == 2
+
+
+async def test_create_probe_without_deadline_fails_on_first_miss(make_provider, fake_session: FakeSession) -> None:
+    fake_session.bash_results = [IdeGymBashResult(stdout="", stderr="broken", exit_code=1)]
+    provider = make_provider(probe={"deadline_s": None})
+    with pytest.raises(SandboxCreateVerificationError, match="failed its readiness probe"):
+        await provider.create(spec())
+
+
+async def test_create_fails_when_the_workdir_is_unusable(make_provider, fake_session: FakeSession) -> None:
+    fake_session.bash_results = [
+        IdeGymBashResult(stdout="idegym-sandbox-ready", stderr="", exit_code=0),
+        IdeGymBashResult(stdout="", stderr="", exit_code=1),
+    ]
+    provider = make_provider()
+    with pytest.raises(SandboxCreateVerificationError, match="is not usable in the IdeGYM sandbox"):
+        await provider.create(spec(workdir="/nope"))
+    assert len(fake_session.bash_calls) == 2
+    assert fake_session.stop_calls
+
+
+async def test_create_can_skip_the_probe_entirely(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None, "verify_workdir": False})
+    await provider.create(spec(workdir="/testbed"))
+    assert fake_session.bash_calls == []
+
+
+async def test_create_retries_transient_failures_with_a_fresh_name(make_provider, fake_session: FakeSession) -> None:
+    fake_session.start_results = [
+        orchestrator_error(429),
+        IdeGymServerRef(server_id=9, server_name="nemo-gym-second", namespace="idegym"),
+    ]
+    provider = make_provider()
+    handle = await provider.create(spec())
+    assert handle.sandbox_id == "9"
+    first, second = (call["request"]["server_name"] for call in fake_session.start_calls)
+    assert first != second
+    assert first.rpartition("-")[0] == second.rpartition("-")[0]
+
+
+async def test_create_keeps_a_pinned_name_across_retries(make_provider, fake_session: FakeSession) -> None:
+    fake_session.start_results = [
+        orchestrator_error(503),
+        IdeGymServerRef(server_id=9, server_name="pinned", namespace="idegym"),
+    ]
+    provider = make_provider()
+    await provider.create(spec(provider_options={"server_name": "pinned"}))
+    assert [call["request"]["server_name"] for call in fake_session.start_calls] == ["pinned", "pinned"]
+
+
+async def test_create_exhausted_retries_are_wrapped(make_provider, fake_session: FakeSession) -> None:
+    fake_session.start_results = [orchestrator_error(429)]
+    provider = make_provider(create={"retries": 1})
+    with pytest.raises(SandboxCreateError, match="could not start a server"):
+        await provider.create(spec())
+    assert len(fake_session.start_calls) == 2
+
+
+async def test_create_does_not_retry_an_exhausted_readiness_budget(make_provider, fake_session: FakeSession) -> None:
+    """Retrying would silently multiply ready_timeout_s by the retry count."""
+    fake_session.start_results = [TimeoutError("Server start timed out after 1200 seconds")]
+    provider = make_provider(create={"retries": 3})
+    with pytest.raises(SandboxCreateError, match="could not start a server"):
+        await provider.create(spec())
+    assert len(fake_session.start_calls) == 1
+
+
+async def test_create_retries_a_transport_timeout(make_provider, fake_session: FakeSession) -> None:
+    """A transport timeout is one lost request, not the whole budget."""
+    import httpx
+
+    fake_session.start_results = [
+        httpx.ReadTimeout("orchestrator slow"),
+        IdeGymServerRef(server_id=9, server_name="nemo-gym-second", namespace="idegym"),
+    ]
+    provider = make_provider()
+    handle = await provider.create(spec())
+    assert handle.sandbox_id == "9"
+    assert len(fake_session.start_calls) == 2
+
+
+async def test_create_non_retryable_failure_is_not_retried(make_provider, fake_session: FakeSession) -> None:
+    fake_session.start_results = [orchestrator_error(400, "bad image")]
+    provider = make_provider()
+    with pytest.raises(SandboxCreateError, match="could not start a server"):
+        await provider.create(spec())
+    assert len(fake_session.start_calls) == 1
+
+
+async def test_create_teardown_failure_only_warns(
+    make_provider, fake_session: FakeSession, caplog: pytest.LogCaptureFixture
+) -> None:
+    fake_session.bash_results = [IdeGymBashResult(stdout="", stderr="broken", exit_code=1)]
+    fake_session.stop_results = [orchestrator_error(500)]
+    provider = make_provider()
+    with caplog.at_level("WARNING"), pytest.raises(SandboxCreateVerificationError):
+        await provider.create(spec())
+    assert "may be left running on the cluster" in caplog.text
+
+
+# --- exec ------------------------------------------------------------------
+
+
+async def test_exec_shapes_the_script_and_the_timeouts(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None, "verify_workdir": False})
+    handle = await provider.create(spec(workdir="/testbed", env={"CONDA_ENV": "testbed"}))
+    fake_session.bash_results = [IdeGymBashResult(stdout="out", stderr="err", exit_code=3)]
+    # A value needing quoting proves the export is shell-safe; the call's env is
+    # merged on top of the sandbox's.
+    result = await provider.exec(handle, "pytest -q", env={"EXTRA": "a b'c"}, timeout_s=120)
+    assert result == SandboxExecResult(stdout="out", stderr="err", return_code=3)
+    call = fake_session.bash_calls[-1]
+    assert call["script"] == (
+        "{ :\ncd -- /testbed || exit 1\nexport CONDA_ENV=testbed\nexport EXTRA='a b'\"'\"'c'\npytest -q\n}"
+    )
+    assert call["command_timeout_s"] == 120
+    # The client waits longer than the sandbox, so the sandbox's own timeout wins
+    # and the caller gets output instead of a transport error.
+    assert call["request_timeout_s"] == 120 + 60
+
+
+async def test_exec_cwd_argument_overrides_the_sandbox_workdir(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None, "verify_workdir": False})
+    handle = await provider.create(spec(workdir="/testbed"))
+    await provider.exec(handle, "true", cwd="/other")
+    assert "cd -- /other" in fake_session.bash_calls[-1]["script"]
+
+
+async def test_exec_without_timeout_uses_a_finite_ceiling(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None}, exec={"default_timeout_s": None})
+    handle = await provider.create(spec())
+    await provider.exec(handle, "true")
+    assert fake_session.bash_calls[-1]["command_timeout_s"] == NO_TIMEOUT_COMMAND_SECONDS
+
+
+async def test_exec_reports_a_sandbox_side_timeout(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    fake_session.bash_results = [forward_error(500, "Command execution timed out after 5 seconds")]
+    result = await provider.exec(handle, "sleep 100", timeout_s=5)
+    assert result.error_type == "timeout"
+    assert result.return_code == SANDBOX_RUNTIME_RETURN_CODE
+
+
+async def test_exec_on_a_deleted_sandbox_marks_it_stopped(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    fake_session.bash_results = [orchestrator_error(410, "gone")]
+    result = await provider.exec(handle, "true")
+    assert result.error_type == "sandbox"
+    assert handle.raw.stopped is True
+    assert await provider.status(handle) is SandboxStatus.STOPPED
+    # A stopped sandbox short-circuits rather than making another round trip.
+    calls_before = len(fake_session.bash_calls)
+    assert (await provider.exec(handle, "true")).error_type == "sandbox"
+    assert len(fake_session.bash_calls) == calls_before
+
+
+async def test_exec_other_failures_are_reported_not_raised(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    fake_session.bash_results = [orchestrator_error(500, "kaboom")]
+    result = await provider.exec(handle, "true")
+    assert (result.error_type, result.return_code) == ("sandbox", SANDBOX_RUNTIME_RETURN_CODE)
+
+
+async def test_exec_reports_an_undeliverable_command_instead_of_raising(make_provider) -> None:
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    too_long = await provider.exec(handle, "echo " + "x" * MAX_COMMAND_BYTES)
+    assert too_long.error_type == "command_too_long"
+    assert "byte limit" in (too_long.stderr or "")
+    bad_env = await provider.exec(handle, "true", env={"NOT AN IDENT": "v"})
+    assert bad_env.error_type == "invalid_request"
+
+
+async def test_exec_user_request_warns_once(
+    make_provider, fake_session: FakeSession, caplog: pytest.LogCaptureFixture
+) -> None:
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    with caplog.at_level("WARNING"):
+        await provider.exec(handle, "true", user="root")
+        await provider.exec(handle, "true", user="root")
+    assert caplog.text.count("cannot run commands as user") == 1
+    assert "runuser" not in fake_session.bash_calls[-1]["script"]
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [("runuser", "exec runuser -u tester -- bash -c"), ("su", "exec su tester -c")],
+)
+def test_user_switch_modes_wrap_the_script(mode: str, expected: str) -> None:
+    builder = BashScriptBuilder(IdeGymExecConfig(user_mode=mode))
+    script = builder.build("true", cwd="/w", user="tester")
+    assert expected in script
+    assert "cd -- /w" in script
+
+
+@pytest.mark.parametrize("mode", ["runuser", "su"])
+def test_user_switch_modes_reject_numeric_ids(mode: str) -> None:
+    builder = BashScriptBuilder(IdeGymExecConfig(user_mode=mode))
+    with pytest.raises(ValueError, match="needs a user name"):
+        builder.build("true", user=0)
+
+
+def test_script_size_limit_is_enforced() -> None:
+    builder = BashScriptBuilder(IdeGymExecConfig())
+    with pytest.raises(IdeGymCommandTooLongError, match="one argument"):
+        builder.build("x" * (MAX_COMMAND_BYTES + 1))
+
+
+@requires_bash
+@pytest.mark.parametrize("command", ["", "   ", "\n", "# just a comment"])
+def test_a_command_with_nothing_to_run_is_not_a_syntax_error(command: str) -> None:
+    """An empty brace group is a bash syntax error, not a no-op.
+
+    A model that emits a blank or comment-only action would otherwise be told its
+    command had a shell syntax error.
+    """
+    script = BashScriptBuilder(IdeGymExecConfig()).build(command)
+    completed = subprocess.run(["bash", "-c", script], capture_output=True, text=True, check=False)
+    assert completed.returncode == 0, completed.stderr
+    assert "syntax error" not in completed.stderr
+
+
+@requires_bash
+def test_the_largest_permitted_upload_chunk_still_fits_in_one_command() -> None:
+    """The validator's ceiling has to leave room for the rest of the script."""
+    files = IdeGymFilesConfig(upload_chunk_bytes=MAX_UPLOAD_CHUNK_BYTES)
+    transfer = Base64BashFileTransfer(files, run=None)  # type: ignore[arg-type]
+    chunk_script = transfer._write_chunk_script(
+        "/testbed/nested/blob.bin", b"x" * files.upload_chunk_bytes, first=True
+    )
+    script = BashScriptBuilder(IdeGymExecConfig()).build(chunk_script, cwd="/testbed")
+    assert len(script.encode()) <= MAX_COMMAND_BYTES
+
+
+@pytest.mark.parametrize("name", ["FOO\n", "FO O", "1FOO", ""])
+def test_env_names_that_export_cannot_carry_are_rejected(name: str) -> None:
+    """A `$`-anchored check would accept a trailing newline and corrupt the script."""
+    builder = BashScriptBuilder(IdeGymExecConfig())
+    with pytest.raises(ValueError, match="not a valid shell identifier"):
+        builder.build("true", env={name: "v"})
+
+
+def test_an_image_with_a_trailing_newline_is_rejected() -> None:
+    translator = ServerRequestTranslator(idegym_provider.IdeGymCreateConfig())
+    with pytest.raises(SandboxCreateError, match="not a valid OCI image reference"):
+        translator.translate(spec(image="reg.example/env:1\n"), IdeGymProviderOptions())
+
+
+def test_a_relayed_sandbox_body_is_not_read_as_the_orchestrator_status() -> None:
+    """The body carries the sandbox's own output; scraping it would kill live sandboxes."""
+    relayed = forward_error(500, "curl failed: status=404 not found")
+    assert orchestrator_status(relayed) == 500
+    assert is_sandbox_gone(relayed) is False
+    # Likewise for the timeout marker: ordinary tool output must not read as a timeout.
+    assert is_command_timeout(forward_error(500, "pytest: test_foo timed out after 30 seconds")) is False
+    assert is_command_timeout(forward_error(500, "Command execution timed out after 5 seconds")) is True
+
+
+# --- files -----------------------------------------------------------------
+
+
+@requires_bash
+async def test_file_transfer_round_trips_binary_content(make_provider, tmp_path: Path) -> None:
+    session = LocalBashSession()
+    # Chunk sizes far below the defaults, so the chunk-boundary handling is what is
+    # under test rather than a single-chunk shortcut.
+    provider = make_provider(
+        session,
+        probe={"command": None, "verify_workdir": False},
+        files={"upload_chunk_bytes": 100, "download_chunk_bytes": 60},
+    )
+    remote = tmp_path / "sandbox"
+    remote.mkdir()
+    handle = await provider.create(spec(workdir=str(remote)))
+    payload = bytes(range(256)) * 3
+    source = tmp_path / "blob.bin"
+    source.write_bytes(payload)
+
+    await provider.upload_file(handle, source, str(remote / "nested/dir/blob.bin"))
+    assert (remote / "nested/dir/blob.bin").read_bytes() == payload
+
+    out = tmp_path / "back.bin"
+    await provider.download_file(handle, str(remote / "nested/dir/blob.bin"), out)
+    assert out.read_bytes() == payload
+
+
+@requires_bash
+async def test_file_transfer_handles_empty_files_and_odd_names(make_provider, tmp_path: Path) -> None:
+    provider = make_provider(LocalBashSession(), probe={"command": None, "verify_workdir": False})
+    handle = await provider.create(spec())
+    empty = tmp_path / "empty"
+    empty.write_bytes(b"")
+    target = tmp_path / "-dash name'with quote.bin"
+    await provider.upload_file(handle, empty, str(target))
+    assert target.exists() and target.stat().st_size == 0
+    out = tmp_path / "empty-back"
+    await provider.download_file(handle, str(target), out)
+    assert out.read_bytes() == b""
+
+
+@requires_bash
+async def test_upload_resolves_relative_paths_against_the_workdir(make_provider, tmp_path: Path) -> None:
+    provider = make_provider(LocalBashSession(), probe={"command": None, "verify_workdir": False})
+    handle = await provider.create(spec(workdir=str(tmp_path)))
+    source = tmp_path / "src.txt"
+    source.write_text("hello\n")
+    await provider.upload_file(handle, source, "relative/target.txt")
+    assert (tmp_path / "relative/target.txt").read_text() == "hello\n"
+
+
+@requires_bash
+async def test_download_of_a_missing_file_raises(make_provider, tmp_path: Path) -> None:
+    provider = make_provider(LocalBashSession(), probe={"command": None, "verify_workdir": False})
+    handle = await provider.create(spec())
+    with pytest.raises(idegym_provider.IdeGymOperationError, match="Cannot read"):
+        await provider.download_file(handle, str(tmp_path / "nope"), tmp_path / "out")
+
+
+@requires_bash
+async def test_download_refuses_files_over_the_configured_cap(make_provider, tmp_path: Path) -> None:
+    provider = make_provider(
+        LocalBashSession(), probe={"command": None, "verify_workdir": False}, files={"max_download_bytes": 8}
+    )
+    handle = await provider.create(spec())
+    big = tmp_path / "big.bin"
+    big.write_bytes(b"x" * 64)
+    with pytest.raises(idegym_provider.IdeGymOperationError, match="max_download_bytes"):
+        await provider.download_file(handle, str(big), tmp_path / "out")
+
+
+async def test_upload_failure_reports_the_failing_chunk(
+    make_provider, fake_session: FakeSession, tmp_path: Path
+) -> None:
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    source = tmp_path / "src.bin"
+    source.write_bytes(b"abcdefghij")
+    fake_session.bash_results = [IdeGymBashResult(stdout="", stderr="disk full", exit_code=1)]
+    with pytest.raises(idegym_provider.IdeGymOperationError, match="failed on chunk 1/"):
+        await provider.upload_file(handle, source, "/tmp/x.bin")
+
+
+async def test_download_rejects_unparsable_size_and_bad_base64(
+    make_provider, fake_session: FakeSession, tmp_path: Path
+) -> None:
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    fake_session.bash_results = [IdeGymBashResult(stdout="not-a-number", stderr="", exit_code=0)]
+    with pytest.raises(idegym_provider.IdeGymOperationError, match="unparsable size"):
+        await provider.download_file(handle, "/tmp/x", tmp_path / "out")
+
+    fake_session.bash_results = [
+        IdeGymBashResult(stdout="4", stderr="", exit_code=0),
+        IdeGymBashResult(stdout="!!!not base64!!!", stderr="", exit_code=0),
+    ]
+    with pytest.raises(idegym_provider.IdeGymOperationError, match="invalid base64"):
+        await provider.download_file(handle, "/tmp/x", tmp_path / "out")
+
+
+async def test_download_chunk_failure_names_the_offset(
+    make_provider, fake_session: FakeSession, tmp_path: Path
+) -> None:
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    fake_session.bash_results = [
+        IdeGymBashResult(stdout="16", stderr="", exit_code=0),
+        IdeGymBashResult(stdout="", stderr="I/O error", exit_code=1),
+    ]
+    with pytest.raises(idegym_provider.IdeGymOperationError, match="at offset 0"):
+        await provider.download_file(handle, "/tmp/x", tmp_path / "out")
+
+
+async def test_download_short_read_is_detected(make_provider, fake_session: FakeSession, tmp_path: Path) -> None:
+    import base64
+
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    fake_session.bash_results = [
+        IdeGymBashResult(stdout="8", stderr="", exit_code=0),
+        IdeGymBashResult(stdout=base64.b64encode(b"abc").decode(), stderr="", exit_code=0),
+    ]
+    with pytest.raises(idegym_provider.IdeGymOperationError, match="Expected 8 bytes"):
+        await provider.download_file(handle, "/tmp/x", tmp_path / "out")
+
+
+# --- status ----------------------------------------------------------------
+
+
+async def test_status_running_stopped_and_unknown(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    assert await provider.status(handle) is SandboxStatus.RUNNING
+
+    fake_session.capability_results = [orchestrator_error(404)]
+    assert await provider.status(handle) is SandboxStatus.STOPPED
+
+    fake_session.capability_results = [orchestrator_error(500)]
+    assert await provider.status(handle) is SandboxStatus.UNKNOWN
+
+
+async def test_status_of_a_closed_sandbox_is_stopped(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    await provider.close(handle)
+    assert await provider.status(handle) is SandboxStatus.STOPPED
+    assert fake_session.capability_calls == []
+
+
+# --- teardown --------------------------------------------------------------
+
+
+async def test_close_is_idempotent(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    await provider.close(handle)
+    await provider.close(handle)
+    assert len(fake_session.stop_calls) == 1
+
+
+async def test_close_treats_an_already_gone_server_as_success(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    fake_session.stop_results = [orchestrator_error(404)]
+    await provider.close(handle)
+
+
+async def test_close_treats_a_server_the_session_forgot_as_success(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    fake_session.live_servers.clear()
+    await provider.close(handle)
+    assert handle.raw.stopped is True
+
+
+async def test_a_failed_stop_can_be_retried_against_the_same_server(make_provider, fake_session: FakeSession) -> None:
+    """A failed stop must not make the pod unaddressable.
+
+    The session forgets a server only once it is really stopped, so a caller retrying
+    after a failure reaches the same pod rather than an "already stopped" answer that
+    would leave it running.
+    """
+    provider = make_provider(probe={"command": None}, operations={"retries": 0})
+    handle = await provider.create(spec())
+    fake_session.stop_results = [orchestrator_error(500), None]
+    with pytest.raises(IdeGymOperationError):
+        await provider.close(handle)
+    assert handle.raw.stopped is False
+    await provider.close(handle)
+    assert handle.raw.stopped is True
+    assert [call["server_id"] for call in fake_session.stop_calls] == [7, 7]
+
+
+async def test_close_retries_then_raises_and_keeps_the_sandbox_live(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None}, operations={"retries": 2})
+    handle = await provider.create(spec())
+    fake_session.stop_results = [orchestrator_error(500)]
+    with pytest.raises(IdeGymOperationError, match="Failed to stop IdeGYM sandbox"):
+        await provider.close(handle)
+    assert len(fake_session.stop_calls) == 3
+    # A stop that failed for real must not leave the sandbox looking stopped: the
+    # pod may well still be running, and status() has to keep saying so.
+    assert handle.raw.stopped is False
+    assert await provider.status(handle) is SandboxStatus.RUNNING
+
+
+async def test_close_succeeds_after_a_transient_failure(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None})
+    handle = await provider.create(spec())
+    fake_session.stop_results = [orchestrator_error(503), None]
+    await provider.close(handle)
+    assert len(fake_session.stop_calls) == 2
+
+
+async def test_aclose_releases_the_session_once(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None})
+    await provider.create(spec())
+    await provider.aclose()
+    await provider.aclose()
+    assert provider.released == [fake_session]
+    with pytest.raises(IdeGymOperationError, match="has been closed"):
+        await provider.session()
+
+
+async def test_aclose_without_a_session_is_a_no_op(make_provider) -> None:
+    provider = make_provider()
+    await provider.aclose()
+    assert provider.released == []
+
+
+async def test_health_reports_the_orchestrator_status(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider()
+    assert await provider.health() == "healthy"
+    assert fake_session.health_calls == 1
+
+
+async def test_the_session_is_acquired_only_once(make_provider, fake_session: FakeSession) -> None:
+    provider = make_provider(probe={"command": None})
+    first, second = await asyncio.gather(provider.session(), provider.session())
+    assert first is second is fake_session

--- a/tests/unit_tests/test_idegym_provider.py
+++ b/tests/unit_tests/test_idegym_provider.py
@@ -988,6 +988,37 @@ async def test_upload_failure_reports_the_failing_chunk(
         await provider.upload_file(handle, source, "/tmp/x.bin")
 
 
+async def test_upload_failure_names_a_later_chunk(make_provider, fake_session: FakeSession, tmp_path: Path) -> None:
+    """The reported index counts chunks, and a later chunk must still be attempted."""
+    provider = make_provider(probe={"command": None}, files={"upload_chunk_bytes": 4})
+    handle = await provider.create(spec())
+    source = tmp_path / "src.bin"
+    source.write_bytes(b"abcdefghij")
+    fake_session.bash_results = [
+        IdeGymBashResult(stdout="", stderr="", exit_code=0),
+        IdeGymBashResult(stdout="", stderr="disk full", exit_code=1),
+    ]
+    with pytest.raises(idegym_provider.IdeGymOperationError, match="failed on chunk 2/3"):
+        await provider.upload_file(handle, source, "/tmp/x.bin")
+
+
+@requires_bash
+async def test_download_without_a_cap_is_uncapped(make_provider, tmp_path: Path) -> None:
+    """`max_download_bytes: null` disables the check rather than comparing against None."""
+    provider = make_provider(
+        LocalBashSession(),
+        probe={"command": None, "verify_workdir": False},
+        files={"max_download_bytes": None, "download_chunk_bytes": 16},
+    )
+    handle = await provider.create(spec())
+    payload = bytes(range(64))
+    source = tmp_path / "blob.bin"
+    source.write_bytes(payload)
+    out = tmp_path / "back.bin"
+    await provider.download_file(handle, str(source), out)
+    assert out.read_bytes() == payload
+
+
 async def test_download_rejects_unparsable_size_and_bad_base64(
     make_provider, fake_session: FakeSession, tmp_path: Path
 ) -> None:

--- a/tests/unit_tests/test_idegym_session.py
+++ b/tests/unit_tests/test_idegym_session.py
@@ -423,8 +423,8 @@ def test_build_client_constructs_a_real_sdk_client(monkeypatch: pytest.MonkeyPat
     """Construct the real ``IdeGYMClient`` (no I/O) and check what it was handed.
 
     This is the one place the provider's constructor arguments meet the SDK's, and
-    it is also where tracing is pinned off: the SDK's own default endpoint is a
-    JetBrains-hosted collector.
+    it is also where tracing is pinned off: the SDK ships a default OTLP endpoint
+    that traces off-box.
     """
     from idegym.client import IdeGYMClient
 
@@ -666,7 +666,7 @@ def test_aiohttp_backend_falls_back_when_the_bridge_is_missing(
 
 
 def test_tracing_stays_off_unless_an_endpoint_is_configured() -> None:
-    """The SDK defaults to a JetBrains-hosted collector; the provider must not."""
+    """The SDK traces to its default off-box collector; the provider must not."""
     from idegym.api.config import OTELConfig, TracingConfig
 
     assert OTELConfig(tracing=TracingConfig(endpoint=None)).tracing.enabled is False

--- a/tests/unit_tests/test_idegym_session.py
+++ b/tests/unit_tests/test_idegym_session.py
@@ -352,8 +352,8 @@ def test_attribution_can_be_disabled() -> None:
 async def test_session_calls_bind_against_the_installed_sdk() -> None:
     """Bind the session's exact SDK call shapes against the installed signatures.
 
-    The provider talks to IdeGYM only through these calls, so this is what catches
-    a pre-1.0 SDK changing its argument names underneath the pinned range.
+    The provider talks to IdeGYM only through these calls, and the dependency carries no
+    upper bound, so this is the guard against a pre-1.0 SDK renaming an argument.
     """
     import inspect
 

--- a/tests/unit_tests/test_idegym_session.py
+++ b/tests/unit_tests/test_idegym_session.py
@@ -1,0 +1,674 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the shared IdeGYM orchestrator session.
+
+The session is where the provider's two structural claims live -- one registered
+IdeGYM client per process, reference-counted, on a private event loop -- so these
+tests are about that machinery rather than about sandbox behavior: refcounting,
+cross-loop bridging, and the SDK call shapes. The SDK itself is faked at the
+``IdeGYMClient`` boundary; the tests gated on ``idegym`` being installed check that
+the provider's real calls bind against the published signatures.
+"""
+
+import asyncio
+import importlib.util
+import threading
+from typing import Any
+
+import pytest
+
+from nemo_gym.sandbox.providers.idegym import session as idegym_session
+from nemo_gym.sandbox.providers.idegym.config import (
+    IdeGymAttributionConfig,
+    IdeGymConnectionConfig,
+    IdeGymPollingConfig,
+)
+from nemo_gym.sandbox.providers.idegym.errors import IdeGymError, IdeGymUnknownServerError
+from nemo_gym.sandbox.providers.idegym.session import (
+    IdeGymSession,
+    _SessionLoop,
+    acquire_session,
+    active_session_count,
+    build_transport,
+    install_transport,
+    release_session,
+    resolve_client_name,
+)
+
+
+pytestmark = pytest.mark.sandbox
+
+idegym = pytest.importorskip("idegym.client", reason="idegym-client optional dependency is not installed")
+
+# Captured before the autouse fixture replaces it, so the tests that exercise the
+# real SDK construction can still reach it.
+REAL_BUILD_CLIENT = IdeGymSession._build_client
+
+
+class FakeServer:
+    """Stands in for the SDK's ``IdeGYMServer`` handle."""
+
+    def __init__(self, server_id: int) -> None:
+        self.server_id = server_id
+        self.bash_calls: list[dict[str, Any]] = []
+        self.capability_calls = 0
+
+    async def execute_bash(self, **kwargs: Any) -> Any:
+        self.bash_calls.append(kwargs)
+        from idegym.api.tools.bash import BashCommandResponse
+
+        return BashCommandResponse(stdout="out", stderr="err", exit_code=0)
+
+    async def list_capabilities(self) -> Any:
+        self.capability_calls += 1
+        from idegym.api.capabilities import CapabilitiesResponse
+
+        return CapabilitiesResponse(plugins=["tools"])
+
+
+class FakeClient:
+    """Stands in for the SDK's ``IdeGYMClient``, recording lifecycle transitions."""
+
+    instances: list["FakeClient"] = []
+
+    def __init__(self) -> None:
+        from uuid import uuid4
+
+        self.client_id = uuid4()
+        self.entered = 0
+        self.exited = 0
+        self.start_calls: list[dict[str, Any]] = []
+        self.stop_calls: list[Any] = []
+        self.servers: list[FakeServer] = []
+        self.next_server_id = 1
+        self.start_error: Exception | None = None
+        self.enter_error: Exception | None = None
+        FakeClient.instances.append(self)
+
+    async def __aenter__(self) -> "FakeClient":
+        if self.enter_error is not None:
+            raise self.enter_error
+        self.entered += 1
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        self.exited += 1
+
+    async def health_check(self) -> Any:
+        from idegym.api.health import HealthCheckResponse
+
+        return HealthCheckResponse(status="healthy")
+
+    async def start_server(self, **kwargs: Any) -> FakeServer:
+        self.start_calls.append(kwargs)
+        if self.start_error is not None:
+            raise self.start_error
+        server = FakeServer(self.next_server_id)
+        self.next_server_id += 1
+        self.servers.append(server)
+        return server
+
+    async def stop_server(self, server: Any, polling_config: Any = None) -> None:
+        self.stop_calls.append(server)
+
+
+@pytest.fixture(autouse=True)
+def isolate_sessions(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Keep the module-level session registry from leaking between tests."""
+    FakeClient.instances = []
+    idegym_session._SESSIONS.clear()
+    monkeypatch.setattr(IdeGymSession, "_build_client", lambda self: FakeClient())
+    monkeypatch.setattr(idegym_session, "require_idegym_client", lambda: None)
+    yield
+    idegym_session._SESSIONS.clear()
+
+
+def connection(**overrides: Any) -> IdeGymConnectionConfig:
+    return IdeGymConnectionConfig(**{"orchestrator_url": "idegym.test", "client_name": "test-client", **overrides})
+
+
+POLLING = IdeGymPollingConfig()
+
+
+# --- private event loop ----------------------------------------------------
+
+
+async def test_session_loop_runs_work_on_its_own_thread_and_propagates_results() -> None:
+    loop = _SessionLoop("test-session-loop")
+    caller_thread = threading.get_ident()
+    try:
+
+        async def where() -> int:
+            return threading.get_ident()
+
+        assert await asyncio.wrap_future(loop.submit(where)) != caller_thread
+
+        async def boom() -> None:
+            raise ValueError("from the session loop")
+
+        with pytest.raises(ValueError, match="from the session loop"):
+            await asyncio.wrap_future(loop.submit(boom))
+    finally:
+        loop.stop()
+        loop.stop()  # idempotent
+
+
+# --- registration and refcounting -----------------------------------------
+
+
+async def test_sandboxes_sharing_a_connection_share_one_registration() -> None:
+    config = connection()
+    first = await acquire_session(config, IdeGymAttributionConfig())
+    second = await acquire_session(config, IdeGymAttributionConfig())
+    assert first is second
+    assert active_session_count() == 1
+    assert len(FakeClient.instances) == 1
+    assert FakeClient.instances[0].entered == 1
+
+    # Only the last release unregisters, otherwise stopping one sandbox would
+    # terminate every other sandbox owned by the same IdeGYM client.
+    await release_session(first)
+    assert active_session_count() == 1
+    assert FakeClient.instances[0].exited == 0
+
+    await release_session(second)
+    assert active_session_count() == 0
+    assert FakeClient.instances[0].exited == 1
+
+
+async def test_sessions_are_acquired_concurrently_without_duplicate_registration() -> None:
+    config = connection()
+    sessions = await asyncio.gather(*(acquire_session(config, IdeGymAttributionConfig()) for _ in range(5)))
+    assert len({id(session) for session in sessions}) == 1
+    assert len(FakeClient.instances) == 1
+    for session in sessions:
+        await release_session(session)
+    assert active_session_count() == 0
+
+
+async def test_different_connections_and_client_names_get_different_sessions() -> None:
+    a = await acquire_session(connection(), IdeGymAttributionConfig())
+    b = await acquire_session(connection(namespace="other"), IdeGymAttributionConfig())
+    c = await acquire_session(connection(client_name="other-client"), IdeGymAttributionConfig())
+    assert len({id(a), id(b), id(c)}) == 3
+    assert active_session_count() == 3
+    for session in (a, b, c):
+        await release_session(session)
+
+
+async def test_a_session_acquired_after_the_last_release_registers_again() -> None:
+    config = connection()
+    first = await acquire_session(config, IdeGymAttributionConfig())
+    await release_session(first)
+    second = await acquire_session(config, IdeGymAttributionConfig())
+    assert second is not first
+    assert len(FakeClient.instances) == 2
+    await release_session(second)
+
+
+async def test_failed_registration_is_not_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    def build_failing_client(self: IdeGymSession) -> FakeClient:
+        client = FakeClient()
+        client.enter_error = RuntimeError("orchestrator refused the registration")
+        return client
+
+    monkeypatch.setattr(IdeGymSession, "_build_client", build_failing_client)
+    with pytest.raises(RuntimeError, match="refused the registration"):
+        await acquire_session(connection(), IdeGymAttributionConfig())
+    # A cached failure would make every later sandbox in the process fail too.
+    assert active_session_count() == 0
+    with pytest.raises(RuntimeError, match="refused the registration"):
+        await acquire_session(connection(), IdeGymAttributionConfig())
+    assert len(FakeClient.instances) == 2
+
+
+async def test_releasing_an_unknown_session_is_a_no_op() -> None:
+    session = await acquire_session(connection(), IdeGymAttributionConfig())
+    await release_session(session)
+    await release_session(session)
+    assert active_session_count() == 0
+
+
+async def test_stopping_a_session_that_never_started_is_safe() -> None:
+    session = IdeGymSession(connection(), "unstarted")
+    await session.stop()
+    await session.stop()
+    assert session.client_name == "unstarted"
+
+
+async def test_a_factory_that_raises_before_awaiting_reaches_the_caller() -> None:
+    """A synchronous raise inside the submitted factory must resolve the future.
+
+    Left to the loop's exception handler it would never be reported, and the caller
+    would wait forever instead of seeing the error.
+    """
+    session = await acquire_session(connection(), IdeGymAttributionConfig())
+    try:
+        async with asyncio.timeout(5):
+            with pytest.raises(IdeGymUnknownServerError, match="not held"):
+                await session.list_capabilities(999)
+    finally:
+        await release_session(session)
+
+
+async def test_an_operation_in_flight_when_the_session_stops_is_failed_not_hung(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stopping the loop must fail anything still waiting on it."""
+    release = threading.Event()
+
+    async def blocking_capabilities(self: FakeServer) -> Any:
+        while not release.is_set():
+            await asyncio.sleep(0)
+
+    session = await acquire_session(connection(), IdeGymAttributionConfig())
+    ref = await session.start_server({"image_tag": "reg/env:1", "server_name": "s"}, polling=POLLING, timeout_s=5)
+    monkeypatch.setattr(FakeServer, "list_capabilities", blocking_capabilities)
+    try:
+        pending = asyncio.create_task(session.list_capabilities(ref.server_id))
+        await asyncio.sleep(0.05)
+        await release_session(session)
+        async with asyncio.timeout(5):
+            with pytest.raises(IdeGymError, match="stopped while this operation was in flight"):
+                await pending
+    finally:
+        release.set()
+
+
+async def test_a_cancelled_acquirer_does_not_fail_the_others(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Acquirers share one readiness future, and cancellation propagates into it.
+
+    Without a per-waiter view, one cancelled acquirer would cancel the registration
+    that its peers are waiting on.
+    """
+    gate = threading.Event()
+    real_build = IdeGymSession._build_client
+
+    def slow_client(self: IdeGymSession) -> Any:
+        gate.wait(5)
+        return real_build(self)
+
+    monkeypatch.setattr(IdeGymSession, "_build_client", slow_client)
+    config = connection()
+    first = asyncio.create_task(acquire_session(config, IdeGymAttributionConfig()))
+    second = asyncio.create_task(acquire_session(config, IdeGymAttributionConfig()))
+    await asyncio.sleep(0.05)
+    first.cancel()
+    gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    session = await second
+    try:
+        assert await session.health() == "healthy"
+    finally:
+        await release_session(session)
+
+
+async def test_operations_on_a_stopped_session_fail_clearly() -> None:
+    session = await acquire_session(connection(), IdeGymAttributionConfig())
+    await release_session(session)
+    with pytest.raises(IdeGymError, match="has been stopped"):
+        await session.health()
+
+
+# --- client naming ---------------------------------------------------------
+
+
+def test_explicit_client_name_wins_over_attribution() -> None:
+    name = resolve_client_name(connection(client_name="pinned-by-operator"), IdeGymAttributionConfig(team="t"))
+    assert name == "pinned-by-operator"
+
+
+def test_attribution_derived_client_name_excludes_the_run_id() -> None:
+    attribution = IdeGymAttributionConfig(team="My Team", user="dev", workload="swebench", run="run-1234")
+    name = resolve_client_name(connection(client_name=None), attribution)
+    assert name == "nemo-gym-my-team-dev-swebench"
+    # The name has to stay stable across launches for quota-rule matching, so the
+    # per-launch run id must not appear in it.
+    assert "run-1234" not in name
+
+
+def test_attribution_can_be_disabled() -> None:
+    name = resolve_client_name(connection(client_name=None), IdeGymAttributionConfig(enabled=False))
+    assert name == "nemo-gym"
+
+
+# --- SDK call shapes -------------------------------------------------------
+
+
+async def test_session_calls_bind_against_the_installed_sdk() -> None:
+    """Bind the session's exact SDK call shapes against the installed signatures.
+
+    The provider talks to IdeGYM only through these calls, so this is what catches
+    a pre-1.0 SDK changing its argument names underneath the pinned range.
+    """
+    import inspect
+
+    from idegym.client import IdeGYMClient
+    from idegym.client.operations.utils import PollingConfig
+    from idegym.client.server import IdeGYMServer
+
+    inspect.signature(IdeGYMClient.__init__).bind(
+        None,
+        orchestrator_url="idegym.test",
+        name="n",
+        namespace="ns",
+        nodes_count=0,
+        auth=None,
+        heartbeat_interval_in_seconds=60,
+        request_timeout_in_seconds=60,
+        otel_config=None,
+    )
+    inspect.signature(IdeGYMClient.start_server).bind(
+        None,
+        image_tag="reg/env:1",
+        server_name="nemo-gym-abcdef12",
+        namespace="ns",
+        runtime_class_name=None,
+        run_as_root=True,
+        service_port=80,
+        container_port=8000,
+        resources=None,
+        node_selector=None,
+        volumes=None,
+        volume_mounts=None,
+        env_from=None,
+        service_account_name=None,
+        pod_overrides=None,
+        server_start_wait_timeout_in_seconds=60,
+        retry_delay_in_seconds=15,
+        polling_config=PollingConfig(),
+        reuse_strategy="NONE",
+        server_kind="idegym",
+        snapshot=None,
+        max_restarts=0,
+    )
+    inspect.signature(IdeGYMClient.health_check).bind(None)
+    inspect.signature(IdeGYMServer.execute_bash).bind(
+        None,
+        script="true",
+        command_timeout=1.0,
+        graceful_termination_timeout=2.0,
+        request_timeout=3,
+        polling_config=PollingConfig(),
+    )
+    inspect.signature(IdeGYMServer.list_capabilities).bind(None)
+    # `IdeGYMClient.stop_server` is wrapped by a retry decorator that does not
+    # preserve the signature, so only its presence can be asserted here.
+    assert inspect.iscoroutinefunction(IdeGYMClient.stop_server)
+    PollingConfig(
+        initial_delay_in_sec=0.25,
+        wait_timeout_in_sec=60,
+        poll_interval_in_sec=0.0,
+        factor_for_exponential_wait=1.5,
+        max_delay_for_exponential_wait_in_sec=30.0,
+    )
+
+
+@pytest.mark.parametrize("with_auth", [False, True])
+def test_build_client_constructs_a_real_sdk_client(monkeypatch: pytest.MonkeyPatch, with_auth: bool) -> None:
+    """Construct the real ``IdeGYMClient`` (no I/O) and check what it was handed.
+
+    This is the one place the provider's constructor arguments meet the SDK's, and
+    it is also where tracing is pinned off: the SDK's own default endpoint is a
+    JetBrains-hosted collector.
+    """
+    from idegym.client import IdeGYMClient
+
+    monkeypatch.delenv("IDEGYM_AUTH_USERNAME", raising=False)
+    monkeypatch.delenv("IDEGYM_AUTH_PASSWORD", raising=False)
+    config = connection(
+        client_name="build-client-test",
+        username="user" if with_auth else None,
+        password="secret" if with_auth else None,
+        heartbeat_interval_s=17,
+        request_timeout_s=23,
+    )
+    session = IdeGymSession(config, "build-client-test")
+    client = None
+    try:
+        client = REAL_BUILD_CLIENT(session)
+        assert isinstance(client, IdeGYMClient)
+        assert client.name == "build-client-test"
+        assert str(client._http_client.base_url).rstrip("/") == "http://idegym.test"
+        assert client._http_client.timeout.read == 23
+        assert session._connection.heartbeat_interval_s == 17
+        assert client._otel_config.tracing.enabled is False
+        expected = "Basic dXNlcjpzZWNyZXQ=" if with_auth else None
+        assert client._http_client.headers.get("authorization") == expected
+    finally:
+        if client is not None:
+            asyncio.run(client._http_client.aclose())
+        session._loop.stop()
+
+
+def test_build_client_requires_credentials_for_a_real_orchestrator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The SDK only allows anonymous access to its local-testing host."""
+    monkeypatch.delenv("IDEGYM_AUTH_USERNAME", raising=False)
+    monkeypatch.delenv("IDEGYM_AUTH_PASSWORD", raising=False)
+    session = IdeGymSession(connection(orchestrator_url="idegym.example.com"), "no-creds")
+    try:
+        with pytest.raises(ValueError, match="[Uu]sername and password"):
+            REAL_BUILD_CLIENT(session)
+    finally:
+        session._loop.stop()
+
+
+async def test_start_server_builds_real_sdk_models() -> None:
+    """The plain-dict request is validated into the SDK's own pydantic models."""
+    from idegym.api.orchestrator.servers import ServerKind, ServerReuseStrategy
+    from idegym.api.pod_spec import KubernetesEnvFromSource, KubernetesPodOverrides, KubernetesVolume
+    from idegym.api.resources import KubernetesResources
+
+    session = await acquire_session(connection(), IdeGymAttributionConfig())
+    try:
+        ref = await session.start_server(
+            {
+                "image_tag": "reg/env:1",
+                "server_name": "nemo-gym-abcdef12",
+                "run_as_root": True,
+                "resources": {"requests": {"cpu": "500m"}, "limits": {"cpu": "2", "memory": "8192Mi"}},
+                "volumes": [{"name": "creds", "secret": {"secretName": "creds"}}],
+                "volume_mounts": [{"name": "creds", "mountPath": "/etc/creds"}],
+                "env_from": [{"secretRef": {"name": "creds"}}],
+                "pod_overrides": {"tolerations": [{"key": "dedicated", "operator": "Exists"}]},
+                "snapshot": {"id": "17"},
+                "reuse_strategy": "NONE",
+                "server_kind": "idegym",
+            },
+            polling=POLLING,
+            timeout_s=42.4,
+        )
+        assert ref.server_id == 1
+        assert ref.server_name == "nemo-gym-abcdef12"
+        assert ref.namespace == "idegym"
+
+        call = FakeClient.instances[0].start_calls[0]
+        assert isinstance(call["resources"], KubernetesResources)
+        assert str(call["resources"].limits.cpu) == "2"
+        assert isinstance(call["volumes"][0], KubernetesVolume)
+        assert isinstance(call["env_from"][0], KubernetesEnvFromSource)
+        assert isinstance(call["pod_overrides"], KubernetesPodOverrides)
+        assert call["reuse_strategy"] is ServerReuseStrategy.NONE
+        assert call["server_kind"] is ServerKind.IDEGYM
+        assert call["namespace"] == "idegym"
+        # The readiness budget is handed to the SDK, which owns the wait, rounded
+        # up to the whole seconds its API takes.
+        assert call["server_start_wait_timeout_in_seconds"] == 43
+        assert call["polling_config"].wait_timeout_in_sec == 43
+    finally:
+        await release_session(session)
+
+
+async def test_execute_bash_stop_and_capabilities_use_the_tracked_server() -> None:
+    session = await acquire_session(connection(), IdeGymAttributionConfig())
+    try:
+        ref = await session.start_server({"image_tag": "reg/env:1", "server_name": "s"}, polling=POLLING, timeout_s=5)
+        result = await session.execute_bash(
+            ref.server_id,
+            "true",
+            command_timeout_s=12.0,
+            graceful_termination_timeout_s=2.0,
+            request_timeout_s=30.5,
+            polling=POLLING,
+        )
+        assert (result.stdout, result.stderr, result.exit_code) == ("out", "err", 0)
+        server = FakeClient.instances[0].servers[0]
+        assert server.bash_calls[0]["command_timeout"] == 12.0
+        assert server.bash_calls[0]["request_timeout"] == 31
+
+        assert await session.list_capabilities(ref.server_id) == ["tools"]
+        assert await session.health() == "healthy"
+
+        await session.stop_server(ref.server_id, polling=POLLING, timeout_s=5)
+        assert FakeClient.instances[0].stop_calls == [server]
+        # Stopping forgets the server, so a stale id fails loudly instead of
+        # silently addressing a pod that is already gone.
+        with pytest.raises(IdeGymUnknownServerError, match="not held by this session"):
+            await session.list_capabilities(ref.server_id)
+    finally:
+        await release_session(session)
+
+
+async def test_a_failed_start_does_not_track_a_server() -> None:
+    session = await acquire_session(connection(), IdeGymAttributionConfig())
+    try:
+        FakeClient.instances[0].start_error = RuntimeError("no capacity")
+        with pytest.raises(RuntimeError, match="no capacity"):
+            await session.start_server({"image_tag": "reg/env:1", "server_name": "s"}, polling=POLLING, timeout_s=5)
+        with pytest.raises(IdeGymUnknownServerError, match="not held"):
+            await session.stop_server(1, polling=POLLING, timeout_s=5)
+    finally:
+        await release_session(session)
+
+
+async def test_a_slow_operation_does_not_block_the_others(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Concurrency is bounded by the HTTP pool, not by serializing whole operations.
+
+    A create can poll for the whole readiness timeout, so holding a slot for an entire
+    operation would let provisioning block the exec calls of running sandboxes.
+    """
+    release = threading.Event()
+    started = 0
+
+    async def slow_capabilities(self: FakeServer) -> Any:
+        nonlocal started
+        started += 1
+        while not release.is_set():
+            await asyncio.sleep(0)
+        from idegym.api.capabilities import CapabilitiesResponse
+
+        return CapabilitiesResponse(plugins=[])
+
+    monkeypatch.setattr(FakeServer, "list_capabilities", slow_capabilities)
+    session = await acquire_session(connection(), IdeGymAttributionConfig())
+    try:
+        refs = [
+            await session.start_server(
+                {"image_tag": "reg/env:1", "server_name": f"s{index}"}, polling=POLLING, timeout_s=5
+            )
+            for index in range(5)
+        ]
+        pending = [asyncio.create_task(session.list_capabilities(ref.server_id)) for ref in refs]
+        await asyncio.sleep(0.05)
+        assert started == len(refs)
+        # An unrelated operation still gets through while all five are in flight.
+        assert await session.health() == "healthy"
+    finally:
+        release.set()
+        await asyncio.gather(*pending)
+        await release_session(session)
+
+
+# --- HTTP transport --------------------------------------------------------
+
+
+requires_aiohttp_bridge = pytest.mark.skipif(
+    importlib.util.find_spec("httpx_aiohttp") is None,
+    reason="httpx-aiohttp (nemo-gym[sandbox]) is not installed",
+)
+
+
+@requires_aiohttp_bridge
+def test_build_transport_honors_the_configured_backend() -> None:
+    aiohttp_transport = build_transport(connection(transport_backend="aiohttp"))
+    httpx_transport = build_transport(connection(transport_backend="httpx"))
+    assert type(aiohttp_transport).__name__ == "AiohttpTransport"
+    assert type(httpx_transport).__name__ == "AsyncHTTPTransport"
+
+
+def test_build_transport_applies_the_configured_pool_limits() -> None:
+    transport = build_transport(
+        connection(
+            transport_backend="httpx",
+            max_connections=7,
+            max_keepalive_connections=3,
+            keepalive_expiry_s=4.0,
+        )
+    )
+    # httpx exposes the resolved limits only on the pool, hence the private reach.
+    pool = transport._pool
+    assert (pool._max_connections, pool._max_keepalive_connections, pool._keepalive_expiry) == (7, 3, 4.0)
+
+
+def test_install_transport_replaces_the_sdk_transport() -> None:
+    import httpx
+
+    client = type("Client", (), {})()
+    client._http_client = httpx.AsyncClient()
+    original = client._http_client._transport
+    install_transport(client, connection(transport_backend="httpx"))
+    assert client._http_client._transport is not original
+    assert type(client._http_client._transport).__name__ == "AsyncHTTPTransport"
+
+
+def test_install_transport_degrades_when_the_sdk_shape_changes(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Reaching into the SDK's private httpx client must never be fatal."""
+    monkeypatch.setattr(idegym_session, "_TRANSPORT_WARNED", False)
+    with caplog.at_level("WARNING"):
+        install_transport(type("Client", (), {})(), connection())
+    assert "falling back to the SDK's own transport" in caplog.text
+
+
+@requires_aiohttp_bridge
+def test_aiohttp_backend_falls_back_when_the_bridge_is_missing(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "httpx_aiohttp":
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with caplog.at_level("WARNING"):
+        transport = build_transport(connection(transport_backend="aiohttp"))
+    assert type(transport).__name__ == "AsyncHTTPTransport"
+    assert "httpx-aiohttp is not installed" in caplog.text
+
+
+def test_tracing_stays_off_unless_an_endpoint_is_configured() -> None:
+    """The SDK defaults to a JetBrains-hosted collector; the provider must not."""
+    from idegym.api.config import OTELConfig, TracingConfig
+
+    assert OTELConfig(tracing=TracingConfig(endpoint=None)).tracing.enabled is False
+    assert connection().tracing_enabled is False
+    assert connection(tracing_endpoint="http://collector.example/v1/traces").tracing_enabled is True

--- a/tests/unit_tests/test_idegym_session.py
+++ b/tests/unit_tests/test_idegym_session.py
@@ -433,7 +433,7 @@ def test_build_client_constructs_a_real_sdk_client(monkeypatch: pytest.MonkeyPat
     config = connection(
         client_name="build-client-test",
         username="user" if with_auth else None,
-        password="secret" if with_auth else None,
+        password="secret" if with_auth else None,  # pragma: allowlist secret
         heartbeat_interval_s=17,
         request_timeout_s=23,
     )
@@ -481,7 +481,7 @@ async def test_start_server_builds_real_sdk_models() -> None:
                 "server_name": "nemo-gym-abcdef12",
                 "run_as_root": True,
                 "resources": {"requests": {"cpu": "500m"}, "limits": {"cpu": "2", "memory": "8192Mi"}},
-                "volumes": [{"name": "creds", "secret": {"secretName": "creds"}}],
+                "volumes": [{"name": "creds", "secret": {"secretName": "creds"}}],  # pragma: allowlist secret
                 "volume_mounts": [{"name": "creds", "mountPath": "/etc/creds"}],
                 "env_from": [{"secretRef": {"name": "creds"}}],
                 "pod_overrides": {"tolerations": [{"key": "dedicated", "operator": "Exists"}]},

--- a/uv.lock
+++ b/uv.lock
@@ -414,7 +414,7 @@ name = "cffi"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
 wheels = [
@@ -756,7 +756,7 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7d/ee943554f83d6a143d9e0a5cf27cd7f5f8f6ef447c7e8366d9ad6a5d1bf2/cuda_tile-1.3.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:8a9bd4dae193cddf438f55d617b6f25b4b0b0fcf4ac4acde7d2695898e396c30", size = 245750, upload-time = "2026-04-20T15:52:12.91Z" },
@@ -765,9 +765,9 @@ wheels = [
 
 [package.optional-dependencies]
 tileiras = [
-    { name = "nvidia-cuda-nvcc", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cuda-tileiras", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cuda-nvcc", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-cuda-tileiras", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
 ]
 
 [[package]]
@@ -781,7 +781,7 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/a6/e3f6e9aefcc94d548e5d69f01a02ba5da7c5e200702eba3eb7a4f572a883/cuda_tile-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:c400918faa8492d84c4da3da81ce01ed30d81ed780f9ddbc1a9bdd588058b776", size = 304825, upload-time = "2026-07-08T01:49:37.749Z" },
@@ -791,7 +791,7 @@ wheels = [
 
 [package.optional-dependencies]
 tileiras = [
-    { name = "cuda-toolkit", version = "13.3.1", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvvm", "tileiras"] },
+    { name = "cuda-toolkit", version = "13.3.1", source = { registry = "https://pypi.org/simple" }, extra = ["nvcc", "nvvm", "tileiras"], marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -808,37 +808,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1126,6 +1126,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "durationpy"
+version = "0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
 ]
 
 [[package]]
@@ -1728,16 +1737,61 @@ cu13 = [
 
 [[package]]
 name = "hydra-core"
-version = "1.3.2"
+version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antlr4-python3-runtime" },
     { name = "omegaconf" },
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz", hash = "sha256:8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824", size = 3263494, upload-time = "2023-02-23T18:33:43.03Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/e4/69a522676faf88994d93d8a5e69e0666c61cae7f73d1bbcc483222023e74/hydra_core-1.3.5.tar.gz", hash = "sha256:71c441eabbde086062045e4d3fce9e26015244f1a4ac721cf3e444c7edf10633", size = 3264337, upload-time = "2026-08-05T18:33:21.394Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-py3-none-any.whl", hash = "sha256:fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b", size = 154547, upload-time = "2023-02-23T18:33:40.801Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/f9d463a6f3c7d0955753eca5cbbf35b596ac471dd13fe357211a53fd37be/hydra_core-1.3.5-py3-none-any.whl", hash = "sha256:a3ff35b4ea6794e4c83d993016f4bde4ac35797ebe7a08f30e83ed9341880331", size = 155768, upload-time = "2026-08-05T18:33:19.834Z" },
+]
+
+[[package]]
+name = "idegym-api"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idegym-common-utils" },
+    { name = "kubernetes" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "structlog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/3d/5dd13d2d8d6c985d3b47e3e5c0a1b3e982e32d4315bff9ce971d22616711/idegym_api-0.11.1.tar.gz", hash = "sha256:ae2b2a16846d48471e38843f6ffda3dfeb9ec44650bf065df66c9324689752e6", size = 24493, upload-time = "2026-07-30T15:23:23.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/48/72e215c157299d940e7e2bb1f66601d34d35645f572fa44b0da3ce0aaeb8/idegym_api-0.11.1-py3-none-any.whl", hash = "sha256:ea4dd0b6bbb5e143216fe7a6f90870ab8ea5137ceacc64927e3df92b81a6b6e7", size = 35445, upload-time = "2026-07-30T15:23:18.64Z" },
+]
+
+[[package]]
+name = "idegym-client"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "idegym-api" },
+    { name = "idegym-common-utils" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/13/7fc17a8bb41c0c219b6d362a30a1b26c88e20146bc3455f18d8438332d96/idegym_client-0.11.1.tar.gz", hash = "sha256:2744956add0b27560625c7ac625fe053af8344abcf41fb2dde59f0872846ec5d", size = 16093, upload-time = "2026-07-30T15:23:24.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/8b/be6c956383cebdfd36050de38823c97a67fa3708df7d64de0956a1344fa6/idegym_client-0.11.1-py3-none-any.whl", hash = "sha256:0daa67205653d7e529243b64795e5a19104e00953f09fbf12b85edad7d076d02", size = 21493, upload-time = "2026-07-30T15:23:19.516Z" },
+]
+
+[[package]]
+name = "idegym-common-utils"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hydra-core" },
+    { name = "pydantic" },
+    { name = "structlog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/df/c8a16eb76b2140a15d915e43474250fe68cf698b382c219c00df310fa4b1/idegym_common_utils-0.11.1.tar.gz", hash = "sha256:e548be3c0d97bf4ab9369d8dd40e74fffc6e050cd95821519d5f2029163386f2", size = 4838, upload-time = "2026-07-30T15:23:25.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/9e/994e4a150d3ecd4f5c5e582a6c4b669d333bb7a84506a4b050608c672f76/idegym_common_utils-0.11.1-py3-none-any.whl", hash = "sha256:cc0ac1f0792b9d28832168c37951cae9ba8cfe28943a9e562968a4b47684c3d2", size = 4833, upload-time = "2026-07-30T15:23:20.304Z" },
 ]
 
 [[package]]
@@ -1999,6 +2053,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/18/43a5f24608d8c313dd189cf838c8e68d75b115567c6279de7796197cfb6a/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646", size = 2394403, upload-time = "2026-03-09T13:15:31.517Z" },
     { url = "https://files.pythonhosted.org/packages/3b/b5/98222136d839b8afabcaa943b09bd05888c2d36355b7e448550211d1fca4/kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681", size = 79687, upload-time = "2026-03-09T13:15:33.204Z" },
     { url = "https://files.pythonhosted.org/packages/99/a2/ca7dc962848040befed12732dff6acae7fb3c4f6fc4272b3f6c9a30b8713/kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57", size = 70032, upload-time = "2026-03-09T13:15:34.411Z" },
+]
+
+[[package]]
+name = "kubernetes"
+version = "36.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/57/b07b96353f902aa1bdbe00e878e3a12a137977d03a962479785576aa8ec9/kubernetes-36.0.3.tar.gz", hash = "sha256:36993ed25ce59b789c9341473a228fcf268504a2fec7c2b2b1531d73072e5ce7", size = 2337528, upload-time = "2026-07-13T20:38:12.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/30/a96d47df739689ac0001ade0afefc16e3b477fc2fb426b568515fdc8afce/kubernetes-36.0.3-py2.py3-none-any.whl", hash = "sha256:8fde9241c4b298e6374a069dcf728359b4e72c2fb29489a975ba4e1c047cf10f", size = 4618066, upload-time = "2026-07-13T20:38:10.172Z" },
 ]
 
 [[package]]
@@ -2616,6 +2691,10 @@ dev = [
     { name = "requests-mock" },
     { name = "ruff" },
 ]
+idegym = [
+    { name = "httpx-aiohttp" },
+    { name = "idegym-client" },
+]
 openshell = [
     { name = "openshell" },
 ]
@@ -2653,8 +2732,10 @@ requires-dist = [
     { name = "fonttools", specifier = ">=4.60.2" },
     { name = "gitpython", specifier = ">=3.1.57" },
     { name = "gprof2dot", marker = "extra == 'dev'" },
+    { name = "httpx-aiohttp", marker = "extra == 'idegym'", specifier = ">=0.2.0" },
     { name = "httpx-aiohttp", marker = "extra == 'sandbox'", specifier = ">=0.2.0" },
     { name = "hydra-core" },
+    { name = "idegym-client", marker = "extra == 'idegym'", specifier = ">=0.11.1,<0.12" },
     { name = "itsdangerous" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "mlflow", specifier = ">=3.15.1" },
@@ -2692,7 +2773,7 @@ requires-dist = [
     { name = "wandb" },
     { name = "yappi", specifier = ">=1.7.6" },
 ]
-provides-extras = ["all", "vllm", "sandbox", "openshell", "dev"]
+provides-extras = ["all", "vllm", "sandbox", "openshell", "idegym", "dev"]
 
 [package.metadata.requires-dev]
 codec = [
@@ -2868,9 +2949,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "nvidia-cuda-crt" },
-    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cuda-crt", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/a3/403638f80960e677ae8ecc78059d8c85dc2519b85ed8c0229840dc6f3b54/nvidia_cuda_nvcc-13.2.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:909140a1f942b943982b2eff120e618c94e29d75d9e33f5cd074f0e64eb411e8", size = 38716270, upload-time = "2026-07-16T09:37:12.754Z" },
@@ -2888,10 +2969,10 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "nvidia-cuda-crt" },
-    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cuda-crt", marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime", version = "13.0.96", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
     { name = "nvidia-cuda-runtime", version = "13.3.29", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
-    { name = "nvidia-nvvm", version = "13.3.73", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvvm", version = "13.3.73", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/89/97eb797bb8bdee1d4e74069d072c24b79ae90c012fa3b539f2a7ccecf6cf/nvidia_cuda_nvcc-13.3.73-py3-none-win_amd64.whl", hash = "sha256:3d9da631bcac3dee49d1357b84cd05abe56aa3ccf76b05a7df8a80ef78addcb5", size = 32536529, upload-time = "2026-06-29T17:11:25.455Z" },
@@ -2943,9 +3024,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "nvidia-cuda-nvcc", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cuda-nvcc", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-nvvm", version = "13.2.86", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/a2/ade26f7fb55a5bb87815f7650660463d6601db411d5a9228f414b3ed5dfe/nvidia_cuda_tileiras-13.2.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5f79c6a9bf8583dae105cd67b985555f39f4576416664a86383ba892e8c346c9", size = 36418795, upload-time = "2026-07-16T09:43:35.006Z" },
@@ -2961,9 +3042,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "nvidia-cuda-nvcc", version = "13.3.73", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-nvvm", version = "13.3.73", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cuda-nvcc", version = "13.3.73", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
+    { name = "nvidia-nvvm", version = "13.3.73", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/b1/9dcc1aa140205c8f9ecdb671b488e1189462d870e5ed0eac02522722cb9a/nvidia_cuda_tileiras-13.3.36-py3-none-win_amd64.whl", hash = "sha256:0dd286086c6d273826218d02c076ddea8e285b50ee223bd1429756b706b7bbc7", size = 29715011, upload-time = "2026-05-26T17:05:29.974Z" },
@@ -2974,7 +3055,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -3002,7 +3083,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3032,9 +3113,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3046,7 +3127,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3204,6 +3285,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "obstore"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3319,7 +3409,7 @@ name = "opencv-python-headless"
 version = "5.0.0.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/99/76b7c80252aa83c1af16393454aafd125a0287101afe8deb0a6821af0e30/opencv_python_headless-5.0.0.93.tar.gz", hash = "sha256:b82f9831daab90b725c7c1ee1b36cb5732c367096ac76d119e64e14eb70d5f3c", size = 81817738, upload-time = "2026-07-02T07:01:06.039Z" }
 
@@ -4318,19 +4408,38 @@ wheels = [
 
 [[package]]
 name = "pyyaml"
-version = "6.0.2"
+version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309, upload-time = "2024-08-06T20:32:43.4Z" },
-    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679, upload-time = "2024-08-06T20:32:44.801Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428, upload-time = "2024-08-06T20:32:46.432Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361, upload-time = "2024-08-06T20:32:51.188Z" },
-    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523, upload-time = "2024-08-06T20:32:53.019Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660, upload-time = "2024-08-06T20:32:54.708Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
-    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]
@@ -4543,6 +4652,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/92/32/587625f91f9a0a3d84688bf9cfc4b2480a7e8ec327cefd0ff2ac891fd2cf/requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401", size = 60901, upload-time = "2024-03-29T03:54:29.446Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/97/ec/889fbc557727da0c34a33850950310240f2040f3b1955175fdb2b36a8910/requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563", size = 27695, upload-time = "2024-03-29T03:54:27.64Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]
@@ -5031,6 +5153,15 @@ wheels = [
 ]
 
 [[package]]
+name = "structlog"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
+]
+
+[[package]]
 name = "supervisor"
 version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5269,9 +5400,9 @@ name = "torchvision"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch" },
+    { name = "numpy", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "pillow", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
+    { name = "torch", marker = "sys_platform != 'darwin' and sys_platform != 'win32'" },
 ]
 
 [[package]]
@@ -5609,6 +5740,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
     { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
     { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2735,7 +2735,7 @@ requires-dist = [
     { name = "httpx-aiohttp", marker = "extra == 'idegym'", specifier = ">=0.2.0" },
     { name = "httpx-aiohttp", marker = "extra == 'sandbox'", specifier = ">=0.2.0" },
     { name = "hydra-core" },
-    { name = "idegym-client", marker = "extra == 'idegym'", specifier = ">=0.11.1,<0.12" },
+    { name = "idegym-client", marker = "extra == 'idegym'", specifier = ">=0.11.1" },
     { name = "itsdangerous" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "mlflow", specifier = ">=3.15.1" },


### PR DESCRIPTION
## What does this PR do?

Closes #1780

Adds an `idegym` sandbox provider, so a NeMo Gym sandbox can be an
[IdeGYM](https://github.com/JetBrains-Research/idegym) server pod on Kubernetes — letting teams whose
environments already live in IdeGYM run them through Gym's agents without re-hosting the images. It
implements the provider-neutral `SandboxProvider` contract, so switching a benchmark to IdeGYM is
swapping one config path. `endpoint()`, PTY and `serialize()` are deliberately not claimed;
`DESIGN-DECISIONS.md` records why.

## Structure

```mermaid
flowchart LR
    API["AsyncSandbox / Sandbox<br/>(unchanged)"] --> R["provider registry<br/>(+1 entry)"]
    R --> P["IdeGymProvider<br/>(new)"]
    P -.-> T["spec · naming · shell<br/>transfer · errors<br/>(new)"]
    P --> S["IdeGymSession<br/>(new, only SDK import)"]
    S -->|HTTP| O["orchestrator<br/>(external)"]
    O -->|forwards as JSON| Pod["server pod<br/>(external)"]
```

`+2296` provider, `+1894` tests, `+709` docs, plus a registry entry and an opt-in
`nemo-gym[idegym]` extra.

## Verify

```bash
uv pip install 'nemo-gym[idegym]'
pytest tests/unit_tests/test_idegym_provider.py tests/unit_tests/test_idegym_session.py   # 159 tests
```

Unit tests cover config, spec translation, naming and error classification. For wiring, a
`bash`-backed fake session *executes* the generated scripts, so quoting, `cd` and base64 chunking at
unaligned boundaries are tested by running them. `test_session_calls_bind_against_the_installed_sdk`
pins every SDK call shape — the guard now that the dependency has no upper bound.

## Against a local IdeGYM

The provider defaults to `orchestrator_url: idegym.test`, so minikube needs no config:

```python
# curl -s idegym.test/health  ->  {"status":"healthy"}
spec = SandboxSpec(image="<an IdeGYM *server* image>", workdir="/home/appuser")
async with AsyncSandbox({"idegym": {}}, spec) as sb:
    await sb.start()                                  # pod scheduled, workdir checked
    print((await sb.exec("echo hi && pwd")).stdout)   # "hi\n/home/appuser"
    await sb.upload_file(Path("p.diff"), "/home/appuser/p.diff")
# leaving the block deletes the pod: kubectl get pods -n idegym  ->  empty
```

The image must run the IdeGYM server; a plain `swebench/*` image never becomes ready. Verified live
this way, including `mini_swe_agent_2` on a real SWE-bench task (gold patch → reward 1.0, 5/5 F2P)
and 3-way concurrency with no leaked pods.

One prerequisite outside this PR: `mini_swe_agent_2.yaml` declares `datasets: []` twice, which the
config loader rejects, so the `gym env start` flow the README documents needs that one-line fix
first. Deliberately not bundled here.

Full suite 2725 passed, 4 skipped. `pre-commit --all-files` clean. 15 commits, all DCO signed.

## Checklist

- [x] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [x] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [x] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [x] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [x] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
