### PR TITLE
[GDPVal] Add per-provider judge transports with deterministic eligibility replay

### DIFF
--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -966,6 +966,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                                 native_page_cap=caps.pop(),
                                 native_pdf_bytes_per_document=byte_caps.pop(),
                                 image_cap=self.config.judge_max_images_per_request,
+                                render_page_cap=self.config.judge_pdf_max_pages,
                             )
                         matchup_judges, media_exclusions = filter_media_eligible_judges(
                             matchup_judges,

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -41,7 +41,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -174,6 +174,16 @@ class JudgePanelMember(BaseModel):
     # with a warning (video/images/text are still graded).
     handles_audio: bool = False
     handles_video: bool = False
+    # Representation and request limits are provider-specific. Keeping them on
+    # the panel member prevents one global knob from breaking a different API.
+    media_mode: Optional[Literal["native_pdf", "images_and_text", "native_pdf_overflow_images"]] = None
+    max_native_pdf_pages: Optional[int] = None
+    max_native_pdf_documents: Optional[int] = None
+    max_native_pdf_bytes: Optional[int] = None
+    # Tried in order for images_and_text. The first lossless projection below
+    # max_serialized_request_bytes wins; otherwise this member is excluded.
+    raster_dpi_tiers: Tuple[int, ...] = ()
+    max_serialized_request_bytes: Optional[int] = None
 
 
 def _strict_comparison_trial_failure(
@@ -253,6 +263,8 @@ class GDPValResourcesServerConfig(BaseResourcesServerConfig):
     judge_pdf_max_pages: int = 50
     # Attach the extracted text copy alongside the page images. Off → images only.
     judge_pdf_include_text: bool = True
+    # Exact request-wide image cap for raster and PDF-overflow transports.
+    judge_max_images_per_request: int = 450
     # Whether the (single) local judge natively reads audio / video, tracked
     # SEPARATELY because MiniMax-M3 — the reference self-hosted judge — reads video
     # but NOT audio (its config has an image + video tower but no audio config). So
@@ -321,6 +333,8 @@ class GDPValResourcesServerConfig(BaseResourcesServerConfig):
 
 
 class GDPValVerifyRequest(BaseVerifyRequest):
+    model_config = ConfigDict(populate_by_name=True)
+
     task_id: str
     sector: Optional[str] = None
     occupation: Optional[str] = None
@@ -335,6 +349,15 @@ class GDPValVerifyRequest(BaseVerifyRequest):
     # reference. Used by the multi-stage ELO driver to select a different set of
     # reference models per judgementstage without reconfiguring the server.
     reference_ids: Optional[List[str]] = None
+    # Preserve multistage identity through /verify so Stirrup's namespace-keyed
+    # cache and the incrementally tagged output remain auditable.
+    verify_cache_namespace: Optional[str] = None
+    stage_index: Optional[int] = None
+    expected_final_stage_index: Optional[int] = None
+    expected_stage_row_count: Optional[int] = None
+    ng_task_index: Optional[int] = Field(default=None, alias="_ng_task_index")
+    ng_rollout_index: Optional[int] = Field(default=None, alias="_ng_rollout_index")
+    ng_attempt_index: Optional[int] = Field(default=None, alias="_ng_attempt_index")
 
 
 # The reference model has no deliverable for this task, so no battle can be
@@ -463,6 +486,12 @@ class GDPValResourcesServer(SimpleResourcesServer):
                     weight=member.weight,
                     handles_audio=member.handles_audio,
                     handles_video=member.handles_video,
+                    media_mode=member.media_mode or self.config.judge_media_mode,
+                    max_native_pdf_pages=member.max_native_pdf_pages,
+                    max_native_pdf_documents=member.max_native_pdf_documents,
+                    max_native_pdf_bytes=member.max_native_pdf_bytes,
+                    raster_dpi_tiers=tuple(member.raster_dpi_tiers),
+                    max_serialized_request_bytes=member.max_serialized_request_bytes,
                 )
             )
         return judges
@@ -680,8 +709,13 @@ class GDPValResourcesServer(SimpleResourcesServer):
         from resources_servers.gdpval.comparison import (
             JUDGE_REQUEST_TIMEOUT_SECONDS,
             Judge,
+            apply_native_pdf_overflow,
             build_file_section,
             clean_up_paths,
+            filter_media_eligible_judges,
+            plan_native_pdf_overflow,
+            preflight_judge_transport,
+            preview_trial_judges,
             run_trials,
             task_attempted,
         )
@@ -778,6 +812,12 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 weight=rj.weight,
                 handles_audio=rj.handles_audio,
                 handles_video=rj.handles_video,
+                media_mode=rj.media_mode,
+                max_native_pdf_pages=rj.max_native_pdf_pages,
+                max_native_pdf_documents=rj.max_native_pdf_documents,
+                max_native_pdf_bytes=rj.max_native_pdf_bytes,
+                raster_dpi_tiers=rj.raster_dpi_tiers,
+                max_serialized_request_bytes=rj.max_serialized_request_bytes,
             )
             for rj in resolved_judges
         ]
@@ -815,27 +855,56 @@ class GDPValResourcesServer(SimpleResourcesServer):
         ref_errors: Dict[str, List[str]] = {}
         attempted_matchups = 0
         last_error: Optional[Exception] = None
-        # Present PDFs/Office docs either as native PDF data URLs (frontier
-        # judges) or rasterized page images + text (image-only local VLM judges
-        # like a gym-spawned Kimi K2.6) — see ``judge_media_mode``.
-        media_kwargs: Dict[str, Any] = {
-            "media_mode": self.config.judge_media_mode,
-            "render_dpi": self.config.judge_pdf_render_dpi,
-            "max_pages": self.config.judge_pdf_max_pages,
-            "include_text": self.config.judge_pdf_include_text,
-            # Forward each AV modality only when a (routed) judge can read it.
-            "audio_capable": audio_capable,
-            "video_capable": video_capable,
-        }
-        try:
-            # ``build_file_section`` rasterizes pages (PyMuPDF) and extracts text
-            # (pdfminer) in images_and_text mode — CPU-bound work that must not
-            # run on the event loop, same reasoning as the ``run_trials`` dispatch
-            # below.
-            eval_submission = await asyncio.to_thread(
-                build_file_section, str(eval_task_dir), clean_up_list, **media_kwargs
+        # Cache each semantic side independently by representation and DPI.
+        # Native sections are also the exact source for provider-cap preflight.
+        section_cache: Dict[Tuple[str, str, int], List[dict]] = {}
+
+        async def _section(path: Optional[Path], mode: str, render_dpi: int) -> List[dict]:
+            key = (str(path) if path is not None else "<none>", mode, render_dpi)
+            if key not in section_cache:
+                section_cache[key] = await asyncio.to_thread(
+                    build_file_section,
+                    str(path) if path is not None else None,
+                    clean_up_list,
+                    media_mode=mode,
+                    render_dpi=render_dpi,
+                    max_pages=self.config.judge_pdf_max_pages,
+                    include_text=self.config.judge_pdf_include_text,
+                    audio_capable=audio_capable,
+                    video_capable=video_capable,
+                )
+            return section_cache[key]
+
+        def _image_count(*sections: List[dict]) -> int:
+            return sum(
+                1
+                for section in sections
+                for block in section
+                if block.get("type") == "image_url"
+                and str((block.get("image_url") or {}).get("url", "")).startswith("data:image/")
             )
 
+        def _native_pdf_stats(*sections: List[dict]) -> Dict[str, int]:
+            import base64
+
+            from resources_servers.gdpval.media_conversion import pdf_page_count
+
+            pages = documents = byte_count = 0
+            prefix = "data:application/pdf;base64,"
+            for section in sections:
+                for block in section:
+                    if block.get("type") != "image_url":
+                        continue
+                    url = str((block.get("image_url") or {}).get("url", ""))
+                    if not url.startswith(prefix):
+                        continue
+                    payload = base64.b64decode(url[len(prefix) :], validate=True)
+                    documents += 1
+                    byte_count += len(payload)
+                    pages += pdf_page_count(payload)
+            return {"pages": pages, "documents": documents, "bytes": byte_count}
+
+        try:
             # Judge the eval submission against every reference model, and within
             # each model against every available reference repeat. Raw vote
             # counts (not just per-matchup majority) are summed so the win rate
@@ -845,32 +914,182 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 ref_judged_repeats = 0
                 for ref_dir in dirs:
                     refs_subdir = ref_dir / "reference_files"
-                    refs = await asyncio.to_thread(
-                        build_file_section,
-                        str(refs_subdir) if refs_subdir.is_dir() else None,
-                        clean_up_list,
-                        **media_kwargs,
-                    )
-                    ref_submission = await asyncio.to_thread(
-                        build_file_section, str(ref_dir), clean_up_list, **media_kwargs
-                    )
                     attempted_matchups += 1
                     # Seed per (task, ref_id, ref_repeat) so judge sampling is
                     # reproducible and each reference subset draws independently —
                     # this makes multi-stage ELO reruns replayable per stage.
                     rng = make_rng(self.config.judge_sampling_seed, body.task_id, ref_id, ref_dir.name)
                     try:
+                        matchup_judges = list(judges)
+                        media_exclusions: List[Dict[str, Any]] = []
+                        render_dpi = self.config.judge_pdf_render_dpi
+                        native = {
+                            "refs": await _section(
+                                refs_subdir if refs_subdir.is_dir() else None,
+                                "native_pdf",
+                                render_dpi,
+                            ),
+                            "submission_a": await _section(ref_dir, "native_pdf", render_dpi),
+                            "submission_b": await _section(eval_task_dir, "native_pdf", render_dpi),
+                        }
+                        native_stats = _native_pdf_stats(*native.values())
+                        estimated_images = native_stats["pages"] + _image_count(*native.values())
+                        overflow_judges = [
+                            judge for judge in matchup_judges if judge.media_mode == "native_pdf_overflow_images"
+                        ]
+                        overflow_plan: Optional[Dict[str, Any]] = None
+                        if overflow_judges:
+                            caps = {
+                                judge.max_native_pdf_pages
+                                for judge in overflow_judges
+                                if judge.max_native_pdf_pages is not None
+                            }
+                            if len(caps) != 1:
+                                raise ValueError(f"overflow judges require one explicit native page cap, got {caps}")
+                            overflow_plan = plan_native_pdf_overflow(
+                                native,
+                                native_page_cap=caps.pop(),
+                                image_cap=self.config.judge_max_images_per_request,
+                            )
+                        matchup_judges, media_exclusions = filter_media_eligible_judges(
+                            matchup_judges,
+                            native_stats=native_stats,
+                            estimated_images=estimated_images,
+                            image_cap=self.config.judge_max_images_per_request,
+                            overflow_plan=overflow_plan,
+                        )
+                        if not matchup_judges:
+                            raise ValueError("media routing excluded every judge")
+
+                        sections_by_judge: Dict[str, Dict[str, List[dict]]] = {}
+                        transport_receipts: Dict[str, Dict[str, Any]] = {}
+                        failed_names: Set[str] = set()
+                        # Sampling is replayed from the untouched RNG after any
+                        # pre-dispatch exclusion. Only modes that can actually be
+                        # sampled are materialized, avoiding needless raster work.
+                        while True:
+                            active = [judge for judge in matchup_judges if judge.name not in failed_names]
+                            if not active:
+                                raise ValueError("transport preflight excluded every judge")
+                            schedule = preview_trial_judges(active, self.config.num_comparison_trials, rng)
+                            needed = {judge.name: judge for judge in schedule}
+                            new_failure = False
+                            for judge_name, judge in needed.items():
+                                if judge_name in sections_by_judge or judge_name in failed_names:
+                                    continue
+                                candidates: List[Tuple[Optional[int], Dict[str, List[dict]]]] = []
+                                attempted_preflights: List[Dict[str, Any]] = []
+                                if judge.media_mode == "native_pdf":
+                                    candidates.append((None, native))
+                                elif judge.media_mode == "native_pdf_overflow_images":
+                                    if overflow_plan is None:
+                                        raise ValueError("overflow mode selected without a plan")
+                                    transformed = native
+                                    if overflow_plan.get("selected"):
+                                        transformed = await asyncio.to_thread(
+                                            apply_native_pdf_overflow,
+                                            native,
+                                            overflow_plan,
+                                            render_dpi=render_dpi,
+                                            max_pages=self.config.judge_pdf_max_pages,
+                                            include_text=self.config.judge_pdf_include_text,
+                                        )
+                                    candidates.append((render_dpi, transformed))
+                                elif judge.media_mode == "images_and_text":
+                                    tiers = judge.raster_dpi_tiers or (render_dpi,)
+                                    if any(dpi < 36 or dpi > 600 for dpi in tiers):
+                                        raise ValueError(f"invalid raster DPI tiers for {judge.name}: {tiers}")
+                                    # Build and preflight one tier at a time. A
+                                    # 300-page task can allocate tens of MiB per
+                                    # tier, so eagerly materializing every tier
+                                    # defeats the purpose of adaptive routing.
+                                    for dpi in tiers:
+                                        candidate_sections = {
+                                            "refs": await _section(
+                                                refs_subdir if refs_subdir.is_dir() else None,
+                                                "images_and_text",
+                                                dpi,
+                                            ),
+                                            "submission_a": await _section(ref_dir, "images_and_text", dpi),
+                                            "submission_b": await _section(eval_task_dir, "images_and_text", dpi),
+                                        }
+                                        receipt = await asyncio.to_thread(
+                                            preflight_judge_transport,
+                                            judge,
+                                            body.prompt or "",
+                                            candidate_sections,
+                                        )
+                                        receipt["render_dpi"] = dpi
+                                        attempted_preflights.append(receipt)
+                                        if receipt["eligible"]:
+                                            sections_by_judge[judge_name] = candidate_sections
+                                            transport_receipts[judge_name] = receipt
+                                            break
+                                        # Do not retain rejected raster payloads;
+                                        # only the small receipt survives.
+                                        for path in (
+                                            refs_subdir if refs_subdir.is_dir() else None,
+                                            ref_dir,
+                                            eval_task_dir,
+                                        ):
+                                            section_cache.pop(
+                                                (
+                                                    str(path) if path is not None else "<none>",
+                                                    "images_and_text",
+                                                    dpi,
+                                                ),
+                                                None,
+                                            )
+                                else:
+                                    raise ValueError(f"unknown judge media mode: {judge.media_mode}")
+
+                                if judge_name in sections_by_judge:
+                                    continue
+                                for dpi, candidate_sections in candidates:
+                                    receipt = await asyncio.to_thread(
+                                        preflight_judge_transport,
+                                        judge,
+                                        body.prompt or "",
+                                        candidate_sections,
+                                    )
+                                    receipt["render_dpi"] = dpi
+                                    attempted_preflights.append(receipt)
+                                    if receipt["eligible"]:
+                                        sections_by_judge[judge_name] = candidate_sections
+                                        transport_receipts[judge_name] = receipt
+                                        break
+                                if judge_name not in sections_by_judge:
+                                    failed_names.add(judge_name)
+                                    new_failure = True
+                                    media_exclusions.append(
+                                        {
+                                            "mode": judge.media_mode,
+                                            "judges": [judge.name],
+                                            "reason": "transport_preflight",
+                                            "attempts": attempted_preflights,
+                                        }
+                                    )
+                            if not new_failure:
+                                matchup_judges = active
+                                break
+
                         result = await asyncio.to_thread(
                             run_trials,
-                            judges=judges,
+                            judges=matchup_judges,
                             task_prompt=body.prompt or "",
-                            refs=refs,
-                            submission_a=ref_submission,
-                            submission_b=eval_submission,
+                            refs=native["refs"],
+                            submission_a=native["submission_a"],
+                            submission_b=native["submission_b"],
+                            sections_by_judge=sections_by_judge,
                             num_trials=self.config.num_comparison_trials,
                             return_raw_responses=self.config.persist_raw_judge_responses,
                             rng=rng,
                         )
+                        result["transport_by_judge"] = transport_receipts
+                        if media_exclusions:
+                            result["media_routing_exclusions"] = media_exclusions
+                        if overflow_plan and overflow_plan.get("selected"):
+                            result["native_pdf_overflow"] = overflow_plan
                     except Exception as e:  # noqa: BLE001 — isolate per-matchup judge failures
                         last_error = e
                         ref_errors.setdefault(ref_id, []).append(f"{ref_dir.name}: {e!r}")

--- a/resources_servers/gdpval/app.py
+++ b/resources_servers/gdpval/app.py
@@ -180,6 +180,10 @@ class JudgePanelMember(BaseModel):
     max_native_pdf_pages: Optional[int] = None
     max_native_pdf_documents: Optional[int] = None
     max_native_pdf_bytes: Optional[int] = None
+    # Provider limit for one native PDF document. Unlike the aggregate
+    # max_native_pdf_bytes eligibility ceiling, overflow mode rasterizes only
+    # documents above this lossless representation threshold.
+    max_native_pdf_bytes_per_document: Optional[int] = None
     # Tried in order for images_and_text. The first lossless projection below
     # max_serialized_request_bytes wins; otherwise this member is excluded.
     raster_dpi_tiers: Tuple[int, ...] = ()
@@ -490,6 +494,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                     max_native_pdf_pages=member.max_native_pdf_pages,
                     max_native_pdf_documents=member.max_native_pdf_documents,
                     max_native_pdf_bytes=member.max_native_pdf_bytes,
+                    max_native_pdf_bytes_per_document=member.max_native_pdf_bytes_per_document,
                     raster_dpi_tiers=tuple(member.raster_dpi_tiers),
                     max_serialized_request_bytes=member.max_serialized_request_bytes,
                 )
