### PR TITLE
fix(pty): eliminate attach-refusal race, diagnose dead/OOM-killed sandboxes, clean exec stdout

### DIFF
--- a/nemo_gym/sandbox/api.py
+++ b/nemo_gym/sandbox/api.py
@@ -62,14 +62,21 @@ def _pty_timeout_result(command: str, timeout_s: float | int | None, *, reusable
 
 
 async def _run_in_pty_session(session: SandboxPtySession, command: str) -> SandboxExecResult:
-    """Run ``command`` in a live session, delimited by a unique marker."""
+    """Run ``command`` in a live session, delimited by unique markers."""
     token = f"NGPTY{uuid.uuid4().hex[:12]}"
-    # The marker is assembled from two literals so the shell's echo of this
-    # line cannot itself match the marker we scan for. The brace group keeps
-    # shell state while putting stdin at EOF: the session's stdin never ends,
-    # so a stdin-reading command would block forever and eat the marker line.
+    # Markers are assembled from two literals so the shell's echo of the typed
+    # lines cannot match what we scan for. Both printfs live inside the brace
+    # group: every echoed input line and prompt lands before the start marker,
+    # and the status marker follows the output with no prompt in between, so
+    # the slice between the markers is the command's output alone. The group
+    # keeps shell state while putting stdin at EOF: the session's stdin never
+    # ends, so a stdin-reading command would block forever and eat the marker
+    # line.
     await session.write(
-        f"{{ {command}\n}} </dev/null\nprintf '%s%s:%s\\n' '{token[:5]}' '{token[5:]}' \"$?\"\n".encode()
+        f"{{ printf '%s%s\\n' '{token[:5]}' '{token[5:]}S'\n"
+        f"{command}\n"
+        f"printf '%s%s:%s\\n' '{token[:5]}' '{token[5:]}' \"$?\"\n"
+        f"}} </dev/null\n".encode()
     )
 
     needle = f"{token}:".encode()
@@ -81,6 +88,11 @@ async def _run_in_pty_session(session: SandboxPtySession, command: str) -> Sandb
         buffer.extend(chunk)
 
     stdout, _, trailing = bytes(buffer).partition(needle)
+    # Drop the echoed input and prompts: real output starts on the line after
+    # the start marker.
+    _, seen_start, after_start = stdout.partition(f"{token}S".encode())
+    if seen_start:
+        stdout = after_start.partition(b"\n")[2]
     while b"\n" not in trailing:
         # The status digits can straddle the chunk that carried the marker.
         chunk = await session.read()

--- a/nemo_gym/sandbox/api.py
+++ b/nemo_gym/sandbox/api.py
@@ -64,14 +64,13 @@ def _pty_timeout_result(command: str, timeout_s: float | int | None, *, reusable
 async def _run_in_pty_session(session: SandboxPtySession, command: str) -> SandboxExecResult:
     """Run ``command`` in a live session, delimited by unique markers."""
     token = f"NGPTY{uuid.uuid4().hex[:12]}"
-    # Markers are assembled from two literals so the shell's echo of the typed
-    # lines cannot match what we scan for. Both printfs live inside the brace
-    # group: every echoed input line and prompt lands before the start marker,
-    # and the status marker follows the output with no prompt in between, so
-    # the slice between the markers is the command's output alone. The group
-    # keeps shell state while putting stdin at EOF: the session's stdin never
-    # ends, so a stdin-reading command would block forever and eat the marker
-    # line.
+    # The markers are split across two printf arguments so the shell's echo of
+    # these lines can never match them. Both printfs run inside the brace
+    # group: all echoed input and prompts appear before the start marker, and
+    # the exit-status marker directly follows the output, so the slice between
+    # the markers is the command's output alone. The group also puts stdin at
+    # EOF — the session's stdin never ends, so a stdin-reading command would
+    # otherwise block forever.
     await session.write(
         f"{{ printf '%s%s\\n' '{token[:5]}' '{token[5:]}S'\n"
         f"{command}\n"

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -1493,6 +1493,15 @@ class OpenSandboxProvider:
         from nemo_gym.sandbox.providers.opensandbox.pty import _PTY_TAKEOVER_RETRY_DELAYS, attach_pty_session
 
         base_url, headers, request_timeout_s = await self._pty_target(handle)
+        if takeover:
+            # Release our own live attachment first: execd then has nothing to
+            # evict, instead of racing its eviction of a client that may
+            # already be half-open (the 1008 policy-violation close below).
+            for stale in [s for s in self._pty_sessions if s.session_id == session_id and not s.closed]:
+                try:
+                    await stale.detach()
+                except SandboxPtyError:
+                    pass  # already dead; the retry loop below rides out eviction
         # A takeover evicts the attached client, and execd waits for that
         # client to acknowledge. A half-open peer (silently dropped along the
         # proxy path) cannot answer, so execd's eviction times out and the

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -1487,7 +1487,7 @@ class OpenSandboxProvider:
             headers=headers,
             spec=spec,
             request_timeout_s=request_timeout_s,
-            diagnose=lambda: self._oom_death_notice(handle),
+            diagnose=lambda: self._oom_death_notice(handle, any_death=True),
         )
         await self._retire_closed_pty_sessions()
         self._pty_sessions.add(session)
@@ -1529,7 +1529,7 @@ class OpenSandboxProvider:
                     takeover=takeover,
                     since=since,
                     request_timeout_s=request_timeout_s,
-                    diagnose=lambda: self._oom_death_notice(handle),
+                    diagnose=lambda: self._oom_death_notice(handle, any_death=True),
                 )
                 break
             except SandboxPtyError as e:

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -1288,11 +1288,14 @@ class OpenSandboxProvider:
                 raise SandboxBackendUnreachableError(notice) from error
             raise
 
-    async def _oom_death_notice(self, handle: SandboxHandle) -> str | None:
+    async def _oom_death_notice(self, handle: SandboxHandle, *, any_death: bool = False) -> str | None:
         """Briefly poll the sandbox status; describe an OOM kill, else None.
 
-        When the backend stops answering it usually takes the control plane a
-        moment to record why, so poll for up to 5s before giving up."""
+        With ``any_death`` every terminal state is reported, not just an OOM
+        kill — for callers that need to know whether the sandbox is gone at
+        all, not specifically why. When the backend stops answering it usually
+        takes the control plane a moment to record why, so poll for up to 5s
+        before giving up."""
         get_info = getattr(handle.raw, "get_info", None)
         if get_info is None:
             return None
@@ -1311,14 +1314,14 @@ class OpenSandboxProvider:
             state = getattr(raw_status, "state", None)
             reason = getattr(raw_status, "reason", None)
             message = getattr(raw_status, "message", None)
+            status_text = (
+                f"OpenSandbox status: state={state!r}, reason={reason!r}, message={str(message or '')[:500]!r}; "
+                f"sandbox_id={handle.sandbox_id!r}"
+            )
             if re.search(r"\boom[\s_-]*killed\b|\bout of memory\b", f"{reason} {message}", re.IGNORECASE):
-                return (
-                    "Sandbox was OOM-killed. "
-                    f"OpenSandbox status: state={state!r}, reason={reason!r}, message={str(message or '')[:500]!r}; "
-                    f"sandbox_id={handle.sandbox_id!r}"
-                )
+                return f"Sandbox was OOM-killed. {status_text}"
             if message and _to_sandbox_status(state) in {SandboxStatus.ERROR, SandboxStatus.STOPPED}:
-                return None
+                return f"Sandbox is dead. {status_text}" if any_death else None
             await asyncio.sleep(min(0.5, max(0.0, deadline - asyncio.get_running_loop().time())))
         return None
 
@@ -1530,7 +1533,17 @@ class OpenSandboxProvider:
                 )
                 break
             except SandboxPtyError as e:
-                if not takeover or delay is None or "already has an attached client" not in str(e):
+                if not takeover or "already has an attached client" not in str(e):
+                    raise
+                if delay is None:
+                    # The eviction never completed across every retry. When the
+                    # sandbox itself is gone (node loss, OOM kill) the stale
+                    # attachment can never acknowledge its eviction, so the
+                    # takeover is refused forever — report the sandbox's death
+                    # instead of the refusal.
+                    notice = await self._oom_death_notice(handle, any_death=True)
+                    if notice is not None:
+                        raise SandboxPtyError(f"PTY attach takeover kept being refused: {notice}") from e
                     raise
             await asyncio.sleep(delay)
         await self._retire_closed_pty_sessions()

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -1494,9 +1494,8 @@ class OpenSandboxProvider:
 
         base_url, headers, request_timeout_s = await self._pty_target(handle)
         if takeover:
-            # Release our own live attachment first: execd then has nothing to
-            # evict, instead of racing its eviction of a client that may
-            # already be half-open (the 1008 policy-violation close below).
+            # Release our own live attachment first, so the takeover below has
+            # nothing to evict and cannot be refused as "already attached".
             for stale in [s for s in self._pty_sessions if s.session_id == session_id and not s.closed]:
                 try:
                     await stale.detach()

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -1283,36 +1283,44 @@ class OpenSandboxProvider:
         except Exception as error:
             if not isinstance(error, SandboxBackendUnreachableError) and _exception_status_code(error) != 502:
                 raise
-
-            get_info = getattr(handle.raw, "get_info", None)
-            if get_info is not None:
-                deadline = asyncio.get_running_loop().time() + 5.0
-                while (remaining_s := deadline - asyncio.get_running_loop().time()) > 0:
-                    try:
-                        info = await self._await_sdk_call(
-                            get_info(),
-                            operation="get_info after exec 502",
-                            sandbox_id=handle.sandbox_id,
-                            timeout_s=min(2.0, remaining_s),
-                        )
-                    except Exception:
-                        break
-                    raw_status = getattr(info, "status", None)
-                    state = getattr(raw_status, "state", None)
-                    reason = getattr(raw_status, "reason", None)
-                    message = getattr(raw_status, "message", None)
-                    status_text = f"{reason} {message}"
-                    if re.search(r"\boom[\s_-]*killed\b|\bout of memory\b", status_text, re.IGNORECASE):
-                        message = str(message or "")[:500]
-                        raise SandboxBackendUnreachableError(
-                            "Sandbox was OOM-killed. "
-                            f"OpenSandbox status: state={state!r}, reason={reason!r}, message={message!r}; "
-                            f"sandbox_id={handle.sandbox_id!r}"
-                        ) from error
-                    if message and _to_sandbox_status(state) in {SandboxStatus.ERROR, SandboxStatus.STOPPED}:
-                        break
-                    await asyncio.sleep(min(0.5, max(0.0, deadline - asyncio.get_running_loop().time())))
+            notice = await self._oom_death_notice(handle)
+            if notice is not None:
+                raise SandboxBackendUnreachableError(notice) from error
             raise
+
+    async def _oom_death_notice(self, handle: SandboxHandle) -> str | None:
+        """Briefly poll the sandbox status; describe an OOM kill, else None.
+
+        When the backend stops answering it usually takes the control plane a
+        moment to record why, so poll for up to 5s before giving up."""
+        get_info = getattr(handle.raw, "get_info", None)
+        if get_info is None:
+            return None
+        deadline = asyncio.get_running_loop().time() + 5.0
+        while (remaining_s := deadline - asyncio.get_running_loop().time()) > 0:
+            try:
+                info = await self._await_sdk_call(
+                    get_info(),
+                    operation="get_info after backend loss",
+                    sandbox_id=handle.sandbox_id,
+                    timeout_s=min(2.0, remaining_s),
+                )
+            except Exception:
+                return None
+            raw_status = getattr(info, "status", None)
+            state = getattr(raw_status, "state", None)
+            reason = getattr(raw_status, "reason", None)
+            message = getattr(raw_status, "message", None)
+            if re.search(r"\boom[\s_-]*killed\b|\bout of memory\b", f"{reason} {message}", re.IGNORECASE):
+                return (
+                    "Sandbox was OOM-killed. "
+                    f"OpenSandbox status: state={state!r}, reason={reason!r}, message={str(message or '')[:500]!r}; "
+                    f"sandbox_id={handle.sandbox_id!r}"
+                )
+            if message and _to_sandbox_status(state) in {SandboxStatus.ERROR, SandboxStatus.STOPPED}:
+                return None
+            await asyncio.sleep(min(0.5, max(0.0, deadline - asyncio.get_running_loop().time())))
+        return None
 
     async def _exec_background(
         self,
@@ -1476,6 +1484,7 @@ class OpenSandboxProvider:
             headers=headers,
             spec=spec,
             request_timeout_s=request_timeout_s,
+            diagnose=lambda: self._oom_death_notice(handle),
         )
         await self._retire_closed_pty_sessions()
         self._pty_sessions.add(session)
@@ -1517,6 +1526,7 @@ class OpenSandboxProvider:
                     takeover=takeover,
                     since=since,
                     request_timeout_s=request_timeout_s,
+                    diagnose=lambda: self._oom_death_notice(handle),
                 )
                 break
             except SandboxPtyError as e:

--- a/nemo_gym/sandbox/providers/opensandbox/pty.py
+++ b/nemo_gym/sandbox/providers/opensandbox/pty.py
@@ -116,9 +116,9 @@ class OpenSandboxPtySession:
         # Attached sessions belong to whoever created them: closing one detaches
         # rather than ending it.
         self._owned = owned
-        # True when the initial socket was dialed with takeover=1: a policy
-        # violation then means execd is still evicting a dead peer, not that
-        # another client legitimately owns the session.
+        # True when the initial socket asked to take the session over: an
+        # "already attached" refusal then just means execd is still evicting
+        # the previous, dead client — not that another client owns the session.
         self._takeover = takeover
         self.mode: str | None = None
         self.replay_offset: int | None = None
@@ -225,11 +225,11 @@ class OpenSandboxPtySession:
                 if self._ws.close_code == WS_CLOSE_TAKEN_OVER:
                     break
                 if self._ws.close_code == WS_CLOSE_POLICY_VIOLATION:
-                    # After a reattach — or on an initial socket dialed with
-                    # takeover=1 — this is a race: execd hasn't torn down the
-                    # dead TCP peer yet. Retry with _PTY_TAKEOVER_RETRY_DELAYS
-                    # to wait out the eviction. Otherwise another client owns
-                    # the session, so break immediately.
+                    # Execd refused us because it still counts the previous
+                    # client as attached. After a reattach — or when we asked
+                    # to take the session over — that client is dead and execd
+                    # just hasn't finished evicting it, so wait and retry.
+                    # Otherwise another client really owns the session: give up.
                     if not (reattached or self._takeover) or takeover_retries >= len(_PTY_TAKEOVER_RETRY_DELAYS):
                         break
                     await asyncio.sleep(_PTY_TAKEOVER_RETRY_DELAYS[takeover_retries])
@@ -385,11 +385,10 @@ class OpenSandboxPtySession:
         """
         token = f"NGPTY{uuid.uuid4().hex[:12]}"
         needle = f"{token}:".encode()
-        # Markers from two literals so the echo cannot match them; both
-        # printfs sit inside the brace group so echoed input and prompts land
-        # before the start marker and the status marker directly follows the
-        # output (see _run_in_pty_session in the api module for the same
-        # discipline). The group keeps shell state while putting stdin at EOF.
+        # Same marker discipline as _run_in_pty_session in the api module:
+        # markers split across two printf arguments so the shell's echo can
+        # never match them, both printfs inside the brace group so the slice
+        # between the markers is the command's output alone, stdin at EOF.
         await self.write(
             f"{{ printf '%s%s\\n' '{token[:5]}' '{token[5:]}S'\n"
             f"{command}\n"
@@ -422,8 +421,8 @@ class OpenSandboxPtySession:
             await self.reattach()
         output, _, trailing = bytes(buffer).partition(needle)
         # Drop the echoed input and prompts: real output starts on the line
-        # after the start marker. (The marker can be missing if the retained
-        # window evicted it while detached; keep the prefix then.)
+        # after the start marker. (Replay may have evicted the marker while
+        # detached; keep the prefix then.)
         _, seen_start, after_start = output.partition(f"{token}S".encode())
         if seen_start:
             output = after_start.partition(b"\n")[2]

--- a/nemo_gym/sandbox/providers/opensandbox/pty.py
+++ b/nemo_gym/sandbox/providers/opensandbox/pty.py
@@ -385,11 +385,16 @@ class OpenSandboxPtySession:
         """
         token = f"NGPTY{uuid.uuid4().hex[:12]}"
         needle = f"{token}:".encode()
-        # Marker from two literals so the echo cannot match it; brace group
-        # keeps shell state while putting stdin at EOF (see _run_in_pty_session
-        # in the api module for the same discipline).
+        # Markers from two literals so the echo cannot match them; both
+        # printfs sit inside the brace group so echoed input and prompts land
+        # before the start marker and the status marker directly follows the
+        # output (see _run_in_pty_session in the api module for the same
+        # discipline). The group keeps shell state while putting stdin at EOF.
         await self.write(
-            f"{{ {command}\n}} </dev/null\nprintf '%s%s:%s\\n' '{token[:5]}' '{token[5:]}' \"$?\"\n".encode()
+            f"{{ printf '%s%s\\n' '{token[:5]}' '{token[5:]}S'\n"
+            f"{command}\n"
+            f"printf '%s%s:%s\\n' '{token[:5]}' '{token[5:]}' \"$?\"\n"
+            f"}} </dev/null\n".encode()
         )
         buffer = bytearray()
         while True:
@@ -416,6 +421,12 @@ class OpenSandboxPtySession:
             await asyncio.sleep(poll_interval_s)
             await self.reattach()
         output, _, trailing = bytes(buffer).partition(needle)
+        # Drop the echoed input and prompts: real output starts on the line
+        # after the start marker. (The marker can be missing if the retained
+        # window evicted it while detached; keep the prefix then.)
+        _, seen_start, after_start = output.partition(f"{token}S".encode())
+        if seen_start:
+            output = after_start.partition(b"\n")[2]
         while b"\n" not in trailing:
             # The status digits can straddle the chunk that carried the marker.
             chunk = await self.read(timeout_s=5.0)

--- a/nemo_gym/sandbox/providers/opensandbox/pty.py
+++ b/nemo_gym/sandbox/providers/opensandbox/pty.py
@@ -32,7 +32,7 @@ import logging
 import shlex
 import sys
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 from urllib.parse import urlencode
 
@@ -106,6 +106,7 @@ class OpenSandboxPtySession:
         request_timeout_s: float | None,
         owned: bool = True,
         takeover: bool = False,
+        diagnose: Callable[[], Awaitable[str | None]] | None = None,
     ) -> None:
         self._client = client
         self._ws = ws
@@ -120,6 +121,9 @@ class OpenSandboxPtySession:
         # "already attached" refusal then just means execd is still evicting
         # the previous, dead client — not that another client owns the session.
         self._takeover = takeover
+        # Asked for a better cause when the socket dies for no admitted reason
+        # (the provider checks whether the sandbox itself was OOM-killed).
+        self._diagnose = diagnose
         self.mode: str | None = None
         self.replay_offset: int | None = None
         self._output: asyncio.Queue[bytes | None] = asyncio.Queue()
@@ -252,6 +256,22 @@ class OpenSandboxPtySession:
             # A detach ends the pump without ending the session: skip the
             # finalization so reads and the exit future survive reattach().
             if not self._detached:
+                if (
+                    self._diagnose is not None
+                    and not self._closed
+                    and not self._exit.done()
+                    and self._error is None
+                    and self._ws.close_code not in (WS_CLOSE_TAKEN_OVER, WS_CLOSE_POLICY_VIOLATION)
+                ):
+                    # The socket died for no admitted reason — often the whole
+                    # sandbox is gone. Ask the provider for a real cause (an
+                    # OOM kill, typically) instead of a bare close code.
+                    try:
+                        notice = await asyncio.wait_for(self._diagnose(), timeout=8.0)
+                    except Exception:
+                        notice = None
+                    if notice is not None:
+                        self._error = SandboxPtyError(notice)
                 if not self._exit.done():
                     self._exit.set_exception(self._close_error())
                     self._exit.exception()  # retrieved; silences never-retrieved warnings
@@ -490,6 +510,7 @@ async def open_pty_session(
     headers: dict[str, str],
     spec: SandboxPtySpec,
     request_timeout_s: float | None,
+    diagnose: Callable[[], Awaitable[str | None]] | None = None,
 ) -> OpenSandboxPtySession:
     """Create an execd PTY session and attach its WebSocket.
 
@@ -559,6 +580,7 @@ async def open_pty_session(
         session_id=session_id,
         headers=headers,
         request_timeout_s=request_timeout_s,
+        diagnose=diagnose,
     )
     # execd hardcodes 80x24 at spawn; size is only settable post-attach.
     if spec.pty and (spec.rows, spec.cols) != (24, 80):
@@ -579,6 +601,7 @@ async def attach_pty_session(
     takeover: bool = True,
     since: int | None = None,
     request_timeout_s: float | None,
+    diagnose: Callable[[], Awaitable[str | None]] | None = None,
 ) -> OpenSandboxPtySession:
     """Attach to an existing execd PTY session. Owns ``client`` as above."""
     query: dict[str, str] = {}
@@ -620,6 +643,7 @@ async def attach_pty_session(
         request_timeout_s=request_timeout_s,
         owned=False,
         takeover=takeover,
+        diagnose=diagnose,
     )
 
 
@@ -663,6 +687,7 @@ async def _start_session(
     request_timeout_s: float | None,
     owned: bool = True,
     takeover: bool = False,
+    diagnose: Callable[[], Awaitable[str | None]] | None = None,
 ) -> OpenSandboxPtySession:
     session = OpenSandboxPtySession(
         client=client,
@@ -673,6 +698,7 @@ async def _start_session(
         request_timeout_s=request_timeout_s,
         owned=owned,
         takeover=takeover,
+        diagnose=diagnose,
     )
     try:
         await session._wait_connected(request_timeout_s)

--- a/nemo_gym/sandbox/providers/opensandbox/pty.py
+++ b/nemo_gym/sandbox/providers/opensandbox/pty.py
@@ -365,6 +365,10 @@ class OpenSandboxPtySession:
             query={"takeover": "1", "since": str(self._received)},
             request_timeout_s=self._request_timeout_s,
         )
+        # This socket asked to take the session over, so the new pump must
+        # treat an "already attached" refusal as execd still evicting our own
+        # previous socket, and retry.
+        self._takeover = True
         self._detached = False
         self._pump_task = asyncio.create_task(self._pump())
 

--- a/nemo_gym/sandbox/providers/opensandbox/pty.py
+++ b/nemo_gym/sandbox/providers/opensandbox/pty.py
@@ -625,7 +625,7 @@ async def _connect_ws(
         except aiohttp.WSServerHandshakeError as e:
             if e.status not in (502, 503) or delay is None:
                 raise
-        except (aiohttp.ClientConnectorError, asyncio.TimeoutError):
+        except (aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError, asyncio.TimeoutError):
             if delay is None:
                 raise
         await asyncio.sleep(delay)

--- a/nemo_gym/sandbox/providers/opensandbox/pty.py
+++ b/nemo_gym/sandbox/providers/opensandbox/pty.py
@@ -210,18 +210,37 @@ class OpenSandboxPtySession:
         """
         try:
             barren = 0
+            reattached = False
+            takeover_retries = 0
             while True:
                 received_before = self._received
                 await self._pump_socket()
                 if self._closed or self._exit.done() or self._error is not None:
                     break
-                if self._ws.close_code in (WS_CLOSE_TAKEN_OVER, WS_CLOSE_POLICY_VIOLATION):
+                if self._ws.close_code == WS_CLOSE_TAKEN_OVER:
                     break
+                if self._ws.close_code == WS_CLOSE_POLICY_VIOLATION:
+                    # On reattach, this is a race: execd hasn't torn down the
+                    # dead TCP peer yet. Retry with _PTY_TAKEOVER_RETRY_DELAYS
+                    # to wait out the eviction. On the initial socket this means
+                    # another client owns the session, so break immediately.
+                    if not reattached or takeover_retries >= len(_PTY_TAKEOVER_RETRY_DELAYS):
+                        break
+                    await asyncio.sleep(_PTY_TAKEOVER_RETRY_DELAYS[takeover_retries])
+                    takeover_retries += 1
+                    reattached = await self._reattach_socket()
+                    if not reattached:
+                        break
+                    continue
+                takeover_retries = 0
                 # A socket that reconnects but keeps dying without delivering a
                 # byte would spin forever; three barren rounds mean the session
                 # is gone in a way the close code does not admit.
                 barren = barren + 1 if self._received == received_before else 0
-                if barren >= 3 or not await self._reattach_socket():
+                if barren >= 3:
+                    break
+                reattached = await self._reattach_socket()
+                if not reattached:
                     break
         finally:
             # A detach ends the pump without ending the session: skip the

--- a/nemo_gym/sandbox/providers/opensandbox/pty.py
+++ b/nemo_gym/sandbox/providers/opensandbox/pty.py
@@ -105,6 +105,7 @@ class OpenSandboxPtySession:
         headers: dict[str, str],
         request_timeout_s: float | None,
         owned: bool = True,
+        takeover: bool = False,
     ) -> None:
         self._client = client
         self._ws = ws
@@ -115,6 +116,10 @@ class OpenSandboxPtySession:
         # Attached sessions belong to whoever created them: closing one detaches
         # rather than ending it.
         self._owned = owned
+        # True when the initial socket was dialed with takeover=1: a policy
+        # violation then means execd is still evicting a dead peer, not that
+        # another client legitimately owns the session.
+        self._takeover = takeover
         self.mode: str | None = None
         self.replay_offset: int | None = None
         self._output: asyncio.Queue[bytes | None] = asyncio.Queue()
@@ -220,11 +225,12 @@ class OpenSandboxPtySession:
                 if self._ws.close_code == WS_CLOSE_TAKEN_OVER:
                     break
                 if self._ws.close_code == WS_CLOSE_POLICY_VIOLATION:
-                    # On reattach, this is a race: execd hasn't torn down the
+                    # After a reattach — or on an initial socket dialed with
+                    # takeover=1 — this is a race: execd hasn't torn down the
                     # dead TCP peer yet. Retry with _PTY_TAKEOVER_RETRY_DELAYS
-                    # to wait out the eviction. On the initial socket this means
-                    # another client owns the session, so break immediately.
-                    if not reattached or takeover_retries >= len(_PTY_TAKEOVER_RETRY_DELAYS):
+                    # to wait out the eviction. Otherwise another client owns
+                    # the session, so break immediately.
+                    if not (reattached or self._takeover) or takeover_retries >= len(_PTY_TAKEOVER_RETRY_DELAYS):
                         break
                     await asyncio.sleep(_PTY_TAKEOVER_RETRY_DELAYS[takeover_retries])
                     takeover_retries += 1
@@ -599,6 +605,7 @@ async def attach_pty_session(
         headers=headers,
         request_timeout_s=request_timeout_s,
         owned=False,
+        takeover=takeover,
     )
 
 
@@ -641,6 +648,7 @@ async def _start_session(
     headers: dict[str, str],
     request_timeout_s: float | None,
     owned: bool = True,
+    takeover: bool = False,
 ) -> OpenSandboxPtySession:
     session = OpenSandboxPtySession(
         client=client,
@@ -650,6 +658,7 @@ async def _start_session(
         headers=headers,
         request_timeout_s=request_timeout_s,
         owned=owned,
+        takeover=takeover,
     )
     try:
         await session._wait_connected(request_timeout_s)

--- a/resources_servers/terminal_bench_2_1/app.py
+++ b/resources_servers/terminal_bench_2_1/app.py
@@ -24,7 +24,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.global_config import get_global_config_dict
-from nemo_gym.sandbox import AsyncSandbox, SandboxPtySession, SandboxResources, SandboxSpec
+from nemo_gym.sandbox import AsyncSandbox, SandboxPtyError, SandboxPtySession, SandboxResources, SandboxSpec
 from nemo_gym.sandbox.config import resolve_provider_config, resolve_provider_metadata
 from nemo_gym.sandbox.utils import cpu_cap_env
 from nemo_gym.server_utils import SESSION_ID_KEY
@@ -267,8 +267,14 @@ class TerminalBench21ResourcesServer(SimpleResourcesServer):
             if self.config.debug:
                 print(f"Golden patch output for {body.task_name}: {golden_patch_output}", file=stderr)
         else:
-            # Re-use the original sandbox
+            # Re-use the original sandbox.  Detach first so the server marks the
+            # session free before we reattach; otherwise takeover=True races with
+            # execd detecting the abandoned WebSocket (→ repeated 1008 failures).
             eval_sandbox, pty_session = self._session_id_to_sandbox.pop(request.session[SESSION_ID_KEY])
+            try:
+                await pty_session.detach()
+            except SandboxPtyError:
+                pass  # already dead; provider's retry loop handles the 1008 race
             pty_session = await eval_sandbox.pty.attach(session_id=pty_session.session_id, takeover=True)
             golden_patch_output = None
 

--- a/resources_servers/terminal_bench_2_1/app.py
+++ b/resources_servers/terminal_bench_2_1/app.py
@@ -24,7 +24,7 @@ from nemo_gym.base_resources_server import (
     SimpleResourcesServer,
 )
 from nemo_gym.global_config import get_global_config_dict
-from nemo_gym.sandbox import AsyncSandbox, SandboxPtyError, SandboxPtySession, SandboxResources, SandboxSpec
+from nemo_gym.sandbox import AsyncSandbox, SandboxPtySession, SandboxResources, SandboxSpec
 from nemo_gym.sandbox.config import resolve_provider_config, resolve_provider_metadata
 from nemo_gym.sandbox.utils import cpu_cap_env
 from nemo_gym.server_utils import SESSION_ID_KEY
@@ -267,14 +267,10 @@ class TerminalBench21ResourcesServer(SimpleResourcesServer):
             if self.config.debug:
                 print(f"Golden patch output for {body.task_name}: {golden_patch_output}", file=stderr)
         else:
-            # Re-use the original sandbox.  Detach first so the server marks the
-            # session free before we reattach; otherwise takeover=True races with
-            # execd detecting the abandoned WebSocket (→ repeated 1008 failures).
+            # Re-use the original sandbox. attach(takeover=True) detaches our
+            # stale attachment first and rides out execd's eviction of a
+            # half-open peer (the 1008 policy-violation race).
             eval_sandbox, pty_session = self._session_id_to_sandbox.pop(request.session[SESSION_ID_KEY])
-            try:
-                await pty_session.detach()
-            except SandboxPtyError:
-                pass  # already dead; provider's retry loop handles the 1008 race
             pty_session = await eval_sandbox.pty.attach(session_id=pty_session.session_id, takeover=True)
             golden_patch_output = None
 

--- a/resources_servers/terminal_bench_2_1/app.py
+++ b/resources_servers/terminal_bench_2_1/app.py
@@ -267,9 +267,8 @@ class TerminalBench21ResourcesServer(SimpleResourcesServer):
             if self.config.debug:
                 print(f"Golden patch output for {body.task_name}: {golden_patch_output}", file=stderr)
         else:
-            # Re-use the original sandbox. attach(takeover=True) detaches our
-            # stale attachment first and rides out execd's eviction of a
-            # half-open peer (the 1008 policy-violation race).
+            # Re-use the original sandbox; attach(takeover=True) handles
+            # releasing and evicting the stale attachment from the agent phase.
             eval_sandbox, pty_session = self._session_id_to_sandbox.pop(request.session[SESSION_ID_KEY])
             pty_session = await eval_sandbox.pty.attach(session_id=pty_session.session_id, takeover=True)
             golden_patch_output = None

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -845,6 +845,96 @@ async def test_barren_reconnects_give_up(monkeypatch: pytest.MonkeyPatch) -> Non
     await session.close()
 
 
+async def test_policy_violation_on_reattach_retries_after_delay(monkeypatch: pytest.MonkeyPatch) -> None:
+    """1008 on a reattach is a race (server hasn't evicted the dead TCP peer yet);
+    the pump must wait out _PTY_TAKEOVER_RETRY_DELAYS and succeed on the next attempt."""
+    monkeypatch.setattr(pty_module, "_PTY_RETRY_DELAYS", ())
+    monkeypatch.setattr(pty_module, "_PTY_TAKEOVER_RETRY_DELAYS", (0,))
+    monkeypatch.setattr(pty_module.OpenSandboxPtySession, "_reattach_socket", _REAL_REATTACH)
+
+    # Initial socket: connected + data, then dies with 1006 (TCP drop, no close frame).
+    first = FakeWs([CONNECTED, _binary(b"\x01ab")], close_code=1006)
+    first.closed = True
+
+    # First reattach: server immediately closes with 1008 (dead peer not yet evicted).
+    race = FakeWs([], close_code=pty_module.WS_CLOSE_POLICY_VIOLATION)
+    race.closed = True
+
+    # Second reattach: server cleaned up; session resumes from offset 2.
+    resume = b"\x03" + (2).to_bytes(8, "big") + b"cd"
+    second = FakeWs([_binary(resume), _text({"type": "exit", "exit_code": 0})])
+    second.closed = True
+
+    client = FakeHttpClient(ws=[first, race, second])
+    session = OpenSandboxPtySession(
+        client=client,  # type: ignore[arg-type]
+        ws=await client.ws_connect("ws://server/base/pty/s-1/ws", headers={}),
+        session_id="s-1",
+        session_url="http://server/base/pty/s-1",
+        headers={},
+        request_timeout_s=5.0,
+    )
+    assert await session.read() == b"ab"
+    assert await session.read() == b"cd", "session must resume after the takeover-race delay"
+    assert await session.wait_exit() == 0
+    assert len(client.ws_calls) == 3, "initial + 1 race reattach + 1 successful reattach"
+    await session.close()
+
+
+async def test_policy_violation_exhausted_gives_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When all _PTY_TAKEOVER_RETRY_DELAYS are consumed the pump gives up."""
+    monkeypatch.setattr(pty_module, "_PTY_RETRY_DELAYS", ())
+    monkeypatch.setattr(pty_module, "_PTY_TAKEOVER_RETRY_DELAYS", (0, 0))
+    monkeypatch.setattr(pty_module.OpenSandboxPtySession, "_reattach_socket", _REAL_REATTACH)
+
+    first = FakeWs([CONNECTED, _binary(b"\x01x")], close_code=1006)
+    first.closed = True
+    # Every reattach returns 1008 — the server never recovers.
+    always_race = FakeWs([], close_code=pty_module.WS_CLOSE_POLICY_VIOLATION)
+    always_race.closed = True
+
+    client = FakeHttpClient(ws=[first, always_race, always_race, always_race])
+    session = OpenSandboxPtySession(
+        client=client,  # type: ignore[arg-type]
+        ws=await client.ws_connect("ws://server/base/pty/s-1/ws", headers={}),
+        session_id="s-1",
+        session_url="http://server/base/pty/s-1",
+        headers={},
+        request_timeout_s=5.0,
+    )
+    await session.read()  # b"x" from first
+    with pytest.raises(SandboxPtyError, match="already has an attached client"):
+        await session.wait_exit(timeout_s=5)
+    # initial + reattach_after_1006 + 2 takeover retries (delays exhausted on 3rd 1008)
+    assert len(client.ws_calls) == 4
+    await session.close()
+
+
+async def test_policy_violation_on_initial_socket_does_not_reattach(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 1008 on the very first socket means another client owns the session;
+    the pump must not retry — this is not a race."""
+    monkeypatch.setattr(pty_module, "_PTY_RETRY_DELAYS", ())
+    monkeypatch.setattr(pty_module, "_PTY_TAKEOVER_RETRY_DELAYS", (0,))
+    monkeypatch.setattr(pty_module.OpenSandboxPtySession, "_reattach_socket", _REAL_REATTACH)
+
+    ws = FakeWs([CONNECTED], close_code=pty_module.WS_CLOSE_POLICY_VIOLATION)
+    ws.closed = True
+    client = FakeHttpClient(ws=[ws])  # a re-dial would pop an empty list and fail
+
+    session = OpenSandboxPtySession(
+        client=client,  # type: ignore[arg-type]
+        ws=await client.ws_connect("ws://server/base/pty/s-1/ws", headers={}),
+        session_id="s-1",
+        session_url="http://server/base/pty/s-1",
+        headers={},
+        request_timeout_s=5.0,
+    )
+    with pytest.raises(SandboxPtyError, match="already has an attached client"):
+        await session.wait_exit(timeout_s=5)
+    assert len(client.ws_calls) == 1, "initial policy violation must not trigger reattach"
+    await session.close()
+
+
 async def test_takeover_close_does_not_reattach(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pty_module, "_PTY_RETRY_DELAYS", (0,))
     monkeypatch.setattr(pty_module.OpenSandboxPtySession, "_reattach_socket", _REAL_REATTACH)

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -903,17 +903,18 @@ async def test_barren_reconnects_give_up(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 async def test_policy_violation_on_reattach_retries_after_delay(monkeypatch: pytest.MonkeyPatch) -> None:
-    """1008 on a reattach is a race (server hasn't evicted the dead TCP peer yet);
-    the pump must wait out _PTY_TAKEOVER_RETRY_DELAYS and succeed on the next attempt."""
+    """An "already attached" refusal on a reattach is a race (the server hasn't
+    evicted the dead previous client yet); the pump must wait out
+    _PTY_TAKEOVER_RETRY_DELAYS and succeed on the next attempt."""
     monkeypatch.setattr(pty_module, "_PTY_RETRY_DELAYS", ())
     monkeypatch.setattr(pty_module, "_PTY_TAKEOVER_RETRY_DELAYS", (0,))
     monkeypatch.setattr(pty_module.OpenSandboxPtySession, "_reattach_socket", _REAL_REATTACH)
 
-    # Initial socket: connected + data, then dies with 1006 (TCP drop, no close frame).
+    # Initial socket: connected + data, then the connection drops without a close frame.
     first = FakeWs([CONNECTED, _binary(b"\x01ab")], close_code=1006)
     first.closed = True
 
-    # First reattach: server immediately closes with 1008 (dead peer not yet evicted).
+    # First reattach: refused — the server still counts the dead client as attached.
     race = FakeWs([], close_code=pty_module.WS_CLOSE_POLICY_VIOLATION)
     race.closed = True
 
@@ -946,7 +947,7 @@ async def test_policy_violation_exhausted_gives_up(monkeypatch: pytest.MonkeyPat
 
     first = FakeWs([CONNECTED, _binary(b"\x01x")], close_code=1006)
     first.closed = True
-    # Every reattach returns 1008 — the server never recovers.
+    # Every reattach is refused as "already attached" — the server never recovers.
     always_race = FakeWs([], close_code=pty_module.WS_CLOSE_POLICY_VIOLATION)
     always_race.closed = True
 
@@ -962,14 +963,14 @@ async def test_policy_violation_exhausted_gives_up(monkeypatch: pytest.MonkeyPat
     await session.read()  # b"x" from first
     with pytest.raises(SandboxPtyError, match="already has an attached client"):
         await session.wait_exit(timeout_s=5)
-    # initial + reattach_after_1006 + 2 takeover retries (delays exhausted on 3rd 1008)
+    # initial + reattach after the drop + 2 takeover retries (delays exhausted on the 3rd refusal)
     assert len(client.ws_calls) == 4
     await session.close()
 
 
 async def test_policy_violation_on_initial_socket_does_not_reattach(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A 1008 on the very first socket means another client owns the session;
-    the pump must not retry — this is not a race."""
+    """An "already attached" refusal on the very first socket means another
+    client really owns the session; the pump must not retry."""
     monkeypatch.setattr(pty_module, "_PTY_RETRY_DELAYS", ())
     monkeypatch.setattr(pty_module, "_PTY_TAKEOVER_RETRY_DELAYS", (0,))
     monkeypatch.setattr(pty_module.OpenSandboxPtySession, "_reattach_socket", _REAL_REATTACH)
@@ -988,22 +989,22 @@ async def test_policy_violation_on_initial_socket_does_not_reattach(monkeypatch:
     )
     with pytest.raises(SandboxPtyError, match="already has an attached client"):
         await session.wait_exit(timeout_s=5)
-    assert len(client.ws_calls) == 1, "initial policy violation must not trigger reattach"
+    assert len(client.ws_calls) == 1, "a refusal on the initial socket must not trigger reattach"
     await session.close()
 
 
 async def test_policy_violation_on_initial_takeover_socket_retries(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A 1008 on an initial socket dialed with takeover=1 is the dead-peer race
-    (execd hasn't evicted the previous, dirtily-dropped client yet); the pump
-    must wait out _PTY_TAKEOVER_RETRY_DELAYS and succeed, exactly as on reattach."""
+    """An "already attached" refusal on an initial takeover socket means the
+    server is still evicting the previous, dead client; the pump must wait out
+    _PTY_TAKEOVER_RETRY_DELAYS and succeed, exactly as on reattach."""
     monkeypatch.setattr(pty_module, "_PTY_RETRY_DELAYS", ())
     monkeypatch.setattr(pty_module, "_PTY_TAKEOVER_RETRY_DELAYS", (0,))
     monkeypatch.setattr(pty_module.OpenSandboxPtySession, "_reattach_socket", _REAL_REATTACH)
 
-    # Initial takeover attach: server closes with 1008 before any frame.
+    # Initial takeover attach: refused before any frame arrives.
     race = FakeWs([], close_code=pty_module.WS_CLOSE_POLICY_VIOLATION)
     race.closed = True
-    # Retry: server evicted the dead peer; session attaches from offset 0.
+    # Retry: the server has evicted the dead client; session attaches from offset 0.
     good = FakeWs([CONNECTED, _binary(b"\x01ab"), _text({"type": "exit", "exit_code": 0})])
     good.closed = True
 
@@ -1020,7 +1021,7 @@ async def test_policy_violation_on_initial_takeover_socket_retries(monkeypatch: 
     )
     assert await session.read() == b"ab", "session must attach after waiting out the eviction race"
     assert await session.wait_exit() == 0
-    assert len(client.ws_calls) == 2, "initial takeover 1008 + 1 successful retry"
+    assert len(client.ws_calls) == 2, "refused initial takeover + 1 successful retry"
     await session.close()
 
 

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -1239,6 +1239,37 @@ async def test_detach_keeps_session_alive_and_reattach_resumes() -> None:
     assert len(client.delete_calls) == 1, "an owned close still ends the session"
 
 
+async def test_reattach_retries_refused_takeover(monkeypatch: pytest.MonkeyPatch) -> None:
+    """reattach() dials with takeover: an "already attached" refusal on that
+    socket is execd still evicting our own detached socket, so the new pump
+    must retry rather than end the session (seen live in run_detached polls)."""
+    monkeypatch.setattr(pty_module, "_PTY_TAKEOVER_RETRY_DELAYS", (0,))
+    monkeypatch.setattr(pty_module.OpenSandboxPtySession, "_reattach_socket", _REAL_REATTACH)
+
+    ws1 = FakeWs([CONNECTED, _binary(b"\x01before")])
+    refused = FakeWs([], close_code=pty_module.WS_CLOSE_POLICY_VIOLATION)
+    refused.closed = True
+    resume = b"\x03" + (6).to_bytes(8, "big") + b"after"
+    ws3 = FakeWs([_binary(resume), _text({"type": "exit", "exit_code": 0})])
+    ws3.closed = True
+    client = FakeHttpClient(ws=[refused, ws3])
+    session = OpenSandboxPtySession(
+        client=client,  # type: ignore[arg-type]
+        ws=ws1,  # type: ignore[arg-type]
+        session_id="s-1",
+        session_url="http://server/v1/sandboxes/sb-1/proxy/44772/pty/s-1",
+        headers={},
+        request_timeout_s=5.0,
+    )
+    assert await session.read() == b"before"
+    await session.detach()
+    await session.reattach()
+    assert await session.read() == b"after", "the refused reattach must be retried, not fatal"
+    assert await session.wait_exit() == 0
+    assert len(client.ws_calls) == 2, "reattach dial + one takeover retry"
+    await session.close()
+
+
 async def test_close_while_detached_releases_and_unblocks_readers() -> None:
     ws = FakeWs([CONNECTED])
     client = FakeHttpClient(ws=ws)

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -776,6 +776,66 @@ async def test_provider_attach_pty_detaches_own_stale_attachment(monkeypatch: py
     await old.close()
 
 
+def _always_refused_provider(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Provider whose every takeover attach is refused as 'already attached'."""
+    from nemo_gym.sandbox.providers.opensandbox.provider import OpenSandboxProvider
+
+    provider = OpenSandboxProvider(connection={"domain": "server", "api_key": "k", "protocol": "https"})
+
+    def _client() -> FakeHttpClient:
+        rejected = FakeWs([], close_code=1008)
+        rejected.closed = True
+        return FakeHttpClient(ws=rejected)
+
+    monkeypatch.setattr(provider, "_pty_http_client", _client)
+    monkeypatch.setattr(pty_module, "_PTY_TAKEOVER_RETRY_DELAYS", (0.0,))
+    return provider
+
+
+async def test_provider_attach_pty_reports_dead_sandbox_on_exhausted_takeover(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A takeover refused across every retry usually means the sandbox is gone
+    (its stale attachment can never acknowledge the eviction); the error must
+    say that, not 'already has an attached client'."""
+    pytest.importorskip("tenacity", reason="tenacity optional sandbox dependency is not installed")
+    pytest.importorskip("opensandbox", reason="opensandbox SDK is not installed")
+
+    class DeadRaw:
+        async def get_endpoint(self, port: int) -> SimpleNamespace:
+            return SimpleNamespace(endpoint="server/v1/sandboxes/sb-1/proxy/44772", headers={})
+
+        async def get_info(self) -> SimpleNamespace:
+            return SimpleNamespace(
+                status=SimpleNamespace(state="Failed", reason="FAILED", message="1/1 observed pods failed; node lost")
+            )
+
+    provider = _always_refused_provider(monkeypatch)
+    handle = SandboxHandle(sandbox_id="sb-1", provider_name="opensandbox", raw=DeadRaw())
+    with pytest.raises(SandboxPtyError, match="Sandbox is dead") as exc_info:
+        await provider.attach_pty(handle, "s-7", takeover=True)
+    assert "already has an attached client" in str(exc_info.value.__cause__)
+
+
+async def test_provider_attach_pty_keeps_refusal_when_status_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("tenacity", reason="tenacity optional sandbox dependency is not installed")
+    pytest.importorskip("opensandbox", reason="opensandbox SDK is not installed")
+
+    class OpaqueRaw:
+        async def get_endpoint(self, port: int) -> SimpleNamespace:
+            return SimpleNamespace(endpoint="server/v1/sandboxes/sb-1/proxy/44772", headers={})
+
+        async def get_info(self) -> SimpleNamespace:
+            raise RuntimeError("control plane unavailable")
+
+    provider = _always_refused_provider(monkeypatch)
+    handle = SandboxHandle(sandbox_id="sb-1", provider_name="opensandbox", raw=OpaqueRaw())
+    with pytest.raises(SandboxPtyError, match="already has an attached client"):
+        await provider.attach_pty(handle, "s-7", takeover=True)
+
+
 async def test_create_rejected_before_connected_raises_and_cleans_up() -> None:
     # The session we created is torn down when the socket is rejected.
     ws = FakeWs([], close_code=1008)

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -1240,8 +1240,10 @@ class _LaunchWs(FakeWs):
     async def send_bytes(self, data: bytes) -> None:
         await super().send_bytes(data)
         self._state["launch"] = data
-        quoted = data.decode().splitlines()[-1].split("'")
-        self._state["marker"] = f"{quoted[3]}{quoted[5]}:0\r\n".encode()
+        quoted = data.decode().splitlines()[-2].split("'")
+        token = quoted[3] + quoted[5]
+        self._state["start"] = f"{token}S\r\n".encode()
+        self._state["marker"] = f"{token}:0\r\n".encode()
 
 
 class _ReplayWs(FakeWs):
@@ -1255,7 +1257,7 @@ class _ReplayWs(FakeWs):
     async def __anext__(self) -> SimpleNamespace:
         if not self._messages and not self._state.get("served"):
             self._state["served"] = True
-            payload = b"work-output\n" + self._state["marker"]
+            payload = self._state["start"] + b"work-output\n" + self._state["marker"]
             return _binary(b"\x03" + struct.pack(">Q", self._offset) + payload)
         return await super().__anext__()
 

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -836,6 +836,32 @@ async def test_provider_attach_pty_keeps_refusal_when_status_unavailable(
         await provider.attach_pty(handle, "s-7", takeover=True)
 
 
+async def test_provider_session_reports_non_oom_death_on_server_error_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A session whose socket dies with a server-error close while the sandbox
+    is in a terminal non-OOM state (node lost) must name the death, not the
+    close code — seen live as a bare 'close code 1011' on verify()."""
+    pytest.importorskip("tenacity", reason="tenacity optional sandbox dependency is not installed")
+    pytest.importorskip("opensandbox", reason="opensandbox SDK is not installed")
+    from nemo_gym.sandbox.providers.opensandbox.provider import OpenSandboxProvider
+
+    class LostRaw:
+        async def get_endpoint(self, port: int) -> SimpleNamespace:
+            return SimpleNamespace(endpoint="server/v1/sandboxes/sb-1/proxy/44772", headers={})
+
+        async def get_info(self) -> SimpleNamespace:
+            return SimpleNamespace(status=SimpleNamespace(state="Failed", reason="FAILED", message="node lost"))
+
+    provider = OpenSandboxProvider(connection={"domain": "server", "api_key": "k", "protocol": "https"})
+    dying = FakeWs([CONNECTED], close_code=1011)
+    dying.closed = True
+    monkeypatch.setattr(provider, "_pty_http_client", lambda: FakeHttpClient(ws=dying))
+    handle = SandboxHandle(sandbox_id="sb-1", provider_name="opensandbox", raw=LostRaw())
+    session = await provider.attach_pty(handle, "s-7", takeover=True)
+    with pytest.raises(SandboxPtyError, match="Sandbox is dead"):
+        await session.wait_exit(timeout_s=5)
+    await session.close()
+
+
 async def test_create_rejected_before_connected_raises_and_cleans_up() -> None:
     # The session we created is torn down when the socket is rejected.
     ws = FakeWs([], close_code=1008)

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -590,6 +590,67 @@ async def test_evicted_session_reports_takeover() -> None:
     await session.close()
 
 
+async def _diagnosed_session(close_code: int, notice: str | None) -> tuple[OpenSandboxPtySession, FakeWs, list[int]]:
+    """Session whose socket dies with ``close_code``; diagnose returns ``notice``."""
+    calls: list[int] = []
+
+    async def diagnose() -> str | None:
+        calls.append(1)
+        return notice
+
+    ws = FakeWs([CONNECTED], close_code=close_code)
+    session = OpenSandboxPtySession(
+        client=FakeHttpClient(ws=ws),  # type: ignore[arg-type]
+        ws=ws,  # type: ignore[arg-type]
+        session_id="s-1",
+        session_url="http://server/v1/sandboxes/sb-1/proxy/44772/pty/s-1",
+        headers={},
+        request_timeout_s=5.0,
+        diagnose=diagnose,
+    )
+    return session, ws, calls
+
+
+async def test_unexpected_close_reports_oom_diagnosis() -> None:
+    # A socket dying with a bare server-error close often means the sandbox
+    # itself died; the diagnosis (an OOM kill here) must replace the close code
+    # everywhere the session's death surfaces.
+    session, ws, calls = await _diagnosed_session(1011, "Sandbox was OOM-killed. state='Failed'")
+    ws.closed = True
+    with pytest.raises(SandboxPtyError, match="OOM-killed"):
+        await session.wait_exit(timeout_s=5)
+    with pytest.raises(SandboxPtyError, match="OOM-killed"):
+        await session.read()
+    assert calls == [1]
+    await session.close()
+
+
+async def test_unexpected_close_without_diagnosis_keeps_close_code() -> None:
+    session, ws, calls = await _diagnosed_session(1011, None)
+    ws.closed = True
+    with pytest.raises(SandboxPtyError, match="close code 1011"):
+        await session.wait_exit(timeout_s=5)
+    assert calls == [1]
+    await session.close()
+
+
+async def test_takeover_close_skips_diagnosis() -> None:
+    # An eviction names its own cause; the sandbox is alive, so don't poll it.
+    session, ws, calls = await _diagnosed_session(4001, "Sandbox was OOM-killed.")
+    ws.closed = True
+    with pytest.raises(SandboxPtyError, match="taken over"):
+        await session.wait_exit(timeout_s=5)
+    assert calls == []
+    await session.close()
+
+
+async def test_user_close_skips_diagnosis() -> None:
+    session, _, calls = await _diagnosed_session(1000, "Sandbox was OOM-killed.")
+    await session._wait_connected(1.0)
+    await session.close()
+    assert calls == []
+
+
 async def test_provider_attach_pty_reuses_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
     pytest.importorskip("tenacity", reason="tenacity optional sandbox dependency is not installed")
     pytest.importorskip("opensandbox", reason="opensandbox SDK is not installed")

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -544,6 +544,28 @@ async def test_attach_pty_session_query(takeover: bool, since: int | None, expec
     await session.close()
 
 
+async def test_connect_ws_retries_server_disconnected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ServerDisconnectedError during WS upgrade is transient; _connect_ws must retry."""
+    import aiohttp
+
+    from nemo_gym.sandbox.providers.opensandbox.pty import attach_pty_session
+
+    monkeypatch.setattr(pty_module, "_PTY_RETRY_DELAYS", (0,))
+    client = FakeHttpClient(
+        ws=[FakeWs([CONNECTED])],
+        ws_error=[aiohttp.ServerDisconnectedError()],
+    )
+    session = await attach_pty_session(
+        client=client,  # type: ignore[arg-type]
+        base_url="http://server/base",
+        headers={},
+        session_id="s-1",
+        request_timeout_s=5.0,
+    )
+    assert len(client.ws_calls) == 2, "first call raised ServerDisconnected; second should succeed"
+    await session.close()
+
+
 async def test_attach_pty_session_failure_closes_client() -> None:
     from nemo_gym.sandbox.providers.opensandbox.pty import attach_pty_session
 

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -957,6 +957,38 @@ async def test_policy_violation_on_initial_socket_does_not_reattach(monkeypatch:
     await session.close()
 
 
+async def test_policy_violation_on_initial_takeover_socket_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 1008 on an initial socket dialed with takeover=1 is the dead-peer race
+    (execd hasn't evicted the previous, dirtily-dropped client yet); the pump
+    must wait out _PTY_TAKEOVER_RETRY_DELAYS and succeed, exactly as on reattach."""
+    monkeypatch.setattr(pty_module, "_PTY_RETRY_DELAYS", ())
+    monkeypatch.setattr(pty_module, "_PTY_TAKEOVER_RETRY_DELAYS", (0,))
+    monkeypatch.setattr(pty_module.OpenSandboxPtySession, "_reattach_socket", _REAL_REATTACH)
+
+    # Initial takeover attach: server closes with 1008 before any frame.
+    race = FakeWs([], close_code=pty_module.WS_CLOSE_POLICY_VIOLATION)
+    race.closed = True
+    # Retry: server evicted the dead peer; session attaches from offset 0.
+    good = FakeWs([CONNECTED, _binary(b"\x01ab"), _text({"type": "exit", "exit_code": 0})])
+    good.closed = True
+
+    client = FakeHttpClient(ws=[race, good])
+    session = OpenSandboxPtySession(
+        client=client,  # type: ignore[arg-type]
+        ws=await client.ws_connect("ws://server/base/pty/s-1/ws?takeover=1", headers={}),
+        session_id="s-1",
+        session_url="http://server/base/pty/s-1",
+        headers={},
+        request_timeout_s=5.0,
+        owned=False,
+        takeover=True,
+    )
+    assert await session.read() == b"ab", "session must attach after waiting out the eviction race"
+    assert await session.wait_exit() == 0
+    assert len(client.ws_calls) == 2, "initial takeover 1008 + 1 successful retry"
+    await session.close()
+
+
 async def test_takeover_close_does_not_reattach(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pty_module, "_PTY_RETRY_DELAYS", (0,))
     monkeypatch.setattr(pty_module.OpenSandboxPtySession, "_reattach_socket", _REAL_REATTACH)

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -680,6 +680,41 @@ async def test_provider_attach_pty_does_not_retry_without_takeover(monkeypatch: 
     assert clients_handed == 1, "without takeover the rejection is definitive"
 
 
+async def test_provider_attach_pty_detaches_own_stale_attachment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A takeover attach must release the provider's own live attachment to
+    that session first: execd then has nothing to evict, so callers need no
+    manual detach() before re-attaching (the terminal_bench verify() path)."""
+    pytest.importorskip("tenacity", reason="tenacity optional sandbox dependency is not installed")
+    pytest.importorskip("opensandbox", reason="opensandbox SDK is not installed")
+    from nemo_gym.sandbox.providers.opensandbox.provider import OpenSandboxProvider
+
+    class FakeRaw:
+        async def get_endpoint(self, port: int) -> SimpleNamespace:
+            return SimpleNamespace(endpoint="server/v1/sandboxes/sb-1/proxy/44772", headers={})
+
+    provider = OpenSandboxProvider(connection={"domain": "server", "api_key": "k", "protocol": "https"})
+    old_ws = FakeWs([CONNECTED])  # parks after the frame: a live attachment
+    old = OpenSandboxPtySession(
+        client=FakeHttpClient(ws=old_ws),  # type: ignore[arg-type]
+        ws=old_ws,  # type: ignore[arg-type]
+        session_id="s-7",
+        session_url="https://server/v1/sandboxes/sb-1/proxy/44772/pty/s-7",
+        headers={},
+        request_timeout_s=5.0,
+        owned=False,
+    )
+    await old._wait_connected(1.0)
+    provider._pty_sessions.add(old)
+
+    monkeypatch.setattr(provider, "_pty_http_client", lambda: FakeHttpClient(ws=FakeWs([CONNECTED])))
+    handle = SandboxHandle(sandbox_id="sb-1", provider_name="opensandbox", raw=FakeRaw())
+    session = await provider.attach_pty(handle, "s-7", takeover=True)
+    assert old._detached, "the stale local attachment must be detached before the takeover dial"
+    assert old_ws.closed
+    await session.close()
+    await old.close()
+
+
 async def test_create_rejected_before_connected_raises_and_cleans_up() -> None:
     # The session we created is torn down when the socket is rejected.
     ws = FakeWs([], close_code=1008)

--- a/tests/unit_tests/test_sandbox.py
+++ b/tests/unit_tests/test_sandbox.py
@@ -1472,13 +1472,16 @@ async def test_pty_exec_on_existing_session() -> None:
     session = _LiveShellSession(stderr=[b"warn\r\n"], rc=7)
     result = await sandbox.pty.exec("make all", session=session)
     assert result.return_code == 7
-    assert "live-output" in result.stdout
+    # Echoed input, prompts, and the marker lines must all be stripped: the
+    # slice between the start and status markers is the command output alone.
+    assert result.stdout == "live-output\r\n"
     assert result.stderr == "warn\r\n"
-    # The marker must not be matchable from the shell's echo of the typed line.
+    # Neither marker may be matchable from the shell's echo of the typed lines.
     typed = session.written[0].decode()
-    quoted = typed.split("'")
-    token = quoted[3] + quoted[5]
-    assert f"{token}:" not in typed
+    lines = typed.splitlines()
+    start_quoted, end_quoted = lines[0].split("'"), lines[-2].split("'")
+    assert start_quoted[3] + start_quoted[5] not in typed
+    assert f"{end_quoted[3] + end_quoted[5]}:" not in typed
     # The session's stdin never reaches EOF, so the command group must run
     # with stdin redirected or a stdin-reading command blocks forever.
     assert "</dev/null" in typed
@@ -1509,9 +1512,16 @@ class _LiveShellSession:
         if self._die or self._hang:
             return
         typed = data.decode()
-        quoted = typed.splitlines()[-1].split("'")
+        quoted = typed.splitlines()[-2].split("'")
         token = quoted[3] + quoted[5]
-        self._pending = [typed.encode(), b"live-output\r\n", f"{token}:{self._rc}\r\n".encode()]
+        # Echo of all typed lines, then the start marker, output, end marker —
+        # the order a real shell produces for the brace-group discipline.
+        self._pending = [
+            typed.encode(),
+            f"{token}S\r\n".encode(),
+            b"live-output\r\n",
+            f"{token}:{self._rc}\r\n".encode(),
+        ]
 
     async def read(self, *, timeout_s: float | None = None) -> bytes:
         if self._hang:
@@ -1699,7 +1709,7 @@ async def test_pty_exec_marker_edges() -> None:
             self.closed = False
 
         async def write(self, data: bytes) -> None:
-            quoted = data.decode().split("'")
+            quoted = data.decode().splitlines()[-2].split("'")
             token = quoted[3] + quoted[5]
             line = f"{token}:{self._reply}\r\n".encode()
             self._chunks = [line[:8], line[8:]] if self._split else [line]


### PR DESCRIPTION
## Problem

Long-lived PTY sessions against OpenSandbox failed in three opaque ways that together made terminal-bench runs unstable:

1. `SandboxPtyError: PTY session already has an attached client` on re-attach — the WebSocket was closed with a policy-violation code (1008). The retry constant `_PTY_TAKEOVER_RETRY_DELAYS` existed but was never wired into the pump. Verified live: the *persistent* form is a stale attachment on a **dead backend** (node loss / OOM kill) that can never acknowledge its eviction, so every takeover is refused; the *transient* form is execd still evicting a dropped peer.
2. `PTY connection closed unexpectedly (close code 1011)` when a sandbox died underneath a session — no indication that the sandbox itself was OOM-killed, which was the actual cause of most of them in production.
3. Session exec stdout carried the shell's echo of the typed command (with `bash-5.2#` / `> ` prompts) as a prefix and the echoed status `printf` line as a suffix.

## Changes

**Attach-refusal race**
- `_pump()` retries a refusal with `_PTY_TAKEOVER_RETRY_DELAYS` (2s/5s/10s) after a mid-session reattach, and on any socket that was dialed with takeover — the fresh `attach(takeover=True)` verify() path, and `reattach()` after `detach()` (the `run_detached` polling path, where the raw refusal was still surfacing in production runs).
- `attach_pty()` first detaches the provider's own tracked live attachment, so execd has nothing to evict in the common same-process case; `terminal_bench_2_1` drops its manual detach.
- When the refusal persists across the whole retry budget, `attach_pty()` checks the sandbox status and reports the death (`PTY attach takeover kept being refused: Sandbox was OOM-killed. OpenSandbox status: state='Failed', ...`) instead of the refusal.
- `_connect_ws` also retries `aiohttp.ServerDisconnectedError` during the WS upgrade.

**Dead-sandbox diagnosis (from #2927, merged here)**
- Exec's OOM status-poll is extracted into `_oom_death_notice()` (exec behavior unchanged).
- PTY sessions get a `diagnose` callback wired to it: when the socket dies for no admitted reason (not close/detach/takeover/exit), the session reports `Sandbox was OOM-killed ...` instead of a bare close code.

**Exec stdout cleanup**
- Both markers move inside the brace group: echoed input and prompts land before the start marker and the status marker directly follows the output, so `stdout` is the command output alone. Same discipline in `run_detached`.

## Test plan

- Unit (`test_opensandbox_pty.py`, `test_opensandbox_provider.py`, `test_sandbox.py`): exact wire sequences for refusal-after-reattach, refusal-on-initial-takeover, refusal-after-`reattach()`, exhaustion gives up, no retry without takeover, provider detaches its own stale attachment, dead-sandbox notice on exhausted takeover, diagnosed close vs undiagnosed close, takeover/user-close skip diagnosis, exec OOM path unchanged, stdout is exactly the command output. 180 passed.
- E2E against a live OpenSandbox cluster:
  - OOM-killed a 1 GiB sandbox under a live session: exec reports `Sandbox was OOM-killed ... OOMKilled (exit code 137)` instead of `close code 1011`.
  - Killed / TTL-reaped sandboxes mid-exec fail promptly with clean errors; provider recovers.
  - Three full terminal-bench 2.1 runs (712 rollouts each, 256–1024 parallel) with the combined change: every takeover refusal was diagnosed (`...kept being refused: Sandbox was OOM-killed`) and absorbed as a failed rollout; zero 500s, zero bare close codes. Before this change an identical run died at 21% on the first such refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)