### PR TITLE
[Unvalidated] Terminus 2

### DIFF
--- a/benchmarks/nemotron_3.5_super/eval_container_config.yaml
+++ b/benchmarks/nemotron_3.5_super/eval_container_config.yaml
@@ -9,11 +9,10 @@ config_paths:
 - benchmarks/swebench/verified/opencode.yaml
 - benchmarks/swebench/multilingual/opencode.yaml
 - benchmarks/deepswe/opencode.yaml
-- benchmarks/terminal_bench_2_1/opencode.yaml
+- benchmarks/terminal_bench_2_1/terminus_2.yaml
 - benchmarks/swebench/pro/opencode.yaml
 - responses_api_models/vllm_model/configs/vllm_model.yaml
-# - nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml
-# SWE Bench Pro
+- benchmarks/nemotron_3.5_super/sandbox_utils.yaml
 
 ########################################
 # START Secrets
@@ -109,9 +108,9 @@ opencode_sandboxed_agent_deepswe:
   responses_api_agents:
     opencode_sandboxed_agent:
       datasets: []
-opencode_sandboxed_agent_terminal_bench_2_1:
+terminus_2_sandboxed_agent_terminal_bench_2_1:
   responses_api_agents:
-    opencode_sandboxed_agent:
+    terminus_2_sandboxed_agent:
       datasets: []
 opencode_sandboxed_agent_swebench_pro:
   responses_api_agents:

--- a/benchmarks/nemotron_3.5_super/eval_container_config_with_staged.yaml
+++ b/benchmarks/nemotron_3.5_super/eval_container_config_with_staged.yaml
@@ -32,9 +32,9 @@ opencode_sandboxed_agent_deepswe:
           prepare_script: benchmarks/deepswe/prepare.py
           num_repeats: 5
 
-opencode_sandboxed_agent_terminal_bench_2_1:
+terminus_2_sandboxed_agent_terminal_bench_2_1:
   responses_api_agents:
-    opencode_sandboxed_agent:
+    terminus_2_sandboxed_agent:
       datasets:
         - name: terminal_bench_2_1
           type: benchmark

--- a/benchmarks/terminal_bench_2_1/terminus_2.yaml
+++ b/benchmarks/terminal_bench_2_1/terminus_2.yaml
@@ -1,0 +1,21 @@
+config_paths:
+- responses_api_agents/terminus_2_sandboxed_agent/configs/terminus_2_sandboxed_agent.yaml
+- resources_servers/terminal_bench_2_1/configs/terminal_bench_2_1.yaml
+
+
+terminus_2_sandboxed_terminal_bench_2_1_resources_server:
+  _inherit_from: terminal_bench_2_1_resources_server
+
+terminus_2_sandboxed_agent_terminal_bench_2_1:
+  _inherit_from: terminus_2_sandboxed_agent
+  responses_api_agents:
+    terminus_2_sandboxed_agent:
+      resources_server:
+        type: resources_servers
+        name: terminus_2_sandboxed_terminal_bench_2_1_resources_server
+      datasets:
+        - name: terminal_bench_2_1
+          type: benchmark
+          jsonl_fpath: benchmarks/terminal_bench_2_1/data/benchmark.jsonl
+          prepare_script: benchmarks/terminal_bench_2_1/prepare.py
+          num_repeats: 8

--- a/responses_api_agents/terminus_2_sandboxed_agent/README.md
+++ b/responses_api_agents/terminus_2_sandboxed_agent/README.md
@@ -1,0 +1,39 @@
+# Harbor Terminus 2 Agent
+
+This agent runs Harbor's `Terminus2` control loop in the task sandbox supplied by
+the NeMo Gym resources server. It adapts the small Harbor environment interface
+that Terminus uses (`exec` and `is_dir`) to `AsyncSandbox`; task state therefore
+remains owned by the resources server.
+
+```bash
+gym env start \
+    --config responses_api_models/vllm_model/configs/vllm_model.yaml \
+    --config nemo_gym/sandbox/providers/opensandbox/configs/opensandbox.yaml \
+    --config responses_api_agents/terminus_2_sandboxed_agent/configs/terminus_2_sandboxed_agent.yaml \
+    --config resources_servers/swebench/configs/swebench.yaml
+```
+
+To run one row from a benchmark JSONL after starting the servers:
+
+```bash
+python responses_api_agents/terminus_2_sandboxed_agent/client.py \
+    +benchmark_jsonl=benchmarks/swebench/data/swebench_verified_benchmark.jsonl
+```
+
+The agent calls the configured model server exclusively through the Responses
+API. Its returned response contains every model request and response from the
+Terminus trajectory. Set `dump_trajectory: true` to also have Harbor write its
+per-turn JSON trajectory files; it is `false` by default.
+
+## Download and mount Tmux binary
+```bash
+curl -fL \
+  -o tmux-3.7c-linux-x86_64.tar.gz \
+  https://github.com/tmux/tmux-builds/releases/download/v3.7c/tmux-3.7c-linux-x86_64.tar.gz
+tar -xzf tmux-3.7c-linux-x86_64.tar.gz
+mv tmux tmux-3.7c-linux-x86_64
+
+# e.g. copy to mounted S3 bucket
+aws s3 cp tmux-3.7c-linux-x86_64 \
+  s3://tmux/tmux-3.7c-linux-x86_64
+```

