### PR TITLE
perf(server): replace HTTP middleware wrappers with ASGI

### DIFF
--- a/nemo_gym/mcp_auto_exposure.py
+++ b/nemo_gym/mcp_auto_exposure.py
@@ -116,8 +116,15 @@ _MCP_TOOL_NAME_RE = re.compile(r"[A-Za-z0-9_-]+")
 # Path-template params from the public route.path string ("/{tool_name}", "/items/{id:int}").
 _PATH_PARAM_RE = re.compile(r"{([^}:]+)(?::[^}]*)?}")
 
-# Gym's function-based middleware (add_session_id + exception middleware); SessionMiddleware is matched by class name.
-_GYM_MIDDLEWARE_MODULES = frozenset({"nemo_gym.server_utils"})
+# Direct dispatch may skip only these known middleware classes.
+_DIRECT_DISPATCH_MIDDLEWARE = frozenset(
+    {
+        "nemo_gym.server_utils.ExceptionHandlingMiddleware",
+        "nemo_gym.server_utils.SessionIDMiddleware",
+        "nemo_gym.rollout_correlation.RolloutContextMiddleware",
+        "starlette.middleware.sessions.SessionMiddleware",
+    }
+)
 
 
 # ==================================================================================================
@@ -283,12 +290,10 @@ class DirectDispatchError(Exception):
 async def call_direct(
     app: FastAPI, binding: DirectBinding, session_id: str, arguments: dict, path_value: Optional[str] = None
 ) -> Any:
-    """Invoke the handler resolved at startup once and return its JSON-able payload.
+    """Invoke a bound handler with the supplied session ID.
 
