### PR TITLE
perf(openai-utils): discriminate response item unions

### DIFF
--- a/nemo_gym/openai_utils.py
+++ b/nemo_gym/openai_utils.py
@@ -25,6 +25,7 @@ from typing import (
     Required,
     TypeAlias,
     Union,
+    get_args,
 )
 
 from openai.types.chat import (
@@ -138,7 +139,7 @@ from openai.types.responses.response_usage import OutputTokensDetails as Respons
 from openai.types.responses.response_usage import ResponseUsage
 from openai.types.shared.chat_model import ChatModel
 from openai.types.shared_params import FunctionDefinition
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Discriminator, Field, Tag, model_validator
 from typing_extensions import TypedDict
 
 from nemo_gym.server_utils import (
@@ -529,9 +530,8 @@ RESPONSES_TO_TRAIN = {
 # It holds only NeMoGymResponseReasoningItem, NeMoGymResponseOutputMessage
 # or NeMoGymResponseFunctionToolCall, all registered above.
 #
-# Each variant is also another member of NeMoGymResponseInputItem.
-# That union is validated in smart mode, so an unrecognised item reports the errors of every member.
-# Variants that nothing can emit only make those errors harder to read.
+# Each variant is also a member of the response item unions.
+# Complete token metadata selects that variant.
 #
 # The upstream models permit extra fields.
 # An item carrying token IDs without a declared variant still round-trips through its base class.
@@ -554,49 +554,188 @@ def training_variant_of(item_cls: type) -> type:
         ) from None
 
 
+########################################
+# Item union discrimination
+########################################
+
+# Route each item to one concrete model.
+# Shared type literals use stable shape-based tags.
+# Typeless input preserves the existing permissive fallback.
+_SIMPLE_MESSAGE_ROLES = frozenset({"user", "system", "developer"})
+_MESSAGE_ROLES = _SIMPLE_MESSAGE_ROLES | {"assistant"}
+_ITEM_STATUSES = frozenset({"in_progress", "completed", "incomplete"})
+_OUTPUT_CONTENT_PART_TYPES = frozenset({"output_text", "refusal"})
+_TRAINING_TAG_SUFFIX = "__training"
+# Tags whose models have a ForTraining variant registered in RESPONSES_TO_TRAIN.
+_TRAINABLE_ITEM_TAGS = frozenset({"easy_message", "input_message", "output_message", "function_call", "reasoning"})
+
+# Exact member class -> union tag, populated from the annotated unions defined below.
+_RESPONSE_INPUT_ITEM_TAG_BY_CLASS: Dict[type, str] = {}
+_RESPONSE_OUTPUT_ITEM_TAG_BY_CLASS: Dict[type, str] = {}
+
+
+def _register_item_tags(item_union: Any, tag_by_class: Dict[type, str]) -> None:
+    """Index each union member class by its Tag, so instances discriminate by class."""
+    union_type = get_args(item_union)[0]
+    for member in get_args(union_type):
+        member_cls, *metadata = get_args(member)
+        tag = next(meta for meta in metadata if isinstance(meta, Tag))
+        tag_by_class[member_cls] = tag.tag
+
+
+def _tag_for_item_instance(value: Any, tag_by_class: Dict[type, str]) -> Optional[str]:
+    """Map an item instance to its nearest registered class tag."""
+    for cls in type(value).__mro__:
+        tag = tag_by_class.get(cls)
+        if tag is not None:
+            return tag
+    return getattr(value, "type", None)
+
+
+def _first_content_part_type(content: Any) -> Optional[str]:
+    """Return the type of the first content part, or None for empty or non-list content."""
+    if not isinstance(content, list) or not content:
+        return None
+    first_part = content[0]
+    return first_part.get("type") if isinstance(first_part, dict) else getattr(first_part, "type", None)
+
+
+def _discriminate_message_item(value: Dict[str, Any]) -> str:
+    """Choose a message model from its role, content, and status."""
+    content = value.get("content")
+    if value.get("role") in _SIMPLE_MESSAGE_ROLES:
+        if isinstance(content, list) and value.get("status") in _ITEM_STATUSES:
+            return "input_message"
+        return "easy_message"
+    if isinstance(content, list):
+        if content:
+            if _first_content_part_type(content) in _OUTPUT_CONTENT_PART_TYPES:
+                return "output_message"
+        elif isinstance(value.get("id"), str):
+            return "output_message"
+    return "easy_message"
+
+
+def _discriminate_untyped_input_item(value: Dict[str, Any]) -> str:
+    """Infer a typeless input model or use the permissive fallback."""
+    role = value.get("role")
+    content = value.get("content")
+    if role in _MESSAGE_ROLES and isinstance(content, (str, list)):
+        tag = _discriminate_message_item(value)
+        if tag == "output_message":
+            if isinstance(value.get("id"), str):
+                return tag
+        elif _first_content_part_type(content) not in _OUTPUT_CONTENT_PART_TYPES:
+            return tag
+        return "mcp_list_tools"
+    if (
+        "role" not in value
+        and isinstance(value.get("id"), str)
+        and isinstance(content, list)
+        and (not content or _first_content_part_type(content) in _OUTPUT_CONTENT_PART_TYPES)
+    ):
+        return "output_message"
+    if "arguments" in value and "name" in value:
+        return "function_call" if "call_id" in value else "mcp_call"
+    if isinstance(value.get("call_id"), str) and "output" in value:
+        return "function_call_output"
+    if isinstance(value.get("id"), str) and isinstance(value.get("summary"), list):
+        return "reasoning"
+    return "mcp_list_tools"
+
+
+def _training_variant_tag(tag: str, value: Dict[str, Any]) -> str:
+    """Route to the ForTraining member when the item carries complete token metadata."""
+    if tag in _TRAINABLE_ITEM_TAGS and REQUIRED_TOKEN_METADATA_FIELDS.issubset(value):
+        return tag + _TRAINING_TAG_SUFFIX
+    return tag
+
+
+def _discriminate_response_input_item(value: Any) -> Optional[str]:
+    """Pick the input union tag for a request item."""
+    if not isinstance(value, dict):
+        return _tag_for_item_instance(value, _RESPONSE_INPUT_ITEM_TAG_BY_CLASS)
+
+    item_type = value.get("type")
+    if item_type == "message":
+        tag = _discriminate_message_item(value)
+    elif isinstance(item_type, str):
+        tag = item_type
+    elif item_type is None:
+        tag = _discriminate_untyped_input_item(value)
+    else:
+        return None
+    return _training_variant_tag(tag, value)
+
+
+def _discriminate_response_output_item(value: Any) -> Optional[str]:
+    """Pick the output union tag for a response item."""
+    if not isinstance(value, dict):
+        return _tag_for_item_instance(value, _RESPONSE_OUTPUT_ITEM_TAG_BY_CLASS)
+
+    item_type = value.get("type")
+    if item_type == "message":
+        tag = _discriminate_message_item(value)
+    elif item_type == "function_call_output":
+        # The SDK output item additionally requires an id and a status; results without
+        # them only fit the request-input model.
+        if isinstance(value.get("id"), str) and value.get("status") in _ITEM_STATUSES:
+            tag = "function_call_output"
+        else:
+            tag = "function_call_output_input"
+    elif isinstance(item_type, str):
+        tag = item_type
+    else:
+        # _require_response_output_item_type already rejected untyped dicts.
+        return None
+    return _training_variant_tag(tag, value)
+
+
 NeMoGymResponseInputItem = Annotated[
     Union[
-        NeMoGymEasyInputMessage,
-        NeMoGymMessage,
-        NeMoGymResponseOutputMessage,
-        NeMoGymResponseFunctionToolCall,
-        NeMoGymFunctionCallOutput,
-        NeMoGymResponseReasoningItem,
-        NeMoGymResponseMcpCall,
-        NeMoGymResponseMcpListTools,
-        NeMoGymResponseMcpApprovalRequest,
+        Annotated[NeMoGymEasyInputMessage, Tag("easy_message")],
+        Annotated[NeMoGymMessage, Tag("input_message")],
+        Annotated[NeMoGymResponseOutputMessage, Tag("output_message")],
+        Annotated[NeMoGymResponseFunctionToolCall, Tag("function_call")],
+        Annotated[NeMoGymFunctionCallOutput, Tag("function_call_output")],
+        Annotated[NeMoGymResponseReasoningItem, Tag("reasoning")],
+        Annotated[NeMoGymResponseMcpCall, Tag("mcp_call")],
+        Annotated[NeMoGymResponseMcpListTools, Tag("mcp_list_tools")],
+        Annotated[NeMoGymResponseMcpApprovalRequest, Tag("mcp_approval_request")],
         # The SDK includes these items in both response output and request input.
         # Outputs are replayed as input on subsequent turns.
-        NeMoGymResponseFileSearchToolCall,
-        NeMoGymResponseFunctionWebSearch,
-        NeMoGymResponseComputerToolCall,
-        NeMoGymImageGenerationCall,
-        NeMoGymResponseCodeInterpreterToolCall,
-        NeMoGymLocalShellCall,
-        NeMoGymResponseCustomToolCall,
-        NeMoGymComputerCallOutput,
-        NeMoGymResponseCustomToolCallOutput,
-        NeMoGymLocalShellCallOutput,
-        NeMoGymMcpApprovalResponse,
+        Annotated[NeMoGymResponseFileSearchToolCall, Tag("file_search_call")],
+        Annotated[NeMoGymResponseFunctionWebSearch, Tag("web_search_call")],
+        Annotated[NeMoGymResponseComputerToolCall, Tag("computer_call")],
+        Annotated[NeMoGymImageGenerationCall, Tag("image_generation_call")],
+        Annotated[NeMoGymResponseCodeInterpreterToolCall, Tag("code_interpreter_call")],
+        Annotated[NeMoGymLocalShellCall, Tag("local_shell_call")],
+        Annotated[NeMoGymResponseCustomToolCall, Tag("custom_tool_call")],
+        Annotated[NeMoGymComputerCallOutput, Tag("computer_call_output")],
+        Annotated[NeMoGymResponseCustomToolCallOutput, Tag("custom_tool_call_output")],
+        Annotated[NeMoGymLocalShellCallOutput, Tag("local_shell_call_output")],
+        Annotated[NeMoGymMcpApprovalResponse, Tag("mcp_approval_response")],
         # Codex tool family and context management.
-        NeMoGymResponseApplyPatchToolCall,
-        NeMoGymResponseApplyPatchToolCallOutput,
-        NeMoGymResponseCompactionItem,
-        NeMoGymResponseFunctionShellToolCall,
-        NeMoGymResponseFunctionShellToolCallOutput,
-        NeMoGymResponseToolSearchCall,
-        NeMoGymResponseToolSearchOutputItem,
-        NeMoGymCompactionTrigger,
-        NeMoGymAdditionalTools,
+        Annotated[NeMoGymResponseApplyPatchToolCall, Tag("apply_patch_call")],
+        Annotated[NeMoGymResponseApplyPatchToolCallOutput, Tag("apply_patch_call_output")],
+        Annotated[NeMoGymResponseCompactionItem, Tag("compaction")],
+        Annotated[NeMoGymResponseFunctionShellToolCall, Tag("shell_call")],
+        Annotated[NeMoGymResponseFunctionShellToolCallOutput, Tag("shell_call_output")],
+        Annotated[NeMoGymResponseToolSearchCall, Tag("tool_search_call")],
+        Annotated[NeMoGymResponseToolSearchOutputItem, Tag("tool_search_output")],
+        Annotated[NeMoGymCompactionTrigger, Tag("compaction_trigger")],
+        Annotated[NeMoGymAdditionalTools, Tag("additional_tools")],
         # Training variants.
-        NeMoGymEasyInputMessageForTraining,
-        NeMoGymMessageForTraining,
-        NeMoGymResponseOutputMessageForTraining,
-        NeMoGymResponseFunctionToolCallForTraining,
-        NeMoGymResponseReasoningItemForTraining,
+        Annotated[NeMoGymEasyInputMessageForTraining, Tag("easy_message__training")],
+        Annotated[NeMoGymMessageForTraining, Tag("input_message__training")],
+        Annotated[NeMoGymResponseOutputMessageForTraining, Tag("output_message__training")],
+        Annotated[NeMoGymResponseFunctionToolCallForTraining, Tag("function_call__training")],
+        Annotated[NeMoGymResponseReasoningItemForTraining, Tag("reasoning__training")],
     ],
+    Discriminator(_discriminate_response_input_item),
     BeforeValidator(_validate_atomic_token_metadata),
 ]
+_register_item_tags(NeMoGymResponseInputItem, _RESPONSE_INPUT_ITEM_TAG_BY_CLASS)
 NeMoGymResponseInput: TypeAlias = List[NeMoGymResponseInputItem]
 
 
@@ -690,45 +829,48 @@ class NeMoGymResponseFunctionCallOutput(ResponseFunctionToolCallOutputItem):
 
 NeMoGymResponseOutputItem = Annotated[
     Union[
-        NeMoGymResponseOutputMessage,
-        NeMoGymResponseFunctionToolCall,
-        NeMoGymResponseFunctionCallOutput,
-        NeMoGymResponseReasoningItem,
-        NeMoGymResponseMcpCall,
-        NeMoGymResponseMcpListTools,
-        NeMoGymResponseMcpApprovalRequest,
-        NeMoGymResponseFileSearchToolCall,
-        NeMoGymResponseFunctionWebSearch,
-        NeMoGymResponseComputerToolCall,
-        NeMoGymImageGenerationCall,
-        NeMoGymResponseCodeInterpreterToolCall,
-        NeMoGymLocalShellCall,
-        NeMoGymResponseCustomToolCall,
-        NeMoGymResponseComputerCallOutput,
-        NeMoGymResponseCustomToolCallOutputItem,
-        NeMoGymResponseLocalShellCallOutput,
-        NeMoGymResponseMcpApprovalResponse,
-        NeMoGymResponseApplyPatchToolCall,
-        NeMoGymResponseApplyPatchToolCallOutput,
-        NeMoGymResponseCompactionItem,
-        NeMoGymResponseFunctionShellToolCall,
-        NeMoGymResponseFunctionShellToolCallOutput,
-        NeMoGymResponseToolSearchCall,
-        NeMoGymResponseToolSearchOutputItem,
-        NeMoGymResponseAdditionalTools,
+        Annotated[NeMoGymResponseOutputMessage, Tag("output_message")],
+        Annotated[NeMoGymResponseFunctionToolCall, Tag("function_call")],
+        Annotated[NeMoGymResponseFunctionCallOutput, Tag("function_call_output")],
+        Annotated[NeMoGymResponseReasoningItem, Tag("reasoning")],
+        Annotated[NeMoGymResponseMcpCall, Tag("mcp_call")],
+        Annotated[NeMoGymResponseMcpListTools, Tag("mcp_list_tools")],
+        Annotated[NeMoGymResponseMcpApprovalRequest, Tag("mcp_approval_request")],
+        Annotated[NeMoGymResponseFileSearchToolCall, Tag("file_search_call")],
+        Annotated[NeMoGymResponseFunctionWebSearch, Tag("web_search_call")],
+        Annotated[NeMoGymResponseComputerToolCall, Tag("computer_call")],
+        Annotated[NeMoGymImageGenerationCall, Tag("image_generation_call")],
+        Annotated[NeMoGymResponseCodeInterpreterToolCall, Tag("code_interpreter_call")],
+        Annotated[NeMoGymLocalShellCall, Tag("local_shell_call")],
+        Annotated[NeMoGymResponseCustomToolCall, Tag("custom_tool_call")],
+        Annotated[NeMoGymResponseComputerCallOutput, Tag("computer_call_output")],
+        Annotated[NeMoGymResponseCustomToolCallOutputItem, Tag("custom_tool_call_output")],
+        Annotated[NeMoGymResponseLocalShellCallOutput, Tag("local_shell_call_output")],
+        Annotated[NeMoGymResponseMcpApprovalResponse, Tag("mcp_approval_response")],
+        Annotated[NeMoGymResponseApplyPatchToolCall, Tag("apply_patch_call")],
+        Annotated[NeMoGymResponseApplyPatchToolCallOutput, Tag("apply_patch_call_output")],
+        Annotated[NeMoGymResponseCompactionItem, Tag("compaction")],
+        Annotated[NeMoGymResponseFunctionShellToolCall, Tag("shell_call")],
+        Annotated[NeMoGymResponseFunctionShellToolCallOutput, Tag("shell_call_output")],
+        Annotated[NeMoGymResponseToolSearchCall, Tag("tool_search_call")],
+        Annotated[NeMoGymResponseToolSearchOutputItem, Tag("tool_search_output")],
+        Annotated[NeMoGymResponseAdditionalTools, Tag("additional_tools")],
         # Local agents include prompt messages and function results in returned trajectories.
         # Accept their request models alongside the SDK output models.
-        NeMoGymEasyInputMessage,
-        NeMoGymMessage,
-        NeMoGymFunctionCallOutput,
-        NeMoGymEasyInputMessageForTraining,
-        NeMoGymMessageForTraining,
-        NeMoGymResponseOutputMessageForTraining,
-        NeMoGymResponseFunctionToolCallForTraining,
-        NeMoGymResponseReasoningItemForTraining,
+        Annotated[NeMoGymEasyInputMessage, Tag("easy_message")],
+        Annotated[NeMoGymMessage, Tag("input_message")],
+        Annotated[NeMoGymFunctionCallOutput, Tag("function_call_output_input")],
+        Annotated[NeMoGymEasyInputMessageForTraining, Tag("easy_message__training")],
+        Annotated[NeMoGymMessageForTraining, Tag("input_message__training")],
+        Annotated[NeMoGymResponseOutputMessageForTraining, Tag("output_message__training")],
+        Annotated[NeMoGymResponseFunctionToolCallForTraining, Tag("function_call__training")],
+        Annotated[NeMoGymResponseReasoningItemForTraining, Tag("reasoning__training")],
     ],
+    Discriminator(_discriminate_response_output_item),
+    BeforeValidator(_validate_atomic_token_metadata),
     BeforeValidator(_require_response_output_item_type),
 ]
+_register_item_tags(NeMoGymResponseOutputItem, _RESPONSE_OUTPUT_ITEM_TAG_BY_CLASS)
 
 
 class NeMoGymResponseInputTokensDetails(ResponseInputTokensDetails):

--- a/tests/unit_tests/test_openai_utils.py
+++ b/tests/unit_tests/test_openai_utils.py
@@ -85,6 +85,7 @@ from nemo_gym.openai_utils import (
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseCustomToolCall,
     NeMoGymResponseFileSearchToolCall,
+    NeMoGymResponseFunctionCallOutput,
     NeMoGymResponseFunctionToolCall,
     NeMoGymResponseFunctionWebSearch,
     NeMoGymResponseInputItem,
@@ -220,6 +221,214 @@ class TestTokenMetadataValidation:
                     "prompt_token_ids": [1],
                 },
             )
+
+    @pytest.mark.parametrize("container", ["input", "output"])
+    def test_response_items_reject_partial_metadata(self, container: str) -> None:
+        item = {
+            "type": "message",
+            "id": "msg_1",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "answer", "annotations": []}],
+            "prompt_token_ids": [1],
+        }
+
+        with pytest.raises(ValidationError, match="Token metadata must include all required fields"):
+            if container == "input":
+                NeMoGymResponseCreateParamsNonStreaming(input=[item])
+            else:
+                NeMoGymResponse.model_validate(_response_with_output([item]))
+
+
+class TestDiscriminatedResponseItems:
+    _TOKEN_METADATA = {
+        "prompt_token_ids": [1, 2],
+        "generation_token_ids": [3],
+        "generation_log_probs": [-0.1],
+        "routed_experts": [[[0, 1]]],
+    }
+
+    @pytest.mark.parametrize(
+        "payload, expected_type",
+        [
+            (
+                {"type": "message", "role": "user", "content": "question", "phase": "commentary"},
+                NeMoGymEasyInputMessage,
+            ),
+            (
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "question"}],
+                },
+                NeMoGymEasyInputMessage,
+            ),
+            (
+                {
+                    "type": "message",
+                    "role": "system",
+                    "status": "completed",
+                    "content": [{"type": "input_text", "text": "instructions"}],
+                },
+                NeMoGymMessage,
+            ),
+            (
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "answer", "annotations": []}],
+                    "phase": "final_answer",
+                },
+                NeMoGymResponseOutputMessage,
+            ),
+            (
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "input_text", "text": "local observation"}],
+                },
+                NeMoGymEasyInputMessage,
+            ),
+            (
+                {
+                    "type": "message",
+                    "id": "msg_2",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [],
+                },
+                NeMoGymResponseOutputMessage,
+            ),
+            (
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                },
+                NeMoGymEasyInputMessage,
+            ),
+        ],
+        ids=[
+            "easy-string",
+            "easy-input-content",
+            "input-status",
+            "output-content",
+            "assistant-input-content",
+            "output-empty-content",
+            "easy-empty-content",
+        ],
+    )
+    def test_message_shape_selects_concrete_class(self, payload: dict, expected_type: type) -> None:
+        request_item = NeMoGymResponseCreateParamsNonStreaming(input=[payload]).input[0]
+        response_item = NeMoGymResponse.model_validate(_response_with_output([payload])).output[0]
+
+        assert type(request_item) is expected_type
+        assert type(response_item) is expected_type
+
+    @pytest.mark.parametrize(
+        "base_type, payload",
+        [
+            (
+                NeMoGymEasyInputMessage,
+                {"type": "message", "role": "user", "content": "question", "phase": "commentary"},
+            ),
+            (
+                NeMoGymMessage,
+                {
+                    "type": "message",
+                    "role": "developer",
+                    "status": "in_progress",
+                    "content": [{"type": "input_text", "text": "instructions"}],
+                },
+            ),
+            (
+                NeMoGymResponseOutputMessage,
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "status": "incomplete",
+                    "content": [{"type": "refusal", "refusal": "no"}],
+                    "phase": "final_answer",
+                },
+            ),
+            (
+                NeMoGymResponseFunctionToolCall,
+                {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "lookup",
+                    "arguments": "{}",
+                    "status": "completed",
+                    "namespace": "tools",
+                },
+            ),
+            (
+                NeMoGymResponseReasoningItem,
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [],
+                    "encrypted_content": "opaque",
+                },
+            ),
+        ],
+        ids=["easy-message", "input-message", "output-message", "function-call", "reasoning"],
+    )
+    def test_all_training_variants_preserve_fields_and_revalidate(self, base_type: type, payload: dict) -> None:
+        payload = {**payload, **self._TOKEN_METADATA}
+        expected_type = RESPONSES_TO_TRAIN[base_type]
+
+        request = NeMoGymResponseCreateParamsNonStreaming(input=[payload])
+        response = NeMoGymResponse.model_validate(_response_with_output([payload]))
+        assert type(request.input[0]) is expected_type
+        assert type(response.output[0]) is expected_type
+
+        request_dump = request.model_dump(mode="json", exclude_unset=True)
+        response_dump = response.model_dump(mode="json", exclude_unset=True)
+        for key, value in payload.items():
+            assert request_dump["input"][0][key] == value
+            assert response_dump["output"][0][key] == value
+
+        revalidated_request = NeMoGymResponseCreateParamsNonStreaming.model_validate(request_dump)
+        revalidated_response = NeMoGymResponse.model_validate(response_dump)
+        assert type(revalidated_request.input[0]) is expected_type
+        assert type(revalidated_response.output[0]) is expected_type
+        assert revalidated_request.model_dump(mode="json", exclude_unset=True) == request_dump
+        assert revalidated_response.model_dump(mode="json", exclude_unset=True) == response_dump
+
+        instance = expected_type.model_validate(payload)
+        assert type(NeMoGymResponseCreateParamsNonStreaming(input=[instance]).input[0]) is expected_type
+        assert type(NeMoGymResponse.model_validate(_response_with_output([instance])).output[0]) is expected_type
+
+    def test_typeless_input_uses_field_preserving_fallback(self) -> None:
+        payload = {"role": "tool", "tool_call_id": "call_1", "content": "result", "provider_field": {"x": 1}}
+
+        request = NeMoGymResponseCreateParamsNonStreaming(input=[payload])
+
+        assert type(request.input[0]) is NeMoGymResponseMcpListTools
+        assert request.model_dump(mode="json", exclude_unset=True)["input"][0] == payload
+
+    def test_function_call_output_models_route_by_output_fields(self) -> None:
+        input_payload = {"type": "function_call_output", "call_id": "call_1", "output": "result"}
+        output_payload = {
+            **input_payload,
+            "id": "fco_1",
+            "status": "completed",
+        }
+
+        request_item = NeMoGymResponseCreateParamsNonStreaming(input=[input_payload]).input[0]
+        local_output_item = NeMoGymResponse.model_validate(_response_with_output([input_payload])).output[0]
+        provider_output_item = NeMoGymResponse.model_validate(_response_with_output([output_payload])).output[0]
+
+        assert type(request_item) is NeMoGymFunctionCallOutput
+        assert type(local_output_item) is NeMoGymFunctionCallOutput
+        assert type(provider_output_item) is NeMoGymResponseFunctionCallOutput
+        assert provider_output_item.model_dump(mode="json", exclude_unset=True) == output_payload
 
 
 class TestNeMoGymChatCompletionSchemas:


