### PR TITLE
feat(checkpoint): resume Gymnasium agent turns

### DIFF
--- a/responses_api_agents/gymnasium_agent/app.py
+++ b/responses_api_agents/gymnasium_agent/app.py
@@ -18,12 +18,12 @@
 import logging
 import uuid
 from collections.abc import Mapping
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import Body, Request, Response
 from pydantic import ConfigDict, Field, TypeAdapter
 
-from nemo_gym._checkpoint import AgentBoundaryRecord
+from nemo_gym._checkpoint import RESOURCE_STATE_REVISION_HEADER, AgentBoundaryRecord
 from nemo_gym.base_resources_server import (
     BaseRunRequest,
     BaseVerifyResponse,
@@ -48,6 +48,13 @@ _LOGGER = logging.getLogger(__name__)
 _INPUT_ITEMS_ADAPTER = TypeAdapter(list[NeMoGymResponseInputItem])
 
 
+def _cookie_values(cookies: Any) -> dict[str, str]:
+    return {
+        name: str(getattr(cookie, "value", cookie))
+        for name, cookie in (cookies.items() if cookies is not None else ())
+    }
+
+
 class GymnasiumAgentConfig(BaseResponsesAPIAgentConfig):
     resources_server: ResourcesServerRef
     model_server: ModelServerRef
@@ -67,6 +74,7 @@ class GymnasiumRunResponse(BaseVerifyResponse):
 
 class GymnasiumAgent(SimpleResponsesAPIAgent):
     config: GymnasiumAgentConfig
+    checkpoint_continuation_supported = True
 
     async def responses(
         self,
@@ -96,11 +104,13 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
         supports_explicit_close = False
         try:
             if continuation is None:
-                reset_resp = await self.server_client.post(
-                    server_name=self.config.resources_server.name,
-                    url_path="/reset",
-                    json=body.model_dump(),
-                    cookies=env_cookies,
+                reset_resp = await self.retry_checkpoint_refusal(
+                    lambda: self.server_client.post(
+                        server_name=self.config.resources_server.name,
+                        url_path="/reset",
+                        json=body.model_dump(),
+                        cookies=env_cookies,
+                    )
                 )
                 await raise_for_status(reset_resp)
                 if reset_resp.cookies:
@@ -191,6 +201,7 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
         last_model_response = None
         finished = False
         start_step = 0
+        resource_revision = 0
         if continuation is not None:
             new_outputs.extend(_INPUT_ITEMS_ADAPTER.validate_python(continuation.output_items))
             total_reward = float(continuation.agent_state.get("total_reward", 0.0))
@@ -198,15 +209,32 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
             model_server_cookies = continuation.agent_state.get("model_server_cookies") or None
             step_data = EnvStepResponse.model_validate(continuation.agent_state["step_data"])
             start_step = continuation.boundary_index
+            resource_revision = continuation.resource_state_revisions.get(self.config.resources_server.name, 0)
+            restored_response = continuation.agent_state.get("last_model_response")
+            if restored_response is not None:
+                last_model_response = NeMoGymResponse.model_validate(restored_response)
+            else:
+                last_model_response = NeMoGymResponse(
+                    id=continuation.last_committed_model_call_id or "restored-checkpoint-boundary",
+                    created_at=continuation.created_at,
+                    model=base_body.model or self.config.model_server.name,
+                    object="response",
+                    output=[],
+                    parallel_tool_calls=True,
+                    tool_choice="auto",
+                    tools=[],
+                )
 
         for step in range(start_step + 1, self.config.max_steps + 1):
             new_body = base_body.model_copy(update={"input": base_body.input + new_outputs})
 
-            model_resp = await self.server_client.post(
-                server_name=self.config.model_server.name,
-                url_path=model_url_path,
-                json=new_body,
-                cookies=model_server_cookies,
+            model_resp = await self.retry_checkpoint_refusal(
+                lambda: self.server_client.post(
+                    server_name=self.config.model_server.name,
+                    url_path=model_url_path,
+                    json=new_body,
+                    cookies=model_server_cookies,
+                )
             )
             model_call_id = None
             headers = getattr(model_resp, "headers", None)
@@ -224,14 +252,19 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
             step_body = body.model_dump() | {"response": model_response.model_dump()}
             if (reset_data.info or {}).get("supports_step_idempotency") is True:
                 step_body["_ng_step_request_id"] = uuid.uuid4().hex
-            step_resp = await self.server_client.post(
-                server_name=self.config.resources_server.name,
-                url_path="/step",
-                json=step_body,
-                cookies=env_cookies,
+            step_resp = await self.retry_checkpoint_refusal(
+                lambda: self.server_client.post(
+                    server_name=self.config.resources_server.name,
+                    url_path="/step",
+                    json=step_body,
+                    cookies=env_cookies,
+                )
             )
             await raise_for_status(step_resp)
             step_data = EnvStepResponse.model_validate(await get_response_json(step_resp))
+            step_headers = getattr(step_resp, "headers", None)
+            if isinstance(step_headers, Mapping) and step_headers.get(RESOURCE_STATE_REVISION_HEADER) is not None:
+                resource_revision = int(step_headers[RESOURCE_STATE_REVISION_HEADER])
             total_reward += step_data.reward
             if step_resp.cookies:
                 env_cookies.update(step_resp.cookies)
@@ -248,11 +281,17 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
             if step_data.observation:
                 new_outputs.append(NeMoGymEasyInputMessage(role="user", content=step_data.observation))
 
-            if self._checkpoint_participant is not None:
+            if (
+                self._checkpoint_participant is not None
+                and not (step_data.terminated or step_data.truncated)
+                and step < self.config.max_steps
+            ):
                 logical_rollout_id = current_logical_rollout_id()
                 attempt_index = current_attempt_index()
-                if logical_rollout_id is not None and attempt_index is not None:
+                execution = self.checkpoint_execution()
+                if logical_rollout_id is not None and attempt_index is not None and execution is not None:
                     await self.checkpoint_participant().commit_boundary(
+                        execution,
                         AgentBoundaryRecord(
                             rollout_id=logical_rollout_id,
                             attempt_index=attempt_index,
@@ -260,14 +299,18 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
                             output_items=[item.model_dump(mode="json") for item in new_outputs],
                             usage=usage.model_dump(mode="json") if usage is not None else None,
                             last_committed_model_call_id=model_call_id,
+                            resource_state_revisions={self.config.resources_server.name: resource_revision},
                             agent_state={
                                 "reset_data": reset_data.model_dump(mode="json"),
                                 "step_data": step_data.model_dump(mode="json"),
                                 "total_reward": total_reward,
-                                "model_server_cookies": dict(model_server_cookies or {}),
-                                "env_cookies": dict(env_cookies),
+                                "model_server_cookies": _cookie_values(model_server_cookies),
+                                "env_cookies": _cookie_values(env_cookies),
+                                "last_model_response": model_response.model_copy(
+                                    update={"output": new_outputs, "usage": usage}
+                                ).model_dump(mode="json"),
                             },
-                        )
+                        ),
                     )
 
             if step_data.terminated or step_data.truncated:
@@ -277,6 +320,8 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
         if not finished:
             step_data = step_data.model_copy(update={"truncated": True})
 
+        if last_model_response is None:
+            raise RuntimeError("Gymnasium episode ended before producing or restoring a model response")
         last_model_response.output = new_outputs
         last_model_response.usage = usage
 

--- a/responses_api_agents/gymnasium_agent/app.py
+++ b/responses_api_agents/gymnasium_agent/app.py
@@ -17,10 +17,13 @@
 
 import logging
 import uuid
+from collections.abc import Mapping
+from typing import Optional
 
 from fastapi import Body, Request, Response
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, TypeAdapter
 
+from nemo_gym._checkpoint import AgentBoundaryRecord
 from nemo_gym.base_resources_server import (
     BaseRunRequest,
     BaseVerifyResponse,
@@ -32,13 +35,17 @@ from nemo_gym.openai_utils import (
     NeMoGymFunctionCallOutput,
     NeMoGymResponse,
     NeMoGymResponseCreateParamsNonStreaming,
+    NeMoGymResponseInputItem,
+    NeMoGymResponseUsage,
     accumulate_response_usage,
 )
+from nemo_gym.rollout_correlation import MODEL_CALL_ID_HEADER, current_attempt_index, current_logical_rollout_id
 from nemo_gym.server_utils import get_response_json, raise_for_status
 from resources_servers.gymnasium import EnvResetResponse, EnvStepResponse
 
 
 _LOGGER = logging.getLogger(__name__)
+_INPUT_ITEMS_ADAPTER = TypeAdapter(list[NeMoGymResponseInputItem])
 
 
 class GymnasiumAgentConfig(BaseResponsesAPIAgentConfig):
@@ -84,27 +91,39 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
         # issued by the resource server during the rollout.
         env_cookies = dict(request.cookies)
         model_url_path = self.url_path_for_run("/v1/responses", body)
-
-        reset_resp = await self.server_client.post(
-            server_name=self.config.resources_server.name,
-            url_path="/reset",
-            json=body.model_dump(),
-            cookies=env_cookies,
-        )
-        await raise_for_status(reset_resp)
-        if reset_resp.cookies:
-            env_cookies.update(reset_resp.cookies)
+        continuation = self.checkpoint_continuation(body)
 
         supports_explicit_close = False
         try:
-            # A successful reset owns a stateful server slot even if response
-            # decoding or schema validation fails, so validation belongs
-            # inside the same cleanup boundary as the rollout itself.
-            reset_payload = await get_response_json(reset_resp)
-            if isinstance(reset_payload, dict) and isinstance(reset_payload.get("info"), dict):
-                supports_explicit_close = reset_payload["info"].get("supports_explicit_close") is True
-            reset_data = EnvResetResponse.model_validate(reset_payload)
-            result = await self._run_open_episode(body, model_url_path, reset_data, env_cookies)
+            if continuation is None:
+                reset_resp = await self.server_client.post(
+                    server_name=self.config.resources_server.name,
+                    url_path="/reset",
+                    json=body.model_dump(),
+                    cookies=env_cookies,
+                )
+                await raise_for_status(reset_resp)
+                if reset_resp.cookies:
+                    env_cookies.update(reset_resp.cookies)
+                # A successful reset owns a stateful server slot even if response
+                # decoding or schema validation fails.
+                reset_payload = await get_response_json(reset_resp)
+                if isinstance(reset_payload, dict) and isinstance(reset_payload.get("info"), dict):
+                    supports_explicit_close = reset_payload["info"].get("supports_explicit_close") is True
+                reset_data = EnvResetResponse.model_validate(reset_payload)
+            else:
+                reset_data = EnvResetResponse.model_validate(continuation.agent_state["reset_data"])
+                env_cookies = dict(continuation.agent_state.get("env_cookies") or env_cookies)
+            supports_explicit_close = supports_explicit_close or (
+                (reset_data.info or {}).get("supports_explicit_close") is True
+            )
+            result = await self._run_open_episode(
+                body,
+                model_url_path,
+                reset_data,
+                env_cookies,
+                continuation=continuation,
+            )
         except BaseException:
             if supports_explicit_close:
                 # Preserve the original model/transport/cancellation failure.
@@ -151,6 +170,8 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
         model_url_path: str,
         reset_data: EnvResetResponse,
         env_cookies,
+        *,
+        continuation: Optional[AgentBoundaryRecord] = None,
     ) -> GymnasiumRunResponse:
         """Drive an already-reset episode; :meth:`run` owns its cleanup."""
 
@@ -169,8 +190,16 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
         step_data = EnvStepResponse(terminated=False, truncated=True, reward=0.0)
         last_model_response = None
         finished = False
+        start_step = 0
+        if continuation is not None:
+            new_outputs.extend(_INPUT_ITEMS_ADAPTER.validate_python(continuation.output_items))
+            total_reward = float(continuation.agent_state.get("total_reward", 0.0))
+            usage = NeMoGymResponseUsage.model_validate(continuation.usage) if continuation.usage is not None else None
+            model_server_cookies = continuation.agent_state.get("model_server_cookies") or None
+            step_data = EnvStepResponse.model_validate(continuation.agent_state["step_data"])
+            start_step = continuation.boundary_index
 
-        for _ in range(self.config.max_steps):
+        for step in range(start_step + 1, self.config.max_steps + 1):
             new_body = base_body.model_copy(update={"input": base_body.input + new_outputs})
 
             model_resp = await self.server_client.post(
@@ -179,6 +208,10 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
                 json=new_body,
                 cookies=model_server_cookies,
             )
+            model_call_id = None
+            headers = getattr(model_resp, "headers", None)
+            if self._checkpoint_participant is not None and isinstance(headers, Mapping):
+                model_call_id = headers.get(MODEL_CALL_ID_HEADER)
             await raise_for_status(model_resp)
             model_response = NeMoGymResponse.model_validate(await get_response_json(model_resp))
             model_server_cookies = model_resp.cookies
@@ -203,10 +236,6 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
             if step_resp.cookies:
                 env_cookies.update(step_resp.cookies)
 
-            if step_data.terminated or step_data.truncated:
-                finished = True
-                break
-
             for tool_output in (step_data.info or {}).get("tool_outputs", []):
                 new_outputs.append(
                     NeMoGymFunctionCallOutput(
@@ -218,6 +247,32 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
 
             if step_data.observation:
                 new_outputs.append(NeMoGymEasyInputMessage(role="user", content=step_data.observation))
+
+            if self._checkpoint_participant is not None:
+                logical_rollout_id = current_logical_rollout_id()
+                attempt_index = current_attempt_index()
+                if logical_rollout_id is not None and attempt_index is not None:
+                    await self.checkpoint_participant().commit_boundary(
+                        AgentBoundaryRecord(
+                            rollout_id=logical_rollout_id,
+                            attempt_index=attempt_index,
+                            boundary_index=step,
+                            output_items=[item.model_dump(mode="json") for item in new_outputs],
+                            usage=usage.model_dump(mode="json") if usage is not None else None,
+                            last_committed_model_call_id=model_call_id,
+                            agent_state={
+                                "reset_data": reset_data.model_dump(mode="json"),
+                                "step_data": step_data.model_dump(mode="json"),
+                                "total_reward": total_reward,
+                                "model_server_cookies": dict(model_server_cookies or {}),
+                                "env_cookies": dict(env_cookies),
+                            },
+                        )
+                    )
+
+            if step_data.terminated or step_data.truncated:
+                finished = True
+                break
 
         if not finished:
             step_data = step_data.model_copy(update={"truncated": True})

--- a/responses_api_agents/gymnasium_agent/app.py
+++ b/responses_api_agents/gymnasium_agent/app.py
@@ -23,7 +23,7 @@ from typing import Any, Optional
 from fastapi import Body, Request, Response
 from pydantic import ConfigDict, Field, TypeAdapter
 
-from nemo_gym._checkpoint import RESOURCE_STATE_REVISION_HEADER, AgentBoundaryRecord
+from nemo_gym._checkpoint import AgentBoundaryRecord
 from nemo_gym.base_resources_server import (
     BaseRunRequest,
     BaseVerifyResponse,
@@ -53,6 +53,17 @@ def _cookie_values(cookies: Any) -> dict[str, str]:
         name: str(getattr(cookie, "value", cookie))
         for name, cookie in (cookies.items() if cookies is not None else ())
     }
+
+
+def _merge_cookies(current: Any, updates: Any) -> Any:
+    if current is None or current is updates:
+        return updates
+    merged = _cookie_values(current)
+    merged.update(_cookie_values(updates))
+    return merged
+
+
+RESOURCE_STATE_REVISION_HEADER = "x-nemo-gym-resource-state-revision"
 
 
 class GymnasiumAgentConfig(BaseResponsesAPIAgentConfig):
@@ -242,7 +253,7 @@ class GymnasiumAgent(SimpleResponsesAPIAgent):
                 model_call_id = headers.get(MODEL_CALL_ID_HEADER)
             await raise_for_status(model_resp)
             model_response = NeMoGymResponse.model_validate(await get_response_json(model_resp))
-            model_server_cookies = model_resp.cookies
+            model_server_cookies = _merge_cookies(model_server_cookies, model_resp.cookies)
             last_model_response = model_response
 
             new_outputs.extend(model_response.output)

--- a/responses_api_agents/gymnasium_agent/tests/test_app.py
+++ b/responses_api_agents/gymnasium_agent/tests/test_app.py
@@ -12,16 +12,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import json
+from http.cookies import SimpleCookie
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from nemo_gym._checkpoint import AgentBoundaryRecord
 from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
 from nemo_gym.global_config import ATTEMPT_INDEX_KEY_NAME, ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
 from nemo_gym.server_utils import ServerClient
-from responses_api_agents.gymnasium_agent.app import GymnasiumAgent, GymnasiumAgentConfig, GymnasiumAgentRunRequest
+from responses_api_agents.gymnasium_agent.app import (
+    GymnasiumAgent,
+    GymnasiumAgentConfig,
+    GymnasiumAgentRunRequest,
+    _cookie_values,
+)
 
 
 def _make_agent(max_steps=10, observability=True):
@@ -37,6 +45,13 @@ def _make_agent(max_steps=10, observability=True):
     server_client = MagicMock(spec=ServerClient)
     server_client.global_config_dict = {"observability_enabled": observability}
     return GymnasiumAgent(config=config, server_client=server_client)
+
+
+def test_checkpoint_cookie_values_do_not_serialize_morsel_attributes():
+    cookies = SimpleCookie()
+    cookies["sid"] = "abc"
+    cookies["sid"]["path"] = "/"
+    assert _cookie_values(cookies) == {"sid": "abc"}
 
 
 def _model_response(text: str, input_toks=1, output_toks=1, cached_toks=0, reasoning_toks=0) -> dict:
@@ -68,11 +83,11 @@ def _model_response(text: str, input_toks=1, output_toks=1, cached_toks=0, reaso
 
 
 class _FakeHttpResp:
-    def __init__(self, payload: dict):
+    def __init__(self, payload: dict, *, status: int = 200):
         self._payload = payload
         self.cookies = {}
-        self.status = 200
-        self.ok = True
+        self.status = status
+        self.ok = status < 400
 
     async def json(self):
         return self._payload
@@ -197,7 +212,15 @@ class TestRun:
             },
         )
 
-        result = await agent.run(request, body)
+        participant = agent.checkpoint_participant()
+        await participant.resume()
+        execution = await participant.begin("2-0", 1, task=None)
+        token = participant.bind(execution)
+        try:
+            result = await agent.run(request, body)
+        finally:
+            participant.unbind(token)
+        await participant.finish(execution, outcome="completed", result=result)
 
         assert result.reward == 1.0
         assert result.response.usage.total_tokens == 18
@@ -206,8 +229,111 @@ class TestRun:
         assert any(getattr(item, "content", None) == "observation-1" for item in model_body.input)
 
     @pytest.mark.asyncio
+    async def test_legacy_boundary_at_step_budget_returns_truncated_result(self):
+        agent = _make_agent(max_steps=2)
+        continuation = AgentBoundaryRecord(
+            rollout_id="2-0",
+            attempt_index=0,
+            boundary_index=2,
+            output_items=_model_response("turn-2")["output"],
+            usage=_model_response("turn-2")["usage"],
+            last_committed_model_call_id="call-2",
+            agent_state={
+                "reset_data": {"observation": "start", "info": {}},
+                "step_data": {
+                    "observation": "still-running",
+                    "reward": 0.5,
+                    "terminated": False,
+                    "truncated": False,
+                    "info": {},
+                },
+                "total_reward": 1.25,
+            },
+        )
+        participant = agent.checkpoint_participant()
+        participant.install_restored([continuation])
+        await participant.resume()
+        execution = await participant.begin("2-0", 1, task=None)
+        token = participant.bind(execution)
+        request = MagicMock(cookies={})
+        body = GymnasiumAgentRunRequest(
+            responses_create_params={"input": [{"role": "user", "content": "play"}]},
+            **{
+                TASK_INDEX_KEY_NAME: 2,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                ATTEMPT_INDEX_KEY_NAME: 1,
+            },
+        )
+        try:
+            result = await agent.run(request, body)
+        finally:
+            participant.unbind(token)
+
+        assert result.truncated is True
+        assert result.reward == 1.25
+        assert result.response.id == "call-2"
+        agent.server_client.post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_run_parks_and_retries_refused_step_without_recording_error(self):
+        agent = _make_agent(max_steps=2)
+        participant = agent.checkpoint_participant()
+        refused = asyncio.Event()
+        calls: list[tuple[str, object]] = []
+        responses = {
+            "/reset": [_FakeHttpResp({"observation": "start", "info": {}})],
+            "/ng-rollout/2-0/v1/responses": [_FakeHttpResp(_model_response("act"))],
+            "/step": [
+                _FakeHttpResp(
+                    {"error": {"code": "checkpoint_parked", "detail": "paused"}},
+                    status=409,
+                ),
+                _FakeHttpResp(
+                    {
+                        "observation": None,
+                        "reward": 1.0,
+                        "terminated": True,
+                        "truncated": False,
+                        "info": {},
+                    }
+                ),
+            ],
+        }
+
+        async def post(server_name, url_path, json=None, **kwargs):
+            calls.append((url_path, json))
+            response = responses[url_path].pop(0)
+            if url_path == "/step" and response.status == 409:
+                refused.set()
+            return response
+
+        agent.server_client.post = AsyncMock(side_effect=post)
+        app = agent.setup_webserver()
+        body = {
+            "responses_create_params": {"input": [{"role": "user", "content": "play"}]},
+            TASK_INDEX_KEY_NAME: 2,
+            ROLLOUT_INDEX_KEY_NAME: 0,
+            ATTEMPT_INDEX_KEY_NAME: 0,
+        }
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://agent") as client:
+            run = asyncio.create_task(client.post("/run", json=body))
+            await refused.wait()
+            while participant.status()["parked"] != 1:
+                await asyncio.sleep(0)
+            await participant.resume()
+            response = await run
+
+        assert response.status_code == 200
+        assert [url for url, _body in calls].count("/step") == 2
+        assert "checkpoint_parked" not in str(calls)
+
+    @pytest.mark.asyncio
     async def test_terminates_on_first_step(self):
         agent = _make_agent()
+        checkpoint_participant = MagicMock()
+        checkpoint_participant.commit_boundary = AsyncMock()
+        checkpoint_participant.continuation.return_value = None
+        agent._checkpoint_participant = checkpoint_participant
         model_path = "/ng-rollout/2-0/v1/responses"
         payloads = {
             "/reset": [{"observation": "go", "info": {}}],
@@ -237,6 +363,7 @@ class TestRun:
         assert urls.count("/close") == 0
         model_calls = [(u, h) for (u, h) in seen if u == model_path]
         assert model_calls == [(model_path, None)]
+        checkpoint_participant.commit_boundary.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_successful_rollout_survives_close_http_failure(self):

--- a/responses_api_agents/gymnasium_agent/tests/test_app.py
+++ b/responses_api_agents/gymnasium_agent/tests/test_app.py
@@ -17,8 +17,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from nemo_gym._checkpoint import AgentBoundaryRecord
 from nemo_gym.config_types import ModelServerRef, ResourcesServerRef
-from nemo_gym.global_config import ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
+from nemo_gym.global_config import ATTEMPT_INDEX_KEY_NAME, ROLLOUT_INDEX_KEY_NAME, TASK_INDEX_KEY_NAME
 from nemo_gym.server_utils import ServerClient
 from responses_api_agents.gymnasium_agent.app import GymnasiumAgent, GymnasiumAgentConfig, GymnasiumAgentRunRequest
 
@@ -140,6 +141,70 @@ class TestConfig:
 
 
 class TestRun:
+    @pytest.mark.asyncio
+    async def test_restored_attempt_skips_reset_and_preserves_reward_usage_and_history(self):
+        agent = _make_agent(max_steps=3)
+        continuation = AgentBoundaryRecord(
+            rollout_id="2-0",
+            attempt_index=0,
+            boundary_index=1,
+            output_items=_model_response("turn-1", input_toks=3, output_toks=4)["output"]
+            + [{"role": "user", "content": "observation-1", "type": "message"}],
+            usage={
+                "input_tokens": 3,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens": 4,
+                "output_tokens_details": {"reasoning_tokens": 0},
+                "total_tokens": 7,
+            },
+            agent_state={
+                "reset_data": {"observation": "start", "info": {}},
+                "step_data": {
+                    "observation": "observation-1",
+                    "reward": 0.25,
+                    "terminated": False,
+                    "truncated": False,
+                    "info": {},
+                },
+                "total_reward": 0.25,
+                "env_cookies": {"session": "restored"},
+            },
+        )
+        agent.checkpoint_participant().install_restored([continuation])
+        call_log = _wire_mock_client(
+            agent,
+            {
+                "/ng-rollout/2-0-a1/v1/responses": [_model_response("turn-2", input_toks=5, output_toks=6)],
+                "/step": [
+                    {
+                        "observation": None,
+                        "reward": 0.75,
+                        "terminated": True,
+                        "truncated": False,
+                        "info": {},
+                    }
+                ],
+            },
+        )
+        request = MagicMock()
+        request.cookies = {}
+        body = GymnasiumAgentRunRequest(
+            responses_create_params={"input": [{"role": "user", "content": "play"}]},
+            **{
+                TASK_INDEX_KEY_NAME: 2,
+                ROLLOUT_INDEX_KEY_NAME: 0,
+                ATTEMPT_INDEX_KEY_NAME: 1,
+            },
+        )
+
+        result = await agent.run(request, body)
+
+        assert result.reward == 1.0
+        assert result.response.usage.total_tokens == 18
+        assert all(url != "/reset" for _server, url, _payload in call_log)
+        model_body = next(payload for _server, url, payload in call_log if url == "/ng-rollout/2-0-a1/v1/responses")
+        assert any(getattr(item, "content", None) == "observation-1" for item in model_body.input)
+
     @pytest.mark.asyncio
     async def test_terminates_on_first_step(self):
         agent = _make_agent()


### PR DESCRIPTION
> [!NOTE]
> This checkpoint implementation is experimental. Its Python modules live under `nemo_gym._checkpoint`; they are not a supported public import surface yet.

## Summary
- checkpoint nonterminal Gymnasium turn boundaries
- restore history, rewards, usage, resource revision, and cookies
- retry refused model and resource operations from the same committed turn
- stop at the step budget without generating an extra action

## How a Gymnasium episode resumes
The Gymnasium agent owns conversation and reward bookkeeping. The resources server owns the environment object. This PR records the agent half of a completed nonterminal step; #2945 and #2946 add the matching environment-state snapshot.

```mermaid
sequenceDiagram
    participant A as Gymnasium agent
    participant E as Gymnasium resources server
    participant M as Policy model
    participant P as Agent checkpoint participant

    A->>E: reset only for a fresh attempt
    E-->>A: observation and session cookie
    A->>M: generate action
    M-->>A: action and model-call ID
    A->>E: step(action)
    E-->>A: observation, reward, revision, terminal flag
    alt nonterminal step
        A->>P: commit boundary with history, reward, usage, cookies, revision
        P-->>A: continue or park for checkpoint
    else model or step refused for checkpoint
        A->>P: park without recording an error
        P-->>A: retry the same operation after explicit resume
    else terminal or truncated
        A->>E: close when supported
        A-->>A: return result without a resumable boundary
    end
```

Not writing a terminal boundary matters because the environment session may already have been retired. Restoring that point and issuing another `step` would continue an episode that no longer exists. The step-budget check happens before another model call, so a legacy boundary at the limit returns a truncated result without creating an extra turn.

## Stack
- depends on: [#2943](https://github.com/NVIDIA-NeMo/Gym/pull/2943)
- next: [#2945](https://github.com/NVIDIA-NeMo/Gym/pull/2945)

## Test plan
- [x] Gymnasium continuation and cleanup tests
- [x] refusal retry, step-budget, terminal-boundary, and cookie regressions

## Generation-safe checkpoint update

- records generation-safe Gymnasium continuation phases
- avoids terminal boundaries that reference retired resource state and merges cookies

Layer validation: 16 tests passed.