### PR TITLE
fix(genrm): make cohort retries failure-safe

### DIFF
--- a/resources_servers/genrm_compare/app.py
+++ b/resources_servers/genrm_compare/app.py
@@ -32,10 +32,11 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import defaultdict
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import FastAPI
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 from nemo_gym.base_resources_server import (
     BaseResourcesServerConfig,
@@ -61,10 +62,40 @@ from resources_servers.genrm_compare.utils import (
 
 logger = logging.getLogger(__name__)
 
-# Cohort state for verify(): buffer by prompt_key until num_rollouts_per_prompt received (Difference 1)
-_cohort_lock: asyncio.Lock = asyncio.Lock()
-_cohort_buffers: Dict[str, List[Tuple[Any, asyncio.Future]]] = defaultdict(list)
-_cohort_jit_buffers: Dict[str, Tuple[List[float, float, float], List[int, int, int]]] = defaultdict(lambda: ([], []))
+
+@dataclass
+class _VerifyCohortState:
+    """Mutable state for one prompt cohort."""
+
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    buffer: List[Tuple[Any, asyncio.Future[float]]] = field(default_factory=list)
+    comparison_results: List[Tuple[float, float, float]] = field(default_factory=list)
+    comparison_metadata: List[Tuple[int, int, int]] = field(default_factory=list)
+    completed_rewards: Dict[int, float] = field(default_factory=dict)
+
+
+def _fail_pending_cohort(prompt_key: str, state: _VerifyCohortState, error: BaseException) -> None:
+    """Clear partial state and unblock every request waiting on this cohort."""
+    cohort_buffer = state.buffer
+    state.buffer = []
+    state.comparison_results = []
+    state.comparison_metadata = []
+
+    for _, future in cohort_buffer:
+        if future.done():
+            continue
+        if isinstance(error, asyncio.CancelledError):
+            future.cancel()
+        else:
+            future.set_exception(
+                RuntimeError(
+                    f"GenRM cohort {prompt_key!r} failed while computing rewards: {type(error).__name__}: {error}"
+                )
+            )
+            # A request may have disconnected before this cohort failed. Mark
+            # the exception retrieved to avoid an unobserved-future warning;
+            # active waiters still receive the exception when they await it.
+            future.exception()
 
 
 class GenRMCompareConfig(BaseResourcesServerConfig):
@@ -203,6 +234,13 @@ class GenRMCompareResourcesServer(SimpleResourcesServer):
     """
 
     config: GenRMCompareConfig
+    # A verify request can be retried after the server has accepted it (for
+    # example, when the HTTP connection drops before the cohort reward is
+    # returned). Keep each cohort's mutation serialized and remember completed
+    # rollout rewards for the lifetime of this server process.
+    _verify_cohorts: Dict[str, _VerifyCohortState] = PrivateAttr(
+        default_factory=lambda: defaultdict(_VerifyCohortState)
+    )
 
     async def verify(self, body: GenRMCompareVerifyRequest) -> BaseVerifyResponse:
         """Verify a single rollout. When num_rollouts_per_prompt > 1, buffers by prompt and runs comparison when cohort is full."""
@@ -221,60 +259,99 @@ class GenRMCompareResourcesServer(SimpleResourcesServer):
             input_messages if isinstance(input_messages, list) else list(input_messages),
             principle,
         )
-        future: asyncio.Future[float] = asyncio.get_running_loop().create_future()
+        state = self._verify_cohorts[prompt_key]
+        future: asyncio.Future[float] | None = None
+        completed_reward: float | None = None
 
-        _cohort_buffers[prompt_key].append((body, future))
+        async with state.lock:
+            if body.rollout_index is not None:
+                completed_reward = state.completed_rewards.get(body.rollout_index)
+                if completed_reward is None:
+                    for existing_body, existing_future in state.buffer:
+                        if existing_body.rollout_index == body.rollout_index:
+                            future = existing_future
+                            break
 
-        conversation_history = _input_to_conversation_history(getattr(body.responses_create_params, "input", []) or [])
-        buf = _cohort_buffers[prompt_key]
-        response_objs = [
-            (b.response.model_dump() if hasattr(b.response, "model_dump") else b.response) for b, _ in buf
-        ]
-        principle_val = getattr(body, "principle", None) or principle
+            if completed_reward is None and future is None:
+                future = asyncio.get_running_loop().create_future()
+                state.buffer.append((body, future))
 
-        existing_results, existing_metadata = _cohort_jit_buffers[prompt_key]
-        new_results, new_metadata = await self._run_jit_compare_using_most_recent_response_obj(
-            conversation_history, response_objs, existing_metadata, principle_val
-        )
-        existing_results.extend(new_results)
-        existing_metadata.extend(new_metadata)
+                try:
+                    conversation_history = _input_to_conversation_history(
+                        getattr(body.responses_create_params, "input", []) or []
+                    )
+                    response_objs = [
+                        (
+                            cohort_body.response.model_dump()
+                            if hasattr(cohort_body.response, "model_dump")
+                            else cohort_body.response
+                        )
+                        for cohort_body, _ in state.buffer
+                    ]
+                    principle_val = getattr(body, "principle", None) or principle
 
-        cohort_ready = False
-        if len(response_objs) >= cfg.num_rollouts_per_prompt:
-            assert len(response_objs) == cfg.num_rollouts_per_prompt
-            cohort_ready = True
+                    new_results, new_metadata = await self._run_jit_compare_using_most_recent_response_obj(
+                        conversation_history,
+                        response_objs,
+                        state.comparison_metadata,
+                        principle_val,
+                    )
+                    state.comparison_results.extend(new_results)
+                    state.comparison_metadata.extend(new_metadata)
 
-        # Only run for the final response
-        if cohort_ready:
-            existing_results, existing_metadata = _cohort_jit_buffers.pop(prompt_key)
+                    if len(response_objs) == cfg.num_rollouts_per_prompt:
+                        sorted_results = sorted(
+                            zip(state.comparison_results, state.comparison_metadata),
+                            key=lambda pair: (pair[1][2], pair[1][0], pair[1][1]),
+                        )
+                        comparison_results, comparison_metadata = zip(*sorted_results)
 
-            # Sort to match the ordering of the original `_run_compare` logic
-            existing_results, existing_metadata = zip(
-                *sorted(
-                    zip(existing_results, existing_metadata), key=lambda pair: (pair[1][2], pair[1][0], pair[1][1])
-                )
-            )
+                        rewards, _, _, _ = aggregate_scores(
+                            comparison_results=comparison_results,
+                            comparison_metadata=comparison_metadata,
+                            response_objs=response_objs,
+                            aggregator_method=cfg.aggregator_method,
+                            default_score=cfg.default_score,
+                            reasoning_bonus=cfg.reasoning_bonus,
+                            answer_bonus=cfg.answer_bonus,
+                            top_percentile=cfg.top_percentile,
+                            group_reasoning_length_penalty_coeff=cfg.group_reasoning_length_penalty_coeff,
+                            group_answer_length_penalty_coeff=cfg.group_answer_length_penalty_coeff,
+                            group_style_penalty_coeff=cfg.group_style_penalty_coeff,
+                        )
+                        if len(rewards) != len(state.buffer):
+                            raise RuntimeError(
+                                f"GenRM cohort {prompt_key!r} produced {len(rewards)} rewards "
+                                f"for {len(state.buffer)} rollouts"
+                            )
 
-            rewards, _, _, _ = aggregate_scores(
-                comparison_results=existing_results,
-                comparison_metadata=existing_metadata,
-                response_objs=response_objs,
-                aggregator_method=cfg.aggregator_method,
-                default_score=cfg.default_score,
-                reasoning_bonus=cfg.reasoning_bonus,
-                answer_bonus=cfg.answer_bonus,
-                top_percentile=cfg.top_percentile,
-                group_reasoning_length_penalty_coeff=cfg.group_reasoning_length_penalty_coeff,
-                group_answer_length_penalty_coeff=cfg.group_answer_length_penalty_coeff,
-                group_style_penalty_coeff=cfg.group_style_penalty_coeff,
-            )
+                        cohort_buffer = state.buffer
+                        state.buffer = []
+                        state.comparison_results = []
+                        state.comparison_metadata = []
+                        for reward, (cohort_body, cohort_future) in zip(rewards, cohort_buffer):
+                            if cohort_body.rollout_index is not None:
+                                state.completed_rewards[cohort_body.rollout_index] = reward
+                            if not cohort_future.done():
+                                cohort_future.set_result(reward)
+                    elif len(response_objs) > cfg.num_rollouts_per_prompt:
+                        raise RuntimeError(
+                            f"GenRM cohort {prompt_key!r} exceeded its configured size "
+                            f"({len(response_objs)} > {cfg.num_rollouts_per_prompt})"
+                        )
+                except asyncio.CancelledError as error:
+                    _fail_pending_cohort(prompt_key, state, error)
+                    raise
+                except Exception as error:
+                    _fail_pending_cohort(prompt_key, state, error)
+                    raise
 
-            cohort_buf = _cohort_buffers.pop(prompt_key)
-            for i, (_, f) in enumerate(cohort_buf):
-                if not f.done():
-                    f.set_result(rewards[i])
-
-        reward = await future
+        if completed_reward is not None:
+            reward = completed_reward
+        else:
+            assert future is not None
+            # A disconnected duplicate waiter must not cancel the shared cohort result.
+            reward = await asyncio.shield(future)
         return BaseVerifyResponse(
             responses_create_params=body.responses_create_params,
             response=body.response,

--- a/resources_servers/genrm_compare/tests/test_app.py
+++ b/resources_servers/genrm_compare/tests/test_app.py
@@ -189,6 +189,57 @@ class TestGenRMCompareResourcesServer:
             f"prompt_id::prompt-123::{prompt_hash}"
         )
 
+    def _make_cohort_server(self) -> GenRMCompareResourcesServer:
+        config = GenRMCompareConfig(
+            host="localhost",
+            port=8000,
+            entrypoint="app.py",
+            domain="rlhf",
+            name="genrm_compare",
+            genrm_model_server=ModelServerRef(type="responses_api_models", name="genrm_model"),
+            genrm_responses_create_params=NeMoGymResponseCreateParamsNonStreaming(input=[], max_output_tokens=1024),
+            comparison_strategy="circular",
+            num_judges_per_comparison=1,
+            num_rollouts_per_prompt=2,
+        )
+        return GenRMCompareResourcesServer.model_construct(config=config, server_client=MagicMock())
+
+    def _make_verify_request(self, rollout_index: int, response_id: str) -> GenRMCompareVerifyRequest:
+        return GenRMCompareVerifyRequest.model_validate(
+            {
+                "responses_create_params": {
+                    "input": [{"role": "user", "content": "hello"}],
+                },
+                "response": {
+                    "id": response_id,
+                    "created_at": 0.0,
+                    "model": "dummy_model",
+                    "tools": [],
+                    "parallel_tool_calls": True,
+                    "tool_choice": "auto",
+                    "output": [],
+                    "object": "response",
+                },
+                TASK_INDEX_KEY_NAME: 7,
+                ROLLOUT_INDEX_KEY_NAME: rollout_index,
+            }
+        )
+
+    @staticmethod
+    async def _successful_jit_compare(*args, **kwargs):
+        response_objs = args[1]
+        if len(response_objs) == 1:
+            return [], []
+        return [(1.0, 2.0, 4.0)], [(0, 1, 0)]
+
+    @staticmethod
+    def _mock_rewards(monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            resources_servers.genrm_compare.app,
+            "aggregate_scores",
+            MagicMock(return_value=([0.25, 0.75], {}, [], [])),
+        )
+
     async def test_run_jit_compare_using_most_recent_response_obj(self, monkeypatch: MonkeyPatch) -> None:
         config = GenRMCompareConfig(
             host="localhost",
@@ -365,6 +416,122 @@ class TestGenRMCompareResourcesServer:
         expected_rewards = golden_rewards
         actual_rewards = [r.reward for r in results]
         assert expected_rewards == actual_rewards
+
+    async def test_verify_duplicate_rollout_is_idempotent(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._make_cohort_server()
+        monkeypatch.setattr(
+            server,
+            "_run_jit_compare_using_most_recent_response_obj",
+            self._successful_jit_compare,
+        )
+        self._mock_rewards(monkeypatch)
+
+        first = asyncio.create_task(server.verify(self._make_verify_request(0, "response-0")))
+        await asyncio.sleep(0)
+        duplicate = asyncio.create_task(server.verify(self._make_verify_request(0, "response-0-retry")))
+        await asyncio.sleep(0)
+        second = asyncio.create_task(server.verify(self._make_verify_request(1, "response-1")))
+
+        first_result, duplicate_result, second_result = await asyncio.gather(first, duplicate, second)
+        assert first_result.reward == duplicate_result.reward == 0.25
+        assert second_result.reward == 0.75
+
+        completed_retry = await server.verify(self._make_verify_request(0, "response-0-late-retry"))
+        assert completed_retry.reward == 0.25
+
+    async def test_verify_jit_failure_clears_pending_cohort_for_retry(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._make_cohort_server()
+        should_fail = True
+
+        async def run_jit_compare(*args, **kwargs):
+            if len(args[1]) == 1:
+                return [], []
+            if should_fail:
+                raise RuntimeError("judge failed")
+            return await self._successful_jit_compare(*args, **kwargs)
+
+        monkeypatch.setattr(server, "_run_jit_compare_using_most_recent_response_obj", run_jit_compare)
+        self._mock_rewards(monkeypatch)
+
+        first = asyncio.create_task(server.verify(self._make_verify_request(0, "response-0")))
+        await asyncio.sleep(0)
+        with pytest.raises(RuntimeError, match="judge failed"):
+            await server.verify(self._make_verify_request(1, "response-1"))
+        with pytest.raises(RuntimeError, match="GenRM cohort.*judge failed"):
+            await asyncio.wait_for(first, timeout=1)
+
+        state = next(iter(server._verify_cohorts.values()))
+        assert state.buffer == []
+        assert state.comparison_results == []
+        assert state.comparison_metadata == []
+
+        should_fail = False
+        retried = await asyncio.gather(
+            server.verify(self._make_verify_request(0, "response-0-retry")),
+            server.verify(self._make_verify_request(1, "response-1-retry")),
+        )
+        assert [result.reward for result in retried] == [0.25, 0.75]
+
+    async def test_verify_jit_cancellation_clears_pending_cohort_for_retry(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._make_cohort_server()
+        judge_started = asyncio.Event()
+
+        async def blocked_jit_compare(*args, **kwargs):
+            if len(args[1]) == 1:
+                return [], []
+            judge_started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(server, "_run_jit_compare_using_most_recent_response_obj", blocked_jit_compare)
+        self._mock_rewards(monkeypatch)
+
+        first = asyncio.create_task(server.verify(self._make_verify_request(0, "response-0")))
+        await asyncio.sleep(0)
+        final = asyncio.create_task(server.verify(self._make_verify_request(1, "response-1")))
+        await asyncio.wait_for(judge_started.wait(), timeout=1)
+        final.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await final
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(first, timeout=1)
+
+        state = next(iter(server._verify_cohorts.values()))
+        assert state.buffer == []
+        assert state.comparison_results == []
+        assert state.comparison_metadata == []
+
+        monkeypatch.setattr(
+            server,
+            "_run_jit_compare_using_most_recent_response_obj",
+            self._successful_jit_compare,
+        )
+        retried = await asyncio.gather(
+            server.verify(self._make_verify_request(0, "response-0-retry")),
+            server.verify(self._make_verify_request(1, "response-1-retry")),
+        )
+        assert [result.reward for result in retried] == [0.25, 0.75]
+
+    async def test_cancelled_duplicate_does_not_cancel_shared_reward(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._make_cohort_server()
+        monkeypatch.setattr(
+            server,
+            "_run_jit_compare_using_most_recent_response_obj",
+            self._successful_jit_compare,
+        )
+        self._mock_rewards(monkeypatch)
+
+        first = asyncio.create_task(server.verify(self._make_verify_request(0, "response-0")))
+        await asyncio.sleep(0)
+        duplicate = asyncio.create_task(server.verify(self._make_verify_request(0, "response-0-retry")))
+        await asyncio.sleep(0)
+        duplicate.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await duplicate
+
+        second = asyncio.create_task(server.verify(self._make_verify_request(1, "response-1")))
+        first_result, second_result = await asyncio.gather(first, second)
+        assert first_result.reward == 0.25
+        assert second_result.reward == 0.75
 
 
 class TestRunSingleComparison:


### PR DESCRIPTION
## Summary

- serialize mutations independently for each GenRM verification cohort
- deduplicate in-flight requests by task-scoped rollout index and cache completed rewards
- atomically clear partial cohort state and settle every pending future after judge/aggregation failure or cancellation
- shield shared cohort futures so a disconnected duplicate waiter cannot cancel the underlying reward

## Why

A rollout may be delivered again after the server accepted the original request. Treating that retry as a new response can overfill a configured cohort. Deduplicating the happy path prevents the extra member, but an exception or cancellation while computing JIT judge results can otherwise leave unresolved futures in the cohort. Later retries then attach to a future that can never complete.

This change makes both success and failure idempotent. Successful rewards remain cached for the server process lifetime. Failed or cancelled cohort computations clear their partial response/comparison state, unblock all current waiters, and allow a clean retry.

## Failure semantics

- judge or aggregation exception: clear the partial cohort and fail all waiters
- request cancellation during cohort computation: clear the partial cohort and cancel all waiters
- duplicate waiter cancellation: preserve the shared computation with asyncio.shield
- retry after failure/cancellation: build a fresh cohort and complete normally

## Validation

- 63 tests passed under resources_servers/genrm_compare/tests
- added coverage for in-flight and completed duplicates, judge exceptions, owner cancellation, retry recovery, and duplicate-waiter cancellation
- Ruff 0.12.11 format/lint passed
- scoped pre-commit hooks passed
