### PR TITLE
fix(lmarena_v2, lmarena_v3): set max_steps=1 to stop unbounded rollout loops

### DIFF
--- a/benchmarks/lmarena_v2/config.yaml
+++ b/benchmarks/lmarena_v2/config.yaml
@@ -22,6 +22,7 @@ lmarena_v2_benchmark_agent:
   _inherit_from: lmarena_v2_simple_agent
   responses_api_agents:
     simple_agent:
+      max_steps: 1
       resources_server:
         type: resources_servers
         name: lmarena_v2_benchmark_resources_server

--- a/benchmarks/lmarena_v3/config.yaml
+++ b/benchmarks/lmarena_v3/config.yaml
@@ -22,6 +22,7 @@ lmarena_v3_benchmark_agent:
   _inherit_from: lmarena_v3_simple_agent
   responses_api_agents:
     simple_agent:
+      max_steps: 1
       resources_server:
         type: resources_servers
         name: lmarena_v3_benchmark_resources_server


### PR DESCRIPTION
## Summary

`SimpleAgent`'s response loop only stops on a final assistant message, a tool call, or an explicitly configured `max_steps`. `lmarena` is single-turn and no-tools, and never set `max_steps`, so it defaults to unbounded. If a model turn produces neither a tool call nor a final message (e.g. reasoning-only output), the loop keeps re-invoking the model forever, feeding the growing output back as context each time.

Found while investigating stuck `lmarena` rollouts in production: one rollout made **2,703 sequential model calls over ~8h** before an external SLURM walltime kill stopped it. Root-caused via direct rundir log inspection (rollout accumulated 3.9M chars of `policy_reasoning`, `policy_answer=None`, ending in degenerate repetition).

## Fix

Set `max_steps: 1` on both `lmarena_v2` and `lmarena_v3` (`benchmarks/lmarena_v2/config.yaml`, `benchmarks/lmarena_v3/config.yaml`), matching the benchmark's actual single-turn design — one policy-model call per rollout, no tool use. Verified both configs resolve correctly via `gym env resolve`.