### PR TITLE
perf(model-server): add token metadata envelopes

### DIFF
--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -37,7 +37,7 @@ import time
 from abc import abstractmethod
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Any, Iterator, Literal, Mapping, Optional
 from uuid import uuid4
 
 import orjson
@@ -87,6 +87,7 @@ from nemo_gym.token_id_capture import (
 from nemo_gym.token_id_capture.config import token_id_capture_config
 from nemo_gym.token_id_capture.lineage import FileLineageStore
 from nemo_gym.token_id_capture.store import make_token_store
+from nemo_gym.token_metadata_codec import encode_output_item_token_fields, encode_token_list
 
 
 logger = logging.getLogger(__name__)
@@ -172,8 +173,48 @@ def _orjson_dispatch_response(content: Any) -> Any:
     return Response(content=orjson.dumps(content), media_type="application/json")
 
 
+def _token_bearing_items(response: Any) -> Iterator[Any]:
+    """Yield the response parts that may carry token metadata.
+
+    Responses payloads carry ``output`` items; Chat payloads carry ``choices[*].message``.
+    Accept Pydantic models and plain dictionaries alike.
+    """
+    getter = response.get if isinstance(response, dict) else lambda key: getattr(response, key, None)
+    for item in getter("output") or []:
+        if item is not None:
+            yield item
+    for choice in getter("choices") or []:
+        message = choice.get("message") if isinstance(choice, dict) else getattr(choice, "message", None)
+        if message is not None:
+            yield message
+
+
+def _encode_token_metadata_in_place(response: Any, encoding: str) -> None:
+    """Encode token metadata after capture and before transport."""
+    if encoding == "json":
+        return
+    float_dtype = encoding.removeprefix("base64_")
+    for item in _token_bearing_items(response):
+        if isinstance(item, dict):
+            encode_output_item_token_fields(item, float_dtype=float_dtype)
+            continue
+        for field, dtype in (
+            ("prompt_token_ids", "i32"),
+            ("generation_token_ids", "i32"),
+            ("generation_log_probs", float_dtype),
+        ):
+            value = getattr(item, field, None)
+            if isinstance(value, list):
+                setattr(item, field, encode_token_list(value, dtype))
+
+
 class BaseResponsesAPIModelConfig(BaseRunServerInstanceConfig):
-    pass
+    # Select the token-metadata representation on served responses.
+    # JSON preserves numeric lists.
+    # Base64 modes encode token IDs as i32 and log probabilities as the selected float dtype.
+    # Enable a base64 mode only when the downstream harness accepts envelope strings.
+    # Harnesses that parse raw Chat Completions token lists require JSON.
+    token_metadata_encoding: Literal["json", "base64_f32", "base64_f64"] = "json"
 
 
 class BaseResponsesAPIModel(BaseServer):
@@ -318,6 +359,8 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
             completion,
             request_messages=request_messages,
         )
+        # Encode only after capture: capture must see the raw token lists.
+        _encode_token_metadata_in_place(completion, self.config.token_metadata_encoding)
         return completion
 
     async def messages(self, request: Request, body: dict = Body()):
@@ -365,6 +408,8 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
             response,
             request_messages=request_messages,
         )
+        # Encode only after capture: capture must see the raw token lists.
+        _encode_token_metadata_in_place(response, self.config.token_metadata_encoding)
         return response
 
 

--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -193,15 +193,16 @@ def _encode_token_metadata_in_place(response: Any, encoding: str) -> None:
     """Encode token metadata after capture and before transport."""
     if encoding == "json":
         return
-    float_dtype = encoding.removeprefix("base64_")
+    if encoding != "base64":
+        raise ValueError(f"unsupported token metadata encoding {encoding!r}")
     for item in _token_bearing_items(response):
         if isinstance(item, dict):
-            encode_output_item_token_fields(item, float_dtype=float_dtype)
+            encode_output_item_token_fields(item)
             continue
         for field, dtype in (
             ("prompt_token_ids", "i32"),
             ("generation_token_ids", "i32"),
-            ("generation_log_probs", float_dtype),
+            ("generation_log_probs", "f64"),
         ):
             value = getattr(item, field, None)
             if isinstance(value, list):
@@ -211,10 +212,10 @@ def _encode_token_metadata_in_place(response: Any, encoding: str) -> None:
 class BaseResponsesAPIModelConfig(BaseRunServerInstanceConfig):
     # Select the token-metadata representation on served responses.
     # JSON preserves numeric lists.
-    # Base64 modes encode token IDs as i32 and log probabilities as the selected float dtype.
-    # Enable a base64 mode only when the downstream harness accepts envelope strings.
+    # Base64 encodes token IDs as i32 and log probabilities as f64.
+    # Enable base64 only when the downstream harness accepts envelope strings.
     # Harnesses that parse raw Chat Completions token lists require JSON.
-    token_metadata_encoding: Literal["json", "base64_f32", "base64_f64"] = "json"
+    token_metadata_encoding: Literal["json", "base64"] = "json"
 
 
 class BaseResponsesAPIModel(BaseServer):

