### PR TITLE
feat(pty): report sandbox OOM kills instead of bare websocket close codes

### DIFF
--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -1288,11 +1288,14 @@ class OpenSandboxProvider:
                 raise SandboxBackendUnreachableError(notice) from error
             raise
 
-    async def _oom_death_notice(self, handle: SandboxHandle) -> str | None:
+    async def _oom_death_notice(self, handle: SandboxHandle, *, any_death: bool = False) -> str | None:
         """Briefly poll the sandbox status; describe an OOM kill, else None.
 
-        When the backend stops answering it usually takes the control plane a
-        moment to record why, so poll for up to 5s before giving up."""
+        With ``any_death`` every terminal state is reported, not just an OOM
+        kill — for callers that need to know whether the sandbox is gone at
+        all, not specifically why. When the backend stops answering it usually
+        takes the control plane a moment to record why, so poll for up to 5s
+        before giving up."""
         get_info = getattr(handle.raw, "get_info", None)
         if get_info is None:
             return None
@@ -1311,14 +1314,14 @@ class OpenSandboxProvider:
             state = getattr(raw_status, "state", None)
             reason = getattr(raw_status, "reason", None)
             message = getattr(raw_status, "message", None)
+            status_text = (
+                f"OpenSandbox status: state={state!r}, reason={reason!r}, message={str(message or '')[:500]!r}; "
+                f"sandbox_id={handle.sandbox_id!r}"
+            )
             if re.search(r"\boom[\s_-]*killed\b|\bout of memory\b", f"{reason} {message}", re.IGNORECASE):
-                return (
-                    "Sandbox was OOM-killed. "
-                    f"OpenSandbox status: state={state!r}, reason={reason!r}, message={str(message or '')[:500]!r}; "
-                    f"sandbox_id={handle.sandbox_id!r}"
-                )
+                return f"Sandbox was OOM-killed. {status_text}"
             if message and _to_sandbox_status(state) in {SandboxStatus.ERROR, SandboxStatus.STOPPED}:
-                return None
+                return f"Sandbox is dead. {status_text}" if any_death else None
             await asyncio.sleep(min(0.5, max(0.0, deadline - asyncio.get_running_loop().time())))
         return None
 
@@ -1522,7 +1525,17 @@ class OpenSandboxProvider:
                 )
                 break
             except SandboxPtyError as e:
-                if not takeover or delay is None or "already has an attached client" not in str(e):
+                if not takeover or "already has an attached client" not in str(e):
+                    raise
+                if delay is None:
+                    # The eviction never completed across every retry. When the
+                    # sandbox itself is gone (node loss, OOM kill) the stale
+                    # attachment can never acknowledge its eviction, so the
+                    # takeover is refused forever — report the sandbox's death
+                    # instead of the refusal.
+                    notice = await self._oom_death_notice(handle, any_death=True)
+                    if notice is not None:
+                        raise SandboxPtyError(f"PTY attach takeover kept being refused: {notice}") from e
                     raise
             await asyncio.sleep(delay)
         await self._retire_closed_pty_sessions()

--- a/nemo_gym/sandbox/providers/opensandbox/provider.py
+++ b/nemo_gym/sandbox/providers/opensandbox/provider.py
@@ -1283,36 +1283,44 @@ class OpenSandboxProvider:
         except Exception as error:
             if not isinstance(error, SandboxBackendUnreachableError) and _exception_status_code(error) != 502:
                 raise
-
-            get_info = getattr(handle.raw, "get_info", None)
-            if get_info is not None:
-                deadline = asyncio.get_running_loop().time() + 5.0
-                while (remaining_s := deadline - asyncio.get_running_loop().time()) > 0:
-                    try:
-                        info = await self._await_sdk_call(
-                            get_info(),
-                            operation="get_info after exec 502",
-                            sandbox_id=handle.sandbox_id,
-                            timeout_s=min(2.0, remaining_s),
-                        )
-                    except Exception:
-                        break
-                    raw_status = getattr(info, "status", None)
-                    state = getattr(raw_status, "state", None)
-                    reason = getattr(raw_status, "reason", None)
-                    message = getattr(raw_status, "message", None)
-                    status_text = f"{reason} {message}"
-                    if re.search(r"\boom[\s_-]*killed\b|\bout of memory\b", status_text, re.IGNORECASE):
-                        message = str(message or "")[:500]
-                        raise SandboxBackendUnreachableError(
-                            "Sandbox was OOM-killed. "
-                            f"OpenSandbox status: state={state!r}, reason={reason!r}, message={message!r}; "
-                            f"sandbox_id={handle.sandbox_id!r}"
-                        ) from error
-                    if message and _to_sandbox_status(state) in {SandboxStatus.ERROR, SandboxStatus.STOPPED}:
-                        break
-                    await asyncio.sleep(min(0.5, max(0.0, deadline - asyncio.get_running_loop().time())))
+            notice = await self._oom_death_notice(handle)
+            if notice is not None:
+                raise SandboxBackendUnreachableError(notice) from error
             raise
+
+    async def _oom_death_notice(self, handle: SandboxHandle) -> str | None:
+        """Briefly poll the sandbox status; describe an OOM kill, else None.
+
+        When the backend stops answering it usually takes the control plane a
+        moment to record why, so poll for up to 5s before giving up."""
+        get_info = getattr(handle.raw, "get_info", None)
+        if get_info is None:
+            return None
+        deadline = asyncio.get_running_loop().time() + 5.0
+        while (remaining_s := deadline - asyncio.get_running_loop().time()) > 0:
+            try:
+                info = await self._await_sdk_call(
+                    get_info(),
+                    operation="get_info after backend loss",
+                    sandbox_id=handle.sandbox_id,
+                    timeout_s=min(2.0, remaining_s),
+                )
+            except Exception:
+                return None
+            raw_status = getattr(info, "status", None)
+            state = getattr(raw_status, "state", None)
+            reason = getattr(raw_status, "reason", None)
+            message = getattr(raw_status, "message", None)
+            if re.search(r"\boom[\s_-]*killed\b|\bout of memory\b", f"{reason} {message}", re.IGNORECASE):
+                return (
+                    "Sandbox was OOM-killed. "
+                    f"OpenSandbox status: state={state!r}, reason={reason!r}, message={str(message or '')[:500]!r}; "
+                    f"sandbox_id={handle.sandbox_id!r}"
+                )
+            if message and _to_sandbox_status(state) in {SandboxStatus.ERROR, SandboxStatus.STOPPED}:
+                return None
+            await asyncio.sleep(min(0.5, max(0.0, deadline - asyncio.get_running_loop().time())))
+        return None
 
     async def _exec_background(
         self,
@@ -1476,6 +1484,7 @@ class OpenSandboxProvider:
             headers=headers,
             spec=spec,
             request_timeout_s=request_timeout_s,
+            diagnose=lambda: self._oom_death_notice(handle),
         )
         await self._retire_closed_pty_sessions()
         self._pty_sessions.add(session)
@@ -1509,6 +1518,7 @@ class OpenSandboxProvider:
                     takeover=takeover,
                     since=since,
                     request_timeout_s=request_timeout_s,
+                    diagnose=lambda: self._oom_death_notice(handle),
                 )
                 break
             except SandboxPtyError as e:

--- a/nemo_gym/sandbox/providers/opensandbox/pty.py
+++ b/nemo_gym/sandbox/providers/opensandbox/pty.py
@@ -32,7 +32,7 @@ import logging
 import shlex
 import sys
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 from urllib.parse import urlencode
 
@@ -105,6 +105,7 @@ class OpenSandboxPtySession:
         headers: dict[str, str],
         request_timeout_s: float | None,
         owned: bool = True,
+        diagnose: Callable[[], Awaitable[str | None]] | None = None,
     ) -> None:
         self._client = client
         self._ws = ws
@@ -115,6 +116,9 @@ class OpenSandboxPtySession:
         # Attached sessions belong to whoever created them: closing one detaches
         # rather than ending it.
         self._owned = owned
+        # Asked for a better cause when the socket dies for no admitted reason
+        # (the provider checks whether the sandbox itself was OOM-killed).
+        self._diagnose = diagnose
         self.mode: str | None = None
         self.replay_offset: int | None = None
         self._output: asyncio.Queue[bytes | None] = asyncio.Queue()
@@ -227,6 +231,22 @@ class OpenSandboxPtySession:
             # A detach ends the pump without ending the session: skip the
             # finalization so reads and the exit future survive reattach().
             if not self._detached:
+                if (
+                    self._diagnose is not None
+                    and not self._closed
+                    and not self._exit.done()
+                    and self._error is None
+                    and self._ws.close_code not in (WS_CLOSE_TAKEN_OVER, WS_CLOSE_POLICY_VIOLATION)
+                ):
+                    # The socket died for no admitted reason — often the whole
+                    # sandbox is gone. Ask the provider for a real cause (an
+                    # OOM kill, typically) instead of a bare close code.
+                    try:
+                        notice = await asyncio.wait_for(self._diagnose(), timeout=8.0)
+                    except Exception:
+                        notice = None
+                    if notice is not None:
+                        self._error = SandboxPtyError(notice)
                 if not self._exit.done():
                     self._exit.set_exception(self._close_error())
                     self._exit.exception()  # retrieved; silences never-retrieved warnings
@@ -451,6 +471,7 @@ async def open_pty_session(
     headers: dict[str, str],
     spec: SandboxPtySpec,
     request_timeout_s: float | None,
+    diagnose: Callable[[], Awaitable[str | None]] | None = None,
 ) -> OpenSandboxPtySession:
     """Create an execd PTY session and attach its WebSocket.
 