-    Replicates what skipping Gym's own stack would otherwise lose: SessionMiddleware + add_session_id
-    become ``scope["session"] = {SESSION_ID_KEY: sid}`` (handlers only read request.session); the
-    exception middleware's status-carrying text is reproduced by pre-formatting HTTPException /
-    ValidationError / ClientResponseError into DirectDispatchError.
+    The fabricated request exposes the session ID without running the HTTP middleware stack.
+    Handler-visible failures retain their HTTP status and detail in ``DirectDispatchError``.
     """
     kwargs: dict[str, Any] = {}
     if binding.path_param is not None:
@@ -436,14 +441,10 @@ def harvest_tools(app: FastAPI, server: Any) -> dict[str, MCPTool]:
     custom_middleware: list[str] = []
     for m in app.user_middleware:
         cls = m.cls
-        if f"{cls.__module__}.{cls.__name__}" == "starlette.middleware.sessions.SessionMiddleware":
-            continue  # Gym's SessionMiddleware — replaced by a materialized session on direct dispatch
-        if f"{cls.__module__}.{cls.__name__}" == "nemo_gym.rollout_correlation.RolloutContextMiddleware":
-            continue  # Correlation prefixes are handled before resource routes; direct MCP dispatch has no prefix.
-        dispatch = m.kwargs.get("dispatch")
-        if dispatch is not None and getattr(dispatch, "__module__", None) in _GYM_MIDDLEWARE_MODULES:
-            continue  # Gym's add_session_id / exception middleware
-        custom_middleware.append(f"{cls.__module__}.{cls.__name__}")
+        middleware_name = f"{cls.__module__}.{cls.__name__}"
+        if middleware_name in _DIRECT_DISPATCH_MIDDLEWARE:
+            continue
+        custom_middleware.append(middleware_name)
     if custom_middleware:
         raise ValueError(
             f"{type(server).__name__} installs non-Gym middleware {custom_middleware}, which direct MCP "

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -53,6 +53,7 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 from requests.exceptions import ConnectionError
 from starlette.middleware.sessions import SessionMiddleware
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from nemo_gym import WORKING_DIR
 from nemo_gym.config_types import (
@@ -564,6 +565,96 @@ def _has_injected_global_config_env() -> bool:
 SESSION_ID_KEY = "session_id"
 
 
+class SessionIDMiddleware:
+    """Add a stable Gym session ID to each HTTP request.
+
+    ``SessionMiddleware`` must wrap this middleware so ``scope["session"]`` is available.
+    Non-HTTP scopes pass through unchanged.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        session = scope["session"]
+        session_id = session.get(SESSION_ID_KEY)
+        if session_id is None:
+            session_id = str(uuid4())
+        # Assignment marks the session as modified.
+        # SessionMiddleware therefore persists the ID on every response.
+        session[SESSION_ID_KEY] = session_id
+
+        await self.app(scope, receive, send)
+
+
+class ExceptionHandlingMiddleware:
+    """Convert pre-response exceptions into Gym's JSON 500 responses.
+
+    Exceptions propagate after ``http.response.start`` because the status and headers are committed.
+    Non-HTTP scopes pass through unchanged.
+    """
+
+    def __init__(self, app: ASGIApp, server: "SimpleServer") -> None:
+        self.app = app
+        self.server = server
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        response_started = False
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+            return
+        except ClientResponseError as e:
+            if response_started:
+                raise
+            assert hasattr(e, "response_content"), (
+                "Please use `nemo_gym.server_utils.raise_for_status` for HTTP exceptions!"
+            )
+
+            response_content = f"Hit an exception in {self.server.get_session_middleware_key()} calling an inner server: {e.response_content}"
+            if _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG:
+                print(response_content)
+
+            response = JSONResponse(content=response_content, status_code=500)
+        except CancelledError:
+            if response_started:
+                raise
+            response = JSONResponse(content="An unknown error occurred", status_code=500)
+        except Exception as e:
+            if response_started:
+                raise
+            print(
+                f"""🚨 Caught an exception printed above in {self.server.config.name} ({self.server.__class__.__name__}). If you expect this to be fed back into this model, the exception repr i.e. `repr(e)` is returned to the model. However, please make sure this exception is caught in your server and returned to the model as appropriate. See https://fastapi.tiangolo.com/tutorial/handling-errors/#use-httpexception
+Formatted exception: {format_exc()}
+repr(e): {repr(e)}"""
+            )
+            response = JSONResponse(content=repr(e), status_code=500)
+        except:  # noqa: E722
+            if response_started:
+                raise
+            print_exc()
+            print(
+                f"""🚨 Caught an unknown exception printed above in {self.server.config.name} ({self.server.__class__.__name__}). If you expect this to be fed back into this model, nothing meaningful is returned to the model. Please make sure this exception is caught in your server and returned to the model as appropriate. See https://fastapi.tiangolo.com/tutorial/handling-errors/#use-httpexception"""
+            )
+            response = JSONResponse(content="An unknown error occurred", status_code=500)
+
+        await response(scope, receive, send)
+
+
 class BaseServer(BaseModel):
     """
     All instances of BaseServer are queryable using ServerClient.
@@ -757,53 +848,16 @@ class SimpleServer(BaseServer):
             return
         app.state.nemo_gym_session_middleware_installed = True
 
-        # The multiple middleware execution order described in https://fastapi.tiangolo.com/tutorial/middleware/#multiple-middleware-execution-order
-        # Says that if you register middlewares A and then B,
-        # - at request time: They execute B first then A
-        # - at response time: They return to A first and then B
-        # So for adding session IDs, that middleware must run after SessionMiddleware, so it must be registered before it.
-
-        @app.middleware("http")
-        async def add_session_id(request: Request, call_next):  # pragma: no cover
-            # Always assign so Starlette 1.0+ marks session.modified=True and re-sends Set-Cookie.
-            request.session[SESSION_ID_KEY] = request.session.get(SESSION_ID_KEY, str(uuid4()))
-
-            response: Response = await call_next(request)
-            return response
+        # Middleware added later runs first.
+        # SessionMiddleware must populate the session before SessionIDMiddleware reads it.
+        app.add_middleware(SessionIDMiddleware)
 
         session_middleware_key = self.get_session_middleware_key()
         app.add_middleware(SessionMiddleware, secret_key=session_middleware_key, session_cookie=session_middleware_key)
 
-    def setup_exception_middleware(self, app: FastAPI) -> None:  # pragma: no cover
-        @app.middleware("http")
-        async def exception_handling_middleware(request: Request, call_next):
-            try:
-                return await call_next(request)
-            except ClientResponseError as e:
-                assert hasattr(e, "response_content"), (
-                    "Please use `nemo_gym.server_utils.raise_for_status` for HTTP exceptions!"
-                )
-
-                response_content = f"Hit an exception in {self.get_session_middleware_key()} calling an inner server: {e.response_content}"
-                if _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG:
-                    print(response_content)
-
-                return JSONResponse(content=response_content, status_code=500)
-            except CancelledError:
-                return JSONResponse(content="An unknown error occurred", status_code=500)
-            except Exception as e:
-                print(
-                    f"""🚨 Caught an exception printed above in {self.config.name} ({self.__class__.__name__}). If you expect this to be fed back into this model, the exception repr i.e. `repr(e)` is returned to the model. However, please make sure this exception is caught in your server and returned to the model as appropriate. See https://fastapi.tiangolo.com/tutorial/handling-errors/#use-httpexception
-Formatted exception: {format_exc()}
-repr(e): {repr(e)}"""
-                )
-                return JSONResponse(content=repr(e), status_code=500)
-            except:
-                print_exc()
-                print(
-                    f"""🚨 Caught an unknown exception printed above in {self.config.name} ({self.__class__.__name__}). If you expect this to be fed back into this model, nothing meaningful is returned to the model. Please make sure this exception is caught in your server and returned to the model as appropriate. See https://fastapi.tiangolo.com/tutorial/handling-errors/#use-httpexception"""
-                )
-                return JSONResponse(content="An unknown error occurred", status_code=500)
+    def setup_exception_middleware(self, app: FastAPI) -> None:
+        # This middleware is registered last and handles failures from the full request stack.
+        app.add_middleware(ExceptionHandlingMiddleware, server=self)
 
     def setup_profiling(self, app: FastAPI, profiling_config: ProfilingMiddlewareConfig) -> None:  # pragma: no cover
         base_profile_dir = WORKING_DIR / profiling_config.profiling_results_dirpath / self.get_session_middleware_key()

