### PR TITLE
fix(vllm): propagate provider HTTP errors

### DIFF
--- a/fern/versions/latest/pages/model-server/vllm.mdx
+++ b/fern/versions/latest/pages/model-server/vllm.mdx
@@ -286,37 +286,38 @@ base_url:
 
 ## Context Length Exceeded Handling
 
-When a conversation exceeds the vLLM model's maximum context length (`max_seq_length`), VLLMModel handles the error gracefully instead of crashing the entire rollout collection.
+When a request exceeds the vLLM model's maximum context length (`max_model_len`), vLLM rejects it before generation. VLLMModel preserves that provider error so the calling agent can recover according to its own context-management policy.
 
 ### How it works
 
 1. **vLLM rejects the request**: vLLM returns an HTTP 400 error with a message like `"This model's maximum context length is 32768 tokens. However, you requested 32818 tokens..."`.
-2. **VLLMModel catches the error**: Instead of propagating the exception, VLLMModel returns an empty response with `finish_reason: "length"`.
-3. **Responses API mapping**: The `finish_reason: "length"` is converted to `incomplete_details: { reason: "max_output_tokens" }` in the Responses API response returned to the agent.
+2. **VLLMModel preserves the error**: `/v1/chat/completions` and `/v1/responses` return the same HTTP status and OpenAI-compatible error body. This also applies when the caller requested streaming because Gym validates and buffers the provider call before starting its synthesized SSE stream.
+3. **Anthropic compatibility**: `/v1/messages` returns the same status in an Anthropic error envelope. Context-overflow messages begin with `prompt is too long` so Claude Code recognizes the condition and can run its compaction flow; the original vLLM detail follows that prefix.
 
-This is particularly important for multi-turn agentic rollouts where conversation length can grow unpredictably across tool-call turns.
+The adapter does not convert the rejection into a successful empty completion. A `finish_reason: "length"` or `incomplete_details.reason: "max_output_tokens"` now describes only a request that generated output and exhausted its output budget.
 
-### How to detect truncated responses
+### Handle context overflow
 
-Downstream consumers (agents, RL training frameworks) can check the `incomplete_details` field on the response:
+OpenAI clients raise their bad-request exception for this response. Agents that manage long histories should catch that exception, identify the context-overflow message, and compact, truncate, or stop according to their rollout policy:
 
 ```python
-response = await model_server.responses(request, body)
-
-if response.incomplete_details and response.incomplete_details["reason"] == "max_output_tokens":
-    # The conversation exceeded the model's context window.
-    # The response output will be empty — handle accordingly.
-    pass
+try:
+    response = await client.responses.create(**params)
+except openai.BadRequestError as exc:
+    if "maximum context length" in str(exc).lower():
+        # Compact or truncate the conversation, then retry.
+        ...
+    raise
 ```
 
 <Note>
-When `incomplete_details.reason == "max_output_tokens"`, the response output is empty because vLLM rejected the request before generation began. This differs from a normal `max_output_tokens` truncation where the model generates up to the token limit — in this case, the input itself was too long.
+Gym's built-in agents use a shared classifier that also checks the provider response body. This matters for aiohttp exceptions, whose string representation does not include `response_content`.
 
 </Note>
 
 ### Implications for training
 
-When using NeMo Gym with NeMo RL or another training framework, responses with `incomplete_details.reason == "max_output_tokens"` indicate that the full conversation (prompt + prior generations) exceeded `max_seq_length`. Training frameworks should filter or handle these responses appropriately since they contain no generated tokens.
+Because vLLM rejects an overlong input before sampling, the error contains no generated tokens and must not be recorded as a successful on-policy completion. The model-call capture records the failed status and provider body for rollout diagnostics.
 
 ## Training vs Offline Inference
 By default, VLLMModel will not track any token IDs explicitly. However, token IDs are necessary when using NeMo Gym in conjunction with a training framework in order to train a model. For training workflows, use the training-dedicated config which enables token ID tracking:

--- a/nemo_gym/anthropic_converter.py
+++ b/nemo_gym/anthropic_converter.py
@@ -53,6 +53,7 @@ from uuid import uuid4
 from anthropic.types.message_create_params import MessageCreateParams
 
 from nemo_gym.anthropic_utils import NeMoGymAnthropicMessage