@@ -520,6 +541,7 @@ async def open_pty_session(
         session_id=session_id,
         headers=headers,
         request_timeout_s=request_timeout_s,
+        diagnose=diagnose,
     )
     # execd hardcodes 80x24 at spawn; size is only settable post-attach.
     if spec.pty and (spec.rows, spec.cols) != (24, 80):
@@ -540,6 +562,7 @@ async def attach_pty_session(
     takeover: bool = True,
     since: int | None = None,
     request_timeout_s: float | None,
+    diagnose: Callable[[], Awaitable[str | None]] | None = None,
 ) -> OpenSandboxPtySession:
     """Attach to an existing execd PTY session. Owns ``client`` as above."""
     query: dict[str, str] = {}
@@ -580,6 +603,7 @@ async def attach_pty_session(
         headers=headers,
         request_timeout_s=request_timeout_s,
         owned=False,
+        diagnose=diagnose,
     )
 
 
@@ -622,6 +646,7 @@ async def _start_session(
     headers: dict[str, str],
     request_timeout_s: float | None,
     owned: bool = True,
+    diagnose: Callable[[], Awaitable[str | None]] | None = None,
 ) -> OpenSandboxPtySession:
     session = OpenSandboxPtySession(
         client=client,
@@ -631,6 +656,7 @@ async def _start_session(
         headers=headers,
         request_timeout_s=request_timeout_s,
         owned=owned,
+        diagnose=diagnose,
     )
     try:
         await session._wait_connected(request_timeout_s)

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -719,6 +719,66 @@ async def test_provider_attach_pty_does_not_retry_without_takeover(monkeypatch: 
     assert clients_handed == 1, "without takeover the rejection is definitive"
 
 
+def _always_refused_provider(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Provider whose every takeover attach is refused as 'already attached'."""
+    from nemo_gym.sandbox.providers.opensandbox.provider import OpenSandboxProvider
+
+    provider = OpenSandboxProvider(connection={"domain": "server", "api_key": "k", "protocol": "https"})
+
+    def _client() -> FakeHttpClient:
+        rejected = FakeWs([], close_code=1008)
+        rejected.closed = True
+        return FakeHttpClient(ws=rejected)
+
+    monkeypatch.setattr(provider, "_pty_http_client", _client)
+    monkeypatch.setattr(pty_module, "_PTY_TAKEOVER_RETRY_DELAYS", (0.0,))
+    return provider
+
+
+async def test_provider_attach_pty_reports_dead_sandbox_on_exhausted_takeover(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A takeover refused across every retry usually means the sandbox is gone
+    (its stale attachment can never acknowledge the eviction); the error must
+    say that, not 'already has an attached client'."""
+    pytest.importorskip("tenacity", reason="tenacity optional sandbox dependency is not installed")
+    pytest.importorskip("opensandbox", reason="opensandbox SDK is not installed")
+
+    class DeadRaw:
+        async def get_endpoint(self, port: int) -> SimpleNamespace:
+            return SimpleNamespace(endpoint="server/v1/sandboxes/sb-1/proxy/44772", headers={})
+
+        async def get_info(self) -> SimpleNamespace:
+            return SimpleNamespace(
+                status=SimpleNamespace(state="Failed", reason="FAILED", message="1/1 observed pods failed; node lost")
+            )
+
+    provider = _always_refused_provider(monkeypatch)
+    handle = SandboxHandle(sandbox_id="sb-1", provider_name="opensandbox", raw=DeadRaw())
+    with pytest.raises(SandboxPtyError, match="Sandbox is dead") as exc_info:
+        await provider.attach_pty(handle, "s-7", takeover=True)
+    assert "already has an attached client" in str(exc_info.value.__cause__)
+
+
+async def test_provider_attach_pty_keeps_refusal_when_status_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("tenacity", reason="tenacity optional sandbox dependency is not installed")
+    pytest.importorskip("opensandbox", reason="opensandbox SDK is not installed")
+
+    class OpaqueRaw:
+        async def get_endpoint(self, port: int) -> SimpleNamespace:
+            return SimpleNamespace(endpoint="server/v1/sandboxes/sb-1/proxy/44772", headers={})
+
+        async def get_info(self) -> SimpleNamespace:
+            raise RuntimeError("control plane unavailable")
+
+    provider = _always_refused_provider(monkeypatch)
+    handle = SandboxHandle(sandbox_id="sb-1", provider_name="opensandbox", raw=OpaqueRaw())
+    with pytest.raises(SandboxPtyError, match="already has an attached client"):
+        await provider.attach_pty(handle, "s-7", takeover=True)
+
+
 async def test_create_rejected_before_connected_raises_and_cleans_up() -> None:
     # The session we created is torn down when the socket is rejected.
     ws = FakeWs([], close_code=1008)

--- a/tests/unit_tests/test_opensandbox_pty.py
+++ b/tests/unit_tests/test_opensandbox_pty.py
@@ -568,6 +568,67 @@ async def test_evicted_session_reports_takeover() -> None:
     await session.close()
 
 
+async def _diagnosed_session(close_code: int, notice: str | None) -> tuple[OpenSandboxPtySession, FakeWs, list[int]]:
+    """Session whose socket dies with ``close_code``; diagnose returns ``notice``."""
+    calls: list[int] = []
+
+    async def diagnose() -> str | None:
+        calls.append(1)
+        return notice
+
+    ws = FakeWs([CONNECTED], close_code=close_code)
+    session = OpenSandboxPtySession(
+        client=FakeHttpClient(ws=ws),  # type: ignore[arg-type]
+        ws=ws,  # type: ignore[arg-type]
+        session_id="s-1",
+        session_url="http://server/v1/sandboxes/sb-1/proxy/44772/pty/s-1",
+        headers={},
+        request_timeout_s=5.0,
+        diagnose=diagnose,
+    )
+    return session, ws, calls
+
+
+async def test_unexpected_close_reports_oom_diagnosis() -> None:
+    # A socket dying with a bare server-error close often means the sandbox
+    # itself died; the diagnosis (an OOM kill here) must replace the close code
+    # everywhere the session's death surfaces.
+    session, ws, calls = await _diagnosed_session(1011, "Sandbox was OOM-killed. state='Failed'")
+    ws.closed = True
+    with pytest.raises(SandboxPtyError, match="OOM-killed"):
+        await session.wait_exit(timeout_s=5)
+    with pytest.raises(SandboxPtyError, match="OOM-killed"):
+        await session.read()
+    assert calls == [1]
+    await session.close()
+
+
+async def test_unexpected_close_without_diagnosis_keeps_close_code() -> None:
+    session, ws, calls = await _diagnosed_session(1011, None)
+    ws.closed = True
+    with pytest.raises(SandboxPtyError, match="close code 1011"):
+        await session.wait_exit(timeout_s=5)
+    assert calls == [1]
+    await session.close()
+
+
+async def test_takeover_close_skips_diagnosis() -> None:
+    # An eviction names its own cause; the sandbox is alive, so don't poll it.
+    session, ws, calls = await _diagnosed_session(4001, "Sandbox was OOM-killed.")
+    ws.closed = True
+    with pytest.raises(SandboxPtyError, match="taken over"):
+        await session.wait_exit(timeout_s=5)
+    assert calls == []
+    await session.close()
+
+
+async def test_user_close_skips_diagnosis() -> None:
+    session, _, calls = await _diagnosed_session(1000, "Sandbox was OOM-killed.")
+    await session._wait_connected(1.0)
+    await session.close()
+    assert calls == []
+
+
 async def test_provider_attach_pty_reuses_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
     pytest.importorskip("tenacity", reason="tenacity optional sandbox dependency is not installed")
     pytest.importorskip("opensandbox", reason="opensandbox SDK is not installed")


### PR DESCRIPTION
## Problem

When a sandbox dies underneath a live PTY session (OOM kill, TTL reap, node loss), the client surfaces `SandboxPtyError: PTY connection closed unexpectedly (close code 1011)` — a bare WebSocket close code that tells the user nothing about what actually happened. During a recent terminal-bench run, roughly half of these errors were sandboxes exceeding their memory limit, which took cluster-side digging to establish.

The non-PTY exec path already handles this: on backend loss it briefly polls the sandbox status and reports `Sandbox was OOM-killed ...` when that is the cause.

## Change

- Extract exec's OOM status-poll into `OpenSandboxProvider._oom_death_notice()` (behavior preserved; the existing exec OOM test passes unchanged).
- Give `OpenSandboxPtySession` an optional `diagnose` callback, wired by the provider to that helper on `create_pty`/`attach_pty`.
- When the pump ends with an unexpected close — not `close()`, not `detach()`, not a takeover eviction, not a process exit — it consults the callback (bounded at 8s) and, if the sandbox was OOM-killed, surfaces the OOM notice everywhere the session's death is observed (reads, execs, `wait_exit`, a pending attach).

A takeover eviction and a legitimate "already attached" refusal never trigger the poll: the sandbox is alive in both cases.

## Test plan

- Unit (`tests/unit_tests/test_opensandbox_pty.py`): diagnosed unexpected close reports the OOM notice on `wait_exit` and reads; an undiagnosed close keeps the close-code message; takeover closes and user `close()` never invoke the diagnosis. Existing exec OOM test (`test_exec_background_reports_oom_status_after_502`) unchanged and green.
- E2E against a live OpenSandbox cluster: created a sandbox with a 1 GiB memory limit, opened a PTY session, and allocated past the limit from inside the session. The in-flight exec now reports the OOM instead of a bare close code:

<details><summary>E2E log (identifiers are ephemeral sandbox/session UUIDs)</summary>

```
=== e2e PTY OOM-diagnosis test ===
Image: swebench/sweb.eval.x86_64.sympy_1776_sympy-22080:latest
Sandbox created: a6077f54-0e84-4956-ab4b-eaa9cdc95227 (memory limit 1024Mi)
initial exec ok: True

=== hog: 'tail /dev/zero' (allocating past the 1GiB limit) ===
  exec raised in 68.2s: Sandbox was OOM-killed. OpenSandbox status: state='Failed', reason='FAILED', message='1/1 observed pods failed; primary reason=OOMKilled; sample pod=a6077f54-0e84-4956-ab4b-eaa9cdc95227-0; Pod a6077f54-0e84-4956-ab4b-eaa9cdc95227-0: container sandbox terminated with OOMKilled (exit code 137)'; sandbox_id='a6077f54-0e84-4956-ab4b-eaa9cdc95227'
  control-plane status: state='Failed' reason='FAILED' message='1/1 observed pods failed; primary reason=OOMKilled; sample pod=a6077f54-0e84-4956-ab4b-eaa9cdc95227-0; Pod a6077f54-0e84-4956-ab4b-eaa9cdc95227-0: container sandbox terminated with OOMKilled (exit cod'

=== post-death checks ===
  exec on held session: SandboxPtyError('PTY session is closed')
  fresh attach: SandboxPtyError('Failed to attach to PTY session 1b67a2fb-1b5a-4ad9-a494-413aa485ab79: Server disconnected')

=== SUMMARY ===
  errors seen: 3; with OOM diagnosis: 1; bare close codes: 0
  VERDICT: PASS — PTY death was diagnosed as an OOM kill
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)