### PR TITLE
feat(docker): interactive PTY sessions with cross-process attach

### DIFF
--- a/nemo_gym/sandbox/providers/docker/__init__.py
+++ b/nemo_gym/sandbox/providers/docker/__init__.py
@@ -22,6 +22,7 @@ from nemo_gym.sandbox.providers.docker.provider import (
     DockerProbeConfig,
     DockerProvider,
 )
+from nemo_gym.sandbox.providers.docker.pty import DockerPtySession
 
 
 __all__ = [
@@ -31,4 +32,5 @@ __all__ = [
     "DockerExecConfig",
     "DockerProbeConfig",
     "DockerProvider",
+    "DockerPtySession",
 ]

--- a/nemo_gym/sandbox/providers/docker/provider.py
+++ b/nemo_gym/sandbox/providers/docker/provider.py
@@ -17,6 +17,7 @@
 import asyncio
 import contextlib
 import ipaddress
+import json
 import logging
 import math
 import os
@@ -36,10 +37,13 @@ from nemo_gym.sandbox.providers.base import (
     SandboxEndpoint,
     SandboxExecResult,
     SandboxHandle,
+    SandboxPtyError,
+    SandboxPtySpec,
     SandboxResources,
     SandboxSpec,
     SandboxStatus,
 )
+from nemo_gym.sandbox.providers.docker import pty as docker_pty
 
 
 LOGGER = logging.getLogger(__name__)
@@ -579,6 +583,160 @@ class DockerProvider:
         if host in {"0.0.0.0", "::"}:
             host = self._create_config.publish_host
         return SandboxEndpoint(endpoint=_http_endpoint(host, host_port))
+
+    async def create_pty(self, handle: SandboxHandle, spec: SandboxPtySpec) -> "docker_pty.DockerPtySession":
+        """Open an interactive terminal inside the container.
+
+        Stages a small python3 broker into the container and starts it with
+        ``docker exec -d``; all session state lives in the container, so the
+        session survives this process and can be re-attached by id from any
+        process sharing the docker daemon (see ``attach_pty`` and the
+        ``docker_pty`` module docstring). Requires ``python3`` in the image.
+        """
+        inst = handle.raw
+        session_id = uuid.uuid4().hex
+        token = uuid.uuid4().hex
+        mode = "pty" if spec.pty else "pipe"
+        state_dir = docker_pty._session_dir(session_id)
+        timeout_s = self._exec_config.default_timeout_s
+
+        stage_argv = [self._binary, "exec", "-i", inst.name, "sh", "-c"]
+        stage_argv.append(docker_pty.staging_script(session_id, token, mode))
+        code, _out, err = await self._run(stage_argv, timeout_s=timeout_s, stdin=docker_pty.HELPER_SOURCE.encode())
+        if code == docker_pty.EXIT_NO_PYTHON3:
+            raise SandboxPtyError(
+                "docker PTY sessions require python3 inside the sandbox image "
+                f"(image {inst.image!r} has none); install python3 or use exec() instead"
+            )
+        if code != 0:
+            raise SandboxPtyError(f"failed to stage PTY session state (code={code}): {err.strip()}")
+
+        broker_flags: list[str] = ["-d"]
+        if spec.cwd is not None:
+            broker_flags += ["-w", spec.cwd]
+        merged_env = dict(inst.env)
+        if spec.env:
+            merged_env.update(spec.env)
+        for key, value in merged_env.items():
+            broker_flags += ["--env", f"{key}={value}"]
+        if spec.user is not None:
+            broker_flags += ["--user", "0" if spec.user == "root" or spec.user == 0 else str(spec.user)]
+        broker_argv = [
+            self._binary,
+            "exec",
+            *broker_flags,
+            inst.name,
+            "python3",
+            docker_pty._helper_path(session_id),
+            "broker",
+            state_dir,
+            inst.shell,
+            str(spec.rows),
+            str(spec.cols),
+            mode,
+        ]
+        if spec.command is not None:
+            broker_argv.append(spec.command)
+
+        async def _cleanup() -> None:
+            with contextlib.suppress(Exception):
+                await self._run(
+                    [self._binary, "exec", inst.name, "sh", "-c", f"rm -rf {state_dir}"], timeout_s=timeout_s
+                )
+
+        code, _out, err = await self._run(broker_argv, timeout_s=timeout_s)
+        if code != 0:
+            await _cleanup()
+            raise SandboxPtyError(f"failed to start PTY broker (code={code}): {err.strip()}")
+
+        # The broker signals readiness (FIFOs created, process spawned) by
+        # touching a `ready` file; wait for it before handing the session out.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + docker_pty.READY_DEADLINE_S
+        while True:
+            code, _out, _err = await self._run(
+                [self._binary, "exec", inst.name, "sh", "-c", f"test -f {state_dir}/ready"], timeout_s=timeout_s
+            )
+            if code == 0:
+                break
+            if loop.time() >= deadline:
+                _code, log, _err2 = await self._run(
+                    [self._binary, "exec", inst.name, "sh", "-c", f"cat {state_dir}/broker.log 2>/dev/null"],
+                    timeout_s=timeout_s,
+                )
+                await _cleanup()
+                raise SandboxPtyError(
+                    f"PTY broker did not become ready within {docker_pty.READY_DEADLINE_S:g}s; "
+                    f"broker log: {log.strip()!r}"
+                )
+            await asyncio.sleep(0.1)
+
+        return docker_pty.DockerPtySession(
+            provider=self,
+            container_name=inst.name,
+            session_id=session_id,
+            token=token,
+            mode=mode,
+            owned=True,
+        )
+
+    async def attach_pty(
+        self,
+        handle: SandboxHandle,
+        session_id: str,
+        *,
+        takeover: bool = True,
+        since: int | None = None,
+    ) -> "docker_pty.DockerPtySession":
+        """Re-attach to a PTY session by id, possibly from another process.
+
+        ``takeover`` rotates the session's owner token, so the evicted
+        client's next operation raises ``SandboxPtyError``; without it,
+        attaching to a held session raises. ``since`` is a byte offset into
+        the session's output log to replay from (``0`` replays everything;
+        the log retains the session's whole output). Pipe-mode attaches
+        always tail stderr live.
+        """
+        inst = handle.raw
+        token = uuid.uuid4().hex
+        argv = [
+            self._binary,
+            "exec",
+            inst.name,
+            "python3",
+            docker_pty._helper_path(session_id),
+            "attach",
+            docker_pty._session_dir(session_id),
+            token,
+            "1" if takeover else "0",
+        ]
+        try:
+            code, out, err = await self._run(argv, timeout_s=self._exec_config.default_timeout_s)
+        except TimeoutError as e:
+            raise SandboxPtyError(f"PTY attach to session {session_id} timed out: {e}") from e
+        if code == docker_pty.EXIT_HELD:
+            raise SandboxPtyError(
+                f"PTY session {session_id} already has an attached client (pass takeover=True to evict)"
+            )
+        if code == docker_pty.EXIT_DEAD or (code != 0 and "can't open file" in err.lower()):
+            raise SandboxPtyError(f"PTY session {session_id} does not exist in container {inst.name!r}")
+        if code != 0:
+            raise SandboxPtyError(f"PTY attach to session {session_id} failed (code={code}): {err.strip()}")
+        try:
+            meta = json.loads(out)
+        except ValueError as e:
+            raise SandboxPtyError(f"PTY attach to session {session_id} returned malformed metadata: {e!r}") from e
+        return docker_pty.DockerPtySession(
+            provider=self,
+            container_name=inst.name,
+            session_id=session_id,
+            token=token,
+            mode=str(meta.get("mode") or "pty"),
+            owned=False,
+            out_offset=int(since) if since is not None else int(meta.get("out_size") or 0),
+            err_offset=int(meta.get("err_size") or 0),
+            exit_code=meta["exit"] if meta.get("exit") is not None else None,
+        )
 
     async def close(self, handle: SandboxHandle) -> None:
         """Force-remove the container (already-gone counts as success)."""

--- a/nemo_gym/sandbox/providers/docker/pty.py
+++ b/nemo_gym/sandbox/providers/docker/pty.py
@@ -1,0 +1,726 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Interactive PTY sessions for the docker provider.
+
+A session is a tiny in-container python3 "broker" started with ``docker exec
+-d``. The broker allocates a real PTY (or plain pipes in pipe mode), runs the
+interactive shell / command on it, and mirrors everything through files under
+``/tmp/.nemo-gym-pty/<session_id>/`` inside the container:
+
+- ``ngpty.py``     this module's helper program, staged at create time
+- ``broker.pid`` / ``child.pid``  the broker and its shell/command process
+- ``stdin`` / ``control``  FIFOs carrying input and resize/signal requests
+- ``output.log``   append-only merged terminal output (stdout in pipe mode)
+- ``stderr.log``   append-only stderr (pipe mode only)
+- ``exit_code``    written once when the process exits
+- ``owner``        the current holder's token (empty = released)
+- ``meta.json`` / ``ready`` / ``broker.log``  bookkeeping and diagnostics
+
+Because all state lives in the container, sessions survive the creating
+process: any process that shares the docker daemon can ``connect()`` to the
+container and ``attach_pty()`` by session id. The client side drives the
+session with short-lived ``docker exec`` calls: ``write()`` appends to the
+stdin FIFO, ``read()`` polls ``output.log`` from a tracked byte offset (which
+is also what makes ``attach(since=...)`` replay work), ``resize()`` and
+``send_signal()`` go through the control FIFO, and ``wait_exit()`` polls the
+exit-code file.
+
+Requirements and simplifications vs the OpenSandbox execd backend:
+
+- ``python3`` must exist in the sandbox image; ``create_pty`` fails with a
+  clear error otherwise (SWE-bench task images all carry python3). No tmux or
+  other terminal multiplexer is required.
+- Retained output is the session's *entire* output log (bounded only by
+  container disk), not execd's ~1 MiB ring. ``attach(since=0)`` therefore
+  replays everything, and ``run_detached`` can never lose output between
+  polls, so the "retained window exceeded" error path of the protocol never
+  triggers here.
+- There is no live connection, so "attached" is a token, not a socket: the
+  ``owner`` file holds the current holder's token. ``attach(takeover=True)``
+  rotates it and the evicted client's next ``read``/``write``/``poll`` sees
+  the rotation and raises ``SandboxPtyError``. Without takeover, attaching to
+  a held session raises; it succeeds only after the holder released it (an
+  attached — non-creator — session's ``close()`` releases; the creator's
+  ``close()`` ends the session outright, matching the protocol).
+- Eviction is detected on the evicted client's *next* operation (there is no
+  push channel), and output is delivered with the client's polling latency
+  (~100 ms) rather than streamed.
+- The broker stops draining output ~1 s after process exit even if a
+  background grandchild still holds the terminal open, mirroring execd's
+  "clean EOF means the stream drained, not that every byte was delivered".
+- ``since`` replay offsets index ``output.log`` (the merged stream in PTY
+  mode, stdout in pipe mode); a pipe-mode attach always tails stderr live.
+- ``rows``/``cols`` are applied at spawn (before the command runs), so unlike
+  execd there is no window where the command observes the backend default.
+"""
+
+import asyncio
+import base64
+import json
+import shlex
+import signal as signal_module
+import uuid
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+
+from nemo_gym.sandbox.providers.base import SandboxPtyError
+
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard, typing only
+    from nemo_gym.sandbox.providers.docker.provider import DockerProvider
+
+
+PTY_STATE_ROOT = "/tmp/.nemo-gym-pty"
+# Not "pty.py": the script's own directory is sys.path[0], so that name would
+# shadow the stdlib `pty` module the broker imports.
+HELPER_FILENAME = "ngpty.py"
+
+# Helper exit codes (chosen away from shell/docker conventions).
+EXIT_EVICTED = 90  # owner token no longer matches: another client took over
+EXIT_DEAD = 91  # session state or broker is gone
+EXIT_HELD = 92  # attach without takeover while another client holds the session
+EXIT_NO_PYTHON3 = 97  # staging: python3 missing from the image
+
+READ_POLL_INTERVAL_S = 0.1
+POLL_MAX_BYTES = 262144
+READY_DEADLINE_S = 30.0
+_WRITE_EXTRA_TIMEOUT_S = 15.0  # helper-side FIFO write deadline; give the CLI at least this long
+
+# The in-container helper program. Kept as a string so coverage and import
+# machinery never see it; it targets the *image's* python3 (>= 3.6: no
+# walrus, no dataclasses, no X | Y annotations).
+HELPER_SOURCE = r'''
+"""NeMo Gym docker PTY session helper. Runs inside the sandbox container."""
+import base64
+import errno
+import fcntl
+import json
+import os
+import select
+import shutil
+import signal
+import struct
+import sys
+import time
+
+EXIT_EVICTED = 90
+EXIT_DEAD = 91
+EXIT_HELD = 92
+
+
+def _read_text(path):
+    try:
+        with open(path) as f:
+            return f.read()
+    except OSError:
+        return None
+
+
+def _write_atomic(path, text):
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        f.write(text)
+    os.replace(tmp, path)
+
+
+def _check_token(d, token):
+    owner = _read_text(os.path.join(d, "owner"))
+    if owner is None:
+        sys.exit(EXIT_DEAD)
+    if owner != token:
+        sys.exit(EXIT_EVICTED)
+
+
+def _size(path):
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return 0
+
+
+def _exit_code(d):
+    text = _read_text(os.path.join(d, "exit_code"))
+    if text is None:
+        return None
+    try:
+        return int(text.strip())
+    except ValueError:
+        return None
+
+
+def _broker_alive(d):
+    text = _read_text(os.path.join(d, "broker.pid"))
+    if text is None:
+        return False
+    try:
+        os.kill(int(text.strip()), 0)
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def op_poll(d, token, out_off, err_off, max_bytes):
+    _check_token(d, token)
+
+    def _slice(name, off):
+        path = os.path.join(d, name)
+        size = _size(path)
+        data = b""
+        if max_bytes > 0 and size > off:
+            with open(path, "rb") as f:
+                f.seek(off)
+                data = f.read(max_bytes)
+        return data, size
+
+    out, out_size = _slice("output.log", out_off)
+    err, err_size = _slice("stderr.log", err_off)
+    print(json.dumps({
+        "out": base64.b64encode(out).decode("ascii"),
+        "out_size": out_size,
+        "err": base64.b64encode(err).decode("ascii"),
+        "err_size": err_size,
+        "exit": _exit_code(d),
+        "alive": _broker_alive(d),
+    }))
+
+
+def _open_fifo_writer(path):
+    try:
+        return os.open(path, os.O_WRONLY | os.O_NONBLOCK)
+    except OSError as e:
+        if e.errno in (errno.ENXIO, errno.ENOENT):
+            sys.exit(EXIT_DEAD)
+        raise
+
+
+def _fifo_write_all(fd, data, deadline_s=10.0):
+    end = time.time() + deadline_s
+    view = memoryview(data)
+    while view:
+        try:
+            n = os.write(fd, view[:4096])
+            view = view[n:]
+        except OSError as e:
+            if e.errno != errno.EAGAIN:
+                sys.exit(EXIT_DEAD)
+            if time.time() >= end:
+                sys.exit(EXIT_DEAD)
+            time.sleep(0.05)
+
+
+def op_write(d, token, fifo_name):
+    _check_token(d, token)
+    data = sys.stdin.buffer.read()
+    fd = _open_fifo_writer(os.path.join(d, fifo_name))
+    try:
+        _fifo_write_all(fd, data)
+    finally:
+        os.close(fd)
+
+
+def op_attach(d, new_token, takeover):
+    owner_path = os.path.join(d, "owner")
+    owner = _read_text(owner_path)
+    if owner is None or _read_text(os.path.join(d, "meta.json")) is None:
+        sys.exit(EXIT_DEAD)
+    if owner and not takeover:
+        sys.exit(EXIT_HELD)
+    _write_atomic(owner_path, new_token)
+    meta = json.loads(_read_text(os.path.join(d, "meta.json")))
+    print(json.dumps({
+        "mode": meta.get("mode"),
+        "out_size": _size(os.path.join(d, "output.log")),
+        "err_size": _size(os.path.join(d, "stderr.log")),
+        "exit": _exit_code(d),
+        "alive": _broker_alive(d),
+    }))
+
+
+def op_release(d, token):
+    owner_path = os.path.join(d, "owner")
+    if _read_text(owner_path) == token:
+        _write_atomic(owner_path, "")
+
+
+def _kill_from_pidfile(d, name, whole_group):
+    text = _read_text(os.path.join(d, name))
+    if text is None:
+        return
+    try:
+        pid = int(text.strip())
+    except ValueError:
+        return
+    try:
+        if whole_group:
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
+        else:
+            os.kill(pid, signal.SIGKILL)
+    except OSError:
+        pass
+
+
+def op_end(d):
+    _kill_from_pidfile(d, "child.pid", True)
+    _kill_from_pidfile(d, "broker.pid", False)
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def _status_to_exit_code(status):
+    if os.WIFEXITED(status):
+        return os.WEXITSTATUS(status)
+    if os.WIFSIGNALED(status):
+        return 128 + os.WTERMSIG(status)
+    return 128
+
+
+def _handle_ctl(line, master, child_pid):
+    try:
+        msg = json.loads(line.decode("utf-8", "replace"))
+    except ValueError:
+        return
+    kind = msg.get("type")
+    if kind == "resize" and master is not None:
+        try:
+            import termios
+            winsz = struct.pack("HHHH", int(msg["rows"]), int(msg["cols"]), 0, 0)
+            fcntl.ioctl(master, termios.TIOCSWINSZ, winsz)
+        except (OSError, KeyError, TypeError, ValueError):
+            pass
+    elif kind == "signal":
+        signum = getattr(signal, str(msg.get("signal", "")), None)
+        if signum is None:
+            return
+        try:
+            os.killpg(os.getpgid(child_pid), signum)
+        except OSError:
+            try:
+                os.kill(child_pid, signum)
+            except OSError:
+                pass
+
+
+def op_broker(d, shell, rows, cols, mode, command):
+    log = open(os.path.join(d, "broker.log"), "ab", 0)
+    os.dup2(log.fileno(), 2)
+    _write_atomic(os.path.join(d, "broker.pid"), str(os.getpid()))
+    for name in ("stdin", "control"):
+        path = os.path.join(d, name)
+        if not os.path.exists(path):
+            os.mkfifo(path)
+    argv = [shell, "-c", command] if command is not None else [shell]
+    out_log = open(os.path.join(d, "output.log"), "ab", 0)
+    use_pty = mode == "pty"
+    master = None
+    if use_pty:
+        import pty
+        import termios
+        pid, master = pty.fork()
+        if pid == 0:
+            try:
+                os.execvp(argv[0], argv)
+            except OSError:
+                os._exit(127)
+        fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+        read_fds = {master: out_log}
+        stdin_target = master
+    else:
+        import subprocess
+        err_log = open(os.path.join(d, "stderr.log"), "ab", 0)
+        proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        pid = proc.pid
+        read_fds = {proc.stdout.fileno(): out_log, proc.stderr.fileno(): err_log}
+        stdin_target = proc.stdin.fileno()
+    _write_atomic(os.path.join(d, "child.pid"), str(pid))
+    stdin_fd = os.open(os.path.join(d, "stdin"), os.O_RDWR | os.O_NONBLOCK)
+    ctl_fd = os.open(os.path.join(d, "control"), os.O_RDWR | os.O_NONBLOCK)
+    _write_atomic(os.path.join(d, "ready"), "1")
+
+    ctl_buf = b""
+    exit_code = None
+    quiet_rounds = 0
+    while True:
+        try:
+            ready, _, _ = select.select(list(read_fds) + [stdin_fd, ctl_fd], [], [], 0.2)
+        except InterruptedError:
+            continue
+        got_output = False
+        for fd in list(read_fds):
+            if fd not in ready:
+                continue
+            try:
+                data = os.read(fd, 65536)
+            except OSError:
+                data = b""  # EIO: pty slave side fully closed
+            if data:
+                read_fds[fd].write(data)
+                got_output = True
+            else:
+                del read_fds[fd]
+        if stdin_fd in ready:
+            try:
+                data = os.read(stdin_fd, 65536)
+            except OSError:
+                data = b""
+            if data:
+                try:
+                    view = memoryview(data)
+                    while view:
+                        view = view[os.write(stdin_target, view) :]
+                except OSError:
+                    pass  # process side gone; drop input
+        if ctl_fd in ready:
+            try:
+                ctl_buf += os.read(ctl_fd, 65536)
+            except OSError:
+                pass
+            while b"\n" in ctl_buf:
+                line, ctl_buf = ctl_buf.split(b"\n", 1)
+                if line.strip():
+                    _handle_ctl(line, master, pid)
+        if exit_code is None:
+            try:
+                wpid, status = os.waitpid(pid, os.WNOHANG)
+            except ChildProcessError:
+                wpid, status = pid, 0
+            if wpid == pid:
+                exit_code = _status_to_exit_code(status)
+        if exit_code is not None:
+            quiet_rounds = 0 if got_output else quiet_rounds + 1
+            if not read_fds or quiet_rounds >= 5:
+                break
+    _write_atomic(os.path.join(d, "exit_code"), str(exit_code))
+
+
+def main():
+    op = sys.argv[1]
+    if op == "broker":
+        d, shell, rows, cols, mode = sys.argv[2:7]
+        command = sys.argv[7] if len(sys.argv) > 7 else None
+        op_broker(d, shell, int(rows), int(cols), mode, command)
+    elif op == "poll":
+        d, token, out_off, err_off, max_bytes = sys.argv[2:7]
+        op_poll(d, token, int(out_off), int(err_off), int(max_bytes))
+    elif op == "write":
+        op_write(sys.argv[2], sys.argv[3], "stdin")
+    elif op == "ctl":
+        op_write(sys.argv[2], sys.argv[3], "control")
+    elif op == "attach":
+        op_attach(sys.argv[2], sys.argv[3], sys.argv[4] == "1")
+    elif op == "release":
+        op_release(sys.argv[2], sys.argv[3])
+    elif op == "end":
+        op_end(sys.argv[2])
+    else:
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def _session_dir(session_id: str) -> str:
+    return f"{PTY_STATE_ROOT}/{session_id}"
+
+
+def _helper_path(session_id: str) -> str:
+    return f"{_session_dir(session_id)}/{HELPER_FILENAME}"
+
+
+def staging_script(session_id: str, token: str, mode: str) -> str:
+    """Shell script that stages the helper (fed on stdin) and seeds session state."""
+    d = _session_dir(session_id)
+    meta = json.dumps({"mode": mode})
+    return (
+        f"command -v python3 >/dev/null 2>&1 || exit {EXIT_NO_PYTHON3}\n"
+        f"mkdir -p {d} && cat > {d}/{HELPER_FILENAME} && "
+        f"printf %s {shlex.quote(token)} > {d}/owner && "
+        f"printf %s {shlex.quote(meta)} > {d}/meta.json && "
+        f"chmod -R 777 {d}"
+    )
+
+
+class DockerPtySession:
+    """One docker PTY session, driven via short-lived ``docker exec`` calls.
+
+    Created by ``DockerProvider.create_pty`` / ``attach_pty``. All methods are
+    safe to call from the creating process or any process that rebuilt the
+    handle via ``connect()``.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: "DockerProvider",
+        container_name: str,
+        session_id: str,
+        token: str,
+        mode: str,
+        owned: bool,
+        out_offset: int = 0,
+        err_offset: int = 0,
+        exit_code: int | None = None,
+    ) -> None:
+        self._provider = provider
+        self._container_name = container_name
+        self.session_id = session_id
+        self._token = token
+        self.mode: str | None = mode
+        self._owned = owned
+        self._out_offset = out_offset
+        self._err_offset = err_offset
+        self._exit_code = exit_code
+        self._closed = False
+        self._dead = False  # evicted, broker died, or exited-and-drained
+        # Serialize offset bookkeeping so concurrent reads never return
+        # duplicate bytes (each read atomically fetches-from-offset+advances).
+        self._read_lock = asyncio.Lock()
+
+    @property
+    def closed(self) -> bool:
+        """True once the session can no longer run commands: after ``close()``,
+        after eviction by a takeover, or once the process exited and the
+        output was drained."""
+        return self._closed or self._dead
+
+    async def _helper(
+        self, args: list[str], *, stdin: bytes | None = None, extra_timeout_s: float = 0.0
+    ) -> tuple[int, str, str]:
+        """Run one helper op inside the container, mapping helper exit codes."""
+        provider = self._provider
+        argv = [provider._binary, "exec"]
+        if stdin is not None:
+            argv.append("-i")
+        argv += [self._container_name, "python3", _helper_path(self.session_id), *args]
+        timeout_s = provider._exec_config.default_timeout_s
+        if timeout_s is not None:
+            timeout_s += extra_timeout_s
+        try:
+            code, out, err = await provider._run(argv, timeout_s=timeout_s, stdin=stdin)
+        except TimeoutError as e:
+            raise SandboxPtyError(f"PTY session {self.session_id} operation timed out: {e}") from e
+        if code == EXIT_EVICTED:
+            self._dead = True
+            raise SandboxPtyError("PTY session was taken over by another client")
+        if code == EXIT_DEAD:
+            self._dead = True
+            raise SandboxPtyError(f"PTY session {self.session_id} no longer exists in the sandbox")
+        if code == EXIT_HELD:
+            raise SandboxPtyError(
+                f"PTY session {self.session_id} already has an attached client (pass takeover=True to evict)"
+            )
+        return code, out, err
+
+    async def _poll(self, *, max_bytes: int) -> dict[str, Any]:
+        code, out, err = await self._helper(
+            [
+                "poll",
+                _session_dir(self.session_id),
+                self._token,
+                str(self._out_offset),
+                str(self._err_offset),
+                str(max_bytes),
+            ]
+        )
+        if code != 0:
+            self._dead = True
+            raise SandboxPtyError(f"PTY session {self.session_id} poll failed (code={code}): {err.strip()}")
+        try:
+            info = json.loads(out)
+            info["out_bytes"] = base64.b64decode(info.pop("out"))
+            info["err_bytes"] = base64.b64decode(info.pop("err"))
+            return info
+        except (ValueError, KeyError, TypeError) as e:
+            raise SandboxPtyError(f"PTY session {self.session_id} poll returned malformed data: {e!r}") from e
+
+    def _ensure_writable(self) -> None:
+        if self._closed:
+            raise SandboxPtyError("PTY session is closed")
+        if self._dead:
+            raise SandboxPtyError("PTY session has ended")
+
+    async def _read_stream(self, stream: str, timeout_s: float | None) -> bytes:
+        if self._closed and self._exit_code is None:
+            raise SandboxPtyError("PTY session is closed")
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout_s if timeout_s is not None else None
+        while True:
+            async with self._read_lock:
+                if self._dead and self._exit_code is None:
+                    raise SandboxPtyError("PTY session has ended")
+                info = await self._poll(max_bytes=POLL_MAX_BYTES)
+                if info.get("exit") is not None:
+                    self._exit_code = int(info["exit"])
+                chunk: bytes = info[f"{stream}_bytes"]
+                if chunk:
+                    self._advance(stream, len(chunk))
+                    return chunk
+                if self._exit_code is not None:
+                    # Exited and this stream is drained.
+                    if self._out_offset >= int(info["out_size"]) and self._err_offset >= int(info["err_size"]):
+                        self._dead = True
+                    return b""
+                if not info.get("alive", False):
+                    self._dead = True
+                    raise SandboxPtyError("PTY session died without exiting")
+            now = loop.time()
+            if deadline is not None and now >= deadline:
+                raise TimeoutError(f"no PTY {'stderr' if stream == 'err' else 'output'} within {timeout_s:g}s")
+            sleep_s = READ_POLL_INTERVAL_S if deadline is None else min(READ_POLL_INTERVAL_S, deadline - now)
+            await asyncio.sleep(sleep_s)
+
+    def _advance(self, stream: str, n: int) -> None:
+        if stream == "out":
+            self._out_offset += n
+        else:
+            self._err_offset += n
+
+    async def read(self, *, timeout_s: float | None = None) -> bytes:
+        """Next output chunk (all terminal output in PTY mode; stdout in pipe
+        mode). ``b""`` once the process exited and the stream is drained."""
+        return await self._read_stream("out", timeout_s)
+
+    async def read_stderr(self, *, timeout_s: float | None = None) -> bytes:
+        """Next stderr chunk (pipe mode only; the PTY-mode stderr stream is
+        empty and returns ``b""`` once the process exits)."""
+        return await self._read_stream("err", timeout_s)
+
+    def __aiter__(self) -> AsyncIterator[bytes]:
+        async def _iterate() -> AsyncIterator[bytes]:
+            while chunk := await self.read():
+                yield chunk
+
+        return _iterate()
+
+    async def write(self, data: bytes) -> None:
+        """Send raw bytes to the terminal's stdin (via the session's FIFO)."""
+        self._ensure_writable()
+        await self._helper(
+            ["write", _session_dir(self.session_id), self._token],
+            stdin=data,
+            extra_timeout_s=_WRITE_EXTRA_TIMEOUT_S,
+        )
+
+    async def _ctl(self, payload: dict[str, Any]) -> None:
+        self._ensure_writable()
+        await self._helper(
+            ["ctl", _session_dir(self.session_id), self._token],
+            stdin=json.dumps(payload).encode() + b"\n",
+            extra_timeout_s=_WRITE_EXTRA_TIMEOUT_S,
+        )
+
+    async def resize(self, rows: int, cols: int) -> None:
+        """Resize the terminal (ignored by pipe-mode sessions)."""
+        await self._ctl({"type": "resize", "rows": int(rows), "cols": int(cols)})
+
+    async def send_signal(self, signal: str) -> None:
+        """Deliver a named signal (e.g. ``"SIGTERM"``) to the session's
+        process group."""
+        if not signal.startswith("SIG") or not hasattr(signal_module, signal):
+            raise ValueError(f"unknown signal name: {signal!r}")
+        await self._ctl({"type": "signal", "signal": signal})
+
+    async def wait_exit(self, *, timeout_s: float | None = None) -> int:
+        """Block (polling the exit-code file) until the process exits."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout_s if timeout_s is not None else None
+        while True:
+            if self._exit_code is not None:
+                return self._exit_code
+            if self._closed:
+                raise SandboxPtyError("PTY session closed before process exit")
+            info = await self._poll(max_bytes=0)
+            if info.get("exit") is not None:
+                self._exit_code = int(info["exit"])
+                return self._exit_code
+            if not info.get("alive", False):
+                self._dead = True
+                raise SandboxPtyError("PTY session died without exiting")
+            now = loop.time()
+            if deadline is not None and now >= deadline:
+                raise TimeoutError(f"PTY process did not exit within {timeout_s:g}s")
+            sleep_s = READ_POLL_INTERVAL_S if deadline is None else min(READ_POLL_INTERVAL_S, deadline - now)
+            await asyncio.sleep(sleep_s)
+
+    async def run_detached(self, command: str, *, poll_interval_s: float = 15.0) -> tuple[bytes, int | None]:
+        """Run one command, polling the session's output log every
+        ``poll_interval_s`` while it works.
+
+        Docker sessions hold no connection between polls and retain the whole
+        output log, so unlike the OpenSandbox backend nothing can be lost
+        between polls and no retained-window error exists. Returns
+        ``(merged output, exit code or None)``; ``None`` means the marker
+        line came back mangled. Callers serialize: one command per session.
+        """
+        token = f"NGPTY{uuid.uuid4().hex[:12]}"
+        needle = f"{token}:".encode()
+        # Marker from two literals so the terminal's echo of this line cannot
+        # match it; the brace group keeps shell state while putting stdin at
+        # EOF (same discipline as _run_in_pty_session in the api module).
+        await self.write(
+            f"{{ {command}\n}} </dev/null\nprintf '%s%s:%s\\n' '{token[:5]}' '{token[5:]}' \"$?\"\n".encode()
+        )
+        buffer = bytearray()
+        while needle not in buffer:
+            try:
+                chunk = await self.read(timeout_s=1.0)
+            except (TimeoutError, asyncio.TimeoutError):
+                await asyncio.sleep(poll_interval_s)
+                continue
+            if not chunk:
+                raise SandboxPtyError("PTY session ended before the command finished")
+            buffer.extend(chunk)
+        output, _, trailing = bytes(buffer).partition(needle)
+        while b"\n" not in trailing:
+            # The status digits can straddle the chunk that carried the marker.
+            chunk = await self.read(timeout_s=5.0)
+            if not chunk:
+                break
+            trailing += chunk
+        exit_text = trailing.split(b"\n", 1)[0].strip()
+        stderr = bytearray()
+        try:
+            # Pipe mode carries stderr separately; fold it in best-effort.
+            while chunk := await self.read_stderr(timeout_s=0.05):
+                stderr.extend(chunk)
+        except (TimeoutError, asyncio.TimeoutError):
+            pass
+        return bytes(output + stderr), int(exit_text) if exit_text.isdigit() else None
+
+    async def close(self) -> None:
+        """Idempotent. The creator's session is ended (process killed, state
+        removed); an attached session is merely released and lives on."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self._owned:
+                await self._helper(["end", _session_dir(self.session_id)])
+            else:
+                await self._helper(["release", _session_dir(self.session_id), self._token])
+        except Exception:
+            pass  # already-evicted/gone sessions and stopped containers close cleanly
+
+    async def __aenter__(self) -> "DockerPtySession":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        await self.close()