+from nemo_gym.context_errors import is_context_overflow_error
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymFunctionCallOutput,
@@ -71,8 +72,45 @@ from nemo_gym.openai_utils import (
 
 SUPPORTED_ANTHROPIC_IMAGE_MEDIA_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
 
+_ANTHROPIC_ERROR_TYPES = {
+    400: "invalid_request_error",
+    401: "authentication_error",
+    403: "permission_error",
+    404: "not_found_error",
+    413: "request_too_large",
+    429: "rate_limit_error",
+    529: "overloaded_error",
+}
+
 
 class AnthropicConverter:
+    def error_response(self, content: bytes | str, status: int) -> bytes:
+        """Translate an OpenAI-compatible provider error to Anthropic's envelope."""
+
+        try:
+            payload = json.loads(content)
+        except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
+            message = content.decode(errors="replace") if isinstance(content, bytes) else content
+        else:
+            error = payload.get("error", payload) if isinstance(payload, dict) else {}
+            message = error.get("message") if isinstance(error, dict) else None
+            if not message:
+                message = json.dumps(payload, ensure_ascii=False)
+        if not isinstance(message, str):
+            message = json.dumps(message, ensure_ascii=False)
+
+        # Claude Code recognizes this wording and invokes its context-compaction path.
+        # Retain the provider's original detail after the compatibility prefix.
+        if is_context_overflow_error(content) and "prompt is too long" not in message.lower():
+            message = f"prompt is too long: {message}"
+
+        error_type = _ANTHROPIC_ERROR_TYPES.get(status, "api_error" if status >= 500 else "invalid_request_error")
+        return json.dumps(
+            {"type": "error", "error": {"type": error_type, "message": message}},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode()
+
     ############################################################################
     # Egress: NeMo Gym Responses  ->  Anthropic Messages request
     ############################################################################

--- a/nemo_gym/base_responses_api_model.py
+++ b/nemo_gym/base_responses_api_model.py
@@ -41,6 +41,7 @@ from typing import Any, Mapping, Optional
 from uuid import uuid4
 
 import orjson
+from aiohttp import ClientResponseError
 from fastapi import Body, FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse
@@ -215,6 +216,24 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
 
         return app
 
+    def _model_client_response_error_response(self, request: Request, exc: ClientResponseError) -> Optional[Response]:
+        """Let a model adapter expose a downstream HTTP response on its public API."""
+
+        return None
+
+    def _client_response_error_response(self, request: Request, exc: ClientResponseError) -> Optional[Response]:
+        """Apply shared API-dialect translation to an adapter-preserved HTTP error."""
+
+        response = self._model_client_response_error_response(request, exc)
+        if response is None or not request.url.path.rstrip("/").endswith("/v1/messages"):
+            return response
+
+        return Response(
+            content=_ANTHROPIC_CONVERTER.error_response(response.body, response.status_code),
+            status_code=response.status_code,
+            media_type="application/json",
+        )
+
     @abstractmethod
     async def chat_completions(
         self, body: NeMoGymChatCompletionCreateParamsNonStreaming = Body()
@@ -235,9 +254,10 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
         always do), the request is first sanitized from the streaming wire dialect (extra
         bookkeeping fields, ``namespace`` tool specs — see ``nemo_gym.responses_streaming``),
         delegated to the same ``responses()``, and the complete response is re-emitted as a
-        synthesized Responses SSE event stream. A ``responses()`` failure on this path is turned
-        into a terminal ``response.failed`` event rather than an HTTP 500 (bad-request validation
-        still fails eagerly, before the stream is committed).
+        synthesized Responses SSE event stream. By default, a ``responses()`` failure on this path
+        becomes a terminal ``response.failed`` event rather than an HTTP 500. A model adapter may
+        instead preserve an explicit downstream HTTP error raised before synthesized SSE starts.
+        Bad-request validation still fails eagerly.
         """
         if not body.get("stream"):
             params = _validate_responses_params(body)
@@ -253,8 +273,10 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
             response = await self._invoke_responses(request, params)
             response_json = response.model_dump(mode="json") if isinstance(response, BaseModel) else dict(response)
         except Exception as exc:
-            # The streaming contract is already the response's shape, so a backend failure must be a
-            # terminal response.failed event, not an HTTP 500 the client would see as a broken stream.
+            if self._should_propagate_streaming_responses_exception(exc):
+                raise
+            # Preserve the established streaming shape for internal backend failures. Model adapters
+            # can opt explicit downstream HTTP errors out before StreamingResponse commits headers.
             logger.exception("responses() failed while serving a streaming /v1/responses request")
             return StreamingResponse(
                 synthesize_responses_failure_sse(str(exc)),
@@ -264,6 +286,11 @@ class SimpleResponsesAPIModel(BaseResponsesAPIModel, SimpleServer):
             synthesize_responses_sse(response_json, ns_map),
             media_type="text/event-stream",
         )
+
+    def _should_propagate_streaming_responses_exception(self, exc: Exception) -> bool:
+        """Whether an error raised before synthesized SSE starts should retain its HTTP response."""
+
+        return False
 
     async def chat_completions_dispatch(self, request: Request, body: dict = Body()):
         """Default ``/v1/chat/completions`` entrypoint shared by every Gym model server.

--- a/nemo_gym/context_errors.py
+++ b/nemo_gym/context_errors.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared context-window error classification for model clients and agents."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+
+_CONTEXT_OVERFLOW_RE = re.compile(
+    r"maximum context length|"
+    r"context[_ ]length[_ ]exceeded|"
+    r"context length is (?:only )?\d+ tokens|"
+    r"maximum input length|"
+    r"please reduce the length of the input|"
+    r"exceed.*context (?:limit|window|length)|"
+    r"context window exceeds|"
+    r"exceeds maximum length|"
+    r"too long.*tokens.*maximum|"
+    r"too large for model with \d+ maximum context length|"
+    r"longer than the model's context length|"
+    r"too many tokens|"
+    r"prompt is too long|"
+    r"maximum prompt length|"
+    r"input length should be|"
+    r"sent message larger than max|"
+    r"input tokens exceeded|"
+    r"(?:messages?|total length).*too long|"
+    r"payload.*too large|"
+    r"string too long|"
+    r"input exceeded the context window|"
+    r"cannot be greater than max_model_len|"
+    r"`inputs` tokens \+ `max_new_tokens`",
+    re.IGNORECASE,
+)
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def error_text(error: Any) -> str:
+    """Return searchable text, including HTTP bodies omitted by exception ``str()``."""
+
+    parts = [_stringify(error)]
+    for attribute in ("response_content", "body"):
+        text = _stringify(getattr(error, attribute, None))
+        if text and text not in parts:
+            parts.append(text)
+    return " ".join(part for part in parts if part)
+
+
+def is_context_overflow_error(error: Any) -> bool:
+    """Whether text, a response body, or an exception describes context overflow."""
+
+    return _CONTEXT_OVERFLOW_RE.search(error_text(error)) is not None

--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -774,17 +774,33 @@ class SimpleServer(BaseServer):
         session_middleware_key = self.get_session_middleware_key()
         app.add_middleware(SessionMiddleware, secret_key=session_middleware_key, session_cookie=session_middleware_key)
 
+    def _client_response_error_response(
+        self, request: Request, exc: ClientResponseError
+    ) -> Optional[Response]:  # pragma: no cover
+        """Let adapters preserve a downstream HTTP response for their public API."""
+
+        return None
+
     def setup_exception_middleware(self, app: FastAPI) -> None:  # pragma: no cover
         @app.middleware("http")
         async def exception_handling_middleware(request: Request, call_next):
             try:
                 return await call_next(request)
             except ClientResponseError as e:
-                assert hasattr(e, "response_content"), (
-                    "Please use `nemo_gym.server_utils.raise_for_status` for HTTP exceptions!"
-                )
+                adapter_response = self._client_response_error_response(request, e)
+                if adapter_response is not None:
+                    return adapter_response
 
-                response_content = f"Hit an exception in {self.get_session_middleware_key()} calling an inner server: {e.response_content}"
+                if hasattr(e, "response_content"):
+                    detail = e.response_content
+                else:
+                    detail = (
+                        f"{type(e).__name__} did not include response content. "
+                        "HTTP responses must be checked with `nemo_gym.server_utils.raise_for_status`."
+                    )
+                response_content = (
+                    f"Hit an exception in {self.get_session_middleware_key()} calling an inner server: {detail}"
+                )
                 if _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG:
                     print(response_content)
 

--- a/responses_api_models/vllm_model/app.py
+++ b/responses_api_models/vllm_model/app.py
@@ -24,7 +24,7 @@ from time import monotonic, time, time_ns
 from typing import Any, ClassVar, Dict, List, Optional, Union
 
 from aiohttp.client_exceptions import ClientResponseError
-from fastapi import Request
+from fastapi import Request, Response
 from pydantic import Field, PrivateAttr, model_validator
 
 from nemo_gym.base_responses_api_model import (
@@ -64,6 +64,8 @@ _TRANSPORT_LOG_CONTEXT_HEADERS = {
     "step": "x-nemo-gym-log-step",
     "parse_attempt": "x-nemo-gym-log-parse-attempt",
 }
+
+_AUXILIARY_ERROR_ATTRIBUTE = "nemo_gym_auxiliary"
 
 
 def _transport_log_context(request: Request) -> Dict[str, Any]:
@@ -272,6 +274,42 @@ class VLLMModel(SimpleResponsesAPIModel):
         "mm_processor_kwargs",
         "required_prefix_token_ids",
     )
+
+    def _model_client_response_error_response(self, request: Request, exc: ClientResponseError) -> Optional[Response]:
+        """Restore a real provider response after model-call capture observes its exception."""
+
+        if not self._is_propagatable_provider_error(exc):
+            return None
+
+        content_type = exc.headers.get("content-type") if exc.headers else None
+        headers = {"content-type": content_type} if content_type else None
+        return Response(
+            content=exc.response_content,
+            status_code=exc.status,
+            headers=headers,
+            media_type=None if headers else "application/json",
+        )
+
+    @staticmethod
+    def _is_propagatable_provider_error(exc: Exception) -> bool:
+        content = getattr(exc, "response_content", None)
+        status = getattr(exc, "status", None)
+        return (
+            isinstance(exc, ClientResponseError)
+            and not getattr(exc, _AUXILIARY_ERROR_ATTRIBUTE, False)
+            and isinstance(content, (bytes, str))
+            and isinstance(status, int)
+            and 400 <= status <= 599
+        )
+
+    @staticmethod
+    def _mark_auxiliary_error(exc: Exception) -> None:
+        setattr(exc, _AUXILIARY_ERROR_ATTRIBUTE, True)
+
+    def _should_propagate_streaming_responses_exception(self, exc: Exception) -> bool:
+        """Preserve vLLM HTTP failures raised before a synthesized Responses stream starts."""
+
+        return self._is_propagatable_provider_error(exc)
 
     def get_converter(self) -> "VLLMConverter":
         """Return the converter used for Responses API <-> Chat Completions mapping.
@@ -812,32 +850,15 @@ class VLLMModel(SimpleResponsesAPIModel):
                         "elapsed_ns": finished_ns - started_ns,
                         "pid": os.getpid(),
                         "http_status": e.status,
-                        "raw_response_body": e.response_content.decode(errors="replace"),
+                        "raw_response_body": (
+                            e.response_content.decode(errors="replace")
+                            if isinstance(getattr(e, "response_content", None), bytes)
+                            else str(getattr(e, "response_content", ""))
+                        ),
                         "error": repr(e),
                     }
                 )
-            """
-            Example messages for out of context length:
-
-            1. https://github.com/vllm-project/vllm/blob/685c99ee77b4818dcdd15b30fe0e0eff0d5d22ec/vllm/entrypoints/openai/serving_engine.py#L914
-            ```json
-            {"object":"error","message":"This model\'s maximum context length is 32768 tokens. However, you requested 32818 tokens in the messages, Please reduce the length of the messages. None","type":"BadRequestError","param":null,"code":400}
-            ```
-            2. https://github.com/vllm-project/vllm/blob/685c99ee77b4818dcdd15b30fe0e0eff0d5d22ec/vllm/entrypoints/openai/serving_engine.py#L940
-            3. https://github.com/vllm-project/vllm/blob/685c99ee77b4818dcdd15b30fe0e0eff0d5d22ec/vllm/entrypoints/openai/serving_engine.py#L948
-            4. https://github.com/vllm-project/vllm/blob/685c99ee77b4818dcdd15b30fe0e0eff0d5d22ec/vllm/sampling_params.py#L463
-            """
-            result_content_str = e.response_content.decode()
-
-            is_out_of_context_length = e.status == 400 and (
-                "context length" in result_content_str or "max_tokens" in result_content_str
-            )
-            if is_out_of_context_length:
-                res = self._create_empty_chat_completion()
-                res.choices[0].finish_reason = "length"
-                return res
-            else:
-                raise e
+            raise
         except Exception as e:
             if transport_io_enabled:
                 finished_ns = time_ns()
@@ -926,7 +947,11 @@ class VLLMModel(SimpleResponsesAPIModel):
                             "vLLM response generation token IDs disagree with choice logprob token IDs."
                         )
                 else:
-                    tokenize_response = await client.create_tokenize(**self._get_tokenize_chat_body(body_dict))
+                    try:
+                        tokenize_response = await client.create_tokenize(**self._get_tokenize_chat_body(body_dict))
+                    except ClientResponseError as exc:
+                        self._mark_auxiliary_error(exc)
+                        raise
                     prompt_token_ids = self._require_token_id_list(
                         tokenize_response.get("tokens"),
                         "tokenize.tokens",
@@ -1138,18 +1163,7 @@ class VLLMModel(SimpleResponsesAPIModel):
 
         client = self._resolve_client(request)
 
-        try:
-            completion_dict = await client.create_completion(**completion_body)
-        except ClientResponseError as e:
-            result_content_str = e.response_content.decode()
-            is_out_of_context_length = e.status == 400 and (
-                "context length" in result_content_str or "max_tokens" in result_content_str
-            )
-            if is_out_of_context_length:
-                res = self._create_empty_chat_completion()
-                res.choices[0].finish_reason = "length"
-                return res
-            raise
+        completion_dict = await client.create_completion(**completion_body)
 
         if self.config.return_token_id_information:
             choice_dict = completion_dict["choices"][0]
@@ -1160,7 +1174,11 @@ class VLLMModel(SimpleResponsesAPIModel):
                 )
                 if "add_special_tokens" in completion_body:
                     tokenize_body["add_special_tokens"] = completion_body["add_special_tokens"]
-                tokenize_response = await client.create_tokenize(**tokenize_body)
+                try:
+                    tokenize_response = await client.create_tokenize(**tokenize_body)
+                except ClientResponseError as exc:
+                    self._mark_auxiliary_error(exc)
+                    raise
                 choice_dict["prompt_token_ids"] = tokenize_response["tokens"]
 
         return self._completion_dict_to_chat_completion(completion_dict)

--- a/responses_api_models/vllm_model/tests/test_app.py
+++ b/responses_api_models/vllm_model/tests/test_app.py
@@ -18,11 +18,13 @@ import logging
 from typing import Any, Union
 from unittest.mock import AsyncMock, MagicMock
 
+from aiohttp.client_exceptions import ClientResponseError, TooManyRedirects
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch, mark, raises
 
 import nemo_gym.server_utils
 from nemo_gym import PARENT_DIR
+from nemo_gym.base_responses_api_model import CaptureStore
 from nemo_gym.openai_utils import (
     NeMoGymAsyncOpenAI,
     NeMoGymChatCompletion,
@@ -178,6 +180,35 @@ OPENAI_2_44_OPTIONAL_CHAT_FIELDS = {
     "safety_identifier",
     "verbosity",
 }
+
+UPSTREAM_CONTEXT_LENGTH_ERROR = {
+    "object": "error",
+    "message": "This model's maximum context length is 32768 tokens.",
+    "type": "BadRequestError",
+    "param": None,
+    "code": 400,
+}
+
+
+def _upstream_http_error(
+    body: dict, *, status: int = 400, upstream_path: str = "/v1/chat/completions"
+) -> ClientResponseError:
+    request_info = MagicMock()
+    request_info.url = f"http://vllm.test{upstream_path}"
+    request_info.real_url = request_info.url
+    error = ClientResponseError(
+        request_info=request_info,
+        history=(),
+        status=status,
+        message="Bad Request",
+    )
+    error.response_content = json.dumps(body).encode()
+    return error
+
+
+def _upstream_context_length_error() -> ClientResponseError:
+    return _upstream_http_error(UPSTREAM_CONTEXT_LENGTH_ERROR)
+
 
 PARAMETERIZE_DATA = [
     # ----- EasyInputMessageParam: content as a list, id: "ez_list" -----
@@ -782,6 +813,186 @@ class TestApp:
 
     async def test_sanity(self, monkeypatch: MonkeyPatch) -> None:
         self._setup_server(monkeypatch)
+
+    @mark.parametrize("stream", [False, True])
+    def test_upstream_context_length_error_propagates_from_chat_completions(
+        self, monkeypatch: MonkeyPatch, stream: bool
+    ) -> None:
+        server = self._setup_server(monkeypatch)
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=_upstream_context_length_error())
+        server._clients = [mock_client]
+
+        app = server.setup_webserver()
+        server.setup_exception_middleware(app)
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={
+                "model": "dummy_model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": stream,
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json() == UPSTREAM_CONTEXT_LENGTH_ERROR
+
+    @mark.parametrize("stream", [False, True])
+    def test_upstream_context_length_error_propagates_from_responses(
+        self, monkeypatch: MonkeyPatch, stream: bool
+    ) -> None:
+        server = self._setup_server(monkeypatch)
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=_upstream_context_length_error())
+        server._clients = [mock_client]
+
+        app = server.setup_webserver()
+        server.setup_exception_middleware(app)
+        response = TestClient(app).post(
+            "/v1/responses",
+            json={"input": "hello", "model": "dummy_model", "stream": stream},
+        )
+
+        assert response.status_code == 400
+        assert response.json() == UPSTREAM_CONTEXT_LENGTH_ERROR
+
+    def test_internal_streaming_responses_error_remains_response_failed(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._setup_server(monkeypatch)
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=RuntimeError("backend exploded"))
+        server._clients = [mock_client]
+
+        app = server.setup_webserver()
+        server.setup_exception_middleware(app)
+        response = TestClient(app).post(
+            "/v1/responses",
+            json={"input": "hello", "model": "dummy_model", "stream": True},
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        assert "event: response.failed" in response.text
+        assert "backend exploded" in response.text
+
+    def test_native_streaming_responses_propagates_upstream_context_length_error(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        server = self._setup_server(monkeypatch)
+        server.config.is_responses_native = True
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_response = AsyncMock(side_effect=_upstream_context_length_error())
+        server._clients = [mock_client]
+
+        app = server.setup_webserver()
+        server.setup_exception_middleware(app)
+        response = TestClient(app).post(
+            "/v1/responses",
+            json={"input": "hello", "model": "dummy_model", "stream": True},
+        )
+
+        assert response.status_code == 400
+        assert response.json() == UPSTREAM_CONTEXT_LENGTH_ERROR
+
+    @mark.parametrize("stream", [False, True])
+    def test_messages_translates_upstream_error_to_anthropic_shape(
+        self, monkeypatch: MonkeyPatch, stream: bool
+    ) -> None:
+        server = self._setup_server(monkeypatch)
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=_upstream_context_length_error())
+        server._clients = [mock_client]
+
+        app = server.setup_webserver()
+        server.setup_exception_middleware(app)
+        response = TestClient(app).post(
+            "/v1/messages",
+            json={
+                "model": "dummy_model",
+                "max_tokens": 8,
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": stream,
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": f"prompt is too long: {UPSTREAM_CONTEXT_LENGTH_ERROR['message']}",
+            },
+        }
+
+    def test_bodyless_client_error_remains_streaming_response_failed(self, monkeypatch: MonkeyPatch) -> None:
+        server = self._setup_server(monkeypatch)
+        redirect_error = TooManyRedirects(request_info=MagicMock(), history=(), status=0)
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=redirect_error)
+        server._clients = [mock_client]
+
+        app = server.setup_webserver()
+        server.setup_exception_middleware(app)
+        response = TestClient(app).post(
+            "/v1/responses",
+            json={"input": "hello", "model": "dummy_model", "stream": True},
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        assert "event: response.failed" in response.text
+        assert "server_error" in response.text
+
+    def test_transport_client_response_error_without_body_becomes_internal_error_and_is_logged(
+        self, monkeypatch: MonkeyPatch, tmp_path
+    ) -> None:
+        log_path = tmp_path / "transport.jsonl"
+        monkeypatch.setenv("NEMO_GYM_VLLM_TRANSPORT_LOG", str(log_path))
+        server = self._setup_server(monkeypatch)
+        redirect_error = TooManyRedirects(request_info=MagicMock(), history=(), status=0)
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=redirect_error)
+        server._clients = [mock_client]
+
+        app = server.setup_webserver()
+        server.setup_exception_middleware(app)
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={"model": "dummy_model", "messages": [{"role": "user", "content": "hello"}]},
+        )
+
+        assert response.status_code == 500
+        assert "TooManyRedirects did not include response content" in response.json()
+        events = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+        assert events[-1]["event"] == "transport_error_response"
+        assert events[-1]["raw_response_body"] == ""
+
+    def test_upstream_context_length_error_is_captured_before_propagation(
+        self, monkeypatch: MonkeyPatch, tmp_path
+    ) -> None:
+        server = self._setup_server(monkeypatch)
+        server.server_client.global_config_dict = {
+            "observability_enabled": True,
+            "model_call_capture_dir": str(tmp_path),
+        }
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(side_effect=_upstream_context_length_error())
+        server._clients = [mock_client]
+
+        app = server.setup_webserver()
+        server.setup_exception_middleware(app)
+        response = TestClient(app).post(
+            "/ng-rollout/context-error/v1/chat/completions",
+            json={
+                "model": "dummy_model",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+        assert response.status_code == 400
+        [exchange] = CaptureStore(tmp_path).read("context-error")
+        assert exchange["status_code"] == 400
+        assert exchange["error_category"] == "client_error"
+        assert json.loads(exchange["response_raw"]) == UPSTREAM_CONTEXT_LENGTH_ERROR
 
     def test_session_client_routing_is_stable_across_workers(self, monkeypatch: MonkeyPatch) -> None:
         workers = [self._setup_server(monkeypatch) for _ in range(2)]
@@ -4192,6 +4403,27 @@ class TestCompletionsBackendEndToEnd:
         # Server-config model wins over whatever the caller put in "model".
         assert captured["kwargs"]["model"] == "base-model"
 
+    def test_upstream_context_length_error_propagates(self, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", MagicMock(return_value=dict()))
+
+        model = _make_completions_backend_model()
+        fake_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        fake_client.create_completion = AsyncMock(side_effect=_upstream_context_length_error())
+        model._clients = [fake_client]
+
+        app = model.setup_webserver()
+        model.setup_exception_middleware(app)
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={
+                "model": "ignored-by-server",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json() == UPSTREAM_CONTEXT_LENGTH_ERROR
+
     def test_responses_with_string_input_routes_to_completions(self, monkeypatch: MonkeyPatch) -> None:
         monkeypatch.setattr(nemo_gym.server_utils, "get_global_config_dict", MagicMock(return_value=dict()))
         monkeypatch.setattr("nemo_gym.responses_converter.uuid4", lambda: FakeUUID())
@@ -4797,6 +5029,64 @@ class TestTopLogprobsHandling:
         assert message["generation_token_ids"] == [123, 456]
         assert message["generation_log_probs"] == [-0.1, -0.2]
         assert message["prompt_token_ids"] == [10, 20, 30]
+
+    def test_auxiliary_tokenize_error_is_not_exposed_as_generation_response(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+        model.setup_exception_middleware(app)
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(
+            return_value=self._capture_chat_completion_dict(
+                logprobs={"content": [{"token": "token_id:123", "logprob": -0.1, "bytes": None, "top_logprobs": []}]}
+            )
+        )
+        mock_client.create_tokenize = AsyncMock(
+            side_effect=_upstream_http_error(
+                {"detail": "tokenize route unavailable"},
+                status=404,
+                upstream_path="/tokenize",
+            )
+        )
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/chat/completions",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert response.status_code == 500
+        assert "tokenize route unavailable" in response.json()
+
+    def test_auxiliary_tokenize_error_remains_streaming_response_failed(self) -> None:
+        model = _make_top_logprobs_model(return_token_id_information=True)
+        app = model.setup_webserver()
+        model.setup_exception_middleware(app)
+
+        mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+        mock_client.create_chat_completion = AsyncMock(
+            return_value=self._capture_chat_completion_dict(
+                logprobs={"content": [{"token": "token_id:123", "logprob": -0.1, "bytes": None, "top_logprobs": []}]}
+            )
+        )
+        mock_client.create_tokenize = AsyncMock(
+            side_effect=_upstream_http_error(
+                {"detail": "tokenize route unavailable"},
+                status=404,
+                upstream_path="/tokenize",
+            )
+        )
+        model._clients = [mock_client]
+
+        response = TestClient(app).post(
+            "/v1/responses",
+            json={"input": "hi", "stream": True},
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        assert "event: response.failed" in response.text
+        assert "vllm.test/tokenize" in response.text
 
     def test_capture_path_prefers_vllm_response_token_ids(self) -> None:
         model = _make_top_logprobs_model(

--- a/responses_api_models/vllm_model_with_compaction/app.py
+++ b/responses_api_models/vllm_model_with_compaction/app.py
@@ -89,6 +89,8 @@ class VLLMModelWithCompaction(VLLMModel):
             response = await self._invoke_responses(request, params)
             response_json = response.model_dump(mode="json") if isinstance(response, BaseModel) else dict(response)
         except Exception as exc:
+            if self._should_propagate_streaming_responses_exception(exc):
+                raise
             LOG.exception("responses() failed while serving a streaming /v1/responses request")
             return StreamingResponse(
                 synthesize_responses_failure_sse(str(exc)),

--- a/responses_api_models/vllm_model_with_compaction/tests/test_app.py
+++ b/responses_api_models/vllm_model_with_compaction/tests/test_app.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiohttp.client_exceptions import ClientResponseError
 from fastapi.testclient import TestClient
 
 from nemo_gym.openai_utils import NeMoGymAsyncOpenAI
@@ -34,6 +35,34 @@ def _make_model() -> VLLMModelWithCompaction:
         config=config,
         server_client=MagicMock(spec=ServerClient, global_config_dict={}),
     )
+
+
+def _upstream_context_length_error() -> ClientResponseError:
+    request_info = MagicMock()
+    request_info.url = "http://vllm.test/v1/chat/completions"
+    request_info.real_url = request_info.url
+    error = ClientResponseError(
+        request_info=request_info,
+        history=(),
+        status=400,
+        message="Bad Request",
+    )
+    error.response_content = b'{"error":{"message":"maximum context length","code":400}}'
+    return error
+
+
+def _upstream_tokenize_error() -> ClientResponseError:
+    request_info = MagicMock()
+    request_info.url = "http://vllm.test/tokenize"
+    request_info.real_url = request_info.url
+    error = ClientResponseError(
+        request_info=request_info,
+        history=(),
+        status=400,
+        message="Bad Request",
+    )
+    error.response_content = b'{"error":{"message":"invalid tokenize input","code":400}}'
+    return error
 
 
 def test_base_vllm_model_has_no_compaction_routes() -> None:
@@ -124,6 +153,23 @@ def test_plain_responses_endpoint_forwards_exact_prefix() -> None:
     assert captured_kwargs["return_token_ids"] is True
 
 
+def test_streaming_responses_propagates_upstream_context_length_error() -> None:
+    model = _make_model()
+    mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+    mock_client.create_chat_completion = AsyncMock(side_effect=_upstream_context_length_error())
+    model._clients = [mock_client]
+
+    app = model.setup_webserver()
+    model.setup_exception_middleware(app)
+    response = TestClient(app).post(
+        "/v1/responses",
+        json={"input": "hi", "required_prefix_token_ids": [10, 11], "stream": True},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"error": {"message": "maximum context length", "code": 400}}
+
+
 def test_generation_fails_closed_instead_of_retokenizing_missing_exact_ids() -> None:
     model = _make_model()
 
@@ -190,3 +236,20 @@ def test_tokenize_endpoint_forwards_exact_prefix_without_sampling() -> None:
     assert captured_kwargs["required_prefix_token_ids"] == [10, 11]
     assert "logprobs" not in captured_kwargs
     assert "return_token_ids" not in captured_kwargs
+
+
+def test_direct_tokenize_endpoint_preserves_upstream_http_error() -> None:
+    model = _make_model()
+    mock_client = MagicMock(spec=NeMoGymAsyncOpenAI)
+    mock_client.create_tokenize = AsyncMock(side_effect=_upstream_tokenize_error())
+    model._clients = [mock_client]
+
+    app = model.setup_webserver()
+    model.setup_exception_middleware(app)
+    response = TestClient(app).post(
+        "/tokenize",
+        json={"input": "hi", "required_prefix_token_ids": [10, 11]},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"error": {"message": "invalid tokenize input", "code": 400}}

--- a/tests/unit_tests/test_anthropic_converter.py
+++ b/tests/unit_tests/test_anthropic_converter.py
@@ -35,6 +35,24 @@ def _converter() -> AnthropicConverter:
     return AnthropicConverter()
 
 
+class TestErrorResponse:
+    def test_context_overflow_uses_claude_code_compatible_message(self) -> None:
+        content = b'{"error":{"message":"This model maximum context length is 512 tokens"}}'
+        result = json.loads(_converter().error_response(content, 400))
+
+        assert result == {
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "prompt is too long: This model maximum context length is 512 tokens",
+            },
+        }
+
+    def test_non_context_error_preserves_message(self) -> None:
+        result = json.loads(_converter().error_response('{"message":"invalid temperature"}', 400))
+        assert result["error"] == {"type": "invalid_request_error", "message": "invalid temperature"}
+
+
 class TestAnthropicRequestToResponses:
     def test_system_string_and_user_text(self) -> None:
         params = _converter().anthropic_request_to_responses(

--- a/tests/unit_tests/test_context_errors.py
+++ b/tests/unit_tests/test_context_errors.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from nemo_gym.context_errors import error_text, is_context_overflow_error
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "This model's maximum context length is 8192 tokens",
+        "max_completion_tokens cannot be greater than max_model_len",
+        b'{"error":{"message":"prompt is too long"}}',
+        {"message": "input exceeded the context window"},
+    ],
+)
+def test_context_overflow_text_is_detected(value) -> None:
+    assert is_context_overflow_error(value)
+
+
+def test_exception_response_content_is_searched() -> None:
+    exc = RuntimeError("400, message='Bad Request'")
+    exc.response_content = b'{"error":{"message":"maximum context length is 512 tokens"}}'
+
+    assert "maximum context length" in error_text(exc)
+    assert is_context_overflow_error(exc)
+
+
+def test_exception_body_is_searched() -> None:
+    exc = SimpleNamespace(body={"message": "`inputs` tokens + `max_new_tokens` exceeded"})
+    assert is_context_overflow_error(exc)
+
+
+def test_unrelated_error_is_not_detected() -> None:
+    assert not is_context_overflow_error(RuntimeError("connection refused"))

--- a/tests/unit_tests/test_responses_api_model_messages.py
+++ b/tests/unit_tests/test_responses_api_model_messages.py
@@ -23,7 +23,8 @@ from time import time
 from unittest.mock import MagicMock
 from uuid import uuid4
 
-from fastapi import Body, Request
+from aiohttp import ClientResponseError
+from fastapi import Body, Request, Response
 from fastapi.testclient import TestClient
 
 from nemo_gym.base_responses_api_model import BaseResponsesAPIModelConfig, SimpleResponsesAPIModel
@@ -93,6 +94,11 @@ class _RequestAwareModel(SimpleResponsesAPIModel):
         raise NotImplementedError
 
 
+class _ErrorPreservingModel(_BodyOnlyModel):
+    def _model_client_response_error_response(self, request, exc):
+        return Response(content=exc.response_content, status_code=exc.status, media_type="application/json")
+
+
 def _config() -> BaseResponsesAPIModelConfig:
     return BaseResponsesAPIModelConfig(host="0.0.0.0", port=8099, entrypoint="", name="")
 
@@ -150,3 +156,18 @@ class TestDefaultMessagesRoute:
         assert "event: message_start" in body
         assert "event: content_block_delta" in body
         assert "event: message_stop" in body
+
+    def test_shared_messages_boundary_translates_preserved_provider_error(self) -> None:
+        server = _ErrorPreservingModel(
+            config=_config(), server_client=MagicMock(spec=ServerClient, global_config_dict={})
+        )
+        request = MagicMock()
+        request.url.path = "/v1/messages"
+        exc = ClientResponseError(MagicMock(), (), status=400, message="Bad Request")
+        exc.response_content = b'{"message":"maximum context length is 512 tokens"}'
+
+        response = server._client_response_error_response(request, exc)
+
+        assert response.status_code == 400
+        assert response.media_type == "application/json"
+        assert b'"message":"prompt is too long: maximum context length is 512 tokens"' in response.body


### PR DESCRIPTION
## Summary

- preserve vLLM HTTP status codes, content types, and OpenAI-compatible error bodies on Chat Completions and Responses routes instead of manufacturing an empty successful completion
- buffer synthesized streaming Responses long enough to return an explicit provider error before SSE headers are committed, while retaining `response.failed` SSE events for internal, auxiliary-tokenization, and bodyless transport failures
- translate preserved errors at the shared `/v1/messages` boundary into Anthropic-compatible envelopes; context overflow receives Claude Code's recognized `prompt is too long` prefix while retaining the original vLLM detail
- capture failed model calls before restoring their status and body to the public response
- centralize context-overflow classification, including aiohttp `response_content`, and make bodyless transport-error logging safe
- document the corrected vLLM context-overflow contract

## Why

vLLM rejects an overlong prompt before generation with an OpenAI-compatible HTTP 400. Gym previously converted that rejection into HTTP 200 with an empty `chatcmpl-123` completion and `finish_reason: length`. That hid the provider failure from clients such as OpenCode and incorrectly represented a request with no sampled tokens as a successful model call.

The adapter can preserve these failures even for the synthesized streaming Responses path because the provider call completes before Gym constructs and commits its SSE response. Internal failures continue to use the existing terminal `response.failed` event contract.

## Stack

1. **#2924 — vLLM adapter/core (this PR)**
2. #2958 — OpenCode recovery and integration coverage
3. #2959 — remaining in-repo harness consumers

Review and merge bottom-up. The later PRs are drafts and are based on the preceding branch.

## Compatibility

Consumers now receive the real provider HTTP error rather than a synthetic success. Overflow-aware consumer changes are isolated in #2958 and #2959.

## Validation

- 249 adapter/core-focused tests passed after the split
- repository unit suite from the complete implementation: 4,080 passed and 112 skipped; ten unrelated environment/platform tests require optional E2B/OpenSandbox packages or Linux `/proc`
- scoped pre-commit checks passed after the split; the complete implementation previously passed `pre-commit run --all-files`
- `fern check` passed with zero errors
- real local vLLM-Metal E2E with `mlx-community/Qwen2.5-0.5B-Instruct-4bit`: valid Chat returned 200; Chat and streaming Responses overflow returned the original 400 JSON; streaming Messages overflow returned Anthropic 400 with `prompt is too long` plus the original vLLM detail
- model-call capture records the propagated overflow status and provider content before the adapter restores the public response

Fixes #2792