--- a/responses_api_agents/terminus_2_sandboxed_agent/__init__.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/responses_api_agents/terminus_2_sandboxed_agent/app.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/app.py
@@ -1,0 +1,393 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+import logging
+import sys
+import tempfile
+from pathlib import Path
+from time import time
+from traceback import format_exc
+from types import SimpleNamespace
+from typing import Any, Optional, Tuple
+from uuid import uuid4
+
+from fastapi import Request
+from harbor.agents.terminus_2 import Terminus2
+from harbor.llms.base import BaseLLM, LLMResponse
+from harbor.models.agent.context import AgentContext
+from harbor.models.metric.usage_info import UsageInfo
+from harbor.utils.logger import logger as harbor_logger
+from pydantic import ConfigDict, Field
+
+from nemo_gym.base_resources_server import BaseRunRequest, BaseVerifyRequest, BaseVerifyResponse
+from nemo_gym.base_responses_api_agent import BaseResponsesAPIAgentConfig, SimpleResponsesAPIAgent
+from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
+from nemo_gym.global_config import get_global_config_dict
+from nemo_gym.openai_utils import (
+    NeMoGymAsyncOpenAI,
+    NeMoGymEasyInputMessage,
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseInputTokensDetails,
+    NeMoGymResponseOutputItem,
+    NeMoGymResponseOutputMessage,
+    NeMoGymResponseOutputText,
+    NeMoGymResponseOutputTokensDetails,
+    NeMoGymResponseReasoningItem,
+    NeMoGymResponseUsage,
+)
+from nemo_gym.sandbox import AsyncSandbox, create_provider
+from nemo_gym.sandbox.config import resolve_provider_config
+from nemo_gym.sandbox.providers.base import SandboxPtySession
+from nemo_gym.server_utils import (
+    SESSION_ID_KEY,
+    get_response_json,
+    get_server_url,
+    is_nemo_gym_fastapi_entrypoint,
+    raise_for_status,
+)
+
+
+class Terminus2AgentConfig(BaseResponsesAPIAgentConfig):
+    resources_server: ResourcesServerRef
+    model_server: ModelServerRef
+    max_turns: int | None
+    parser_name: str = "json"
+    enable_summarize: bool
+    proactive_summarization_threshold: int
+    tmux_pane_width: int
+    tmux_pane_height: int
+    dump_trajectory: bool = False
+    debug: bool = False
+    model_context_limit: int = 1_000_000
+    model_output_limit: int | None = None
+
+    sandbox_provider: str
+    sandbox_config: dict[str, Any] = Field(default_factory=dict)
+    sandbox_timeout: float
+    remote_tmux_binary_path: Optional[str]
+
+
+class Terminus2AgentRunRequest(BaseRunRequest):
+    model_config = ConfigDict(extra="allow")
+
+
+class Terminus2AgentVerifyRequest(BaseVerifyRequest):
+    model_config = ConfigDict(extra="allow")
+
+
+class Terminus2AgentVerifyResponse(BaseVerifyResponse):
+    model_config = ConfigDict(extra="allow")
+
+    terminus2_completed: bool
+
+
+class NeMoGymSandboxEnvironment:
+    """The Harbor environment surface used by Terminus 2, backed by AsyncSandbox."""
+
+    def __init__(self, sandbox: AsyncSandbox, logs_dir: Path, pty_session: SandboxPtySession, session_id: str):
+        self._sandbox = sandbox
+        self._pty_session = pty_session
+        self.default_user = None
+        self.trial_paths = SimpleNamespace(agent_dir=logs_dir)
+        self.session_id = session_id
+
+    async def exec(
+        self,
+        command: str,
+        timeout_sec: float | None = None,
+        user: str | int | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        **_: Any,
+    ) -> Any:
+        if env is None:
+            result = await self._sandbox.pty.exec(command, session=self._pty_session, timeout_s=timeout_sec, cwd=cwd)
+        else:
+            raise NotImplementedError
+
+        if "new-session" in command:
+            print(f"Created new tmux session for {self.session_id}: {result}", file=sys.stderr)
+
+        return SimpleNamespace(
+            stdout=result.stdout or "",
+            stderr=result.stderr or "",
+            return_code=result.return_code,
+        )
+
+    async def is_dir(self, path: str, user: str | int | None = None) -> bool:
+        result = await self._sandbox.exec(f"test -d {json.dumps(path)}", user=user)
+        return result.return_code == 0
+
+
+def _instruction(input_value: Any) -> str:
+    if isinstance(input_value, str):
+        return input_value
+    messages: list[str] = []
+    for item in input_value or []:
+        value = item.model_dump(mode="json") if hasattr(item, "model_dump") else item
+        if not isinstance(value, dict):
+            messages.append(str(value))
+            continue
+        content = value.get("content", "")
+        if isinstance(content, str):
+            messages.append(content)
+        elif isinstance(content, list):
+            messages.extend(
+                str(part.get("text", "")) for part in content if isinstance(part, dict) and part.get("text")
+            )
+    return "\n\n".join(messages)
+
+
+class NeMoGymLLM(BaseLLM):
+    """Responses-only Harbor LLM adapter backed by NeMo Gym's aiohttp client."""
+
+    def __init__(
+        self,
+        client: NeMoGymAsyncOpenAI,
+        model_name: str,
+        model_context_limit: int,
+        model_output_limit: int | None,
+    ):
+        super().__init__()
+        self._client = client
+        self._model_name = model_name
+        self._model_context_limit = model_context_limit
+        self._model_output_limit = model_output_limit
+        self.trajectory: list[NeMoGymResponseOutputItem] = []
+
+    @staticmethod
+    def _input_items(message_history: list[dict[str, Any]], prompt: str) -> list[NeMoGymEasyInputMessage]:
+        messages = [*message_history, {"role": "user", "content": prompt}]
+        return [
+            NeMoGymEasyInputMessage(role=message.get("role", "user"), content=message.get("content", ""))
+            for message in messages
+        ]
+
+    @staticmethod
+    def _response_text(response: NeMoGymResponse) -> tuple[str, str | None]:
+        content: list[str] = []
+        reasoning: list[str] = []
+        for item in response.output:
+            if isinstance(item, NeMoGymResponseOutputMessage):
+                content.extend(part.text for part in item.content if isinstance(part, NeMoGymResponseOutputText))
+            elif isinstance(item, NeMoGymResponseReasoningItem):
+                reasoning.extend(summary.text for summary in item.summary)
+        return "".join(content), "\n".join(reasoning) or None
+
+    async def call(self, prompt: str, **kwargs: Any) -> LLMResponse:
+        message_history = kwargs.pop("message_history", [])
+        kwargs.pop("previous_response_id", None)
+        kwargs.pop("logging_path", None)
+        if kwargs:
+            raise NotImplementedError(f"NeMoGymLLM does not support call options: {sorted(kwargs)}")
+
+        input_items = self._input_items(message_history, prompt)
+        response = NeMoGymResponse.model_validate(
+            await self._client.create_response(
+                model=self._model_name,
+                input=[item.model_dump(mode="json", exclude_none=True) for item in input_items],
+            )
+        )
+        self.trajectory.extend([*input_items, *response.output])
+        usage = response.usage
+        usage_info = None
+        if usage is not None:
+            usage_info = UsageInfo(
+                prompt_tokens=usage.input_tokens,
+                completion_tokens=usage.output_tokens,
+                cache_tokens=usage.input_tokens_details.cached_tokens or 0,
+                cost_usd=0.0,
+            )
+        content, reasoning_content = self._response_text(response)
+        return LLMResponse(
+            content=content,
+            reasoning_content=reasoning_content,
+            model_name=response.model,
+            usage=usage_info,
+            response_id=response.id,
+        )
+
+    def get_model_context_limit(self) -> int:
+        return self._model_context_limit
+
+    def get_model_output_limit(self) -> int | None:
+        return self._model_output_limit
+
+
+class NeMoGymTerminus2(Terminus2):
+    """Terminus 2 with NeMo Gym model calls and optional Harbor file trajectories."""
+
+    def __init__(self, *args: Any, llm: NeMoGymLLM, dump_trajectory: bool, **kwargs: Any):
+        self._nemo_gym_llm = llm
+        self._dump_trajectory_enabled = dump_trajectory
+        super().__init__(*args, **kwargs)
+
+    def _init_llm(self, *args: Any, **kwargs: Any) -> BaseLLM:
+        return self._nemo_gym_llm
+
+    def _count_total_tokens(self, chat: Any) -> int:
+        return sum(len(str(message.get("content", ""))) // 4 for message in chat.messages)
+
+    def _dump_trajectory_with_continuation_index(self, continuation_index: int) -> None:
+        if self._dump_trajectory_enabled:
+            super()._dump_trajectory_with_continuation_index(continuation_index)
+
+
+class Terminus2Agent(SimpleResponsesAPIAgent):
+    config: Terminus2AgentConfig
+
+    def model_post_init(self, context: Any, /) -> None:
+        super().model_post_init(context)
+        self._session_sandboxes: dict[str, tuple[AsyncSandbox, SandboxPtySession]] = {}
+
+        if not self.config.debug:
+            harbor_logger.setLevel(logging.WARNING)
+
+    async def _connect_sandbox(self, sandbox_id: str, pty_session_id: str) -> tuple[AsyncSandbox, SandboxPtySession]:
+        provider = create_provider(resolve_provider_config(self.config.sandbox_provider, get_global_config_dict()))
+        sandbox = await AsyncSandbox.connect({"sandbox_id": sandbox_id}, provider=provider)
+        pty_session = await sandbox.pty.attach(session_id=pty_session_id, takeover=True)
+        return sandbox, pty_session
+
+    async def _execute(
+        self,
+        request: Request,
+        body: NeMoGymResponseCreateParamsNonStreaming,
+        sandbox: AsyncSandbox,
+        pty_session: SandboxPtySession | None,
+    ) -> Tuple[NeMoGymResponse, bool]:
+        instruction = _instruction(body.input)
+
+        model_base_url = (
+            self.base_url_for_run(base_url=get_server_url(self.config.model_server.name), body=await request.json())
+            + "/v1"
+        )
+        llm = NeMoGymLLM(
+            client=NeMoGymAsyncOpenAI(base_url=model_base_url, api_key="dummy", internal=True),
+            model_name=self.config.model_server.name,
+            model_context_limit=self.config.model_context_limit,
+            model_output_limit=self.config.model_output_limit,
+        )
+
+        with tempfile.TemporaryDirectory(prefix="nemo-gym-terminus-2-") as log_dir:
+            environment = NeMoGymSandboxEnvironment(
+                sandbox, Path(log_dir), pty_session, request.session[SESSION_ID_KEY]
+            )
+            context = AgentContext()
+            agent = NeMoGymTerminus2(
+                logs_dir=Path(log_dir),
+                model_name=self.config.model_server.name,
+                max_turns=self.config.max_turns,
+                parser_name=self.config.parser_name,
+                enable_summarize=self.config.enable_summarize,
+                proactive_summarization_threshold=self.config.proactive_summarization_threshold,
+                tmux_pane_width=self.config.tmux_pane_width,
+                tmux_pane_height=self.config.tmux_pane_height,
+                record_terminal_session=False,
+                llm=llm,
+                dump_trajectory=self.config.dump_trajectory,
+            )
+
+            await environment.exec("mkdir -p /logs/agent", user="root")
+            if self.config.remote_tmux_binary_path:
+                # We add the /usr/local/bin path at the end to not supersede and pre-existing orderings.
+                tmux_install_result = await sandbox.pty.exec(
+                    f"""mkdir -p /usr/local/bin \
+&& cp {self.config.remote_tmux_binary_path} /usr/local/bin/tmux \
+&& chmod +x /usr/local/bin/tmux \
+&& export PATH=$PATH:/usr/local/bin \
+&& tmux -V""",
+                    session=pty_session,
+                )
+                assert tmux_install_result.return_code == 0, tmux_install_result
+            else:
+                print(
+                    "Downloading and installing tmux in the sandbox. Please consider mounting or uploading the appropriate tmux binary instead!",
+                    file=sys.stderr,
+                )
+            await agent.setup(environment)
+
+            try:
+                async with asyncio.timeout(self.config.sandbox_timeout):
+                    await agent.run(instruction, environment, context)
+                terminus2_completed = True
+            except TimeoutError:
+                terminus2_completed = False
+            finally:
+                await agent._session.stop()
+
+        usage = NeMoGymResponseUsage(
+            input_tokens=context.n_input_tokens or 0,
+            input_tokens_details=NeMoGymResponseInputTokensDetails(cached_tokens=context.n_cache_tokens or 0),
+            output_tokens=context.n_output_tokens or 0,
+            output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=0),
+            total_tokens=(context.n_input_tokens or 0) + (context.n_output_tokens or 0),
+        )
+        return NeMoGymResponse(
+            id=f"resp_{uuid4().hex}",
+            created_at=int(time()),
+            model=self.config.model_server.name,
+            object="response",
+            output=llm.trajectory,
+            tool_choice=body.tool_choice,
+            tools=body.tools,
+            parallel_tool_calls=body.parallel_tool_calls,
+            usage=usage,
+        ), terminus2_completed
+
+    async def responses(self, request: Request, body: NeMoGymResponseCreateParamsNonStreaming) -> NeMoGymResponse:
+        session_key = request.session[SESSION_ID_KEY]
+        sandbox, pty_session = self._session_sandboxes[session_key]
+        response, _ = await self._execute(request, body, sandbox, pty_session)
+        return response
+
+    async def run(self, request: Request, body: Terminus2AgentRunRequest) -> Terminus2AgentVerifyResponse:
+        cookies = request.cookies
+        seed_session_response = await self.server_client.post(
+            server_name=self.config.resources_server.name,
+            url_path="/seed_session",
+            json=body.model_dump(),
+            cookies=cookies,
+        )
+        await raise_for_status(seed_session_response)
+        cookies = cookies | seed_session_response.cookies
+        seed_session_result = await seed_session_response.json()
+
+        sandbox_id = seed_session_result["sandbox_handle"]
+        pty_session_id = seed_session_result["pty_session_id"]
+
+        sandbox, pty_session = await self._connect_sandbox(sandbox_id, pty_session_id)
+        session_key = request.session[SESSION_ID_KEY]
+        self._session_sandboxes[session_key] = (sandbox, pty_session)
+
+        response, terminus2_completed = await self._execute(
+            request, body.responses_create_params, sandbox, pty_session
+        )
+
+        verification = await self.server_client.post(
+            server_name=self.config.resources_server.name,
+            url_path="/verify",
+            json=body.model_dump() | {"response": response.model_dump()},
+            cookies=cookies,
+        )
+        await raise_for_status(verification)
+
+        self._session_sandboxes.pop(session_key)
+        try:
+            await pty_session.close()
+            await sandbox.stop()
+        except:
+            print(f"Hit an exception stopping sandbox in Terminus2: {format_exc()}")
+
+        result = await get_response_json(verification)
+        result["terminus2_completed"] = terminus2_completed
+        return Terminus2AgentVerifyResponse.model_validate(result)
+
+
+if __name__ == "__main__":
+    Terminus2Agent.run_webserver()
+elif is_nemo_gym_fastapi_entrypoint(__file__):
+    app = Terminus2Agent.run_webserver()  # noqa: F401