@@ -816,6 +821,7 @@ class GDPValResourcesServer(SimpleResourcesServer):
                 max_native_pdf_pages=rj.max_native_pdf_pages,
                 max_native_pdf_documents=rj.max_native_pdf_documents,
                 max_native_pdf_bytes=rj.max_native_pdf_bytes,
+                max_native_pdf_bytes_per_document=rj.max_native_pdf_bytes_per_document,
                 raster_dpi_tiers=rj.raster_dpi_tiers,
                 max_serialized_request_bytes=rj.max_serialized_request_bytes,
             )
@@ -946,9 +952,19 @@ class GDPValResourcesServer(SimpleResourcesServer):
                             }
                             if len(caps) != 1:
                                 raise ValueError(f"overflow judges require one explicit native page cap, got {caps}")
+                            byte_caps = {
+                                judge.max_native_pdf_bytes_per_document
+                                for judge in overflow_judges
+                                if judge.max_native_pdf_bytes_per_document is not None
+                            }
+                            if len(byte_caps) != 1:
+                                raise ValueError(
+                                    f"overflow judges require one explicit native PDF byte cap, got {byte_caps}"
+                                )
                             overflow_plan = plan_native_pdf_overflow(
                                 native,
                                 native_page_cap=caps.pop(),
+                                native_pdf_bytes_per_document=byte_caps.pop(),
                                 image_cap=self.config.judge_max_images_per_request,
                             )
                         matchup_judges, media_exclusions = filter_media_eligible_judges(

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
 import logging
 import math
 import os
@@ -70,6 +71,10 @@ JUDGE_PROMPT = (
     "better completed the task. "
     "Explain your reasoning then answer BOXED[A], BOXED[B], or BOXED[TIE].\n"
 )
+FINAL_VERDICT_REMINDER = (
+    "End your response with exactly one verdict token on its own final line: "
+    "BOXED[A], BOXED[B], or BOXED[TIE]. A response without one is invalid.\n"
+)
 
 A_WIN_RESPONSE = "BOXED[A]"
 B_WIN_RESPONSE = "BOXED[B]"
@@ -98,30 +103,50 @@ REQUEST_MAX_BACKOFF_SECONDS = 60.0
 # (below) so a genuinely dead upstream still bounds wall-clock rather than
 # retrying N x timeout.
 JUDGE_REQUEST_TIMEOUT_SECONDS = float(os.environ.get("GDPVAL_JUDGE_REQUEST_TIMEOUT_SECONDS", "300"))
+
+
+def _byte_limit(name: str, default: int) -> int:
+    """Read a positive byte limit while retaining the hardened default."""
+    value = int(os.environ.get(name, str(default)))
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value}")
+    return value
+
+
 # Per-file size cap on multimodal content blocks. Above this the file is
 # replaced with a one-line text marker so the judge still knows what was
 # claimed without us pushing 100s of MB of base64 through the proxy.
 # Set high enough (250 MB) that normal multi-stem audio and reference
 # videos in the GDPVal task set still go through; only catches the truly
 # pathological cases (e.g. ``task_a941b6d8`` 657 MB overlay clip).
-MAX_FILE_BYTES_FOR_JUDGE = 250 * 1024 * 1024
+MAX_FILE_BYTES_FOR_JUDGE = _byte_limit("GDPVAL_MAX_FILE_BYTES_FOR_JUDGE", 250 * 1024 * 1024)
 # Aggregate encoded payload is what the HTTP server sees. Keeping it below
 # 400 MiB leaves roughly 80 MB even if the model server's advertised 500 MB
 # ceiling is decimal, for JSON, prompts, spreadsheet text, and framing. The raw
 # ceiling separately prevents pathological media accumulation before base64.
-MAX_TOTAL_RAW_ATTACHMENT_BYTES_FOR_JUDGE = 300 * 1024 * 1024
-MAX_TOTAL_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE = 400 * 1024 * 1024
+MAX_TOTAL_RAW_ATTACHMENT_BYTES_FOR_JUDGE = _byte_limit(
+    "GDPVAL_MAX_TOTAL_RAW_ATTACHMENT_BYTES_FOR_JUDGE", 300 * 1024 * 1024
+)
+MAX_TOTAL_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE = _byte_limit(
+    "GDPVAL_MAX_TOTAL_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE", 400 * 1024 * 1024
+)
 # Each directory is built independently. Keeping every section below an equal,
 # conservative share means references can never consume the bytes needed to
 # show both submissions, and limits peak memory before message assembly.
-MAX_SECTION_RAW_ATTACHMENT_BYTES_FOR_JUDGE = 96 * 1024 * 1024
-MAX_SECTION_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE = 128 * 1024 * 1024
+MAX_SECTION_RAW_ATTACHMENT_BYTES_FOR_JUDGE = _byte_limit(
+    "GDPVAL_MAX_SECTION_RAW_ATTACHMENT_BYTES_FOR_JUDGE", 96 * 1024 * 1024
+)
+MAX_SECTION_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE = _byte_limit(
+    "GDPVAL_MAX_SECTION_ENCODED_ATTACHMENT_CHARS_FOR_JUDGE", 128 * 1024 * 1024
+)
 MAX_TEXT_FILE_CHARS_FOR_JUDGE = 200_000
 MAX_SECTION_TEXT_CHARS_FOR_JUDGE = 1_000_000
 MAX_XLSX_TEXT_CHARS_FOR_JUDGE = 120_000
 # Includes base64, all text, data-URL prefixes, and conservative JSON framing.
 # This stays below endpoints configured with a 500 MB request-body ceiling.
-MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE = 420 * 1024 * 1024
+MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE = _byte_limit(
+    "GDPVAL_MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE", 420 * 1024 * 1024
+)
 MAX_TASK_PROMPT_CHARS_FOR_JUDGE = 1_000_000
 # Archives expand before their members enter the normal payload builders, so
 # bound that work independently. Extracting more than one section's raw budget
