### PR TITLE
fix(swerl_gen): gen_eval_scripts.py always exits with TypeError (no --image-dir option)

### DIFF
--- a/resources_servers/swerl_gen/gen_eval_scripts.py
+++ b/resources_servers/swerl_gen/gen_eval_scripts.py
@@ -143,6 +143,12 @@ def parse_args() -> argparse.Namespace:
         default=str(default_output_dir),
         help="Directory where generated shell scripts will be written (default: %(default)s).",
     )
+    parser.add_argument(
+        "--image-dir",
+        type=str,
+        required=True,
+        help="Path to the directory containing the singularity images.",
+    )
 
     return parser.parse_args()
 
@@ -154,6 +160,7 @@ def main() -> None:
         dataset_name=args.dataset_name,
         dataset_split=args.dataset_split,
         output_dir=output_dir,
+        image_dir=args.image_dir,
     )
 
 


### PR DESCRIPTION
## Problem

`resources_servers/swerl_gen/gen_eval_scripts.py` cannot be run at all. `process_dataset` requires `image_dir`:

```python
def process_dataset(dataset_name: str, dataset_split: str, output_dir: Path, image_dir: str) -> None:
    ...
        if not os.path.exists(f"{image_dir}/{image_path}.sif"):
            continue
```

but `main()` never passes it, and `parse_args()` has no option that could supply it:

```python
def main() -> None:
    args = parse_args()
    output_dir = Path(args.output_dir)
    process_dataset(
        dataset_name=args.dataset_name,
        dataset_split=args.dataset_split,
        output_dir=output_dir,
    )
```

So `python gen_eval_scripts.py` fails before it loads anything:

```
TypeError: process_dataset() missing 1 required positional argument: 'image_dir'
```

## Fix

The sibling script in the same directory, `dataset_preprocess.py`, already consumes the same value and shows the intended shape:

```python
parser.add_argument(
    "--image_dir", type=str, required=True, help="Path to the directory containing the singularity images"
)
...
    image_dir=args.image_dir,
```

This adds the matching option to `gen_eval_scripts.py` (spelled `--image-dir` to match the hyphenated `--dataset-name` / `--dataset-split` / `--output-dir` options already in this file) and forwards it. `required=True` matches the sibling and is correct here: `image_dir` has no sensible default, and every instance is skipped unless the `.sif` image is found under it.

## Verification

No SWE-Gym images available locally, so I verified two ways.

**End-to-end**, executing the real module with `datasets` / `tqdm` / `swebench` stubbed and `load_dataset` instrumented to announce if it is reached:

```
TypeError BEFORE any dataset work: process_dataset() missing 1 required positional argument: 'image_dir'
```

The crash happens before `load_dataset` is ever called, confirming this is not reachable only on some data-dependent path.

**Signature replay**, binding the real call site against a stub extracted from the file with `ast`:

```
### NVIDIA-NeMo/Gym  gen_eval_scripts.process_dataset
  signature: (dataset_name, dataset_split, output_dir, image_dir)
  RAISE line 153 (flagged, main): TypeError: missing a required argument: 'image_dir'
  OK    proposed fix
```

`ruff check`, `ruff check --select I` and `ruff format --check` (v0.9.9, the `.pre-commit-config.yaml` pin) all pass on the modified file, run from the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