--- a/responses_api_agents/terminus_2_sandboxed_agent/client.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/client.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from asyncio import run
+
+from nemo_gym.global_config import get_global_config_dict
+from nemo_gym.server_utils import ServerClient
+
+
+async def main():
+    with open(get_global_config_dict()["benchmark_jsonl"]) as file:
+        first_example = json.loads(next(file))
+
+    server_client = ServerClient.load_from_global_config()
+    result = await server_client.post(
+        server_name="terminus_2_sandboxed_agent",
+        url_path="/run",
+        json=first_example,
+    )
+    print(json.dumps(await result.json(), indent=4))
+
+
+if __name__ == "__main__":
+    run(main())

--- a/responses_api_agents/terminus_2_sandboxed_agent/configs/terminus_2_sandboxed_agent.yaml
+++ b/responses_api_agents/terminus_2_sandboxed_agent/configs/terminus_2_sandboxed_agent.yaml
@@ -1,0 +1,38 @@
+terminus_2_sandboxed_agent:
+  responses_api_agents:
+    terminus_2_sandboxed_agent:
+      entrypoint: app.py
+      num_workers: 4
+      resources_server:
+        type: resources_servers
+        name: swebench_resources_server
+      model_server:
+        type: responses_api_models
+        name: policy_model
+
+      max_turns: null
+      parser_name: json
+      enable_summarize: true
+      proactive_summarization_threshold: 8000
+      tmux_pane_width: 160
+      tmux_pane_height: 40
+      dump_trajectory: false
+      debug: false
+      model_context_limit: 262144
+      model_output_limit: null
+
+      sandbox_provider: sandbox
+      sandbox_timeout: 10800  # 3 hrs
+      sandbox_config:
+        ttl_s: 18000
+        ready_timeout_s: 1200
+        resources:
+          cpu: 0.25
+          memory_mib: 512MB
+          disk_gib: 30
+        provider_options: {}
+        metadata:
+          harness: terminus-2
+      remote_tmux_binary_path: null
+
+      datasets: []