--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -87,7 +87,12 @@ from nemo_gym.token_id_capture import (
 from nemo_gym.token_id_capture.config import token_id_capture_config
 from nemo_gym.token_id_capture.lineage import FileLineageStore
 from nemo_gym.token_id_capture.store import make_token_store
-from nemo_gym.token_metadata_codec import encode_output_item_token_fields, encode_token_list
+from nemo_gym.token_metadata_codec import (
+    F64_DTYPE,
+    I32_DTYPE,
+    encode_output_item_token_fields,
+    encode_token_list,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -200,9 +205,9 @@ def _encode_token_metadata_in_place(response: Any, encoding: str) -> None:
             encode_output_item_token_fields(item)
             continue
         for field, dtype in (
-            ("prompt_token_ids", "i32"),
-            ("generation_token_ids", "i32"),
-            ("generation_log_probs", "f64"),
+            ("prompt_token_ids", I32_DTYPE),
+            ("generation_token_ids", I32_DTYPE),
+            ("generation_log_probs", F64_DTYPE),
         ):
             value = getattr(item, field, None)
             if isinstance(value, list):

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -223,6 +223,15 @@ def _validate_atomic_token_metadata(value: Any) -> Any:
     return value
 
 
+def _validate_atomic_token_envelopes(value: Any) -> Any:
+    """Validate envelope metadata before an output union can discard it."""
+    if not isinstance(value, dict):
+        return value
+    if not any(isinstance(value.get(field), str) for field in REQUIRED_TOKEN_METADATA_FIELDS):
+        return value
+    return _validate_atomic_token_metadata(value)
+
+
 ########################################
 # Responses API inputs
 ########################################
@@ -747,7 +756,7 @@ NeMoGymResponseOutputItem = Annotated[
         NeMoGymResponseReasoningItemForTraining,
     ],
     BeforeValidator(_require_response_output_item_type),
-    BeforeValidator(_validate_atomic_token_metadata),
+    BeforeValidator(_validate_atomic_token_envelopes),
 ]
 
 

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -171,7 +171,7 @@ def _validate_token_id_envelope(value: str) -> str:
 
 
 def _validate_log_prob_envelope(value: str) -> str:
-    token_envelope_dtype(value, ("f32", "f64"))
+    token_envelope_dtype(value, ("f64",))
     return value
 
 

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -149,7 +149,7 @@ from nemo_gym.server_utils import (
     raise_for_status,
     request,
 )
-from nemo_gym.token_metadata_codec import token_envelope_dtype
+from nemo_gym.token_metadata_codec import F64_DTYPE, I32_DTYPE, token_envelope_dtype
 
 
 ########################################
@@ -166,12 +166,12 @@ RoutedExperts: TypeAlias = Union[str, List[List[List[int]]]]
 # Token metadata accepts plain lists and versioned envelopes.
 # Consumers must decode an envelope before reading individual values.
 def _validate_token_id_envelope(value: str) -> str:
-    token_envelope_dtype(value, ("i32",))
+    token_envelope_dtype(value, (I32_DTYPE,))
     return value
 
 
 def _validate_log_prob_envelope(value: str) -> str:
-    token_envelope_dtype(value, ("f64",))
+    token_envelope_dtype(value, (F64_DTYPE,))
     return value
 
 

--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -138,7 +138,7 @@ from openai.types.responses.response_usage import OutputTokensDetails as Respons
 from openai.types.responses.response_usage import ResponseUsage
 from openai.types.shared.chat_model import ChatModel
 from openai.types.shared_params import FunctionDefinition
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_validator
+from pydantic import AfterValidator, BaseModel, BeforeValidator, ConfigDict, Field, model_validator
 from typing_extensions import TypedDict
 
 from nemo_gym.server_utils import (
@@ -149,6 +149,7 @@ from nemo_gym.server_utils import (
     raise_for_status,
     request,
 )
+from nemo_gym.token_metadata_codec import token_envelope_dtype
 
 
 ########################################
@@ -162,17 +163,35 @@ from nemo_gym.server_utils import (
 RoutedExperts: TypeAlias = Union[str, List[List[List[int]]]]
 
 
+# Token metadata accepts plain lists and versioned envelopes.
+# Consumers must decode an envelope before reading individual values.
+def _validate_token_id_envelope(value: str) -> str:
+    token_envelope_dtype(value, ("i32",))
+    return value
+
+
+def _validate_log_prob_envelope(value: str) -> str:
+    token_envelope_dtype(value, ("f32", "f64"))
+    return value
+
+
+TokenIDEnvelope: TypeAlias = Annotated[str, AfterValidator(_validate_token_id_envelope)]
+LogProbEnvelope: TypeAlias = Annotated[str, AfterValidator(_validate_log_prob_envelope)]
+TokenIDsWire: TypeAlias = Union[List[int], TokenIDEnvelope]
+LogProbsWire: TypeAlias = Union[List[float], LogProbEnvelope]
+
+
 class TokenIDLogProbMixin(BaseModel):
-    prompt_token_ids: List[int]
-    generation_token_ids: List[int]
-    generation_log_probs: List[float]
+    prompt_token_ids: TokenIDsWire
+    generation_token_ids: TokenIDsWire
+    generation_log_probs: LogProbsWire
     routed_experts: Optional[RoutedExperts] = None
 
 
 class TokenIDLogProbTypedDictMixin(TypedDict):
-    prompt_token_ids: List[int]
-    generation_token_ids: List[int]
-    generation_log_probs: List[float]
+    prompt_token_ids: TokenIDsWire
+    generation_token_ids: TokenIDsWire
+    generation_log_probs: LogProbsWire
     routed_experts: NotRequired[RoutedExperts]
 
 
@@ -728,6 +747,7 @@ NeMoGymResponseOutputItem = Annotated[
         NeMoGymResponseReasoningItemForTraining,
     ],
     BeforeValidator(_require_response_output_item_type),
+    BeforeValidator(_validate_atomic_token_metadata),
 ]
 
 

--- a/nemo_gym/token_id_capture/delivery.py
+++ b/nemo_gym/token_id_capture/delivery.py
@@ -38,7 +38,7 @@ import warnings
 from nemo_gym.rollout_correlation import maybe_rollout_id_from_run_body
 from nemo_gym.token_id_capture.consumer import trajectories_from_source
 from nemo_gym.token_id_capture.protocols import TokenSource
-from nemo_gym.token_metadata_codec import decode_token_list
+from nemo_gym.token_metadata_codec import I32_DTYPE, decode_token_list
 
 
 # Attach token-capture health to each rollout record.
@@ -75,7 +75,7 @@ def _carries_generated_tokens(item: dict) -> bool:
     value = item.get("generation_token_ids")
     if isinstance(value, str):
         try:
-            return len(decode_token_list(value, ("i32",))) > 0
+            return len(decode_token_list(value, (I32_DTYPE,))) > 0
         except ValueError:
             return False
     return bool(value)

--- a/nemo_gym/token_id_capture/delivery.py
+++ b/nemo_gym/token_id_capture/delivery.py
@@ -38,6 +38,7 @@ import warnings
 from nemo_gym.rollout_correlation import maybe_rollout_id_from_run_body
 from nemo_gym.token_id_capture.consumer import trajectories_from_source
 from nemo_gym.token_id_capture.protocols import TokenSource
+from nemo_gym.token_metadata_codec import decode_token_list
 
 
 # Attach token-capture health to each rollout record.
@@ -66,7 +67,18 @@ def rollout_carries_token_ids(result: dict) -> bool:
     response = result.get("response")
     if not isinstance(response, dict):
         return False
-    return any(isinstance(item, dict) and item.get("generation_token_ids") for item in (response.get("output") or []))
+    return any(isinstance(item, dict) and _carries_generated_tokens(item) for item in (response.get("output") or []))
+
+
+def _carries_generated_tokens(item: dict) -> bool:
+    """Return whether an output item has a non-empty generation."""
+    value = item.get("generation_token_ids")
+    if isinstance(value, str):
+        try:
+            return len(decode_token_list(value, ("i32",))) > 0
+        except ValueError:
+            return False
+    return bool(value)
 
 
 def _unusable(result: dict, error: str, message: str) -> dict:

--- a/nemo_gym/token_id_capture/records.py
+++ b/nemo_gym/token_id_capture/records.py
@@ -32,7 +32,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from nemo_gym.token_metadata_codec import decode_token_list
+from nemo_gym.token_metadata_codec import F64_DTYPE, I32_DTYPE, decode_token_list
 
 
 # These fields carry token metadata on a served response.
@@ -317,9 +317,9 @@ def extract_token_fields(response_json: dict) -> dict | None:
     info = {field: source.get(field) for field in TOKEN_FIELDS}
     # Capture records store decoded lists.
     for field, expected_dtypes in (
-        ("prompt_token_ids", ("i32",)),
-        ("generation_token_ids", ("i32",)),
-        ("generation_log_probs", ("f64",)),
+        ("prompt_token_ids", (I32_DTYPE,)),
+        ("generation_token_ids", (I32_DTYPE,)),
+        ("generation_log_probs", (F64_DTYPE,)),
     ):
         if isinstance(info[field], str):
             info[field] = decode_token_list(info[field], expected_dtypes)

--- a/nemo_gym/token_id_capture/records.py
+++ b/nemo_gym/token_id_capture/records.py
@@ -319,7 +319,7 @@ def extract_token_fields(response_json: dict) -> dict | None:
     for field, expected_dtypes in (
         ("prompt_token_ids", ("i32",)),
         ("generation_token_ids", ("i32",)),
-        ("generation_log_probs", ("f32", "f64")),
+        ("generation_log_probs", ("f64",)),
     ):
         if isinstance(info[field], str):
             info[field] = decode_token_list(info[field], expected_dtypes)

--- a/nemo_gym/token_id_capture/records.py
+++ b/nemo_gym/token_id_capture/records.py
@@ -32,6 +32,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from nemo_gym.token_metadata_codec import decode_token_list
+
 
 # These fields carry token metadata on a served response.
 # ``routed_experts`` is optional for MoE backends.
@@ -312,4 +314,13 @@ def extract_token_fields(response_json: dict) -> dict | None:
     missing = [field for field in required if source.get(field) is None]
     if missing:
         raise ValueError(f"partial token metadata is missing: {', '.join(missing)}")
-    return {field: source.get(field) for field in TOKEN_FIELDS}
+    info = {field: source.get(field) for field in TOKEN_FIELDS}
+    # Capture records store decoded lists.
+    for field, expected_dtypes in (
+        ("prompt_token_ids", ("i32",)),
+        ("generation_token_ids", ("i32",)),
+        ("generation_log_probs", ("f32", "f64")),
+    ):
+        if isinstance(info[field], str):
+            info[field] = decode_token_list(info[field], expected_dtypes)
+    return info

--- a/nemo_gym/token_metadata_codec.py
+++ b/nemo_gym/token_metadata_codec.py
@@ -30,6 +30,8 @@ from typing import Any, Dict, Iterable, List, Union
 
 # Change the prefix when the byte layout changes.
 TOKEN_ENVELOPE_PREFIX = "ngtok1:"
+I32_DTYPE = "i32"
+F64_DTYPE = "f64"
 
 
 def is_token_envelope(value: Any) -> bool:
@@ -103,18 +105,18 @@ def encode_output_item_token_fields(item_dict: Dict[str, Any]) -> None:
     for field in ("prompt_token_ids", "generation_token_ids"):
         value = item_dict.get(field)
         if isinstance(value, list):
-            item_dict[field] = encode_token_list(value, "i32")
+            item_dict[field] = encode_token_list(value, I32_DTYPE)
     value = item_dict.get("generation_log_probs")
     if isinstance(value, list):
-        item_dict["generation_log_probs"] = encode_token_list(value, "f64")
+        item_dict["generation_log_probs"] = encode_token_list(value, F64_DTYPE)
 
 
 def decode_output_item_token_fields(item_dict: Dict[str, Any]) -> None:
     """Decode token-metadata envelopes on an output item in place."""
     for field, expected_dtypes in (
-        ("prompt_token_ids", ("i32",)),
-        ("generation_token_ids", ("i32",)),
-        ("generation_log_probs", ("f64",)),
+        ("prompt_token_ids", (I32_DTYPE,)),
+        ("generation_token_ids", (I32_DTYPE,)),
+        ("generation_log_probs", (F64_DTYPE,)),
     ):
         value = item_dict.get(field)
         if isinstance(value, str):
@@ -136,4 +138,4 @@ def _int32_typecode() -> str:
     raise RuntimeError("no 4-byte signed integer array typecode on this platform")  # pragma: no cover
 
 
-_TYPECODES = {"i32": _int32_typecode(), "f64": "d"}
+_TYPECODES = {I32_DTYPE: _int32_typecode(), F64_DTYPE: "d"}

--- a/nemo_gym/token_metadata_codec.py
+++ b/nemo_gym/token_metadata_codec.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Encode token metadata as versioned base64 strings.
+
+The wire format is ``ngtok1:<dtype>:<base64>``.
+Token IDs use little-endian ``i32`` values.
+Log probabilities use little-endian ``f32`` or ``f64`` values.
+Decoders also accept plain lists.
+"""
+
+from __future__ import annotations
+
+import base64
+import sys
+from array import array
+from typing import Any, Dict, Iterable, List, Union
+
+
+# Change the prefix when the byte layout changes.
+TOKEN_ENVELOPE_PREFIX = "ngtok1:"
+
+
+def is_token_envelope(value: Any) -> bool:
+    """Return whether ``value`` has a supported envelope header."""
+    if not isinstance(value, str):
+        return False
+    try:
+        token_envelope_dtype(value)
+    except ValueError:
+        return False
+    return True
+
+
+def token_envelope_dtype(value: str, expected: Iterable[str] | None = None) -> str:
+    """Return the dtype from a supported envelope header.
+
+    This validates the header without decoding the payload.
+    """
+    if not value.startswith(TOKEN_ENVELOPE_PREFIX):
+        raise ValueError(f"expected an {TOKEN_ENVELOPE_PREFIX!r} token-metadata envelope")
+    dtype, separator, _ = value[len(TOKEN_ENVELOPE_PREFIX) :].partition(":")
+    if not separator:
+        raise ValueError("token-metadata envelope header must end with ':'")
+    _typecode_for(dtype)
+    if expected is not None:
+        expected_dtypes = tuple(expected)
+        if dtype not in expected_dtypes:
+            raise ValueError(f"token-metadata dtype must be one of {expected_dtypes}, got {dtype!r}")
+    return dtype
+
+
+def encode_token_list(values: List[Union[int, float]], dtype: str) -> str:
+    """Pack a numeric list into a token-metadata envelope."""
+    typecode = _typecode_for(dtype)
+    try:
+        packed = array(typecode, values)
+    except (TypeError, OverflowError) as error:
+        raise ValueError(f"cannot encode token metadata as {dtype}: {error}") from error
+    if sys.byteorder == "big":  # pragma: no cover - little-endian everywhere we run
+        packed.byteswap()
+    return f"{TOKEN_ENVELOPE_PREFIX}{dtype}:{base64.b64encode(packed.tobytes()).decode('ascii')}"
+
+
+def decode_token_list(value: Union[str, list], expected_dtypes: Iterable[str] | None = None) -> list:
+    """Decode an envelope or return an existing list unchanged."""
+    if isinstance(value, list):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"expected a list or an {TOKEN_ENVELOPE_PREFIX!r} envelope, got {type(value).__name__}")
+    if not value.startswith(TOKEN_ENVELOPE_PREFIX):
+        raise ValueError(f"expected a list or an {TOKEN_ENVELOPE_PREFIX!r} envelope, got str")
+    dtype = token_envelope_dtype(value, expected_dtypes)
+    payload = value.split(":", 2)[2]
+    typecode = _typecode_for(dtype)
+    try:
+        raw = base64.b64decode(payload, validate=True)
+    except (ValueError, TypeError) as error:
+        raise ValueError(f"malformed base64 payload in token-metadata envelope: {error}") from error
+    unpacked = array(typecode)
+    itemsize = unpacked.itemsize
+    if len(raw) % itemsize:
+        raise ValueError(f"token-metadata envelope payload of {len(raw)} bytes is not a multiple of {itemsize}")
+    unpacked.frombytes(raw)
+    if sys.byteorder == "big":  # pragma: no cover - little-endian everywhere we run
+        unpacked.byteswap()
+    return unpacked.tolist()
+
+
+def encode_output_item_token_fields(item_dict: Dict[str, Any], float_dtype: str = "f32") -> None:
+    """Encode token-metadata lists on an output item in place."""
+    if float_dtype not in ("f32", "f64"):
+        raise ValueError(f"float_dtype must be 'f32' or 'f64', got {float_dtype!r}")
+    for field in ("prompt_token_ids", "generation_token_ids"):
+        value = item_dict.get(field)
+        if isinstance(value, list):
+            item_dict[field] = encode_token_list(value, "i32")
+    value = item_dict.get("generation_log_probs")
+    if isinstance(value, list):
+        item_dict["generation_log_probs"] = encode_token_list(value, float_dtype)
+
+
+def decode_output_item_token_fields(item_dict: Dict[str, Any]) -> None:
+    """Decode token-metadata envelopes on an output item in place."""
+    for field, expected_dtypes in (
+        ("prompt_token_ids", ("i32",)),
+        ("generation_token_ids", ("i32",)),
+        ("generation_log_probs", ("f32", "f64")),
+    ):
+        value = item_dict.get(field)
+        if isinstance(value, str):
+            item_dict[field] = decode_token_list(value, expected_dtypes)
+
+
+def _typecode_for(dtype: str) -> str:
+    try:
+        return _TYPECODES[dtype]
+    except KeyError:
+        raise ValueError(f"unsupported token-metadata dtype {dtype!r}; expected one of {sorted(_TYPECODES)}") from None
+
+
+def _int32_typecode() -> str:
+    # Resolve a four-byte signed typecode for the fixed wire layout.
+    for code in ("i", "l"):
+        if array(code).itemsize == 4:
+            return code
+    raise RuntimeError("no 4-byte signed integer array typecode on this platform")  # pragma: no cover
+
+
+_TYPECODES = {"i32": _int32_typecode(), "f32": "f", "f64": "d"}

--- a/nemo_gym/token_metadata_codec.py
+++ b/nemo_gym/token_metadata_codec.py
@@ -16,7 +16,7 @@
 
 The wire format is ``ngtok1:<dtype>:<base64>``.
 Token IDs use little-endian ``i32`` values.
-Log probabilities use little-endian ``f32`` or ``f64`` values.
+Log probabilities use little-endian ``f64`` values.
 Decoders also accept plain lists.
 """
 
@@ -98,17 +98,15 @@ def decode_token_list(value: Union[str, list], expected_dtypes: Iterable[str] | 
     return unpacked.tolist()
 
 
-def encode_output_item_token_fields(item_dict: Dict[str, Any], float_dtype: str = "f32") -> None:
+def encode_output_item_token_fields(item_dict: Dict[str, Any]) -> None:
     """Encode token-metadata lists on an output item in place."""
-    if float_dtype not in ("f32", "f64"):
-        raise ValueError(f"float_dtype must be 'f32' or 'f64', got {float_dtype!r}")
     for field in ("prompt_token_ids", "generation_token_ids"):
         value = item_dict.get(field)
         if isinstance(value, list):
             item_dict[field] = encode_token_list(value, "i32")
     value = item_dict.get("generation_log_probs")
     if isinstance(value, list):
-        item_dict["generation_log_probs"] = encode_token_list(value, float_dtype)
+        item_dict["generation_log_probs"] = encode_token_list(value, "f64")
 
 
 def decode_output_item_token_fields(item_dict: Dict[str, Any]) -> None:
@@ -116,7 +114,7 @@ def decode_output_item_token_fields(item_dict: Dict[str, Any]) -> None:
     for field, expected_dtypes in (
         ("prompt_token_ids", ("i32",)),
         ("generation_token_ids", ("i32",)),
-        ("generation_log_probs", ("f32", "f64")),
+        ("generation_log_probs", ("f64",)),
     ):
         value = item_dict.get(field)
         if isinstance(value, str):
@@ -138,4 +136,4 @@ def _int32_typecode() -> str:
     raise RuntimeError("no 4-byte signed integer array typecode on this platform")  # pragma: no cover
 
 
-_TYPECODES = {"i32": _int32_typecode(), "f32": "f", "f64": "d"}
+_TYPECODES = {"i32": _int32_typecode(), "f64": "d"}

--- a/responses_api_agents/simple_agent_with_compaction/compaction/history.py
+++ b/responses_api_agents/simple_agent_with_compaction/compaction/history.py
@@ -29,7 +29,7 @@ from typing import Any, Literal, Mapping, Sequence
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from nemo_gym.token_metadata_codec import decode_token_list
+from nemo_gym.token_metadata_codec import F64_DTYPE, I32_DTYPE, decode_token_list
 
 
 BUILTIN_SEMANTIC_PART_KINDS = frozenset(
@@ -902,9 +902,9 @@ def capture_observed_completion(
         )
 
     evidence = evidence_items[0]
-    prompt_token_ids = tuple(decode_token_list(evidence["prompt_token_ids"], ("i32",)))
-    sampled_token_ids = tuple(decode_token_list(evidence["generation_token_ids"], ("i32",)))
-    sampled_logprobs = tuple(decode_token_list(evidence["generation_log_probs"], ("f64",)))
+    prompt_token_ids = tuple(decode_token_list(evidence["prompt_token_ids"], (I32_DTYPE,)))
+    sampled_token_ids = tuple(decode_token_list(evidence["generation_token_ids"], (I32_DTYPE,)))
+    sampled_logprobs = tuple(decode_token_list(evidence["generation_log_probs"], (F64_DTYPE,)))
     required_prefix = tuple(required_prefix_token_ids or ())
     if required_prefix and prompt_token_ids[: len(required_prefix)] != required_prefix:
         raise RuntimeError(

--- a/responses_api_agents/simple_agent_with_compaction/compaction/history.py
+++ b/responses_api_agents/simple_agent_with_compaction/compaction/history.py
@@ -904,7 +904,7 @@ def capture_observed_completion(
     evidence = evidence_items[0]
     prompt_token_ids = tuple(decode_token_list(evidence["prompt_token_ids"], ("i32",)))
     sampled_token_ids = tuple(decode_token_list(evidence["generation_token_ids"], ("i32",)))
-    sampled_logprobs = tuple(decode_token_list(evidence["generation_log_probs"], ("f32", "f64")))
+    sampled_logprobs = tuple(decode_token_list(evidence["generation_log_probs"], ("f64",)))
     required_prefix = tuple(required_prefix_token_ids or ())
     if required_prefix and prompt_token_ids[: len(required_prefix)] != required_prefix:
         raise RuntimeError(

--- a/responses_api_agents/simple_agent_with_compaction/compaction/history.py
+++ b/responses_api_agents/simple_agent_with_compaction/compaction/history.py
@@ -29,6 +29,8 @@ from typing import Any, Literal, Mapping, Sequence
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from nemo_gym.token_metadata_codec import decode_token_list
+
 
 BUILTIN_SEMANTIC_PART_KINDS = frozenset(
     {
@@ -900,9 +902,9 @@ def capture_observed_completion(
         )
 
     evidence = evidence_items[0]
-    prompt_token_ids = tuple(evidence["prompt_token_ids"])
-    sampled_token_ids = tuple(evidence["generation_token_ids"])
-    sampled_logprobs = tuple(evidence["generation_log_probs"])
+    prompt_token_ids = tuple(decode_token_list(evidence["prompt_token_ids"], ("i32",)))
+    sampled_token_ids = tuple(decode_token_list(evidence["generation_token_ids"], ("i32",)))
+    sampled_logprobs = tuple(decode_token_list(evidence["generation_log_probs"], ("f32", "f64")))
     required_prefix = tuple(required_prefix_token_ids or ())
     if required_prefix and prompt_token_ids[: len(required_prefix)] != required_prefix:
         raise RuntimeError(

--- a/responses_api_agents/simple_agent_with_compaction/tests/test_compaction.py
+++ b/responses_api_agents/simple_agent_with_compaction/tests/test_compaction.py
@@ -4,6 +4,7 @@
 import subprocess
 import sys
 
+from nemo_gym.token_metadata_codec import encode_token_list
 from responses_api_agents.simple_agent_with_compaction.compaction import (
     ContextGuardConfig,
     ContextMeasurements,
@@ -711,6 +712,42 @@ def test_capture_observed_completion_preserves_exact_evidence_and_media_order():
     assert observed.policy_output_spans[0].end == 2
     assert [item.media_id for item in observed.media_occurrences] == list(view.media_ids)
     assert observed.evidence_source == "generation_response"
+
+
+def test_capture_observed_completion_accepts_token_envelopes():
+    history = SemanticHistory("rollout-envelope-evidence")
+    history.append_items([_observation("initial")], turn_id=0, is_initial_context=True)
+    view = materialize_history_view(
+        history,
+        IdentityHistoryPolicy().plan(history, decision_turn=1),
+    )
+    observed = capture_observed_completion(
+        [
+            {
+                "role": "assistant",
+                "type": "message",
+                "content": "answer",
+                "prompt_token_ids": encode_token_list([1, 2], "i32"),
+                "generation_token_ids": encode_token_list([3, 4], "i32"),
+                "generation_log_probs": encode_token_list([-0.5, -0.25], "f32"),
+            }
+        ],
+        rollout_id=history.rollout_id,
+        turn_id=1,
+        media_ids=view.media_ids,
+        policy_decision=view.decision,
+        prepared_request_id="prepared-request-1",
+        context_epoch=0,
+        segment_index=0,
+        segment_id="segment-0",
+        expected_append_compatible=False,
+        compaction_event_id=None,
+        generation_contract_id="generation-contract-1",
+    )
+
+    assert observed.prompt_token_ids == (1, 2)
+    assert observed.sampled_token_ids == (3, 4)
+    assert observed.sampled_logprobs == (-0.5, -0.25)
 
 
 def test_capture_observed_completion_rejects_misaligned_logprobs():

--- a/responses_api_agents/simple_agent_with_compaction/tests/test_compaction.py
+++ b/responses_api_agents/simple_agent_with_compaction/tests/test_compaction.py
@@ -729,7 +729,7 @@ def test_capture_observed_completion_accepts_token_envelopes():
                 "content": "answer",
                 "prompt_token_ids": encode_token_list([1, 2], "i32"),
                 "generation_token_ids": encode_token_list([3, 4], "i32"),
-                "generation_log_probs": encode_token_list([-0.5, -0.25], "f32"),
+                "generation_log_probs": encode_token_list([-0.5, -0.25], "f64"),
             }
         ],
         rollout_id=history.rollout_id,

--- a/tests/unit_tests/test_token_metadata_codec.py
+++ b/tests/unit_tests/test_token_metadata_codec.py
@@ -52,7 +52,7 @@ from nemo_gym.token_metadata_codec import (
 
 PTOKS = [101, 102, 103]
 GTOKS = [7, 9]
-LPS = [-0.125, -0.5]  # exact in float32, so f32 round trips verbatim
+LPS = [-0.125, -0.5]
 
 
 class TestCodecRoundTrip:
@@ -60,7 +60,6 @@ class TestCodecRoundTrip:
         ("values", "dtype", "expected"),
         [
             ([0, 1, -1, 2**31 - 1, -(2**31)], "i32", "ngtok1:i32:AAAAAAEAAAD/////////fwAAAIA="),
-            ([0.0, -0.5, 1.5], "f32", "ngtok1:f32:AAAAAAAAAL8AAMA/"),
             ([0.0, -0.5, 1.5], "f64", "ngtok1:f64:AAAAAAAAAAAAAAAAAADgvwAAAAAAAPg/"),
         ],
     )
@@ -80,15 +79,8 @@ class TestCodecRoundTrip:
         assert envelope.startswith(f"{TOKEN_ENVELOPE_PREFIX}f64:")
         assert decode_token_list(envelope) == values
 
-    def test_f32_round_trip_is_close(self) -> None:
-        values = [-0.1, -2.302585092994046, -1e-7, -15.75]
-        decoded = decode_token_list(encode_token_list(values, "f32"))
-        assert len(decoded) == len(values)
-        for original, restored in zip(values, decoded):
-            assert abs(restored - original) <= 1e-6 * abs(original)
-
     def test_empty_list_round_trips(self) -> None:
-        for dtype in ("i32", "f32", "f64"):
+        for dtype in ("i32", "f64"):
             assert decode_token_list(encode_token_list([], dtype)) == []
 
     def test_decode_passes_plain_lists_through(self) -> None:
@@ -123,7 +115,7 @@ class TestCodecErrors:
 
     def test_decode_rejects_unknown_dtype(self) -> None:
         with pytest.raises(ValueError, match="unsupported token-metadata dtype"):
-            decode_token_list(f"{TOKEN_ENVELOPE_PREFIX}i64:AAAA")
+            decode_token_list(f"{TOKEN_ENVELOPE_PREFIX}f32:AAAA")
 
     def test_decode_rejects_incomplete_header(self) -> None:
         with pytest.raises(ValueError, match="header must end"):
@@ -152,7 +144,7 @@ class TestItemHelpers:
 
     def test_encode_then_decode_restores_lists_in_place(self) -> None:
         item = self._item()
-        encode_output_item_token_fields(item, float_dtype="f64")
+        encode_output_item_token_fields(item)
         assert is_token_envelope(item["prompt_token_ids"])
         assert is_token_envelope(item["generation_token_ids"])
         assert item["generation_log_probs"].startswith(f"{TOKEN_ENVELOPE_PREFIX}f64:")
@@ -165,10 +157,10 @@ class TestItemHelpers:
         assert item["generation_token_ids"] == GTOKS
         assert item["generation_log_probs"] == LPS
 
-    def test_encode_defaults_to_f32_and_is_idempotent(self) -> None:
+    def test_encode_uses_f64_and_is_idempotent(self) -> None:
         item = self._item()
         encode_output_item_token_fields(item)
-        assert item["generation_log_probs"].startswith(f"{TOKEN_ENVELOPE_PREFIX}f32:")
+        assert item["generation_log_probs"].startswith(f"{TOKEN_ENVELOPE_PREFIX}f64:")
         encoded_once = dict(item)
         encode_output_item_token_fields(item)
         assert item == encoded_once
@@ -180,13 +172,9 @@ class TestItemHelpers:
         decode_output_item_token_fields(item)
         assert item == {"type": "message", "content": []}
 
-    def test_encode_rejects_invalid_float_dtype(self) -> None:
-        with pytest.raises(ValueError, match="float_dtype must be"):
-            encode_output_item_token_fields(self._item(), float_dtype="i32")
-
     def test_decode_enforces_field_dtypes(self) -> None:
         item = self._item()
-        item["prompt_token_ids"] = encode_token_list([1.0], "f32")
+        item["prompt_token_ids"] = encode_token_list([1.0], "f64")
         with pytest.raises(ValueError, match="dtype must be"):
             decode_output_item_token_fields(item)
 
@@ -201,7 +189,7 @@ def _envelope_fields() -> dict:
     return {
         "prompt_token_ids": encode_token_list(PTOKS, "i32"),
         "generation_token_ids": encode_token_list(GTOKS, "i32"),
-        "generation_log_probs": encode_token_list(LPS, "f32"),
+        "generation_log_probs": encode_token_list(LPS, "f64"),
     }
 
 
@@ -420,20 +408,20 @@ class TestEndpointEncoding:
         response = _response_dict(
             {"prompt_token_ids": PTOKS, "generation_token_ids": GTOKS, "generation_log_probs": LPS}
         )
-        _encode_token_metadata_in_place(response, "base64_f32")
+        _encode_token_metadata_in_place(response, "base64")
         [item] = response["output"]
         assert decode_token_list(item["prompt_token_ids"], ("i32",)) == PTOKS
-        assert decode_token_list(item["generation_log_probs"], ("f32",)) == LPS
+        assert decode_token_list(item["generation_log_probs"], ("f64",)) == LPS
 
     def test_responses_route_serves_envelopes_while_capture_retains_lists(self, tmp_path) -> None:
-        client = _client(tmp_path, "base64_f32")
+        client = _client(tmp_path, "base64")
         resp = client.post("/ng-rollout/enc-a/training-token-capture/v1/responses", json={"input": "hi"})
         assert resp.status_code == 200
         [item] = resp.json()["output"]
         assert item["prompt_token_ids"] == encode_token_list(PTOKS, "i32")
         assert item["generation_token_ids"] == encode_token_list(GTOKS, "i32")
-        assert item["generation_log_probs"].startswith(f"{TOKEN_ENVELOPE_PREFIX}f32:")
-        assert decode_token_list(item["generation_log_probs"]) == LPS  # exact in f32
+        assert item["generation_log_probs"] == encode_token_list(LPS, "f64")
+        assert decode_token_list(item["generation_log_probs"]) == LPS
         assert item["content"][0]["text"] == "hi"
 
         # Capture ran before encoding, so the recorded entry holds the raw lists.
@@ -442,16 +430,8 @@ class TestEndpointEncoding:
         assert entry.generation_token_ids == GTOKS
         assert entry.generation_log_probs == LPS
 
-    def test_responses_route_f64_envelope_is_bit_exact(self, tmp_path) -> None:
-        client = _client(tmp_path, "base64_f64")
-        resp = client.post("/ng-rollout/enc-b/training-token-capture/v1/responses", json={"input": "hi"})
-        assert resp.status_code == 200
-        [item] = resp.json()["output"]
-        assert item["generation_log_probs"] == encode_token_list(LPS, "f64")
-        assert decode_token_list(item["generation_log_probs"]) == LPS
-
     def test_chat_route_serves_envelopes(self, tmp_path) -> None:
-        client = _client(tmp_path, "base64_f32")
+        client = _client(tmp_path, "base64")
         resp = client.post(
             "/ng-rollout/enc-c/training-token-capture/v1/chat/completions",
             json={"messages": [{"role": "user", "content": "hi"}]},
@@ -478,6 +458,17 @@ class TestEndpointEncoding:
         assert item["prompt_token_ids"] == PTOKS
         assert item["generation_token_ids"] == GTOKS
         assert item["generation_log_probs"] == LPS
+
+    @pytest.mark.parametrize("encoding", ["base64_f32", "base64_f64"])
+    def test_precision_specific_modes_are_rejected(self, encoding) -> None:
+        with pytest.raises(ValidationError):
+            BaseResponsesAPIModelConfig(
+                host="",
+                port=0,
+                entrypoint="",
+                name="",
+                token_metadata_encoding=encoding,
+            )
 
     def test_encoding_defaults_to_json(self) -> None:
         config = BaseResponsesAPIModelConfig(host="", port=0, entrypoint="", name="")

--- a/tests/unit_tests/test_token_metadata_codec.py
+++ b/tests/unit_tests/test_token_metadata_codec.py
@@ -1,0 +1,477 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test the token-metadata envelope wire contract."""
+
+import math
+from time import time
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import orjson
+import pytest
+from fastapi import Body, Request
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from nemo_gym.base_responses_api_model import (
+    BaseResponsesAPIModelConfig,
+    SimpleResponsesAPIModel,
+    _encode_token_metadata_in_place,
+)
+from nemo_gym.openai_utils import (
+    NeMoGymChatCompletion,
+    NeMoGymChatCompletionCreateParamsNonStreaming,
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseOutputMessageForTraining,
+)
+from nemo_gym.server_utils import ServerClient
+from nemo_gym.token_id_capture import TokenCaptureStore
+from nemo_gym.token_id_capture.records import extract_token_fields, strip_token_fields
+from nemo_gym.token_metadata_codec import (
+    TOKEN_ENVELOPE_PREFIX,
+    decode_output_item_token_fields,
+    decode_token_list,
+    encode_output_item_token_fields,
+    encode_token_list,
+    is_token_envelope,
+)
+
+
+PTOKS = [101, 102, 103]
+GTOKS = [7, 9]
+LPS = [-0.125, -0.5]  # exact in float32, so f32 round trips verbatim
+
+
+class TestCodecRoundTrip:
+    @pytest.mark.parametrize(
+        ("values", "dtype", "expected"),
+        [
+            ([0, 1, -1, 2**31 - 1, -(2**31)], "i32", "ngtok1:i32:AAAAAAEAAAD/////////fwAAAIA="),
+            ([0.0, -0.5, 1.5], "f32", "ngtok1:f32:AAAAAAAAAL8AAMA/"),
+            ([0.0, -0.5, 1.5], "f64", "ngtok1:f64:AAAAAAAAAAAAAAAAAADgvwAAAAAAAPg/"),
+        ],
+    )
+    def test_protocol_golden_vectors(self, values, dtype, expected) -> None:
+        assert encode_token_list(values, dtype) == expected
+        assert decode_token_list(expected) == values
+
+    def test_i32_round_trip_is_bit_exact(self) -> None:
+        values = [0, 1, 151_936, 2**31 - 1, -(2**31)]
+        envelope = encode_token_list(values, "i32")
+        assert envelope.startswith(f"{TOKEN_ENVELOPE_PREFIX}i32:")
+        assert decode_token_list(envelope) == values
+
+    def test_f64_round_trip_is_bit_exact(self) -> None:
+        values = [0.0, -0.123456789012345, -math.pi, 1e-300, -1e300]
+        envelope = encode_token_list(values, "f64")
+        assert envelope.startswith(f"{TOKEN_ENVELOPE_PREFIX}f64:")
+        assert decode_token_list(envelope) == values
+
+    def test_f32_round_trip_is_close(self) -> None:
+        values = [-0.1, -2.302585092994046, -1e-7, -15.75]
+        decoded = decode_token_list(encode_token_list(values, "f32"))
+        assert len(decoded) == len(values)
+        for original, restored in zip(values, decoded):
+            assert abs(restored - original) <= 1e-6 * abs(original)
+
+    def test_empty_list_round_trips(self) -> None:
+        for dtype in ("i32", "f32", "f64"):
+            assert decode_token_list(encode_token_list([], dtype)) == []
+
+    def test_decode_passes_plain_lists_through(self) -> None:
+        values = [1, 2, 3]
+        assert decode_token_list(values) is values
+
+    def test_is_token_envelope(self) -> None:
+        assert is_token_envelope(encode_token_list([1], "i32"))
+        assert not is_token_envelope([1, 2, 3])
+        assert not is_token_envelope(None)
+        assert not is_token_envelope("nrlre1:int16:2x1x2:AAABAAIAAwA=")
+        assert not is_token_envelope("plain text")
+
+
+class TestCodecErrors:
+    def test_encode_rejects_unknown_dtype(self) -> None:
+        with pytest.raises(ValueError, match="unsupported token-metadata dtype"):
+            encode_token_list([1], "i64")
+
+    def test_encode_rejects_out_of_range_ints(self) -> None:
+        with pytest.raises(ValueError, match="cannot encode token metadata as i32"):
+            encode_token_list([2**40], "i32")
+
+    def test_encode_rejects_non_numeric_values(self) -> None:
+        with pytest.raises(ValueError, match="cannot encode token metadata as i32"):
+            encode_token_list(["a"], "i32")
+
+    def test_decode_rejects_non_list_non_envelope(self) -> None:
+        for bad in (42, None, "not an envelope"):
+            with pytest.raises(ValueError, match="expected a list or an"):
+                decode_token_list(bad)
+
+    def test_decode_rejects_unknown_dtype(self) -> None:
+        with pytest.raises(ValueError, match="unsupported token-metadata dtype"):
+            decode_token_list(f"{TOKEN_ENVELOPE_PREFIX}i64:AAAA")
+
+    def test_decode_rejects_incomplete_header(self) -> None:
+        with pytest.raises(ValueError, match="header must end"):
+            decode_token_list(f"{TOKEN_ENVELOPE_PREFIX}i32")
+
+    def test_decode_rejects_malformed_base64(self) -> None:
+        with pytest.raises(ValueError, match="malformed base64"):
+            decode_token_list(f"{TOKEN_ENVELOPE_PREFIX}i32:!!!not-base64!!!")
+
+    def test_decode_rejects_misaligned_payload(self) -> None:
+        # Two bytes cannot hold an int32.
+        with pytest.raises(ValueError, match="not a multiple of"):
+            decode_token_list(f"{TOKEN_ENVELOPE_PREFIX}i32:AAA=")
+
+
+class TestItemHelpers:
+    def _item(self) -> dict:
+        return {
+            "type": "message",
+            "content": [{"type": "output_text", "text": "hi", "annotations": []}],
+            "prompt_token_ids": list(PTOKS),
+            "generation_token_ids": list(GTOKS),
+            "generation_log_probs": list(LPS),
+            "routed_experts": "nrlre1:int16:2x1x2:AAABAAIAAwA=",
+        }
+
+    def test_encode_then_decode_restores_lists_in_place(self) -> None:
+        item = self._item()
+        encode_output_item_token_fields(item, float_dtype="f64")
+        assert is_token_envelope(item["prompt_token_ids"])
+        assert is_token_envelope(item["generation_token_ids"])
+        assert item["generation_log_probs"].startswith(f"{TOKEN_ENVELOPE_PREFIX}f64:")
+        # The routed_experts envelope and content are not this codec's to touch.
+        assert item["routed_experts"] == "nrlre1:int16:2x1x2:AAABAAIAAwA="
+        assert item["content"][0]["text"] == "hi"
+
+        decode_output_item_token_fields(item)
+        assert item["prompt_token_ids"] == PTOKS
+        assert item["generation_token_ids"] == GTOKS
+        assert item["generation_log_probs"] == LPS
+
+    def test_encode_defaults_to_f32_and_is_idempotent(self) -> None:
+        item = self._item()
+        encode_output_item_token_fields(item)
+        assert item["generation_log_probs"].startswith(f"{TOKEN_ENVELOPE_PREFIX}f32:")
+        encoded_once = dict(item)
+        encode_output_item_token_fields(item)
+        assert item == encoded_once
+
+    def test_encode_skips_absent_fields(self) -> None:
+        item = {"type": "message", "content": []}
+        encode_output_item_token_fields(item)
+        assert item == {"type": "message", "content": []}
+        decode_output_item_token_fields(item)
+        assert item == {"type": "message", "content": []}
+
+    def test_encode_rejects_invalid_float_dtype(self) -> None:
+        with pytest.raises(ValueError, match="float_dtype must be"):
+            encode_output_item_token_fields(self._item(), float_dtype="i32")
+
+    def test_decode_enforces_field_dtypes(self) -> None:
+        item = self._item()
+        item["prompt_token_ids"] = encode_token_list([1.0], "f32")
+        with pytest.raises(ValueError, match="dtype must be"):
+            decode_output_item_token_fields(item)
+
+    def test_decode_rejects_malformed_field_envelope(self) -> None:
+        item = self._item()
+        item["generation_token_ids"] = "ngtok1:i32"
+        with pytest.raises(ValueError, match="header must end"):
+            decode_output_item_token_fields(item)
+
+
+def _envelope_fields() -> dict:
+    return {
+        "prompt_token_ids": encode_token_list(PTOKS, "i32"),
+        "generation_token_ids": encode_token_list(GTOKS, "i32"),
+        "generation_log_probs": encode_token_list(LPS, "f32"),
+    }
+
+
+def _response_dict(token_fields: dict) -> dict:
+    return {
+        "id": "resp_1",
+        "created_at": 0,
+        "model": "m",
+        "object": "response",
+        "output": [
+            {
+                "type": "message",
+                "id": "msg_1",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "hi", "annotations": []}],
+                **token_fields,
+            }
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": True,
+        "tools": [],
+    }
+
+
+class TestModelValidation:
+    def test_response_output_item_with_envelope_strings_validates(self) -> None:
+        response = NeMoGymResponse.model_validate(_response_dict(_envelope_fields()))
+        [item] = response.output
+        assert isinstance(item, NeMoGymResponseOutputMessageForTraining)
+        assert decode_token_list(item.prompt_token_ids) == PTOKS
+        assert decode_token_list(item.generation_token_ids) == GTOKS
+        # The envelope strings survive serialization untouched.
+        dumped = response.model_dump(mode="json")
+        assert dumped["output"][0]["prompt_token_ids"] == item.prompt_token_ids
+
+    def test_chat_message_with_envelope_strings_validates(self) -> None:
+        completion = NeMoGymChatCompletion.model_validate(
+            {
+                "id": "chatcmpl_1",
+                "created": 0,
+                "model": "m",
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {"role": "assistant", "content": "hi", **_envelope_fields()},
+                    }
+                ],
+            }
+        )
+        message = completion.choices[0].message
+        assert decode_token_list(message.generation_token_ids) == GTOKS
+
+    def test_atomic_token_metadata_holds_for_envelope_form(self) -> None:
+        # A replayed input item carrying only part of the metadata must still fail,
+        # whether the present field is a list or an envelope.
+        partial = {
+            "role": "assistant",
+            "content": "hi",
+            "generation_token_ids": encode_token_list(GTOKS, "i32"),
+        }
+        with pytest.raises(ValidationError, match="must include all required fields"):
+            NeMoGymResponseCreateParamsNonStreaming.model_validate({"input": [partial]})
+        complete = {"role": "assistant", "content": "hi", **_envelope_fields()}
+        NeMoGymResponseCreateParamsNonStreaming.model_validate({"input": [complete]})
+
+    def test_chat_params_accept_envelope_training_messages(self) -> None:
+        NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(
+            {"messages": [{"role": "assistant", "content": "hi", **_envelope_fields()}]}
+        )
+
+    def test_mixed_list_and_envelope_fields_validate(self) -> None:
+        fields = _envelope_fields()
+        fields["prompt_token_ids"] = PTOKS
+        response = NeMoGymResponse.model_validate(_response_dict(fields))
+        [item] = response.output
+        assert item.prompt_token_ids == PTOKS
+        assert decode_token_list(item.generation_token_ids) == GTOKS
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("prompt_token_ids", "ngtok1:i32"),
+            ("prompt_token_ids", "ngtok1:f32:AAAAAA=="),
+            ("generation_token_ids", "ngtok1:f64:AAAAAAAAAAA="),
+            ("generation_log_probs", "ngtok1:i32:AAAAAA=="),
+        ],
+    )
+    def test_envelope_headers_and_field_dtypes_are_validated(self, field, value) -> None:
+        fields = _envelope_fields()
+        fields[field] = value
+        with pytest.raises(ValidationError):
+            NeMoGymResponse.model_validate(_response_dict(fields))
+
+    def test_non_envelope_strings_are_rejected(self) -> None:
+        # The string wire form is reserved for "ngtok1:" envelopes; an arbitrary
+        # string stays malformed token metadata.
+        from nemo_gym.openai_utils import TokenIDLogProbMixin
+
+        with pytest.raises(ValidationError, match="ngtok1"):
+            TokenIDLogProbMixin.model_validate(
+                {
+                    "prompt_token_ids": [1],
+                    "generation_token_ids": "not-a-list",
+                    "generation_log_probs": [-0.1],
+                }
+            )
+
+
+class TestCaptureAcceptsBothForms:
+    def test_extract_token_fields_decodes_envelopes(self) -> None:
+        info = extract_token_fields(_response_dict(_envelope_fields()))
+        assert info is not None
+        assert info["prompt_token_ids"] == PTOKS
+        assert info["generation_token_ids"] == GTOKS
+        assert info["generation_log_probs"] == LPS
+
+    def test_extract_token_fields_still_passes_lists_through(self) -> None:
+        info = extract_token_fields(
+            _response_dict({"prompt_token_ids": PTOKS, "generation_token_ids": GTOKS, "generation_log_probs": LPS})
+        )
+        assert info is not None
+        assert info["generation_log_probs"] == LPS
+
+    def test_strip_token_fields_finds_envelope_bearing_item(self) -> None:
+        items = [{"type": "reasoning"}, _response_dict(_envelope_fields())["output"][0]]
+        stripped, index = strip_token_fields(items)
+        assert index == 1
+        assert "generation_token_ids" not in stripped[1]
+
+    def test_rollout_carries_token_ids_accepts_envelopes(self) -> None:
+        from nemo_gym.token_id_capture.delivery import rollout_carries_token_ids
+
+        assert rollout_carries_token_ids({"response": _response_dict(_envelope_fields())})
+        empty = {"generation_token_ids": encode_token_list([], "i32")}
+        assert not rollout_carries_token_ids({"response": {"output": [empty]}})
+        malformed = {"generation_token_ids": "ngtok1:i32"}
+        assert not rollout_carries_token_ids({"response": {"output": [malformed]}})
+        assert rollout_carries_token_ids({"response": _response_dict({"generation_token_ids": GTOKS})})
+
+
+class _EncodingModel(SimpleResponsesAPIModel):
+    """A minimal model server that always serves one training-shaped response."""
+
+    config: BaseResponsesAPIModelConfig
+    model_config = {"arbitrary_types_allowed": True}
+
+    async def responses(
+        self, request: Request, body: NeMoGymResponseCreateParamsNonStreaming = Body()
+    ) -> NeMoGymResponse:
+        return NeMoGymResponse.model_validate(
+            _response_dict(
+                {
+                    "prompt_token_ids": list(PTOKS),
+                    "generation_token_ids": list(GTOKS),
+                    "generation_log_probs": list(LPS),
+                }
+            )
+            | {"id": f"resp_{uuid4().hex}", "created_at": int(time())}
+        )
+
+    async def chat_completions(
+        self, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
+    ) -> NeMoGymChatCompletion:
+        return NeMoGymChatCompletion.model_validate(
+            {
+                "id": f"chatcmpl_{uuid4().hex}",
+                "created": int(time()),
+                "model": "m",
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {
+                            "role": "assistant",
+                            "content": "hi",
+                            "prompt_token_ids": list(PTOKS),
+                            "generation_token_ids": list(GTOKS),
+                            "generation_log_probs": list(LPS),
+                        },
+                    }
+                ],
+            }
+        )
+
+
+def _client(tmp_path, encoding: str) -> TestClient:
+    server = _EncodingModel(
+        config=BaseResponsesAPIModelConfig(
+            host="0.0.0.0",
+            port=8099,
+            entrypoint="",
+            name="srv",
+            token_metadata_encoding=encoding,
+        ),
+        server_client=MagicMock(
+            spec=ServerClient,
+            global_config_dict={"token_id_capture": {"enabled": True, "dir": str(tmp_path)}},
+        ),
+    )
+    return TestClient(server.setup_webserver())
+
+
+class TestEndpointEncoding:
+    def test_dictionary_response_is_encoded_in_place(self) -> None:
+        response = _response_dict(
+            {"prompt_token_ids": PTOKS, "generation_token_ids": GTOKS, "generation_log_probs": LPS}
+        )
+        _encode_token_metadata_in_place(response, "base64_f32")
+        [item] = response["output"]
+        assert decode_token_list(item["prompt_token_ids"], ("i32",)) == PTOKS
+        assert decode_token_list(item["generation_log_probs"], ("f32",)) == LPS
+
+    def test_responses_route_serves_envelopes_while_capture_retains_lists(self, tmp_path) -> None:
+        client = _client(tmp_path, "base64_f32")
+        resp = client.post("/ng-rollout/enc-a/training-token-capture/v1/responses", json={"input": "hi"})
+        assert resp.status_code == 200
+        [item] = resp.json()["output"]
+        assert item["prompt_token_ids"] == encode_token_list(PTOKS, "i32")
+        assert item["generation_token_ids"] == encode_token_list(GTOKS, "i32")
+        assert item["generation_log_probs"].startswith(f"{TOKEN_ENVELOPE_PREFIX}f32:")
+        assert decode_token_list(item["generation_log_probs"]) == LPS  # exact in f32
+        assert item["content"][0]["text"] == "hi"
+
+        # Capture ran before encoding, so the recorded entry holds the raw lists.
+        [entry] = TokenCaptureStore(tmp_path).read_entries("enc-a")
+        assert entry.prompt_token_ids == PTOKS
+        assert entry.generation_token_ids == GTOKS
+        assert entry.generation_log_probs == LPS
+
+    def test_responses_route_f64_envelope_is_bit_exact(self, tmp_path) -> None:
+        client = _client(tmp_path, "base64_f64")
+        resp = client.post("/ng-rollout/enc-b/training-token-capture/v1/responses", json={"input": "hi"})
+        assert resp.status_code == 200
+        [item] = resp.json()["output"]
+        assert item["generation_log_probs"] == encode_token_list(LPS, "f64")
+        assert decode_token_list(item["generation_log_probs"]) == LPS
+
+    def test_chat_route_serves_envelopes(self, tmp_path) -> None:
+        client = _client(tmp_path, "base64_f32")
+        resp = client.post(
+            "/ng-rollout/enc-c/training-token-capture/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert resp.status_code == 200
+        message = resp.json()["choices"][0]["message"]
+        assert message["prompt_token_ids"] == encode_token_list(PTOKS, "i32")
+        assert decode_token_list(message["generation_token_ids"]) == GTOKS
+        [entry] = TokenCaptureStore(tmp_path).read_entries("enc-c")
+        assert entry.generation_token_ids == GTOKS
+
+    def test_default_json_encoding_serves_plain_lists(self, tmp_path) -> None:
+        expected = _response_dict(
+            {"prompt_token_ids": PTOKS, "generation_token_ids": GTOKS, "generation_log_probs": LPS}
+        )
+        expected_bytes = orjson.dumps(expected)
+        _encode_token_metadata_in_place(expected, "json")
+        assert orjson.dumps(expected) == expected_bytes
+
+        client = _client(tmp_path, "json")
+        resp = client.post("/ng-rollout/enc-d/training-token-capture/v1/responses", json={"input": "hi"})
+        assert resp.status_code == 200
+        [item] = resp.json()["output"]
+        assert item["prompt_token_ids"] == PTOKS
+        assert item["generation_token_ids"] == GTOKS
+        assert item["generation_log_probs"] == LPS
+
+    def test_encoding_defaults_to_json(self) -> None:
+        config = BaseResponsesAPIModelConfig(host="", port=0, entrypoint="", name="")
+        assert config.token_metadata_encoding == "json"

--- a/tests/unit_tests/test_token_metadata_codec.py
+++ b/tests/unit_tests/test_token_metadata_codec.py
@@ -270,6 +270,13 @@ class TestModelValidation:
         complete = {"role": "assistant", "content": "hi", **_envelope_fields()}
         NeMoGymResponseCreateParamsNonStreaming.model_validate({"input": [complete]})
 
+    def test_response_rejects_partial_envelope_metadata(self) -> None:
+        fields = _envelope_fields()
+        del fields["prompt_token_ids"]
+
+        with pytest.raises(ValidationError, match="must include all required fields"):
+            NeMoGymResponse.model_validate(_response_dict(fields))
+
     def test_chat_params_accept_envelope_training_messages(self) -> None:
         NeMoGymChatCompletionCreateParamsNonStreaming.model_validate(
             {"messages": [{"role": "assistant", "content": "hi", **_envelope_fields()}]}


### PR DESCRIPTION
## Summary

Gym currently carries prompt token IDs, generated token IDs, and generation log probabilities as JSON number arrays. Every server hop parses each number into a Python object, validates every element with Pydantic, and serializes it back to decimal JSON. That repeated scalar work and its wire representation become expensive for long generations: the 65,536-token benchmark response is 1.95 MB, and one parse/validate/dump/serialize relay takes 10.20 ms.

This change adds an opt-in, versioned base64 envelope backed by contiguous little-endian numeric arrays. Token IDs use bit-exact `i32`, and log probabilities always use bit-exact `f64`. The model server encodes responses after model-call capture, so capture records retain numeric lists. Token-capture and context-compaction consumers decode either representation at their boundaries. JSON lists remain the default and retain the same wire format.

Envelope headers and field-specific dtypes are validated before output-union selection. This validation runs only for envelope-bearing outputs, avoiding a second traversal of large arrays in default JSON mode.

Harnesses that inspect raw Chat Completions token fields must continue using JSON mode unless they add envelope decoding. The base64 mode does not offer reduced-precision log probabilities; training metadata round-trips exactly.

## Opting in

Set `token_metadata_encoding: base64` on the policy model server instance. For example:

```yaml
policy_model:
  responses_api_models:
    vllm_model:
      token_metadata_encoding: base64
```

The same setting can be supplied as a Hydra override without editing the model config:

```bash
gym eval run \
  --benchmark <benchmark> \
  --model-type vllm_model \
  --model <model> \
  ++policy_model.responses_api_models.vllm_model.token_metadata_encoding=base64
```

Replace `vllm_model` in the configuration path with the selected model-server type, such as `local_vllm_model` or `openai_model`. Omit the setting, or set it to `json`, to retain numeric JSON arrays. Enable `base64` only when every downstream harness that reads raw token metadata supports the envelope representation; Gym's token-capture and simple-compaction consumers support both forms after this change.

## Serialization benchmark

Compared with current `upstream/main` on one pinned CPU. Each relay parses an `orjson` response, validates it as `NeMoGymResponse`, dumps the model, and serializes it again. Results are medians from five alternating rounds with nine samples per round.

- 32 output tokens: 0.0796 -> 0.0550 ms per relay (1.45x); 4,766 -> 3,940 bytes (-17.3%)
- 1,024 output tokens: 0.2309 -> 0.0632 ms per relay (3.66x); 34,243 -> 23,787 bytes (-30.5%)
- 65,536 output tokens: 10.20 -> 0.881 ms per relay (11.58x); 1,951,102 -> 1,314,031 bytes (-32.7%)

Encoding has a producer-side cost. For the 65,536-token response, constructing and serializing the existing JSON form took 1.893 ms; lossless envelope encoding plus serialization took 2.314 ms. Including one downstream relay, total in-process serialization work falls from 12.09 to 3.19 ms (3.79x), with each additional hop adding the relay savings. The PR's default JSON path remained within 5% of `upstream/main` at all three sizes and produced identical byte counts.

## Test plan
- [x] focused schema, codec, token-capture, and compaction tests (388 passed)
- [x] scoped pre-commit checks for changed files
- [ ] `uv run pytest tests/unit_tests/ -q` (two unrelated baseline failures: terminal-width-dependent Rich output and missing optional `httpx_aiohttp`)