@@ -754,6 +779,15 @@ def build_file_section(
     text_used = 0
     text_omitted = False
     text_marker = "\n[...additional text omitted: section judge text budget exhausted]"
+    retained_av_payloads: dict[tuple[int, str], str] = {}
+
+    def _av_identity(path: Path) -> tuple[int, str]:
+        digest = hashlib.sha256()
+        size = path.stat().st_size
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return size, digest.hexdigest()
 
     def _append_block(block: dict) -> None:
         nonlocal text_used, text_omitted
@@ -852,6 +886,21 @@ def build_file_section(
         if full_path in provenance.suppressed_pdfs or full_path in fallback_suppressed_by_dir[parent]:
             return
         _append_block({"type": "text", "text": f"\n{file_name}:\n"})
+        info = FILE_TYPE_MAP.get(full_path.suffix.lower().lstrip(".")) or {}
+        av_identity: tuple[int, str] | None = None
+        if info.get("type") in {"AUDIO", "VIDEO"}:
+            av_identity = _av_identity(full_path)
+            retained_as = retained_av_payloads.get(av_identity)
+            if retained_as is not None:
+                _append_block(
+                    {
+                        "type": "text",
+                        "text": f"[byte-identical duplicate attachment; content retained once as "
+                        f"{retained_as}; sha256={av_identity[1]}]",
+                    }
+                )
+                no_files = False
+                return
         cached_office_pdf = provenance.office_pdfs.get(full_path) or fallback_pdfs_by_dir[parent].get(full_path)
         remaining_text = max(0, MAX_SECTION_TEXT_CHARS_FOR_JUDGE - text_used)
         if media_mode == "images_and_text":
@@ -870,6 +919,8 @@ def build_file_section(
             )
             if blocks:
                 _append_blocks(blocks)
+                if av_identity is not None and any(_attachment_payload(block)[0] for block in blocks):
+                    retained_av_payloads[av_identity] = file_name
                 no_files = False
             sheet_text = _structured_xlsx_text(full_path)
             if sheet_text:
@@ -891,6 +942,8 @@ def build_file_section(
         )
         if block is not None:
             _append_block(block)
+            if av_identity is not None and _attachment_payload(block)[0]:
+                retained_av_payloads[av_identity] = file_name
             no_files = False
         sheet_text = _structured_xlsx_text(full_path)
         if sheet_text:
@@ -1206,9 +1259,13 @@ def construct_judge_messages(
     submission_b: list[dict],
 ) -> list[dict]:
     """Assemble OpenAI messages for the judge: prompt + task + refs + submissions."""
+    verdict_reminder_block = {"type": "text", "text": FINAL_VERDICT_REMINDER}
     # Text can require up to twelve JSON bytes per Unicode code point. Give the
-    # task and three sections equal worst-case shares after reserving framing.
-    available_text_chars = max(0, MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE - 16 * 1024) // 12
+    # task and three sections equal worst-case shares after reserving framing,
+    # including the trailing verdict reminder, so the final serialized bound
+    # cannot exceed the request cap once every share is fully used.
+    framing_reserve = 16 * 1024 + _block_serialized_upper_bound(verdict_reminder_block)
+    available_text_chars = max(0, MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE - framing_reserve) // 12
     fair_text_cap = available_text_chars // 4
     section_text_cap = min(MAX_SECTION_TEXT_CHARS_FOR_JUDGE, fair_text_cap)
     refs = _bound_section_text(refs, section_text_cap)
@@ -1224,6 +1281,7 @@ def construct_judge_messages(
         {"type": "text", "text": SUBMISSION_A_CLOSE},
         {"type": "text", "text": SUBMISSION_B_OPEN},
         {"type": "text", "text": SUBMISSION_B_CLOSE},
+        verdict_reminder_block,
     ]
     sections = [refs, submission_a, submission_b]
     fixed_blocks = framing + [block for section in sections for block in section if _attachment_cost(block)[1] == 0]
@@ -1253,6 +1311,7 @@ def construct_judge_messages(
     content.append({"type": "text", "text": SUBMISSION_B_OPEN})
     content.extend(submission_b)
     content.append({"type": "text", "text": SUBMISSION_B_CLOSE})
+    content.append(verdict_reminder_block)
 
     serialized_bound = _content_serialized_upper_bound(content)
     if serialized_bound > MAX_TOTAL_SERIALIZED_REQUEST_BYTES_FOR_JUDGE:
@@ -1404,6 +1463,231 @@ class Judge:
     # video but not audio.
     handles_audio: bool = False
     handles_video: bool = False
+    media_mode: str = "native_pdf"
+    max_native_pdf_pages: Optional[int] = None
+    max_native_pdf_documents: Optional[int] = None
+    max_native_pdf_bytes: Optional[int] = None
+    raster_dpi_tiers: tuple[int, ...] = ()
+    max_serialized_request_bytes: Optional[int] = None
+
+
+def preview_trial_judges(judges: list[Judge], num_trials: int, rng: random.Random) -> list[Judge]:
+    """Preview the seeded schedule without consuming *rng*."""
+    if not judges:
+        raise ValueError("preview_trial_judges requires a non-empty judge panel")
+    clone = random.Random()
+    clone.setstate(rng.getstate())
+    return [sample_judge(judges, clone) for _ in range(num_trials)]
+
+
+def filter_media_eligible_judges(
+    judges: list[Judge],
+    *,
+    native_stats: dict[str, int],
+    estimated_images: int,
+    image_cap: int,
+    overflow_plan: Optional[dict] = None,
+) -> tuple[list[Judge], list[dict]]:
+    """Capability-gate the complete panel before seeded trial sampling."""
+    eligible: list[Judge] = []
+    exclusions: list[dict] = []
+    for judge in judges:
+        if judge.media_mode == "native_pdf_overflow_images":
+            if overflow_plan is None or not overflow_plan.get("eligible", False):
+                exclusions.append(
+                    {
+                        "mode": judge.media_mode,
+                        "judges": [judge.name],
+                        "overflow_plan": overflow_plan,
+                        "reason": "native_pdf_overflow_unavailable",
+                    }
+                )
+                continue
+            eligible.append(judge)
+            continue
+        if judge.media_mode == "images_and_text" and estimated_images > image_cap:
+            exclusions.append(
+                {
+                    "mode": judge.media_mode,
+                    "judges": [judge.name],
+                    "estimated_image_count": estimated_images,
+                    "pdf_stats": dict(native_stats),
+                    "cap": image_cap,
+                    "reason": "request_image_cap_preflight",
+                }
+            )
+            continue
+        if judge.media_mode == "native_pdf":
+            over = (
+                (judge.max_native_pdf_pages is not None and native_stats["pages"] > judge.max_native_pdf_pages)
+                or (
+                    judge.max_native_pdf_documents is not None
+                    and native_stats["documents"] > judge.max_native_pdf_documents
+                )
+                or (judge.max_native_pdf_bytes is not None and native_stats["bytes"] > judge.max_native_pdf_bytes)
+            )
+            if over:
+                exclusions.append(
+                    {
+                        "mode": judge.media_mode,
+                        "judges": [judge.name],
+                        "pdf_stats": dict(native_stats),
+                        "reason": "native_pdf_cap",
+                    }
+                )
+                continue
+        eligible.append(judge)
+    return eligible, exclusions
+
+
+def plan_native_pdf_overflow(sections: dict[str, list[dict]], *, native_page_cap: int, image_cap: int) -> dict:
+    """Choose the fewest PDF pages to rasterize to satisfy a native-page cap."""
+    from resources_servers.gdpval.media_conversion import pdf_page_count
+
+    prefix = "data:application/pdf;base64,"
+    documents: list[dict] = []
+    for section_name, blocks in sections.items():
+        for block_index, block in enumerate(blocks):
+            if block.get("type") != "image_url":
+                continue
+            url = str((block.get("image_url") or {}).get("url", ""))
+            if not url.startswith(prefix):
+                continue
+            payload = base64.b64decode(url[len(prefix) :], validate=True)
+            documents.append(
+                {
+                    "section": section_name,
+                    "block_index": block_index,
+                    "pages": pdf_page_count(payload),
+                    "bytes": len(payload),
+                    "sha256": hashlib.sha256(payload).hexdigest(),
+                }
+            )
+    total_pages = sum(item["pages"] for item in documents)
+    excess = max(0, total_pages - native_page_cap)
+    selected: list[dict] = []
+    if excess:
+        choices: dict[int, tuple[int, ...]] = {0: ()}
+        for index, item in enumerate(documents):
+            for subtotal, indices in list(choices.items())[::-1]:
+                candidate = subtotal + int(item["pages"])
+                prior = choices.get(candidate)
+                proposed = (*indices, index)
+                if prior is None or len(proposed) < len(prior):
+                    choices[candidate] = proposed
+        viable = [subtotal for subtotal in choices if subtotal >= excess]
+        if viable:
+            best = min(viable, key=lambda subtotal: (subtotal, len(choices[subtotal])))
+            selected = [documents[index] for index in choices[best]]
+    raster_pages = sum(item["pages"] for item in selected)
+    native_pages = total_pages - raster_pages
+    return {
+        "eligible": native_pages <= native_page_cap and raster_pages <= image_cap,
+        "total_pdf_pages": total_pages,
+        "native_page_cap": native_page_cap,
+        "native_pages_after": native_pages,
+        "raster_pages": raster_pages,
+        "image_cap": image_cap,
+        "selected": selected,
+    }
+
+
+def apply_native_pdf_overflow(
+    sections: dict[str, list[dict]],
+    plan: dict,
+    *,
+    render_dpi: int,
+    max_pages: int,
+    include_text: bool,
+) -> dict[str, list[dict]]:
+    """Apply a preflighted overflow plan without changing semantic sections."""
+    from resources_servers.gdpval.media_conversion import pdf_bytes_to_blocks
+
+    selected = {(x["section"], int(x["block_index"])): x for x in plan.get("selected", [])}
+    prefix = "data:application/pdf;base64,"
+    output: dict[str, list[dict]] = {}
+    for section_name, blocks in sections.items():
+        converted: list[dict] = []
+        for block_index, block in enumerate(blocks):
+            item = selected.get((section_name, block_index))
+            if item is None:
+                converted.append(block)
+                continue
+            url = str((block.get("image_url") or {}).get("url", ""))
+            if not url.startswith(prefix):
+                raise ValueError(f"overflow plan block drift: {section_name}/{block_index}")
+            payload = base64.b64decode(url[len(prefix) :], validate=True)
+            if hashlib.sha256(payload).hexdigest() != item["sha256"]:
+                raise ValueError(f"overflow plan hash drift: {section_name}/{block_index}")
+            rendered = pdf_bytes_to_blocks(
+                payload,
+                dpi=render_dpi,
+                max_pages=max_pages,
+                include_text=include_text,
+            )
+            image_count = sum(1 for x in rendered if x.get("type") == "image_url")
+            if image_count != item["pages"] or any(
+                str(x.get("text", "")).startswith("[truncated: rendered") for x in rendered
+            ):
+                raise ValueError(
+                    f"overflow render mismatch {section_name}/{block_index}: "
+                    f"images={image_count} pages={item['pages']}"
+                )
+            converted.extend(rendered)
+        output[section_name] = converted
+    return output
+
+
+_LOSSY_TRANSPORT_PREFIXES = (
+    "[attachment omitted",
+    "[oversize:",
+    "[truncated: rendered",
+)
+
+
+def preflight_judge_transport(
+    judge: Judge,
+    task_prompt: str,
+    sections: dict[str, list[dict]],
+) -> dict[str, Any]:
+    """Project one provider request and reject lossy or oversized transport."""
+    messages = construct_judge_messages(
+        task_prompt=task_prompt,
+        refs=sections["refs"],
+        submission_a=sections["submission_a"],
+        submission_b=sections["submission_b"],
+    )
+    markers: list[str] = []
+    for message in messages:
+        for block in message.get("content") or []:
+            text = str(block.get("text", ""))
+            if text.startswith(_LOSSY_TRANSPORT_PREFIXES):
+                markers.append(text.splitlines()[0][:240])
+    create_kwargs = merge_create_kwargs(
+        {
+            "model": judge.model,
+            "messages": messages,
+            "max_tokens": 65535,
+            "temperature": 1.0,
+        },
+        judge.create_overrides,
+    )
+    serialized_bytes = len(json.dumps(create_kwargs, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+    cap = judge.max_serialized_request_bytes
+    reasons: list[str] = []
+    if markers:
+        reasons.append("lossy_attachment_omission")
+    if cap is not None and serialized_bytes >= cap:
+        reasons.append("provider_wire_cap")
+    return {
+        "eligible": not reasons,
+        "judge": judge.name,
+        "media_mode": judge.media_mode,
+        "serialized_request_bytes": serialized_bytes,
+        "max_serialized_request_bytes": cap,
+        "loss_markers": markers,
+        "reasons": reasons,
+    }
 
 
 def run_trials(
@@ -1412,6 +1696,7 @@ def run_trials(
     refs: list[dict],
     submission_a: list[dict],
     submission_b: list[dict],
+    sections_by_judge: Optional[dict[str, dict[str, list[dict]]]] = None,
     num_trials: int = 4,
     max_output_tokens: int = 65535,
     return_raw_responses: bool = False,
@@ -1455,6 +1740,13 @@ def run_trials(
     for i in range(num_trials):
         judge = sample_judge(judges, rng)
         trial_judges.append(judge.name)
+        if sections_by_judge is not None:
+            if judge.name not in sections_by_judge:
+                raise ValueError(f"missing sections for judge {judge.name!r}")
+            judge_sections = sections_by_judge[judge.name]
+            refs = judge_sections["refs"]
+            submission_a = judge_sections["submission_a"]
+            submission_b = judge_sections["submission_b"]
         swapped = i % 2 != 0
         current_a = submission_b if swapped else submission_a
         current_b = submission_a if swapped else submission_b

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -1467,6 +1467,7 @@ class Judge:
     max_native_pdf_pages: Optional[int] = None
     max_native_pdf_documents: Optional[int] = None
     max_native_pdf_bytes: Optional[int] = None
+    max_native_pdf_bytes_per_document: Optional[int] = None
     raster_dpi_tiers: tuple[int, ...] = ()
     max_serialized_request_bytes: Optional[int] = None
 
@@ -1540,56 +1541,117 @@ def filter_media_eligible_judges(
     return eligible, exclusions
 
 
-def plan_native_pdf_overflow(sections: dict[str, list[dict]], *, native_page_cap: int, image_cap: int) -> dict:
-    """Choose the fewest PDF pages to rasterize to satisfy a native-page cap."""
+def plan_native_pdf_overflow(
+    sections: dict[str, list[dict]],
+    *,
+    native_page_cap: int,
+    native_pdf_bytes_per_document: int,
+    image_cap: int,
+) -> dict:
+    """Rasterize oversize PDFs and exactly enough pages for the page cap.
+
+    Any PDF above the provider's per-file limit is fully rasterized. For an
+    additional page-count overflow, whole small PDFs are rasterized first and
+    only the required prefix of the final document is rasterized. Every source
+    page remains represented while avoiding unnecessary image expansion.
+    """
     from resources_servers.gdpval.media_conversion import pdf_page_count
 
     prefix = "data:application/pdf;base64,"
     documents: list[dict] = []
+    existing_images = 0
     for section_name, blocks in sections.items():
         for block_index, block in enumerate(blocks):
             if block.get("type") != "image_url":
                 continue
             url = str((block.get("image_url") or {}).get("url", ""))
             if not url.startswith(prefix):
+                if url.startswith("data:image/"):
+                    existing_images += 1
                 continue
             payload = base64.b64decode(url[len(prefix) :], validate=True)
+            pages = pdf_page_count(payload)
+            if pages <= 0:
+                raise ValueError(f"native PDF has no pages: {section_name}/{block_index}")
             documents.append(
                 {
                     "section": section_name,
                     "block_index": block_index,
-                    "pages": pdf_page_count(payload),
+                    "pages": pages,
                     "bytes": len(payload),
                     "sha256": hashlib.sha256(payload).hexdigest(),
                 }
             )
     total_pages = sum(item["pages"] for item in documents)
     excess = max(0, total_pages - native_page_cap)
-    selected: list[dict] = []
-    if excess:
-        choices: dict[int, tuple[int, ...]] = {0: ()}
-        for index, item in enumerate(documents):
-            for subtotal, indices in list(choices.items())[::-1]:
-                candidate = subtotal + int(item["pages"])
-                prior = choices.get(candidate)
-                proposed = (*indices, index)
-                if prior is None or len(proposed) < len(prior):
-                    choices[candidate] = proposed
-        viable = [subtotal for subtotal in choices if subtotal >= excess]
-        if viable:
-            best = min(viable, key=lambda subtotal: (subtotal, len(choices[subtotal])))
-            selected = [documents[index] for index in choices[best]]
-    raster_pages = sum(item["pages"] for item in selected)
+    forced = {index for index, item in enumerate(documents) if item["bytes"] > native_pdf_bytes_per_document}
+    selected: list[dict] = [
+        {
+            **documents[index],
+            "raster_page_start": 0,
+            "raster_page_count": int(documents[index]["pages"]),
+            "native_page_count": 0,
+            "reason": "native_pdf_bytes_per_document",
+        }
+        for index in sorted(forced)
+    ]
+    forced_pages = sum(int(documents[index]["pages"]) for index in forced)
+    remaining = max(0, excess - forced_pages)
+    for index in sorted(range(len(documents)), key=lambda value: (documents[value]["pages"], value)):
+        if index in forced:
+            continue
+        if remaining <= 0:
+            break
+        document = documents[index]
+        raster_page_count = min(int(document["pages"]), remaining)
+        selected.append(
+            {
+                **document,
+                "raster_page_start": 0,
+                "raster_page_count": raster_page_count,
+                "native_page_count": int(document["pages"]) - raster_page_count,
+                "reason": "native_pdf_page_cap",
+            }
+        )
+        remaining -= raster_page_count
+    raster_pages = sum(int(item["raster_page_count"]) for item in selected)
     native_pages = total_pages - raster_pages
+    total_images_after = existing_images + raster_pages
     return {
-        "eligible": native_pages <= native_page_cap and raster_pages <= image_cap,
+        "eligible": (remaining == 0 and native_pages <= native_page_cap and total_images_after <= image_cap),
         "total_pdf_pages": total_pages,
         "native_page_cap": native_page_cap,
+        "native_pdf_bytes_per_document": native_pdf_bytes_per_document,
         "native_pages_after": native_pages,
         "raster_pages": raster_pages,
         "image_cap": image_cap,
+        "existing_images": existing_images,
+        "total_images_after": total_images_after,
         "selected": selected,
     }
+
+
+def _split_pdf_prefix(pdf_bytes: bytes, raster_page_count: int) -> tuple[bytes, bytes]:
+    """Return PDF byte streams for a non-empty prefix and suffix."""
+    try:
+        import fitz  # PyMuPDF
+    except ImportError as exc:
+        raise RuntimeError("PyMuPDF is required for native-PDF overflow splitting") from exc
+
+    source = fitz.open(stream=pdf_bytes, filetype="pdf")
+    prefix = fitz.open()
+    suffix = fitz.open()
+    try:
+        pages = int(source.page_count)
+        if not 0 < raster_page_count < pages:
+            raise ValueError(f"invalid PDF prefix split: {raster_page_count}/{pages}")
+        prefix.insert_pdf(source, from_page=0, to_page=raster_page_count - 1, links=True, annots=True)
+        suffix.insert_pdf(source, from_page=raster_page_count, to_page=pages - 1, links=True, annots=True)
+        return prefix.tobytes(garbage=0, deflate=False), suffix.tobytes(garbage=0, deflate=False)
+    finally:
+        suffix.close()
+        prefix.close()
+        source.close()
 
 
 def apply_native_pdf_overflow(
@@ -1600,10 +1662,12 @@ def apply_native_pdf_overflow(
     max_pages: int,
     include_text: bool,
 ) -> dict[str, list[dict]]:
-    """Apply a preflighted overflow plan without changing semantic sections."""
-    from resources_servers.gdpval.media_conversion import pdf_bytes_to_blocks
+    """Apply a preflighted overflow plan while retaining every PDF page."""
+    from resources_servers.gdpval.media_conversion import pdf_bytes_to_blocks, pdf_page_count
 
     selected = {(x["section"], int(x["block_index"])): x for x in plan.get("selected", [])}
+    if len(selected) != len(plan.get("selected", [])):
+        raise ValueError("overflow plan selects a PDF block more than once")
     prefix = "data:application/pdf;base64,"
     output: dict[str, list[dict]] = {}
     for section_name, blocks in sections.items():
@@ -1619,21 +1683,47 @@ def apply_native_pdf_overflow(
             payload = base64.b64decode(url[len(prefix) :], validate=True)
             if hashlib.sha256(payload).hexdigest() != item["sha256"]:
                 raise ValueError(f"overflow plan hash drift: {section_name}/{block_index}")
+            pages = pdf_page_count(payload)
+            if pages != int(item["pages"]):
+                raise ValueError(f"overflow plan page-count drift: {section_name}/{block_index}")
+            raster_page_start = int(item.get("raster_page_start", 0))
+            raster_page_count = int(item.get("raster_page_count", pages))
+            native_page_count = int(item.get("native_page_count", pages - raster_page_count))
+            if raster_page_start != 0 or raster_page_count <= 0 or raster_page_count > pages:
+                raise ValueError(f"invalid overflow page range: {section_name}/{block_index}")
+            if native_page_count != pages - raster_page_count:
+                raise ValueError(f"overflow plan page partition drift: {section_name}/{block_index}")
+            if native_page_count:
+                raster_payload, native_payload = _split_pdf_prefix(payload, raster_page_count)
+                if pdf_page_count(raster_payload) != raster_page_count:
+                    raise ValueError(f"overflow prefix page-count drift: {section_name}/{block_index}")
+                if pdf_page_count(native_payload) != native_page_count:
+                    raise ValueError(f"overflow suffix page-count drift: {section_name}/{block_index}")
+            else:
+                raster_payload = payload
+                native_payload = b""
             rendered = pdf_bytes_to_blocks(
-                payload,
+                raster_payload,
                 dpi=render_dpi,
                 max_pages=max_pages,
                 include_text=include_text,
             )
             image_count = sum(1 for x in rendered if x.get("type") == "image_url")
-            if image_count != item["pages"] or any(
+            if image_count != raster_page_count or any(
                 str(x.get("text", "")).startswith("[truncated: rendered") for x in rendered
             ):
                 raise ValueError(
                     f"overflow render mismatch {section_name}/{block_index}: "
-                    f"images={image_count} pages={item['pages']}"
+                    f"images={image_count} pages={raster_page_count}"
                 )
             converted.extend(rendered)
+            if native_payload:
+                converted.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": prefix + base64.b64encode(native_payload).decode("ascii")},
+                    }
+                )
         output[section_name] = converted
     return output
 

--- a/resources_servers/gdpval/comparison.py
+++ b/resources_servers/gdpval/comparison.py
@@ -1504,6 +1504,29 @@ def filter_media_eligible_judges(
                     }
                 )
                 continue
+            documents_after = overflow_plan.get("native_documents_after")
+            bytes_after = overflow_plan.get("native_bytes_after_bound")
+            over_aggregate = (
+                judge.max_native_pdf_documents is not None
+                and documents_after is not None
+                and documents_after > judge.max_native_pdf_documents
+            ) or (
+                judge.max_native_pdf_bytes is not None
+                and bytes_after is not None
+                and bytes_after > judge.max_native_pdf_bytes
+            )
+            if over_aggregate:
+                exclusions.append(
+                    {
+                        "mode": judge.media_mode,
+                        "judges": [judge.name],
+                        "pdf_stats": dict(native_stats),
+                        "native_documents_after": documents_after,
+                        "native_bytes_after_bound": bytes_after,
+                        "reason": "native_pdf_cap_after_overflow",
+                    }
+                )
+                continue
             eligible.append(judge)
             continue
         if judge.media_mode == "images_and_text" and estimated_images > image_cap:
@@ -1547,6 +1570,7 @@ def plan_native_pdf_overflow(
     native_page_cap: int,
     native_pdf_bytes_per_document: int,
     image_cap: int,
+    render_page_cap: Optional[int] = None,
 ) -> dict:
     """Rasterize oversize PDFs and exactly enough pages for the page cap.
 
@@ -1597,6 +1621,7 @@ def plan_native_pdf_overflow(
     ]
     forced_pages = sum(int(documents[index]["pages"]) for index in forced)
     remaining = max(0, excess - forced_pages)
+    fully_rasterized: set[int] = set(forced)
     for index in sorted(range(len(documents)), key=lambda value: (documents[value]["pages"], value)):
         if index in forced:
             continue
@@ -1613,16 +1638,30 @@ def plan_native_pdf_overflow(
                 "reason": "native_pdf_page_cap",
             }
         )
+        if raster_page_count == int(document["pages"]):
+            fully_rasterized.add(index)
         remaining -= raster_page_count
     raster_pages = sum(int(item["raster_page_count"]) for item in selected)
     native_pages = total_pages - raster_pages
     total_images_after = existing_images + raster_pages
+    # A fully rasterized document leaves the native payload entirely; a prefix
+    # split keeps a native suffix whose size is bounded by the original bytes.
+    native_documents_after = sum(1 for index in range(len(documents)) if index not in fully_rasterized)
+    native_bytes_after_bound = sum(
+        int(documents[index]["bytes"]) for index in range(len(documents)) if index not in fully_rasterized
+    )
+    render_ok = render_page_cap is None or all(int(item["raster_page_count"]) <= render_page_cap for item in selected)
     return {
-        "eligible": (remaining == 0 and native_pages <= native_page_cap and total_images_after <= image_cap),
+        "eligible": (
+            remaining == 0 and native_pages <= native_page_cap and total_images_after <= image_cap and render_ok
+        ),
         "total_pdf_pages": total_pages,
         "native_page_cap": native_page_cap,
         "native_pdf_bytes_per_document": native_pdf_bytes_per_document,
         "native_pages_after": native_pages,
+        "native_documents_after": native_documents_after,
+        "native_bytes_after_bound": native_bytes_after_bound,
+        "render_page_cap": render_page_cap,
         "raster_pages": raster_pages,
         "image_cap": image_cap,
         "existing_images": existing_images,

--- a/resources_servers/gdpval/judge_panel.py
+++ b/resources_servers/gdpval/judge_panel.py
@@ -76,6 +76,7 @@ class ResolvedJudge:
     max_native_pdf_pages: Optional[int] = None
     max_native_pdf_documents: Optional[int] = None
     max_native_pdf_bytes: Optional[int] = None
+    max_native_pdf_bytes_per_document: Optional[int] = None
     # Raster tiers are tried in order. The first complete request below the
     # provider wire cap is used; otherwise that judge is excluded pre-dispatch.
     raster_dpi_tiers: tuple[int, ...] = ()

--- a/resources_servers/gdpval/judge_panel.py
+++ b/resources_servers/gdpval/judge_panel.py
@@ -70,6 +70,16 @@ class ResolvedJudge:
     # server's routing).
     handles_audio: bool = False
     handles_video: bool = False
+    # The transport is selected per provider. Hosted GPT uses rasterized pages,
+    # while Gemini and Claude can consume native PDFs.
+    media_mode: str = "native_pdf"
+    max_native_pdf_pages: Optional[int] = None
+    max_native_pdf_documents: Optional[int] = None
+    max_native_pdf_bytes: Optional[int] = None
+    # Raster tiers are tried in order. The first complete request below the
+    # provider wire cap is used; otherwise that judge is excluded pre-dispatch.
+    raster_dpi_tiers: tuple[int, ...] = ()
+    max_serialized_request_bytes: Optional[int] = None
 
 
 class _HasWeight(Protocol):

--- a/resources_servers/gdpval/media_conversion.py
+++ b/resources_servers/gdpval/media_conversion.py
@@ -172,6 +172,22 @@ def pdf_bytes_to_image_blocks(
     return blocks
 
 
+def pdf_page_count(pdf_bytes: bytes) -> int:
+    """Return the exact page count for an in-memory PDF, failing closed."""
+    try:
+        import fitz  # PyMuPDF
+    except ImportError as exc:
+        raise RuntimeError("PyMuPDF is required for native-PDF request gating") from exc
+    try:
+        doc = fitz.open(stream=pdf_bytes, filetype="pdf")
+    except Exception as exc:
+        raise RuntimeError(f"cannot count PDF pages: {exc!r}") from exc
+    try:
+        return int(doc.page_count)
+    finally:
+        doc.close()
+
+
 def pdf_bytes_to_text(pdf_bytes: bytes, *, max_chars: int = DEFAULT_MAX_TEXT_CHARS) -> str:
     """Extract text from a PDF (as bytes), truncated to *max_chars*.
 

--- a/resources_servers/gdpval/multistage_orchestrator.py
+++ b/resources_servers/gdpval/multistage_orchestrator.py
@@ -103,6 +103,10 @@ from resources_servers.gdpval.multistage_elo import (
 # return ``(row, result)`` pairs (result == the agent's /run response, i.e. the
 # GDPVal verify response). Injected so tests can avoid real servers.
 RolloutRunner = Callable[[List[Dict[str, Any]]], Awaitable[List[Tuple[Dict[str, Any], Dict[str, Any]]]]]
+AssignmentRepair = Callable[
+    [int, Sequence[str], Mapping[str, str]],
+    Tuple[Dict[str, str], Dict[str, Any]],
+]
 
 
 @dataclass
@@ -771,6 +775,8 @@ def tag_results(
         out[AGENT_REF_KEY_NAME] = row[AGENT_REF_KEY_NAME]
         if ATTEMPT_INDEX_KEY_NAME in row:
             out[ATTEMPT_INDEX_KEY_NAME] = row[ATTEMPT_INDEX_KEY_NAME]
+        if "verify_cache_namespace" in row:
+            out["verify_cache_namespace"] = row["verify_cache_namespace"]
         out["stage_index"] = stage_index
         if expected_final_stage_index is not None:
             out["expected_final_stage_index"] = expected_final_stage_index
@@ -800,6 +806,7 @@ async def run_multistage_stages(
     on_event: Optional[Callable[[str, dict], None]] = None,
     resume: Optional[StageResume] = None,
     dispatch_longest_first: bool = False,
+    assignment_repair: Optional[AssignmentRepair] = None,
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Run every stage and return ``(all_result_rows, stage_summaries)``.
 
@@ -960,7 +967,14 @@ async def run_multistage_stages(
             }
 
         reference_ids, task_ids, task_reference_ids, replayed = _plan_stage(
-            index, stage, reference_elos, eval_elo, stage_task_sets, multistage_config, resume
+            index,
+            stage,
+            reference_elos,
+            eval_elo,
+            stage_task_sets,
+            multistage_config,
+            resume,
+            assignment_repair,
         )
 
         stage_rows = build_stage_rows(
@@ -1222,6 +1236,7 @@ def _plan_stage(
     stage_task_sets: Sequence[Sequence[str]],
     multistage_config: MultiStageRunConfig,
     resume: Optional[StageResume],
+    assignment_repair: Optional[AssignmentRepair] = None,
 ) -> Tuple[List[str], List[str], Dict[str, str], bool]:
     """Return ``(reference_ids, task_ids, task_reference_ids, replayed)`` for a stage.
 
@@ -1258,19 +1273,30 @@ def _plan_stage(
         rng=rng,
         balanced=stage.partial_completion is not None,
     )
-    if resume is not None:
-        resume.on_plan(
+    repair_receipt: Optional[Dict[str, Any]] = None
+    if assignment_repair is not None:
+        task_reference_ids, repair_receipt = assignment_repair(
             index,
-            {
-                "stage_index": index,
-                "status": "planned",
-                "reference_ids": list(reference_ids),
-                "task_ids": list(task_ids),
-                "task_reference_ids": task_reference_ids,
-                "seed": stage.seed,
-                "prior_eval_elo": eval_elo,
-            },
+            reference_ids,
+            task_reference_ids,
         )
+        if set(task_reference_ids) != set(task_ids):
+            raise ValueError("transport assignment repair changed the stage task set")
+        if any(reference_id not in reference_ids for reference_id in task_reference_ids.values()):
+            raise ValueError("transport assignment repair selected a reference outside the stage")
+    if resume is not None:
+        plan = {
+            "stage_index": index,
+            "status": "planned",
+            "reference_ids": list(reference_ids),
+            "task_ids": list(task_ids),
+            "task_reference_ids": task_reference_ids,
+            "seed": stage.seed,
+            "prior_eval_elo": eval_elo,
+        }
+        if repair_receipt is not None:
+            plan["transport_assignment_repair"] = repair_receipt
+        resume.on_plan(index, plan)
     return list(reference_ids), task_ids, task_reference_ids, False
 
 
@@ -2016,6 +2042,13 @@ async def run_e2e_multistage(
         row["verify_cache_namespace"] = fingerprint
     resume = _prepare_resume(rollout_collection_config, output_fpath, journal_fpath, fingerprint)
 
+    assignment_repair = None
+    transport_config = (global_config_dict.get("multistage") or {}).get("transport_assignment_repair")
+    if isinstance(transport_config, Mapping) and transport_config.get("enabled"):
+        from resources_servers.gdpval.transport_assignment import make_assignment_repair
+
+        assignment_repair = make_assignment_repair(global_config_dict, transport_config)
+
     all_results, stage_summaries = await run_multistage_stages(
         multistage_config,
         reference_elos,
@@ -2025,6 +2058,7 @@ async def run_e2e_multistage(
         on_event=_log_event,
         resume=resume,
         dispatch_longest_first=bool(getattr(rollout_collection_config, "dispatch_longest_first", False)),
+        assignment_repair=assignment_repair,
     )
 
     print(latency_tracker.summary())

--- a/resources_servers/gdpval/multistage_orchestrator.py
+++ b/resources_servers/gdpval/multistage_orchestrator.py
@@ -510,6 +510,12 @@ def compute_fingerprint(
             for name, block in resolved_global_config.items()
             if isinstance(block, Mapping) and component_types.intersection(block)
         }
+        # Transport-assignment repair rewrites which reference each task is
+        # judged against, so its settings must invalidate journals like any
+        # other planner input. Absent config hashes exactly as before.
+        transport_repair = (resolved_global_config.get("multistage") or {}).get("transport_assignment_repair")
+        if transport_repair is not None:
+            payload["transport_assignment_repair"] = jsonable(transport_repair)
     encoded = orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)
     return hashlib.sha256(encoded).hexdigest()
 

--- a/resources_servers/gdpval/tests/test_transport_modes.py
+++ b/resources_servers/gdpval/tests/test_transport_modes.py
@@ -282,3 +282,96 @@ class TestFingerprintTransportRepair:
         without_block = compute_fingerprint(cfg, self.REF_ELOS, self.DIST, resolved_global_config={})
         empty_block = compute_fingerprint(cfg, self.REF_ELOS, self.DIST, resolved_global_config={"multistage": {}})
         assert without_block == empty_block
+
+
+class TestOverflowRenderPageCap:
+    def test_ineligible_when_forced_raster_exceeds_render_page_cap(self) -> None:
+        big = _pdf_bytes(3)
+        sections = {"refs": [_pdf_block(big)]}
+        capped = plan_native_pdf_overflow(
+            sections,
+            native_page_cap=100,
+            native_pdf_bytes_per_document=len(big) - 1,
+            image_cap=50,
+            render_page_cap=2,
+        )
+        assert capped["eligible"] is False
+
+        roomy = plan_native_pdf_overflow(
+            sections,
+            native_page_cap=100,
+            native_pdf_bytes_per_document=len(big) - 1,
+            image_cap=50,
+            render_page_cap=3,
+        )
+        assert roomy["eligible"] is True
+        # An eligible plan renders successfully under the same page bound.
+        converted = apply_native_pdf_overflow(sections, roomy, render_dpi=36, max_pages=3, include_text=False)
+        rendered = [
+            b for b in converted["refs"] if str((b.get("image_url") or {}).get("url", "")).startswith("data:image/")
+        ]
+        assert len(rendered) == 3
+
+
+class TestOverflowAggregateCaps:
+    def test_plan_reports_post_overflow_aggregates(self) -> None:
+        short = _pdf_bytes(3)
+        long = _pdf_bytes(5)
+        sections = {"refs": [_pdf_block(short), _pdf_block(long)]}
+        plan = plan_native_pdf_overflow(
+            sections,
+            native_page_cap=6,
+            native_pdf_bytes_per_document=10**9,
+            image_cap=50,
+        )
+        # Prefix split keeps a native suffix, so both documents remain native.
+        assert plan["native_documents_after"] == 2
+        assert plan["native_bytes_after_bound"] == len(short) + len(long)
+
+        forced = plan_native_pdf_overflow(
+            {"refs": [_pdf_block(short), _pdf_block(long)]},
+            native_page_cap=100,
+            native_pdf_bytes_per_document=len(long) - 1,
+            image_cap=50,
+        )
+        # The long document is fully rasterized and leaves the native payload.
+        assert forced["native_documents_after"] == 1
+        assert forced["native_bytes_after_bound"] == len(short)
+
+    def test_overflow_judge_excluded_when_aggregate_caps_exceeded_after_overflow(self) -> None:
+        stats = {"pages": 8, "documents": 2, "bytes": 5_000}
+        plan = {"eligible": True, "native_documents_after": 2, "native_bytes_after_bound": 4_000}
+
+        capped_documents = _judge("gemini", media_mode="native_pdf_overflow_images", max_native_pdf_documents=1)
+        _, exclusions = filter_media_eligible_judges(
+            [capped_documents], native_stats=stats, estimated_images=0, image_cap=450, overflow_plan=plan
+        )
+        assert exclusions[0]["reason"] == "native_pdf_cap_after_overflow"
+
+        capped_bytes = _judge("gemini", media_mode="native_pdf_overflow_images", max_native_pdf_bytes=3_000)
+        _, exclusions = filter_media_eligible_judges(
+            [capped_bytes], native_stats=stats, estimated_images=0, image_cap=450, overflow_plan=plan
+        )
+        assert exclusions[0]["reason"] == "native_pdf_cap_after_overflow"
+
+        roomy = _judge(
+            "gemini",
+            media_mode="native_pdf_overflow_images",
+            max_native_pdf_documents=2,
+            max_native_pdf_bytes=4_000,
+        )
+        eligible, exclusions = filter_media_eligible_judges(
+            [roomy], native_stats=stats, estimated_images=0, image_cap=450, overflow_plan=plan
+        )
+        assert [j.name for j in eligible] == ["gemini"] and not exclusions
+
+    def test_legacy_plan_without_aggregates_stays_eligible(self) -> None:
+        judge = _judge("gemini", media_mode="native_pdf_overflow_images", max_native_pdf_documents=1)
+        eligible, exclusions = filter_media_eligible_judges(
+            [judge],
+            native_stats={"pages": 8, "documents": 2, "bytes": 5_000},
+            estimated_images=0,
+            image_cap=450,
+            overflow_plan={"eligible": True},
+        )
+        assert [j.name for j in eligible] == ["gemini"] and not exclusions

--- a/resources_servers/gdpval/tests/test_transport_modes.py
+++ b/resources_servers/gdpval/tests/test_transport_modes.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Per-provider judge transport: overflow planning, eligibility, seeded replay."""
+
+import base64
+import random
+
+import fitz
+import pytest
+
+from resources_servers.gdpval.comparison import (
+    Judge,
+    apply_native_pdf_overflow,
+    filter_media_eligible_judges,
+    plan_native_pdf_overflow,
+    preview_trial_judges,
+)
+from resources_servers.gdpval.judge_panel import sample_judge
+from resources_servers.gdpval.media_conversion import pdf_page_count
+from resources_servers.gdpval.multistage_orchestrator import (
+    MultiStageRunConfig,
+    compute_fingerprint,
+    parse_multistage_config,
+)
+from resources_servers.gdpval.transport_assignment import PairCost, _solve_capacity_assignment
+
+
+PDF_PREFIX = "data:application/pdf;base64,"
+
+
+def _pdf_bytes(pages: int) -> bytes:
+    document = fitz.open()
+    for index in range(pages):
+        page = document.new_page(width=200, height=200)
+        page.insert_text((20, 40), f"page {index}")
+    payload = document.tobytes()
+    document.close()
+    return payload
+
+
+def _pdf_block(payload: bytes) -> dict:
+    return {"type": "image_url", "image_url": {"url": PDF_PREFIX + base64.b64encode(payload).decode()}}
+
+
+def _judge(name: str, **kwargs) -> Judge:
+    return Judge(name=name, client=None, model="judge-model", **kwargs)
+
+
+class TestPlanNativePdfOverflow:
+    def test_forces_full_rasterization_above_per_document_byte_cap(self) -> None:
+        small = _pdf_bytes(1)
+        big = _pdf_bytes(2)
+        sections = {"refs": [_pdf_block(small)], "submission_a": [_pdf_block(big)]}
+
+        plan = plan_native_pdf_overflow(
+            sections,
+            native_page_cap=100,
+            native_pdf_bytes_per_document=len(big) - 1,
+            image_cap=50,
+        )
+
+        assert plan["eligible"] is True
+        (selected,) = plan["selected"]
+        assert selected["section"] == "submission_a"
+        assert selected["reason"] == "native_pdf_bytes_per_document"
+        assert selected["raster_page_count"] == 2
+        assert selected["native_page_count"] == 0
+        # Every source page stays represented, natively or as images.
+        assert plan["native_pages_after"] + plan["raster_pages"] == plan["total_pdf_pages"] == 3
+
+    def test_prefix_only_rasterization_for_page_cap_overflow(self) -> None:
+        short = _pdf_bytes(3)
+        long = _pdf_bytes(5)
+        sections = {"refs": [_pdf_block(short), _pdf_block(long)]}
+
+        plan = plan_native_pdf_overflow(
+            sections,
+            native_page_cap=6,
+            native_pdf_bytes_per_document=10**9,
+            image_cap=50,
+        )
+
+        # Two pages over the cap: the smallest document gives up exactly its
+        # two-page prefix; its final page and the whole long document stay native.
+        assert plan["eligible"] is True
+        (selected,) = plan["selected"]
+        assert selected["pages"] == 3
+        assert selected["reason"] == "native_pdf_page_cap"
+        assert selected["raster_page_start"] == 0
+        assert selected["raster_page_count"] == 2
+        assert selected["native_page_count"] == 1
+        assert plan["native_pages_after"] == 6
+        assert plan["raster_pages"] == 2
+
+    def test_ineligible_when_raster_pages_exceed_image_cap(self) -> None:
+        big = _pdf_bytes(3)
+        plan = plan_native_pdf_overflow(
+            {"refs": [_pdf_block(big)]},
+            native_page_cap=100,
+            native_pdf_bytes_per_document=len(big) - 1,
+            image_cap=2,
+        )
+        assert plan["eligible"] is False
+
+
+class TestApplyNativePdfOverflow:
+    def test_every_page_retained_across_raster_and_native_suffix(self) -> None:
+        short = _pdf_bytes(3)
+        long = _pdf_bytes(5)
+        sections = {"refs": [_pdf_block(short), _pdf_block(long)]}
+        plan = plan_native_pdf_overflow(
+            sections,
+            native_page_cap=6,
+            native_pdf_bytes_per_document=10**9,
+            image_cap=50,
+        )
+
+        converted = apply_native_pdf_overflow(sections, plan, render_dpi=36, max_pages=100, include_text=False)
+
+        blocks = converted["refs"]
+        urls = [str((block.get("image_url") or {}).get("url", "")) for block in blocks]
+        rendered_images = sum(1 for url in urls if url.startswith("data:image/"))
+        native_pages = sum(
+            pdf_page_count(base64.b64decode(url[len(PDF_PREFIX) :])) for url in urls if url.startswith(PDF_PREFIX)
+        )
+        assert rendered_images == 2
+        assert native_pages == 6
+
+    def test_rejects_plan_hash_drift(self) -> None:
+        payload = _pdf_bytes(2)
+        sections = {"refs": [_pdf_block(payload)]}
+        plan = plan_native_pdf_overflow(
+            sections,
+            native_page_cap=1,
+            native_pdf_bytes_per_document=10**9,
+            image_cap=50,
+        )
+        drifted = {"refs": [_pdf_block(_pdf_bytes(2))]}
+        with pytest.raises(ValueError, match="hash drift"):
+            apply_native_pdf_overflow(drifted, plan, render_dpi=36, max_pages=100, include_text=False)
+
+
+class TestFilterMediaEligibleJudges:
+    NATIVE_STATS = {"pages": 120, "documents": 6, "bytes": 30_000_000}
+
+    def test_exclusion_reasons_are_recorded_per_cap(self) -> None:
+        judges = [
+            _judge("claude", media_mode="native_pdf", max_native_pdf_bytes=24 * 1024 * 1024),
+            _judge("gpt", media_mode="images_and_text"),
+            _judge("gemini", media_mode="native_pdf_overflow_images"),
+            _judge("roomy", media_mode="native_pdf"),
+        ]
+
+        eligible, exclusions = filter_media_eligible_judges(
+            judges,
+            native_stats=self.NATIVE_STATS,
+            estimated_images=500,
+            image_cap=450,
+            overflow_plan=None,
+        )
+
+        assert [judge.name for judge in eligible] == ["roomy"]
+        reasons = {exclusion["judges"][0]: exclusion["reason"] for exclusion in exclusions}
+        assert reasons == {
+            "claude": "native_pdf_cap",
+            "gpt": "request_image_cap_preflight",
+            "gemini": "native_pdf_overflow_unavailable",
+        }
+
+    def test_overflow_judge_eligible_only_with_eligible_plan(self) -> None:
+        judge = _judge("gemini", media_mode="native_pdf_overflow_images")
+        eligible, _ = filter_media_eligible_judges(
+            [judge],
+            native_stats=self.NATIVE_STATS,
+            estimated_images=0,
+            image_cap=450,
+            overflow_plan={"eligible": True},
+        )
+        assert [j.name for j in eligible] == ["gemini"]
+        _, exclusions = filter_media_eligible_judges(
+            [judge],
+            native_stats=self.NATIVE_STATS,
+            estimated_images=0,
+            image_cap=450,
+            overflow_plan={"eligible": False},
+        )
+        assert exclusions[0]["reason"] == "native_pdf_overflow_unavailable"
+
+
+class TestPreviewTrialJudges:
+    def test_replays_seeded_schedule_without_consuming_rng(self) -> None:
+        judges = [_judge("a"), _judge("b"), _judge("c")]
+        rng = random.Random(7)
+        state = rng.getstate()
+
+        first = [judge.name for judge in preview_trial_judges(judges, 5, rng)]
+        second = [judge.name for judge in preview_trial_judges(judges, 5, rng)]
+
+        assert first == second
+        assert rng.getstate() == state
+        # The preview is exactly what dispatch will draw from the untouched RNG.
+        assert [sample_judge(judges, rng).name for _ in range(5)] == first
+
+    def test_exclusion_then_replay_is_deterministic(self) -> None:
+        judges = [_judge("a"), _judge("b"), _judge("c")]
+        rng = random.Random(11)
+        survivors = [judge for judge in judges if judge.name != "b"]
+        assert [j.name for j in preview_trial_judges(survivors, 4, rng)] == [
+            j.name for j in preview_trial_judges(survivors, 4, rng)
+        ]
+
+
+class TestSolveCapacityAssignment:
+    def test_minimum_change_reassignment_respects_capacities(self) -> None:
+        tasks = ["t0", "t1", "t2"]
+        references = ["ra", "rb"]
+        original = {"t0": "ra", "t1": "ra", "t2": "rb"}
+
+        def cost(compatible: bool, wire: int = 1) -> PairCost:
+            return PairCost(compatible=compatible, wire_bytes=wire, raw_bytes=wire, max_file_bytes=wire, reasons=())
+
+        # t1/ra is incompatible; the only capacity-preserving repair swaps t1 and t2.
+        costs = {
+            ("t0", "ra"): cost(True),
+            ("t0", "rb"): cost(True),
+            ("t1", "ra"): cost(False),
+            ("t1", "rb"): cost(True),
+            ("t2", "ra"): cost(True),
+            ("t2", "rb"): cost(True),
+        }
+
+        result = _solve_capacity_assignment(tasks, references, original, costs)
+
+        assert result == {"t0": "ra", "t1": "rb", "t2": "ra"}
+        assert sorted(result.values()) == sorted(original.values())
+
+
+class TestFingerprintTransportRepair:
+    REF_ELOS = {"ref_a": 1000.0}
+    DIST = {"grp": {"task_ids": ["t0"], "percentage": 100.0}}
+
+    def _cfg(self) -> MultiStageRunConfig:
+        return MultiStageRunConfig(
+            enabled=True,
+            stages=parse_multistage_config({"enabled": True, "stages": [{"num_tasks": 1}]}).stages,
+            seed=0,
+        )
+
+    def test_repair_settings_invalidate_fingerprint(self) -> None:
+        cfg = self._cfg()
+        base = compute_fingerprint(cfg, self.REF_ELOS, self.DIST, resolved_global_config={"multistage": {}})
+        repair_a = compute_fingerprint(
+            cfg,
+            self.REF_ELOS,
+            self.DIST,
+            resolved_global_config={"multistage": {"transport_assignment_repair": {"max_file_bytes": 1}}},
+        )
+        repair_b = compute_fingerprint(
+            cfg,
+            self.REF_ELOS,
+            self.DIST,
+            resolved_global_config={"multistage": {"transport_assignment_repair": {"max_file_bytes": 2}}},
+        )
+        assert repair_a != base
+        assert repair_b != base
+        assert repair_a != repair_b
+
+    def test_absent_repair_config_preserves_legacy_fingerprint(self) -> None:
+        cfg = self._cfg()
+        without_block = compute_fingerprint(cfg, self.REF_ELOS, self.DIST, resolved_global_config={})
+        empty_block = compute_fingerprint(cfg, self.REF_ELOS, self.DIST, resolved_global_config={"multistage": {}})
+        assert without_block == empty_block

--- a/resources_servers/gdpval/transport_assignment.py
+++ b/resources_servers/gdpval/transport_assignment.py
@@ -1,0 +1,481 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic provider-free repair for transport-incompatible GDPVal pairs."""
+
+from __future__ import annotations
+
+import hashlib
+import heapq
+import json
+import math
+import os
+import stat
+import zipfile
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping, Sequence, Tuple
+
+
+_BINARY_EXTENSIONS = {
+    ".pdf",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".bmp",
+    ".tif",
+    ".tiff",
+    ".wav",
+    ".wave",
+    ".flac",
+    ".mp3",
+    ".m4a",
+    ".aac",
+    ".ogg",
+    ".aif",
+    ".aiff",
+    ".mp4",
+    ".mov",
+    ".mkv",
+    ".webm",
+    ".avi",
+}
+_AV_EXTENSIONS = {
+    ".wav",
+    ".wave",
+    ".flac",
+    ".mp3",
+    ".m4a",
+    ".aac",
+    ".ogg",
+    ".aif",
+    ".aiff",
+    ".mp4",
+    ".mov",
+    ".mkv",
+    ".webm",
+    ".avi",
+}
+_IGNORED_NAMES = {
+    "finish_params.json",
+    "last_responses.jsonl",
+    "last_responses.jsonl.lock",
+    "last_responses.jsonl.offset",
+}
+
+
+@dataclass(frozen=True)
+class Footprint:
+    raw_bytes: int
+    max_file_bytes: int
+    has_av: bool
+    file_count: int
+
+
+@dataclass(frozen=True)
+class PairCost:
+    compatible: bool
+    wire_bytes: int
+    raw_bytes: int
+    max_file_bytes: int
+    reasons: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _BinaryArtifact:
+    path: Path
+    member: str | None
+    suffix: str
+    size: int
+
+
+def _artifact_sha256(artifact: _BinaryArtifact) -> str:
+    digest = hashlib.sha256()
+    if artifact.member is None:
+        with artifact.path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    else:
+        with zipfile.ZipFile(artifact.path, "r") as archive, archive.open(artifact.member, "r") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _find_gdpval_config(global_config: Mapping[str, Any]) -> Mapping[str, Any]:
+    matches = []
+    for value in global_config.values():
+        if not isinstance(value, Mapping):
+            continue
+        resources = value.get("resources_servers")
+        if not isinstance(resources, Mapping):
+            continue
+        gdpval = resources.get("gdpval")
+        if isinstance(gdpval, Mapping) and gdpval.get("reference_models"):
+            matches.append(gdpval)
+    if len(matches) != 1:
+        raise ValueError(f"expected one GDPVal reference config, found {len(matches)}")
+    return matches[0]
+
+
+def _repeat_dirs(root: Path, task_id: str) -> list[Path]:
+    task = root / f"task_{task_id}"
+    if not task.is_dir():
+        return []
+    repeats = sorted(path for path in task.iterdir() if path.is_dir() and path.name.startswith("repeat_"))
+    return repeats or [task]
+
+
+def _has_valid_finish_marker(repeat_dirs: Sequence[Path]) -> bool:
+    """Whether a reference task has at least one persisted completion marker."""
+    for repeat in repeat_dirs:
+        marker = repeat / "finish_params.json"
+        try:
+            marker_stat = marker.stat()  # Follow the immutable transport-view symlink.
+            if not stat.S_ISREG(marker_stat.st_mode) or marker_stat.st_size > 16 * 1024 * 1024:
+                continue
+            document = json.loads(marker.read_text())
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        # Stirrup writes null for a normal max-turn completion without explicit
+        # finish arguments. Atomic persistence is the completion signal; reject
+        # other JSON shapes and corrupt files.
+        if document is None or isinstance(document, dict):
+            return True
+    return False
+
+
+def _footprint(directory: Path, *, include_reference_files: bool = True) -> Footprint:
+    artifacts: list[_BinaryArtifact] = []
+    # Match app.py exactly: the submission directory and its optional
+    # reference_files directory are built as two semantic sections. Reference
+    # assets recurse below reference_files; candidate run-state subdirectories
+    # are not evidence and must not affect routing.
+    paths = list(directory.iterdir())
+    reference_files = directory / "reference_files"
+    if include_reference_files and reference_files.is_dir():
+        paths.extend(reference_files.rglob("*"))
+    for path in sorted(paths, key=lambda item: item.as_posix()):
+        if not path.is_file() or path.name in _IGNORED_NAMES:
+            continue
+        suffix = path.suffix.lower()
+        if suffix == ".zip":
+            with zipfile.ZipFile(path, "r") as archive:
+                for info in archive.infolist():
+                    member = Path(info.filename.replace("\\", "/"))
+                    if (
+                        info.is_dir()
+                        or member.is_absolute()
+                        or ".." in member.parts
+                        or stat.S_ISLNK(info.external_attr >> 16)
+                    ):
+                        continue
+                    member_suffix = member.suffix.lower()
+                    if member_suffix not in _BINARY_EXTENSIONS:
+                        continue
+                    artifacts.append(
+                        _BinaryArtifact(
+                            path=path,
+                            member=info.filename,
+                            suffix=member_suffix,
+                            size=info.file_size,
+                        )
+                    )
+            continue
+        if suffix not in _BINARY_EXTENSIONS:
+            continue
+        artifacts.append(_BinaryArtifact(path=path, member=None, suffix=suffix, size=path.stat().st_size))
+
+    # A common deliverable layout includes both loose stems and a convenience
+    # ZIP containing those exact stems. The judge renderer retains the bytes
+    # once and labels byte-identical duplicates, so the provider-cap planner
+    # must use the same lossless semantic footprint. Only exact AV payloads are
+    # deduplicated; same-size but different files remain distinct evidence.
+    av_size_counts = Counter(artifact.size for artifact in artifacts if artifact.suffix in _AV_EXTENSIONS)
+    seen_av: set[tuple[int, str]] = set()
+    retained: list[_BinaryArtifact] = []
+    for artifact in artifacts:
+        if artifact.suffix in _AV_EXTENSIONS and av_size_counts[artifact.size] > 1:
+            identity = (artifact.size, _artifact_sha256(artifact))
+            if identity in seen_av:
+                continue
+            seen_av.add(identity)
+        retained.append(artifact)
+
+    raw = sum(artifact.size for artifact in retained)
+    maximum = max((artifact.size for artifact in retained), default=0)
+    count = len(retained)
+    has_av = any(artifact.suffix in _AV_EXTENSIONS for artifact in retained)
+    return Footprint(raw_bytes=raw, max_file_bytes=maximum, has_av=has_av, file_count=count)
+
+
+def _pair_cost(
+    candidate: Footprint,
+    reference: Footprint,
+    *,
+    max_file_bytes: int,
+    max_raw_bytes: int,
+    max_wire_bytes: int,
+    framing_reserve_bytes: int,
+) -> PairCost:
+    raw = candidate.raw_bytes + reference.raw_bytes
+    maximum = max(candidate.max_file_bytes, reference.max_file_bytes)
+    # Audio/video is routed only to Gemini, so its native base64 request is the
+    # binding case. PDF/image-only tasks retain GPT raster and native-PDF paths;
+    # their exact provider request is gated later by the resource server.
+    if not (candidate.has_av or reference.has_av):
+        reasons = ("file_over_cap",) if maximum > max_file_bytes else ()
+        return PairCost(not reasons, raw, raw, maximum, reasons)
+    wire = 4 * math.ceil(raw / 3) + framing_reserve_bytes
+    reasons_list = []
+    if maximum > max_file_bytes:
+        reasons_list.append("file_over_cap")
+    if raw > max_raw_bytes:
+        reasons_list.append("aggregate_raw_over_cap")
+    if wire >= max_wire_bytes:
+        reasons_list.append("serialized_request_over_cap")
+    return PairCost(not reasons_list, wire, raw, maximum, tuple(reasons_list))
+
+
+class _Edge:
+    __slots__ = ("to", "rev", "capacity", "cost")
+
+    def __init__(self, to: int, rev: int, capacity: int, cost: int) -> None:
+        self.to = to
+        self.rev = rev
+        self.capacity = capacity
+        self.cost = cost
+
+
+def _add_edge(graph: list[list[_Edge]], source: int, target: int, capacity: int, cost: int) -> None:
+    graph[source].append(_Edge(target, len(graph[target]), capacity, cost))
+    graph[target].append(_Edge(source, len(graph[source]) - 1, 0, -cost))
+
+
+def _solve_capacity_assignment(
+    task_ids: Sequence[str],
+    reference_ids: Sequence[str],
+    original: Mapping[str, str],
+    costs: Mapping[tuple[str, str], PairCost],
+) -> Dict[str, str]:
+    """Minimum-change min-cost flow with exact original reference capacities."""
+    tasks = sorted(task_ids)
+    references = sorted(reference_ids)
+    capacities = Counter(original.values())
+    maximum_pair_cost = max((pair.wire_bytes for pair in costs.values() if pair.compatible), default=0)
+    change_penalty = (maximum_pair_cost + len(references) + 1) * (len(tasks) + 1)
+
+    source = 0
+    task_base = 1
+    reference_base = task_base + len(tasks)
+    sink = reference_base + len(references)
+    graph: list[list[_Edge]] = [[] for _ in range(sink + 1)]
+    for task_index, task_id in enumerate(tasks):
+        _add_edge(graph, source, task_base + task_index, 1, 0)
+        for reference_index, reference_id in enumerate(references):
+            pair = costs[(task_id, reference_id)]
+            if not pair.compatible:
+                continue
+            changed = reference_id != original[task_id]
+            cost = (change_penalty if changed else 0) + pair.wire_bytes + reference_index
+            _add_edge(graph, task_base + task_index, reference_base + reference_index, 1, cost)
+    for reference_index, reference_id in enumerate(references):
+        _add_edge(graph, reference_base + reference_index, sink, capacities[reference_id], 0)
+
+    potential = [0] * len(graph)
+    flow = 0
+    while flow < len(tasks):
+        infinity = 10**40
+        distance = [infinity] * len(graph)
+        previous_node = [-1] * len(graph)
+        previous_edge = [-1] * len(graph)
+        distance[source] = 0
+        queue: list[tuple[int, int]] = [(0, source)]
+        while queue:
+            current_distance, node = heapq.heappop(queue)
+            if current_distance != distance[node]:
+                continue
+            for edge_index, edge in enumerate(graph[node]):
+                if edge.capacity <= 0:
+                    continue
+                candidate = current_distance + edge.cost + potential[node] - potential[edge.to]
+                if candidate < distance[edge.to]:
+                    distance[edge.to] = candidate
+                    previous_node[edge.to] = node
+                    previous_edge[edge.to] = edge_index
+                    heapq.heappush(queue, (candidate, edge.to))
+        if previous_node[sink] < 0:
+            blocked = sorted(
+                task_id
+                for task_id in tasks
+                if not any(costs[(task_id, reference_id)].compatible for reference_id in references)
+            )
+            raise ValueError(f"no count-preserving transport-compatible assignment; tasks_without_any_route={blocked}")
+        for node, value in enumerate(distance):
+            if value < infinity:
+                potential[node] += value
+        node = sink
+        while node != source:
+            parent = previous_node[node]
+            edge = graph[parent][previous_edge[node]]
+            edge.capacity -= 1
+            graph[node][edge.rev].capacity += 1
+            node = parent
+        flow += 1
+
+    result: Dict[str, str] = {}
+    for task_index, task_id in enumerate(tasks):
+        node = task_base + task_index
+        for edge in graph[node]:
+            if reference_base <= edge.to < sink and edge.capacity == 0:
+                result[task_id] = references[edge.to - reference_base]
+                break
+    if len(result) != len(tasks) or Counter(result.values()) != capacities:
+        raise RuntimeError("transport assignment solver violated its capacity contract")
+    return result
+
+
+def make_assignment_repair(
+    global_config: Mapping[str, Any],
+    config: Mapping[str, Any],
+) -> Callable[[int, Sequence[str], Mapping[str, str]], tuple[Dict[str, str], Dict[str, Any]]]:
+    """Bind filesystem roots and return the multistage plan-repair callback."""
+    gdpval = _find_gdpval_config(global_config)
+    candidate_root = Path(
+        str(gdpval.get("persist_deliverables_dir") or os.environ.get("PERSIST_DELIVERABLES_DIR", ""))
+    )
+    if not candidate_root.is_dir():
+        raise ValueError(f"candidate transport view is unreadable: {candidate_root}")
+    all_references = {
+        str(reference_id): Path(str(reference_config["deliverables_dir"]))
+        for reference_id, reference_config in (gdpval.get("reference_models") or {}).items()
+        if isinstance(reference_config, Mapping)
+    }
+    if not all_references or any(not path.is_dir() for path in all_references.values()):
+        raise ValueError("one or more reference transport views are unreadable")
+
+    max_file_bytes = int(config.get("max_file_bytes", 320 * 1024 * 1024))
+    max_raw_bytes = int(config.get("max_raw_bytes", 315 * 1024 * 1024))
+    max_wire_bytes = int(config.get("max_wire_bytes", 420 * 1024 * 1024))
+    framing_reserve_bytes = int(config.get("framing_reserve_bytes", 4 * 1024 * 1024))
+    footprint_cache: dict[tuple[str, str, bool, bool], list[Footprint]] = {}
+
+    def footprints(
+        root: Path,
+        task_id: str,
+        *,
+        require_completed_reference: bool = False,
+        include_reference_files: bool = False,
+    ) -> list[Footprint]:
+        key = (str(root), task_id, require_completed_reference, include_reference_files)
+        if key not in footprint_cache:
+            directories = _repeat_dirs(root, task_id)
+            if not directories:
+                if require_completed_reference:
+                    return []
+                raise ValueError(f"missing transport deliverable: {root}/task_{task_id}")
+            if require_completed_reference and not _has_valid_finish_marker(directories):
+                return []
+            footprint_cache[key] = [
+                _footprint(directory, include_reference_files=include_reference_files) for directory in directories
+            ]
+        return footprint_cache[key]
+
+    def repair(
+        stage_index: int,
+        reference_ids: Sequence[str],
+        original: Mapping[str, str],
+    ) -> tuple[Dict[str, str], Dict[str, Any]]:
+        references = sorted(str(reference_id) for reference_id in reference_ids)
+        missing = sorted(set(references) - set(all_references))
+        if missing:
+            raise ValueError(f"stage selected unknown reference transport views: {missing}")
+        costs: dict[tuple[str, str], PairCost] = {}
+        for task_id in sorted(original):
+            candidates = footprints(candidate_root, task_id)
+            for reference_id in references:
+                references_for_task = footprints(
+                    all_references[reference_id],
+                    task_id,
+                    require_completed_reference=True,
+                    include_reference_files=True,
+                )
+                if not references_for_task:
+                    costs[(task_id, reference_id)] = PairCost(
+                        compatible=False,
+                        wire_bytes=0,
+                        raw_bytes=0,
+                        max_file_bytes=0,
+                        reasons=("reference_incomplete",),
+                    )
+                    continue
+                combinations = [
+                    _pair_cost(
+                        candidate,
+                        reference,
+                        max_file_bytes=max_file_bytes,
+                        max_raw_bytes=max_raw_bytes,
+                        max_wire_bytes=max_wire_bytes,
+                        framing_reserve_bytes=framing_reserve_bytes,
+                    )
+                    for candidate in candidates
+                    for reference in references_for_task
+                ]
+                # One assignment must work for every candidate/reference repeat.
+                incompatible = [pair for pair in combinations if not pair.compatible]
+                if incompatible:
+                    worst = max(incompatible, key=lambda pair: (pair.wire_bytes, pair.raw_bytes))
+                    costs[(task_id, reference_id)] = worst
+                else:
+                    costs[(task_id, reference_id)] = max(
+                        combinations,
+                        key=lambda pair: (pair.wire_bytes, pair.raw_bytes),
+                    )
+
+        repaired = _solve_capacity_assignment(list(original), references, original, costs)
+        changes = []
+        for task_id in sorted(original):
+            before = original[task_id]
+            after = repaired[task_id]
+            if before != after:
+                before_cost = costs[(task_id, before)]
+                after_cost = costs[(task_id, after)]
+                changes.append(
+                    {
+                        "task_id": task_id,
+                        "before": before,
+                        "after": after,
+                        "before_compatible": before_cost.compatible,
+                        "before_reasons": list(before_cost.reasons),
+                        "before_wire_bytes": before_cost.wire_bytes,
+                        "after_wire_bytes": after_cost.wire_bytes,
+                    }
+                )
+        initially_incompatible = [
+            {
+                "task_id": task_id,
+                "reference_id": original[task_id],
+                "reasons": list(costs[(task_id, original[task_id])].reasons),
+            }
+            for task_id in sorted(original)
+            if not costs[(task_id, original[task_id])].compatible
+        ]
+        receipt = {
+            "schema": "gdpval.transport-assignment-repair.v1",
+            "stage_index": stage_index,
+            "policy": "minimum changed tasks; exact selected-reference counts; provider-free",
+            "limits": {
+                "max_file_bytes": max_file_bytes,
+                "max_raw_bytes": max_raw_bytes,
+                "max_wire_bytes": max_wire_bytes,
+                "framing_reserve_bytes": framing_reserve_bytes,
+            },
+            "reference_counts": dict(sorted(Counter(original.values()).items())),
+            "initially_incompatible": initially_incompatible,
+            "changes": changes,
+        }
+        return repaired, receipt
+
+    return repair


### PR DESCRIPTION
Ports the per-provider judge transport layer, executed and validated in a full 220-task GDPVal evaluation campaign, onto the production-hardening branch.

## Changes

- Per-judge media transport modes: `native_pdf`, `images_and_text`, and `native_pdf_overflow_images` (native PDFs kept; over-cap PDFs rasterized at a pinned DPI with every page retained).
- Provider-specific request limits as judge-panel config: serialized-request bytes, native-PDF page/document/byte caps (aggregate and per-document), video count, raster DPI tiers.
- Per-document native-PDF cap (`max_native_pdf_bytes_per_document`) forces lossless full rasterization of any PDF above the provider's per-file limit; page-count overflow rasterizes only the required prefix, keeping the suffix native.
- Deterministic transport eligibility preflight before any billable call, with seeded schedule replay; exclusions recorded per row (`media_routing_exclusions`, `transport_by_judge`).
- Overflow eligibility also enforces the judge's aggregate document/byte caps against the post-overflow native remainder, and a render page cap so a plan the renderer cannot satisfy is excluded at preflight instead of failing at dispatch.
- New `transport_assignment.py`: provider-free task/reference reassignment repair using exact artifact footprints against provider caps.
- `transport_assignment_repair` settings enter the multistage fingerprint, so changing them invalidates journals instead of silently replaying stale plans on resume.
- Final verdict reminder block appended to judge messages; the text budget's framing reserve includes its serialized upper bound so the request-size invariant holds at any configured cap.

## Validation

- `resources_servers/gdpval/tests`: 379 passed, 3 skipped, including 16 new tests in `test_transport_modes.py` (overflow planning/application, eligibility receipts, seeded replay, assignment solver capacity contract, fingerprint invalidation).
- `ruff check` / `ruff format` clean.
- Same code path that produced a strict 220/220-task, 880/880-trial judging PASS in the validating campaign, rebased onto this branch.

First of four planned child PRs (media caps/tiling, provider timeout/retry hardening, transport receipts follow). Draft until the example three-provider judge panel config lands.
