### PR TITLE
cp: `perf: serialize non-streaming responses with orjson in model server (2867)` into `r0.6.0`

### DIFF
--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -41,7 +41,7 @@ from typing import Any, Mapping, Optional
 from uuid import uuid4
 
 import orjson
-from fastapi import Body, FastAPI, Request
+from fastapi import Body, FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, ValidationError, model_validator
@@ -153,6 +153,23 @@ def _plain(value: Any) -> Any:
     return value
 
 
+def _orjson_dispatch_response(content: Any) -> Any:
+    """Serialize a completed non-streaming model response with orjson.
+
+    FastAPI serializes a bare dictionary or Pydantic model with ``jsonable_encoder``.
+    That function recursively visits every token ID and log probability before standard-library ``json.dumps`` runs.
+
+    Convert Pydantic models to JSON-compatible values before encoding the result.
+    Return the encoded bytes as a ``Response`` so FastAPI does not encode them again.
+    Preserve ``Response`` objects created by model-server overrides.
+    """
+    if isinstance(content, Response):
+        return content
+    if isinstance(content, BaseModel):
+        content = content.model_dump(mode="json")
+    return Response(content=orjson.dumps(content), media_type="application/json")
+
+
 class BaseResponsesAPIModelConfig(BaseRunServerInstanceConfig):
     pass
 
@@ -213,7 +230,7 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
         """
         if not body.get("stream"):
             params = _validate_responses_params(body)
-            return await self._invoke_responses(request, params)
+            return _orjson_dispatch_response(await self._invoke_responses(request, params))
 
         cleaned, ns_map = sanitize_streaming_responses_body(body)
         try:
@@ -257,7 +274,7 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
         """
         if body.get("stream") is not True:
             params = _validate_chat_params(body)
-            return await self._invoke_chat_completions(request, params)
+            return _orjson_dispatch_response(await self._invoke_chat_completions(request, params))
 
         cleaned, include_usage = sanitize_streaming_chat_body(body)
         params = _validate_chat_params(cleaned)
@@ -310,7 +327,7 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
                 _ANTHROPIC_CONVERTER.anthropic_response_to_sse(anthropic_response),
                 media_type="text/event-stream",
             )
-        return anthropic_response
+        return _orjson_dispatch_response(anthropic_response)
 
     async def _invoke_responses(
         self, request: Request, params: NeMoGymResponseCreateParamsNonStreaming

--- a/tests/unit_tests/test_base_responses_api_model.py
+++ b/tests/unit_tests/test_base_responses_api_model.py
@@ -18,9 +18,10 @@ from unittest.mock import MagicMock
 
 import orjson
 import pytest
-from fastapi import Body, FastAPI
+from fastapi import Body, FastAPI, Response
 from fastapi.testclient import TestClient
 from omegaconf import OmegaConf
+from pydantic import BaseModel
 
 from nemo_gym.base_responses_api_agent import SimpleResponsesAPIAgent
 from nemo_gym.base_responses_api_model import (
@@ -29,6 +30,7 @@ from nemo_gym.base_responses_api_model import (
     CaptureStore,
     ModelCallCaptureConfig,
     SimpleResponsesAPIModel,
+    _orjson_dispatch_response,
     build_model_call_record,
     install_model_call_capture,
     make_capture_store,
@@ -66,6 +68,32 @@ class TestBaseResponsesAPIModel:
         server_client.global_config_dict = {}
         model = TestSimpleResponsesAPIModel(config=config, server_client=server_client)
         model.setup_webserver()
+
+
+class _DispatchPayload(BaseModel):
+    text: str
+    token_ids: list[int]
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ({"text": "café", "token_ids": [1, 2, 3]}, {"text": "café", "token_ids": [1, 2, 3]}),
+        (_DispatchPayload(text="café", token_ids=[1, 2, 3]), {"text": "café", "token_ids": [1, 2, 3]}),
+    ],
+)
+def test_orjson_dispatch_response_serializes_json(content, expected):
+    response = _orjson_dispatch_response(content)
+
+    assert type(response) is Response
+    assert response.body == orjson.dumps(expected)
+    assert response.headers["content-type"] == "application/json"
+
+
+def test_orjson_dispatch_response_preserves_existing_response():
+    existing_response = Response(content=b"already encoded", media_type="application/octet-stream", status_code=202)
+
+    assert _orjson_dispatch_response(existing_response) is existing_response
 
 
 def _capture_config(tmp_path, *, enabled: bool = True) -> ModelCallCaptureConfig:


### PR DESCRIPTION
beep boop [🤖]: Hi @ananthsub 👋,

    we've cherry picked #2867 into r0.6.0 for you! 🚀

    Please review and approve this cherry pick by your convenience!