### PR DESCRIPTION
## Summary

`NeMoGymResponseInputItem` and `NeMoGymResponseOutputItem` are large untagged Pydantic unions. Validating each response item tries the union members in sequence to determine which model fits. This work repeats for every item whenever a request or response is validated, making validation cost grow with both the number of union members and the trajectory length.

This change converts the unions to callable discriminated unions. The discriminator selects one tagged model from the item's `type` and, where multiple models share a type, from stable fields such as message role, content shape, ID, and status. Typeless input keeps its existing permissive fallback behavior. Complete token metadata selects the corresponding training model, while partial metadata is rejected instead of being discarded by a base model.

Tests cover concrete class selection, all training variants, field preservation, and dump/revalidation.

## Pydantic validation microbenchmark

Compared with `upstream/main` using mixed payloads containing messages, reasoning, function calls, function results, MCP items, training variants, and typeless tool turns.

- 80 items: input union 22.19 -> 1.47 microseconds/item (15.1x); output union 22.70 -> 1.57 (14.4x); full request model 22.12 -> 1.60 (13.9x)
- 320 items: input union 22.40 -> 1.48 microseconds/item (15.2x); output union 23.53 -> 1.58 (14.8x); full request model 22.24 -> 1.58 (14.1x)

## Test plan
- [x] `uv run pytest tests/unit_tests/test_openai_utils.py tests/unit_tests/test_responses_api_model_streaming.py tests/unit_tests/test_responses_converter.py -q`
- [x] scoped pre-commit checks for changed files
- [x] `uv run pytest tests/unit_tests/ -q`