--- a/tests/unit_tests/test_asgi_middlewares.py
+++ b/tests/unit_tests/test_asgi_middlewares.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from asyncio.exceptions import CancelledError
+from contextlib import asynccontextmanager
+from typing import Optional
+
+import pytest
+from aiohttp import ClientResponseError
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+from fastapi.testclient import TestClient
+from omegaconf import DictConfig
+from starlette.middleware.sessions import SessionMiddleware
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+import nemo_gym.server_utils as server_utils
+from nemo_gym.config_types import BaseRunServerInstanceConfig, BaseServerConfig
+from nemo_gym.server_utils import (
+    SESSION_ID_KEY,
+    ExceptionHandlingMiddleware,
+    ServerClient,
+    SessionIDMiddleware,
+    SimpleServer,
+)
+
+
+class _MiddlewareTestServer(SimpleServer):
+    def setup_webserver(self) -> FastAPI:
+        raise AssertionError("not used in these tests")
+
+
+def _make_server() -> _MiddlewareTestServer:
+    return _MiddlewareTestServer(
+        config=BaseRunServerInstanceConfig(name="my_server", host="", port=0, entrypoint=""),
+        server_client=ServerClient(
+            head_server_config=BaseServerConfig(host="", port=0),
+            global_config_dict=DictConfig({}),
+        ),
+    )
+
+
+def _make_app(server: SimpleServer, lifespan=None) -> FastAPI:
+    """Mirror run_webserver's real order: session middleware first, exception middleware last."""
+    app = FastAPI(lifespan=lifespan)
+    server.setup_session_middleware(app)
+    server.setup_exception_middleware(app)
+    return app
+
+
+def _client_response_error(response_content: Optional[bytes]) -> ClientResponseError:
+    error = ClientResponseError(request_info=None, history=(), status=502, message="bad gateway")
+    if response_content is not None:
+        error.response_content = response_content
+    return error
+
+
+def _http_scope(session: Optional[dict] = None) -> Scope:
+    scope: Scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [],
+        "client": ("127.0.0.1", 1),
+        "server": ("testserver", 80),
+    }
+    if session is not None:
+        scope["session"] = session
+    return scope
+
+
+async def _receive() -> Message:
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+async def _run_asgi(app: ASGIApp, scope: Optional[Scope] = None) -> list[Message]:
+    sent: list[Message] = []
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    await app(scope or _http_scope(), _receive, send)
+    return sent
+
+
+class TestSessionIDMiddleware:
+    def test_session_id_and_cookie_payload_stay_stable(self) -> None:
+        server = _make_server()
+        app = _make_app(server)
+
+        @app.get("/session")
+        async def get_session(request: Request) -> dict:
+            return {"session_id": request.session[SESSION_ID_KEY]}
+
+        with TestClient(app) as client:
+            first = client.get("/session")
+            second = client.get("/session")
+
+        first_id = first.json()["session_id"]
+        second_id = second.json()["session_id"]
+        assert first_id
+        assert first_id == second_id
+
+        # Each response persists the stable session ID.
+        assert 1 == len(first.headers.get_list("set-cookie"))
+        assert 1 == len(second.headers.get_list("set-cookie"))
+
+    async def test_uuid_is_generated_only_when_session_id_is_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        generated: list[str] = []
+
+        def make_uuid() -> str:
+            generated.append("generated-id")
+            return generated[-1]
+
+        monkeypatch.setattr(server_utils, "uuid4", make_uuid)
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            return None
+
+        middleware = SessionIDMiddleware(downstream)
+        existing_session = {SESSION_ID_KEY: "existing-id"}
+        missing_session: dict = {}
+
+        await _run_asgi(middleware, _http_scope(existing_session))
+        await _run_asgi(middleware, _http_scope(missing_session))
+
+        assert existing_session[SESSION_ID_KEY] == "existing-id"
+        assert missing_session[SESSION_ID_KEY] == "generated-id"
+        assert generated == ["generated-id"]
+
+    def test_registration_order_populates_session_before_use(self) -> None:
+        server = _make_server()
+        app = _make_app(server)
+
+        # user_middleware lists request-time order from outermost to innermost.
+        assert [ExceptionHandlingMiddleware, SessionMiddleware, SessionIDMiddleware] == [
+            m.cls for m in app.user_middleware
+        ]
+
+    def test_lifespan_scope_passes_through(self) -> None:
+        events: list[str] = []
+
+        @asynccontextmanager
+        async def lifespan(app: FastAPI):
+            events.append("startup")
+            yield
+            events.append("shutdown")
+
+        server = _make_server()
+        app = _make_app(server, lifespan=lifespan)
+
+        with TestClient(app):
+            assert ["startup"] == events
+        assert ["startup", "shutdown"] == events
+
+    @pytest.mark.parametrize("scope_type", ["lifespan", "websocket"])
+    async def test_non_http_scope_passes_through_unchanged(self, scope_type: str) -> None:
+        server = _make_server()
+        scope = {"type": scope_type}
+        observed: list[tuple[Scope, Receive, Send]] = []
+
+        async def downstream(actual_scope: Scope, receive: Receive, send: Send) -> None:
+            observed.append((actual_scope, receive, send))
+
+        async def receive() -> Message:
+            return {"type": f"{scope_type}.disconnect"}
+
+        async def send(message: Message) -> None:
+            raise AssertionError(f"unexpected message: {message}")
+
+        app = ExceptionHandlingMiddleware(SessionIDMiddleware(downstream), server)
+        await app(scope, receive, send)
+
+        assert observed == [(scope, receive, send)]
+
+
+class TestExceptionHandlingMiddleware:
+    def test_normal_response_passes_through(self) -> None:
+        server = _make_server()
+        app = _make_app(server)
+
+        @app.get("/ok")
+        async def ok() -> dict:
+            return {"status": "ok"}
+
+        with TestClient(app) as client:
+            response = client.get("/ok")
+        assert 200 == response.status_code
+        assert {"status": "ok"} == response.json()
+
+    async def test_streaming_response_messages_pass_through(self) -> None:
+        server = _make_server()
+        expected: list[Message] = [
+            {"type": "http.response.start", "status": 200, "headers": [(b"x-test", b"stream")]},
+            {"type": "http.response.body", "body": b"first", "more_body": True},
+            {"type": "http.response.body", "body": b"second", "more_body": False},
+        ]
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            for message in expected:
+                await send(message)
+
+        sent = await _run_asgi(ExceptionHandlingMiddleware(downstream, server))
+
+        assert sent == expected
+
+    def test_client_response_error_with_response_content(self) -> None:
+        server = _make_server()
+        app = _make_app(server)
+
+        @app.get("/boom")
+        async def boom() -> None:
+            raise _client_response_error(b"inner server said no")
+
+        with TestClient(app) as client:
+            response = client.get("/boom")
+
+        assert 500 == response.status_code
+        expected = (
+            f"Hit an exception in {server.get_session_middleware_key()} "
+            f"calling an inner server: {b'inner server said no'}"
+        )
+        assert expected == response.json()
+
+    def test_client_response_error_without_response_content_asserts(self) -> None:
+        server = _make_server()
+        app = _make_app(server)
+
+        @app.get("/boom")
+        async def boom() -> None:
+            raise _client_response_error(None)
+
+        with TestClient(app) as client:
+            with pytest.raises(AssertionError, match="raise_for_status"):
+                client.get("/boom")
+
+    def test_generic_exception_returns_repr(self, capsys: pytest.CaptureFixture) -> None:
+        server = _make_server()
+        app = _make_app(server)
+
+        @app.get("/boom")
+        async def boom() -> None:
+            raise ValueError("something went wrong")
+
+        with TestClient(app) as client:
+            response = client.get("/boom")
+
+        assert 500 == response.status_code
+        assert repr(ValueError("something went wrong")) == response.json()
+
+        printed = capsys.readouterr().out
+        assert "Caught an exception printed above in my_server (_MiddlewareTestServer)" in printed
+        assert "repr(e): ValueError('something went wrong')" in printed
+
+    def test_bare_except_returns_unknown_error(self, capsys: pytest.CaptureFixture) -> None:
+        class NotAnException(BaseException):
+            pass
+
+        server = _make_server()
+        app = _make_app(server)
+
+        @app.get("/boom")
+        async def boom() -> None:
+            raise NotAnException()
+
+        with TestClient(app) as client:
+            response = client.get("/boom")
+
+        assert 500 == response.status_code
+        assert "An unknown error occurred" == response.json()
+
+        captured = capsys.readouterr()
+        assert "Caught an unknown exception printed above in my_server (_MiddlewareTestServer)" in captured.out
+        assert "NotAnException" in captured.err  # print_exc()
+
+    def test_cancelled_error_returns_unknown_error(self) -> None:
+        server = _make_server()
+        app = _make_app(server)
+
+        @app.get("/boom")
+        async def boom() -> None:
+            raise CancelledError()
+
+        with TestClient(app) as client:
+            response = client.get("/boom")
+
+        assert 500 == response.status_code
+        assert "An unknown error occurred" == response.json()
+
+    def test_exception_after_response_start_is_reraised(self) -> None:
+        server = _make_server()
+        app = _make_app(server)
+
+        @app.get("/stream")
+        async def stream() -> StreamingResponse:
+            async def body():
+                yield b"partial"
+                raise ValueError("mid-stream failure")
+
+            return StreamingResponse(body())
+
+        with TestClient(app) as client:
+            with pytest.raises(ValueError, match="mid-stream failure"):
+                client.get("/stream")
+
+    async def test_raw_streaming_exception_preserves_partial_response(self) -> None:
+        server = _make_server()
+        sent: list[Message] = []
+        expected: list[Message] = [
+            {"type": "http.response.start", "status": 200, "headers": []},
+            {"type": "http.response.body", "body": b"partial", "more_body": True},
+        ]
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            for message in expected:
+                await send(message)
+            raise ValueError("mid-stream failure")
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        middleware = ExceptionHandlingMiddleware(downstream, server)
+        with pytest.raises(ValueError, match="mid-stream failure"):
+            await middleware(_http_scope(), _receive, send)
+
+        assert sent == expected

