### PR TITLE
feat(opencode): separate output-token cap from the context-window knob

### DIFF
--- a/responses_api_agents/opencode_sandboxed_agent/app.py
+++ b/responses_api_agents/opencode_sandboxed_agent/app.py
@@ -392,6 +392,12 @@ class OpenCodeSandboxedAgentConfig(BaseResponsesAPIAgentConfig):
     remote_opencode_musl_binary_path: Optional[str] = None
     opencode_config: Dict[str, Any] = Field(default_factory=dict)
     opencode_max_context_window: int
+    # Cap for OpenCode's `limit.output` (its maxOutputTokens). When unset, falls back to
+    # `opencode_max_context_window`, which makes every request carry max_tokens == the full
+    # window; backends that enforce prompt_tokens + max_tokens <= served context then reject
+    # every request outright. Set this to a sane generation cap (e.g. 32-64k) so the context
+    # window can stay at the served maximum.
+    opencode_max_output_tokens: Optional[int] = None
 
     # Sandbox config
     sandbox_provider: str
@@ -563,8 +569,11 @@ class OpenCodeSandboxedAgent(SimpleResponsesAPIAgent):
                             "limit": {
                                 "context": self.config.opencode_max_context_window,
                                 "input": self.config.opencode_max_context_window,
-                                # See the OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX flag below for more information.
-                                "output": self.config.opencode_max_context_window,
+                                # OpenCode derives maxOutputTokens from `output` (already distinct
+                                # from `context` in the pinned binary). See also the
+                                # OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX flag below.
+                                "output": self.config.opencode_max_output_tokens
+                                or self.config.opencode_max_context_window,
                             },
                         },
                     },


### PR DESCRIPTION
## What

Adds `opencode_max_output_tokens` to `opencode_sandboxed_agent`: an independent cap for OpenCode's `limit.output` (its `maxOutputTokens`). Unset falls back to `opencode_max_context_window` — current behavior, no change for existing configs.

## Why

Today the single `opencode_max_context_window` knob feeds `limit.context`, `limit.input` **and** `limit.output`, and the agent lifts OpenCode's 32k output ceiling via `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX` — so every request goes out with `max_tokens` equal to the full window (confirmed in model-call captures: all calls in a run carried `max_tokens=131072` with the knob at 131072).

Any backend that enforces `prompt_tokens + max_tokens <= served context` therefore rejects every request at any prompt size — compaction can't help, since the output term alone fills the window. In practice operators clamp the window knob to ~half the served context to compensate, which halves agent memory and lowers OpenCode's compaction threshold; long-horizon runs (SWE-bench Pro) feel this hardest. Even on clamping frontends, window-sized `max_tokens` declarations can distort scheduling at high concurrency.

No OpenCode binary bump is needed: the pinned 1.17.11 already derives `maxOutputTokens` from `limit.output` as a distinct field — the split only needed to exist on the Gym config side.

With this field, a config can run e.g. `opencode_max_context_window: 262144` + `opencode_max_output_tokens: 65536` and satisfy strict-backend constraints at the full served window.

cc @bxyu-nvidia

🤖 Generated with [Claude Code](https://claude.com/claude-code)