### PR TITLE
fix(server_utils): close aiohttp client on its owner loop

### DIFF
--- a/nemo_gym/server_utils.py
+++ b/nemo_gym/server_utils.py
@@ -153,7 +153,8 @@ def _make_keepalive_socket_factory(
 
 def set_global_aiohttp_client(cfg: GlobalAIOHTTPAsyncClientConfig) -> ClientSession:  # pragma: no cover
     assert not is_global_aiohttp_client_setup(), (
-        "There is already a global aiohttp client setup. Please refactor your code or call `global_aiohttp_client_exit` if you want to explicitly re-make the client!"
+        "There is already a global aiohttp client setup. Please refactor your code or await "
+        "`close_global_aiohttp_client` if you want to explicitly re-make the client!"
     )
 
     num_workers = get_nemo_gym_fastapi_num_workers()
@@ -189,14 +190,46 @@ def is_global_aiohttp_client_request_debug_enabled() -> bool:
     return _GLOBAL_AIOHTTP_CLIENT_REQUEST_DEBUG
 
 
-def global_aiohttp_client_exit():  # pragma: no cover
-    if not is_global_aiohttp_client_setup():
+async def close_global_aiohttp_client() -> None:
+    """Idempotently close the global session on its owning event loop."""
+    global _GLOBAL_AIOHTTP_CLIENT
+    client = _GLOBAL_AIOHTTP_CLIENT
+    if client is None:
+        return
+    if client.closed:
+        _GLOBAL_AIOHTTP_CLIENT = None
+        return
+    if asyncio.get_running_loop() is not client._loop:
+        raise RuntimeError("the global aiohttp client must be closed on its owning event loop")
+    try:
+        await client.close()
+    finally:
+        if _GLOBAL_AIOHTTP_CLIENT is client and client.closed:
+            _GLOBAL_AIOHTTP_CLIENT = None
+
+
+def global_aiohttp_client_exit() -> None:  # pragma: no cover
+    global _GLOBAL_AIOHTTP_CLIENT
+    client = _GLOBAL_AIOHTTP_CLIENT
+    if client is None:
         return
 
-    global _GLOBAL_AIOHTTP_CLIENT
-    asyncio.run(_GLOBAL_AIOHTTP_CLIENT.close())
+    owner_loop = client._loop
+    if client.closed or owner_loop.is_closed():
+        _GLOBAL_AIOHTTP_CLIENT = None
+        return
 
-    _GLOBAL_AIOHTTP_CLIENT = None
+    try:
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = None
+
+    if running_loop is owner_loop:
+        return
+    if owner_loop.is_running():
+        asyncio.run_coroutine_threadsafe(close_global_aiohttp_client(), owner_loop).result()
+    else:
+        owner_loop.run_until_complete(close_global_aiohttp_client())
 
 
 atexit.register(global_aiohttp_client_exit)
@@ -914,6 +947,11 @@ repr(e): {repr(e)}"""
 
             maybe_auto_expose(server, app)
         server.setup_liveness(app)
+
+        @app.on_event("shutdown")
+        async def close_http_client() -> None:
+            await close_global_aiohttp_client()
+
         server.set_ulimit()
         server.prefix_server_logs()
         server.setup_exception_middleware(app)

--- a/tests/unit_tests/test_aiohttp_client_lifecycle.py
+++ b/tests/unit_tests/test_aiohttp_client_lifecycle.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import asyncio
+import queue
+import threading
+
+import pytest
+
+import nemo_gym.server_utils
+from nemo_gym.server_utils import close_global_aiohttp_client, global_aiohttp_client_exit
+
+
+class _LoopBoundClient:
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loop = loop
+        self.closed = False
+        self.close_calls = 0
+        self.close_loop: asyncio.AbstractEventLoop | None = None
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self.close_loop = asyncio.get_running_loop()
+        self.closed = True
+
+
+def _set_global_client(client: _LoopBoundClient) -> None:
+    nemo_gym.server_utils._GLOBAL_AIOHTTP_CLIENT = client
+
+
+def test_exit_closes_on_stopped_owner_loop_clears_and_is_idempotent() -> None:
+    owner_loop = asyncio.new_event_loop()
+    client = _LoopBoundClient(owner_loop)
+    _set_global_client(client)
+    try:
+        global_aiohttp_client_exit()
+        global_aiohttp_client_exit()
+
+        assert client.closed
+        assert client.close_calls == 1
+        assert client.close_loop is owner_loop
+        assert not nemo_gym.server_utils.is_global_aiohttp_client_setup()
+    finally:
+        owner_loop.close()
+
+
+def test_exit_schedules_close_on_running_owner_loop_in_another_thread() -> None:
+    ready: queue.Queue[tuple[asyncio.AbstractEventLoop, _LoopBoundClient]] = queue.Queue()
+
+    def run_owner_loop() -> None:
+        owner_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(owner_loop)
+        ready.put((owner_loop, _LoopBoundClient(owner_loop)))
+        owner_loop.run_forever()
+        owner_loop.close()
+
+    owner_thread = threading.Thread(target=run_owner_loop)
+    owner_thread.start()
+    owner_loop, client = ready.get(timeout=2)
+    _set_global_client(client)
+    try:
+        global_aiohttp_client_exit()
+
+        assert client.closed
+        assert client.close_calls == 1
+        assert client.close_loop is owner_loop
+        assert not nemo_gym.server_utils.is_global_aiohttp_client_setup()
+    finally:
+        owner_loop.call_soon_threadsafe(owner_loop.stop)
+        owner_thread.join(timeout=2)
+    assert not owner_thread.is_alive()
+
+
+def test_exit_with_closed_owner_loop_clears_without_foreign_loop_close() -> None:
+    owner_loop = asyncio.new_event_loop()
+    client = _LoopBoundClient(owner_loop)
+    owner_loop.close()
+    _set_global_client(client)
+
+    global_aiohttp_client_exit()
+
+    assert not client.closed
+    assert client.close_calls == 0
+    assert not nemo_gym.server_utils.is_global_aiohttp_client_setup()
+
+
+def test_explicit_async_close_clears_and_is_idempotent() -> None:
+    async def scenario() -> None:
+        owner_loop = asyncio.get_running_loop()
+        client = _LoopBoundClient(owner_loop)
+        _set_global_client(client)
+
+        await close_global_aiohttp_client()
+        await close_global_aiohttp_client()
+
+        assert client.closed
+        assert client.close_calls == 1
+        assert client.close_loop is owner_loop
+        assert not nemo_gym.server_utils.is_global_aiohttp_client_setup()
+
+    asyncio.run(scenario())
+
+
+def test_explicit_async_close_rejects_a_foreign_loop() -> None:
+    owner_loop = asyncio.new_event_loop()
+    client = _LoopBoundClient(owner_loop)
+    _set_global_client(client)
+    try:
+        with pytest.raises(RuntimeError, match="owning event loop"):
+            asyncio.run(close_global_aiohttp_client())
+
+        assert not client.closed
+        assert nemo_gym.server_utils.is_global_aiohttp_client_setup()
+        owner_loop.run_until_complete(close_global_aiohttp_client())
+    finally:
+        if not client.closed:
+            owner_loop.run_until_complete(client.close())
+        nemo_gym.server_utils._GLOBAL_AIOHTTP_CLIENT = None
+        owner_loop.close()


### PR DESCRIPTION
## Summary

- add an explicit async close for the process-global aiohttp client and run it during FastAPI shutdown
- make the synchronous atexit bridge close a stopped owner loop directly or schedule onto a running owner loop in another thread
- discard the singleton without creating a foreign event loop when its owner loop is already closed
- cover stopped, running-thread, closed-loop, idempotent, and explicit async shutdown behavior

The current atexit handler uses `asyncio.run(client.close())`. aiohttp binds `ClientSession` to the loop that created it, so manufacturing a new loop during teardown can emit a cross-event-loop traceback.

## Tests

- `.venv/bin/python -m pytest -q tests/unit_tests/test_aiohttp_client_lifecycle.py tests/unit_tests/test_server_utils.py` — 29 passed, 0 failed, 0 skipped (1 existing Starlette deprecation warning)
- `.venv/bin/ruff check nemo_gym/server_utils.py tests/unit_tests/test_aiohttp_client_lifecycle.py` — passed
- `.venv/bin/ruff format --check nemo_gym/server_utils.py tests/unit_tests/test_aiohttp_client_lifecycle.py` — 2 files already formatted