--- a/responses_api_agents/terminus_2_sandboxed_agent/requirements.txt
+++ b/responses_api_agents/terminus_2_sandboxed_agent/requirements.txt
@@ -1,0 +1,2 @@
+-e nemo-gym[dev,sandbox] @ ../../
+harbor==0.22.0

--- a/responses_api_agents/terminus_2_sandboxed_agent/tests/__init__.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
@@ -35,28 +35,32 @@ def test_instruction_joins_text_content():
 
 @pytest.mark.asyncio
 async def test_sandbox_environment_adapts_exec_and_is_dir():
-    sandbox = SimpleNamespace()
-    calls = []
+    sandbox = SimpleNamespace(pty=SimpleNamespace())
+    pty_calls = []
+    sandbox_calls = []
 
-    async def exec(command, **kwargs):
-        calls.append((command, kwargs))
+    async def pty_exec(command, **kwargs):
+        pty_calls.append((command, kwargs))
         return SimpleNamespace(stdout="output", stderr=None, return_code=0)
 
-    sandbox.exec = exec
+    async def sandbox_exec(command, **kwargs):
+        sandbox_calls.append((command, kwargs))
+        return SimpleNamespace(stdout="", stderr=None, return_code=0)
+
+    sandbox.pty.exec = pty_exec
+    sandbox.exec = sandbox_exec
     environment = NeMoGymSandboxEnvironment(
-        sandbox, logs_dir=SimpleNamespace(), pty_session=None, session_id="session-1"
+        sandbox, logs_dir=SimpleNamespace(), pty_session="seeded-pty", session_id="session-1"
     )
 
