### PR TITLE
feat(checkpoint): resume simple agent turns

### DIFF
--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -20,7 +20,7 @@ from typing import Any, List, Optional
 from fastapi import Request, Response
 from pydantic import ConfigDict, TypeAdapter, ValidationError
 
-from nemo_gym._checkpoint import AgentBoundaryRecord
+from nemo_gym._checkpoint import RESOURCE_STATE_REVISION_HEADER, AgentBoundaryRecord
 from nemo_gym.base_resources_server import (
     AggregateMetrics,
     AggregateMetricsRequest,
@@ -66,6 +66,13 @@ _INTERNAL_TRAJECTORY_KEY = "_ng_trajectory"
 _INPUT_ITEMS_ADAPTER = TypeAdapter(List[NeMoGymResponseInputItem])
 
 
+def _cookie_values(cookies: Any) -> dict[str, str]:
+    return {
+        name: str(getattr(cookie, "value", cookie))
+        for name, cookie in (cookies.items() if cookies is not None else ())
+    }
+
+
 class SimpleAgentConfig(BaseResponsesAPIAgentConfig):
     resources_server: ResourcesServerRef
     model_server: ModelServerRef
@@ -86,6 +93,7 @@ class SimpleAgentVerifyResponse(BaseVerifyResponse):
 
 class SimpleAgent(SimpleResponsesAPIAgent):
     config: SimpleAgentConfig
+    checkpoint_continuation_supported = True
 
     async def _create_episode(
         self,
@@ -97,6 +105,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         rollout_id: str = "unscoped",
         collect_trajectory: bool = False,
         continuation: Optional[AgentBoundaryRecord] = None,
+        request: Optional[Request] = None,
     ) -> tuple[NeMoGymResponse, TrajectoryRecord | None, Any, Any]:
         invocation_id = "root"
         tool_records: list[TrajectoryToolCall] = []
@@ -113,24 +122,47 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         step = 0
         invocation_status = "completed"
         model_server_cookies = None
+        resource_revision = 0
+        model_response = None
         if continuation is not None:
             new_outputs.extend(_INPUT_ITEMS_ADAPTER.validate_python(continuation.output_items))
             usage = NeMoGymResponseUsage.model_validate(continuation.usage) if continuation.usage is not None else None
             step = continuation.boundary_index
             model_server_cookies = continuation.agent_state.get("model_server_cookies") or None
             resources_server_cookies = continuation.agent_state.get("resources_server_cookies") or None
+            resource_revision = continuation.resource_state_revisions.get(self.config.resources_server.name, 0)
+            restored_response = continuation.agent_state.get("last_model_response")
+            if restored_response is not None:
+                model_response = NeMoGymResponse.model_validate(restored_response)
+            else:
+                model_response = NeMoGymResponse(
+                    id=continuation.last_committed_model_call_id or "restored-checkpoint-boundary",
+                    created_at=continuation.created_at,
+                    model=body.model or self.config.model_server.name,
+                    object="response",
+                    output=[],
+                    parallel_tool_calls=True,
+                    tool_choice="auto",
+                    tools=[],
+                )
 
         while True:
+            if self.config.max_steps and step >= self.config.max_steps:
+                invocation_status = "incomplete"
+                break
             step += 1
             new_body = body.model_copy(update={"input": body.input + new_outputs})
             if collect_trajectory:
                 turn_timestamp = time()
 
-            model_response = await self.server_client.post(
-                server_name=self.config.model_server.name,
-                url_path=model_url_path,
-                json=new_body,
-                cookies=model_server_cookies,
+            model_response = await self.retry_checkpoint_refusal(
+                lambda: self.server_client.post(
+                    server_name=self.config.model_server.name,
+                    url_path=model_url_path,
+                    json=new_body,
+                    cookies=model_server_cookies,
+                ),
+                request=request,
             )
             model_call_id = None
             if self._checkpoint_participant is not None:
@@ -206,14 +238,20 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                         tool_status = "failed"
                 else:
                     # Resource-server errors are valid model-visible tool outputs.
-                    api_response = await self.server_client.post(
-                        server_name=self.config.resources_server.name,
-                        url_path=f"/{output_function_call.name}",
-                        json=parsed_arguments,
-                        cookies=resources_server_cookies,
+                    api_response = await self.retry_checkpoint_refusal(
+                        lambda: self.server_client.post(
+                            server_name=self.config.resources_server.name,
+                            url_path=f"/{output_function_call.name}",
+                            json=parsed_arguments,
+                            cookies=resources_server_cookies,
+                        ),
+                        request=request,
                     )
                     tool_output = (await api_response.content.read()).decode()
                     resources_server_cookies = api_response.cookies
+                    headers = getattr(api_response, "headers", None)
+                    if isinstance(headers, Mapping) and headers.get(RESOURCE_STATE_REVISION_HEADER) is not None:
+                        resource_revision = int(headers[RESOURCE_STATE_REVISION_HEADER])
                     if collect_trajectory:
                         completed = 200 <= api_response.status < 400
                         tool_status = "completed" if completed else "failed"
@@ -245,11 +283,17 @@ class SimpleAgent(SimpleResponsesAPIAgent):
             if collect_trajectory and all_fn_calls:
                 turns[-1].step_count = len(tool_records)
 
-            if all_fn_calls and self._checkpoint_participant is not None:
+            if (
+                all_fn_calls
+                and self._checkpoint_participant is not None
+                and (not self.config.max_steps or step < self.config.max_steps)
+            ):
                 logical_rollout_id = current_logical_rollout_id()
                 attempt_index = current_attempt_index()
-                if logical_rollout_id is not None and attempt_index is not None:
+                execution = self.checkpoint_execution(request)
+                if logical_rollout_id is not None and attempt_index is not None and execution is not None:
                     await self.checkpoint_participant().commit_boundary(
+                        execution,
                         AgentBoundaryRecord(
                             rollout_id=logical_rollout_id,
                             attempt_index=attempt_index,
@@ -257,18 +301,19 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                             output_items=[item.model_dump(mode="json") for item in new_outputs],
                             usage=usage.model_dump(mode="json") if usage is not None else None,
                             last_committed_model_call_id=model_call_id,
+                            resource_state_revisions={self.config.resources_server.name: resource_revision},
                             agent_state={
-                                "model_server_cookies": dict(model_server_cookies or {}),
-                                "resources_server_cookies": dict(resources_server_cookies or {}),
+                                "model_server_cookies": _cookie_values(model_server_cookies),
+                                "resources_server_cookies": _cookie_values(resources_server_cookies),
+                                "last_model_response": model_response.model_copy(
+                                    update={"output": new_outputs, "usage": usage}
+                                ).model_dump(mode="json"),
                             },
-                        )
+                        ),
                     )
 
-            # Check if max steps is not None and if we have exhausted it.
-            if self.config.max_steps and step >= self.config.max_steps:
-                invocation_status = "incomplete"
-                break
-
+        if model_response is None:
+            raise RuntimeError("agent episode ended before producing or restoring a model response")
         model_response.output = new_outputs
         model_response.usage = usage
         trajectory = None
@@ -300,15 +345,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         if rollout_id is None and isinstance(path_params, Mapping):
             rollout_id = path_params.get("rollout_id")
         collect_trajectory = self._model_call_capture_enabled() and isinstance(rollout_id, str)
-        logical_rollout_id = current_logical_rollout_id()
-        attempt_index = current_attempt_index()
-        continuation = (
-            self.checkpoint_participant().continuation(logical_rollout_id, attempt_index)
-            if self._checkpoint_participant is not None
-            and logical_rollout_id is not None
-            and attempt_index is not None
-            else None
-        )
+        continuation = self.checkpoint_continuation(body, request)
         model_response, trajectory, model_server_cookies, resources_server_cookies = await self._create_episode(
             body,
             model_url_path=self.url_path_for_request("/v1/responses", request),
@@ -316,6 +353,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
             rollout_id=rollout_id or "unscoped",
             collect_trajectory=collect_trajectory,
             continuation=continuation,
+            request=request,
         )
         # Propogate any extra cookies necessary for downstream verification
         for k, v in (*resources_server_cookies.items(), *model_server_cookies.items()):
@@ -330,22 +368,28 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         cookies = request.cookies
         continuation = self.checkpoint_continuation(body)
         if continuation is None:
-            seed_session_response = await self.server_client.post(
-                server_name=self.config.resources_server.name,
-                url_path="/seed_session",
-                json=body.model_dump(),
-                cookies=cookies,
+            seed_session_response = await self.retry_checkpoint_refusal(
+                lambda: self.server_client.post(
+                    server_name=self.config.resources_server.name,
+                    url_path="/seed_session",
+                    json=body.model_dump(),
+                    cookies=cookies,
+                )
             )
             await raise_for_status(seed_session_response)
             cookies = seed_session_response.cookies
         else:
             cookies = continuation.agent_state.get("resources_server_cookies") or cookies
 
-        response = await self.server_client.post(
-            server_name=self.config.name,
-            url_path=self.url_path_for_run("/v1/responses", body),
-            json=body.responses_create_params,
-            cookies=cookies,
+        execution_headers = self.checkpoint_execution_headers()
+        response = await self.retry_checkpoint_refusal(
+            lambda: self.server_client.post(
+                server_name=self.config.name,
+                url_path=self.url_path_for_run("/v1/responses", body),
+                json=body.responses_create_params,
+                cookies=cookies,
+                **({"headers": execution_headers} if execution_headers is not None else {}),
+            )
         )
         await raise_for_status(response)
         model_response_json = await get_response_json(response)
@@ -389,11 +433,13 @@ class SimpleAgent(SimpleResponsesAPIAgent):
             verify_request = SimpleAgentVerifyRequest.model_validate(
                 body.model_dump() | {"response": model_response_json}
             )
-            verify_response = await self.server_client.post(
-                server_name=self.config.resources_server.name,
-                url_path="/verify",
-                json=verify_request.model_dump(),
-                cookies=cookies,
+            verify_response = await self.retry_checkpoint_refusal(
+                lambda: self.server_client.post(
+                    server_name=self.config.resources_server.name,
+                    url_path="/verify",
+                    json=verify_request.model_dump(),
+                    cookies=cookies,
+                )
             )
             await raise_for_status(verify_response)
             result = await get_response_json(verify_response)

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -15,11 +15,12 @@
 import json
 from collections.abc import Mapping
 from time import perf_counter, time
-from typing import Any, List
+from typing import Any, List, Optional
 
 from fastapi import Request, Response
-from pydantic import ConfigDict, ValidationError
+from pydantic import ConfigDict, TypeAdapter, ValidationError
 
+from nemo_gym._checkpoint import AgentBoundaryRecord
 from nemo_gym.base_resources_server import (
     AggregateMetrics,
     AggregateMetricsRequest,
@@ -39,8 +40,16 @@ from nemo_gym.openai_utils import (
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
     NeMoGymResponseFunctionToolCall,
+    NeMoGymResponseInputItem,
     NeMoGymResponseOutputMessage,
+    NeMoGymResponseUsage,
     accumulate_response_usage,
+)
+from nemo_gym.rollout_correlation import (
+    MODEL_CALL_ID_HEADER,
+    current_attempt_index,
+    current_logical_rollout_id,
+    current_rollout_id,
 )
 from nemo_gym.rollout_observability import (
     AgentInvocation,
@@ -54,6 +63,7 @@ from nemo_gym.server_utils import get_response_json, raise_for_status
 
 
 _INTERNAL_TRAJECTORY_KEY = "_ng_trajectory"
+_INPUT_ITEMS_ADAPTER = TypeAdapter(List[NeMoGymResponseInputItem])
 
 
 class SimpleAgentConfig(BaseResponsesAPIAgentConfig):
@@ -86,6 +96,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         task_id: str = "unscoped",
         rollout_id: str = "unscoped",
         collect_trajectory: bool = False,
+        continuation: Optional[AgentBoundaryRecord] = None,
     ) -> tuple[NeMoGymResponse, TrajectoryRecord | None, Any, Any]:
         invocation_id = "root"
         tool_records: list[TrajectoryToolCall] = []
@@ -102,6 +113,12 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         step = 0
         invocation_status = "completed"
         model_server_cookies = None
+        if continuation is not None:
+            new_outputs.extend(_INPUT_ITEMS_ADAPTER.validate_python(continuation.output_items))
+            usage = NeMoGymResponseUsage.model_validate(continuation.usage) if continuation.usage is not None else None
+            step = continuation.boundary_index
+            model_server_cookies = continuation.agent_state.get("model_server_cookies") or None
+            resources_server_cookies = continuation.agent_state.get("resources_server_cookies") or None
 
         while True:
             step += 1
@@ -115,6 +132,11 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                 json=new_body,
                 cookies=model_server_cookies,
             )
+            model_call_id = None
+            if self._checkpoint_participant is not None:
+                headers = getattr(model_response, "headers", None)
+                if isinstance(headers, Mapping):
+                    model_call_id = headers.get(MODEL_CALL_ID_HEADER)
             # We raise for status here since we expect model calls to always work.
             await raise_for_status(model_response)
             model_response_json = await get_response_json(model_response)
@@ -213,16 +235,34 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                         )
                     )
 
-                new_outputs.append(
-                    NeMoGymFunctionCallOutput(
-                        type="function_call_output",
-                        call_id=output_function_call.call_id,
-                        output=tool_output,
-                    )
+                function_output = NeMoGymFunctionCallOutput(
+                    type="function_call_output",
+                    call_id=output_function_call.call_id,
+                    output=tool_output,
                 )
+                new_outputs.append(function_output)
 
             if collect_trajectory and all_fn_calls:
                 turns[-1].step_count = len(tool_records)
+
+            if all_fn_calls and self._checkpoint_participant is not None:
+                logical_rollout_id = current_logical_rollout_id()
+                attempt_index = current_attempt_index()
+                if logical_rollout_id is not None and attempt_index is not None:
+                    await self.checkpoint_participant().commit_boundary(
+                        AgentBoundaryRecord(
+                            rollout_id=logical_rollout_id,
+                            attempt_index=attempt_index,
+                            boundary_index=step,
+                            output_items=[item.model_dump(mode="json") for item in new_outputs],
+                            usage=usage.model_dump(mode="json") if usage is not None else None,
+                            last_committed_model_call_id=model_call_id,
+                            agent_state={
+                                "model_server_cookies": dict(model_server_cookies or {}),
+                                "resources_server_cookies": dict(resources_server_cookies or {}),
+                            },
+                        )
+                    )
 
             # Check if max steps is not None and if we have exhausted it.
             if self.config.max_steps and step >= self.config.max_steps:
@@ -256,14 +296,26 @@ class SimpleAgent(SimpleResponsesAPIAgent):
         body: NeMoGymResponseCreateParamsNonStreaming = Body(),
     ) -> NeMoGymResponse:
         path_params = getattr(request, "path_params", None)
-        rollout_id = path_params.get("rollout_id") if isinstance(path_params, Mapping) else None
+        rollout_id = current_rollout_id()
+        if rollout_id is None and isinstance(path_params, Mapping):
+            rollout_id = path_params.get("rollout_id")
         collect_trajectory = self._model_call_capture_enabled() and isinstance(rollout_id, str)
+        logical_rollout_id = current_logical_rollout_id()
+        attempt_index = current_attempt_index()
+        continuation = (
+            self.checkpoint_participant().continuation(logical_rollout_id, attempt_index)
+            if self._checkpoint_participant is not None
+            and logical_rollout_id is not None
+            and attempt_index is not None
+            else None
+        )
         model_response, trajectory, model_server_cookies, resources_server_cookies = await self._create_episode(
             body,
             model_url_path=self.url_path_for_request("/v1/responses", request),
             resources_server_cookies=request.cookies,
             rollout_id=rollout_id or "unscoped",
             collect_trajectory=collect_trajectory,
+            continuation=continuation,
         )
         # Propogate any extra cookies necessary for downstream verification
         for k, v in (*resources_server_cookies.items(), *model_server_cookies.items()):
@@ -276,15 +328,18 @@ class SimpleAgent(SimpleResponsesAPIAgent):
 
     async def run(self, request: Request, body: SimpleAgentRunRequest) -> SimpleAgentVerifyResponse:
         cookies = request.cookies
-
-        seed_session_response = await self.server_client.post(
-            server_name=self.config.resources_server.name,
-            url_path="/seed_session",
-            json=body.model_dump(),
-            cookies=cookies,
-        )
-        await raise_for_status(seed_session_response)
-        cookies = seed_session_response.cookies
+        continuation = self.checkpoint_continuation(body)
+        if continuation is None:
+            seed_session_response = await self.server_client.post(
+                server_name=self.config.resources_server.name,
+                url_path="/seed_session",
+                json=body.model_dump(),
+                cookies=cookies,
+            )
+            await raise_for_status(seed_session_response)
+            cookies = seed_session_response.cookies
+        else:
+            cookies = continuation.agent_state.get("resources_server_cookies") or cookies
 
         response = await self.server_client.post(
             server_name=self.config.name,

--- a/responses_api_agents/simple_agent/app.py
+++ b/responses_api_agents/simple_agent/app.py
@@ -20,7 +20,7 @@ from typing import Any, List, Optional
 from fastapi import Request, Response
 from pydantic import ConfigDict, TypeAdapter, ValidationError
 
-from nemo_gym._checkpoint import RESOURCE_STATE_REVISION_HEADER, AgentBoundaryRecord
+from nemo_gym._checkpoint import AgentBoundaryRecord
 from nemo_gym.base_resources_server import (
     AggregateMetrics,
     AggregateMetricsRequest,
@@ -64,6 +64,7 @@ from nemo_gym.server_utils import get_response_json, raise_for_status
 
 _INTERNAL_TRAJECTORY_KEY = "_ng_trajectory"
 _INPUT_ITEMS_ADAPTER = TypeAdapter(List[NeMoGymResponseInputItem])
+RESOURCE_STATE_REVISION_HEADER = "x-nemo-gym-resource-state-revision"
 
 
 def _cookie_values(cookies: Any) -> dict[str, str]:
@@ -71,6 +72,14 @@ def _cookie_values(cookies: Any) -> dict[str, str]:
         name: str(getattr(cookie, "value", cookie))
         for name, cookie in (cookies.items() if cookies is not None else ())
     }
+
+
+def _merge_cookies(current: Any, updates: Any) -> Any:
+    if current is None or current is updates:
+        return updates
+    merged = _cookie_values(current)
+    merged.update(_cookie_values(updates))
+    return merged
 
 
 class SimpleAgentConfig(BaseResponsesAPIAgentConfig):
@@ -172,7 +181,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
             # We raise for status here since we expect model calls to always work.
             await raise_for_status(model_response)
             model_response_json = await get_response_json(model_response)
-            model_server_cookies = model_response.cookies
+            model_server_cookies = _merge_cookies(model_server_cookies, model_response.cookies)
             try:
                 model_response = NeMoGymResponse.model_validate(model_response_json)
             except ValidationError as e:
@@ -248,7 +257,7 @@ class SimpleAgent(SimpleResponsesAPIAgent):
                         request=request,
                     )
                     tool_output = (await api_response.content.read()).decode()
-                    resources_server_cookies = api_response.cookies
+                    resources_server_cookies = _merge_cookies(resources_server_cookies, api_response.cookies)
                     headers = getattr(api_response, "headers", None)
                     if isinstance(headers, Mapping) and headers.get(RESOURCE_STATE_REVISION_HEADER) is not None:
                         resource_revision = int(headers[RESOURCE_STATE_REVISION_HEADER])

--- a/responses_api_agents/simple_agent/tests/test_app.py
+++ b/responses_api_agents/simple_agent/tests/test_app.py
@@ -12,16 +12,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
+import contextvars
 import json
+import time
+from http.cookies import SimpleCookie
 from unittest.mock import AsyncMock, MagicMock, call
 
+import httpx
 import orjson
 import pytest
 from fastapi import Response
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 
-from nemo_gym.global_config import ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
+from nemo_gym._checkpoint import AgentBoundaryRecord
+from nemo_gym.global_config import ATTEMPT_INDEX_KEY_NAME, ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
 from nemo_gym.openai_utils import (
     NeMoGymEasyInputMessage,
     NeMoGymFunctionCallOutput,
@@ -31,6 +37,7 @@ from nemo_gym.openai_utils import (
     NeMoGymSummary,
 )
 from nemo_gym.rollout_collection import _attach_trajectory_record
+from nemo_gym.rollout_correlation import rollout_context
 from nemo_gym.rollout_observability import TrajectoryRecord
 from nemo_gym.server_utils import ServerClient
 from responses_api_agents.simple_agent.app import (
@@ -39,6 +46,7 @@ from responses_api_agents.simple_agent.app import (
     SimpleAgent,
     SimpleAgentConfig,
     SimpleAgentRunRequest,
+    _cookie_values,
 )
 
 
@@ -54,6 +62,13 @@ def _drop_nulls(value):
     if isinstance(value, list):
         return [_drop_nulls(v) for v in value]
     return value
+
+
+def test_checkpoint_cookie_values_do_not_serialize_morsel_attributes() -> None:
+    cookies = SimpleCookie()
+    cookies["sid"] = "abc"
+    cookies["sid"]["path"] = "/"
+    assert _cookie_values(cookies) == {"sid": "abc"}
 
 
 def _make_agent(
@@ -931,6 +946,7 @@ class TestApp:
             skip_verification_reward=0.25,
         )
         server = SimpleAgent(config=config, server_client=MagicMock(spec=ServerClient))
+        server.checkpoint_participant()
         app = server.setup_webserver()
         client = TestClient(app)
 
@@ -955,12 +971,18 @@ class TestApp:
 
         server.server_client.post.side_effect = [seed_response, model_response]
 
-        response = client.post(
-            "/run",
-            json={"responses_create_params": {"input": [{"role": "user", "content": "hello"}]}},
-        )
+        request_body = {
+            "responses_create_params": {"input": [{"role": "user", "content": "hello"}]},
+            TASK_INDEX_KEY_NAME: 4,
+            ROLLOUT_INDEX_KEY_NAME: 1,
+            ATTEMPT_INDEX_KEY_NAME: 0,
+        }
+        response = client.post("/run", json=request_body)
+        replay = client.post("/run", json=request_body)
 
         assert response.status_code == 200
+        assert replay.status_code == 200
+        assert replay.json() == response.json()
         response_json = response.json()
         assert response_json["reward"] == 0.25
         assert response_json["verification_skipped"] is True
@@ -974,3 +996,197 @@ class TestApp:
         assert post_call_kwargs[0]["server_name"] == "my resources server"
         assert post_call_kwargs[1]["server_name"] == "simple_agent"
         assert post_call_kwargs[1]["cookies"] == {"session": "seeded"}
+
+    async def test_legacy_boundary_at_step_budget_does_not_generate_an_extra_turn(self) -> None:
+        server, client = _make_agent(observability_enabled=False)
+        server.config.max_steps = 2
+        continuation = AgentBoundaryRecord(
+            rollout_id="4-1",
+            attempt_index=0,
+            boundary_index=2,
+            output_items=[],
+            last_committed_model_call_id="call-2",
+        )
+
+        response, _trajectory, _model_cookies, _resource_cookies = await server._create_episode(
+            NeMoGymResponseCreateParamsNonStreaming(input=[{"role": "user", "content": "hello"}]),
+            model_url_path="/v1/responses",
+            continuation=continuation,
+        )
+
+        assert response.id == "call-2"
+        client.post.assert_not_awaited()
+
+    async def test_refused_tool_call_parks_and_retries_without_entering_history(self) -> None:
+        server, client = _make_agent(observability_enabled=False)
+        participant = server.checkpoint_participant()
+        execution = await participant.begin("4-1", 0, task=asyncio.current_task())
+        refused = asyncio.Event()
+        calls = []
+        tool_call = {
+            "id": "fc_1",
+            "call_id": "call_1",
+            "name": "my_tool",
+            "arguments": "{}",
+            "type": "function_call",
+            "status": "completed",
+        }
+        final_message = {
+            "id": "msg_final",
+            "content": [{"annotations": [], "text": "done", "type": "output_text"}],
+            "role": "assistant",
+            "status": "completed",
+            "type": "message",
+        }
+        model_payloads = [
+            {
+                "id": "resp_tool",
+                "created_at": 1.0,
+                "model": "dummy_model",
+                "object": "response",
+                "output": [tool_call],
+                "parallel_tool_calls": True,
+                "tool_choice": "auto",
+                "tools": [],
+            },
+            {
+                "id": "resp_final",
+                "created_at": 2.0,
+                "model": "dummy_model",
+                "object": "response",
+                "output": [final_message],
+                "parallel_tool_calls": True,
+                "tool_choice": "auto",
+                "tools": [],
+            },
+        ]
+        tool_payloads = [
+            _mock_response(
+                {"error": {"code": "checkpoint_parked", "detail": "paused"}},
+                status=409,
+            ),
+            _mock_response(content="tool-result"),
+        ]
+
+        async def post(server_name, url_path, **kwargs):
+            calls.append((server_name, url_path, kwargs))
+            if server_name == "model":
+                return _mock_response(model_payloads.pop(0))
+            response = tool_payloads.pop(0)
+            if response.status == 409:
+                refused.set()
+            return response
+
+        client.post = AsyncMock(side_effect=post)
+        token = participant.bind(execution)
+        with rollout_context("4-1", attempt_index=0, logical_rollout_id="4-1"):
+            episode = asyncio.create_task(
+                server._create_episode(
+                    NeMoGymResponseCreateParamsNonStreaming(input=[{"role": "user", "content": "hello"}]),
+                    model_url_path="/v1/responses",
+                )
+            )
+        participant.unbind(token)
+        await refused.wait()
+        while participant.status()["parked"] != 1:
+            await asyncio.sleep(0)
+        await participant.resume()
+        response, _trajectory, _model_cookies, _resource_cookies = await episode
+
+        assert response.output[-1].type == "message"
+        assert [url for _server_name, url, _kwargs in calls].count("/my_tool") == 2
+        second_model_input = [kwargs["json"].input for name, _url, kwargs in calls if name == "model"][1]
+        assert "checkpoint_parked" not in str(second_model_input)
+        assert "tool-result" in str(second_model_input)
+
+    async def test_retire_cancels_outer_run_and_internal_responses_handler(self) -> None:
+        server, client = _make_agent(observability_enabled=True)
+        server.config.skip_verification = True
+        participant = server.checkpoint_participant()
+        app = server.setup_webserver()
+        model_started = asyncio.Event()
+        release_model = asyncio.Event()
+        calls: list[tuple[str, str]] = []
+        tool_call_payload = {
+            "id": "resp_tool",
+            "created_at": 1.0,
+            "model": "dummy_model",
+            "object": "response",
+            "output": [
+                {
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "my_tool",
+                    "arguments": "{}",
+                    "type": "function_call",
+                    "status": "completed",
+                }
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+
+        class SelfResponse:
+            def __init__(self, response: httpx.Response) -> None:
+                self.status = response.status_code
+                self.ok = response.is_success
+                self.cookies = response.cookies
+                self._content = response.content
+
+            async def read(self) -> bytes:
+                return self._content
+
+        async def post(server_name, url_path, json=None, cookies=None, headers=None, **kwargs):
+            calls.append((server_name, url_path))
+            if server_name == "resources" and url_path == "/seed_session":
+                return _mock_response()
+            if server_name == "simple":
+                payload = json.model_dump(exclude_unset=True) if hasattr(json, "model_dump") else json
+
+                async def call_internal_handler() -> SelfResponse:
+                    async with httpx.AsyncClient(
+                        transport=httpx.ASGITransport(app=app),
+                        base_url="http://agent",
+                    ) as internal_client:
+                        response = await internal_client.post(
+                            url_path,
+                            json=payload,
+                            cookies=cookies,
+                            headers=headers,
+                        )
+                    return SelfResponse(response)
+
+                return await asyncio.create_task(call_internal_handler(), context=contextvars.Context())
+            if server_name == "model":
+                model_started.set()
+                await release_model.wait()
+                return _mock_response(tool_call_payload)
+            if server_name == "resources" and url_path == "/my_tool":
+                return _mock_response(content="tool-result")
+            raise AssertionError(f"unexpected call: {server_name} {url_path}")
+
+        client.post = AsyncMock(side_effect=post)
+        body = {
+            "responses_create_params": {"input": [{"role": "user", "content": "hello"}]},
+            TASK_INDEX_KEY_NAME: 4,
+            ROLLOUT_INDEX_KEY_NAME: 1,
+            ATTEMPT_INDEX_KEY_NAME: 0,
+        }
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://actor") as actor:
+            run = asyncio.create_task(actor.post("/run", json=body))
+            await model_started.wait()
+            prepare = asyncio.create_task(participant.prepare(time.time() + 2))
+            await asyncio.sleep(0)
+            release_model.set()
+            report = await prepare
+            assert report["parked_with_boundary"] == 1
+            await participant.retire("4-1", 0)
+            with pytest.raises((asyncio.CancelledError, RuntimeError)) as cancelled:
+                await run
+            if isinstance(cancelled.value, RuntimeError):
+                assert str(cancelled.value) == "No response returned."
+
+        await asyncio.sleep(0)
+        assert sum(server_name == "model" for server_name, _url_path in calls) == 1
+        assert calls.count(("resources", "/my_tool")) == 1


### PR DESCRIPTION
> [!NOTE]
> This checkpoint implementation is experimental. Its Python modules live under `nemo_gym._checkpoint`; they are not a supported public import surface yet.

## Summary
- emit serializable `SimpleAgent` boundaries after completed turns
- restore model and resources cookies as plain values
- retry checkpoint refusals without recording false tool failures
- stop retired self-dispatched handlers before they can mutate successor state

## How `SimpleAgent` resumes
This PR applies the participant from #2942 to `SimpleAgent`. A boundary is emitted only after the current model/tool turn has completed. It records enough state to begin the next operation without seeding a new resources session or repeating the completed model call.

```mermaid
flowchart TD
    A[Fresh /run attempt] --> B[Seed resources session]
    B --> C[Call policy model]
    C --> D[Apply tool or resources operation]
    D --> E{Terminal?}
    E -->|yes| F[Return final result; await framework durability]
    E -->|no| G[Commit AgentBoundaryRecord]
    G --> H{Checkpoint requested?}
    H -->|no| C
    H -->|yes| I[Park at boundary]
    I --> J[Commit output, usage, cookies, model-call ID, and resource revision]
    J --> K[Restore under attempt N+1]
    K --> L[Recover cookies and prior output; skip session seed]
    L --> C
    C -->|checkpoint refusal| I
    D -->|checkpoint refusal| I
```

A checkpoint refusal is control flow, not a model-visible tool error. The agent parks, waits for explicit resume, and retries the same operation without appending a failed tool result to history.

Cookie values are converted to plain strings before Pydantic serialization; `SimpleCookie` morsel attributes are not written into checkpoint state. The resources revision follows the agent boundary so the controller can reconcile it with a matching resources snapshot.

## Stack
- depends on: [#2942](https://github.com/NVIDIA-NeMo/Gym/pull/2942)
- next: [#2944](https://github.com/NVIDIA-NeMo/Gym/pull/2944)

## Test plan
- [x] `SimpleAgent` route and continuation tests
- [x] refusal retry, retirement, step-budget, and cookie serialization regressions

## Generation-safe checkpoint update

- records generation-safe SimpleAgent continuation phases
- restores pending actions exactly once and merges continuation cookies

Layer validation: 16 tests passed.