--- a/tests/unit_tests/test_mcp_auto_exposure.py
+++ b/tests/unit_tests/test_mcp_auto_exposure.py
@@ -55,7 +55,13 @@ from nemo_gym.mcp_auto_exposure import (  # noqa: E402
     install_auto_exposure,
     maybe_auto_expose,
 )
-from nemo_gym.server_utils import SESSION_ID_KEY, ServerClient, SimpleServer  # noqa: E402
+from nemo_gym.server_utils import (  # noqa: E402
+    SESSION_ID_KEY,
+    ExceptionHandlingMiddleware,
+    ServerClient,
+    SessionIDMiddleware,
+    SimpleServer,
+)
 
 
 RPC_HEADERS = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
@@ -528,6 +534,36 @@ def test_refuses_custom_middleware():
         return await call_next(request)
 
     with pytest.raises(ValueError, match="non-Gym middleware"):
+        install_auto_exposure(server, app)
+
+
+def test_accepts_exact_direct_dispatch_middleware_classes():
+    server = _server()
+    app = server.setup_webserver()
+    server.setup_exception_middleware(app)
+
+    install_auto_exposure(server, app)
+
+    middleware_classes = {middleware.cls for middleware in app.user_middleware}
+    assert SessionIDMiddleware in middleware_classes
+    assert ExceptionHandlingMiddleware in middleware_classes
+
+
+def test_refuses_unknown_middleware_from_server_utils_module():
+    class UnknownMiddleware:
+        __module__ = "nemo_gym.server_utils"
+
+        def __init__(self, app):
+            self.app = app
+
+        async def __call__(self, scope, receive, send):
+            await self.app(scope, receive, send)
+
+    server = _server()
+    app = server.setup_webserver()
+    app.add_middleware(UnknownMiddleware)
+
+    with pytest.raises(ValueError, match=r"nemo_gym\.server_utils\.UnknownMiddleware"):
         install_auto_exposure(server, app)
 
 