-    result = await environment.exec("pwd", timeout_sec=12, user="root", cwd="/work", env={"A": "B"})
+    result = await environment.exec("pwd", timeout_sec=12, user="root", cwd="/work")
 
     assert result.stdout == "output"
     assert result.stderr == ""
     assert result.return_code == 0
     assert await environment.is_dir("/workspace")
-    assert calls == [
-        ("pwd", {"cwd": "/work", "env": {"A": "B"}, "timeout_s": 12, "user": "root"}),
-        ('test -d "/workspace"', {"user": None}),
-    ]
+    assert pty_calls == [("pwd", {"session": "seeded-pty", "timeout_s": 12, "cwd": "/work"})]
+    assert sandbox_calls == [('test -d "/workspace"', {"user": None})]
 
 
 @pytest.mark.asyncio
@@ -75,7 +79,7 @@ async def test_sandbox_environment_uses_seeded_pty_for_stateful_commands():
 
     await environment.exec("tmux new-session")
 
-    assert calls == [("tmux new-session", {"session": "seeded-pty", "timeout_s": None})]
+    assert calls == [("tmux new-session", {"session": "seeded-pty", "timeout_s": None, "cwd": None})]
 
 
 def test_agent_implements_required_responses_endpoint():
@@ -171,6 +175,7 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
         debug=debug,
         sandbox_provider="opensandbox",
         sandbox_timeout=10,