--- a/tests/unit_tests/test_docker_pty.py
+++ b/tests/unit_tests/test_docker_pty.py
@@ -1,0 +1,520 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the docker provider's PTY sessions (no docker daemon needed)."""
+
+import base64
+import json
+from typing import Any, Callable
+
+import pytest
+
+from nemo_gym.sandbox.providers.base import (
+    SandboxHandle,
+    SandboxPtyError,
+    SandboxPtySpec,
+    SupportsSandboxPty,
+    SupportsSandboxPtyAttach,
+)
+from nemo_gym.sandbox.providers.docker import provider as docker_provider
+from nemo_gym.sandbox.providers.docker import pty as docker_pty
+
+
+pytestmark = pytest.mark.sandbox
+
+
+FAKE_BINARY = "/usr/bin/docker"
+
+
+class RunRecorder:
+    """Stand-in for DockerProvider._run that records argv and returns canned output."""
+
+    def __init__(self, responder: Callable[[list[str]], tuple[int, str, str]]) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._responder = responder
+
+    async def __call__(
+        self, argv: list[str], *, timeout_s: float | None, stdin: bytes | None = None
+    ) -> tuple[int, str, str]:
+        self.calls.append({"argv": list(argv), "timeout_s": timeout_s, "stdin": stdin})
+        return self._responder(list(argv))
+
+
+def _contains_seq(haystack: list[str], needle: list[str]) -> bool:
+    return any(haystack[i : i + len(needle)] == needle for i in range(len(haystack) - len(needle) + 1))
+
+
+def _make_handle(*, name: str = "nemo-gym-x", shell: str = "sh", env: dict[str, str] | None = None) -> SandboxHandle:
+    inst = docker_provider._DockerContainer(name=name, image="img", shell=shell, env=env or {})
+    return SandboxHandle(sandbox_id=name, provider_name="docker", raw=inst)
+
+
+def _make_provider(
+    monkeypatch: pytest.MonkeyPatch, responder: Callable[[list[str]], tuple[int, str, str]], **kwargs: Any
+) -> tuple[Any, RunRecorder]:
+    monkeypatch.setattr(docker_provider, "_require_docker", lambda: FAKE_BINARY)
+    kwargs.setdefault("exec", {"exec_shell": "sh"})
+    provider = docker_provider.DockerProvider(**kwargs)
+    rec = RunRecorder(responder)
+    monkeypatch.setattr(provider, "_run", rec)
+    return provider, rec
+
+
+def _poll_payload(
+    *,
+    out: bytes = b"",
+    out_size: int = 0,
+    err: bytes = b"",
+    err_size: int = 0,
+    exit_code: int | None = None,
+    alive: bool = True,
+) -> str:
+    return json.dumps(
+        {
+            "out": base64.b64encode(out).decode(),
+            "out_size": out_size,
+            "err": base64.b64encode(err).decode(),
+            "err_size": err_size,
+            "exit": exit_code,
+            "alive": alive,
+        }
+    )
+
+
+class SessionResponder:
+    """Scripted per-op responder for helper calls (`ngpty.py <op> ...`)."""
+
+    def __init__(self) -> None:
+        self.poll_results: list[tuple[int, str, str]] = []
+        self.write_result: tuple[int, str, str] = (0, "", "")
+        self.default: tuple[int, str, str] = (0, "", "")
+
+    def __call__(self, argv: list[str]) -> tuple[int, str, str]:
+        op = self._op(argv)
+        if op == "poll":
+            if not self.poll_results:
+                raise AssertionError("unexpected poll")
+            return self.poll_results.pop(0)
+        if op in ("write", "ctl"):
+            return self.write_result
+        return self.default
+
+    @staticmethod
+    def _op(argv: list[str]) -> str | None:
+        for i, tok in enumerate(argv):
+            if tok.endswith(docker_pty.HELPER_FILENAME) and i + 1 < len(argv):
+                return argv[i + 1]
+        return None
+
+
+def _make_session(
+    monkeypatch: pytest.MonkeyPatch, responder: Callable[[list[str]], tuple[int, str, str]], **kwargs: Any
+) -> tuple[docker_pty.DockerPtySession, RunRecorder]:
+    provider, rec = _make_provider(monkeypatch, responder)
+    session = docker_pty.DockerPtySession(
+        provider=provider,
+        container_name="nemo-gym-x",
+        session_id="sid1",
+        token="tok1",
+        mode=kwargs.pop("mode", "pty"),
+        owned=kwargs.pop("owned", True),
+        **kwargs,
+    )
+    return session, rec
+
+
+# --------------------------------------------------------------------------- #
+# Protocol conformance
+# --------------------------------------------------------------------------- #
+def test_provider_satisfies_pty_protocols(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+    assert isinstance(provider, SupportsSandboxPty)
+    assert isinstance(provider, SupportsSandboxPtyAttach)
+
+
+def test_helper_source_is_valid_python() -> None:
+    import ast
+
+    ast.parse(docker_pty.HELPER_SOURCE)
+
+
+# --------------------------------------------------------------------------- #
+# create_pty
+# --------------------------------------------------------------------------- #
+async def test_create_pty_stages_and_starts_broker(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+    handle = _make_handle(shell="bash", env={"BASE": "1"})
+    spec = SandboxPtySpec(command="htop", cwd="/work", env={"EXTRA": "2"}, rows=40, cols=120, user="root")
+
+    session = await provider.create_pty(handle, spec)
+
+    assert session.session_id
+    assert session.mode == "pty"
+    assert session.closed is False
+
+    stage = rec.calls[0]
+    assert stage["argv"][:4] == [FAKE_BINARY, "exec", "-i", "nemo-gym-x"]
+    assert stage["argv"][4:6] == ["sh", "-c"]
+    assert f"exit {docker_pty.EXIT_NO_PYTHON3}" in stage["argv"][6]
+    assert docker_pty._session_dir(session.session_id) in stage["argv"][6]
+    assert stage["stdin"] == docker_pty.HELPER_SOURCE.encode()
+
+    broker = rec.calls[1]["argv"]
+    assert broker[:3] == [FAKE_BINARY, "exec", "-d"]
+    assert _contains_seq(broker, ["-w", "/work"])
+    assert _contains_seq(broker, ["--env", "BASE=1"])
+    assert _contains_seq(broker, ["--env", "EXTRA=2"])
+    assert _contains_seq(broker, ["--user", "0"])
+    helper = docker_pty._helper_path(session.session_id)
+    assert _contains_seq(broker, ["python3", helper, "broker"])
+    assert broker[-5:] == ["bash", "40", "120", "pty", "htop"]
+
+    ready = rec.calls[2]["argv"]
+    assert ready[-1].endswith("/ready")
+
+
+async def test_create_pty_shell_session_and_pipe_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, rec = _make_provider(monkeypatch, lambda argv: (0, "", ""))
+    session = await provider.create_pty(_make_handle(), SandboxPtySpec(pty=False))
+    assert session.mode == "pipe"
+    broker = rec.calls[1]["argv"]
+    # No command -> the shell itself is the session process.
+    assert broker[-4:] == ["sh", "24", "80", "pipe"]
+
+
+async def test_create_pty_requires_python3(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (docker_pty.EXIT_NO_PYTHON3, "", ""))
+    with pytest.raises(SandboxPtyError, match="python3"):
+        await provider.create_pty(_make_handle(), SandboxPtySpec())
+
+
+async def test_create_pty_broker_start_failure_cleans_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        if "-d" in argv:
+            return (1, "", "boom")
+        return (0, "", "")
+
+    provider, rec = _make_provider(monkeypatch, responder)
+    with pytest.raises(SandboxPtyError, match="broker"):
+        await provider.create_pty(_make_handle(), SandboxPtySpec())
+    assert any("rm -rf" in tok for c in rec.calls for tok in c["argv"])
+
+
+async def test_create_pty_ready_timeout_reports_broker_log(monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        if any("test -f" in tok for tok in argv):
+            return (1, "", "")
+        if any("broker.log" in tok for tok in argv):
+            return (0, "Traceback: kaput", "")
+        return (0, "", "")
+
+    provider, rec = _make_provider(monkeypatch, responder)
+    monkeypatch.setattr(docker_pty, "READY_DEADLINE_S", 0.0)
+    with pytest.raises(SandboxPtyError, match="kaput"):
+        await provider.create_pty(_make_handle(), SandboxPtySpec())
+    assert any("rm -rf" in tok for c in rec.calls for tok in c["argv"])
+
+
+# --------------------------------------------------------------------------- #
+# attach_pty
+# --------------------------------------------------------------------------- #
+async def test_attach_pty_defaults_to_live_tail(monkeypatch: pytest.MonkeyPatch) -> None:
+    meta = json.dumps({"mode": "pty", "out_size": 500, "err_size": 0, "exit": None, "alive": True})
+    provider, rec = _make_provider(monkeypatch, lambda argv: (0, meta, ""))
+    session = await provider.attach_pty(_make_handle(), "sid9")
+
+    argv = rec.calls[0]["argv"]
+    assert _contains_seq(argv, ["python3", docker_pty._helper_path("sid9"), "attach"])
+    assert argv[-1] == "1"  # takeover default
+    assert session.session_id == "sid9"
+    assert session.mode == "pty"
+    assert session._out_offset == 500  # live tail: replay nothing
+    assert session._owned is False
+
+
+async def test_attach_pty_since_replays_from_offset(monkeypatch: pytest.MonkeyPatch) -> None:
+    meta = json.dumps({"mode": "pty", "out_size": 500, "err_size": 0, "exit": None, "alive": True})
+    provider, _rec = _make_provider(monkeypatch, lambda argv: (0, meta, ""))
+    session = await provider.attach_pty(_make_handle(), "sid9", since=0)
+    assert session._out_offset == 0
+
+
+async def test_attach_pty_without_takeover_on_held_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, rec = _make_provider(monkeypatch, lambda argv: (docker_pty.EXIT_HELD, "", ""))
+    with pytest.raises(SandboxPtyError, match="takeover=True"):
+        await provider.attach_pty(_make_handle(), "sid9", takeover=False)
+    assert rec.calls[0]["argv"][-1] == "0"
+
+
+async def test_attach_pty_missing_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _rec = _make_provider(
+        monkeypatch, lambda argv: (2, "", "python3: can't open file '/tmp/.nemo-gym-pty/sid9/ngpty.py'")
+    )
+    with pytest.raises(SandboxPtyError, match="does not exist"):
+        await provider.attach_pty(_make_handle(), "sid9")
+
+
+# --------------------------------------------------------------------------- #
+# session read / offset bookkeeping
+# --------------------------------------------------------------------------- #
+async def test_read_advances_offset_and_scans_from_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    responder = SessionResponder()
+    responder.poll_results = [
+        (0, _poll_payload(out=b"hello ", out_size=6), ""),
+        (0, _poll_payload(out=b"world", out_size=11), ""),
+    ]
+    session, rec = _make_session(monkeypatch, responder)
+
+    assert await session.read() == b"hello "
+    assert await session.read() == b"world"
+    assert session._out_offset == 11
+
+    first_poll = rec.calls[0]["argv"]
+    second_poll = rec.calls[1]["argv"]
+    assert _contains_seq(first_poll, ["poll", docker_pty._session_dir("sid1"), "tok1", "0", "0"])
+    assert _contains_seq(second_poll, ["poll", docker_pty._session_dir("sid1"), "tok1", "6", "0"])
+
+
+async def test_read_returns_eof_after_exit_and_drain(monkeypatch: pytest.MonkeyPatch) -> None:
+    responder = SessionResponder()
+    responder.poll_results = [
+        (0, _poll_payload(out=b"bye", out_size=3, exit_code=0), ""),
+        (0, _poll_payload(out_size=3, exit_code=0), ""),
+    ]
+    session, _rec = _make_session(monkeypatch, responder)
+    assert await session.read() == b"bye"
+    assert await session.read() == b""
+    assert session.closed is True  # exited and drained
+    assert await session.wait_exit() == 0
+
+
+async def test_read_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    responder = SessionResponder()
+    responder.poll_results = [(0, _poll_payload(), "")] * 10
+    session, _rec = _make_session(monkeypatch, responder)
+    with pytest.raises(TimeoutError):
+        await session.read(timeout_s=0.15)
+
+
+async def test_read_raises_when_broker_died_without_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    responder = SessionResponder()
+    responder.poll_results = [(0, _poll_payload(alive=False), "")]
+    session, _rec = _make_session(monkeypatch, responder)
+    with pytest.raises(SandboxPtyError, match="died without exiting"):
+        await session.read()
+    assert session.closed is True
+
+
+async def test_read_stderr_pipe_mode_and_pty_eof(monkeypatch: pytest.MonkeyPatch) -> None:
+    responder = SessionResponder()
+    responder.poll_results = [
+        (0, _poll_payload(err=b"oops", err_size=4), ""),
+        (0, _poll_payload(out_size=0, err_size=4, exit_code=3), ""),
+    ]
+    session, _rec = _make_session(monkeypatch, responder, mode="pipe")
+    assert await session.read_stderr() == b"oops"
+    assert await session.read_stderr() == b""  # exited, drained
+
+
+async def test_aiter_yields_until_eof(monkeypatch: pytest.MonkeyPatch) -> None:
+    responder = SessionResponder()
+    responder.poll_results = [
+        (0, _poll_payload(out=b"a", out_size=1), ""),
+        (0, _poll_payload(out=b"b", out_size=2, exit_code=0), ""),
+        (0, _poll_payload(out_size=2, exit_code=0), ""),
+    ]
+    session, _rec = _make_session(monkeypatch, responder)
+    chunks = [chunk async for chunk in session]
+    assert chunks == [b"a", b"b"]
+
+
+async def test_poll_malformed_json_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    responder = SessionResponder()
+    responder.poll_results = [(0, "not json", "")]
+    session, _rec = _make_session(monkeypatch, responder)
+    with pytest.raises(SandboxPtyError, match="malformed"):
+        await session.read()
+
+
+# --------------------------------------------------------------------------- #
+# takeover / eviction
+# --------------------------------------------------------------------------- #
+async def test_evicted_session_raises_on_read_and_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    responder = SessionResponder()
+    responder.poll_results = [(docker_pty.EXIT_EVICTED, "", "")]
+    session, _rec = _make_session(monkeypatch, responder)
+    with pytest.raises(SandboxPtyError, match="taken over"):
+        await session.read()
+    assert session.closed is True
+    with pytest.raises(SandboxPtyError):
+        await session.write(b"ls\n")
+
+
+async def test_dead_session_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    responder = SessionResponder()
+    responder.poll_results = [(docker_pty.EXIT_DEAD, "", "")]
+    session, _rec = _make_session(monkeypatch, responder)
+    with pytest.raises(SandboxPtyError, match="no longer exists"):
+        await session.read()
+
+
+# --------------------------------------------------------------------------- #
+# write / resize / signal
+# --------------------------------------------------------------------------- #
+async def test_write_sends_stdin_to_fifo(monkeypatch: pytest.MonkeyPatch) -> None:
+    session, rec = _make_session(monkeypatch, SessionResponder())
+    await session.write(b"echo hi\n")
+    call = rec.calls[0]
+    assert call["stdin"] == b"echo hi\n"
+    assert "-i" in call["argv"]
+    assert _contains_seq(call["argv"], ["write", docker_pty._session_dir("sid1"), "tok1"])
+
+
+async def test_resize_and_signal_go_through_control_fifo(monkeypatch: pytest.MonkeyPatch) -> None:
+    session, rec = _make_session(monkeypatch, SessionResponder())
+    await session.resize(50, 132)
+    await session.send_signal("SIGTERM")
+
+    resize_call, signal_call = rec.calls
+    assert _contains_seq(resize_call["argv"], ["ctl", docker_pty._session_dir("sid1"), "tok1"])
+    assert json.loads(resize_call["stdin"]) == {"type": "resize", "rows": 50, "cols": 132}
+    assert json.loads(signal_call["stdin"]) == {"type": "signal", "signal": "SIGTERM"}
+
+
+async def test_send_signal_rejects_unknown_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    session, rec = _make_session(monkeypatch, SessionResponder())
+    with pytest.raises(ValueError, match="unknown signal"):
+        await session.send_signal("FROBNICATE")
+    assert rec.calls == []
+
+
+async def test_write_on_closed_session_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    session, _rec = _make_session(monkeypatch, SessionResponder())
+    await session.close()
+    with pytest.raises(SandboxPtyError, match="closed"):
+        await session.write(b"x")
+
+
+# --------------------------------------------------------------------------- #
+# wait_exit
+# --------------------------------------------------------------------------- #
+async def test_wait_exit_polls_until_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    responder = SessionResponder()
+    responder.poll_results = [
+        (0, _poll_payload(), ""),
+        (0, _poll_payload(exit_code=7), ""),
+    ]
+    session, rec = _make_session(monkeypatch, responder)
+    assert await session.wait_exit() == 7
+    # wait_exit polls with max_bytes=0: it must not consume output.
+    assert all(c["argv"][-1] == "0" for c in rec.calls)
+    assert session._out_offset == 0
+
+
+async def test_wait_exit_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    responder = SessionResponder()
+    responder.poll_results = [(0, _poll_payload(), "")] * 10
+    session, _rec = _make_session(monkeypatch, responder)
+    with pytest.raises(TimeoutError):
+        await session.wait_exit(timeout_s=0.15)
+
+
+# --------------------------------------------------------------------------- #
+# run_detached
+# --------------------------------------------------------------------------- #
+async def test_run_detached_parses_marker_and_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    session, rec = _make_session(monkeypatch, SessionResponder())
+
+    written: list[bytes] = []
+
+    async def fake_write(data: bytes) -> None:
+        written.append(data)
+
+    reads: list[bytes] = []
+
+    async def fake_read(*, timeout_s: float | None = None) -> bytes:
+        if reads:
+            return reads.pop(0)
+        raise TimeoutError
+
+    async def fake_read_stderr(*, timeout_s: float | None = None) -> bytes:
+        raise TimeoutError
+
+    monkeypatch.setattr(session, "write", fake_write)
+    monkeypatch.setattr(session, "read", fake_read)
+    monkeypatch.setattr(session, "read_stderr", fake_read_stderr)
+
+    async def run() -> tuple[bytes, int | None]:
+        return await session.run_detached("echo done", poll_interval_s=0.01)
+
+    # Feed output that includes the marker assembled from the written command.
+    task = __import__("asyncio").get_running_loop().create_task(run())
+    while not written:
+        await __import__("asyncio").sleep(0.001)
+    marker = written[0].decode().rsplit("'", 4)  # printf '%s%s:%s\n' 'NGPTY' 'rest' "$?"
+    token = marker[1] + marker[3]
+    reads.extend([b"done\n", f"{token}:0\n".encode()])
+    output, exit_code = await task
+    assert output == b"done\n"
+    assert exit_code == 0
+    assert rec.calls == []  # everything went through the patched methods
+
+
+# --------------------------------------------------------------------------- #
+# close semantics
+# --------------------------------------------------------------------------- #
+async def test_close_owned_ends_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    session, rec = _make_session(monkeypatch, SessionResponder(), owned=True)
+    await session.close()
+    assert session.closed is True
+    assert _contains_seq(rec.calls[0]["argv"], ["end", docker_pty._session_dir("sid1")])
+    await session.close()  # idempotent
+    assert len(rec.calls) == 1
+
+
+async def test_close_attached_releases_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    session, rec = _make_session(monkeypatch, SessionResponder(), owned=False)
+    await session.close()
+    assert _contains_seq(rec.calls[0]["argv"], ["release", docker_pty._session_dir("sid1"), "tok1"])
+
+
+async def test_close_suppresses_backend_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    def responder(argv: list[str]) -> tuple[int, str, str]:
+        return (1, "", "Error: No such container: nemo-gym-x")
+
+    session, _rec = _make_session(monkeypatch, responder)
+    await session.close()  # does not raise
+    assert session.closed is True
+
+
+async def test_context_manager_closes(monkeypatch: pytest.MonkeyPatch) -> None:
+    session, rec = _make_session(monkeypatch, SessionResponder())
+    async with session as s:
+        assert s is session
+    assert session.closed is True
+    assert _contains_seq(rec.calls[0]["argv"], ["end", docker_pty._session_dir("sid1")])
+
+
+# --------------------------------------------------------------------------- #
+# staging script shape
+# --------------------------------------------------------------------------- #
+def test_staging_script_contents() -> None:
+    script = docker_pty.staging_script("sid1", "tok1", "pty")
+    d = docker_pty._session_dir("sid1")
+    assert f"mkdir -p {d}" in script
+    assert f"cat > {d}/{docker_pty.HELPER_FILENAME}" in script
+    assert "tok1" in script
+    assert '"mode": "pty"' in script
+    assert f"chmod -R 777 {d}" in script

--- a/tests/unit_tests/test_docker_pty_live.py
+++ b/tests/unit_tests/test_docker_pty_live.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Live PTY tests against a real local docker daemon.
+
+Skipped unless a reachable docker daemon is available. Uses
+``python:3.12-slim`` (multi-arch: runs natively on amd64 and arm64), pulled on
+first run.
+"""
+
+import shutil
+import subprocess
+
+import pytest
+
+from nemo_gym.sandbox.providers.base import SandboxPtyError, SandboxPtySpec, SandboxSpec
+from nemo_gym.sandbox.providers.docker import DockerProvider
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return subprocess.run(["docker", "info"], capture_output=True, timeout=20).returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+pytestmark = [
+    pytest.mark.sandbox,
+    pytest.mark.skipduringci,
+    pytest.mark.skipif(not _docker_available(), reason="docker daemon not available"),
+]
+
+# Small public image that carries python3 (required by the docker PTY broker).
+IMAGE = "python:3.12-slim"
+
+
+async def _read_until(session, needle: bytes, *, timeout_s: float = 30.0) -> bytes:
+    buffer = bytearray()
+    while needle not in buffer:
+        buffer.extend(await session.read(timeout_s=timeout_s))
+    return bytes(buffer)
+
+
+async def test_pty_cross_process_attach_flow() -> None:
+    provider = DockerProvider()
+    handle = await provider.create(SandboxSpec(image=IMAGE, ttl_s=600))
+    try:
+        creator_session = await provider.create_pty(handle, SandboxPtySpec())
+        assert creator_session.mode == "pty"
+        assert not creator_session.closed
+
+        await creator_session.write(b"echo hello-$((1+1))\n")
+        output = await _read_until(creator_session, b"hello-2")
+        assert b"hello-2" in output
+
+        # Simulate another process: a fresh provider instance that shares only
+        # the docker daemon rebuilds the handle from the descriptor and
+        # attaches to the same session by id.
+        descriptor = await provider.serialize_handle(handle)
+        other_provider = DockerProvider()
+        other_handle = await other_provider.connect(descriptor)
+        attached = await other_provider.attach_pty(other_handle, creator_session.session_id, takeover=True, since=0)
+        try:
+            assert attached.session_id == creator_session.session_id
+            assert attached.mode == "pty"
+
+            # since=0 replays the retained output, which includes the earlier command.
+            replay = await _read_until(attached, b"hello-2")
+            assert b"hello-2" in replay
+
+            # The evicted creator's next use fails.
+            with pytest.raises(SandboxPtyError):
+                await creator_session.read(timeout_s=10.0)
+            with pytest.raises(SandboxPtyError):
+                await creator_session.write(b"echo nope\n")
+            assert creator_session.closed
+
+            # The attached session is live: shell state still works.
+            await attached.write(b"echo again-$((2+2))\n")
+            assert b"again-4" in await _read_until(attached, b"again-4")
+
+            # run_detached: marker discipline over the polled output log.
+            output, exit_code = await attached.run_detached("sleep 1; echo done", poll_interval_s=0.5)
+            assert b"done" in output
+            assert exit_code == 0
+        finally:
+            await attached.close()  # attached: releases, does not end the session
+
+        # Released (not ended): a non-takeover attach now succeeds.
+        reattached = await other_provider.attach_pty(other_handle, creator_session.session_id, takeover=False)
+        await reattached.close()
+        await other_provider.aclose()
+    finally:
+        await provider.close(handle)
+        await provider.aclose()
+
+
+async def test_pty_command_session_exit_and_cleanup() -> None:
+    provider = DockerProvider()
+    handle = await provider.create(SandboxSpec(image=IMAGE, ttl_s=600))
+    try:
+        session = await provider.create_pty(handle, SandboxPtySpec(command="echo bye; exit 7", rows=30, cols=100))
+        output = await _read_until(session, b"bye")
+        assert b"bye" in output
+        assert await session.wait_exit(timeout_s=30.0) == 7
+        # Drain to EOF.
+        while await session.read(timeout_s=10.0):
+            pass
+        await session.close()
+
+        # The creator's close ends the session: its state dir is gone.
+        probe = await provider.exec(handle, f"test -d /tmp/.nemo-gym-pty/{session.session_id}")
+        assert probe.return_code != 0
+
+        # And re-attaching raises.
+        with pytest.raises(SandboxPtyError):
+            await provider.attach_pty(handle, session.session_id)
+    finally:
+        await provider.close(handle)
+        await provider.aclose()
+
+
+async def test_pty_resize_and_signal() -> None:
+    provider = DockerProvider()
+    handle = await provider.create(SandboxSpec(image=IMAGE, ttl_s=600))
+    try:
+        session = await provider.create_pty(handle, SandboxPtySpec(rows=24, cols=80))
+        try:
+            await session.write(b"stty size\n")
+            assert b"24 80" in await _read_until(session, b"24 80")
+
+            await session.resize(40, 120)
+            await session.write(b"stty size\n")
+            assert b"40 120" in await _read_until(session, b"40 120")
+
+            # SIGKILL the shell's process group (interactive shells ignore
+            # SIGTERM): the session process exits with 128 + 9.
+            await session.send_signal("SIGKILL")
+            assert await session.wait_exit(timeout_s=30.0) == 128 + 9
+        finally:
+            await session.close()
+    finally:
+        await provider.close(handle)
+        await provider.aclose()


### PR DESCRIPTION
## What / why

Stacked on #2878 (`glovisotto/docker-provider-connect`). This completes the local-docker story for PTY-driven agents: `DockerProvider` now satisfies `SupportsSandboxPty` and `SupportsSandboxPtyAttach`, so the post-#2498 `opencode_sandboxed_agent` flow works on a plain local docker daemon — the resources server calls `sandbox.pty.create()`, hands `(container id, pty session_id)` to the agent process, which does `AsyncSandbox.connect(...)` followed by `sandbox.pty.attach(session_id=..., takeover=True)`.

## Broker design

`create_pty` stages a small python3 helper into the container and starts a **broker** with `docker exec -d`. The broker allocates a real PTY via `pty.fork()` (plain pipes in `pty=False` mode), runs the interactive shell or command on it, and mirrors all session state through files under `/tmp/.nemo-gym-pty/<session_id>/`:

- `stdin` / `control` FIFOs — input and resize/signal requests
- `output.log` — append-only merged terminal output (stdout in pipe mode), which doubles as the replay buffer for `attach(since=...)`
- `stderr.log` — pipe mode only
- `exit_code`, `broker.pid` / `child.pid`, `owner` (holder token), `meta.json`, `broker.log`

Because *all* state lives in the container, sessions survive the creating process; any process sharing the daemon can attach by session id. The client side (`DockerPtySession`) drives everything with short-lived `docker exec` calls through the provider's existing `_run` plumbing (shared semaphore + timeouts): `write()` appends to the input FIFO, `read()` polls the output log from a tracked byte offset, `resize()`/`send_signal()` go through the control FIFO, `wait_exit()` polls the exit-code file. Takeover is an owner-token rotation: `attach_pty(takeover=True)` rotates the token and the evicted client's next operation raises `SandboxPtyError`; without takeover, attaching to a held session raises (it succeeds after the holder releases — an attached session's `close()` releases; the creator's `close()` ends the session and removes its state).

## Requirements & simplifications vs OpenSandbox execd (documented in the module docstring)

- **`python3` must exist in the sandbox image** — `create_pty` fails with a clear error naming the requirement otherwise (SWE-bench task images all carry python3). No tmux or other multiplexer dependency.
- Retained output is the session's **entire** output log (bounded by container disk), not execd's ~1 MiB ring: `attach(since=0)` replays everything, and `run_detached` can never lose output between polls, so the protocol's "retained window exceeded" error path never triggers here.
- No live connection: "attached" is a token, not a socket, so eviction is detected on the evicted client's *next* operation, and output arrives with polling latency (~100 ms) rather than streamed.
- The broker stops draining ~1 s after process exit even if a background grandchild still holds the terminal (mirrors execd's "clean EOF means drained, not delivered").
- `since` offsets index `output.log`; a pipe-mode attach always tails stderr live.
- `rows`/`cols` are applied at spawn (unlike execd there is no window where the command sees the 80x24 default).

## Validation

Unit tests (`tests/unit_tests/test_docker_pty.py`, RunRecorder-style, no daemon needed, 32 tests): argv construction for staging/broker/attach, python3-missing error, read offset bookkeeping and EOF-after-exit, timeout semantics, eviction/held/dead error paths, write/ctl payloads, `wait_exit` non-consuming polls, `run_detached` marker parsing, owned-vs-attached close semantics.

Live tests (`tests/unit_tests/test_docker_pty_live.py`, skipped unless a docker daemon is reachable; `python:3.12-slim`, multi-arch so it runs natively on amd64/arm64) — all run green against a real local daemon:

1. create sandbox → `create_pty` → `write("echo hello-$((1+1))")` → read until `hello-2`;
2. a **second provider instance** (simulating another process) `connect`s by container id, `attach_pty`s with `takeover=True, since=0`, sees `hello-2` in the replay; the evicted first session raises `SandboxPtyError` on its next read *and* write; the attached session still has live shell state and runs `run_detached("sleep 1; echo done")` to `(…done…, 0)`; after the attached close, a non-takeover attach succeeds (released);
3. command sessions: `exit 7` propagates through `wait_exit`, creator close removes the state dir and later attaches raise;
4. `resize` observed via `stty size` (24x80 → 40x120) and `SIGKILL` via `send_signal` → exit 137.

Also validated end-to-end through the public API (`sandbox.pty.exec`, session-mode marker exec with kept shell state, cross-process `AsyncSandbox.connect` + `pty.attach`, and `detach=True` exec) against the live daemon, plus a smoke run on a SWE-bench task image. `tests/unit_tests/test_docker_provider.py` (71 tests) and the sandbox connect/facade suites pass unchanged; `pre-commit` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