### PR DESCRIPTION
## Summary

Every Gym server currently registers session ID assignment and exception handling with `@app.middleware("http")`. Starlette implements each decorator with `BaseHTTPMiddleware`, so every request crosses two task groups and two pairs of in-memory streams. The downstream application runs in separate tasks, and each response message is relayed through both middleware layers on every server hop.

This change replaces both wrappers with direct ASGI middleware. `SessionIDMiddleware` updates the session scope before calling the application. `ExceptionHandlingMiddleware` calls the application directly and converts failures only before response headers are committed. Streaming response messages pass through unchanged, and later failures propagate because a second response can no longer be sent.

Cancellation handling changes before a response starts. On `upstream/main`, a downstream `CancelledError` crosses the `BaseHTTPMiddleware` task boundary and surfaces as `RuntimeError("No response returned.")`, which the generic handler returns in a 500 response. The direct ASGI middleware receives the original cancellation, so the existing `CancelledError` branch now returns `"An unknown error occurred"` with status 500. Cancellation after response headers are sent continues to propagate.

The middleware order, session persistence, and existing pre-response error bodies remain covered by tests. Direct MCP dispatch may skip only the exact Gym middleware classes it replaces; another middleware in the same module is rejected.

## HTTP throughput microbenchmark

Compared with `upstream/main` using deterministic responses over loopback HTTP with `httptools`.

- Tiny response: 3,057 -> 5,299 requests/s at concurrency 1 (+73%); 3,652 -> 10,768 at concurrency 32 (+195%)
- 37 KB response: 2,892 -> 4,650 requests/s at concurrency 1 (+61%); 3,319 -> 8,132 at concurrency 32 (+145%)
- 2 MB response: 499 -> 510 requests/s at concurrency 1 (+2%); 430 -> 630 at concurrency 32 (+46%)

The improvement is largest when fixed per-request middleware work dominates. Large-response serialization and transfer reduce the relative gain.

## Test plan
- [x] `uv run pytest tests/unit_tests/test_asgi_middlewares.py tests/unit_tests/test_mcp_auto_exposure.py tests/unit_tests/test_server_utils.py -q`
- [x] scoped pre-commit checks for changed files
- [ ] `uv run pytest tests/unit_tests/ -q` (two unrelated baseline failures: terminal-width-dependent Rich output and missing optional `httpx_aiohttp`)