+        remote_tmux_binary_path=None,
     )
     set_level = MagicMock()
     monkeypatch.setattr(app_module.harbor_logger, "setLevel", set_level)
@@ -248,7 +253,7 @@ async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_traject
     else:
         set_level.assert_not_called()
     assert sandbox_calls == [
-        ("mkdir -p /logs/agent", {"cwd": None, "env": None, "timeout_s": None, "user": "root"}),
-        ("tmux setup", {"session": "seeded-pty", "timeout_s": None}),
-        ("tmux run", {"session": "seeded-pty", "timeout_s": None}),
+        ("mkdir -p /logs/agent", {"session": "seeded-pty", "timeout_s": None, "cwd": None}),
+        ("tmux setup", {"session": "seeded-pty", "timeout_s": None, "cwd": None}),
+        ("tmux run", {"session": "seeded-pty", "timeout_s": None, "cwd": None}),
     ]

--- a/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
+++ b/responses_api_agents/terminus_2_sandboxed_agent/tests/test_app.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
+from nemo_gym.openai_utils import (
+    NeMoGymEasyInputMessage,
+    NeMoGymResponse,
+    NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseInputTokensDetails,
+    NeMoGymResponseOutputMessage,
+    NeMoGymResponseOutputText,
+    NeMoGymResponseOutputTokensDetails,
+    NeMoGymResponseUsage,
+)
+from nemo_gym.server_utils import ServerClient
+from responses_api_agents.terminus_2_sandboxed_agent import app as app_module
+from responses_api_agents.terminus_2_sandboxed_agent.app import (
+    NeMoGymLLM,
+    NeMoGymSandboxEnvironment,
+    Terminus2Agent,
+    Terminus2AgentConfig,
+    _instruction,
+)
+
+
+def test_instruction_joins_text_content():
+    assert _instruction([{"content": [{"text": "first"}]}, {"content": "second"}]) == "first\n\nsecond"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_environment_adapts_exec_and_is_dir():
+    sandbox = SimpleNamespace()
+    calls = []
+
+    async def exec(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(stdout="output", stderr=None, return_code=0)
+
+    sandbox.exec = exec
+    environment = NeMoGymSandboxEnvironment(
+        sandbox, logs_dir=SimpleNamespace(), pty_session=None, session_id="session-1"
+    )
+
+    result = await environment.exec("pwd", timeout_sec=12, user="root", cwd="/work", env={"A": "B"})
+
+    assert result.stdout == "output"
+    assert result.stderr == ""
+    assert result.return_code == 0
+    assert await environment.is_dir("/workspace")
+    assert calls == [
+        ("pwd", {"cwd": "/work", "env": {"A": "B"}, "timeout_s": 12, "user": "root"}),
+        ('test -d "/workspace"', {"user": None}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sandbox_environment_uses_seeded_pty_for_stateful_commands():
+    sandbox = SimpleNamespace(pty=SimpleNamespace())
+    calls = []
+
+    async def pty_exec(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(stdout="output", stderr=None, return_code=0)
+
+    sandbox.pty.exec = pty_exec
+    environment = NeMoGymSandboxEnvironment(
+        sandbox, logs_dir=SimpleNamespace(), pty_session="seeded-pty", session_id="session-1"
+    )
+
+    await environment.exec("tmux new-session")
+
+    assert calls == [("tmux new-session", {"session": "seeded-pty", "timeout_s": None})]
+
+
+def test_agent_implements_required_responses_endpoint():
+    assert not getattr(Terminus2Agent, "__abstractmethods__", set())
+
+
+@pytest.mark.asyncio
+async def test_nemo_gym_llm_records_every_responses_request_and_output():
+    class Client:
+        def __init__(self):
+            self.requests = []
+
+        async def create_response(self, **kwargs):
+            self.requests.append(kwargs)
+            index = len(self.requests)
+            return NeMoGymResponse(
+                id=f"resp_{index}",
+                created_at=0,
+                model="policy_model",
+                object="response",
+                output=[
+                    NeMoGymResponseOutputMessage(
+                        id=f"msg_{index}",
+                        content=[
+                            NeMoGymResponseOutputText(type="output_text", text=f"answer {index}", annotations=[])
+                        ],
+                        role="assistant",
+                        status="completed",
+                        type="message",
+                    )
+                ],
+                tool_choice="auto",
+                tools=[],
+                parallel_tool_calls=True,
+                usage=NeMoGymResponseUsage(
+                    input_tokens=10,
+                    input_tokens_details=NeMoGymResponseInputTokensDetails(cached_tokens=2),
+                    output_tokens=3,
+                    output_tokens_details=NeMoGymResponseOutputTokensDetails(reasoning_tokens=0),
+                    total_tokens=13,
+                ),
+            )
+
+    client = Client()
+    llm = NeMoGymLLM(client=client, model_name="policy_model", model_context_limit=32_000, model_output_limit=4_000)
+
+    first = await llm.call("first")
+    second = await llm.call(
+        "second",
+        message_history=[{"role": "user", "content": "first"}, {"role": "assistant", "content": "answer 1"}],
+        previous_response_id="resp_1",
+    )
+
+    assert first.content == "answer 1"
+    assert first.usage.prompt_tokens == 10
+    assert second.content == "answer 2"
+    assert client.requests == [
+        {"model": "policy_model", "input": [{"content": "first", "role": "user", "type": "message"}]},
+        {
+            "model": "policy_model",
+            "input": [
+                {"content": "first", "role": "user", "type": "message"},
+                {"content": "answer 1", "role": "assistant", "type": "message"},
+                {"content": "second", "role": "user", "type": "message"},
+            ],
+        },
+    ]
+    assert [item.content for item in llm.trajectory if isinstance(item, NeMoGymEasyInputMessage)] == [
+        "first",
+        "first",
+        "answer 1",
+        "second",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dump_trajectory", [False, True])
+@pytest.mark.parametrize("debug", [False, True])
+async def test_execute_runs_terminus_in_seeded_sandbox(monkeypatch, dump_trajectory, debug):
+    config = Terminus2AgentConfig(
+        host="0.0.0.0",
+        port=8080,
+        entrypoint="app.py",
+        name="terminus_2_1_agent",
+        resources_server=ResourcesServerRef(type="resources_servers", name="swebench_resources_server"),
+        model_server=ModelServerRef(type="responses_api_models", name="policy_model"),
+        max_turns=100,
+        enable_summarize=True,
+        proactive_summarization_threshold=8000,
+        tmux_pane_width=160,
+        tmux_pane_height=40,
+        dump_trajectory=dump_trajectory,
+        debug=debug,
+        sandbox_provider="opensandbox",
+        sandbox_timeout=10,
+    )
+    set_level = MagicMock()
+    monkeypatch.setattr(app_module.harbor_logger, "setLevel", set_level)
+    server = Terminus2Agent(config=config, server_client=MagicMock(spec=ServerClient))
+    sandbox_calls = []
+
+    async def sandbox_exec(command, **kwargs):
+        sandbox_calls.append((command, kwargs))
+        return SimpleNamespace(stdout="", stderr="", return_code=0)
+
+    sandbox = SimpleNamespace(exec=sandbox_exec, pty=SimpleNamespace())
+
+    class FakeTerminus:
+        session = SimpleNamespace()
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self._session = SimpleNamespace(stop=self.stop)
+
+        async def stop(self):
+            return None
+
+        async def setup(self, environment):
+            await environment.exec("tmux setup")
+
+        async def run(self, instruction, environment, context):
+            assert instruction == "solve this"
+            assert self.kwargs["dump_trajectory"] is dump_trajectory
+            await environment.exec("tmux run")
+            context.n_input_tokens = 4
+            context.n_output_tokens = 3
+            self.kwargs["llm"].trajectory.append(
+                NeMoGymResponseOutputMessage(
+                    id="msg_done",
+                    content=[NeMoGymResponseOutputText(type="output_text", text="done", annotations=[])],
+                    role="assistant",
+                    status="completed",
+                    type="message",
+                )
+            )
+
+    class FakeContext:
+        n_input_tokens = None
+        n_cache_tokens = None
+        n_output_tokens = None
+        metadata = None
+
+    async def pty_exec(command, **kwargs):
+        sandbox_calls.append((command, kwargs))
+        return SimpleNamespace(stdout="", stderr="", return_code=0)
+
+    sandbox.pty.exec = pty_exec
+    monkeypatch.setattr(app_module, "NeMoGymTerminus2", FakeTerminus)
+    monkeypatch.setattr(app_module, "AgentContext", FakeContext)
+    monkeypatch.setattr(Terminus2Agent, "base_url_for_run", lambda *_args, **_kwargs: "http://model")
+    monkeypatch.setattr(app_module, "get_server_url", lambda _: "http://model")
+
+    async def request_json():
+        return {"task_id": "task"}
+
+    request = SimpleNamespace(json=request_json, session={app_module.SESSION_ID_KEY: "session-1"})
+    response, terminus2_completed = await server._execute(
+        request,
+        NeMoGymResponseCreateParamsNonStreaming(input="solve this"),
+        sandbox,
+        "seeded-pty",
+    )
+
+    assert terminus2_completed is True
+    assert response.output[-1].content[0].text == "done"
+    assert response.usage.input_tokens == 4
+    assert response.usage.output_tokens == 3
+    if not debug:
+        set_level.assert_called_once_with(logging.WARNING)
+    else:
+        set_level.assert_not_called()
+    assert sandbox_calls == [
+        ("mkdir -p /logs/agent", {"cwd": None, "env": None, "timeout_s": None, "user": "root"}),
+        ("tmux setup", {"session": "seeded-pty", "timeout_s": None}),
+        ("tmux run", {"session": "seeded-pty", "timeout_s": None}),
+    ]


### PR DESCRIPTION
<!-- Thanks for contributing to NeMo Gym! Please fill out the sections below. -->

## What does this PR do?

1. Terminus 2 initial implementation. Functionally works, but not fully stable: responses_api_agents/terminus_2_sandboxed_agent, benchmarks/terminal_bench_2_1/terminus_2.yaml
2. Append to Super 3.5 evals config: benchmarks/nemotron_3.5_super/eval_container_config_with_staged.yaml, benchmarks/nemotron_3.5_super/eval_container_config.yaml

## Checklist

- [ ] I have read the [contributing guidelines](https://docs.nvidia.com/nemo/gym/latest/contribute/development-setup).
- [ ] The change is focused; unrelated "drive-by" edits are tracked as separate issues/PRs.
- [ ] Tests added or updated and pass locally, or N/A for docs-only / non-code changes (so CI unit/server checks pass when applicable).
- [ ] Pre-commit checks pass locally (`pre-commit run --all-files`) (so CI lint/format/copyright pass).
- [ ] All commits have DCO sign-off (`git commit -s`) (so the DCO check passes).
