### PR TITLE
fix: update configs to specify allowed_agents

### DIFF
--- a/resources_servers/deepswe/configs/deepswe.yaml
+++ b/resources_servers/deepswe/configs/deepswe.yaml
@@ -1,6 +1,7 @@
 deepswe_resources_server:
   resources_servers:
     deepswe:
+      allowed_agents: [opencode_sandboxed_agent]
       entrypoint: app.py
       domain: coding
       verified: false

--- a/resources_servers/swebench_pro/configs/swebench_pro.yaml
+++ b/resources_servers/swebench_pro/configs/swebench_pro.yaml
@@ -2,6 +2,7 @@
 swebench_pro_resources_server:
   resources_servers:
     swebench_pro:
+      allowed_agents: [opencode_sandboxed_agent]
       entrypoint: app.py
       domain: coding
       verified: false

--- a/resources_servers/terminal_bench_2_1/configs/terminal_bench_2_1.yaml
+++ b/resources_servers/terminal_bench_2_1/configs/terminal_bench_2_1.yaml
@@ -2,6 +2,7 @@
 terminal_bench_2_1_resources_server:          # instance name — how agents/CLI refer to this server
   resources_servers:                    # server type: resources_servers | responses_api_agents | responses_api_models
     terminal_bench_2_1:                      # implementation directory under resources_servers/
+      allowed_agents: [opencode_sandboxed_agent, terminus_2_sandboxed_agent]
       entrypoint: app.py                # server entry module
       domain: other                     # task domain; change to the closest supported domain
       verified: false                   # set true once the benchmark has been baselined and reviewed

--- a/responses_api_agents/opencode_sandboxed_agent/configs/opencode_sandboxed_agent.yaml
+++ b/responses_api_agents/opencode_sandboxed_agent/configs/opencode_sandboxed_agent.yaml
@@ -5,7 +5,7 @@ opencode_sandboxed_agent:
       num_workers: 4
       resources_server:
         type: resources_servers
-        name: swebench_resources_server
+        name: ???
       model_server:
         type: responses_api_models
         name: policy_model

--- a/responses_api_agents/terminus_2_sandboxed_agent/configs/terminus_2_sandboxed_agent.yaml
+++ b/responses_api_agents/terminus_2_sandboxed_agent/configs/terminus_2_sandboxed_agent.yaml
@@ -5,7 +5,7 @@ terminus_2_sandboxed_agent:
       num_workers: 4
       resources_server:
         type: resources_servers
-        name: swebench_resources_server
+        name: ???
       model_server:
         type: responses_api_models
         name: policy_model


### PR DESCRIPTION
While working on #2661 Several configs that require `allowed_agents` to be specified were added later on. This PR updates them as well as agent configs associated with them.